### PR TITLE
Delete node_modules symlink after test

### DIFF
--- a/docker/build_and_test.sh
+++ b/docker/build_and_test.sh
@@ -6,6 +6,8 @@ grep -rnw './test' -e 'it.only' && echo '' && echo 'ERROR: it.only() found in te
 grep -rnw './test' -e 'describe.only' && echo '' && echo 'ERROR: describe.only() found in tests, Exiting' && exit 1
 grep -rnw './test' -e 'context.only' && echo '' && echo 'ERROR: context.only() found in tests, Exiting' && exit 1
 
+rm -rf node_modules &&\
 ln -s /tmp/node_modules /app/node_modules &&\
 npm run compile &&\
-npm test
+npm test &&\
+rm -rf node_modules


### PR DESCRIPTION
## What
- a dead node_modules symlink remained in the workspace after a test run which prevented future builds
- this commit will remove this symlink once done

