### PR TITLE
PP-2326 - Replicating new product page footer across self-service

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -17,7 +17,7 @@ $grey-8: #fff;
 
 @mixin media-down($mobile) {
   @content;
-};
+}
 
 @import 'govuk-elements';
 
@@ -52,12 +52,10 @@ $grey-8: #fff;
 @import "modules/_related_information";
 @import "modules/_marked_grid";
 
-
-
 @import 'gov-uk-overrides/_forms';
 @import 'gov-uk-overrides/_icons';
 @import 'gov-uk-overrides/_movement';
-
+@import 'gov-uk-overrides/_footer-categories';
 
 @import "template/template";
 @import "template/fonts";

--- a/app/assets/sass/gov-uk-overrides/_footer-categories.scss
+++ b/app/assets/sass/gov-uk-overrides/_footer-categories.scss
@@ -1,0 +1,29 @@
+#footer {
+  .footer-categories {
+    margin: 0 auto;
+
+    &-wrapper {
+      margin-bottom: $gutter;
+      padding-bottom: $gutter * 2;
+      border-bottom: 1px solid $grey-2;
+    }
+
+    h2 {
+      margin: 20px 0;
+
+      @include media(tablet) {
+        margin-top: 0;
+      }
+    }
+
+    ul {
+      margin: 0;
+      padding: 0;
+    }
+
+    li {
+      margin-bottom: 5px;
+      font-size: 16px;
+    }
+  }
+}

--- a/app/views/includes/crown-copyright.html
+++ b/app/views/includes/crown-copyright.html
@@ -1,0 +1,1 @@
+© Crown copyright

--- a/app/views/includes/footer-categories.html
+++ b/app/views/includes/footer-categories.html
@@ -1,0 +1,24 @@
+<div class="footer-categories">
+  <div class="footer-categories-wrapper">
+    <div class="grid-row">
+      <div class="column-one-third">
+        <h2>About</h2>
+        <ul>
+          <li><a href="https://www.payments.service.gov.uk/getstarted/">Get started</a></li>
+          <li><a href="https://www.payments.service.gov.uk/features/">Features</a></li>
+          <li><a href="https://www.payments.service.gov.uk/roadmap/">Roadmap</a></li>
+          <li><a href="https://www.gov.uk/performance/govuk-pay">Performance</a></li>
+        </ul>
+      </div>
+      <div class="column-one-third">
+        <h2>Support</h2>
+        <ul>
+          <li><a href="https://www.payments.service.gov.uk/contact/">Contact</a></li>
+          <li><a href="https://ukgovernmentdigital.slack.com/messages/govuk-pay">Chat with GOV.UK Pay on Slack</a></li>
+          <li><a href="https://gds-payments.gelato.io/docs/versions/1.0.0">Documentation</a></li>
+          <li><a href="http://stats.pingdom.com/ejtodj13fqqx">System status</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/includes/license-message.html
+++ b/app/views/includes/license-message.html
@@ -1,0 +1,1 @@
+<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise&nbsp;stated</p>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -35,6 +35,18 @@
         </main>
     {{/content}}
 
+    {{$footerTop}}
+      {{>includes/footer-categories}}
+    {{/footerTop}}
+
+    {{$licenceMessage}}
+      {{>includes/license-message}}
+    {{/licenceMessage}}
+
+    {{$crownCopyrightMessage}}
+      {{>includes/crown-copyright}}
+    {{/crownCopyrightMessage}}
+
     {{$bodyEnd}}
       {{>includes/scripts}}
       {{$pageSpecificJS}}

--- a/app/views/layout_logged_out.html
+++ b/app/views/layout_logged_out.html
@@ -22,6 +22,18 @@
         </main>
     {{/content}}
 
+    {{$footerTop}}
+      {{>includes/footer-categories}}
+    {{/footerTop}}
+
+    {{$licenceMessage}}
+      {{>includes/license-message}}
+    {{/licenceMessage}}
+
+    {{$crownCopyrightMessage}}
+      {{>includes/crown-copyright}}
+    {{/crownCopyrightMessage}}
+
     {{$bodyEnd}}
       {{>includes/scripts}}
       {{$pageSpecificJS}}

--- a/lib/template-config.js
+++ b/lib/template-config.js
@@ -11,6 +11,9 @@ module.exports = {
   insideHeader: "{{$insideHeader}}{{/insideHeader}}",
   homepageUrl: "{{$homepageUrl}}https://www.gov.uk{{/homepageUrl}}",
   globalHeaderText: "{{$globalHeaderText}}GOV.UK{{/globalHeaderText}}",
-  pageTitle: "{{$pageTitle}}GOV.UK - The best place to find government services and information{{/pageTitle}}",
-  propositionHeader: "{{$propositionHeader}}{{/propositionHeader}}"
+  pageTitle:
+    "{{$pageTitle}}GOV.UK - The best place to find government services and information{{/pageTitle}}",
+  propositionHeader: "{{$propositionHeader}}{{/propositionHeader}}",
+  licenceMessage: "{{$licenceMessage}}{{/licenceMessage}}",
+  crownCopyrightMessage: "{{$crownCopyrightMessage}}{{/crownCopyrightMessage}}"
 };

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "forever": "0.15.x",
     "govuk-elements-sass": "3.1.0",
     "govuk_frontend_toolkit": "6.0.4",
-    "govuk_template_mustache": "0.22.x",
+    "govuk_template_mustache": "0.22.2",
     "hogan.js": "3.0.x",
     "html5shiv": "3.7.x",
     "http-proxy": "1.16.x",


### PR DESCRIPTION
Added in the new footer catergory links and assosiated styles.
Also the license and copyright messages were missing and have been for a while, was because the mustache version of govuk_template doesn't come with them and we weren't configuring them in ourselves.

