### PR TITLE
PP-1224 refund amount available pence vs pounds

### DIFF
--- a/app/controllers/transaction_controller.js
+++ b/app/controllers/transaction_controller.js
@@ -112,13 +112,11 @@ module.exports = {
     });
     
     var refundAmount = (req.body['refund-type'] === 'full' ) ? req.body['full-amount'] : req.body['refund-amount'];
-    var refundAmountAvailable = req.body['refund-amount-available'];
-
+    var refundAmountAvailableInPence = parseInt(req.body['refund-amount-available-in-pence']);
     var refundMatch = /^([0-9]+)(?:\.([0-9]{2}))?$/.exec(refundAmount);
-    
+
     if (refundMatch) {
       var refundAmountForConnector = parseInt(refundMatch[1]) * 100;
-      var refundAmountAvailableForConnector = parseInt(refundAmountAvailable) * 100;
       if (refundMatch[2]) refundAmountForConnector += parseInt(refundMatch[2]);
       
       var errReasonMessages = {
@@ -130,7 +128,7 @@ module.exports = {
       };
 
       var chargeModel = Charge(req.headers[CORRELATION_HEADER]);
-      chargeModel.refund(accountId, chargeId, refundAmountForConnector, refundAmountAvailableForConnector)
+      chargeModel.refund(accountId, chargeId, refundAmountForConnector, refundAmountAvailableInPence)
         .then(function () {
           res.redirect(show);
         }, function (err) {

--- a/app/views/transactions/_refund.html
+++ b/app/views/transactions/_refund.html
@@ -2,7 +2,7 @@
 
 <div id="show-refund">
   <form action="/transactions/{{charge_id}}/refund" method="post" class="refund-form">
-      <input id="amount-available" type="hidden" name="refund-amount-available" value="{{ refund_summary.amount_available }}" />
+      <input id="amount-available" type="hidden" name="refund-amount-available-in-pence" value="{{ refund_summary.amount_available }}" />
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
     <div class="container">
       <h2 class="heading-medium">Refund payment</h2>

--- a/test/integration/transaction_details_refunds_ft_tests.js
+++ b/test/integration/transaction_details_refunds_ft_tests.js
@@ -38,7 +38,7 @@ describe('The transaction view - refund scenarios', function () {
 
     var viewFormData = {
       'refund-amount': '19.90',
-      'refund-amount-available': '50.00',
+      'refund-amount-available-in-pence': '5000',
       'csrfToken': csrf().create('123')
     };
 
@@ -66,7 +66,7 @@ describe('The transaction view - refund scenarios', function () {
 
     var viewFormData = {
       'refund-amount': '10',
-      'refund-amount-available': '50.00',
+      'refund-amount-available-in-pence': '5000',
       'csrfToken': csrf().create('123')
     };
 
@@ -84,7 +84,7 @@ describe('The transaction view - refund scenarios', function () {
 
     var viewFormData = {
       'refund-amount': '1.9',
-      'refund-amount-available': '50.00',
+      'refund-amount-available-in-pence': '5000',
       'csrfToken': csrf().create('123')
     };
 
@@ -112,7 +112,7 @@ describe('The transaction view - refund scenarios', function () {
 
     var viewFormData = {
       'refund-amount': '999.99',
-      'refund-amount-available': '50.00',
+      'refund-amount-available-in-pence': '5000',
       'csrfToken': csrf().create('123')
     };
 
@@ -141,7 +141,7 @@ describe('The transaction view - refund scenarios', function () {
 
     var viewFormData = {
       'refund-amount': '0',
-      'refund-amount-available': '50.00',
+      'refund-amount-available-in-pence': '5000',
       'csrfToken': csrf().create('123')
     };
 
@@ -170,7 +170,7 @@ describe('The transaction view - refund scenarios', function () {
 
     var viewFormData = {
       'refund-amount': '10',
-      'refund-amount-available': '0.00',
+      'refund-amount-available-in-pence': '000',
       'csrfToken': csrf().create('123')
     };
 
@@ -199,7 +199,7 @@ describe('The transaction view - refund scenarios', function () {
 
     var viewFormData = {
       'refund-amount': '10',
-      'refund-amount-available': '50.00',
+      'refund-amount-available-in-pence': '5000',
       'csrfToken': csrf().create('123')
     };
 
@@ -227,7 +227,7 @@ describe('The transaction view - refund scenarios', function () {
 
     var viewFormData = {
       'refund-amount': '10',
-      'refund-amount-available': '50.00',
+      'refund-amount-available-in-pence': '5000',
       'csrfToken': csrf().create('123')
     };
 


### PR DESCRIPTION
- The hidden field in the refunds post form was posting available amount
  in pence and the controller was multiplying by 100 to get pence again.
  Fixed by not trying to change the value again to pence.
- Renamed the var names to be more explicit
- this fixes the tests to pass the value in the form as pence
- takes the refund amount available and parse it to int.
