### PR TITLE
PP-833 Include the transactions list filters in the link

### DIFF
--- a/app/controllers/transaction_controller.js
+++ b/app/controllers/transaction_controller.js
@@ -10,12 +10,14 @@ var router = require('../routes.js');
 var Transaction = require('../models/transaction.js');
 var Charge = require('../models/charge.js');
 var getFilters = require('../utils/filters.js').getFilters;
+var url = require('url');
 
 module.exports = {
 
   index: function (req, res) {
     var accountId = auth.get_account_id(req);
     var filters = getFilters(req);
+    req.session.filters= url.parse(req.url).query;
     var init = function () {
         if (!filters.valid) return error("Invalid search");
         Transaction
@@ -79,6 +81,7 @@ module.exports = {
       },
 
       render = function (data) {
+        data.indexFilters = req.session.filters;
         response(req.headers.accept, res, 'transactions/show', data);
       },
 

--- a/app/views/transactions/show.html
+++ b/app/views/transactions/show.html
@@ -10,7 +10,7 @@ GOV.UK Pay - Transaction Details
 {{$content}}
 <h1 class="page-title pull-bottom">Transactions</h1>
 <div class="actions">
-  <a href="{{routes.transactions.index}}" class="arrowed"> &#9664; Back to transactions list </a>
+  <a href="{{routes.transactions.index}}?{{indexFilters}}" id="arrowed" class="arrowed"> &#9664; Back to transactions list </a>
   {{#refundable}}
   <a href="#show-refund" class="button show-refund-button delete"> Refund Payment </a>
   {{/refundable}}

--- a/test/ui/transaction_details_ui_tests.js
+++ b/test/ui/transaction_details_ui_tests.js
@@ -9,6 +9,7 @@ describe('The transaction details view', function () {
     var templateData = {
       'reference': '<123412341234> &',
       'email': 'alice.111@mail.fake',
+      'indexFilters': 'reference=&email=&state=&fromDate=&fromTime=&toDate=&toTime=',
       'amount': '£10.00',
       'gateway_account_id': '1',
       'refundable': false,
@@ -60,6 +61,7 @@ describe('The transaction details view', function () {
     var $ = cheerio.load(body);
     body.should.not.containSelector('#show-refund');
     body.should.not.containSelector('#refunded-amount');
+    $('#arrowed').attr('href').should.equal('?reference=&email=&state=&fromDate=&fromTime=&toDate=&toTime=');
     $('#reference').html().should.equal('&lt;123412341234&gt; &amp;');
     $('#email').html().should.equal('alice.111@mail.fake');
     $('#amount').text().should.equal(templateData.amount);


### PR DESCRIPTION
## WHAT

_A brief description of the pull request:_
- After filtering a list of results in the Transactions List, and
  clicking on one of the results to view Transaction Detail, if we
  then clicked 'Back to Transaction List' we would return to the
  unfiltered list of transactions rather than than the filtered list
  we have just came from.
- This commit maintains the filter list in the 'Back to Transaction List'

with @simad
## HOW

_Steps to test or reproduce:_

```
cd $WORKSPACE/pay-selfservice
npm test
```
