### PR TITLE
PP-2655 - Reusable client side form validation

### DIFF
--- a/app/browsered.js
+++ b/app/browsered.js
@@ -2,8 +2,10 @@
 // NPM dependencies
 const $ = require('jquery')
 const multiSelects = require('./client-side-scripts/multi-select')
+const fieldValidation = require('./browsered/field-validation')
 
 // This adds jquery globally for non-browserified contexts
 window.$ = window.jQuery = $
 
 multiSelects.enableMultiSelects()
+fieldValidation.enableFieldValidation()

--- a/app/browsered/field-validation-checks.js
+++ b/app/browsered/field-validation-checks.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const validationErrors = {
+  required: 'This is field cannot be blank',
+  email: 'Please use a valid email address',
+  currency: 'Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”'
+}
+
+module.exports.isEmpty = function (value) {
+  if (value === '') {
+    return validationErrors.required
+  } else {
+    return false
+  }
+}
+
+module.exports.isCurrency = function (value) {
+  if (!/^([0-9]+)(?:\.([0-9]{2}))?$/.test(value)) {
+    return validationErrors.currency
+  } else {
+    return false
+  }
+}

--- a/app/browsered/field-validation.js
+++ b/app/browsered/field-validation.js
@@ -1,0 +1,98 @@
+'use strict'
+
+// NPM Dependencies
+const lodash = require('lodash')
+
+// Local Dependencies
+const checks = require('./field-validation-checks')
+const validationErrorsTemplate = require('../views/includes/validation-errors.html')
+
+exports.enableFieldValidation = function () {
+  const allForms = [...document.getElementsByTagName('form')]
+
+  allForms.filter(form => {
+    return form.hasAttribute('data-validate')
+  }).map(form => {
+    form.addEventListener('submit', initValidation, false)
+  })
+}
+
+function initValidation (e) {
+  let form = e.target
+  e.preventDefault()
+  clearPreviousErrors()
+
+  let validatedFields = findFields(form)
+  .map(field => validateField(form, field))
+
+  if (lodash.every(validatedFields)) {
+    form.submit()
+  } else {
+    populateErrorSummary(form)
+  }
+}
+
+function clearPreviousErrors () {
+  let previousErrorsMessages = [...document.querySelectorAll('.error-message, .error-summary')]
+  let previousErrorsFields = [...document.querySelectorAll('.form-group.error')]
+
+  previousErrorsMessages.map(error => error.remove())
+  previousErrorsFields.map(errorField => errorField.classList.remove('error'))
+}
+
+function findFields (form) {
+  const formFields = [...form.querySelectorAll('input, textarea, select')]
+
+  return formFields.filter(field => {
+    return field.hasAttribute('data-validate')
+  })
+}
+
+function validateField (form, field) {
+  let result
+  let validationTypes = field.getAttribute('data-validate').split(' ')
+
+  for (let validationType of validationTypes) {
+    switch (validationType) {
+      case 'currency' :
+        result = checks.isCurrency(field.value)
+        break
+      default :
+        result = checks.isEmpty(field.value)
+        break
+    }
+    if (result) {
+      applyErrorMessaging(form, field, result)
+    }
+  }
+
+  if (!result) {
+    return true
+  }
+}
+
+function applyErrorMessaging (form, field, result) {
+  let formGroup = field.closest('.form-group')
+  if (!formGroup.classList.contains('error')) {
+    formGroup.classList.add('error')
+    document.querySelector('label[for="' + field.name + '"]').insertAdjacentHTML('beforeend',
+      '<span class="error-message">' + result + '</span>')
+  }
+}
+
+function populateErrorSummary (form) {
+  let erroringFields = [...form.querySelectorAll('.form-group.error label')]
+  let configuration = {
+    field: erroringFields.map(field => {
+      let label = field.innerHTML.split('<')[0].trim()
+      let id = field.getAttribute('for')
+      return {label, id}
+    })
+  }
+
+  form.parentNode.insertAdjacentHTML(
+    'afterbegin',
+    validationErrorsTemplate.render(configuration)
+  )
+  window.scroll(0, 0)
+}

--- a/app/views/includes/validation-errors.html
+++ b/app/views/includes/validation-errors.html
@@ -1,0 +1,10 @@
+<div id="error-summary-{{form.id}}" class="error-summary" role="group" aria-labelledby="error-summary-heading-{{form.id}}" tabindex="-1">
+  <h2 class="heading-medium error-summary-heading" id="error-summary-heading-{{form.id}}">
+    There was a problem with the details you gave for:
+  </h2>
+  <ul class="error-summary-list">
+    {{#field}}
+      <li class="error-{{id}}"><a href="#{{id}}">{{label}}</a></li>
+    {{/field}}
+  </ul>
+</div>


### PR DESCRIPTION
Usually we write validation into the controllers
which ends up meaning we have a lot of duplication
which is a shame and is loooong.

So this is a generic browserified validation engine.
To use it anywhere you need to do a couple of things

- add `data-validate="true"` to the form you want to validate
- add `data-validate` to each of the `input/select/textarea`'s you want validated
- by default it will check that the value is not blank but you can add a space separated list of validations e.g. `data-validate="required currency"`

Currently I have only written validators for `isCurrency`
and `isEmpty`. You can add new ones to `field-validation-checks.js`

The validator expects them to return a `string` with the error message or else `false`