### PR TITLE
PP-698 Adding a new HealthCheck Response function

### DIFF
--- a/app/controllers/healthcheck_controller.js
+++ b/app/controllers/healthcheck_controller.js
@@ -9,11 +9,11 @@ module.exports.healthcheck = function (req, res) {
     .authenticate()
     .then(function(err) {
       logger.info('Connection has been established successfully.');
-      responseHandler.response(req.headers.accept, res, null, data);
+      responseHandler.healthCheckResponse(req.headers.accept, res, data);
     }, function (err) {
       logger.warn('Unable to connect to the database:', err);
       data.database.healthy = false;
       res.status(503);
-      responseHandler.response(req.headers.accept, res, null, data);
+      responseHandler.healthCheckResponse(req.headers.accept, res, data);
     });
 };

--- a/app/utils/response.js
+++ b/app/utils/response.js
@@ -9,12 +9,18 @@ function response(accept, res, template, data) {
   }
 }
 
+function healthCheckResponse(accept, res, data) {
+  res.setHeader('Content-Type', 'application/json');
+  res.json(data);
+}
+
 module.exports = {
   ERROR_MESSAGE : 'There is a problem with the payments platform',
   ERROR_VIEW : 'error',
   PAGE_NOT_FOUND_ERROR_MESSAGE : 'Page cannot be found',
 
   response : response,
+  healthCheckResponse: healthCheckResponse,
 
   renderErrorView : function (req, res, msg) {
     logger.error('An error occurred: ' + msg);

--- a/test/unit/healthcheck_controller_test.js
+++ b/test/unit/healthcheck_controller_test.js
@@ -49,11 +49,10 @@ describe('health check controller', function () {
     };
 
     var mockResponseHandler = {
-      response: function (accept, res, template, data) {
+      healthCheckResponse: function (accept, res, data) {
         assert(data.database.healthy === false);
         assert(data.ping.healthy === true);
         assert(accept === 'application/json');
-        assert(template === null);
       }
     };
 
@@ -78,11 +77,10 @@ describe('health check controller', function () {
     };
 
     var mockResponseHandler = {
-      response: function (accept, res, template, data) {
+      healthCheckResponse: function (accept, res, data) {
         assert(data.database.healthy === true);
         assert(data.ping.healthy === true);
         assert(accept === 'application/json');
-        assert(template === null);
       }
     };
 


### PR DESCRIPTION
## WHAT

_A brief description of the pull request:_
- We cannot use the existing `response` function because the ELB  cannot set the header `accept: application/json`
## HOW

_Steps to test or reproduce:_
- This will need to be running local tests and E2E tests from a developer perspective, or simply `curl -i selfservice.pymnt.localdomain/healthcheck` on our local environments.
- Josh will test this from an infrastructure POV
## WHO

_Who should review this pull request:_
- [x] Developers
- [x] WebOps
