### PR TITLE
PP-1584 Add toggle for 3D Secure to self-service

### DIFF
--- a/app/controllers/toggle_3ds_controller.js
+++ b/app/controllers/toggle_3ds_controller.js
@@ -1,0 +1,93 @@
+var logger    = require('winston');
+var csrf                  = require('csrf');
+var response              = require('../utils/response.js').response;
+var auth                  = require('../services/auth_service.js');
+var router                = require('../routes.js');
+var renderErrorView       = require('../utils/response.js').renderErrorView;
+var ConnectorClient       = require('../services/clients/connector_client.js').ConnectorClient;
+var CORRELATION_HEADER    = require('../utils/correlation_header.js').CORRELATION_HEADER;
+
+module.exports.index = function (req, res) {
+  var correlationId = req.headers[CORRELATION_HEADER] || '';
+
+  var init = function () {
+    var accountId = auth.getCurrentGatewayAccountId(req);
+
+    var params = {
+      gatewayAccountId: accountId,
+      correlationId: correlationId
+    };
+
+    connectorClient()
+      .getAccount(params, onSuccess)
+      .on('connectorError', onError);
+  };
+
+  var onSuccess = function (data) {
+    var model = {
+      requires3ds: data.requires3ds,
+      justToggled: typeof req.query.toggled !== 'undefined'
+    };
+
+    show(req, res, 'index', model);
+  };
+
+  var onError = function (connectorError) {
+    renderErrorView(req, res, 'Unable to retrieve the 3D Secure setting.');
+  };
+
+  init();
+};
+
+module.exports.onConfirm = (req, res) => {
+  show(req, res,  "on_confirm", {});
+};
+
+module.exports.on = function (req, res) {
+    toggle(req, res, true)
+};
+
+module.exports.off = function (req, res) {
+    toggle(req, res, false)
+};
+
+var connectorClient = function () {
+  return new ConnectorClient(process.env.CONNECTOR_URL);
+};
+
+var show = function(req, res, resource, data) {
+  var template =  "3d_secure/" + resource;
+  response(req, res, template, data);
+};
+
+var toggle = function (req, res, trueOrFalse) {
+  var correlationId = req.headers[CORRELATION_HEADER] ||'';
+
+  var init = function () {
+    var accountId = auth.getCurrentGatewayAccountId(req);
+
+    var payload = {
+      toggle_3ds: trueOrFalse
+    };
+
+    var params = {
+      gatewayAccountId: accountId,
+      payload : payload,
+      correlationId: correlationId
+    };
+
+    connectorClient()
+      .update3dsEnabled(params, onSuccess)
+      .on('connectorError', onError);
+  };
+
+  var onSuccess = function () {
+    res.redirect(303, router.paths.toggle3ds.index + '?toggled');
+  };
+
+  var onError = function () {
+    renderErrorView(req, res, 'Unable to toggle 3D Secure.');
+  };
+
+  init();
+}

--- a/app/paths.js
+++ b/app/paths.js
@@ -61,6 +61,12 @@ module.exports = {
     on: '/email-notifications/on'
 
   },
+  toggle3ds: {
+    index: '/3ds',
+    onConfirm: '/3ds/confirm',
+    on: '/3ds/on',
+    off: '/3ds/off'
+  },
   healthcheck: {
     path: '/healthcheck'
   },

--- a/app/routes.js
+++ b/app/routes.js
@@ -10,6 +10,7 @@ var paymentTypesSelectType = require('./controllers/payment_types_select_type_co
 var paymentTypesSelectBrand = require('./controllers/payment_types_select_brand_controller.js');
 var paymentTypesSummary = require('./controllers/payment_types_summary_controller.js');
 var emailNotifications = require('./controllers/email_notifications_controller.js');
+var toggle3ds = require('./controllers/toggle_3ds_controller.js');
 var forgotPassword = require('./controllers/forgotten_password_controller.js');
 
 var static = require('./controllers/static_controller.js');
@@ -111,6 +112,13 @@ module.exports.bind = function (app) {
   app.post(en.off, auth.enforceUserAuthenticated, csrf, permission('email-notification-toggle:update'), retrieveAccount, emailNotifications.off);
   app.get(en.offConfirm, auth.enforceUserAuthenticated, csrf, permission('email-notification-toggle:update'), retrieveAccount, emailNotifications.offConfirm);
   app.post(en.on, auth.enforceUserAuthenticated, csrf, permission('email-notification-toggle:update'), retrieveAccount, emailNotifications.on);
+
+  // 3D SECURE TOGGLE
+  var t3ds = paths.toggle3ds;
+  app.get(t3ds.index, auth.enforceUserAuthenticated, csrf, permission('toggle-3ds:read'), toggle3ds.index);
+  app.post(t3ds.onConfirm, auth.enforceUserAuthenticated, csrf, permission('toggle-3ds:update'), toggle3ds.onConfirm);
+  app.post(t3ds.on, auth.enforceUserAuthenticated, csrf, permission('toggle-3ds:update'), toggle3ds.on);
+  app.post(t3ds.off, auth.enforceUserAuthenticated, csrf, permission('toggle-3ds:update'), toggle3ds.off);
 
   // HEALTHCHECK
   var hc = paths.healthcheck;

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -23,6 +23,7 @@ var ACCEPTED_CARD_TYPES_FRONTEND_PATH = ACCOUNT_FRONTEND_PATH + '/card-types';
 var ACCOUNT_NOTIFICATION_CREDENTIALS_PATH = '/v1/api/accounts' + '/{accountId}' + '/notification-credentials';
 var ACCOUNT_CREDENTIALS_PATH = ACCOUNT_FRONTEND_PATH + '/credentials';
 var EMAIL_NOTIFICATION__PATH = '/v1/api/accounts/{accountId}/email-notification';
+var TOGGLE_3DS_PATH = ACCOUNTS_FRONTEND_PATH + '/{accountId}/3ds-toggle';
 
 /**
  * @private
@@ -103,6 +104,11 @@ function _chargeRefundsUrlFor(gatewayAccountId, chargeId, url) {
 /** @private */
 var _getNotificationEmailUrlFor = function(accountID){
   return process.env.CONNECTOR_URL + EMAIL_NOTIFICATION__PATH.replace("{accountId}", accountID);
+};
+
+/** @private */
+var _getToggle3dsUrlFor = function(accountID){
+  return process.env.CONNECTOR_URL + TOGGLE_3DS_PATH.replace("{accountId}", accountID);
 };
 
 function _options(url) {
@@ -448,7 +454,18 @@ ConnectorClient.prototype = {
     baseClient.patch(url, params, this.responseHandler(successCallback));
 
     return this;
-  }
+  },
+
+    /**
+     *
+     * @param {Object} params
+     * @param {Function} successCallback
+     */
+    update3dsEnabled: function(params, successCallback) {
+      var url = _getToggle3dsUrlFor(params.gatewayAccountId);
+      baseClient.patch(url, params, this.responseHandler(successCallback));
+      return this;
+    }
 };
 
 util.inherits(ConnectorClient, EventEmitter);

--- a/app/views/3d_secure/index.html
+++ b/app/views/3d_secure/index.html
@@ -1,0 +1,75 @@
+{{< layout}}
+
+{{$pageTitle}}
+GOV.UK Pay - 3D Secure
+{{/pageTitle}}
+
+{{$content}}
+
+<div class="column-two-thirds">
+
+{{#permissions.toggle_3ds_read}}
+{{#justToggled}}
+<div id="3ds-toggled" class="govuk-box-highlight">
+{{#requires3ds}}
+    <p>3D Secure is turned on for this service</p>
+{{/requires3ds}}
+{{^requires3ds}}
+    <p>3D Secure is turned off for this service</p>
+{{/requires3ds}}
+</div>
+{{/justToggled}}
+{{/permissions.toggle_3ds_read}}
+
+<h1 class="page-title">3D Secure</h1>
+
+<p>3D Secure (3DS) adds an extra layer of authentication to user payments. This can help reduce fraud, but also makes it <strong class="bold-small">harder for your service users to complete payments.</strong></p>
+<p><strong class="bold-small">Verified by Visa</strong> and <strong class="bold-small">MasterCard SecureCode</strong> are common examples of 3D Secure.</p>
+
+{{^requires3ds}}
+{{#permissions.toggle_3ds_read}}
+<h2 id="3ds-status" class="heading-medium remove-top-margin">3D Secure is off</h2>
+{{/permissions.toggle_3ds_read}}
+
+{{#permissions.toggle_3ds_update}}
+<div class="panel panel-border-wide">
+    <h2 class="heading-small">Activating 3D Secure</h2>
+    <p>Check with your Worldpay account manager that your merchant code has been configured to support 3D Secure. Read more about this in our <a href="https://gds-payments.gelato.io/docs/versions/1.0.0/switching-to-production">technical documentation</a>.</p>
+</div>
+
+<p>Once that’s done, you can turn on 3D Secure for all payments to your service.</p>
+
+<form class="permission-main" method="post" action="{{routes.toggle3ds.onConfirm}}">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    <div class="form-group">
+        <input id="3ds-on-button" class="button" type="submit" value="Turn on 3D Secure">
+    </div>
+</form>
+{{/permissions.toggle_3ds_update}}
+{{/requires3ds}}
+
+{{#requires3ds}}
+{{#permissions.toggle_3ds_read}}
+<h2 id="3ds-status" class="heading-medium remove-top-margin">3D Secure is activated</h2>
+
+<div class="panel panel-border-wide">
+    <h2 class="heading-small">Having problems with 3D Secure?</h2>
+    <p>If 3D Secure isn’t working on your service’s payment pages you’ll need to check with your Worldpay account manager that your merchant code has been configured to support 3D Secure.</p>
+</div>
+{{/permissions.toggle_3ds_read}}
+
+{{#permissions.toggle_3ds_update}}
+<form class="permission-main" method="post" action="{{routes.toggle3ds.off}}">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    <div class="form-group">
+        <input id="3ds-off-button" class="button" type="submit" value="Turn off 3D Secure">
+    </div>
+</form>
+{{/permissions.toggle_3ds_update}}
+{{/requires3ds}}
+
+</div>
+
+{{/content}}
+
+{{/layout}}

--- a/app/views/3d_secure/on_confirm.html
+++ b/app/views/3d_secure/on_confirm.html
@@ -1,0 +1,31 @@
+{{< layout}}
+
+{{$pageTitle}}
+GOV.UK Pay - Activate 3D Secure
+{{/pageTitle}}
+
+{{$content}}
+
+<div class="column-two-thirds">
+
+<h1 class="page-title">3D Secure</h1>
+
+{{#permissions.toggle_3ds_update}}
+<h2 class="heading-medium remove-top-margin">Has your merchant code been configured to support 3D Secure?</h2>
+<p>If you haven’t confirmed this with Worldpay, 3D Secure won’t work on your service’s payment pages.</p>
+
+
+<form class="permission-main" method="post" action="{{routes.toggle3ds.on}}">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    <div class="form-group">
+        <input id="3ds-confirm-on-button" class="button" type="submit" value="Yes, turn on 3D secure">
+    </div>
+    <a href="{{routes.toggle3ds.index}}" class="remove-cancel">No, cancel</a>
+</form>
+
+</div>
+{{/permissions.toggle_3ds_update}}
+
+{{/content}}
+
+{{/layout}}

--- a/app/views/staff_frontend_template.html
+++ b/app/views/staff_frontend_template.html
@@ -57,6 +57,9 @@
                     {{#permissions.payment_types_read}}
                     <li><a href="{{ routes.paymentTypes.summary }}">Payment types</a></li>
                     {{/permissions.payment_types_read}}
+                    {{#permissions.toggle_3ds_read}}
+                    <li><a href="{{ routes.toggle3ds.index }}">3D Secure</a></li>
+                    {{/permissions.toggle_3ds_read}}
                     {{#permissions.email_notification_template_read}}
                     <li><a href="{{ routes.emailNotifications.index }}">Email notifications</a></li>
                     {{/permissions.email_notification_template_read}}

--- a/test/integration/toggle_3ds_ft_tests.js
+++ b/test/integration/toggle_3ds_ft_tests.js
@@ -1,0 +1,294 @@
+require(__dirname + '/../test_helpers/serialize_mock.js');
+var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
+var request = require('supertest');
+var getApp = require(__dirname + '/../../server.js').getApp;
+var nock = require('nock');
+var should = require('chai').should();
+var paths = require(__dirname + '/../../app/paths.js');
+var session = require(__dirname + '/../test_helpers/mock_session.js');
+var csrf = require('csrf');
+
+var ACCOUNT_ID = 182364;
+
+var app;
+
+var requestId = 'unique-request-id';
+var aCorrelationHeader = {
+  reqheaders: {'x-request-id': requestId}
+};
+
+var CONNECTOR_ACCOUNT_PATH = "/v1/frontend/accounts/" + ACCOUNT_ID;
+var CONNECTOR_TOGGLE_3DS_PATH = CONNECTOR_ACCOUNT_PATH + "/3ds-toggle";
+var connectorMock = nock(process.env.CONNECTOR_URL, aCorrelationHeader);
+
+function build_get_request(path, app) {
+  return request(app)
+    .get(path)
+    .set('Accept', 'application/json')
+    .set('x-request-id',requestId);
+}
+
+function build_form_post_request(path, sendData, sendCSRF, app) {
+  sendCSRF = (sendCSRF === undefined) ? true : sendCSRF;
+  if (sendCSRF) {
+    sendData.csrfToken = csrf().create('123');
+  }
+  return request(app)
+    .post(path)
+    .set('Accept', 'application/json')
+    .set('Content-Type', 'application/x-www-form-urlencoded')
+    .set('x-request-id',requestId)
+    .send(sendData);
+}
+
+describe('The 3D Secure index endpoint', function () {
+  afterEach(function () {
+    nock.cleanAll();
+    app = null;
+  });
+
+  beforeEach(function (done) {
+    let permissions = 'toggle-3ds:read';
+    var user = session.getUser({
+      gateway_account_ids: [ACCOUNT_ID], permissions: [permissions]
+    });
+    app = session.getAppWithLoggedInUser(getApp(), user);
+
+    userCreator.mockUserResponse(user.toJson(), done);
+  });
+
+  it('should display if 3D Secure is on', function (done) {
+    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+      .reply(200, {
+        "requires3ds": true
+      });
+
+    var expectedData = {
+      requires3ds: true,
+      justToggled: false,
+      permissions: {
+        'toggle_3ds_read': true
+      }
+    };
+
+    build_get_request(paths.toggle3ds.index, app)
+      .expect(200, expectedData)
+      .end(done);
+  });
+
+  it('should display if 3D Secure is on and has just been toggled', function (done) {
+    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+      .reply(200, {
+        "requires3ds": true
+      });
+
+    var expectedData = {
+      requires3ds: true,
+      justToggled: true,
+      permissions: {
+        'toggle_3ds_read': true
+      }
+    };
+
+    build_get_request(paths.toggle3ds.index + '?toggled', app)
+      .expect(200, expectedData)
+      .end(done);
+  });
+
+   it('should display if 3D Secure is off', function (done) {
+     connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+       .reply(200, {
+         "requires3ds": false
+       });
+
+     var expectedData = {
+       requires3ds: false,
+       justToggled: false,
+       permissions: {
+         'toggle_3ds_read': true
+       }
+     };
+
+     build_get_request(paths.toggle3ds.index, app)
+       .expect(200, expectedData)
+       .end(done);
+   });
+
+   it('should display if 3D Secure is off and has just been toggled', function (done) {
+     connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+       .reply(200, {
+         "requires3ds": false
+       });
+
+     var expectedData = {
+       requires3ds: false,
+       justToggled: true,
+       permissions: {
+         'toggle_3ds_read': true
+       }
+     };
+
+     build_get_request(paths.toggle3ds.index + '?toggled', app)
+       .expect(200, expectedData)
+       .end(done);
+   });
+
+  it('should display an error if the account does not exist', function (done) {
+    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+      .reply(404, {
+        "message": "The gateway account id '" + ACCOUNT_ID + "' does not exist"
+      });
+
+    build_get_request(paths.toggle3ds.index, app)
+      .expect(200, {"message": "Unable to retrieve the 3D Secure setting."})
+      .end(done);
+  });
+
+  it('should display an error if connector returns any other error', function (done) {
+    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+      .reply(999, {
+        "message": "Some error in Connector"
+      });
+
+    build_get_request(paths.toggle3ds.index, app)
+      .expect(200, {"message": "Unable to retrieve the 3D Secure setting."})
+      .end(done);
+  });
+
+  it('should display an error if the connection to connector fails', function (done) {
+    // No connectorMock defined on purpose to mock a network failure
+    build_get_request(paths.toggle3ds.index, app)
+      .expect(200, {"message": "Unable to retrieve the 3D Secure setting."})
+      .end(done);
+  });
+});
+
+describe('The turn on 3D Secure endpoint', function () {
+
+  afterEach(function () {
+    nock.cleanAll();
+    app = null;
+  });
+
+  beforeEach(function (done) {
+    let permissions = 'toggle-3ds:update';
+    var user = session.getUser({
+      gateway_account_ids: [ACCOUNT_ID], permissions: [permissions]
+    });
+    app = session.getAppWithLoggedInUser(getApp(), user);
+
+    userCreator.mockUserResponse(user.toJson(), done);
+  });
+
+  it('should tell connector to turn on 3D Secure', function (done) {
+    connectorMock.patch(CONNECTOR_TOGGLE_3DS_PATH, {"toggle_3ds": true})
+      .reply(200, {});
+
+    build_form_post_request(paths.toggle3ds.on, {}, true, app)
+      .expect(303, {})
+      .expect('Location', paths.toggle3ds.index + '?toggled')
+      .end(done);
+  });
+
+  it('should display an error if connector returns failure', function (done) {
+    connectorMock.patch(CONNECTOR_TOGGLE_3DS_PATH, {"toggle_3ds": true})
+      .reply(999, {
+        "message": "Error message"
+      });
+
+    build_form_post_request(paths.toggle3ds.on, {}, true, app)
+      .expect(200, {"message": "Unable to toggle 3D Secure."})
+      .end(done);
+  });
+
+  it('should display an error if the connection to connector fails', function (done) {
+    // No connectorMock defined on purpose to mock a network failure
+    build_form_post_request(paths.toggle3ds.on, {}, true, app)
+      .expect(200, {"message": "Unable to toggle 3D Secure."})
+      .end(done);
+  });
+
+  it('should display an error if CSRF token does not exist', function (done) {
+    build_form_post_request(paths.toggle3ds.on, {}, false, app)
+      .expect(200, {message: "There is a problem with the payments platform"})
+      .end(done);
+  });
+});
+
+describe('The turn off 3D Secure endpoint', function () {
+
+  afterEach(function () {
+    nock.cleanAll();
+    app = null;
+  });
+
+  beforeEach(function (done) {
+    let permissions = 'toggle-3ds:update';
+    var user = session.getUser({
+      gateway_account_ids: [ACCOUNT_ID], permissions: [permissions]
+    });
+    app = session.getAppWithLoggedInUser(getApp(), user);
+
+    userCreator.mockUserResponse(user.toJson(), done);
+  });
+
+  it('should tell connector to turn off 3D Secure', function (done) {
+    connectorMock.patch(CONNECTOR_TOGGLE_3DS_PATH, {"toggle_3ds": false})
+      .reply(200, {});
+
+    build_form_post_request(paths.toggle3ds.off, {}, true, app)
+      .expect(303, {})
+      .expect('Location', paths.toggle3ds.index + '?toggled')
+      .end(done);
+  });
+
+  it('should display an error if connector returns failure', function (done) {
+    connectorMock.patch(CONNECTOR_TOGGLE_3DS_PATH, {"toggle_3ds": false})
+      .reply(999, {
+        "message": "Error message"
+      });
+
+    build_form_post_request(paths.toggle3ds.off, {}, true, app)
+      .expect(200, {"message": "Unable to toggle 3D Secure."})
+      .end(done);
+  });
+
+  it('should display an error if the connection to connector fails', function (done) {
+    // No connectorMock defined on purpose to mock a network failure
+    build_form_post_request(paths.toggle3ds.off, {}, true, app)
+      .expect(200, {"message": "Unable to toggle 3D Secure."})
+      .end(done);
+  });
+
+  it('should display an error if CSRF token does not exist', function (done) {
+    build_form_post_request(paths.toggle3ds.off, {}, false, app)
+      .expect(200, {message: "There is a problem with the payments platform"})
+      .end(done);
+  });
+
+});
+
+describe('The confirm that you want to turn on 3D Secure endpoint', function () {
+
+  afterEach(function () {
+    nock.cleanAll();
+    app = null;
+  });
+
+  beforeEach(function (done) {
+    let permissions = 'toggle-3ds:update';
+    var user = session.getUser({
+      gateway_account_ids: [ACCOUNT_ID], permissions: [permissions]
+    });
+    app = session.getAppWithLoggedInUser(getApp(), user);
+
+    userCreator.mockUserResponse(user.toJson(), done);
+  });
+
+  it('should display an error if CSRF token does not exist', function (done) {
+    build_form_post_request(paths.toggle3ds.onConfirm, {}, false, app)
+      .expect(200, {message: "There is a problem with the payments platform"})
+      .end(done);
+  });
+
+});

--- a/test/ui/toggle_3ds_ui_tests.js
+++ b/test/ui/toggle_3ds_ui_tests.js
@@ -1,0 +1,225 @@
+let should = require('chai').should();
+let renderTemplate = require(__dirname + '/../test_helpers/html_assertions.js').render;
+let paths = require(__dirname + '/../../app/paths.js');
+
+describe('The toggle 3D Secure page when 3D Secure is off', function () {
+
+  it('should say that 3D Secure is off but not show the toggle button if the user only has read permission', function () {
+
+    let templateData = {
+     "requires3ds": false,
+      permissions: {
+        toggle_3ds_read: true
+      }
+    };
+
+    let body = renderTemplate('3d_secure/index', templateData);
+
+    body.should.containSelector('#3ds-status').withExactText('3D Secure is off');
+    body.should.containNoSelector('#3ds-on-button');
+    body.should.containNoSelector('#3ds-off-button');
+  });
+
+  it('should say not that 3D Secure is off if the user does not have read permission', function () {
+
+    let templateData = {
+      "requires3ds": false,
+      permissions: {
+        toggle_3ds_read: false
+      }
+    };
+
+    let body = renderTemplate('3d_secure/index', templateData);
+
+    body.should.containNoSelector('#3ds-status');
+  });
+
+  it('should show the toggle button if the user also has update permission', function () {
+
+    let templateData = {
+      "requires3ds": false,
+      permissions: {
+        toggle_3ds_read: true,
+        toggle_3ds_update: true
+      }
+    };
+
+    let body = renderTemplate('3d_secure/index', templateData);
+
+    body.should.containSelector('#3ds-on-button');
+    body.should.containNoSelector('#3ds-off-button');
+  });
+
+  it('should show the highlight if the permission has just been toggled and the user has read permission', function () {
+
+    let templateData = {
+      "requires3ds": false,
+      "justToggled": true,
+      permissions: {
+        toggle_3ds_read: true,
+      }
+    };
+
+    let body = renderTemplate('3d_secure/index', templateData);
+
+    body.should.containSelector('#3ds-toggled').withText('3D Secure is turned off for this service');
+  });
+
+  it('should not show the highlight if the permission has just been toggled and the user does not has read permission', function () {
+
+    let templateData = {
+      "requires3ds": false,
+      "justToggled": true,
+      permissions: {
+        toggle_3ds_read: false,
+      }
+    };
+
+    let body = renderTemplate('3d_secure/index', templateData);
+
+    body.should.containNoSelector('#3ds-toggled');
+  });
+
+  it('should not show the highlight if the permission has not been toggled and the user has read permission', function () {
+
+    let templateData = {
+      "requires3ds": false,
+      "justToggled": false,
+      permissions: {
+        toggle_3ds_read: true,
+      }
+    };
+
+    let body = renderTemplate('3d_secure/index', templateData);
+
+    body.should.containNoSelector('#3ds-toggled');
+  });
+
+});
+
+describe('The toggle 3D Secure page when 3D Secure is on', function () {
+
+  it('should say that 3D Secure is on but not show the toggle button if the user only has read permission', function () {
+
+    let templateData = {
+     "requires3ds": true,
+      permissions: {
+        toggle_3ds_read: true
+      }
+    };
+
+    let body = renderTemplate('3d_secure/index', templateData);
+
+    body.should.containSelector('#3ds-status').withExactText('3D Secure is activated');
+    body.should.containNoSelector('#3ds-turn-on');
+    body.should.containNoSelector('#3ds-turn-off');
+  });
+
+  it('should say not that 3D Secure is on if the user does not have read permission', function () {
+
+    let templateData = {
+      "requires3ds": true,
+      permissions: {
+        toggle_3ds_read: false
+      }
+    };
+
+    let body = renderTemplate('3d_secure/index', templateData);
+
+    body.should.containNoSelector('#3ds-status');
+  });
+
+  it('should show the toggle button if the user also has update permission', function () {
+
+    let templateData = {
+      "requires3ds": true,
+      permissions: {
+        toggle_3ds_read: true,
+        toggle_3ds_update: true
+      }
+    };
+
+    let body = renderTemplate('3d_secure/index', templateData);
+
+    body.should.containSelector('#3ds-off-button');
+    body.should.containNoSelector('#3ds-on-button');
+  });
+
+  it('should show the highlight if the permission has just been toggled and the user has read permission', function () {
+
+    let templateData = {
+      "requires3ds": true,
+      "justToggled": true,
+      permissions: {
+        toggle_3ds_read: true,
+      }
+    };
+
+    let body = renderTemplate('3d_secure/index', templateData);
+
+    body.should.containSelector('#3ds-toggled').withText('3D Secure is turned on for this service');
+  });
+
+  it('should not show the highlight if the permission has just been toggled and the user does not has read permission', function () {
+
+    let templateData = {
+      "requires3ds": true,
+      "justToggled": true,
+      permissions: {
+        toggle_3ds_read: false,
+      }
+    };
+
+    let body = renderTemplate('3d_secure/index', templateData);
+
+    body.should.containNoSelector('#3ds-toggled');
+  });
+
+  it('should not show the highlight if the permission has not been toggled and the user has read permission', function () {
+
+    let templateData = {
+      "requires3ds": true,
+      "justToggled": false,
+      permissions: {
+        toggle_3ds_read: true,
+      }
+    };
+
+    let body = renderTemplate('3d_secure/index', templateData);
+
+    body.should.containNoSelector('#3ds-toggled');
+  });
+
+});
+
+describe('The turn 3D Secure on confirmation page', function () {
+
+  it('should show the button if the user has edit permission', function () {
+
+    let templateData = {
+      permissions: {
+        toggle_3ds_read: true,
+        toggle_3ds_update: true
+      }
+    };
+
+    let body = renderTemplate('3d_secure/on_confirm', templateData);
+
+    body.should.containSelector('#3ds-confirm-on-button');
+  });
+
+  it('should not show the button if the user has does not have  permission', function () {
+
+    let templateData = {
+      permissions: {
+        toggle_3ds_read: true,
+        toggle_3ds_update: false
+      }
+    };
+
+    let body = renderTemplate('3d_secure/on_confirm', templateData);
+
+    body.should.containNoSelector('#3ds-confirm-on-button');
+  });
+
+});


### PR DESCRIPTION
Sets the `requires_3ds` flag in the `gateway_accounts` table in the `connector` database.

Assumes the existence of two new permissions: `toggle_3ds:read` (view setting but not change) and `toggle_3ds:update` (change it).

Can’t be merged until https://github.com/alphagov/pay-adminusers/pull/36 has been merged.

with @imranbohoran 

![3d secure off](https://cloud.githubusercontent.com/assets/24316348/23475324/27a265c6-feaf-11e6-95a0-a9ad8e0012ec.png)
![3d secure confirm](https://cloud.githubusercontent.com/assets/24316348/23475326/2a98d594-feaf-11e6-969e-6a480bd1412a.png)
![3d secure toggled on](https://cloud.githubusercontent.com/assets/24316348/23475334/3049566c-feaf-11e6-8e98-3b3c72b0a4b1.png)
![3d secure on](https://cloud.githubusercontent.com/assets/24316348/23475348/38b0e720-feaf-11e6-90c5-3aa7b339bb57.png)
![3d secure toggled off](https://cloud.githubusercontent.com/assets/24316348/23475356/3e64bf7a-feaf-11e6-8c70-6913e669557b.png)
