### PR TITLE
PP-3193 fix nasty refund transaction download bug

### DIFF
--- a/app/controllers/transactions/transaction_download_controller.js
+++ b/app/controllers/transactions/transaction_download_controller.js
@@ -10,13 +10,14 @@ const auth = require('../../services/auth_service.js')
 const date = require('../../utils/dates.js')
 const {renderErrorView} = require('../../utils/response.js')
 const {CORRELATION_HEADER} = require('../../utils/correlation_header.js')
+const REFUNDS_IN_TRANSACTION_LIST_FEATURE_HEADER = 'REFUNDS_IN_TX_LIST'
 
 module.exports = (req, res) => {
   const accountId = auth.getCurrentGatewayAccountId(req)
   const filters = req.query
   const name = `GOVUK Pay ${date.dateToDefaultFormat(new Date())}.csv`
   const correlationId = req.headers[CORRELATION_HEADER]
-
+  filters.refundReportingEnabled = req.user.hasFeature(REFUNDS_IN_TRANSACTION_LIST_FEATURE_HEADER)
   transactionService.searchAll(accountId, filters, correlationId)
     .then(json => jsonToCsv(json.results))
     .then(csv => {

--- a/app/controllers/transactions/transaction_list_controller.js
+++ b/app/controllers/transactions/transaction_list_controller.js
@@ -18,6 +18,7 @@ const client = new ConnectorClient(process.env.CONNECTOR_URL)
 const {CORRELATION_HEADER} = require('../../utils/correlation_header.js')
 const REFUNDS_IN_TRANSACTION_LIST_FEATURE_HEADER = 'REFUNDS_IN_TX_LIST'
 
+
 module.exports = (req, res) => {
   const accountId = auth.getCurrentGatewayAccountId(req)
   const filters = getFilters(req)
@@ -25,7 +26,7 @@ module.exports = (req, res) => {
 
   req.session.filters = url.parse(req.url).query
   if (!filters.valid) return error('Invalid search')
-
+  filters.result.refundReportingEnabled = req.user.hasFeature(REFUNDS_IN_TRANSACTION_LIST_FEATURE_HEADER)
   transactionService
     .search(accountId, filters.result, correlationId)
     .then(transactions => {

--- a/app/controllers/transactions/transaction_list_controller.js
+++ b/app/controllers/transactions/transaction_list_controller.js
@@ -18,7 +18,6 @@ const client = new ConnectorClient(process.env.CONNECTOR_URL)
 const {CORRELATION_HEADER} = require('../../utils/correlation_header.js')
 const REFUNDS_IN_TRANSACTION_LIST_FEATURE_HEADER = 'REFUNDS_IN_TX_LIST'
 
-
 module.exports = (req, res) => {
   const accountId = auth.getCurrentGatewayAccountId(req)
   const filters = getFilters(req)

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -6,10 +6,10 @@ var logger = require('winston')
 var querystring = require('querystring')
 const q = require('q')
 
-var dates = require('../../utils/dates.js')
 const baseClient = require('./old_base_client')
 const requestLogger = require('../../utils/request_logger')
 const createCallbackToPromiseConverter = require('../../utils/response_converter').createCallbackToPromiseConverter
+const getQueryStringForParams = require('../../utils/get_query_string_for_params')
 
 const SERVICE_NAME = 'connector'
 var ACCOUNTS_API_PATH = '/v1/api/accounts'
@@ -119,37 +119,6 @@ var _getToggle3dsUrlFor = function (accountID) {
 /** @private */
 var _getTransactionSummaryUrlFor = function (accountID, period) {
   return process.env.CONNECTOR_URL + TRANSACTIONS_SUMMARY.replace('{accountId}', accountID) + '?' + period
-}
-
-function getQueryStringForParams (params) {
-  const queryStrings = {
-    reference: params.reference,
-    email: params.email,
-    state: params.state,
-    card_brand: params.brand,
-    from_date: dates.fromDateToApiFormat(params.fromDate, params.fromTime),
-    to_date: dates.toDateToApiFormat(params.toDate, params.toTime),
-    page: params.page || 1,
-    display_size: params.pageSize || 100
-  }
-
-  if (params.payment_states && params.payment_states instanceof Array) {
-    queryStrings.payment_states = params.payment_states.join(',')
-  } else if (params.payment_states) {
-    queryStrings.payment_states = params.payment_states
-  }
-
-  if (params.refund_states && params.refund_states instanceof Array) {
-    queryStrings.refund_states = params.refund_states.join(',')
-  } else if (params.refund_states) {
-    queryStrings.refund_states = params.refund_states
-  }
-
-  if ((queryStrings.payment_states || queryStrings.refund_states) && queryStrings.state) {
-    queryStrings.state = undefined
-  }
-
-  return querystring.stringify(queryStrings)
 }
 
 function searchUrl (baseUrl, params) {

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -132,8 +132,23 @@ function getQueryStringForParams (params) {
     page: params.page || 1,
     display_size: params.pageSize || 100
   }
-  if (params.payment_states) queryStrings.payment_states = params.payment_states.join(',')
-  if (params.refund_states) queryStrings.refund_states = params.refund_states.join(',')
+
+  if (params.payment_states && params.payment_states instanceof Array) {
+    queryStrings.payment_states = params.payment_states.join(',')
+  } else if (params.payment_states) {
+    queryStrings.payment_states = params.payment_states
+  }
+
+  if (params.refund_states && params.refund_states instanceof Array) {
+    queryStrings.refund_states = params.refund_states.join(',')
+  } else if (params.refund_states) {
+    queryStrings.refund_states = params.refund_states
+  }
+
+  if ((queryStrings.payment_states || queryStrings.refund_states) && queryStrings.state) {
+    queryStrings.state = undefined
+  }
+
   return querystring.stringify(queryStrings)
 }
 

--- a/app/services/transaction_service.js
+++ b/app/services/transaction_service.js
@@ -47,14 +47,6 @@ exports.searchAll = (accountId, filters, correlationId) => {
   params.gatewayAccountId = accountId
   params.correlationId = correlationId
 
-  if (params.payment_states) {
-    params.payment_states = params.payment_states.split(',')
-  }
-
-  if (params.refund_states) {
-    params.refund_states = params.refund_states.split(',')
-  }
-
   connectorClient.getAllTransactions(params, results => defer.resolve({results}))
     .on('connectorError', (err, connectorResponse) => {
       if (connectorResponse) return defer.reject(new Error('GET_FAILED'))

--- a/app/utils/get_query_string_for_params.js
+++ b/app/utils/get_query_string_for_params.js
@@ -4,8 +4,6 @@ const querystring = require('querystring')
 const dates = require('./dates.js')
 
 function getQueryStringForParams (params = {}) {
-
-
   const queryStrings = {
     reference: params.reference,
     email: params.email,
@@ -17,7 +15,7 @@ function getQueryStringForParams (params = {}) {
   }
 
   if (params.refundReportingEnabled) {
-    if (params.payment_states){
+    if (params.payment_states) {
       queryStrings.payment_states = params.payment_states instanceof Array ? params.payment_states.join(',') : params.payment_states
     }
     if (params.refund_states) {
@@ -25,11 +23,10 @@ function getQueryStringForParams (params = {}) {
     }
     queryStrings.state = ''
   } else {
-    queryStrings.state  = params.state
+    queryStrings.state = params.state
   }
 
   return querystring.stringify(queryStrings)
 }
-
 
 module.exports = getQueryStringForParams

--- a/app/utils/get_query_string_for_params.js
+++ b/app/utils/get_query_string_for_params.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const querystring = require('querystring')
+const dates = require('./dates.js')
+
+function getQueryStringForParams (params = {}) {
+
+
+  const queryStrings = {
+    reference: params.reference,
+    email: params.email,
+    card_brand: params.brand,
+    from_date: dates.fromDateToApiFormat(params.fromDate, params.fromTime),
+    to_date: dates.toDateToApiFormat(params.toDate, params.toTime),
+    page: params.page || 1,
+    display_size: params.pageSize || 100
+  }
+
+  if (params.refundReportingEnabled) {
+    if (params.payment_states){
+      queryStrings.payment_states = params.payment_states instanceof Array ? params.payment_states.join(',') : params.payment_states
+    }
+    if (params.refund_states) {
+      queryStrings.refund_states = params.refund_states instanceof Array ? params.refund_states.join(',') : params.refund_states
+    }
+    queryStrings.state = ''
+  } else {
+    queryStrings.state  = params.state
+  }
+
+  return querystring.stringify(queryStrings)
+}
+
+
+module.exports = getQueryStringForParams

--- a/test/integration/pagination_ft_tests.js
+++ b/test/integration/pagination_ft_tests.js
@@ -8,6 +8,7 @@ var paths = require(path.join(__dirname, '/../../app/paths.js'))
 var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
 var assert = require('assert')
 var querystring = require('querystring')
+const getQueryStringForParams = require('../../app/utils/get_query_string_for_params')
 var app
 
 var gatewayAccountId = 452345
@@ -26,25 +27,19 @@ var ALL_CARD_TYPES = {
 }
 
 function connectorMockResponds (data, searchParameters) {
-  var queryStr = '?'
-  queryStr += 'reference=' + (searchParameters.reference ? searchParameters.reference : '') +
-    '&email=' + (searchParameters.email ? searchParameters.email : '') +
-    '&state=' + (searchParameters.state ? searchParameters.state : '') +
-    '&card_brand=' + (searchParameters.brand ? searchParameters.brand : '') +
-    '&from_date=' + (searchParameters.fromDate ? searchParameters.fromDate : '') +
-    '&to_date=' + (searchParameters.toDate ? searchParameters.toDate : '') +
-    '&page=' + (searchParameters.page ? searchParameters.page : '1') +
-    '&display_size=' + (searchParameters.pageSize ? searchParameters.pageSize : '100')
+  var queryStr = '?' + getQueryStringForParams(searchParameters)
 
-  return connectorMock.get(CONNECTOR_CHARGES_SEARCH_API_PATH + encodeURI(queryStr))
+  return connectorMock.get(CONNECTOR_CHARGES_SEARCH_API_PATH + queryStr)
     .reply(200, data)
 }
 
 function searchTransactions (data) {
   var query = querystring.stringify(data)
 
-  return request(app).get(paths.transactions.index + '?' + query)
-    .set('Accept', 'application/json').send()
+  return request(app)
+    .get(paths.transactions.index + '?' + query)
+    .set('Accept', 'application/json')
+    .send()
 }
 
 describe('Pagination', function () {

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -11,6 +11,7 @@ var paths = require(path.join(__dirname, '/../../app/paths.js'))
 var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
 var assert = require('chai').assert
 var expect = require('chai').expect
+var getQueryStringForParams = require('../../app/utils/get_query_string_for_params')
 
 var gatewayAccountId = 651342
 var app
@@ -19,28 +20,7 @@ var CHARGES_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges'
 var connectorMock = nock(process.env.CONNECTOR_URL)
 
 function connectorMockResponds (code, data, searchParameters) {
-  var queryStr = '?'
-  queryStr += 'reference=' + (searchParameters.reference ? searchParameters.reference : '') +
-    '&email=' + (searchParameters.email ? searchParameters.email : '')
-
-  if (searchParameters.payment_states || searchParameters.refund_states) {
-    delete searchParameters.state
-  }
-
-  queryStr += '&state=' + (searchParameters.state ? searchParameters.state : '') +
-    '&card_brand=' + (searchParameters.brand ? searchParameters.brand : '') +
-    '&from_date=' + (searchParameters.fromDate ? searchParameters.fromDate : '') +
-    '&to_date=' + (searchParameters.toDate ? searchParameters.toDate : '') +
-    '&page=' + (searchParameters.page ? searchParameters.page : '1') +
-    '&display_size=' + (searchParameters.pageSize ? searchParameters.pageSize : '100')
-
-  if (searchParameters.payment_states) {
-    queryStr += '&payment_states=' + searchParameters.payment_states
-  }
-
-  if (searchParameters.refund_states) {
-    queryStr += '&refund_states=' + searchParameters.refund_states
-  }
+  var queryStr = '?' + getQueryStringForParams(searchParameters)
 
   return connectorMock.get(CHARGES_API_PATH + queryStr)
     .reply(code, data)

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -21,8 +21,13 @@ var connectorMock = nock(process.env.CONNECTOR_URL)
 function connectorMockResponds (code, data, searchParameters) {
   var queryStr = '?'
   queryStr += 'reference=' + (searchParameters.reference ? searchParameters.reference : '') +
-    '&email=' + (searchParameters.email ? searchParameters.email : '') +
-    '&state=' + (searchParameters.state ? searchParameters.state : '') +
+    '&email=' + (searchParameters.email ? searchParameters.email : '')
+
+  if (searchParameters.payment_states || searchParameters.refund_states) {
+    delete searchParameters.state
+  }
+
+  queryStr += '&state=' + (searchParameters.state ? searchParameters.state : '') +
     '&card_brand=' + (searchParameters.brand ? searchParameters.brand : '') +
     '&from_date=' + (searchParameters.fromDate ? searchParameters.fromDate : '') +
     '&to_date=' + (searchParameters.toDate ? searchParameters.toDate : '') +

--- a/test/integration/transaction_list_ft_tests.js
+++ b/test/integration/transaction_list_ft_tests.js
@@ -139,7 +139,7 @@ describe('The /transactions endpoint', function () {
       .end(done)
   })
 
-  it('should return a list of transactions for the gateway account', function (done) {
+  it('should return a list of transactions for the gateway account when a state is selected', function (done) {
     connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
       .reply(200, ALL_CARD_TYPES)
 
@@ -178,7 +178,7 @@ describe('The /transactions endpoint', function () {
       ]
     }
 
-    connectorMockResponds(200, connectorData, {state: 'started'})
+    connectorMockResponds(200, connectorData, {state: 'started', payment_states: 'started'})
     request(app)
       .get(paths.transactions.index + '?state=started')
       .set('Accept', 'application/json')
@@ -529,6 +529,8 @@ function connectorMockResponds (code, data, searchParameters) {
     display_size: searchParameters.pageSize ? searchParameters.pageSize : '100'
   }
 
+
+
   if (!searchParameters.payment_states && !searchParameters.refund_states && searchParameters.state) {
     toStringify.payment_states = [searchParameters.state]
   }
@@ -538,6 +540,11 @@ function connectorMockResponds (code, data, searchParameters) {
   if (searchParameters.payment_states) {
     toStringify.payment_states = searchParameters.payment_states
   }
+
+  if (searchParameters.payment_states || searchParameters.refund_states) {
+    toStringify.state = ''
+  }
+
 
   var queryString = querystring.stringify(toStringify)
 

--- a/test/integration/transaction_list_ft_tests.js
+++ b/test/integration/transaction_list_ft_tests.js
@@ -9,7 +9,7 @@ const nock = require('nock')
 const getApp = require('../../server.js').getApp
 const paths = require('../../app/paths.js')
 const session = require('../test_helpers/mock_session.js')
-const querystring = require('querystring')
+const getQueryStringForParams = require('../../app/utils/get_query_string_for_params')
 
 const CONNECTOR_DATE = '2016-02-10T12:44:01.000Z'
 const DISPLAY_DATE = '10 Feb 2016 — 12:44:01'
@@ -456,7 +456,7 @@ describe('The /transactions endpoint (when feature flag: \'REFUNDS_IN_TX_LIST\' 
       'results': []
     }
 
-    connectorMockResponds(200, connectorData, {state: 'started', payment_states: 'started'})
+    connectorMockResponds(200, connectorData, {state: 'started', payment_states: 'started', refundReportingEnabled: true})
 
     request(app)
       .get(paths.transactions.index + '?state=payment-started')
@@ -490,7 +490,7 @@ describe('The /transactions endpoint (when feature flag: \'REFUNDS_IN_TX_LIST\' 
       'results': []
     }
 
-    connectorMockResponds(200, connectorData, {state: 'started', refund_states: 'started'})
+    connectorMockResponds(200, connectorData, {state: 'started', refund_states: 'started', refundReportingEnabled: true})
 
     request(app)
       .get(paths.transactions.index + '?state=refund-started')
@@ -518,35 +518,7 @@ describe('The /transactions endpoint (when feature flag: \'REFUNDS_IN_TX_LIST\' 
 })
 
 function connectorMockResponds (code, data, searchParameters) {
-  var toStringify = {
-    reference: searchParameters.reference ? searchParameters.reference : '',
-    email: searchParameters.email ? searchParameters.email : '',
-    state: searchParameters.state ? searchParameters.state : '',
-    card_brand: searchParameters.brand ? searchParameters.brand : '',
-    from_date: searchParameters.fromDate ? searchParameters.fromDate : '',
-    to_date: searchParameters.toDate ? searchParameters.toDate : '',
-    page: searchParameters.page ? searchParameters.page : '1',
-    display_size: searchParameters.pageSize ? searchParameters.pageSize : '100'
-  }
-
-
-
-  if (!searchParameters.payment_states && !searchParameters.refund_states && searchParameters.state) {
-    toStringify.payment_states = [searchParameters.state]
-  }
-  if (searchParameters.refund_states) {
-    toStringify.refund_states = searchParameters.refund_states
-  }
-  if (searchParameters.payment_states) {
-    toStringify.payment_states = searchParameters.payment_states
-  }
-
-  if (searchParameters.payment_states || searchParameters.refund_states) {
-    toStringify.state = ''
-  }
-
-
-  var queryString = querystring.stringify(toStringify)
+  var queryString = getQueryStringForParams(searchParameters)
 
   return connectorMock.get(CONNECTOR_CHARGES_API_PATH + '?' + queryString)
     .reply(code, data)

--- a/test/integration/transaction_search_ft_tests.js
+++ b/test/integration/transaction_search_ft_tests.js
@@ -12,6 +12,7 @@ var dates = require('../../app/utils/dates.js')
 var paths = require(path.join(__dirname, '/../../app/paths.js'))
 var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
 var querystring = require('querystring')
+var getQueryStringForParams = require('../../app/utils/get_query_string_for_params')
 var _ = require('lodash')
 chai.use(chaiAsPromised)
 chai.should()
@@ -36,23 +37,9 @@ var ALL_CARD_TYPES = {
 }
 
 function connectorMockResponds (data, searchParameters) {
-  var toStringify = {
-    reference: searchParameters.reference ? searchParameters.reference : '',
-    email: searchParameters.email ? searchParameters.email : '',
-    state: searchParameters.state ? searchParameters.state : '',
-    card_brand: searchParameters.brand ? searchParameters.brand : '',
-    from_date: searchParameters.fromDate ? searchParameters.fromDate : '',
-    to_date: searchParameters.toDate ? searchParameters.toDate : '',
-    page: searchParameters.page ? searchParameters.page : '1',
-    display_size: searchParameters.pageSize ? searchParameters.pageSize : '100'
-  }
-  if (searchParameters.state) {
-    toStringify.payment_states = [searchParameters.state]
-    toStringify.state = ''
-  }
-  var queryString = querystring.stringify(toStringify)
+  var queryString = '?' + getQueryStringForParams(searchParameters)
 
-  return connectorMock.get(CONNECTOR_CHARGES_SEARCH_API_PATH + '?' + queryString)
+  return connectorMock.get(CONNECTOR_CHARGES_SEARCH_API_PATH + queryString)
     .reply(200, data)
 }
 
@@ -464,8 +451,8 @@ describe('The search transactions endpoint', function () {
     }
 
     var queryStringParams = _.extend({}, data, {
-      'fromDate': '2016-01-21T13:04:45.000Z',
-      'toDate': '2016-01-22T14:12:19.000Z'
+      'from_date': '2016-01-21T13:04:45.000Z',
+      'to_date': '2016-01-22T14:12:19.000Z'
     })
 
     connectorMockResponds(connectorData, queryStringParams)

--- a/test/integration/transaction_search_ft_tests.js
+++ b/test/integration/transaction_search_ft_tests.js
@@ -46,7 +46,10 @@ function connectorMockResponds (data, searchParameters) {
     page: searchParameters.page ? searchParameters.page : '1',
     display_size: searchParameters.pageSize ? searchParameters.pageSize : '100'
   }
-  if (searchParameters.state) toStringify.payment_states = [searchParameters.state]
+  if (searchParameters.state) {
+    toStringify.payment_states = [searchParameters.state]
+    toStringify.state = ''
+  }
   var queryString = querystring.stringify(toStringify)
 
   return connectorMock.get(CONNECTOR_CHARGES_SEARCH_API_PATH + '?' + queryString)

--- a/test/unit/services/transaction_service_test.js
+++ b/test/unit/services/transaction_service_test.js
@@ -54,17 +54,42 @@ describe('transaction service', () => {
 
   describe('searchAll', () => {
     describe('when connector returns correctly', () => {
-      before(() => {
+
+
+      it('should return into the correct promise when it uses the legacy \'state\' method of querying states', () => {
         nock(process.env.CONNECTOR_URL)
-          .get('/v1/api/accounts/123/charges?reference=&email=&state=&card_brand=&from_date=&to_date=&page=1&display_size=100')
+          .get('/v1/api/accounts/123/charges?reference=&email=&state=success&card_brand=&from_date=&to_date=&page=1&display_size=100')
           .reply(200, {})
+        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, state:'success'}, 'some-unique-id'))
+          .to.eventually.be.fulfilled
+      })
+
+      it('should return into the correct promise when it uses the new  \'refund_states\' method of querying refund states and mulitple have been selected', () => {
+        nock(process.env.CONNECTOR_URL)
+          .get('/v1/api/accounts/123/charges?reference=&email=&state=&card_brand=&from_date=&to_date=&page=1&display_size=100&refund_states=refund_success%2Crefund_error')
+          .reply(200, {})
+        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, refund_states: ['refund_success','refund_error']}, 'some-unique-id'))
+          .to.eventually.be.fulfilled
+      })
+
+      it('should return into the correct promise when it uses the new  \'refund_states\' method of querying refund states and only one has been selected', () => {
+        nock(process.env.CONNECTOR_URL)
+          .get('/v1/api/accounts/123/charges?reference=&email=&state=&card_brand=&from_date=&to_date=&page=1&display_size=100&refund_states=refund_success')
+          .reply(200, {})
+        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, refund_states: 'refund_success'}, 'some-unique-id'))
+          .to.eventually.be.fulfilled
       })
 
       it('should return into the correct promise', () => {
+        nock(process.env.CONNECTOR_URL)
+          .get('/v1/api/accounts/123/charges?reference=&email=&state=&card_brand=&from_date=&to_date=&page=1&display_size=100')
+          .reply(200, {})
         return expect(transactionService.searchAll(123, {pageSize: 100, page: 1}, 'some-unique-id'))
           .to.eventually.be.fulfilled
       })
     })
+
+
 
     describe('when connector is unavailable', () => {
       it('should return client unavailable', () => {

--- a/test/unit/services/transaction_service_test.js
+++ b/test/unit/services/transaction_service_test.js
@@ -55,26 +55,23 @@ describe('transaction service', () => {
 
   describe('searchAll', () => {
     describe('when connector returns correctly', () => {
-
-
       it('should return into the correct promise when it uses the legacy \'state\' method of querying states', () => {
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams({pageSize: 100, page: 1, state:'success'})}`)
+          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams({pageSize: 100, page: 1, state: 'success'})}`)
           .reply(200, {})
-        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, state:'success'}, 'some-unique-id'))
+        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, state: 'success'}, 'some-unique-id'))
           .to.eventually.be.fulfilled
       })
 
       it('should return into the correct promise when it uses the new  \'refund_states\' method of querying refund states and multiple have been selected', () => {
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams({pageSize: 100, page: 1, refund_states: ['refund_success','refund_error'], refundReportingEnabled: true})}`)
+          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams({pageSize: 100, page: 1, refund_states: ['refund_success', 'refund_error'], refundReportingEnabled: true})}`)
           .reply(200, {})
-        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, refund_states: ['refund_success','refund_error'], refundReportingEnabled: true}, 'some-unique-id'))
+        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, refund_states: ['refund_success', 'refund_error'], refundReportingEnabled: true}, 'some-unique-id'))
           .to.eventually.be.fulfilled
       })
 
       it('should return into the correct promise when it uses the new  \'refund_states\' method of querying refund states and only one has been selected', () => {
-
         nock(process.env.CONNECTOR_URL)
           .get(`/v1/api/accounts/123/charges?${getQueryStringForParams({pageSize: 100, page: 1, refund_states: 'refund_success', refundReportingEnabled: true})}`)
           .reply(200, {})
@@ -90,8 +87,6 @@ describe('transaction service', () => {
           .to.eventually.be.fulfilled
       })
     })
-
-
 
     describe('when connector is unavailable', () => {
       it('should return client unavailable', () => {

--- a/test/unit/services/transaction_service_test.js
+++ b/test/unit/services/transaction_service_test.js
@@ -7,6 +7,7 @@ const chaiAsPromised = require('chai-as-promised')
 
 // Local Dependencies
 const transactionService = require('../../../app/services/transaction_service')
+var getQueryStringForParams = require('../../../app/utils/get_query_string_for_params')
 
 const {expect} = chai
 chai.use(chaiAsPromised)
@@ -20,7 +21,7 @@ describe('transaction service', () => {
         nock.cleanAll()
 
         nock(process.env.CONNECTOR_URL)
-          .get('/v1/api/accounts/123/charges?reference=&email=&state=&card_brand=&from_date=&to_date=&page=1&display_size=100')
+          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams()}`)
           .reply(200, {})
       })
 
@@ -41,7 +42,7 @@ describe('transaction service', () => {
     describe('when connector returns incorrect response code while retrieving the list of transactions', () => {
       before(() => {
         nock(process.env.CONNECTOR_URL)
-          .get('/v1/api/accounts/123/charges?reference=&email=&state=&card_brand=&from_date=&to_date=&page=1&display_size=100')
+          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams()}`)
           .reply(404, '')
       })
 
@@ -58,31 +59,32 @@ describe('transaction service', () => {
 
       it('should return into the correct promise when it uses the legacy \'state\' method of querying states', () => {
         nock(process.env.CONNECTOR_URL)
-          .get('/v1/api/accounts/123/charges?reference=&email=&state=success&card_brand=&from_date=&to_date=&page=1&display_size=100')
+          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams({pageSize: 100, page: 1, state:'success'})}`)
           .reply(200, {})
         return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, state:'success'}, 'some-unique-id'))
           .to.eventually.be.fulfilled
       })
 
-      it('should return into the correct promise when it uses the new  \'refund_states\' method of querying refund states and mulitple have been selected', () => {
+      it('should return into the correct promise when it uses the new  \'refund_states\' method of querying refund states and multiple have been selected', () => {
         nock(process.env.CONNECTOR_URL)
-          .get('/v1/api/accounts/123/charges?reference=&email=&state=&card_brand=&from_date=&to_date=&page=1&display_size=100&refund_states=refund_success%2Crefund_error')
+          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams({pageSize: 100, page: 1, refund_states: ['refund_success','refund_error'], refundReportingEnabled: true})}`)
           .reply(200, {})
-        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, refund_states: ['refund_success','refund_error']}, 'some-unique-id'))
+        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, refund_states: ['refund_success','refund_error'], refundReportingEnabled: true}, 'some-unique-id'))
           .to.eventually.be.fulfilled
       })
 
       it('should return into the correct promise when it uses the new  \'refund_states\' method of querying refund states and only one has been selected', () => {
+
         nock(process.env.CONNECTOR_URL)
-          .get('/v1/api/accounts/123/charges?reference=&email=&state=&card_brand=&from_date=&to_date=&page=1&display_size=100&refund_states=refund_success')
+          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams({pageSize: 100, page: 1, refund_states: 'refund_success', refundReportingEnabled: true})}`)
           .reply(200, {})
-        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, refund_states: 'refund_success'}, 'some-unique-id'))
+        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, refund_states: 'refund_success', refundReportingEnabled: true}, 'some-unique-id'))
           .to.eventually.be.fulfilled
       })
 
       it('should return into the correct promise', () => {
         nock(process.env.CONNECTOR_URL)
-          .get('/v1/api/accounts/123/charges?reference=&email=&state=&card_brand=&from_date=&to_date=&page=1&display_size=100')
+          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams()}`)
           .reply(200, {})
         return expect(transactionService.searchAll(123, {pageSize: 100, page: 1}, 'some-unique-id'))
           .to.eventually.be.fulfilled
@@ -102,7 +104,7 @@ describe('transaction service', () => {
     describe('when connector returns incorrect response code', () => {
       before(() => {
         nock(process.env.CONNECTOR_URL)
-          .get('/v1/api/accounts/123/charges?reference=&email=&state=&card_brand=&from_date=&to_date=&page=1&display_size=100')
+          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams()}`)
           .reply(404, '')
       })
 


### PR DESCRIPTION
## WHAT
This moves the use of 'state' vs 'refund_states' & 'payment_states' to being switched on the feature flag.

This should fix the broken _.csv_ download when the feature flag is enabled.

