### PR TITLE
PP-2392 Fix service name when creating gateway accounts

### DIFF
--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -276,13 +276,13 @@ ConnectorClient.prototype = {
    *
    * @param paymentProvider
    * @param type
-   * @param description
+   * @param serviceName
    * @param analyticsId
    * @param correlationId
    *
    * @returns {*|Constructor|promise}
    */
-  createGatewayAccount: function (paymentProvider, type, description, analyticsId, correlationId) {
+  createGatewayAccount: function (paymentProvider, type, serviceName, analyticsId, correlationId) {
     const url = this.connectorUrl + ACCOUNTS_API_PATH
     const defer = q.defer()
     const startTime = new Date()
@@ -306,8 +306,8 @@ ConnectorClient.prototype = {
     if (type) {
       params.payload.type = type
     }
-    if (description) {
-      params.payload.description = description
+    if (serviceName) {
+      params.payload.service_name = serviceName
     }
     if (analyticsId) {
       params.payload.analytics_id = analyticsId

--- a/test/fixtures/gateway_account_fixtures.js
+++ b/test/fixtures/gateway_account_fixtures.js
@@ -35,7 +35,7 @@ module.exports = {
   validCreateGatewayAccountRequest: (opts = {}) => {
     const data = {
       payment_provider: opts.payment_provider || 'sandbox',
-      description: opts.description || 'This is an account for the GOV.UK Pay team',
+      service_name: opts.service_name || 'This is an account for the GOV.UK Pay team',
       analytics_id: opts.analytics_id || 'PAY-GA-123',
       type: opts.type || 'test'
     }

--- a/test/unit/clients/connector_client/connector_client_create_gateway_account_test.js
+++ b/test/unit/clients/connector_client/connector_client_create_gateway_account_test.js
@@ -73,7 +73,7 @@ describe('connector client - create gateway account', function () {
         connectorClient.createGatewayAccount(
           createGatewayAccount.payment_provider,
           createGatewayAccount.type,
-          createGatewayAccount.description,
+          createGatewayAccount.service_name,
           createGatewayAccount.analytics_id
         ).should.be.fulfilled.should.notify(done)
       })
@@ -113,7 +113,7 @@ describe('connector client - create gateway account', function () {
         connectorClient.createGatewayAccount(
           createGatewayAccount.payment_provider,
           createGatewayAccount.type,
-          createGatewayAccount.description,
+          createGatewayAccount.service_name,
           createGatewayAccount.analytics_id
         ).should.be.rejected.then(function (response) {
           expect(response.errorCode).to.equal(400)


### PR DESCRIPTION
It was using `description` field which we do not use. Service name however, is more important and must be set when creating a gateway account.
