### PR TITLE
PP-2967 Created custom Docker image, audited package version against CVEs and added manual upgrades where necessary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,4 @@
-FROM node:6.12.2-alpine
-
-# This section is to fix some security vulnerabilities present in our baselayer.
-# Here, we update the vulnerable packages pulling them from the Alpine edge branch.
-# This is just a short-term patch.
-RUN set -x \
-        && apk add --no-cache \
-                musl="1.1.18-r5" \
-                musl-dev="1.1.18-r5" \
-                libc6-compat="1.1.18-r5" \
-                openssl="1.0.2n-r0" \
-                c-ares="1.13.0-r0" \
-                busybox="1.27.2-r7" \
-                bash="4.4.12-r5" \
-           --repository http://dl-cdn.alpinelinux.org/alpine/edge/main
-
-
-RUN apk update &&\
-    apk upgrade &&\
-    apk add --update bash libc6-compat
+FROM govukpay/nodejs:6.12.2
 
 ADD package.json /tmp/package.json
 RUN cd /tmp && npm install --production

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 npm start

--- a/docker/build_and_test.Dockerfile
+++ b/docker/build_and_test.Dockerfile
@@ -1,14 +1,14 @@
-FROM node:6.12.2-alpine
+FROM govukpay/nodejs:6.12.2
 
 RUN apk update &&\
     apk upgrade &&\
-    apk add --update bash python make g++ ruby openssl
+    apk add --update bash ruby
 
 ADD docker/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
 
 RUN apk --no-cache add ca-certificates
-RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk
-RUN apk add glibc-2.25-r0.apk
+RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.26-r0/glibc-2.26-r0.apk
+RUN apk del libc6-compat && apk add glibc-2.26-r0.apk
 
 # add package.json before source for node_module cache layer
 ADD package.json /tmp/package.json

--- a/docker/build_and_test.sh
+++ b/docker/build_and_test.sh
@@ -6,3 +6,5 @@ npm run compile &&\
 npm run lint &&\
 npm test -- --forbid-only --forbid-pending &&\
 rm -rf node_modules
+apk del glibc-2.26-r0 bash
+rm /glibc-2.26-r0.apk


### PR DESCRIPTION
## WHAT
Experimental. 

Rather than using the maintained Docker image for Node.js, we have instead derived an image from Alpine 3.7 (as opposed to 3.4), used the same pattern as Node.js for installing v6.12.2 and then upgraded c-ares to a version clear from CVEs that were being flagged up for older versions than those installed by default.

This enables us to reduce the number of updated packages we need to track, to keep ahead of CVEs, as well as reduce false positives in vulnerability scans through Docker hub.

