### PR TITLE
Updated local build of docker image

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -1,21 +1,7 @@
 #!/bin/bash
 
-if [ -d "node_modules_local" ]; then
-    rm -rf node_modules_local
-fi
-
-if [ -d "node_modules" ]; then
-  mv node_modules node_modules_local
-fi
-
 docker build --file docker/build_and_test.Dockerfile -t govukpay/selfservice-build:local . &&\
 docker run --volume $(pwd):/app:rw govukpay/selfservice-build:local &&\
-docker build -t govukpay/selfservice:local .
-
-if [ -d "node_modules" ]; then
-  rm -rf node_modules
-fi
-
-if [ -d "node_modules_local" ]; then
-  mv node_modules_local node_modules
-fi
+docker build -t govukpay/selfservice:local . &&\
+npm rebuild &&
+npm --prefer-offline install

--- a/docker/build_and_test.sh
+++ b/docker/build_and_test.sh
@@ -6,8 +6,13 @@ grep -rnw './test' -e 'it.only' && echo '' && echo 'ERROR: it.only() found in te
 grep -rnw './test' -e 'describe.only' && echo '' && echo 'ERROR: describe.only() found in tests, Exiting' && exit 1
 grep -rnw './test' -e 'context.only' && echo '' && echo 'ERROR: context.only() found in tests, Exiting' && exit 1
 
-mkdir -p /app &&\
-cp -a /tmp/node_modules /app/ &&\
-npm run compile &&\
-npm test &&\
-npm prune --production
+if [ -d "node_modules" ]; then
+    npm rebuild
+    npm --prefer-offline install
+else
+    mkdir -p /app &&\
+    cp -a /tmp/node_modules /app/
+fi
+
+npm run compile && npm test && npm prune --production
+


### PR DESCRIPTION
WHAT
- local build use `npm rebuild` rather than move many MB of installed deps around

WHY
- should speed up `msl up` docker builds on local machine
