### PR TITLE
PP-2454 Redirect Logged In users to root page

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -10,7 +10,7 @@ const paths = require('./paths.js')
 const CORRELATION_HEADER = require('./utils/correlation_header').CORRELATION_HEADER
 
 // - Middleware
-const {lockOutDisabledUsers, enforceUserAuthenticated, enforceUserFirstFactor} = require('./services/auth_service')
+const {lockOutDisabledUsers, enforceUserAuthenticated, enforceUserFirstFactor, redirectLoggedInUser} = require('./services/auth_service')
 const {validateAndRefreshCsrf, ensureSessionHasCsrfSecret} = require('./middleware/csrf')
 const getEmailNotification = require('./middleware/get_email_notification')
 const getAccount = require('./middleware/get_gateway_account')
@@ -89,7 +89,7 @@ module.exports.bind = function (app) {
   app.get(registerUser.logUserIn, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, loginCtrl.loginAfterRegister, enforceUserAuthenticated, hasServices, resolveService, getAccount, loginCtrl.loggedIn)
 
   // LOGIN
-  app.get(user.logIn, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, loginCtrl.logInGet)
+  app.get(user.logIn, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, redirectLoggedInUser, loginCtrl.logInGet)
   app.post(user.logIn, validateAndRefreshCsrf, trimUsername, loginCtrl.logUserin, getAccount, loginCtrl.postLogin)
   app.get(user.loggedIn, enforceUserAuthenticated, validateAndRefreshCsrf, hasServices, resolveService, getAccount, loginCtrl.loggedIn)
   app.get(user.noAccess, loginCtrl.noAccess)

--- a/app/services/auth_service.js
+++ b/app/services/auth_service.js
@@ -26,7 +26,8 @@ module.exports = {
   localDirectStrategy,
   noAccess,
   getCurrentGatewayAccountId,
-  setSessionVersion
+  setSessionVersion,
+  redirectLoggedInUser
 }
 
 // Middleware
@@ -72,6 +73,13 @@ function enforceUserAuthenticated (req, res, next) {
     return redirectToLogin(req, res)
   }
   enforceUserBothFactors(req, res, next)
+}
+
+function redirectLoggedInUser (req, res, next) {
+  if (hasValidSession(req)) {
+    return res.redirect(paths.user.loggedIn)
+  }
+  next()
 }
 
 // Other Methods

--- a/test/unit/services/auth_service_test.js
+++ b/test/unit/services/auth_service_test.js
@@ -160,7 +160,8 @@ describe('auth service', function () {
       }
       const user = {username: 'user@example.com'}
       const password = 'correctPassword'
-      const doneSpy = sinon.spy(() => {})
+      const doneSpy = sinon.spy(() => {
+      })
       const userServiceMock = {
         authenticate: (username, password, correlationId) => {
           expect(username).to.be.equal(user.username)
@@ -189,7 +190,8 @@ describe('auth service', function () {
       }
       const username = 'user@example.com'
       const password = 'imagineThisIsInvalid'
-      const doneSpy = sinon.spy(() => {})
+      const doneSpy = sinon.spy(() => {
+      })
       const userServiceMock = {
         authenticate: (username, password, correlationId) => {
           expect(username).to.be.equal('user@example.com')
@@ -332,6 +334,24 @@ describe('auth service', function () {
       assert.equal(test2, null)
       assert.equal(test3, null)
       assert.equal(test4, null)
+      done()
+    })
+  })
+
+  describe.only('redirectLoggedInUser', function (done) {
+    it('should redirect a user with a valid session to the user.loggedIn path', function (done) {
+      const req = _.cloneDeep(validRequest())
+      auth.redirectLoggedInUser(req, response, next)
+      expect(next.called).to.be.false // eslint-disable-line
+      assert(redirect.calledWith(paths.user.loggedIn))
+      done()
+    })
+
+    it('should call next if user is not logged in', function (done) {
+      let invalidSession = validRequest()
+      invalidSession.session.version = 1
+      auth.redirectLoggedInUser(invalidSession, response, next)
+      expect(next.calledOnce).to.be.true // eslint-disable-line
       done()
     })
   })


### PR DESCRIPTION
## WHAT
- When accessing to `/login` redirect the user to `/` (root, dashboard) if has a valid session.
- Both factors will be ensured again for this protected resource.

## HOW 
- Log a user in and try access `/login` should redirect the user to `/`

