### PR TITLE
Removing the csrf.js from scripts.html

### DIFF
--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -1,2 +1,1 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-<script src="/public/js/components/csrf.js"></script>


### PR DESCRIPTION
## WHAT

_A brief description of the pull request:_
When navigating to `https://selfservice.pymnt.uk` we get  **404** on the following `https://selfservice.pymnt.uk/public/js/components/csrf.js`
## HOW

_Steps to test or reproduce:_
This seems to be introduced by mistake and should be removed.
## WHO

_Who should review this pull request:_
- [x] Developers
