### PR TITLE
PP-2543 - Setting up Babel polyfill for IE

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -122,7 +122,13 @@ module.exports = function (grunt) {
           [
             'babelify',
             {
-              presets: ['es2015']
+              presets: [
+                ['env', {
+                  'targets': {
+                    'browsers': ['last 2 versions', 'safari >= 7', 'ie >= 10']
+                  }
+                }]
+              ]
             }], [
               'hoganify',
               {

--- a/app/browsered.js
+++ b/app/browsered.js
@@ -1,5 +1,6 @@
 'use strict'
 // NPM dependencies
+require('babel-polyfill')
 const $ = require('jquery')
 const multiSelects = require('./browsered/multi-select')
 const fieldValidation = require('./browsered/field-validation')

--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
   },
   "devDependencies": {
     "@pact-foundation/pact-node": "4.6.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-es2015": "^6.24.1",
     "babelify": "^7.3.0",
     "chai": "^4.0.2",


### PR DESCRIPTION
We weren't polyfilling ES2015+ features for IE (and Opera, etc)
Added the config in to do so. Without this the multiselect
doesn't work in IE.


