### PR TITLE
PP-1717 Remove "is_new_api_request" parameter

### DIFF
--- a/app/services/clients/adminusers_client.js
+++ b/app/services/clients/adminusers_client.js
@@ -66,7 +66,7 @@ module.exports = function (clientOptions = {}) {
     let params = {
       correlationId: correlationId
     };
-    let url = `${userResource}/${externalId}?is_new_api_request=y`;
+    let url = `${userResource}/${externalId}`;
     let defer = q.defer();
     let startTime = new Date();
     let context = {
@@ -174,7 +174,7 @@ module.exports = function (clientOptions = {}) {
       }
     };
 
-    let url = `${userResource}/${externalId}?is_new_api_request=y`;
+    let url = `${userResource}/${externalId}`;
     let defer = q.defer();
     let startTime = new Date();
     let context = {

--- a/test/fixtures/user_fixtures.js
+++ b/test/fixtures/user_fixtures.js
@@ -118,7 +118,7 @@ module.exports = {
       telephone_number: request.telephone_number || "0123441",
       permissions: request.permissions || ["perm-1", "perm-2", "perm-3"],
       "_links": [{
-        "href": `http://adminusers.service/v1/api/users/${req_external_id}?is_new_api_request=y`,
+        "href": `http://adminusers.service/v1/api/users/${req_external_id}`,
         "rel": "self",
         "method": "GET"
       }]

--- a/test/integration/login_ft_tests.js
+++ b/test/integration/login_ft_tests.js
@@ -23,7 +23,7 @@ describe('User clicks on Logout', function() {
   it('should get redirected to login page', function(done) {
 
     let incrementMock = adminusersMock
-      .patch(`${USER_RESOURCE}/${user.externalId}?is_new_api_request=y`)
+      .patch(`${USER_RESOURCE}/${user.externalId}`)
       .reply(200);
 
     build_get_request(paths.user.logOut)
@@ -31,7 +31,7 @@ describe('User clicks on Logout', function() {
       .expect('Location', paths.user.logIn)
       .expect(() => {
         assert(incrementMock.isDone());
-        assert(session.destroy.called == true);
+        assert(session.destroy.called === true);
       })
       .end(done);
   });

--- a/test/integration/service_roles_update_ft_test.js
+++ b/test/integration/service_roles_update_ft_test.js
@@ -58,7 +58,7 @@ describe('user permissions update controller', function () {
 
       let getUserResponse = userFixtures.validUserResponse(userToView);
 
-      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}?is_new_api_request=y`)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
         .reply(200, getUserResponse.getPlain());
 
       app = session.getAppWithLoggedInUser(getApp(), userInSession);
@@ -82,7 +82,7 @@ describe('user permissions update controller', function () {
 
     it('should error if user not found', function (done) {
 
-      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}?is_new_api_request=y`)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
         .reply(404);
 
       app = session.getAppWithLoggedInUser(getApp(), userInSession);
@@ -103,7 +103,7 @@ describe('user permissions update controller', function () {
       targetUser.service_ids[0] = '2';
 
       let getUserResponse = userFixtures.validUserResponse(targetUser);
-      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}?is_new_api_request=y`)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
         .reply(200, getUserResponse.getPlain());
 
       app = session.getAppWithLoggedInUser(getApp(), userInSession);
@@ -140,7 +140,7 @@ describe('user permissions update controller', function () {
 
       let getUserResponse = userFixtures.validUserResponse(userToView);
 
-      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}?is_new_api_request=y`)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
         .reply(200, getUserResponse.getPlain());
 
       adminusersMock.put(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}/services/${SERVICE_ID}`, {'role_name': 'admin'})
@@ -166,7 +166,7 @@ describe('user permissions update controller', function () {
 
       let getUserResponse = userFixtures.validUserResponse(userToView);
 
-      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}?is_new_api_request=y`)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
         .reply(200, getUserResponse.getPlain());
 
       app = session.getAppWithLoggedInUser(getApp(), userInSession);
@@ -209,7 +209,7 @@ describe('user permissions update controller', function () {
 
       app = session.getAppWithLoggedInUser(getApp(), userInSession);
 
-      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}?is_new_api_request=y`)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
         .reply(404);
 
       return supertest(app)
@@ -234,7 +234,7 @@ describe('user permissions update controller', function () {
       targetUser.service_ids[0] = '2';
 
       let getUserResponse = userFixtures.validUserResponse(targetUser);
-      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}?is_new_api_request=y`)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
         .reply(200, getUserResponse.getPlain());
 
       app = session.getAppWithLoggedInUser(getApp(), userInSession);
@@ -281,7 +281,7 @@ describe('user permissions update controller', function () {
       let getUserResponse = userFixtures.validUserResponse(userToView);
       app = session.getAppWithLoggedInUser(getApp(), userInSession);
 
-      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}?is_new_api_request=y`)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
         .reply(200, getUserResponse.getPlain());
 
       adminusersMock.put(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}/services/${SERVICE_ID}`, {'role_name': 'admin'})

--- a/test/integration/service_users_ft_test.js
+++ b/test/integration/service_users_ft_test.js
@@ -117,7 +117,7 @@ describe('service users resource', function () {
 
     let getUserResponse = userFixtures.validUserResponse(user_to_view);
 
-    adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}?is_new_api_request=y`)
+    adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
       .reply(200, getUserResponse.getPlain());
 
     app = session.getAppWithLoggedInUser(getApp(), user_in_session);
@@ -150,7 +150,7 @@ describe('service users resource', function () {
 
     let getUserResponse = userFixtures.validUserResponse(user);
 
-    adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_LOGGED_IN}?is_new_api_request=y`)
+    adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_LOGGED_IN}`)
       .reply(200, getUserResponse.getPlain());
 
     app = session.getAppWithLoggedInUser(getApp(), user_in_session);
@@ -205,7 +205,7 @@ describe('service users resource', function () {
       service_ids: ['2']
     });
 
-    adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}?is_new_api_request=y`)
+    adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
       .reply(200, getUserResponse.getPlain());
 
     app = session.getAppWithLoggedInUser(getApp(), user);

--- a/test/test_helpers/user_creator.js
+++ b/test/test_helpers/user_creator.js
@@ -5,7 +5,7 @@ let adminusersMock = nock(process.env.ADMINUSERS_URL);
 const USER_RESOURCE = '/v1/api/users';
 
 function mockUserResponse(userData, cb) {
-  adminusersMock.get(`${USER_RESOURCE}/${userData.external_id}?is_new_api_request=y`).times(5)
+  adminusersMock.get(`${USER_RESOURCE}/${userData.external_id}`).times(5)
     .reply(200, userFixtures.validUserResponse(userData).getPlain());
 
   adminusersMock.get(`${USER_RESOURCE}?username=${userData.username}`).times(5)


### PR DESCRIPTION
## WHAT
Remove `is_new_api_request` parameter - clean up

## HOW 
- Remove `is_new_api_request` parameter from **AdminUsers** client and related code, because **AdminUsers** does not use this parameter anymore


