### PR TITLE
PP-1584 Make Worldpay 3DS setup link destination more specific

### DIFF
--- a/app/views/3d_secure/index.html
+++ b/app/views/3d_secure/index.html
@@ -34,7 +34,7 @@ GOV.UK Pay - 3D Secure
 {{#permissions.toggle_3ds_update}}
 <div class="panel panel-border-wide">
     <h2 class="heading-small">Activating 3D Secure</h2>
-    <p>Check with your Worldpay account manager that your merchant code has been configured to support 3D Secure. Read more about this in our <a href="https://gds-payments.gelato.io/docs/versions/1.0.0/switching-to-production">technical documentation</a>.</p>
+    <p>Check with your Worldpay account manager that your merchant code has been configured to support 3D Secure. Read more about this in our <a href="https://gds-payments.gelato.io/docs/versions/1.0.0/switching-to-production#worldpay-setup-for-3d-secure">technical documentation</a>.</p>
 </div>
 
 <p>Once that’s done, you can turn on 3D Secure for all payments to your service.</p>


### PR DESCRIPTION
We have some text that says this:

“Check with your Worldpay account manager that your merchant code has been configured to support 3D Secure. Read more about this in our technical documentation.”

Right now, “technical documentation” is a link to:

https://gds-payments.gelato.io/docs/versions/1.0.0/switching-to-production

This pull request changes the link to point to the actual part of the page with the relevant information:

https://gds-payments.gelato.io/docs/versions/1.0.0/switching-to-production#worldpay-setup-for-3d-secure
