### PR TITLE
PP-1720 Improve account switcher styling

### DIFF
--- a/app/assets/sass/modules/_service_switcher.scss
+++ b/app/assets/sass/modules/_service_switcher.scss
@@ -3,15 +3,16 @@ input.service_switcher {
   background: none;
   display: inline-block;
   font: inherit;
-  margin: 0;
+  margin: $gutter-one-quarter 0;
   border: none;
   outline: none;
   outline-offset: 0;
   /* Additional styles to look like a link */
   color: $link-colour;
   cursor: pointer;
-  padding: 0 $gutter-half;
-  line-height: 30px;
+  text-decoration: underline;
+  padding:0;
+
 }
 
 input.service_switcher.active {

--- a/app/utils/display_converter.js
+++ b/app/utils/display_converter.js
@@ -5,8 +5,7 @@ const hideNavBarTemplates = [
 ];
 
 const testHasMultipleGatewayAccounts = user => {
-  let gatewayAccountIds = _.get(user, 'gatewayAccountIds', false);
-  return gatewayAccountIds && gatewayAccountIds.length > 1;
+  return user.gatewayAccountIds && user.gatewayAccountIds.length > 1;
 };
 
 /**
@@ -68,7 +67,7 @@ module.exports = function(user, data, template) {
 
   let hasMultipleGatewayAccounts = testHasMultipleGatewayAccounts(user);
   if (hasMultipleGatewayAccounts) {
-    convertedData.hasMultipleGatewayAccounts = hasMultipleGatewayAccounts;
+    convertedData.multipleGatewayAccounts = true;
   }
   convertedData.navigation = showNavigationBar(template);
   addGatewayAccountProviderDisplayNames(convertedData);

--- a/app/views/service_switcher/index.html
+++ b/app/views/service_switcher/index.html
@@ -1,9 +1,10 @@
 {{< layout}}
 
 {{$pageTitle}}
-GOV.UK Pay - My Services
+GOV.UK Pay - My accounts
 {{/pageTitle}}
 {{$content}}
+    <h2 class="heading-large">My accounts</h2>
     <p>Choose the environment you want to enter</p>
 
     {{#gatewayAccounts}}

--- a/app/views/staff_frontend_template.html
+++ b/app/views/staff_frontend_template.html
@@ -27,9 +27,9 @@
           <a href="{{$homepageUrl}}/{{/homepageUrl}}" title="Go to the GOV.UK Pay Self Service homepage" id="logo" class="content">
             <img src="/public/images/crown.png" width="35" alt=""> {{$globalHeaderText}}GOV.UK Pay{{/globalHeaderText}}
           </a>
-            <a href="/logout" title="Log me out" id="logout" class="content logout">Log Out</a>
+            <a href="/logout" title="Log me out" id="logout" class="content logout">Sign out</a>
             {{#multipleGatewayAccounts}}
-            <a href="{{ routes.serviceSwitcher.index }}" title="My Services" id="my-services" class="content logout">My Services</a>
+            <a href="{{ routes.serviceSwitcher.index }}" title="My accounts" id="my-services" class="content logout">My accounts</a>
             {{/multipleGatewayAccounts}}
         </div>
       </div>

--- a/test/ui/service_switcher_tests.js
+++ b/test/ui/service_switcher_tests.js
@@ -12,7 +12,7 @@ describe('The account switcher link', function () {
 
     let body = renderTemplate('staff_frontend_template', templateData);
 
-    body.should.containSelector('#my-services').withExactText('My Services');
+    body.should.containSelector('#my-services').withExactText('My accounts');
   });
 
   it('should not display if user has one or fewer gateway accounts', function () {


### PR DESCRIPTION
- add underline to 'links'
- add heading
- make margins and spacing more sensible
- change `My Services` to `My accounts`
- change `Log Out` to `Sign out`

stephen has given this the 👍 

<img width="1438" alt="screen shot 2017-03-08 at 15 40 19" src="https://cloud.githubusercontent.com/assets/1420504/23710722/a08580fc-0415-11e7-869e-756342c06b66.png">



