### PR TITLE
PP-1442 Fix users migrations

### DIFF
--- a/migrations/20161114152445-add-users-to-admin-role.js
+++ b/migrations/20161114152445-add-users-to-admin-role.js
@@ -8,15 +8,19 @@ module.exports = {
     var date = new Date();
     queryInterface.select(User, 'users')
       .then((users)=> {
-        var bulkUserRole = _.map(users, function (user) {
-          return {
-            user_id: user.id,
-            role_id: roleAdminId,
-            createdAt: date,
-            updatedAt: date
-          };
-        });
-        queryInterface.bulkInsert('user_role', bulkUserRole).then(()=>done())
+        if (Array.isArray(users) && users.length != 0) {
+          var bulkUserRole = _.map(users, function (user) {
+            return {
+              user_id: user.id,
+              role_id: roleAdminId,
+              createdAt: date,
+              updatedAt: date
+            };
+          });
+          queryInterface.bulkInsert('user_role', bulkUserRole).then(()=>done());
+        } else {
+          done();
+        }
       });
   },
 


### PR DESCRIPTION
## WHAT
- When users table is empty, users migration fails silently and SequelizeMeta does not get reflected with this change. This fix that situation by checking users is not empty.