### PR TITLE
PP-2712 Upgrade serve-favicon

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "readdir": "0.0.x",
     "requestretry": "^1.12.0",
     "rfc822-validate": "^1.0.0",
-    "serve-favicon": "2.4.3",
+    "serve-favicon": "2.4.5",
     "sleep": "^5.1.1",
     "staticify": "0.0.8",
     "thirty-two": "^1.0.2",


### PR DESCRIPTION
Snyk is reporting a vulnerability in fresh
included through serve-favicon
https://snyk.io/vuln/npm:fresh:20170908

Upgrading to 2.4.5 fixes this.