### PR TITLE
PP-335 change value of input from ref to reference in pagination filters

### DIFF
--- a/app/views/transactions/display_size.html
+++ b/app/views/transactions/display_size.html
@@ -7,7 +7,7 @@
       <div style="display:none">
           <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
           <input class="state" name="state" type="text" value="{{filters.state}}"/>
-          <input class="ref" name="ref" type="text" value="{{filters.reference}}"/>
+          <input class="reference" name="reference" type="text" value="{{filters.reference}}" />
           <input class="fromDate" name="fromDate" type="text" value="{{filters.fromDate}}" />
           <input class="toDate" name="toDate" type="text" value="{{filters.toDate}}"/>
           <input class="page" name="page" type="text" value="1"/>

--- a/app/views/transactions/paginator.html
+++ b/app/views/transactions/paginator.html
@@ -5,7 +5,7 @@
 		<div style="display:none">
 	    	<input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 				<input class="state" name="state" type="text" value="{{filters.state}}"/>
-				<input class="ref" name="ref" type="text" value="{{filters.reference}}"/>
+        <input class="reference" name="reference" type="text" value="{{filters.reference}}" />
 				<input class="fromDate" name="fromDate" type="text" value="{{filters.fromDate}}" />
 	      <input class="toDate" name="toDate" type="text" value="{{filters.toDate}}"/>
 	      <input class="page" name="page" type="text" value="{{pageNumber}}"/>

--- a/test/ui/pagination_ui_tests.js
+++ b/test/ui/pagination_ui_tests.js
@@ -55,7 +55,7 @@ describe('The pagination links', function () {
       body.should.containSelector('.paginationForm.' + paginationLinks[ctr].pageName);
       body.should.containSelector('.paginationForm.' + paginationLinks[ctr].pageName + ' .state')
         .withAttribute('value','Testing2');
-      body.should.containSelector('.paginationForm.' + paginationLinks[ctr].pageName + ' .ref')
+      body.should.containSelector('.paginationForm.' + paginationLinks[ctr].pageName + ' .reference')
         .withAttribute('value','ref1');
       body.should.containSelector('.paginationForm.' + paginationLinks[ctr].pageName + ' .fromDate')
         .withAttribute('value','2015-01-11 01:01:01');


### PR DESCRIPTION
## WHAT

_A brief description of the pull request:_
Small fix to forms for pagination, display_size - input was called ref, now reference
## HOW

_Steps to test or reproduce:_
## WHO

_Who should review this pull request:_
- [x] Developers
- [] WebOps
