### PR TITLE
PP-2329 Upgraded Dockerfile so base image is 6.11.1-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.10.0-alpine
+FROM node:6.11.1-alpine
 
 RUN apk update && apk upgrade
 


### PR DESCRIPTION
## WHAT
Updates the application Dockerfile to use the latest patched version of Node.js for the 6.x LTS

## HOW 
Build the docker image locally to ensure no issues

> docker build -t mynamehere/self-service-6.11.1 .


