### PR TITLE
PP-1754 Improved handling of internal error

### DIFF
--- a/app/utils/response.js
+++ b/app/utils/response.js
@@ -16,6 +16,8 @@ function errorResponse (req, res, msg) {
   let correlationId = req.correlationId;
   let data = { 'message': msg };
   logger.error(`[${correlationId}] An error has occurred. Rendering error view -`, {errorMessage: msg});
+  res.setHeader('Content-Type', 'text/html');
+  res.status(500);
   render(req, res, ERROR_VIEW, data);
 }
 

--- a/test/integration/credentials_ft_tests.js
+++ b/test/integration/credentials_ft_tests.js
@@ -182,7 +182,7 @@ describe('The ' + paths.credentials.index + ' endpoint', function () {
       });
 
     build_get_request(paths.credentials.index, app)
-      .expect(200, {"message": "There is a problem with the payments platform"})
+      .expect(500, {"message": "There is a problem with the payments platform"})
       .end(done);
   });
 
@@ -194,7 +194,7 @@ describe('The ' + paths.credentials.index + ' endpoint', function () {
       });
 
     build_get_request(paths.credentials.index, app)
-      .expect(200, {"message": "There is a problem with the payments platform"})
+      .expect(500, {"message": "There is a problem with the payments platform"})
       .end(done);
   });
 
@@ -202,7 +202,7 @@ describe('The ' + paths.credentials.index + ' endpoint', function () {
     // No connectorMock defined on purpose to mock a network failure
 
     build_get_request(paths.credentials.index, app)
-      .expect(200, {"message": "There is a problem with the payments platform"})
+      .expect(500, {"message": "There is a problem with the payments platform"})
       .end(done);
   });
 });
@@ -342,7 +342,7 @@ describe('The ' + paths.credentials.edit + ' endpoint', function () {
       });
 
     build_get_request(paths.credentials.edit, app)
-      .expect(200, {"message": "There is a problem with the payments platform"})
+      .expect(500, {"message": "There is a problem with the payments platform"})
       .end(done);
   });
 
@@ -354,7 +354,7 @@ describe('The ' + paths.credentials.edit + ' endpoint', function () {
       });
 
     build_get_request(paths.credentials.edit, app)
-      .expect(200, {"message": "There is a problem with the payments platform"})
+      .expect(500, {"message": "There is a problem with the payments platform"})
       .end(done);
   });
 
@@ -362,7 +362,7 @@ describe('The ' + paths.credentials.edit + ' endpoint', function () {
     // No connectorMock defined on purpose to mock a network failure
 
     build_get_request(paths.credentials.edit, app)
-      .expect(200, {"message": "There is a problem with the payments platform"})
+      .expect(500, {"message": "There is a problem with the payments platform"})
       .end(done);
   });
 });
@@ -507,7 +507,7 @@ describe('The ' + paths.notificationCredentials.edit + ' endpoint', function () 
       });
 
     build_get_request(paths.notificationCredentials.edit, app)
-      .expect(200, {"message": "There is a problem with the payments platform"})
+      .expect(500, {"message": "There is a problem with the payments platform"})
       .end(done);
   });
 
@@ -519,7 +519,7 @@ describe('The ' + paths.notificationCredentials.edit + ' endpoint', function () 
       });
 
     build_get_request(paths.notificationCredentials.edit, app)
-      .expect(200, {"message": "There is a problem with the payments platform"})
+      .expect(500, {"message": "There is a problem with the payments platform"})
       .end(done);
   });
 
@@ -527,7 +527,7 @@ describe('The ' + paths.notificationCredentials.edit + ' endpoint', function () 
     // No connectorMock defined on purpose to mock a network failure
 
     build_get_request(paths.notificationCredentials.edit, app)
-      .expect(200, {"message": "There is a problem with the payments platform"})
+      .expect(500, {"message": "There is a problem with the payments platform"})
       .end(done);
   });
 });
@@ -654,7 +654,7 @@ describe('The provider update credentials endpoint', function () {
     var expectedData = {"message": "There is a problem with the payments platform"};
     var path = paths.credentials.index;
     build_form_post_request(path, sendData, true, app)
-      .expect(200, expectedData)
+      .expect(500, expectedData)
       .end(done);
   });
 
@@ -665,7 +665,7 @@ describe('The provider update credentials endpoint', function () {
     var expectedData = {"message": "There is a problem with the payments platform"};
     var path = paths.credentials.index;
     build_form_post_request(path, sendData, true, app)
-      .expect(200, expectedData)
+      .expect(500, expectedData)
       .end(done);
   });
 
@@ -681,7 +681,7 @@ describe('The provider update credentials endpoint', function () {
     var sendData = {'username': 'a-username', 'password': 'a-password'};
     var path = paths.credentials.index;
     build_form_post_request(path, sendData, false, app)
-      .expect(200, {message: "There is a problem with the payments platform"})
+      .expect(500, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 });

--- a/test/integration/dev_tokens_ft_tests.js
+++ b/test/integration/dev_tokens_ft_tests.js
@@ -313,7 +313,7 @@ describe('Dev Tokens Endpoints', function() {
       });
 
       build_put_request(false)
-        .expect(200, {
+        .expect(500, {
           'message': 'There is a problem with the payments platform'
         })
         .end(done);
@@ -381,7 +381,7 @@ describe('Dev Tokens Endpoints', function() {
         .delete(paths.devTokens.index + "?token_link=550e8400-e29b-41d4-a716-446655440000")
         .set('x-request-id',requestId)
         .set('Accept', 'application/json')
-        .expect(200, {message: "There is a problem with the payments platform"})
+        .expect(500, {message: "There is a problem with the payments platform"})
         .end(done);
     });
 
@@ -480,7 +480,7 @@ describe('Dev Tokens Endpoints', function() {
       });
 
       build_form_post_request(paths.devTokens.create,{})
-        .expect(200, {
+        .expect(500, {
           'message' : 'There is a problem with the payments platform'
         })
         .end(done);
@@ -512,7 +512,7 @@ describe('Dev Tokens Endpoints', function() {
         navigation: true});
 
       build_form_post_request(paths.devTokens.create,{},true)
-        .expect(200, {
+        .expect(500, {
           'message' : 'There is a problem with the payments platform'
         })
         .end(done);

--- a/test/integration/login_controller_test.js
+++ b/test/integration/login_controller_test.js
@@ -206,7 +206,7 @@ describe('login post endpoint', function () {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .send({})
-      .expect(200, {message: "There is a problem with the payments platform"})
+      .expect(500, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 });
@@ -225,7 +225,7 @@ describe('otp login post enpoint', function () {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .send({code: notp.totp.gen("12345")})
-      .expect(200, {message: "There is a problem with the payments platform"})
+      .expect(500, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 });
@@ -245,7 +245,7 @@ describe('otp send again post enpoint', function () {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .send({})
-      .expect(200, {message: "There is a problem with the payments platform"})
+      .expect(500, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 });

--- a/test/integration/pagination_ft_tests.js
+++ b/test/integration/pagination_ft_tests.js
@@ -249,21 +249,21 @@ describe('Pagination', function () {
       var data = {'page': -1};
 
       search_transactions(data)
-        .expect(200, {'message': "Invalid search"}).end(done);
+        .expect(500, {'message': "Invalid search"}).end(done);
     });
 
     it('should return return error if pageSize out of bounds 1', function (done) {
       var data = {'pageSize': 600};
 
       search_transactions(data)
-        .expect(200, {'message': "Invalid search"}).end(done);
+        .expect(500, {'message': "Invalid search"}).end(done);
     });
 
     it('should return return error if pageSize out of bounds 2', function (done) {
       var data = {'pageSize': 0};
 
       search_transactions(data)
-        .expect(200, {'message': "Invalid search"}).end(done);
+        .expect(500, {'message': "Invalid search"}).end(done);
     });
   });
 });

--- a/test/integration/payment_types_select_brand_ft_tests.js
+++ b/test/integration/payment_types_select_brand_ft_tests.js
@@ -229,7 +229,7 @@ describe('The payment types endpoint,', function () {
         });
 
       build_get_request(paths.paymentTypes.selectBrand, app)
-        .expect(200, {"message": "Unable to retrieve accepted card types for the account."})
+        .expect(500, {"message": "Unable to retrieve accepted card types for the account."})
         .end(done);
     });
 
@@ -242,7 +242,7 @@ describe('The payment types endpoint,', function () {
         });
 
       build_get_request(paths.paymentTypes.selectBrand, app)
-        .expect(200, {"message": "Unable to retrieve accepted card types for the account."})
+        .expect(500, {"message": "Unable to retrieve accepted card types for the account."})
         .end(done);
     });
 
@@ -255,7 +255,7 @@ describe('The payment types endpoint,', function () {
         .reply(200, {});
 
       build_get_request(paths.paymentTypes.selectBrand, app)
-        .expect(200, {"message": "Unable to retrieve card types."})
+        .expect(500, {"message": "Unable to retrieve card types."})
         .end(done);
     });
 
@@ -263,7 +263,7 @@ describe('The payment types endpoint,', function () {
       // No connectorMock defined on purpose to mock a network failure
 
       build_get_request(paths.paymentTypes.selectBrand, app)
-        .expect(200, {"message": "Internal server error"})
+        .expect(500, {"message": "Internal server error"})
         .end(done);
     });
   });
@@ -366,7 +366,7 @@ describe('The payment types endpoint,', function () {
         "acceptedType": TYPES.ALL,
         "acceptedBrands": ["discover", "unknown"]
       }, true, app)
-        .expect(200, {"message": "Unable to retrieve card types."})
+        .expect(500, {"message": "Unable to retrieve card types."})
         .end(done);
     });
 
@@ -384,7 +384,7 @@ describe('The payment types endpoint,', function () {
         "acceptedType": TYPES.ALL,
         "acceptedBrands": ["discover", "unknown"]
       }, true, app)
-        .expect(200, {"message": "Unable to save accepted card types."})
+        .expect(500, {"message": "Unable to save accepted card types."})
         .end(done);
     });
   });

--- a/test/integration/payment_types_select_summary_ft_tests.js
+++ b/test/integration/payment_types_select_summary_ft_tests.js
@@ -99,7 +99,7 @@ describe('The payment types endpoint,', function () {
         });
 
       build_get_request(paths.paymentTypes.summary, app)
-        .expect(200, {"message": "Unable to retrieve accepted card types for the account."})
+        .expect(500, {"message": "Unable to retrieve accepted card types for the account."})
         .end(done);
     });
 
@@ -112,7 +112,7 @@ describe('The payment types endpoint,', function () {
         });
 
       build_get_request(paths.paymentTypes.summary, app)
-        .expect(200, {"message": "Unable to retrieve accepted card types for the account."})
+        .expect(500, {"message": "Unable to retrieve accepted card types for the account."})
         .end(done);
     });
 
@@ -125,7 +125,7 @@ describe('The payment types endpoint,', function () {
         .reply(200, {});
 
       build_get_request(paths.paymentTypes.summary, app)
-        .expect(200, {"message": "Unable to retrieve card types."})
+        .expect(500, {"message": "Unable to retrieve card types."})
         .end(done);
     });
 
@@ -133,7 +133,7 @@ describe('The payment types endpoint,', function () {
       // No connectorMock defined on purpose to mock a network failure
 
       build_get_request(paths.paymentTypes.summary, app)
-        .expect(200, {"message": "Internal server error"})
+        .expect(500, {"message": "Internal server error"})
         .end(done);
     });
   });

--- a/test/integration/payment_types_select_type_ft_tests.js
+++ b/test/integration/payment_types_select_type_ft_tests.js
@@ -144,7 +144,7 @@ describe('The payment types endpoint,', function () {
         });
 
       build_get_request(paths.paymentTypes.selectType, app)
-        .expect(200, {"message": "Unable to retrieve accepted card types for the account."})
+        .expect(500, {"message": "Unable to retrieve accepted card types for the account."})
         .end(done);
     });
 
@@ -155,7 +155,7 @@ describe('The payment types endpoint,', function () {
         });
 
       build_get_request(paths.paymentTypes.selectType, app)
-        .expect(200, {"message": "Unable to retrieve accepted card types for the account."})
+        .expect(500, {"message": "Unable to retrieve accepted card types for the account."})
         .end(done);
     });
 
@@ -163,7 +163,7 @@ describe('The payment types endpoint,', function () {
       // No connectorMock defined on purpose to mock a network failure
 
       build_get_request(paths.paymentTypes.selectType, app)
-        .expect(200, {"message": "Internal server error"})
+        .expect(500, {"message": "Internal server error"})
         .end(done);
     });
   });

--- a/test/integration/service_name_ft_tests.js
+++ b/test/integration/service_name_ft_tests.js
@@ -44,11 +44,11 @@ function build_form_post_request(path, sendData, sendCSRF, app) {
 [
   {
     'path': paths.serviceName.index,
-    'edit': false,
+    'edit': false
   },
   {
     'path': paths.serviceName.edit,
-    'edit': true,
+    'edit': true
   }
 ].forEach(function (testSetup) {
 
@@ -98,7 +98,7 @@ function build_form_post_request(path, sendData, sendCSRF, app) {
           });
 
         build_get_request(testSetup.path, app)
-          .expect(200, {"message": "Unable to retrieve the service name."})
+          .expect(500, {"message": "Unable to retrieve the service name."})
           .end(done);
       });
 
@@ -109,7 +109,7 @@ function build_form_post_request(path, sendData, sendCSRF, app) {
           });
 
         build_get_request(testSetup.path, app)
-          .expect(200, {"message": "Unable to retrieve the service name."})
+          .expect(500, {"message": "Unable to retrieve the service name."})
           .end(done);
       });
 
@@ -117,7 +117,7 @@ function build_form_post_request(path, sendData, sendCSRF, app) {
         // No connectorMock defined on purpose to mock a network failure
 
         build_get_request(testSetup.path, app)
-          .expect(200, {"message": "Unable to retrieve the service name."})
+          .expect(500, {"message": "Unable to retrieve the service name."})
           .end(done);
       });
     });
@@ -165,7 +165,7 @@ describe('The provider update service name endpoint', function () {
     var expectedData = {"message": "Internal server error"};
     var path = paths.serviceName.index;
     build_form_post_request(path, sendData, true, app)
-      .expect(200, expectedData)
+      .expect(500, expectedData)
       .end(done);
   });
 
@@ -175,7 +175,7 @@ describe('The provider update service name endpoint', function () {
     var expectedData = {"message": "Internal server error"};
     var path = paths.serviceName.index;
     build_form_post_request(path, sendData, true, app)
-      .expect(200, expectedData)
+      .expect(500, expectedData)
       .end(done);
   });
 
@@ -183,7 +183,7 @@ describe('The provider update service name endpoint', function () {
     var sendData = {'service-name-input': 'Service name'};
     var path = paths.serviceName.index;
     build_form_post_request(path, sendData, false, app)
-      .expect(200, {message: "There is a problem with the payments platform"})
+      .expect(500, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 });

--- a/test/integration/service_roles_update_ft_test.js
+++ b/test/integration/service_roles_update_ft_test.js
@@ -83,7 +83,7 @@ describe('user permissions update controller', function () {
       return supertest(app)
         .get(updatePermissionPath(usernameToView))
         .set('Accept', 'application/json')
-        .expect(200)
+        .expect(500)
         .expect((res) => {
           expect(res.body.message).to.equal('Unable to locate the user');
         })
@@ -97,7 +97,7 @@ describe('user permissions update controller', function () {
       return supertest(app)
         .get(updatePermissionPath(userInSession.username))
         .set('Accept', 'application/json')
-        .expect(200)
+        .expect(500)
         .expect((res) => {
           expect(res.body.message).to.equal('Not allowed to update self permission');
         })
@@ -170,7 +170,7 @@ describe('user permissions update controller', function () {
           'role-input': roles['admin'].extId,
           csrfToken: csrf().create('123')
         })
-        .expect(200)
+        .expect(500)
         .expect((res) => {
           expect(res.body.message).to.equal('Not allowed to update self permission');
         })
@@ -193,7 +193,7 @@ describe('user permissions update controller', function () {
           'role-input': roles['admin'].extId,
           csrfToken: csrf().create('123')
         })
-        .expect(200)
+        .expect(500)
         .expect((res) => {
           expect(res.body.message).to.equal('Unable to locate the user');
         })
@@ -214,7 +214,7 @@ describe('user permissions update controller', function () {
           'role-input': nonExistentRoleId,
           csrfToken: csrf().create('123')
         })
-        .expect(200)
+        .expect(500)
         .expect((res) => {
           expect(res.body.message).to.equal('Unable to update user permission');
         })
@@ -241,7 +241,7 @@ describe('user permissions update controller', function () {
           'role-input': roles['admin'].extId,
           csrfToken: csrf().create('123')
         })
-        .expect(200)
+        .expect(500)
         .expect((res) => {
           expect(res.body.message).to.equal('Unable to update user permission');
         })

--- a/test/integration/service_users_ft_test.js
+++ b/test/integration/service_users_ft_test.js
@@ -197,7 +197,7 @@ describe('service users resource', function () {
     return supertest(app)
       .get('/team-members/other-user')
       .set('Accept', 'application/json')
-      .expect(200)
+      .expect(500)
       .expect((res) => {
         expect(res.body.message).to.equal('Error displaying this user of the current service');
       })

--- a/test/integration/toggle_3ds_ft_tests.js
+++ b/test/integration/toggle_3ds_ft_tests.js
@@ -157,7 +157,7 @@ describe('The 3D Secure index endpoint', function () {
       });
 
     build_get_request(paths.toggle3ds.index, app)
-      .expect(200, {"message": "Unable to retrieve the 3D Secure setting."})
+      .expect(500, {"message": "Unable to retrieve the 3D Secure setting."})
       .end(done);
   });
 
@@ -168,14 +168,14 @@ describe('The 3D Secure index endpoint', function () {
       });
 
     build_get_request(paths.toggle3ds.index, app)
-      .expect(200, {"message": "Unable to retrieve the 3D Secure setting."})
+      .expect(500, {"message": "Unable to retrieve the 3D Secure setting."})
       .end(done);
   });
 
   it('should display an error if the connection to connector fails', function (done) {
     // No connectorMock defined on purpose to mock a network failure
     build_get_request(paths.toggle3ds.index, app)
-      .expect(200, {"message": "Unable to retrieve the 3D Secure setting."})
+      .expect(500, {"message": "Unable to retrieve the 3D Secure setting."})
       .end(done);
   });
 });
@@ -214,20 +214,20 @@ describe('The turn on 3D Secure endpoint', function () {
       });
 
     build_form_post_request(paths.toggle3ds.on, {}, true, app)
-      .expect(200, {"message": "Unable to toggle 3D Secure."})
+      .expect(500, {"message": "Unable to toggle 3D Secure."})
       .end(done);
   });
 
   it('should display an error if the connection to connector fails', function (done) {
     // No connectorMock defined on purpose to mock a network failure
     build_form_post_request(paths.toggle3ds.on, {}, true, app)
-      .expect(200, {"message": "Unable to toggle 3D Secure."})
+      .expect(500, {"message": "Unable to toggle 3D Secure."})
       .end(done);
   });
 
   it('should display an error if CSRF token does not exist', function (done) {
     build_form_post_request(paths.toggle3ds.on, {}, false, app)
-      .expect(200, {message: "There is a problem with the payments platform"})
+      .expect(500, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 });
@@ -266,20 +266,20 @@ describe('The turn off 3D Secure endpoint', function () {
       });
 
     build_form_post_request(paths.toggle3ds.off, {}, true, app)
-      .expect(200, {"message": "Unable to toggle 3D Secure."})
+      .expect(500, {"message": "Unable to toggle 3D Secure."})
       .end(done);
   });
 
   it('should display an error if the connection to connector fails', function (done) {
     // No connectorMock defined on purpose to mock a network failure
     build_form_post_request(paths.toggle3ds.off, {}, true, app)
-      .expect(200, {"message": "Unable to toggle 3D Secure."})
+      .expect(500, {"message": "Unable to toggle 3D Secure."})
       .end(done);
   });
 
   it('should display an error if CSRF token does not exist', function (done) {
     build_form_post_request(paths.toggle3ds.off, {}, false, app)
-      .expect(200, {message: "There is a problem with the payments platform"})
+      .expect(500, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 
@@ -304,7 +304,7 @@ describe('The confirm that you want to turn on 3D Secure endpoint', function () 
 
   it('should display an error if CSRF token does not exist', function (done) {
     build_form_post_request(paths.toggle3ds.onConfirm, {}, false, app)
-      .expect(200, {message: "There is a problem with the payments platform"})
+      .expect(500, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 

--- a/test/integration/transaction_details_ft_tests.js
+++ b/test/integration/transaction_details_ft_tests.js
@@ -700,7 +700,7 @@ describe('The transaction view scenarios', function () {
         .reply(404, connectorError);
 
       when_getTransactionHistory(nonExistentChargeId, app)
-        .expect(200, connectorError)
+        .expect(500, connectorError)
         .end(done);
     });
 
@@ -711,14 +711,14 @@ describe('The transaction view scenarios', function () {
         .reply(500, connectorError);
 
       when_getTransactionHistory(nonExistentChargeId, app)
-        .expect(200, {'message': 'Error processing transaction view'})
+        .expect(500, {'message': 'Error processing transaction view'})
         .end(done);
     });
 
     it('should return a generic if unable to communicate with connector', function (done) {
       var chargeId = 452345;
       when_getTransactionHistory(chargeId, app)
-        .expect(200, {'message': 'Error processing transaction view'})
+        .expect(500, {'message': 'Error processing transaction view'})
         .end(done);
     });
   });

--- a/test/integration/transaction_details_refunds_ft_tests.js
+++ b/test/integration/transaction_details_refunds_ft_tests.js
@@ -99,7 +99,7 @@ describe('The transaction view - refund scenarios', function () {
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .set('Accept', 'application/json')
       .send(viewFormData)
-      .expect(200, {"message": "Can't do refund: amount must be pounds (10) or pounds and pence (10.10)"})
+      .expect(500, {"message": "Can't do refund: amount must be pounds (10) or pounds and pence (10.10)"})
       .end(done);
   });
 
@@ -127,7 +127,7 @@ describe('The transaction view - refund scenarios', function () {
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .set('Accept', 'application/json')
       .send(viewFormData)
-      .expect(200, {"message": "Can't do refund: The requested amount is bigger than the amount available for refund"})
+      .expect(500, {"message": "Can't do refund: The requested amount is bigger than the amount available for refund"})
       .end(done);
   });
 
@@ -156,7 +156,7 @@ describe('The transaction view - refund scenarios', function () {
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .set('Accept', 'application/json')
       .send(viewFormData)
-      .expect(200, {"message": "Can't do refund: The requested amount is less than the minimum accepted for issuing a refund for this charge"})
+      .expect(500, {"message": "Can't do refund: The requested amount is less than the minimum accepted for issuing a refund for this charge"})
       .end(done);
   });
 
@@ -185,7 +185,7 @@ describe('The transaction view - refund scenarios', function () {
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .set('Accept', 'application/json')
       .send(viewFormData)
-      .expect(200, {"message": "Can't do refund: This charge has been already fully refunded"})
+      .expect(500, {"message": "Can't do refund: This charge has been already fully refunded"})
       .end(done);
   });
 
@@ -214,7 +214,7 @@ describe('The transaction view - refund scenarios', function () {
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .set('Accept', 'application/json')
       .send(viewFormData)
-      .expect(200, {"message": "Can't process refund"})
+      .expect(500, {"message": "Can't process refund"})
       .end(done);
   });
 
@@ -242,7 +242,7 @@ describe('The transaction view - refund scenarios', function () {
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .set('Accept', 'application/json')
       .send(viewFormData)
-      .expect(200, {"message": "Refund failed. This refund request has already been submitted."})
+      .expect(500, {"message": "Refund failed. This refund request has already been submitted."})
       .end(done);
   });
 });

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -163,7 +163,7 @@ describe('Transaction download endpoints', function () {
       connectorMock_responds(400, {'message': errorMessage}, {});
 
       download_transaction_list()
-        .expect(200, {'message': 'Internal server error'})
+        .expect(500, {'message': 'Internal server error'})
         .end(done);
 
     });
@@ -173,7 +173,7 @@ describe('Transaction download endpoints', function () {
       connectorMock_responds(500, {'message': 'some error from connector'}, {});
 
       download_transaction_list()
-        .expect(200, {'message': 'Internal server error'})
+        .expect(500, {'message': 'Internal server error'})
         .end(done);
     });
 
@@ -181,7 +181,7 @@ describe('Transaction download endpoints', function () {
       // No connectorMock defined on purpose to mock a network failure
 
       download_transaction_list()
-        .expect(200, {'message': 'Internal server error'})
+        .expect(500, {'message': 'Internal server error'})
         .end(done);
     });
   });

--- a/test/integration/transaction_list_ft_tests.js
+++ b/test/integration/transaction_list_ft_tests.js
@@ -324,7 +324,7 @@ describe('The /transactions endpoint', function () {
     connectorMock_responds(400, {'message': errorMessage}, searchParameters);
 
     get_transaction_list()
-      .expect(200, {'message': errorMessage})
+      .expect(500, {'message': errorMessage})
       .end(done);
   });
 
@@ -333,7 +333,7 @@ describe('The /transactions endpoint', function () {
     connectorMock_responds(500, {'message': 'some error from connector'}, searchParameters);
 
     get_transaction_list()
-      .expect(200, {'message': 'Unable to retrieve list of transactions.'})
+      .expect(500, {'message': 'Unable to retrieve list of transactions.'})
       .end(done);
   });
 
@@ -341,7 +341,7 @@ describe('The /transactions endpoint', function () {
     // No connectorMock defined on purpose to mock a network failure
 
     get_transaction_list()
-      .expect(200, {'message': 'Unable to retrieve list of transactions.'})
+      .expect(500, {'message': 'Unable to retrieve list of transactions.'})
       .end(done);
   });
 
@@ -370,7 +370,7 @@ describe('The /transactions endpoint', function () {
   //    .reply(400, {'message': errorMessage});
   //
   //  get_transaction_list()
-  //    .expect(200, {'message': errorMessage})
+  //    .expect(500, {'message': errorMessage})
   //    .end(done);
   //});
 
@@ -385,7 +385,7 @@ describe('The /transactions endpoint', function () {
   //    .reply(500, {'message': 'some error from connector'});
   //
   //  get_transaction_list()
-  //    .expect(200, {'message': 'Unable to retrieve list of transactions.'})
+  //    .expect(500, {'message': 'Unable to retrieve list of transactions.'})
   //    .end(done);
   //});
 
@@ -397,7 +397,7 @@ describe('The /transactions endpoint', function () {
   //  connectorMock_responds(200, connectorData, searchParameters);
   //
   //  get_transaction_list()
-  //    .expect(200, {'message': 'Unable to retrieve list of transactions.'})
+  //    .expect(500, {'message': 'Unable to retrieve list of transactions.'})
   //    .end(done);
   //});
 

--- a/test/unit/controller/service_switch_controller_test.js
+++ b/test/unit/controller/service_switch_controller_test.js
@@ -110,6 +110,8 @@ describe('service switch controller: list of accounts', function () {
 
   it('should show error if no gateway accounts', function () {
     let renderSpy = sinon.spy();
+    let setHeaderSpy = sinon.spy();
+    let statusSpy = sinon.spy();
 
     let req = {
       user: userFixtures.validUserResponse({
@@ -120,12 +122,16 @@ describe('service switch controller: list of accounts', function () {
     };
 
     let res = {
-      render: renderSpy
+      render: renderSpy,
+      setHeader: setHeaderSpy,
+      status: statusSpy
     };
 
     serviceSwitchController.index(req, res);
 
     expect(renderSpy.calledWith('error', { message: 'No accounts found for user'})).to.be.equal(true);
+    expect(setHeaderSpy.calledWith('Content-Type', 'text/html')).to.be.equal(true);
+    expect(statusSpy.calledWith(500)).to.be.equal(true);
   });
 });
 

--- a/test/unit/middleware/retrieve_account_test.js
+++ b/test/unit/middleware/retrieve_account_test.js
@@ -25,7 +25,8 @@ describe('retrieve param test', function () {
 
   var response = {
     status: function(){},
-    render: function(){}
+    render: function(){},
+    setHeader: function() {}
   },
   status = undefined,
   render = undefined,
@@ -48,9 +49,6 @@ describe('retrieve param test', function () {
     status.restore();
     render.restore();
   });
-
-
-
 
   it('should call the error view if the connector fails', function (done) {
     retrieveAccount( { params: {}, body: {}, headers: {} }, response, next);


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

- If a request is valid but self service fails to complete the request for any
   reason (i.e. connector cannot be reached) a generic error page is rendered stating
   the error condition. The service then responds with a 200 status code which is
   misleading. Error handling has been improved to respond with a 500 status code instead.
   Also the content type has been set explicitly to 'text/html' on all error pages.

 NOTE: It is still unclear how to reproduce the bug reported in PP-1754 due to a lack
 of contextual information to carry out a proper investigation. The exact time when the
 error occurred is unknown, the csv file showing the error was not provided, also the
 error was never reproducible and deemed transient.


