### PR TITLE
PP-2999 Moved Demo Product Creation to POST Endpoint

### DIFF
--- a/app/controllers/make_a_demo_payment/go_to_payment_controller.js
+++ b/app/controllers/make_a_demo_payment/go_to_payment_controller.js
@@ -4,7 +4,6 @@
 const lodash = require('lodash')
 
 // Local dependencies
-const {response} = require('../../utils/response.js')
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products_client.js')
 const publicAuthClient = require('../../services/clients/public_auth_client')
@@ -12,7 +11,7 @@ const auth = require('../../services/auth_service.js')
 
 module.exports = (req, res) => {
   const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
-  const {paymentAmount, paymentDescription} = lodash.get(req, 'session.pageData.makeADemoPayment')
+  const {paymentAmount, paymentDescription} = lodash.get(req, 'session.pageData.makeADemoPayment', {})
 
   if (!paymentAmount || !paymentDescription) {
     return res.redirect(paths.prototyping.demoPayment.index)
@@ -34,11 +33,8 @@ module.exports = (req, res) => {
       price: Math.trunc(paymentAmount * 100)
     }))
     .then(product => {
-      response(req, res, 'dashboard/demo-payment/confirm', {
-        prototypeLink: lodash.get(product, 'links.pay.href'),
-        indexPage: paths.user.loggedIn
-      })
       lodash.unset(req, 'session.pageData.makeADemoPayment')
+      res.redirect(product.links.pay.href)
     })
     .catch(() => {
       req.flash('genericError', `<h2>There were errors</h2> Error while creating demo payment`)

--- a/app/controllers/make_a_demo_payment/index.js
+++ b/app/controllers/make_a_demo_payment/index.js
@@ -2,4 +2,5 @@
 
 exports.index = require('./index_controller')
 exports.edit = require('./edit_controller')
-exports.confirm = require('./confirm_controller')
+exports.mockCardDetails = require('./mock_card_details_controller')
+exports.goToPayment = require('./go_to_payment_controller')

--- a/app/controllers/make_a_demo_payment/mock_card_details_controller.js
+++ b/app/controllers/make_a_demo_payment/mock_card_details_controller.js
@@ -1,0 +1,23 @@
+'use strict'
+
+// NPM dependencies
+const lodash = require('lodash')
+
+// Local dependencies
+const {response} = require('../../utils/response.js')
+const paths = require('../../paths')
+
+const PAGE_DATA = {
+  nextPage: paths.prototyping.demoPayment.goToPaymentScreens,
+  lastPage: paths.prototyping.demoPayment.index
+}
+
+module.exports = (req, res) => {
+  const {paymentAmount, paymentDescription} = lodash.get(req, 'session.pageData.makeADemoPayment', {})
+
+  if (!paymentAmount || !paymentDescription) {
+    return res.redirect(paths.prototyping.demoPayment.index)
+  }
+
+  response(req, res, 'dashboard/demo-payment/mock-card-details', PAGE_DATA)
+}

--- a/app/paths.js
+++ b/app/paths.js
@@ -119,7 +119,8 @@ module.exports = {
       index: '/make-a-demo-payment',
       editDescription: '/make-a-demo-payment/edit-description',
       editAmount: '/make-a-demo-payment/edit-amount',
-      mockCardDetails: '/make-a-demo-payment/mock-card-numbers'
+      mockCardDetails: '/make-a-demo-payment/mock-card-numbers',
+      goToPaymentScreens: '/make-a-demo-payment/go-to-payment'
     }
   },
   generateRoute: require(path.join(__dirname, '/utils/generate_route.js'))

--- a/app/routes.js
+++ b/app/routes.js
@@ -229,5 +229,6 @@ module.exports.bind = function (app) {
   app.post(prototyping.demoPayment.index, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.index)
   app.get(prototyping.demoPayment.editDescription, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.edit)
   app.get(prototyping.demoPayment.editAmount, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.edit)
-  app.get(prototyping.demoPayment.mockCardDetails, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.confirm)
+  app.get(prototyping.demoPayment.mockCardDetails, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.mockCardDetails)
+  app.post(prototyping.demoPayment.goToPaymentScreens, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPayment.goToPayment)
 }

--- a/app/views/dashboard/demo-payment/mock-card-details.html
+++ b/app/views/dashboard/demo-payment/mock-card-details.html
@@ -4,7 +4,7 @@ Mock card numbers for demo payment - {{currentServiceName}} {{currentGatewayAcco
 {{/pageTitle}}
 
 {{$mainContent}}
-  <a href="{{indexPage}}" class="link-back">Back to dashboard</a>
+  <a href="{{lastPage}}" class="link-back">Back to dashboard</a>
   <h1 class="heading-large prototyping__heading">Mock card numbers</h1>
   <p>Use this card number to test a successful payment. Don’t use real card numbers.</p>
 
@@ -14,6 +14,10 @@ Mock card numbers for demo payment - {{currentServiceName}} {{currentGatewayAcco
 
   <p>You can enter any valid value for the other details. For example, it doesn’t matter what expiry date you enter, but it must be in the future.</p>
   <p>You can also use other card types and see errors. <a href="https://govukpay-docs.cloudapps.digital/#mock-card-numbers-for-testing-purposes">See more card types in our documentation</a>.</p>
-  <a id="prototyping__make-demo-payment" class="button" href="{{prototypeLink}}">Make a demo payment</a>
+  <form method="post" action="{{nextPage}}" >
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    <input id="prototyping__make-demo-payment" class="button" type="submit" value="Make a demo payment">
+  </form>
+
 {{/mainContent}}
 {{/layout}}

--- a/test/unit/controller/make_a_demo_payment_controller/mock_card_details_controller_test.js
+++ b/test/unit/controller/make_a_demo_payment_controller/mock_card_details_controller_test.js
@@ -1,0 +1,176 @@
+'use strict'
+
+// NPM dependencies
+const supertest = require('supertest')
+const {expect} = require('chai')
+const cheerio = require('cheerio')
+const nock = require('nock')
+const lodash = require('lodash')
+
+// Local dependencies
+const {getApp} = require('../../../../server')
+const {getMockSession, createAppWithSession, getUser} = require('../../../test_helpers/mock_session')
+const paths = require('../../../../app/paths')
+const {CONNECTOR_URL} = process.env
+const GATEWAY_ACCOUNT_ID = 929
+
+describe('make a demo payment - mock card details controller', () => {
+  describe('when both paymentDescription and paymentAmount exist in the session', () => {
+    let result, $, app
+
+    before('Arrange', () => {
+      const session = getMockSession(getUser({
+        gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+        permissions: [{name: 'transactions:read'}]
+      }))
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
+        payment_provider: 'sandbox'
+      })
+      lodash.set(session, 'pageData.makeADemoPayment', {
+        paymentDescription: 'A demo payment',
+        paymentAmount: '10.50'
+      })
+      app = createAppWithSession(getApp(), session)
+    })
+
+    before('Act', done => {
+      supertest(app)
+        .get(paths.prototyping.demoPayment.mockCardDetails)
+        .end((err, res) => {
+          result = res
+          $ = cheerio.load(res.text)
+          done(err)
+        })
+    })
+
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should return a statusCode of 200', () => {
+      expect(result.statusCode).to.equal(200)
+    })
+
+    it(`should include a back link linking to the demoservice index page`, () => {
+      expect($('.link-back').attr('href')).to.equal(paths.prototyping.demoPayment.index)
+    })
+
+    it(`should include form which has the go to demo payment page as its action`, () => {
+      expect($('form').attr('action')).to.equal(paths.prototyping.demoPayment.goToPaymentScreens)
+    })
+  })
+
+  describe('when paymentDescription exists in the session but paymentAmount does not', () => {
+    let result, app
+
+    before('Arrange', () => {
+      const session = getMockSession(getUser({
+        gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+        permissions: [{name: 'transactions:read'}]
+      }))
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
+        payment_provider: 'sandbox'
+      })
+      lodash.set(session, 'pageData.makeADemoPayment', {
+        paymentDescription: 'A demo payment'
+      })
+      app = createAppWithSession(getApp(), session)
+    })
+
+    before('Act', done => {
+      supertest(app)
+        .get(paths.prototyping.demoPayment.mockCardDetails)
+        .end((err, res) => {
+          result = res
+          done(err)
+        })
+    })
+
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should return a statusCode of 302', () => {
+      expect(result.statusCode).to.equal(302)
+    })
+
+    it('should redirect back to the index page', () => {
+      expect(result.headers).to.have.property('location').to.equal(paths.prototyping.demoPayment.index)
+    })
+  })
+
+  describe('when paymentAmount exists in the session but paymentAmount does not', () => {
+    let result, app
+
+    before('Arrange', () => {
+      const session = getMockSession(getUser({
+        gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+        permissions: [{name: 'transactions:read'}]
+      }))
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
+        payment_provider: 'sandbox'
+      })
+      lodash.set(session, 'pageData.makeADemoPayment', {
+        paymentAmount: '10.50'
+      })
+      app = createAppWithSession(getApp(), session)
+    })
+
+    before('Act', done => {
+      supertest(app)
+        .get(paths.prototyping.demoPayment.mockCardDetails)
+        .end((err, res) => {
+          result = res
+          done(err)
+        })
+    })
+
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should return a statusCode of 302', () => {
+      expect(result.statusCode).to.equal(302)
+    })
+
+    it('should redirect back to the index page', () => {
+      expect(result.headers).to.have.property('location').to.equal(paths.prototyping.demoPayment.index)
+    })
+  })
+
+  describe('when there neither paymentDescription or paymentAmount exist in the session', () => {
+    let result, app
+
+    before('Arrange', () => {
+      const session = getMockSession(getUser({
+        gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+        permissions: [{name: 'transactions:read'}]
+      }))
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
+        payment_provider: 'sandbox'
+      })
+      app = createAppWithSession(getApp(), session)
+    })
+
+    before('Act', done => {
+      supertest(app)
+        .get(paths.prototyping.demoPayment.mockCardDetails)
+        .end((err, res) => {
+          result = res
+          done(err)
+        })
+    })
+
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should return a statusCode of 302', () => {
+      expect(result.statusCode).to.equal(302)
+    })
+
+    it('should redirect back to the index page', () => {
+      expect(result.headers).to.have.property('location').to.equal(paths.prototyping.demoPayment.index)
+    })
+  })
+})


### PR DESCRIPTION
- added `POST:/make-a-demo-payment/go-to-payment` and moved demo product creation logic to here
- updated mock card numbers page to point at new post endpoint
- updated tests accordingly


