### PR TITLE
pp-3167: use run-with-chamber.sh instead of npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "compile": "grunt generate-assets",
     "clean": "grunt clean",
     "start": "node_modules/forever/bin/forever --minUptime 1000 --spinSleepTime 500 start.js",
-    "start-with-chamber": "AWS_REGION=${ECS_AWS_REGION} chamber exec ${ECS_SERVICE} -- npm start",
     "stop": "node_modules/forever/bin/forever stop start.js",
     "watch": "chokidar app test *.js --initial -c 'npm run test'",
     "watch-live-reload": "./node_modules/.bin/grunt watch",

--- a/run-with-chamber.sh
+++ b/run-with-chamber.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -u
+
+AWS_REGION="$ECS_AWS_REGION" chamber exec "$ECS_SERVICE" -- npm start


### PR DESCRIPTION
All the other microservices that require secrets use run-with-chamber.sh

This service used npm start-with-chamber

Now it uses run-with-chamber.sh
