### PR TITLE
PP-2878 - was using wrong class

### DIFF
--- a/app/views/3d_secure/index.html
+++ b/app/views/3d_secure/index.html
@@ -63,7 +63,7 @@
 
 {{#hasAnyCardTypeRequiring3dsSelected}}
 <div id="info-message" class="notice">
-    <i class="icon info">
+    <i class="icon icon-important">
         <span class="visually-hidden">Warning</span>
     </i>
 

--- a/app/views/services/team_member_permissions.html
+++ b/app/views/services/team_member_permissions.html
@@ -59,7 +59,7 @@ Edit team member permissions - GOV.UK Pay
                 </div>
             </fieldset>
             <div class="notice">
-                <i class="icon info">
+                <i class="icon icon-important">
                     <span class="visually-hidden">Warning</span>
                 </i>
                 <strong class="bold-small">


### PR DESCRIPTION
`info` was a non standard implementation of thing that already existed. I removed it a few weeks back and broke this icon