### PR TITLE
PP-1715 No logging CSRF tokens

### DIFF
--- a/app/services/auth_service.js
+++ b/app/services/auth_service.js
@@ -20,7 +20,7 @@ var ensureSessionHasCsrfSecret = function (req, res, next) {
   if (req.session.csrfSecret) return next();
   req.session.csrfSecret = csrf().secretSync();
   var correlationId = req.headers[CORRELATION_HEADER] ||'';
-  logger.info(`[${correlationId}] Saved csrfSecret: ${req.session.csrfSecret}`);
+  logger.debug(`[${correlationId}] Saved csrfSecret: ${req.session.csrfSecret}`);
 
   return next();
 };


### PR DESCRIPTION
## WHAT
- They are not really useful for debugging and this data could be potentially helpful to an attacker.
- Changed logging from _Info_ level to _Debug._

