### PR TITLE
PP-2517 - Improved account creation validation messaging

### DIFF
--- a/app/browsered/field-validation-checks.js
+++ b/app/browsered/field-validation-checks.js
@@ -1,9 +1,16 @@
 'use strict'
 
+// local dependencies
+const emailValidator = require('../utils/email_tools.js')
+
+// Constants
+const NUMBERS_ONLY = new RegExp('^[0-9]+$')
+
 const validationErrors = {
   required: 'This is field cannot be blank',
-  email: 'Please use a valid email address',
-  currency: 'Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”'
+  currency: 'Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”',
+  phoneNumber: 'Must be a 11 digit phone number',
+  validEmail: 'Please use a valid email address'
 }
 
 module.exports.isEmpty = function (value) {
@@ -17,6 +24,23 @@ module.exports.isEmpty = function (value) {
 module.exports.isCurrency = function (value) {
   if (!/^([0-9]+)(?:\.([0-9]{2}))?$/.test(value)) {
     return validationErrors.currency
+  } else {
+    return false
+  }
+}
+
+module.exports.isValidEmail = function (value) {
+  if (!emailValidator(value)) {
+    return validationErrors.validEmail
+  } else {
+    return false
+  }
+}
+
+module.exports.isPhoneNumber = function (value) {
+  const trimmedTelephoneNumber = value.replace(/\s/g, '')
+  if (trimmedTelephoneNumber.length < 11 || !NUMBERS_ONLY.test(trimmedTelephoneNumber)) {
+    return validationErrors.phoneNumber
   } else {
     return false
   }

--- a/app/browsered/field-validation.js
+++ b/app/browsered/field-validation.js
@@ -57,6 +57,12 @@ function validateField (form, field) {
       case 'currency' :
         result = checks.isCurrency(field.value)
         break
+      case 'email' :
+        result = checks.isValidEmail(field.value)
+        break
+      case 'phone' :
+        result = checks.isPhoneNumber(field.value)
+        break
       default :
         result = checks.isEmpty(field.value)
         break

--- a/app/controllers/forgotten_password_controller.js
+++ b/app/controllers/forgotten_password_controller.js
@@ -1,8 +1,8 @@
+const emailValidator = require('../utils/email_tools.js')
 var paths = require('../paths.js')
 var errorView = require('../utils/response.js').renderErrorView
 var userService = require('../services/user_service.js')
 var e = module.exports
-var emailTools = require('../utils/email_tools')()
 
 e.emailGet = (req, res) => {
   res.render('forgotten_password/username_get')
@@ -12,7 +12,7 @@ e.emailPost = (req, res) => {
   let correlationId = req.correlationId
   let username = req.body.username
 
-  if (emailTools.validateEmail(username)) {
+  if (emailValidator(username)) {
     return userService.sendPasswordResetToken(username, correlationId)
       .finally(() => {
         res.redirect(paths.user.passwordRequested)

--- a/app/controllers/invite_user_controller.js
+++ b/app/controllers/invite_user_controller.js
@@ -5,7 +5,7 @@ let paths = require('../paths.js')
 let successResponse = response.response
 let errorResponse = response.renderErrorView
 let rolesModule = require('../utils/roles')
-let emailTools = require('../utils/email_tools')()
+const emailValidator = require('../utils/email_tools.js')
 
 const formattedPathFor = require('../../app/utils/replace_params_in_path')
 
@@ -82,7 +82,7 @@ module.exports = {
       }
     }
 
-    if (!emailTools.validateEmail(invitee)) {
+    if (!emailValidator(invitee)) {
       req.flash('genericError', `Invalid email address`)
       res.redirect(303, formattedPathFor(paths.teamMembers.invite, externalServiceId))
       return

--- a/app/controllers/invite_user_controller.js
+++ b/app/controllers/invite_user_controller.js
@@ -82,6 +82,7 @@ module.exports = {
       }
     }
 
+    console.log(emailValidator(invitee))
     if (!emailValidator(invitee)) {
       req.flash('genericError', `Invalid email address`)
       res.redirect(303, formattedPathFor(paths.teamMembers.invite, externalServiceId))

--- a/app/services/user_service.js
+++ b/app/services/user_service.js
@@ -117,7 +117,7 @@ module.exports = {
     if (newPassword.length < MIN_PASSWORD_LENGTH) {
       defer.reject({message: 'Your password must be at least 10 characters.'})
     } else if (commonPassword(newPassword)) {
-      defer.reject({message: 'Your password is too simple. Choose a password that is harder for people to guess.'})
+      defer.reject({message: 'The password you tried to create contains a common phrase or combination of characters. Choose something that’s harder to guess.'})
     } else {
       getAdminUsersClient().updatePasswordForUser(token, newPassword)
         .then(

--- a/app/utils/email_tools.js
+++ b/app/utils/email_tools.js
@@ -1,47 +1,13 @@
-/* Uses Regexes from the rfc822-validate library.
- We use rfc822-validate in our email validation
- so this follows that standard. */
-let rfc822Validator = require('rfc822-validate')
+'use strict'
 
-var emailTools = function () {
-  'use strict'
+// NPM dependencies
+const rfc822Validator = require('rfc822-validate')
 
-  var init = (function () {
-    var sQtext = '[^\\x0d\\x22\\x5c\\x80-\\xff]'
-    var sDtext = '[^\\x0d\\x5b-\\x5d\\x80-\\xff]'
-    var sAtom = '[^\\x00-\\x20\\x22\\x28\\x29\\x2c\\x2e\\x3a-\\x3c\\x3e\\x40\\x5b-\\x5d\\x7f-\\xff]+'
-    var sQuotedPair = '\\x5c[\\x00-\\x7f]'
-    var sDomainLiteral = '\\x5b(' + sDtext + '|' + sQuotedPair + ')*\\x5d'
-    var sQuotedString = '\\x22(' + sQtext + '|' + sQuotedPair + ')*\\x22'
-    var sDomainRef = sAtom
-    var sSubDomain = '(' + sDomainRef + '|' + sDomainLiteral + ')'
-    var sWord = '(' + sAtom + '|' + sQuotedString + ')'
-    var sDomain = sSubDomain + '(\\x2e' + sSubDomain + ')*'
-    var sLocalPart = sWord + '(\\x2e' + sWord + ')*'
-    var sAddrSpec = '(' + sLocalPart + ')' + '\\x40' + '(' + sDomain + ')' // complete RFC822 email address spec
-    var sValidEmail = '^' + sAddrSpec + '$' // as whole string
-
-    var reValidEmail = new RegExp(sValidEmail)
-
-    var f = function (email) {
-      return reValidEmail.exec(email)
-    }
-
-    return f
-  }())
-
-  return {
-    validateEmail: function (email) {
-      var match = init(email)
-      let validEmail = rfc822Validator(email)
-      if (!validEmail) {
-        return false
-      } else {
-        let domain = match[7]
-        return !(domain && domain.indexOf('.') === -1)
-      }
-    }
+module.exports = (email) => {
+  if (!rfc822Validator(email)) {
+    return false
+  } else {
+    let domain = email.split('@')[1]
+    return !(domain && domain.indexOf('.') === -1)
   }
 }
-
-module.exports = emailTools

--- a/app/utils/registration_validations.js
+++ b/app/utils/registration_validations.js
@@ -5,8 +5,8 @@ const q = require('q')
 const _ = require('lodash')
 const commonPassword = require('common-password')
 
-// Custom dependencies
-const emailTools = require('../utils/email_tools')()
+// Local dependencies
+const emailValidator = require('../utils/email_tools.js')
 
 // Constants
 const MIN_PHONE_NUMBER_LENGTH = 11
@@ -54,8 +54,10 @@ module.exports = {
       return defer.promise
     }
 
-    if (!password || password.length < MIN_PASSWORD_LENGTH || commonPassword(password)) {
-      defer.reject('Your password is too simple. Choose a password that is harder for people to guess')
+    if (!password || password.length < MIN_PASSWORD_LENGTH) {
+      defer.reject('Your password must be at least 10 characters.')
+    } else if (commonPassword(password)) {
+      defer.reject('The password you tried to create contains a common phrase or combination of characters. Choose something that’s harder to guess.')
     } else {
       defer.resolve()
     }
@@ -90,7 +92,7 @@ module.exports = {
   validateServiceRegistrationInputs: (email, telephoneNumber, password) => {
     const defer = q.defer()
 
-    if (!emailTools.validateEmail(email)) {
+    if (!emailValidator(email)) {
       defer.reject('Invalid email')
       return defer.promise
     }
@@ -100,8 +102,10 @@ module.exports = {
       return defer.promise
     }
 
-    if (!password || password.length < MIN_PASSWORD_LENGTH || commonPassword(password)) {
-      defer.reject('Your password is too simple. Choose a password that is harder for people to guess')
+    if (!password || password.length < MIN_PASSWORD_LENGTH) {
+      defer.reject('Your password must be at least 10 characters.')
+    } else if (commonPassword(password)) {
+      defer.reject('The password you tried to create contains a common phrase or combination of characters. Choose something that’s harder to guess.')
     } else {
       defer.resolve()
     }

--- a/app/views/self_create_service/register.html
+++ b/app/views/self_create_service/register.html
@@ -5,43 +5,46 @@ Create an account - GOV.UK Pay
 {{/pageTitle}}
 {{$mainContent}}
 <div class="column-two-thirds">
-    <form action="{{routes.selfCreateService.register}}" method="post" id="submit-service-creation" class="form submit-registration">
-        <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-        <h1 class="heading-large">Create an account</h1>
-        <div class="form-group">
-            <label class="form-label" for="email">
-                Email
-                <span class="form-hint">
-	              Must be from a central government organisation
-	            </span>
-            </label>
-            <input type="text" class="form-control form-control-2-3" id="email" name="email" value="{{email}}">
-        </div>
-        <div class="form-group">
-            <label class="form-label" for="telephone-number">
-                Mobile number
-                <span class="form-hint">
-	              We'll send you a security code by text message
-	            </span>
-            </label>
-            <input type="text" class="form-control form-control-2-3" id="telephone-number" name="telephone-number" value="{{telephoneNumber}}">
-        </div>
-        <div class="form-group">
-            <label class="form-label" for="password">Password</label>
-            <input class="form-control form-control-2-3"
-                   data-module=""
-                   id="password"
-                   name="password"
-                   type="password"
-                   value=""
-            />
-        </div>
-        <div class="form-group">
-            <input class="button" type="submit" value="Continue"/>
-        </div>
-    </form>
-
+  <form action="{{routes.selfCreateService.register}}" method="post" id="submit-service-creation" class="form submit-registration" data-validate="true">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    <h1 class="heading-large">Create an account</h1>
+    <div class="form-group">
+      <label class="form-label" for="email">
+        Email
+        <span class="form-hint">
+          Must be from a central government organisation
+        </span>
+      </label>
+      <input data-validate="required email" type="email" class="form-control form-control-2-3" id="email" name="email" value="{{email}}">
+    </div>
+    <div class="form-group">
+        <label class="form-label" for="telephone-number">
+            Mobile number
+            <span class="form-hint">
+                We'll send you a security code by text message
+            </span>
+        </label>
+        <input data-validate="required phone" type="text" class="form-control form-control-2-3" id="telephone-number" name="telephone-number" value="{{telephoneNumber}}">
+    </div>
+    <div class="form-group">
+      <label class="form-label" for="password">
+          Password
+          <span class="form-hint">
+              Must be at least 10 characters
+          </span>
+      </label>
+      <input class="form-control form-control-2-3"
+        data-validate="required"
+        id="password"
+        name="password"
+        type="password"
+        value=""
+      />
+    </div>
+    <div class="form-group">
+      <input class="button" type="submit" value="Continue"/>
+    </div>
+</form>
 </div>
-
 {{/mainContent}}
 {{/layout_logged_out}}

--- a/app/views/user_registration/register.html
+++ b/app/views/user_registration/register.html
@@ -6,36 +6,41 @@ Create an account - GOV.UK Pay
 
 {{$mainContent}}
 <div class="column-two-thirds">
-    <form action="{{routes.registerUser.registration}}" method="post" id="submit-registration" class="form submit-registration">
-        <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-        <h1 class="heading-large">
-            Create an account
-        </h1>
-        <p id="email-display">Your account will be created with this email: {{email}}</p>
-        <div class="form-group">
-            <label class="form-label" for="telephone-number">
-                Mobile number
-                <span class="form-hint">
-	              We'll send you a security code by text message
-	            </span>
-            </label>
-            <input type="text" class="form-control" id="telephone-number" name="telephone-number" value="{{telephone_number}}">
-        </div>
-        <div class="form-group">
-            <label class="form-label" for="password">Password</label>
-            <input class="form-control"
-                   data-module=""
-                   id="password"
-                   name="password"
-                   rows="6"
-                   type="password"
-                   value=""
-            />
-        </div>
-        <div class="form-group">
-            <input class="button" type="submit" value="Continue"/>
-        </div>
-    </form>
+  <form action="{{routes.registerUser.registration}}" method="post" id="submit-registration" class="form submit-registration" data-validate="true">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    <h1 class="heading-large">
+      Create an account
+    </h1>
+    <p id="email-display">Your account will be created with this email: {{email}}</p>
+    <div class="form-group">
+      <label class="form-label" for="telephone-number">
+        Mobile number
+        <span class="form-hint">
+         We'll send you a security code by text message
+       </span>
+     </label>
+     <input type="text" class="form-control" id="telephone-number" name="telephone-number" value="{{telephone_number}}" data-validate="required phone">
+   </div>
+   <div class="form-group">
+    <label class="form-label" for="password">
+      Password
+      <span class="form-hint">
+        Must be at least 10 characters
+      </span>
+    </label>
+    <input class="form-control"
+    data-validate
+    id="password"
+    name="password"
+    rows="6"
+    type="password"
+    value=""
+    />
+  </div>
+  <div class="form-group">
+    <input class="button" type="submit" value="Continue"/>
+  </div>
+</form>
 
 </div>
 

--- a/test/integration/forgotten_password_ft_test.js
+++ b/test/integration/forgotten_password_ft_test.js
@@ -194,7 +194,7 @@ describe('forgotten_password_controller', function () {
 
     aForgottenPasswordController.newPasswordPost(req, res).should.be.fulfilled
       .then(() => {
-        expect(req.flash.calledWith('genericError', 'Your password is too simple. Choose a password that is harder for people to guess.')).to.equal(true)
+        expect(req.flash.calledWith('genericError', 'The password you tried to create contains a common phrase or combination of characters. Choose something that’s harder to guess.')).to.equal(true)
         expect(res.redirect.calledWith('/reset-password/' + token)).to.equal(true)
       }).should.notify(done)
   })

--- a/test/ui/self_create_service_ui_tests.js
+++ b/test/ui/self_create_service_ui_tests.js
@@ -13,7 +13,7 @@ describe('Self-create service view', function () {
     body.should.containSelector('h1').withExactText('Create an account')
 
     body.should.containSelector('form#submit-service-creation').withAttribute('action', paths.selfCreateService.register)
-    body.should.containInputField('email', 'text')
+    body.should.containInputField('email', 'email')
     body.should.containInputField('telephone-number', 'text')
     body.should.containInputField('password', 'password')
 

--- a/test/unit/utils/registration_validations_test.js
+++ b/test/unit/utils/registration_validations_test.js
@@ -48,7 +48,7 @@ describe('registration_validation module', function () {
       const password = undefined
       validation.validateUserRegistrationInputs(validPhoneNumber, password)
         .should.be.rejected.then((response) => {
-          expect(response).to.equal('Your password is too simple. Choose a password that is harder for people to guess')
+          expect(response).to.equal('Your password must be at least 10 characters.')
         })
         .should.notify(done)
     })
@@ -58,7 +58,7 @@ describe('registration_validation module', function () {
       const password = '1234567890'
       validation.validateUserRegistrationInputs(validPhoneNumber, password)
         .should.be.rejected.then((response) => {
-          expect(response).to.equal('Your password is too simple. Choose a password that is harder for people to guess')
+          expect(response).to.equal('The password you tried to create contains a common phrase or combination of characters. Choose something that’s harder to guess.')
         })
         .should.notify(done)
     })
@@ -68,7 +68,7 @@ describe('registration_validation module', function () {
       const validPassword = '2se45&s'
       validation.validateUserRegistrationInputs(validPhoneNumber, validPassword)
         .should.be.rejected.then((response) => {
-          expect(response).to.equal('Your password is too simple. Choose a password that is harder for people to guess')
+          expect(response).to.equal('Your password must be at least 10 characters.')
         })
         .should.notify(done)
     })


### PR DESCRIPTION
Error messaging about whether a password was strong enough
wasnt very helpful and was inconsistent. I've made it
explicitly tell you whether your password is too simple or
too short.

Whilst doing this I have noticed that the email validation
was entirely a duplication. So I have stripped it back and
updated all applications of it.

I also added the new client side validation to the sign up
forms to give more immediate feedback to users.


