### PR TITLE
PP-1615 Handle obsolete invites

### DIFF
--- a/app/controllers/invite_validation_controller.js
+++ b/app/controllers/invite_validation_controller.js
@@ -67,14 +67,17 @@ module.exports = {
         const redirectTarget = invite.user_exist ? paths.registerUser.subscribeService : paths.registerUser.registration
         res.redirect(302, redirectTarget)
       } else if (invite.type === 'service') {
-        serviceRegistrationService.generateServiceInviteOtpCode(code, correlationId)
-          .then(() => {
-            const redirectTarget = paths.selfCreateService.otpVerify
-            res.redirect(302, redirectTarget)
-          })
-          .catch((err) => {
-            handleError(req, res, err)
-          })
+        if (invite.user_exist) {
+          res.redirect(302, paths.serviceSwitcher.index)
+        } else {
+          serviceRegistrationService.generateServiceInviteOtpCode(code, correlationId)
+            .then(() => {
+              res.redirect(302, paths.selfCreateService.otpVerify)
+            })
+            .catch((err) => {
+              handleError(req, res, err)
+            })
+        }
       } else {
         handleError(req, res, 'Unrecognised invite type')
       }

--- a/test/fixtures/invite_fixtures.js
+++ b/test/fixtures/invite_fixtures.js
@@ -38,11 +38,13 @@ module.exports = {
     const invitee = 'random@example.com'
     const type = 'user'
     const disabled = opts.disabled === true
+    const userExist = opts.user_exist === true
 
     const data = {
       email: opts.email || invitee,
       type: opts.type || type,
-      disabled
+      disabled,
+      user_exist: userExist
     }
 
     if (opts.telephone_number) {


### PR DESCRIPTION
## WHAT

Handle obsolete invites in case:
  1. `User1` created `service` invite, but haven't applied it.
  2. `User2` created `user` invite by inviting `User1` into existing service.
  3. `User1` used the `user` invite from point `2` and then also used the initial invite from point `1`.

In that case we need to redirect to "My services" page.
