### PR TITLE
PP-1193 Fix refund of the wrong amount

### DIFF
--- a/create_user.js
+++ b/create_user.js
@@ -9,10 +9,10 @@ var User      = require(__dirname + '/app/models/user.js');
 var logger    = require('winston');
 user = {
    username: Math.random().toString(36).substring(7),
-   password: "12345",
+   password: "1234567890",
    email: "andrew.hilton1@digital.cabinet-office.gov.uk",
    telephone_number: "07809610784",
    gateway_account_id: "12345"
  };
 logger.debug('creating user',user);
-User.create(user).then(()=> logger.debug('created user'),(err)=> logger.debug('failed to create user',err));
+User.create(user).then(()=> logger.info('created user'),(err)=> logger.info('failed to create user',err));


### PR DESCRIPTION
## WHAT

Fix refund of the wrong amount by reworking amount handling to remove any notion of multiply floats. Add some more tests.

Spoke to Stephen McCarthy and we agreed amounts looking like "£10.1"
should be rejected as they are confusing.
