### PR TITLE
PP-2584 - Allowing view-only users to _just_ view settings

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -51,6 +51,7 @@ $grey-8: #fff;
 @import "modules/_related_information";
 @import "modules/_marked_grid";
 @import "modules/_toggle_3ds";
+@import "modules/_info_box";
 
 @import 'gov-uk-overrides/_forms';
 @import 'gov-uk-overrides/_icons';

--- a/app/assets/sass/modules/_info_box.scss
+++ b/app/assets/sass/modules/_info_box.scss
@@ -1,0 +1,10 @@
+.info-box {
+  margin-bottom: $gutter;
+  padding: $gutter / 2;
+  border-left: 10px solid $yellow;
+  background-color: transparentize($yellow, .75);
+
+  p {
+    margin-bottom: 0;
+  }
+}

--- a/app/utils/navBuilder.js
+++ b/app/utils/navBuilder.js
@@ -9,10 +9,10 @@ const serviceNavigationItems = (originalUrl, permissions) => {
     settingsPath = paths.devTokens.index
   } else if (permissions.gateway_credentials_read) {
     settingsPath = paths.credentials.index
-  } else if (permissions.payment_types_read) {
-    settingsPath = paths.paymentTypes.summary
   } else if (permissions.toggle_3ds_read) {
     settingsPath = paths.toggle3ds.index
+  } else if (permissions.payment_types_read) {
+    settingsPath = paths.paymentTypes.summary
   } else if (permissions.email_notification_template_read) {
     settingsPath = paths.emailNotifications.index
   }
@@ -62,21 +62,14 @@ const adminNavigationItems = (originalUrl, permissions) => {
       name: 'API keys',
       url: paths.devTokens.index,
       current: pathLookup(originalUrl, paths.devTokens.index),
-      permissions: permissions.tokens_read
+      permissions: permissions.tokens_update || false
     },
     {
       id: 'navigation-menu-gateway-credentials',
       name: 'Account credentials',
       url: paths.credentials.index,
       current: pathLookup(originalUrl, paths.credentials.index),
-      permissions: permissions.gateway_credentials_read
-    },
-    {
-      id: 'navigation-menu-payment-types',
-      name: 'Payment types',
-      url: paths.paymentTypes.summary,
-      current: pathLookup(originalUrl, paths.paymentTypes.summary),
-      permissions: permissions.payment_types_read
+      permissions: permissions.gateway_credentials_update || false
     },
     {
       id: 'navigation-menu-3d-secure',
@@ -84,6 +77,13 @@ const adminNavigationItems = (originalUrl, permissions) => {
       url: paths.toggle3ds.index,
       current: pathLookup(originalUrl, paths.toggle3ds.index),
       permissions: permissions.toggle_3ds_read
+    },
+    {
+      id: 'navigation-menu-payment-types',
+      name: 'Payment types',
+      url: paths.paymentTypes.summary,
+      current: pathLookup(originalUrl, paths.paymentTypes.summary),
+      permissions: permissions.payment_types_read
     },
     {
       id: 'navigation-menu-email-notifications',

--- a/app/views/3d_secure/index.html
+++ b/app/views/3d_secure/index.html
@@ -6,6 +6,10 @@
 
 {{$mainContent}}
 
+{{^permissions.toggle_3ds_update}}
+  {{>settings_read_only}}
+{{/permissions.toggle_3ds_update}}
+
 {{#supports3ds}}
 {{#permissions.toggle_3ds_read}}
 {{#justToggled}}
@@ -87,7 +91,7 @@
 
 {{^supports3ds}}
 <h1 class="page-title">3D Secure</h1>
-<p>3D Secure is not currently supported for this Payment Service Provider.</p>
+<p>3D Secure is not currently supported for this payment service provider (PSP).</p>
 {{/supports3ds}}
 
 {{/mainContent}}

--- a/app/views/email_notifications/index.html
+++ b/app/views/email_notifications/index.html
@@ -6,6 +6,10 @@ Email notifications - {{currentServiceName}} {{currentGatewayAccount.full_type}}
 
 {{$mainContent}}
 
+{{^permissions.email_notification_toggle_update}}
+  {{>settings_read_only}}
+{{/permissions.email_notification_toggle_update}}
+
 <h1 class="page-title">
   Email notifications
 </h1>

--- a/app/views/payment_types.html
+++ b/app/views/payment_types.html
@@ -10,9 +10,15 @@ Payment types - GOV.UK Pay
 
 {{$mainContent}}
 
+{{^permissions.payment_types_update}}
+  {{>settings_read_only}}
+{{/permissions.payment_types_update}}
+
 <h1 class="page-title">Payment types</h1>
 
+{{#permissions.payment_types_update}}
 <h2 class="heading-medium remove-top-margin">Manage accepted payment types</h2>
+{{/permissions.payment_types_update}}
 
 <div id="payment-types">
 {{$page_content}}{{/page_content}}

--- a/app/views/payment_types_summary.html
+++ b/app/views/payment_types_summary.html
@@ -55,9 +55,9 @@ Payment types - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV
         </tbody>
     </table>
 </div>
-<a id="payment-types-manage-button" href="{{routes.paymentTypes.selectType}}" class="button">
-    Manage
-</a>
+{{#permissions.payment_types_update}}
+<a id="payment-types-manage-button" href="{{routes.paymentTypes.selectType}}" class="button">Manage</a>
+{{/permissions.payment_types_update}}
 
 {{/permissions.payment_types_read}}
 {{/page_content}}

--- a/app/views/settings_read_only.html
+++ b/app/views/settings_read_only.html
@@ -1,0 +1,3 @@
+<aside class="info-box">
+  <p>You don’t have permission to manage settings. Contact your service admin if you would like to manage 3D secure, accepted payment types or email notifications.</p>
+</aside>

--- a/test/ui/navigation_ui_tests.js
+++ b/test/ui/navigation_ui_tests.js
@@ -41,7 +41,7 @@ describe('navigation menu', function () {
 
   it('should render API keys navigation link when user have tokens read permission', function () {
     let testPermissions = {
-      tokens_read: true
+      tokens_update: true
     }
     let templateData = {
       permissions: testPermissions,
@@ -56,8 +56,8 @@ describe('navigation menu', function () {
 
   it('should render Accounts credentials navigation link when user have gateway credentials read permission', function () {
     let testPermissions = {
-      tokens_read: false,
-      gateway_credentials_read: true,
+      tokens_update: false,
+      gateway_credentials_update: true,
       service_name_read: false,
       payment_types_read: false,
       toggle_3ds_read: false,
@@ -76,8 +76,8 @@ describe('navigation menu', function () {
 
   it('should render Payment types navigation link when user have payment types read permission', function () {
     let testPermissions = {
-      tokens_read: false,
-      gateway_credentials_read: false,
+      tokens_update: false,
+      gateway_credentials_update: false,
       service_name_read: false,
       payment_types_read: true,
       toggle_3ds_read: false,
@@ -96,8 +96,8 @@ describe('navigation menu', function () {
 
   it('should render 3D Secure navigation link when user have email notification template read permission', function () {
     let testPermissions = {
-      tokens_read: false,
-      gateway_credentials_read: false,
+      tokens_update: false,
+      gateway_credentials_update: false,
       service_name_read: false,
       payment_types_read: false,
       toggle_3ds_read: true,
@@ -116,8 +116,8 @@ describe('navigation menu', function () {
 
   it('should render Email notifications navigation link when user have email notification template read permission', function () {
     let testPermissions = {
-      tokens_read: false,
-      gateway_credentials_read: false,
+      tokens_update: false,
+      gateway_credentials_update: false,
       service_name_read: false,
       payment_types_read: false,
       toggle_3ds_read: false,

--- a/test/ui/payment_types_summary_ui_tests.js
+++ b/test/ui/payment_types_summary_ui_tests.js
@@ -17,7 +17,8 @@ var templateData = {
     'selected': true
   },
   permissions: {
-    'payment_types_read': true
+    'payment_types_read': true,
+    'payment_types_update': true
   }
 }
 

--- a/test/ui/toggle_3ds_ui_tests.js
+++ b/test/ui/toggle_3ds_ui_tests.js
@@ -220,7 +220,7 @@ describe('The toggle 3D Secure page when 3D Secure is not supported', function (
 
     let body = renderTemplate('3d_secure/index', templateData)
 
-    body.should.contain('3D Secure is not currently supported for this Payment Service Provider.')
+    body.should.contain('3D Secure is not currently supported for this payment service provider (PSP).')
   })
 
   it('should not say that 3D Secure is on or off', function () {


### PR DESCRIPTION
Before know view-only users would and on settings and not
see a lot, know they can view the settings for 3D Secure,
Payment tyles and Email notifications but not edit them.
They cannot see API keys or Account credentials though
(as it was before).



