### PR TITLE
PP-2655 Temporary Fix for Missing Correlation ID in products client calls

### DIFF
--- a/app/services/auth_service.js
+++ b/app/services/auth_service.js
@@ -7,6 +7,14 @@ const passport = require('passport')
 const LocalStrategy = require('passport-local').Strategy
 const CustomStrategy = require('passport-custom').Strategy
 
+// TODO: Remove when issue solved
+/*
+ This is in because otherwise the correlationID stored in using the correlation-id library gets lost while passing through one of the
+ functions in this file. When we have either stopped this happening, or have removed usage of the correlation-id library,
+ we can remove this
+ */
+require('correlation-id')
+
 // Local Dependencies
 const sessionValidator = require('./session_validator.js')
 const paths = require('../paths.js')


### PR DESCRIPTION
# PP-2655 Temporary Fix for Missing Correlation ID in products client calls

## Why
For some reason the correlation ID stored using the `correlation-id` library is going missing in `/services/auth_service`.

## What
In order to rectify this while we search for a cause, just including the `correlation-id` module in the `auth_service` file seems to solve it.


