### PR TITLE
PP-101 Make the cookie name unique

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ var port = (process.env.PORT || 3000);
 var app = express();
 
 app.use(clientSessions({
-  cookieName: 'session_state',
+  cookieName: 'selfservice_cookie',
   secret: process.env.SESSION_ENCRYPTION_KEY
 }));
 


### PR DESCRIPTION
PP-101 Make the cookie name unique so it doesn't interfere with other things running on the the same host (disturbs things even on other ports)
