### PR TITLE
PP-1302 Add `merchant_id` field for smartpay

### DIFF
--- a/app/views/provider_credentials/smartpay.html
+++ b/app/views/provider_credentials/smartpay.html
@@ -8,6 +8,9 @@
 
 {{^editMode}}
 <dl id="credentials">
+    <dt id="merchant-id-key" class="font-xsmall"><p>Merchant ID</p></dt>
+    <dd id="merchant-id-value"><b>{{credentials.merchant_id}}</b></dd>
+
     <dt id="username-key" class="font-xsmall"><p>Username</p></dt>
     <dd id="username-value"><b>{{credentials.username}}</b></dd>
 
@@ -22,6 +25,11 @@
 {{#editMode}}
 <form id="credentials-form" method="post" action="{{routes.credentials.create}}">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
+    <div class="form-group">
+        <label class="form-label" for="merchantId">Merchant ID</label>
+        <input class="form-control" id="merchantId" name="merchantId" type="text" value="{{credentials.merchant_id}}">
+    </div>
+
     <div class="form-group">
         <label class="form-label" for="username">Username</label>
         <input class="form-control" id="username" name="username" type="text" value="{{credentials.username}}">

--- a/test/integration/credentails_ft_tests.js
+++ b/test/integration/credentails_ft_tests.js
@@ -210,7 +210,10 @@ var app = session.mockValidAccount(_app, ACCOUNT_ID);
         .reply(200, {
           "payment_provider": "smartpay",
           "gateway_account_id": "1",
-          "credentials": {username: "a-username"},
+          "credentials": {
+            'username': "a-username",
+            'merchant_id': 'a-merchant-id'
+          },
           "notificationCredentials": {username: "a-notification-username"}
         });
 
@@ -219,7 +222,8 @@ var app = session.mockValidAccount(_app, ACCOUNT_ID);
         "editMode": false,
         "editNotificationCredentialsMode": false,
         "credentials": {
-          'username': 'a-username'
+          'username': 'a-username',
+          'merchant_id': 'a-merchant-id'
         },
         "notification_credentials": {username: "a-notification-username"}
       };
@@ -241,18 +245,19 @@ var app = session.mockValidAccount(_app, ACCOUNT_ID);
       winston.level = 'none';
     });
 
-    it('should send new username and password credentials to connector', function (done) {
+    it('should send new username, password and merchant_id credentials to connector', function (done) {
       connectorMock.patch(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
         "credentials": {
           "username": "a-username",
-          "password": "a-password"
+          "password": "a-password",
+          "merchant_id": "a-merchant-id"
         }
       })
       .reply(200, {});
 
 
 //    verify_post_request(path, sendData, cookieValue, expectedRespCode, expectedData, expectedLocation) {
-    var sendData = {'username': 'a-username', 'password': 'a-password'};
+    var sendData = {'username': 'a-username', 'password': 'a-password', 'merchantId': 'a-merchant-id'};
     var expectedLocation = paths.credentials.index;
     var path = paths.credentials.index;
     build_form_post_request(path, sendData)
@@ -265,13 +270,12 @@ var app = session.mockValidAccount(_app, ACCOUNT_ID);
       connectorMock.patch(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
         "credentials": {
           "username": "a-username",
-          "password": "a-password",
-          "merchant_id": "a-merchant-id"
+          "password": "a-password"
         }
       })
       .reply(200, {});
 
-    var sendData = {'username': 'a-username', 'password': 'a-password', 'merchantId': 'a-merchant-id'};
+    var sendData = {'username': 'a-username', 'password': 'a-password'};
     var expectedLocation = paths.credentials.index;
     var path = paths.credentials.index;
     build_form_post_request(path, sendData)

--- a/test/ui/credentails_ui_tests.js
+++ b/test/ui/credentails_ui_tests.js
@@ -53,7 +53,8 @@ describe('The credentials view in normal mode', function () {
     var templateData = {
       "payment_provider": "Smartpay",
       "credentials": {
-        'username': 'a-username'
+        'username': 'a-username',
+        'merchant_id': 'a-merchant-id'
       }
     };
 
@@ -68,8 +69,8 @@ describe('The credentials view in normal mode', function () {
 
     body.should.containSelector('dl#credentials');
 
-    body.should.not.containSelector('dt#merchant-id-key');
-    body.should.not.containSelector('dd#merchant-id-value');
+    body.should.containSelector('dt#merchant-id-key');
+    body.should.containSelector('dd#merchant-id-value');
 
     body.should.containSelector('dt#username-key').withExactText('Username');
     body.should.containSelector('dd#username-value').withExactText('a-username');
@@ -82,7 +83,8 @@ describe('The credentials view in normal mode', function () {
     var templateData = {
       "payment_provider": "Smartpay",
       "credentials": {
-        'username': 'a-username'
+        'username': 'a-username',
+        'merchant_id': 'a-merchant-id'
       },
       "notification_credentials": {
         'userName': 'a-notification-username'
@@ -100,8 +102,8 @@ describe('The credentials view in normal mode', function () {
 
     body.should.containSelector('dl#credentials');
 
-    body.should.not.containSelector('dt#merchant-id-key');
-    body.should.not.containSelector('dd#merchant-id-value');
+    body.should.containSelector('dt#merchant-id-key');
+    body.should.containSelector('dd#merchant-id-value');
 
     body.should.containSelector('dt#notification-username-key').withExactText('Username');
     body.should.containSelector('dd#notification-username-value').withExactText('a-notification-username');
@@ -193,7 +195,9 @@ describe('The credentials view in edit mode', function () {
 
     body.should.not.containSelector('a#edit-credentials-link');
 
-    body.should.not.containSelector('input#merchant-id');
+    body.should.containInputField('merchantId', 'text')
+      .withAttribute('value', 'a-merchant-id')
+      .withLabel('Merchant ID');
 
     body.should.containInputField('username', 'text')
       .withAttribute('value', 'a-username')


### PR DESCRIPTION
## WHAT
As we realised there needs to be a `merchant_id` captured and used when integrating with smartpay, this PR updates the selfservice UI to capture and save the new field 

 - added a new form field `merchantId` to capture smartpay merchant code (similar to worldpay)
 - handling the display to view the existing merchant id if already exists/stored.
 - Updating credentials already handles the merchantId field irrespective of worldpay/smartpay if exists.
 - Leaving the ft test for arbitrary credentials support, as it might be useful in the future.