### PR TITLE
PP-2655 Update productsClient

### DIFF
--- a/app/models/Payment.class.js
+++ b/app/models/Payment.class.js
@@ -1,0 +1,30 @@
+'use strict'
+
+// NPM Dependencies
+const lodash = require('lodash')
+
+/**
+ @class Payment
+ */
+class Payment {
+  /**
+   * @param {Object} opts - The raw payment object from pay-products
+   * @param {string} opts.external_id - The external ID of the payment
+   * @param {string} opts.product_external_id - The external ID of the product associated with the payment
+   * @param {status} opts.status - The current status of the payment
+   * @param {Object[]} opts._links - Links relevent to the payment
+   * @param {string} opts._links[].href - url of the link
+   * @param {string} opts._links[].method - the http method of the link
+   * @param {string} opts._links[].rel - the name of the link
+   * @returns Payment
+   */
+  constructor (opts) {
+    this.externalId = opts.external_id
+    this.productExternalId = opts.product_external_id
+    this.status = opts.status
+    this.nextUrl = opts.next_url
+    opts._links.forEach(link => lodash.set(this, `links.${link.rel}`, {method: link.method, href: link.href}))
+  }
+}
+
+module.exports = Payment

--- a/app/models/Product.class.js
+++ b/app/models/Product.class.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// NPM Dependencies
+const lodash = require('lodash')
+
 /**
  @class Product
  * @property {string} externalId - The external ID of the product
@@ -37,10 +40,9 @@ class Product {
     this.gatewayAccountId = opts.gateway_account_id
     this.name = opts.name
     this.price = opts.price
-    this.description = opts.description || ''
-    this.returnUrl = opts.return_url || ''
-    this.payLink = opts._links.find(link => link.rel === 'pay')
-    this.selfLink = opts._links.find(link => link.rel === 'self')
+    this.description = opts.description
+    this.returnUrl = opts.return_url
+    opts._links.forEach(link => lodash.set(this, `links.${link.rel}`, {method: link.method, href: link.href}))
   }
 }
 

--- a/app/services/clients/products_client.js
+++ b/app/services/clients/products_client.js
@@ -2,6 +2,7 @@
 
 // Local Dependencies
 const Product = require('../../models/Product.class')
+const Payment = require('../../models/Payment.class')
 const baseClient = require('./base_client/base_client')
 const {PRODUCTS_URL, PRODUCTS_API_TOKEN} = require('../../../config')
 
@@ -16,24 +17,20 @@ const headers = {
 
 // Exports
 module.exports = {
-  createProduct,
-  getProduct
+  product: {
+    create: createProduct,
+    disable: disableProduct,
+    getByProductExternalId: getProductByExternalId,
+    getByGatewayAccountId: getProductsByGatewayAccountId
+  },
+  payment: {
+    create: createPayment,
+    getByPaymentExternalId: getPaymentByPaymentExternalId,
+    getByProductExternalId: getPaymentsByProductExternalId
+  }
 }
 
-/**
- * @param {String} externalProductId: the external id of the product you wish to retrieve
- * @returns {Promise<Product>}
- */
-function getProduct (externalProductId) {
-  return baseClient.get({
-    headers,
-    baseUrl,
-    url: `/products/${externalProductId}`,
-    description: 'find a product',
-    service: SERVICE_NAME
-  }).then(product => new Product(product))
-}
-
+// PRODUCT
 /**
  * @param {Object} options
  * @param {string} options.gatewayAccountId - The id of the gateway account you wish to use to pay for the product
@@ -61,4 +58,92 @@ function createProduct (options) {
     description: 'create a product for a service',
     service: SERVICE_NAME
   }).then(product => new Product(product))
+}
+
+/**
+ * @param {String} externalProductId: the external id of the product you wish to retrieve
+ * @returns {Promise<Product>}
+ */
+function getProductByExternalId (externalProductId) {
+  return baseClient.get({
+    headers,
+    baseUrl,
+    url: `/products/${externalProductId}`,
+    description: `find a product by it's external id`,
+    service: SERVICE_NAME
+  }).then(product => new Product(product))
+}
+
+/**
+ * @param {String} gatewayAccountId - The id of the gateway account to retrieve products associated with
+ * @returns {Promise<Array<Product>>}
+ */
+function getProductsByGatewayAccountId (gatewayAccountId) {
+  return baseClient.get({
+    headers,
+    baseUrl,
+    url: '/products',
+    qs: {
+      gatewayAccountId
+    },
+    description: 'find a list products associated with a gateway account',
+    service: SERVICE_NAME
+  }).then(products => products.map(product => new Product(product)))
+}
+
+/**
+ * @param {String} productExternalId: the external id of the product you wish to disable
+ * @returns {undefined}
+ */
+function disableProduct (productExternalId) {
+  return baseClient.patch({
+    headers,
+    baseUrl,
+    url: `/products/${productExternalId}/disable`,
+    description: `disable a product`,
+    service: SERVICE_NAME
+  })
+}
+
+// PAYMENT
+/**
+ * @param {String} productExternalId The external ID of the product to create a payment for
+ * @returns Promise<Payment>
+ */
+function createPayment (productExternalId) {
+  return baseClient.post({
+    headers,
+    baseUrl,
+    url: `/products/${productExternalId}/payments`,
+    description: 'create a payment for a product',
+    service: SERVICE_NAME
+  }).then(payment => new Payment(payment))
+}
+
+/**
+ * @param {String} paymentExternalId
+ * @returns Promise<Payment>
+ */
+function getPaymentByPaymentExternalId (paymentExternalId) {
+  return baseClient.get({
+    headers,
+    baseUrl,
+    url: `/payments/${paymentExternalId}`,
+    description: `find a payment by it's external id`,
+    service: SERVICE_NAME
+  }).then(charge => new Payment(charge))
+}
+
+/**
+ * @param {String} productExternalId
+ * @returns Promise<Array<Payment>>
+ */
+function getPaymentsByProductExternalId (productExternalId) {
+  return baseClient.get({
+    headers,
+    baseUrl,
+    url: `/products/${productExternalId}/payments`,
+    description: `find a payments associated with a particular product`,
+    service: SERVICE_NAME
+  }).then(payments => payments.map(payment => new Payment(payment)))
 }

--- a/test/fixtures/product_fixtures.js
+++ b/test/fixtures/product_fixtures.js
@@ -10,6 +10,9 @@ const randomGatewayAccountId = () => Math.round(Math.random() * 1000) + 1
 const randomPrice = () => Math.round(Math.random() * 10000) + 1
 
 module.exports = {
+  pactifyRandomData: (opts = {}) => {
+    pactProducts.pactify(opts)
+  },
 
   validCreateProductRequest: (opts = {}) => {
     const data = {
@@ -20,6 +23,36 @@ module.exports = {
     }
     if (opts.description) data.description = opts.description
     if (opts.returnUrl) data.return_url = opts.returnUrl
+    return {
+      getPactified: () => {
+        return pactProducts.pactify(data)
+      },
+      getPlain: () => {
+        return data
+      }
+    }
+  },
+
+  validCreatePaymentResponse: (opts = {}) => {
+    const data = {
+      external_id: opts.external_id || randomExternalId(),
+      product_external_id: opts.product_external_id || randomExternalId(),
+      next_url: opts.next_url || `http://service.url/next`,
+      status: opts.status || 'CREATED',
+      _links: opts.links
+    }
+    if (!data._links) {
+      data._links = [{
+        href: `http://products.url/v1/api/payments/${(data.external_id)}`,
+        rel: 'self',
+        method: 'GET'
+      }, {
+        href: `http://frontend.url/charges/${(data.external_id)}`,
+        rel: 'pay',
+        method: 'POST'
+      }]
+    }
+
     return {
       getPactified: () => {
         return pactProducts.pactify(data)

--- a/test/unit/clients/product_client/payment/create_test.js
+++ b/test/unit/clients/product_client/payment/create_test.js
@@ -1,0 +1,146 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+const {expect} = require('chai')
+const proxyquire = require('proxyquire')
+
+// Custom dependencies
+const pactProxy = require('../../../../test_helpers/pact_proxy')
+const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const productFixtures = require('../../../../fixtures/product_fixtures')
+
+// Constants
+const PRODUCTS_RESOURCE = '/v1/api/products'
+const mockPort = Math.floor(Math.random() * 65535)
+const mockServer = pactProxy.create('localhost', mockPort)
+let productsMock, result, response, productExternalId
+
+function getProductsClient (baseUrl = `http://localhost:${mockPort}`, productsApiKey = 'ABC1234567890DEF') {
+  return proxyquire('../../../../../app/services/clients/products_client', {
+    '../../../config': {
+      PRODUCTS_URL: baseUrl,
+      PRODUCTS_API_TOKEN: productsApiKey
+    }
+  })
+}
+
+describe('products client - creating a new payment', () => {
+  /**
+   * Start the server and set up Pact
+   */
+  before(function (done) {
+    this.timeout(5000)
+    mockServer.start().then(() => {
+      productsMock = Pact({consumer: 'Selfservice-create-new-charge', provider: 'products', port: mockPort})
+      done()
+    })
+  })
+
+  /**
+   * Remove the server and publish pacts to broker
+   */
+  after(done => {
+    mockServer.delete()
+      .then(() => pactProxy.removeAll())
+      .then(() => done())
+  })
+
+  describe('when a charge is successfully created', () => {
+    before((done) => {
+      const productsClient = getProductsClient()
+      productExternalId = 'a-valid-product-id'
+      response = productFixtures.validCreatePaymentResponse({product_external_id: productExternalId})
+      productsMock.addInteraction(
+        new PactInteractionBuilder(`${PRODUCTS_RESOURCE}/${productExternalId}/payments`)
+          .withUponReceiving('a valid create charge create request')
+          .withMethod('POST')
+          .withStatusCode(201)
+          .withResponseBody(response.getPactified())
+          .build()
+      )
+        .then(() => productsClient.payment.create(productExternalId))
+        .then(res => {
+          result = res
+          done()
+        })
+        .catch(e => done(e))
+    })
+
+    after((done) => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should create a new product', () => {
+      const plainResponse = response.getPlain()
+      expect(result.productExternalId).to.equal(plainResponse.product_external_id).and.to.equal(productExternalId)
+      expect(result.externalId).to.equal(plainResponse.external_id)
+      expect(result.status).to.equal(plainResponse.status)
+      expect(result.nextUrl).to.equal(plainResponse.next_url)
+      expect(result).to.have.property('links')
+      expect(Object.keys(result.links).length).to.equal(2)
+      expect(result.links).to.have.property('self')
+      expect(result.links.self).to.have.property('method').to.equal(plainResponse._links.find(link => link.rel === 'self').method)
+      expect(result.links.self).to.have.property('href').to.equal(plainResponse._links.find(link => link.rel === 'self').href)
+      expect(result.links).to.have.property('pay')
+      expect(result.links.pay).to.have.property('method').to.equal(plainResponse._links.find(link => link.rel === 'pay').method)
+      expect(result.links.pay).to.have.property('href').to.equal(plainResponse._links.find(link => link.rel === 'pay').href)
+    })
+  })
+
+  describe('when the request has invalid authorization credentials', () => {
+    before(done => {
+      const productsClient = getProductsClient(`http://localhost:${mockPort}`, 'invalid-api-key')
+      productExternalId = 'valid-id'
+      productsMock.addInteraction(
+        new PactInteractionBuilder(`${PRODUCTS_RESOURCE}/${productExternalId}/payments`)
+          .withUponReceiving('a valid create charge request with invalid PRODUCTS_API_TOKEN')
+          .withMethod('POST')
+          .withStatusCode(401)
+          .build()
+      )
+        .then(() => productsClient.payment.create(productExternalId), err => done(err))
+        .then(() => done(new Error('Promise unexpectedly resolved')))
+        .catch((err) => {
+          result = err
+          done()
+        })
+    })
+
+    afterEach((done) => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should reject with error unauthorised', () => {
+      expect(result.errorCode).to.equal(401)
+    })
+  })
+
+  describe('when creating a charge using a malformed request', () => {
+    beforeEach(done => {
+      const productsClient = getProductsClient()
+      productExternalId = 'invalid-id'
+      productsMock.addInteraction(
+        new PactInteractionBuilder(`${PRODUCTS_RESOURCE}/${productExternalId}/payments`)
+          .withUponReceiving('an invalid create charge request')
+          .withMethod('POST')
+          .withStatusCode(400)
+          .build()
+      )
+        .then(() => productsClient.payment.create(productExternalId), done)
+        .then(() => done(new Error('Promise unexpectedly resolved')))
+        .catch((err) => {
+          result = err
+          done()
+        })
+    })
+
+    afterEach(done => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should reject with error: bad request', () => {
+      expect(result.errorCode).to.equal(400)
+    })
+  })
+})

--- a/test/unit/clients/product_client/payment/get_by_product_external_id_test.js
+++ b/test/unit/clients/product_client/payment/get_by_product_external_id_test.js
@@ -1,0 +1,154 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+const {expect} = require('chai')
+const proxyquire = require('proxyquire')
+
+// Custom dependencies
+const Payment = require('../../../../../app/models/Payment.class')
+const pactProxy = require('../../../../test_helpers/pact_proxy')
+const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const productFixtures = require('../../../../fixtures/product_fixtures')
+
+// Constants
+const PRODUCT_RESOURCE = '/v1/api/products'
+const mockPort = Math.floor(Math.random() * 65535)
+const mockServer = pactProxy.create('localhost', mockPort)
+let productsMock, response, result, productExternalId
+
+function getProductsClient (baseUrl = `http://localhost:${mockPort}`, productsApiKey = 'ABC1234567890DEF') {
+  return proxyquire('../../../../../app/services/clients/products_client', {
+    '../../../config': {
+      PRODUCTS_URL: baseUrl,
+      PRODUCTS_API_TOKEN: productsApiKey
+    }
+  })
+}
+
+describe('products client - find a payment by it\'s associated product external id', function () {
+  /**
+   * Start the server and set up Pact
+   */
+  before(function (done) {
+    this.timeout(5000)
+    mockServer.start().then(function () {
+      productsMock = Pact({consumer: 'Selfservice-find-product', provider: 'products', port: mockPort})
+      done()
+    })
+  })
+
+  /**
+   * Remove the server and publish pacts to broker
+   */
+  after(done => {
+    mockServer.delete()
+      .then(() => pactProxy.removeAll())
+      .then(() => done())
+  })
+
+  describe('when a product is successfully found', () => {
+    before(done => {
+      const productsClient = getProductsClient()
+      productExternalId = 'existing-id'
+      response = [
+        productFixtures.validCreatePaymentResponse({product_external_id: productExternalId}),
+        productFixtures.validCreatePaymentResponse({product_external_id: productExternalId}),
+        productFixtures.validCreatePaymentResponse({product_external_id: productExternalId})
+      ]
+      const interaction = new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}/payments`)
+        .withUponReceiving('a valid get payment request')
+        .withMethod('GET')
+        .withStatusCode(200)
+        .withResponseBody(response.map(item => item.getPactified()))
+        .build()
+      productsMock.addInteraction(interaction)
+        .then(() => productsClient.payment.getByProductExternalId(productExternalId))
+        .then(res => {
+          result = res
+          done()
+        })
+        .catch(e => done(e))
+    })
+
+    after((done) => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should return a list of payments', () => {
+      expect(result.length).to.equal(3)
+      expect(result.map(item => item.constructor)).to.deep.equal([Payment, Payment, Payment])
+      result.forEach((payment, index) => {
+        const plainResponse = response[index].getPlain()
+        expect(payment.productExternalId).to.equal(plainResponse.product_external_id).and.to.equal(productExternalId)
+        expect(payment.externalId).to.equal(plainResponse.external_id)
+        expect(payment.status).to.equal(plainResponse.status)
+        expect(payment.nextUrl).to.equal(plainResponse.next_url)
+        expect(payment).to.have.property('links')
+        expect(Object.keys(payment.links).length).to.equal(2)
+        expect(payment.links).to.have.property('self')
+        expect(payment.links.self).to.have.property('method').to.equal(plainResponse._links.find(link => link.rel === 'self').method)
+        expect(payment.links.self).to.have.property('href').to.equal(plainResponse._links.find(link => link.rel === 'self').href)
+        expect(payment.links).to.have.property('pay')
+        expect(payment.links.pay).to.have.property('method').to.equal(plainResponse._links.find(link => link.rel === 'pay').method)
+        expect(payment.links.pay).to.have.property('href').to.equal(plainResponse._links.find(link => link.rel === 'pay').href)
+      })
+    })
+  })
+
+  describe('when the request has invalid authorization credentials', () => {
+    beforeEach(done => {
+      const productsClient = getProductsClient(`http://localhost:${mockPort}`, 'invalid-api-key')
+      productExternalId = 'existing-id'
+      productsMock.addInteraction(
+        new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}/payments`)
+          .withUponReceiving('a valid find payment request with invalid PRODUCTS_API_TOKEN')
+          .withMethod('GET')
+          .withStatusCode(401)
+          .build()
+      )
+        .then(() => productsClient.payment.getByProductExternalId(productExternalId), done)
+        .then(() => done(new Error('Promise unexpectedly resolved')))
+        .catch((err) => {
+          result = err
+          done()
+        })
+    })
+
+    after((done) => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should reject with error: 401 unauthorised', () => {
+      expect(result.errorCode).to.equal(401)
+    })
+  })
+
+  describe('when a product is not found', () => {
+    before(done => {
+      const productsClient = getProductsClient()
+      productExternalId = 'non-existing-id'
+      productsMock.addInteraction(
+        new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}/payments`)
+          .withUponReceiving('a valid find product request with non existing id')
+          .withMethod('GET')
+          .withStatusCode(404)
+          .build()
+      )
+        .then(() => productsClient.payment.getByProductExternalId(productExternalId), done)
+        .then(() => done(new Error('Promise unexpectedly resolved')))
+        .catch((err) => {
+          result = err
+          done()
+        })
+    })
+
+    after((done) => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should reject with error: 404 not found', () => {
+      expect(result.errorCode).to.equal(404)
+    })
+  })
+})

--- a/test/unit/clients/product_client/product/create_test.js
+++ b/test/unit/clients/product_client/product/create_test.js
@@ -6,9 +6,9 @@ const {expect} = require('chai')
 const proxyquire = require('proxyquire')
 
 // Custom dependencies
-const pactProxy = require('../../../test_helpers/pact_proxy')
-const PactInteractionBuilder = require('../../../fixtures/pact_interaction_builder').PactInteractionBuilder
-const productFixtures = require('../../../fixtures/product_fixtures')
+const pactProxy = require('../../../../test_helpers/pact_proxy')
+const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const productFixtures = require('../../../../fixtures/product_fixtures')
 
 // Constants
 const PRODUCT_RESOURCE = '/v1/api/products'
@@ -17,7 +17,7 @@ const mockServer = pactProxy.create('localhost', mockPort)
 let productsMock, request, response, result
 
 function getProductsClient (baseUrl = `http://localhost:${mockPort}`, productsApiKey = 'ABC1234567890DEF') {
-  return proxyquire('../../../../app/services/clients/products_client', {
+  return proxyquire('../../../../../app/services/clients/products_client', {
     '../../../config': {
       PRODUCTS_URL: baseUrl,
       PRODUCTS_API_TOKEN: productsApiKey
@@ -25,7 +25,7 @@ function getProductsClient (baseUrl = `http://localhost:${mockPort}`, productsAp
   })
 }
 
-describe('products client - creating a new product', () => {
+describe('products client - create a new product', () => {
   /**
    * Start the server and set up Pact
    */
@@ -64,7 +64,7 @@ describe('products client - creating a new product', () => {
           .withResponseBody(response.getPactified())
           .build()
       )
-        .then(() => productsClient.createProduct({
+        .then(() => productsClient.product.create({
           gatewayAccountId: requestPlain.gateway_account_id,
           payApiToken: requestPlain.pay_api_token,
           name: requestPlain.name,
@@ -84,15 +84,21 @@ describe('products client - creating a new product', () => {
     })
 
     it('should create a new product', () => {
-      const requestPlain = request.getPlain()
-      const responsePlain = response.getPlain()
-      expect(result.gatewayAccountId).to.equal(requestPlain.gateway_account_id)
-      expect(result.name).to.equal(requestPlain.name)
-      expect(result.description).to.equal(requestPlain.description)
-      expect(result.price).to.equal(requestPlain.price)
+      const plainRequest = request.getPlain()
+      const plainResponse = response.getPlain()
+      expect(result.gatewayAccountId).to.equal(plainRequest.gateway_account_id)
+      expect(result.name).to.equal(plainRequest.name)
+      expect(result.description).to.equal(plainRequest.description)
+      expect(result.price).to.equal(plainRequest.price)
       expect(result.returnUrl).to.equal('https://example.gov.uk/paid-for-somet')
-      expect(result.payLink.href).to.equal(`http://products-ui.url/pay/${responsePlain.external_id}`)
-      expect(result.selfLink.href).to.equal(`http://products.url/v1/api/products/${responsePlain.external_id}`)
+      expect(result).to.have.property('links')
+      expect(Object.keys(result.links).length).to.equal(2)
+      expect(result.links).to.have.property('self')
+      expect(result.links.self).to.have.property('method').to.equal(plainResponse._links.find(link => link.rel === 'self').method)
+      expect(result.links.self).to.have.property('href').to.equal(plainResponse._links.find(link => link.rel === 'self').href)
+      expect(result.links).to.have.property('pay')
+      expect(result.links.pay).to.have.property('method').to.equal(plainResponse._links.find(link => link.rel === 'pay').method)
+      expect(result.links.pay).to.have.property('href').to.equal(plainResponse._links.find(link => link.rel === 'pay').href)
     })
   })
 
@@ -109,7 +115,7 @@ describe('products client - creating a new product', () => {
           .withStatusCode(401)
           .build()
       )
-        .then(() => productsClient.createProduct({
+        .then(() => productsClient.product.create({
           gatewayAccountId: requestPlain.gateway_account_id,
           payApiToken: requestPlain.pay_api_token,
           name: requestPlain.name,
@@ -146,7 +152,7 @@ describe('products client - creating a new product', () => {
           .withStatusCode(400)
           .build()
       )
-        .then(() => productsClient.createProduct({
+        .then(() => productsClient.product.create({
           gatewayAccountId: requestPlain.gateway_account_id,
           payApiToken: requestPlain.pay_api_token,
           name: requestPlain.name,

--- a/test/unit/clients/product_client/product/disable_test.js
+++ b/test/unit/clients/product_client/product/disable_test.js
@@ -1,0 +1,131 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+const {expect} = require('chai')
+const proxyquire = require('proxyquire')
+
+// Custom dependencies
+const pactProxy = require('../../../../test_helpers/pact_proxy')
+const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+
+// Constants
+const PRODUCT_RESOURCE = '/v1/api/products'
+const mockPort = Math.floor(Math.random() * 65535)
+const mockServer = pactProxy.create('localhost', mockPort)
+let productsMock, result, productExternalId
+
+function getProductsClient (baseUrl = `http://localhost:${mockPort}`, productsApiKey = 'ABC1234567890DEF') {
+  return proxyquire('../../../../../app/services/clients/products_client', {
+    '../../../config': {
+      PRODUCTS_URL: baseUrl,
+      PRODUCTS_API_TOKEN: productsApiKey
+    }
+  })
+}
+
+describe('products client - disable a product', () => {
+  /**
+   * Start the server and set up Pact
+   */
+  before(function (done) {
+    this.timeout(5000)
+    mockServer.start().then(function () {
+      productsMock = Pact({consumer: 'Selfservice-create-new-product', provider: 'products', port: mockPort})
+      done()
+    })
+  })
+
+  /**
+   * Remove the server and publish pacts to broker
+   */
+  after(done => {
+    mockServer.delete()
+      .then(() => pactProxy.removeAll())
+      .then(() => done())
+  })
+
+  describe('when a product is successfully disabled', () => {
+    before(done => {
+      const productsClient = getProductsClient()
+      productExternalId = 'a_valid_external_id'
+      productsMock.addInteraction(
+        new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}/disable`)
+          .withUponReceiving('a valid disable product request')
+          .withMethod('PATCH')
+          .withStatusCode(204)
+          .build()
+      )
+        .then(() => productsClient.product.disable(productExternalId))
+        .then(res => {
+          result = res
+          done()
+        })
+        .catch(e => done(e))
+    })
+
+    afterEach(done => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should create a new product', () => {
+      expect(result).to.equal(undefined)
+    })
+  })
+
+  describe('when the request has invalid authorization credentials', () => {
+    before(done => {
+      const productsClient = getProductsClient(`http://localhost:${mockPort}`, 'invalid-api-key')
+      productExternalId = 'a_valid_external_id'
+      productsMock.addInteraction(
+        new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}/disable`)
+          .withUponReceiving('a valid disable product request with invalid PRODUCTS_API_TOKEN')
+          .withMethod('PATCH')
+          .withStatusCode(401)
+          .build()
+      )
+        .then(() => productsClient.product.disable(productExternalId), done)
+        .then(() => done(new Error('Promise unexpectedly resolved')))
+        .catch((err) => {
+          result = err
+          done()
+        })
+    })
+
+    afterEach(done => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should error unauthorised', () => {
+      expect(result.errorCode).to.equal(401)
+    })
+  })
+
+  describe('create a product - bad request', () => {
+    before(done => {
+      const productsClient = getProductsClient()
+      productExternalId = 'a_non_existant_external_id'
+      productsMock.addInteraction(
+        new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}/disable`)
+          .withUponReceiving('an invalid create product request')
+          .withMethod('PATCH')
+          .withStatusCode(400)
+          .build()
+      )
+        .then(() => productsClient.product.disable(productExternalId), done)
+        .then(() => done(new Error('Promise unexpectedly resolved')))
+        .catch((err) => {
+          result = err
+          done()
+        })
+    })
+
+    afterEach(done => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should reject with error: bad request', () => {
+      expect(result.errorCode).to.equal(400)
+    })
+  })
+})

--- a/test/unit/clients/product_client/product/get_by_gateway_account_id_test.js
+++ b/test/unit/clients/product_client/product/get_by_gateway_account_id_test.js
@@ -1,0 +1,152 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+const {expect} = require('chai')
+const proxyquire = require('proxyquire')
+
+// Custom dependencies
+const pactProxy = require('../../../../test_helpers/pact_proxy')
+const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const productFixtures = require('../../../../fixtures/product_fixtures')
+
+// Constants
+const PRODUCT_RESOURCE = '/v1/api/products'
+const mockPort = Math.floor(Math.random() * 65535)
+const mockServer = pactProxy.create('localhost', mockPort)
+let productsMock, response, result, gatewayAccountId
+
+function getProductsClient (baseUrl = `http://localhost:${mockPort}`, productsApiKey = 'ABC1234567890DEF') {
+  return proxyquire('../../../../../app/services/clients/products_client', {
+    '../../../config': {
+      PRODUCTS_URL: baseUrl,
+      PRODUCTS_API_TOKEN: productsApiKey
+    }
+  })
+}
+
+describe('products client - find products associated with a particular gateway account id', function () {
+  /**
+   * Start the server and set up Pact
+   */
+  before(function (done) {
+    this.timeout(5000)
+    mockServer.start().then(() => {
+      productsMock = Pact({consumer: 'Selfservice-find-product', provider: 'products', port: mockPort})
+      done()
+    })
+  })
+
+  /**
+   * Remove the server and publish pacts to broker
+   */
+  after(done => {
+    mockServer.delete()
+      .then(() => pactProxy.removeAll())
+      .then(() => done())
+  })
+
+  describe('when products are successfully found', () => {
+    before(done => {
+      const productsClient = getProductsClient()
+      gatewayAccountId = 123456
+      response = [
+        productFixtures.validCreateProductResponse({gateway_account_id: gatewayAccountId}),
+        productFixtures.validCreateProductResponse({gateway_account_id: gatewayAccountId}),
+        productFixtures.validCreateProductResponse({gateway_account_id: gatewayAccountId})
+      ]
+      const interaction = new PactInteractionBuilder(PRODUCT_RESOURCE)
+        .withQuery('gatewayAccountId', String(gatewayAccountId))
+        .withUponReceiving('a valid get product by gateway account id request')
+        .withMethod('GET')
+        .withStatusCode(200)
+        .withResponseBody(response.map(item => item.getPactified()))
+        .build()
+      productsMock.addInteraction(interaction)
+        .then(() => productsClient.product.getByGatewayAccountId(gatewayAccountId))
+        .then(res => {
+          result = res
+          done()
+        })
+        .catch(e => done(e))
+    })
+    after((done) => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should find an existing product', () => {
+      const plainResponse = response.map(item => item.getPlain())
+      expect(result.length).to.equal(3)
+      result.forEach((product, index) => {
+        expect(product.gatewayAccountId).to.equal(gatewayAccountId)
+        expect(product.externalId).to.exist.and.equal(plainResponse[index].external_id)
+        expect(product.name).to.exist.and.equal(plainResponse[index].name)
+        expect(product.price).to.exist.and.equal(plainResponse[index].price)
+        expect(product).to.have.property('links')
+        expect(Object.keys(product.links).length).to.equal(2)
+        expect(product.links).to.have.property('self')
+        expect(product.links.self).to.have.property('method').to.equal(plainResponse[index]._links.find(link => link.rel === 'self').method)
+        expect(product.links.self).to.have.property('href').to.equal(plainResponse[index]._links.find(link => link.rel === 'self').href)
+        expect(product.links).to.have.property('pay')
+        expect(product.links.pay).to.have.property('method').to.equal(plainResponse[index]._links.find(link => link.rel === 'pay').method)
+        expect(product.links.pay).to.have.property('href').to.equal(plainResponse[index]._links.find(link => link.rel === 'pay').href)
+      })
+    })
+  })
+
+  describe('when the request has invalid authorization credentials', () => {
+    beforeEach(done => {
+      const productsClient = getProductsClient(`http://localhost:${mockPort}`, 'invalid-api-key')
+      gatewayAccountId = 76543
+      const interaction = new PactInteractionBuilder(PRODUCT_RESOURCE)
+        .withQuery('gatewayAccountId', String(gatewayAccountId))
+        .withUponReceiving('a valid get product by gateway account id request with invalid PRODUCTS_API_TOKEN ')
+        .withMethod('GET')
+        .withStatusCode(401)
+        .build()
+      productsMock.addInteraction(interaction)
+        .then(() => productsClient.product.getByGatewayAccountId(gatewayAccountId), done)
+        .then(() => done(new Error('Promise unexpectedly resolved')))
+        .catch((err) => {
+          result = err
+          done()
+        })
+    })
+
+    after((done) => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should reject with error: 401 unauthorised', () => {
+      expect(result.errorCode).to.equal(401)
+    })
+  })
+
+  describe('when no products are found', () => {
+    before(done => {
+      const productsClient = getProductsClient()
+      gatewayAccountId = 98765
+      const interaction = new PactInteractionBuilder(PRODUCT_RESOURCE)
+        .withQuery('gatewayAccountId', String(gatewayAccountId))
+        .withUponReceiving('a valid get product by gateway account id where the gateway account has no products')
+        .withMethod('GET')
+        .withStatusCode(404)
+        .build()
+      productsMock.addInteraction(interaction)
+        .then(() => productsClient.product.getByGatewayAccountId(gatewayAccountId), done)
+        .then(() => done(new Error('Promise unexpectedly resolved')))
+        .catch((err) => {
+          result = err
+          done()
+        })
+    })
+
+    after((done) => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should reject with error: 404 not found', () => {
+      expect(result.errorCode).to.equal(404)
+    })
+  })
+})

--- a/test/unit/clients/product_client/product/get_by_product_external_id_test.js
+++ b/test/unit/clients/product_client/product/get_by_product_external_id_test.js
@@ -1,0 +1,153 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+const {expect} = require('chai')
+const proxyquire = require('proxyquire')
+
+// Custom dependencies
+const pactProxy = require('../../../../test_helpers/pact_proxy')
+const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const productFixtures = require('../../../../fixtures/product_fixtures')
+
+// Constants
+const PRODUCT_RESOURCE = '/v1/api/products'
+const mockPort = Math.floor(Math.random() * 65535)
+const mockServer = pactProxy.create('localhost', mockPort)
+let productsMock, response, result, productExternalId
+
+function getProductsClient (baseUrl = `http://localhost:${mockPort}`, productsApiKey = 'ABC1234567890DEF') {
+  return proxyquire('../../../../../app/services/clients/products_client', {
+    '../../../config': {
+      PRODUCTS_URL: baseUrl,
+      PRODUCTS_API_TOKEN: productsApiKey
+    }
+  })
+}
+
+describe('products client - find a product by it\'s external id', function () {
+  /**
+   * Start the server and set up Pact
+   */
+  before(function (done) {
+    this.timeout(5000)
+    mockServer.start().then(function () {
+      productsMock = Pact({consumer: 'Selfservice-find-product', provider: 'products', port: mockPort})
+      done()
+    })
+  })
+
+  /**
+   * Remove the server and publish pacts to broker
+   */
+  after(done => {
+    mockServer.delete()
+      .then(() => pactProxy.removeAll())
+      .then(() => done())
+  })
+
+  describe('when a product is successfully found', () => {
+    before(done => {
+      const productsClient = getProductsClient()
+      productExternalId = 'existing-id'
+      response = productFixtures.validCreateProductResponse({
+        external_id: productExternalId,
+        price: 1000,
+        name: 'A Product Name',
+        description: 'About this product',
+        return_url: 'https://example.gov.uk'
+      })
+      productsMock.addInteraction(
+        new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}`)
+          .withUponReceiving('a valid get product request')
+          .withMethod('GET')
+          .withStatusCode(200)
+          .withResponseBody(response.getPactified())
+          .build()
+      )
+        .then(() => productsClient.product.getByProductExternalId(productExternalId))
+        .then(res => {
+          result = res
+          done()
+        })
+        .catch(e => done(e))
+    })
+
+    after((done) => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should find an existing product', () => {
+      const plainResponse = response.getPlain()
+      expect(result.externalId).to.equal(productExternalId)
+      expect(result.name).to.exist.and.equal(plainResponse.name)
+      expect(result.description).to.exist.and.equal(plainResponse.description)
+      expect(result.price).to.exist.and.equal(plainResponse.price)
+      expect(result.returnUrl).to.exist.and.equal(plainResponse.return_url)
+      expect(result).to.have.property('links')
+      expect(Object.keys(result.links).length).to.equal(2)
+      expect(result.links).to.have.property('self')
+      expect(result.links.self).to.have.property('method').to.equal(plainResponse._links.find(link => link.rel === 'self').method)
+      expect(result.links.self).to.have.property('href').to.equal(plainResponse._links.find(link => link.rel === 'self').href)
+      expect(result.links).to.have.property('pay')
+      expect(result.links.pay).to.have.property('method').to.equal(plainResponse._links.find(link => link.rel === 'pay').method)
+      expect(result.links.pay).to.have.property('href').to.equal(plainResponse._links.find(link => link.rel === 'pay').href)
+    })
+  })
+
+  describe('when the request has invalid authorization credentials', () => {
+    beforeEach(done => {
+      const productsClient = getProductsClient(`http://localhost:${mockPort}`, 'invalid-api-key')
+      productExternalId = 'existing-id'
+      productsMock.addInteraction(
+        new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}`)
+          .withUponReceiving('a valid find product request with invalid PRODUCTS_API_TOKEN')
+          .withMethod('GET')
+          .withStatusCode(401)
+          .build()
+      )
+        .then(() => productsClient.product.getByProductExternalId(productExternalId), done)
+        .then(() => done(new Error('Promise unexpectedly resolved')))
+        .catch((err) => {
+          result = err
+          done()
+        })
+    })
+
+    after((done) => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should reject with error: 401 unauthorised', () => {
+      expect(result.errorCode).to.equal(401)
+    })
+  })
+
+  describe('when a product is not found', () => {
+    before(done => {
+      const productsClient = getProductsClient()
+      productExternalId = 'non-existing-id'
+      productsMock.addInteraction(
+        new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}`)
+          .withUponReceiving('a valid find product request with non existing id')
+          .withMethod('GET')
+          .withStatusCode(404)
+          .build()
+      )
+        .then(() => productsClient.product.getByProductExternalId(productExternalId), done)
+        .then(() => done(new Error('Promise unexpectedly resolved')))
+        .catch((err) => {
+          result = err
+          done()
+        })
+    })
+
+    after((done) => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should reject with error: 404 not found', () => {
+      expect(result.errorCode).to.equal(404)
+    })
+  })
+})


### PR DESCRIPTION
# PP-2655 Update productsClient
Migration to pay-selfservice of changes to productsClient made in pay-products-ui

## What
- Updated productsClient with changes from products_ui
- Moved from `.createProduct()` style to `.product.create()` style
- Product client now includes following methods:
    - create payment
    - get payment by payment external id
    - get payments by product external id
    - create product
    - get product by product external id
    - get product by gateway account id
- Also copied over corresponding Pact tests from products ui


