### PR TITLE
PP-307 Add ids to transaction list headers

### DIFF
--- a/app/views/transactions.html
+++ b/app/views/transactions.html
@@ -9,10 +9,10 @@ View transactions
 <table id="transaction-list">
   <thead>
     <tr>
-      <th>Charge ID</th>
-      <th>Gateway transaction ID</th>
-      <th>Amount (£)</th>
-      <th>Status</th>
+      <th id="charge-id-header">Charge ID</th>
+      <th id="transaction-id-header">Gateway transaction ID</th>
+      <th id="amount-header">Amount (£)</th>
+      <th id="status-header">Status</th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
- If we decide at any point to add a new column or change the order of the columns
  for example in the list of transactions, the end to end tests will immediately break
  and this is probably not what we want
- Even if we wanted to enforce a check for order in the end to end tests, the tests
  that check that on a row we have a charge id with a certain status should still pass
  as they have nothing to do with the fact that we changed the order of these columns
- In order to make our tests more granular and more resilient to the above mentioned
  changes, as a first step, we need to identify the columns in the transaction list
  in a way that is independent of the design of the page
