### PR TITLE
PP-2254 Protect against Spreadsheet Formula Injection attack when dow…

### DIFF
--- a/app/utils/json_to_csv.js
+++ b/app/utils/json_to_csv.js
@@ -3,9 +3,32 @@ var dates     = require('../utils/dates.js');
 var logger    = require('winston');
 var json2csv  = require('json2csv');
 
+
+
 module.exports = function (data) {
+
   logger.debug('Converting transactions list from json to csv');
   var defer = q.defer();
+
+  var sanitiseAgainstSpreadsheetFormulaInjection = function(fieldValue) {
+
+        if (typeof(fieldValue) !== 'string') { return fieldValue; }
+
+        var escapingCharacter = "'";
+
+        var injectionTriggerCharacters = ['=', '@', '+', '-'];
+
+        for (var i = 0; i < injectionTriggerCharacters.length; i++) {
+            injectionTriggerCharacter = injectionTriggerCharacters[i];
+            if (fieldValue.startsWith(injectionTriggerCharacter)) {
+                fieldValue = escapingCharacter + fieldValue;
+                break;
+            }
+        }
+
+        return fieldValue;
+  }
+
   json2csv(
     {
       data: data,
@@ -13,15 +36,21 @@ module.exports = function (data) {
       fields: [
         {
           label: 'Reference',
-          value: "reference"
+            value: function(row) {
+                return sanitiseAgainstSpreadsheetFormulaInjection(row.reference);
+            }
         },
         {
           label: 'Description',
-          value: "description"
+          value: function(row) {
+            return sanitiseAgainstSpreadsheetFormulaInjection(row.description);
+          }
         },
         {
           label: 'Email',
-          value: "email"
+            value: function(row) {
+                return sanitiseAgainstSpreadsheetFormulaInjection(row.email);
+            }
         },
         {
           label: "Amount",
@@ -31,43 +60,78 @@ module.exports = function (data) {
         },
         {
           label: 'Card Brand',
-          value: "card_details.card_brand"
+            value: function(row) {
+                return row.card_details
+                    ? sanitiseAgainstSpreadsheetFormulaInjection(row.card_details.card_brand)
+                    : null;
+
+            }
         },
         {
           label: 'Cardholder Name',
-          value: "card_details.cardholder_name"
+            value: function(row) {
+                return row.card_details
+                    ? sanitiseAgainstSpreadsheetFormulaInjection(row.card_details.cardholder_name)
+                    : null;
+            }
         },
         {
           label: 'Card Expiry Date',
-          value: "card_details.expiry_date"
+            value: function(row) {
+                return row.card_details
+                    ? sanitiseAgainstSpreadsheetFormulaInjection(row.card_details.expiry_date)
+                    : null;
+            }
         },
         {
           label: 'Card Number',
-          value: "card_details.last_digits_card_number"
+            value: function(row) {
+                return  row.card_details
+                    ? sanitiseAgainstSpreadsheetFormulaInjection(row.card_details.last_digits_card_number)
+                    : null;
+            }
         },
         {
           label: 'State',
-          value: "state.status"
+            value: function(row) {
+                return  row.state
+                    ? sanitiseAgainstSpreadsheetFormulaInjection(row.state.status)
+                    : null;
+            }
         },
         {
           label: 'Finished',
-          value: "state.finished"
+            value: function(row) {
+                return  row.state
+                    ? sanitiseAgainstSpreadsheetFormulaInjection(row.state.finished)
+                    : null;
+            }
         },
         {
           label: 'Error Code',
-          value: "state.code"
+            value: function(row) {
+                return  row.state
+                    ? sanitiseAgainstSpreadsheetFormulaInjection(row.state.code)
+                    : null;
+            }
         },
         {
           label: 'Error Message',
-          value: "state.message"
+            value: function(row) {
+                return sanitiseAgainstSpreadsheetFormulaInjection(row.state.message);
+            }
         },
         {
           label: 'Provider ID',
-          value: "gateway_transaction_id"
+            value: function(row) {
+                return sanitiseAgainstSpreadsheetFormulaInjection(row.gateway_transaction_id);
+            }
         },
         {
           label: 'GOV.UK Payment ID',
-          value: "charge_id"
+            value: function(row) {
+                return sanitiseAgainstSpreadsheetFormulaInjection(row.charge_id);
+            }
         },
         {
           label: 'Date Created',

--- a/test/unit/utils/json_to_csv_tests.js
+++ b/test/unit/utils/json_to_csv_tests.js
@@ -1,0 +1,32 @@
+let chai = require('chai');
+let chaiAsPromised = require('chai-as-promised');
+let json_to_csv = require('../../../app/utils/json_to_csv');
+
+chai.use(chaiAsPromised);
+
+let expect = chai.expect;
+
+describe('json2csv module', function () {
+
+    it('should transform JSON data to CSV format', () => {
+
+        let jsonData = JSON.parse('[' +
+            '{"amount":12345,"state":{"status":"succeeded","finished":false},"card_brand":"Visa","description":"desc-red","reference":"red","email":"alice.111@mail.fake","links":[],"charge_id":"charge1","gateway_transaction_id":"transaction-1","return_url":"https://demoservice.pymnt.localdomain:443/return/red","payment_provider":"sandbox","created_date":"2016-05-12T16:37:29.245Z","card_details":{"billing_address":{"city":"TEST01","country":"GB","line1":"TEST","line2":"TEST - DO NOT PROCESS","postcode":"SE1 3UZ"},"card_brand":"Visa","cardholder_name":"TEST01","expiry_date":"12/19","last_digits_card_number":"4242"}},' +
+            '{"amount":999,"state":{"status":"canceled","finished":true,"code":"P01234","message":"Something happened"},"card_brand":"Mastercard","description":"desc-blue","reference":"blue","email":"alice.222@mail.fake","links":[],"charge_id":"charge2","gateway_transaction_id":"transaction-2","return_url":"https://demoservice.pymnt.localdomain:443/return/blue","payment_provider":"worldpay","created_date":"2015-04-12T18:55:29.999Z","card_details":{"billing_address":{"city":"TEST02","country":"GB","line1":"TEST","line2":"TEST - DO NOT PROCESS","postcode":"SE1 3UZ"},"card_brand":"Mastercard","cardholder_name":"TEST02","expiry_date":"12/19","last_digits_card_number":"4241"}},' +
+            '{"amount":1234,"state":{"status":"succeeded","finished":false},"card_brand":"Visa","description":"desc-red","reference":"red","email":"alice.111@mail.fake","links":[],"charge_id":"charge1","gateway_transaction_id":"transaction-1","return_url":"https://demoservice.pymnt.localdomain:443/return/red","payment_provider":"sandbox","created_date":"2016-05-12T16:37:29.245Z","card_details":{"billing_address":{"city":"TEST01","country":"GB","line1":"TEST","line2":"TEST - DO NOT PROCESS","postcode":"SE1 3UZ"},"card_brand":"Visa","cardholder_name":"TEST01","expiry_date":"12/19","last_digits_card_number":"4242"}},' +
+            '{"amount":123,"state":{"status":"canceled","finished":true,"code":"P01234","message":"Something happened"},"card_brand":"Mastercard","description":"desc-blue","reference":"blue","email":"alice.222@mail.fake","links":[],"charge_id":"charge2","gateway_transaction_id":"transaction-2","return_url":"https://demoservice.pymnt.localdomain:443/return/blue","payment_provider":"worldpay","created_date":"2015-04-12T18:55:29.999Z","card_details":{"billing_address":{"city":"TEST02","country":"GB","line1":"TEST","line2":"TEST - DO NOT PROCESS","postcode":"SE1 3UZ"},"card_brand":"Mastercard","cardholder_name":"TEST02","expiry_date":"12/19","last_digits_card_number":"4241"}}]');
+
+        let csvDataPromise = json_to_csv(jsonData);
+
+        let csvDataExpected = `"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Date Created"
+"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"
+"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","canceled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"
+"red","desc-red","alice.111@mail.fake","12.34","Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"
+"blue","desc-blue","alice.222@mail.fake","1.23","Mastercard","TEST02","12/19","4241","canceled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"`;
+
+        return csvDataPromise.then(csvData => {
+            return expect(csvData).to.deep.equal(csvDataExpected);
+        });
+
+    });
+});


### PR DESCRIPTION
## WHAT
PP-2254 Protect against Spreadsheet Formula Injection attack when downloading list of transactions

During penetration testing, it was discovered that the downloading of the list of transactions
was vulnerable to a Spreadsheet Formula Injection attack.
This PR protects against that scenario.

See ticket https://payments-platform.atlassian.net/browse/PP-2254
and https://www.contextis.com/resources/blog/comma-separated-vulnerabilities/

We have also added a unit test for json2csv.

Potential todo's (which can be done even after deploying, as this story is quite urgent):
1) json_to_cvs.js module, sanitiseAgainstSpreadsheetFormulaInjection method. Move it to the end of the file or to a util class, and potentially create a test for it
2) json_to_cvs.js module, sanitiseAgainstSpreadsheetFormulaInjection method. Maybe this could return a function itself, so that the fields configuration array looks cleaner and more similar to the original
3) json_to_csv_test.js: move data to files
 
with @ebiere 
