### PR TITLE
PP-307 Add payment reference

### DIFF
--- a/app/controllers/transaction_list_controller.js
+++ b/app/controllers/transaction_list_controller.js
@@ -10,6 +10,7 @@ var CONNECTOR_CHARGE_PATH = '/v1/frontend/charges';
 function formatForView(connectorData) {
   connectorData.results.forEach(function (element) {
     element.amount = (element.amount / 100).toFixed(2);
+    element.reference = element.reference || ""; // tolerate missing reference
   });
   return connectorData;
 }

--- a/app/views/transactions.html
+++ b/app/views/transactions.html
@@ -12,6 +12,7 @@ View transactions
       <th id="charge-id-header">Charge ID</th>
       <th id="transaction-id-header">Gateway transaction ID</th>
       <th id="amount-header">Amount (£)</th>
+      <th id="reference-header">Reference</th>
       <th id="status-header">Status</th>
     </tr>
   </thead>
@@ -21,6 +22,7 @@ View transactions
       <td>{{charge_id}}</td>
       <td>{{gateway_transaction_id}}</td>
       <td>{{amount}}</td>
+      <td>{{reference}}</td>
       <td>{{status}}</td>
     </tr>
   {{/results}}

--- a/test/transaction_list_ft_tests.js
+++ b/test/transaction_list_ft_tests.js
@@ -45,12 +45,14 @@ portfinder.getPort(function (err, connectorPort) {
               'charge_id': '100',
               'gateway_transaction_id': 'tnx-id-1',
               'amount': 5000,
+              'reference': 'ref1',
               'status': 'TEST STATUS'
             },
             {
               'charge_id': '101',
               'gateway_transaction_id': 'tnx-id-2',
               'amount': 2000,
+              'reference': 'ref2',
               'status': 'TEST STATUS 2'
             }
           ]
@@ -63,12 +65,59 @@ portfinder.getPort(function (err, connectorPort) {
               'charge_id': '100',
               'gateway_transaction_id': 'tnx-id-1',
               'amount': '50.00',
+              'reference': 'ref1',
               'status': 'TEST STATUS'
             },
             {
               'charge_id': '101',
               'gateway_transaction_id': 'tnx-id-2',
               'amount': '20.00',
+              'reference': 'ref2',
+              'status': 'TEST STATUS 2'
+            }
+          ]
+        };
+
+        get_transaction_list()
+          .expect(200, expectedData)
+          .end(done);
+      });
+
+      it('should return a list of transactions for the gateway account with reference missing', function (done) {
+
+        var connectorData = {
+          'results': [
+            {
+              'charge_id': '100',
+              'gateway_transaction_id': 'tnx-id-1',
+              'amount': 5000,
+              'status': 'TEST STATUS'
+            },
+            {
+              'charge_id': '101',
+              'gateway_transaction_id': 'tnx-id-2',
+              'amount': 2000,
+              'reference': 'ref2',
+              'status': 'TEST STATUS 2'
+            }
+          ]
+        };
+        connectorMock_responds(connectorData);
+
+        var expectedData = {
+          'results': [
+            {
+              'charge_id': '100',
+              'gateway_transaction_id': 'tnx-id-1',
+              'amount': '50.00',
+              'reference': '',
+              'status': 'TEST STATUS'
+            },
+            {
+              'charge_id': '101',
+              'gateway_transaction_id': 'tnx-id-2',
+              'amount': '20.00',
+              'reference': 'ref2',
               'status': 'TEST STATUS 2'
             }
           ]

--- a/test/transaction_list_ui_tests.js
+++ b/test/transaction_list_ui_tests.js
@@ -12,12 +12,14 @@ describe('The transaction list view', function () {
           'charge_id': '100',
           'gateway_transaction_id': 'tnx-id-1',
           'amount': '50.00',
+          'reference': 'ref1',
           'status': 'TEST STATUS'
         },
         {
           'charge_id': '101',
           'gateway_transaction_id': 'tnx-id-2',
           'amount': '20.00',
+          'reference': 'ref1',
           'status': 'TEST STATUS 2'
         }
       ]
@@ -31,7 +33,8 @@ describe('The transaction list view', function () {
         .withTableDataAt(1, templateData.results[ix].charge_id)
         .withTableDataAt(2, templateData.results[ix].gateway_transaction_id)
         .withTableDataAt(3, templateData.results[ix].amount)
-        .withTableDataAt(4, templateData.results[ix].status);
+        .withTableDataAt(4, templateData.results[ix].reference)
+        .withTableDataAt(5, templateData.results[ix].status);
     });
   });
 });


### PR DESCRIPTION
- please merge https://github.com/alphagov/pay-endtoend/pull/52 first in order to preserve backwards compatibility
- added Reference field to the transaction list
- made sure that the tests pass even in the case that the reference field is not returned from the connector in order to retain backwards compatibility
