### PR TITLE
Use symlink in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN cd /tmp && npm install --production
 WORKDIR /app
 ADD . /app
 
-RUN cp -a /tmp/node_modules /app/
+RUN ln -s /tmp/node_modules /app/node_modules
 
 CMD npm start

--- a/docker/build_and_test.sh
+++ b/docker/build_and_test.sh
@@ -6,7 +6,6 @@ grep -rnw './test' -e 'it.only' && echo '' && echo 'ERROR: it.only() found in te
 grep -rnw './test' -e 'describe.only' && echo '' && echo 'ERROR: describe.only() found in tests, Exiting' && exit 1
 grep -rnw './test' -e 'context.only' && echo '' && echo 'ERROR: context.only() found in tests, Exiting' && exit 1
 
-mkdir -p /app &&\
-cp -a /tmp/node_modules /app/ &&\
+ln -s /tmp/node_modules /app/node_modules &&\
 npm run compile &&\
 npm test


### PR DESCRIPTION
# Use Symlink in Docker Build

## What
- Use symlink rather than directory copy for node_modules caching layer in dockerfiles

## Why
- Speeds up the docker image build process both for the test image and the deploy image
- Makes the images smaller too