### PR TITLE
PP-2683 - Rejigging type hierarchy

### DIFF
--- a/app/assets/sass/modules/_service_switcher.scss
+++ b/app/assets/sass/modules/_service_switcher.scss
@@ -11,6 +11,16 @@
   font: inherit;
   text-decoration: underline;
   cursor: pointer;
+
+  &::first-letter {
+    text-transform: uppercase;
+  }
+
+  &.live {
+   @include core-24;
+   font-weight: bold;
+   margin-bottom: $gutter / 2;
+  }
 }
 
 .service-name a {
@@ -23,10 +33,6 @@
 
 .service-switcher.active {
   background-color: $highlight-colour;
-}
-
-.service-switcher::first-letter {
-  text-transform: capitalize;
 }
 
 .create-service {

--- a/app/controllers/my_services_controller.js
+++ b/app/controllers/my_services_controller.js
@@ -49,6 +49,7 @@ module.exports = {
 
       serviceService.getGatewayAccounts(serviceRole.service.gatewayAccountIds, req.correlationId)
         .then(accounts => {
+          accounts.sort((a, b) => a.type === b.type ? 0 : a.type === 'live' ? -1 : 1)
           defer.resolve({
             name: displayNameOf(serviceRole.service),
             external_id: serviceRole.service.externalId,

--- a/app/views/services/_service_section.html
+++ b/app/views/services/_service_section.html
@@ -16,7 +16,7 @@
                 <form method="post" action="{{routes.serviceSwitcher.switch}}">
                     <input name="csrfToken" type="hidden" value="{{csrf}}" />
                     <input name="gatewayAccountId" type="hidden" value="{{id}}"/>
-                    <input class="service-switcher {{type}} {{payment_provider}}" type="submit" role="link" value="{{payment_provider}} {{type}}">
+                    <button class="service-switcher {{type}} {{payment_provider}}" type="submit" role="link">{{type}} account ({{payment_provider}})</button>
                 </form>
             </li>
             {{/gateway_accounts}}


### PR DESCRIPTION
I thought this would be quite straight forward but the I don't data available to use in the template. I had a quick go a wrangling the controllers but there are a lot of async requests and I feel out of my depth and could do with pairing with someone to see how best to do it (without loads of duplication of functionality elsewhere)

- [x] Reworded gateway naming
- [x] Added class to live accounts so they are displayed more prominently 
- [x] Reorder returned gateways array so that the live gateways show first

## How it needs to look
<img width="986" alt="screen shot 2017-09-26 at 17 01 17" src="https://user-images.githubusercontent.com/440503/30962436-9aeeecec-a441-11e7-8fa7-0e3191f7ba3c.png">
