### PR TITLE
PP-2728 Add DeployEcs step to deploy task

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,8 @@ pipeline {
         branch 'master'
       }
       steps {
-        deploy("selfservice", "test", null, true)
+        deploy("selfservice", "test", null, true, false)
+        deployEcs("selfservice", "test", null, true, true)
       }
     }
   }


### PR DESCRIPTION
## WHAT

This adds an extra step for deploying to the ECS cluster after deploying
to the normal cluster. We pass an extra boolean flag to both steps which
corresponds to `run_tests` boolean flag. This is so that we don’t smoke
test an environment after deploying to the first cluster, but haven’t
actually deployed anything yet to the ECS cluster.

