### PR TITLE
PP-2966 IE flexbox and dashboard bugs 

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -55,7 +55,7 @@ $grey-8: #fff;
 @import "modules/_toggle_3ds";
 @import "modules/_merchant_details";
 @import "modules/_info_box";
-@import "modules/_dashboard";
+@import "modules/_dashboard-first-steps";
 @import "modules/_prototyping";
 
 @import "gov-uk-overrides/_forms";

--- a/app/assets/sass/modules/_dashboard-first-steps.scss
+++ b/app/assets/sass/modules/_dashboard-first-steps.scss
@@ -8,11 +8,6 @@
     position: relative;
     width: 100%;
 
-    @include media(tablet) {
-      display: flex;
-      flex-direction: column;
-    }
-
     a {
       display: block;
       text-decoration: none;

--- a/app/assets/sass/modules/_flex_grid.scss
+++ b/app/assets/sass/modules/_flex_grid.scss
@@ -29,7 +29,6 @@
     @include media(tablet) {
       min-width: 50%;
       flex: 0 0 auto;
-      flex-basis: 50%;
 
       &.marked:nth-child(even) {
         border-right: solid 1px $grey-2;

--- a/app/utils/display_converter.js
+++ b/app/utils/display_converter.js
@@ -116,6 +116,7 @@ module.exports = function (req, data, template) {
   addGatewayAccountProviderDisplayNames(convertedData)
   convertedData.currentGatewayAccount = getAccount(account)
   convertedData.isTestGateway = _.get(convertedData, 'currentGatewayAccount.type') === 'test'
+  convertedData.isSandbox = _.get(convertedData, 'currentGatewayAccount.payment_provider') === 'sandbox'
   convertedData.currentServiceName = _.get(req, 'service.name')
   if (permissions) {
     convertedData.serviceNavigationItems = serviceNavigationItems(originalUrl, permissions)

--- a/app/views/dashboard/_first-steps.html
+++ b/app/views/dashboard/_first-steps.html
@@ -1,7 +1,7 @@
 <div class="flex-grid">
   <div class="flex-grid--row">
 
-    {{#isTestGateway}}
+    {{#isSandbox}}
     <article class="flex-grid--column-half first-steps__box border-bottom">
       <a href="/make-a-demo-payment">
         <h2 class="heading-small">Make a demo payment</h2>
@@ -15,16 +15,16 @@
         <p>Create a reusable link to integrate your service prototype with GOV.UK&nbsp;Pay and test with users.</p>
       </a>
     </article>
-    {{/isTestGateway}}
+    {{/isSandbox}}
 
-    {{^isTestGateway}}
+    {{^isSandbox}}
     <article class="flex-grid--column-half first-steps__box">
       <a href="https://govukpay-docs.cloudapps.digital/#payment-flow-making-a-payment">
         <h2 class="heading-small">See the payment flow</h2>
         <p>Get an overview of payment pages in our documentation.</p>
       </a>
     </article>
-    {{/isTestGateway}}
+    {{/isSandbox}}
 
     <article class="flex-grid--column-half first-steps__box">
       <a href="/my-services/">


### PR DESCRIPTION
On IE, the dashboard layout was a total mess because of flexbox css, it was actually superfluous anyway, so taken it out. So that's fixed

Also the two payment prototype links should have been restricted to sandbox accounts only. So made that change too