### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+govuk_modules
+public
+.settings
+.project
+*.log
+*.txt


### PR DESCRIPTION
- This will prevent the listed files/folders from being used in Dockerfile
  commands such as ADD
