### PR TITLE
PP-3112 - Generic google analytics event tracking builder

### DIFF
--- a/app/browsered.js
+++ b/app/browsered.js
@@ -5,6 +5,7 @@ const $ = require('jquery')
 const multiSelects = require('./browsered/multi-select')
 const fieldValidation = require('./browsered/field-validation')
 const dashboardActivity = require('./browsered/dashboard-activity')
+const analytics = require('./browsered/analytics')
 
 // This adds jquery globally for non-browserified contexts
 window.$ = window.jQuery = $
@@ -12,3 +13,5 @@ window.$ = window.jQuery = $
 multiSelects.enableMultiSelects()
 fieldValidation.enableFieldValidation()
 dashboardActivity.init()
+dashboardActivity.init()
+analytics.init()

--- a/app/browsered/analytics.js
+++ b/app/browsered/analytics.js
@@ -1,0 +1,71 @@
+// Works in combination with the following data-attributes
+// data-click-events - this just sets the thing up designed to work with A, INPUT[type~="button radio checkbox"], BUTTON
+// OR you can put it on a whole div/form and it will track all the aforementioned elements within it
+// data-click-category="Header" - this is the category GA will put it in
+// data-click-action="Navigation link clicked" - this is the action GA will label it
+
+'use strict'
+
+module.exports.init = () => {
+  const elementsToTrack = Array.prototype.slice.call(document.querySelectorAll('[data-click-events]'))
+
+  if (elementsToTrack) {
+    setupTracking(elementsToTrack)
+  }
+}
+
+const setupTracking = elements => {
+  elements.forEach(element => {
+    const eventCategory = element.dataset.clickCategory
+    let eventAction = element.dataset.clickAction
+
+    switch (element.tagName) {
+      case 'A':
+      case 'BUTTON':
+      case 'INPUT':
+        const label = element.tagName === 'INPUT' ? element.value : element.innerText
+        addListener(element, eventCategory, eventAction, label)
+        break
+      default:
+        const childClickables = Array.prototype.slice.call(element.querySelectorAll(
+          'a, button, input[type~="button radio checkbox"], summary'
+        ))
+
+        if (childClickables.length) {
+          childClickables.forEach(element => {
+            let label
+            switch (element.tagName) {
+              case 'A':
+              case 'BUTTON':
+              case 'SUMMARY':
+                label = element.innerText
+                break
+              default:
+                label = element.value
+                break
+            }
+
+            addListener(element, eventCategory, eventAction, label)
+          })
+        }
+        break
+    }
+  })
+}
+
+const addListener = (element, category, action, label) => {
+  if (element.tagName === 'SUMMARY') {
+    action = `${action} opened`
+  }
+  element.addEventListener('click', () => {
+    action = toggleAction(element, action)
+    ga('send', 'event', category, action, label) // eslint-disable-line no-undef
+  })
+}
+
+const toggleAction = (element, action) => {
+  const actionWords = action.split(' ')
+  const oldState = actionWords[actionWords.length - 1]
+  const newState = element.parentElement.hasAttribute('open') ? 'closed' : 'opened'
+  return action.replace(oldState, newState)
+}

--- a/app/views/includes/propositional_navigation.njk
+++ b/app/views/includes/propositional_navigation.njk
@@ -1,7 +1,7 @@
 <div class="header-proposition">
   <div class="content">
     <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
-    <nav id="proposition-menu" aria-label="Top Level Navigation" aria-hidden="true">
+    <nav id="proposition-menu" aria-label="Top Level Navigation" aria-hidden="true" data-click-events data-click-category="Header" data-click-action="Navigation link clicked">
       <ul id="proposition-links">
         <li><a href="https://govukpay-docs.cloudapps.digital" title="Read the GOV.UK Pay Documentation">Documentation</a></li>
         <li><a {% if services %}class="active"{% endif %} href="{{ routes.serviceSwitcher.index }}" title="My services" id="my-services">My services</a></li>

--- a/app/views/includes/propositional_navigation_logged_out.njk
+++ b/app/views/includes/propositional_navigation_logged_out.njk
@@ -1,7 +1,7 @@
 <div class="header-proposition">
   <div class="content">
     <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
-    <nav id="proposition-menu" aria-label="Top Level Navigation" aria-hidden="true">
+    <nav id="proposition-menu" aria-label="Top Level Navigation" aria-hidden="true" data-click-events data-click-category="Header" data-click-action="Navigation link clicked">
       <ul id="proposition-links">
         <li><a href="https://www.payments.service.gov.uk/#main" title="Learn more about GOV.UK Pay">About</a></li>
         <li><a href="https://govukpay-docs.cloudapps.digital" title="Read the GOV.UK Pay Documentation">Documentation</a></li>


### PR DESCRIPTION
We’d like to start tracking events across pay and in the wider GAAP team, this script will add event listeners to fire the google analytics tracking event when an element is clicked

It can be applied to a single link/input/button or can be applied to a parent element and will search for `a/input/button`’s within it and try to label them appropriately.

I've tagged up our header and propositional nav to show how the data-attributes work. 

I'll tag up the rest of selfservice in a separate PR