### PR TITLE
PP-2671 Updated Disable prototype link to use generic

### DIFF
--- a/app/controllers/test_with_your_users/disable_controller.js
+++ b/app/controllers/test_with_your_users/disable_controller.js
@@ -7,7 +7,7 @@ const productsClient = require('../../services/clients/products_client.js')
 module.exports = (req, res) => {
   productsClient.product.disable(req.params.productExternalId)
     .then(() => {
-      req.flash('genericError', '<p>Prototype link deleted</p>')
+      req.flash('generic', '<p>Prototype link deleted</p>')
       res.redirect(paths.prototyping.demoService.links)
     })
     .catch(() => {

--- a/test/unit/controller/test_with_your_users_controller/disable_controller_test.js
+++ b/test/unit/controller/test_with_your_users_controller/disable_controller_test.js
@@ -47,10 +47,10 @@ describe('test with your users - disable controller', () => {
       expect(response.header).to.have.property('location').to.equal(paths.prototyping.demoService.links)
     })
 
-    it('should add a relevant error message to the session \'flash\'', () => {
-      expect(session.flash).to.have.property('genericError')
-      expect(session.flash.genericError.length).to.equal(1)
-      expect(session.flash.genericError[0]).to.equal('<p>Prototype link deleted</p>')
+    it('should add a relevant generic message to the session \'flash\'', () => {
+      expect(session.flash).to.have.property('generic')
+      expect(session.flash.generic.length).to.equal(1)
+      expect(session.flash.generic[0]).to.equal('<p>Prototype link deleted</p>')
     })
   })
 


### PR DESCRIPTION
- Now when you disable a prototype link it uses flash.generic not flash.genericError

