### PR TITLE
PP-705 fix display size bug

### DIFF
--- a/app/controllers/transaction_controller.js
+++ b/app/controllers/transaction_controller.js
@@ -18,8 +18,13 @@ function connectorClient() {
 }
 
 function validateFilters(filters) {
-  return (!check.assigned(filters.pageSize) || check.inRange(Number(filters.pageSize), 1, Paginator.MAX_PAGE_SIZE)) &&
-         (!check.assigned(filters.page) || check.positive(Number(filters.page)));
+  var pageSizeIsNull = !check.assigned(filters.pageSize),
+    pageSizeInRange = check.inRange(Number(filters.pageSize), 1, Paginator.MAX_PAGE_SIZE),
+    pageIsNull = !check.assigned(filters.page),
+    pageIsPositive = check.positive(Number(filters.page));
+
+  return (pageSizeIsNull || pageSizeInRange) &&
+         (pageIsNull || pageIsPositive);
 }
 
 function getFilters(req) {

--- a/app/utils/paginator.js
+++ b/app/utils/paginator.js
@@ -173,12 +173,24 @@ Paginator.prototype = {
     if (this.total < SMALL_PAGE_SIZE) {
       return [createDisplaySizeOption.call(this, null, "Show all", SMALL_PAGE_SIZE)];
     } else if(this.total < LARGE_PAGE_SIZE) {
-      return [ createDisplaySizeOption.call(this,'small', SMALL_PAGE_SIZE, SMALL_PAGE_SIZE),
-               createDisplaySizeOption.call(this,'large', 'Show all', LARGE_PAGE_SIZE)];
+      return [
+        createDisplaySizeOption.call(this,'small', SMALL_PAGE_SIZE, SMALL_PAGE_SIZE),
+        createDisplaySizeOption.call(this,'large', 'Show all', LARGE_PAGE_SIZE)
+      ];
     } else {
-      return [ createDisplaySizeOption.call(this,'small', SMALL_PAGE_SIZE, SMALL_PAGE_SIZE),
-               createDisplaySizeOption.call(this,'large', LARGE_PAGE_SIZE, LARGE_PAGE_SIZE)];
+      return [
+        createDisplaySizeOption.call(this,'small', SMALL_PAGE_SIZE, SMALL_PAGE_SIZE),
+        createDisplaySizeOption.call(this,'large', LARGE_PAGE_SIZE, LARGE_PAGE_SIZE)
+      ];
     }
+  },
+
+  /**
+   * @return {boolean}
+   */
+  showDisplaySizeLinks: function () {
+    return this.total > SMALL_PAGE_SIZE ||
+           this.total > this.limit;
   }
 };
 

--- a/app/utils/transaction_view.js
+++ b/app/utils/transaction_view.js
@@ -54,7 +54,8 @@ function getCurrentPageSize (connectorData) {
 }
 
 function hasPageSizeLinks(connectorData) {
-  return connectorData.total > getCurrentPageSize(connectorData);
+    var paginator = new Paginator(connectorData.total, getCurrentPageSize(connectorData), getCurrentPageNumber(connectorData));
+    return paginator.showDisplaySizeLinks();
 }
 
 module.exports = {

--- a/test/integration/pagination_ft_tests.js
+++ b/test/integration/pagination_ft_tests.js
@@ -242,6 +242,26 @@ portfinder.getPort(function (err, connectorPort) {
               .end(done);
         });
 
+        it('should return correct display size options when total under 100', function (done) {
+          var connectorData = {};
+          var data= {'display_size': 500};
+          connectorData.total = 150;
+          connectorData.results = [];
+
+
+          connectorData._links = {
+            self: {"href":"/v1/api/accounts/111/charges?&page=1&display_size=500&state="},
+          }
+          connectorMock_responds(connectorData, data);
+
+          search_transactions(data)
+              .expect(200)
+              .expect(function(res) {
+                assert.equal(res.body.hasPageSizeLinks, true);
+               })
+              .end(done);
+        });
+
         it('should return return error if page out of bounds', function (done) {
           var data= {'page': -1};
 


### PR DESCRIPTION
## WHAT

_A brief description of the pull request:_
Was the case that if you had #charges between 100 and 500 and clicked show all, the display size links disappeared.
This fixes that.
## HOW

_Steps to test or reproduce:_
load up a page with #charges between 100 and 500 and click show all. Display size options should still be visible
## WHO

_Who should review this pull request:_
- [x] Developers
- [] WebOps
