### PR TITLE
PP-2688 Fix deploy step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
         branch 'master'
       }
       steps {
-        deploy("selfservice", "test", null, false, true)
+        deploy("selfservice", "test", null, true, true)
       }
     }
   }


### PR DESCRIPTION
## WHAT

Currently we don't tag selfservice after deployment.

We need to call deploy step with `tagAfterDeployment` set to `true` to tag selfservice properly.

see: https://github.com/alphagov/pay-jenkins-library/blob/1230893d0689f5f256ada585c79b6498ba872267/vars/deploy.groovy#L3
