### PR TITLE
PP-582 Add logging middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "minimist": "0.0.8",
     "moment": "2.11.1",
     "moment-timezone": "^0.5.4",
+    "morgan": "1.7.0",
     "newrelic": "^1.24.0",
     "node-rest-client": "^1.5.1",
     "node-sass": "3.4.2",

--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ var customCertificate = require(__dirname + '/app/utils/custom_certificate.js');
 var proxy             = require(__dirname + '/app/utils/proxy.js');
 var dependenciesCheck = require(__dirname + '/app/utils/dependent_resource_checker.js');
 var logger            = require('winston');
+var loggingMiddleware = require('morgan');
 var argv              = require('minimist')(process.argv.slice(2));
 var environment       = require(__dirname + '/app/services/environment.js');
 var auth              = require(__dirname + '/app/services/auth_service.js');      
@@ -19,7 +20,12 @@ var unconfiguredApp   = express();
 
 function initialiseGlobalMiddleware (app) {
   app.use(cookieParser());
-
+  logger.stream = {
+    write: function(message, encoding){
+      logger.info(message);
+    }
+  };
+  app.use('/\/((?!public\/).)*/',loggingMiddleware('combined', {'stream' : logger.stream}));
   app.use(favicon(path.join(__dirname, 'public', 'images','favicon.ico')));
   app.use(function (req, res, next) {
     res.locals.assetPath  = '/public/';


### PR DESCRIPTION
# WHAT
- The aim is to log all the incoming requests with logging level as INFO.
- Added a logging middleware and its output must be added to current the current app logging stream, so streaming these middleware logs _(morgan)_ to the current app logger _(winston)._
- Public assets are excluded from the logging middleware.
# WHO
- Any dev
