### PR TITLE
PP-1615 Handle 409 error as success

### DIFF
--- a/app/controllers/create_service_controller.js
+++ b/app/controllers/create_service_controller.js
@@ -50,11 +50,16 @@ module.exports = {
     const password = req.body['password']
 
     const handleServerError = (err) => {
-      if ((err.errorCode === 400) ||
-        (err.errorCode === 403) ||
-        (err.errorCode === 409)) {
+      if ((err.errorCode === 400) || (err.errorCode === 403)) {
         const error = (err.message && err.message.errors) ? err.message.errors : 'Invalid input'
         handleInvalidUserInput(error)
+      } else if (err.errorCode === 409) {
+        // we should redirect in all cases regardless whether the user exists, disabled or new
+        _.set(req, 'session.pageData.submitRegistration', {
+          email,
+          telephoneNumber
+        })
+        res.redirect(303, paths.selfCreateService.confirm)
       } else {
         errorResponse(req, res, 'Unable to process registration at this time', err.errorCode)
       }

--- a/test/unit/controller/create_service_controller/create_service_controller_register_test.js
+++ b/test/unit/controller/create_service_controller/create_service_controller_register_test.js
@@ -106,7 +106,7 @@ describe('Error handler register service', function () {
       }).should.notify(done)
   })
 
-  it('should handle 409 as 303 redirect to index', function (done) {
+  it('should handle 409 as 303 redirect to confirmation page', function (done) {
     email = 'be@mail.com'
     const errorMessage = `email [${email}] already exists`
     const error = {
@@ -118,8 +118,7 @@ describe('Error handler register service', function () {
 
     controller(error).submitRegistration(req, res).should.be.fulfilled
       .then(() => {
-        expect(flashStub.calledWith('genericError', errorMessage)).to.equal(true)
-        expect(redirectStub.calledWith(303, paths.selfCreateService.register)).to.equal(true)
+        expect(redirectStub.calledWith(303, paths.selfCreateService.confirm)).to.equal(true)
       }).should.notify(done)
   })
 


### PR DESCRIPTION
## WHAT

We need to handle `409` server error code as success and redirect to confirmation page in all cases regardless whether the user exists, disabled or new as stated by the story.
