### PR TITLE
PP-2655 Added unit tests for make_demo_payment controllers

### DIFF
--- a/app/controllers/make_a_demo_payment/confirm_controller.js
+++ b/app/controllers/make_a_demo_payment/confirm_controller.js
@@ -15,6 +15,12 @@ module.exports = (req, res) => {
   let gatewayAccountId = auth.getCurrentGatewayAccountId(req)
 
   if (protoData) {
+    let paymentAmount = protoData.protoPaymentAmount * 100
+    let index = protoData.protoPaymentAmount.indexOf('.')
+    if (index !== -1) {
+      paymentAmount = paymentAmount.substr(0, index)
+    }
+
     let params = {
       indexPage: paths.user.loggedIn,
       name: protoData.protoPaymentDescription,
@@ -35,7 +41,7 @@ module.exports = (req, res) => {
         payApiToken: publicAuthData.token,
         gatewayAccountId,
         name: protoData.protoPaymentDescription,
-        price: protoData.protoPaymentAmount
+        price: paymentAmount
       }))
       .then(product => {
         params.prototypeLink = lodash.get(product, 'links.pay.href')

--- a/app/controllers/make_a_demo_payment/confirm_controller.js
+++ b/app/controllers/make_a_demo_payment/confirm_controller.js
@@ -11,47 +11,37 @@ const publicAuthClient = require('../../services/clients/public_auth_client')
 const auth = require('../../services/auth_service.js')
 
 module.exports = (req, res) => {
-  let protoData = lodash.get(req, 'session.pageData.protoData')
-  let gatewayAccountId = auth.getCurrentGatewayAccountId(req)
+  const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
+  const {paymentAmount, paymentDescription} = lodash.get(req, 'session.pageData.makeADemoPayment')
 
-  if (protoData) {
-    let paymentAmount = protoData.protoPaymentAmount * 100
-    let index = protoData.protoPaymentAmount.indexOf('.')
-    if (index !== -1) {
-      paymentAmount = paymentAmount.substr(0, index)
-    }
-
-    let params = {
-      indexPage: paths.user.loggedIn,
-      name: protoData.protoPaymentDescription,
-      price: protoData.protoPaymentAmount,
-      gateway_account_id: gatewayAccountId
-    }
-
-    publicAuthClient.createTokenForAccount({
-      accountId: gatewayAccountId,
-      correlationId: req.correlationId,
-      payload: {
-        account_id: gatewayAccountId,
-        created_by: req.user.email,
-        description: `Token for Prototype: ${req.body['payment-description']}`
-      }
-    })
-      .then(publicAuthData => productsClient.product.create({
-        payApiToken: publicAuthData.token,
-        gatewayAccountId,
-        name: protoData.protoPaymentDescription,
-        price: paymentAmount
-      }))
-      .then(product => {
-        params.prototypeLink = lodash.get(product, 'links.pay.href')
-        return response(req, res, 'dashboard/demo-payment/confirm', params)
-      })
-      .catch(error => {
-        req.flash('genericError', `<h2>There were errors</h2> ${error}`)
-        return res.redirect(paths.prototyping.demoPayment.index)
-      })
-  } else {
-    res.redirect(paths.prototyping.demoPayment.index)
+  if (!paymentAmount || !paymentDescription) {
+    return res.redirect(paths.prototyping.demoPayment.index)
   }
+
+  publicAuthClient.createTokenForAccount({
+    accountId: gatewayAccountId,
+    correlationId: req.correlationId,
+    payload: {
+      account_id: gatewayAccountId,
+      created_by: req.user.email,
+      description: `Token for Demo Payment`
+    }
+  })
+    .then(publicAuthData => productsClient.product.create({
+      payApiToken: publicAuthData.token,
+      gatewayAccountId,
+      name: paymentDescription,
+      price: Math.trunc(paymentAmount * 100)
+    }))
+    .then(product => {
+      response(req, res, 'dashboard/demo-payment/confirm', {
+        prototypeLink: lodash.get(product, 'links.pay.href'),
+        indexPage: paths.user.loggedIn
+      })
+      lodash.unset(req, 'session.pageData.makeADemoPayment')
+    })
+    .catch(() => {
+      req.flash('genericError', `<h2>There were errors</h2> Error while creating demo payment`)
+      return res.redirect(paths.prototyping.demoPayment.index)
+    })
 }

--- a/app/controllers/make_a_demo_payment/edit_controller.js
+++ b/app/controllers/make_a_demo_payment/edit_controller.js
@@ -5,18 +5,15 @@ const lodash = require('lodash')
 
 // Local dependencies
 const {response} = require('../../utils/response.js')
-const paths = require('../../paths')
+const {editDescription, index} = require('../../paths').prototyping.demoPayment
 
 module.exports = (req, res) => {
-  let params = {
-    protoPaymentDescription: lodash.get(req, 'session.pageData.protoData.protoPaymentDescription'),
-    protoPaymentAmount: lodash.get(req, 'session.pageData.protoData.protoPaymentAmount'),
-    nextPage: paths.prototyping.demoPayment.index
-  }
+  const pageData = lodash.get(req, 'session.pageData.makeADemoPayment', {})
+  const template = req.path === editDescription ? 'dashboard/demo-payment/edit-description' : 'dashboard/demo-payment/edit-amount'
 
-  if (req.path === paths.prototyping.demoPayment.editDescription) {
-    response(req, res, 'dashboard/demo-payment/edit-description', params)
-  } else {
-    response(req, res, 'dashboard/demo-payment/edit-amount', params)
-  }
+  response(req, res, template, {
+    paymentDescription: pageData.paymentDescription,
+    paymentAmount: pageData.paymentAmount,
+    nextPage: index
+  })
 }

--- a/app/controllers/make_a_demo_payment/index_controller.js
+++ b/app/controllers/make_a_demo_payment/index_controller.js
@@ -6,35 +6,38 @@ const lodash = require('lodash')
 // Local dependencies
 const {response} = require('../../utils/response.js')
 const paths = require('../../paths')
+const {isCurrency} = require('../../browsered/field-validation-checks')
+
+const DEFAULTS = {
+  paymentDescription: 'An example payment description',
+  paymentAmount: '20.00'
+}
+const AMOUNT_FORMAT = /^([0-9]+)(?:\.([0-9]{2}))?$/
 
 module.exports = (req, res) => {
-  let paymentAmount = req.body['payment-amount']
+  const pageData = lodash.get(req, 'session.pageData.makeADemoPayment', {})
+  const paymentDescription = req.body['payment-description'] || pageData.paymentDescription || DEFAULTS.paymentDescription
+  let paymentAmount = req.body['payment-amount'] || pageData.paymentAmount || DEFAULTS.paymentAmount
 
-  if (paymentAmount) {
-    paymentAmount = paymentAmount.replace(/[^0-9.-]+/g, '')
+  if (!paymentAmount || isCurrency(paymentAmount)) {
+    lodash.set(req, 'session.pageData.makeADemoPayment.paymentAmount', paymentAmount)
+    req.flash('genericError', `<h2>Use valid characters only</h2> ${isCurrency(paymentAmount)}`)
+    return res.redirect(paths.prototyping.demoPayment.editAmount)
   }
 
-  const currencyMatch = /^([0-9]+)(?:\.([0-9]{2}))?$/.exec(paymentAmount)
-
-  if (currencyMatch && !currencyMatch[2]) {
+  paymentAmount = paymentAmount.replace(/[^0-9.-]+/g, '')
+  const currencyMatch = AMOUNT_FORMAT.exec(paymentAmount)
+  if (!currencyMatch[2]) {
     paymentAmount = paymentAmount + '.00'
   }
 
-  let protoPaymentDescription = req.body['payment-description'] || lodash.get(req, 'session.pageData.protoData.protoPaymentDescription', 'An example payment description')
-  let protoPaymentAmount = paymentAmount || lodash.get(req, 'session.pageData.protoData.protoPaymentAmount', '20.00')
+  lodash.set(req, 'session.pageData.makeADemoPayment', {paymentDescription, paymentAmount})
 
-  let params = {
-    protoPaymentDescription,
-    protoPaymentAmount,
+  response(req, res, 'dashboard/demo-payment/index', {
+    paymentAmount,
+    paymentDescription,
     nextPage: paths.prototyping.demoPayment.mockCardDetails,
     editDescription: paths.prototyping.demoPayment.editDescription,
     editAmount: paths.prototyping.demoPayment.editAmount
-  }
-
-  lodash.set(req, 'session.pageData.protoData', {
-    protoPaymentDescription,
-    protoPaymentAmount
   })
-
-  response(req, res, 'dashboard/demo-payment/index', params)
 }

--- a/app/controllers/test_with_your_users/links_controller.js
+++ b/app/controllers/test_with_your_users/links_controller.js
@@ -18,9 +18,6 @@ module.exports = (req, res) => {
     .then(products => {
       params.productsLength = products.length
       params.productsSingular = products.length < 2
-      products.forEach(function (product) {
-        product.price = (product.price / 100).toFixed(2)
-      })
       params.products = products
       return response(req, res, 'dashboard/demo-service/index', params)
     })

--- a/app/models/Product.class.js
+++ b/app/models/Product.class.js
@@ -8,7 +8,8 @@ const lodash = require('lodash')
  * @property {string} externalId - The external ID of the product
  * @property {string} gatewayAccountId
  * @property {string} name
- * @property {number} price
+ * @property {number} price - The price of the product in pence
+ * @property {number} priceInPounds - The price of the products in pounds
  * @property {string} description
  * @property {string} returnUrl
  * @property {object} payLink
@@ -43,6 +44,9 @@ class Product {
     this.description = opts.description
     this.returnUrl = opts.return_url
     opts._links.forEach(link => lodash.set(this, `links.${link.rel}`, {method: link.method, href: link.href}))
+  }
+  get priceInPounds () {
+    if (this.price) return (this.price / 100).toFixed(2)
   }
 }
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -230,5 +230,4 @@ module.exports.bind = function (app) {
   app.get(prototyping.demoPayment.editDescription, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.edit)
   app.get(prototyping.demoPayment.editAmount, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.edit)
   app.get(prototyping.demoPayment.mockCardDetails, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.confirm)
-  app.post(prototyping.demoPayment.mockCardDetails, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.confirm)
 }

--- a/app/views/dashboard/demo-payment/confirm.html
+++ b/app/views/dashboard/demo-payment/confirm.html
@@ -14,6 +14,6 @@ Mock card numbers for demo payment - {{currentServiceName}} {{currentGatewayAcco
   
   <p>You can enter any valid value for the other details. For example, it doesn’t matter what expiry date you enter, but it must be in the future.</p>
   <p>You can also use other card types and see errors. <a href="See more card types in our documentation">See more card types in our documentation</a>.</p>
-  <a class="button" href="{{prototypeLink}}">Make a demo payment</a>
+  <a id="make-demo-payment" class="button" href="{{prototypeLink}}">Make a demo payment</a>
 {{/mainContent}}
 {{/layout}}

--- a/app/views/dashboard/demo-payment/edit-amount.html
+++ b/app/views/dashboard/demo-payment/edit-amount.html
@@ -15,7 +15,7 @@ Edit payment amount for demo payment - {{currentServiceName}} {{currentGatewayAc
       </label>
       <div class="currency-input__inner">
         <span class="currency-input__inner__unit">&pound;</span>
-        <input class="form-control" aria-label="Enter amount in pounds" name="payment-amount" data-non-numeric type="text" id="payment-amount" value="{{protoPaymentAmount}}" data-validate="required currency" data-trim>
+        <input class="form-control" aria-label="Enter amount in pounds" name="payment-amount" data-non-numeric type="text" id="payment-amount" value="{{paymentAmount}}" data-validate="required currency" data-trim>
       </div>
     </div>
     <input class="button" type="submit" value="Save changes">

--- a/app/views/dashboard/demo-payment/edit-description.html
+++ b/app/views/dashboard/demo-payment/edit-description.html
@@ -13,7 +13,7 @@ Edit payment description for demo payment - {{currentServiceName}} {{currentGate
         Payment description
         <span class="form-hint">Tell users what they are paying for</span>
       </label>
-      <textarea class="form-control form-control-3-4" name="payment-description" id="payment-description" rows="2" autofocus data-validate data-trim>{{protoPaymentDescription}}</textarea>
+      <textarea class="form-control form-control-3-4" name="payment-description" id="payment-description" rows="2" autofocus data-validate data-trim>{{paymentDescription}}</textarea>
     </div>
     <input class="button" type="submit" value="Save changes">
   </form>

--- a/app/views/dashboard/demo-payment/index.html
+++ b/app/views/dashboard/demo-payment/index.html
@@ -4,41 +4,36 @@ Make a demo payment - {{currentServiceName}} {{currentGatewayAccount.full_type}}
 {{/pageTitle}}
 
 {{$mainContent}}
-  <a href="/" class="link-back">Back to dashboard</a>
-  <h1 class="heading-large prototyping__heading">Make a demo payment</h1>
-  <p>Try the payment experience as a user. Then view the completed payment as an administrator on GOV.UK Pay.</p>
-  <form action="{{nextPage}}" method="post">
-    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-    <input type="hidden" name="prototype-payment-descrition" value="{{protoPaymentDescription}}">
-    <input type="hidden" name="prototype-payment-amount" value="{{protoPaymentAmount}}">
-    <table class="prototyping__settings-table">
-      <thead>
-        <tr>
-          <h2 class="heading-small">Payment description</h2>
-          <p class="prototyping__hint">Tell users what they are paying for</p>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{{protoPaymentDescription}}</td>
-          <td class="prototyping__edit-cell"><a class="prototyping__edit-button" href="{{editDescription}}">Edit</a></td>
-        </tr>
-      </tbody>
-    </table>
-    <table class="prototyping__settings-table">
-      <thead>
-        <tr>
-          <h2 class="heading-small">Payment amount</h2>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>&pound;{{protoPaymentAmount}}</td>
-          <td class="prototyping__edit-cell"><a class="prototyping__edit-button" href="{{editAmount}}">Edit</a></td>
-        </tr>
-      </tbody>
-    </table>
-    <input class="button" type="submit" value="Continue">
-  </form>
+<a href="/" class="link-back">Back to dashboard</a>
+<h1 class="heading-large prototyping__heading">Make a demo payment</h1>
+<p>Try the payment experience as a user. Then view the completed payment as an administrator on GOV.UK Pay.</p>
+<table class="prototyping__settings-table">
+  <thead>
+  <tr>
+    <h2 class="heading-small">Payment description</h2>
+    <p class="prototyping__hint">Tell users what they are paying for</p>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td id="payment-description">{{paymentDescription}}</td>
+    <td class="prototyping__edit-cell"><a class="prototyping__edit-button" href="{{editDescription}}">Edit</a></td>
+  </tr>
+  </tbody>
+</table>
+<table class="prototyping__settings-table">
+  <thead>
+  <tr>
+    <h2 class="heading-small">Payment amount</h2>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td id="payment-amount">&pound;{{paymentAmount}}</td>
+    <td class="prototyping__edit-cell"><a class="prototyping__edit-button" href="{{editAmount}}">Edit</a></td>
+  </tr>
+  </tbody>
+</table>
+<a class="button" href="{{nextPage}}">Continue</a>
 {{/mainContent}}
 {{/layout}}

--- a/app/views/dashboard/demo-service/index.html
+++ b/app/views/dashboard/demo-service/index.html
@@ -50,7 +50,7 @@ Test with your users - {{currentServiceName}} {{currentGatewayAccount.full_type}
         <div class="key-list-item prototyping__links-list-item">
           <h3 class="heading-small"><a href="{{links.pay.href}}">{{links.pay.href}}</a></h3>
           <p>Payment description: <strong class="prototyping__links-list-item-description">{{name}}</strong> <br/>
-          Payment amount: <strong class="prototyping__links-list-item-amount">&pound;{{price}}</strong> <br/>
+          Payment amount: <strong class="prototyping__links-list-item-amount">&pound;{{priceInPounds}}</strong> <br/>
           {{#returnUrl}}Success page: <strong class="prototyping__links-list-item-success-page">{{returnUrl}}</strong></p>{{/returnUrl}}
           <p><a class="prototyping__links-list-item-delete-link" href="links/disable/{{externalId}}">Delete prototype link</a></p>
         </div>

--- a/test/unit/controller/make_a_demo_payment_controller/confirm_controller_test.js
+++ b/test/unit/controller/make_a_demo_payment_controller/confirm_controller_test.js
@@ -1,0 +1,204 @@
+'use strict'
+
+// NPM dependencies
+const supertest = require('supertest')
+const {expect} = require('chai')
+const cheerio = require('cheerio')
+const lodash = require('lodash')
+const nock = require('nock')
+
+// Local dependencies
+const {getApp} = require('../../../../server')
+const {getMockSession, createAppWithSession, getUser} = require('../../../test_helpers/mock_session')
+const paths = require('../../../../app/paths')
+const {randomUuid} = require('../../../../app/utils/random')
+const {validCreateProductRequest, validCreateProductResponse} = require('../../../fixtures/product_fixtures')
+
+const {PUBLIC_AUTH_URL, PRODUCTS_URL, CONNECTOR_URL} = process.env
+const GATEWAY_ACCOUNT_ID = 929
+const PAYMENT_DESCRIPTION = 'Pay your window tax'
+const PAYMENT_AMOUNT = '20.00'
+const VALID_USER = getUser({
+  gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+  permissions: [{name: 'transactions:read'}]
+})
+const VALID_CREATE_TOKEN_REQUEST = {
+  account_id: GATEWAY_ACCOUNT_ID,
+  created_by: VALID_USER.email,
+  description: 'Token for Demo Payment'
+}
+const VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE = {
+  payment_provider: 'sandbox'
+}
+const VALID_CREATE_TOKEN_RESPONSE = {token: randomUuid()}
+const VALID_CREATE_PRODUCT_REQUEST = validCreateProductRequest({
+  name: PAYMENT_DESCRIPTION,
+  payApiToken: VALID_CREATE_TOKEN_RESPONSE.token,
+  price: PAYMENT_AMOUNT * 100,
+  gatewayAccountId: GATEWAY_ACCOUNT_ID
+}).getPlain()
+const VALID_CREATE_PRODUCT_RESPONSE = validCreateProductResponse(VALID_CREATE_PRODUCT_REQUEST).getPlain()
+
+describe('make a demo payment - confirm controller', () => {
+  describe(`when both paymentDescription and paymentAmount exist in the session`, () => {
+    describe(`when the API token is successfully created`, () => {
+      describe(`and the product is successfully created`, () => {
+        let result, $, session
+        before(done => {
+          nock(PUBLIC_AUTH_URL).post('', VALID_CREATE_TOKEN_REQUEST).reply(201, VALID_CREATE_TOKEN_RESPONSE)
+          nock(PRODUCTS_URL).post('/v1/api/products', VALID_CREATE_PRODUCT_REQUEST).reply(201, VALID_CREATE_PRODUCT_RESPONSE)
+          nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+          session = getMockSession(VALID_USER)
+          lodash.set(session, 'pageData.makeADemoPayment.paymentDescription', PAYMENT_DESCRIPTION)
+          lodash.set(session, 'pageData.makeADemoPayment.paymentAmount', PAYMENT_AMOUNT)
+          supertest(createAppWithSession(getApp(), session))
+            .get(paths.prototyping.demoPayment.mockCardDetails)
+            .end((err, res) => {
+              result = res
+              $ = cheerio.load(res.text)
+              done(err)
+            })
+        })
+        after(() => {
+          nock.cleanAll()
+        })
+
+        it('should respond with statusCode 200', () => {
+          expect(result.statusCode).to.equal(200)
+        })
+
+        it('should show the mock card details page', () => {
+          expect($('h1').text()).to.equal('Mock card numbers')
+        })
+
+        it('should have a back button that takes the user back to the landing page for a logged in user', () => {
+          expect($('.link-back').attr('href')).to.equal(paths.user.loggedIn)
+        })
+
+        it(`should have a 'Make a demo payment' button that points at the pay url of the product`, () => {
+          const expectedHref = VALID_CREATE_PRODUCT_RESPONSE._links.find(link => link.rel === 'pay').href
+          expect($('#make-demo-payment').attr('href')).to.equal(expectedHref)
+        })
+
+        it(`should clear the values stored in the session`, () => {
+          expect(session.pageData).not.to.have.property('makeADemoPayment')
+        })
+      })
+      describe(`but the product creation fails`, () => {
+        let result, session
+        before(done => {
+          nock(PUBLIC_AUTH_URL).post('', VALID_CREATE_TOKEN_REQUEST).reply(201, VALID_CREATE_TOKEN_RESPONSE)
+          nock(PRODUCTS_URL).post('/v1/api/products', VALID_CREATE_PRODUCT_REQUEST).replyWithError('Something went wrong')
+          nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+          session = getMockSession(VALID_USER)
+          lodash.set(session, 'pageData.makeADemoPayment.paymentDescription', PAYMENT_DESCRIPTION)
+          lodash.set(session, 'pageData.makeADemoPayment.paymentAmount', PAYMENT_AMOUNT)
+          supertest(createAppWithSession(getApp(), session))
+            .get(paths.prototyping.demoPayment.mockCardDetails)
+            .end((err, res) => {
+              result = res
+              done(err)
+            })
+        })
+        after(() => {
+          nock.cleanAll()
+        })
+
+        it('should redirect with status code 302', () => {
+          expect(result.statusCode).to.equal(302)
+        })
+
+        it('should redirect back to the index page', () => {
+          expect(result.headers).to.have.property('location').to.equal(paths.prototyping.demoPayment.index)
+        })
+
+        it('should add a relevant error message to the session \'flash\'', () => {
+          expect(session.flash).to.have.property('genericError')
+          expect(session.flash.genericError.length).to.equal(1)
+          expect(session.flash.genericError[0]).to.equal('<h2>There were errors</h2> Error while creating demo payment')
+        })
+      })
+    })
+    describe(`when the API token creation fails`, () => {
+      let result, session
+      before(done => {
+        nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+        nock(PUBLIC_AUTH_URL).post('', VALID_CREATE_TOKEN_REQUEST).replyWithError('Something went wrong')
+        session = getMockSession(VALID_USER)
+        lodash.set(session, 'pageData.makeADemoPayment.paymentDescription', PAYMENT_DESCRIPTION)
+        lodash.set(session, 'pageData.makeADemoPayment.paymentAmount', PAYMENT_AMOUNT)
+        supertest(createAppWithSession(getApp(), session))
+          .get(paths.prototyping.demoPayment.mockCardDetails)
+          .end((err, res) => {
+            result = res
+            done(err)
+          })
+      })
+      after(() => {
+        nock.cleanAll()
+      })
+
+      it('should redirect with status code 302', () => {
+        expect(result.statusCode).to.equal(302)
+      })
+
+      it('should redirect back to the index page', () => {
+        expect(result.headers).to.have.property('location').to.equal(paths.prototyping.demoPayment.index)
+      })
+
+      it('should add a relevant error message to the session \'flash\'', () => {
+        expect(session.flash).to.have.property('genericError')
+        expect(session.flash.genericError.length).to.equal(1)
+        expect(session.flash.genericError[0]).to.equal('<h2>There were errors</h2> Error while creating demo payment')
+      })
+    })
+  })
+  describe(`when paymentDescription is missing from the session`, () => {
+    let result
+    before(done => {
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+      const session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.makeADemoPayment.paymentAmount', PAYMENT_AMOUNT)
+      supertest(createAppWithSession(getApp(), session))
+        .get(paths.prototyping.demoPayment.mockCardDetails)
+        .end((err, res) => {
+          result = res
+          done(err)
+        })
+    })
+
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should redirect with status code 302', () => {
+      expect(result.statusCode).to.equal(302)
+    })
+
+    it('should redirect back to the index page', () => {
+      expect(result.headers).to.have.property('location').to.equal(paths.prototyping.demoPayment.index)
+    })
+  })
+  describe(`when paymentAmount is missing from the session`, () => {
+    let result
+    before(done => {
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+      const session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.makeADemoPayment.paymentDescription', PAYMENT_DESCRIPTION)
+      supertest(createAppWithSession(getApp(), session))
+        .get(paths.prototyping.demoPayment.mockCardDetails)
+        .end((err, res) => {
+          result = res
+          done(err)
+        })
+    })
+
+    it('should redirect with status code 302', () => {
+      expect(result.statusCode).to.equal(302)
+    })
+
+    it('should redirect back to the index page', () => {
+      expect(result.headers).to.have.property('location').to.equal(paths.prototyping.demoPayment.index)
+    })
+  })
+})

--- a/test/unit/controller/make_a_demo_payment_controller/edit_controller_test.js
+++ b/test/unit/controller/make_a_demo_payment_controller/edit_controller_test.js
@@ -1,0 +1,98 @@
+'use strict'
+
+// NPM dependencies
+const supertest = require('supertest')
+const {expect} = require('chai')
+const cheerio = require('cheerio')
+const lodash = require('lodash')
+const nock = require('nock')
+
+// Local dependencies
+const {getApp} = require('../../../../server')
+const {getMockSession, createAppWithSession, getUser} = require('../../../test_helpers/mock_session')
+const paths = require('../../../../app/paths')
+
+const GATEWAY_ACCOUNT_ID = 929
+const {CONNECTOR_URL} = process.env
+const VALID_USER = getUser({
+  gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+  permissions: [{name: 'transactions:read'}]
+})
+const VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE = {
+  payment_provider: 'sandbox'
+}
+
+describe('make a demo payment - edit controller', () => {
+  describe(`when the path navigated to is the 'edit amount' path`, () => {
+    let result, $, session, paymentAmount
+    before(done => {
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+      paymentAmount = '100.00'
+      session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.makeADemoPayment.paymentAmount', paymentAmount)
+      supertest(createAppWithSession(getApp(), session))
+        .get(paths.prototyping.demoPayment.editAmount)
+        .end((err, res) => {
+          result = res
+          $ = cheerio.load(res.text)
+          done(err)
+        })
+    })
+
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should return with a statusCode of 200', () => {
+      expect(result.statusCode).to.equal(200)
+    })
+
+    it('should render the edit amount page', () => {
+      expect($('h1').text()).to.equal('Edit payment amount')
+    })
+
+    it('should have a back button that takes the user back to the demo payment index page', () => {
+      expect($('.link-back').attr('href')).to.equal(paths.prototyping.demoPayment.index)
+    })
+
+    it(`should set the 'payment-amount' value to be that found in the session`, () => {
+      expect($(`input[name='payment-amount']`).val()).to.equal(paymentAmount)
+    })
+  })
+  describe(`when the path navigated to is the 'edit description' path`, () => {
+    let result, $, session, paymentDescription
+    before(done => {
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+      paymentDescription = 'Pay your window tax'
+      session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.makeADemoPayment.paymentDescription', paymentDescription)
+      supertest(createAppWithSession(getApp(), session))
+        .get(paths.prototyping.demoPayment.editDescription)
+        .end((err, res) => {
+          result = res
+          $ = cheerio.load(res.text)
+          done(err)
+        })
+    })
+
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should return with a statusCode of 200', () => {
+      expect(result.statusCode).to.equal(200)
+    })
+
+    it('should render the edit amount page', () => {
+      expect($('h1').text()).to.equal('Edit payment description')
+    })
+
+    it('should have a back button that takes the user back to the demo payment index page', () => {
+      expect($('.link-back').attr('href')).to.equal(paths.prototyping.demoPayment.index)
+    })
+
+    it(`should set the 'payment-description' value to be that found in the session`, () => {
+      expect($(`textarea[name='payment-description']`).val()).to.equal(paymentDescription)
+    })
+  })
+})

--- a/test/unit/controller/make_a_demo_payment_controller/index_controller_test.js
+++ b/test/unit/controller/make_a_demo_payment_controller/index_controller_test.js
@@ -1,0 +1,241 @@
+'use strict'
+
+// NPM dependencies
+const supertest = require('supertest')
+const {expect} = require('chai')
+const cheerio = require('cheerio')
+const lodash = require('lodash')
+const csrf = require('csrf')
+const nock = require('nock')
+
+// Local dependencies
+const {getApp} = require('../../../../server')
+const {getMockSession, createAppWithSession, getUser} = require('../../../test_helpers/mock_session')
+const paths = require('../../../../app/paths')
+
+const GATEWAY_ACCOUNT_ID = 929
+const {CONNECTOR_URL} = process.env
+const VALID_USER = getUser({
+  gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+  permissions: [{name: 'transactions:read'}]
+})
+const VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE = {
+  payment_provider: 'sandbox'
+}
+
+describe('make a demo payment - index controller', () => {
+  describe('when no values exist in the body and none are in session', () => {
+    let result, $, session
+    before(done => {
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+      session = getMockSession(VALID_USER)
+      supertest(createAppWithSession(getApp(), session))
+        .get(paths.prototyping.demoPayment.index)
+        .end((err, res) => {
+          result = res
+          $ = cheerio.load(res.text)
+          done(err)
+        })
+    })
+
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should return with a statusCode of 200', () => {
+      expect(result.statusCode).to.equal(200)
+    })
+
+    it(`should default to a payment amount of '20.00'`, () => {
+      expect($(`#payment-amount`).text()).to.equal(`£${'20.00'}`)
+    })
+
+    it(`should default to a payment description of 'An example payment description'`, () => {
+      expect($(`#payment-description`).text()).to.equal('An example payment description')
+    })
+  })
+  describe('when values exist in the session but none are in the body', () => {
+    let result, $, session, paymentAmount, paymentDescription
+    before(done => {
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+      paymentAmount = '100.00'
+      paymentDescription = 'Pay your window tax'
+      session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.makeADemoPayment.paymentAmount', paymentAmount)
+      lodash.set(session, 'pageData.makeADemoPayment.paymentDescription', paymentDescription)
+      supertest(createAppWithSession(getApp(), session))
+        .get(paths.prototyping.demoPayment.index)
+        .end((err, res) => {
+          result = res
+          $ = cheerio.load(res.text)
+          done(err)
+        })
+    })
+
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should return with a statusCode of 200', () => {
+      expect(result.statusCode).to.equal(200)
+    })
+
+    it(`should show the payment amount stored in the session`, () => {
+      expect($(`#payment-amount`).text()).to.equal(`£${paymentAmount}`)
+    })
+
+    it(`should show the payment description stored in the session`, () => {
+      expect($(`#payment-description`).text()).to.equal(paymentDescription)
+    })
+  })
+  describe('when values exist in the body', () => {
+    describe('and they are valid', () => {
+      describe('and there are also values in the session', () => {
+        let result, $, session, paymentAmount, paymentDescription
+        before(done => {
+          nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+          paymentAmount = '100.00'
+          paymentDescription = 'Pay your window tax'
+          session = getMockSession(VALID_USER)
+          lodash.set(session, 'pageData.makeADemoPayment.paymentAmount', '180.00')
+          lodash.set(session, 'pageData.makeADemoPayment.paymentDescription', 'Pay your door tax')
+          supertest(createAppWithSession(getApp(), session))
+            .post(paths.prototyping.demoPayment.index)
+            .send({
+              'csrfToken': csrf().create('123'),
+              'payment-amount': paymentAmount,
+              'payment-description': paymentDescription
+            })
+            .end((err, res) => {
+              result = res
+              $ = cheerio.load(res.text)
+              done(err)
+            })
+        })
+
+        after(() => {
+          nock.cleanAll()
+        })
+
+        it('should return with a statusCode of 200', () => {
+          expect(result.statusCode).to.equal(200)
+        })
+
+        it(`should show the payment amount from the body`, () => {
+          expect($(`#payment-amount`).text()).to.equal(`£${paymentAmount}`)
+        })
+
+        it(`should show the payment description from the body`, () => {
+          expect($(`#payment-description`).text()).to.equal(paymentDescription)
+        })
+      })
+      describe('and there are no values in the session', () => {
+        let result, $, session, paymentAmount, paymentDescription
+        before(done => {
+          nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+          paymentAmount = '100.00'
+          paymentDescription = 'Pay your window tax'
+          session = getMockSession(VALID_USER)
+          supertest(createAppWithSession(getApp(), session))
+            .post(paths.prototyping.demoPayment.index)
+            .send({
+              'csrfToken': csrf().create('123'),
+              'payment-amount': paymentAmount,
+              'payment-description': paymentDescription
+            })
+            .end((err, res) => {
+              result = res
+              $ = cheerio.load(res.text)
+              done(err)
+            })
+        })
+
+        after(() => {
+          nock.cleanAll()
+        })
+
+        it('should return with a statusCode of 200', () => {
+          expect(result.statusCode).to.equal(200)
+        })
+
+        it(`should show the payment amount from the body`, () => {
+          expect($(`#payment-amount`).text()).to.equal(`£${paymentAmount}`)
+        })
+
+        it(`should show the payment description from the body`, () => {
+          expect($(`#payment-description`).text()).to.equal(paymentDescription)
+        })
+      })
+    })
+    describe('but the payment amount is invalid', () => {
+      describe('because the value includes text', () => {
+        let result, session
+        before(done => {
+          nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+          session = getMockSession(VALID_USER)
+          supertest(createAppWithSession(getApp(), session))
+            .post(paths.prototyping.demoPayment.index)
+            .send({
+              'csrfToken': csrf().create('123'),
+              'payment-amount': 'One Hundred and Eighty Pounds and No Pence',
+              'payment-description': 'Pay your window tax'
+            })
+            .end((err, res) => {
+              result = res
+              done(err)
+            })
+        })
+
+        after(() => {
+          nock.cleanAll()
+        })
+
+        it('should redirect with a statusCode of 302', () => {
+          expect(result.statusCode).to.equal(302)
+        })
+        it(`should redirect to the edit payment amount page`, () => {
+          expect(result.headers).to.have.property('location').to.equal(paths.prototyping.demoPayment.editAmount)
+        })
+        it('should add a relevant error message to the session \'flash\'', () => {
+          expect(session.flash).to.have.property('genericError')
+          expect(session.flash.genericError.length).to.equal(1)
+          expect(session.flash.genericError[0]).to.equal('<h2>Use valid characters only</h2> Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”')
+        })
+      })
+      describe('because the value has too many digits to the right of the decimal point', () => {
+        let result, session
+        before(done => {
+          nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+          session = getMockSession(VALID_USER)
+          supertest(createAppWithSession(getApp(), session))
+            .post(paths.prototyping.demoPayment.index)
+            .send({
+              'csrfToken': csrf().create('123'),
+              'payment-amount': '£1234.567',
+              'payment-description': 'Pay your window tax'
+            })
+            .end((err, res) => {
+              result = res
+              done(err)
+            })
+        })
+
+        after(() => {
+          nock.cleanAll()
+        })
+
+        it('should redirect with a statusCode of 302', () => {
+          expect(result.statusCode).to.equal(302)
+        })
+        it(`should redirect to the edit payment amount page`, () => {
+          expect(result.headers).to.have.property('location').to.equal(paths.prototyping.demoPayment.editAmount)
+        })
+        it('should add a relevant error message to the session \'flash\'', () => {
+          expect(session.flash).to.have.property('genericError')
+          expect(session.flash.genericError.length).to.equal(1)
+          expect(session.flash.genericError[0]).to.equal('<h2>Use valid characters only</h2> Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”')
+        })
+      })
+    })
+  })
+})

--- a/test/unit/controller/test_with_your_users_controller/links_controller_test.js
+++ b/test/unit/controller/test_with_your_users_controller/links_controller_test.js
@@ -131,7 +131,7 @@ describe('Show the prototype links', () => {
         externalId: 'product-external-id-1',
         gatewayAccountId: 'product-gateway-account-id-1',
         name: 'payment-name-1',
-        price: '1.50',
+        price: '150',
         returnUrl: 'http://return.url',
         links: {
           pay: {
@@ -183,7 +183,7 @@ describe('Show the prototype links', () => {
         externalId: 'product-external-id-1',
         gatewayAccountId: 'product-gateway-account-id-1',
         name: 'payment-name-1',
-        price: '1.50',
+        price: '150',
         returnUrl: 'http://return.url',
         links: {
           pay: {
@@ -196,7 +196,7 @@ describe('Show the prototype links', () => {
         externalId: 'product-external-id-2',
         gatewayAccountId: 'product-gateway-account-id-2',
         name: 'payment-name-2',
-        price: '1.50',
+        price: '150',
         returnUrl: 'http://return.url',
         links: {
           pay: {

--- a/test/unit/middleware/get_gateway_account_test.js
+++ b/test/unit/middleware/get_gateway_account_test.js
@@ -45,7 +45,6 @@ describe('middleware: getGatewayAccount', () => {
       expect(connectorGetAccountMock.calledWith({gatewayAccountId: 1, correlationId: 'sdfghjk'})).to.equal(true)
       expect(next.called).to.equal(true)
       expect(res.redirect.called).to.equal(false)
-      console.log(req)
       done()
     })
   })


### PR DESCRIPTION
# PP-2655 Added unit tests for make_demo_payment controllers

## WHAT
- refactored confirm page so as to be a GET using session variables only
- added validation to index page on POST copying validation from prototype links pages
- added tests for index, confirm and edit pages


