### PR TITLE
PP-2331 Only show the 3D Secure toggle for Worldpay accounts

### DIFF
--- a/app/controllers/toggle_3ds_controller.js
+++ b/app/controllers/toggle_3ds_controller.js
@@ -13,6 +13,7 @@ module.exports.index = function (req, res) {
   }
 
   var model = {
+    supports3ds: req.account.payment_provider === 'worldpay',
     requires3ds: req.account.requires3ds,
     justToggled: typeof req.query.toggled !== 'undefined'
   };

--- a/app/views/3d_secure/index.html
+++ b/app/views/3d_secure/index.html
@@ -8,6 +8,7 @@ GOV.UK Pay - 3D Secure
 
 <div class="column-two-thirds">
 
+{{#supports3ds}}
 {{#permissions.toggle_3ds_read}}
 {{#justToggled}}
 <div id="3ds-toggled" class="govuk-box-highlight">
@@ -67,6 +68,12 @@ GOV.UK Pay - 3D Secure
 </form>
 {{/permissions.toggle_3ds_update}}
 {{/requires3ds}}
+{{/supports3ds}}
+
+{{^supports3ds}}
+<h1 class="page-title">3D Secure</h1>
+<p>3D Secure is not currently supported for this Payment Service Provider.</p>
+{{/supports3ds}}
 
 </div>
 

--- a/test/integration/toggle_3ds_ft_tests.js
+++ b/test/integration/toggle_3ds_ft_tests.js
@@ -57,13 +57,42 @@ describe('The 3D Secure index endpoint', function () {
     userCreator.mockUserResponse(user.toJson(), done);
   });
 
+  it('should not support 3D Secure for payment providers that are not Worldpay', function (done) {
+    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+      .times(2)
+      .reply(200, {
+        "payment_provider": "sandbox",
+        "requires3ds": false
+      });
+
+    var expectedData = {
+      supports3ds: false,
+      requires3ds: false,
+      justToggled: false,
+      permissions: {
+        'toggle_3ds_read': true
+      },
+      navigation: true,
+      currentGatewayAccount: {
+        "payment_provider": "sandbox",
+        "requires3ds": false
+      }
+    };
+
+    build_get_request(paths.toggle3ds.index, app)
+      .expect(200, expectedData)
+      .end(done);
+   });
+
   it('should display if 3D Secure is on', function (done) {
     connectorMock.get(CONNECTOR_ACCOUNT_PATH)
       .reply(200, {
+        "payment_provider": "worldpay",
         "requires3ds": true
       });
 
     var expectedData = {
+      supports3ds: true,
       requires3ds: true,
       justToggled: false,
       permissions: {
@@ -71,6 +100,7 @@ describe('The 3D Secure index endpoint', function () {
       },
       navigation: true,
       currentGatewayAccount: {
+        "payment_provider": "worldpay",
         "requires3ds": true
       }
     };
@@ -84,10 +114,12 @@ describe('The 3D Secure index endpoint', function () {
     connectorMock.get(CONNECTOR_ACCOUNT_PATH)
       .times(2)
       .reply(200, {
+        "payment_provider": "worldpay",
         "requires3ds": true
       });
 
     var expectedData = {
+      supports3ds: true,
       requires3ds: true,
       justToggled: true,
       permissions: {
@@ -95,6 +127,7 @@ describe('The 3D Secure index endpoint', function () {
       },
       navigation: true,
       currentGatewayAccount: {
+        "payment_provider": "worldpay",
         "requires3ds": true
       }
     };
@@ -107,10 +140,12 @@ describe('The 3D Secure index endpoint', function () {
    it('should display if 3D Secure is off', function (done) {
      connectorMock.get(CONNECTOR_ACCOUNT_PATH)
        .reply(200, {
+         "payment_provider": "worldpay",
          "requires3ds": false
        });
 
      var expectedData = {
+       supports3ds: true,
        requires3ds: false,
        justToggled: false,
        permissions: {
@@ -118,6 +153,7 @@ describe('The 3D Secure index endpoint', function () {
        },
        navigation: true,
        currentGatewayAccount: {
+         "payment_provider": "worldpay",
          "requires3ds": false
        }
      };
@@ -130,10 +166,12 @@ describe('The 3D Secure index endpoint', function () {
    it('should display if 3D Secure is off and has just been toggled', function (done) {
      connectorMock.get(CONNECTOR_ACCOUNT_PATH)
        .reply(200, {
+         "payment_provider": "worldpay",
          "requires3ds": false
        });
 
      var expectedData = {
+       supports3ds: true,
        requires3ds: false,
        justToggled: true,
        permissions: {
@@ -141,6 +179,7 @@ describe('The 3D Secure index endpoint', function () {
        },
        navigation: true,
        currentGatewayAccount: {
+         "payment_provider": "worldpay",
          "requires3ds": false
        }
      };

--- a/test/ui/toggle_3ds_ui_tests.js
+++ b/test/ui/toggle_3ds_ui_tests.js
@@ -7,6 +7,7 @@ describe('The toggle 3D Secure page when 3D Secure is off', function () {
   it('should say that 3D Secure is off but not show the toggle button if the user only has read permission', function () {
 
     let templateData = {
+     "supports3ds": true,
      "requires3ds": false,
       permissions: {
         toggle_3ds_read: true
@@ -20,9 +21,10 @@ describe('The toggle 3D Secure page when 3D Secure is off', function () {
     body.should.containNoSelector('#3ds-off-button');
   });
 
-  it('should say not that 3D Secure is off if the user does not have read permission', function () {
+  it('should not say that 3D Secure is off if the user does not have read permission', function () {
 
     let templateData = {
+      "supports3ds": true,
       "requires3ds": false,
       permissions: {
         toggle_3ds_read: false
@@ -37,6 +39,7 @@ describe('The toggle 3D Secure page when 3D Secure is off', function () {
   it('should show the toggle button if the user also has update permission', function () {
 
     let templateData = {
+      "supports3ds": true,
       "requires3ds": false,
       permissions: {
         toggle_3ds_read: true,
@@ -53,6 +56,7 @@ describe('The toggle 3D Secure page when 3D Secure is off', function () {
   it('should show the highlight if the permission has just been toggled and the user has read permission', function () {
 
     let templateData = {
+      "supports3ds": true,
       "requires3ds": false,
       "justToggled": true,
       permissions: {
@@ -68,6 +72,7 @@ describe('The toggle 3D Secure page when 3D Secure is off', function () {
   it('should not show the highlight if the permission has just been toggled and the user does not has read permission', function () {
 
     let templateData = {
+      "supports3ds": true,
       "requires3ds": false,
       "justToggled": true,
       permissions: {
@@ -83,6 +88,7 @@ describe('The toggle 3D Secure page when 3D Secure is off', function () {
   it('should not show the highlight if the permission has not been toggled and the user has read permission', function () {
 
     let templateData = {
+      "supports3ds": true,
       "requires3ds": false,
       "justToggled": false,
       permissions: {
@@ -102,6 +108,7 @@ describe('The toggle 3D Secure page when 3D Secure is on', function () {
   it('should say that 3D Secure is on but not show the toggle button if the user only has read permission', function () {
 
     let templateData = {
+     "supports3ds": true,
      "requires3ds": true,
       permissions: {
         toggle_3ds_read: true
@@ -115,9 +122,10 @@ describe('The toggle 3D Secure page when 3D Secure is on', function () {
     body.should.containNoSelector('#3ds-turn-off');
   });
 
-  it('should say not that 3D Secure is on if the user does not have read permission', function () {
+  it('should not say that 3D Secure is on if the user does not have read permission', function () {
 
     let templateData = {
+      "supports3ds": true,
       "requires3ds": true,
       permissions: {
         toggle_3ds_read: false
@@ -132,6 +140,7 @@ describe('The toggle 3D Secure page when 3D Secure is on', function () {
   it('should show the toggle button if the user also has update permission', function () {
 
     let templateData = {
+      "supports3ds": true,
       "requires3ds": true,
       permissions: {
         toggle_3ds_read: true,
@@ -148,6 +157,7 @@ describe('The toggle 3D Secure page when 3D Secure is on', function () {
   it('should show the highlight if the permission has just been toggled and the user has read permission', function () {
 
     let templateData = {
+      "supports3ds": true,
       "requires3ds": true,
       "justToggled": true,
       permissions: {
@@ -163,6 +173,7 @@ describe('The toggle 3D Secure page when 3D Secure is on', function () {
   it('should not show the highlight if the permission has just been toggled and the user does not has read permission', function () {
 
     let templateData = {
+      "supports3ds": true,
       "requires3ds": true,
       "justToggled": true,
       permissions: {
@@ -178,6 +189,7 @@ describe('The toggle 3D Secure page when 3D Secure is on', function () {
   it('should not show the highlight if the permission has not been toggled and the user has read permission', function () {
 
     let templateData = {
+      "supports3ds": true,
       "requires3ds": true,
       "justToggled": false,
       permissions: {
@@ -192,11 +204,65 @@ describe('The toggle 3D Secure page when 3D Secure is on', function () {
 
 });
 
+describe('The toggle 3D Secure page when 3D Secure is not supported', function () {
+
+  it('should say that 3D Secure is not supported', function () {
+
+    let templateData = {
+      "supports3ds": false,
+      "requires3ds": false,
+      permissions: {
+        toggle_3ds_read: false
+      }
+    };
+
+    let body = renderTemplate('3d_secure/index', templateData);
+
+    body.should.contain('3D Secure is not currently supported for this Payment Service Provider.');
+  });
+
+  it('should not say that 3D Secure is on or off', function () {
+
+    let templateData = {
+     "supports3ds": false,
+     "requires3ds": false,
+      permissions: {
+        toggle_3ds_read: true,
+        toggle_3ds_update: true
+      }
+    };
+
+    let body = renderTemplate('3d_secure/index', templateData);
+
+    body.should.containNoSelector('#3ds-status');
+    body.should.containNoSelector('#3ds-on-button');
+    body.should.containNoSelector('#3ds-off-button');
+  });
+
+  it('should not show the toggle button', function () {
+
+    let templateData = {
+      "supports3ds": false,
+      "requires3ds": false,
+      permissions: {
+        toggle_3ds_read: false
+      }
+    };
+
+    let body = renderTemplate('3d_secure/index', templateData);
+
+    body.should.containNoSelector('#3ds-on-button');
+    body.should.containNoSelector('#3ds-off-button');
+  });
+
+});
+
 describe('The turn 3D Secure on confirmation page', function () {
 
   it('should show the button if the user has edit permission', function () {
 
     let templateData = {
+      "supports3ds": true,
       permissions: {
         toggle_3ds_read: true,
         toggle_3ds_update: true
@@ -208,9 +274,10 @@ describe('The turn 3D Secure on confirmation page', function () {
     body.should.containSelector('#3ds-confirm-on-button');
   });
 
-  it('should not show the button if the user has does not have  permission', function () {
+  it('should not show the button if the user has does not have permission', function () {
 
     let templateData = {
+      "supports3ds": true,
       permissions: {
         toggle_3ds_read: true,
         toggle_3ds_update: false


### PR DESCRIPTION
If the payment provider is not Worldpay (i.e. sandbox, Smartpay or ePDQ), show a message saying, “3D Secure is not currently supported for this Payment Service Provider.”

A determined user could still toggle the setting (e.g. by posting to the `3ds/confirm` page and then pressing the confirmation button) but this would require them to seriously know what they’re doing and would do no harm in any case.