### PR TITLE
PP-2244 My profile page accessible withouth 2FA Bug

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -184,7 +184,7 @@ module.exports.bind = function (app) {
   app.get(teamMembers.show, permission('users-service:read'), serviceUsersController.show);
   app.get(teamMembers.permissions, permission('users-service:create'), permissionController.index);
   app.post(teamMembers.permissions, permission('users-service:create'), permissionController.update);
-  app.get(user.profile, serviceUsersController.profile);
+  app.get(user.profile, enforceUserAuthenticated, serviceUsersController.profile);
 
   // TEAM MEMBERS - INVITE
   app.get(teamMembers.invite, permission('users-service:create'), inviteUserController.index);

--- a/test/integration/service_users_ft_test.js
+++ b/test/integration/service_users_ft_test.js
@@ -184,6 +184,31 @@ describe('service users resource', function () {
       .end(done);
   });
 
+  it('should not show my profile without second factor', function (done) {
+
+    const user = {
+      external_id: EXTERNAL_ID_LOGGED_IN,
+      username: USERNAME_LOGGED_IN,
+      email: USERNAME_LOGGED_IN + '@example.com',
+      telephone_number: '+447876548778',
+      service_ids: ['1']
+    };
+    const user_in_session = session.getUser(user);
+    const getUserResponse = userFixtures.validUserResponse(user);
+
+    adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_LOGGED_IN}`)
+      .reply(200, getUserResponse.getPlain());
+
+    app = session.getAppWithSessionWithoutSecondFactor(getApp(), user_in_session);
+
+    return supertest(app)
+      .get('/my-profile')
+      .set('Accept', 'application/json')
+      .expect(302)
+      .expect('Location', '/otp-login')
+      .end(done);
+  });
+
   it('should redirect to my profile when trying to access my user through team members path', function (done) {
 
     const user_in_session = session.getUser({


### PR DESCRIPTION
## WHAT
- Access control issue. Profile information available without 2FA authentication. To retrieve details is enough to login but not send OTP and the following URL is accessible: `https://selfservice.staging.payments.service.gov.uk/my-profile` this defeats the 2FA on the profile page

- Add enforce second factor when requested show my profile.

