### PR TITLE
PP-2575 updated `submitted by` markup yet again

### DIFF
--- a/app/views/transaction_detail/_events.html
+++ b/app/views/transaction_detail/_events.html
@@ -5,7 +5,8 @@
     <td>
         <span class="state">{{state_friendly}}</span>
         {{#state.message}}<br>{{state.code}} - {{state.message}}{{/state.message}}
-        <span class="submitted-by">{{#submitted_by_friendly}}by <br>{{submitted_by_friendly}}{{/submitted_by_friendly}}</span>
+        {{#submitted_by_friendly}}by <br>{{/submitted_by_friendly}}
+        <span class="submitted-by">{{#submitted_by_friendly}}{{submitted_by_friendly}}{{/submitted_by_friendly}}</span>
     </td>
     <td class="amount" align="right">{{amount_friendly}}</td>
     <td class="date" align="right">{{updated_friendly}}</td>

--- a/test/ui/transaction_details_ui_tests.js
+++ b/test/ui/transaction_details_ui_tests.js
@@ -300,7 +300,7 @@ describe('The transaction details view', function () {
       tableRow.find('td.amount').text().should.equal(event.amount_friendly)
       tableRow.find('span.state').text().should.equal(event.state_friendly)
 
-      if (event.submitted_by_friendly) tableRow.find('span.submitted-by').text().should.equal('by ' + event.submitted_by_friendly)
+      if (event.submitted_by_friendly) tableRow.find('span.submitted-by').text().should.equal(event.submitted_by_friendly)
       if (event.type === 'REFUND') tableRow.attr('data-gateway-refund-id').should.equal(event.refund_reference)
     })
   })


### PR DESCRIPTION
- moved `by <br>` out of `span.submitted-by` to make tests cleaner on transaction events template



