### PR TITLE
PP-2155 Suppress stack traces

### DIFF
--- a/env.js
+++ b/env.js
@@ -1,0 +1,1 @@
+process.env.NODE_ENV = process.env.NODE_ENV || 'production';

--- a/server.js
+++ b/server.js
@@ -1,3 +1,6 @@
+// Setting default environment variables
+require(__dirname + '/env');
+// Load libraries
 if(process.env.ENABLE_NEWRELIC == 'yes') require('newrelic');
 var express           = require('express');
 var path              = require('path');


### PR DESCRIPTION
## WHAT

As described in Express.js documentation: https://expressjs.com/en/advanced/best-practice-performance.html, we should set `NODE_ENV` to `production` to generate less verbose error messages.

## HOW 

Update docker startup script with `NODE_ENV=production`.

with @SandorArpa