### PR TITLE
PP-1727 Retry on ECONNRESET error

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "q": "^1.4.1",
     "qs": "^6.2.0",
     "readdir": "0.0.x",
+    "requestretry": "^1.12.0",
     "serve-favicon": "2.3.x",
     "sleep": "^3.0.1",
     "thirty-two": "^1.0.2",


### PR DESCRIPTION
## WHAT
- We are experiencing failing and flakey tests (staging, production and
  on deployment) because of ECONNRESET errors coming from calls to
  publicauth and connector
- As this seems to be a problem related to the `request` library
  together with keep alives, and it might require additional
  wrangling, this is a fix to stop smoke tests becoming red at random
  times.
  This is not a permanent fix, PP-1727 still needs to get picked up and
  we need to carry over the proper investigation

## HOW 
_Steps to test or reproduce:_


