### PR TITLE
PP-605 Making heroku deployed auth-stub accessible for dev environments

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -10,4 +10,9 @@ fi
 export CERTS_PATH=$WORKSPACE/pay-scripts/services/ssl/certs
 export PGSSLROOTCERT=$CERTS_PATH/selfservice.db.pymnt.localdomain.crt
 
+# Adding this so we can make self-service talk to auth-stubs deployed in a different environment i.e. heroku.
+# Otherwise self-service fails to acquire the issuer cert and fails the auth process. This is only for development
+# environments and this is why we have it in this file. This should NOT be copied to pay-scripts.
+export NODE_TLS_REJECT_UNAUTHORIZED=0
+
 eval "$@"


### PR DESCRIPTION
## WHAT

When we configure self-service to talk to auth-stub deployed in heroku, passport library fails to access auth-stub as it fails to acquire the certificate. Therefore for development purposes we are disabling TLS rejections.
## WHO

Any dev
