### PR TITLE
PP 1615 Self create service

### DIFF
--- a/app/controllers/create_service_controller.js
+++ b/app/controllers/create_service_controller.js
@@ -45,7 +45,7 @@ module.exports = {
    * @param res
    */
   showOtpVerify: (req, res) => {
-    res.render('self_create_service/service_creation_verify_otp');
+    res.render('self_create_service/verify_otp');
   },
 
   /**

--- a/app/controllers/invite_validation_controller.js
+++ b/app/controllers/invite_validation_controller.js
@@ -1,0 +1,77 @@
+'use strict';
+
+// Node.js core dependencies
+const logger = require('winston');
+
+// Custom dependencies
+const response = require('../utils/response');
+const errorResponse = response.renderErrorView;
+const registrationService = require('../services/validate_invite_service');
+const paths = require('../paths');
+
+const messages = {
+  missingCookie: 'Unable to process registration at this time',
+  internalError: 'Unable to process registration at this time',
+  linkExpired: 'This invitation is no longer valid',
+  invalidOtp: 'Invalid verification code'
+};
+
+const handleError = (req, res, err) => {
+  logger.warn(`[requestId=${req.correlationId}] Invalid invite code attempted ${req.code}, error = ${err.errorCode}`);
+
+  switch (err.errorCode) {
+    case 404:
+      errorResponse(req, res, messages.missingCookie, 404);
+      break;
+    case 410:
+      errorResponse(req, res, messages.linkExpired, 410);
+      break;
+    default:
+      errorResponse(req, res, messages.missingCookie, 500);
+  }
+};
+
+module.exports = {
+
+  /**
+   * intermediate endpoint which captures the invite code and validate.
+   * Upon success this forwards the request to proceed with registration
+   * @param req
+   * @param res
+   * @returns {Promise.<T>}
+   */
+  validateInvite: (req, res) => {
+    const code = req.params.code;
+    const correlationId = req.correlationId;
+    const redirect = (invite) => {
+      let redirectTarget;
+
+      if (!req.register_invite) {
+        req.register_invite = {};
+      }
+
+      req.register_invite.code = code;
+
+      if (invite.telephone_number) {
+        req.register_invite.telephone_number = invite.telephone_number;
+      }
+
+      switch(invite.type) {
+        case 'user':
+          req.register_invite.email = invite.email;
+          redirectTarget = paths.registerUser.registration;
+          break;
+        case 'service':
+          redirectTarget = paths.selfCreateService.otpVerify;
+          break;
+        default:
+          handleError(req, res, 'Unrecognised invite type');
+      }
+      res.redirect(302, redirectTarget);
+    };
+
+    return registrationService.getValidatedInvite(code, correlationId)
+      .then(redirect)
+      .catch((err) => handleError(req, res, err));
+  }
+};

--- a/app/controllers/register_user_controller.js
+++ b/app/controllers/register_user_controller.js
@@ -52,33 +52,6 @@ const handleError = (req, res, err) => {
 module.exports = {
 
   /**
-   * intermediate endpoint which captures the invite code and validate.
-   * Upon success this forwards the request to proceed with registration
-   * @param req
-   * @param res
-   * @returns {Promise.<T>}
-   */
-  validateInvite: (req, res) => {
-    const code = req.params.code;
-    const correlationId = req.correlationId;
-    const redirectToRegister = (invite) => {
-      if (!req.register_invite) {
-        req.register_invite = {};
-      }
-      req.register_invite.code = code;
-      req.register_invite.email = invite.email;
-      if (invite.telephone_number) {
-        req.register_invite.telephone_number = invite.telephone_number;
-      }
-      res.redirect(302, paths.register.registration);
-    };
-
-    return registrationService.getValidatedInvite(code, correlationId)
-      .then(redirectToRegister)
-      .catch((err) => handleError(req, res, err));
-  },
-
-  /**
    * display user registration data entry form.
    * @param req
    * @param res
@@ -91,7 +64,7 @@ module.exports = {
       if (req.register_invite.telephone_number) {
         data.telephone_number = req.register_invite.telephone_number;
       }
-      successResponse(req, res, 'registration/register', data);
+      successResponse(req, res, 'user_registration/register', data);
     };
 
     return withValidatedRegistrationCookie(req, res, renderRegistrationPage);
@@ -112,7 +85,7 @@ module.exports = {
       registrationService.submitRegistration(code, telephoneNumber, password, correlationId)
         .then(() => {
           req.register_invite.telephone_number = telephoneNumber;
-          res.redirect(303, paths.register.otpVerify);
+          res.redirect(303, paths.registerUser.otpVerify);
         })
         .catch((err) => handleError(req, res, err));
     };
@@ -120,7 +93,7 @@ module.exports = {
     const redirectToDetailEntry = (err) => {
       req.register_invite.telephone_number = telephoneNumber;
       req.flash('genericError', err);
-      res.redirect(303, paths.register.registration);
+      res.redirect(303, paths.registerUser.registration);
     };
 
     return withValidatedRegistrationCookie(req, res, () => {
@@ -141,7 +114,7 @@ module.exports = {
     };
 
     const displayVerifyCodePage = () => {
-      successResponse(req, res, 'registration/verify_otp', data);
+      successResponse(req, res, 'user_registration/verify_otp', data);
     };
 
     return withValidatedRegistrationCookie(req, res, displayVerifyCodePage);
@@ -158,13 +131,13 @@ module.exports = {
     const code = req.register_invite.code;
 
     const redirectToAutoLogin = (req, res) => {
-      res.redirect(303, paths.register.logUserIn);
+      res.redirect(303, paths.registerUser.logUserIn);
     };
 
     const handleInvalidOtp = (message) => {
       logger.debug(`[requestId=${correlationId}] invalid user input - otp code`);
       req.flash('genericError', message);
-      res.redirect(303, paths.register.otpVerify);
+      res.redirect(303, paths.registerUser.otpVerify);
     };
 
     const verifyOtpAndCreateUser = function () {
@@ -201,7 +174,7 @@ module.exports = {
       const data = {
         telephone_number: telephoneNumber
       };
-      successResponse(req, res, 'registration/re_verify_phone', data);
+      successResponse(req, res, 'user_registration/re_verify_phone', data);
     };
 
     return withValidatedRegistrationCookie(req, res, displayReVerifyCodePage);
@@ -221,7 +194,7 @@ module.exports = {
       registrationService.resendOtpCode(code, telephoneNumber, correlationId)
         .then(() => {
           req.register_invite.telephone_number = telephoneNumber;
-          res.redirect(303, paths.register.otpVerify);
+          res.redirect(303, paths.registerUser.otpVerify);
         })
         .catch(err => handleError(req, res, err));
     };
@@ -233,7 +206,7 @@ module.exports = {
           logger.debug(`[requestId=${correlationId}] invalid user input - telephone number`);
           req.flash('genericError', err);
           req.register_invite.telephone_number = telephoneNumber;
-          res.redirect(303, paths.register.reVerifyPhone);
+          res.redirect(303, paths.registerUser.reVerifyPhone);
         });
     });
   }

--- a/app/paths.js
+++ b/app/paths.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   root: "/",
   transactions: {
@@ -71,8 +73,10 @@ module.exports = {
     permissions: '/team-members/:externalId/permissions',
     invite: '/team-members-invite'
   },
-  register: {
+  inviteValidation: {
     validateInvite:'/invites/:code',
+  },
+  registerUser: {
     registration: '/register',
     otpVerify: '/verify-otp',
     reVerifyPhone: '/re-verify-phone',

--- a/app/routes.js
+++ b/app/routes.js
@@ -40,9 +40,10 @@ const registerCtrl = require('./controllers/register_user_controller.js');
 const permissionController = require('./controllers/service_roles_update_controller.js');
 const toggle3ds = require('./controllers/toggle_3ds_controller.js');
 const selfCreateServiceCtrl = require('./controllers/create_service_controller.js');
+const inviteValidationCtrl = require('./controllers/invite_validation_controller.js');
 
 // Assignments
-const {healthcheck, register, user, selfCreateService, transactions, credentials, devTokens, serviceSwitcher, teamMembers, staticPaths} = paths;
+const {healthcheck, registerUser, user, selfCreateService, transactions, credentials, devTokens, serviceSwitcher, teamMembers, staticPaths, inviteValidation} = paths;
 const {notificationCredentials: nc, serviceName: sn, paymentTypes: pt, emailNotifications: en, toggle3ds: t3ds} = paths;
 
 
@@ -72,15 +73,17 @@ module.exports.bind = function (app) {
   // STATIC
   app.all(staticPaths.naxsiError, staticCtrl.naxsiError);
 
+  //VALIDATE INVITE
+  app.get(inviteValidation.validateInvite, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, inviteValidationCtrl.validateInvite);
+
   // REGISTER USER
-  app.get(register.validateInvite, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, registerCtrl.validateInvite);
-  app.get(register.registration, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, registerCtrl.showRegistration);
-  app.post(register.registration, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, registerCtrl.submitRegistration);
-  app.get(register.otpVerify, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, registerCtrl.showOtpVerify);
-  app.post(register.otpVerify, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, registerCtrl.submitOtpVerify);
-  app.get(register.reVerifyPhone, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, registerCtrl.showReVerifyPhone);
-  app.post(register.reVerifyPhone, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, registerCtrl.submitReVerifyPhone);
-  app.get(register.logUserIn, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, loginCtrl.loginAfterRegister, enforceUserAuthenticated, getAccount, loginCtrl.loggedIn);
+  app.get(registerUser.registration, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, registerCtrl.showRegistration);
+  app.post(registerUser.registration, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, registerCtrl.submitRegistration);
+  app.get(registerUser.otpVerify, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, registerCtrl.showOtpVerify);
+  app.post(registerUser.otpVerify, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, registerCtrl.submitOtpVerify);
+  app.get(registerUser.reVerifyPhone, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, registerCtrl.showReVerifyPhone);
+  app.post(registerUser.reVerifyPhone, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, registerCtrl.submitReVerifyPhone);
+  app.get(registerUser.logUserIn, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, loginCtrl.loginAfterRegister, enforceUserAuthenticated, getAccount, loginCtrl.loggedIn);
   
   // LOGIN
   app.get(user.logIn, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, loginCtrl.logInGet);

--- a/app/services/user_registration_service.js
+++ b/app/services/user_registration_service.js
@@ -6,15 +6,6 @@ const paths = require(__dirname + '/../paths.js');
 module.exports = {
 
   /**
-   * gets the invite identified by `code`. Assumes its validates (i.e. not expired)
-   * @param code
-   * @param correlationId
-   */
-  getValidatedInvite: function (code, correlationId) {
-    return getAdminUsersClient({correlationId: correlationId}).getValidatedInvite(code);
-  },
-
-  /**
    * submit the user details for new user creation
    * @param code
    * @param phoneNumber

--- a/app/services/validate_invite_service.js
+++ b/app/services/validate_invite_service.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const getAdminUsersClient = require('./clients/adminusers_client');
+const paths = require(__dirname + '/../paths.js');
+
+module.exports = {
+
+  /**
+   * gets the invite identified by `code`. Assumes its valid (i.e. not expired)
+   * @param code
+   * @param correlationId
+   */
+  getValidatedInvite: function (code, correlationId) {
+    return getAdminUsersClient({correlationId: correlationId}).getValidatedInvite(code);
+  }
+};

--- a/app/views/self_create_service/set_name.html
+++ b/app/views/self_create_service/set_name.html
@@ -5,7 +5,7 @@ Set the service name - GOV.UK Pay
 {{/pageTitle}}
 {{$mainContent}}
 <div id="display-name-your-service" class="column-half no-padding">
-    <form action="{{routes.register.otpVerify}}" class="form" method="post" class="submit-two-fa" id="name-your-service-form">
+    <form action="{{routes.selfCreateService.serviceNaming}}" class="form" method="post" class="submit-two-fa" id="name-your-service-form">
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
         <h1 class="form-title heading-large">What service will you be taking payments for?</h1>
         <div class="form-group">

--- a/app/views/self_create_service/verify_otp.html
+++ b/app/views/self_create_service/verify_otp.html
@@ -5,7 +5,7 @@ Verify code - GOV.UK Pay
 {{/pageTitle}}
 {{$mainContent}}
 <div id="display_otp_verify" class="column-half no-padding">
-  <form action="{{routes.register.otpVerify}}" class="form" method="post" class="submit-two-fa" id="verify-phone-form">
+  <form action="{{routes.selfCreateService.otpVerify}}" class="form" method="post" class="submit-two-fa" id="verify-phone-form">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
     <h1 class="form-title heading-large">Check your phone</h1>
     <p>We've sent you a text message with a security code</p>
@@ -17,7 +17,7 @@ Verify code - GOV.UK Pay
       <input class="button" type="submit" value="Continue">
     </div>
   </form>
-  <p><a href="{{routes.register.reVerifyPhone}}">Not received a text message?</a></p>
+  <p><a href="{{routes.selfCreateService.reVerifyPhone}}">Not received a text message?</a></p>
 
 </div>
 

--- a/app/views/user_registration/re_verify_phone.html
+++ b/app/views/user_registration/re_verify_phone.html
@@ -15,7 +15,7 @@ Resend verification code - GOV.UK Pay
     If you no longer have access to the phone with the number registered for this service,
     speak to your service manager to reset the number
   </p>
-  <form action="{{routes.register.reVerifyPhone}}" class="form" method="post" id="otp-send-again">
+  <form action="{{routes.registerUser.reVerifyPhone}}" class="form" method="post" id="otp-send-again">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
     <div class="form-group">
       <label class="form-label" for="telephone-number">

--- a/app/views/user_registration/register.html
+++ b/app/views/user_registration/register.html
@@ -5,7 +5,7 @@ Self registration - GOV.UK Pay
 {{/pageTitle}}
 {{$mainContent}}
 <div class="column-half no-padding">
-    <form action="{{routes.register.registration}}" method="post" id="submit-registration" class="form submit-registration">
+    <form action="{{routes.registerUser.registration}}" method="post" id="submit-registration" class="form submit-registration">
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
         <h1 class="heading-large">
             Create an account

--- a/app/views/user_registration/verify_otp.html
+++ b/app/views/user_registration/verify_otp.html
@@ -5,7 +5,7 @@ Verify code - GOV.UK Pay
 {{/pageTitle}}
 {{$mainContent}}
 <div class="column-half no-padding">
-  <form action="{{routes.register.otpVerify}}" class="form" method="post" class="submit-two-fa" id="verify-phone-form">
+  <form action="{{routes.registerUser.otpVerify}}" class="form" method="post" class="submit-two-fa" id="verify-phone-form">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
     <h1 class="form-title heading-large">
       Check your phone
@@ -19,7 +19,7 @@ Verify code - GOV.UK Pay
       <input class="button" type="submit" value="Continue">
     </div>
   </form>
-  <p><a href="{{routes.register.reVerifyPhone}}">Not received a text message?</a></p>
+  <p><a href="{{routes.registerUser.reVerifyPhone}}">Not received a text message?</a></p>
 
 </div>
 

--- a/test/fixtures/invite_fixtures.js
+++ b/test/fixtures/invite_fixtures.js
@@ -1,17 +1,17 @@
-let random = require(__dirname + '/../../app/utils/random');
-let pactBase = require(__dirname + '/pact_base');
-let pactInvites = pactBase();
-let _ = require('lodash');
+const random = require(__dirname + '/../../app/utils/random');
+const pactBase = require(__dirname + '/pact_base');
+const pactInvites = pactBase();
+const _ = require('lodash');
 
 module.exports = {
 
   validInviteRequest: (opts = {}) => {
 
-    let invitee = "random@example.com";
-    let senderId = random.randomUuid();
-    let role = {name: "admin"};
+    const invitee = "random@example.com";
+    const senderId = random.randomUuid();
+    const role = {name: "admin"};
 
-    let data = {
+    const data = {
       email: opts.email || invitee,
       sender: opts.sender || senderId,
       role_name: opts.role_name || role
@@ -28,10 +28,12 @@ module.exports = {
   },
 
   validInviteResponse: (opts = {}) => {
-    let invitee = "random@example.com";
+    const invitee = "random@example.com";
+    const type = 'user';
 
-    let data = {
+    const data = {
       email: opts.email || invitee,
+      type: opts.type || type
     };
 
     if (opts.telephone_number) {
@@ -50,10 +52,10 @@ module.exports = {
 
   invalidInviteRequest: (opts = {}) => {
 
-    let senderId = random.randomUuid();
-    let role = {name: "admin"};
+    const senderId = random.randomUuid();
+    const role = {name: "admin"};
 
-    let data = {
+    const data = {
       email: opts.email || '',
       sender: opts.sender || senderId,
       role_name: opts.role_name || role
@@ -70,7 +72,7 @@ module.exports = {
   },
 
   notPermittedInviteResponse: (userName, serviceId) => {
-    let response = {
+    const response = {
       errors: ["user [" + userName + "] not authorised to perform operation [invite] in service [" + serviceId + "]"]
     };
 
@@ -79,7 +81,7 @@ module.exports = {
 
   validRegistrationRequest: (opts = {}) => {
 
-    let data = {
+    const data = {
       code: opts.code || random.randomUuid(),
       telephone_number: opts.telephone_number || '12345678901',
       password: opts.password || 'password1234'
@@ -96,10 +98,10 @@ module.exports = {
   },
 
   badRequestResponseWhenFieldsMissing: (missingFields) => {
-    let responseData = _.map(missingFields, (field) => {
+    const responseData = _.map(missingFields, (field) => {
       return `Field [${field}] is required`;
     });
-    let response = {
+    const response = {
       errors: responseData
     };
 
@@ -107,7 +109,7 @@ module.exports = {
   },
 
   invalidInviteCreateResponseWhenFieldsMissing: () => {
-    let response = {
+    const response = {
       // At the moment to discuss Failfast approach to the API rather than error collection
       errors: ["Field [email] is required"]
     };
@@ -116,7 +118,7 @@ module.exports = {
   },
 
   conflictingInviteResponseWhenEmailUserAlreadyCreated: (email) => {
-    let response = {
+    const response = {
       errors: ['invite with email [' + email + '] already exists']
     };
 
@@ -132,7 +134,7 @@ module.exports = {
   },
 
   validVerifyOtpCodeRequest: (opts = {}) => {
-    let data = {
+    const data = {
       code: opts.code || random.randomUuid(),
       otp: opts.otp || '123456'
     };
@@ -148,7 +150,7 @@ module.exports = {
   },
 
   validResendOtpCodeRequest: (opts = {}) => {
-    let data = {
+    const data = {
       code: opts.code || random.randomUuid(),
       telephone_number: opts.telephone_number || '01234567891'
     };

--- a/test/integration/login_controller_test.js
+++ b/test/integration/login_controller_test.js
@@ -279,7 +279,7 @@ describe('direct login after user registration', function () {
     let app2 = mock_session.getAppWithRegisterInvitesCookie(getApp(), gatewayAccountData);
 
     request(app2)
-      .get(paths.register.logUserIn)
+      .get(paths.registerUser.logUserIn)
       .set('Accept', 'application/json')
       .expect(200)
       .expect((res)=>{

--- a/test/integration/validate_invite_controller_ft_tests.js
+++ b/test/integration/validate_invite_controller_ft_tests.js
@@ -1,0 +1,287 @@
+'use strict';
+
+const nock = require('nock');
+const supertest = require('supertest');
+const paths = require(__dirname + '/../../app/paths.js');
+const getApp = require(__dirname + '/../../server.js').getApp;
+const session = require(__dirname + '/../test_helpers/mock_session.js');
+const inviteFixtures = require(__dirname + '/../fixtures/invite_fixtures');
+const userFixtures = require(__dirname + '/../fixtures/user_fixtures');
+const csrf = require('csrf');
+
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+
+const adminusersMock = nock(process.env.ADMINUSERS_URL);
+const INVITE_RESOURCE_PATH = '/v1/api/invites';
+const expect = chai.expect;
+
+let app;
+let mockRegisterAccountCookie;
+
+describe('register user controller', function () {
+
+  beforeEach((done) => {
+    mockRegisterAccountCookie = {};
+    app = session.getAppWithRegisterInvitesCookie(getApp(), mockRegisterAccountCookie);
+    done();
+  });
+
+  afterEach((done) => {
+    nock.cleanAll();
+    app = null;
+    done();
+  });
+
+  /**
+   *  ENDPOINT validateInvite
+   */
+  describe('verify invitation endpoint', function () {
+
+    it('should redirect to register view on a valid invite code for user', function (done) {
+
+      const code = '23rer87t8shjkaf';
+      const validInviteResponse = inviteFixtures.validInviteResponse().getPlain();
+
+      adminusersMock.get(`${INVITE_RESOURCE_PATH}/${code}`)
+        .reply(200, validInviteResponse);
+
+      return supertest(app)
+        .get(`/invites/${code}`)
+        .set('x-request-id', 'bob')
+        .expect(302)
+        .expect('Location', paths.registerUser.registration)
+        .expect(() => {
+          expect(mockRegisterAccountCookie.code).to.equal(code);
+          expect(mockRegisterAccountCookie.email).to.equal(validInviteResponse.email);
+        })
+        .end(done);
+
+    });
+
+    it('should redirect to register view on a valid invite code for service', function (done) {
+
+      const code = '23rer87t8shjkaf';
+      const type = 'service';
+      const telephoneNumber = '07562327123';
+      const opts = {
+        type,
+        telephone_number: telephoneNumber
+      };
+      const validInviteResponse = inviteFixtures.validInviteResponse(opts).getPlain();
+
+      adminusersMock.get(`${INVITE_RESOURCE_PATH}/${code}`)
+        .reply(200, validInviteResponse);
+
+      return supertest(app)
+        .get(`/invites/${code}`)
+        .set('x-request-id', 'bob')
+        .expect(302)
+        .expect('Location', paths.selfCreateService.otpVerify)
+        .expect(() => {
+          expect(mockRegisterAccountCookie.code).to.equal(code);
+          expect(mockRegisterAccountCookie.telephone_number).to.equal(telephoneNumber);
+        })
+        .end(done);
+
+    });
+
+    it('should redirect to register with telephone number, if user did not complete previous attempt after entering registration details', function (done) {
+
+      const code = '7s8ftgw76rwgu';
+      const telephoneNumber = '123456789';
+      const validInviteResponse = inviteFixtures.validInviteResponse({telephone_number: telephoneNumber}).getPlain();
+
+      adminusersMock.get(`${INVITE_RESOURCE_PATH}/${code}`)
+        .reply(200, validInviteResponse);
+
+      return supertest(app)
+        .get(`/invites/${code}`)
+        .set('x-request-id', 'bob')
+        .expect(302)
+        .expect('Location', paths.registerUser.registration)
+        .expect(() => {
+          expect(mockRegisterAccountCookie.code).to.equal(code);
+          expect(mockRegisterAccountCookie.email).to.equal(validInviteResponse.email);
+          expect(mockRegisterAccountCookie.telephone_number).to.equal(telephoneNumber);
+        })
+        .end(done);
+
+    });
+
+    it('should error if the invite code is invalid', function (done) {
+
+      const invalidCode = 'invalidCode';
+      adminusersMock.get(`${INVITE_RESOURCE_PATH}/${invalidCode}`)
+        .reply(404);
+
+      return supertest(app)
+        .get(`/invites/${invalidCode}`)
+        .set('Accept', 'application/json')
+        .set('x-request-id', 'bob')
+        .expect(404)
+        .expect((res) => {
+          expect(res.body.message).to.equal('Unable to process registration at this time');
+        })
+        .end(done);
+
+    });
+  });
+
+
+  /**
+   *  ENDPOINT showRegistration
+   */
+  describe('show registration view endpoint', function () {
+
+    it('should display create account form', function (done) {
+
+      mockRegisterAccountCookie.email = 'invitee@example.com';
+      mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf';
+
+      return supertest(app)
+        .get(paths.registerUser.registration)
+        .set('Accept', 'application/json')
+        .set('x-request-id', 'bob')
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.email).to.equal('invitee@example.com');
+        })
+        .end(done);
+
+    });
+
+    it('should display create account form with telephone populated, if invite has been attempted', function (done) {
+
+      mockRegisterAccountCookie.email = 'invitee@example.com';
+      mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf';
+      mockRegisterAccountCookie.telephone_number = '123456789';
+
+      return supertest(app)
+        .get(paths.registerUser.registration)
+        .set('Accept', 'application/json')
+        .set('x-request-id', 'bob')
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.email).to.equal('invitee@example.com');
+          expect(res.body.telephone_number).to.equal('123456789');
+        })
+        .end(done);
+
+    });
+
+    it('should display error when email and/or code is not in the cookie', function (done) {
+      return supertest(app)
+        .get(paths.registerUser.registration)
+        .set('Accept', 'application/json')
+        .set('x-request-id', 'bob')
+        .expect(404)
+        .expect((res) => {
+          expect(res.body.message).to.equal('Unable to process registration at this time');
+        })
+        .end(done);
+    });
+  });
+
+  /**
+   *  ENDPOINT submitRegistration
+   */
+
+  describe('submit registration details endpoint', function () {
+
+    it('should error if cookie details are missing', function (done) {
+
+      return supertest(app)
+        .post(paths.registerUser.registration)
+        .set('Accept', 'application/json')
+        .set('Content-Type', 'application/x-www-form-urlencoded')
+        .set('x-request-id', 'bob')
+        .send({
+          csrfToken: csrf().create('123')
+        })
+        .expect(404)
+        .expect((res) => {
+          expect(res.body.message).to.equal('Unable to process registration at this time');
+        })
+        .end(done);
+
+    });
+
+    it('should redirect back to registration form if error in phone number', function (done) {
+
+      mockRegisterAccountCookie.email = 'invitee@example.com';
+      mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf';
+
+      const invalidPhone = '123456789';
+      return supertest(app)
+        .post(paths.registerUser.registration)
+        .set('Accept', 'application/json')
+        .set('Content-Type', 'application/x-www-form-urlencoded')
+        .set('x-request-id', 'bob')
+        .send({
+          'telephone-number': invalidPhone,
+          'password': 'password1234',
+          csrfToken: csrf().create('123')
+        })
+        .expect(303, {})
+        .expect('Location', paths.registerUser.registration)
+        .expect((res) => {
+          expect(mockRegisterAccountCookie.telephone_number).to.equal(invalidPhone);
+        })
+        .end(done);
+
+    });
+
+    it('should redirect to phone verification page', function (done) {
+
+      mockRegisterAccountCookie.email = 'invitee@example.com';
+      mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf';
+
+      adminusersMock.post(`${INVITE_RESOURCE_PATH}/otp/generate`)
+        .reply(200);
+
+      return supertest(app)
+        .post(paths.registerUser.registration)
+        .set('Accept', 'application/json')
+        .set('Content-Type', 'application/x-www-form-urlencoded')
+        .set('x-request-id', 'bob')
+        .send({
+          'telephone-number': '12345678901',
+          'password': 'password1234',
+          csrfToken: csrf().create('123')
+        })
+        .expect(303, {})
+        .expect('Location', paths.registerUser.otpVerify)
+        .end(done);
+
+    });
+
+    it('should error for valid registration data, if code not found', function (done) {
+
+      mockRegisterAccountCookie.email = 'invitee@example.com';
+      mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf';
+
+      adminusersMock.post(`${INVITE_RESOURCE_PATH}/otp/generate`)
+        .reply(404);
+
+      return supertest(app)
+        .post(paths.registerUser.registration)
+        .set('Accept', 'application/json')
+        .set('Content-Type', 'application/x-www-form-urlencoded')
+        .set('x-request-id', 'bob')
+        .send({
+          'telephone-number': '12345678901',
+          'password': 'password1234',
+          csrfToken: csrf().create('123')
+        })
+        .expect(404)
+        .expect((res) => {
+          expect(res.body.message).to.equal('Unable to process registration at this time');
+        })
+        .end(done);
+
+    });
+
+  });
+});

--- a/test/ui/register_user_ui_tests.js
+++ b/test/ui/register_user_ui_tests.js
@@ -10,9 +10,9 @@ describe('Register user view', function () {
       email: 'invitee@example.com'
     };
 
-    let body = renderTemplate('registration/register', templateData);
+    let body = renderTemplate('user_registration/register', templateData);
 
-    body.should.containSelector('form#submit-registration').withAttribute('action', paths.register.registration);
+    body.should.containSelector('form#submit-registration').withAttribute('action', paths.registerUser.registration);
     body.should.containSelector('p#email-display').withExactText('Your account will be created with this email: invitee@example.com');
     body.should.containSelector('input#telephone-number');
     body.should.containSelector('input#password');
@@ -26,9 +26,9 @@ describe('Register user view', function () {
       telephone_number: '0328534765'
     };
 
-    let body = renderTemplate('registration/register', templateData);
+    let body = renderTemplate('user_registration/register', templateData);
 
-    body.should.containSelector('form#submit-registration').withAttribute('action', paths.register.registration);
+    body.should.containSelector('form#submit-registration').withAttribute('action', paths.registerUser.registration);
     body.should.containSelector('p#email-display').withExactText('Your account will be created with this email: invitee@example.com');
     body.should.containSelector('input#telephone-number')
       .withAttribute("value", "0328534765");
@@ -42,9 +42,9 @@ describe('Register user view', function () {
       email: 'invitee@example.com'
     };
 
-    let body = renderTemplate('registration/verify_otp', templateData);
+    let body = renderTemplate('user_registration/verify_otp', templateData);
 
-    body.should.containSelector('form#verify-phone-form').withAttribute('action', paths.register.otpVerify);
+    body.should.containSelector('form#verify-phone-form').withAttribute('action', paths.registerUser.otpVerify);
     body.should.containSelector('input#verify-code');
     done();
   });
@@ -57,9 +57,9 @@ describe('Register user view', function () {
       telephone_number: telephoneNumber
     };
 
-    let body = renderTemplate('registration/re_verify_phone', templateData);
+    let body = renderTemplate('user_registration/re_verify_phone', templateData);
 
-    body.should.containSelector('form#otp-send-again').withAttribute('action', paths.register.reVerifyPhone);
+    body.should.containSelector('form#otp-send-again').withAttribute('action', paths.registerUser.reVerifyPhone);
     body.should.containSelector('input#telephone-number').withAttribute('value', telephoneNumber);
     done();
   });

--- a/test/ui/self_create_service_ui_tests.js
+++ b/test/ui/self_create_service_ui_tests.js
@@ -47,7 +47,7 @@ describe('Self-create service view', function () {
     body.should.containSelector('h1').withExactText('Check your phone');
 
     body.should.containSelector('form#verify-phone-form > p:nth-child(3)').withExactText(`We've sent you a text message with a security code`);
-    body.should.containSelector('form#verify-phone-form');//.withAttribute('action', paths.register.registration);
+    body.should.containSelector('form#verify-phone-form').withAttribute('action', paths.selfCreateService.otpVerify);
     body.should.containInputField('verify-code', 'text');
 
     body.should.containSelector('div#display_otp_verify > p:nth-child(2) > a').withExactText('Not received a text message?');
@@ -65,7 +65,7 @@ describe('Self-create service view', function () {
     body.should.containSelector('h1').withExactText('What service will you be taking payments for?');
 
     body.should.containInputField('service-name', 'text');
-    body.should.containSelector('form#name-your-service-form');//.withAttribute('action', paths.register.registration);
+    body.should.containSelector('form#name-your-service-form').withAttribute('action', paths.selfCreateService.serviceNaming);
 
     done();
   });

--- a/test/unit/clients/adminusers_client_get_invite_test.js
+++ b/test/unit/clients/adminusers_client_get_invite_test.js
@@ -1,20 +1,22 @@
-let Pact = require('pact');
-let helpersPath = __dirname + '/../../test_helpers/';
-let pactProxy = require(helpersPath + '/pact_proxy.js');
-let chai = require('chai');
-let chaiAsPromised = require('chai-as-promised');
-let inviteFixtures = require(__dirname + '/../../fixtures/invite_fixtures');
-let getAdminUsersClient = require('../../../app/services/clients/adminusers_client');
-let PactInteractionBuilder = require(__dirname + '/../../fixtures/pact_interaction_builder').PactInteractionBuilder;
+'use strict';
+
+const Pact = require('pact');
+const helpersPath = __dirname + '/../../test_helpers/';
+const pactProxy = require(helpersPath + '/pact_proxy.js');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const inviteFixtures = require(__dirname + '/../../fixtures/invite_fixtures');
+const getAdminUsersClient = require('../../../app/services/clients/adminusers_client');
+const PactInteractionBuilder = require(__dirname + '/../../fixtures/pact_interaction_builder').PactInteractionBuilder;
 
 chai.use(chaiAsPromised);
 
 const expect = chai.expect;
 
 const INVITES_PATH = '/v1/api/invites';
-let mockPort = Math.floor(Math.random() * 65535);
-let mockServer = pactProxy.create('localhost', mockPort);
-let adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${mockPort}`});
+const mockPort = Math.floor(Math.random() * 65535);
+const mockServer = pactProxy.create('localhost', mockPort);
+const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${mockPort}`});
 
 describe('adminusers client - get a validated invite', function () {
 
@@ -44,15 +46,15 @@ describe('adminusers client - get a validated invite', function () {
 
     context('GET invite api - success', () => {
 
-      let inviteCode = '7d19aff33f8948deb97ed16b2912dcd3';
+      const inviteCode = '7d19aff33f8948deb97ed16b2912dcd3';
 
-      let params = {
+      const params = {
         invite_code: inviteCode,
         telephone_number: '0123456789'
       };
 
 
-      let getInviteResponse = inviteFixtures.validInviteResponse(params);
+      const getInviteResponse = inviteFixtures.validInviteResponse(params);
 
       beforeEach((done) => {
         adminUsersMock.addInteraction(
@@ -69,18 +71,19 @@ describe('adminusers client - get a validated invite', function () {
       });
 
       it('should find an invite successfully', function (done) {
-        let expectedInviteData = getInviteResponse.getPlain();
+        const expectedInviteData = getInviteResponse.getPlain();
 
         adminusersClient.getValidatedInvite(params.invite_code).should.be.fulfilled.then(function(invite) {
           expect(invite.email).to.be.equal(expectedInviteData.email);
           expect(invite.telephone_number).to.be.equal(expectedInviteData.telephone_number);
+          expect(invite.type).to.be.equal(expectedInviteData.type);
         }).should.notify(done);
       });
     });
 
     context('GET invite api - expired', () => {
 
-      let expiredCode = '7d19aff33f8948deb97ed16b2912dcd3';
+      const expiredCode = '7d19aff33f8948deb97ed16b2912dcd3';
 
       beforeEach((done) => {
         adminUsersMock.addInteraction(
@@ -107,7 +110,7 @@ describe('adminusers client - get a validated invite', function () {
 
     context('GET invite api - not found', () => {
 
-      let nonExistingCode = '7d19aff33f8948deb97ed16b2912dcd3';
+      const nonExistingCode = '7d19aff33f8948deb97ed16b2912dcd3';
 
       beforeEach((done) => {
         adminUsersMock.addInteraction(

--- a/test/unit/controller/validate_invite_controller_test.js
+++ b/test/unit/controller/validate_invite_controller_test.js
@@ -1,8 +1,10 @@
-let proxyquire = require('proxyquire');
-let sinon = require('sinon');
-let q = require('q');
-let chai = require('chai');
-let chaiAsPromised = require('chai-as-promised');
+'use strict';
+
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const q = require('q');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
 
 chai.use(chaiAsPromised);
 
@@ -38,12 +40,12 @@ describe('Error handler', function () {
     renderStub.reset();
   });
 
-  let controller = function (errorCode) {
-    return proxyquire(__dirname + '/../../../app/controllers/register_user_controller.js',
+  const controller = function (errorCode) {
+    return proxyquire(__dirname + '/../../../app/controllers/invite_validation_controller.js',
       {
-        '../services/user_registration_service': {
+        '../services/validate_invite_service': {
           getValidatedInvite: () => {
-            let defer = q.defer();
+            const defer = q.defer();
             defer.reject({errorCode: errorCode});
             return defer.promise;
           }
@@ -54,7 +56,7 @@ describe('Error handler', function () {
 
   it('should handle 404 as unable to process registration at this time', function (done) {
 
-    let errorCode = 404;
+    const errorCode = 404;
 
     controller(errorCode).validateInvite(req, res).should.be.fulfilled
       .then(() => {
@@ -64,7 +66,7 @@ describe('Error handler', function () {
   });
 
   it('should handle 410 as this invitation link has expired', function (done) {
-    let errorCode = 410;
+    const errorCode = 410;
 
     controller(errorCode).validateInvite(req, res).should.be.fulfilled
       .then(() => {
@@ -74,7 +76,7 @@ describe('Error handler', function () {
   });
 
   it('should handle undefined as unable to process registration at this time with error code 500', function (done) {
-    let errorCode = undefined;
+    const errorCode = undefined;
 
     controller(errorCode).validateInvite(req, res).should.be.fulfilled
       .then(() => {


### PR DESCRIPTION
## WHAT
Implemented a handler for generic invite url ( `/invites/{code}` ). Based on `type` (`user`, `service`), redirect to register user, create service or invalid/expired page.

## HOW
- refactored handling of generic invite url sent to user 
- refactored relevant pact, ui, unit and ft tests
- updated lint styles of touched files
