### PR TITLE
PP-2543 - text was not being cleared on subsequent update

### DIFF
--- a/app/browsered/multi-select.js
+++ b/app/browsered/multi-select.js
@@ -21,6 +21,7 @@ const DROPDOWN_SELECTOR = '.multi-select-dropdown'
 const SCROLL_CONTAINER_SELECTOR = '.multi-select-dropdown-inner-container'
 const ITEM_SELECTOR = '.multi-select-item'
 const ALL_SELECTOR = `${ITEM_SELECTOR}[value=""]`
+const CURRENT_SELECTIONS = '.multi-select-current-selections'
 
 exports.enableMultiSelects = () => $(DOCUMENT_SELECTOR).ready(progressivelyEnhanceSelects)
 
@@ -108,7 +109,7 @@ function updateDisplayedValue () {
     .map(item => $(item).parent().text().trim())
     .join(', ')
 
-  TOP_LEVEL.find(`${OPEN_BUTTON_SELECTOR} div span`).after(buttonText)
+  TOP_LEVEL.find(`${CURRENT_SELECTIONS}`).text(buttonText)
 }
 
 function randomElementId () {

--- a/app/views/includes/multi-select.html
+++ b/app/views/includes/multi-select.html
@@ -3,7 +3,7 @@
             class="form-control large multi-select-title"
             aria-describedby="state-select-box"
             id="option-select-title-state">
-        <div><span class="visually-hidden">Currently selected: </span></div>
+        <div><span class="visually-hidden">Currently selected: </span><span class="multi-select-current-selections"></span></div>
     </button>
     <div role="group" aria-labelledby="option-select-title-state"
          class="multi-select-dropdown"


### PR DESCRIPTION
I switched to using `.after()` which was foolish because it appended every change leading to a huge list of words which broke the layout, switched back to `.text()` but wrapped what we update in specific `<span>` so that we can keep the screen reader text all the time.