### PR TITLE
Bumped musl, musl-dev and libc6-compat from r2 to r3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ FROM node:6.12.2-alpine
 # This is just a short-term patch.
 RUN set -x \
         && apk add --no-cache \
-                musl="1.1.18-r2" \
-                musl-dev="1.1.18-r2" \
-                libc6-compat="1.1.18-r2" \
+                musl="1.1.18-r3" \
+                musl-dev="1.1.18-r3" \
+                libc6-compat="1.1.18-r3" \
                 openssl="1.0.2n-r0" \
                 c-ares="1.13.0-r0" \
                 busybox="1.27.2-r7" \


### PR DESCRIPTION
Bumped `musl`, `musl-dev` and `libc6-compat` from `r2` to `r3`

