### PR TITLE
BAU - removed central, as we want to encourage Local Gov to sign up too

### DIFF
--- a/app/views/self_create_service/register.njk
+++ b/app/views/self_create_service/register.njk
@@ -13,7 +13,7 @@
       <label class="form-label" for="email">
         Email
         <span class="form-hint">
-          Must be from a central government organisation
+          Must be from a government organisation
         </span>
       </label>
       <input type="email" class="form-control form-control-2-3" id="email" name="email" value="{{email}}">


### PR DESCRIPTION
We are starting a pilot with local authorities and so central government email is no longer required.

## WHAT
Remove 'central' from email hint copy

this replaces #621 as it fell behind and I can't rebase