### PR TITLE
Change “3D secure” to “3D Secure” on confirmation page button

### DIFF
--- a/app/views/3d_secure/on_confirm.html
+++ b/app/views/3d_secure/on_confirm.html
@@ -18,7 +18,7 @@ GOV.UK Pay - Activate 3D Secure
 <form class="permission-main" method="post" action="{{routes.toggle3ds.on}}">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <div class="form-group">
-        <input id="3ds-confirm-on-button" class="button" type="submit" value="Yes, turn on 3D secure">
+        <input id="3ds-confirm-on-button" class="button" type="submit" value="Yes, turn on 3D Secure">
     </div>
     <a href="{{routes.toggle3ds.index}}" class="remove-cancel">No, cancel</a>
 </form>


### PR DESCRIPTION
Noticed during the demo in the sprint review that the button that appears on the confirmation page when enabling 3D Secure says “Yes, turn on 3D secure”. It should be “Yes, turn on 3D Secure” because it’s a proper noun.
