### PR TITLE
PP-1246 Add title to 'Email notifications' section

### DIFF
--- a/app/views/email_notifications/confirm.html
+++ b/app/views/email_notifications/confirm.html
@@ -1,5 +1,9 @@
 {{< layout}}
 
+{{$pageTitle}}
+GOV.UK Pay - Email notifications
+{{/pageTitle}}
+
 {{$mainContent}}
 
 <h1 class="page-title">Confirm new email template</h1>

--- a/app/views/email_notifications/edit.html
+++ b/app/views/email_notifications/edit.html
@@ -1,5 +1,9 @@
 {{< layout}}
 
+{{$pageTitle}}
+GOV.UK Pay - Email notifications
+{{/pageTitle}}
+
 {{$mainContent}}
 
 <h1 class="page-title heading-large">

--- a/app/views/email_notifications/off_confirm.html
+++ b/app/views/email_notifications/off_confirm.html
@@ -1,5 +1,9 @@
 {{< layout}}
 
+{{$pageTitle}}
+GOV.UK Pay - Email notifications
+{{/pageTitle}}
+
 {{$mainContent}}
 
 <h1 class="heading-medium">


### PR DESCRIPTION
## WHAT
- Was only added in the index but necessary in the rest of pages of this section. Probably we need discussion, after accessibility session to rename all page titles per section and sub-section

