### PR TITLE
PP-2239 Include ids for 'date created' and 'provider' fields on transaction details

### DIFF
--- a/app/views/transaction_detail/_details.html
+++ b/app/views/transaction_detail/_details.html
@@ -35,12 +35,12 @@
 
     <tr>
       <td>Date created:</td>
-      <td>{{updated}}</td>
+      <td id="date-created">{{updated}}</td>
     </tr>
 
     <tr>
       <td>Provider:</td>
-      <td>{{payment_provider}}</td>
+      <td id="provider">{{payment_provider}}</td>
     </tr>
 
     <tr>


### PR DESCRIPTION
## WHAT
Add ids to the only to fields that don't have an id in the transaction details section to make it more more testable from an end-to-end tests perspective.



