### PR TITLE
PP-647 Bringing back docker sleep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN mkdir -p /app && cp -a /tmp/node_modules /app/
 
 RUN npm install && npm test && npm prune --production
 
-CMD NODE_ENV=production npm start
+CMD sleep 20 && NODE_ENV=production npm start


### PR DESCRIPTION
## WHAT
- Removing docker sleep meant that initialising the sessions db didn't
  happen intermitently. So putthing this back until will work out a better
  way to do the initialising.

with @mrlumbu
## WHO

Any Dev other than @mrlumbu 
