### PR TITLE
PP-1881 removing link potentially causing ZAP test failures

### DIFF
--- a/app/views/login/login.html
+++ b/app/views/login/login.html
@@ -8,7 +8,7 @@ Sign in to GOV.UK Pay
 <div id="global-message">
   <p>Thursday, March 30th, between 8:00 and 8:50 am you may not be able to log into GOV.UK Pay. Your users will not be affected and will be able to complete payments during this time.
 
-    This is due to a planned outage of <a href="https://status.notifications.service.gov.uk/">GOV.UK Notify</a>, we use to send your security code during the login process.
+    This is due to a planned outage of <b>GOV.UK Notify</b>, we use to send your security code during the login process.
 
     We apologise for any inconvenience.
   </p>


### PR DESCRIPTION
## WHAT
ZAP test continue to fail. Could be due to that it follows the link to notify status page which may not be ZAP complaint.
