### PR TITLE
PP-2655 Restrict demo and prototype payments to sandbox

### DIFF
--- a/app/middleware/restrict_to_sandbox.js
+++ b/app/middleware/restrict_to_sandbox.js
@@ -1,0 +1,16 @@
+'use strict'
+
+// NPM dependencies
+const lodash = require('lodash')
+
+// Local dependencies
+const {renderErrorView} = require('../utils/response')
+
+module.exports = (req, res, next) => {
+  const provider = lodash.get(req, 'account.payment_provider', '')
+  if (provider.toLowerCase() !== 'sandbox') {
+    renderErrorView(req, res, 'This page is only available on Sandbox accounts', 403)
+  } else {
+    next()
+  }
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -21,6 +21,7 @@ const validateRegistrationInviteCookie = require('./middleware/validate_registra
 const otpVerify = require('./middleware/otp_verify')
 const correlationIdMiddleware = require('./middleware/correlation_id')
 const getRequestContext = require('./middleware/get_request_context').middleware
+const restrictToSandbox = require('./middleware/restrict_to_sandbox')
 
 // - Controllers
 const staticCtrl = require('./controllers/static_controller')
@@ -218,16 +219,16 @@ module.exports.bind = function (app) {
   app.post(t3ds.off, permission('toggle-3ds:update'), getAccount, toggle3ds.off)
 
   // Prototyping
-  app.get(prototyping.demoService.index, permission('transactions:read'), resolveService, getAccount, testWithYourUsers.index)
-  app.get(prototyping.demoService.links, permission('transactions:read'), resolveService, getAccount, testWithYourUsers.links)
-  app.get(prototyping.demoService.create, permission('transactions:read'), resolveService, getAccount, testWithYourUsers.create)
-  app.post(prototyping.demoService.confirm, permission('transactions:read'), resolveService, getAccount, testWithYourUsers.submit)
-  app.get(prototyping.demoService.disable, permission('transactions:read'), resolveService, getAccount, testWithYourUsers.disable)
+  app.get(prototyping.demoService.index, permission('transactions:read'), resolveService, getAccount, restrictToSandbox, testWithYourUsers.index)
+  app.get(prototyping.demoService.links, permission('transactions:read'), resolveService, getAccount, restrictToSandbox, testWithYourUsers.links)
+  app.get(prototyping.demoService.create, permission('transactions:read'), resolveService, getAccount, restrictToSandbox, testWithYourUsers.create)
+  app.post(prototyping.demoService.confirm, permission('transactions:read'), resolveService, getAccount, restrictToSandbox, testWithYourUsers.submit)
+  app.get(prototyping.demoService.disable, permission('transactions:read'), resolveService, getAccount, restrictToSandbox, testWithYourUsers.disable)
 
-  app.get(prototyping.demoPayment.index, permission('transactions:read'), getAccount, makeADemoPayment.index)
-  app.post(prototyping.demoPayment.index, permission('transactions:read'), getAccount, makeADemoPayment.index)
-  app.get(prototyping.demoPayment.editDescription, permission('transactions:read'), getAccount, makeADemoPayment.edit)
-  app.get(prototyping.demoPayment.editAmount, permission('transactions:read'), getAccount, makeADemoPayment.edit)
-  app.get(prototyping.demoPayment.mockCardDetails, permission('transactions:read'), getAccount, makeADemoPayment.confirm)
-  app.post(prototyping.demoPayment.mockCardDetails, permission('transactions:read'), getAccount, makeADemoPayment.confirm)
+  app.get(prototyping.demoPayment.index, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.index)
+  app.post(prototyping.demoPayment.index, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.index)
+  app.get(prototyping.demoPayment.editDescription, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.edit)
+  app.get(prototyping.demoPayment.editAmount, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.edit)
+  app.get(prototyping.demoPayment.mockCardDetails, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.confirm)
+  app.post(prototyping.demoPayment.mockCardDetails, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.confirm)
 }

--- a/test/unit/controller/test_with_your_users_controller/disable_controller_test.js
+++ b/test/unit/controller/test_with_your_users_controller/disable_controller_test.js
@@ -11,7 +11,8 @@ const {getMockSession, createAppWithSession, getUser} = require('../../../test_h
 const paths = require('../../../../app/paths')
 const {randomUuid} = require('../../../../app/utils/random')
 
-const {PRODUCTS_URL} = process.env
+const GATEWAY_ACCOUNT_ID = 929
+const {PRODUCTS_URL, CONNECTOR_URL} = process.env
 
 describe('test with your users - disable controller', () => {
   describe('when the prototype link is successfully disabled', () => {
@@ -19,8 +20,11 @@ describe('test with your users - disable controller', () => {
     before(done => {
       const productExternalId = randomUuid()
       const user = getUser({
-        gateway_account_ids: [929],
+        gateway_account_ids: [GATEWAY_ACCOUNT_ID],
         permissions: [{name: 'transactions:read'}]
+      })
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
+        payment_provider: 'sandbox'
       })
       nock(PRODUCTS_URL).patch(`/v1/api/products/${productExternalId}/disable`).reply(200)
       session = getMockSession(user)
@@ -30,6 +34,9 @@ describe('test with your users - disable controller', () => {
           response = res
           done(err)
         })
+    })
+    after(() => {
+      nock.cleanAll()
     })
 
     it('should redirect with code 302', () => {
@@ -52,8 +59,11 @@ describe('test with your users - disable controller', () => {
     before(done => {
       const productExternalId = randomUuid()
       const user = getUser({
-        gateway_account_ids: [929],
+        gateway_account_ids: [GATEWAY_ACCOUNT_ID],
         permissions: [{name: 'transactions:read'}]
+      })
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
+        payment_provider: 'sandbox'
       })
       nock(PRODUCTS_URL).patch(`/v1/api/products/${productExternalId}/disable`)
         .replyWithError('Ruhroh! Something terrible has happened Shaggy!')
@@ -64,6 +74,9 @@ describe('test with your users - disable controller', () => {
           response = res
           done(err)
         })
+    })
+    after(() => {
+      nock.cleanAll()
     })
 
     it('should redirect with code 302', () => {

--- a/test/unit/middleware/restrict_to_sandbox.js
+++ b/test/unit/middleware/restrict_to_sandbox.js
@@ -1,0 +1,52 @@
+'use strict'
+
+// NPM dependencies
+const lodash = require('lodash')
+const sinon = require('sinon')
+const {expect} = require('chai')
+
+// Local dependencies
+const restrictToSandbox = require('../../../app/middleware/restrict_to_sandbox')
+
+describe('restrict_to_sandbox middleware', () => {
+  describe('when a user is using a sandbox account', () => {
+    let req, res, next
+    before(done => {
+      req = {}
+      res = {}
+      next = sinon.spy(done)
+      lodash.set(req, 'account.payment_provider', 'sandbox')
+      restrictToSandbox(req, res, next)
+    })
+
+    it('should call next', () => {
+      expect(next.called).to.equal(true)
+      expect(next.lastCall.args.length).to.equal(0)
+    })
+  })
+
+  describe('when a user is not using a sandbox account', () => {
+    let req, res, next
+    before(done => {
+      req = {}
+      res = {}
+      lodash.set(req, 'account.payment_provider', 'worldpay')
+      lodash.set(res, 'render', sinon.spy(() => done()))
+      res.render = sinon.spy(() => done())
+      res.status = sinon.spy()
+      res.setHeader = () => {}
+      restrictToSandbox(req, res, next)
+    })
+
+    it('should render the error view with the correct message', () => {
+      expect(res.render.called).to.equal(true)
+      expect(res.render.lastCall.args[0]).to.equal('error')
+      expect(res.render.lastCall.args[1]).to.have.property('message').to.equal('This page is only available on Sandbox accounts')
+    })
+
+    it('should render the error view with code 403: forbidden', () => {
+      expect(res.status.called).to.equal(true)
+      expect(res.status.lastCall.args[0]).to.equal(403)
+    })
+  })
+})


### PR DESCRIPTION
# PP-2655 Restrict demo and prototype payments to sandbox

## What
- Restricted demo and prototype payments to sandbox accounts
- Created `restrict_to_sandbox` middleware
- Added tests for new middleware




