### PR TITLE
PP-2023 Add user disabled integration test

### DIFF
--- a/test/integration/auth_ft_tests.js
+++ b/test/integration/auth_ft_tests.js
@@ -52,6 +52,18 @@ describe('An endpoint not protected', function () {
       .expect('Hello, World!')
       .end(done);
   });
+
+  it('redirects to noaccess if user disabled', function (done) {
+    let user = mockSession.getUser();
+    user.disabled = true;
+    app = getAppWithLoggedInUser(server.getApp(), user);
+    addProtectedEndpointToApp(app);
+    request(app)
+      .get('/protected')
+      .expect(302)
+      .expect('Location', paths.user.noAccess)
+      .end(done);
+  });
 });
 
 describe('An endpoint protected by auth.enforceUserBothFactors', function () {


### PR DESCRIPTION
This PR adds an integration test to check whether when a user who is disabled hits an arbitrary endpoint they get directed to /noaccess. This is to hopefully enable us to delete an accept test that tests whether users are locked out after too many invalid 2fa attempts.

I have analysed the code paths that this accept test exercises here: https://docs.google.com/spreadsheets/d/1KiapUV_2wWbUvhg9rl_sVYlBOuKwnOFAwIhti6xe6Yg/edit#gid=0

