### PR TITLE
PP-1874 Change error responses

### DIFF
--- a/app/middleware/csrf.js
+++ b/app/middleware/csrf.js
@@ -1,28 +1,28 @@
 "use strict";
-var csrf = require('csrf'),
+let csrf = require('csrf'),
   logger = require('winston'),
   errorView = require('../utils/response.js').renderErrorView,
+  errorMsg = 'There is a problem with the payments platform',
 
   csrfValid = function (req) {
-    return  csrf().verify(req.session.csrfSecret, req.body.csrfToken);
+    return csrf().verify(req.session.csrfSecret, req.body.csrfToken);
   };
 
 module.exports = function (req, res, next) {
-  var session = req.session;
-
+  let session = req.session;
   if (!session) {
     logger.warn('Session is not defined');
-    return errorView(req, res);
+    return errorView(req, res, errorMsg, 400);
   }
 
   if (!session.csrfSecret) {
     logger.warn('CSRF secret is not defined for session');
-    return errorView(req, res);
+    return errorView(req, res, errorMsg, 400);
   }
 
   if (!req.route.methods.get && !csrfValid(req)) {
     logger.warn('CSRF secret provided is invalid');
-    return errorView(req, res);
+    return errorView(req, res, errorMsg, 400);
   }
 
   res.locals.csrf = csrf().create(session.csrfSecret);

--- a/app/utils/response.js
+++ b/app/utils/response.js
@@ -11,13 +11,17 @@ function response(req, res, template, data) {
   render(req, res, template, convertedData);
 }
 
-function errorResponse (req, res, msg) {
+function errorResponse (req, res, msg, status) {
   if (!msg) msg = ERROR_MESSAGE;
   let correlationId = req.correlationId;
   let data = { 'message': msg };
   logger.error(`[${correlationId}] An error has occurred. Rendering error view -`, {errorMessage: msg});
   res.setHeader('Content-Type', 'text/html');
-  res.status(500);
+  if(status) {
+    res.status(status);
+  } else {
+    res.status(500);
+  }
   render(req, res, ERROR_VIEW, data);
 }
 

--- a/test/integration/credentials_ft_tests.js
+++ b/test/integration/credentials_ft_tests.js
@@ -681,7 +681,7 @@ describe('The provider update credentials endpoint', function () {
     var sendData = {'username': 'a-username', 'password': 'a-password'};
     var path = paths.credentials.index;
     build_form_post_request(path, sendData, false, app)
-      .expect(500, {message: "There is a problem with the payments platform"})
+      .expect(400, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 });

--- a/test/integration/dev_tokens_ft_tests.js
+++ b/test/integration/dev_tokens_ft_tests.js
@@ -313,7 +313,7 @@ describe('Dev Tokens Endpoints', function() {
       });
 
       build_put_request(false)
-        .expect(500, {
+        .expect(400, {
           'message': 'There is a problem with the payments platform'
         })
         .end(done);
@@ -381,7 +381,7 @@ describe('Dev Tokens Endpoints', function() {
         .delete(paths.devTokens.index + "?token_link=550e8400-e29b-41d4-a716-446655440000")
         .set('x-request-id',requestId)
         .set('Accept', 'application/json')
-        .expect(500, {message: "There is a problem with the payments platform"})
+        .expect(400, {message: "There is a problem with the payments platform"})
         .end(done);
     });
 

--- a/test/integration/login_controller_test.js
+++ b/test/integration/login_controller_test.js
@@ -206,7 +206,7 @@ describe('login post endpoint', function () {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .send({})
-      .expect(500, {message: "There is a problem with the payments platform"})
+      .expect(400, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 });
@@ -225,7 +225,7 @@ describe('otp login post enpoint', function () {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .send({code: notp.totp.gen("12345")})
-      .expect(500, {message: "There is a problem with the payments platform"})
+      .expect(400, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 });
@@ -245,7 +245,7 @@ describe('otp send again post enpoint', function () {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .send({})
-      .expect(500, {message: "There is a problem with the payments platform"})
+      .expect(400, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 });

--- a/test/integration/service_name_ft_tests.js
+++ b/test/integration/service_name_ft_tests.js
@@ -60,7 +60,7 @@ function build_form_post_request(path, sendData, sendCSRF, app) {
 
       beforeEach(function (done) {
         let permissions = 'service-name:read';
-        var user = session.getUser({
+        let user = session.getUser({
           gateway_account_ids: [ACCOUNT_ID], permissions: [permissions]
         });
         app = session.getAppWithLoggedInUser(getApp(), user);
@@ -183,7 +183,7 @@ describe('The provider update service name endpoint', function () {
     var sendData = {'service-name-input': 'Service name'};
     var path = paths.serviceName.index;
     build_form_post_request(path, sendData, false, app)
-      .expect(500, {message: "There is a problem with the payments platform"})
+      .expect(400, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 });

--- a/test/integration/toggle_3ds_ft_tests.js
+++ b/test/integration/toggle_3ds_ft_tests.js
@@ -227,7 +227,7 @@ describe('The turn on 3D Secure endpoint', function () {
 
   it('should display an error if CSRF token does not exist', function (done) {
     build_form_post_request(paths.toggle3ds.on, {}, false, app)
-      .expect(500, {message: "There is a problem with the payments platform"})
+      .expect(400, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 });
@@ -279,7 +279,7 @@ describe('The turn off 3D Secure endpoint', function () {
 
   it('should display an error if CSRF token does not exist', function (done) {
     build_form_post_request(paths.toggle3ds.off, {}, false, app)
-      .expect(500, {message: "There is a problem with the payments platform"})
+      .expect(400, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 
@@ -304,7 +304,7 @@ describe('The confirm that you want to turn on 3D Secure endpoint', function () 
 
   it('should display an error if CSRF token does not exist', function (done) {
     build_form_post_request(paths.toggle3ds.onConfirm, {}, false, app)
-      .expect(500, {message: "There is a problem with the payments platform"})
+      .expect(400, {message: "There is a problem with the payments platform"})
       .end(done);
   });
 


### PR DESCRIPTION
## WHAT  
In some cases ZAP tests are giving us some reports about 500 errors that should not happen. After investigating these reports we find out that some 500 errors has been arisen on client errors:

- Invalid CSRF returns 400 response rather than a 500 (since is a client error).
- Change service name, when account is missing, is also a client error,  therefore returning a 400 too.
