### PR TITLE
On the 3D Secure settings page, change “MasterCard” to “Mastercard”

### DIFF
--- a/app/views/3d_secure/index.html
+++ b/app/views/3d_secure/index.html
@@ -23,7 +23,7 @@
 <h1 class="page-title">3D Secure</h1>
 
 <p>3D Secure (3DS) adds an extra layer of authentication to user payments. This can help reduce fraud, but also makes it <strong class="bold-small">harder for your service users to complete payments.</strong></p>
-<p><strong class="bold-small">Verified by Visa</strong> and <strong class="bold-small">MasterCard SecureCode</strong> are common examples of 3D Secure.</p>
+<p><strong class="bold-small">Verified by Visa</strong> and <strong class="bold-small">Mastercard SecureCode</strong> are common examples of 3D Secure.</p>
 
 {{^requires3ds}}
 {{#permissions.toggle_3ds_read}}


### PR DESCRIPTION
We use “Mastercard” elsewhere in selfservice and the company themselves seem to have standardised on this over the former “MasterCard” (even though it’s easy to find stuff from them online that still uses the capital “C”).

_“When referencing the Mastercard® name in text, use an uppercase ‘M’ and lowercase ‘c’ with no space between ‘Master’ and ‘card’. The name should not appear with a capital ‘C’.”_
— from the ‘Using the Mastercard® name in text’ section of
https://brand.mastercard.com/brandcenter/mastercard-brand-mark.html