### PR TITLE
PP-424 View detailed information on a specific payment via API

### DIFF
--- a/app/utils/transaction_view.js
+++ b/app/utils/transaction_view.js
@@ -1,11 +1,5 @@
+var moment = require('moment');
 var CURRENCY = '£';
-
-String.prototype.capitalize = function() {
-    return this.replace(/(?:^|\s)\S/g, function(a) { return a.toUpperCase(); });
-};
-
-var monthNames = ["January","February", "March",    "April",    "May",      "June",
-                  "July",   "August",   "September","October",  "November", "December" ];
 
 //TODO: Ask Rory for the friendly text for the below order statuses
 var TransactionView = function () {
@@ -40,7 +34,7 @@ TransactionView.prototype.buildPaymentView = function (chargeData, eventsData) {
     eventsData.events.forEach(function (event) {
         event.status = this.eventStatuses[event.status];
         event.status = event.status.replace('AMOUNT', CURRENCY + (chargeData.amount / 100).toFixed(2));
-        event.updated2 = convertDate(event.updated);
+        event.updated_friendly = convertDate(event.updated);
     }.bind(this));
 
     chargeData.amount = CURRENCY + (chargeData.amount / 100).toFixed(2);
@@ -51,14 +45,8 @@ TransactionView.prototype.buildPaymentView = function (chargeData, eventsData) {
 };
 
 function convertDate(updated) {
-  function pad(s) { return (s < 10) ? '0' + s : s; };
   var date = new Date(updated);
-  return    pad(date.getDate()) +            " " +
-            monthNames[date.getMonth()] +   " " +
-            date.getFullYear() +            " " +
-            pad(date.getHours()) +          ":" +
-            pad(date.getMinutes()) +        ":" +
-            pad(date.getSeconds());
+  return moment(date).format('DD MMMM YYYY HH:mm:ss');
 }
 
 exports.TransactionView = TransactionView;

--- a/app/views/transaction_details.html
+++ b/app/views/transaction_details.html
@@ -55,7 +55,7 @@ Transaction Details
     {{#events}}
     <tr>
       <td>{{status}}</td>
-      <td align="right">{{updated2}}</td>
+      <td align="right">{{updated_friendly}}</td>
     </tr>
     {{/events}}
     </tbody>

--- a/test/transaction_details_ft_tests.js
+++ b/test/transaction_details_ft_tests.js
@@ -99,17 +99,17 @@ portfinder.getPort(function (err, connectorPort) {
                         {
                             'status': 'Payment of £50.00 succeeded',
                             'updated': '2015-12-24 12:05:43',
-                            'updated2': '24 December 2015 12:05:43'
+                            'updated_friendly': '24 December 2015 12:05:43'
                         },
                         {
                             'status': 'Payment of £50.00 is in progress',
                             'updated': '2015-12-24 13:23:12',
-                            'updated2': '24 December 2015 13:23:12'
+                            'updated_friendly': '24 December 2015 13:23:12'
                         },
                         {
                             'status': 'Payment of £50.00 was created',
                             'updated': '2015-12-24 13:21:05',
-                            'updated2': '24 December 2015 13:21:05'
+                            'updated_friendly': '24 December 2015 13:21:05'
                         }
                     ]
                 };

--- a/test/transaction_details_ui_tests.js
+++ b/test/transaction_details_ui_tests.js
@@ -20,22 +20,22 @@ describe('The transaction details view', function () {
             {'chargeId':1,
              'status':'Payment of £10.00 succeeded',
              'updated': "2015-12-24 13:21:05",
-             'updated2': "24 January 2015 13:21:05"},
+             'updated_friendly': "24 January 2015 13:21:05"},
 
             {'chargeId':1,
              'status':'Payment of £10.00 is in progress',
              'updated': "2015-12-24 13:21:05",
-             'updated2': "24 January 2015 13:21:05"},
+             'updated_friendly': "24 January 2015 13:21:05"},
 
             {'chargeId':1,
              'status':'Payment of £10.00 is in progress',
              'updated': "2015-12-24 13:21:05",
-             'updated2': "24 January 2015 13:21:05"},
+             'updated_friendly': "24 January 2015 13:21:05"},
 
             {'chargeId':1,
              'status':'Payment of £10.00 was created',
              'updated': "2015-12-24 13:21:05",
-             'updated2': "24 January 2015 13:21:05"},
+             'updated_friendly': "24 January 2015 13:21:05"},
         ]
     };
 
@@ -51,7 +51,7 @@ describe('The transaction details view', function () {
       body.should.containSelector('table#transaction-events')
         .havingRowAt(ix + 1)
         .withTableDataAt(1, templateData.events[ix].status)
-        .withTableDataAt(2, templateData.events[ix].updated2);
+        .withTableDataAt(2, templateData.events[ix].updated_friendly);
     });
   });
 });


### PR DESCRIPTION
- The major work of this commit was to refactor the way we
  were handling the updated date.
  Before pay-connector was returning a JSON object in the format
  of update: {year: 2016, month: 14, fullMonth: "May" ...}.
  This was very tedious to work and required a lot of boiler plate
  code to display it on the view.
  
  The introduction of the JsonDateSerializer and JsonDateDeserializer
  in pay-connector made the manipulation of the dates trivial and
  transparent for the developer.
- Changed the unit tests accordingly
