### PR TITLE
BAU: Use chamber in base image

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "compile": "grunt generate-assets",
     "clean": "grunt clean",
     "start": "node_modules/forever/bin/forever --minUptime 1000 --spinSleepTime 500 start.js",
-    "start-with-chamber": "AWS_REGION=${ECS_AWS_REGION} ./chamber--linux-amd64 exec ${ECS_SERVICE} -- npm start",
+    "start-with-chamber": "AWS_REGION=${ECS_AWS_REGION} chamber exec ${ECS_SERVICE} -- npm start",
     "stop": "node_modules/forever/bin/forever stop start.js",
     "watch": "chokidar app test *.js --initial -c 'npm run test'",
     "watch-live-reload": "./node_modules/.bin/grunt watch",


### PR DESCRIPTION
Chamber is now in our base image, we should use that instead.

solo @tlwr


