### PR TITLE
Add an EXPOSE line for port 9000.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ENV PORT 9000
 ENV ENABLE_NEWRELIC no
 ENV NEW_RELIC_HOME /app/newrelic
 
+EXPOSE 9000
+
 ADD . /app
 WORKDIR /app
 RUN npm install --production


### PR DESCRIPTION
Add an EXPOSE line for port 9000. It being removed recently may have caused issues on production-like infrastructure, as the containers do not seem to be listening to network ports properly. This may be reverted on further investigation
