### PR TITLE
PP-1378 Default to use postgres database.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ WORKDIR /app
 # copy cached node_modules to /app/node_modules
 RUN mkdir -p /app && cp -a /tmp/node_modules /app/
 
-RUN npm install && NODE_ENV=development npm test && npm prune --production
+RUN npm install && npm test && npm prune --production
 
 CMD bash ./docker-startup.sh

--- a/app/utils/sequelize_config.js
+++ b/app/utils/sequelize_config.js
@@ -1,9 +1,9 @@
 'use strict';
 var Sequelize = require('sequelize');
-var env       = process.env.NODE_ENV || "development";
-
+var testMode       = process.env.NODE_TEST_MODE || false;
+// This will go away as soon database goes away (Sequelize dies)
 function createInstance() {
-  if(env === "development") {
+  if(testMode) {
     return new Sequelize('database', 'username', 'password', {
       dialect: 'sqlite',
       storage: __dirname + '/../../database.sqlite',

--- a/config/test-env.json
+++ b/config/test-env.json
@@ -17,5 +17,6 @@
   "SELFSERVICE_BASE": "https://selfservice.pymnt.localdomain",
   "DATABASE_URL": "postgres://foo",
   "LOGIN_ATTEMPT_CAP": 2,
-  "DISABLE_REQUEST_LOGGING": "true"
+  "DISABLE_REQUEST_LOGGING": "true",
+  "NODE_TEST_MODE": true
 }


### PR DESCRIPTION
## WHAT
- Not use NODE_ENV for sequelize config, temporaly use an extra variable only set by Grunt when running "test" task. This is temporary until Sequelize goes out.