### PR TITLE
PP-2499 - Fixing otp width and nav links

### DIFF
--- a/app/views/includes/propositional_navigation.html
+++ b/app/views/includes/propositional_navigation.html
@@ -4,7 +4,7 @@
     <nav id="proposition-menu" aria-label="Top Level Navigation" aria-hidden="true">
       <ul id="proposition-links">
         <li><a href="https://govukpay-docs.cloudapps.digital" title="Read the GOV.UK Pay Documentation">Documentation</a></li>
-        <li><a href="{{ routes.serviceSwitcher.index }}" title="My Services" id="my-services">My Services</a></li>
+        <li><a {{#services}}class="active"{{/services}} href="{{ routes.serviceSwitcher.index }}" title="My Services" id="my-services">My Services</a></li>
         <li><a href="/logout" title="Log me out" id="logout" class="content logout">Sign out</a></li>
       </ul>
     </nav>

--- a/app/views/includes/propositional_navigation_logged_out.html
+++ b/app/views/includes/propositional_navigation_logged_out.html
@@ -3,8 +3,9 @@
     <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
     <nav id="proposition-menu" aria-label="Top Level Navigation" aria-hidden="true">
       <ul id="proposition-links">
+        <li><a href="https://www.payments.service.gov.uk/#main" title="Learn more about GOV.UK Pay">About</a></li>
         <li><a href="https://govukpay-docs.cloudapps.digital" title="Read the GOV.UK Pay Documentation">Documentation</a></li>
-        <li><a href="{{ routes.serviceSwitcher.index }}" title="My Services" id="my-services">My Services</a></li>
+        <li><a href="https://www.payments.service.gov.uk/contact/" title="Contact the GOV.UK Pay Team">Contact</a></li>
         <li><a href="/login" title="Log me in" id="login" class="content login active">Sign in</a></li>
       </ul>
     </nav>

--- a/app/views/layout_logged_out.html
+++ b/app/views/layout_logged_out.html
@@ -2,7 +2,7 @@
 
     {{$pageTitle}}GOV.UK Pay Self Service{{/pageTitle}}
 
-    {{$homepageUrl}}/{{/homepageUrl}}
+    {{$homepageUrl}}https://www.payments.service.gov.uk/{{/homepageUrl}}
     {{$globalHeaderText}}GOV.UK <span>Pay <strong class="phase-tag">Beta</strong></span>{{/globalHeaderText}}
 
     {{$propositionHeader}}

--- a/app/views/login/login.html
+++ b/app/views/login/login.html
@@ -32,6 +32,8 @@ Sign in to GOV.UK Pay
 
   <h1 class="heading-large">Sign in</h1>
 
+  <p>If you do not have an account, you can <a href="{{ routes.selfCreateService.register }}">create one now</a>.</p>
+
   <form action="/login" method="post" name="userLoginForm" class="push-bottom">
   <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <div class="form-group{{#flash.error}}{{#messages}}{{#username}} error{{/username}}{{/messages}}{{/flash.error}}">

--- a/app/views/login/otp-login.html
+++ b/app/views/login/otp-login.html
@@ -26,7 +26,7 @@ Enter security code - GOV.UK Pay
         <span class="error-message">{{flash.error}}</span>
         {{/flash.error}}
       </label>
-      <input class="form-control" data-module="" id="sms_code" name="code" rows="6" type="text" value="">
+      <input class="form-control form-control-1-4" data-module="" id="sms_code" name="code" rows="6" type="text" value="">
     </div>
     <div class="form-group">
       <input class="button" type="submit" value="Continue">

--- a/app/views/self_create_service/verify_otp.html
+++ b/app/views/self_create_service/verify_otp.html
@@ -12,7 +12,7 @@ Enter security code - GOV.UK Pay
     <p>We've sent you a text message with a security code</p>
     <div class="form-group">
       <label class="form-label" for="verify-code">Text message code</label>
-      <input class="form-control" data-module="" id="verify-code" name="verify-code" type="text" value="">
+      <input class="form-control form-control-1-4" data-module="" id="verify-code" name="verify-code" type="text" value="">
     </div>
     <div class="form-group">
       <input class="button" type="submit" value="Continue">

--- a/app/views/user_registration/verify_otp.html
+++ b/app/views/user_registration/verify_otp.html
@@ -14,7 +14,7 @@ Enter security code - GOV.UK Pay
     <p>We've sent you a text message with a security code</p>
     <div class="form-group">
       <label class="form-label" for="verify-code">Text message code</label>
-      <input class="form-control" data-module="" id="verify-code" name="verify-code" rows="6" type="text" value="">
+      <input class="form-control form-control-1-4" data-module="" id="verify-code" name="verify-code" rows="6" type="text" value="">
     </div>
     <div class="form-group">
       <input class="button" type="submit" value="Continue">


### PR DESCRIPTION
OTP input was too wide so set to a quarter (instead of half)

Made logged out nav more like https://www.payments.service.gov.uk/


