### PR TITLE
PP-1112 Fix edit description for multiple keys

### DIFF
--- a/app/assets/js/devtokens.js
+++ b/app/assets/js/devtokens.js
@@ -9,8 +9,8 @@ $(document).ready(function(){
 
 
   function toggleDescription(evt) {
-    var oldDescription = $('.js-old-description').text();
-    $('.js-new-description').val(oldDescription);
+    var oldDescription = getListItem(this).find('.js-old-description').text();
+    getListItem(this).find('.js-new-description').val(oldDescription);
     toggle.call(this, '.js-edit-description');
     toggle.call(this, '.js-edit-controls');
     evt.preventDefault();


### PR DESCRIPTION
## WHAT

_A brief description of the pull request:_
- Using a generic $(.x) jquery selector is too broad when multiple keys are there,
  so we are narrowing the scope to the specific key-list
## HOW

_Steps to test or reproduce:_
