### PR TITLE
PP-1866 Call dockerTag function after test stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,15 @@ pipeline {
         runEndToEnd("selfservice")
       }
     }
+    stage('Docker Tag') {
+      steps {
+        script {
+          dockerTag {
+            app = "selfservice"
+          }
+        }
+      }
+    }
     stage('Deploy') {
       when {
         branch 'master'


### PR DESCRIPTION
Changes the Jenkinsfile to call the library function `dockerTag` after running tests. This is necessary because the `buildApp` function called earlier no longer does Docker tagging (it was doing it too early and getting it wrong in any case).

