### PR TITLE
PP-864 Adding a data-charge-id attribute to a link

### DIFF
--- a/app/views/transactions/list.html
+++ b/app/views/transactions/list.html
@@ -13,7 +13,7 @@
   {{#results}}
     <tr data-follow-link data-link="{{link}}">
       <td class="charge-column">
-        <a id="charge-id-{{charge_id}}" href="{{link}}">
+        <a id="charge-id-{{charge_id}}" data-charge-id="{{charge_id}}" href="{{link}}">
           {{charge_id}}
         </a>
       </td>


### PR DESCRIPTION
## WHAT

_A brief description of the pull request:_
- As part of this ticket we decided to remove the charge id from the
  transactions list. Because the logic of transaction on the E2E relies
  heavily on this we need to put a data-charge-id field to capture
  the chargeId information.
## HOW

_Steps to test or reproduce:_

```
cd $WORKSPACE
msl reset && msl -a up && ./run-endtoend.sh
```
