### PR TITLE
PP-1407 Change user_permissions helper to user_creator

### DIFF
--- a/test/integration/credentails_ft_tests.js
+++ b/test/integration/credentails_ft_tests.js
@@ -1,5 +1,5 @@
 var dbMock = require(__dirname + '/../test_helpers/db_mock.js');
-var userPermissions = require(__dirname + '/../test_helpers/user_permissions.js');
+var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
 var request = require('supertest');
 var _app = require(__dirname + '/../../server.js').getApp;
 var winston = require('winston');
@@ -59,7 +59,7 @@ describe('The ' + paths.credentials.index + ' endpoint', function () {
       email: user.email,
       telephone_number: "1"
     };
-    userPermissions.create(userAttributes, 'gateway-credentials:read', done);
+    userCreator.createUserWithPermission(userAttributes, 'gateway-credentials:read', done);
   });
 
   it('should display payment provider name in title case', function (done) {
@@ -197,7 +197,7 @@ describe('The ' + paths.credentials.edit + ' endpoint', function () {
       email: user.email,
       telephone_number: "1"
     };
-    userPermissions.create(userAttributes, 'gateway-credentials:update', done);
+    userCreator.createUserWithPermission(userAttributes, 'gateway-credentials:update', done);
   });
 
   it('should display payment provider name in title case', function (done) {
@@ -335,7 +335,7 @@ describe('The ' + paths.notificationCredentials.edit + ' endpoint', function () 
       email: user.email,
       telephone_number: "1"
     };
-    userPermissions.create(userAttributes, 'gateway-credentials:update', done);
+    userCreator.createUserWithPermission(userAttributes, 'gateway-credentials:update', done);
   });
 
   it('should display payment provider name in title case', function (done) {
@@ -473,7 +473,7 @@ describe('The notification credentials', function () {
       email: user.email,
       telephone_number: "1"
     };
-    userPermissions.create(userAttributes, 'gateway-credentials:read', done);
+    userCreator.createUserWithPermission(userAttributes, 'gateway-credentials:read', done);
   });
 
   it('should pass through the notification credentials', function (done) {
@@ -521,7 +521,7 @@ describe('The provider update credentials endpoint', function () {
       email: user.email,
       telephone_number: "1"
     };
-    userPermissions.create(userAttributes, 'gateway-credentials:update', done);
+    userCreator.createUserWithPermission(userAttributes, 'gateway-credentials:update', done);
   });
 
   it('should send new username, password and merchant_id credentials to connector', function (done) {
@@ -623,7 +623,7 @@ describe('The provider update notification credentials endpoint', function () {
       email: user.email,
       telephone_number: "1"
     };
-    userPermissions.create(userAttributes, 'gateway-credentials:update', done);
+    userCreator.createUserWithPermission(userAttributes, 'gateway-credentials:update', done);
   });
 
   it('should send new username and password notification credentials to connector', function (done) {

--- a/test/integration/dev_tokens_ft_tests.js
+++ b/test/integration/dev_tokens_ft_tests.js
@@ -1,5 +1,5 @@
 var dbMock       = require(__dirname + '/../test_helpers/db_mock.js');
-var userPermissions = require(__dirname + '/../test_helpers/user_permissions.js');
+var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
 var request      = require('supertest');
 var _app         = require(__dirname + '/../../server.js').getApp;
 var winston      = require('winston');
@@ -88,7 +88,7 @@ portfinder.getPort(function(err, freePort) {
             email: user.email,
             telephone_number: "1"
           };
-          userPermissions.create(userAttributes, 'tokens-revoked:read', done);
+          userCreator.createUserWithPermission(userAttributes, 'tokens-revoked:read', done);
         });
 
         it('should return an empty list of tokens if no tokens have been revoked yet', function (done) {
@@ -175,7 +175,7 @@ portfinder.getPort(function(err, freePort) {
             email: user.email,
             telephone_number: "1"
           };
-          userPermissions.create(userAttributes, 'tokens-active:read', done);
+          userCreator.createUserWithPermission(userAttributes, 'tokens-active:read', done);
         });
 
         it('should return an empty list of tokens if no tokens have been issued yet', function (done){
@@ -262,7 +262,7 @@ portfinder.getPort(function(err, freePort) {
           email: user.email,
           telephone_number: "1"
         };
-        userPermissions.create(userAttributes, 'tokens:update', done);
+        userCreator.createUserWithPermission(userAttributes, 'tokens:update', done);
       });
 
       it('should update the description', function (done){
@@ -340,7 +340,7 @@ portfinder.getPort(function(err, freePort) {
           email: user.email,
           telephone_number: "1"
         };
-        userPermissions.create(userAttributes, 'tokens:delete', done);
+        userCreator.createUserWithPermission(userAttributes, 'tokens:delete', done);
       });
 
       it('should revoke and existing token', function (done){
@@ -413,7 +413,7 @@ portfinder.getPort(function(err, freePort) {
             email: user.email,
             telephone_number: "1"
           };
-          userPermissions.create(userAttributes, 'tokens:create', done);
+          userCreator.createUserWithPermission(userAttributes, 'tokens:create', done);
         });
 
         it('should create a token successfully', function (done){

--- a/test/integration/pagination_ft_tests.js
+++ b/test/integration/pagination_ft_tests.js
@@ -1,5 +1,5 @@
 var dbMock = require(__dirname + '/../test_helpers/db_mock.js');
-var userPermissions = require(__dirname + '/../test_helpers/user_permissions.js');
+var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
 var request = require('supertest');
 var csrf = require('csrf');
 var nock = require('nock');
@@ -68,7 +68,7 @@ describe('Pagination', function () {
       email: user.email,
       telephone_number: "1"
     };
-    userPermissions.create(userAttributes, 'transactions:read', done);
+    userCreator.createUserWithPermission(userAttributes, 'transactions:read', done);
   });
 
   describe('Pagination', function () {

--- a/test/integration/payment_types_select_brand_ft_tests.js
+++ b/test/integration/payment_types_select_brand_ft_tests.js
@@ -1,5 +1,5 @@
 var dbMock = require(__dirname + '/../test_helpers/db_mock.js');
-var userPermissions = require(__dirname + '/../test_helpers/user_permissions.js');
+var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
 var request = require('supertest');
 var _app = require(__dirname + '/../../server.js').getApp;
 var winston = require('winston');
@@ -73,7 +73,7 @@ describe('The payment types endpoint,', function () {
         email: user.email,
         telephone_number: "1"
       };
-      userPermissions.create(userAttributes, 'payment-types:read', done);
+      userCreator.createUserWithPermission(userAttributes, 'payment-types:read', done);
     });
 
     beforeEach(function () {
@@ -263,7 +263,7 @@ describe('The payment types endpoint,', function () {
         email: user.email,
         telephone_number: "1"
       };
-      userPermissions.create(userAttributes, 'payment-types:update', done);
+      userCreator.createUserWithPermission(userAttributes, 'payment-types:update', done);
     });
 
     it('should post debit and credit card options if accepted type is debit and credit cards', function (done) {

--- a/test/integration/payment_types_select_summary_ft_tests.js
+++ b/test/integration/payment_types_select_summary_ft_tests.js
@@ -1,5 +1,5 @@
 var dbMock = require(__dirname + '/../test_helpers/db_mock.js');
-var userPermissions = require(__dirname + '/../test_helpers/user_permissions.js');
+var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
 var request = require('supertest');
 var _app = require(__dirname + '/../../server.js').getApp;
 var winston = require('winston');
@@ -62,7 +62,7 @@ describe('The payment types endpoint,', function () {
         email: user.email,
         telephone_number: "1"
       };
-      userPermissions.create(userAttributes, 'payment-types:read', done);
+      userCreator.createUserWithPermission(userAttributes, 'payment-types:read', done);
     });
 
     it('should show all the card type options that have been previously accepted', function (done) {

--- a/test/integration/payment_types_select_type_ft_tests.js
+++ b/test/integration/payment_types_select_type_ft_tests.js
@@ -1,5 +1,5 @@
 var dbMock = require(__dirname + '/../test_helpers/db_mock.js');
-var userPermissions = require(__dirname + '/../test_helpers/user_permissions.js');
+var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
 var request = require('supertest');
 var _app = require(__dirname + '/../../server.js').getApp;
 var winston = require('winston');
@@ -54,7 +54,7 @@ describe('The payment types endpoint,', function () {
         email: user.email,
         telephone_number: "1"
       };
-      userPermissions.create(userAttributes, 'payment-types:read', done);
+      userCreator.createUserWithPermission(userAttributes, 'payment-types:read', done);
     });
 
     beforeEach(function () {
@@ -168,7 +168,7 @@ describe('The payment types endpoint,', function () {
         email: user.email,
         telephone_number: "1"
       };
-      userPermissions.create(userAttributes, 'payment-types:update', done);
+      userCreator.createUserWithPermission(userAttributes, 'payment-types:update', done);
     });
 
     it('should redirect to select brand view when debit cards option selected', function (done) {

--- a/test/integration/service_name_ft_tests.js
+++ b/test/integration/service_name_ft_tests.js
@@ -1,5 +1,5 @@
 var dbMock = require(__dirname + '/../test_helpers/db_mock.js');
-var userPermissions = require(__dirname + '/../test_helpers/user_permissions.js');
+var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
 var request = require('supertest');
 var _app = require(__dirname + '/../../server.js').getApp;
 var winston = require('winston');
@@ -68,7 +68,7 @@ function build_form_post_request(path, sendData, sendCSRF) {
           email: user.email,
           telephone_number: "1"
         };
-        userPermissions.create(userAttributes, 'service-name:read', done);
+        userCreator.createUserWithPermission(userAttributes, 'service-name:read', done);
       });
 
       it('should display received service name from connector', function (done) {
@@ -133,7 +133,7 @@ describe('The provider update service name endpoint', function () {
       email: user.email,
       telephone_number: "1"
     };
-    userPermissions.create(userAttributes, 'service-name:update', done);
+    userCreator.createUserWithPermission(userAttributes, 'service-name:update', done);
   });
 
   it('should send new service name to connector', function (done) {

--- a/test/integration/transaction_details_ft_tests.js
+++ b/test/integration/transaction_details_ft_tests.js
@@ -1,7 +1,7 @@
 var request     = require('supertest');
 var nock        = require('nock');
 var dbMock      = require(__dirname + '/../test_helpers/db_mock.js');
-var userPermissions = require(__dirname + '/../test_helpers/user_permissions.js');
+var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
 var _app        = require(__dirname + '/../../server.js').getApp;
 var winston     = require('winston');
 var paths       = require(__dirname + '/../../app/paths.js');
@@ -45,7 +45,7 @@ describe('The transaction view scenarios', function () {
       email: user.email,
       telephone_number: "1"
     };
-    userPermissions.create(userAttributes, 'transactions-details:read', done);
+    userCreator.createUserWithPermission(userAttributes, 'transactions-details:read', done);
   });
 
   describe('The transaction history endpoint', function () {

--- a/test/integration/transaction_details_refunds_ft_tests.js
+++ b/test/integration/transaction_details_refunds_ft_tests.js
@@ -5,7 +5,7 @@ var _app = require(__dirname + '/../../server.js').getApp;
 var winston = require('winston');
 var paths = require(__dirname + '/../../app/paths.js');
 var session = require(__dirname + '/../test_helpers/mock_session.js');
-var userPermissions = require(__dirname + '/../test_helpers/user_permissions.js');
+var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
 
 var ACCOUNT_ID = 15486734;
 var app = session.mockValidAccount(_app, ACCOUNT_ID);
@@ -26,7 +26,7 @@ describe('The transaction view - refund scenarios', function () {
       email: user.email,
       telephone_number: "1"
     };
-    userPermissions.create(userAttributes, 'refunds:create', done);
+    userCreator.createUserWithPermission(userAttributes, 'refunds:create', done);
   });
 
   // known FP issue with node, it cannot mulitply 19.90 by 100 accurately

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -1,6 +1,6 @@
 process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk';
 var dbMock = require(__dirname + '/../test_helpers/db_mock.js');
-var userPermissions = require(__dirname + '/../test_helpers/user_permissions.js');
+var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
 var request = require('supertest');
 var nock = require('nock');
 var _ = require('lodash');
@@ -57,7 +57,7 @@ describe('Transaction download endpoints', function () {
       email: user.email,
       telephone_number: "1"
     };
-    userPermissions.create(userAttributes, 'transactions-download:read', done);
+    userCreator.createUserWithPermission(userAttributes, 'transactions-download:read', done);
   });
 
   describe('The /transactions/download endpoint', function () {

--- a/test/integration/transaction_list_ft_tests.js
+++ b/test/integration/transaction_list_ft_tests.js
@@ -1,5 +1,5 @@
 var dbMock = require(__dirname + '/../test_helpers/db_mock.js');
-var userPermissions = require(__dirname + '/../test_helpers/user_permissions.js');
+var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
 var request = require('supertest');
 var nock = require('nock');
 var _app = require(__dirname + '/../../server.js').getApp;
@@ -66,7 +66,7 @@ describe('Transactions endpoints', function () {
         email: user.email,
         telephone_number: "1"
       };
-      userPermissions.create(userAttributes, 'transactions:read', done);
+      userCreator.createUserWithPermission(userAttributes, 'transactions:read', done);
     });
 
     beforeEach(function () {

--- a/test/integration/transaction_search_ft_tests.js
+++ b/test/integration/transaction_search_ft_tests.js
@@ -1,5 +1,5 @@
 var dbMock = require(__dirname + '/../test_helpers/db_mock.js');
-var userPermissions = require(__dirname + '/../test_helpers/user_permissions.js');
+var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
 var request = require('supertest');
 var csrf = require('csrf');
 var nock = require('nock');
@@ -66,7 +66,7 @@ describe('Transactions endpoints', function () {
         email: user.email,
         telephone_number: "1"
       };
-      userPermissions.create(userAttributes, 'transactions:read', done);
+      userCreator.createUserWithPermission(userAttributes, 'transactions:read', done);
     });
 
     beforeEach(function () {

--- a/test/test_helpers/user_creator.js
+++ b/test/test_helpers/user_creator.js
@@ -12,7 +12,7 @@ function sync_db() {
     .then(() => UserRole.sequelize.sync({force: true}))
 }
 
-function create(user, permissionName, cb) {
+function createUserWithPermission(user, permissionName, cb) {
   var roleDef;
   var permissionDef;
   sync_db()
@@ -25,6 +25,11 @@ function create(user, permissionName, cb) {
     .then(()=> cb());
 }
 
+function createUser(user, cb) {
+  createUserWithPermission(user, 'meaningless-permission-needed-by-Sequelize', cb);
+}
+
 module.exports = {
-  create: create
+  createUserWithPermission: createUserWithPermission,
+  createUser: createUser
 };


### PR DESCRIPTION
`test_helpers/user_permissions` actually has more general use for creating a user in a given state in the DB. Rename module and methods to make this clear, and add new generic `createUser` method.

with @alexbishop1