### PR TITLE
PP-488 secure cookie enabled by default

### DIFF
--- a/app/utils/cookies.js
+++ b/app/utils/cookies.js
@@ -2,9 +2,12 @@
 
 module.exports = function () {
   function cookieOpts() {
-    var cookieOpts = {httpOnly: true};
-    if (process.env.SECURED_ENV == "true") {
-      cookieOpts.secure = true;
+    var cookieOpts = {
+      httpOnly: true,
+      secure: true
+    };
+    if (process.env.SECURE_COOKIE_OFF === "true") {
+      cookieOpts.secure = false;
     }
     return cookieOpts;
   }

--- a/test/auth_ft_tests.js
+++ b/test/auth_ft_tests.js
@@ -2,6 +2,7 @@ process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwe
 process.env.AUTH0_URL = 'my.test.auth0';
 process.env.AUTH0_CLIENT_ID = 'client12345';
 process.env.AUTH0_CLIENT_SECRET = 'clientsupersecret';
+process.env.SECURE_COOKIE_OFF = "true"; // to make sure this affects all tests so that local tests won't fail due to secured cookie
 
 var request = require('supertest');
 var auth = require(__dirname + '/../app/services/auth_service.js');

--- a/test/util_cookies_ft_tests.js
+++ b/test/util_cookies_ft_tests.js
@@ -1,4 +1,3 @@
-require(__dirname + '/utils/html_assertions.js');
 var should = require('chai').should();
 var assert = require('assert');
 var cookies  = require(__dirname + '/../app/utils/cookies.js');
@@ -6,13 +5,13 @@ var cookies  = require(__dirname + '/../app/utils/cookies.js');
 describe('session cookie', function () {
 
   it('should have empty opts when unsecured', function () {
-    process.env.SECURED_ENV = "false";
-    assert.deepEqual({httpOnly: true}, cookies.sessionCookie().cookie);
+    process.env.SECURE_COOKIE_OFF = "true";
+    assert.deepEqual({httpOnly: true, secure: false}, cookies.sessionCookie().cookie);
     assert.equal('session', cookies.sessionCookie().cookieName);
   });
 
   it('should have secure opts when secured', function () {
-    process.env.SECURED_ENV = "true";
+    process.env.SECURE_COOKIE_OFF = "false";
     assert.deepEqual({httpOnly: true, secure: true}, cookies.sessionCookie().cookie);
     assert.equal('session',cookies.sessionCookie().cookieName);
   });
@@ -22,13 +21,13 @@ describe('session cookie', function () {
 describe('selfservice cookie', function () {
 
   it('should have empty opts when unsecured', function () {
-    process.env.SECURED_ENV = "false";
-    assert.deepEqual({httpOnly: true}, cookies.selfServiceCookie().cookie);
+    process.env.SECURE_COOKIE_OFF = "true";
+    assert.deepEqual({httpOnly: true, secure: false}, cookies.selfServiceCookie().cookie);
     assert.equal('selfservice_state', cookies.selfServiceCookie().cookieName);
   });
 
   it('should have secure opts when secured', function () {
-    process.env.SECURED_ENV = "true";
+    process.env.SECURE_COOKIE_OFF = "false";
     assert.deepEqual({httpOnly: true, secure: true}, cookies.selfServiceCookie().cookie);
     assert.equal('selfservice_state', cookies.selfServiceCookie().cookieName);
   });


### PR DESCRIPTION
Changing the previous PR behaviour so that secure cookies are enable by default

env property added (SECURE_COOKIE_OFF) to switch this off in development environments
