### PR TITLE
PP-1615 Added validate registration cookie middleware

### DIFF
--- a/app/middleware/validate_registration_invite_cookie.js
+++ b/app/middleware/validate_registration_invite_cookie.js
@@ -1,0 +1,18 @@
+'use strict'
+
+// NPM dependencies
+const logger = require('winston')
+
+// Custom dependencies
+const {renderErrorView} = require('../utils/response')
+const {shouldProceedWithRegistration} = require('../utils/registration_validations')
+
+module.exports = function (req, res, next) {
+  const correlationId = req.correlationId
+  return shouldProceedWithRegistration(req.register_invite)
+    .then(next)
+    .catch(err => {
+      logger.warn(`[requestId=${correlationId}] unable to validate required cookie for registration - ${err}`)
+      renderErrorView(req, res, 'Unable to process registration at this time', 404)
+    })
+}

--- a/test/unit/middleware/validate_registration_invite_cookie_test.js
+++ b/test/unit/middleware/validate_registration_invite_cookie_test.js
@@ -1,0 +1,55 @@
+'use strict'
+
+// NPM dependencies
+const proxyquire = require('proxyquire')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const sinon = require('sinon')
+
+// Constants
+const expect = chai.expect
+
+// Global setup
+chai.use(chaiAsPromised)
+
+describe('validate registration invite cookie middleware', function () {
+
+  it('should call next when called with valid register_invite object', function (done) {
+    const validateRegistrationInviteCookie = require('../../../app/middleware/validate_registration_invite_cookie')
+
+    const req = {
+      correlationId: 'a-correlationId',
+      register_invite: {
+        code: 'a-code',
+        email: 'a-user@gov.uk'
+      }
+    }
+    const res = {}
+    const next = sinon.spy()
+
+    validateRegistrationInviteCookie(req, res, next).should.be.fulfilled.then(valid => {
+      expect(next.called).to.be.true
+    }).should.notify(done)
+  })
+
+  it('should render error view when called with empty register_invite object', function (done) {
+    const renderErrorViewSpy = sinon.spy()
+    const validateRegistrationInviteCookie = proxyquire('../../../app/middleware/validate_registration_invite_cookie', {
+      '../utils/response': {
+        renderErrorView: renderErrorViewSpy
+      }
+    })
+
+    const req = {
+      correlationId: 'a-correlationId',
+      register_invite: {}
+    }
+    const res = {}
+    const next = sinon.spy()
+
+    validateRegistrationInviteCookie(req, res, next).should.be.fulfilled.then(error => {
+      expect(renderErrorViewSpy.calledWith(req, res, 'Unable to process registration at this time', 404)).to.be.true
+      expect(next.called).to.be.false
+    }).should.notify(done)
+  })
+})


### PR DESCRIPTION
## WHAT

- This middleware is used to validate registration invite objects.
- In the future we may modify it to validate different types of invites.

with @mrlumbu

