### PR TITLE
PP-1408 add JPA support for adminusers

### DIFF
--- a/migrations/20161202081021-add-users-version.js
+++ b/migrations/20161202081021-add-users-version.js
@@ -1,0 +1,19 @@
+'use strict';
+var Sequel = require('sequelize');
+
+module.exports = {
+  up: function (queryInterface) {
+    return queryInterface.addColumn(
+      'users',
+      'version',
+      {
+        type: Sequel.INTEGER,
+        allowNull: false,
+        defaultValue: 0
+      });
+  },
+
+  down: function (queryInterface) {
+    return queryInterface.removeColumn('users', 'version');
+  }
+};

--- a/migrations/20161202081213-add-forgotten-passwords-version.js
+++ b/migrations/20161202081213-add-forgotten-passwords-version.js
@@ -1,0 +1,19 @@
+'use strict';
+var Sequel = require('sequelize');
+
+module.exports = {
+  up: function (queryInterface) {
+    return queryInterface.addColumn(
+      'forgotten_passwords',
+      'version',
+      {
+        type: Sequel.INTEGER,
+        allowNull: false,
+        defaultValue: 0
+      });
+  },
+
+  down: function (queryInterface) {
+    return queryInterface.removeColumn('forgotten_passwords', 'version');
+  }
+};


### PR DESCRIPTION
## WHAT
 - Until a complete `postgres` DB migration out of `selfservice` to `adminusers` we will not run any migrations from `adminusers` module (due to DB user ownership of tables).
 - These columns are are required for `adminuser`s JPA backed DAO's for handling optimistic concurrency.
 - For now defaulting to value `0`. Thereafter will be managed by JPA.