### PR TITLE
PP-2001 - correct error styling for forms

### DIFF
--- a/app/assets/sass/gov-uk-overrides/_forms.scss
+++ b/app/assets/sass/gov-uk-overrides/_forms.scss
@@ -36,11 +36,12 @@ textarea {
 
 .form-group {
   &.error {
+    margin-right: 15px;
     padding-left: 10px;
-    border-left: 4px solid $red;
+    border-left: 4px solid $error-colour;
 
     input {
-      border: 4px solid $red;
+      border: 4px solid $error-colour;
     }
   }
 }


### PR DESCRIPTION
We weren't styling up form errors correctly, now we are. 

(also fixed lint issues in the file) the meaningful change is at lines 37-46