### PR TITLE
PP-1027 Fix refunds ui - toggle full/partial amount + transaction details view

### DIFF
--- a/app/assets/js/components/refund.js
+++ b/app/assets/js/components/refund.js
@@ -10,6 +10,7 @@
       selects.on('change',toggleAmount);
       showButton.on('click',addLightBox);
       close.on('click',removeLightBox);
+      toggleAmount();
     },
 
     toggleAmount = function(){

--- a/app/views/transactions/_details.html
+++ b/app/views/transactions/_details.html
@@ -18,7 +18,7 @@
     </tr>
     {{#refunded}}
     <tr>
-      <td>Refunded amount</td>
+      <td>Refunded amount:</td>
       <td id="refunded-amount" class="qa-refunded-amount">{{refunded_amount}}</td>
     </tr>
     {{/refunded}}


### PR DESCRIPTION
## WHAT
- Make sure toggleAmount is executed when calling init() so the screen is displayed initially as expected. Current _accepttests_ should work as expected, this situation is reproduced when users click back and forward in the browser.
- Fix colon for Refund amount in transaction details view.
