### PR TITLE
Fix delete ajax call

### DIFF
--- a/app/assets/js/devtokens.js
+++ b/app/assets/js/devtokens.js
@@ -83,12 +83,12 @@ $(document).ready(function(){
         var revokedDiv = descendant(tokenDiv,"div#revoked");
         var revokedDateSpan = descendant(tokenDiv,"span#revoked-date");
 
+        var deleteUrl = '/tokens/' + accountId+"?token_link="+tokenLink;
+
         $.ajax({
             type: 'DELETE',
-            url: '/tokens/' + accountId,
-            data: {
-                'token_link': tokenLink,
-            },
+            url: deleteUrl,
+            dataType : 'json',
             success: function(responseData){
                 revokedDateSpan.text(responseData.revoked);
                 editLink.hide();

--- a/app/controllers/dev_tokens_controller.js
+++ b/app/controllers/dev_tokens_controller.js
@@ -139,7 +139,7 @@ module.exports.bindRoutesTo = function (app) {
     var requestPayload = {
       headers:{"Content-Type": "application/json"},
       data: {
-        token_link: req.body.token_link
+        token_link: req.query.token_link
       }
     };
 


### PR DESCRIPTION
- Some browsers, e.g. the ones used for E2ETests phantomjs or htmlunit, do not pass body parameters
  in a DELETE call, so they need to be specified as query parameters.
