### PR TITLE
Pp 2755 Removed syntactic sugar that has been used in field validation

### DIFF
--- a/app/browsered/field-validation.js
+++ b/app/browsered/field-validation.js
@@ -33,15 +33,15 @@ function initValidation (e) {
 }
 
 function clearPreviousErrors () {
-  let previousErrorsMessages = [...document.querySelectorAll('.error-message, .error-summary')]
-  let previousErrorsFields = [...document.querySelectorAll('.form-group.error')]
+  let previousErrorsMessages = Array.prototype.slice.call(document.querySelectorAll('.error-message, .error-summary'))
+  let previousErrorsFields = Array.prototype.slice.call(document.querySelectorAll('.form-group.error'))
 
   previousErrorsMessages.map(error => error.remove())
   previousErrorsFields.map(errorField => errorField.classList.remove('error'))
 }
 
 function findFields (form) {
-  const formFields = [...form.querySelectorAll('input, textarea, select')]
+  const formFields = Array.prototype.slice.call(form.querySelectorAll('input, textarea, select'))
 
   return formFields.filter(field => {
     return field.hasAttribute('data-validate')
@@ -52,7 +52,7 @@ function validateField (form, field) {
   let result
   let validationTypes = field.getAttribute('data-validate').split(' ')
 
-  for (let validationType of validationTypes) {
+  validationTypes.forEach(validationType => {
     switch (validationType) {
       case 'currency' :
         result = checks.isCurrency(field.value)
@@ -73,7 +73,7 @@ function validateField (form, field) {
     if (result) {
       applyErrorMessaging(form, field, result)
     }
-  }
+  })
 
   if (!result) {
     return true
@@ -90,7 +90,7 @@ function applyErrorMessaging (form, field, result) {
 }
 
 function populateErrorSummary (form) {
-  let erroringFields = [...form.querySelectorAll('.form-group.error label')]
+  let erroringFields = Array.prototype.slice.call(form.querySelectorAll('.form-group.error label'))
   let configuration = {
     field: erroringFields.map(field => {
       let label = field.innerHTML.split('<')[0].trim()

--- a/app/views/dashboard/demo-service/confirm.html
+++ b/app/views/dashboard/demo-service/confirm.html
@@ -4,12 +4,12 @@ Your prototype link - {{currentServiceName}} {{currentGatewayAccount.full_type}}
 {{/pageTitle}}
 
 {{$mainContent}}
-  <a href="{{linksPage}}" class="link-back">Back to prototype links</a>
+  <a id="prototyping__links-link-back" href="{{linksPage}}" class="link-back">Back to prototype links</a>
   <h1 class="heading-large prototyping__heading">Your prototype link</h1>
   <p>This link will send the user to our payment pages. Use it in a “pay now” button, for example, to integrate it with your prototype.</p>
 
   <div class="panel panel-border-wide">
-    <p class="heading-small"><a href="{{prototypeLink}}" class="prototype-link">{{prototypeLink}}</a></p>
+    <p class="heading-small"><a id="prototyping__links-link-create-payment" href="{{prototypeLink}}" class="prototype-link">{{prototypeLink}}</a></p>
   </div>
   <p>Links will be saved for as long as you need them in the prototype links tab.</p>
 

--- a/app/views/dashboard/demo-service/create.html
+++ b/app/views/dashboard/demo-service/create.html
@@ -13,7 +13,7 @@ Create a prototype link - {{currentServiceName}} {{currentGatewayAccount.full_ty
         Payment description
         <span class="form-hint">Tell users what they are paying for</span>
       </label>
-      <input class="form-control form-control-full" name="payment-description" id="payment-description" rows="2" autofocus value="{{paymentDescription}}" data-validate/>
+      <input id="prototyping__links-input-description" class="form-control form-control-full" name="payment-description" id="payment-description" rows="2" autofocus value="{{paymentDescription}}" data-validate/>
     </div>
     <div class="currency-input form-group">
       <label class="form-label-bold" for="payment-amount">
@@ -22,7 +22,7 @@ Create a prototype link - {{currentServiceName}} {{currentGatewayAccount.full_ty
       </label>
       <div class="currency-input__inner">
         <span class="currency-input__inner__unit">&pound;</span>
-        <input class="form-control form-control-1-4 " aria-label="Enter amount in pounds" name="payment-amount" data-non-numeric type="text" id="payment-amount" value="{{paymentAmount}}"  data-validate="required currency">
+        <input id="prototyping__links-input-amount" class="form-control form-control-1-4 " aria-label="Enter amount in pounds" name="payment-amount" data-non-numeric type="text" id="payment-amount" value="{{paymentAmount}}"  data-validate="required currency">
       </div>
     </div>
     <div class="form-group">
@@ -30,9 +30,9 @@ Create a prototype link - {{currentServiceName}} {{currentGatewayAccount.full_ty
         Confirmation page
         <span class="form-hint">Enter the secure URL users will go to after they have completed the test payment</span>
       </label>
-      <input class="form-control form-control-full" name="confirmation-page" id="confirmation-page" rows="2" autofocus value="{{confirmationPage}}" data-validate="required https" data-trim />
+      <input id="prototyping__links-input-confirmation-page" class="form-control form-control-full" name="confirmation-page" id="confirmation-page" rows="2" autofocus value="{{confirmationPage}}" data-validate="required https" data-trim />
     </div>
-    <input class="button" type="submit" value="Create prototype link">
+    <input id="prototyping__links-button-create-prototype-link" class="button" type="submit" value="Create prototype link">
   </form>
 
 {{/mainContent}}

--- a/app/views/dashboard/demo-service/index.html
+++ b/app/views/dashboard/demo-service/index.html
@@ -7,7 +7,7 @@ Test with your users - {{currentServiceName}} {{currentGatewayAccount.full_type}
   <a href="/" class="link-back">Back to dashboard</a>
   <h1 class="heading-large prototyping__heading">Test with your users</h1>
   <p>Create a reusable link to integrate your service prototype with GOV.UK Pay and test with users.</p>
-  <a class="button" href="{{createPage}}">Create prototype link</a>
+  <a id="prototyping__links-button-create" class="button" href="{{createPage}}">Create prototype link</a>
 
   <ul class="tabs prototyping__tabs">
     {{#productsTab}}
@@ -32,7 +32,7 @@ Test with your users - {{currentServiceName}} {{currentGatewayAccount.full_type}
       <p>You can also use other card types and see errors. <a href="https://govukpay-docs.cloudapps.digital/#mock-card-numbers-for-testing-purposes">See more card types in our documentation</a>.</p>
     {{/productsTab}}
     {{#productsTab}}
-      <h2 id="{{header}}" class="heading-medium remove-top-margin">
+      <h2 id="prototyping__links-header" class="heading-medium remove-top-margin">
           {{#productsLength}}
           {{#productsSingular}}
           There is 1 {{token_state}} prototype link
@@ -49,10 +49,10 @@ Test with your users - {{currentServiceName}} {{currentGatewayAccount.full_type}
         {{#products}}
         <div class="key-list-item prototyping__links-list-item">
           <h3 class="heading-small"><a href="{{links.pay.href}}">{{links.pay.href}}</a></h3>
-          <p>Payment description: <strong>{{name}}</strong> <br/>
-          Payment amount: <strong>&pound;{{price}}</strong> <br/>
-          {{#returnUrl}}Success page: <strong>{{returnUrl}}</strong></p>{{/returnUrl}}
-          <p><a href="links/disable/{{externalId}}">Delete prototype link</a></p>
+          <p>Payment description: <strong class="prototyping__links-list-item-description">{{name}}</strong> <br/>
+          Payment amount: <strong class="prototyping__links-list-item-amount">&pound;{{price}}</strong> <br/>
+          {{#returnUrl}}Success page: <strong class="prototyping__links-list-item-success-page">{{returnUrl}}</strong></p>{{/returnUrl}}
+          <p><a class="prototyping__links-list-item-delete-link" href="links/disable/{{externalId}}">Delete prototype link</a></p>
         </div>
         {{/products}}
       </div>


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

- Removed syntactic sugar that has been used in the field validation that is unfortunately only supported in the more recent version of browsers which causes problems during end to end testing with our version of PhantomJs. The following has been replaced with a more backward compatible alternative:

```
- Spread: `[... ]` replaced by equivalent `Array.prototype.slice.call()`
- let... of replaced by equivalent `forEach`
```

- Added `id` attributes to certain elements to facilitate E2E.


