### PR TITLE
PP-1386 Introducing appmetrics+statsd for metrics

### DIFF
--- a/app/utils/metrics.js
+++ b/app/utils/metrics.js
@@ -1,0 +1,19 @@
+'use strict';
+var appmetrics = require('appmetrics');
+var metricsHost = process.env.METRICS_HOST || "localhost";
+var metricsPort = process.env.METRICS_PORT || 8125;
+var metricsPrefix = "selfservice.";
+
+function initialiseMonitoring () {
+  appmetrics.configure({'mqtt':'off'});
+  var appmetricsStatsd = require('appmetrics-statsd');
+
+  return appmetricsStatsd.StatsD(null, metricsHost, metricsPort, metricsPrefix);
+}
+
+module.exports = function() {
+
+  return {
+    metrics: initialiseMonitoring()
+  }
+}();

--- a/package.json
+++ b/package.json
@@ -88,7 +88,9 @@
     "throng": "4.0.x",
     "tunnel": "0.0.4",
     "winston": "2.2.x",
-    "yargs": "4.7.x"
+    "yargs": "4.7.x",
+    "appmetrics": "1.1.2",
+    "appmetrics-statsd": "1.0.1"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ var port              = (process.env.PORT || 3000);
 var unconfiguredApp   = express();
 var flash             = require('connect-flash');
 var middlwareUtils    = require('./app/utils/middleware.js');
-
+var applicationMetrics= require('./app/utils/metrics.js').metrics;
 
 function initialiseGlobalMiddleware (app) {
   app.use(cookieParser());


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_
* appmetrics-statsd library allows us to capture nodejs runtime metrics as well as custom metrics. Runtime metrics are through appmetrics while custom metrics can be captured using statsd. The library combines both.
* The current version of appmetrics-statsd doesn't allow for turning off mqtt. This has been raised with the maintainers and they are in the midst of rolling out a new release with a fix. Until then we can still use it - https://github.com/RuntimeTools/appmetrics/issues/341. The library tries to connect to mqtt, but there wont be any mqtt actions performed as there there's no mqtt running.
* This change only initialises the appmetrics-statsd library and sends nodejs runtime metrics to a statsd endpoint.
* The statsd endpoint is expected to be available through the METRICS_HOST variable, if not 'localhost' is used.
* The prefix provided in metrics.js serves as the root node name for the application in graphite metrics.

with @simad