### PR TITLE
pp-159 Fix javascript asset path

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -2,7 +2,7 @@
 
 {{$head}}
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-  <script type="text/javascript" src="/public/js/devtokens.js"></script>
+  <script type="text/javascript" src="/selfservice/public/js/devtokens.js"></script>
   {{>includes/head}}
 {{/head}}
 

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ app.set('views', __dirname + '/app/views');
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
-app.use('/public', express.static(__dirname + '/public'));
+app.use('/selfservice/public', express.static(__dirname + '/public'));
 app.use('/public', express.static(__dirname + '/govuk_modules/govuk_template/assets'));
 app.use('/public', express.static(__dirname + '/govuk_modules/govuk_frontend_toolkit'));
 app.use(favicon(path.join(__dirname, 'govuk_modules', 'govuk_template', 'assets', 'images','favicon.ico')));


### PR DESCRIPTION
- The js was not being served because nginx routes requests to
  selfservice only when they start with /selfservice

with @kakumara, @PauloJorgeMonteiro
