### PR TITLE
PP-209 Allow the service name to be changed

### DIFF
--- a/app/controllers/credentials_controller.js
+++ b/app/controllers/credentials_controller.js
@@ -57,18 +57,19 @@ module.exports.update = function (req, res) {
   var requestPayload = {
     headers:{"Content-Type": "application/json"},
     data: {
-      username: req.body.username,
-      password: req.body.password
+      credentials: {
+        username: req.body.username,
+        password: req.body.password
+      }
     }
   };
 
   if('merchantId' in req.body) {
-    requestPayload.data.merchant_id = req.body.merchantId;
+    requestPayload.data.credentials.merchant_id = req.body.merchantId;
   }
 
   var connectorUrl = process.env.CONNECTOR_URL;
-  client.put(connectorUrl + "/v1/frontend/accounts/" + accountId, requestPayload, function (connectorData, connectorResponse) {
-
+  client.patch(connectorUrl + "/v1/frontend/accounts/" + accountId + "/credentials", requestPayload, function (connectorData, connectorResponse) {
     switch (connectorResponse.statusCode) {
       case 200:
         res.redirect(303, router.paths.credentials.index);

--- a/app/controllers/service_name_controller.js
+++ b/app/controllers/service_name_controller.js
@@ -1,0 +1,74 @@
+var response = require('../utils/response.js').response;
+var auth = require('../services/auth_service.js');
+var router = require('../routes.js');
+var ConnectorClient = require('../services/connector_client.js').ConnectorClient;
+var renderErrorView = require('../utils/response.js').renderErrorView;
+
+var connectorClient = function () {
+  return new ConnectorClient(process.env.CONNECTOR_URL);
+}
+
+module.exports.index = function (req, res) {
+
+  var init = function () {
+    var accountId = auth.get_account_id(req);
+
+    connectorClient()
+      .withGetAccountServiceName(accountId, onSuccess)
+      .on('connectorError', onError);
+  };
+
+  var onSuccess = function (data) {
+    var model = {
+      serviceName: data.service_name,
+      editMode: !(req.query.edit === undefined)
+    };
+
+    response(req.headers.accept, res, 'service_name', model);
+  };
+
+  var onError = function (connectorError) {
+    if (connectorError) {
+      renderErrorView(req, res, 'Internal server error');
+      return;
+    }
+    
+    renderErrorView(req, res, 'Unable to retrieve the service name.');
+  };
+
+  init();
+};
+
+module.exports.update = function (req, res) {
+
+  var init = function () {
+    var accountId = auth.get_account_id(req);
+
+    var payload = {
+      service_name: req.body['service-name-input']
+    };
+
+    connectorClient()
+      .withPatchServiceName(accountId, payload, onSuccess)
+      .on('connectorError', onError);
+  };
+
+  var onSuccess = function () {
+    res.redirect(303, router.paths.serviceName.index);
+  };
+
+  var onError = function (connectorError) {
+    if (connectorError) {
+      renderErrorView(req, res, 'Internal server error');
+      return;
+    }
+    ;
+
+    renderErrorView(req, res, 'Unable to update the service name.');
+  };
+
+  init();
+};
+
+module.exports.bindRoutesTo = function () {
+}

--- a/app/paths.js
+++ b/app/paths.js
@@ -1,30 +1,34 @@
 module.exports = {
-    root: "/",
-    transactions: {
-      index: '/transactions',
-      download: '/transactions/download',
-      show: '/transactions/:chargeId'
-    },
-    credentials: {
-      index: '/credentials',
-      edit: '/credentials?edit', // TODO LOLWUT?
-      create: '/credentials'
-    },
-    user: {
-      logIn: '/login',
-      logOut: '/logout',
-      callback: '/callback',
-      loggedIn: '/',
-      noAccess: '/noaccess'
-    },
-    devTokens: {
-      index: '/tokens',
-      // we only show the token once, hence strange url
-      show: '/tokens/generate',
-      create: '/tokens/generate',
-      // should these two not rely take an id in the url?
-      update: '/tokens',
-      delete: '/tokens'
-    },
-    generateRoute: require(__dirname + '/utils/generate_route.js')
+  root: "/",
+  transactions: {
+    index: '/transactions',
+    download: '/transactions/download',
+    show: '/transactions/:chargeId'
+  },
+  credentials: {
+    index: '/credentials',
+    edit: '/credentials?edit',
+    create: '/credentials'
+  },
+  user: {
+    logIn: '/login',
+    logOut: '/logout',
+    callback: '/callback',
+    loggedIn: '/',
+    noAccess: '/noaccess'
+  },
+  devTokens: {
+    index: '/tokens',
+    // we only show the token once, hence strange url
+    show: '/tokens/generate',
+    create: '/tokens/generate',
+    // should these two not rely take an id in the url?
+    update: '/tokens',
+    delete: '/tokens'
+  },
+  serviceName: {
+    index: '/service-name',
+    edit: '/service-name?edit'
+  },
+  generateRoute: require(__dirname + '/utils/generate_route.js')
 };

--- a/app/routes.js
+++ b/app/routes.js
@@ -4,6 +4,7 @@ var transactions  = require('./controllers/transaction_controller.js');
 var credentials   = require('./controllers/credentials_controller.js');
 var login         = require('./controllers/login_controller.js');
 var devTokens     = require('./controllers/dev_tokens_controller.js');
+var serviceName   = require('./controllers/service_name_controller.js');
 var auth          = require('./services/auth_service.js');
 var querystring   = require('querystring');
 var _             = require('lodash');
@@ -57,4 +58,10 @@ module.exports.bind = function (app) {
   app.post(dt.create, auth.enforce, csrf, devTokens.create);
   app.put(dt.update, auth.enforce, csrf,  devTokens.update);
   app.delete(dt.delete, auth.enforce, csrf, devTokens.destroy);
+
+  // SERVICE NAME
+
+  var sn = paths.serviceName;
+  app.get(sn.index, auth.enforce, csrf, serviceName.index);
+  app.post(sn.index, auth.enforce, csrf, serviceName.update);
 };

--- a/app/services/connector_client.js
+++ b/app/services/connector_client.js
@@ -7,8 +7,16 @@ var request = require('request');
 var dates = require('../utils/dates.js');
 var querystring = require('querystring');
 
-var CHARGES_API_PATH = '/v1/api/accounts/{accountId}/charges';
+
+var ACCOUNTS_API_PATH = '/v1/api/accounts';
+var ACCOUNT_API_PATH = ACCOUNTS_API_PATH + '/{accountId}';
+
+var CHARGES_API_PATH = ACCOUNT_API_PATH + '/charges';
 var CHARGE_API_PATH = CHARGES_API_PATH + '/{chargeId}';
+
+var ACCOUNTS_FRONTEND_PATH = '/v1/frontend/accounts';
+var ACCOUNT_FRONTEND_PATH = ACCOUNTS_FRONTEND_PATH + '/{accountId}';
+var SERVICE_NAME_FRONTEND_PATH = ACCOUNT_FRONTEND_PATH + '/servicename';
 
 var CONTENT_TYPE_CSV = 'text/csv';
 
@@ -43,7 +51,7 @@ var createOnResponseEventHandler = function (self) {
 
         //
         // Necessary when streaming a response
-        // @See https://github.com/request/request/issues/1268
+        // @See https://github  .com/request/request/issues/1268
         //
         this.abort();
 
@@ -125,7 +133,7 @@ ConnectorClient.prototype.withGetCharge = function (gatewayAccountId, chargeId, 
 };
 
 /**
- * Retrives transaction history for a given charge Id that belongs to a gateway account Id.
+ * Retrieves transaction history for a given charge Id that belongs to a gateway account Id.
  * @param gatewayAccountId
  * @param chargeId
  * @param successCallback the callback to perform upon `200 OK` from connector along with history result set.
@@ -136,6 +144,36 @@ ConnectorClient.prototype.withChargeEvents = function (gatewayAccountId, chargeI
     logger.info('CONNECTOR GET ' + url);
     this.client(url, this.responseHandler(successCallback));
     return this;
+};
+
+/**
+ * Retrieves the service name for the given gateway account
+ * @param gatewayAccountId
+ */
+ConnectorClient.prototype.withGetAccountServiceName = function (gatewayAccountId, successCallback) {
+    var url = this._accountUrlFor(gatewayAccountId);
+    logger.info('CONNECTOR GET ' + url);
+    this.client(url, this.responseHandler(successCallback));
+    return this;
+};
+
+/**
+ * Updates the service name for to the given gateway account
+ * @param gatewayAccountId
+ */
+ConnectorClient.prototype.withPatchServiceName = function (gatewayAccountId, payload, successCallback) {
+    var url = this._serviceNameUrlFor(gatewayAccountId);
+    logger.info('CONNECTOR PUT ' + url);
+    this.client.patch({url: url, body: payload}, this.responseHandler(successCallback));
+    return this;
+};
+
+ConnectorClient.prototype._accountUrlFor = function (gatewayAccountId) {
+    return this.connectorUrl + ACCOUNT_FRONTEND_PATH.replace("{accountId}", gatewayAccountId);
+};
+
+ConnectorClient.prototype._serviceNameUrlFor = function (gatewayAccountId) {
+    return this.connectorUrl + SERVICE_NAME_FRONTEND_PATH.replace("{accountId}", gatewayAccountId);
 };
 
 ConnectorClient.prototype._chargeUrlFor = function (gatewayAccountId, chargeId) {

--- a/app/views/service_name.html
+++ b/app/views/service_name.html
@@ -1,0 +1,46 @@
+{{< layout}}
+
+{{$pageTitle}}
+GOV.UK Pay - Change service name
+{{/pageTitle}}
+
+{{$content}}
+
+<h1 class="page-title">GOV.UK Pay - Change service name</h1>
+
+{{^editMode}}
+<h2 class="heading-medium remove-top-margin">Current service name</h2>
+
+<p>As it appears on the user facing payment screens</p>
+
+<div class="panel panel-border-wide">
+    <p class="lede" id="service-name">{{serviceName}}</p>
+</div>
+<a id="service-name-change-link" class="button" href="{{routes.serviceName.edit}}">
+Change service name
+</a>
+{{/editMode}}
+
+{{#editMode}}
+<form id="service-name-form" method="post" action="{{routes.serviceName.save}}">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
+    <div class="form-group">
+        <label class="form-label-bold" for="service-name-input">
+            Enter new service name
+
+            <span class="form-hint">The service name can't be more than 50 characters.</span>
+        </label>
+        <input id="service-name-input" class="form-control" name="service-name-input" type="text" value="{{serviceName}}" maxlength="50">
+    </div>
+    <div class="form-group">
+        <input id="service-name-save-button" name="service-name-save-button" type="submit" class="button" value="Save service name">
+    </div>
+    <a id="service-name-cancel-link" href="{{routes.serviceName.index}}">
+        Cancel
+    </a>
+</form>
+{{/editMode}}
+
+{{/content}}
+
+{{/layout}}

--- a/app/views/staff_frontend_template.html
+++ b/app/views/staff_frontend_template.html
@@ -43,6 +43,7 @@
               <li><a href="{{ routes.devTokens.index }}">API keys</a></li>
               <li><a href="{{ routes.transactions.index }}" data-qa-transaction-link>Transactions</a></li>
               <li><a href="{{ routes.credentials.index }}">Account credentials</a></li>
+              <li><a href="{{ routes.serviceName.index }}">Change service name</a></li>
             </ul>
           </nav>
         </div>

--- a/test/credentails_ft_tests.js
+++ b/test/credentails_ft_tests.js
@@ -13,7 +13,8 @@ var app = session.mockValidAccount(_app, ACCOUNT_ID);
 
 portfinder.getPort(function (err, freePort) {
 
-  var CONNECTOR_ACCOUNT_CREDENTIALS_PATH = "/v1/frontend/accounts/" + ACCOUNT_ID;
+  var CONNECTOR_ACCOUNT_PATH = "/v1/frontend/accounts/" + ACCOUNT_ID;
+  var CONNECTOR_ACCOUNT_CREDENTIALS_PATH = CONNECTOR_ACCOUNT_PATH + "/credentials";
   var localServer = 'http://localhost:' + freePort;
   var connectorMock = nock(localServer);
 
@@ -57,7 +58,7 @@ portfinder.getPort(function (err, freePort) {
       });
 
       it('should display payment provider name in title case', function (done) {
-        connectorMock.get(CONNECTOR_ACCOUNT_CREDENTIALS_PATH)
+        connectorMock.get(CONNECTOR_ACCOUNT_PATH)
           .reply(200, {
             "payment_provider": "sandbox",
             "gateway_account_id": "1",
@@ -77,7 +78,7 @@ portfinder.getPort(function (err, freePort) {
       });
 
       it('should display empty credential values when no gateway credentials are set', function (done) {
-        connectorMock.get(CONNECTOR_ACCOUNT_CREDENTIALS_PATH)
+        connectorMock.get(CONNECTOR_ACCOUNT_PATH)
           .reply(200, {
             "payment_provider": "sandbox",
             "gateway_account_id": "1",
@@ -97,7 +98,7 @@ portfinder.getPort(function (err, freePort) {
       });
 
       it('should display received credentials from connector', function (done) {
-        connectorMock.get(CONNECTOR_ACCOUNT_CREDENTIALS_PATH)
+        connectorMock.get(CONNECTOR_ACCOUNT_PATH)
           .reply(200, {
             "payment_provider": "sandbox",
             "gateway_account_id": "1",
@@ -119,7 +120,7 @@ portfinder.getPort(function (err, freePort) {
       });
 
       it('should return the account', function (done) {
-        connectorMock.get(CONNECTOR_ACCOUNT_CREDENTIALS_PATH)
+        connectorMock.get(CONNECTOR_ACCOUNT_PATH)
           .reply(200, {
             "payment_provider": "sandbox",
             "gateway_account_id": "1",
@@ -142,7 +143,7 @@ portfinder.getPort(function (err, freePort) {
       });
 
       it('should display an error if the account does not exist', function (done) {
-        connectorMock.get(CONNECTOR_ACCOUNT_CREDENTIALS_PATH)
+        connectorMock.get(CONNECTOR_ACCOUNT_PATH)
           .reply(404, {
             "message": "The gateway account id '"+ACCOUNT_ID+"' does not exist"
           });
@@ -154,7 +155,7 @@ portfinder.getPort(function (err, freePort) {
 
       it('should display an error if connector returns any other error', function (done) {
 
-        connectorMock.get(CONNECTOR_ACCOUNT_CREDENTIALS_PATH)
+        connectorMock.get(CONNECTOR_ACCOUNT_PATH)
           .reply(999, {
             "message": "Some error in Connector"
           });
@@ -174,6 +175,7 @@ portfinder.getPort(function (err, freePort) {
     });
   });
 
+
   describe('The provider update credentials endpoint', function () {
     beforeEach(function () {
       process.env.CONNECTOR_URL = localServer;
@@ -186,9 +188,11 @@ portfinder.getPort(function (err, freePort) {
     });
 
     it('should send new username and password credentials to connector', function (done) {
-      connectorMock.put(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
-        "username": "a-username",
-        "password": "a-password"
+      connectorMock.patch(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
+        "credentials": {
+          "username": "a-username",
+          "password": "a-password"
+        }
       })
       .reply(200, {});
 
@@ -205,10 +209,12 @@ portfinder.getPort(function (err, freePort) {
     });
 
     it('should send any arbitrary credentials together with username and password to connector', function (done) {
-      connectorMock.put(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
-        "username": "a-username",
-        "password": "a-password",
-        "merchant_id": "a-merchant-id"
+      connectorMock.patch(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
+        "credentials": {
+          "username": "a-username",
+          "password": "a-password",
+          "merchant_id": "a-merchant-id"
+        }
       })
       .reply(200, {});
 
@@ -222,7 +228,7 @@ portfinder.getPort(function (err, freePort) {
     });
 
     it('should display an error if connector returns failure', function (done) {
-      connectorMock.put(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
+      connectorMock.patch(CONNECTOR_ACCOUNT_PATH, {
         "username": "a-username",
         "password": "a-password"
       })
@@ -250,7 +256,7 @@ portfinder.getPort(function (err, freePort) {
     });
 
     it('fail if there is no csrf', function (done) {
-      connectorMock.put(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
+      connectorMock.patch(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
         "username": "a-username",
         "password": "a-password"
       })
@@ -259,7 +265,6 @@ portfinder.getPort(function (err, freePort) {
 
 //    verify_post_request(path, sendData, cookieValue, expectedRespCode, expectedData, expectedLocation) {
     var sendData = {'username': 'a-username', 'password': 'a-password'};
-    var expectedLocation = paths.credentials.index;
     var path = paths.credentials.index;
     build_form_post_request(path, sendData,false)
       .expect(200, { message: "There is a problem with the payments platform"})

--- a/test/service_name_ft_tests.js
+++ b/test/service_name_ft_tests.js
@@ -1,0 +1,168 @@
+var request     = require('supertest');
+var _app        = require(__dirname + '/../server.js').getApp;
+var winston     = require('winston');
+var portfinder  = require('portfinder');
+var nock        = require('nock');
+var csrf        = require('csrf');
+var should      = require('chai').should();
+var paths       = require(__dirname + '/../app/paths.js');
+var session     = require(__dirname + '/test_helpers/mock_session.js');
+var ACCOUNT_ID  = 182364;
+
+var app = session.mockValidAccount(_app, ACCOUNT_ID);
+
+portfinder.getPort(function (err, freePort) {
+
+  var CONNECTOR_ACCOUNT_PATH = "/v1/frontend/accounts/" + ACCOUNT_ID;
+  var CONNECTOR_ACCOUNT_SERVICE_NAME_PATH = CONNECTOR_ACCOUNT_PATH + "/servicename";
+  var localServer = 'http://localhost:' + freePort;
+  var connectorMock = nock(localServer);
+
+  function build_get_request(path) {
+    return request(app)
+      .get(path)
+      .set('Accept', 'application/json');
+  }
+
+  function build_form_post_request(path, sendData, sendCSRF) {
+    sendCSRF = (sendCSRF === undefined) ? true : sendCSRF;
+    if (sendCSRF) {
+      sendData.csrfToken = csrf().create('123');
+    }
+    return request(app)
+      .post(path)
+      .set('Accept', 'application/json')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send(sendData);
+  }
+
+  [
+    {
+      'path': paths.serviceName.index,
+      'edit': false
+    },
+    {
+      'path': paths.serviceName.edit,
+      'edit': true
+    }
+  ].forEach(function (testSetup) {
+
+      describe('The ' + testSetup.path + ' endpoint', function () {
+        beforeEach(function () {
+          process.env.CONNECTOR_URL = localServer;
+          nock.cleanAll();
+        });
+
+        before(function () {
+          // Disable logging.
+          winston.level = 'none';
+        });
+
+        it('should display received service name from connector', function (done) {
+          connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+            .reply(200, {
+              "service_name": "Service name"
+            });
+
+          var expectedData = {
+            "serviceName": "Service name",
+            "editMode": testSetup.edit
+          };
+
+          build_get_request(testSetup.path)
+            .expect(200, expectedData)
+            .end(done);
+        });
+
+        it('should display an error if the account does not exist', function (done) {
+          connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+            .reply(404, {
+              "message": "The gateway account id '" + ACCOUNT_ID + "' does not exist"
+            });
+
+          build_get_request(testSetup.path)
+            .expect(200, {"message": "Unable to retrieve the service name."})
+            .end(done);
+        });
+
+        it('should display an error if connector returns any other error', function (done) {
+          connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+            .reply(999, {
+              "message": "Some error in Connector"
+            });
+
+          build_get_request(testSetup.path)
+            .expect(200, {"message": "Unable to retrieve the service name."})
+            .end(done);
+        });
+
+        it('should display an error if the connection to connector fails', function (done) {
+          // No connectorMock defined on purpose to mock a network failure
+
+          build_get_request(testSetup.path)
+            .expect(200, {"message": "Internal server error"})
+            .end(done);
+        });
+      });
+    });
+
+
+  describe('The provider update service name endpoint', function () {
+    beforeEach(function () {
+      process.env.CONNECTOR_URL = localServer;
+      nock.cleanAll();
+    });
+
+    before(function () {
+      // Disable logging.
+      winston.level = 'none';
+    });
+
+    it('should send new service name to connector', function (done) {
+      connectorMock.patch(CONNECTOR_ACCOUNT_SERVICE_NAME_PATH, {
+        "service_name": "Service name"
+      })
+        .reply(200, {});
+
+      var sendData = {'service-name-input': 'Service name'};
+      var expectedLocation = paths.serviceName.index;
+      var path = paths.serviceName.index;
+      build_form_post_request(path, sendData)
+        .expect(303, {})
+        .expect('Location', expectedLocation)
+        .end(done);
+    });
+
+    it('should display an error if connector returns failure', function (done) {
+      connectorMock.patch(CONNECTOR_ACCOUNT_PATH, {"service_name": "Service name"})
+        .reply(999, {
+          "message": "Error message"
+        });
+
+      var sendData = {'service-name-input': 'Service name'};
+      var expectedData = {"message": "Internal server error"};
+      var path = paths.serviceName.index;
+      build_form_post_request(path, sendData)
+        .expect(200, expectedData)
+        .end(done);
+    });
+
+    it('should display an error if the connection to connector fails', function (done) {
+      // No connectorMock defined on purpose to mock a network failure
+      var sendData = {'service-name-input': 'Service name'};
+      var expectedData = {"message": "Internal server error"};
+      var path = paths.serviceName.index;
+      build_form_post_request(path, sendData)
+        .expect(200, expectedData)
+        .end(done);
+    });
+
+    it('should display an error if csrf token does not exist for the update', function (done) {
+      var sendData = {'service-name-input': 'Service name'};
+      var path = paths.serviceName.index;
+      build_form_post_request(path, sendData, false)
+          .expect(200, { message: "There is a problem with the payments platform"})
+          .end(done);
+    });
+  });
+});

--- a/test/service_name_ui_tests.js
+++ b/test/service_name_ui_tests.js
@@ -1,0 +1,46 @@
+var should = require('chai').should();
+var renderTemplate = require(__dirname + '/test_helpers/html_assertions.js').render;
+var paths = require(__dirname + '/../app/paths.js');
+
+describe('The service name view in normal mode', function () {
+  it('should display the service name view', function () {
+    var templateData = {
+      "serviceName": "Service Name",
+      "editMode": false
+    };
+
+    var body = renderTemplate('service_name', templateData);
+
+    body.should.containSelector('h1.page-title').withExactText('GOV.UK Pay - Change service name');
+
+    body.should.containSelector('a#service-name-change-link')
+      .withAttribute("class", "button")
+      .withAttribute("href", paths.serviceName.edit)
+      .withText("Change service name");
+
+    body.should.containSelector('#service-name').withExactText('Service Name');
+  });
+});
+
+describe('The service name view in edit mode', function () {
+  it('should display the service name view', function () {
+    var templateData = {
+      "serviceName": "Service Name",
+      "editMode": true
+    };
+
+    var body = renderTemplate('service_name', templateData);
+
+    body.should.containSelector('h1.page-title').withExactText('GOV.UK Pay - Change service name');
+
+    body.should.containInputField('service-name-input', 'text')
+      .withAttribute('value', 'Service Name')
+      .withLabel('Enter new service name');
+
+    body.should.containInputField('service-name-save-button', 'submit');
+
+    body.should.containSelector('a#service-name-cancel-link')
+      .withAttribute("href", paths.serviceName.index)
+      .withText("Cancel");
+  });
+});


### PR DESCRIPTION
# WHAT
- New view accessible from the main menu under _Change service name_ showing the service name as set up in connector. A button allows to transition the view in 'edit' mode then showing the service name in an input text field along with options to save the change or cancel the change.
- _Updated credentials controller_ to reflect the latest connector API changes: username and password fields are now embedded inside of credentials.
# WHO

Any dev
