### PR TITLE
PP-2816 fix irregular spacing on smartpay creds page

### DIFF
--- a/app/assets/sass/helpers/_headings.scss
+++ b/app/assets/sass/helpers/_headings.scss
@@ -1,7 +1,7 @@
 .heading-with-border {
-  border-bottom: 5px solid $black;
-  padding-bottom: $gutter-two-thirds;
   margin-bottom: $gutter;
+  padding-bottom: $gutter-two-thirds;
+  border-bottom: 5px solid $black;
 }
 
 .page-title {
@@ -10,8 +10,13 @@
 }
 
 .heading-group {
-  /* Allow other tags to sit alongside the heading */
-  h1, h2, h3, h4, h5, h6 {
+  // Allow other tags to sit alongside the heading
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     @include inline-block;
   }
 
@@ -23,4 +28,8 @@
 
 .sign-in-heading {
   margin-top: $gutter;
+}
+
+.pad-top {
+  margin-top: $gutter * 2;
 }

--- a/app/assets/sass/helpers/_tables.scss
+++ b/app/assets/sass/helpers/_tables.scss
@@ -1,12 +1,21 @@
 table {
-  margin-bottom: $gutter*2;
   width: $full-width;
+  margin-bottom: $gutter * 2;
+
   td {
     @include core-14;
-    padding: 0.75em 1.25em 0.5625em 0;
+    padding: .75em 1.25em .5625em 0;
     line-height: 1;
+
     &.details {
       font-weight: bold;
+    }
+
+    &.one-third {
+      width: 33.333%;
+    }
+    &.two-thirds {
+      width: 66.666%;
     }
   }
 

--- a/app/views/provider_credentials/epdq.html
+++ b/app/views/provider_credentials/epdq.html
@@ -11,24 +11,24 @@
 <table id="credentials">
   <tbody>
     <tr>
-      <th id="merchant-id-key">PSP ID</th>
-      <td id="merchant-id-value" class="font-small">{{currentGatewayAccount.credentials.merchant_id}}</td>
+      <th class="one-third" id="merchant-id-key">PSP ID</th>
+      <td id="merchant-id-value" class="font-small two-thirds">{{currentGatewayAccount.credentials.merchant_id}}</td>
     </tr>
     <tr>
-      <th id="username-key">Username</th>
-      <td id="username-value" class="font-small">{{currentGatewayAccount.credentials.username}}</td>
+      <th class="one-third" id="username-key">Username</th>
+      <td id="username-value" class="font-small two-thirds">{{currentGatewayAccount.credentials.username}}</td>
     </tr>
     <tr>
-      <th id="password-key">Password</th>
-      <td id="password-value" class="font-small">{{#currentGatewayAccount.credentials.username}}****{{/currentGatewayAccount.credentials.username}}</td>
+      <th class="one-third" id="password-key">Password</th>
+      <td id="password-value" class="font-small two-thirds">{{#currentGatewayAccount.credentials.username}}****{{/currentGatewayAccount.credentials.username}}</td>
     </tr>
     <tr>
-      <th id="sha-in-passphrase-key">SHA-IN passphrase</th>
-      <td id="sha-in-passphrase-value" class="font-small">{{#currentGatewayAccount.credentials.username}}****{{/currentGatewayAccount.credentials.username}}</td>
+      <th class="one-third" id="sha-in-passphrase-key">SHA-IN passphrase</th>
+      <td id="sha-in-passphrase-value" class="font-small two-thirds">{{#currentGatewayAccount.credentials.username}}****{{/currentGatewayAccount.credentials.username}}</td>
     </tr>
     <tr>
-      <th id="sha-out-passphrase-key">SHA-OUT passphrase</th>
-      <td id="sha-out-passphrase-value" class="font-small">{{#currentGatewayAccount.credentials.username}}****{{/currentGatewayAccount.credentials.username}}</td>
+      <th class="one-third" id="sha-out-passphrase-key">SHA-OUT passphrase</th>
+      <td id="sha-out-passphrase-value" class="font-small two-thirds">{{#currentGatewayAccount.credentials.username}}****{{/currentGatewayAccount.credentials.username}}</td>
     </tr>
   </tbody>
 </table>

--- a/app/views/provider_credentials/smartpay.html
+++ b/app/views/provider_credentials/smartpay.html
@@ -10,16 +10,16 @@
 <table id="credentials">
   <tbody>
     <tr>
-      <th id="merchant-id-key">Merchant ID</th>
-      <td id="merchant-id-value" class="font-small">{{currentGatewayAccount.credentials.merchant_id}}</td>
+      <th class="one-third" id="merchant-id-key">Merchant ID</th>
+      <td id="merchant-id-value" class="font-small two-thirds">{{currentGatewayAccount.credentials.merchant_id}}</td>
     </tr>
     <tr>
-      <th id="username-key">Username</th>
-      <td id="username-value" class="font-small">{{currentGatewayAccount.credentials.username}}</td>
+      <th class="one-third" id="username-key">Username</th>
+      <td id="username-value" class="font-small two-thirds">{{currentGatewayAccount.credentials.username}}</td>
     </tr>
     <tr>
-      <th id="password-key">Password</th>
-      <td id="password-value" class="font-small">{{#currentGatewayAccount.credentials.username}}****{{/currentGatewayAccount.credentials.username}}</td>
+      <th class="one-third" id="password-key">Password</th>
+      <td id="password-value" class="font-small two-thirds">{{#currentGatewayAccount.credentials.username}}****{{/currentGatewayAccount.credentials.username}}</td>
     </tr>
   </tbody>
 </table>
@@ -54,9 +54,8 @@
 {{/editMode}}
 {{/permissions.gateway_credentials_update}}
 
-<p>
-<h4 class="heading-small" id="view-notification-title">Your {{currentGatewayAccount.payment_provider}} Notification Credentials</h4>
-</p>
+<h4 class="heading-small pad-top" id="view-notification-title">Your {{currentGatewayAccount.payment_provider}} Notification Credentials</h4>
+
 {{#permissions.gateway_credentials_read}}
 {{^editNotificationCredentialsMode}}
     {{^currentGatewayAccount.notificationCredentials.userName}}
@@ -74,12 +73,12 @@
     <table id="notification_credentials">
       <tbody>
       <tr>
-        <th id="notification-username-key">Username</th>
-        <td id="notification-username-value" class="font-small">{{currentGatewayAccount.notificationCredentials.userName}}</td>
+        <th class="one-third" id="notification-username-key">Username</th>
+        <td id="notification-username-value" class="font-small two-thirds">{{currentGatewayAccount.notificationCredentials.userName}}</td>
       </tr>
       <tr>
-        <th id="notification-password-key">Password</th>
-        <td id="notification-password-value" class="font-small">{{#currentGatewayAccount.notificationCredentials.userName}}****{{/currentGatewayAccount.notificationCredentials.userName}}</td>
+        <th class="one-third" id="notification-password-key">Password</th>
+        <td id="notification-password-value" class="font-small two-thirds">{{#currentGatewayAccount.notificationCredentials.userName}}****{{/currentGatewayAccount.notificationCredentials.userName}}</td>
       </tbody>
     </table>
     <a id="edit-notification_credentials-link" class="button" href="{{routes.notificationCredentials.edit}}">

--- a/app/views/provider_credentials/worldpay.html
+++ b/app/views/provider_credentials/worldpay.html
@@ -10,16 +10,16 @@
   <table id="credentials">
     <tbody>
       <tr>
-        <th id="merchant-id-key">Merchant ID</th>
-        <td id="merchant-id-value" class="font-small">{{currentGatewayAccount.credentials.merchant_id}}</td>
+        <th class="one-third" id="merchant-id-key">Merchant ID</th>
+        <td id="merchant-id-value" class="font-small two-thirds">{{currentGatewayAccount.credentials.merchant_id}}</td>
       </tr>
       <tr>
-        <th id="username-key">Username</th>
-        <td id="username-value" class="font-small">{{currentGatewayAccount.credentials.username}}</td>
+        <th class="one-third" id="username-key">Username</th>
+        <td id="username-value" class="font-small two-thirds">{{currentGatewayAccount.credentials.username}}</td>
       </tr>
       <tr>
-        <th id="password-key">Password</th>
-        <td id="password-value" class="font-small">{{#currentGatewayAccount.credentials.username}}****{{/currentGatewayAccount.credentials.username}}</td>
+        <th class="one-third" id="password-key">Password</th>
+        <td id="password-value" class="font-small two-thirds">{{#currentGatewayAccount.credentials.username}}****{{/currentGatewayAccount.credentials.username}}</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
The smartpay creds tables didnt line up vertically also the were close together which was consfusing and ugly.
Now it's all uniform across all provider creds tables