### PR TITLE
Quoting csv content

### DIFF
--- a/app/utils/json_to_csv.js
+++ b/app/utils/json_to_csv.js
@@ -9,8 +9,7 @@ module.exports = function (data) {
   json2csv(
     {
       data: data,
-      default: 'NULL',
-      quotes: "",
+      defaultValue: "",
       fields: [
         {
           label: 'Reference',

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "hogan.js": "3.0.x",
     "html5shiv": "3.7.x",
     "http-proxy": "1.14.x",
-    "json2csv": "3.4.x",
+    "json2csv": "3.7.x",
     "lodash": "4.13.x",
     "luhn": "2.1.x",
     "minimist": "0.0.x",

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -148,19 +148,19 @@ describe('Transaction download endpoints', function () {
           var csvContent = res.text;
           var arrayOfLines = csvContent.split("\n");
           assert(5, arrayOfLines.length);
-          assert.equal('red,desc-red,alice.111@mail.fake,123.45,Visa,TEST01,12/19,4242,succeeded,false,,,transaction-1,charge1,12 May 2016 — 17:37:29', arrayOfLines[1]);
-          assert.equal('blue,desc-blue,alice.222@mail.fake,9.99,Mastercard,TEST02,12/19,4241,canceled,true,P01234,Something happened,transaction-2,charge2,12 Apr 2015 — 19:55:29', arrayOfLines[2]);
+          assert.equal('"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"', arrayOfLines[1]);
+          assert.equal('"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","canceled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"', arrayOfLines[2]);
         })
         .end(function (err, res) {
           if (err) return done(err);
           var csvContent = res.text;
           var arrayOfLines = csvContent.split("\n");
           expect(arrayOfLines.length).to.equal(5);
-          expect(arrayOfLines[0]).to.equal('Reference,Description,Email,Amount,Card Brand,Cardholder Name,Card Expiry Date,Card Number,State,Finished,Error Code,Error Message,Provider ID,GOV.UK Payment ID,Date Created');
-          expect(arrayOfLines[1]).to.equal('red,desc-red,alice.111@mail.fake,123.45,Visa,TEST01,12/19,4242,succeeded,false,,,transaction-1,charge1,12 May 2016 — 17:37:29');
-          expect(arrayOfLines[2]).to.equal('blue,desc-blue,alice.222@mail.fake,9.99,Mastercard,TEST02,12/19,4241,canceled,true,P01234,Something happened,transaction-2,charge2,12 Apr 2015 — 19:55:29');
-          expect(arrayOfLines[3]).to.equal('red,desc-red,alice.111@mail.fake,12.34,Visa,TEST01,12/19,4242,succeeded,false,,,transaction-1,charge1,12 May 2016 — 17:37:29');
-          expect(arrayOfLines[4]).to.equal('blue,desc-blue,alice.222@mail.fake,1.23,Mastercard,TEST02,12/19,4241,canceled,true,P01234,Something happened,transaction-2,charge2,12 Apr 2015 — 19:55:29');
+          expect(arrayOfLines[0]).to.equal('"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Date Created"');
+          expect(arrayOfLines[1]).to.equal('"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"');
+          expect(arrayOfLines[2]).to.equal('"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","canceled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"');
+          expect(arrayOfLines[3]).to.equal('"red","desc-red","alice.111@mail.fake","12.34","Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"');
+          expect(arrayOfLines[4]).to.equal('"blue","desc-blue","alice.222@mail.fake","1.23","Mastercard","TEST02","12/19","4241","canceled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"');
           done()
         });
     });


### PR DESCRIPTION
Requires https://github.com/alphagov/pay-endtoend/pull/315 to be merged

- The csv content is not double-quoted and as a result when content
  (i.e. description of charge) has a comma, the csv format is wrong.
- The json2csv library does add the quotes by default. But because we had
  the `quote` option with a 2 double quotes, the library has failed to do it.
  The configuration is removed so we get the default behaviour.
- The value for `finished` is a boolean and the library doesn't wrap this around
  double quote. We could override the behaviour by a custom function to do a
  toString() on the boolean, but that seems unnecessary.
- The `defaultValue` configuration is added to provide an empty string by default.
- Updated the version of the library as it has bug fixes.
- A ticked was raised for this as well - https://gaap.deskpro.com/agent/#app.tickets,inbox:agent,t.o:3042,vis:7


