### PR TITLE
PP-1275 Add upgrade-base.sh script to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:6.7.0
 
+ADD docker/upgrade-base.sh /upgrade-base.sh
+
 ENV PORT 9000
 ENV ENABLE_NEWRELIC no
 ENV NEW_RELIC_HOME /app/newrelic


### PR DESCRIPTION
PP-1275 Add upgrade-base.sh script to container, as per the same
done in frontend. Apparently forgot to do this on the commit
from a few weeks ago.