### PR TITLE
PP-1442 Add script to wait for postgres to be available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ENV NEW_RELIC_HOME /app/newrelic
 
 EXPOSE 9000
 
+RUN apt-get update && apt-get install -y postgresql-client-9.4
+
 # add package.json before source for node_module cache
 ADD package.json /tmp/package.json
 RUN cd /tmp && npm install

--- a/wait-for-postgres.sh
+++ b/wait-for-postgres.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+cmd="$1"
+
+until psql "$DATABASE_URL" -c '\l'; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "Postgres is up - executing command $cmd"
+exec $cmd


### PR DESCRIPTION
## WHAT
- We are facing issues in the docker-compose environment due to migration scripts are run when database is not ready.
- Postgres client is being used by this script so _psql_ needs to be installed in the docker image.
- **wait_for_postgres.sh** script is only used for docker-compose environment so do not expect this script to be used in here. it needs to be available in the docker image in order to be used as _entrypoint_ for the image in docker-compose: https://github.com/alphagov/pay-scripts/blob/master/all.yml#L90