### PR TITLE
Remove ecs deploy step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,8 +55,7 @@ pipeline {
         branch 'master'
       }
       steps {
-        deploy("selfservice", "test", null, false)
-        deployEcs("selfservice", "test", null, true, true)
+        deploy("selfservice", "test", null, false, true)
       }
     }
   }


### PR DESCRIPTION
Due to changes in ecs terraform the ecs deploy job is currently failing
To unblock rest of team removing this step for now.