### PR TITLE
PP-3078 - Added info message about links changed

### DIFF
--- a/app/views/dashboard/demo-service/index.njk
+++ b/app/views/dashboard/demo-service/index.njk
@@ -7,6 +7,9 @@ Test with your users - {{currentServiceName}} {{currentGatewayAccount.full_type}
 {% block mainContent %}
   <a href="/" class="link-back">Back to dashboard</a>
   <h1 class="heading-large prototyping__heading">Test with your users</h1>
+  <aside class="info-box">
+    <p>Prototype link urls will be updated on 11 January 2018. You will need to create new links and update your prototypes.</p>
+  </aside>
   <p>Create a reusable link to integrate your service prototype with GOV.UK Pay and test with users.</p>
   <a id="prototyping__links-button-create" class="button" href="{{createPage}}">Create prototype link</a>
 


### PR DESCRIPTION
We’re updating our links (because we're moving from Paas back to our own AWS infrastructure) so we need to let users know this is happening.