### PR TITLE
PP-2398 Backwards compatibility filter out REFUND events

### DIFF
--- a/app/utils/transaction_view.js
+++ b/app/utils/transaction_view.js
@@ -120,6 +120,8 @@ module.exports = {
   },
 
   buildPaymentView: function (chargeData, eventsData) {
+    eventsData.events = eventsData.events.filter(event => event.type !== 'REFUND')
+
     eventsData.events.forEach(function (event) {
       event.state_friendly = eventStates[event.state.status]
       if (event.state_friendly) {


### PR DESCRIPTION
- added filter to transaction detail events list that filters out events with `event.type !== 'REFUND'`



