### PR TITLE
PP-1215 Retrieve safely email field

### DIFF
--- a/app/middleware/login_counter.js
+++ b/app/middleware/login_counter.js
@@ -2,6 +2,7 @@
 var errorView = require('../utils/response.js').renderErrorView;
 var User      = require('../models/user.js');
 var paths     = require('../paths.js');
+var _         = require('lodash');
 var logger    = require('winston');
 
 
@@ -12,10 +13,9 @@ var lockOut = (req,res, user) => {
   })
 }
 
-
 module.exports = {
   enforce: function (req, res, next) {
-   var email = req.body.email || req.user.email;
+   var email = _.get(req.body, 'email') || _.get(req.user, 'email');
     User.find(email).then((user)=> {
       user.incrementLoginCount().then(
         ()=> {
@@ -29,4 +29,4 @@ module.exports = {
       )
     },next)
   }
-}
+};

--- a/test/middleware/login_counter_test.js
+++ b/test/middleware/login_counter_test.js
@@ -37,16 +37,12 @@ describe('login counter test', function () {
   var login = (userMock)=> {
     return proxyquire(__dirname + '/../../app/middleware/login_counter.js',
     {'../models/user.js': userMock});
-  }
+  };
 
-
-
-
-
-  it('should call incrementloginCount',function(){
+  it('should call increment login count',function(){
     var user = {
-      find: ()=> { 
-        return  { 
+      find: ()=> {
+        return  {
           then: (success,fail)=> {
             success({
               login_counter: 0,
@@ -63,8 +59,7 @@ describe('login counter test', function () {
     var loginMiddleware = login(user);
     loginMiddleware.enforce({body: {email: "foo"}},{
     },()=> assert("next is called","next is called"))
-  })
-
+  });
 
   it('should call disable user and render noacess when over limit',function(){
 
@@ -92,6 +87,26 @@ describe('login counter test', function () {
     loginMiddleware.enforce({body: {email: "foo"}},{
       render: (path) => assert("login/noaccess",path)
     },()=> assert("next is called",false))
-  })
+  });
 
-})
+  it('should retrieve safely email field',function(){
+    var user = {
+      find: ()=> {
+        return  {
+          then: (success,fail)=> {
+            success({
+              login_counter: 0,
+              incrementLoginCount: () => {
+                assert("increment is called","increment is called");
+                return { then: (suc,fail)=> suc()}
+              }
+            })
+          }
+        }
+      }
+    };
+    var loginMiddleware = login(user);
+    loginMiddleware.enforce({body:{}},{
+    },()=> assert("next is called","next is called"))
+  });
+});


### PR DESCRIPTION
## WHAT
- Error has been thrown when empty email in login_counter middleware. An acceptance test has been added in order to fix this issue. 
## RELEASE NOTE

This is a test release note !!!
