### PR TITLE
PP-2655 - PhantomJS doesnt like fancy ES6 stuff

### DIFF
--- a/app/browsered/field-validation.js
+++ b/app/browsered/field-validation.js
@@ -8,7 +8,7 @@ const checks = require('./field-validation-checks')
 const validationErrorsTemplate = require('../views/includes/validation-errors.html')
 
 exports.enableFieldValidation = function () {
-  const allForms = [...document.getElementsByTagName('form')]
+  const allForms = Array.prototype.slice.call(document.getElementsByTagName('form'))
 
   allForms.filter(form => {
     return form.hasAttribute('data-validate')


### PR DESCRIPTION
We were using the spread operator [...] to convert a node list
into a standard array and as its ES6 it was converted on build.
in then used Array.from() which upset PhantomJS. We could update
PhantomJS but we're phasing it out so easier to not use the spread operator here.



