### PR TITLE
PP-1112 Fix Edit Description of api tokens + guest bug

### DIFF
--- a/app/assets/js/devtokens.js
+++ b/app/assets/js/devtokens.js
@@ -9,6 +9,8 @@ $(document).ready(function(){
 
 
   function toggleDescription(evt) {
+    var oldDescription = $('.js-old-description').text();
+    $('.js-new-description').val(oldDescription);
     toggle.call(this, '.js-edit-description');
     toggle.call(this, '.js-edit-controls');
     evt.preventDefault();


### PR DESCRIPTION
## WHAT

_A brief description of the pull request:_
- As we were dynamically replacing the edit description link, but
  statically binding the on click listener, we could edit the description
  only once.
- Now, event listeners are dynamically bound to any object with a
  `.js-toggle-*` class

NOTE: 
- While working on the story, I discovered another minor bug (see HOW section), which was sneakily fixed as part of PP-1112.
## HOW

_Steps to test or reproduce:_

MAIN BUG:
- Click on Edit description of any api key
- Click on Save description
- Click on Edit description again, it will not work

SECOND BUG:
- Click on Edit description of any api key
- Type something in the text area
- Press Cancel
- Click on Edit description again
- The text area will still contain the text typed before, instead of the api key's description
