### PR TITLE
PP-2582 - Restyled refund flow and updated messaging

### DIFF
--- a/app/assets/js/components/refund.js
+++ b/app/assets/js/components/refund.js
@@ -1,32 +1,36 @@
 (function(){
   refund = function(){
-    var selects = $('input[name=refund-type]'),
-    partial     =  selects.filter('[value=partial]'),
-    close       = $('#show-refund .close'),
-    showButton  = $('.show-refund-button'),
-    lightbox    = $('#show-refund'),
-    submit       = lightbox.find('input[type=submit]'),
-    refundForm  = $('.refund-form');
+    var selects         = $('input[name=refund-type]'),
+    partial             =  selects.filter('[value=partial]'),
+    showButton          = $('.refund__toggle'),
+    showButtonContainer = $('.refund__toggle-container'),
+    refundForm          = $('.refund__form'),
+    refundAmount        = $('.refund__amount'),
+    submit              = refundForm.find('input[type=submit]'),
+    cancelRefund        = $('.refund__cancel-button');
 
     var init = function(){
       selects.on('change',toggleAmount);
-      showButton.on('click',addLightBox);
-      close.on('click',removeLightBox);
+      showButton.on('click',showRefundForm);
+      cancelRefund.on('click',hideRefundForm);
       toggleAmount();
       refundForm.on('submit',disableSubmit);
     },
 
     toggleAmount = function(){
-      $('.refund-amount').toggleClass('shown',partial.is(':checked'));
+      refundAmount.toggleClass('active',partial.is(':checked'));
     },
 
-    removeLightBox = function(e) {
-      lightbox.removeClass('shown');
-    },
-
-    addLightBox = function(e){
+    showRefundForm = function(e){
       e.preventDefault();
-      lightbox.addClass('shown');
+      refundForm.addClass('active');
+      showButtonContainer.toggleClass('active');
+    },
+
+    hideRefundForm = function(e) {
+      e.preventDefault();
+      refundForm.removeClass('active');
+      showButtonContainer.toggleClass('active');
     },
 
     disableSubmit = function(e){

--- a/app/assets/sass/helpers/_links.scss
+++ b/app/assets/sass/helpers/_links.scss
@@ -2,10 +2,10 @@ a {
   color: $black;
 
   &.arrowed {
+    display: inline-block;
+    padding: $gutter-half 0 $gutter * 1.5;
     text-decoration: none;
-    display: block;
     @include core-16;
-    padding: $gutter-half 0 $gutter*1.5;
   }
 
 }

--- a/app/assets/sass/modules/_flash.scss
+++ b/app/assets/sass/modules/_flash.scss
@@ -2,13 +2,16 @@
   @include core-19;
   padding: $gutter $gutter / 2;
   border: 5px solid $green;
-  color: $green;
-  font-weight: bold;
+
+  h2 {
+    margin: 0 0 em(20, 24);
+    @include core-24;
+    font-weight: bold;
+  }
 }
 
 .generic-error {
   border-color: $red;
-  color: $red;
 }
 
 .error-summary ul {

--- a/app/assets/sass/modules/_flash.scss
+++ b/app/assets/sass/modules/_flash.scss
@@ -1,10 +1,9 @@
 .notification {
-  margin-top: $gutter;
+  @include core-19;
   padding: $gutter $gutter / 2;
   border: 5px solid $green;
   color: $green;
   font-weight: bold;
-  text-align: center;
 }
 
 .generic-error {

--- a/app/assets/sass/modules/_transaction_detail.scss
+++ b/app/assets/sass/modules/_transaction_detail.scss
@@ -1,25 +1,22 @@
-.show-refund-button {
-  margin: 15px 0;
-}
-
-.transaction-details, .transaction-events {
+.transaction-details,
+.transaction-events {
+  margin-top: $gutter;
   table-layout: fixed;
-  margin-top:30px;
+
   * {
     @include core-16;
   }
 
   tr td:first-child {
-    width:40%;
+    width: 40%;
     overflow: hidden;
     text-overflow: ellipsis;
   }
-
 }
 
-
 .transaction-events {
-  td.amount {
+  .amount,
+  .date {
     text-align: left;
     @include core-16($tabular-numbers: true);
   }

--- a/app/assets/sass/modules/_transaction_refund.scss
+++ b/app/assets/sass/modules/_transaction_refund.scss
@@ -1,95 +1,62 @@
+.refund {
 
-#show-refund {
-  display:none;
-  &:target,
-  &.shown {
-    display: block;
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    background: rgba(0,0,0,0.2);
-    opacity: 1;
+  &__toggle-container {
+    display: none;
+
+    &.active {
+      display: block;
+    }
   }
 
-  .container {
-    position: absolute;
-    left:50%;
-    top:50%;
-    width: 400px;
-    height: 460px;
-    margin-left: -200px;
-    margin-top: -250px;
-    background: white;
-    padding: 15px;
+  &__toggle {
+    margin: $gutter / 2 0;
   }
 
-  .heading-medium {
-    border-bottom: 1px solid black;
-    margin-top: 10px;
-    padding-bottom: 15px;
-    text-align: center;
+  &__form {
+    display: none;
+
+    & .form-hint {
+      @include core-16;
+    }
+
+    &.active {
+      display: block;
+    }
+
+    .heading-medium {
+      margin: $gutter / 2 0;
+    }
   }
 
-  .panel {
-    padding-top: 0;
+  &__amount {
+    display: none;
+    margin-left: $gutter / 2;
+
+    &.active {
+      display: block;
+    }
   }
 
-  .block-label {
-    min-width: 300px;
-    font-weight: bold;
-    margin-bottom: 15px;
-  }
-
-  .block-label input[type=radio] {
-    top: 32px;
-    width: auto;
-    height: auto;
-    outline-offset:5px;
-
-  }
-
-  .block-label .form-hint {
-    font-weight: normal;
-    font-size: 14px;
-  }
-
-  .refund-amount {
-    margin-bottom: 15px;
-    visibility: hidden;
-    opacity: 0;
-    pointer-events: none;
-    transition: 0.1s;
-  }
-
-  body:not(.js-enabled) & .refund-amount,
-  .refund-amount.shown {
-    pointer-events: all;
-    visibility: visible;
-    opacity: 1;
-  }
-
-  .refund-amount p {
-    font-weight: bold;
-    margin-bottom: 10px;
-  }
-
-  .refund-amount .currency {
-    padding-right: 10px;
-    font-size: 16px;
-    font-weight: bold;
-  }
-
-  .close {
-    text-decoration: none;
-    padding-left: 15px;
-    line-height: 40px;
-    color: $link-colour;
-  }
-  .close:visited {
-    color: $link-colour;
+  &__submit-button {
+    margin: 0 $gutter / 2 $gutter / 2 0;
   }
 }
 
+// One day `.currency-input` will be part of elements or patterns and tools -  https://github.com/alphagov/temporary-event-notice-prototype/blob/master/app/assets/sass/patterns/currency-input.scss
 
+.currency-input {
+  &__inner {
+    position: relative;
+
+    &__unit {
+      position: absolute;
+      bottom: $gutter / 6;
+      left: $gutter / 3;
+      font-weight: bold;
+    }
+  }
+
+  .form-control {
+    padding: 6px 0 3px 25px;
+  }
+}

--- a/app/controllers/transactions/transaction_refund_controller.js
+++ b/app/controllers/transactions/transaction_refund_controller.js
@@ -4,15 +4,16 @@
 const Charge = require('../../models/charge.js')
 const auth = require('../../services/auth_service.js')
 const router = require('../../routes.js')
-const {renderErrorView} = require('../../utils/response.js')
 const {CORRELATION_HEADER} = require('../../utils/correlation_header.js')
 
-const errReasonMessages = {
-  'REFUND_FAILED': "Can't process refund",
-  'full': "Can't do refund: This charge has been already fully refunded",
-  'amount_not_available': "Can't do refund: The requested amount is bigger than the amount available for refund",
-  'amount_min_validation': "Can't do refund: The requested amount is less than the minimum accepted for issuing a refund for this charge",
-  'refund_amount_available_mismatch': 'Refund failed. This refund request has already been submitted.'
+const reasonMessages = {
+  'refund_complete': '<h2>Refund successful</h2> It may take up to 6 days to process.',
+  'REFUND_FAILED': '<h2>Refund failed</h2> We couldn’t process this refund. Try again later.',
+  'full': '<h2>Repeat request</h2> This refund request has already been submitted. Refresh your transactions list.',
+  'amount_not_available': '<h2>Select another amount</h2> The amount you tried to refund is greater than the transaction total',
+  'amount_min_validation': '<h2>Select another amount</h2> The amount you tried to refund is less than the accepted minimum for this transaction.',
+  'refund_amount_available_mismatch': '<h2>Repeat request</h2> This refund request has already been submitted. Refresh your transactions list.',
+  'invalid_chars': '<h2>Use valid characters only</h2> Choose an amount to refund in pounds and pence using digits and a decimal point. For example “10.50”'
 }
 
 module.exports = (req, res) => {
@@ -28,15 +29,22 @@ module.exports = (req, res) => {
   const refundMatch = /^([0-9]+)(?:\.([0-9]{2}))?$/.exec(refundAmount)
 
   if (!refundMatch) {
-    return renderErrorView(req, res, "Can't do refund: amount must be pounds (10) or pounds and pence (10.10)")
+    req.flash('genericError', reasonMessages['invalid_chars'])
+    return res.redirect(show)
   }
 
   let refundAmountForConnector = parseInt(refundMatch[1]) * 100
   if (refundMatch[2]) refundAmountForConnector += parseInt(refundMatch[2])
 
   charge.refund(accountId, chargeId, refundAmountForConnector, refundAmountAvailableInPence, userExternalId)
-    .then(() => res.redirect(show))
+    .then(
+      () => {
+        req.flash('generic', reasonMessages['refund_complete'])
+        res.redirect(show)
+      }
+    )
     .catch(err => {
-      renderErrorView(req, res, errReasonMessages[err] ? errReasonMessages[err] : errReasonMessages.REFUND_FAILED)
+      req.flash('genericError', reasonMessages[err] ? reasonMessages[err] : reasonMessages.REFUND_FAILED)
+      res.redirect(show)
     })
 }

--- a/app/controllers/transactions/transaction_refund_controller.js
+++ b/app/controllers/transactions/transaction_refund_controller.js
@@ -36,7 +36,7 @@ module.exports = (req, res) => {
   let refundAmountForConnector = parseInt(refundMatch[1]) * 100
   if (refundMatch[2]) refundAmountForConnector += parseInt(refundMatch[2])
 
-  charge.refund(accountId, chargeId, refundAmountForConnector, refundAmountAvailableInPence, userExternalId)
+  return charge.refund(accountId, chargeId, refundAmountForConnector, refundAmountAvailableInPence, userExternalId)
     .then(
       () => {
         req.flash('generic', reasonMessages['refund_complete'])

--- a/app/views/includes/flash.html
+++ b/app/views/includes/flash.html
@@ -1,6 +1,14 @@
-{{#flash.genericError}}
-<div class="flash-container"><p class="notification generic-error"> {{flash.genericError}} </p></div>
-{{/flash.genericError}}
-{{#flash.generic}}
-<div class="flash-container"><p class="notification generic-flash">{{flash.generic}}</p></div>
-{{/flash.generic}}
+{{#flash}}
+<div class="grid-row">
+  {{#flash.genericError}}
+  <div class="column-two-thirds flash-container">
+    <p class="notification generic-error"> {{{flash.genericError}}} </p>
+  </div>
+  {{/flash.genericError}}
+  {{#flash.generic}}
+  <div class="column-two-thirds flash-container">
+    <p class="notification generic-flash">{{{flash.generic}}}</p>
+  </div>
+  {{/flash.generic}}
+</div>
+{{/flash}}

--- a/app/views/includes/flash.html
+++ b/app/views/includes/flash.html
@@ -2,12 +2,16 @@
 <div class="grid-row">
   {{#flash.genericError}}
   <div class="column-two-thirds flash-container">
-    <p class="notification generic-error"> {{{flash.genericError}}} </p>
+    <div class="notification generic-error">
+      {{{flash.genericError}}}
+    </div>
   </div>
   {{/flash.genericError}}
   {{#flash.generic}}
   <div class="column-two-thirds flash-container">
-    <p class="notification generic-flash">{{{flash.generic}}}</p>
+    <div class="notification generic-flash">
+      {{{flash.generic}}}
+    </div>
   </div>
   {{/flash.generic}}
 </div>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -22,12 +22,12 @@
     {{/cookieMessage}}
 
     {{$content}}
-        {{>includes/flash}}
         {{^hideServiceHeader}}
         {{> includes/phase_banner }}
         {{/hideServiceHeader}}
 
         <main id="content" role="main" class="{{$mainClasses}}{{/mainClasses}}">
+            {{>includes/flash}}
             {{$full_width_content}}{{/full_width_content}}
             <div class="grid-row">
               {{#showSettingsNav}}

--- a/app/views/settings_read_only.html
+++ b/app/views/settings_read_only.html
@@ -1,3 +1,3 @@
 <aside class="info-box">
-  <p>You don’t have permission to manage settings. Contact your service admin if you would like to manage 3D secure, accepted payment types or email notifications.</p>
+  <p>You don’t have permission to manage settings. Contact your service admin if you would like to manage 3D secure, accepted payment types, or email notifications.</p>
 </aside>

--- a/app/views/transaction_detail/_refund.html
+++ b/app/views/transaction_detail/_refund.html
@@ -26,7 +26,7 @@
       {{/refunded}}
 
       <div class="multiple-choice">
-        <input id="partial" type="radio" name="refund-type" value="partial" id="partial-refund">
+        <input id="partial" type="radio" name="refund-type" value="partial">
         <label class="block-label" for="partial">Partial refund
           <span class="form-hint">refund a partial amount</span>
         </label>

--- a/app/views/transaction_detail/_refund.html
+++ b/app/views/transaction_detail/_refund.html
@@ -1,42 +1,52 @@
-{{#refundable}}
-
-<div id="show-refund">
-  <form action="/transactions/{{charge_id}}/refund" method="post" class="refund-form">
-      <input id="amount-available" type="hidden" name="refund-amount-available-in-pence" value="{{ refund_summary.amount_available }}" />
-    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
-    <div class="container">
-      <h2 class="heading-medium">Refund payment</h2>
-      <input id="full-amount" type="hidden" name="full-amount" value="{{ net_amount }}" >
+<form action="/transactions/{{charge_id}}/refund" method="post" class="refund__form {{#flash.genericError}}active{{/flash.genericError}}">
+  <input id="full-amount" type="hidden" name="full-amount" value="{{ net_amount }}" >
+  <input id="amount-available" type="hidden" name="refund-amount-available-in-pence" value="{{ refund_summary.amount_available }}" />
+  <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
+  <div class="form-group">
+    <fieldset>
+      <legend>
+        <h2 class="heading-medium">Refund payment</h2>
+      </legend>
 
       {{#refunded}}
-      <label class="block-label" for="full">
+      <div class="multiple-choice">
         <input id="full" type="radio" name="refund-type" value="full" checked="checked">
-        Remaining amount
-        <span class="form-hint">refund the remaining £{{ net_amount }}, ({{refunded_amount}} has already been refunded) </span>
-      </label>
+        <label class="block-label" for="full">Remaining amount
+          <span class="form-hint">refund the remaining £{{ net_amount }}, ({{refunded_amount}} has already been refunded) </span>
+        </label>
+      </div>
       {{/refunded}}
-
       {{^refunded}}
-      <label class="block-label" for="full">
-          <input id="full" type="radio" name="refund-type" value="full" checked="checked">
-        Full refund
-        <span class="form-hint">refund the full amount of {{ amount }}</span>
-      </label>
+      <div class="multiple-choice">
+        <input id="full" type="radio" name="refund-type" value="full" checked="checked">
+        <label class="block-label" for="full">Full refund
+          <span class="form-hint">refund the full amount of {{ amount }}</span>
+        </label>
+      </div>
       {{/refunded}}
 
-      <label class="block-label" for="partial">
+      <div class="multiple-choice">
         <input id="partial" type="radio" name="refund-type" value="partial" id="partial-refund">
-        Partial refund
-        <span class="form-hint">refund a partial amount</span>
-      </label>
-      <div class="panel panel-border-wide refund-amount">
-       <p>refund amount</p>
-       <span class="currency">£</span>
-       <input class="form-control refund-amount-input" name="refund-amount" type="number" step="any">
-     </div>
-     <input type="submit" value="Refund" class="button delete" />
-     <a href="#" class="close">cancel</a>
-   </div>
- </form>
-</div>
-{{/refundable}}
+        <label class="block-label" for="partial">Partial refund
+          <span class="form-hint">refund a partial amount</span>
+        </label>
+      </div>
+      <div class="panel panel-border-wide refund__amount">
+        <div class="currency-input">
+          <label class="form-label" for="refund-amount">
+            Refund amount
+            <span class="visually-hidden">in £</span>
+          </label>
+          <div class="currency-input__inner">
+            <span class="currency-input__inner__unit">£</span>
+            <input class="form-control" aria-label="Enter amount in pounds" name="refund-amount" data-non-numeric type="text" id="refund-amount" pattern="[0-9]\d*(\.\d+)?">
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="form-group">
+      <input type="submit" value="Refund payment" class="button refund__submit-button delete" />
+      <a href="#" class="button-link refund__cancel-button">cancel</a>
+    </div>
+  </fieldset>
+</form>

--- a/app/views/transaction_detail/index.html
+++ b/app/views/transaction_detail/index.html
@@ -8,43 +8,38 @@ Transaction details {{reference}} - {{currentServiceName}} {{currentGatewayAccou
 {{/pageSpecificJS}}
 
 {{$full_width_content}}
-<a href="{{routes.transactions.index}}?{{indexFilters}}" id="arrowed" class="arrowed"> &#9664; Transactions list</a>
 
-
-
-
-<div class="column-three-quarters">
-
-
-
-  {{>transaction_detail/_refund}}
-  <h1 class="page-title heading-large">Transaction detail</h1>
-  {{>transaction_detail/_details}}
-
-  <h2 class="heading-medium">Payment method</h2>
-  {{>transaction_detail/_payment}}
-
-  {{#permissions.transactions_events_read}}
-  <h2 class="heading-medium">Transaction events</h2>
-  {{>transaction_detail/_events}}
-  {{/permissions.transactions_events_read}}
-
+<div class="grid-row">
+  <div class="column-full">
+    <a href="{{routes.transactions.index}}?{{indexFilters}}" id="arrowed" class="arrowed"> &#9664; Transactions list</a>
+  </div>
 </div>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="page-title heading-large">Transaction detail</h1>
+    {{>transaction_detail/_details}}
 
-<div class="column-one-quarter">
-  <div class="actions">
+    <h2 class="heading-medium">Payment method</h2>
+    {{>transaction_detail/_payment}}
 
+    {{#permissions.transactions_events_read}}
+    <h2 class="heading-medium">Transaction events</h2>
+    {{>transaction_detail/_events}}
+    {{/permissions.transactions_events_read}}
+  </div>
+
+  <div class="column-one-third">
     {{#refundable}}
-    {{#permissions.refunds_create}}
-    <a href="#show-refund" class="button show-refund-button delete"> Refund Payment </a>
-    <p class="small">
-      You can also give partial refunds
-    </p>
-    {{/permissions.refunds_create}}
+      {{#permissions.refunds_create}}
+      <div class="refund__toggle-container {{^flash.genericError}}active{{/flash.genericError}}">
+        <button class="button refund__toggle delete">Refund Payment</button>
+        <p>You can also give partial&nbsp;refunds</p>
+      </div>
+      {{>transaction_detail/_refund}}
+      {{/permissions.refunds_create}}
     {{/refundable}}
   </div>
 </div>
-
 
 {{/full_width_content}}
 

--- a/test/ui/transaction_details_ui_tests.js
+++ b/test/ui/transaction_details_ui_tests.js
@@ -64,7 +64,7 @@ describe('The transaction details view', function () {
 
     let body = renderTemplate('transaction_detail/index', templateData)
     let $ = cheerio.load(body)
-    body.should.not.containSelector('#show-refund')
+    body.should.not.containSelector('.refund__toggle-container')
     $('#arrowed').attr('href').should.equal('?reference=&email=&state=&fromDate=&fromTime=&toDate=&toTime=')
     $('#reference').html().should.equal('&lt;123412341234&gt; &amp;')
     $('#description').html().should.equal('First ever')
@@ -167,7 +167,7 @@ describe('The transaction details view', function () {
 
     let body = renderTemplate('transaction_detail/index', templateData)
     let $ = cheerio.load(body)
-    body.should.not.containSelector('#show-refund')
+    body.should.not.containSelector('.refund__toggle-container')
     $('#arrowed').attr('href').should.equal('?reference=&email=&state=&fromDate=&fromTime=&toDate=&toTime=')
     $('#reference').html().should.equal('&lt;123412341234&gt; &amp;')
     $('#description').html().should.equal('First ever')
@@ -281,7 +281,7 @@ describe('The transaction details view', function () {
 
     let body = renderTemplate('transaction_detail/index', templateData)
     let $ = cheerio.load(body)
-    body.should.containSelector('#show-refund')
+    body.should.not.containSelector('.refund__toggle-container')
     $('#reference').html().should.equal('&lt;123412341234&gt; &amp;')
     $('#description').html().should.equal('First ever')
     $('#email').html().should.equal('alice.111@mail.fake')

--- a/test/unit/controller/refunds_controller_test.js
+++ b/test/unit/controller/refunds_controller_test.js
@@ -54,7 +54,7 @@ describe('Refund scenario:', function () {
 
     refundController(req, res).then(() => {
       expect(res.redirect.calledWith('/transactions/123456')).to.equal(true)
-      expect(req.flash.calledWith('generic', 'Refund successful<br/> It may take up to 6 days to process.')).to.equal(true)
+      expect(req.flash.calledWith('generic', '<h2>Refund successful</h2> It may take up to 6 days to process.')).to.equal(true)
     }).should.notify(done)
   })
 
@@ -71,7 +71,7 @@ describe('Refund scenario:', function () {
 
     refundController(req, res).catch(() => {
       expect(res.redirect.calledWith('/transactions/123456')).to.equal(true)
-      expect(req.flash.calledWith('genericError', 'Select another amount<br/> The amount you tried to refund is greater than the transaction total')).to.equal(true)
+      expect(req.flash.calledWith('genericError', '<h2>Select another amount</h2> The amount you tried to refund is greater than the transaction total')).to.equal(true)
     }).should.notify(done)
   })
 
@@ -88,7 +88,7 @@ describe('Refund scenario:', function () {
 
     refundController(req, res).catch(() => {
       expect(res.redirect.calledWith('/transactions/123456')).to.equal(true)
-      expect(req.flash.calledWith('genericError', 'Select another amount<br/> The amount you tried to refund is less than the accepted minimum for this transaction.')).to.equal(true)
+      expect(req.flash.calledWith('genericError', '<h2>Select another amount</h2> The amount you tried to refund is less than the accepted minimum for this transaction.')).to.equal(true)
     }).should.notify(done)
   })
 
@@ -105,7 +105,7 @@ describe('Refund scenario:', function () {
 
     refundController(req, res).catch(() => {
       expect(res.redirect.calledWith('/transactions/123456')).to.equal(true)
-      expect(req.flash.calledWith('genericError', 'Repeat request<br/> This refund request has already been submitted. Refresh your transactions list.')).to.equal(true)
+      expect(req.flash.calledWith('genericError', '<h2>Repeat request</h2> This refund request has already been submitted. Refresh your transactions list.')).to.equal(true)
     }).should.notify(done)
   })
 
@@ -122,7 +122,7 @@ describe('Refund scenario:', function () {
 
     refundController(req, res).catch(() => {
       expect(res.redirect.calledWith('/transactions/123456')).to.equal(true)
-      expect(req.flash.calledWith('Repeat request<br/> This refund request has already been submitted. Refresh your transactions list.')).to.equal(true)
+      expect(req.flash.calledWith('Repeat request<h2> This </h2>refund request has already been submitted. Refresh your transactions list.')).to.equal(true)
     }).should.notify(done)
   })
 
@@ -139,7 +139,7 @@ describe('Refund scenario:', function () {
 
     refundController(req, res).catch(() => {
       expect(res.redirect.calledWith('/transactions/123456')).to.equal(true)
-      expect(req.flash.calledWith('genericError', 'Refund failed<br/> We couldn’t process this refund. Try again later.')).to.equal(true)
+      expect(req.flash.calledWith('genericError', '<h2>Refund failed</h2> We couldn’t process this refund. Try again later.')).to.equal(true)
     }).should.notify(done)
   })
 })

--- a/test/unit/controller/refunds_controller_test.js
+++ b/test/unit/controller/refunds_controller_test.js
@@ -1,0 +1,145 @@
+'use strict'
+
+// NPM dependencies
+const sinon = require('sinon')
+const {expect} = require('chai')
+const nock = require('nock')
+
+// Custom dependencies
+const refundController = require('../../../app/controllers/transactions/transaction_refund_controller.js')
+
+// Global setup
+let req, res
+
+describe('Refund scenario:', function () {
+  beforeEach(function () {
+    req = {}
+    req.headers = {
+      'x-request-id': '1234'
+    }
+    req.user = {
+      externalId: '92734386'
+    }
+    req.service = {
+      gatewayAccountIds: ['123', '456']
+    }
+    req.gateway_account = {
+      currentGatewayAccountId: '123'
+    }
+    req.params = {
+      chargeId: '123456'
+    }
+    req.body = {
+      'refund-type': 'full',
+      'refund-amount-available-in-pence': '5000',
+      'full-amount': '5000'
+    }
+    req.flash = sinon.spy()
+
+    res = {
+      redirect: sinon.spy()
+    }
+  })
+
+  it('should redirect back to transaction details and show refund sucess message', function (done) {
+    var mockRefundResponse = {
+      'refund_id': 'Just looking the status code of the response at the moment'
+    }
+    nock(process.env.CONNECTOR_URL).post('/v1/api/accounts/' + '123' + '/charges/' + '123456' + '/refunds', {
+      'user_external_id': req.user.externalId,
+      'amount': 500000,
+      'refund_amount_available': 5000
+    })
+    .reply(202, mockRefundResponse)
+
+    refundController(req, res).then(() => {
+      expect(res.redirect.calledWith('/transactions/123456')).to.equal(true)
+      expect(req.flash.calledWith('generic', 'Refund successful<br/> It may take up to 6 days to process.')).to.equal(true)
+    }).should.notify(done)
+  })
+
+  it('should redirect back to transaction details and show error message if refund amount is greater than initial charge', function (done) {
+    var mockRefundResponse = {
+      'refund_id': 'Just looking the status code of the response at the moment'
+    }
+    nock(process.env.CONNECTOR_URL).post('/v1/api/accounts/' + '123' + '/charges/' + '123456' + '/refunds', {
+      'user_external_id': req.user.externalId,
+      'amount': 600000,
+      'refund_amount_available': 5000
+    })
+    .reply(400, mockRefundResponse)
+
+    refundController(req, res).catch(() => {
+      expect(res.redirect.calledWith('/transactions/123456')).to.equal(true)
+      expect(req.flash.calledWith('genericError', 'Select another amount<br/> The amount you tried to refund is greater than the transaction total')).to.equal(true)
+    }).should.notify(done)
+  })
+
+  it('should redirect back to transaction details and show error message if refund amount is smaller than minimum accepted', function (done) {
+    var mockRefundResponse = {
+      'refund_id': 'Just looking the status code of the response at the moment'
+    }
+    nock(process.env.CONNECTOR_URL).post('/v1/api/accounts/' + '123' + '/charges/' + '123456' + '/refunds', {
+      'user_external_id': req.user.externalId,
+      'amount': 1,
+      'refund_amount_available': 5000
+    })
+    .reply(400, mockRefundResponse)
+
+    refundController(req, res).catch(() => {
+      expect(res.redirect.calledWith('/transactions/123456')).to.equal(true)
+      expect(req.flash.calledWith('genericError', 'Select another amount<br/> The amount you tried to refund is less than the accepted minimum for this transaction.')).to.equal(true)
+    }).should.notify(done)
+  })
+
+  it('should redirect back to transaction details and show error message if refund request has already been submitted', function (done) {
+    var mockRefundResponse = {
+      'message': 'Precondition Failed!'
+    }
+    nock(process.env.CONNECTOR_URL).post('/v1/api/accounts/' + '123' + '/charges/' + '123456' + '/refunds', {
+      'user_external_id': req.user.externalId,
+      'amount': 1,
+      'refund_amount_available': 5000
+    })
+    .reply(400, mockRefundResponse)
+
+    refundController(req, res).catch(() => {
+      expect(res.redirect.calledWith('/transactions/123456')).to.equal(true)
+      expect(req.flash.calledWith('genericError', 'Repeat request<br/> This refund request has already been submitted. Refresh your transactions list.')).to.equal(true)
+    }).should.notify(done)
+  })
+
+  it('should redirect back to transaction details and show error message if refund request has already been fully refunded', function (done) {
+    var mockRefundResponse = {
+      'reason': 'full'
+    }
+    nock(process.env.CONNECTOR_URL).post('/v1/api/accounts/' + '123' + '/charges/' + '123456' + '/refunds', {
+      'user_external_id': req.user.externalId,
+      'amount': 1,
+      'refund_amount_available': 5000
+    })
+    .reply(400, mockRefundResponse)
+
+    refundController(req, res).catch(() => {
+      expect(res.redirect.calledWith('/transactions/123456')).to.equal(true)
+      expect(req.flash.calledWith('Repeat request<br/> This refund request has already been submitted. Refresh your transactions list.')).to.equal(true)
+    }).should.notify(done)
+  })
+
+  it('should redirect back to transaction details and show error message if unexpected error has occured', function (done) {
+    var mockRefundResponse = {
+      'message': 'what happeneeed!'
+    }
+    nock(process.env.CONNECTOR_URL).post('/v1/api/accounts/' + '123' + '/charges/' + '123456' + '/refunds', {
+      'user_external_id': req.user.externalId,
+      'amount': 1,
+      'refund_amount_available': 5000
+    })
+    .reply(400, mockRefundResponse)
+
+    refundController(req, res).catch(() => {
+      expect(res.redirect.calledWith('/transactions/123456')).to.equal(true)
+      expect(req.flash.calledWith('genericError', 'Refund failed<br/> We couldn’t process this refund. Try again later.')).to.equal(true)
+    }).should.notify(done)
+  })
+})


### PR DESCRIPTION
I’ve removed the refund modal as modals don't work
well on mobile and I have restyled to use GOV.UK
standards for radio buttons and currency inputs.

There was no messaging for a successfully submitted
refund so I have added one and I’ve also changed it
so that error messages show up using the flash
pattern we use around pay rather than redirect to an
error page which feels more helpful and less 'dead-end'.

Need to update unit tests as they fail now as error
messaging has moved.