### PR TITLE
form controls we're full width on transactions

### DIFF
--- a/app/assets/sass/helpers/_forms.scss
+++ b/app/assets/sass/helpers/_forms.scss
@@ -1,3 +1,11 @@
+.form-control {
+  &.large {
+    @include respond-to(tablet) {
+      width: 100%;
+    }
+  }
+}
+
 /********** Spacing **********/
 
 %form-module-spacing {


### PR DESCRIPTION
Some CSS was removed that set transaction filters to 100% width this adds it back