### PR TITLE
PP-2051 Pin pact version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "newrelic": "1.26.x",
     "node-sass": "3.8.x",
     "notp": "^2.0.3",
-    "pact": "^1.0.0",
     "passport": "0.3.x",
     "passport-custom": "^1.0.5",
     "passport-local": "^1.0.0",
@@ -90,7 +89,8 @@
     "yargs": "4.7.x"
   },
   "devDependencies": {
-    "@pact-foundation/pact-node": "^4.6.0",
+    "@pact-foundation/pact-node": "4.6.0",
+    "pact": "1.0.0",
     "chai": "^3.2.0",
     "chai-as-promised": "^6.0.0",
     "chai-string": "^1.1.2",


### PR DESCRIPTION
Previously we had pact version in package.json as `^1.0.0`
(minimum of 1.0.0). We recently started seeing unit tests failin gon master
(see https://build.ci.pymnt.uk/job/pay-selfservice/job/master/4/consoleFull), which
appears due to new version of pact that was incompatible with our tests.

This commit pins the version of both pact libraries that we use. It also moves
the `pact` library to dev dependencies, as it is not needed in prod.

If we wish to upgrade pact version in future, we can do so explicitly.