### PR TITLE
PP-157 jshint needs to know it's supposed to parse EcmaScript 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,18 @@
   "engines" : {
     "node" : ">5.6.0"
   },
+  "jshintConfig" : {
+    "node": true,
+    "esversion": 6,
+    "globals": {
+      "describe": false,
+      "it": false,
+      "before": false,
+      "beforeEach": false,
+      "after": false,
+      "afterEach": false
+    }
+  },
   "scripts": {
     "start": "node start.js",
     "watch": "chokidar app test *.js --initial -c 'npm run test'",


### PR DESCRIPTION
Otherwise things like fat arrows break the build
