### PR TITLE
PP-3193 Fix transaction download bug

### DIFF
--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -132,8 +132,23 @@ function getQueryStringForParams (params) {
     page: params.page || 1,
     display_size: params.pageSize || 100
   }
-  if (params.payment_states) queryStrings.payment_states = params.payment_states.join(',')
-  if (params.refund_states) queryStrings.refund_states = params.refund_states.join(',')
+
+  if (params.payment_states && params.payment_states instanceof Array) {
+    queryStrings.payment_states = params.payment_states.join(',')
+  } else if (params.payment_states) {
+    queryStrings.payment_states = params.payment_states
+  }
+
+  if (params.refund_states && params.refund_states instanceof Array) {
+    queryStrings.refund_states = params.refund_states.join(',')
+  } else if (params.refund_states) {
+    queryStrings.refund_states = params.refund_states
+  }
+
+  if ((queryStrings.payment_states || queryStrings.refund_states) && queryStrings.state) {
+    queryStrings.state = undefined
+  }
+
   return querystring.stringify(queryStrings)
 }
 

--- a/app/services/transaction_service.js
+++ b/app/services/transaction_service.js
@@ -47,14 +47,6 @@ exports.searchAll = (accountId, filters, correlationId) => {
   params.gatewayAccountId = accountId
   params.correlationId = correlationId
 
-  if (params.payment_states) {
-    params.payment_states = params.payment_states.split(',')
-  }
-
-  if (params.refund_states) {
-    params.refund_states = params.refund_states.split(',')
-  }
-
   connectorClient.getAllTransactions(params, results => defer.resolve({results}))
     .on('connectorError', (err, connectorResponse) => {
       if (connectorResponse) return defer.reject(new Error('GET_FAILED'))

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -21,8 +21,13 @@ var connectorMock = nock(process.env.CONNECTOR_URL)
 function connectorMockResponds (code, data, searchParameters) {
   var queryStr = '?'
   queryStr += 'reference=' + (searchParameters.reference ? searchParameters.reference : '') +
-    '&email=' + (searchParameters.email ? searchParameters.email : '') +
-    '&state=' + (searchParameters.state ? searchParameters.state : '') +
+    '&email=' + (searchParameters.email ? searchParameters.email : '')
+
+  if (searchParameters.payment_states || searchParameters.refund_states) {
+    delete searchParameters.state
+  }
+
+  queryStr += '&state=' + (searchParameters.state ? searchParameters.state : '') +
     '&card_brand=' + (searchParameters.brand ? searchParameters.brand : '') +
     '&from_date=' + (searchParameters.fromDate ? searchParameters.fromDate : '') +
     '&to_date=' + (searchParameters.toDate ? searchParameters.toDate : '') +

--- a/test/integration/transaction_list_ft_tests.js
+++ b/test/integration/transaction_list_ft_tests.js
@@ -139,7 +139,7 @@ describe('The /transactions endpoint', function () {
       .end(done)
   })
 
-  it('should return a list of transactions for the gateway account', function (done) {
+  it('should return a list of transactions for the gateway account when a state is selected', function (done) {
     connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
       .reply(200, ALL_CARD_TYPES)
 
@@ -178,7 +178,7 @@ describe('The /transactions endpoint', function () {
       ]
     }
 
-    connectorMockResponds(200, connectorData, {state: 'started'})
+    connectorMockResponds(200, connectorData, {state: 'started', payment_states: 'started'})
     request(app)
       .get(paths.transactions.index + '?state=started')
       .set('Accept', 'application/json')
@@ -529,6 +529,8 @@ function connectorMockResponds (code, data, searchParameters) {
     display_size: searchParameters.pageSize ? searchParameters.pageSize : '100'
   }
 
+
+
   if (!searchParameters.payment_states && !searchParameters.refund_states && searchParameters.state) {
     toStringify.payment_states = [searchParameters.state]
   }
@@ -538,6 +540,11 @@ function connectorMockResponds (code, data, searchParameters) {
   if (searchParameters.payment_states) {
     toStringify.payment_states = searchParameters.payment_states
   }
+
+  if (searchParameters.payment_states || searchParameters.refund_states) {
+    toStringify.state = ''
+  }
+
 
   var queryString = querystring.stringify(toStringify)
 

--- a/test/integration/transaction_search_ft_tests.js
+++ b/test/integration/transaction_search_ft_tests.js
@@ -46,7 +46,10 @@ function connectorMockResponds (data, searchParameters) {
     page: searchParameters.page ? searchParameters.page : '1',
     display_size: searchParameters.pageSize ? searchParameters.pageSize : '100'
   }
-  if (searchParameters.state) toStringify.payment_states = [searchParameters.state]
+  if (searchParameters.state) {
+    toStringify.payment_states = [searchParameters.state]
+    toStringify.state = ''
+  }
   var queryString = querystring.stringify(toStringify)
 
   return connectorMock.get(CONNECTOR_CHARGES_SEARCH_API_PATH + '?' + queryString)

--- a/test/unit/services/transaction_service_test.js
+++ b/test/unit/services/transaction_service_test.js
@@ -54,17 +54,42 @@ describe('transaction service', () => {
 
   describe('searchAll', () => {
     describe('when connector returns correctly', () => {
-      before(() => {
+
+
+      it('should return into the correct promise when it uses the legacy \'state\' method of querying states', () => {
         nock(process.env.CONNECTOR_URL)
-          .get('/v1/api/accounts/123/charges?reference=&email=&state=&card_brand=&from_date=&to_date=&page=1&display_size=100')
+          .get('/v1/api/accounts/123/charges?reference=&email=&state=success&card_brand=&from_date=&to_date=&page=1&display_size=100')
           .reply(200, {})
+        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, state:'success'}, 'some-unique-id'))
+          .to.eventually.be.fulfilled
+      })
+
+      it('should return into the correct promise when it uses the new  \'refund_states\' method of querying refund states and mulitple have been selected', () => {
+        nock(process.env.CONNECTOR_URL)
+          .get('/v1/api/accounts/123/charges?reference=&email=&state=&card_brand=&from_date=&to_date=&page=1&display_size=100&refund_states=refund_success%2Crefund_error')
+          .reply(200, {})
+        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, refund_states: ['refund_success','refund_error']}, 'some-unique-id'))
+          .to.eventually.be.fulfilled
+      })
+
+      it('should return into the correct promise when it uses the new  \'refund_states\' method of querying refund states and only one has been selected', () => {
+        nock(process.env.CONNECTOR_URL)
+          .get('/v1/api/accounts/123/charges?reference=&email=&state=&card_brand=&from_date=&to_date=&page=1&display_size=100&refund_states=refund_success')
+          .reply(200, {})
+        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, refund_states: 'refund_success'}, 'some-unique-id'))
+          .to.eventually.be.fulfilled
       })
 
       it('should return into the correct promise', () => {
+        nock(process.env.CONNECTOR_URL)
+          .get('/v1/api/accounts/123/charges?reference=&email=&state=&card_brand=&from_date=&to_date=&page=1&display_size=100')
+          .reply(200, {})
         return expect(transactionService.searchAll(123, {pageSize: 100, page: 1}, 'some-unique-id'))
           .to.eventually.be.fulfilled
       })
     })
+
+
 
     describe('when connector is unavailable', () => {
       it('should return client unavailable', () => {


### PR DESCRIPTION
## WHAT
- removed `state` param from transactions search when downloading csv and when refund_states or payment_states filters have been selected

## WHY
- because connector expects selfservice to make this call either with the old pattern ('state') or the new pattern ('refund_states', 'payment_states') and not both. This has been handled for the transactions list page but not the download page.

## HOW
- on selfservice, with refund reporting enabled, filter by refund states and try to download a csv.




