### PR TITLE
Fix shocking lack of uppercase and apostrophes

### DIFF
--- a/app/views/email_notifications/edit.html
+++ b/app/views/email_notifications/edit.html
@@ -42,19 +42,19 @@ Add a custom paragraph
         link to a page on GOV.UK if you want to provide contact service details
     </li>
     <li>
-        links must point to a .gov.uk domain and show the url in full
+        links must point to a .gov.uk domain and show the URL in full
     </li>
     <li>
-        dont use redirects or tracking links
+        don’t use redirects or tracking links
     </li>
     <li>
-        dont link directly to a sign in page
+        don’t link directly to a sign in page
     </li>
     <li>
-        use https where available
+        use HTTPS where available
     </li>
     <li>
-        dont request personal data passwords or payment details
+        don’t request personal data passwords or payment details
     </li>
 </ul>
 


### PR DESCRIPTION
Upper-case “HTTPS”, “URL” and add apostrophes to “don’t”