### PR TITLE
PP-573 Perform an npm test run as part of the docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,16 @@ ENV NEW_RELIC_HOME /app/newrelic
 
 EXPOSE 9000
 
+# add package.json before source for node_module cache
+ADD package.json /tmp/package.json
+RUN cd /tmp && npm install
+
 ADD . /app
 WORKDIR /app
-RUN npm install --production
+
+# copy cached node_modules to /app/node_modules
+RUN mkdir -p /app && cp -a /tmp/node_modules /app/
+
+RUN npm install && npm test && npm prune --production
+
 CMD NODE_ENV=production npm start


### PR DESCRIPTION
This means we don't have to install npm or node on Jenkins
