### PR TITLE
PP-101 Make the cookie name unique

### DIFF
--- a/app/controllers/dev_tokens_controller.js
+++ b/app/controllers/dev_tokens_controller.js
@@ -56,12 +56,12 @@ module.exports.bindRoutesTo = function (app) {
     withValidAccountId(req, res, req.params.accountId, function(accountId, req, res) {
 
       responsePayload = {'account_id': accountId};
-      var tokenInSession = req.session_state.token;
+      var tokenInSession = req.selfservice_state.token;
       if (tokenInSession) {
         responsePayload.token = tokenInSession;
-        responsePayload.description = req.session_state.description;
-        delete req.session_state.token;
-        delete req.session_state.description;
+        responsePayload.description = req.selfservice_state.description;
+        delete req.selfservice_state.token;
+        delete req.selfservice_state.description;
       }
       response(req.headers.accept, res, TOKEN_GENERATE_VIEW, responsePayload);
 
@@ -73,9 +73,9 @@ module.exports.bindRoutesTo = function (app) {
 
     logger.info('POST ' + TOKEN_GENERATION_POST_PATH);
 
-    if (req.session_state.token) {
-      delete req.session_state.token;
-      delete req.session_state.description;
+    if (req.selfservice_state.token) {
+      delete req.selfservice_state.token;
+      delete req.selfservice_state.description;
       renderErrorView(req, res, ERROR_MESSAGE);
       return;
     }
@@ -94,8 +94,8 @@ module.exports.bindRoutesTo = function (app) {
       client.post(publicAuthUrl, payload, function (publicAuthData, publicAuthResponse) {
 
         if (publicAuthResponse.statusCode === 200) {
-          req.session_state.token = publicAuthData.token;
-          req.session_state.description = description;
+          req.selfservice_state.token = publicAuthData.token;
+          req.selfservice_state.description = description;
           res.redirect(303, TOKEN_GENERATION_GET_PATH.replace(":accountId",accountId));
           return;
         }

--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ var port = (process.env.PORT || 3000);
 var app = express();
 
 app.use(clientSessions({
-  cookieName: 'session_state',
+  cookieName: 'selfservice_state',
   secret: process.env.SESSION_ENCRYPTION_KEY
 }));
 

--- a/test/dev_tokens_ft_tests.js
+++ b/test/dev_tokens_ft_tests.js
@@ -412,7 +412,7 @@ portfinder.getPort(function(err, freePort) {
               .post(TOKEN_GENERATION_POST_PATH)
               .set('Content-Type', 'application/x-www-form-urlencoded')
               .set('Accept', 'application/json')
-              .set('Cookie', ['session_state=' + cookie.create(TOKEN)])
+              .set('Cookie', ['selfservice_state=' + cookie.create(TOKEN)])
               .send({
                   'accountId': ACCOUNT_ID,
                   'description': "description"
@@ -436,7 +436,7 @@ portfinder.getPort(function(err, freePort) {
             request(app)
               .get(TOKEN_GENERATION_GET_PATH.replace("{accountId}", ACCOUNT_ID))
               .set('Accept', 'application/json')
-              .set('Cookie', ['session_state=' + cookie.create(TOKEN)])
+              .set('Cookie', ['selfservice_state=' + cookie.create(TOKEN)])
               .expect(200, {
                 'account_id': ACCOUNT_ID,
                 'token': TOKEN,

--- a/test/utils/session.js
+++ b/test/utils/session.js
@@ -1,7 +1,7 @@
 var clientSessions = require("client-sessions");
 
 var sessionConfig = {
-    'cookieName': 'session_state',
+    'cookieName': 'selfservice_state',
     'secret':     process.env.SESSION_ENCRYPTION_KEY
 };
 


### PR DESCRIPTION
Make the cookie name unique so it doesn't interfere with other things running on the the same host (disturbs things even on other ports). This is to address the 'demoservice' hack we've been doing in our dev environments, however will also help us in production (where many things may be on the same domain name hidden behind a rewrite proxy such as nginx) as well as on dev.
