### PR TITLE
PP-2219 Moved appmetrics config. Removed superflous NODE_ENV code as …

### DIFF
--- a/env.js
+++ b/env.js
@@ -1,3 +1,0 @@
-'use strict';
-
-process.env.NODE_ENV = process.env.NODE_ENV || 'production';

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
-// Setting default environment variables
-require(__dirname + '/env');
+//Please leave here even though it looks unused - this enables Node.js metrics to be pushed to Hosted Graphite
+require(__dirname + '/app/utils/metrics').metrics;
 
 // Node.js core dependencies
 const path = require('path');
@@ -24,7 +24,6 @@ const proxy = require(__dirname + '/app/utils/proxy');
 const environment = require(__dirname + '/app/services/environment');
 const auth = require(__dirname + '/app/services/auth_service');
 const middlwareUtils = require(__dirname + '/app/utils/middleware');
-const applicationMetrics = require(__dirname + '/app/utils/metrics').metrics;
 const errorHandler = require(__dirname + '/app/middleware/error_handler');
 
 // Global constants


### PR DESCRIPTION
…this is configured at the Ansible level

## WHAT
Appmetrics needs to be configured before other module import statements so it can monitor these. Deleted the now un-needed NODE_ENV setting code as these are set via Ansible

## HOW 
Run NPM test to verify these do not affect other operations.


