### PR TITLE
Reinstate ecs deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,8 @@ pipeline {
         branch 'master'
       }
       steps {
-        deploy("selfservice", "test", null, true, true)
+        deploy("selfservice", "test", null, false, false)
+        deployEcs("selfservice", "test", null, true, true)
       }
     }
   }


### PR DESCRIPTION
We disabled ecs deploys as they were broken.
They are now fixed, so re-enabling.