### PR TITLE
PP-3032 Specify the `type` during product creation

### DIFF
--- a/app/controllers/make_a_demo_payment/go_to_payment_controller.js
+++ b/app/controllers/make_a_demo_payment/go_to_payment_controller.js
@@ -6,6 +6,7 @@ const lodash = require('lodash')
 // Local dependencies
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products_client.js')
+const productTypes = require('../../utils/product_types')
 const publicAuthClient = require('../../services/clients/public_auth_client')
 const auth = require('../../services/auth_service.js')
 
@@ -30,7 +31,8 @@ module.exports = (req, res) => {
       gatewayAccountId,
       name: paymentDescription,
       serviceName: req.service.name,
-      price: Math.trunc(paymentAmount * 100)
+      price: Math.trunc(paymentAmount * 100),
+      type: productTypes.DEMO
     }))
     .then(product => {
       lodash.unset(req, 'session.pageData.makeADemoPayment')

--- a/app/controllers/test_with_your_users/submit_controller.js
+++ b/app/controllers/test_with_your_users/submit_controller.js
@@ -7,6 +7,7 @@ const lodash = require('lodash')
 const {response} = require('../../utils/response.js')
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products_client.js')
+const productTypes = require('../../utils/product_types')
 const publicAuthClient = require('../../services/clients/public_auth_client')
 const authService = require('../../services/auth_service.js')
 const {isCurrency, isHttps, isBelowMaxAmount} = require('../../browsered/field-validation-checks')
@@ -58,7 +59,8 @@ module.exports = (req, res) => {
       name: req.body['payment-description'],
       returnUrl: req.body['confirmation-page'],
       serviceName: req.service.name,
-      price: Math.trunc(paymentAmount * 100)
+      price: Math.trunc(paymentAmount * 100),
+      type: productTypes.PROTOTYPE
     }))
     .then(product => {
       params.prototypeLink = lodash.get(product, 'links.pay.href')

--- a/app/models/Product.class.js
+++ b/app/models/Product.class.js
@@ -10,6 +10,7 @@ const lodash = require('lodash')
  * @property {string} name
  * @property {number} price
  * @property {string} description
+ * @property {string} type - The type of the product
  * @property {string} returnUrl
  * @property {string} govukStatus - the current status of the gov.uk pay charge
  * @property {string} serviceName - the name of the service with which the product is associated
@@ -36,6 +37,7 @@ class Product {
    * @param {string} opts._links[].method - the http method of the link
    * @param {string} opts._links[].rel - the name of the link
    * @param {string=} opts.description - The name of the product
+   * @param {string=} opts.type - The type of the product
    * @param {string=} opts.return_url - return url of where to redirect for any charge of this product
    **/
   constructor (opts) {
@@ -46,6 +48,7 @@ class Product {
     this.govukStatus = opts.govuk_status
     this.serviceName = opts.service_name
     this.description = opts.description
+    this.type = opts.type
     this.returnUrl = opts.return_url
     opts._links.forEach(link => lodash.set(this, `links.${link.rel}`, {method: link.method, href: link.href}))
   }

--- a/app/services/clients/products_client.js
+++ b/app/services/clients/products_client.js
@@ -39,6 +39,7 @@ module.exports = {
  * @param {number} options.price - The price of product in pence
  * @param {string} options.serviceName - The name of the service with which the product is associated
  * @param {string=} options.description - The description of the product
+ * @param {string=} options.type - The type of the product
  * @param {string=} options.returnUrl - Where to redirect to upon completion of a charge for this product
  * @returns {Promise<Product>}
  */
@@ -55,6 +56,7 @@ function createProduct (options) {
       price: options.price,
       description: options.description,
       service_name: options.serviceName,
+      type: options.type,
       return_url: options.returnUrl
     },
     description: 'create a product for a service',

--- a/app/utils/product_types.js
+++ b/app/utils/product_types.js
@@ -1,0 +1,7 @@
+const PRODUCT_TYPES = {
+  DEMO: 'DEMO',
+  PROTOTYPE: 'PROTOTYPE',
+  ADHOC: 'ADHOC'
+}
+
+module.exports = PRODUCT_TYPES

--- a/test/fixtures/product_fixtures.js
+++ b/test/fixtures/product_fixtures.js
@@ -20,7 +20,8 @@ module.exports = {
       pay_api_token: opts.payApiToken || 'pay-api-token',
       name: opts.name || 'A Product Name',
       service_name: opts.serviceName || 'Example Service',
-      price: opts.price || randomPrice()
+      price: opts.price || randomPrice(),
+      type: opts.type || 'DEMO'
     }
     if (opts.description) data.description = opts.description
     if (opts.returnUrl) data.return_url = opts.returnUrl
@@ -71,6 +72,7 @@ module.exports = {
       name: opts.name || 'A Product Name',
       service_name: opts.serviceName || 'Example Service',
       price: opts.price || randomPrice(),
+      type: opts.type || 'DEMO',
       _links: opts.links
     }
     if (opts.description) data.description = opts.description

--- a/test/unit/clients/product_client/product/create_test.js
+++ b/test/unit/clients/product_client/product/create_test.js
@@ -71,7 +71,8 @@ describe('products client - create a new product', () => {
           price: requestPlain.price,
           serviceName: requestPlain.service_name,
           description: requestPlain.description,
-          returnUrl: requestPlain.return_url
+          returnUrl: requestPlain.return_url,
+          type: 'DEMO'
         }))
         .then(res => {
           result = res
@@ -92,6 +93,7 @@ describe('products client - create a new product', () => {
       expect(result.description).to.equal(plainRequest.description)
       expect(result.price).to.equal(plainRequest.price)
       expect(result.returnUrl).to.equal('https://example.gov.uk/paid-for-somet')
+      expect(result.type).to.equal('DEMO')
       expect(result).to.have.property('links')
       expect(Object.keys(result.links).length).to.equal(2)
       expect(result.links).to.have.property('self')
@@ -123,7 +125,8 @@ describe('products client - create a new product', () => {
           price: requestPlain.price,
           serviceName: requestPlain.service_name,
           description: requestPlain.description,
-          returnUrl: requestPlain.return_url
+          returnUrl: requestPlain.return_url,
+          type: requestPlain.type
         }), done)
         .then(() => done(new Error('Promise unexpectedly resolved')))
         .catch((err) => {
@@ -161,7 +164,8 @@ describe('products client - create a new product', () => {
           price: requestPlain.price,
           description: requestPlain.description,
           serviceName: requestPlain.service_name,
-          returnUrl: requestPlain.return_url
+          returnUrl: requestPlain.return_url,
+          type: requestPlain.type
         }), done)
         .then(() => done(new Error('Promise unexpectedly resolved')))
         .catch((err) => {

--- a/test/unit/clients/product_client/product/get_by_product_external_id_test.js
+++ b/test/unit/clients/product_client/product/get_by_product_external_id_test.js
@@ -55,7 +55,8 @@ describe('products client - find a product by it\'s external id', function () {
         price: 1000,
         name: 'A Product Name',
         description: 'About this product',
-        return_url: 'https://example.gov.uk'
+        return_url: 'https://example.gov.uk',
+        type: 'DEMO'
       })
       productsMock.addInteraction(
         new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}`)
@@ -84,6 +85,7 @@ describe('products client - find a product by it\'s external id', function () {
       expect(result.description).to.exist.and.equal(plainResponse.description)
       expect(result.price).to.exist.and.equal(plainResponse.price)
       expect(result.returnUrl).to.exist.and.equal(plainResponse.return_url)
+      expect(result.type).to.equal('DEMO')
       expect(result).to.have.property('links')
       expect(Object.keys(result.links).length).to.equal(2)
       expect(result.links).to.have.property('self')

--- a/test/unit/controller/make_a_demo_payment_controller/go_to_payment_controller_test.js
+++ b/test/unit/controller/make_a_demo_payment_controller/go_to_payment_controller_test.js
@@ -39,7 +39,8 @@ const VALID_CREATE_PRODUCT_REQUEST = validCreateProductRequest({
   payApiToken: VALID_CREATE_TOKEN_RESPONSE.token,
   serviceName: VALID_USER.serviceRoles[0].service.name,
   price: PAYMENT_AMOUNT * 100,
-  gatewayAccountId: GATEWAY_ACCOUNT_ID
+  gatewayAccountId: GATEWAY_ACCOUNT_ID,
+  type: 'DEMO'
 }).getPlain()
 const VALID_CREATE_PRODUCT_RESPONSE = validCreateProductResponse(VALID_CREATE_PRODUCT_REQUEST).getPlain()
 

--- a/test/unit/controller/test_with_your_users_controller/submit_controller_test.js
+++ b/test/unit/controller/test_with_your_users_controller/submit_controller_test.js
@@ -38,7 +38,8 @@ const VALID_CREATE_PRODUCT_REQUEST = validCreateProductRequest({
   price: parseInt(VALID_PAYLOAD['payment-amount']) * 100,
   returnUrl: VALID_PAYLOAD['confirmation-page'],
   serviceName: VALID_USER.serviceRoles[0].service.name,
-  gatewayAccountId: GATEWAY_ACCOUNT_ID
+  gatewayAccountId: GATEWAY_ACCOUNT_ID,
+  type: 'PROTOTYPE'
 }).getPlain()
 const VALID_CREATE_PRODUCT_RESPONSE = validCreateProductResponse(VALID_CREATE_PRODUCT_REQUEST).getPlain()
 


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

Post the product `type`during product creation, which for now can be either `DEMO` or `PROTOTYPE`depending on whether we want to create demo payments or prototype links. Note that this field will be ignored until the accompanying backend piece is merged: 
https://github.com/alphagov/pay-products/pull/54


