### PR TITLE
PP-2548 Fixed ./build-local.sh conflicting compiled npm deps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,9 +6,11 @@ docs
 .sass-lint.yml
 CONTRIBUTING.md
 env.sh
+node_modules_local
 docker/build_and_test.Dockerfile
 Dockerfile
 Gruntfile.js
+Jenkinsfile
 .snyk
 build-local.sh
 pacts

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@
 config/dev-env.json
 public
 govuk_modules
-node_modules/*
+node_modules
+node_modules_local
 */node_modules/*
 pacts/
 

--- a/build-local.sh
+++ b/build-local.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+
+if [ -d "node_modules_local" ]; then
+    rm -rf node_modules_local
+fi
+
+if [ -d "node_modules" ]; then
+  mv node_modules node_modules_local
+fi
+
 docker build --file docker/build_and_test.Dockerfile -t govukpay/selfservice-build:local . &&\
 docker run --volume $(pwd):/app:rw govukpay/selfservice-build:local &&\
 docker build -t govukpay/selfservice:local .
+
+if [ -d "node_modules" ]; then
+  rm -rf node_modules
+fi
+
+if [ -d "node_modules_local" ]; then
+  mv node_modules_local node_modules
+fi

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
       "expect"
     ],
     "ignore": [
-      "app/assets/**/*.js"
+      "app/assets/**/*.js",
+      "node_modules_local/**/*.*"
     ]
   },
   "scripts": {


### PR DESCRIPTION
## WHAT
- fixed build-local.sh so that it restores previously existing node_modules after it runs

## HOW 
- bug used to occur when a non-linux user ran `msl run` after having run `build-local.sh` as the latter would install platform dependent deps in the project for running in the mounted test image. These then naturally would not run locally on the users machine.


