### PR TITLE
PP-1611 - Fix redirect when user has no services

### DIFF
--- a/app/middleware/get_gateway_account.js
+++ b/app/middleware/get_gateway_account.js
@@ -1,12 +1,8 @@
 const auth          = require('../services/auth_service.js');
 const Connector     = require('../services/clients/connector_client.js').ConnectorClient;
-const paths = require('../paths');
 const connectorClient = new Connector(process.env.CONNECTOR_URL);
 
 module.exports = function (req, res, next) {
-  if(!req.user.serviceRoles || req.user.serviceRoles.length <= 0) {
-    return res.redirect(paths.serviceSwitcher.index);
-  }
   const accountId = auth.getCurrentGatewayAccountId(req);
   const params = {
     gatewayAccountId: accountId,

--- a/app/middleware/has_services.js
+++ b/app/middleware/has_services.js
@@ -1,15 +1,14 @@
 const logger    = require('winston');
 const _         = require('lodash');
-const errorView = require('../utils/response.js').renderErrorView;
+const paths = require('../paths');
 
 module.exports = function (req, res, next) {
 
-  const serviceRoles = _.get(req, "user.serviceRoles");
-
-  if ((!serviceRoles) || (serviceRoles.length === 0)) {
+  const serviceRoles = _.get(req, "user.serviceRoles", []);
+  if (req.url !== paths.serviceSwitcher.index && serviceRoles.length === 0) {
     logger.info('User does not belong to any service user_external_id=', _.get(req, "user.externalId"));
-    return errorView(req, res, "This user does not belong to any service. Ask your service administrator to invite you to GOV.UK Pay.", 200);
+    res.redirect(paths.serviceSwitcher.index);
+  } else {
+    next()
   }
-
-  return next();
 };

--- a/app/routes.js
+++ b/app/routes.js
@@ -86,6 +86,7 @@ module.exports.bind = function (app) {
   app.get(registerUser.reVerifyPhone, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, registerCtrl.showReVerifyPhone)
   app.post(registerUser.reVerifyPhone, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, registerCtrl.submitReVerifyPhone)
   app.get(registerUser.logUserIn, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, loginCtrl.loginAfterRegister, enforceUserAuthenticated, getAccount, loginCtrl.loggedIn)
+
   // LOGIN
   app.get(user.logIn, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, loginCtrl.logInGet)
   app.post(user.logIn, validateAndRefreshCsrf, trimUsername, loginCtrl.logUserin, getAccount, loginCtrl.postLogin)
@@ -133,7 +134,8 @@ module.exports.bind = function (app) {
     ...lodash.values(t3ds)
   ] // Extract all the authenticated paths as a single array
 
-  app.use(authenticatedPaths, enforceUserAuthenticated, validateAndRefreshCsrf, hasServices) // Enforce authentication on all get requests
+  app.use(authenticatedPaths, enforceUserAuthenticated, validateAndRefreshCsrf); // Enforce authentication on all get requests
+  app.use(authenticatedPaths.filter(item => !lodash.values(serviceSwitcher).includes(item)), hasServices) // Require services everywhere but the switcher page
 
   //  TRANSACTIONS
   app.get(transactions.index, permission('transactions:read'), getAccount, transactionsCtrl.index)

--- a/test/integration/service_users_ft_test.js
+++ b/test/integration/service_users_ft_test.js
@@ -75,27 +75,6 @@ describe('service users resource', function () {
       .end(done)
   })
 
-  it('should redirect to an error page when user does not belong to any service', function (done) {
-
-    const notAllowedServiceId = '47835y3478thew'
-    const user = session.getUser({
-      external_id: EXTERNAL_ID_LOGGED_IN,
-      username: USERNAME_LOGGED_IN,
-      email: USERNAME_LOGGED_IN + '@example.com',
-      service_roles: []
-    })
-
-    app = session.getAppWithLoggedInUser(getApp(), user)
-
-    supertest(app)
-      .get(formattedPathFor(paths.teamMembers.index, notAllowedServiceId))
-      .set('Accept', 'application/json')
-      .expect(200)
-      .expect((res) => {
-        expect(res.body.message).to.equal('This user does not belong to any service. Ask your service administrator to invite you to GOV.UK Pay.')
-      })
-      .end(done)
-  })
 
   it('get list of service users should link to a users view details for other users', function (done) {
 

--- a/test/unit/middleware/get_gateway_account_test.js
+++ b/test/unit/middleware/get_gateway_account_test.js
@@ -46,12 +46,5 @@ describe('middleware: getGatewayAccount', () => {
     })
   })
 
-  it('should redirect to service switcher if the user has no services', () => {
-    currentGatewayAccountID = 1
-    lodash.set(req,'user.serviceRoles',[])
-    getGatewayAccount(req,res,next)
-    expect(res.redirect.called).to.equal(true)
-    expect(res.redirect.calledWith(paths.serviceSwitcher.index))
-  })
 
 })

--- a/test/unit/middleware/has_services_test.js
+++ b/test/unit/middleware/has_services_test.js
@@ -1,60 +1,58 @@
+'use strict';
+
 const assert = require('assert');
 const sinon = require('sinon');
 const nock = require('nock');
 const chai = require('chai');
 const {should, expect} = chai;
 const chaiAsPromised = require('chai-as-promised');
+const paths = require('../../../app/paths');
 const hasServices = require(__dirname + '/../../../app/middleware/has_services.js');
 const userFixtures = require('../../fixtures/user_fixtures');
+
+let res, next;
 
 chai.use(chaiAsPromised);
 
 describe('user has services middleware', function () {
 
-  const response = {
-    status: () => {},
-    render: () => {},
-    setHeader: () => {}
-  };
-  let render, status, next;
+    beforeEach(function () {
+        res = {
+            redirect: sinon.spy(),
+            status: sinon.spy()
+        };
+        next = sinon.spy()
+        nock.cleanAll();
+    });
 
-  beforeEach(function () {
-    render = sinon.stub(response, "render");
-    status = sinon.stub(response, "status");
-    next = sinon.spy();
-    nock.cleanAll();
-  });
+    it("should call next when user has services", function (done) {
+        const user = userFixtures.validUser({
+            services_roles: [{service: {external_id: '1'}}],
+            external_id: 'external-id'
+        }).getAsObject();
 
-  afterEach(function () {
-    render.restore();
-    status.restore();
-  });
+        const req = {user: user, headers: {}};
 
-  it("should call next when user has services", function (done) {
-    const user = userFixtures.validUser({
-      services_roles: [{service: {external_id: '1'}}],
-      external_id: 'external-id'
-    }).getAsObject();
+        hasServices(req, res, next);
 
-    const req = {user: user, headers: {}};
+        expect(next.called).to.be.true;
 
-    hasServices(req, response, next);
+        done();
+    });
 
-    expect(next.called).to.be.true;
+    it('should redirect to service switcher if the user has no services', function (done) {
 
-    done();
-  });
+        const req = {user: {services: []}, headers: {}};
 
-  it('should show error view when user does not have services', function (done) {
+        hasServices(req, res, next);
 
-    const req = {user: {services: []}, headers: {}};
+        expect(next.notCalled).to.be.true
+        expect(res.redirect.called).to.equal(true)
+        expect(res.redirect.calledWith(paths.serviceSwitcher.index))
 
-    hasServices(req, response, next);
+        done();
+    });
 
-    expect(next.notCalled).to.be.true;
-    assert(render.calledWith("error", {message: 'This user does not belong to any service. Ask your service administrator to invite you to GOV.UK Pay.'}));
-    assert(status.calledWith(200));
 
-    done();
-  });
+
 });


### PR DESCRIPTION
# PP-1611 - Fix redirect when user has no services

## What 
* Moved the logic for redirecting users that have no services from get_account to has_services middleware

## Why
* A user with no services was rendered unable to log in using the previous logic



