### PR TITLE
PP-2457 Added Remaining 'services/team_member_details' view to hideServiceNavTemplates

### DIFF
--- a/app/utils/display_converter.js
+++ b/app/utils/display_converter.js
@@ -24,6 +24,7 @@ const hideServiceNavTemplates = [
   'services/add_service',
   'services/team_members',
   'services/team_member_invite',
+  'services/team_member_details',
   'services/team_member_profile',
   'services/team_member_permissions'
 ]


### PR DESCRIPTION


* 'services/team_member_details' view had been missed from the hideServiceNavTemplates, now has been added


