### PR TITLE
PP-647 Removing sleep in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN mkdir -p /app && cp -a /tmp/node_modules /app/
 
 RUN npm install && npm test && npm prune --production
 
-CMD sleep 20 && NODE_ENV=production npm start
+CMD NODE_ENV=production npm start


### PR DESCRIPTION
## WHAT

We had a sleep 20 in the Dockerfile prior to running npm start. This
was done to allow some time for the database to be ready for the
application. Since we now have a separate setup prior to startup that
checks and waits for the database to be ready, removing the sleep 
## WHO

Any Dev
