### PR TITLE
PP-1506 Serialize/Deserialize Passport session by username

### DIFF
--- a/app/services/auth_service.js
+++ b/app/services/auth_service.js
@@ -5,7 +5,7 @@ var localStrategy = require('passport-local').Strategy;
 var TotpStrategy = require('passport-totp').Strategy;
 var paths = require(__dirname + '/../paths.js');
 var csrf = require('csrf');
-var User = require(__dirname + '/../models/user.js');
+var User = require('../models/user.js');
 var _ = require('lodash');
 var CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER;
 
@@ -99,14 +99,14 @@ var initialise = function (app, override_strategy) {
 
 };
 
-var deserializeUser = function (email, done) {
-  User.find(email).then(function(user){
+var deserializeUser = function (username, done) {
+  User.findByUsername(username).then(function(user){
     done(null, user);
   });
-}
+};
 
 var serializeUser = function (user, done) {
-  done(null, user.email);
+  done(null, user.username);
 };
 
 module.exports = {

--- a/test/services/auth_service_test.js
+++ b/test/services/auth_service_test.js
@@ -61,6 +61,40 @@ describe('auth service', function () {
     redirect.restore();
   });
 
+  describe('serialize user', function() {
+
+    it("should call done function with username", function (done) {
+      let user = {username: 'foo'};
+      let doneSpy = sinon.spy(done);
+
+      auth.serializeUser(user, doneSpy);
+
+      assert(doneSpy.calledWithExactly(null, 'foo'))
+    });
+  });
+
+  describe('deserialize user', function(){
+
+    it("should find user by username", function (done) {
+
+      let authService = (userMock)=> {
+        return proxyquire(__dirname + '/../../app/services/auth_service.js',
+          {'../models/user.js': userMock});
+      };
+
+      let user = {};
+      let doneSpy = sinon.spy(done);
+      let userMock = {
+        findByUsername: (username) => {
+          expect(username).to.be.equal('foo');
+          return {then: (suc, fail)=> suc(user)}
+        }
+      };
+
+      authService(userMock).deserializeUser('foo', doneSpy);
+      assert(doneSpy.calledWithExactly(null, user))
+    });
+  });
 
   describe('enforceUserAndSecondFactor', function () {
     it("should call next if has valid user", function (done) {


### PR DESCRIPTION
## WHAT
- Currently doing it with email can cause issue when concurrent sessions for same user email. This is caused by a temporary workaround where users can have duplicated emails (different usernames). It wasn't covered by tests in selfservice so could not be spotted. (Unlikely that this situation arises).