### PR TITLE
Streamline Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,10 @@
 pipeline {
   agent any
 
+  parameters {
+    booleanParam(defaultValue: false, description: '', name: 'runEndToEndOnPR')
+  }
+
   options {
     ansiColor('xterm')
     timestamps()
@@ -10,6 +14,10 @@ pipeline {
 
   libraries {
     lib("pay-jenkins-library@master")
+  }
+
+  environment {
+    RUN_END_TO_END_ON_PR = "${params.runEndToEndOnPR}"
   }
 
   stages {
@@ -23,6 +31,12 @@ pipeline {
       }
     }
     stage('Test') {
+      when {
+        anyOf {
+          branch 'master'
+          environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
+        }
+      }
       steps {
         runEndToEnd("selfservice")
       }
@@ -41,7 +55,7 @@ pipeline {
         branch 'master'
       }
       steps {
-        deploy("selfservice", "test", null, true, false)
+        deploy("selfservice", "test", null, false)
         deployEcs("selfservice", "test", null, true, true)
       }
     }


### PR DESCRIPTION
This PR removes the requirement that end-to-end tests are run on
PR build. This change has been tried out already on connector and
has been successful. This removal is potentially  controversial - it makes
it possible to commit potentially broken (or incompatible) code to master.
However, I believe developer discipline and intuition should guide whether
running this before merge is necessary or not. For small changes (which
we should be encouraging) this seems way too much largely irrelevant
testing. And if you do break master, it would be much quicker to get out
a fix. If you feel need for Jenkins to run e2e against your branch before
merge, I have added a manually configurable option to be able to do that.