### PR TITLE
PP-488 adding secure properties to selfservice cookies

### DIFF
--- a/app/services/auth_service.js
+++ b/app/services/auth_service.js
@@ -3,6 +3,7 @@ var clientSessions = require("client-sessions");
 var Auth0Strategy = require('passport-auth0');
 var passport = require('passport');
 var util = require('util');
+var sessionCookie = require(__dirname + '/../utils/cookies.js').sessionCookie;
 
 var AUTH_STRATEGY_NAME = 'auth0';
 var AUTH_STRATEGY = new Auth0Strategy({
@@ -68,10 +69,7 @@ var auth = module.exports = {
         app.use(passport.initialize());
         app.use(passport.session());
         
-        app.use(clientSessions({
-            cookieName: 'session',
-            secret: process.env.SESSION_ENCRYPTION_KEY
-        }));
+        app.use(clientSessions(sessionCookie()));
     },
     
     no_access: function(req, res, next) {

--- a/app/utils/cookies.js
+++ b/app/utils/cookies.js
@@ -1,0 +1,36 @@
+'use strict';
+
+module.exports = function () {
+  function cookieOpts() {
+    if (process.env.SECURED == "true") {
+      return {
+        httpOnly: true,
+        secure: true
+      };
+    } else {
+      return {};
+    }
+  }
+
+  function namedCookie(name) {
+    return {
+      cookieName: name,
+      secret: process.env.SESSION_ENCRYPTION_KEY,
+      cookie: cookieOpts()
+    };
+  }
+
+  var selfServiceCookie = function () {
+    return namedCookie('selfservice_state');
+  };
+
+  var sessionCookie = function () {
+    return namedCookie('session');
+  };
+
+  return {
+    selfServiceCookie: selfServiceCookie,
+    sessionCookie: sessionCookie
+  }
+
+}();

--- a/server.js
+++ b/server.js
@@ -5,14 +5,12 @@ var favicon = require('serve-favicon');
 var routes = require(__dirname + '/app/routes.js');
 var bodyParser = require('body-parser');
 var clientSessions = require("client-sessions");
+var selfServiceCookie = require(__dirname + '/app/utils/cookies.js').selfServiceCookie;
 
 var port = (process.env.PORT || 3000);
 var app = express();
 
-app.use(clientSessions({
-  cookieName: 'selfservice_state',
-  secret: process.env.SESSION_ENCRYPTION_KEY
-}));
+app.use(clientSessions(selfServiceCookie()));
 
 app.engine('html', require(__dirname + '/lib/template-engine.js').__express);
 app.set('view engine', 'html');

--- a/test/util_cookies_ft_tests.js
+++ b/test/util_cookies_ft_tests.js
@@ -1,0 +1,36 @@
+require(__dirname + '/utils/html_assertions.js');
+var should = require('chai').should();
+var assert = require('assert');
+var cookies  = require(__dirname + '/../app/utils/cookies.js');
+
+describe('session cookie', function () {
+
+  it('should have empty opts when unsecured', function () {
+    process.env.SECURED = "false";
+    assert.deepEqual({},cookies.sessionCookie().cookie);
+    assert.equal('session',cookies.sessionCookie().cookieName);
+  });
+
+  it('should have secure opts when secured', function () {
+    process.env.SECURED = "true";
+    assert.deepEqual({httpOnly: true, secure: true},cookies.sessionCookie().cookie);
+    assert.equal('session',cookies.sessionCookie().cookieName);
+  });
+
+});
+
+describe('selfservice cookie', function () {
+
+  it('should have empty opts when unsecured', function () {
+    process.env.SECURED = "false";
+    assert.deepEqual({},cookies.selfServiceCookie().cookie);
+    assert.equal('selfservice_state',cookies.selfServiceCookie().cookieName);
+  });
+
+  it('should have secure opts when secured', function () {
+    process.env.SECURED = "true";
+    assert.deepEqual({httpOnly: true, secure: true},cookies.selfServiceCookie().cookie);
+    assert.equal('selfservice_state',cookies.selfServiceCookie().cookieName);
+  });
+
+});

--- a/test/utils/login-session.js
+++ b/test/utils/login-session.js
@@ -1,19 +1,15 @@
 var clientSessions = require("client-sessions");
-
-var sessionConfig = {
-    'cookieName': 'session',
-    'secret':     process.env.SESSION_ENCRYPTION_KEY
-};
+var sessionCookie = require(__dirname + '/../../app/utils/cookies.js').sessionCookie;
 
 module.exports = {
     create : function(value) {
-      return clientSessions.util.encode(sessionConfig, value);
+      return clientSessions.util.encode(sessionCookie(), value);
     },
 
     decrypt: function decryptCookie(res) {
       var setCookieHeader = res.headers['set-cookie'];
       if (!setCookieHeader) return {};
-      else return clientSessions.util.decode(sessionConfig, setCookieHeader[0].split(";")[0].split("=")[1]).content;
+      else return clientSessions.util.decode(sessionCookie(), setCookieHeader[0].split(";")[0].split("=")[1]).content;
     }
 
 };

--- a/test/utils/session.js
+++ b/test/utils/session.js
@@ -1,19 +1,15 @@
 var clientSessions = require("client-sessions");
-
-var sessionConfig = {
-    'cookieName': 'selfservice_state',
-    'secret':     process.env.SESSION_ENCRYPTION_KEY
-};
+var selfServiceCookie = require(__dirname + '/../../app/utils/cookies.js').selfServiceCookie;
 
 module.exports = {
     create : function (tokenValue) {
-      return clientSessions.util.encode(sessionConfig, {"token": tokenValue, "description": "description"});
+      return clientSessions.util.encode(selfServiceCookie(), {"token": tokenValue, "description": "description"});
     },
 
     decrypt: function decryptCookie(res) {
       var setCookieHeader = res.headers['set-cookie'];
       if (!setCookieHeader) return {};
-      else return clientSessions.util.decode(sessionConfig, setCookieHeader[0].split(";")[0].split("=")[1]).content;
+      else return clientSessions.util.decode(selfServiceCookie(), setCookieHeader[0].split(";")[0].split("=")[1]).content;
     }
 
 };


### PR DESCRIPTION
- This is done based on a env property "SECURED" (defaults to "false"/"undefined" to support development in dev boxes)
- Moved the cookie construction to a utility module.
- refactored the usage of cookie creation to use the utility module.

Need to discuss with DevOpts as to how this will fit in the integration environment. (Once enabled the express app must run in HTTPS mode to support secure cookies. Not sure if we currently have this in infrastructure.) 
