### PR TITLE
PP-1708 - Updated update service name implementation to use service service

### DIFF
--- a/app/controllers/register_service_controller.js
+++ b/app/controllers/register_service_controller.js
@@ -8,6 +8,7 @@ const _ = require('lodash')
 const paths = require('../paths')
 const response = require('../utils/response')
 const errorResponse = response.renderErrorView
+const serviceService = require('../services/service_service')
 const registrationService = require('../services/service_registration_service')
 const loginController = require('../controllers/login_controller')
 const {validateServiceRegistrationInputs, validateRegistrationTelephoneNumber, validateServiceNamingInputs} = require('../utils/registration_validations')
@@ -230,7 +231,7 @@ module.exports = {
 
     return validateServiceNamingInputs(serviceName)
       .then(() => {
-        return registrationService.updateServiceName(req.user.serviceRoles[0].service.externalId, serviceName, correlationId)
+        return serviceService.updateServiceName(req.user.serviceRoles[0].service.externalId, serviceName, correlationId)
       })
       .then((updatedService) => {
         _.unset(req, 'session.pageData.submitYourServiceName')

--- a/app/services/service_registration_service.js
+++ b/app/services/service_registration_service.js
@@ -85,16 +85,5 @@ module.exports = {
    */
   resendOtpCode: function (code, phoneNumber, correlationId) {
     return getAdminUsersClient({correlationId}).resendOtpCode(code, phoneNumber)
-  },
-
-  /**
-   * Update service name
-   *
-   * @param serviceId
-   * @param serviceName
-   * @param correlationId
-   */
-  updateServiceName: function (serviceId, serviceName, correlationId) {
-    return getAdminUsersClient({correlationId}).updateServiceName(serviceId, serviceName)
   }
 }

--- a/app/services/service_service.js
+++ b/app/services/service_service.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const q = require('q')
+const lodash = require('lodash')
 const getAdminUsersClient = require('./clients/adminusers_client')
 const {ConnectorClient} = require('../services/clients/connector_client')
 const GatewayAccount = require('../models/GatewayAccount.class')
@@ -47,7 +48,7 @@ function updateServiceName (serviceExternalId, serviceName, correlationId) {
 
   return getAdminUsersClient({correlationId}).updateServiceName(serviceExternalId, serviceName)
     .then(result => {
-      const gatewayAccountIds = result.gateway_account_ids || []
+      const gatewayAccountIds = lodash.get(result, 'gateway_account_ids', [])
       // Update gateway account service names
       if (gatewayAccountIds.length > 0) {
         return q.all([].concat(gatewayAccountIds).map(gatewayAccountId => {


### PR DESCRIPTION
# PP-1708 - Updated update service name implementation to use service service

## WHAT
* removed `registrationService.updateServiceName` in favour of `serviceService.updateServiceName`
* altered tests

## WHY
`serviceService.updateServiceName` is more generic and also additionally updates the serviceName of each gateway account that belongs to the service in question


