### PR TITLE
Missing headers in fake requests is failing tests

### DIFF
--- a/test/services/auth_service_test.js
+++ b/test/services/auth_service_test.js
@@ -40,6 +40,8 @@ describe('auth service', function () {
       user: {
         name: 'Michael',
         gateway_account_id: 123
+      },
+      headers: {
       }
     };
 


### PR DESCRIPTION
## WHAT

_A brief description of the pull request:_
Given that the correlationID is retrieved from request headers, we need the fake request
to include a headers object. Else the test complains that correlationID cannot be
retrieved from an undefined object.
## HOW

_Steps to test or reproduce:_
