### PR TITLE
PP-736 Refunds integration. Remove stubs.

### DIFF
--- a/app/controllers/transaction_controller.js
+++ b/app/controllers/transaction_controller.js
@@ -2,41 +2,36 @@ var response = require('../utils/response.js').response;
 var renderErrorView = require('../utils/response.js').renderErrorView;
 var transactionView = require('../utils/transaction_view.js');
 var jsonToCsv = require('../utils/json_to_csv.js');
-var ConnectorClient = require('../services/connector_client.js').ConnectorClient;
 var auth = require('../services/auth_service.js');
 var _ = require('lodash');
 var date = require('../utils/dates.js');
 var logger = require('winston');
 var router = require('../routes.js');
 var Transaction = require('../models/transaction.js');
-var Charge  = require('../models/charge.js');
+var Charge = require('../models/charge.js');
 var getFilters = require('../utils/filters.js').getFilters;
-
-function connectorClient() {
-  return new ConnectorClient(process.env.CONNECTOR_URL);
-}
 
 module.exports = {
 
   index: function (req, res) {
     var accountId = auth.get_account_id(req);
     var filters = getFilters(req);
-    var init = function(){
-      if (!filters.valid) return error("Invalid search");
-      Transaction
-        .search(accountId, filters.result)
-        .then(render, ()=> error("Unable to retrieve list of transactions."));
-    },
+    var init = function () {
+        if (!filters.valid) return error("Invalid search");
+        Transaction
+          .search(accountId, filters.result)
+          .then(render, ()=> error("Unable to retrieve list of transactions."));
+      },
 
-    render = function(json){
-      json.search_path = router.paths.transactions.index;
-      var data = transactionView.buildPaymentList(json, accountId, filters.result);
-      response(req.headers.accept, res, 'transactions/index', data);
-    },
+      render = function (json) {
+        json.search_path = router.paths.transactions.index;
+        var data = transactionView.buildPaymentList(json, accountId, filters.result);
+        response(req.headers.accept, res, 'transactions/index', data);
+      },
 
-    error = function(msg){
-      renderErrorView(req, res, msg);
-    };
+      error = function (msg) {
+        renderErrorView(req, res, msg);
+      };
 
     init();
   },
@@ -47,68 +42,77 @@ module.exports = {
     var name = "GOVUK Pay " + date.dateToDefaultFormat(new Date()) + '.csv';
 
     var init = function () {
-      Transaction.searchAll(accountId, filters)
-        .then(toCsv)
-        .then(render)
-        .catch(error);
-    },
+        Transaction.searchAll(accountId, filters)
+          .then(toCsv)
+          .then(render)
+          .catch(error);
+      },
 
-    toCsv = function(json) {
-      return jsonToCsv(json.results);
-    },
+      toCsv = function (json) {
+        return jsonToCsv(json.results);
+      },
 
-    render = function(csv){
-      logger.info('Sending csv attachment download -', {'filename': name});
-      res.setHeader('Content-disposition', 'attachment; filename=' + name);
-      res.setHeader('Content-Type', 'text/csv');
-      res.send(csv);
-    },
+      render = function (csv) {
+        logger.info('Sending csv attachment download -', {'filename': name});
+        res.setHeader('Content-disposition', 'attachment; filename=' + name);
+        res.setHeader('Content-Type', 'text/csv');
+        res.send(csv);
+      },
 
-    error = function (connectorError) {
-      var msg = (connectorError) ? 'Internal server error' :
-        'Unable to download list of transactions.';
-      renderErrorView(req, res, msg);
-    };
+      error = function (connectorError) {
+        var msg = (connectorError) ? 'Internal server error' :
+          'Unable to download list of transactions.';
+        renderErrorView(req, res, msg);
+      };
 
     init();
   },
 
   show: function (req, res) {
     var accountId = auth.get_account_id(req);
-    var chargeId  = req.params.chargeId;
-    var defaultMsg= 'Error processing transaction view';
-    var notFound  = 'Charge not found';
-    var init = function(){
-      // REMOVE REQ GOING THROUGH ONCE WE HAVE REFUNDS
-      Charge.findWithEvents(accountId, chargeId, req)
-      .then(render,error);
-    },
+    var chargeId = req.params.chargeId;
+    var defaultMsg = 'Error processing transaction view';
+    var notFound = 'Charge not found';
+    var init = function () {
+        Charge.findWithEvents(accountId, chargeId)
+          .then(render, error);
+      },
 
-    render = function(data) {
-      response(req.headers.accept, res, 'transactions/show', data);
-    },
+      render = function (data) {
+        response(req.headers.accept, res, 'transactions/show', data);
+      },
 
-    error = function(err){
-      var msg = (err == 'NOT_FOUND') ? notFound : defaultMsg;
-      renderErrorView(req, res, msg);
-    };
+      error = function (err) {
+        var msg = (err == 'NOT_FOUND') ? notFound : defaultMsg;
+        renderErrorView(req, res, msg);
+      };
 
     init();
   },
 
-  refund: function(req, res) {
+  refund: function (req, res) {
+
     var accountId = auth.get_account_id(req);
-    var chargeId  = req.params.chargeId;
+    var chargeId = req.params.chargeId;
     var show = router.generateRoute(router.paths.transactions.show, {
       chargeId: chargeId
     });
-    var error = function(){
-      renderErrorView(req, res, "Can't process refund");
+    var refundAmount = (req.body['refund-type'] === 'full' ) ? req.body['full-amount'] : req.body['refund-amount'];
+
+    var errReasonMessages = {
+      "REFUND_FAILED": "Can't process refund",
+      "full": "Can't do refund: This charge has been already fully refunded",
+      "amount_not_available": "Can't do refund: The requested amount is bigger than the amount available for refund",
+      "amount_min_validation": "Can't do refund: The requested amount is less than the minimum accepted for issuing a refund for this charge",
     };
-    // REMOVE FULL REQ GOING THROUGH ONCE WE HAVE REFUNDS
-    Charge.refund(accountId, chargeId, req.body['refund-type'],req.body['refund-amount'],req)
-      .then(function(){
+
+    Charge.refund(accountId, chargeId, refundAmount * 100)
+      .then(function () {
         res.redirect(show);
-      },error);
+      }, function (err) {
+        console.log('>>>>>>>>>> err', err);
+        var msg = errReasonMessages[err] ? errReasonMessages[err] : errReasonMessages.REFUND_FAILED;
+        renderErrorView(req, res, msg);
+      });
   }
 };

--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -1,65 +1,63 @@
-var Client  = require('node-rest-client').Client;
-var client  = new Client();
-var q       = require('q');
-var _       = require('lodash');
-var logger  = require('winston');
-var paths   = require('../paths.js');
+var Client = require('node-rest-client').Client;
+var client = new Client();
+var q = require('q');
+var _ = require('lodash');
+var logger = require('winston');
+var paths = require('../paths.js');
 var ConnectorClient = require('../services/connector_client.js').ConnectorClient;
 var connector = new ConnectorClient(process.env.CONNECTOR_URL);
 
 var transactionView = require('../utils/transaction_view.js');
 
-
-
-module.exports = function() {
+module.exports = function () {
   'use strict';
-  // REMOVE REQUEST GOING THROUGH ONCE WE HAVE REFUNDS
-  var findWithEvents = function(accountId, chargeId, req){
+  var findWithEvents = function (accountId, chargeId) {
     var defer = q.defer();
-    connector.withGetCharge(accountId, chargeId, function(charge){
-      connector.withChargeEvents(accountId, chargeId, function(events){
-        defer.resolve(transactionView.buildPaymentView(charge, events, req));
-      }).on('connectorError',(err, response)=> {
+    connector.withGetCharge(accountId, chargeId, function (charge) {
+      connector.withChargeEvents(accountId, chargeId, function (events) {
+        defer.resolve(transactionView.buildPaymentView(charge, events));
+      }).on('connectorError', (err, response)=> {
         findWithEventsError(err, response, defer);
       });
-    }).on('connectorError',(err, response)=> {
+    }).on('connectorError', (err, response)=> {
       findWithEventsError(err, response, defer);
-    });
-    return defer.promise;
-  },
-  // REMOVE FULL REQUEST GOING THROUGH ONCE WE HAVE REFUNDS
-  // AND RELY ON THE API AS OPPOSED TO HOKEY SESSION
-  refund = function(accountId, chargeId, type, amount, req){
-    var defer = q.defer();
-    var session = req.session[chargeId];
-    if (!req.session[chargeId]) req.session[chargeId] = { refunded_amount : 0 };
-    req.session[chargeId].refunded = req.session[chargeId].refunded_amount > 0;
-
-    connector.withGetCharge(accountId, chargeId, function(charge){
-      if (type == "full") {
-        req.session[chargeId]["refunded_amount"] = charge.amount /100;
-        return defer.resolve();
-      }
-
-      var netRefund = req.session[chargeId]["refunded_amount"] + parseFloat(amount);
-      if (netRefund > (charge.amount /100)) {
-        return defer.reject('REFUND_FAILED');
-      }
-      req.session[chargeId]["refunded_amount"] = netRefund;
-
-      defer.resolve();
     });
     return defer.promise;
   };
 
-  var findWithEventsError = function(err, response, defer){
+  var refund = function (accountId, chargeId, amount) {
+    var defer = q.defer();
+
+    var payload = {
+      amount: amount
+    };
+
+    logger.log('info', 'Submitting a refund for a charge', {
+      'chargeId': chargeId,
+      'amount': amount
+    });
+
+    connector.withPostChargeRefund(accountId, chargeId, payload, function () {
+      defer.resolve();
+    }).on('connectorError', (err, response)=> {
+      var err = 'REFUND_FAILED';
+      if (response && response.statusCode === 400) {
+        if (response.body.reason) {
+          err = response.body.reason;
+        }
+      }
+      defer.reject(err);
+    });
+
+    return defer.promise;
+  };
+
+  var findWithEventsError = function (err, response, defer) {
     if (response && response.statusCode === 404) return defer.reject('NOT_FOUND');
     if (response && response.statusCode !== 200) return defer.reject('GET_FAILED');
 
     defer.reject('CLIENT_UNAVAILABLE');
   };
-
-
 
   return {
     findWithEvents: findWithEvents,

--- a/app/views/transactions/_details.html
+++ b/app/views/transactions/_details.html
@@ -14,12 +14,12 @@
     </tr>
     <tr>
       <td>Refunded:</td>
-      <td>{{#refunded}}&#10004;{{/refunded}}{{^refunded}}&#10006;{{/refunded}}</td>
+      <td id="refunded">{{#refunded}}&#10004;{{/refunded}}{{^refunded}}&#10006;{{/refunded}}</td>
     </tr>
     {{#refunded}}
     <tr>
       <td>Refunded amount</td>
-      <td class="qa-refunded-amount">£{{refunded_amount}}</td>
+      <td id="refunded-amount" class="qa-refunded-amount">{{refunded_amount}}</td>
     </tr>
     {{/refunded}}
     <tr>

--- a/app/views/transactions/_refund.html
+++ b/app/views/transactions/_refund.html
@@ -5,23 +5,23 @@
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
     <div class="container">
       <h2 class="heading-medium">Refund payment</h2>
+      <input id="full-amount" type="hidden" name="full-amount" value="{{ net_amount }}" >
 
       {{#refunded}}
       <label class="block-label" for="full">
         <input id="full" type="radio" name="refund-type" value="full" checked="checked">
         Remaining amount
-        <span class="form-hint">refund the remaining £{{ net_amount }}, (£{{refunded_amount}} has already been refunded) </span>
+        <span class="form-hint">refund the remaining £{{ net_amount }}, ({{refunded_amount}} has already been refunded) </span>
       </label>
       {{/refunded}}
 
       {{^refunded}}
       <label class="block-label" for="full">
-        <input id="full" type="radio" name="refund-type" value="full" checked="checked" id="full-refund">
+          <input id="full" type="radio" name="refund-type" value="full" checked="checked">
         Full refund
         <span class="form-hint">refund the full amount of {{ amount }}</span>
       </label>
       {{/refunded}}
-
 
       <label class="block-label" for="partial">
         <input id="partial" type="radio" name="refund-type" value="partial" id="partial-refund">

--- a/test/integration/transaction_details_ft_tests.js
+++ b/test/integration/transaction_details_ft_tests.js
@@ -1,387 +1,408 @@
-var request     = require('supertest');
-var portfinder  = require('portfinder');
-var nock        = require('nock');
-var _app        = require(__dirname + '/../../server.js').getApp;
-var winston     = require('winston');
-var paths       = require(__dirname + '/../../app/paths.js');
-var session     = require(__dirname + '/../test_helpers/mock_session.js');
+var request = require('supertest');
+var portfinder = require('portfinder');
+var nock = require('nock');
+var _app = require(__dirname + '/../../server.js').getApp;
+var winston = require('winston');
+var paths = require(__dirname + '/../../app/paths.js');
+var session = require(__dirname + '/../test_helpers/mock_session.js');
 
-var gatewayAccountId = 15486734;
+var ACCOUNT_ID = 15486734;
+var app = session.mockValidAccount(_app, ACCOUNT_ID);
 
-var app = session.mockValidAccount(_app, gatewayAccountId);
-var chargeId = 452345;
-var chargeWithRefund = 12345;
-var CONNECTOR_EVENTS_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges/' + chargeId + '/events';
-var CONNECTOR_CHARGE_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges/{chargeId}';
-
+var CONNECTOR_CHARGE_PATH = '/v1/api/accounts/' + ACCOUNT_ID + '/charges/{chargeId}';
 var localServer = 'http://aServer:8002';
-
 var connectorMock = nock(localServer);
 
 function connectorMock_responds(path, data) {
-    return connectorMock.get(path)
-        .reply(200, data);
+  return connectorMock.get(path)
+    .reply(200, data);
 }
 
 function when_getTransactionHistory(chargeId) {
-    return request(app)
-        .get(paths.generateRoute(paths.transactions.show,{chargeId: chargeId}))
-        .set('Accept', 'application/json');
+  return request(app)
+    .get(paths.generateRoute(paths.transactions.show, {chargeId: chargeId}))
+    .set('Accept', 'application/json');
 }
 
 function connectorChargePathFor(chargeId) {
-    return CONNECTOR_CHARGE_PATH.replace('{chargeId}', chargeId);
+  return CONNECTOR_CHARGE_PATH.replace('{chargeId}', chargeId);
 }
 
 describe('The transaction view scenarios', function () {
-    beforeEach(function () {
-        process.env.CONNECTOR_URL = localServer;
-        nock.cleanAll();
+
+  beforeEach(function () {
+    process.env.CONNECTOR_URL = localServer;
+    nock.cleanAll();
+  });
+
+  before(function () {
+    // Disable logging.
+    winston.level = 'none';
+  });
+
+  describe('The transaction history endpoint', function () {
+
+    it('should return a list of transaction history for a given charge id', function (done) {
+      var chargeId = 452345;
+      var mockEventsResponse = {
+        'charge_id': chargeId,
+        'events': [
+          {
+            'state': {
+              'status': 'created',
+              'finished': false
+            },
+            'updated': '2015-12-24 13:21:05'
+          },
+          {
+            'state': {
+              'status': 'started',
+              'finished': false
+            },
+            'updated': '2015-12-24 13:23:12'
+          },
+          {
+            'state': {
+              'status': 'success',
+              'finished': true
+            },
+            'updated': '2015-12-24 12:05:43'
+          },
+          {
+            'state': {
+              'status': 'cancelled',
+              'finished': true,
+              'message': 'Payment was cancelled by the service',
+              'code': 'P0040'
+            },
+            'updated': '2015-12-24 12:05:43'
+          },
+          {
+            'state': {
+              'status': 'failed',
+              'finished': true,
+              'message': 'Payment was cancelled by the user',
+              'code': 'P0030'
+            },
+            'updated': '2015-12-24 12:05:43'
+          }
+        ]
+      };
+
+      var mockChargeResponse = {
+        'charge_id': chargeId,
+        'description': 'Breathing licence',
+        'reference': 'Ref-1234',
+        'email': 'alice.111@mail.fake',
+        'amount': 5000,
+        'gateway_account_id': ACCOUNT_ID,
+        'payment_provider': 'sandbox',
+        'gateway_transaction_id': 'dsfh-34578fb-4und-8dhry',
+        'state': {
+          'status': 'success',
+          'finished': true
+        },
+        'refund_summary': {
+          'status': 'available',
+          'amount_available': 5000,
+          'amount_submitted': 0
+        },
+        'return_url': 'http://example.service/return_from_payments',
+        'links': [
+          {
+            'rel': 'self',
+            'method': 'GET',
+            'href': 'http://connector.service/v1/api/charges/1'
+          },
+          {
+            'rel': 'next_url',
+            'method': 'GET',
+            'href': 'http://frontend/charges/1?chargeTokenId=82347'
+          }
+        ],
+      };
+
+      var expectedEventsView = {
+        'charge_id': chargeId,
+        'description': 'Breathing licence',
+        'reference': 'Ref-1234',
+        'email': 'alice.111@mail.fake',
+        'refundable': true,
+        'net_amount': 50,
+        'net_amount_display': '£50.00',
+        'refunded_amount': '£0.00',
+        'refunded': false,
+        'amount': '£50.00',
+        'gateway_account_id': ACCOUNT_ID,
+        'updated': '24 Dec 2015 — 13:21:05',
+        'state': {
+          'status': 'success',
+          'finished': true
+        },
+        'state_friendly': 'Success',
+        'refund_summary': {
+          'status': 'available',
+          'amount_available': 5000,
+          'amount_submitted': 0
+        },
+        'payment_provider': 'Sandbox',
+        'gateway_transaction_id': 'dsfh-34578fb-4und-8dhry',
+        'events': [
+          {
+            'state': {
+              'status': 'failed',
+              'finished': true,
+              'message': 'Payment was cancelled by the user',
+              'code': 'P0030'
+            },
+            "state_friendly": "User failed to complete payment of £50.00",
+            "updated": "2015-12-24 12:05:43",
+            "updated_friendly": "24 Dec 2015 — 12:05:43",
+          },
+          {
+            'state': {
+              'status': 'cancelled',
+              'finished': true,
+              'message': 'Payment was cancelled by the service',
+              'code': 'P0040'
+            },
+            "state_friendly": "Service cancelled payment of £50.00",
+            "updated": "2015-12-24 12:05:43",
+            "updated_friendly": "24 Dec 2015 — 12:05:43"
+          },
+          {
+            'state': {
+              'status': 'success',
+              'finished': true
+            },
+            "state_friendly": "Payment of £50.00 succeeded",
+            "updated": "2015-12-24 12:05:43",
+            "updated_friendly": "24 Dec 2015 — 12:05:43"
+          },
+          {
+            'state': {
+              'status': 'started',
+              'finished': false
+            },
+            'state_friendly': 'User started payment of £50.00',
+            'updated': '2015-12-24 13:23:12',
+            'updated_friendly': '24 Dec 2015 — 13:23:12'
+          },
+          {
+            'state': {
+              'status': 'created',
+              'finished': false
+            },
+            'state_friendly': 'Service created payment of £50.00',
+            'updated': '2015-12-24 13:21:05',
+            'updated_friendly': '24 Dec 2015 — 13:21:05'
+          }
+        ]
+      };
+
+      connectorMock_responds(connectorChargePathFor(chargeId), mockChargeResponse);
+      connectorMock_responds('/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeId + '/events', mockEventsResponse);
+
+      when_getTransactionHistory(chargeId)
+        .expect(200, expectedEventsView)
+        .end(done);
     });
 
-    before(function () {
-        // Disable logging.
-        winston.level = 'none';
+    it('should return a list of transaction history for a given charge id and show refunded', function (done) {
+
+      var chargeWithRefund = 12345;
+      var mockEventsResponse = {
+        'charge_id': chargeWithRefund,
+        'events': [
+          {
+            'state': {
+              'status': 'created',
+              'finished': false
+            },
+            'updated': '2015-12-24 13:21:05'
+          },
+          {
+            'state': {
+              'status': 'started',
+              'finished': false
+            },
+            'updated': '2015-12-24 13:23:12'
+          },
+          {
+            'state': {
+              'status': 'success',
+              'finished': true
+            },
+            'updated': '2015-12-24 12:05:43'
+          },
+          {
+            'state': {
+              'status': 'cancelled',
+              'finished': true,
+              'message': 'Payment was cancelled by the service',
+              'code': 'P0040'
+            },
+            'updated': '2015-12-24 12:05:43'
+          },
+          {
+            'state': {
+              'status': 'failed',
+              'finished': true,
+              'message': 'Payment was cancelled by the user',
+              'code': 'P0030'
+            },
+            'updated': '2015-12-24 12:05:43'
+          }
+        ]
+      };
+
+      var mockChargeResponse = {
+        'charge_id': chargeWithRefund,
+        'description': 'Breathing licence',
+        'reference': 'Ref-1234',
+        'email': 'alice.111@mail.fake',
+        'amount': 5000,
+        'gateway_account_id': ACCOUNT_ID,
+        'payment_provider': 'sandbox',
+        'gateway_transaction_id': 'dsfh-34578fb-4und-8dhry',
+        'state': {
+          'status': 'success',
+          'finished': true
+        },
+        'refund_summary': {
+          'status': 'full',
+          'amount_available': 0,
+          'amount_submitted': 5000
+        },
+        'return_url': 'http://example.service/return_from_payments',
+        'links': [
+          {
+            'rel': 'self',
+            'method': 'GET',
+            'href': 'http://connector.service/v1/api/charges/1'
+          },
+          {
+            'rel': 'next_url',
+            'method': 'GET',
+            'href': 'http://frontend/charges/1?chargeTokenId=82347'
+          }
+        ],
+      };
+
+      var expectedEventsView = {
+        'charge_id': chargeWithRefund,
+        'description': 'Breathing licence',
+        'reference': 'Ref-1234',
+        'email': 'alice.111@mail.fake',
+        'amount': '£50.00',
+        'gateway_account_id': ACCOUNT_ID,
+        'updated': '24 Dec 2015 — 13:21:05',
+        'state': {
+          'status': 'success',
+          'finished': true
+        },
+        'refund_summary': {
+          'status': 'full',
+          'amount_available': 0,
+          'amount_submitted': 5000
+        },
+        'net_amount_display': '£0.00',
+        'net_amount': 0.00,
+        'refundable': false,
+        'refunded_amount': '£50.00',
+        'refunded': true,
+        'state_friendly': 'Success',
+        'payment_provider': 'Sandbox',
+        'gateway_transaction_id': 'dsfh-34578fb-4und-8dhry',
+        'events': [
+          {
+            'state': {
+              'status': 'failed',
+              'finished': true,
+              'message': 'Payment was cancelled by the user',
+              'code': 'P0030'
+            },
+            "state_friendly": "User failed to complete payment of £50.00",
+            "updated": "2015-12-24 12:05:43",
+            "updated_friendly": "24 Dec 2015 — 12:05:43",
+          },
+          {
+            'state': {
+              'status': 'cancelled',
+              'finished': true,
+              'message': 'Payment was cancelled by the service',
+              'code': 'P0040'
+            },
+            "state_friendly": "Service cancelled payment of £50.00",
+            "updated": "2015-12-24 12:05:43",
+            "updated_friendly": "24 Dec 2015 — 12:05:43"
+          },
+          {
+            'state': {
+              'status': 'success',
+              'finished': true
+            },
+            "state_friendly": "Payment of £50.00 succeeded",
+            "updated": "2015-12-24 12:05:43",
+            "updated_friendly": "24 Dec 2015 — 12:05:43"
+          },
+          {
+            'state': {
+              'status': 'started',
+              'finished': false
+            },
+            'state_friendly': 'User started payment of £50.00',
+            'updated': '2015-12-24 13:23:12',
+            'updated_friendly': '24 Dec 2015 — 13:23:12'
+          },
+          {
+            'state': {
+              'status': 'created',
+              'finished': false
+            },
+            'state_friendly': 'Service created payment of £50.00',
+            'updated': '2015-12-24 13:21:05',
+            'updated_friendly': '24 Dec 2015 — 13:21:05'
+          }
+        ]
+      };
+
+      var events = '/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeWithRefund + '/events';
+      connectorMock_responds(connectorChargePathFor(chargeWithRefund), mockChargeResponse);
+      connectorMock_responds(events, mockEventsResponse);
+
+      when_getTransactionHistory(chargeWithRefund)
+        .expect(200, expectedEventsView)
+        .end(done);
     });
 
-    describe('The transaction history endpoint', function () {
-        it('should return a list of transaction history for a given charge id', function (done) {
-            var mockEventsResponse = {
-                'charge_id': chargeId,
-                'events': [
-                    {
-                        'state': {
-                          'status': 'created',
-                          'finished': false
-                        },
-                        'updated': '2015-12-24 13:21:05'
-                    },
-                    {
-                        'state': {
-                          'status': 'started',
-                          'finished': false
-                        },
-                        'updated': '2015-12-24 13:23:12'
-                    },
-                    {
-                        'state': {
-                          'status': 'success',
-                          'finished': true
-                        },
-                        'updated': '2015-12-24 12:05:43'
-                    },
-                    {
-                        'state': {
-                          'status': 'cancelled',
-                          'finished': true,
-                          'message': 'Payment was cancelled by the service',
-                          'code': 'P0040'
-                        },
-                        'updated': '2015-12-24 12:05:43'
-                    },
-                    {
-                        'state': {
-                          'status': 'failed',
-                          'finished': true,
-                          'message': 'Payment was cancelled by the user',
-                          'code': 'P0030'
-                        },
-                        'updated': '2015-12-24 12:05:43'
-                    }
-                ]
-            };
+    it('should return charge not found if a non existing charge id requested', function (done) {
+      var nonExistentChargeId = 888;
+      var connectorError = {'message': 'Charge not found'};
+      connectorMock.get(connectorChargePathFor(nonExistentChargeId))
+        .reply(404, connectorError);
 
-            var mockChargeResponse = {
-                'charge_id': chargeId,
-                'description': 'Breathing licence',
-                'reference': 'Ref-1234',
-                'email': 'alice.111@mail.fake',
-                'amount': 5000,
-                'gateway_account_id': gatewayAccountId,
-                'payment_provider': 'sandbox',
-                'gateway_transaction_id': 'dsfh-34578fb-4und-8dhry',
-                'state': {
-                  'status': 'success',
-                  'finished': true
-                },
-                'return_url': 'http://example.service/return_from_payments',
-                'links': [
-                    {
-                        'rel': 'self',
-                        'method': 'GET',
-                        'href': 'http://connector.service/v1/api/charges/1'
-                    },
-                    {
-                        'rel': 'next_url',
-                        'method': 'GET',
-                        'href': 'http://frontend/charges/1?chargeTokenId=82347'
-                    }
-                ],
-            };
-
-            var expectedEventsView = {
-             'charge_id': chargeId,
-                'description': 'Breathing licence',
-                'reference': 'Ref-1234',
-                'email': 'alice.111@mail.fake',
-                "refundable": true,
-                'amount': '£50.00',
-                'gateway_account_id': gatewayAccountId,
-                'updated': '24 Dec 2015 — 13:21:05',
-                'state': {
-                  'status': 'success',
-                  'finished': true
-                },
-                'state_friendly': 'Success',
-                'payment_provider': 'Sandbox',
-                'gateway_transaction_id': 'dsfh-34578fb-4und-8dhry',
-                'events': [
-                    {
-                        'state': {
-                          'status': 'failed',
-                          'finished': true,
-                          'message': 'Payment was cancelled by the user',
-                          'code': 'P0030'
-                        },
-                         "state_friendly": "User failed to complete payment of £50.00",
-                         "updated": "2015-12-24 12:05:43",
-                         "updated_friendly": "24 Dec 2015 — 12:05:43",
-                     },
-                     {
-                       'state': {
-                         'status': 'cancelled',
-                         'finished': true,
-                         'message': 'Payment was cancelled by the service',
-                         'code': 'P0040'
-                       },
-                        "state_friendly": "Service cancelled payment of £50.00",
-                        "updated": "2015-12-24 12:05:43",
-                        "updated_friendly": "24 Dec 2015 — 12:05:43"
-                    },
-                    {
-                        'state': {
-                          'status': 'success',
-                          'finished': true
-                        },
-                        "state_friendly": "Payment of £50.00 succeeded",
-                        "updated": "2015-12-24 12:05:43",
-                        "updated_friendly": "24 Dec 2015 — 12:05:43"
-                    },
-                    {
-                        'state': {
-                          'status': 'started',
-                          'finished': false
-                        },
-                        'state_friendly': 'User started payment of £50.00',
-                        'updated': '2015-12-24 13:23:12',
-                        'updated_friendly': '24 Dec 2015 — 13:23:12'
-                    },
-                    {
-                        'state': {
-                          'status': 'created',
-                          'finished': false
-                        },
-                        'state_friendly': 'Service created payment of £50.00',
-                        'updated': '2015-12-24 13:21:05',
-                        'updated_friendly': '24 Dec 2015 — 13:21:05'
-                    }
-                ]
-            };
-
-            connectorMock_responds(connectorChargePathFor(chargeId), mockChargeResponse);
-            connectorMock_responds(CONNECTOR_EVENTS_PATH, mockEventsResponse);
-
-            when_getTransactionHistory(chargeId)
-                .expect(200, expectedEventsView)
-                .end(done);
-        });
-
-       it('should return a list of transaction history for a given charge id and show refunded', function (done) {
-            var mockEventsResponse = {
-                'charge_id': chargeWithRefund,
-                'events': [
-                    {
-                        'state': {
-                          'status': 'created',
-                          'finished': false
-                        },
-                        'updated': '2015-12-24 13:21:05'
-                    },
-                    {
-                        'state': {
-                          'status': 'started',
-                          'finished': false
-                        },
-                        'updated': '2015-12-24 13:23:12'
-                    },
-                    {
-                        'state': {
-                          'status': 'success',
-                          'finished': true
-                        },
-                        'updated': '2015-12-24 12:05:43'
-                    },
-                    {
-                        'state': {
-                          'status': 'cancelled',
-                          'finished': true,
-                          'message': 'Payment was cancelled by the service',
-                          'code': 'P0040'
-                        },
-                        'updated': '2015-12-24 12:05:43'
-                    },
-                    {
-                        'state': {
-                          'status': 'failed',
-                          'finished': true,
-                          'message': 'Payment was cancelled by the user',
-                          'code': 'P0030'
-                        },
-                        'updated': '2015-12-24 12:05:43'
-                    }
-                ]
-            };
-
-            var mockChargeResponse = {
-                'charge_id': chargeWithRefund,
-                'description': 'Breathing licence',
-                'reference': 'Ref-1234',
-                'email': 'alice.111@mail.fake',
-                'amount': 5000,
-                'gateway_account_id': gatewayAccountId,
-                'payment_provider': 'sandbox',
-                'gateway_transaction_id': 'dsfh-34578fb-4und-8dhry',
-                'state': {
-                  'status': 'success',
-                  'finished': true
-                },
-                'return_url': 'http://example.service/return_from_payments',
-                'links': [
-                    {
-                        'rel': 'self',
-                        'method': 'GET',
-                        'href': 'http://connector.service/v1/api/charges/1'
-                    },
-                    {
-                        'rel': 'next_url',
-                        'method': 'GET',
-                        'href': 'http://frontend/charges/1?chargeTokenId=82347'
-                    }
-                ],
-            };
-
-            var expectedEventsView = {
-             'charge_id': chargeWithRefund,
-                'description': 'Breathing licence',
-                'reference': 'Ref-1234',
-                'email': 'alice.111@mail.fake',
-                "refundable": true,
-                'amount': '£50.00',
-                'gateway_account_id': gatewayAccountId,
-                'updated': '24 Dec 2015 — 13:21:05',
-                'state': {
-                  'status': 'success',
-                  'finished': true
-                },
-                "net_amount": "45.00",
-                "net_amount_display": "£45.00",
-                "refunded": true,
-                "refunded_amount": "5.00",
-                'state_friendly': 'Success',
-                'payment_provider': 'Sandbox',
-                'gateway_transaction_id': 'dsfh-34578fb-4und-8dhry',
-                'events': [
-                    {
-                        'state': {
-                          'status': 'failed',
-                          'finished': true,
-                          'message': 'Payment was cancelled by the user',
-                          'code': 'P0030'
-                        },
-                         "state_friendly": "User failed to complete payment of £50.00",
-                         "updated": "2015-12-24 12:05:43",
-                         "updated_friendly": "24 Dec 2015 — 12:05:43",
-                     },
-                     {
-                       'state': {
-                         'status': 'cancelled',
-                         'finished': true,
-                         'message': 'Payment was cancelled by the service',
-                         'code': 'P0040'
-                       },
-                        "state_friendly": "Service cancelled payment of £50.00",
-                        "updated": "2015-12-24 12:05:43",
-                        "updated_friendly": "24 Dec 2015 — 12:05:43"
-                    },
-                    {
-                        'state': {
-                          'status': 'success',
-                          'finished': true
-                        },
-                        "state_friendly": "Payment of £50.00 succeeded",
-                        "updated": "2015-12-24 12:05:43",
-                        "updated_friendly": "24 Dec 2015 — 12:05:43"
-                    },
-                    {
-                        'state': {
-                          'status': 'started',
-                          'finished': false
-                        },
-                        'state_friendly': 'User started payment of £50.00',
-                        'updated': '2015-12-24 13:23:12',
-                        'updated_friendly': '24 Dec 2015 — 13:23:12'
-                    },
-                    {
-                        'state': {
-                          'status': 'created',
-                          'finished': false
-                        },
-                        'state_friendly': 'Service created payment of £50.00',
-                        'updated': '2015-12-24 13:21:05',
-                        'updated_friendly': '24 Dec 2015 — 13:21:05'
-                    }
-                ]
-            };
-            var events = '/v1/api/accounts/' + gatewayAccountId + '/charges/' + chargeWithRefund + '/events';
-            connectorMock_responds(connectorChargePathFor(chargeWithRefund), mockChargeResponse);
-            connectorMock_responds(events, mockEventsResponse);
-
-            when_getTransactionHistory(chargeWithRefund)
-                .expect(200, expectedEventsView)
-                .end(done);
-        });
-
-
-
-
-        it('should return charge not found if a non existing charge id requested', function (done) {
-            var nonExistentChargeId = 888;
-            var connectorError = {'message': 'Charge not found'};
-            console.log(connectorChargePathFor(nonExistentChargeId));
-            connectorMock.get(connectorChargePathFor(nonExistentChargeId))
-                .reply(404, connectorError);
-
-            when_getTransactionHistory(nonExistentChargeId)
-                .expect(200, connectorError)
-                .end(done);
-        });
-
-
-        it('should return a generic if connector responds with an error', function (done) {
-            var nonExistentChargeId = 888;
-            var connectorError = {'message': 'Internal server error'};
-            connectorMock.get(connectorChargePathFor(nonExistentChargeId))
-                .reply(500, connectorError);
-
-            when_getTransactionHistory(nonExistentChargeId)
-                .expect(200, {'message': 'Error processing transaction view'})
-                .end(done);
-        });
-
-        it('should return a generic if unable to communicate with connector', function (done) {
-            when_getTransactionHistory(chargeId)
-                .expect(200, {'message': 'Error processing transaction view'})
-                .end(done);
-        });
+      when_getTransactionHistory(nonExistentChargeId)
+        .expect(200, connectorError)
+        .end(done);
     });
+
+    it('should return a generic if connector responds with an error', function (done) {
+      var nonExistentChargeId = 888;
+      var connectorError = {'message': 'Internal server error'};
+      connectorMock.get(connectorChargePathFor(nonExistentChargeId))
+        .reply(500, connectorError);
+
+      when_getTransactionHistory(nonExistentChargeId)
+        .expect(200, {'message': 'Error processing transaction view'})
+        .end(done);
+    });
+
+    it('should return a generic if unable to communicate with connector', function (done) {
+      var chargeId = 452345;
+      when_getTransactionHistory(chargeId)
+        .expect(200, {'message': 'Error processing transaction view'})
+        .end(done);
+    });
+  });
 });

--- a/test/integration/transaction_details_refunds_ft_tests.js
+++ b/test/integration/transaction_details_refunds_ft_tests.js
@@ -1,0 +1,162 @@
+var request = require('supertest');
+var portfinder = require('portfinder');
+var nock = require('nock');
+var csrf = require('csrf');
+var _app = require(__dirname + '/../../server.js').getApp;
+var winston = require('winston');
+var paths = require(__dirname + '/../../app/paths.js');
+var session = require(__dirname + '/../test_helpers/mock_session.js');
+
+var ACCOUNT_ID = 15486734;
+var app = session.mockValidAccount(_app, ACCOUNT_ID);
+
+var localServer = 'http://aServer:8002';
+var connectorMock = nock(localServer);
+
+describe('The transaction view - refund scenarios', function () {
+
+  beforeEach(function () {
+    process.env.CONNECTOR_URL = localServer;
+    nock.cleanAll();
+  });
+
+  before(function () {
+    // Disable logging.
+    winston.level = 'none';
+  });
+
+  it('should redirect to transaction view after issuing a refund', function (done) {
+
+    var chargeWithRefund = 12345;
+    var expectedRefundRequestToConnector = {
+      'amount': 1050
+    };
+    var mockRefundResponse = {
+      'refund_id': 'Just looking the status code of the response at the moment'
+    };
+
+    connectorMock.post('/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeWithRefund + '/refunds', expectedRefundRequestToConnector)
+      .reply(202, mockRefundResponse);
+
+    var viewFormData = {
+      'refund-amount': 10.50,
+      'csrfToken': csrf().create('123')
+    };
+
+    request(app)
+      .post(paths.generateRoute(paths.transactions.refund, {chargeId: chargeWithRefund}))
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send(viewFormData)
+      .expect(302)
+      .expect('Location', '/transactions/' + chargeWithRefund)
+      .end(done);
+  });
+
+  it('should redirect to error view issuing a refund when amount is not available for refund', function (done) {
+
+    var chargeId = 12345;
+    var expectedRefundRequestToConnector = {
+      'amount': 99999
+    };
+    var mockRefundResponse = {
+      'reason': 'amount_not_available'
+    };
+
+    connectorMock.post('/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeId + '/refunds', expectedRefundRequestToConnector)
+      .reply(400, mockRefundResponse);
+
+    var viewFormData = {
+      'refund-amount': 999.99,
+      'csrfToken': csrf().create('123')
+    };
+
+    request(app)
+      .post(paths.generateRoute(paths.transactions.refund, {chargeId: chargeId}))
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .set('Accept', 'application/json')
+      .send(viewFormData)
+      .expect(200, {"message": "Can't do refund: The requested amount is bigger than the amount available for refund"})
+      .end(done);
+  });
+
+  it('should redirect to error view issuing a refund when amount is less than the minimum accepted for a refund', function (done) {
+
+    var chargeId = 12345;
+    var expectedRefundRequestToConnector = {
+      'amount': 0
+    };
+    var mockRefundResponse = {
+      'reason': 'amount_min_validation'
+    };
+
+    connectorMock.post('/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeId + '/refunds', expectedRefundRequestToConnector)
+      .reply(400, mockRefundResponse);
+
+    var viewFormData = {
+      'refund-amount': 0,
+      'csrfToken': csrf().create('123')
+    };
+
+    request(app)
+      .post(paths.generateRoute(paths.transactions.refund, {chargeId: chargeId}))
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .set('Accept', 'application/json')
+      .send(viewFormData)
+      .expect(200, {"message": "Can't do refund: The requested amount is less than the minimum accepted for issuing a refund for this charge"})
+      .end(done);
+  });
+
+  it('should redirect to error view issuing a refund when refund amount has been fully refunded', function (done) {
+
+    var chargeId = 12345;
+    var expectedRefundRequestToConnector = {
+      'amount': 1000
+    };
+    var mockRefundResponse = {
+      'reason': 'full'
+    };
+
+    connectorMock.post('/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeId + '/refunds', expectedRefundRequestToConnector)
+      .reply(400, mockRefundResponse);
+
+    var viewFormData = {
+      'refund-amount': 10,
+      'csrfToken': csrf().create('123')
+    };
+
+    request(app)
+      .post(paths.generateRoute(paths.transactions.refund, {chargeId: chargeId}))
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .set('Accept', 'application/json')
+      .send(viewFormData)
+      .expect(200, {"message": "Can't do refund: This charge has been already fully refunded"})
+      .end(done);
+  });
+
+  it('should redirect to error view when unexpected error issuing a refund', function (done) {
+
+    var chargeId = 12345;
+    var expectedRefundRequestToConnector = {
+      'amount': 1000
+    };
+    var mockRefundResponse = {
+      'message': 'what happeneeed!'
+    };
+
+    connectorMock.post('/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeId + '/refunds', expectedRefundRequestToConnector)
+      .reply(400, mockRefundResponse);
+
+    var viewFormData = {
+      'refund-amount': 10,
+      'csrfToken': csrf().create('123')
+    };
+
+    request(app)
+      .post(paths.generateRoute(paths.transactions.refund, {chargeId: chargeId}))
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .set('Accept', 'application/json')
+      .send(viewFormData)
+      .expect(200, {"message": "Can't process refund"})
+      .end(done);
+  });
+});

--- a/test/ui/transaction_details_ui_tests.js
+++ b/test/ui/transaction_details_ui_tests.js
@@ -5,55 +5,139 @@ var should = require('chai').should();
 var renderTemplate = require(__dirname + '/../test_helpers/test_renderer.js').render;
 
 describe('The transaction details view', function () {
-  it('should render all transaction details', function () {
+  it('should render transaction details when payment is not refundable', function () {
     var templateData = {
-        'reference':'<123412341234> &',
-        'email': 'alice.111@mail.fake',
-        'amount':'£10.00',
-        'gateway_account_id':'1',
-        'charge_id':'1',
-        'description':'First ever',
-        'state' : {
-          'status':'success',
-          'finished': true
+      'reference': '<123412341234> &',
+      'email': 'alice.111@mail.fake',
+      'amount': '£10.00',
+      'gateway_account_id': '1',
+      'refundable': false,
+      'refunded': false,
+      'charge_id': '1',
+      'description': 'First ever',
+      'state': {
+        'status': 'success',
+        'finished': true
+      },
+      'state_friendly': 'Success',
+      'gateway_transaction_id': '938c54a7-4186-4506-bfbe-72a122da6528',
+      'events': [
+        {
+          'chargeId': 1,
+          'state:': {'status': 'success', 'finished': true},
+          'state_friendly': 'Payment of £10.00 succeeded',
+          'updated': "2015-12-24 13:21:05",
+          'updated_friendly': "24 January 2015 13:21:05"
         },
-        'state_friendly': 'Success',
-        'gateway_transaction_id':'938c54a7-4186-4506-bfbe-72a122da6528',
 
-        'events':[
-            {'chargeId':1,
-             'state:' : { 'status': 'success', 'finished' : true },
-             'state_friendly':'Payment of £10.00 succeeded',
-             'updated': "2015-12-24 13:21:05",
-             'updated_friendly': "24 January 2015 13:21:05"},
+        {
+          'chargeId': 1,
+          'state:': {'status': 'submitted', 'finished': false},
+          'state_friendly': 'User submitted payment details for payment of £10.00',
+          'updated': "2015-12-24 13:21:05",
+          'updated_friendly': "24 January 2015 13:21:05"
+        },
 
-            {'chargeId':1,
-             'state:' : { 'status': 'submitted', 'finished' : false },
-             'state_friendly':'User submitted payment details for payment of £10.00',
-             'updated': "2015-12-24 13:21:05",
-             'updated_friendly': "24 January 2015 13:21:05"},
+        {
+          'chargeId': 1,
+          'state:': {'status': 'started', 'finished': false},
+          'state_friendly': 'User started payment of AMOUNT',
+          'updated': "2015-12-24 13:21:05",
+          'updated_friendly': "24 January 2015 13:21:05"
+        },
 
-            {'chargeId':1,
-             'state:' : { 'status': 'started', 'finished' : false },
-             'state_friendly':'User started payment of AMOUNT',
-             'updated': "2015-12-24 13:21:05",
-             'updated_friendly': "24 January 2015 13:21:05"},
-
-            {'chargeId':1,
-             'state:' : { 'status': 'created', 'finished' : false },
-             'state_friendly':'Service created payment of £10.00',
-             'updated': "2015-12-24 13:21:05",
-             'updated_friendly': "24 January 2015 13:21:05"},
-        ]
+        {
+          'chargeId': 1,
+          'state:': {'status': 'created', 'finished': false},
+          'state_friendly': 'Service created payment of £10.00',
+          'updated': "2015-12-24 13:21:05",
+          'updated_friendly': "24 January 2015 13:21:05"
+        },
+      ]
     };
 
     var body = renderTemplate('transactions/show', templateData);
     var $ = cheerio.load(body);
+    body.should.not.containSelector('#show-refund');
+    body.should.not.containSelector('#refunded-amount');
     $('#reference').html().should.equal('&lt;123412341234&gt; &amp;');
     $('#email').html().should.equal('alice.111@mail.fake');
     $('#amount').text().should.equal(templateData.amount);
     $('#payment-id').text().should.equal(templateData.charge_id);
     $('#transaction-id').text().should.equal(templateData.gateway_transaction_id);
+    $('#refunded').text().should.equal("✖");
+    $('#state').text().should.equal(templateData.state_friendly);
+
+    templateData.events.forEach(function (transactionData, ix) {
+      body.should.containSelector('table.transaction-events')
+        .havingRowAt(ix + 1)
+        .withTableDataAt(1, templateData.events[ix].state_friendly)
+        .withTableDataAt(2, templateData.events[ix].updated_friendly);
+    });
+  });
+
+  it('should render transaction details when payment has been refunded', function () {
+    var templateData = {
+      'reference': '<123412341234> &',
+      'email': 'alice.111@mail.fake',
+      'amount': '£10.00',
+      'gateway_account_id': '1',
+      'refundable': true,
+      'refunded': true,
+      'refunded_amount': '£5.00',
+      'charge_id': '1',
+      'description': 'First ever',
+      'state': {
+        'status': 'success',
+        'finished': true
+      },
+      'state_friendly': 'Success',
+      'gateway_transaction_id': '938c54a7-4186-4506-bfbe-72a122da6528',
+      'events': [
+        {
+          'chargeId': 1,
+          'state:': {'status': 'success', 'finished': true},
+          'state_friendly': 'Payment of £10.00 succeeded',
+          'updated': "2015-12-24 13:21:05",
+          'updated_friendly': "24 January 2015 13:21:05"
+        },
+
+        {
+          'chargeId': 1,
+          'state:': {'status': 'submitted', 'finished': false},
+          'state_friendly': 'User submitted payment details for payment of £10.00',
+          'updated': "2015-12-24 13:21:05",
+          'updated_friendly': "24 January 2015 13:21:05"
+        },
+
+        {
+          'chargeId': 1,
+          'state:': {'status': 'started', 'finished': false},
+          'state_friendly': 'User started payment of AMOUNT',
+          'updated': "2015-12-24 13:21:05",
+          'updated_friendly': "24 January 2015 13:21:05"
+        },
+
+        {
+          'chargeId': 1,
+          'state:': {'status': 'created', 'finished': false},
+          'state_friendly': 'Service created payment of £10.00',
+          'updated': "2015-12-24 13:21:05",
+          'updated_friendly': "24 January 2015 13:21:05"
+        },
+      ]
+    };
+
+    var body = renderTemplate('transactions/show', templateData);
+    var $ = cheerio.load(body);
+    body.should.containSelector('#show-refund');
+    $('#reference').html().should.equal('&lt;123412341234&gt; &amp;');
+    $('#email').html().should.equal('alice.111@mail.fake');
+    $('#amount').text().should.equal(templateData.amount);
+    $('#payment-id').text().should.equal(templateData.charge_id);
+    $('#transaction-id').text().should.equal(templateData.gateway_transaction_id);
+    $('#refunded').text().should.equal("✔");
+    $('#refunded-amount').text().should.equal("£5.00");
     $('#state').text().should.equal(templateData.state_friendly);
 
     templateData.events.forEach(function (transactionData, ix) {


### PR DESCRIPTION
## WHAT
- Integrate with providers (removed stubbed data).
- Add connector client refunds method.
- Removed managing refunds from session (as it was temporary).
- Mapped charge responses with refunds_summary to the current refunds view.
- Refund button is only available when _refund_summary.status_ of a charge is _available_. Refund status and amount in transaction details view.
