### PR TITLE
Pp 1282 Card details navailable

### DIFF
--- a/app/utils/transaction_view.js
+++ b/app/utils/transaction_view.js
@@ -9,6 +9,7 @@ var check = require('check-types');
 var url = require('url');
 
 
+const DATA_UNAVAILABLE = 'Data unavailable';
 const PAGINATION_SPREAD = 2;
 const CURRENCY = '£';
 const eventStates = {
@@ -133,6 +134,20 @@ module.exports = {
 
     var amount = (chargeData.amount / 100).toFixed(2);
     chargeData.amount = CURRENCY + amount;
+
+    if (chargeData.card_details) {
+      if (chargeData.card_details.card_brand == null)  chargeData.card_details.card_brand = DATA_UNAVAILABLE;
+      if (chargeData.card_details.cardholder_name == null)  chargeData.card_details.cardholder_name = DATA_UNAVAILABLE;
+      if (chargeData.card_details.expiry_date == null)  chargeData.card_details.expiry_date = DATA_UNAVAILABLE;
+      if (chargeData.card_details.last_digits_card_number == null)  chargeData.card_details.last_digits_card_number = '****';
+    } else {
+      chargeData.card_details = {
+        card_brand: DATA_UNAVAILABLE,
+        cardholder_name: DATA_UNAVAILABLE,
+        expiry_date: DATA_UNAVAILABLE,
+        last_digits_card_number: '****'
+      }
+    }
 
     chargeData.refundable = chargeData.refund_summary.status === 'available';
     chargeData.net_amount = (chargeData.refund_summary.amount_available / 100).toFixed(2);

--- a/test/integration/transaction_details_ft_tests.js
+++ b/test/integration/transaction_details_ft_tests.js
@@ -242,6 +242,246 @@ describe('The transaction view scenarios', function () {
         .end(done);
     });
 
+    it('should show a transaction when no card details are present', function (done) {
+      var chargeId = 452345;
+      var mockEventsResponse = {
+        'charge_id': chargeId,
+        'events': [
+          {
+            'state': {
+              'status': 'created',
+              'finished': false
+            },
+            'updated': '2015-12-24 13:21:05'
+          },
+          {
+            'state': {
+              'status': 'started',
+              'finished': false
+            },
+            'updated': '2015-12-24 13:23:12'
+          }
+        ]
+      };
+
+      var mockChargeResponse = {
+        'charge_id': chargeId,
+        'description': 'Breathing licence',
+        'reference': 'Ref-1234',
+        'email': 'alice.111@mail.fake',
+        'amount': 5000,
+        'gateway_account_id': ACCOUNT_ID,
+        'payment_provider': 'sandbox',
+        'gateway_transaction_id': 'dsfh-34578fb-4und-8dhry',
+        'state': {
+          'status': 'started',
+          'finished': false
+        },
+        'refund_summary': {
+          'status': 'available',
+          'amount_available': 5000,
+          'amount_submitted': 0
+        },
+        'return_url': 'http://example.service/return_from_payments',
+        'links': [
+          {
+            'rel': 'self',
+            'method': 'GET',
+            'href': 'http://connector.service/v1/api/charges/1'
+          },
+          {
+            'rel': 'next_url',
+            'method': 'GET',
+            'href': 'http://frontend/charges/1?chargeTokenId=82347'
+          }
+        ]
+      };
+
+      var expectedEventsView = {
+        'charge_id': chargeId,
+        'description': 'Breathing licence',
+        'reference': 'Ref-1234',
+        'email': 'alice.111@mail.fake',
+        'refundable': true,
+        'net_amount': "50.00",
+        'net_amount_display': '£50.00',
+        'refunded_amount': '£0.00',
+        'refunded': false,
+        'amount': '£50.00',
+        'gateway_account_id': ACCOUNT_ID,
+        'updated': '24 Dec 2015 — 13:21:05',
+        'state': {
+          'status': 'started',
+          'finished': false
+        },
+        'card_details': {
+          'card_brand': 'Data unavailable',
+          'cardholder_name': 'Data unavailable',
+          'expiry_date': 'Data unavailable',
+          'last_digits_card_number': '****'
+        },
+        'state_friendly': 'Started',
+        'refund_summary': {
+          'status': 'available',
+          'amount_available': 5000,
+          'amount_submitted': 0
+        },
+        'payment_provider': 'Sandbox',
+        'gateway_transaction_id': 'dsfh-34578fb-4und-8dhry',
+        'events': [
+          {
+            'state': {
+              'status': 'started',
+              'finished': false
+            },
+            'state_friendly': 'User started payment of £50.00',
+            'updated': '2015-12-24 13:23:12',
+            'updated_friendly': '24 Dec 2015 — 13:23:12'
+          },
+          {
+            'state': {
+              'status': 'created',
+              'finished': false
+            },
+            'state_friendly': 'Service created payment of £50.00',
+            'updated': '2015-12-24 13:21:05',
+            'updated_friendly': '24 Dec 2015 — 13:21:05'
+          }
+        ]
+      };
+
+      connectorMock_responds(connectorChargePathFor(chargeId), mockChargeResponse);
+      connectorMock_responds('/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeId + '/events', mockEventsResponse);
+
+      when_getTransactionHistory(chargeId)
+        .expect(200, expectedEventsView)
+        .end(done);
+    });
+
+    it('should show a transaction when legacy cards details are present', function (done) {
+      var chargeId = 452345;
+      var mockEventsResponse = {
+        'charge_id': chargeId,
+        'events': [
+          {
+            'state': {
+              'status': 'created',
+              'finished': false
+            },
+            'updated': '2015-12-24 13:21:05'
+          },
+          {
+            'state': {
+              'status': 'started',
+              'finished': false
+            },
+            'updated': '2015-12-24 13:23:12'
+          }
+        ]
+      };
+
+      var mockChargeResponse = {
+        'charge_id': chargeId,
+        'description': 'Breathing licence',
+        'reference': 'Ref-1234',
+        'email': 'alice.111@mail.fake',
+        'amount': 5000,
+        'gateway_account_id': ACCOUNT_ID,
+        'payment_provider': 'sandbox',
+        'gateway_transaction_id': 'dsfh-34578fb-4und-8dhry',
+        'state': {
+          'status': 'started',
+          'finished': false
+        },
+        'card_details': {
+          'billing_address': null,
+          'card_brand': 'Mastercard',
+          'cardholder_name': null,
+          'expiry_date': null,
+          'last_digits_card_number': null
+        },
+        'refund_summary': {
+          'status': 'available',
+          'amount_available': 5000,
+          'amount_submitted': 0
+        },
+        'return_url': 'http://example.service/return_from_payments',
+        'links': [
+          {
+            'rel': 'self',
+            'method': 'GET',
+            'href': 'http://connector.service/v1/api/charges/1'
+          },
+          {
+            'rel': 'next_url',
+            'method': 'GET',
+            'href': 'http://frontend/charges/1?chargeTokenId=82347'
+          }
+        ]
+      };
+
+      var expectedEventsView = {
+        'charge_id': chargeId,
+        'description': 'Breathing licence',
+        'reference': 'Ref-1234',
+        'email': 'alice.111@mail.fake',
+        'refundable': true,
+        'net_amount': "50.00",
+        'net_amount_display': '£50.00',
+        'refunded_amount': '£0.00',
+        'refunded': false,
+        'amount': '£50.00',
+        'gateway_account_id': ACCOUNT_ID,
+        'updated': '24 Dec 2015 — 13:21:05',
+        'state': {
+          'status': 'started',
+          'finished': false
+        },
+        'card_details': {
+          'billing_address': null,
+          'card_brand': 'Mastercard',
+          'cardholder_name': 'Data unavailable',
+          'expiry_date': 'Data unavailable',
+          'last_digits_card_number': '****'
+        },
+        'state_friendly': 'Started',
+        'refund_summary': {
+          'status': 'available',
+          'amount_available': 5000,
+          'amount_submitted': 0
+        },
+        'payment_provider': 'Sandbox',
+        'gateway_transaction_id': 'dsfh-34578fb-4und-8dhry',
+        'events': [
+          {
+            'state': {
+              'status': 'started',
+              'finished': false
+            },
+            'state_friendly': 'User started payment of £50.00',
+            'updated': '2015-12-24 13:23:12',
+            'updated_friendly': '24 Dec 2015 — 13:23:12'
+          },
+          {
+            'state': {
+              'status': 'created',
+              'finished': false
+            },
+            'state_friendly': 'Service created payment of £50.00',
+            'updated': '2015-12-24 13:21:05',
+            'updated_friendly': '24 Dec 2015 — 13:21:05'
+          }
+        ]
+      };
+
+      connectorMock_responds(connectorChargePathFor(chargeId), mockChargeResponse);
+      connectorMock_responds('/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeId + '/events', mockEventsResponse);
+
+      when_getTransactionHistory(chargeId)
+        .expect(200, expectedEventsView)
+        .end(done);
+    });
+
     it('should return a list of transaction history for a given charge id and show refunded', function (done) {
 
       var chargeWithRefund = 12345;

--- a/test/ui/transaction_details_ui_tests.js
+++ b/test/ui/transaction_details_ui_tests.js
@@ -5,6 +5,73 @@ var should = require('chai').should();
 var renderTemplate = require(__dirname + '/../test_helpers/test_renderer.js').render;
 
 describe('The transaction details view', function () {
+  it('should render transaction details when payment does not have card details', function () {
+    var templateData = {
+      'reference': '<123412341234> &',
+      'email': 'alice.111@mail.fake',
+      'indexFilters': 'reference=&email=&state=&fromDate=&fromTime=&toDate=&toTime=',
+      'amount': '£10.00',
+      'gateway_account_id': '1',
+      'refundable': false,
+      'refunded': false,
+      'charge_id': '1',
+      'description': 'First ever',
+      'state': {
+        'status': 'success',
+        'finished': true
+      },
+      'card_details': {
+        'card_brand': 'Data unavailable',
+        'cardholder_name': 'Data unavailable',
+        'expiry_date': 'Data unavailable',
+        'last_digits_card_number': '****'
+      },
+      'state_friendly': 'Success',
+      'gateway_transaction_id': '938c54a7-4186-4506-bfbe-72a122da6528',
+      'events': [
+        {
+          'chargeId': 1,
+          'state:': {'status': 'started', 'finished': false},
+          'state_friendly': 'User started payment of AMOUNT',
+          'updated': "2015-12-24 13:21:05",
+          'updated_friendly': "24 January 2015 13:21:05"
+        },
+        {
+          'chargeId': 1,
+          'state:': {'status': 'created', 'finished': false},
+          'state_friendly': 'Service created payment of £10.00',
+          'updated': "2015-12-24 13:21:05",
+          'updated_friendly': "24 January 2015 13:21:05"
+        }
+      ]
+    };
+
+    var body = renderTemplate('transactions/show', templateData);
+    var $ = cheerio.load(body);
+    body.should.not.containSelector('#show-refund');
+    body.should.not.containSelector('#refunded-amount');
+    $('#arrowed').attr('href').should.equal('?reference=&email=&state=&fromDate=&fromTime=&toDate=&toTime=');
+    $('#reference').html().should.equal('&lt;123412341234&gt; &amp;');
+    $('#description').html().should.equal('First ever');
+    $('#email').html().should.equal('alice.111@mail.fake');
+    $('#amount').text().should.equal(templateData.amount);
+    $('#payment-id').text().should.equal(templateData.charge_id);
+    $('#transaction-id').text().should.equal(templateData.gateway_transaction_id);
+    $('#refunded').text().should.equal("✖");
+    $('#state').text().should.equal(templateData.state_friendly);
+    $('#brand').text().should.equal('Data unavailable');
+    $('#cardholder_name').text().should.equal('Data unavailable');
+    $('#card_number').text().should.equal('**** **** **** ****');
+    $('#card_expiry_date').text().should.equal('Data unavailable');
+
+    templateData.events.forEach(function (transactionData, ix) {
+      body.should.containSelector('table.transaction-events')
+          .havingRowAt(ix + 1)
+          .withTableDataAt(1, templateData.events[ix].state_friendly)
+          .withTableDataAt(2, templateData.events[ix].updated_friendly);
+    });
+  });
+
   it('should render transaction details when payment is not refundable', function () {
     var templateData = {
       'reference': '<123412341234> &',
@@ -91,9 +158,9 @@ describe('The transaction details view', function () {
 
     templateData.events.forEach(function (transactionData, ix) {
       body.should.containSelector('table.transaction-events')
-        .havingRowAt(ix + 1)
-        .withTableDataAt(1, templateData.events[ix].state_friendly)
-        .withTableDataAt(2, templateData.events[ix].updated_friendly);
+          .havingRowAt(ix + 1)
+          .withTableDataAt(1, templateData.events[ix].state_friendly)
+          .withTableDataAt(2, templateData.events[ix].updated_friendly);
     });
   });
 
@@ -182,9 +249,9 @@ describe('The transaction details view', function () {
 
     templateData.events.forEach(function (transactionData, ix) {
       body.should.containSelector('table.transaction-events')
-        .havingRowAt(ix + 1)
-        .withTableDataAt(1, templateData.events[ix].state_friendly)
-        .withTableDataAt(2, templateData.events[ix].updated_friendly);
+          .havingRowAt(ix + 1)
+          .withTableDataAt(1, templateData.events[ix].state_friendly)
+          .withTableDataAt(2, templateData.events[ix].updated_friendly);
     });
   });
 });


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

 * Refactoring the tests to mee the actual connector JSON response			
 * Show `card_details` values as `Data unavailable` when no data is found
    * This provides some default data when the status is `created` or `started`, or we are dealing with some legacy card data, where only `card_brand` has  data available

## HOW 
_Steps to test or reproduce:_

```
cd $WORKSPACE/pay-scripts
msl reset && msl -a up && ./run-endtoend.sh
```


