### PR TITLE
PP-1296 Bumping the version of connect-session-sequelize

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cluster": "0.7.x",
     "common-password": "^0.1.2",
     "connect-flash": "^0.1.1",
-    "connect-session-sequelize": "3.2.x",
+    "connect-session-sequelize": "4.1.0-beta.1",
     "cookie-parser": "1.4.x",
     "csrf": "3.0.x",
     "express": "4.13.1",


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_
 * This is a beta version for now, but the version bump was a result
   of https://github.com/mweibel/connect-session-sequelize/pull/47.
 * The change was to change the usage of the sequelize function that
   created temporary postgress functions that has transactions into a
   function that does not have support for transactions and does not
   create temporary postgress functions.
 * Based on the scenarios that create or update a session, the usage of
   the transaction aware function from sequelize didn't make any sense
 * Given that the transaction aware sequelize function was exhausting the
   database memory due to the creation of temporary postgress functions, the
   connection-sesssion-sequelize library is using a more performant sequelize
   function now.
* When we have this running in in production we can report back to the maintainer
  so that this could be made a non-beta release.