### PR TITLE
PP-1378 Fix to start NodeJs app in production mode when NODE_ENV=production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ WORKDIR /app
 # copy cached node_modules to /app/node_modules
 RUN mkdir -p /app && cp -a /tmp/node_modules /app/
 
-RUN npm install && npm test && npm prune --production
+RUN npm install && npm run compile && npm test && npm prune --production
 
 CMD bash ./docker-startup.sh

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -167,7 +167,7 @@ module.exports = function(grunt){
     'sass'
   ]);
 
-  grunt.registerTask('test', ['env:test','generate-assets', 'mochaTest']);
+  grunt.registerTask('test', ['env:test', 'mochaTest']);
 
   var defaultTasks = [
       'generate-assets',

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ vi dev-env.json
 
 ```
 
+to test
+```
+npm run compile && npm test
+```
+
 to run
 ```
 LOCAL_ENV=true msl run

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     }
   },
   "scripts": {
-    "start": "forever --minUptime 1000 --spinSleepTime 500 start.js",
-    "stop": "forever stop start.js",
+    "compile": "grunt generate-assets",
+    "clean": "grunt clean",
+    "start": "node_modules/forever/bin/forever --minUptime 1000 --spinSleepTime 500 start.js",
+    "stop": "node_modules/forever/bin/forever stop start.js",
     "watch": "chokidar app test *.js --initial -c 'npm run test'",
     "test": "npm run lint && npm run grunt-test",
     "lint": "node ./node_modules/.bin/jshint --verbose ./app/*.js",


### PR DESCRIPTION
## WHAT
- NPM supports a `scripts` setting in the package.json called `prestart` where one can
   configure a command line action to be executed before starting the app. The `prestart`
   was configured to launch the app in development mode, simply not handing the
   control back over to NPM and therefore short cicuiting the `start` for production.
   `prestart` has been removed.
- A new NPM `scripts` setting called `compile` has been introduced that currently only
   serves the purpose of generating the assets.
- The `Gruntfile` script has also been modified to stop generating assets before running
   the tests.
- Dockerfile explicitly calls the `compile` NPM script prior to running the tests.

# HOW TO TEST
- Run the application with `msl up` (from https://github.com/alphagov/pay-scripts/pull/370) and check that NodeJs is in production mode running under the supervision of `forever`.
- Run the application with `msl run` (from https://github.com/alphagov/pay-scripts/pull/370) and check that NodeJs is in production mode running under the supervision of `forever`.
- Run the tests locally with `npm run compile && npm test`