### PR TITLE
PP-1362 Bump connect-session-sequelize to 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cluster": "0.7.x",
     "common-password": "^0.1.2",
     "connect-flash": "^0.1.1",
-    "connect-session-sequelize": "4.1.0-beta.1",
+    "connect-session-sequelize": "4.1.0",
     "cookie-parser": "1.4.x",
     "csrf": "3.0.x",
     "express": "4.13.1",


### PR DESCRIPTION
Previously was 4.1.0-beta.1 . Maintainer has now promoted this to version 4.1.0, so
moving us on to that.