### PR TITLE
PP-2800 - fixed missing icon

### DIFF
--- a/app/assets/sass/gov-uk-overrides/_icons.scss
+++ b/app/assets/sass/gov-uk-overrides/_icons.scss
@@ -1,15 +1,7 @@
-.info {
-  max-width: 510px;
-  position: relative;
-  padding-left: 40px;
-  &:before {
-    background: url("/public/images/icons/icon-important-2x.png");
-    background-size: 100%;
-    width:27px;
-    height:27px;
-    content: "";
-    position: absolute;
-    top: 5px;
-    left: 0;
+.icon-important {
+  background-image: url("/public/images/icons/icon-important.png");
+  background-size: 100%;
+  @include device-pixel-ratio {
+    background-image: url("/public/images/icons/icon-important-2x.png");
   }
 }


### PR DESCRIPTION
The icon was missong from turn off email notifications screen

There was a load of CSS to replace it, that was no longer working, I don't know why so much was written when only the background-image: url() was causing the issue

There is a screenshot of the problem on Jira — https://payments-platform.atlassian.net/browse/PP-2800