### PR TITLE
[REVIEW ONLY] Try using a sidecar proxy to capture requests.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ ENV NEW_RELIC_HOME /app/newrelic
 
 EXPOSE 9000
 
+# install squid & proxychains
+RUN apt-get update && apt-get install -y squid3 proxychains
+
 # add package.json before source for node_module cache
 ADD package.json /tmp/package.json
 RUN cd /tmp && npm install
@@ -18,4 +21,10 @@ RUN mkdir -p /app && cp -a /tmp/node_modules /app/
 
 RUN npm install && npm test && npm prune --production
 
-CMD NODE_ENV=production npm start
+RUN rm /etc/proxychains.conf
+ADD sidecar/proxychains.conf /etc/proxychains.conf 
+
+RUN rm /etc/squid3/squid.conf
+ADD sidecar/squid.conf /etc/squid3/squid.conf
+
+CMD /usr/sbin/squid3 -f /etc/squid3/squid.conf && NODE_ENV=production proxychains npm start

--- a/sidecar/proxychains.conf
+++ b/sidecar/proxychains.conf
@@ -1,0 +1,7 @@
+strict_chain
+tcp_read_time_out 15000
+tcp_connect_time_out 8000
+quiet_mode
+
+[ProxyList]
+http 127.0.0.1 8080

--- a/sidecar/squid.conf
+++ b/sidecar/squid.conf
@@ -1,0 +1,16 @@
+acl SSL_ports port 443
+acl Safe_ports port 80
+acl Safe_ports port 443
+acl vpc src all
+acl CONNECT method CONNECT
+http_access deny !Safe_ports
+http_access deny CONNECT !SSL_ports
+http_access allow localhost manager
+http_access deny manager
+http_access allow localhost
+http_access allow vpc
+http_access deny all
+coredump_dir /var/spool/squid3
+http_port 8080
+cache deny all
+workers 1


### PR DESCRIPTION
We can configure the sidecar proxy to proxy on to forward on to the
egress proxies theoretically. I haven't done that here in this PR,
but this shows how the internal stuff might work.

An alternative approach would be to host this as a separate container.

All thoughts welcome.
