### PR TITLE
PP-2350 Applied standard linter fixes to test/integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,12 @@
       "it",
       "expect"
     ],
-    "ignore": ["app/assets/**/*.js", "test/integration/**/*.js", "test/test_helpers/**/*.js", "test/ui/**/*.js", "test/unit/**/*.js"]
+    "ignore": [
+      "app/assets/**/*.js",
+      "test/test_helpers/**/*.js",
+      "test/ui/**/*.js",
+      "test/unit/**/*.js"
+    ]
   },
   "scripts": {
     "compile": "grunt generate-assets",
@@ -27,7 +32,7 @@
     "stop": "node_modules/forever/bin/forever stop start.js",
     "watch": "chokidar app test *.js --initial -c 'npm run test'",
     "watch-live-reload": "./node_modules/.bin/grunt watch",
-    "lint": "standard",
+    "lint": "./node_modules/.bin/standard",
     "lint-sass": "./node_modules/.bin/sass-lint -v",
     "test": "npm run lint && npm run grunt-test",
     "grunt-test": "node ./node_modules/.bin/grunt test",

--- a/test/integration/auth_ft_tests.js
+++ b/test/integration/auth_ft_tests.js
@@ -1,110 +1,105 @@
-require(__dirname + '/../test_helpers/serialize_mock.js');
-const request = require('supertest');
-const auth = require(__dirname + '/../../app/services/auth_service.js');
-const login = require(__dirname + '/../../app/controllers/login_controller.js');
-const express = require('express');
-const mockSession = require(__dirname + '/../test_helpers/mock_session.js');
-const getAppWithSessionAndGatewayAccountCookies = mockSession.getAppWithSessionAndGatewayAccountCookies;
-const getAppWithLoggedInUser = mockSession.getAppWithLoggedInUser;
-const paths = require(__dirname + '/../../app/paths.js');
-const path = require('path');
-const server = require(__dirname + '/../../server.js');
+const path = require('path')
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+const request = require('supertest')
+const auth = require(path.join(__dirname, '/../../app/services/auth_service.js'))
+const mockSession = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+const getAppWithSessionAndGatewayAccountCookies = mockSession.getAppWithSessionAndGatewayAccountCookies
+const getAppWithLoggedInUser = mockSession.getAppWithLoggedInUser
+const paths = require(path.join(__dirname, '/../../app/paths.js'))
+const server = require(path.join(__dirname, '/../../server.js'))
 
-let app;
+let app
 
-function addUnprotectedEndpointToApp(app) {
+function addUnprotectedEndpointToApp (app) {
   app.get('/unprotected', function (req, res) {
-    res.send('Hello, World!');
-  });
+    res.send('Hello, World!')
+  })
 }
 
-function addProtectedEndpointToApp(app) {
+function addProtectedEndpointToApp (app) {
   app.get('/protected', auth.enforceUserAuthenticated, function (req, res) {
-    res.send('Hello, World!');
-  });
+    res.send('Hello, World!')
+  })
 }
 
 describe('An endpoint not protected', function () {
-
   afterEach(function () {
-    app = null;
-  });
-
+    app = null
+  })
 
   it('allows access if not authenticated', function (done) {
-    app = getAppWithSessionAndGatewayAccountCookies(server.getApp(), {});
-    addUnprotectedEndpointToApp(app);
+    app = getAppWithSessionAndGatewayAccountCookies(server.getApp(), {})
+    addUnprotectedEndpointToApp(app)
     request(app)
       .get('/unprotected')
       .expect(200)
       .expect('Hello, World!')
-      .end(done);
-  });
+      .end(done)
+  })
 
   it('allows access if authenticated', function (done) {
-    const user = mockSession.getUser();
-    app = getAppWithLoggedInUser(server.getApp(), user);
-    addUnprotectedEndpointToApp(app);
+    const user = mockSession.getUser()
+    app = getAppWithLoggedInUser(server.getApp(), user)
+    addUnprotectedEndpointToApp(app)
     request(app)
       .get('/unprotected')
       .expect(200)
       .expect('Hello, World!')
-      .end(done);
-  });
+      .end(done)
+  })
 
   it('redirects to noaccess if user disabled', function (done) {
-    const user = mockSession.getUser();
-    user.disabled = true;
-    app = getAppWithLoggedInUser(server.getApp(), user);
-    addProtectedEndpointToApp(app);
+    const user = mockSession.getUser()
+    user.disabled = true
+    app = getAppWithLoggedInUser(server.getApp(), user)
+    addProtectedEndpointToApp(app)
     request(app)
       .get('/protected')
       .expect(302)
       .expect('Location', paths.user.noAccess)
-      .end(done);
-  });
-});
+      .end(done)
+  })
+})
 
 describe('An endpoint protected by auth.enforceUserBothFactors', function () {
-
   afterEach(function () {
-    app = null;
-  });
+    app = null
+  })
 
   it('redirects to /login if not authenticated', function (done) {
-    app = getAppWithSessionAndGatewayAccountCookies(server.getApp(), {});
-    addProtectedEndpointToApp(app);
+    app = getAppWithSessionAndGatewayAccountCookies(server.getApp(), {})
+    addProtectedEndpointToApp(app)
 
     request(app)
       .get('/protected')
       .expect(302)
       .expect('Location', paths.user.logIn)
-      .end(done);
-  });
+      .end(done)
+  })
 
   it('allows access if authenticated', function (done) {
-    const user = mockSession.getUser();
+    const user = mockSession.getUser()
 
-    app = getAppWithLoggedInUser(server.getApp(), user);
-    addProtectedEndpointToApp(app);
+    app = getAppWithLoggedInUser(server.getApp(), user)
+    addProtectedEndpointToApp(app)
 
     request(app)
       .get('/protected')
       .expect(200)
       .expect('Hello, World!')
-      .end(done);
-  });
+      .end(done)
+  })
 
   it('redirects if not second factor loggedin', function (done) {
-    const user = mockSession.getUser();
+    const user = mockSession.getUser()
 
-    app = mockSession.getAppWithSessionWithoutSecondFactor(server.getApp(), user);
-    addProtectedEndpointToApp(app);
+    app = mockSession.getAppWithSessionWithoutSecondFactor(server.getApp(), user)
+    addProtectedEndpointToApp(app)
 
     request(app)
       .get('/protected')
       .expect(302)
       .expect('Location', paths.user.otpLogIn)
-      .end(done);
-  });
-});
+      .end(done)
+  })
+})

--- a/test/integration/create_service_controller/create_service_controller_create_populated_service_ft_test.js
+++ b/test/integration/create_service_controller/create_service_controller_create_populated_service_ft_test.js
@@ -2,8 +2,6 @@
 
 // NPM dependencies
 const nock = require('nock')
-const csrf = require('csrf')
-const supertest = require('supertest')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -11,7 +9,6 @@ const chaiAsPromised = require('chai-as-promised')
 const gatewayAccountFixtures = require('../../fixtures/gateway_account_fixtures')
 const inviteFixtures = require('../../fixtures/invite_fixtures')
 const serviceRegistrationService = require('../../../app/services/service_registration_service')
-const paths = require('../../../app/paths')
 
 // Constants
 const CONNECTOR_ACCOUNTS_URL = '/v1/api/accounts'
@@ -24,7 +21,6 @@ const expect = chai.expect
 chai.use(chaiAsPromised)
 
 describe('create populated service', function () {
-
   afterEach((done) => {
     nock.cleanAll()
     done()
@@ -61,8 +57,8 @@ describe('create populated service', function () {
       .reply(200, mockAdminUsersInviteCompleteResponse)
 
     serviceRegistrationService.createPopulatedService(inviteCode).should.be.fulfilled.then(completeServiceInviteResponse => {
-      expect(createGatewayAccountMock.isDone()).to.be.true
-      expect(completeServiceInviteMock.isDone()).to.be.true
+      expect(createGatewayAccountMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
+      expect(completeServiceInviteMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
       expect(completeServiceInviteResponse.invite.code).to.equal(mockAdminUsersInviteCompleteResponse.invite.code)
       expect(completeServiceInviteResponse.invite.type).to.equal(mockAdminUsersInviteCompleteResponse.invite.type)
       expect(completeServiceInviteResponse.invite.disabled).to.equal(mockAdminUsersInviteCompleteResponse.invite.disabled)
@@ -78,7 +74,7 @@ describe('create populated service', function () {
       .reply(500)
 
     serviceRegistrationService.createPopulatedService(inviteCode).should.be.rejected.then(error => {
-      expect(mockConnectorCreateGatewayAccountResponse.isDone()).to.be.true
+      expect(mockConnectorCreateGatewayAccountResponse.isDone()).to.be.true // eslint-disable-line no-unused-expressions
       expect(error.errorCode).to.equal(500)
     }).should.notify(done)
   })
@@ -102,8 +98,8 @@ describe('create populated service', function () {
       .reply(500)
 
     serviceRegistrationService.createPopulatedService(inviteCode).should.be.rejected.then(error => {
-      expect(createGatewayAccountMock.isDone()).to.be.true
-      expect(completeServiceInviteMock.isDone()).to.be.true
+      expect(createGatewayAccountMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
+      expect(completeServiceInviteMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
       expect(error.errorCode).to.equal(500)
     }).should.notify(done)
   })
@@ -127,8 +123,8 @@ describe('create populated service', function () {
       .reply(409)
 
     serviceRegistrationService.createPopulatedService(inviteCode).should.be.rejected.then(error => {
-      expect(createGatewayAccountMock.isDone()).to.be.true
-      expect(completeServiceInviteMock.isDone()).to.be.true
+      expect(createGatewayAccountMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
+      expect(completeServiceInviteMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
       expect(error.errorCode).to.equal(409)
     }).should.notify(done)
   })

--- a/test/integration/create_service_controller/create_service_controller_otp_resend_ft_test.js
+++ b/test/integration/create_service_controller/create_service_controller_otp_resend_ft_test.js
@@ -24,7 +24,6 @@ chai.use(chaiAsPromised)
 let app
 
 describe('create service otp resend validation', function () {
-
   afterEach((done) => {
     nock.cleanAll()
     app = null

--- a/test/integration/create_service_controller/create_service_controller_otp_verify_ft_test.js
+++ b/test/integration/create_service_controller/create_service_controller_otp_verify_ft_test.js
@@ -28,7 +28,6 @@ chai.use(chaiAsPromised)
 let app
 
 describe('create service otp validation', function () {
-
   afterEach((done) => {
     nock.cleanAll()
     app = null
@@ -91,7 +90,7 @@ describe('create service otp validation', function () {
         .post(paths.selfCreateService.otpVerify)
         .send({
           'verify-code': validServiceInviteOtpRequest.getPlain().otp,
-          csrfToken: csrf().create('123'),
+          csrfToken: csrf().create('123')
         })
         .expect(303)
         .expect('Location', paths.selfCreateService.logUserIn)
@@ -107,7 +106,7 @@ describe('create service otp validation', function () {
         .send({
           code: validServiceInviteOtpRequest.getPlain().code,
           'verify-code': validServiceInviteOtpRequest.getPlain().otp,
-          csrfToken: csrf().create('123'),
+          csrfToken: csrf().create('123')
         })
         .expect(404)
         .end(done)
@@ -129,7 +128,7 @@ describe('create service otp validation', function () {
         .send({
           code: validServiceInviteOtpRequest.getPlain().code,
           'verify-code': validServiceInviteOtpRequest.getPlain().otp,
-          csrfToken: csrf().create('123'),
+          csrfToken: csrf().create('123')
         })
         .expect(303)
         .expect('Location', paths.selfCreateService.otpVerify)

--- a/test/integration/create_service_controller/create_service_controller_register_ft_test.js
+++ b/test/integration/create_service_controller/create_service_controller_register_ft_test.js
@@ -24,7 +24,6 @@ chai.use(chaiAsPromised)
 let app
 
 describe('create service otp validation', function () {
-
   afterEach((done) => {
     nock.cleanAll()
     app = null

--- a/test/integration/create_service_controller/create_service_controller_service_naming_ft_test.js
+++ b/test/integration/create_service_controller/create_service_controller_service_naming_ft_test.js
@@ -16,7 +16,6 @@ const paths = require('../../../app/paths')
 // Constants
 const SERVICE_RESOURCE = '/v1/api/services'
 const adminusersMock = nock(process.env.ADMINUSERS_URL)
-const expect = chai.expect
 
 // Global setup
 chai.use(chaiAsPromised)
@@ -24,7 +23,6 @@ chai.use(chaiAsPromised)
 let app
 
 describe('create service - service naming', function () {
-
   afterEach((done) => {
     nock.cleanAll()
     app = null

--- a/test/integration/credentials_ft_tests.js
+++ b/test/integration/credentials_ft_tests.js
@@ -1,38 +1,37 @@
-require(__dirname + '/../test_helpers/serialize_mock.js');
-var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
-var request = require('supertest');
-var getApp = require(__dirname + '/../../server.js').getApp;
-var winston = require('winston');
-var nock = require('nock');
-var csrf = require('csrf');
-var should = require('chai').should();
-var paths = require(__dirname + '/../../app/paths.js');
-var app;
-var session = require(__dirname + '/../test_helpers/mock_session.js');
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+var userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
+var request = require('supertest')
+var getApp = require(path.join(__dirname, '/../../server.js')).getApp
+var nock = require('nock')
+var csrf = require('csrf')
+var paths = require(path.join(__dirname, '/../../app/paths.js'))
+var app
+var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
 
-var ACCOUNT_ID = 182364;
-var CONNECTOR_ACCOUNT_PATH = "/v1/frontend/accounts/" + ACCOUNT_ID;
-var CONNECTOR_ACCOUNT_CREDENTIALS_PATH = CONNECTOR_ACCOUNT_PATH + "/credentials";
-var CONNECTOR_ACCOUNT_NOTIFICATION_CREDENTIALS_PATH = "/v1/api/accounts/" + ACCOUNT_ID + "/notification-credentials";
+var ACCOUNT_ID = 182364
+var CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts/' + ACCOUNT_ID
+var CONNECTOR_ACCOUNT_CREDENTIALS_PATH = CONNECTOR_ACCOUNT_PATH + '/credentials'
+var CONNECTOR_ACCOUNT_NOTIFICATION_CREDENTIALS_PATH = '/v1/api/accounts/' + ACCOUNT_ID + '/notification-credentials'
 
-var requestId = 'some-unique-id';
+var requestId = 'some-unique-id'
 var defaultCorrelationHeader = {
   reqheaders: {'x-request-id': requestId}
-};
+}
 
-var connectorMock = nock(process.env.CONNECTOR_URL, defaultCorrelationHeader);
+var connectorMock = nock(process.env.CONNECTOR_URL, defaultCorrelationHeader)
 
-function build_get_request(path, app) {
+function buildGetRequest (path, app) {
   return request(app)
     .get(path)
     .set('Accept', 'application/json')
-    .set('x-request-id', requestId);
+    .set('x-request-id', requestId)
 }
 
-function build_form_post_request(path, sendData, sendCSRF, app) {
-  sendCSRF = (sendCSRF === undefined) ? true : sendCSRF;
+function buildFormPostRequest (path, sendData, sendCSRF, app) {
+  sendCSRF = (sendCSRF === undefined) ? true : sendCSRF
   if (sendCSRF) {
-    sendData.csrfToken = csrf().create('123');
+    sendData.csrfToken = csrf().create('123')
   }
 
   return request(app)
@@ -40,707 +39,690 @@ function build_form_post_request(path, sendData, sendCSRF, app) {
     .set('Accept', 'application/json')
     .set('Content-Type', 'application/x-www-form-urlencoded')
     .set('x-request-id', requestId)
-    .send(sendData);
+    .send(sendData)
 }
 
 describe('Credentials endpoints', () => {
   describe('The ' + paths.credentials.index + ' endpoint', function () {
-
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'gateway-credentials:read';
+      let permissions = 'gateway-credentials:read'
       var user = session.getUser({
         gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should display payment provider name in title case', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          "payment_provider": "sandbox",
-          "gateway_account_id": "1",
-          "credentials": {}
-        });
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {}
+        })
 
       var expectedData = {
         currentGatewayAccount: {
-          "gateway_account_id": "1",
-          "payment_provider": "sandbox",
-          "credentials": {}
+          'gateway_account_id': '1',
+          'payment_provider': 'sandbox',
+          'credentials': {}
         },
-        "editMode": false,
-        "editNotificationCredentialsMode": false,
-        "permissions": {
+        'editMode': false,
+        'editNotificationCredentialsMode': false,
+        'permissions': {
           gateway_credentials_read: true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.credentials.index, app)
+      buildGetRequest(paths.credentials.index, app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should display empty credential values when no gateway credentials are set', function (done) {
-
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          "payment_provider": "sandbox",
-          "gateway_account_id": "1",
-          "credentials": {}
-        });
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {}
+        })
 
       var expectedData = {
         currentGatewayAccount: {
-          "payment_provider": "sandbox",
-          "credentials": {},
-          "gateway_account_id": "1",
+          'payment_provider': 'sandbox',
+          'credentials': {},
+          'gateway_account_id': '1'
         },
-        "editMode": false,
-        "editNotificationCredentialsMode": false,
-        "permissions": {
+        'editMode': false,
+        'editNotificationCredentialsMode': false,
+        'permissions': {
           gateway_credentials_read: true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.credentials.index, app)
+      buildGetRequest(paths.credentials.index, app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should display received credentials from connector', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          "payment_provider": "sandbox",
-          "gateway_account_id": "1",
-          "credentials": {"username": "a-username"}
-        });
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {'username': 'a-username'}
+        })
 
       var expectedData = {
         currentGatewayAccount: {
-          "payment_provider": "sandbox",
-          "credentials": {
+          'payment_provider': 'sandbox',
+          'credentials': {
             'username': 'a-username'
           },
-          "gateway_account_id": "1",
+          'gateway_account_id': '1'
         },
-        "editNotificationCredentialsMode": false,
-        "editMode": false,
-        "permissions": {
+        'editNotificationCredentialsMode': false,
+        'editMode': false,
+        'permissions': {
           gateway_credentials_read: true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.credentials.index, app)
+      buildGetRequest(paths.credentials.index, app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return the account', function (done) {
-
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          "payment_provider": "sandbox",
-          "gateway_account_id": "1",
-          "credentials": {username: "a-username", merchant_id: 'a-merchant-id'}
-        });
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {username: 'a-username', merchant_id: 'a-merchant-id'}
+        })
 
       var expectedData = {
         currentGatewayAccount: {
-          "payment_provider": "sandbox",
-          "credentials": {
+          'payment_provider': 'sandbox',
+          'credentials': {
             'username': 'a-username',
             merchant_id: 'a-merchant-id'
           },
-          "gateway_account_id": "1",
+          'gateway_account_id': '1'
         },
-        "editMode": false,
-        "editNotificationCredentialsMode": false,
-        "permissions": {
+        'editMode': false,
+        'editNotificationCredentialsMode': false,
+        'permissions': {
           gateway_credentials_read: true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.credentials.index, app)
+      buildGetRequest(paths.credentials.index, app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should display an error if the account does not exist', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(404, {
-          "message": "The gateway account id '" + ACCOUNT_ID + "' does not exist"
-        });
+          'message': "The gateway account id '" + ACCOUNT_ID + "' does not exist"
+        })
 
-      build_get_request(paths.credentials.index, app)
-        .expect(500, {"message": "There is a problem with the payments platform"})
-        .end(done);
-    });
+      buildGetRequest(paths.credentials.index, app)
+        .expect(500, {'message': 'There is a problem with the payments platform'})
+        .end(done)
+    })
 
     it('should display an error if connector returns any other error', function (done) {
-
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(999, {
-          "message": "Some error in Connector"
-        });
+          'message': 'Some error in Connector'
+        })
 
-      build_get_request(paths.credentials.index, app)
-        .expect(500, {"message": "There is a problem with the payments platform"})
-        .end(done);
-    });
+      buildGetRequest(paths.credentials.index, app)
+        .expect(500, {'message': 'There is a problem with the payments platform'})
+        .end(done)
+    })
 
     it('should display an error if the connection to connector fails', function (done) {
       // No connectorMock defined on purpose to mock a network failure
 
-      build_get_request(paths.credentials.index, app)
-        .expect(500, {"message": "There is a problem with the payments platform"})
-        .end(done);
-    });
-  });
+      buildGetRequest(paths.credentials.index, app)
+        .expect(500, {'message': 'There is a problem with the payments platform'})
+        .end(done)
+    })
+  })
 
   describe('The ' + paths.credentials.edit + ' endpoint', function () {
-
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'gateway-credentials:update';
+      let permissions = 'gateway-credentials:update'
       var user = session.getUser({
         gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should display payment provider name in title case', function (done) {
-
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          "payment_provider": "sandbox",
-          "gateway_account_id": "1",
-          "credentials": {}
-        });
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {}
+        })
 
       var expectedData = {
         currentGatewayAccount: {
-          "gateway_account_id": "1",
-          "payment_provider": "sandbox",
-          "credentials": {}
+          'gateway_account_id': '1',
+          'payment_provider': 'sandbox',
+          'credentials': {}
         },
-        "editMode": true,
-        "editNotificationCredentialsMode": false,
-        "permissions": {
+        'editMode': true,
+        'editNotificationCredentialsMode': false,
+        'permissions': {
           gateway_credentials_update: true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.credentials.edit, app)
+      buildGetRequest(paths.credentials.edit, app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should display empty credential values when no gateway credentials are set', function (done) {
-
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          "payment_provider": "sandbox",
-          "gateway_account_id": "1",
-          "credentials": {}
-        });
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {}
+        })
 
       var expectedData = {
         currentGatewayAccount: {
-          "gateway_account_id": "1",
-          "payment_provider": "sandbox",
-          "credentials": {}
+          'gateway_account_id': '1',
+          'payment_provider': 'sandbox',
+          'credentials': {}
         },
-        "editMode": true,
-        "editNotificationCredentialsMode": false,
-        "permissions": {
+        'editMode': true,
+        'editNotificationCredentialsMode': false,
+        'permissions': {
           gateway_credentials_update: true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.credentials.edit, app)
+      buildGetRequest(paths.credentials.edit, app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should display received credentials from connector', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          "payment_provider": "sandbox",
-          "gateway_account_id": "1",
-          "credentials": {"username": "a-username"}
-        });
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {'username': 'a-username'}
+        })
 
       var expectedData = {
         currentGatewayAccount: {
-          "gateway_account_id": "1",
-          "payment_provider": "sandbox",
-          "credentials": {"username": "a-username"}
+          'gateway_account_id': '1',
+          'payment_provider': 'sandbox',
+          'credentials': {'username': 'a-username'}
         },
-        "editNotificationCredentialsMode": false,
-        "editMode": true,
-        "permissions": {
+        'editNotificationCredentialsMode': false,
+        'editMode': true,
+        'permissions': {
           gateway_credentials_update: true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.credentials.edit, app)
+      buildGetRequest(paths.credentials.edit, app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return the account', function (done) {
-
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          "payment_provider": "sandbox",
-          "gateway_account_id": "1",
-          "credentials": {username: "a-username"},
-        });
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {username: 'a-username'}
+        })
 
       var expectedData = {
         currentGatewayAccount: {
-          "gateway_account_id": "1",
-          "payment_provider": "sandbox",
-          "credentials": {"username": "a-username"}
+          'gateway_account_id': '1',
+          'payment_provider': 'sandbox',
+          'credentials': {'username': 'a-username'}
         },
-        "editMode": true,
-        "editNotificationCredentialsMode": false,
-        "permissions": {
+        'editMode': true,
+        'editNotificationCredentialsMode': false,
+        'permissions': {
           gateway_credentials_update: true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.credentials.edit, app)
+      buildGetRequest(paths.credentials.edit, app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should display an error if the account does not exist', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(404, {
-          "message": "The gateway account id '" + ACCOUNT_ID + "' does not exist"
-        });
+          'message': "The gateway account id '" + ACCOUNT_ID + "' does not exist"
+        })
 
-      build_get_request(paths.credentials.edit, app)
-        .expect(500, {"message": "There is a problem with the payments platform"})
-        .end(done);
-    });
+      buildGetRequest(paths.credentials.edit, app)
+        .expect(500, {'message': 'There is a problem with the payments platform'})
+        .end(done)
+    })
 
     it('should display an error if connector returns any other error', function (done) {
-
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(999, {
-          "message": "Some error in Connector"
-        });
+          'message': 'Some error in Connector'
+        })
 
-      build_get_request(paths.credentials.edit, app)
-        .expect(500, {"message": "There is a problem with the payments platform"})
-        .end(done);
-    });
+      buildGetRequest(paths.credentials.edit, app)
+        .expect(500, {'message': 'There is a problem with the payments platform'})
+        .end(done)
+    })
 
     it('should display an error if the connection to connector fails', function (done) {
       // No connectorMock defined on purpose to mock a network failure
 
-      build_get_request(paths.credentials.edit, app)
-        .expect(500, {"message": "There is a problem with the payments platform"})
-        .end(done);
-    });
-  });
+      buildGetRequest(paths.credentials.edit, app)
+        .expect(500, {'message': 'There is a problem with the payments platform'})
+        .end(done)
+    })
+  })
 
   describe('The ' + paths.notificationCredentials.edit + ' endpoint', function () {
-
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'gateway-credentials:update';
+      let permissions = 'gateway-credentials:update'
       var user = session.getUser({
         gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should display payment provider name in title case', function (done) {
-
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          "payment_provider": "sandbox",
-          "gateway_account_id": "1",
-          "credentials": {}
-        });
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {}
+        })
 
       var expectedData = {
         currentGatewayAccount: {
-          "gateway_account_id": "1",
-          "payment_provider": "sandbox",
-          "credentials": {},
+          'gateway_account_id': '1',
+          'payment_provider': 'sandbox',
+          'credentials': {}
         },
-        "editMode": false,
-        "editNotificationCredentialsMode": true,
-        "permissions": {
+        'editMode': false,
+        'editNotificationCredentialsMode': true,
+        'permissions': {
           gateway_credentials_update: true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.notificationCredentials.edit, app)
+      buildGetRequest(paths.notificationCredentials.edit, app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should display empty credential values when no gateway credentials are set', function (done) {
-
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          "payment_provider": "sandbox",
-          "gateway_account_id": "1",
-          "credentials": {}
-        });
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {}
+        })
 
       var expectedData = {
         currentGatewayAccount: {
-          "gateway_account_id": "1",
-          "payment_provider": "sandbox",
-          "credentials": {},
+          'gateway_account_id': '1',
+          'payment_provider': 'sandbox',
+          'credentials': {}
         },
-        "editMode": false,
-        "editNotificationCredentialsMode": true,
-        "permissions": {
+        'editMode': false,
+        'editNotificationCredentialsMode': true,
+        'permissions': {
           gateway_credentials_update: true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.notificationCredentials.edit, app)
+      buildGetRequest(paths.notificationCredentials.edit, app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should display received credentials from connector', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          "payment_provider": "sandbox",
-          "gateway_account_id": "1",
-          "credentials": {"username": "a-username"}
-        });
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {'username': 'a-username'}
+        })
 
       var expectedData = {
         currentGatewayAccount: {
-          "gateway_account_id": "1",
-          "payment_provider": "sandbox",
-          "credentials": {
+          'gateway_account_id': '1',
+          'payment_provider': 'sandbox',
+          'credentials': {
             'username': 'a-username'
-          },
+          }
         },
-        "editNotificationCredentialsMode": true,
-        "editMode": false,
-        "permissions": {
+        'editNotificationCredentialsMode': true,
+        'editMode': false,
+        'permissions': {
           gateway_credentials_update: true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.notificationCredentials.edit, app)
+      buildGetRequest(paths.notificationCredentials.edit, app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return the account', function (done) {
-
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          "payment_provider": "sandbox",
-          "gateway_account_id": "1",
-          "credentials": {username: "a-username", merchant_id: 'a-merchant-id'},
-        });
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {username: 'a-username', merchant_id: 'a-merchant-id'}
+        })
 
       var expectedData = {
         currentGatewayAccount: {
-          "gateway_account_id": "1",
-          "payment_provider": "sandbox",
-          "credentials": {
+          'gateway_account_id': '1',
+          'payment_provider': 'sandbox',
+          'credentials': {
             'username': 'a-username',
             'merchant_id': 'a-merchant-id'
-          },
+          }
         },
-        "editMode": false,
-        "editNotificationCredentialsMode": true,
-        "permissions": {
+        'editMode': false,
+        'editNotificationCredentialsMode': true,
+        'permissions': {
           gateway_credentials_update: true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.notificationCredentials.edit, app)
+      buildGetRequest(paths.notificationCredentials.edit, app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should display an error if the account does not exist', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(404, {
-          "message": "The gateway account id '" + ACCOUNT_ID + "' does not exist"
-        });
+          'message': "The gateway account id '" + ACCOUNT_ID + "' does not exist"
+        })
 
-      build_get_request(paths.notificationCredentials.edit, app)
-        .expect(500, {"message": "There is a problem with the payments platform"})
-        .end(done);
-    });
+      buildGetRequest(paths.notificationCredentials.edit, app)
+        .expect(500, {'message': 'There is a problem with the payments platform'})
+        .end(done)
+    })
 
     it('should display an error if connector returns any other error', function (done) {
-
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(999, {
-          "message": "Some error in Connector"
-        });
+          'message': 'Some error in Connector'
+        })
 
-      build_get_request(paths.notificationCredentials.edit, app)
-        .expect(500, {"message": "There is a problem with the payments platform"})
-        .end(done);
-    });
+      buildGetRequest(paths.notificationCredentials.edit, app)
+        .expect(500, {'message': 'There is a problem with the payments platform'})
+        .end(done)
+    })
 
     it('should display an error if the connection to connector fails', function (done) {
       // No connectorMock defined on purpose to mock a network failure
 
-      build_get_request(paths.notificationCredentials.edit, app)
-        .expect(500, {"message": "There is a problem with the payments platform"})
-        .end(done);
-    });
-  });
+      buildGetRequest(paths.notificationCredentials.edit, app)
+        .expect(500, {'message': 'There is a problem with the payments platform'})
+        .end(done)
+    })
+  })
 
   describe('The notification credentials', function () {
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'gateway-credentials:read';
+      let permissions = 'gateway-credentials:read'
       var user = session.getUser({
         gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should pass through the notification credentials', function (done) {
-
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          "payment_provider": "smartpay",
-          "gateway_account_id": "1",
-          "credentials": {
-            'username': "a-username",
-            'merchant_id': 'a-merchant-id'
-          },
-          "notification_credentials": {username: "a-notification-username"}
-        });
-
-      var expectedData = {
-        currentGatewayAccount: {
-          "gateway_account_id": "1",
-          "payment_provider": "smartpay",
-          "credentials": {
+          'payment_provider': 'smartpay',
+          'gateway_account_id': '1',
+          'credentials': {
             'username': 'a-username',
             'merchant_id': 'a-merchant-id'
           },
-          "notification_credentials": {username: "a-notification-username"}
+          'notification_credentials': {username: 'a-notification-username'}
+        })
+
+      var expectedData = {
+        currentGatewayAccount: {
+          'gateway_account_id': '1',
+          'payment_provider': 'smartpay',
+          'credentials': {
+            'username': 'a-username',
+            'merchant_id': 'a-merchant-id'
+          },
+          'notification_credentials': {username: 'a-notification-username'}
         },
-        "editNotificationCredentialsMode": false,
+        'editNotificationCredentialsMode': false,
 
-        "editMode": false,
+        'editMode': false,
 
-        "permissions": {
+        'permissions': {
           gateway_credentials_read: true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.credentials.index, app)
+      buildGetRequest(paths.credentials.index, app)
         .expect(200, expectedData)
-        .end(done);
-    });
-  });
+        .end(done)
+    })
+  })
 
   describe('The provider update credentials endpoint', function () {
-
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'gateway-credentials:update';
+      let permissions = 'gateway-credentials:update'
       var user = session.getUser({
         gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should send new username, password and merchant_id credentials to connector', function (done) {
-
       connectorMock.patch(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
-        "credentials": {
-          "username": "a-username",
-          "password": "a-password",
-          "merchant_id": "a-merchant-id"
+        'credentials': {
+          'username': 'a-username',
+          'password': 'a-password',
+          'merchant_id': 'a-merchant-id'
         }
-      }).reply(200, {});
+      }).reply(200, {})
 
-      var sendData = {'username': 'a-username', 'password': 'a-password', 'merchantId': 'a-merchant-id'};
-      var expectedLocation = paths.credentials.index;
-      var path = paths.credentials.index;
-      build_form_post_request(path, sendData, true, app)
+      var sendData = {'username': 'a-username', 'password': 'a-password', 'merchantId': 'a-merchant-id'}
+      var expectedLocation = paths.credentials.index
+      var path = paths.credentials.index
+      buildFormPostRequest(path, sendData, true, app)
         .expect(303, {})
         .expect('Location', expectedLocation)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should send new username, password, merchant_id, sha_in_passphrase and sha_out_passphrase credentials to connector', function (done) {
-
       connectorMock.patch(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
-        "credentials": {
-          "username": "a-username",
-          "password": "a-password",
-          "merchant_id": "a-psp-id",
-          "sha_in_passphrase": "a-sha-in-passphrase",
-          "sha_out_passphrase": "a-sha-out-passphrase"
+        'credentials': {
+          'username': 'a-username',
+          'password': 'a-password',
+          'merchant_id': 'a-psp-id',
+          'sha_in_passphrase': 'a-sha-in-passphrase',
+          'sha_out_passphrase': 'a-sha-out-passphrase'
 
         }
-      }).reply(200, {});
+      }).reply(200, {})
 
       var sendData = {
-        'username': 'a-username', 'password': 'a-password', 'merchantId': 'a-psp-id',
-        'shaInPassphrase': 'a-sha-in-passphrase', 'shaOutPassphrase': 'a-sha-out-passphrase'
-      };
-      var expectedLocation = paths.credentials.index;
-      var path = paths.credentials.index;
-      build_form_post_request(path, sendData, true, app)
+        'username': 'a-username',
+        'password': 'a-password',
+        'merchantId': 'a-psp-id',
+        'shaInPassphrase': 'a-sha-in-passphrase',
+        'shaOutPassphrase': 'a-sha-out-passphrase'
+      }
+      var expectedLocation = paths.credentials.index
+      var path = paths.credentials.index
+      buildFormPostRequest(path, sendData, true, app)
         .expect(303, {})
         .expect('Location', expectedLocation)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should send any arbitrary credentials together with username and password to connector', function (done) {
       connectorMock.patch(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
-        "credentials": {
-          "username": "a-username",
-          "password": "a-password"
+        'credentials': {
+          'username': 'a-username',
+          'password': 'a-password'
         }
       })
-        .reply(200, {});
+        .reply(200, {})
 
-      var sendData = {'username': 'a-username', 'password': 'a-password'};
-      var expectedLocation = paths.credentials.index;
-      var path = paths.credentials.index;
-      build_form_post_request(path, sendData, true, app)
+      var sendData = {'username': 'a-username', 'password': 'a-password'}
+      var expectedLocation = paths.credentials.index
+      var path = paths.credentials.index
+      buildFormPostRequest(path, sendData, true, app)
         .expect(303, {})
         .expect('Location', expectedLocation)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should display an error if connector returns failure', function (done) {
       connectorMock.patch(CONNECTOR_ACCOUNT_PATH, {
-        "username": "a-username",
-        "password": "a-password"
+        'username': 'a-username',
+        'password': 'a-password'
       })
         .reply(999, {
-          "message": "Error message"
-        });
+          'message': 'Error message'
+        })
 
-      var sendData = {'username': 'a-username', 'password': 'a-password'};
-      var expectedData = {"message": "There is a problem with the payments platform"};
-      var path = paths.credentials.index;
-      build_form_post_request(path, sendData, true, app)
+      var sendData = {'username': 'a-username', 'password': 'a-password'}
+      var expectedData = {'message': 'There is a problem with the payments platform'}
+      var path = paths.credentials.index
+      buildFormPostRequest(path, sendData, true, app)
         .expect(500, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should display an error if the connection to connector fails', function (done) {
       // No connectorMock defined on purpose to mock a network failure
 
-      var sendData = {'username': 'a-username', 'password': 'a-password'};
-      var expectedData = {"message": "There is a problem with the payments platform"};
-      var path = paths.credentials.index;
-      build_form_post_request(path, sendData, true, app)
+      var sendData = {'username': 'a-username', 'password': 'a-password'}
+      var expectedData = {'message': 'There is a problem with the payments platform'}
+      var path = paths.credentials.index
+      buildFormPostRequest(path, sendData, true, app)
         .expect(500, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should fail if there is no csrf', done => {
       connectorMock.patch(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
-        "username": "a-username",
-        "password": "a-password"
-      }).reply(200, {});
+        'username': 'a-username',
+        'password': 'a-password'
+      }).reply(200, {})
 
-      const sendData = {'username': 'a-username', 'password': 'a-password'};
-      const path = paths.credentials.index;
-      build_form_post_request(path, sendData, false, app)
-        .expect(400, {message: "There is a problem with the payments platform"})
-        .end(done);
-    });
-  });
+      const sendData = {'username': 'a-username', 'password': 'a-password'}
+      const path = paths.credentials.index
+      buildFormPostRequest(path, sendData, false, app)
+        .expect(400, {message: 'There is a problem with the payments platform'})
+        .end(done)
+    })
+  })
 
   describe('The provider update notification credentials endpoint', function () {
-
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'gateway-credentials:update';
+      let permissions = 'gateway-credentials:update'
       var user = session.getUser({
         gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should send new username and password notification credentials to connector', function (done) {
       connectorMock.post(CONNECTOR_ACCOUNT_NOTIFICATION_CREDENTIALS_PATH, {
-        "username": "a-notification-username",
-        "password": "a-notification-password"
+        'username': 'a-notification-username',
+        'password': 'a-notification-password'
       })
-        .reply(200, {});
+        .reply(200, {})
 
-      var sendData = {'username': 'a-notification-username', 'password': 'a-notification-password'};
-      var expectedLocation = paths.credentials.index;
-      var path = paths.notificationCredentials.update;
-      build_form_post_request(path, sendData, true, app)
+      var sendData = {'username': 'a-notification-username', 'password': 'a-notification-password'}
+      var expectedLocation = paths.credentials.index
+      var path = paths.notificationCredentials.update
+      buildFormPostRequest(path, sendData, true, app)
         .expect(303, {})
         .expect('Location', expectedLocation)
-        .end(done);
-    });
-  });
-});
-
+        .end(done)
+    })
+  })
+})

--- a/test/integration/dev_tokens_ft_tests.js
+++ b/test/integration/dev_tokens_ft_tests.js
@@ -1,39 +1,39 @@
-require(__dirname + '/../test_helpers/serialize_mock.js');
-var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
-var request = require('supertest');
-var getApp = require(__dirname + '/../../server.js').getApp;
-var nock = require('nock');
-var csrf = require('csrf');
-var should = require('chai').should();
-var paths = require(__dirname + '/../../app/paths.js');
-var session = require(__dirname + '/../test_helpers/mock_session.js');
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+var userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
+var request = require('supertest')
+var getApp = require(path.join(__dirname, '/../../server.js')).getApp
+var nock = require('nock')
+var csrf = require('csrf')
+var paths = require(path.join(__dirname, '/../../app/paths.js'))
+var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
 
-var gatewayAccountId = 98344;
-var TOKEN = '00112233';
-var PUBLIC_AUTH_PATH = '/v1/frontend/auth';
-var CONNECTOR_PATH = '/v1/frontend/accounts/{accountId}';
+var gatewayAccountId = 98344
+var TOKEN = '00112233'
+var PUBLIC_AUTH_PATH = '/v1/frontend/auth'
+var CONNECTOR_PATH = '/v1/frontend/accounts/{accountId}'
 
-var app;
+var app
 
-var requestId = 'unique-request-id';
+var requestId = 'unique-request-id'
 var aCorrelationHeader = {
   reqheaders: {'x-request-id': requestId}
-};
+}
 
-var connectorMock = nock(process.env.CONNECTOR_URL, aCorrelationHeader);
-var publicauthMock = nock(process.env.PUBLIC_AUTH_BASE, aCorrelationHeader);
+var connectorMock = nock(process.env.CONNECTOR_URL, aCorrelationHeader)
+var publicauthMock = nock(process.env.PUBLIC_AUTH_BASE, aCorrelationHeader)
 
-function build_get_request(path) {
+function buildGetRequest (path) {
   return request(app)
     .get(path)
     .set('Accept', 'application/json')
-    .set('x-request-id', requestId);
+    .set('x-request-id', requestId)
 }
 
-function build_form_post_request(path, sendData, sendCSRF) {
-  sendCSRF = (sendCSRF === undefined) ? true : sendCSRF;
+function buildFormPostRequest (path, sendData, sendCSRF) {
+  sendCSRF = (sendCSRF === undefined) ? true : sendCSRF
   if (sendCSRF) {
-    sendData.csrfToken = csrf().create('123');
+    sendData.csrfToken = csrf().create('123')
   }
 
   return request(app)
@@ -41,390 +41,374 @@ function build_form_post_request(path, sendData, sendCSRF) {
     .set('Accept', 'application/json')
     .set('Content-Type', 'application/x-www-form-urlencoded')
     .set('x-request-id', requestId)
-    .send(sendData);
+    .send(sendData)
 }
 
-function build_put_request(sendCSRF) {
-  var data = {};
-  sendCSRF = (sendCSRF === undefined) ? true : sendCSRF;
+function buildPutRequest (sendCSRF) {
+  var data = {}
+  sendCSRF = (sendCSRF === undefined) ? true : sendCSRF
   if (sendCSRF) {
-    data.csrfToken = csrf().create('123');
+    data.csrfToken = csrf().create('123')
   }
-  data.token_link = '550e8400-e29b-41d4-a716-446655440000';
-  data.description = "token description";
+  data.token_link = '550e8400-e29b-41d4-a716-446655440000'
+  data.description = 'token description'
   return request(app)
     .put(paths.devTokens.index)
     .set('Accept', 'application/json')
     .set('x-request-id', requestId)
-    .send(data);
+    .send(data)
 }
 
 describe('Dev Tokens Endpoints', function () {
-
   describe('The /tokens/revoked endpoint (read revoked tokens)', function () {
-
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'tokens-revoked:read';
+      let permissions = 'tokens-revoked:read'
       var user = session.getUser({
         gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should return an empty list of tokens if no tokens have been revoked yet', function (done) {
-      publicauthMock.get(PUBLIC_AUTH_PATH + "/" + gatewayAccountId + "?state=revoked")
+      publicauthMock.get(PUBLIC_AUTH_PATH + '/' + gatewayAccountId + '?state=revoked')
         .reply(200, {
-          "account_id": gatewayAccountId
-        });
+          'account_id': gatewayAccountId
+        })
 
-      build_get_request(paths.devTokens.revoked)
+      buildGetRequest(paths.devTokens.revoked)
         .expect(200, {
-          "active": false,
-          "header": 'revoked-tokens',
-          "token_state": 'revoked',
-          "tokens": [],
-          "tokens_singular": false,
+          'active': false,
+          'header': 'revoked-tokens',
+          'token_state': 'revoked',
+          'tokens': [],
+          'tokens_singular': false,
           'permissions': {
             'tokens_revoked_read': true
           },
           navigation: true
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return the account_id and the token list for the only revoked token', function (done) {
-      publicauthMock.get(PUBLIC_AUTH_PATH + "/" + gatewayAccountId + "?state=revoked")
+      publicauthMock.get(PUBLIC_AUTH_PATH + '/' + gatewayAccountId + '?state=revoked')
         .reply(200, {
-          "account_id": gatewayAccountId,
-          "tokens": [{
-            "token_link": "550e8400-e29b-41d4-a716-446655440000",
-            "description": "token 1",
-            'revoked': "18 Oct 2015"
+          'account_id': gatewayAccountId,
+          'tokens': [{
+            'token_link': '550e8400-e29b-41d4-a716-446655440000',
+            'description': 'token 1',
+            'revoked': '18 Oct 2015'
           }]
-        });
+        })
 
-      build_get_request(paths.devTokens.revoked)
+      buildGetRequest(paths.devTokens.revoked)
         .expect(function (res) {
-          if (!res.body.tokens[0].csrfToken)  throw new Error('no token');
-          delete res.body.tokens[0].csrfToken;
+          if (!res.body.tokens[0].csrfToken) throw new Error('no token')
+          delete res.body.tokens[0].csrfToken
         })
         .expect(200, {
-          "active": false,
-          "header": 'revoked-tokens',
-          "token_state": 'revoked',
-          "tokens": [{
-            "token_link": "550e8400-e29b-41d4-a716-446655440000",
-            "description": "token 1",
-            'revoked': "18 Oct 2015"
+          'active': false,
+          'header': 'revoked-tokens',
+          'token_state': 'revoked',
+          'tokens': [{
+            'token_link': '550e8400-e29b-41d4-a716-446655440000',
+            'description': 'token 1',
+            'revoked': '18 Oct 2015'
           }],
-          "tokens_singular": true,
+          'tokens_singular': true,
           'permissions': {
             'tokens_revoked_read': true
           },
           navigation: true
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return the account_id and the token list for multiple revoked tokens', function (done) {
-      publicauthMock.get(PUBLIC_AUTH_PATH + "/" + gatewayAccountId + "?state=revoked")
+      publicauthMock.get(PUBLIC_AUTH_PATH + '/' + gatewayAccountId + '?state=revoked')
         .reply(200, {
-          "account_id": gatewayAccountId,
-          "tokens": [{
-            "token_link": "550e8400-e29b-41d4-a716-446655440000",
-            "description": "description token 1",
-            'revoked': "18 Oct 2015"
+          'account_id': gatewayAccountId,
+          'tokens': [{
+            'token_link': '550e8400-e29b-41d4-a716-446655440000',
+            'description': 'description token 1',
+            'revoked': '18 Oct 2015'
           },
-            {
-              "token_link": "550e8400-e29b-41d4-a716-446655441234",
-              "description": "description token 2",
-              'revoked': "19 Oct 2015"
-            }]
-        });
+          {
+            'token_link': '550e8400-e29b-41d4-a716-446655441234',
+            'description': 'description token 2',
+            'revoked': '19 Oct 2015'
+          }]
+        })
 
-      build_get_request(paths.devTokens.revoked)
+      buildGetRequest(paths.devTokens.revoked)
         .expect(function (res) {
-          if (!res.body.tokens[0].csrfToken)  throw new Error('no token');
-          delete res.body.tokens[0].csrfToken;
-          if (!res.body.tokens[1].csrfToken)  throw new Error('no token');
-          delete res.body.tokens[1].csrfToken;
+          if (!res.body.tokens[0].csrfToken) throw new Error('no token')
+          delete res.body.tokens[0].csrfToken
+          if (!res.body.tokens[1].csrfToken) throw new Error('no token')
+          delete res.body.tokens[1].csrfToken
         })
         .expect(200, {
-          "active": false,
-          "header": 'revoked-tokens',
-          "token_state": 'revoked',
-          "tokens": [{
-            "token_link": "550e8400-e29b-41d4-a716-446655440000",
-            "description": "description token 1",
-            'revoked': "18 Oct 2015"
+          'active': false,
+          'header': 'revoked-tokens',
+          'token_state': 'revoked',
+          'tokens': [{
+            'token_link': '550e8400-e29b-41d4-a716-446655440000',
+            'description': 'description token 1',
+            'revoked': '18 Oct 2015'
           },
-            {
-              "token_link": "550e8400-e29b-41d4-a716-446655441234",
-              "description": "description token 2",
-              'revoked': "19 Oct 2015"
-            }],
-          "tokens_singular": false,
+          {
+            'token_link': '550e8400-e29b-41d4-a716-446655441234',
+            'description': 'description token 2',
+            'revoked': '19 Oct 2015'
+          }],
+          'tokens_singular': false,
           'permissions': {
             'tokens_revoked_read': true
           },
           navigation: true
         })
-        .end(done);
-    });
-  });
+        .end(done)
+    })
+  })
 
   describe('The GET /tokens endpoint (read active tokens)', function () {
-
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'tokens-active:read';
+      let permissions = 'tokens-active:read'
       var user = session.getUser({
         gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should return an empty list of tokens if no tokens have been issued yet', function (done) {
-      publicauthMock.get(PUBLIC_AUTH_PATH + "/" + gatewayAccountId)
+      publicauthMock.get(PUBLIC_AUTH_PATH + '/' + gatewayAccountId)
         .reply(200, {
-          "account_id": gatewayAccountId
-        });
+          'account_id': gatewayAccountId
+        })
 
-      build_get_request(paths.devTokens.index)
+      buildGetRequest(paths.devTokens.index)
         .expect(200, {
-          "active": true,
-          "header": 'available-tokens',
-          "token_state": 'active',
-          "tokens": [],
-          "tokens_singular": false,
+          'active': true,
+          'header': 'available-tokens',
+          'token_state': 'active',
+          'tokens': [],
+          'tokens_singular': false,
           'permissions': {
             'tokens_active_read': true
           },
           navigation: true
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return the account_id and the token list for the only already-issued token', function (done) {
-      publicauthMock.get(PUBLIC_AUTH_PATH + "/" + gatewayAccountId)
+      publicauthMock.get(PUBLIC_AUTH_PATH + '/' + gatewayAccountId)
         .reply(200, {
-          "account_id": gatewayAccountId,
-          "tokens": [{"token_link": "550e8400-e29b-41d4-a716-446655440000", "description": "token 1"}]
-        });
+          'account_id': gatewayAccountId,
+          'tokens': [{'token_link': '550e8400-e29b-41d4-a716-446655440000', 'description': 'token 1'}]
+        })
 
-      build_get_request(paths.devTokens.index)
+      buildGetRequest(paths.devTokens.index)
         .expect(function (res) {
-          if (!res.body.tokens[0].csrfToken)  throw new Error('no token');
-          delete res.body.tokens[0].csrfToken;
+          if (!res.body.tokens[0].csrfToken) throw new Error('no token')
+          delete res.body.tokens[0].csrfToken
         })
         .expect(200, {
-          "active": true,
-          "header": 'available-tokens',
-          "token_state": 'active',
-          "tokens": [{"token_link": "550e8400-e29b-41d4-a716-446655440000", "description": "token 1"}],
-          "tokens_singular": true,
+          'active': true,
+          'header': 'available-tokens',
+          'token_state': 'active',
+          'tokens': [{'token_link': '550e8400-e29b-41d4-a716-446655440000', 'description': 'token 1'}],
+          'tokens_singular': true,
           'permissions': {
             'tokens_active_read': true
           },
           navigation: true
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return the account_id and the token list for already-issued tokens', function (done) {
-      publicauthMock.get(PUBLIC_AUTH_PATH + "/" + gatewayAccountId)
+      publicauthMock.get(PUBLIC_AUTH_PATH + '/' + gatewayAccountId)
         .reply(200, {
-          "account_id": gatewayAccountId,
-          "tokens": [{"token_link": "550e8400-e29b-41d4-a716-446655440000", "description": "description token 1"},
-            {"token_link": "550e8400-e29b-41d4-a716-446655441234", "description": "description token 2"}]
-        });
+          'account_id': gatewayAccountId,
+          'tokens': [{'token_link': '550e8400-e29b-41d4-a716-446655440000', 'description': 'description token 1'},
+            {'token_link': '550e8400-e29b-41d4-a716-446655441234', 'description': 'description token 2'}]
+        })
 
-      build_get_request(paths.devTokens.index)
+      buildGetRequest(paths.devTokens.index)
         .expect(function (res) {
-          if (!res.body.tokens[0].csrfToken)  throw new Error('no token');
-          delete res.body.tokens[0].csrfToken;
-          if (!res.body.tokens[1].csrfToken)  throw new Error('no token');
-          delete res.body.tokens[1].csrfToken;
+          if (!res.body.tokens[0].csrfToken) throw new Error('no token')
+          delete res.body.tokens[0].csrfToken
+          if (!res.body.tokens[1].csrfToken) throw new Error('no token')
+          delete res.body.tokens[1].csrfToken
         })
         .expect(200, {
-          "active": true,
-          "header": 'available-tokens',
-          "token_state": 'active',
-          "tokens": [{"token_link": "550e8400-e29b-41d4-a716-446655440000", "description": "description token 1"},
-            {"token_link": "550e8400-e29b-41d4-a716-446655441234", "description": "description token 2"}],
-          "tokens_singular": false,
+          'active': true,
+          'header': 'available-tokens',
+          'token_state': 'active',
+          'tokens': [{'token_link': '550e8400-e29b-41d4-a716-446655440000', 'description': 'description token 1'},
+            {'token_link': '550e8400-e29b-41d4-a716-446655441234', 'description': 'description token 2'}],
+          'tokens_singular': false,
           'permissions': {
             'tokens_active_read': true
           },
           navigation: true
         })
-        .end(done);
-    });
-  });
+        .end(done)
+    })
+  })
 
   describe('The PUT /tokens endpoint (update token - description)', function () {
-
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'tokens:update';
+      let permissions = 'tokens:update'
       var user = session.getUser({
         gateway_account_id: gatewayAccountId, permissions: [{name: permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-
-    });
-
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should update the description', function (done) {
       publicauthMock.put(PUBLIC_AUTH_PATH, {
-        "token_link": '550e8400-e29b-41d4-a716-446655440000',
-        "description": "token description"
+        'token_link': '550e8400-e29b-41d4-a716-446655440000',
+        'description': 'token description'
       }).reply(200, {
-        "token_link": '550e8400-e29b-41d4-a716-446655440000',
-        "description": "token description",
-        "created_by": "test-user",
-        "issued_date": "18 Feb 2016 - 12:44",
-        "last_used": "23 Feb 2016 - 19:44"
-      });
+        'token_link': '550e8400-e29b-41d4-a716-446655440000',
+        'description': 'token description',
+        'created_by': 'test-user',
+        'issued_date': '18 Feb 2016 - 12:44',
+        'last_used': '23 Feb 2016 - 19:44'
+      })
 
-      build_put_request()
+      buildPutRequest()
         .expect(function (res) {
-          if (!res.body.csrfToken)  throw new Error('no token');
-          delete res.body.csrfToken;
+          if (!res.body.csrfToken) throw new Error('no token')
+          delete res.body.csrfToken
         })
         .expect(200, {
           'token_link': '550e8400-e29b-41d4-a716-446655440000',
-          'description': "token description",
-          'created_by': "test-user",
-          'issued_date': "18 Feb 2016 - 12:44",
-          'last_used': "23 Feb 2016 - 19:44",
+          'description': 'token description',
+          'created_by': 'test-user',
+          'issued_date': '18 Feb 2016 - 12:44',
+          'last_used': '23 Feb 2016 - 19:44',
           'permissions': {
             'tokens_update': true
           },
           navigation: true
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should not update the description without csrf', function (done) {
       publicauthMock.put(PUBLIC_AUTH_PATH, {
-        "token_link": '550e8400-e29b-41d4-a716-446655440000',
-        "description": "token description"
+        'token_link': '550e8400-e29b-41d4-a716-446655440000',
+        'description': 'token description'
       }).reply(200, {
-        "token_link": '550e8400-e29b-41d4-a716-446655440000',
-        "description": "token description"
-      });
+        'token_link': '550e8400-e29b-41d4-a716-446655440000',
+        'description': 'token description'
+      })
 
-      build_put_request(false)
+      buildPutRequest(false)
         .expect(400, {
           'message': 'There is a problem with the payments platform'
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should forward the error status code when updating the description', function (done) {
       publicauthMock.put(PUBLIC_AUTH_PATH, {
-        "token_link": '550e8400-e29b-41d4-a716-446655440000',
-        "description": "token description"
-      }).reply(400, {});
+        'token_link': '550e8400-e29b-41d4-a716-446655440000',
+        'description': 'token description'
+      }).reply(400, {})
 
-      build_put_request()
+      buildPutRequest()
         .expect(400, {})
-        .end(done);
-
-    });
+        .end(done)
+    })
 
     it('should send 500 if any error happens while updating the resource', function (done) {
       // No serverMock defined on purpose to mock a network failure
-      build_put_request()
+      buildPutRequest()
         .expect(500, {})
-        .end(done);
-    });
-  });
+        .end(done)
+    })
+  })
   describe('The DELETE /tokens endpoint (delete tokens)', function () {
-
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'tokens:delete';
+      let permissions = 'tokens:delete'
       var user = session.getUser({
-        gateway_account_ids: [gatewayAccountId], permissions: [{name:permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+        gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should revoke and existing token', function (done) {
-
-      publicauthMock.delete(PUBLIC_AUTH_PATH + "/" + gatewayAccountId, {
-        "token_link": '550e8400-e29b-41d4-a716-446655440000'
-      }).reply(200, {"revoked": "15 Oct 2015"});
+      publicauthMock.delete(PUBLIC_AUTH_PATH + '/' + gatewayAccountId, {
+        'token_link': '550e8400-e29b-41d4-a716-446655440000'
+      }).reply(200, {'revoked': '15 Oct 2015'})
 
       request(app)
-        .delete(paths.devTokens.index + "?token_link=550e8400-e29b-41d4-a716-446655440000")
+        .delete(paths.devTokens.index + '?token_link=550e8400-e29b-41d4-a716-446655440000')
         .set('x-request-id', requestId)
         .send({csrfToken: csrf().create('123')})
-        .expect(200, {"revoked": "15 Oct 2015"})
-        .end(done);
-
-    });
+        .expect(200, {'revoked': '15 Oct 2015'})
+        .end(done)
+    })
 
     it('should fail if no csrf', function (done) {
-
-      publicauthMock.delete(PUBLIC_AUTH_PATH + "/" + gatewayAccountId, {
-        "token_link": '550e8400-e29b-41d4-a716-446655440000'
-      }).reply(200, {"revoked": "15 Oct 2015"});
+      publicauthMock.delete(PUBLIC_AUTH_PATH + '/' + gatewayAccountId, {
+        'token_link': '550e8400-e29b-41d4-a716-446655440000'
+      }).reply(200, {'revoked': '15 Oct 2015'})
 
       request(app)
-        .delete(paths.devTokens.index + "?token_link=550e8400-e29b-41d4-a716-446655440000")
+        .delete(paths.devTokens.index + '?token_link=550e8400-e29b-41d4-a716-446655440000')
         .set('x-request-id', requestId)
         .set('Accept', 'application/json')
-        .expect(400, {message: "There is a problem with the payments platform"})
-        .end(done);
-    });
+        .expect(400, {message: 'There is a problem with the payments platform'})
+        .end(done)
+    })
 
     it('should forward the error status code when revoking the token', function (done) {
-      publicauthMock.delete(PUBLIC_AUTH_PATH + "/" + gatewayAccountId, {
-        "token_link": '550e8400-e29b-41d4-a716-446655440000'
-      }).reply(400, {});
+      publicauthMock.delete(PUBLIC_AUTH_PATH + '/' + gatewayAccountId, {
+        'token_link': '550e8400-e29b-41d4-a716-446655440000'
+      }).reply(400, {})
 
       request(app)
-        .delete(paths.devTokens.index + "?token_link=550e8400-e29b-41d4-a716-446655440000")
+        .delete(paths.devTokens.index + '?token_link=550e8400-e29b-41d4-a716-446655440000')
         .set('x-request-id', requestId)
         .send({csrfToken: csrf().create('123')})
         .expect(400, {})
-        .end(done);
-    });
-
+        .end(done)
+    })
 
     it('should send 500 if any error happens while updating the resource', function (done) {
-
       // No serverMock defined on purpose to mock a network failure
       request(app)
         .delete(paths.devTokens.index)
@@ -435,37 +419,35 @@ describe('Dev Tokens Endpoints', function () {
 
         })
         .expect(500, {})
-        .end(done);
-    });
-  });
+        .end(done)
+    })
+  })
 
   describe('The /tokens/generate endpoint (create tokens and show generated token)', function () {
-    var user;
+    var user
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'tokens:create';
+      let permissions = 'tokens:create'
       user = session.getUser({
-        gateway_account_ids: [gatewayAccountId], permissions: [{name:permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+        gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should create a token successfully', function (done) {
-
       publicauthMock.post(PUBLIC_AUTH_PATH, {
-        "account_id": gatewayAccountId,
-        "description": "description",
-        "created_by": user.email
-      }).reply(200, {"token": TOKEN});
+        'account_id': gatewayAccountId,
+        'description': 'description',
+        'created_by': user.email
+      }).reply(200, {'token': TOKEN})
 
-      build_form_post_request(paths.devTokens.create, {"description": 'description'}, true)
+      buildFormPostRequest(paths.devTokens.create, {'description': 'description'}, true)
         .expect(200, {
           'token': TOKEN,
           'description': 'description',
@@ -474,14 +456,13 @@ describe('Dev Tokens Endpoints', function () {
           },
           navigation: true
         })
-        .end(done);
-
-    });
+        .end(done)
+    })
 
     it('should only return the account_id', function (done) {
-      connectorMock.get(CONNECTOR_PATH.replace("{accountId}", gatewayAccountId)).reply(200);
+      connectorMock.get(CONNECTOR_PATH.replace('{accountId}', gatewayAccountId)).reply(200)
 
-      build_get_request(paths.devTokens.show)
+      buildGetRequest(paths.devTokens.show)
         .expect(200, {
           'account_id': gatewayAccountId,
           'permissions': {
@@ -489,33 +470,31 @@ describe('Dev Tokens Endpoints', function () {
           },
           navigation: true
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should fail if the account does not exist for a POST', function (done) {
-      connectorMock.get(CONNECTOR_PATH.replace("{accountId}", gatewayAccountId)).reply(400);
+      connectorMock.get(CONNECTOR_PATH.replace('{accountId}', gatewayAccountId)).reply(400)
 
       publicauthMock.post(PUBLIC_AUTH_PATH, {
-        "account_id": gatewayAccountId,
-        "description": "description"
+        'account_id': gatewayAccountId,
+        'description': 'description'
       }).reply(200, {
-        "token": TOKEN,
+        'token': TOKEN,
         navigation: true
-      });
+      })
 
-      build_form_post_request(paths.devTokens.create, {})
+      buildFormPostRequest(paths.devTokens.create, {})
         .expect(500, {
           'message': 'There is a problem with the payments platform'
         })
-        .end(done);
-
-    });
+        .end(done)
+    })
 
     it('should return the account_id', function (done) {
+      connectorMock.get(CONNECTOR_PATH.replace('{accountId}', gatewayAccountId)).reply(200)
 
-      connectorMock.get(CONNECTOR_PATH.replace("{accountId}", gatewayAccountId)).reply(200);
-
-      build_get_request(paths.devTokens.show)
+      buildGetRequest(paths.devTokens.show)
         .expect(200, {
           'account_id': gatewayAccountId,
           'permissions': {
@@ -523,25 +502,25 @@ describe('Dev Tokens Endpoints', function () {
           },
           navigation: true
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should fail if the csrf does not exist for the post', function (done) {
-      connectorMock.get(CONNECTOR_PATH.replace("{accountId}", gatewayAccountId)).reply(200);
+      connectorMock.get(CONNECTOR_PATH.replace('{accountId}', gatewayAccountId)).reply(200)
 
       publicauthMock.post(PUBLIC_AUTH_PATH, {
-        "account_id": gatewayAccountId,
-        "description": "description"
+        'account_id': gatewayAccountId,
+        'description': 'description'
       }).reply(200, {
-        "token": TOKEN,
+        'token': TOKEN,
         navigation: true
-      });
+      })
 
-      build_form_post_request(paths.devTokens.create, {}, true)
+      buildFormPostRequest(paths.devTokens.create, {}, true)
         .expect(500, {
           'message': 'There is a problem with the payments platform'
         })
-        .end(done);
-    });
-  });
-});
+        .end(done)
+    })
+  })
+})

--- a/test/integration/forgotten_password_ft_test.js
+++ b/test/integration/forgotten_password_ft_test.js
@@ -1,234 +1,228 @@
-let nock = require('nock');
-let proxyquire = require('proxyquire');
-const reqFixtures = require(__dirname + '/../fixtures/browser/forgotten_password_fixtures');
-const resFixtures = require(__dirname + '/../fixtures/response');
-const userFixtures = require(__dirname + '/../fixtures/user_fixtures');
+const path = require('path')
+const nock = require('nock')
+const proxyquire = require('proxyquire')
+const reqFixtures = require(path.join(__dirname, '/../fixtures/browser/forgotten_password_fixtures'))
+const resFixtures = require(path.join(__dirname, '/../fixtures/response'))
+const userFixtures = require(path.join(__dirname, '/../fixtures/user_fixtures'))
 
-let chai = require('chai');
-let chaiAsPromised = require('chai-as-promised');
+let chai = require('chai')
+let chaiAsPromised = require('chai-as-promised')
 
-chai.use(chaiAsPromised);
+chai.use(chaiAsPromised)
 
-const expect = chai.expect;
+const expect = chai.expect
 
 let alwaysValidPassword = function (password) {
-  return false; // common-password returns false if password is not one of the common passwords (which would be invalid)
-};
+  return false // common-password returns false if password is not one of the common passwords (which would be invalid)
+}
 
 let userService = function (commonPasswordMock) {
-  return proxyquire(__dirname + '/../../app/services/user_service.js', {
+  return proxyquire(path.join(__dirname, '/../../app/services/user_service.js'), {
     'common-password': commonPasswordMock || alwaysValidPassword
-  });
-};
+  })
+}
 
 let forgottenPassword = function (commonPasswordMock) {
-  return proxyquire(__dirname + '/../../app/controllers/forgotten_password_controller.js', {
+  return proxyquire(path.join(__dirname, '/../../app/controllers/forgotten_password_controller.js'), {
     '../services/user_service.js': userService(commonPasswordMock)
-  });
-};
+  })
+}
 
-
-let adminusersMock = nock(process.env.ADMINUSERS_URL);
-const USER_RESOURCE = '/v1/api/users';
-const FORGOTTEN_PASSWORD_RESOURCE = '/v1/api/forgotten-passwords';
-const RESET_PASSWORD_RESOURCE = '/v1/api/reset-password';
+let adminusersMock = nock(process.env.ADMINUSERS_URL)
+const USER_RESOURCE = '/v1/api/users'
+const FORGOTTEN_PASSWORD_RESOURCE = '/v1/api/forgotten-passwords'
+const RESET_PASSWORD_RESOURCE = '/v1/api/reset-password'
 
 describe('forgotten_password_controller', function () {
-
-  let forgottenPasswordController = forgottenPassword();
+  let forgottenPasswordController = forgottenPassword()
 
   afterEach((done) => {
-    nock.cleanAll();
-    done();
-  });
+    nock.cleanAll()
+    done()
+  })
 
   it('send email upon valid forgotten password reset request', function (done) {
-    let req = reqFixtures.validForgottenPasswordPost();
-    let res = resFixtures.getStubbedRes();
-    let username = req.body.username;
-    let userResponse = userFixtures.validUserResponse({username: username});
+    let req = reqFixtures.validForgottenPasswordPost()
+    let res = resFixtures.getStubbedRes()
+    let username = req.body.username
 
     adminusersMock.post(FORGOTTEN_PASSWORD_RESOURCE, userFixtures
       .validForgottenPasswordCreateRequest(username)
       .getPlain())
-      .reply(200);
+      .reply(200)
 
     forgottenPasswordController.emailPost(req, res).should.be.fulfilled
       .then(() => {
-        expect(res.redirect.called).to.equal(true);
-      }).should.notify(done);
-  });
+        expect(res.redirect.called).to.equal(true)
+      }).should.notify(done)
+  })
 
   it('display new password capture form', function (done) {
-    let req = reqFixtures.validForgottenPasswordGet();
-    let res = resFixtures.getStubbedRes();
-    let token = req.params.id;
+    let req = reqFixtures.validForgottenPasswordGet()
+    let res = resFixtures.getStubbedRes()
+    let token = req.params.id
 
-    let forgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({code: token});
+    let forgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({code: token})
 
     adminusersMock.get(`${FORGOTTEN_PASSWORD_RESOURCE}/${token}`)
-      .reply(200, forgottenPasswordResponse.getPlain());
+      .reply(200, forgottenPasswordResponse.getPlain())
 
     forgottenPasswordController.newPasswordGet(req, res).should.be.fulfilled
       .then(() => {
-        expect(res.render.calledWith('forgotten_password/new_password', {id: token})).to.equal(true);
-      }).should.notify(done);
-  });
+        expect(res.render.calledWith('forgotten_password/new_password', {id: token})).to.equal(true)
+      }).should.notify(done)
+  })
 
   it('display error view if token not found/expired', function (done) {
-    let req = reqFixtures.validForgottenPasswordGet();
-    let res = resFixtures.getStubbedRes();
-    let token = req.params.id;
+    let req = reqFixtures.validForgottenPasswordGet()
+    let res = resFixtures.getStubbedRes()
+    let token = req.params.id
 
     adminusersMock.get(`${FORGOTTEN_PASSWORD_RESOURCE}/${token}`)
-      .reply(404);
+      .reply(404)
 
     forgottenPasswordController.newPasswordGet(req, res).should.be.fulfilled
       .then(() => {
-        expect(req.flash.calledWith('genericError', 'Invalid password reset link')).to.equal(true);
-        expect(res.redirect.calledWith('/login')).to.equal(true);
-      }).should.notify(done);
-  });
+        expect(req.flash.calledWith('genericError', 'Invalid password reset link')).to.equal(true)
+        expect(res.redirect.calledWith('/login')).to.equal(true)
+      }).should.notify(done)
+  })
 
   it('reset users password upon valid reset password request', function (done) {
-
-    let req = reqFixtures.validUpdatePasswordPost();
-    let res = resFixtures.getStubbedRes();
-    let userExternalId = '7d19aff33f8948deb97ed16b2912dcd3';
-    let token = req.params.id;
-    let forgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({userExternalId: userExternalId, code: token});
-    let userResponse = userFixtures.validUserResponse({external_id: userExternalId});
+    let req = reqFixtures.validUpdatePasswordPost()
+    let res = resFixtures.getStubbedRes()
+    let userExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
+    let token = req.params.id
+    let forgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({userExternalId: userExternalId, code: token})
+    let userResponse = userFixtures.validUserResponse({external_id: userExternalId})
 
     adminusersMock.get(`${FORGOTTEN_PASSWORD_RESOURCE}/${token}`)
-      .reply(200, forgottenPasswordResponse.getPlain());
+      .reply(200, forgottenPasswordResponse.getPlain())
 
     adminusersMock.get(`${USER_RESOURCE}/${userExternalId}`)
-      .reply(200, userResponse.getPlain());
+      .reply(200, userResponse.getPlain())
 
     adminusersMock.post(RESET_PASSWORD_RESOURCE, userFixtures
       .validUpdatePasswordRequest(token, req.body.password)
       .getPlain())
-      .reply(204);
+      .reply(204)
 
     adminusersMock.patch(`${USER_RESOURCE}/${userExternalId}`, userFixtures
       .validIncrementSessionVersionRequest()
       .getPlain())
-      .reply(200);
+      .reply(200)
 
     forgottenPasswordController.newPasswordPost(req, res).should.be.fulfilled
       .then(() => {
-        expect(req.session.destroy.called).to.equal(true);
-        expect(req.flash.calledWith('generic', 'Password has been updated')).to.equal(true);
-        expect(res.redirect.calledWith('/login')).to.equal(true);
-      }).should.notify(done);
-  });
+        expect(req.session.destroy.called).to.equal(true)
+        expect(req.flash.calledWith('generic', 'Password has been updated')).to.equal(true)
+        expect(res.redirect.calledWith('/login')).to.equal(true)
+      }).should.notify(done)
+  })
 
   it('reset users password upon valid reset password request should destroy session even if incrementing user session fails', function (done) {
-
-    let req = reqFixtures.validUpdatePasswordPost();
-    let res = resFixtures.getStubbedRes();
-    let userExternalId = '7d19aff33f8948deb97ed16b2912dcd3';
-    let token = req.params.id;
-    let forgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({userExternalId: userExternalId, code: token});
-    let userResponse = userFixtures.validUserResponse({external_id: userExternalId});
+    let req = reqFixtures.validUpdatePasswordPost()
+    let res = resFixtures.getStubbedRes()
+    let userExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
+    let token = req.params.id
+    let forgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({userExternalId: userExternalId, code: token})
+    let userResponse = userFixtures.validUserResponse({external_id: userExternalId})
 
     adminusersMock.get(`${FORGOTTEN_PASSWORD_RESOURCE}/${token}`)
-      .reply(200, forgottenPasswordResponse.getPlain());
+      .reply(200, forgottenPasswordResponse.getPlain())
 
     adminusersMock.get(`${USER_RESOURCE}/${userExternalId}`)
-      .reply(200, userResponse.getPlain());
+      .reply(200, userResponse.getPlain())
 
     adminusersMock.post(RESET_PASSWORD_RESOURCE, userFixtures
       .validUpdatePasswordRequest(token, req.body.password)
       .getPlain())
-      .reply(204);
+      .reply(204)
 
     adminusersMock.patch(`${USER_RESOURCE}/${userExternalId}`, userFixtures
       .validIncrementSessionVersionRequest()
       .getPlain())
-      .reply(500);
+      .reply(500)
 
     forgottenPasswordController.newPasswordPost(req, res).should.be.fulfilled
       .then(() => {
-        expect(req.session.destroy.called).to.equal(true);
-        expect(req.flash.calledWith('generic', 'Password has been updated')).to.equal(true);
-        expect(res.redirect.calledWith('/login')).to.equal(true);
-      }).should.notify(done);
-  });
+        expect(req.session.destroy.called).to.equal(true)
+        expect(req.flash.calledWith('generic', 'Password has been updated')).to.equal(true)
+        expect(res.redirect.calledWith('/login')).to.equal(true)
+      }).should.notify(done)
+  })
 
   it('error if password is too short', function (done) {
-    let req = reqFixtures.validUpdatePasswordPost();
-    let res = resFixtures.getStubbedRes();
-    let username = req.body.username;
-    let userExternalId = '7d19aff33f8948deb97ed16b2912dcd3';
-    req.body.password = 'short';
-    let userResponse = userFixtures.validUserResponse({username: username, external_id: userExternalId});
-    let token = req.params.id;
-    let forgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({userExternalId: userExternalId, code: token});
+    let req = reqFixtures.validUpdatePasswordPost()
+    let res = resFixtures.getStubbedRes()
+    let username = req.body.username
+    let userExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
+    req.body.password = 'short'
+    let userResponse = userFixtures.validUserResponse({username: username, external_id: userExternalId})
+    let token = req.params.id
+    let forgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({userExternalId: userExternalId, code: token})
 
     adminusersMock.get(`${FORGOTTEN_PASSWORD_RESOURCE}/${token}`)
-      .reply(200, forgottenPasswordResponse.getPlain());
+      .reply(200, forgottenPasswordResponse.getPlain())
 
     adminusersMock.get(`${USER_RESOURCE}/${userExternalId}`)
-      .reply(200, userResponse.getPlain());
+      .reply(200, userResponse.getPlain())
 
     forgottenPasswordController.newPasswordPost(req, res).should.be.fulfilled
       .then(() => {
-        expect(req.flash.calledWith('genericError', 'Your password must be at least 10 characters.')).to.equal(true);
-        expect(res.redirect.calledWith('/reset-password/' + token)).to.equal(true);
-      }).should.notify(done);
-  });
+        expect(req.flash.calledWith('genericError', 'Your password must be at least 10 characters.')).to.equal(true)
+        expect(res.redirect.calledWith('/reset-password/' + token)).to.equal(true)
+      }).should.notify(done)
+  })
 
   it('error if password is one of the common passwords', function (done) {
-
-    let aForgottenPasswordController = forgottenPassword(() => true);
-    let req = reqFixtures.validUpdatePasswordPost();
-    let res = resFixtures.getStubbedRes();
-    let username = req.body.username;
-    let userExternalId = '7d19aff33f8948deb97ed16b2912dcd3';
-    req.body.password = "common password";
-    let userResponse = userFixtures.validUserResponse({username: username, external_id: userExternalId});
-    let token = req.params.id;
-    let forgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({userExternalId: userExternalId, code: token});
+    let aForgottenPasswordController = forgottenPassword(() => true)
+    let req = reqFixtures.validUpdatePasswordPost()
+    let res = resFixtures.getStubbedRes()
+    let username = req.body.username
+    let userExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
+    req.body.password = 'common password'
+    let userResponse = userFixtures.validUserResponse({username: username, external_id: userExternalId})
+    let token = req.params.id
+    let forgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({userExternalId: userExternalId, code: token})
 
     adminusersMock.get(`${FORGOTTEN_PASSWORD_RESOURCE}/${token}`)
-      .reply(200, forgottenPasswordResponse.getPlain());
+      .reply(200, forgottenPasswordResponse.getPlain())
 
     adminusersMock.get(`${USER_RESOURCE}/${userExternalId}`)
-      .reply(200, userResponse.getPlain());
+      .reply(200, userResponse.getPlain())
 
     aForgottenPasswordController.newPasswordPost(req, res).should.be.fulfilled
       .then(() => {
-        expect(req.flash.calledWith('genericError', 'Your password is too simple. Choose a password that is harder for people to guess.')).to.equal(true);
-        expect(res.redirect.calledWith('/reset-password/' + token)).to.equal(true);
-      }).should.notify(done);
-  });
+        expect(req.flash.calledWith('genericError', 'Your password is too simple. Choose a password that is harder for people to guess.')).to.equal(true)
+        expect(res.redirect.calledWith('/reset-password/' + token)).to.equal(true)
+      }).should.notify(done)
+  })
 
   it('error if unknown error returns from adminusers', function (done) {
-    let req = reqFixtures.validUpdatePasswordPost();
-    let res = resFixtures.getStubbedRes();
-    let username = req.body.username;
-    let userExternalId = '7d19aff33f8948deb97ed16b2912dcd3';
-    let userResponse = userFixtures.validUserResponse({username: username, external_id: userExternalId});
-    let token = req.params.id;
-    let forgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({userExternalId: userExternalId, code: token});
+    let req = reqFixtures.validUpdatePasswordPost()
+    let res = resFixtures.getStubbedRes()
+    let username = req.body.username
+    let userExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
+    let userResponse = userFixtures.validUserResponse({username: username, external_id: userExternalId})
+    let token = req.params.id
+    let forgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({userExternalId: userExternalId, code: token})
 
     adminusersMock.get(`${FORGOTTEN_PASSWORD_RESOURCE}/${token}`)
-      .reply(200, forgottenPasswordResponse.getPlain());
+      .reply(200, forgottenPasswordResponse.getPlain())
 
     adminusersMock.get(`${USER_RESOURCE}/${userExternalId}`)
-      .reply(200, userResponse.getPlain());
+      .reply(200, userResponse.getPlain())
 
     adminusersMock.post(RESET_PASSWORD_RESOURCE, userFixtures
       .validUpdatePasswordRequest(token, req.body.password)
       .getPlain())
-      .reply(500);
+      .reply(500)
 
     forgottenPasswordController.newPasswordPost(req, res).should.be.fulfilled
       .then(() => {
-        expect(req.flash.calledWith('genericError', 'There has been a problem updating password.')).to.equal(true);
-        expect(res.redirect.calledWith('/reset-password/' + token)).to.equal(true);
-      }).should.notify(done);
-  });
-
-});
+        expect(req.flash.calledWith('genericError', 'There has been a problem updating password.')).to.equal(true)
+        expect(res.redirect.calledWith('/reset-password/' + token)).to.equal(true)
+      }).should.notify(done)
+  })
+})

--- a/test/integration/get_gateway_account_ft_test.js
+++ b/test/integration/get_gateway_account_ft_test.js
@@ -1,40 +1,39 @@
-const nock = require('nock');
-const proxyquire = require('proxyquire');
-const supertest = require('supertest');
-const csrf = require('csrf');
+const nock = require('nock')
+const supertest = require('supertest')
+const path = require('path')
 
-const session = require(__dirname + '/../test_helpers/mock_session.js');
-const getApp = require(__dirname + '/../../server.js').getApp;
+const session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+const getApp = require(path.join(__dirname, '/../../server.js')).getApp
 
-const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(chaiAsPromised)
+const expect = chai.expect
 
-let app;
+let app
 
 describe('get account', function () {
   afterEach((done) => {
-    nock.cleanAll();
-    app = null;
-    done();
-  });
+    nock.cleanAll()
+    app = null
+    done()
+  })
 
   it('should get account', function (done) {
     const user = session.getUser({
       gateway_account_ids: ['1', '2', '5'],
       permissions: [{name: 'service-name:read'}]
-    });
-    const mockSession = session.getMockSession(user);
-    session.currentGatewayAccountId = '2';
-    app = session.getAppWithSessionAndGatewayAccountCookies(getApp(), mockSession);
-    const connectorMock = nock(process.env.CONNECTOR_URL);
+    })
+    const mockSession = session.getMockSession(user)
+    session.currentGatewayAccountId = '2'
+    app = session.getAppWithSessionAndGatewayAccountCookies(getApp(), mockSession)
+    const connectorMock = nock(process.env.CONNECTOR_URL)
 
     connectorMock.get('/v1/frontend/accounts/1').times(2).reply(200, {
       bob: 'bob',
       type: 'test',
       payment_provider: 'sandbox'
-    });
+    })
 
     supertest(app)
       .get('/service-name')
@@ -46,8 +45,8 @@ describe('get account', function () {
           type: 'test',
           payment_provider: 'sandbox',
           full_type: 'sandbox test'
-        });
+        })
       })
-      .end(done);
-  });
-});
+      .end(done)
+  })
+})

--- a/test/integration/healthcheck_ft_tests.js
+++ b/test/integration/healthcheck_ft_tests.js
@@ -1,19 +1,18 @@
-require(__dirname + '/../test_helpers/serialize_mock.js');
-var request = require('supertest');
-var should = require('should');
-var getApp = require(__dirname + '/../../server.js').getApp;
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+var request = require('supertest')
+var getApp = require(path.join(__dirname, '/../../server.js')).getApp
 
 describe('The /healthcheck endpoint returned json', function () {
-
   it('should return 200', function (done) {
-    var expectedResponse = {'ping': {'healthy': true}};
+    var expectedResponse = {'ping': {'healthy': true}}
     request(getApp())
       .get('/healthcheck')
       .set('Accept', 'application/json')
       .expect(200)
       .expect(function (res) {
-        response = JSON.parse(res.text);
-        expectedResponse.ping.healthy.should.equal(response.ping.healthy);
-      }).end(done);
-  });
-});
+        var response = JSON.parse(res.text)
+        expectedResponse.ping.healthy.should.equal(response.ping.healthy)
+      }).end(done)
+  })
+})

--- a/test/integration/invite_users_controller_ft_test.js
+++ b/test/integration/invite_users_controller_ft_test.js
@@ -1,59 +1,53 @@
-let nock = require('nock');
-let getApp = require(__dirname + '/../../server.js').getApp;
-let supertest = require('supertest');
-let session = require(__dirname + '/../test_helpers/mock_session.js');
-let csrf = require('csrf');
-let chai = require('chai');
-let roles = require('../../app/utils/roles').roles;
-let paths = require(__dirname + '/../../app/paths.js');
-let inviteFixtures = require(__dirname + '/../fixtures/invite_fixtures');
-let sinon = require('sinon');
-let _ = require('lodash');
-let inviteUserController = require('../../app/controllers/invite_user_controller');
+let path = require('path')
+let nock = require('nock')
+let getApp = require(path.join(__dirname, '/../../server.js')).getApp
+let supertest = require('supertest')
+let session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+let csrf = require('csrf')
+let chai = require('chai')
+let roles = require('../../app/utils/roles').roles
+let paths = require(path.join(__dirname, '/../../app/paths.js'))
+let inviteFixtures = require(path.join(__dirname, '/../fixtures/invite_fixtures'))
+let sinon = require('sinon')
+let _ = require('lodash')
+let inviteUserController = require('../../app/controllers/invite_user_controller')
 
-let expect = chai.expect;
-let adminusersMock = nock(process.env.ADMINUSERS_URL);
+let expect = chai.expect
+let adminusersMock = nock(process.env.ADMINUSERS_URL)
 
-const formattedPathFor = require('../../app/utils/replace_params_in_path');
+const formattedPathFor = require('../../app/utils/replace_params_in_path')
 
 describe('invite user controller', function () {
-
-  const userInSession = session.getUser({});
-  const EXTERNAL_SERVICE_ID = userInSession.serviceRoles[0].service.externalId;
-  userInSession.serviceRoles[0].role.permissions.push({name: 'users-service:create'});
-  const INVITE_RESOURCE = `/v1/api/invites/user`;
+  const userInSession = session.getUser({})
+  const EXTERNAL_SERVICE_ID = userInSession.serviceRoles[0].service.externalId
+  userInSession.serviceRoles[0].role.permissions.push({name: 'users-service:create'})
+  const INVITE_RESOURCE = `/v1/api/invites/user`
 
   describe('invite user index view', function () {
-
     it('should display invite page', function (done) {
-
-      app = session.getAppWithLoggedInUser(getApp(), userInSession);
+      const app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       supertest(app)
         .get(formattedPathFor(paths.teamMembers.invite, EXTERNAL_SERVICE_ID))
         .set('Accept', 'application/json')
         .expect(200)
         .expect((res) => {
-          expect(res.body.teamMemberIndexLink).to.equal(formattedPathFor(paths.teamMembers.index, EXTERNAL_SERVICE_ID));
-          expect(res.body.teamMemberInviteSubmitLink).to.equal(formattedPathFor(paths.teamMembers.invite, EXTERNAL_SERVICE_ID));
-          expect(res.body.admin.id).to.equal(roles['admin'].extId);
-          expect(res.body.viewAndRefund.id).to.equal(roles['view-and-refund'].extId);
-          expect(res.body.view.id).to.equal(roles['view-only'].extId);
+          expect(res.body.teamMemberIndexLink).to.equal(formattedPathFor(paths.teamMembers.index, EXTERNAL_SERVICE_ID))
+          expect(res.body.teamMemberInviteSubmitLink).to.equal(formattedPathFor(paths.teamMembers.invite, EXTERNAL_SERVICE_ID))
+          expect(res.body.admin.id).to.equal(roles['admin'].extId)
+          expect(res.body.viewAndRefund.id).to.equal(roles['view-and-refund'].extId)
+          expect(res.body.view.id).to.equal(roles['view-only'].extId)
         })
         .end(done)
-    });
-
-  });
-
+    })
+  })
 
   describe('invite user', function () {
-
     it('should invite a new team member successfully', function (done) {
-
-      let validInvite = inviteFixtures.validInviteRequest();
+      let validInvite = inviteFixtures.validInviteRequest()
       adminusersMock.post(INVITE_RESOURCE)
-        .reply(201, inviteFixtures.validInviteResponse(validInvite.getPlain()));
-      app = session.getAppWithLoggedInUser(getApp(), userInSession);
+        .reply(201, inviteFixtures.validInviteResponse(validInvite.getPlain()))
+      const app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       supertest(app)
         .post(formattedPathFor(paths.teamMembers.invite, EXTERNAL_SERVICE_ID))
@@ -67,15 +61,14 @@ describe('invite user controller', function () {
         })
         .expect(303, {})
         .expect('Location', formattedPathFor(paths.teamMembers.index, EXTERNAL_SERVICE_ID))
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should error if the user is already invited/exists', function (done) {
-
-      let existingUser = 'existing-user@example.com';
+      let existingUser = 'existing-user@example.com'
       adminusersMock.post(INVITE_RESOURCE)
-        .reply(409, inviteFixtures.conflictingInviteResponseWhenEmailUserAlreadyCreated(existingUser).getPlain());
-      app = session.getAppWithLoggedInUser(getApp(), userInSession);
+        .reply(409, inviteFixtures.conflictingInviteResponseWhenEmailUserAlreadyCreated(existingUser).getPlain())
+      const app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       supertest(app)
         .post(formattedPathFor(paths.teamMembers.invite, EXTERNAL_SERVICE_ID))
@@ -89,16 +82,15 @@ describe('invite user controller', function () {
         })
         .expect(200)
         .expect((res) => {
-          expect(res.body.error.message).to.include(existingUser);
+          expect(res.body.error.message).to.include(existingUser)
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should error on unknown role externalId', function (done) {
+      let unknownRoleId = '999'
 
-      let unknownRoleId = '999';
-
-      app = session.getAppWithLoggedInUser(getApp(), userInSession);
+      const app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       supertest(app)
         .post(formattedPathFor(paths.teamMembers.invite, EXTERNAL_SERVICE_ID))
@@ -112,22 +104,21 @@ describe('invite user controller', function () {
         })
         .expect(200)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to send invitation at this time');
+          expect(res.body.message).to.equal('Unable to send invitation at this time')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should error invitee is an invalid email address', function (done) {
-
       let baseReq = {
         flash: sinon.stub()
-      };
+      }
       let res = {
         redirect: sinon.stub()
-      };
+      }
 
-      let invalidEmail = 'invalid@examplecom';
-      const externalServiceId = 'some-external-service-id';
+      let invalidEmail = 'invalid@examplecom'
+      const externalServiceId = 'some-external-service-id'
       let req = _.merge(baseReq, {
         correlationId: 'blah',
         user: {externalId: 'some-ext-id', serviceIds: ['1']},
@@ -135,14 +126,13 @@ describe('invite user controller', function () {
         params: {
           externalServiceId: externalServiceId
         }
-      });
+      })
 
-      inviteUserController.invite(req, res);
+      inviteUserController.invite(req, res)
 
-      expect(req.flash.calledWith('genericError', 'Invalid email address')).to.equal(true);
-      expect(res.redirect.calledWith(303, formattedPathFor(paths.teamMembers.invite, externalServiceId))).to.equal(true);
-      done();
-    });
-  });
-
-});
+      expect(req.flash.calledWith('genericError', 'Invalid email address')).to.equal(true)
+      expect(res.redirect.calledWith(303, formattedPathFor(paths.teamMembers.invite, externalServiceId))).to.equal(true)
+      done()
+    })
+  })
+})

--- a/test/integration/login_controller_test.js
+++ b/test/integration/login_controller_test.js
@@ -1,260 +1,247 @@
-require(__dirname + '/../test_helpers/serialize_mock.js');
-var request = require('supertest');
-var getApp = require(__dirname + '/../../server.js').getApp;
-var nock = require('nock');
-var assert = require('assert');
-var notp = require('notp');
-var chai = require('chai');
-var _ = require('lodash');
-var userFixtures = require('../fixtures/user_fixtures');
-var sinon = require('sinon');
-var csrf = require('csrf');
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+var request = require('supertest')
+var getApp = require(path.join(__dirname, '/../../server.js')).getApp
+var nock = require('nock')
+var assert = require('assert')
+var notp = require('notp')
+var chai = require('chai')
+var _ = require('lodash')
+var userFixtures = require('../fixtures/user_fixtures')
+var sinon = require('sinon')
 
-var paths = require(__dirname + '/../../app/paths.js');
-var mock_session = require(__dirname + '/../test_helpers/mock_session.js');
-var login_controller = require(__dirname + '/../../app/controllers/login_controller.js');
-createGovukNotifyToken = require('../test_helpers/jwt');
-var mockRes = require('../fixtures/response');
+var paths = require(path.join(__dirname, '/../../app/paths.js'))
+var mockSession = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+var loginController = require(path.join(__dirname, '/../../app/controllers/login_controller.js'))
+var mockRes = require('../fixtures/response')
 
-var should = chai.should();
-var chaiAsPromised = require('chai-as-promised');
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+var chaiAsPromised = require('chai-as-promised')
+chai.use(chaiAsPromised)
+const expect = chai.expect
 
-var adminusersMock = nock(process.env.ADMINUSERS_URL);
-var ACCOUNT_ID = 182364;
-const USER_RESOURCE = '/v1/api/users';
-const CONNECTOR_ACCOUNT_PATH = "/v1/frontend/accounts";
+var adminusersMock = nock(process.env.ADMINUSERS_URL)
+var ACCOUNT_ID = 182364
+const USER_RESOURCE = '/v1/api/users'
+const CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts'
 
-var user = mock_session.getUser({gateway_account_id: ACCOUNT_ID});
+var user = mockSession.getUser({gateway_account_id: ACCOUNT_ID})
 
-function testController(controller, req, res) {
+function testController (controller, req, res) {
   _.assign(req, {
     headers: {'x-request-id': 'some-unique-id'},
     flash: sinon.stub()
-  });
-  controller(req, res);
+  })
+  controller(req, res)
 };
 
 describe('The logged in endpoint', function () {
-
   it('should render ok when logged in', function (done) {
-    var app = mock_session.getAppWithLoggedInUser(getApp(), user);
+    var app = mockSession.getAppWithLoggedInUser(getApp(), user)
     request(app)
-      .get("/")
+      .get('/')
       .expect(200)
       .expect(function (res) {
-        assert(res.text.indexOf(user.username) !== -1);
+        assert(res.text.indexOf(user.username) !== -1)
       })
-      .end(done);
-  });
-
+      .end(done)
+  })
 
   it('should redirecect to login if not logged in', function (done) {
-    var app = mock_session.getAppWithSessionAndGatewayAccountCookies(getApp(), {});
+    var app = mockSession.getAppWithSessionAndGatewayAccountCookies(getApp(), {})
     request(app)
-      .get("/")
+      .get('/')
       .expect(302)
-      .expect('Location', "/login")
-      .end(done);
-  });
+      .expect('Location', '/login')
+      .end(done)
+  })
 
   it('should redirecect to otp login if no otp', function (done) {
-    var app = mock_session.getAppWithSessionWithoutSecondFactor(getApp(), mock_session.getUser({gateway_account_ids: [ACCOUNT_ID]}));
+    var app = mockSession.getAppWithSessionWithoutSecondFactor(getApp(), mockSession.getUser({gateway_account_ids: [ACCOUNT_ID]}))
     request(app)
-      .get("/")
+      .get('/')
       .expect(302)
-      .expect('Location', "/otp-login")
-      .end(done);
-  });
-});
-
+      .expect('Location', '/otp-login')
+      .end(done)
+  })
+})
 
 describe('The logout endpoint', function () {
-
   it('should redirect to login', function (done) {
-    var app = mock_session.getAppWithSessionAndGatewayAccountCookies(getApp(), {});
+    var app = mockSession.getAppWithSessionAndGatewayAccountCookies(getApp(), {})
     request(app)
-      .get("/logout")
+      .get('/logout')
       .expect(302)
-      .expect('Location', "/login")
-      .end(done);
-  });
+      .expect('Location', '/login')
+      .end(done)
+  })
 
-  it("should handle case where mock_session expired", (done) => {
+  it('should handle case where mockSession expired', (done) => {
     request(getApp())
-      .get("/logout")
+      .get('/logout')
       .expect(302)
-      .expect('Location', "/login")
-      .end(done);
-  });
-});
-
+      .expect('Location', '/login')
+      .end(done)
+  })
+})
 
 describe('The postlogin endpoint', function () {
-  it('should redirect to root and clean mock_session of all but passport,currentGatewayAccountId  and last_url', function (done) {
+  it('should redirect to root and clean mockSession of all but passport,currentGatewayAccountId  and last_url', function (done) {
     // happens after the passort middleware, so cant test through supertest
-    const user = mock_session.getUser();
-    const session = mock_session.getMockSession(user);
-    const expectedUrl = paths.user.otpLogIn;
+    const user = mockSession.getUser()
+    const session = mockSession.getMockSession(user)
+    const expectedUrl = paths.user.otpLogIn
     const req = {
-        session: _.merge(session, {currentGatewayAccountId: '13'}),
-        headers: {'x-request-id': 'some-unique-id'},
-        user: user
-    };
-    const res = mockRes.getStubbedRes();
+      session: _.merge(session, {currentGatewayAccountId: '13'}),
+      headers: {'x-request-id': 'some-unique-id'},
+      user: user
+    }
+    const res = mockRes.getStubbedRes()
 
-    login_controller.postLogin(req, res);
-    expect(res.redirect.calledWith(expectedUrl)).to.equal(true);
+    loginController.postLogin(req, res)
+    expect(res.redirect.calledWith(expectedUrl)).to.equal(true)
     expect(req.session).to.deep.equal({
       passport: session.passport,
       last_url: session.last_url,
       currentGatewayAccountId: '13'
-    });
-    done();
-  });
-});
-
+    })
+    done()
+  })
+})
 
 describe('The otplogin endpoint', function () {
   afterEach(() => {
-    nock.cleanAll();
-  });
-
+    nock.cleanAll()
+  })
 
   it('should render and send key on first time', function (done) {
-    var user = mock_session.getUser();
+    var user = mockSession.getUser()
 
     var sessionData = {
-      csrfSecret: "123",
+      csrfSecret: '123',
       passport: {
-        user: user,
+        user: user
       }
-    };
+    }
 
     adminusersMock.post(`${USER_RESOURCE}/${user.externalId}/second-factor/`)
-      .reply(200);
+      .reply(200)
 
-    var app = mock_session.getAppWithSessionAndGatewayAccountCookies(getApp(), sessionData);
+    var app = mockSession.getAppWithSessionAndGatewayAccountCookies(getApp(), sessionData)
     request(app)
-      .get("/otp-login")
+      .get('/otp-login')
       .expect(200)
       .end(function () {
-        assert(sessionData.sentCode === true);
-        done();
-      });
-  });
+        assert(sessionData.sentCode === true)
+        done()
+      })
+  })
 
   it('should render and not send key on seccond time', function (done) {
-    var user = mock_session.getUser();
+    var user = mockSession.getUser()
 
     var sessionData = {
-      csrfSecret: "123",
+      csrfSecret: '123',
       passport: {
-        user: user,
-      },
-      sentCode: true
-    };
-
-    var app = mock_session.getAppWithSessionAndGatewayAccountCookies(getApp(), sessionData);
-
-    request(app)
-      .get("/otp-login")
-      .expect(200)
-      .end(function () {
-        done();
-      });
-  });
-
-});
-
-
-describe('The afterOtpLogin endpoint', function () {
-
-  it('should redirect to login to the last url', function (done) {
-    var user = mock_session.getUser();
-    var session = mock_session.getMockSession(user),
-      req = {
-        session: session,
-        headers: {'x-request-id': 'some-unique-id'},
         user: user
       },
-      lastUrl = session.last_url,
-      res = mockRes.getStubbedRes();
+      sentCode: true
+    }
 
-    login_controller.afterOTPLogin(req, res);
-    expect(res.redirect.calledWith(lastUrl)).to.equal(true);
-    done();
-  });
+    var app = mockSession.getAppWithSessionAndGatewayAccountCookies(getApp(), sessionData)
 
-  it('should redirect to root if lasturl is not defined', function (done) {
-    const user = mock_session.getUser();
-    user.sessionVersion = 1;
-    const req = {
-      session: mock_session.getMockSession(user),
+    request(app)
+      .get('/otp-login')
+      .expect(200)
+      .end(function () {
+        done()
+      })
+  })
+})
+
+describe('The afterOtpLogin endpoint', function () {
+  it('should redirect to login to the last url', function (done) {
+    var user = mockSession.getUser()
+    var session = mockSession.getMockSession(user)
+    var req = {
+      session: session,
       headers: {'x-request-id': 'some-unique-id'},
       user: user
-    };
-    const res = mockRes.getStubbedRes();
-    delete req.session.last_url;
-    delete req.session.secondFactor;
-    req.session.version = 0;
+    }
+    var lastUrl = session.last_url
+    var res = mockRes.getStubbedRes()
 
-    login_controller.afterOTPLogin(req, res);
-    expect(res.redirect.calledWith('/')).to.equal(true);
-    expect(req.session.secondFactor).to.equal('totp');
-    expect(req.session.version).to.equal(1);
-    done();
+    loginController.afterOTPLogin(req, res)
+    expect(res.redirect.calledWith(lastUrl)).to.equal(true)
+    done()
+  })
 
-  });
-});
+  it('should redirect to root if lasturl is not defined', function (done) {
+    const user = mockSession.getUser()
+    user.sessionVersion = 1
+    const req = {
+      session: mockSession.getMockSession(user),
+      headers: {'x-request-id': 'some-unique-id'},
+      user: user
+    }
+    const res = mockRes.getStubbedRes()
+    delete req.session.last_url
+    delete req.session.secondFactor
+    req.session.version = 0
+
+    loginController.afterOTPLogin(req, res)
+    expect(res.redirect.calledWith('/')).to.equal(true)
+    expect(req.session.secondFactor).to.equal('totp')
+    expect(req.session.version).to.equal(1)
+    done()
+  })
+})
 
 describe('login get endpoint', function () {
   it('should set the right flash message if both fields are empty', function (done) {
-    var req = { 'body': { 'username': '', 'password': '' } },
-        res = mockRes.getStubbedRes();
+    var req = { 'body': { 'username': '', 'password': '' } }
+    var res = mockRes.getStubbedRes()
 
-    testController(login_controller.logUserin, req, res);
-    expect(req.flash('error') === 'empty_all');
+    testController(loginController.logUserin, req, res)
+    expect(req.flash('error') === 'empty_all')
 
-    res.locals = { 'flash': {} };
-    testController(login_controller.logInGet, req, res);
+    res.locals = { 'flash': {} }
+    testController(loginController.logInGet, req, res)
     expect(res.locals.flash === {username: 'You must enter a username', password: 'You must enter a password'})
-    done();
-  });
+    done()
+  })
 
   it('should set the right flash message if individual fields are empty', function (done) {
-    var req = { 'body': { 'username': '', 'password': '123' } },
-        res = mockRes.getStubbedRes();
+    var req = { 'body': { 'username': '', 'password': '123' } }
+    var res = mockRes.getStubbedRes()
 
-    testController(login_controller.logUserin, req, res);
-    expect(req.flash('error') === 'empty_username');
+    testController(loginController.logUserin, req, res)
+    expect(req.flash('error') === 'empty_username')
 
-    res.locals = { 'flash': {} };
-    testController(login_controller.logInGet, req, res);
+    res.locals = { 'flash': {} }
+    testController(loginController.logInGet, req, res)
     expect(res.locals.flash === {username: 'You must enter a username'})
-    done();
-  });
-});
+    done()
+  })
+})
 
 describe('login post endpoint', function () {
   it('should set the right flash message if both fields are empty', function (done) {
-    var req = { 'body': { 'username': '', 'password': '' } },
-        res = mockRes.getStubbedRes();
+    var req = { 'body': { 'username': '', 'password': '' } }
+    var res = mockRes.getStubbedRes()
 
-    testController(login_controller.logUserin, req, res);
-    expect(req.flash('error') === 'empty_all');
-    done();
-  });
+    testController(loginController.logUserin, req, res)
+    expect(req.flash('error') === 'empty_all')
+    done()
+  })
 
   it('should set the right flash message if individual fields are empty', function (done) {
-    var req = { 'body': { 'username': '', 'password': '123' } },
-        res = mockRes.getStubbedRes();
+    var req = { 'body': { 'username': '', 'password': '123' } }
+    var res = mockRes.getStubbedRes()
 
-    testController(login_controller.logUserin, req, res);
-    expect(req.flash('error') === 'empty_username');
-    done();
-  });
+    testController(loginController.logUserin, req, res)
+    expect(req.flash('error') === 'empty_username')
+    done()
+  })
 
   it('should display an error if csrf token does not exist for the login post', function (done) {
     request(getApp())
@@ -262,87 +249,82 @@ describe('login post endpoint', function () {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .send({})
-      .expect(400, {message: "There is a problem with the payments platform"})
-      .end(done);
-  });
-});
+      .expect(400, {message: 'There is a problem with the payments platform'})
+      .end(done)
+  })
+})
 
 describe('otp login post enpoint', function () {
   it('should display an error if csrf token does not exist for the login post', function (done) {
+    var user = mockSession.getUser()
+    var session = mockSession.getMockSession(user)
+    delete session.csrfSecret
 
-    var user = mock_session.getUser();
-    var session = mock_session.getMockSession(user);
-    delete session.csrfSecret;
-
-    var app2 = mock_session.getAppWithSessionAndGatewayAccountCookies(getApp(), session);
+    var app2 = mockSession.getAppWithSessionAndGatewayAccountCookies(getApp(), session)
 
     request(app2)
       .post(paths.user.otpLogIn)
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({code: notp.totp.gen("12345")})
-      .expect(400, {message: "There is a problem with the payments platform"})
-      .end(done);
-  });
-});
-
+      .send({code: notp.totp.gen('12345')})
+      .expect(400, {message: 'There is a problem with the payments platform'})
+      .end(done)
+  })
+})
 
 describe('otp send again post enpoint', function () {
   it('should display an error if csrf token does not exist for the send again post', function (done) {
+    var user = mockSession.getUser()
+    var session = mockSession.getMockSession(user)
+    delete session.csrfSecret
 
-    var user = mock_session.getUser();
-    var session = mock_session.getMockSession(user);
-    delete session.csrfSecret;
-
-    var app2 = mock_session.getAppWithSessionAndGatewayAccountCookies(getApp(), session);
+    var app2 = mockSession.getAppWithSessionAndGatewayAccountCookies(getApp(), session)
 
     request(app2)
       .post(paths.user.otpSendAgain)
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .send({})
-      .expect(400, {message: "There is a problem with the payments platform"})
-      .end(done);
-  });
-});
+      .expect(400, {message: 'There is a problem with the payments platform'})
+      .end(done)
+  })
+})
 
 describe('direct login after user registration', function () {
   it('should redirect user to homepage on a successful registration', function (done) {
-
-    let userExternalId = 'an-externalid';
-    let userName = 'bob';
-    let gatewayAccountId = '2';
+    let userExternalId = 'an-externalid'
+    let userName = 'bob'
+    let gatewayAccountId = '2'
 
     let userResponse = userFixtures.validUserResponse({
       external_id: userExternalId,
       username: userName,
-      gateway_account_ids: [gatewayAccountId]}).getPlain();
+      gateway_account_ids: [gatewayAccountId]}).getPlain()
 
     adminusersMock.get(`${USER_RESOURCE}/${userExternalId}`)
-      .reply(200, userResponse);
+      .reply(200, userResponse)
 
-    let connectorMock = nock(process.env.CONNECTOR_URL);
+    let connectorMock = nock(process.env.CONNECTOR_URL)
 
     connectorMock.get(`${CONNECTOR_ACCOUNT_PATH}/${gatewayAccountId}`)
-      .reply(200,{ foo: "bar", gateway_account_id: gatewayAccountId });
+      .reply(200, { foo: 'bar', gateway_account_id: gatewayAccountId })
 
-    let destroyStub = sinon.stub();
+    let destroyStub = sinon.stub()
     let gatewayAccountData = {
       userExternalId: userExternalId,
       destroy: destroyStub
-    };
+    }
 
-    let app2 = mock_session.getAppWithRegisterInvitesCookie(getApp(), gatewayAccountData);
+    let app2 = mockSession.getAppWithRegisterInvitesCookie(getApp(), gatewayAccountData)
 
     request(app2)
       .get(paths.registerUser.logUserIn)
       .set('Accept', 'application/json')
       .expect(200)
-      .expect((res)=>{
-        expect(res.body.name).to.equal(userName);
+      .expect((res) => {
+        expect(res.body.name).to.equal(userName)
         expect(destroyStub.called).to.equal(true)
       })
-      .end(done);
-  });
-});
-
+      .end(done)
+  })
+})

--- a/test/integration/login_ft_tests.js
+++ b/test/integration/login_ft_tests.js
@@ -1,77 +1,72 @@
-require(__dirname + '/../test_helpers/serialize_mock.js');
-const request = require('supertest');
-const nock = require('nock');
-const getApp = require(__dirname + '/../../server.js').getApp;
-const should = require('chai').should();
-const paths = require(__dirname + '/../../app/paths.js');
-const mock_session = require(__dirname + '/../test_helpers/mock_session.js');
-const assert = require('assert');
-const {expect} = require('chai');
-const adminusersMock = nock(process.env.ADMINUSERS_URL);
-const USER_RESOURCE = '/v1/api/users';
+const path = require('path')
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+const request = require('supertest')
+const nock = require('nock')
+const getApp = require(path.join(__dirname, '/../../server.js')).getApp
+const paths = require(path.join(__dirname, '/../../app/paths.js'))
+const mockSession = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+const assert = require('assert')
+const {expect} = require('chai')
+const adminusersMock = nock(process.env.ADMINUSERS_URL)
+const USER_RESOURCE = '/v1/api/users'
 
-const user = mock_session.getUser();
-const session = mock_session.getMockSession(user);
+const user = mockSession.getUser()
+const session = mockSession.getMockSession(user)
 
-const app = mock_session.getAppWithSessionAndGatewayAccountCookies(getApp(), session);
+const app = mockSession.getAppWithSessionAndGatewayAccountCookies(getApp(), session)
 
-function build_get_request(path) {
+function buildGetRequest (path) {
   return request(app)
-    .get(path);
+    .get(path)
 }
 
 describe('User clicks on Logout', function () {
-
   it('should get redirected to login page', function (done) {
-
     const incrementMock = adminusersMock
       .patch(`${USER_RESOURCE}/${user.externalId}`)
-      .reply(200);
+      .reply(200)
 
-    build_get_request(paths.user.logOut)
+    buildGetRequest(paths.user.logOut)
       .expect(302, {})
       .expect('Location', paths.user.logIn)
       .expect(() => {
-        assert(incrementMock.isDone());
-        assert(session.destroy.called === true);
+        assert(incrementMock.isDone())
+        assert(session.destroy.called === true)
       })
-      .end(done);
-  });
+      .end(done)
+  })
 
   it('should redirect to login page when session.version is undefined', function (done) {
+    const gatewayAccountId = 12314
+    const getMockSession = mockSession.getMockSession({sessionVersion: 2, services: ['1'], gateway_account_ids: [gatewayAccountId]})
+    delete getMockSession.version
 
-    const gatewayAccountId = 12314;
-    const mockSession = mock_session.getMockSession({sessionVersion:2, services:['1'], gateway_account_ids: [gatewayAccountId]});
-    delete mockSession.version;
-
-    let app = mock_session.createAppWithSession(getApp(), mockSession);
+    let app = mockSession.createAppWithSession(getApp(), getMockSession)
 
     request(app)
       .get('/')
       .expect(302)
       .expect('Location', '/login')
       .expect(() => {
-        expect(mockSession.version).to.be.undefined;
+        expect(getMockSession.version).to.be.undefined  // eslint-disable-line
       })
-      .end(done);
-  });
+      .end(done)
+  })
 
   it('should update the session version on successful login of a user', done => {
+    const gatewayAccountId = 12314
+    const getMockSession = mockSession.getMockSession({sessionVersion: 2, services: ['1'], gateway_account_ids: [gatewayAccountId]})
+    delete getMockSession.version
 
-    const gatewayAccountId = 12314;
-    const mockSession = mock_session.getMockSession({sessionVersion:2, services:['1'], gateway_account_ids: [gatewayAccountId]});
-    delete mockSession.version;
-
-    let app = mock_session.createAppWithSession(getApp(), mockSession);
+    let app = mockSession.createAppWithSession(getApp(), getMockSession)
 
     request(app)
       .get('/')
       .expect(302)
       .expect('Location', '/login')
       .expect(() => {
-        expect(mockSession.version).to.be.undefined;
+        expect(getMockSession.version).to.be.undefined  // eslint-disable-line
       })
-      .end(done);
-
+      .end(done)
   })
-});
+})

--- a/test/integration/pagination_ft_tests.js
+++ b/test/integration/pagination_ft_tests.js
@@ -1,85 +1,82 @@
-require(__dirname + '/../test_helpers/serialize_mock.js');
-var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
-var request = require('supertest');
-var nock = require('nock');
-var getApp = require(__dirname + '/../../server.js').getApp;
-var dates = require('../../app/utils/dates.js');
-var paths = require(__dirname + '/../../app/paths.js');
-var session = require(__dirname + '/../test_helpers/mock_session.js');
-var assert = require('assert');
-var querystring = require('querystring');
-var app;
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+var userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
+var request = require('supertest')
+var nock = require('nock')
+var getApp = require(path.join(__dirname, '/../../server.js')).getApp
+var paths = require(path.join(__dirname, '/../../app/paths.js'))
+var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+var assert = require('assert')
+var querystring = require('querystring')
+var app
 
-var gatewayAccountId = 452345;
+var gatewayAccountId = 452345
 
-var CONNECTOR_CHARGES_SEARCH_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges';
-var CONNECTOR_ALL_CARD_TYPES_API_PATH = "/v1/api/card-types";
+var CONNECTOR_CHARGES_SEARCH_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges'
+var CONNECTOR_ALL_CARD_TYPES_API_PATH = '/v1/api/card-types'
 
-var connectorMock = nock(process.env.CONNECTOR_URL);
+var connectorMock = nock(process.env.CONNECTOR_URL)
 
 var ALL_CARD_TYPES = {
-  "card_types": [
-    {"id": "1", "brand": "mastercard", "label": "Mastercard", "type": "CREDIT"},
-    {"id": "2", "brand": "mastercard", "label": "Mastercard", "type": "DEBIT"},
-    {"id": "3", "brand": "discover", "label": "Discover", "type": "CREDIT"},
-    {"id": "4", "brand": "maestro", "label": "Maestro", "type": "DEBIT"}]
-};
+  'card_types': [
+    {'id': '1', 'brand': 'mastercard', 'label': 'Mastercard', 'type': 'CREDIT'},
+    {'id': '2', 'brand': 'mastercard', 'label': 'Mastercard', 'type': 'DEBIT'},
+    {'id': '3', 'brand': 'discover', 'label': 'Discover', 'type': 'CREDIT'},
+    {'id': '4', 'brand': 'maestro', 'label': 'Maestro', 'type': 'DEBIT'}]
+}
 
-function connectorMock_responds(data, searchParameters) {
-  var queryStr = '?';
+function connectorMockResponds (data, searchParameters) {
+  var queryStr = '?'
   queryStr += 'reference=' + (searchParameters.reference ? searchParameters.reference : '') +
     '&email=' + (searchParameters.email ? searchParameters.email : '') +
     '&state=' + (searchParameters.state ? searchParameters.state : '') +
     '&card_brand=' + (searchParameters.brand ? searchParameters.brand : '') +
     '&from_date=' + (searchParameters.fromDate ? searchParameters.fromDate : '') +
     '&to_date=' + (searchParameters.toDate ? searchParameters.toDate : '') +
-    '&page=' + (searchParameters.page ? searchParameters.page : "1") +
-    '&display_size=' + (searchParameters.pageSize ? searchParameters.pageSize : "100");
+    '&page=' + (searchParameters.page ? searchParameters.page : '1') +
+    '&display_size=' + (searchParameters.pageSize ? searchParameters.pageSize : '100')
 
   return connectorMock.get(CONNECTOR_CHARGES_SEARCH_API_PATH + encodeURI(queryStr))
-    .reply(200, data);
+    .reply(200, data)
 }
 
-function search_transactions(data) {
-  var query = querystring.stringify(data);
+function searchTransactions (data) {
+  var query = querystring.stringify(data)
 
-  return request(app).get(paths.transactions.index + "?" + query)
-    .set('Accept', 'application/json').send();
+  return request(app).get(paths.transactions.index + '?' + query)
+    .set('Accept', 'application/json').send()
 }
 
 describe('Pagination', function () {
-
   afterEach(function () {
-    nock.cleanAll();
-    app = null;
-  });
+    nock.cleanAll()
+    app = null
+  })
 
   beforeEach(function (done) {
-    let permissions = 'transactions:read';
+    let permissions = 'transactions:read'
     var user = session.getUser({
       gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
-    });
-    app = session.getAppWithLoggedInUser(getApp(), user);
+    })
+    app = session.getAppWithLoggedInUser(getApp(), user)
 
-    userCreator.mockUserResponse(user.toJson(), done);
+    userCreator.mockUserResponse(user.toJson(), done)
 
     connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-      .reply(200, ALL_CARD_TYPES);
-  });
-
+      .reply(200, ALL_CARD_TYPES)
+  })
 
   describe('Pagination', function () {
-
     it('should generate correct pagination data when no page number passed', function (done) {
-      var connectorData = {};
-      var data = {'display_size': 5};
-      connectorData.total = 30;
-      connectorData.results = [];
-      connectorData._links = {self: {"href": "/v1/api/accounts/111/charges?&page=&display_size=5&state="},};
+      var connectorData = {}
+      var data = {'display_size': 5}
+      connectorData.total = 30
+      connectorData.results = []
+      connectorData._links = {self: {'href': '/v1/api/accounts/111/charges?&page=&display_size=5&state='}}
 
-      connectorMock_responds(connectorData, data);
+      connectorMockResponds(connectorData, data)
 
-      search_transactions(data)
+      searchTransactions(data)
         .expect(200)
         .expect(function (res) {
           res.body.paginationLinks.should.eql([
@@ -88,22 +85,22 @@ describe('Pagination', function () {
             {pageNumber: 3, pageName: 3, activePage: false, hasSymbolicName: false},
             {pageNumber: 2, pageName: 'next', activePage: false, hasSymbolicName: true},
             {pageNumber: 6, pageName: 'last', activePage: false, hasSymbolicName: true}
-          ]);
+          ])
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should generate correct pagination data when page number passed', function (done) {
-      var connectorData = {};
-      var data = {'display_size': 5};
-      connectorData.total = 30;
-      connectorData.results = [];
-      connectorData.page = 3;
-      connectorData._links = {self: {"href": "/v1/api/accounts/111/charges?&page=3&display_size=5&state="}};
+      var connectorData = {}
+      var data = {'display_size': 5}
+      connectorData.total = 30
+      connectorData.results = []
+      connectorData.page = 3
+      connectorData._links = {self: {'href': '/v1/api/accounts/111/charges?&page=3&display_size=5&state='}}
 
-      connectorMock_responds(connectorData, data);
+      connectorMockResponds(connectorData, data)
 
-      search_transactions(data)
+      searchTransactions(data)
         .expect(200)
         .expect(function (res) {
           res.body.paginationLinks.should.eql([
@@ -115,22 +112,22 @@ describe('Pagination', function () {
             {pageNumber: 5, pageName: 5, activePage: false, hasSymbolicName: false},
             {pageNumber: 4, pageName: 'next', activePage: false, hasSymbolicName: true},
             {pageNumber: 6, pageName: 'last', activePage: false, hasSymbolicName: true}
-          ]);
+          ])
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should generate correct pagination data with different display size', function (done) {
-      var connectorData = {};
-      var data = {'display_size': 5};
-      connectorData.total = 30;
-      connectorData.results = [];
-      connectorData.page = 3;
-      connectorData._links = {self: {"href": "/v1/api/accounts/111/charges?&page=3&display_size=2&state="}};
+      var connectorData = {}
+      var data = {'display_size': 5}
+      connectorData.total = 30
+      connectorData.results = []
+      connectorData.page = 3
+      connectorData._links = {self: {'href': '/v1/api/accounts/111/charges?&page=3&display_size=2&state='}}
 
-      connectorMock_responds(connectorData, data);
+      connectorMockResponds(connectorData, data)
 
-      search_transactions(data)
+      searchTransactions(data)
         .expect(200)
         .expect(function (res) {
           res.body.paginationLinks.should.eql([
@@ -142,21 +139,21 @@ describe('Pagination', function () {
             {pageNumber: 5, pageName: 5, activePage: false, hasSymbolicName: false},
             {pageNumber: 4, pageName: 'next', activePage: false, hasSymbolicName: true},
             {pageNumber: 15, pageName: 'last', activePage: false, hasSymbolicName: true}
-          ]);
+          ])
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should default to page 1 and display_size 100', function (done) {
-      var connectorData = {};
-      var data = {'display_size': 5};
-      connectorData.total = 600;
-      connectorData.results = [];
-      connectorData._links = {self: {"href": "/v1/api/accounts/111/charges?&page=&display_size=&state="}};
+      var connectorData = {}
+      var data = {'display_size': 5}
+      connectorData.total = 600
+      connectorData.results = []
+      connectorData._links = {self: {'href': '/v1/api/accounts/111/charges?&page=&display_size=&state='}}
 
-      connectorMock_responds(connectorData, data);
+      connectorMockResponds(connectorData, data)
 
-      search_transactions(data)
+      searchTransactions(data)
         .expect(200)
         .expect(function (res) {
           res.body.paginationLinks.should.eql([
@@ -165,105 +162,105 @@ describe('Pagination', function () {
             {pageNumber: 3, pageName: 3, activePage: false, hasSymbolicName: false},
             {pageNumber: 2, pageName: 'next', activePage: false, hasSymbolicName: true},
             {pageNumber: 6, pageName: 'last', activePage: false, hasSymbolicName: true}
-          ]);
+          ])
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return correct display size options when total over 500', function (done) {
-      var connectorData = {};
-      var data = {'display_size': 100};
-      connectorData.total = 600;
-      connectorData.results = [];
-      connectorData._links = {self: {"href": "/v1/api/accounts/111/charges?&page=1&display_size=100&state="}};
+      var connectorData = {}
+      var data = {'display_size': 100}
+      connectorData.total = 600
+      connectorData.results = []
+      connectorData._links = {self: {'href': '/v1/api/accounts/111/charges?&page=1&display_size=100&state='}}
 
-      connectorMock_responds(connectorData, data);
+      connectorMockResponds(connectorData, data)
 
-      search_transactions(data)
+      searchTransactions(data)
         .expect(200)
         .expect(function (res) {
           res.body.pageSizeLinks.should.eql([
             {type: 'small', name: 100, value: 100, active: true},
             {type: 'large', name: 500, value: 500, active: false}
-          ]);
+          ])
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return correct display size options when total between 100 and 500', function (done) {
-      var connectorData = {};
-      var data = {'display_size': 100};
-      connectorData.total = 400;
-      connectorData.results = [];
-      connectorData.page = 1;
-      connectorData._links = {self: {"href": "/v1/api/accounts/111/charges?&page=1&display_size=100&state="}};
+      var connectorData = {}
+      var data = {'display_size': 100}
+      connectorData.total = 400
+      connectorData.results = []
+      connectorData.page = 1
+      connectorData._links = {self: {'href': '/v1/api/accounts/111/charges?&page=1&display_size=100&state='}}
 
-      connectorMock_responds(connectorData, data);
+      connectorMockResponds(connectorData, data)
 
-      search_transactions(data)
+      searchTransactions(data)
         .expect(200)
         .expect(function (res) {
           res.body.pageSizeLinks.should.eql([
             {type: 'small', name: 100, value: 100, active: true},
-            {type: 'large', name: "Show all", value: 500, active: false}
-          ]);
+            {type: 'large', name: 'Show all', value: 500, active: false}
+          ])
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return correct display size options when total under 100', function (done) {
-      var connectorData = {};
-      var data = {'display_size': 100};
-      connectorData.total = 50;
-      connectorData.results = [];
-      connectorData._links = {self: {"href": "/v1/api/accounts/111/charges?&page=1&display_size=100&state="}};
+      var connectorData = {}
+      var data = {'display_size': 100}
+      connectorData.total = 50
+      connectorData.results = []
+      connectorData._links = {self: {'href': '/v1/api/accounts/111/charges?&page=1&display_size=100&state='}}
 
-      connectorMock_responds(connectorData, data);
+      connectorMockResponds(connectorData, data)
 
-      search_transactions(data)
+      searchTransactions(data)
         .expect(200)
         .expect(function (res) {
-          assert.equal(res.body.hasPageSizeLinks, false);
+          assert.equal(res.body.hasPageSizeLinks, false)
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return correct display size options when total under 100', function (done) {
-      var connectorData = {};
-      var data = {'display_size': 500};
-      connectorData.total = 150;
-      connectorData.results = [];
-      connectorData._links = {self: {"href": "/v1/api/accounts/111/charges?&page=1&display_size=500&state="}};
+      var connectorData = {}
+      var data = {'display_size': 500}
+      connectorData.total = 150
+      connectorData.results = []
+      connectorData._links = {self: {'href': '/v1/api/accounts/111/charges?&page=1&display_size=500&state='}}
 
-      connectorMock_responds(connectorData, data);
+      connectorMockResponds(connectorData, data)
 
-      search_transactions(data)
+      searchTransactions(data)
         .expect(200)
         .expect(function (res) {
-          assert.equal(res.body.hasPageSizeLinks, true);
+          assert.equal(res.body.hasPageSizeLinks, true)
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return return error if page out of bounds', function (done) {
-      var data = {'page': -1};
+      var data = {'page': -1}
 
-      search_transactions(data)
-        .expect(500, {'message': "Invalid search"}).end(done);
-    });
+      searchTransactions(data)
+        .expect(500, {'message': 'Invalid search'}).end(done)
+    })
 
     it('should return return error if pageSize out of bounds 1', function (done) {
-      var data = {'pageSize': 600};
+      var data = {'pageSize': 600}
 
-      search_transactions(data)
-        .expect(500, {'message': "Invalid search"}).end(done);
-    });
+      searchTransactions(data)
+        .expect(500, {'message': 'Invalid search'}).end(done)
+    })
 
     it('should return return error if pageSize out of bounds 2', function (done) {
-      var data = {'pageSize': 0};
+      var data = {'pageSize': 0}
 
-      search_transactions(data)
-        .expect(500, {'message': "Invalid search"}).end(done);
-    });
-  });
-});
+      searchTransactions(data)
+        .expect(500, {'message': 'Invalid search'}).end(done)
+    })
+  })
+})

--- a/test/integration/payment_types_select_brand_ft_tests.js
+++ b/test/integration/payment_types_select_brand_ft_tests.js
@@ -1,391 +1,392 @@
-var dbMock = require(__dirname + '/../test_helpers/serialize_mock.js');
-var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
-var request = require('supertest');
-var getApp = require(__dirname + '/../../server.js').getApp;
-var winston = require('winston');
-var nock = require('nock');
-var csrf = require('csrf');
-var should = require('chai').should();
-var paths = require(__dirname + '/../../app/paths.js');
-var session = require(__dirname + '/../test_helpers/mock_session.js');
-var expect = require("chai").expect;
-var _ = require('lodash');
+var path = require('path')
+var userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
+var request = require('supertest')
+var getApp = require(path.join(__dirname, '/../../server.js')).getApp
+var nock = require('nock')
+var csrf = require('csrf')
+var paths = require(path.join(__dirname, '/../../app/paths.js'))
+var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+var expect = require('chai').expect
+var _ = require('lodash')
 
-var requestId = 'unique-request-id';
+var requestId = 'unique-request-id'
 var aCorrelationHeader = {
   reqheaders: {'x-request-id': requestId}
-};
-var {TYPES} = require(__dirname + '/../../app/controllers/payment_types_controller.js');
-var ACCOUNT_ID = 182364;
-var app;
-var CONNECTOR_ALL_CARD_TYPES_API_PATH = "/v1/api/card-types";
-var CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH = "/v1/frontend/accounts/" + ACCOUNT_ID + "/card-types";
+}
+var {TYPES} = require(path.join(__dirname, '/../../app/controllers/payment_types_controller.js'))
+var ACCOUNT_ID = 182364
+var app
+var CONNECTOR_ALL_CARD_TYPES_API_PATH = '/v1/api/card-types'
+var CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH = '/v1/frontend/accounts/' + ACCOUNT_ID + '/card-types'
 
-var connectorMock = nock(process.env.CONNECTOR_URL, aCorrelationHeader);
+var connectorMock = nock(process.env.CONNECTOR_URL, aCorrelationHeader)
 
 var buildAcceptedCardType = function (value, available = true, selected = '') {
   return {
-    "id": `payment-types-${value}-brand`,
-    "value": value,
-    "label": _.capitalize(value),
-    "available": available,
-    "selected": selected
+    'id': `payment-types-${value}-brand`,
+    'value': value,
+    'label': _.capitalize(value),
+    'available': available,
+    'selected': selected
   }
-};
+}
 
 var ALL_CARD_TYPES = {
-  "card_types": [
-    {"id": "1", "brand": "mastercard", "label": "Mastercard", "type": "CREDIT"},
-    {"id": "2", "brand": "mastercard", "label": "Mastercard", "type": "DEBIT"},
-    {"id": "3", "brand": "discover", "label": "Discover", "type": "CREDIT"},
-    {"id": "4", "brand": "maestro", "label": "Maestro", "type": "DEBIT"}]
-};
+  'card_types': [
+    {'id': '1', 'brand': 'mastercard', 'label': 'Mastercard', 'type': 'CREDIT'},
+    {'id': '2', 'brand': 'mastercard', 'label': 'Mastercard', 'type': 'DEBIT'},
+    {'id': '3', 'brand': 'discover', 'label': 'Discover', 'type': 'CREDIT'},
+    {'id': '4', 'brand': 'maestro', 'label': 'Maestro', 'type': 'DEBIT'}]
+}
 
-function build_get_request(path, app) {
+function buildGetRequest (path, app) {
   return request(app)
     .get(path)
     .set('Accept', 'application/json')
-    .set('x-request-id', requestId);
+    .set('x-request-id', requestId)
 }
 
-function build_form_post_request(path, sendData, sendCSRF, app) {
-  sendCSRF = (sendCSRF === undefined) ? true : sendCSRF;
+function buildFormPostRequest (path, sendData, sendCSRF, app) {
+  sendCSRF = (sendCSRF === undefined) ? true : sendCSRF
   if (sendCSRF) {
-    sendData.csrfToken = csrf().create('123');
+    sendData.csrfToken = csrf().create('123')
   }
   return request(app)
     .post(path)
     .set('Accept', 'application/json')
     .set('Content-Type', 'application/x-www-form-urlencoded')
     .set('x-request-id', requestId)
-    .send(sendData);
+    .send(sendData)
 }
 
 describe('The payment types endpoint,', function () {
   describe('render select brand view,', function () {
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'payment-types:read';
+      let permissions = 'payment-types:read'
       var user = session.getUser({
         gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should show all debit and credit card options if accepted type is debit and credit cards', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-        .reply(200, ALL_CARD_TYPES);
+        .reply(200, ALL_CARD_TYPES)
       connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
         .reply(200, {
-          "card_types": [{"id": "1"}]
-        });
+          'card_types': [{'id': '1'}]
+        })
 
       var expectedData = {
-        acceptedType: "ALL",
+        acceptedType: 'ALL',
         isAcceptedTypeAll: true,
         isAcceptedTypeDebit: false,
         brands: [
-          buildAcceptedCardType("mastercard", true, selected = "checked"),
-          buildAcceptedCardType("discover", true),
-          buildAcceptedCardType("maestro", true)
+          buildAcceptedCardType('mastercard', true, 'checked'),
+          buildAcceptedCardType('discover', true),
+          buildAcceptedCardType('maestro', true)
         ],
         permissions: {
-          "payment_types_read": true
+          'payment_types_read': true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.paymentTypes.selectBrand + "?acceptedType=ALL", app)
+      buildGetRequest(paths.paymentTypes.selectBrand + '?acceptedType=ALL', app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should show debit card options only if accepted type is debit cards only', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-        .reply(200, ALL_CARD_TYPES);
+        .reply(200, ALL_CARD_TYPES)
       connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
         .reply(200, {
-          "card_types": [{"id": "1"}]
-        });
+          'card_types': [{'id': '1'}]
+        })
 
       var expectedData = {
-        acceptedType: "DEBIT",
+        acceptedType: 'DEBIT',
         isAcceptedTypeAll: false,
         isAcceptedTypeDebit: true,
         brands: [
-          buildAcceptedCardType("mastercard", true, selected = "checked"),
-          buildAcceptedCardType("maestro", true),
-          buildAcceptedCardType("discover", false)
+          buildAcceptedCardType('mastercard', true, 'checked'),
+          buildAcceptedCardType('maestro', true),
+          buildAcceptedCardType('discover', false)
         ],
         permissions: {
-          "payment_types_read": true
+          'payment_types_read': true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.paymentTypes.selectBrand + "?acceptedType=DEBIT", app)
+      buildGetRequest(paths.paymentTypes.selectBrand + '?acceptedType=DEBIT', app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should select all the options that have been previously accepted', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-        .reply(200, ALL_CARD_TYPES);
+        .reply(200, ALL_CARD_TYPES)
       connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
         .reply(200, {
-          "card_types": [{"id": "1"}, {"id": "3"}, {"id": "4"}]
-        });
+          'card_types': [{'id': '1'}, {'id': '3'}, {'id': '4'}]
+        })
 
       var expectedData = {
-        acceptedType: "ALL",
+        acceptedType: 'ALL',
         isAcceptedTypeAll: true,
         isAcceptedTypeDebit: false,
         brands: [
-          buildAcceptedCardType("mastercard", true, 'checked'),
-          buildAcceptedCardType("discover", true, 'checked'),
-          buildAcceptedCardType("maestro", true, 'checked')
+          buildAcceptedCardType('mastercard', true, 'checked'),
+          buildAcceptedCardType('discover', true, 'checked'),
+          buildAcceptedCardType('maestro', true, 'checked')
         ],
         permissions: {
-          "payment_types_read": true
+          'payment_types_read': true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.paymentTypes.selectBrand + "?acceptedType=ALL", app)
+      buildGetRequest(paths.paymentTypes.selectBrand + '?acceptedType=ALL', app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should select all the options by default none has been previously accepted', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-        .reply(200, ALL_CARD_TYPES);
+        .reply(200, ALL_CARD_TYPES)
       connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
         .reply(200, {
-          "card_types": []
-        });
+          'card_types': []
+        })
 
       var expectedData = {
-        acceptedType: "ALL",
+        acceptedType: 'ALL',
         isAcceptedTypeAll: true,
         isAcceptedTypeDebit: false,
         brands: [
-          buildAcceptedCardType("mastercard", true, 'checked'),
-          buildAcceptedCardType("discover", true, 'checked'),
-          buildAcceptedCardType("maestro", true, 'checked')
+          buildAcceptedCardType('mastercard', true, 'checked'),
+          buildAcceptedCardType('discover', true, 'checked'),
+          buildAcceptedCardType('maestro', true, 'checked')
         ],
         permissions: {
-          "payment_types_read": true
+          'payment_types_read': true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.paymentTypes.selectBrand + "?acceptedType=ALL", app)
+      buildGetRequest(paths.paymentTypes.selectBrand + '?acceptedType=ALL', app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should show the error if provided', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-        .reply(200, ALL_CARD_TYPES);
+        .reply(200, ALL_CARD_TYPES)
       connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
         .reply(200, {
-          "card_types": [{"id": "1"}]
-        });
+          'card_types': [{'id': '1'}]
+        })
 
       var expectedData = {
-        acceptedType: "ALL",
+        acceptedType: 'ALL',
         isAcceptedTypeAll: true,
         isAcceptedTypeDebit: false,
-        error: "Error",
+        error: 'Error',
         brands: [
-          buildAcceptedCardType("mastercard", true, selected = "checked"),
-          buildAcceptedCardType("discover", true),
-          buildAcceptedCardType("maestro", true)
+          buildAcceptedCardType('mastercard', true, 'checked'),
+          buildAcceptedCardType('discover', true),
+          buildAcceptedCardType('maestro', true)
         ],
         permissions: {
-          "payment_types_read": true
+          'payment_types_read': true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.paymentTypes.selectBrand + "?acceptedType=ALL&error=Error", app)
+      buildGetRequest(paths.paymentTypes.selectBrand + '?acceptedType=ALL&error=Error', app)
         .expect(200, expectedData)
-        .end(done);
-    });
-
+        .end(done)
+    })
 
     it('should display an error if the account does not exist', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-        .reply(200, ALL_CARD_TYPES);
+        .reply(200, ALL_CARD_TYPES)
       connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
         .reply(404, {
-          "message": "The gateway account id '" + ACCOUNT_ID + "' does not exist"
-        });
+          'message': "The gateway account id '" + ACCOUNT_ID + "' does not exist"
+        })
 
-      build_get_request(paths.paymentTypes.selectBrand, app)
-        .expect(500, {"message": "Unable to retrieve accepted card types for the account."})
-        .end(done);
-    });
+      buildGetRequest(paths.paymentTypes.selectBrand, app)
+        .expect(500, {'message': 'Unable to retrieve accepted card types for the account.'})
+        .end(done)
+    })
 
     it('should display an error if connector returns any other error while retrieving accepted card types', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-        .reply(200, ALL_CARD_TYPES);
+        .reply(200, ALL_CARD_TYPES)
       connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
         .reply(999, {
-          "message": "Some error in Connector"
-        });
+          'message': 'Some error in Connector'
+        })
 
-      build_get_request(paths.paymentTypes.selectBrand, app)
-        .expect(500, {"message": "Unable to retrieve accepted card types for the account."})
-        .end(done);
-    });
+      buildGetRequest(paths.paymentTypes.selectBrand, app)
+        .expect(500, {'message': 'Unable to retrieve accepted card types for the account.'})
+        .end(done)
+    })
 
     it('should display an error if connector returns any other error while retrieving all card types', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
         .reply(999, {
-          "message": "Some error in Connector"
-        });
-      connectorMock.post(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH, {"card_types": []})
-        .reply(200, {});
+          'message': 'Some error in Connector'
+        })
+      connectorMock.post(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH, {'card_types': []})
+        .reply(200, {})
 
-      build_get_request(paths.paymentTypes.selectBrand, app)
-        .expect(500, {"message": "Unable to retrieve card types."})
-        .end(done);
-    });
+      buildGetRequest(paths.paymentTypes.selectBrand, app)
+        .expect(500, {'message': 'Unable to retrieve card types.'})
+        .end(done)
+    })
 
     it('should display an error if the connection to connector fails', function (done) {
       // No connectorMock defined on purpose to mock a network failure
 
-      build_get_request(paths.paymentTypes.selectBrand, app)
-        .expect(500, {"message": "Internal server error"})
-        .end(done);
-    });
-  });
+      buildGetRequest(paths.paymentTypes.selectBrand, app)
+        .expect(500, {'message': 'Internal server error'})
+        .end(done)
+    })
+  })
 
   describe('submit select brand view,', function () {
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'payment-types:update';
+      let permissions = 'payment-types:update'
       var user = session.getUser({
         gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should post debit and credit card options if accepted type is debit and credit cards', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-        .reply(200, ALL_CARD_TYPES);
+        .reply(200, ALL_CARD_TYPES)
       connectorMock.post(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH, {
-        "card_types": ["1", "2", "3", "4"]
+        'card_types': ['1', '2', '3', '4']
       })
-        .reply(200, {});
+        .reply(200, {})
 
-      build_form_post_request(paths.paymentTypes.selectBrand, {
-        "acceptedType": TYPES.ALL,
-        "acceptedBrands": ["mastercard", "discover", "maestro"]
+      buildFormPostRequest(paths.paymentTypes.selectBrand, {
+        'acceptedType': TYPES.ALL,
+        'acceptedBrands': ['mastercard', 'discover', 'maestro']
       }, true, app)
         .expect(303)
         .end(function (err, res) {
-          expect(res.headers.location).to.deep.equal(paths.paymentTypes.summary + "?acceptedType=ALL");
-          done();
+          if (err) { done(err) }
+          expect(res.headers.location).to.deep.equal(paths.paymentTypes.summary + '?acceptedType=ALL')
+          done()
         })
-    });
+    })
 
     it('should post debit card options only if accepted type is debit only', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-        .reply(200, ALL_CARD_TYPES);
+        .reply(200, ALL_CARD_TYPES)
       connectorMock.post(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH, {
-        "card_types": ["2", "4"]
+        'card_types': ['2', '4']
       })
-        .reply(200, {});
+        .reply(200, {})
 
-      build_form_post_request(paths.paymentTypes.selectBrand, {
-        "acceptedType": TYPES.DEBIT,
-        "acceptedBrands": ["mastercard", "discover", "maestro"]
+      buildFormPostRequest(paths.paymentTypes.selectBrand, {
+        'acceptedType': TYPES.DEBIT,
+        'acceptedBrands': ['mastercard', 'discover', 'maestro']
       }, true, app)
         .expect(303)
         .end(function (err, res) {
-          expect(res.headers.location).to.deep.equal(paths.paymentTypes.summary + "?acceptedType=DEBIT");
-          done();
+          if (err) { done(err) }
+          expect(res.headers.location).to.deep.equal(paths.paymentTypes.summary + '?acceptedType=DEBIT')
+          done()
         })
-    });
+    })
 
     it('should not post any card option that is unknown', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-        .reply(200, ALL_CARD_TYPES);
+        .reply(200, ALL_CARD_TYPES)
       connectorMock.post(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH, {
-        "card_types": ["3"]
+        'card_types': ['3']
       })
-        .reply(200, {});
+        .reply(200, {})
 
-      build_form_post_request(paths.paymentTypes.selectBrand, {
-        "acceptedType": TYPES.ALL,
-        "acceptedBrands": ["discover", "unknown"]
+      buildFormPostRequest(paths.paymentTypes.selectBrand, {
+        'acceptedType': TYPES.ALL,
+        'acceptedBrands': ['discover', 'unknown']
       }, true, app)
         .expect(303)
         .end(function (err, res) {
-          expect(res.headers.location).to.deep.equal(paths.paymentTypes.summary + "?acceptedType=ALL");
-          done();
+          if (err) { done(err) }
+          expect(res.headers.location).to.deep.equal(paths.paymentTypes.summary + '?acceptedType=ALL')
+          done()
         })
-    });
+    })
 
     it('should show an error if no card option selected', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-        .reply(200, ALL_CARD_TYPES);
+        .reply(200, ALL_CARD_TYPES)
 
-      build_form_post_request(paths.paymentTypes.selectBrand, {
-        "acceptedType": TYPES.ALL,
-        "acceptedBrands": []
+      buildFormPostRequest(paths.paymentTypes.selectBrand, {
+        'acceptedType': TYPES.ALL,
+        'acceptedBrands': []
       }, true, app)
         .expect(303)
         .end(function (err, res) {
-          expect(res.headers.location).to.deep.equal(paths.paymentTypes.selectBrand + "?acceptedType=ALL&error=You%20must%20choose%20to%20accept%20at%20least%20one%20card%20brand%20to%20continue");
-          done();
+          if (err) { done(err) }
+          expect(res.headers.location).to.deep.equal(paths.paymentTypes.selectBrand + '?acceptedType=ALL&error=You%20must%20choose%20to%20accept%20at%20least%20one%20card%20brand%20to%20continue')
+          done()
         })
-    });
+    })
 
     it('should display an error if connector returns any other error while retrieving card types', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
         .reply(999, {
-          "message": "Some error in Connector"
-        });
+          'message': 'Some error in Connector'
+        })
 
-      build_form_post_request(paths.paymentTypes.selectBrand, {
-        "acceptedType": TYPES.ALL,
-        "acceptedBrands": ["discover", "unknown"]
+      buildFormPostRequest(paths.paymentTypes.selectBrand, {
+        'acceptedType': TYPES.ALL,
+        'acceptedBrands': ['discover', 'unknown']
       }, true, app)
-        .expect(500, {"message": "Unable to retrieve card types."})
-        .end(done);
-    });
+        .expect(500, {'message': 'Unable to retrieve card types.'})
+        .end(done)
+    })
 
     it('should display an error if connector returns any other error while posting accepted card types', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-        .reply(200, ALL_CARD_TYPES);
+        .reply(200, ALL_CARD_TYPES)
       connectorMock.post(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH, {
-        "card_types": ["3"]
+        'card_types': ['3']
       })
         .reply(999, {
-          "message": "Some error in Connector"
-        });
+          'message': 'Some error in Connector'
+        })
 
-      build_form_post_request(paths.paymentTypes.selectBrand, {
-        "acceptedType": TYPES.ALL,
-        "acceptedBrands": ["discover", "unknown"]
+      buildFormPostRequest(paths.paymentTypes.selectBrand, {
+        'acceptedType': TYPES.ALL,
+        'acceptedBrands': ['discover', 'unknown']
       }, true, app)
-        .expect(500, {"message": "Unable to save accepted card types."})
-        .end(done);
-    });
-  });
-});
+        .expect(500, {'message': 'Unable to save accepted card types.'})
+        .end(done)
+    })
+  })
+})

--- a/test/integration/payment_types_select_summary_ft_tests.js
+++ b/test/integration/payment_types_select_summary_ft_tests.js
@@ -1,140 +1,139 @@
-require(__dirname + '/../test_helpers/serialize_mock.js');
-var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
-var request = require('supertest');
-var getApp = require(__dirname + '/../../server.js').getApp;
-var winston = require('winston');
-var nock = require('nock');
-var csrf = require('csrf');
-var should = require('chai').should();
-var paths = require(__dirname + '/../../app/paths.js');
-var session = require(__dirname + '/../test_helpers/mock_session.js');
-var _ = require('lodash');
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+var userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
+var request = require('supertest')
+var getApp = require(path.join(__dirname, '/../../server.js')).getApp
+var nock = require('nock')
+var paths = require(path.join(__dirname, '/../../app/paths.js'))
+var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+var _ = require('lodash')
 
-var ACCOUNT_ID = 182364;
-var app;
-var requestId = 'unique-request-id';
+var ACCOUNT_ID = 182364
+var app
+var requestId = 'unique-request-id'
 var aCorrelationHeader = {
   reqheaders: {'x-request-id': requestId}
-};
+}
 
-var CONNECTOR_ALL_CARD_TYPES_API_PATH = "/v1/api/card-types";
-var CONNECTOR_ACCOUNT_PATH = "/v1/frontend/accounts/" + ACCOUNT_ID;
-var CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH = CONNECTOR_ACCOUNT_PATH + "/card-types";
-var connectorMock = nock(process.env.CONNECTOR_URL, aCorrelationHeader);
+var CONNECTOR_ALL_CARD_TYPES_API_PATH = '/v1/api/card-types'
+var CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts/' + ACCOUNT_ID
+var CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH = CONNECTOR_ACCOUNT_PATH + '/card-types'
+var connectorMock = nock(process.env.CONNECTOR_URL, aCorrelationHeader)
 
 var buildAcceptedCardType = function (value, available = true, selected = '') {
   return {
-    "id": `payment-types-${value}-brand`,
-    "value": value,
-    "label": _.capitalize(value),
-    "available": available,
-    "selected": selected
+    'id': `payment-types-${value}-brand`,
+    'value': value,
+    'label': _.capitalize(value),
+    'available': available,
+    'selected': selected
   }
-};
+}
 
 var ALL_CARD_TYPES = {
-  "card_types": [
-    {"id": "1", "brand": "mastercard", "label": "Mastercard", "type": "CREDIT"},
-    {"id": "2", "brand": "mastercard", "label": "Mastercard", "type": "DEBIT"},
-    {"id": "3", "brand": "discover", "label": "Discover", "type": "CREDIT"},
-    {"id": "4", "brand": "maestro", "label": "Maestro", "type": "DEBIT"}]
-};
+  'card_types': [
+    {'id': '1', 'brand': 'mastercard', 'label': 'Mastercard', 'type': 'CREDIT'},
+    {'id': '2', 'brand': 'mastercard', 'label': 'Mastercard', 'type': 'DEBIT'},
+    {'id': '3', 'brand': 'discover', 'label': 'Discover', 'type': 'CREDIT'},
+    {'id': '4', 'brand': 'maestro', 'label': 'Maestro', 'type': 'DEBIT'}]
+}
 
-function build_get_request(path, baseApp) {
+function buildGetRequest (path, baseApp) {
   return request(baseApp)
     .get(path)
     .set('Accept', 'application/json')
-    .set('x-request-id',requestId);
+    .set('x-request-id', requestId)
 }
 
 describe('The payment types endpoint,', function () {
   describe('render summary view,', function () {
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'payment-types:read';
+      let permissions = 'payment-types:read'
       var user = session.getUser({
         gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should show all the card type options that have been previously accepted', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-        .reply(200, ALL_CARD_TYPES);
+        .reply(200, ALL_CARD_TYPES)
       connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
         .reply(200, {
-          "card_types": [{"id": "1"}, {"id": "3"}, {"id": "4"}]
-        });
+          'card_types': [{'id': '1'}, {'id': '3'}, {'id': '4'}]
+        })
 
       var expectedData = {
         isAcceptedTypeAll: true,
         isAcceptedTypeDebit: false,
         brands: [
-          buildAcceptedCardType("mastercard", true, 'checked'),
-          buildAcceptedCardType("discover", true, 'checked'),
-          buildAcceptedCardType("maestro", true, 'checked')
+          buildAcceptedCardType('mastercard', true, 'checked'),
+          buildAcceptedCardType('discover', true, 'checked'),
+          buildAcceptedCardType('maestro', true, 'checked')
         ],
-        "permissions": {
-          "payment_types_read": true
-        }, navigation: true
-      };
+        'permissions': {
+          'payment_types_read': true
+        },
+        navigation: true
+      }
 
-      build_get_request(paths.paymentTypes.summary, app)
+      buildGetRequest(paths.paymentTypes.summary, app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should display an error if the account does not exist', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-        .reply(200, ALL_CARD_TYPES);
+        .reply(200, ALL_CARD_TYPES)
       connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
         .reply(404, {
-          "message": "The gateway account id '" + ACCOUNT_ID + "' does not exist"
-        });
+          'message': "The gateway account id '" + ACCOUNT_ID + "' does not exist"
+        })
 
-      build_get_request(paths.paymentTypes.summary, app)
-        .expect(500, {"message": "Unable to retrieve accepted card types for the account."})
-        .end(done);
-    });
+      buildGetRequest(paths.paymentTypes.summary, app)
+        .expect(500, {'message': 'Unable to retrieve accepted card types for the account.'})
+        .end(done)
+    })
 
     it('should display an error if connector returns any other error while retrieving accepted card types', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-        .reply(200, ALL_CARD_TYPES);
+        .reply(200, ALL_CARD_TYPES)
       connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
         .reply(999, {
-          "message": "Some error in Connector"
-        });
+          'message': 'Some error in Connector'
+        })
 
-      build_get_request(paths.paymentTypes.summary, app)
-        .expect(500, {"message": "Unable to retrieve accepted card types for the account."})
-        .end(done);
-    });
+      buildGetRequest(paths.paymentTypes.summary, app)
+        .expect(500, {'message': 'Unable to retrieve accepted card types for the account.'})
+        .end(done)
+    })
 
     it('should display an error if connector returns any other error while retrieving all card types', function (done) {
       connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
         .reply(999, {
-          "message": "Some error in Connector"
-        });
-      connectorMock.post(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH, {"card_types": []})
-        .reply(200, {});
+          'message': 'Some error in Connector'
+        })
+      connectorMock.post(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH, {'card_types': []})
+        .reply(200, {})
 
-      build_get_request(paths.paymentTypes.summary, app)
-        .expect(500, {"message": "Unable to retrieve card types."})
-        .end(done);
-    });
+      buildGetRequest(paths.paymentTypes.summary, app)
+        .expect(500, {'message': 'Unable to retrieve card types.'})
+        .end(done)
+    })
 
     it('should display an error if the connection to connector fails', function (done) {
       // No connectorMock defined on purpose to mock a network failure
 
-      build_get_request(paths.paymentTypes.summary, app)
-        .expect(500, {"message": "Internal server error"})
-        .end(done);
-    });
-  });
-});
+      buildGetRequest(paths.paymentTypes.summary, app)
+        .expect(500, {'message': 'Internal server error'})
+        .end(done)
+    })
+  })
+})

--- a/test/integration/payment_types_select_type_ft_tests.js
+++ b/test/integration/payment_types_select_type_ft_tests.js
@@ -1,70 +1,68 @@
-require(__dirname + '/../test_helpers/serialize_mock.js');
-var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
-var request = require('supertest');
-var getApp = require(__dirname + '/../../server.js').getApp;
-var winston = require('winston');
-var nock = require('nock');
-var csrf = require('csrf');
-var should = require('chai').should();
-var paths = require(__dirname + '/../../app/paths.js');
-var session = require(__dirname + '/../test_helpers/mock_session.js');
-var expect = require("chai").expect;
-var {TYPES} = require(__dirname + '/../../app/controllers/payment_types_controller.js');
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+var userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
+var request = require('supertest')
+var getApp = require(path.join(__dirname, '/../../server.js')).getApp
+var nock = require('nock')
+var csrf = require('csrf')
+var paths = require(path.join(__dirname, '/../../app/paths.js'))
+var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+var expect = require('chai').expect
+var {TYPES} = require(path.join(__dirname, '/../../app/controllers/payment_types_controller.js'))
 
-var ACCOUNT_ID = 182364;
-var app;
-var requestId = 'unique-request-id';
+var ACCOUNT_ID = 182364
+var app
+var requestId = 'unique-request-id'
 var aCorrelationHeader = {
   reqheaders: {'x-request-id': requestId}
-};
+}
 
-var CONNECTOR_ACCOUNT_PATH = "/v1/frontend/accounts/" + ACCOUNT_ID;
-var CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH = CONNECTOR_ACCOUNT_PATH + "/card-types";
-var connectorMock = nock(process.env.CONNECTOR_URL, aCorrelationHeader);
+var CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts/' + ACCOUNT_ID
+var CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH = CONNECTOR_ACCOUNT_PATH + '/card-types'
+var connectorMock = nock(process.env.CONNECTOR_URL, aCorrelationHeader)
 
-function build_get_request(path, baseApp) {
+function buildGetRequest (path, baseApp) {
   return request(baseApp)
     .get(path)
     .set('Accept', 'application/json')
-    .set('x-request-id', requestId);
+    .set('x-request-id', requestId)
 }
 
-function build_form_post_request(path, sendData, sendCSRF, baseApp) {
-  sendCSRF = (sendCSRF === undefined) ? true : sendCSRF;
+function buildFormPostRequest (path, sendData, sendCSRF, baseApp) {
+  sendCSRF = (sendCSRF === undefined) ? true : sendCSRF
   if (sendCSRF) {
-    sendData.csrfToken = csrf().create('123');
+    sendData.csrfToken = csrf().create('123')
   }
   return request(baseApp)
     .post(path)
     .set('Accept', 'application/json')
     .set('Content-Type', 'application/x-www-form-urlencoded')
     .set('x-request-id', requestId)
-    .send(sendData);
+    .send(sendData)
 }
 
 describe('The payment types endpoint,', function () {
   describe('render select type view,', function () {
-
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      const permissions ='payment-types:read';
+      const permissions = 'payment-types:read'
       let user = session.getUser({
         gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should select debit and credit cards option by default if no card types are accepted for the account', function (done) {
       connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
         .reply(200, {
-          "card_types": []
-        });
+          'card_types': []
+        })
 
       var expectedData = {
         allCardOption: {
@@ -76,27 +74,27 @@ describe('The payment types endpoint,', function () {
           selected: ''
         },
         permissions: {
-          "payment_types_read": true
+          'payment_types_read': true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.paymentTypes.selectType, app)
+      buildGetRequest(paths.paymentTypes.selectType, app)
         .expect(200)
         .expect(res => {
-          expect(res.body.allCardOption).to.deep.equal(expectedData.allCardOption);
-          expect(res.body.debitCardOption).to.deep.equal(expectedData.debitCardOption);
-          expect(res.body.permissions).to.include(expectedData.permissions);
-          expect(res.body.navigation).to.equal(expectedData.navigation);
+          expect(res.body.allCardOption).to.deep.equal(expectedData.allCardOption)
+          expect(res.body.debitCardOption).to.deep.equal(expectedData.debitCardOption)
+          expect(res.body.permissions).to.include(expectedData.permissions)
+          expect(res.body.navigation).to.equal(expectedData.navigation)
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should select debit and credit cards option if at least one credit card is accepted for the account', function (done) {
       connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
         .reply(200, {
-          "card_types": [{"type": "DEBIT"}, {"type": "CREDIT"}]
-        });
+          'card_types': [{'type': 'DEBIT'}, {'type': 'CREDIT'}]
+        })
 
       var expectedData = {
         allCardOption: {
@@ -108,27 +106,27 @@ describe('The payment types endpoint,', function () {
           selected: ''
         },
         permissions: {
-          "payment_types_read": true
+          'payment_types_read': true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.paymentTypes.selectType, app)
+      buildGetRequest(paths.paymentTypes.selectType, app)
         .expect(200)
         .expect(res => {
-          expect(res.body.allCardOption).to.deep.equal(expectedData.allCardOption);
-          expect(res.body.debitCardOption).to.deep.equal(expectedData.debitCardOption);
-          expect(res.body.permissions).to.include(expectedData.permissions);
-          expect(res.body.navigation).to.equal(expectedData.navigation);
+          expect(res.body.allCardOption).to.deep.equal(expectedData.allCardOption)
+          expect(res.body.debitCardOption).to.deep.equal(expectedData.debitCardOption)
+          expect(res.body.permissions).to.include(expectedData.permissions)
+          expect(res.body.navigation).to.equal(expectedData.navigation)
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should select debit cards option if only debit cards are accepted for the account', function (done) {
       connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
         .reply(200, {
-          "card_types": [{"type": "DEBIT"}, {"type": "DEBIT"}]
-        });
+          'card_types': [{'type': 'DEBIT'}, {'type': 'DEBIT'}]
+        })
 
       var expectedData = {
         allCardOption: {
@@ -140,86 +138,87 @@ describe('The payment types endpoint,', function () {
           selected: 'checked'
         },
         permissions: {
-          "payment_types_read": true
+          'payment_types_read': true
         },
         navigation: true
-      };
+      }
 
-      build_get_request(paths.paymentTypes.selectType, app)
+      buildGetRequest(paths.paymentTypes.selectType, app)
         .expect(200)
         .expect(res => {
-          expect(res.body.allCardOption).to.deep.equal(expectedData.allCardOption);
-          expect(res.body.debitCardOption).to.deep.equal(expectedData.debitCardOption);
-          expect(res.body.permissions).to.include(expectedData.permissions);
-          expect(res.body.navigation).to.equal(expectedData.navigation);
+          expect(res.body.allCardOption).to.deep.equal(expectedData.allCardOption)
+          expect(res.body.debitCardOption).to.deep.equal(expectedData.debitCardOption)
+          expect(res.body.permissions).to.include(expectedData.permissions)
+          expect(res.body.navigation).to.equal(expectedData.navigation)
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should display an error if the account does not exist', function (done) {
       connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
         .reply(404, {
-          "message": "The gateway account id '" + ACCOUNT_ID + "' does not exist"
-        });
+          'message': "The gateway account id '" + ACCOUNT_ID + "' does not exist"
+        })
 
-      build_get_request(paths.paymentTypes.selectType, app)
-        .expect(500, {"message": "Unable to retrieve accepted card types for the account."})
-        .end(done);
-    });
+      buildGetRequest(paths.paymentTypes.selectType, app)
+        .expect(500, {'message': 'Unable to retrieve accepted card types for the account.'})
+        .end(done)
+    })
 
     it('should display an error if connector returns any other error', function (done) {
       connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
         .reply(999, {
-          "message": "Some error in Connector"
-        });
+          'message': 'Some error in Connector'
+        })
 
-      build_get_request(paths.paymentTypes.selectType, app)
-        .expect(500, {"message": "Unable to retrieve accepted card types for the account."})
-        .end(done);
-    });
+      buildGetRequest(paths.paymentTypes.selectType, app)
+        .expect(500, {'message': 'Unable to retrieve accepted card types for the account.'})
+        .end(done)
+    })
 
     it('should display an error if the connection to connector fails', function (done) {
       // No connectorMock defined on purpose to mock a network failure
 
-      build_get_request(paths.paymentTypes.selectType, app)
-        .expect(500, {"message": "Internal server error"})
-        .end(done);
-    });
-  });
+      buildGetRequest(paths.paymentTypes.selectType, app)
+        .expect(500, {'message': 'Internal server error'})
+        .end(done)
+    })
+  })
 
   describe('submit select type view,', function () {
-
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'payment-types:update';
+      let permissions = 'payment-types:update'
       var user = session.getUser({
         gateway_account_id: ACCOUNT_ID, permissions: [{name: permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-    });
-
-    it('should redirect to select brand view when debit cards option selected', function (done) {
-      build_form_post_request(paths.paymentTypes.selectType, {"payment-types-card-type": TYPES.ALL}, true, app)
-        .expect(303)
-        .end(function (err, res) {
-          expect(res.headers.location).to.deep.equal(paths.paymentTypes.selectBrand + "?acceptedType=ALL");
-          done();
-        })
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should redirect to select brand view when debit cards option selected', function (done) {
-      build_form_post_request(paths.paymentTypes.selectType, {"payment-types-card-type": TYPES.DEBIT}, true, app)
+      buildFormPostRequest(paths.paymentTypes.selectType, {'payment-types-card-type': TYPES.ALL}, true, app)
         .expect(303)
         .end(function (err, res) {
-          expect(res.headers.location).to.deep.equal(paths.paymentTypes.selectBrand + "?acceptedType=DEBIT");
-          done();
+          if (err) { done(err) }
+          expect(res.headers.location).to.deep.equal(paths.paymentTypes.selectBrand + '?acceptedType=ALL')
+          done()
         })
-    });
-  });
-});
+    })
+
+    it('should redirect to select brand view when debit cards option selected', function (done) {
+      buildFormPostRequest(paths.paymentTypes.selectType, {'payment-types-card-type': TYPES.DEBIT}, true, app)
+        .expect(303)
+        .end(function (err, res) {
+          if (err) { done(err) }
+          expect(res.headers.location).to.deep.equal(paths.paymentTypes.selectBrand + '?acceptedType=DEBIT')
+          done()
+        })
+    })
+  })
+})

--- a/test/integration/register_user_controller_ft_tests.js
+++ b/test/integration/register_user_controller_ft_tests.js
@@ -1,11 +1,12 @@
 'use strict'
 
+const path = require('path')
 const nock = require('nock')
 const supertest = require('supertest')
-const paths = require(__dirname + '/../../app/paths.js')
-const getApp = require(__dirname + '/../../server.js').getApp
-const session = require(__dirname + '/../test_helpers/mock_session.js')
-const userFixtures = require(__dirname + '/../fixtures/user_fixtures')
+const paths = require(path.join(__dirname, '/../../app/paths.js'))
+const getApp = require(path.join(__dirname, '/../../server.js')).getApp
+const session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+const userFixtures = require(path.join(__dirname, '/../fixtures/user_fixtures'))
 const csrf = require('csrf')
 
 const chai = require('chai')
@@ -20,7 +21,6 @@ let app
 let mockRegisterAccountCookie
 
 describe('register user controller', function () {
-
   beforeEach((done) => {
     mockRegisterAccountCookie = {}
     app = session.getAppWithRegisterInvitesCookie(getApp(), mockRegisterAccountCookie)
@@ -37,9 +37,7 @@ describe('register user controller', function () {
    *  ENDPOINT showRegistration
    */
   describe('show registration view endpoint', function () {
-
     it('should display create account form', function (done) {
-
       mockRegisterAccountCookie.email = 'invitee@example.com'
       mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
 
@@ -52,11 +50,9 @@ describe('register user controller', function () {
           expect(res.body.email).to.equal('invitee@example.com')
         })
         .end(done)
-
     })
 
     it('should display create account form with telephone populated, if invite has been attempted', function (done) {
-
       mockRegisterAccountCookie.email = 'invitee@example.com'
       mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
       mockRegisterAccountCookie.telephone_number = '123456789'
@@ -71,7 +67,6 @@ describe('register user controller', function () {
           expect(res.body.telephone_number).to.equal('123456789')
         })
         .end(done)
-
     })
 
     it('should display error when email and/or code is not in the cookie', function (done) {
@@ -92,9 +87,7 @@ describe('register user controller', function () {
    */
 
   describe('submit registration details endpoint', function () {
-
     it('should error if cookie details are missing', function (done) {
-
       supertest(app)
         .post(paths.registerUser.registration)
         .set('Accept', 'application/json')
@@ -108,11 +101,9 @@ describe('register user controller', function () {
           expect(res.body.message).to.equal('Unable to process registration at this time')
         })
         .end(done)
-
     })
 
     it('should redirect back to registration form if error in phone number', function (done) {
-
       mockRegisterAccountCookie.email = 'invitee@example.com'
       mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
 
@@ -133,11 +124,9 @@ describe('register user controller', function () {
           expect(mockRegisterAccountCookie.telephone_number).to.equal(invalidPhone)
         })
         .end(done)
-
     })
 
     it('should redirect to phone verification page', function (done) {
-
       mockRegisterAccountCookie.email = 'invitee@example.com'
       mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
 
@@ -157,11 +146,9 @@ describe('register user controller', function () {
         .expect(303, {})
         .expect('Location', paths.registerUser.otpVerify)
         .end(done)
-
     })
 
     it('should error for valid registration data, if code not found', function (done) {
-
       mockRegisterAccountCookie.email = 'invitee@example.com'
       mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
 
@@ -183,18 +170,14 @@ describe('register user controller', function () {
           expect(res.body.message).to.equal('Unable to process registration at this time')
         })
         .end(done)
-
     })
-
   })
 
   /**
    *  ENDPOINT showOtpVerify
    */
   describe('show otp verify endpoint', function () {
-
     it('should error if cookie details are missing', function (done) {
-
       supertest(app)
         .get(paths.registerUser.otpVerify)
         .set('Accept', 'application/json')
@@ -204,11 +187,9 @@ describe('register user controller', function () {
           expect(res.body.message).to.equal('Unable to process registration at this time')
         })
         .end(done)
-
     })
 
     it('should display verify otp page successfully', function (done) {
-
       mockRegisterAccountCookie.email = 'invitee@example.com'
       mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
 
@@ -218,7 +199,6 @@ describe('register user controller', function () {
         .set('x-request-id', 'bob')
         .expect(200)
         .end(done)
-
     })
   })
 
@@ -226,7 +206,6 @@ describe('register user controller', function () {
    *  ENDPOINT submitOtpVerify
    */
   describe('validate otp code endpoint', function () {
-
     it('should validate otp code successfully', function (done) {
       mockRegisterAccountCookie.email = 'invitee@example.com'
       mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
@@ -251,11 +230,9 @@ describe('register user controller', function () {
           expect(mockRegisterAccountCookie.userExternalId).to.equal(newUserExtId)
         })
         .end(done)
-
     })
 
     it('should error if cookie details are missing', function (done) {
-
       supertest(app)
         .post(paths.registerUser.otpVerify)
         .set('Accept', 'application/json')
@@ -273,7 +250,6 @@ describe('register user controller', function () {
     })
 
     it('should error and allow user to reenter otp if invalid otp code entry', function (done) {
-
       mockRegisterAccountCookie.email = 'invitee@example.com'
       mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
 
@@ -283,7 +259,7 @@ describe('register user controller', function () {
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .set('x-request-id', 'bob')
         .send({
-          'verify-code': 'hfwe67q', //non-numeric
+          'verify-code': 'hfwe67q', // non-numeric
           csrfToken: csrf().create('123')
         })
         .expect(303)
@@ -292,7 +268,6 @@ describe('register user controller', function () {
     })
 
     it('should error if error during otp code verification', function (done) {
-
       mockRegisterAccountCookie.email = 'invitee@example.com'
       mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
 
@@ -320,9 +295,7 @@ describe('register user controller', function () {
    *  ENDPOINT showReVerifyPhone
    */
   describe('show re-verify phone endpoint', function () {
-
     it('should display re verify otp code form with pre-populated telephone number', function (done) {
-
       const telephoneNumber = '12345678901'
 
       mockRegisterAccountCookie.email = 'invitee@example.com'
@@ -338,7 +311,6 @@ describe('register user controller', function () {
           expect(res.body.telephone_number).to.equal(telephoneNumber)
         })
         .end(done)
-
     })
 
     it('should display error when email and/or code is not in the cookie', function (done) {
@@ -358,9 +330,7 @@ describe('register user controller', function () {
    *  ENDPOINT submitReVerifyPhone
    */
   describe('submit re-verify phone endpoint', function () {
-
     it('should proceed to verify otp upon successful telephone number re-entry', function (done) {
-
       const telephoneNumber = '12345678901'
 
       mockRegisterAccountCookie.email = 'invitee@example.com'
@@ -384,7 +354,6 @@ describe('register user controller', function () {
     })
 
     it('should error on an error during resend otp', function (done) {
-
       const telephoneNumber = '12345678901'
 
       mockRegisterAccountCookie.email = 'invitee@example.com'
@@ -410,7 +379,6 @@ describe('register user controller', function () {
     })
 
     it('should redirect back to re verify phone view if error in phone number', function (done) {
-
       mockRegisterAccountCookie.email = 'invitee@example.com'
       mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
 
@@ -450,21 +418,19 @@ describe('register user controller', function () {
         })
         .end(done)
     })
-
   })
 
   /**
    * ENDPOINT subscribeService
    */
   describe('subscribe existing user to a service endpoint', () => {
-    
     it('should redirect user to my-services page and display added to new service message', (done) => {
       const inviteCode = 'nfjkh438rf3901jqf'
       mockRegisterAccountCookie.code = inviteCode
 
       const serviceExternalId = '378y235y8234y5'
       adminusersMock.post(`${INVITE_RESOURCE_PATH}/${inviteCode}/complete`)
-        .reply(200, {service_external_id:serviceExternalId})
+        .reply(200, {service_external_id: serviceExternalId})
 
       supertest(app)
         .get(paths.registerUser.subscribeService)
@@ -476,7 +442,6 @@ describe('register user controller', function () {
     })
 
     it('should error if cookie details are missing', function (done) {
-
       supertest(app)
         .get(paths.registerUser.subscribeService)
         .set('Accept', 'application/json')
@@ -486,7 +451,6 @@ describe('register user controller', function () {
           expect(res.body.message).to.equal('Unable to process registration at this time')
         })
         .end(done)
-
     })
 
     it('should error if invitation is expired', function (done) {
@@ -505,7 +469,6 @@ describe('register user controller', function () {
           expect(res.body.message).to.equal('This invitation is no longer valid')
         })
         .end(done)
-
     })
   })
 })

--- a/test/integration/router_test.js
+++ b/test/integration/router_test.js
@@ -1,26 +1,24 @@
-require(__dirname + '/../test_helpers/html_assertions.js');
-var should = require('chai').should();
-var assert = require('assert');
-var router = require(__dirname + '/../../app/routes.js');
-
-
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/html_assertions.js'))
+var assert = require('assert')
+var router = require(path.join(__dirname, '/../../app/routes.js'))
 
 describe('date format', function () {
   it('should return the correct generated url with no query string', function () {
-    dynamicRoute = router.paths.transactions.show;
-    route = router.generateRoute(dynamicRoute,{chargeId: 'foo'});
-    assert.equal("/transactions/foo",route);
-  });
+    var dynamicRoute = router.paths.transactions.show
+    var route = router.generateRoute(dynamicRoute, {chargeId: 'foo'})
+    assert.equal('/transactions/foo', route)
+  })
 
   it('should return the correct url with paramters appended as query if they are not named', function () {
-    dynamicRoute = router.paths.transactions.show;
-    route = router.generateRoute(dynamicRoute,{chargeId: 'foo', foo: 'bar'});
-    assert.equal("/transactions/foo?foo=bar",route);
-  });
+    var dynamicRoute = router.paths.transactions.show
+    var route = router.generateRoute(dynamicRoute, {chargeId: 'foo', foo: 'bar'})
+    assert.equal('/transactions/foo?foo=bar', route)
+  })
 
   it('should remove empty params', function () {
-    dynamicRoute = router.paths.transactions.show;
-    route = router.generateRoute(dynamicRoute,{chargeId: 'foo', foo: 'bar', choc: "bar", empty: ""});
-    assert.equal("/transactions/foo?foo=bar&choc=bar",route);
-  });
-});
+    var dynamicRoute = router.paths.transactions.show
+    var route = router.generateRoute(dynamicRoute, {chargeId: 'foo', foo: 'bar', choc: 'bar', empty: ''})
+    assert.equal('/transactions/foo?foo=bar&choc=bar', route)
+  })
+})

--- a/test/integration/service_name_ft_tests.js
+++ b/test/integration/service_name_ft_tests.js
@@ -1,44 +1,44 @@
-require(__dirname + '/../test_helpers/serialize_mock.js');
-var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
-var request = require('supertest');
-var getApp = require(__dirname + '/../../server.js').getApp;
-var nock = require('nock');
-var should = require('chai').should();
-var paths = require(__dirname + '/../../app/paths.js');
-var session = require(__dirname + '/../test_helpers/mock_session.js');
-var csrf = require('csrf');
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+var userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
+var request = require('supertest')
+var getApp = require(path.join(__dirname, '/../../server.js')).getApp
+var nock = require('nock')
+var paths = require(path.join(__dirname, '/../../app/paths.js'))
+var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+var csrf = require('csrf')
 
-var ACCOUNT_ID = 182364;
+var ACCOUNT_ID = 182364
 
-var app;
+var app
 
-var requestId = 'unique-request-id';
+var requestId = 'unique-request-id'
 var aCorrelationHeader = {
   reqheaders: {'x-request-id': requestId}
-};
+}
 
-var CONNECTOR_ACCOUNT_PATH = "/v1/frontend/accounts/" + ACCOUNT_ID;
-var CONNECTOR_ACCOUNT_SERVICE_NAME_PATH = CONNECTOR_ACCOUNT_PATH + "/servicename";
-var connectorMock = nock(process.env.CONNECTOR_URL, aCorrelationHeader);
+var CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts/' + ACCOUNT_ID
+var CONNECTOR_ACCOUNT_SERVICE_NAME_PATH = CONNECTOR_ACCOUNT_PATH + '/servicename'
+var connectorMock = nock(process.env.CONNECTOR_URL, aCorrelationHeader)
 
-function build_get_request(path, app) {
+function buildGetRequest (path, app) {
   return request(app)
     .get(path)
     .set('Accept', 'application/json')
-    .set('x-request-id', requestId);
+    .set('x-request-id', requestId)
 }
 
-function build_form_post_request(path, sendData, sendCSRF, app) {
-  sendCSRF = (sendCSRF === undefined) ? true : sendCSRF;
+function buildFormPostRequest (path, sendData, sendCSRF, app) {
+  sendCSRF = (sendCSRF === undefined) ? true : sendCSRF
   if (sendCSRF) {
-    sendData.csrfToken = csrf().create('123');
+    sendData.csrfToken = csrf().create('123')
   }
   return request(app)
     .post(path)
     .set('Accept', 'application/json')
     .set('Content-Type', 'application/x-www-form-urlencoded')
     .set('x-request-id', requestId)
-    .send(sendData);
+    .send(sendData)
 }
 
 [
@@ -51,139 +51,137 @@ function build_form_post_request(path, sendData, sendCSRF, app) {
     'edit': true
   }
 ].forEach(function (testSetup) {
-
   describe('The ' + testSetup.path + ' endpoint', function () {
     afterEach(function () {
-      nock.cleanAll();
-      app = null;
-    });
+      nock.cleanAll()
+      app = null
+    })
 
     beforeEach(function (done) {
-      let permissions = 'service-name:read';
+      let permissions = 'service-name:read'
       let user = session.getUser({
         gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
-      });
-      app = session.getAppWithLoggedInUser(getApp(), user);
+      })
+      app = session.getAppWithLoggedInUser(getApp(), user)
 
-      userCreator.mockUserResponse(user.toJson(), done);
-    });
+      userCreator.mockUserResponse(user.toJson(), done)
+    })
 
     it('should display received service name from connector', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          "service_name": "Service name"
-        });
+          'service_name': 'Service name'
+        })
 
       var expectedData = {
-        "serviceName": "Service name",
-        "editMode": testSetup.edit,
+        'serviceName': 'Service name',
+        'editMode': testSetup.edit,
         permissions: {
           'service_name_read': true
         },
         navigation: true,
         currentGatewayAccount: {
-          "service_name": "Service name"
+          'service_name': 'Service name'
         }
-      };
+      }
 
-      build_get_request(testSetup.path, app)
+      buildGetRequest(testSetup.path, app)
         .expect(200, expectedData)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should display an error if the account does not exist', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(404, {
-          "message": "The gateway account id '" + ACCOUNT_ID + "' does not exist"
-        });
+          'message': "The gateway account id '" + ACCOUNT_ID + "' does not exist"
+        })
 
-      build_get_request(testSetup.path, app)
-        .expect(500, {"message": "Unable to retrieve the service name."})
-        .end(done);
-    });
+      buildGetRequest(testSetup.path, app)
+        .expect(500, {'message': 'Unable to retrieve the service name.'})
+        .end(done)
+    })
 
     it('should display an error if connector returns any other error', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(999, {
-          "message": "Some error in Connector"
-        });
+          'message': 'Some error in Connector'
+        })
 
-      build_get_request(testSetup.path, app)
-        .expect(500, {"message": "Unable to retrieve the service name."})
-        .end(done);
-    });
+      buildGetRequest(testSetup.path, app)
+        .expect(500, {'message': 'Unable to retrieve the service name.'})
+        .end(done)
+    })
 
     it('should display an error if the connection to connector fails', function (done) {
       // No connectorMock defined on purpose to mock a network failure
 
-      build_get_request(testSetup.path, app)
-        .expect(500, {"message": "Unable to retrieve the service name."})
-        .end(done);
-    });
-  });
-});
+      buildGetRequest(testSetup.path, app)
+        .expect(500, {'message': 'Unable to retrieve the service name.'})
+        .end(done)
+    })
+  })
+})
 
 describe('The provider update service name endpoint', function () {
-
   afterEach(function () {
-    nock.cleanAll();
-    app = null;
-  });
+    nock.cleanAll()
+    app = null
+  })
 
   beforeEach(function (done) {
-    let permissions = 'service-name:update';
+    let permissions = 'service-name:update'
     var user = session.getUser({
-      gateway_account_ids: [ACCOUNT_ID], permissions: [{name:permissions}]
-    });
-    app = session.getAppWithLoggedInUser(getApp(), user);
+      gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
+    })
+    app = session.getAppWithLoggedInUser(getApp(), user)
 
-    userCreator.mockUserResponse(user.toJson(), done);
-  });
+    userCreator.mockUserResponse(user.toJson(), done)
+  })
 
   it('should send new service name to connector', function (done) {
     connectorMock.patch(CONNECTOR_ACCOUNT_SERVICE_NAME_PATH, {
-      "service_name": "Service name"
+      'service_name': 'Service name'
     })
-      .reply(200, {});
+      .reply(200, {})
 
-    var sendData = {'service-name-input': 'Service name'};
-    var expectedLocation = paths.serviceName.index;
-    var path = paths.serviceName.index;
-    build_form_post_request(path, sendData, true, app)
+    var sendData = {'service-name-input': 'Service name'}
+    var expectedLocation = paths.serviceName.index
+    var path = paths.serviceName.index
+    buildFormPostRequest(path, sendData, true, app)
       .expect(303, {})
       .expect('Location', expectedLocation)
-      .end(done);
-  });
+      .end(done)
+  })
 
   it('should display an error if connector returns failure', function (done) {
-    connectorMock.patch(CONNECTOR_ACCOUNT_PATH, {"service_name": "Service name"})
+    connectorMock.patch(CONNECTOR_ACCOUNT_PATH, {'service_name': 'Service name'})
       .reply(999, {
-        "message": "Error message"
-      });
+        'message': 'Error message'
+      })
 
-    var sendData = {'service-name-input': 'Service name'};
-    var expectedData = {"message": "Internal server error"};
-    var path = paths.serviceName.index;
-    build_form_post_request(path, sendData, true, app)
+    var sendData = {'service-name-input': 'Service name'}
+    var expectedData = {'message': 'Internal server error'}
+    var path = paths.serviceName.index
+    buildFormPostRequest(path, sendData, true, app)
       .expect(500, expectedData)
-      .end(done);
-  });
+      .end(done)
+  })
 
   it('should display an error if the connection to connector fails', function (done) {
     // No connectorMock defined on purpose to mock a network failure
-    var sendData = {'service-name-input': 'Service name'};
-    var expectedData = {"message": "Internal server error"};
-    var path = paths.serviceName.index;
-    build_form_post_request(path, sendData, true, app)
+    var sendData = {'service-name-input': 'Service name'}
+    var expectedData = {'message': 'Internal server error'}
+    var path = paths.serviceName.index
+    buildFormPostRequest(path, sendData, true, app)
       .expect(500, expectedData)
-      .end(done);
-  });
+      .end(done)
+  })
 
   it('should display an error if csrf token does not exist for the update', function (done) {
-    var sendData = {'service-name-input': 'Service name'};
-    var path = paths.serviceName.index;
-    build_form_post_request(path, sendData, false, app)
-      .expect(400, {message: "There is a problem with the payments platform"})
-      .end(done);
-  });
-});
+    var sendData = {'service-name-input': 'Service name'}
+    var path = paths.serviceName.index
+    buildFormPostRequest(path, sendData, false, app)
+      .expect(400, {message: 'There is a problem with the payments platform'})
+      .end(done)
+  })
+})

--- a/test/integration/service_roles_update_ft_test.js
+++ b/test/integration/service_roles_update_ft_test.js
@@ -1,32 +1,32 @@
-let nock = require('nock');
-let session = require(__dirname + '/../test_helpers/mock_session.js');
-let getApp = require(__dirname + '/../../server.js').getApp;
-let supertest = require('supertest');
-let csrf = require('csrf');
-let userFixtures = require(__dirname + '/../fixtures/user_fixtures');
-let paths = require(__dirname + '/../../app/paths.js');
-let roles = require('../../app/utils/roles').roles;
-let chai = require('chai');
-let _ = require('lodash');
-let chaiAsPromised = require('chai-as-promised');
-let app;
+let path = require('path')
+let nock = require('nock')
+let session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+let getApp = require(path.join(__dirname, '/../../server.js')).getApp
+let supertest = require('supertest')
+let csrf = require('csrf')
+let userFixtures = require(path.join(__dirname, '/../fixtures/user_fixtures'))
+let paths = require(path.join(__dirname, '/../../app/paths.js'))
+let roles = require('../../app/utils/roles').roles
+let chai = require('chai')
+let _ = require('lodash')
+let chaiAsPromised = require('chai-as-promised')
+let app
 
-chai.use(chaiAsPromised);
+chai.use(chaiAsPromised)
 
-let expect = chai.expect;
-let adminusersMock = nock(process.env.ADMINUSERS_URL);
+let expect = chai.expect
+let adminusersMock = nock(process.env.ADMINUSERS_URL)
 
-const USER_RESOURCE = '/v1/api/users';
+const USER_RESOURCE = '/v1/api/users'
 
-const formattedPathFor = require('../../app/utils/replace_params_in_path');
+const formattedPathFor = require('../../app/utils/replace_params_in_path')
 
 describe('user permissions update controller', function () {
-
-  const EXTERNAL_SERVICE_ID = '38745gf8y';
-  const EXTERNAL_ID_IN_SESSION = '7d19aff33f8948deb97ed16b2912dcd3';
-  const USERNAME_IN_SESSION = 'existing-user';
-  const EXTERNAL_ID_TO_VIEW = '393266e872594f1593558549caad95ec';
-  const USERNAME_TO_VIEW = 'other-user';
+  const EXTERNAL_SERVICE_ID = '38745gf8y'
+  const EXTERNAL_ID_IN_SESSION = '7d19aff33f8948deb97ed16b2912dcd3'
+  const USERNAME_IN_SESSION = 'existing-user'
+  const EXTERNAL_ID_TO_VIEW = '393266e872594f1593558549caad95ec'
+  const USERNAME_TO_VIEW = 'other-user'
 
   let userInSession = session.getUser({
     external_id: EXTERNAL_ID_IN_SESSION,
@@ -37,9 +37,9 @@ describe('user permissions update controller', function () {
         name: 'System Generated',
         external_id: EXTERNAL_SERVICE_ID
       },
-      role: {name: "admin", description: 'Administrator', permissions: [{name: 'users-service:create'}]}
-    }],
-  });
+      role: {name: 'admin', description: 'Administrator', permissions: [{name: 'users-service:create'}]}
+    }]
+  })
 
   let userToView = {
     external_id: EXTERNAL_ID_TO_VIEW,
@@ -52,109 +52,101 @@ describe('user permissions update controller', function () {
       },
       role: {name: 'view-only', description: 'View only', permissions: []}
     }]
-  };
+  }
 
   afterEach((done) => {
-    nock.cleanAll();
-    app = null;
-    done();
-  });
+    nock.cleanAll()
+    app = null
+    done()
+  })
 
   describe('user permissions update view', function () {
-
     it('should render the permission update view', function (done) {
-
-      let getUserResponse = userFixtures.validUserResponse(userToView);
+      let getUserResponse = userFixtures.validUserResponse(userToView)
 
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
-        .reply(200, getUserResponse.getPlain());
+        .reply(200, getUserResponse.getPlain())
 
-      app = session.getAppWithLoggedInUser(getApp(), userInSession);
+      app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       supertest(app)
         .get(formattedPathFor(paths.teamMembers.permissions, EXTERNAL_SERVICE_ID, EXTERNAL_ID_TO_VIEW))
         .set('Accept', 'application/json')
         .expect(200)
         .expect((res) => {
-          expect(res.body.email).to.equal(userToView.email);
-          expect(res.body.editPermissionsLink).to.equal(formattedPathFor(paths.teamMembers.permissions, EXTERNAL_SERVICE_ID, EXTERNAL_ID_TO_VIEW));
-          expect(res.body.admin.id).to.equal(roles['admin'].extId);
-          expect(res.body.admin.checked).to.equal('');
-          expect(res.body.viewAndRefund.id).to.equal(roles['view-and-refund'].extId);
-          expect(res.body.viewAndRefund.checked).to.equal('');
-          expect(res.body.view.id).to.equal(roles['view-only'].extId);
-          expect(res.body.view.checked).to.equal('checked');
+          expect(res.body.email).to.equal(userToView.email)
+          expect(res.body.editPermissionsLink).to.equal(formattedPathFor(paths.teamMembers.permissions, EXTERNAL_SERVICE_ID, EXTERNAL_ID_TO_VIEW))
+          expect(res.body.admin.id).to.equal(roles['admin'].extId)
+          expect(res.body.admin.checked).to.equal('')
+          expect(res.body.viewAndRefund.id).to.equal(roles['view-and-refund'].extId)
+          expect(res.body.viewAndRefund.checked).to.equal('')
+          expect(res.body.view.id).to.equal(roles['view-only'].extId)
+          expect(res.body.view.checked).to.equal('checked')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should error if user not found', function (done) {
-
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
-        .reply(404);
+        .reply(404)
 
-      app = session.getAppWithLoggedInUser(getApp(), userInSession);
+      app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       supertest(app)
         .get(formattedPathFor(paths.teamMembers.permissions, EXTERNAL_SERVICE_ID, EXTERNAL_ID_TO_VIEW))
         .set('Accept', 'application/json')
         .expect(500)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to locate the user');
+          expect(res.body.message).to.equal('Unable to locate the user')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should error if admin does not belong to users service', function (done) {
+      let targetUser = _.cloneDeep(userToView)
+      targetUser.service_roles[0].service.external_id = 'other-service-id'
 
-      let targetUser = _.cloneDeep(userToView);
-      targetUser.service_roles[0].service.external_id = 'other-service-id';
-
-      let getUserResponse = userFixtures.validUserResponse(targetUser);
+      let getUserResponse = userFixtures.validUserResponse(targetUser)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
-        .reply(200, getUserResponse.getPlain());
+        .reply(200, getUserResponse.getPlain())
 
-      app = session.getAppWithLoggedInUser(getApp(), userInSession);
+      app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       supertest(app)
         .get(formattedPathFor(paths.teamMembers.permissions, EXTERNAL_SERVICE_ID, EXTERNAL_ID_TO_VIEW))
         .set('Accept', 'application/json')
         .expect(500)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to update permissions for this user');
+          expect(res.body.message).to.equal('Unable to update permissions for this user')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should error if user trying to update his own permissions', function (done) {
-
-      app = session.getAppWithLoggedInUser(getApp(), userInSession);
+      app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       supertest(app)
         .get(formattedPathFor(paths.teamMembers.permissions, EXTERNAL_SERVICE_ID, userInSession.externalId))
         .set('Accept', 'application/json')
         .expect(500)
         .expect((res) => {
-          expect(res.body.message).to.equal('Not allowed to update self permission');
+          expect(res.body.message).to.equal('Not allowed to update self permission')
         })
-        .end(done);
-    });
-
-  });
+        .end(done)
+    })
+  })
 
   describe('user permissions update', function () {
-
     it('should update users permission successfully', function (done) {
-
-      let getUserResponse = userFixtures.validUserResponse(userToView);
+      let getUserResponse = userFixtures.validUserResponse(userToView)
 
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
-        .reply(200, getUserResponse.getPlain());
+        .reply(200, getUserResponse.getPlain())
 
       adminusersMock.put(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}/services/${EXTERNAL_SERVICE_ID}`, {'role_name': 'admin'})
-        .reply(200, getUserResponse.getPlain());
+        .reply(200, getUserResponse.getPlain())
 
-      app = session.getAppWithLoggedInUser(getApp(), userInSession);
+      app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       supertest(app)
         .post(formattedPathFor(paths.teamMembers.permissions, EXTERNAL_SERVICE_ID, EXTERNAL_ID_TO_VIEW))
@@ -167,20 +159,19 @@ describe('user permissions update controller', function () {
         })
         .expect(303, {})
         .expect('Location', formattedPathFor(paths.teamMembers.show, EXTERNAL_SERVICE_ID, EXTERNAL_ID_TO_VIEW))
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should update users permission successfully, even if selected role is the same as existing', function (done) {
-
-      let getUserResponse = userFixtures.validUserResponse(userToView);
+      let getUserResponse = userFixtures.validUserResponse(userToView)
 
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
-        .reply(200, getUserResponse.getPlain());
+        .reply(200, getUserResponse.getPlain())
 
       adminusersMock.put(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}/services/${EXTERNAL_SERVICE_ID}`, {'role_name': 'view-only'})
-        .reply(200, getUserResponse.getPlain());
+        .reply(200, getUserResponse.getPlain())
 
-      app = session.getAppWithLoggedInUser(getApp(), userInSession);
+      app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       supertest(app)
         .post(formattedPathFor(paths.teamMembers.permissions, EXTERNAL_SERVICE_ID, EXTERNAL_ID_TO_VIEW))
@@ -188,17 +179,16 @@ describe('user permissions update controller', function () {
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .set('x-request-id', 'bob')
         .send({
-          'role-input': roles['view-only'].extId, //same as existing
+          'role-input': roles['view-only'].extId, // same as existing
           csrfToken: csrf().create('123')
         })
         .expect(303, {})
         .expect('Location', formattedPathFor(paths.teamMembers.show, EXTERNAL_SERVICE_ID, EXTERNAL_ID_TO_VIEW))
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should error if user trying to update his own permissions', function (done) {
-
-      app = session.getAppWithLoggedInUser(getApp(), userInSession);
+      app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       supertest(app)
         .post(formattedPathFor(paths.teamMembers.permissions, EXTERNAL_SERVICE_ID, userInSession.externalId))
@@ -211,17 +201,16 @@ describe('user permissions update controller', function () {
         })
         .expect(500)
         .expect((res) => {
-          expect(res.body.message).to.equal('Not allowed to update self permission');
+          expect(res.body.message).to.equal('Not allowed to update self permission')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should error if user not found', function (done) {
-
-      app = session.getAppWithLoggedInUser(getApp(), userInSession);
+      app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
-        .reply(404);
+        .reply(404)
 
       supertest(app)
         .post(formattedPathFor(paths.teamMembers.permissions, EXTERNAL_SERVICE_ID, EXTERNAL_ID_TO_VIEW))
@@ -234,21 +223,20 @@ describe('user permissions update controller', function () {
         })
         .expect(500)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to locate the user');
+          expect(res.body.message).to.equal('Unable to locate the user')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should error if admin does not belong to users service', function (done) {
+      let targetUser = _.cloneDeep(userToView)
+      targetUser.service_roles[0].service.external_id = 'other-service-id'
 
-      let targetUser = _.cloneDeep(userToView);
-      targetUser.service_roles[0].service.external_id = 'other-service-id';
-
-      let getUserResponse = userFixtures.validUserResponse(targetUser);
+      let getUserResponse = userFixtures.validUserResponse(targetUser)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
-        .reply(200, getUserResponse.getPlain());
+        .reply(200, getUserResponse.getPlain())
 
-      app = session.getAppWithLoggedInUser(getApp(), userInSession);
+      app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       supertest(app)
         .post(formattedPathFor(paths.teamMembers.permissions, EXTERNAL_SERVICE_ID, EXTERNAL_ID_TO_VIEW))
@@ -261,16 +249,15 @@ describe('user permissions update controller', function () {
         })
         .expect(500)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to update permissions for this user');
+          expect(res.body.message).to.equal('Unable to update permissions for this user')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should error if role id cannot be resolved', function (done) {
+      app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
-      app = session.getAppWithLoggedInUser(getApp(), userInSession);
-
-      let nonExistentRoleId = '999';
+      let nonExistentRoleId = '999'
       supertest(app)
         .post(formattedPathFor(paths.teamMembers.permissions, EXTERNAL_SERVICE_ID, EXTERNAL_ID_TO_VIEW))
         .set('Accept', 'application/json')
@@ -282,21 +269,20 @@ describe('user permissions update controller', function () {
         })
         .expect(500)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to update user permission');
+          expect(res.body.message).to.equal('Unable to update user permission')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should error on permission update error in adminusers', function (done) {
-
-      let getUserResponse = userFixtures.validUserResponse(userToView);
-      app = session.getAppWithLoggedInUser(getApp(), userInSession);
+      let getUserResponse = userFixtures.validUserResponse(userToView)
+      app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
-        .reply(200, getUserResponse.getPlain());
+        .reply(200, getUserResponse.getPlain())
 
       adminusersMock.put(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}/services/${EXTERNAL_SERVICE_ID}`, {'role_name': 'admin'})
-        .reply(409);
+        .reply(409)
 
       supertest(app)
         .post(formattedPathFor(paths.teamMembers.permissions, EXTERNAL_SERVICE_ID, EXTERNAL_ID_TO_VIEW))
@@ -309,11 +295,9 @@ describe('user permissions update controller', function () {
         })
         .expect(500)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to update user permission');
+          expect(res.body.message).to.equal('Unable to update user permission')
         })
-        .end(done);
-    });
-
-  });
-
-});
+        .end(done)
+    })
+  })
+})

--- a/test/integration/service_switch_ft_tests.js
+++ b/test/integration/service_switch_ft_tests.js
@@ -1,48 +1,48 @@
-let nock = require('nock');
-var proxyquire = require('proxyquire');
-var supertest = require('supertest');
-var csrf = require('csrf');
+const path = require('path')
+const nock = require('nock')
+const supertest = require('supertest')
+const csrf = require('csrf')
 
-var session = require(__dirname + '/../test_helpers/mock_session.js');
-var getApp = require(__dirname + '/../../server.js').getApp;
+const session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+const getApp = require(path.join(__dirname, '/../../server.js')).getApp
 
-let chai = require('chai');
-let chaiAsPromised = require('chai-as-promised');
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(chaiAsPromised)
+const expect = chai.expect
 
-var app;
+let app
 
 describe('service switch controller', function () {
   afterEach((done) => {
-    nock.cleanAll();
-    app = null;
-    done();
-  });
+    nock.cleanAll()
+    app = null
+    done()
+  })
 
   it('should post request for new account id', function (done) {
     let user = session.getUser({
-      gateway_account_ids: ['1','2','5']
-    });
+      gateway_account_ids: ['1', '2', '5']
+    })
     let mockGatewayAccountCookie = {
       currentGatewayAccountId: 1
-    };
-    let mockSession = session.getMockSession(user);
-    app = session.getAppWithSessionAndGatewayAccountCookies(getApp(), mockSession, mockGatewayAccountCookie);
+    }
+    let mockSession = session.getMockSession(user)
+    app = session.getAppWithSessionAndGatewayAccountCookies(getApp(), mockSession, mockGatewayAccountCookie)
 
     supertest(app)
       .post('/my-services/switch')
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/x-www-form-urlencoded')
-      .set('x-request-id','bob')
+      .set('x-request-id', 'bob')
       .send({
         gatewayAccountId: '5',
         csrfToken: csrf().create('123')
       })
       .expect(302)
       .expect(() => {
-        expect(mockGatewayAccountCookie.currentGatewayAccountId).to.equal('5');
+        expect(mockGatewayAccountCookie.currentGatewayAccountId).to.equal('5')
       })
-      .end(done);
-  });
-});
+      .end(done)
+  })
+})

--- a/test/integration/service_users_ft_test.js
+++ b/test/integration/service_users_ft_test.js
@@ -1,11 +1,11 @@
+const path = require('path')
 const nock = require('nock')
-const session = require(__dirname + '/../test_helpers/mock_session.js')
-const getApp = require(__dirname + '/../../server.js').getApp
+const session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+const getApp = require(path.join(__dirname, '/../../server.js')).getApp
 const supertest = require('supertest')
-const serviceFixtures = require(__dirname + '/../fixtures/service_fixtures')
-const userFixtures = require(__dirname + '/../fixtures/user_fixtures')
-const paths = require(__dirname + '/../../app/paths.js')
-const roles = require('../../app/utils/roles').roles
+const serviceFixtures = require(path.join(__dirname, '/../fixtures/service_fixtures'))
+const userFixtures = require(path.join(__dirname, '/../fixtures/user_fixtures'))
+const paths = require(path.join(__dirname, '/../../app/paths.js'))
 const csrf = require('csrf')
 const chai = require('chai')
 const expect = chai.expect
@@ -20,7 +20,6 @@ chai.use(chaiAsPromised)
 const formattedPathFor = require('../../app/utils/replace_params_in_path')
 
 describe('service users resource', function () {
-
   let EXTERNAL_ID_LOGGED_IN = '7d19aff33f8948deb97ed16b2912dcd3'
   let USERNAME_LOGGED_IN = 'existing-user'
   let EXTERNAL_ID_OTHER_USER = '393266e872594f1593558549caad95ec'
@@ -33,7 +32,6 @@ describe('service users resource', function () {
   })
 
   it('get list of service users should link to my profile for my user', function (done) {
-
     const externalServiceId = '734rgw76jhka'
     const serviceRoles = [{
       service: {
@@ -46,7 +44,7 @@ describe('service users resource', function () {
       external_id: EXTERNAL_ID_LOGGED_IN,
       username: USERNAME_LOGGED_IN,
       email: USERNAME_LOGGED_IN + '@example.com',
-      service_roles: serviceRoles,
+      service_roles: serviceRoles
     })
 
     const serviceUsersRes = serviceFixtures.validServiceUsersResponse([{service_roles: serviceRoles}])
@@ -75,9 +73,7 @@ describe('service users resource', function () {
       .end(done)
   })
 
-
   it('get list of service users should link to a users view details for other users', function (done) {
-
     const externalServiceId = '734rgw76jhka'
 
     const serviceRoles = [{
@@ -85,13 +81,13 @@ describe('service users resource', function () {
         name: 'System Generated',
         external_id: externalServiceId
       },
-      role: {name: 'admin', description: 'Administrator', permissions: [{name:'users-service:create'}]}
+      role: {name: 'admin', description: 'Administrator', permissions: [{name: 'users-service:create'}]}
     }]
     const user = session.getUser({
       external_id: EXTERNAL_ID_LOGGED_IN,
       username: USERNAME_LOGGED_IN,
       email: USERNAME_LOGGED_IN + '@example.com',
-      service_roles: serviceRoles,
+      service_roles: serviceRoles
     })
 
     const serviceUsersRes = serviceFixtures.validServiceUsersResponse([{
@@ -117,9 +113,8 @@ describe('service users resource', function () {
   })
 
   it('view team member details', function (done) {
-
     const externalServiceId = '734rgw76jhka'
-    const user_in_session = session.getUser({
+    const userInSession = session.getUser({
       external_id: EXTERNAL_ID_LOGGED_IN,
       username: USERNAME_LOGGED_IN,
       email: USERNAME_LOGGED_IN + '@example.com',
@@ -132,7 +127,7 @@ describe('service users resource', function () {
       }]
     })
 
-    const user_to_view = {
+    const userToView = {
       external_id: EXTERNAL_ID_OTHER_USER,
       username: USERNAME_OTHER_USER,
       service_roles: [{
@@ -141,14 +136,14 @@ describe('service users resource', function () {
           external_id: externalServiceId
         },
         role: {name: 'view-only', description: 'View only'}
-      }],
+      }]
     }
-    const getUserResponse = userFixtures.validUserResponse(user_to_view)
+    const getUserResponse = userFixtures.validUserResponse(userToView)
 
     adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_OTHER_USER}`)
       .reply(200, getUserResponse.getPlain())
 
-    app = session.getAppWithLoggedInUser(getApp(), user_in_session)
+    app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
     supertest(app)
       .get(formattedPathFor(paths.teamMembers.show, externalServiceId, EXTERNAL_ID_OTHER_USER))
@@ -165,25 +160,24 @@ describe('service users resource', function () {
   })
 
   it('should show my profile', function (done) {
-
     const user = {
       external_id: EXTERNAL_ID_LOGGED_IN,
       username: USERNAME_LOGGED_IN,
       email: USERNAME_LOGGED_IN + '@example.com',
       telephone_number: '+447876548778',
-      //TODO: fix to use serviceRoles
+      // TODO: fix to use serviceRoles
       services: [{
         name: 'System Generated',
         external_id: '8348754ihuwk'
-      }],
+      }]
     }
-    const user_in_session = session.getUser(user)
+    const userInSession = session.getUser(user)
     const getUserResponse = userFixtures.validUserResponse(user)
 
     adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_LOGGED_IN}`)
       .reply(200, getUserResponse.getPlain())
 
-    app = session.getAppWithLoggedInUser(getApp(), user_in_session)
+    app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
     supertest(app)
       .get('/my-profile')
@@ -198,25 +192,24 @@ describe('service users resource', function () {
   })
 
   it('should not show my profile without second factor', function (done) {
-
     const user = {
       external_id: EXTERNAL_ID_LOGGED_IN,
       username: USERNAME_LOGGED_IN,
       email: USERNAME_LOGGED_IN + '@example.com',
       telephone_number: '+447876548778',
-      //TODO: fix to use serviceRoles
+      // TODO: fix to use serviceRoles
       services: [{
         name: 'System Generated',
         external_id: '3894hewfui'
-      }],
+      }]
     }
-    const user_in_session = session.getUser(user)
+    const userInSession = session.getUser(user)
     const getUserResponse = userFixtures.validUserResponse(user)
 
     adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_LOGGED_IN}`)
       .reply(200, getUserResponse.getPlain())
 
-    app = session.getAppWithSessionWithoutSecondFactor(getApp(), user_in_session)
+    app = session.getAppWithSessionWithoutSecondFactor(getApp(), userInSession)
 
     supertest(app)
       .get('/my-profile')
@@ -227,13 +220,13 @@ describe('service users resource', function () {
   })
 
   it('should redirect to my profile when trying to access my user through team members path', function (done) {
-    const user_in_session = session.getUser({
+    const userInSession = session.getUser({
       permissions: [{name: 'users-service:read'}]
     })
-    const externalServiceId = user_in_session.serviceRoles[0].service.externalId
-    EXTERNAL_ID_LOGGED_IN = user_in_session.externalId
+    const externalServiceId = userInSession.serviceRoles[0].service.externalId
+    EXTERNAL_ID_LOGGED_IN = userInSession.externalId
 
-    app = session.getAppWithLoggedInUser(getApp(), user_in_session)
+    app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
     supertest(app)
       .get(formattedPathFor(paths.teamMembers.show, externalServiceId, EXTERNAL_ID_LOGGED_IN))
@@ -244,7 +237,6 @@ describe('service users resource', function () {
   })
 
   it('error when accessing an user from other service profile (cheeky!)', function (done) {
-
     const externalServiceId1 = '48753g874tg'
     const externalServiceId2 = '7huh4y7tu6g'
     const user = session.getUser({
@@ -269,12 +261,12 @@ describe('service users resource', function () {
         },
         role: {name: 'view-only', description: 'View only', permissions: [{name: 'users-service:read'}]}
       }],
-      //TODO: fix to use serviceRoles
+      // TODO: fix to use serviceRoles
 
       services: [{
         name: 'System Generated',
         external_id: externalServiceId2
-      }],
+      }]
     })
 
     adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_OTHER_USER}`)
@@ -293,19 +285,19 @@ describe('service users resource', function () {
   })
 
   it('remove a team member successfully should redirect user to team member', function (done) {
-    let user_in_session = session.getUser({
-      permissions: [{name: 'users-service:delete'}],
+    let userInSession = session.getUser({
+      permissions: [{name: 'users-service:delete'}]
     })
-    const externalServiceId = user_in_session.serviceRoles[0].service.externalId
-    EXTERNAL_ID_LOGGED_IN = user_in_session.externalId
+    const externalServiceId = userInSession.serviceRoles[0].service.externalId
+    EXTERNAL_ID_LOGGED_IN = userInSession.externalId
 
-    let user_to_delete = {
+    let userToDelete = {
       external_id: EXTERNAL_ID_OTHER_USER,
       username: USERNAME_OTHER_USER,
       role: {'name': 'view-only'}
     }
 
-    let getUserResponse = userFixtures.validUserResponse(user_to_delete)
+    let getUserResponse = userFixtures.validUserResponse(userToDelete)
 
     adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_OTHER_USER}`)
       .reply(200, getUserResponse.getPlain())
@@ -313,7 +305,7 @@ describe('service users resource', function () {
     adminusersMock.delete(`${SERVICE_RESOURCE}/${externalServiceId}/users/${EXTERNAL_ID_OTHER_USER}`)
       .reply(200)
 
-    app = session.getAppWithLoggedInUser(getApp(), user_in_session)
+    app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
     supertest(app)
       .post(formattedPathFor(paths.teamMembers.delete, externalServiceId, EXTERNAL_ID_OTHER_USER))
@@ -324,17 +316,17 @@ describe('service users resource', function () {
   })
 
   it('when remove a team member fails when user does not exist should redirect user to error view with link to view team members', function (done) {
-    let user_in_session = session.getUser({
+    let userInSession = session.getUser({
       permissions: [{name: 'users-service:delete'}]
     })
 
-    const externalServiceId = user_in_session.serviceRoles[0].service.externalId
-    EXTERNAL_ID_LOGGED_IN = user_in_session.externalId
+    const externalServiceId = userInSession.serviceRoles[0].service.externalId
+    EXTERNAL_ID_LOGGED_IN = userInSession.externalId
 
     adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_OTHER_USER}`)
       .reply(404)
 
-    app = session.getAppWithLoggedInUser(getApp(), user_in_session)
+    app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
     supertest(app)
       .post(formattedPathFor(paths.teamMembers.delete, externalServiceId, EXTERNAL_ID_OTHER_USER))

--- a/test/integration/static_controller_test.js
+++ b/test/integration/static_controller_test.js
@@ -1,19 +1,16 @@
-require(__dirname + '/../test_helpers/serialize_mock.js');
-var request     = require('supertest');
-var getApp      = require(__dirname + '/../../server.js').getApp;
-var _           = require('lodash');
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+var request = require('supertest')
+var getApp = require(path.join(__dirname, '/../../server.js')).getApp
+var _ = require('lodash')
 
 describe('static controller', function () {
-  _.each(['get','post','delete','put','patch'],function(verb){
+  _.each(['get', 'post', 'delete', 'put', 'patch'], function (verb) {
     it('should return an error page', function (done) {
-      request(getApp())
-      [verb]("/request-denied")
+      request(getApp())[verb]('/request-denied')
       .set('Accept', 'application/json')
       .expect(400)
-      .end(done);
-    });
-  });
-});
-
-
-
+      .end(done)
+    })
+  })
+})

--- a/test/integration/toggle_3ds_ft_tests.js
+++ b/test/integration/toggle_3ds_ft_tests.js
@@ -1,69 +1,69 @@
-require(__dirname + '/../test_helpers/serialize_mock.js');
-var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
-var request = require('supertest');
-var getApp = require(__dirname + '/../../server.js').getApp;
-var nock = require('nock');
-var should = require('chai').should();
-var paths = require(__dirname + '/../../app/paths.js');
-var session = require(__dirname + '/../test_helpers/mock_session.js');
-var csrf = require('csrf');
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+var userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
+var request = require('supertest')
+var getApp = require(path.join(__dirname, '/../../server.js')).getApp
+var nock = require('nock')
+var paths = require(path.join(__dirname, '/../../app/paths.js'))
+var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+var csrf = require('csrf')
 
-var ACCOUNT_ID = 182364;
+var ACCOUNT_ID = 182364
 
-var app;
+var app
 
-var requestId = 'unique-request-id';
+var requestId = 'unique-request-id'
 var aCorrelationHeader = {
   reqheaders: {'x-request-id': requestId}
-};
+}
 
-var CONNECTOR_ACCOUNT_PATH = "/v1/frontend/accounts/" + ACCOUNT_ID;
-var CONNECTOR_TOGGLE_3DS_PATH = CONNECTOR_ACCOUNT_PATH + "/3ds-toggle";
-var connectorMock = nock(process.env.CONNECTOR_URL, aCorrelationHeader);
+var CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts/' + ACCOUNT_ID
+var CONNECTOR_TOGGLE_3DS_PATH = CONNECTOR_ACCOUNT_PATH + '/3ds-toggle'
+var connectorMock = nock(process.env.CONNECTOR_URL, aCorrelationHeader)
 
-function build_get_request(path, app) {
+function buildGetRequest (path, app) {
   return request(app)
     .get(path)
     .set('Accept', 'application/json')
-    .set('x-request-id',requestId);
+    .set('x-request-id', requestId)
 }
 
-function build_form_post_request(path, sendData, sendCSRF, app) {
-  sendCSRF = (sendCSRF === undefined) ? true : sendCSRF;
+function buildFormPostRequest (path, sendData, sendCSRF, app) {
+  sendCSRF = (sendCSRF === undefined) ? true : sendCSRF
   if (sendCSRF) {
-    sendData.csrfToken = csrf().create('123');
+    sendData.csrfToken = csrf().create('123')
   }
   return request(app)
     .post(path)
     .set('Accept', 'application/json')
     .set('Content-Type', 'application/x-www-form-urlencoded')
-    .set('x-request-id',requestId)
-    .send(sendData);
+    .set('x-request-id', requestId)
+    .send(sendData)
 }
 
 describe('The 3D Secure index endpoint', function () {
   afterEach(function () {
-    nock.cleanAll();
-    app = null;
-  });
+    nock.cleanAll()
+    app = null
+  })
 
   beforeEach(function (done) {
-    let permissions = 'toggle-3ds:read';
+    let permissions = 'toggle-3ds:read'
     var user = session.getUser({
       gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
-    });
-    app = session.getAppWithLoggedInUser(getApp(), user);
+    })
+    app = session.getAppWithLoggedInUser(getApp(), user)
 
-    userCreator.mockUserResponse(user.toJson(), done);
-  });
+    userCreator.mockUserResponse(user.toJson(), done)
+  })
 
   it('should not support 3D Secure for payment providers that are not Worldpay', function (done) {
     connectorMock.get(CONNECTOR_ACCOUNT_PATH)
       .times(2)
       .reply(200, {
-        "payment_provider": "sandbox",
-        "requires3ds": false
-      });
+        'payment_provider': 'sandbox',
+        'requires3ds': false
+      })
 
     var expectedData = {
       supports3ds: false,
@@ -74,22 +74,22 @@ describe('The 3D Secure index endpoint', function () {
       },
       navigation: true,
       currentGatewayAccount: {
-        "payment_provider": "sandbox",
-        "requires3ds": false
+        'payment_provider': 'sandbox',
+        'requires3ds': false
       }
-    };
+    }
 
-    build_get_request(paths.toggle3ds.index, app)
+    buildGetRequest(paths.toggle3ds.index, app)
       .expect(200, expectedData)
-      .end(done);
-   });
+      .end(done)
+  })
 
   it('should display if 3D Secure is on', function (done) {
     connectorMock.get(CONNECTOR_ACCOUNT_PATH)
       .reply(200, {
-        "payment_provider": "worldpay",
-        "requires3ds": true
-      });
+        'payment_provider': 'worldpay',
+        'requires3ds': true
+      })
 
     var expectedData = {
       supports3ds: true,
@@ -100,23 +100,23 @@ describe('The 3D Secure index endpoint', function () {
       },
       navigation: true,
       currentGatewayAccount: {
-        "payment_provider": "worldpay",
-        "requires3ds": true
+        'payment_provider': 'worldpay',
+        'requires3ds': true
       }
-    };
+    }
 
-    build_get_request(paths.toggle3ds.index, app)
+    buildGetRequest(paths.toggle3ds.index, app)
       .expect(200, expectedData)
-      .end(done);
-  });
+      .end(done)
+  })
 
   it('should display if 3D Secure is on and has just been toggled', function (done) {
     connectorMock.get(CONNECTOR_ACCOUNT_PATH)
       .times(2)
       .reply(200, {
-        "payment_provider": "worldpay",
-        "requires3ds": true
-      });
+        'payment_provider': 'worldpay',
+        'requires3ds': true
+      })
 
     var expectedData = {
       supports3ds: true,
@@ -127,224 +127,219 @@ describe('The 3D Secure index endpoint', function () {
       },
       navigation: true,
       currentGatewayAccount: {
-        "payment_provider": "worldpay",
-        "requires3ds": true
+        'payment_provider': 'worldpay',
+        'requires3ds': true
       }
-    };
+    }
 
-    build_get_request(paths.toggle3ds.index + '?toggled', app)
+    buildGetRequest(paths.toggle3ds.index + '?toggled', app)
       .expect(200, expectedData)
-      .end(done);
-  });
+      .end(done)
+  })
 
-   it('should display if 3D Secure is off', function (done) {
-     connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+  it('should display if 3D Secure is off', function (done) {
+    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
        .reply(200, {
-         "payment_provider": "worldpay",
-         "requires3ds": false
-       });
+         'payment_provider': 'worldpay',
+         'requires3ds': false
+       })
 
-     var expectedData = {
-       supports3ds: true,
-       requires3ds: false,
-       justToggled: false,
-       permissions: {
-         'toggle_3ds_read': true
-       },
-       navigation: true,
-       currentGatewayAccount: {
-         "payment_provider": "worldpay",
-         "requires3ds": false
-       }
-     };
+    var expectedData = {
+      supports3ds: true,
+      requires3ds: false,
+      justToggled: false,
+      permissions: {
+        'toggle_3ds_read': true
+      },
+      navigation: true,
+      currentGatewayAccount: {
+        'payment_provider': 'worldpay',
+        'requires3ds': false
+      }
+    }
 
-     build_get_request(paths.toggle3ds.index, app)
+    buildGetRequest(paths.toggle3ds.index, app)
        .expect(200, expectedData)
-       .end(done);
-   });
+       .end(done)
+  })
 
-   it('should display if 3D Secure is off and has just been toggled', function (done) {
-     connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+  it('should display if 3D Secure is off and has just been toggled', function (done) {
+    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
        .reply(200, {
-         "payment_provider": "worldpay",
-         "requires3ds": false
-       });
+         'payment_provider': 'worldpay',
+         'requires3ds': false
+       })
 
-     var expectedData = {
-       supports3ds: true,
-       requires3ds: false,
-       justToggled: true,
-       permissions: {
-         'toggle_3ds_read': true
-       },
-       navigation: true,
-       currentGatewayAccount: {
-         "payment_provider": "worldpay",
-         "requires3ds": false
-       }
-     };
+    var expectedData = {
+      supports3ds: true,
+      requires3ds: false,
+      justToggled: true,
+      permissions: {
+        'toggle_3ds_read': true
+      },
+      navigation: true,
+      currentGatewayAccount: {
+        'payment_provider': 'worldpay',
+        'requires3ds': false
+      }
+    }
 
-     build_get_request(paths.toggle3ds.index + '?toggled', app)
+    buildGetRequest(paths.toggle3ds.index + '?toggled', app)
        .expect(200, expectedData)
-       .end(done);
-   });
+       .end(done)
+  })
 
   it('should display an error if the account does not exist', function (done) {
     connectorMock.get(CONNECTOR_ACCOUNT_PATH)
       .reply(404, {
-        "message": "The gateway account id '" + ACCOUNT_ID + "' does not exist"
-      });
+        'message': "The gateway account id '" + ACCOUNT_ID + "' does not exist"
+      })
 
-    build_get_request(paths.toggle3ds.index, app)
-      .expect(500, {"message": "Unable to retrieve the 3D Secure setting."})
-      .end(done);
-  });
+    buildGetRequest(paths.toggle3ds.index, app)
+      .expect(500, {'message': 'Unable to retrieve the 3D Secure setting.'})
+      .end(done)
+  })
 
   it('should display an error if connector returns any other error', function (done) {
     connectorMock.get(CONNECTOR_ACCOUNT_PATH)
       .reply(999, {
-        "message": "Some error in Connector"
-      });
+        'message': 'Some error in Connector'
+      })
 
-    build_get_request(paths.toggle3ds.index, app)
-      .expect(500, {"message": "Unable to retrieve the 3D Secure setting."})
-      .end(done);
-  });
+    buildGetRequest(paths.toggle3ds.index, app)
+      .expect(500, {'message': 'Unable to retrieve the 3D Secure setting.'})
+      .end(done)
+  })
 
   it('should display an error if the connection to connector fails', function (done) {
     // No connectorMock defined on purpose to mock a network failure
-    build_get_request(paths.toggle3ds.index, app)
-      .expect(500, {"message": "Unable to retrieve the 3D Secure setting."})
-      .end(done);
-  });
-});
+    buildGetRequest(paths.toggle3ds.index, app)
+      .expect(500, {'message': 'Unable to retrieve the 3D Secure setting.'})
+      .end(done)
+  })
+})
 
 describe('The turn on 3D Secure endpoint', function () {
-
   afterEach(function () {
-    nock.cleanAll();
-    app = null;
-  });
+    nock.cleanAll()
+    app = null
+  })
 
   beforeEach(function (done) {
-    let permissions = 'toggle-3ds:update';
+    let permissions = 'toggle-3ds:update'
     var user = session.getUser({
       gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
-    });
-    app = session.getAppWithLoggedInUser(getApp(), user);
+    })
+    app = session.getAppWithLoggedInUser(getApp(), user)
 
-    userCreator.mockUserResponse(user.toJson(), done);
-  });
+    userCreator.mockUserResponse(user.toJson(), done)
+  })
 
   it('should tell connector to turn on 3D Secure', function (done) {
-    connectorMock.patch(CONNECTOR_TOGGLE_3DS_PATH, {"toggle_3ds": true})
-      .reply(200, {});
+    connectorMock.patch(CONNECTOR_TOGGLE_3DS_PATH, {'toggle_3ds': true})
+      .reply(200, {})
 
-    build_form_post_request(paths.toggle3ds.on, {}, true, app)
+    buildFormPostRequest(paths.toggle3ds.on, {}, true, app)
       .expect(303, {})
       .expect('Location', paths.toggle3ds.index + '?toggled')
-      .end(done);
-  });
+      .end(done)
+  })
 
   it('should display an error if connector returns failure', function (done) {
-    connectorMock.patch(CONNECTOR_TOGGLE_3DS_PATH, {"toggle_3ds": true})
+    connectorMock.patch(CONNECTOR_TOGGLE_3DS_PATH, {'toggle_3ds': true})
       .reply(999, {
-        "message": "Error message"
-      });
+        'message': 'Error message'
+      })
 
-    build_form_post_request(paths.toggle3ds.on, {}, true, app)
-      .expect(500, {"message": "Unable to toggle 3D Secure."})
-      .end(done);
-  });
+    buildFormPostRequest(paths.toggle3ds.on, {}, true, app)
+      .expect(500, {'message': 'Unable to toggle 3D Secure.'})
+      .end(done)
+  })
 
   it('should display an error if the connection to connector fails', function (done) {
     // No connectorMock defined on purpose to mock a network failure
-    build_form_post_request(paths.toggle3ds.on, {}, true, app)
-      .expect(500, {"message": "Unable to toggle 3D Secure."})
-      .end(done);
-  });
+    buildFormPostRequest(paths.toggle3ds.on, {}, true, app)
+      .expect(500, {'message': 'Unable to toggle 3D Secure.'})
+      .end(done)
+  })
 
   it('should display an error if CSRF token does not exist', function (done) {
-    build_form_post_request(paths.toggle3ds.on, {}, false, app)
-      .expect(400, {message: "There is a problem with the payments platform"})
-      .end(done);
-  });
-});
+    buildFormPostRequest(paths.toggle3ds.on, {}, false, app)
+      .expect(400, {message: 'There is a problem with the payments platform'})
+      .end(done)
+  })
+})
 
 describe('The turn off 3D Secure endpoint', function () {
-
   afterEach(function () {
-    nock.cleanAll();
-    app = null;
-  });
+    nock.cleanAll()
+    app = null
+  })
 
   beforeEach(function (done) {
-    let permissions = 'toggle-3ds:update';
+    let permissions = 'toggle-3ds:update'
     var user = session.getUser({
       gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
-    });
-    app = session.getAppWithLoggedInUser(getApp(), user);
+    })
+    app = session.getAppWithLoggedInUser(getApp(), user)
 
-    userCreator.mockUserResponse(user.toJson(), done);
-  });
+    userCreator.mockUserResponse(user.toJson(), done)
+  })
 
   it('should tell connector to turn off 3D Secure', function (done) {
-    connectorMock.patch(CONNECTOR_TOGGLE_3DS_PATH, {"toggle_3ds": false})
-      .reply(200, {});
+    connectorMock.patch(CONNECTOR_TOGGLE_3DS_PATH, {'toggle_3ds': false})
+      .reply(200, {})
 
-    build_form_post_request(paths.toggle3ds.off, {}, true, app)
+    buildFormPostRequest(paths.toggle3ds.off, {}, true, app)
       .expect(303, {})
       .expect('Location', paths.toggle3ds.index + '?toggled')
-      .end(done);
-  });
+      .end(done)
+  })
 
   it('should display an error if connector returns failure', function (done) {
-    connectorMock.patch(CONNECTOR_TOGGLE_3DS_PATH, {"toggle_3ds": false})
+    connectorMock.patch(CONNECTOR_TOGGLE_3DS_PATH, {'toggle_3ds': false})
       .reply(999, {
-        "message": "Error message"
-      });
+        'message': 'Error message'
+      })
 
-    build_form_post_request(paths.toggle3ds.off, {}, true, app)
-      .expect(500, {"message": "Unable to toggle 3D Secure."})
-      .end(done);
-  });
+    buildFormPostRequest(paths.toggle3ds.off, {}, true, app)
+      .expect(500, {'message': 'Unable to toggle 3D Secure.'})
+      .end(done)
+  })
 
   it('should display an error if the connection to connector fails', function (done) {
     // No connectorMock defined on purpose to mock a network failure
-    build_form_post_request(paths.toggle3ds.off, {}, true, app)
-      .expect(500, {"message": "Unable to toggle 3D Secure."})
-      .end(done);
-  });
+    buildFormPostRequest(paths.toggle3ds.off, {}, true, app)
+      .expect(500, {'message': 'Unable to toggle 3D Secure.'})
+      .end(done)
+  })
 
   it('should display an error if CSRF token does not exist', function (done) {
-    build_form_post_request(paths.toggle3ds.off, {}, false, app)
-      .expect(400, {message: "There is a problem with the payments platform"})
-      .end(done);
-  });
-
-});
+    buildFormPostRequest(paths.toggle3ds.off, {}, false, app)
+      .expect(400, {message: 'There is a problem with the payments platform'})
+      .end(done)
+  })
+})
 
 describe('The confirm that you want to turn on 3D Secure endpoint', function () {
-
   afterEach(function () {
-    nock.cleanAll();
-    app = null;
-  });
+    nock.cleanAll()
+    app = null
+  })
 
   beforeEach(function (done) {
-    let permissions = 'toggle-3ds:update';
+    let permissions = 'toggle-3ds:update'
     var user = session.getUser({
       gateway_account_ids: [ACCOUNT_ID], permissions: [permissions]
-    });
-    app = session.getAppWithLoggedInUser(getApp(), user);
+    })
+    app = session.getAppWithLoggedInUser(getApp(), user)
 
-    userCreator.mockUserResponse(user.toJson(), done);
-  });
+    userCreator.mockUserResponse(user.toJson(), done)
+  })
 
   it('should display an error if CSRF token does not exist', function (done) {
-    build_form_post_request(paths.toggle3ds.onConfirm, {}, false, app)
-      .expect(400, {message: "There is a problem with the payments platform"})
-      .end(done);
-  });
-
-});
+    buildFormPostRequest(paths.toggle3ds.onConfirm, {}, false, app)
+      .expect(400, {message: 'There is a problem with the payments platform'})
+      .end(done)
+  })
+})

--- a/test/integration/transaction_details_ft_tests.js
+++ b/test/integration/transaction_details_ft_tests.js
@@ -1,62 +1,59 @@
-var request     = require('supertest');
-var nock        = require('nock');
-var _        = require('lodash');
+var path = require('path')
+var request = require('supertest')
+var nock = require('nock')
+var _ = require('lodash')
 
-require(__dirname + '/../test_helpers/serialize_mock.js');
-var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
-var getApp        = require(__dirname + '/../../server.js').getApp;
-var paths       = require(__dirname + '/../../app/paths.js');
-var session     = require(__dirname + '/../test_helpers/mock_session.js');
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+var userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
+var getApp = require(path.join(__dirname, '/../../server.js')).getApp
+var paths = require(path.join(__dirname, '/../../app/paths.js'))
+var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
 
-var gatewayAccountId = 15486734;
+var gatewayAccountId = 15486734
 
-var app;
-var chargeId = 452345;
+var app
 
-var CONNECTOR_CHARGE_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges/{chargeId}';
-var connectorMock = nock(process.env.CONNECTOR_URL);
+var CONNECTOR_CHARGE_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges/{chargeId}'
+var connectorMock = nock(process.env.CONNECTOR_URL)
 
-function connectorMock_responds(path, data) {
+function connectorMockResponds (path, data) {
   return connectorMock.get(path)
-    .reply(200, data);
+    .reply(200, data)
 }
 
-function when_getTransactionHistory(chargeId, baseApp) {
+function whenGetTransactionHistory (chargeId, baseApp) {
   return request(baseApp)
     .get(paths.generateRoute(paths.transactions.show, {chargeId: chargeId}))
-    .set('Accept', 'application/json');
+    .set('Accept', 'application/json')
 }
 
-function connectorChargePathFor(chargeId) {
-  return CONNECTOR_CHARGE_PATH.replace('{chargeId}', chargeId);
+function connectorChargePathFor (chargeId) {
+  return CONNECTOR_CHARGE_PATH.replace('{chargeId}', chargeId)
 }
 
-function asTemplate(data) {
-  return _.merge(data, {navigation: true});
+function asTemplate (data) {
+  return _.merge(data, {navigation: true})
 }
 
 describe('The transaction view scenarios', function () {
-
   afterEach(function () {
-    nock.cleanAll();
-    app = null;
-  });
+    nock.cleanAll()
+    app = null
+  })
 
   beforeEach(function (done) {
-    let permissions = 'transactions-details:read';
+    let permissions = 'transactions-details:read'
     var user = session.getUser({
       gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
-    });
-    app = session.getAppWithLoggedInUser(getApp(), user);
+    })
+    app = session.getAppWithLoggedInUser(getApp(), user)
 
-    userCreator.mockUserResponse(user.toJson(), done);
-  });
-
+    userCreator.mockUserResponse(user.toJson(), done)
+  })
 
   describe('The transaction history endpoint', function () {
-
     it('should return a list of transaction history for a given charge id', function (done) {
-      var chargeId = 452345;
+      var chargeId = 452345
       var mockEventsResponse = {
         'charge_id': chargeId,
         'events': [
@@ -100,7 +97,7 @@ describe('The transaction view scenarios', function () {
             'updated': '2015-12-24 12:05:43'
           }
         ]
-      };
+      }
 
       var mockChargeResponse = {
         'charge_id': chargeId,
@@ -145,8 +142,8 @@ describe('The transaction view scenarios', function () {
             'method': 'GET',
             'href': 'http://frontend/charges/1?chargeTokenId=82347'
           }
-        ],
-      };
+        ]
+      }
 
       var expectedEventsView = asTemplate({
         'charge_id': chargeId,
@@ -194,9 +191,9 @@ describe('The transaction view scenarios', function () {
               'message': 'Payment was cancelled by the user',
               'code': 'P0030'
             },
-            "state_friendly": "User failed to complete payment of £50.00",
-            "updated": "2015-12-24 12:05:43",
-            "updated_friendly": "24 Dec 2015 — 12:05:43",
+            'state_friendly': 'User failed to complete payment of £50.00',
+            'updated': '2015-12-24 12:05:43',
+            'updated_friendly': '24 Dec 2015 — 12:05:43'
           },
           {
             'state': {
@@ -205,18 +202,18 @@ describe('The transaction view scenarios', function () {
               'message': 'Payment was cancelled by the service',
               'code': 'P0040'
             },
-            "state_friendly": "Service cancelled payment of £50.00",
-            "updated": "2015-12-24 12:05:43",
-            "updated_friendly": "24 Dec 2015 — 12:05:43"
+            'state_friendly': 'Service cancelled payment of £50.00',
+            'updated': '2015-12-24 12:05:43',
+            'updated_friendly': '24 Dec 2015 — 12:05:43'
           },
           {
             'state': {
               'status': 'success',
               'finished': true
             },
-            "state_friendly": "Payment of £50.00 succeeded",
-            "updated": "2015-12-24 12:05:43",
-            "updated_friendly": "24 Dec 2015 — 12:05:43"
+            'state_friendly': 'Payment of £50.00 succeeded',
+            'updated': '2015-12-24 12:05:43',
+            'updated_friendly': '24 Dec 2015 — 12:05:43'
           },
           {
             'state': {
@@ -237,21 +234,21 @@ describe('The transaction view scenarios', function () {
             'updated_friendly': '24 Dec 2015 — 13:21:05'
           }
         ],
-        "permissions": {
-          "transactions_details_read": true
+        'permissions': {
+          'transactions_details_read': true
         }
-      });
+      })
 
-      connectorMock_responds(connectorChargePathFor(chargeId), mockChargeResponse);
-      connectorMock_responds('/v1/api/accounts/' + gatewayAccountId + '/charges/' + chargeId + '/events', mockEventsResponse);
+      connectorMockResponds(connectorChargePathFor(chargeId), mockChargeResponse)
+      connectorMockResponds('/v1/api/accounts/' + gatewayAccountId + '/charges/' + chargeId + '/events', mockEventsResponse)
 
-      when_getTransactionHistory(chargeId, app)
+      whenGetTransactionHistory(chargeId, app)
         .expect(200, expectedEventsView)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should show a transaction when no card details are present', function (done) {
-      var chargeId = 452345;
+      var chargeId = 452345
       var mockEventsResponse = {
         'charge_id': chargeId,
         'events': [
@@ -270,7 +267,7 @@ describe('The transaction view scenarios', function () {
             'updated': '2015-12-24 13:23:12'
           }
         ]
-      };
+      }
 
       var mockChargeResponse = {
         'charge_id': chargeId,
@@ -303,7 +300,7 @@ describe('The transaction view scenarios', function () {
             'href': 'http://frontend/charges/1?chargeTokenId=82347'
           }
         ]
-      };
+      }
 
       var expectedEventsView = asTemplate({
         'charge_id': chargeId,
@@ -311,7 +308,7 @@ describe('The transaction view scenarios', function () {
         'reference': 'Ref-1234',
         'email': 'alice.111@mail.fake',
         'refundable': true,
-        'net_amount': "50.00",
+        'net_amount': '50.00',
         'net_amount_display': '£50.00',
         'refunded_amount': '£0.00',
         'refunded': false,
@@ -356,21 +353,21 @@ describe('The transaction view scenarios', function () {
             'updated_friendly': '24 Dec 2015 — 13:21:05'
           }
         ],
-        "permissions": {
-          "transactions_details_read": true
+        'permissions': {
+          'transactions_details_read': true
         }
-      });
+      })
 
-      connectorMock_responds(connectorChargePathFor(chargeId), mockChargeResponse);
-      connectorMock_responds('/v1/api/accounts/' + gatewayAccountId + '/charges/' + chargeId + '/events', mockEventsResponse);
+      connectorMockResponds(connectorChargePathFor(chargeId), mockChargeResponse)
+      connectorMockResponds('/v1/api/accounts/' + gatewayAccountId + '/charges/' + chargeId + '/events', mockEventsResponse)
 
-      when_getTransactionHistory(chargeId, app)
+      whenGetTransactionHistory(chargeId, app)
         .expect(200, expectedEventsView)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should show a transaction when legacy cards details are present', function (done) {
-      var chargeId = 452345;
+      var chargeId = 452345
       var mockEventsResponse = {
         'charge_id': chargeId,
         'events': [
@@ -389,7 +386,7 @@ describe('The transaction view scenarios', function () {
             'updated': '2015-12-24 13:23:12'
           }
         ]
-      };
+      }
 
       var mockChargeResponse = {
         'charge_id': chargeId,
@@ -429,7 +426,7 @@ describe('The transaction view scenarios', function () {
             'href': 'http://frontend/charges/1?chargeTokenId=82347'
           }
         ]
-      };
+      }
 
       var expectedEventsView = asTemplate({
         'charge_id': chargeId,
@@ -437,7 +434,7 @@ describe('The transaction view scenarios', function () {
         'reference': 'Ref-1234',
         'email': 'alice.111@mail.fake',
         'refundable': true,
-        'net_amount': "50.00",
+        'net_amount': '50.00',
         'net_amount_display': '£50.00',
         'refunded_amount': '£0.00',
         'refunded': false,
@@ -483,22 +480,21 @@ describe('The transaction view scenarios', function () {
             'updated_friendly': '24 Dec 2015 — 13:21:05'
           }
         ],
-        "permissions": {
-          "transactions_details_read": true
+        'permissions': {
+          'transactions_details_read': true
         }
-      });
+      })
 
-      connectorMock_responds(connectorChargePathFor(chargeId), mockChargeResponse);
-      connectorMock_responds('/v1/api/accounts/' + gatewayAccountId + '/charges/' + chargeId + '/events', mockEventsResponse);
+      connectorMockResponds(connectorChargePathFor(chargeId), mockChargeResponse)
+      connectorMockResponds('/v1/api/accounts/' + gatewayAccountId + '/charges/' + chargeId + '/events', mockEventsResponse)
 
-      when_getTransactionHistory(chargeId, app)
+      whenGetTransactionHistory(chargeId, app)
         .expect(200, expectedEventsView)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return a list of transaction history for a given charge id and show refunded', function (done) {
-
-      var chargeWithRefund = 12345;
+      var chargeWithRefund = 12345
       var mockEventsResponse = {
         'charge_id': chargeWithRefund,
         'events': [
@@ -542,7 +538,7 @@ describe('The transaction view scenarios', function () {
             'updated': '2015-12-24 12:05:43'
           }
         ]
-      };
+      }
 
       var mockChargeResponse = {
         'charge_id': chargeWithRefund,
@@ -587,8 +583,8 @@ describe('The transaction view scenarios', function () {
             'method': 'GET',
             'href': 'http://frontend/charges/1?chargeTokenId=82347'
           }
-        ],
-      };
+        ]
+      }
 
       var expectedEventsView = asTemplate({
         'charge_id': chargeWithRefund,
@@ -636,9 +632,9 @@ describe('The transaction view scenarios', function () {
               'message': 'Payment was cancelled by the user',
               'code': 'P0030'
             },
-            "state_friendly": "User failed to complete payment of £50.00",
-            "updated": "2015-12-24 12:05:43",
-            "updated_friendly": "24 Dec 2015 — 12:05:43",
+            'state_friendly': 'User failed to complete payment of £50.00',
+            'updated': '2015-12-24 12:05:43',
+            'updated_friendly': '24 Dec 2015 — 12:05:43'
           },
           {
             'state': {
@@ -647,18 +643,18 @@ describe('The transaction view scenarios', function () {
               'message': 'Payment was cancelled by the service',
               'code': 'P0040'
             },
-            "state_friendly": "Service cancelled payment of £50.00",
-            "updated": "2015-12-24 12:05:43",
-            "updated_friendly": "24 Dec 2015 — 12:05:43"
+            'state_friendly': 'Service cancelled payment of £50.00',
+            'updated': '2015-12-24 12:05:43',
+            'updated_friendly': '24 Dec 2015 — 12:05:43'
           },
           {
             'state': {
               'status': 'success',
               'finished': true
             },
-            "state_friendly": "Payment of £50.00 succeeded",
-            "updated": "2015-12-24 12:05:43",
-            "updated_friendly": "24 Dec 2015 — 12:05:43"
+            'state_friendly': 'Payment of £50.00 succeeded',
+            'updated': '2015-12-24 12:05:43',
+            'updated_friendly': '24 Dec 2015 — 12:05:43'
           },
           {
             'state': {
@@ -679,47 +675,47 @@ describe('The transaction view scenarios', function () {
             'updated_friendly': '24 Dec 2015 — 13:21:05'
           }
         ],
-        "permissions": {
-          "transactions_details_read": true
+        'permissions': {
+          'transactions_details_read': true
         }
-      });
+      })
 
-      var events = '/v1/api/accounts/' + gatewayAccountId + '/charges/' + chargeWithRefund + '/events';
-      connectorMock_responds(connectorChargePathFor(chargeWithRefund), mockChargeResponse);
-      connectorMock_responds(events, mockEventsResponse);
+      var events = '/v1/api/accounts/' + gatewayAccountId + '/charges/' + chargeWithRefund + '/events'
+      connectorMockResponds(connectorChargePathFor(chargeWithRefund), mockChargeResponse)
+      connectorMockResponds(events, mockEventsResponse)
 
-      when_getTransactionHistory(chargeWithRefund, app)
+      whenGetTransactionHistory(chargeWithRefund, app)
         .expect(200, expectedEventsView)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return charge not found if a non existing charge id requested', function (done) {
-      var nonExistentChargeId = 888;
-      var connectorError = {'message': 'Charge not found'};
+      var nonExistentChargeId = 888
+      var connectorError = {'message': 'Charge not found'}
       connectorMock.get(connectorChargePathFor(nonExistentChargeId))
-        .reply(404, connectorError);
+        .reply(404, connectorError)
 
-      when_getTransactionHistory(nonExistentChargeId, app)
+      whenGetTransactionHistory(nonExistentChargeId, app)
         .expect(500, connectorError)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return a generic if connector responds with an error', function (done) {
-      var nonExistentChargeId = 888;
-      var connectorError = {'message': 'Internal server error'};
+      var nonExistentChargeId = 888
+      var connectorError = {'message': 'Internal server error'}
       connectorMock.get(connectorChargePathFor(nonExistentChargeId))
-        .reply(500, connectorError);
+        .reply(500, connectorError)
 
-      when_getTransactionHistory(nonExistentChargeId, app)
+      whenGetTransactionHistory(nonExistentChargeId, app)
         .expect(500, {'message': 'Error processing transaction view'})
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should return a generic if unable to communicate with connector', function (done) {
-      var chargeId = 452345;
-      when_getTransactionHistory(chargeId, app)
+      var chargeId = 452345
+      whenGetTransactionHistory(chargeId, app)
         .expect(500, {'message': 'Error processing transaction view'})
-        .end(done);
-    });
-  });
-});
+        .end(done)
+    })
+  })
+})

--- a/test/integration/transaction_details_refunds_ft_tests.js
+++ b/test/integration/transaction_details_refunds_ft_tests.js
@@ -1,52 +1,51 @@
-var request = require('supertest');
-var nock = require('nock');
-var csrf = require('csrf');
-var getApp = require(__dirname + '/../../server.js').getApp;
-var winston = require('winston');
-var paths = require(__dirname + '/../../app/paths.js');
-var session = require(__dirname + '/../test_helpers/mock_session.js');
-var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
+var path = require('path')
+var request = require('supertest')
+var nock = require('nock')
+var csrf = require('csrf')
+var getApp = require(path.join(__dirname, '/../../server.js')).getApp
+var paths = require(path.join(__dirname, '/../../app/paths.js'))
+var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+var userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
 
-var ACCOUNT_ID = 15486734;
-var app;
-var connectorMock = nock(process.env.CONNECTOR_URL);
+var ACCOUNT_ID = 15486734
+var app
+var connectorMock = nock(process.env.CONNECTOR_URL)
 
 describe('The transaction view - refund scenarios', function () {
-
   afterEach(function () {
-    nock.cleanAll();
-    app = null;
-  });
+    nock.cleanAll()
+    app = null
+  })
 
   beforeEach(function (done) {
-    let permissions = 'refunds:create';
+    let permissions = 'refunds:create'
     var user = session.getUser({
       gateway_account_ids: [ACCOUNT_ID], permissions: [{name: permissions}]
-    });
-    app = session.getAppWithLoggedInUser(getApp(), user);
+    })
+    app = session.getAppWithLoggedInUser(getApp(), user)
 
-    userCreator.mockUserResponse(user.toJson(), done);
-  });
+    userCreator.mockUserResponse(user.toJson(), done)
+  })
 
   // known FP issue with node, it cannot mulitply 19.90 by 100 accurately
   it('should redirect to transaction view after issuing a refund of £19.90', function (done) {
-    var chargeWithRefund = 12345;
+    var chargeWithRefund = 12345
     var expectedRefundRequestToConnector = {
       'amount': 1990,
       'refund_amount_available': 5000
-    };
+    }
     var mockRefundResponse = {
       'refund_id': 'Just looking the status code of the response at the moment'
-    };
+    }
 
     connectorMock.post('/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeWithRefund + '/refunds', expectedRefundRequestToConnector)
-      .reply(202, mockRefundResponse);
+      .reply(202, mockRefundResponse)
 
     var viewFormData = {
       'refund-amount': '19.90',
       'refund-amount-available-in-pence': '5000',
       'csrfToken': csrf().create('123')
-    };
+    }
 
     request(app)
       .post(paths.generateRoute(paths.transactions.refund, {chargeId: chargeWithRefund}))
@@ -54,27 +53,27 @@ describe('The transaction view - refund scenarios', function () {
       .send(viewFormData)
       .expect(302)
       .expect('Location', '/transactions/' + chargeWithRefund)
-      .end(done);
-  });
+      .end(done)
+  })
 
   it('should redirect to transaction view after issuing a refund of £10 (no pence)', function (done) {
-    var chargeWithRefund = 12345;
+    var chargeWithRefund = 12345
     var expectedRefundRequestToConnector = {
       'amount': 1000,
       'refund_amount_available': 5000
-    };
+    }
     var mockRefundResponse = {
       'refund_id': 'Just looking the status code of the response at the moment'
-    };
+    }
 
     connectorMock.post('/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeWithRefund + '/refunds', expectedRefundRequestToConnector)
-      .reply(202, mockRefundResponse);
+      .reply(202, mockRefundResponse)
 
     var viewFormData = {
       'refund-amount': '10',
       'refund-amount-available-in-pence': '5000',
       'csrfToken': csrf().create('123')
-    };
+    }
 
     request(app)
       .post(paths.generateRoute(paths.transactions.refund, {chargeId: chargeWithRefund}))
@@ -82,167 +81,164 @@ describe('The transaction view - refund scenarios', function () {
       .send(viewFormData)
       .expect(302)
       .expect('Location', '/transactions/' + chargeWithRefund)
-      .end(done);
-  });
+      .end(done)
+  })
 
   it('should redirect to error view issuing a refund for amount that does not look like pounds and pence', function (done) {
-    var chargeId = 12345;
+    var chargeId = 12345
 
     var viewFormData = {
       'refund-amount': '1.9',
       'refund-amount-available-in-pence': '5000',
       'csrfToken': csrf().create('123')
-    };
+    }
 
     request(app)
       .post(paths.generateRoute(paths.transactions.refund, {chargeId: chargeId}))
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .set('Accept', 'application/json')
       .send(viewFormData)
-      .expect(500, {"message": "Can't do refund: amount must be pounds (10) or pounds and pence (10.10)"})
-      .end(done);
-  });
+      .expect(500, {'message': "Can't do refund: amount must be pounds (10) or pounds and pence (10.10)"})
+      .end(done)
+  })
 
   it('should redirect to error view issuing a refund when amount is not available for refund', function (done) {
-    var chargeId = 12345;
+    var chargeId = 12345
     var expectedRefundRequestToConnector = {
       'amount': 99999,
       'refund_amount_available': 5000
-    };
+    }
     var mockRefundResponse = {
       'reason': 'amount_not_available'
-    };
+    }
 
     connectorMock.post('/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeId + '/refunds', expectedRefundRequestToConnector)
-      .reply(400, mockRefundResponse);
+      .reply(400, mockRefundResponse)
 
     var viewFormData = {
       'refund-amount': '999.99',
       'refund-amount-available-in-pence': '5000',
       'csrfToken': csrf().create('123')
-    };
+    }
 
     request(app)
       .post(paths.generateRoute(paths.transactions.refund, {chargeId: chargeId}))
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .set('Accept', 'application/json')
       .send(viewFormData)
-      .expect(500, {"message": "Can't do refund: The requested amount is bigger than the amount available for refund"})
-      .end(done);
-  });
+      .expect(500, {'message': "Can't do refund: The requested amount is bigger than the amount available for refund"})
+      .end(done)
+  })
 
   it('should redirect to error view issuing a refund when amount is less than the minimum accepted for a refund', function (done) {
-
-    var chargeId = 12345;
+    var chargeId = 12345
     var expectedRefundRequestToConnector = {
       'amount': 0,
       'refund_amount_available': 5000
-    };
+    }
     var mockRefundResponse = {
       'reason': 'amount_min_validation'
-    };
+    }
 
     connectorMock.post('/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeId + '/refunds', expectedRefundRequestToConnector)
-      .reply(400, mockRefundResponse);
+      .reply(400, mockRefundResponse)
 
     var viewFormData = {
       'refund-amount': '0',
       'refund-amount-available-in-pence': '5000',
       'csrfToken': csrf().create('123')
-    };
+    }
 
     request(app)
       .post(paths.generateRoute(paths.transactions.refund, {chargeId: chargeId}))
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .set('Accept', 'application/json')
       .send(viewFormData)
-      .expect(500, {"message": "Can't do refund: The requested amount is less than the minimum accepted for issuing a refund for this charge"})
-      .end(done);
-  });
+      .expect(500, {'message': "Can't do refund: The requested amount is less than the minimum accepted for issuing a refund for this charge"})
+      .end(done)
+  })
 
   it('should redirect to error view issuing a refund when refund amount has been fully refunded', function (done) {
-
-    var chargeId = 12345;
+    var chargeId = 12345
     var expectedRefundRequestToConnector = {
       'amount': 1000,
       'refund_amount_available': 0
-    };
+    }
     var mockRefundResponse = {
       'reason': 'full'
-    };
+    }
 
     connectorMock.post('/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeId + '/refunds', expectedRefundRequestToConnector)
-      .reply(400, mockRefundResponse);
+      .reply(400, mockRefundResponse)
 
     var viewFormData = {
       'refund-amount': '10',
       'refund-amount-available-in-pence': '000',
       'csrfToken': csrf().create('123')
-    };
+    }
 
     request(app)
       .post(paths.generateRoute(paths.transactions.refund, {chargeId: chargeId}))
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .set('Accept', 'application/json')
       .send(viewFormData)
-      .expect(500, {"message": "Can't do refund: This charge has been already fully refunded"})
-      .end(done);
-  });
+      .expect(500, {'message': "Can't do refund: This charge has been already fully refunded"})
+      .end(done)
+  })
 
   it('should redirect to error view when unexpected error issuing a refund', function (done) {
-
-    var chargeId = 12345;
+    var chargeId = 12345
     var expectedRefundRequestToConnector = {
       'amount': 1000,
       'refund_amount_available': 5000
-    };
+    }
     var mockRefundResponse = {
       'message': 'what happeneeed!'
-    };
+    }
 
     connectorMock.post('/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeId + '/refunds', expectedRefundRequestToConnector)
-      .reply(400, mockRefundResponse);
+      .reply(400, mockRefundResponse)
 
     var viewFormData = {
       'refund-amount': '10',
       'refund-amount-available-in-pence': '5000',
       'csrfToken': csrf().create('123')
-    };
+    }
 
     request(app)
       .post(paths.generateRoute(paths.transactions.refund, {chargeId: chargeId}))
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .set('Accept', 'application/json')
       .send(viewFormData)
-      .expect(500, {"message": "Can't process refund"})
-      .end(done);
-  });
+      .expect(500, {'message': "Can't process refund"})
+      .end(done)
+  })
 
   it('should redirect to error view if connector returns a 412 error code when issuing a refund', function (done) {
-    var chargeId = 12345;
+    var chargeId = 12345
     var expectedRefundRequestToConnector = {
       'amount': 1000,
       'refund_amount_available': 5000
-    };
+    }
     var mockRefundResponse = {
       'message': 'Precondition Failed!'
-    };
+    }
 
     connectorMock.post('/v1/api/accounts/' + ACCOUNT_ID + '/charges/' + chargeId + '/refunds', expectedRefundRequestToConnector)
-      .reply(412, mockRefundResponse);
+      .reply(412, mockRefundResponse)
 
     var viewFormData = {
       'refund-amount': '10',
       'refund-amount-available-in-pence': '5000',
       'csrfToken': csrf().create('123')
-    };
+    }
 
     request(app)
       .post(paths.generateRoute(paths.transactions.refund, {chargeId: chargeId}))
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .set('Accept', 'application/json')
       .send(viewFormData)
-      .expect(500, {"message": "Refund failed. This refund request has already been submitted."})
-      .end(done);
-  });
-});
+      .expect(500, {'message': 'Refund failed. This refund request has already been submitted.'})
+      .end(done)
+  })
+})

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -1,170 +1,164 @@
-process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk';
-require(__dirname + '/../test_helpers/serialize_mock.js');
-var userCreator = require(__dirname + '/../test_helpers/user_creator.js');
-var request = require('supertest');
-var nock = require('nock');
-var _ = require('lodash');
-var getApp = require(__dirname + '/../../server.js').getApp;
-var querystring = require('querystring');
-var paths = require(__dirname + '/../../app/paths.js');
-var session = require(__dirname + '/../test_helpers/mock_session.js');
-var assert = require('chai').assert;
-var expect = require('chai').expect;
+var path = require('path')
+process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+var userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
+var request = require('supertest')
+var nock = require('nock')
+var _ = require('lodash')
+var getApp = require(path.join(__dirname, '/../../server.js')).getApp
+var querystring = require('querystring')
+var paths = require(path.join(__dirname, '/../../app/paths.js'))
+var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+var assert = require('chai').assert
+var expect = require('chai').expect
 
-var gatewayAccountId = 651342;
-var app;
+var gatewayAccountId = 651342
+var app
 
-var CHARGES_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges';
-var connectorMock = nock(process.env.CONNECTOR_URL);
+var CHARGES_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges'
+var connectorMock = nock(process.env.CONNECTOR_URL)
 
-function connectorMock_responds(code, data, searchParameters) {
-  var queryStr = '?';
+function connectorMockResponds (code, data, searchParameters) {
+  var queryStr = '?'
   queryStr += 'reference=' + (searchParameters.reference ? searchParameters.reference : '') +
     '&email=' + (searchParameters.email ? searchParameters.email : '') +
     '&state=' + (searchParameters.state ? searchParameters.state : '') +
     '&card_brand=' + (searchParameters.brand ? searchParameters.brand : '') +
     '&from_date=' + (searchParameters.fromDate ? searchParameters.fromDate : '') +
     '&to_date=' + (searchParameters.toDate ? searchParameters.toDate : '') +
-    '&page=' + (searchParameters.page ? searchParameters.page : "1") +
-    '&display_size=' + (searchParameters.pageSize ? searchParameters.pageSize : "100");
+    '&page=' + (searchParameters.page ? searchParameters.page : '1') +
+    '&display_size=' + (searchParameters.pageSize ? searchParameters.pageSize : '100')
   return connectorMock.get(CHARGES_API_PATH + queryStr)
-    .reply(code, data);
+    .reply(code, data)
 }
 
-function download_transaction_list(query) {
+function downloadTransactionList (query) {
   return request(app)
-    .get(paths.transactions.download + "?" + querystring.stringify(query))
-    .set('Accept', 'application/json');
+    .get(paths.transactions.download + '?' + querystring.stringify(query))
+    .set('Accept', 'application/json')
 }
 
 describe('Transaction download endpoints', function () {
-
   afterEach(function () {
-    nock.cleanAll();
-    app = null;
-  });
+    nock.cleanAll()
+    app = null
+  })
 
   beforeEach(function (done) {
-    let permissions = 'transactions-download:read';
+    let permissions = 'transactions-download:read'
     var user = session.getUser({
       gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
-    });
-    app = session.getAppWithLoggedInUser(getApp(), user);
+    })
+    app = session.getAppWithLoggedInUser(getApp(), user)
 
-    userCreator.mockUserResponse(user.toJson(), done);
-  });
+    userCreator.mockUserResponse(user.toJson(), done)
+  })
 
   describe('The /transactions/download endpoint', function () {
-
     it('should download a csv file comprising a list of transactions for the gateway account', function (done) {
+      var results = require('./json/transaction_download.json')
 
-        var results = require('./json/transaction_download.json');
-
-        mockJson = {
+      var mockJson = {
         results: results,
         _links: {
           next_page: {href: 'http://localhost:8000/bar'}
         }
-      };
+      }
 
-      var secondPageMock = nock("http://localhost:8000");
-      var secondResults = _.cloneDeep(results);
-      secondResults[0].amount = 1234;
-      secondResults[1].amount = 123;
+      var secondPageMock = nock('http://localhost:8000')
+      var secondResults = _.cloneDeep(results)
+      secondResults[0].amount = 1234
+      secondResults[1].amount = 123
 
-      secondPageMock.get("/bar")
+      secondPageMock.get('/bar')
         .reply(200, {
-          results: secondResults,
-        });
+          results: secondResults
+        })
 
-      connectorMock_responds(200, mockJson, {});
+      connectorMockResponds(200, mockJson, {})
 
-      download_transaction_list()
+      downloadTransactionList()
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
         .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
         .expect(function (res) {
-          var csvContent = res.text;
-          var arrayOfLines = csvContent.split("\n");
-          assert(5, arrayOfLines.length);
-          assert.equal('"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"', arrayOfLines[1]);
-          assert.equal('"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","canceled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"', arrayOfLines[2]);
+          var csvContent = res.text
+          var arrayOfLines = csvContent.split('\n')
+          assert(5, arrayOfLines.length)
+          assert.equal('"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"', arrayOfLines[1])
+          assert.equal('"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","canceled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"', arrayOfLines[2])
         })
         .end(function (err, res) {
-          if (err) return done(err);
-          var csvContent = res.text;
-          var arrayOfLines = csvContent.split("\n");
-          expect(arrayOfLines.length).to.equal(5);
-          expect(arrayOfLines[0]).to.equal('"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Date Created"');
-          expect(arrayOfLines[1]).to.equal('"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"');
-          expect(arrayOfLines[2]).to.equal('"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","canceled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"');
-          expect(arrayOfLines[3]).to.equal('"red","desc-red","alice.111@mail.fake","12.34","Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"');
-          expect(arrayOfLines[4]).to.equal('"blue","desc-blue","alice.222@mail.fake","1.23","Mastercard","TEST02","12/19","4241","canceled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"');
+          if (err) return done(err)
+          var csvContent = res.text
+          var arrayOfLines = csvContent.split('\n')
+          expect(arrayOfLines.length).to.equal(5)
+          expect(arrayOfLines[0]).to.equal('"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Date Created"')
+          expect(arrayOfLines[1]).to.equal('"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"')
+          expect(arrayOfLines[2]).to.equal('"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","canceled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"')
+          expect(arrayOfLines[3]).to.equal('"red","desc-red","alice.111@mail.fake","12.34","Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"')
+          expect(arrayOfLines[4]).to.equal('"blue","desc-blue","alice.222@mail.fake","1.23","Mastercard","TEST02","12/19","4241","canceled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"')
           done()
-        });
-    });
+        })
+    })
 
       // @see https://payments-platform.atlassian.net/browse/PP-2254
-      it('should download a csv file comprising a list of transactions and preventing Spreadsheet Formula Injection', function (done) {
+    it('should download a csv file comprising a list of transactions and preventing Spreadsheet Formula Injection', function (done) {
+      var results = require('./json/transaction_download_spreadsheet_formula_injection.json')
 
-          var results = require('./json/transaction_download_spreadsheet_formula_injection.json');
+      var mockJson = {
+        results: results,
+        _links: {
+          next_page: {href: 'http://localhost:8000/bar'}
+        }
+      }
 
-          mockJson = {
-              results: results,
-              _links: {
-                  next_page: {href: 'http://localhost:8000/bar'}
-              }
-          };
+      var secondPageMock = nock('http://localhost:8000')
 
-          var secondPageMock = nock("http://localhost:8000");
-
-          secondPageMock.get("/bar")
+      secondPageMock.get('/bar')
               .reply(200, {
-                  results: results,
-              });
+                results: results
+              })
 
-          connectorMock_responds(200, mockJson, {});
+      connectorMockResponds(200, mockJson, {})
 
-          download_transaction_list()
+      downloadTransactionList()
               .expect(200)
               .expect('Content-Type', 'text/csv; charset=utf-8')
               .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
               .end(function (err, res) {
-                  if (err) return done(err);
-                  var csvContent = res.text;
-                  var arrayOfLines = csvContent.split("\n");
-                  expect(arrayOfLines[0]).to.equal('"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Date Created"');
-                  expect(arrayOfLines[1]).to.equal('"\'+red","\'=calc+z!A0","\'-alice.111@mail.fake","123.45","\'@Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"');
-                  done()
-              });
-      });
+                if (err) return done(err)
+                var csvContent = res.text
+                var arrayOfLines = csvContent.split('\n')
+                expect(arrayOfLines[0]).to.equal('"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Date Created"')
+                expect(arrayOfLines[1]).to.equal('"\'+red","\'=calc+z!A0","\'-alice.111@mail.fake","123.45","\'@Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"')
+                done()
+              })
+    })
 
     it('should show error message on a bad request', function (done) {
+      var errorMessage = 'Unable to download list of transactions.'
+      connectorMockResponds(400, {'message': errorMessage}, {})
 
-      var errorMessage = 'Unable to download list of transactions.';
-      connectorMock_responds(400, {'message': errorMessage}, {});
-
-      download_transaction_list()
+      downloadTransactionList()
         .expect(500, {'message': 'Internal server error'})
-        .end(done);
-
-    });
+        .end(done)
+    })
 
     it('should show a generic error message on a connector service error.', function (done) {
+      connectorMockResponds(500, {'message': 'some error from connector'}, {})
 
-      connectorMock_responds(500, {'message': 'some error from connector'}, {});
-
-      download_transaction_list()
+      downloadTransactionList()
         .expect(500, {'message': 'Internal server error'})
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should show internal error message if any error happens while retrieving the list from connector', function (done) {
       // No connectorMock defined on purpose to mock a network failure
 
-      download_transaction_list()
+      downloadTransactionList()
         .expect(500, {'message': 'Internal server error'})
-        .end(done);
-    });
-  });
-});
+        .end(done)
+    })
+  })
+})

--- a/test/integration/validate_invite_controller_ft_tests.js
+++ b/test/integration/validate_invite_controller_ft_tests.js
@@ -1,51 +1,48 @@
-'use strict';
+'use strict'
 
-const nock = require('nock');
-const supertest = require('supertest');
-const paths = require(__dirname + '/../../app/paths.js');
-const getApp = require(__dirname + '/../../server.js').getApp;
-const session = require(__dirname + '/../test_helpers/mock_session.js');
-const inviteFixtures = require(__dirname + '/../fixtures/invite_fixtures');
-const userFixtures = require(__dirname + '/../fixtures/user_fixtures');
-const csrf = require('csrf');
+const path = require('path')
+const nock = require('nock')
+const supertest = require('supertest')
+const paths = require(path.join(__dirname, '/../../app/paths.js'))
+const getApp = require(path.join(__dirname, '/../../server.js')).getApp
+const session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+const inviteFixtures = require(path.join(__dirname, '/../fixtures/invite_fixtures'))
+const csrf = require('csrf')
 
-const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
-chai.use(chaiAsPromised);
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(chaiAsPromised)
 
-const adminusersMock = nock(process.env.ADMINUSERS_URL);
-const INVITE_RESOURCE_PATH = '/v1/api/invites';
-const expect = chai.expect;
+const adminusersMock = nock(process.env.ADMINUSERS_URL)
+const INVITE_RESOURCE_PATH = '/v1/api/invites'
+const expect = chai.expect
 
-let app;
-let mockRegisterAccountCookie;
+let app
+let mockRegisterAccountCookie
 
 describe('register user controller', function () {
-
   beforeEach((done) => {
-    mockRegisterAccountCookie = {};
-    app = session.getAppWithRegisterInvitesCookie(getApp(), mockRegisterAccountCookie);
-    done();
-  });
+    mockRegisterAccountCookie = {}
+    app = session.getAppWithRegisterInvitesCookie(getApp(), mockRegisterAccountCookie)
+    done()
+  })
 
   afterEach((done) => {
-    nock.cleanAll();
-    app = null;
-    done();
-  });
+    nock.cleanAll()
+    app = null
+    done()
+  })
 
   /**
    *  ENDPOINT validateInvite
    */
   describe('verify invitation endpoint', function () {
-
     it('should redirect to register view on a valid invite code for user', function (done) {
-
-      const code = '23rer87t8shjkaf';
-      const validInviteResponse = inviteFixtures.validInviteResponse().getPlain();
+      const code = '23rer87t8shjkaf'
+      const validInviteResponse = inviteFixtures.validInviteResponse().getPlain()
 
       adminusersMock.get(`${INVITE_RESOURCE_PATH}/${code}`)
-        .reply(200, validInviteResponse);
+        .reply(200, validInviteResponse)
 
       supertest(app)
         .get(`/invites/${code}`)
@@ -53,26 +50,24 @@ describe('register user controller', function () {
         .expect(302)
         .expect('Location', paths.registerUser.registration)
         .expect(() => {
-          expect(mockRegisterAccountCookie.code).to.equal(code);
-          expect(mockRegisterAccountCookie.email).to.equal(validInviteResponse.email);
+          expect(mockRegisterAccountCookie.code).to.equal(code)
+          expect(mockRegisterAccountCookie.email).to.equal(validInviteResponse.email)
         })
-        .end(done);
-
-    });
+        .end(done)
+    })
 
     it('should redirect to register view on a valid invite code for service', function (done) {
-
-      const code = '23rer87t8shjkaf';
-      const type = 'service';
-      const telephoneNumber = '07562327123';
+      const code = '23rer87t8shjkaf'
+      const type = 'service'
+      const telephoneNumber = '07562327123'
       const opts = {
         type,
         telephone_number: telephoneNumber
-      };
-      const validInviteResponse = inviteFixtures.validInviteResponse(opts).getPlain();
+      }
+      const validInviteResponse = inviteFixtures.validInviteResponse(opts).getPlain()
 
       adminusersMock.get(`${INVITE_RESOURCE_PATH}/${code}`)
-        .reply(200, validInviteResponse);
+        .reply(200, validInviteResponse)
 
       supertest(app)
         .get(`/invites/${code}`)
@@ -80,21 +75,19 @@ describe('register user controller', function () {
         .expect(302)
         .expect('Location', paths.selfCreateService.otpVerify)
         .expect(() => {
-          expect(mockRegisterAccountCookie.code).to.equal(code);
-          expect(mockRegisterAccountCookie.telephone_number).to.equal(telephoneNumber);
+          expect(mockRegisterAccountCookie.code).to.equal(code)
+          expect(mockRegisterAccountCookie.telephone_number).to.equal(telephoneNumber)
         })
-        .end(done);
-
-    });
+        .end(done)
+    })
 
     it('should redirect to register with telephone number, if user did not complete previous attempt after entering registration details', function (done) {
-
-      const code = '7s8ftgw76rwgu';
-      const telephoneNumber = '123456789';
-      const validInviteResponse = inviteFixtures.validInviteResponse({telephone_number: telephoneNumber}).getPlain();
+      const code = '7s8ftgw76rwgu'
+      const telephoneNumber = '123456789'
+      const validInviteResponse = inviteFixtures.validInviteResponse({telephone_number: telephoneNumber}).getPlain()
 
       adminusersMock.get(`${INVITE_RESOURCE_PATH}/${code}`)
-        .reply(200, validInviteResponse);
+        .reply(200, validInviteResponse)
 
       supertest(app)
         .get(`/invites/${code}`)
@@ -102,19 +95,17 @@ describe('register user controller', function () {
         .expect(302)
         .expect('Location', paths.registerUser.registration)
         .expect(() => {
-          expect(mockRegisterAccountCookie.code).to.equal(code);
-          expect(mockRegisterAccountCookie.email).to.equal(validInviteResponse.email);
-          expect(mockRegisterAccountCookie.telephone_number).to.equal(telephoneNumber);
+          expect(mockRegisterAccountCookie.code).to.equal(code)
+          expect(mockRegisterAccountCookie.email).to.equal(validInviteResponse.email)
+          expect(mockRegisterAccountCookie.telephone_number).to.equal(telephoneNumber)
         })
-        .end(done);
-
-    });
+        .end(done)
+    })
 
     it('should error if the invite code is invalid', function (done) {
-
-      const invalidCode = 'invalidCode';
+      const invalidCode = 'invalidCode'
       adminusersMock.get(`${INVITE_RESOURCE_PATH}/${invalidCode}`)
-        .reply(404);
+        .reply(404)
 
       supertest(app)
         .get(`/invites/${invalidCode}`)
@@ -122,23 +113,19 @@ describe('register user controller', function () {
         .set('x-request-id', 'bob')
         .expect(404)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time');
+          expect(res.body.message).to.equal('Unable to process registration at this time')
         })
-        .end(done);
-
-    });
-  });
-
+        .end(done)
+    })
+  })
 
   /**
    *  ENDPOINT showRegistration
    */
   describe('show registration view endpoint', function () {
-
     it('should display create account form', function (done) {
-
-      mockRegisterAccountCookie.email = 'invitee@example.com';
-      mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf';
+      mockRegisterAccountCookie.email = 'invitee@example.com'
+      mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
 
       supertest(app)
         .get(paths.registerUser.registration)
@@ -146,17 +133,15 @@ describe('register user controller', function () {
         .set('x-request-id', 'bob')
         .expect(200)
         .expect((res) => {
-          expect(res.body.email).to.equal('invitee@example.com');
+          expect(res.body.email).to.equal('invitee@example.com')
         })
-        .end(done);
-
-    });
+        .end(done)
+    })
 
     it('should display create account form with telephone populated, if invite has been attempted', function (done) {
-
-      mockRegisterAccountCookie.email = 'invitee@example.com';
-      mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf';
-      mockRegisterAccountCookie.telephone_number = '123456789';
+      mockRegisterAccountCookie.email = 'invitee@example.com'
+      mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
+      mockRegisterAccountCookie.telephone_number = '123456789'
 
       supertest(app)
         .get(paths.registerUser.registration)
@@ -164,12 +149,11 @@ describe('register user controller', function () {
         .set('x-request-id', 'bob')
         .expect(200)
         .expect((res) => {
-          expect(res.body.email).to.equal('invitee@example.com');
-          expect(res.body.telephone_number).to.equal('123456789');
+          expect(res.body.email).to.equal('invitee@example.com')
+          expect(res.body.telephone_number).to.equal('123456789')
         })
-        .end(done);
-
-    });
+        .end(done)
+    })
 
     it('should display error when email and/or code is not in the cookie', function (done) {
       supertest(app)
@@ -178,20 +162,18 @@ describe('register user controller', function () {
         .set('x-request-id', 'bob')
         .expect(404)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time');
+          expect(res.body.message).to.equal('Unable to process registration at this time')
         })
-        .end(done);
-    });
-  });
+        .end(done)
+    })
+  })
 
   /**
    *  ENDPOINT submitRegistration
    */
 
   describe('submit registration details endpoint', function () {
-
     it('should error if cookie details are missing', function (done) {
-
       supertest(app)
         .post(paths.registerUser.registration)
         .set('Accept', 'application/json')
@@ -202,18 +184,16 @@ describe('register user controller', function () {
         })
         .expect(404)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time');
+          expect(res.body.message).to.equal('Unable to process registration at this time')
         })
-        .end(done);
-
-    });
+        .end(done)
+    })
 
     it('should redirect back to registration form if error in phone number', function (done) {
+      mockRegisterAccountCookie.email = 'invitee@example.com'
+      mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
 
-      mockRegisterAccountCookie.email = 'invitee@example.com';
-      mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf';
-
-      const invalidPhone = '123456789';
+      const invalidPhone = '123456789'
       supertest(app)
         .post(paths.registerUser.registration)
         .set('Accept', 'application/json')
@@ -227,19 +207,17 @@ describe('register user controller', function () {
         .expect(303, {})
         .expect('Location', paths.registerUser.registration)
         .expect((res) => {
-          expect(mockRegisterAccountCookie.telephone_number).to.equal(invalidPhone);
+          expect(mockRegisterAccountCookie.telephone_number).to.equal(invalidPhone)
         })
-        .end(done);
-
-    });
+        .end(done)
+    })
 
     it('should redirect to phone verification page', function (done) {
-
-      mockRegisterAccountCookie.email = 'invitee@example.com';
-      mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf';
+      mockRegisterAccountCookie.email = 'invitee@example.com'
+      mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
 
       adminusersMock.post(`${INVITE_RESOURCE_PATH}/otp/generate`)
-        .reply(200);
+        .reply(200)
 
       supertest(app)
         .post(paths.registerUser.registration)
@@ -253,17 +231,15 @@ describe('register user controller', function () {
         })
         .expect(303, {})
         .expect('Location', paths.registerUser.otpVerify)
-        .end(done);
-
-    });
+        .end(done)
+    })
 
     it('should error for valid registration data, if code not found', function (done) {
-
-      mockRegisterAccountCookie.email = 'invitee@example.com';
-      mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf';
+      mockRegisterAccountCookie.email = 'invitee@example.com'
+      mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
 
       adminusersMock.post(`${INVITE_RESOURCE_PATH}/otp/generate`)
-        .reply(404);
+        .reply(404)
 
       supertest(app)
         .post(paths.registerUser.registration)
@@ -277,11 +253,9 @@ describe('register user controller', function () {
         })
         .expect(404)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time');
+          expect(res.body.message).to.equal('Unable to process registration at this time')
         })
-        .end(done);
-
-    });
-
-  });
-});
+        .end(done)
+    })
+  })
+})


### PR DESCRIPTION
## WHAT
Enables standard linter on test/integration directory, and all linting errors were either automatically or hand fixed.

## HOW 
Clone, npm install and run 'npm test' or 'npm run lint'.


