### PR TITLE
PP-2497 Revert jenkins library branch to master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
   }
 
   libraries {
-    lib("pay-jenkins-library@PP-2497_decrease_frontend_image_size")
+    lib("pay-jenkins-library@master")
   }
 
   stages {


### PR DESCRIPTION
- revert the jenkins library branch to master (cleaning up backward compat fix from #468 )


