### PR TITLE
PP-3063 Renamed internal id variables to external ids

### DIFF
--- a/app/controllers/service_users_controller.js
+++ b/app/controllers/service_users_controller.js
@@ -113,12 +113,12 @@ module.exports = {
    * @param res
    */
   delete: (req, res) => {
-    const userToRemoveId = req.params.externalUserId
+    const userToRemoveExternalId = req.params.externalUserId
     const externalServiceId = req.params.externalServiceId
-    const removerId = req.user.externalId
+    const removerExternalId = req.user.externalId
     const correlationId = req.correlationId
 
-    if (userToRemoveId === removerId) {
+    if (userToRemoveExternalId === removerExternalId) {
       errorResponse(req, res, 'Not allowed to delete a user itself')
       return
     }
@@ -143,8 +143,8 @@ module.exports = {
       successResponse(req, res, 'error_logged_in', messageUserHasBeenDeleted)
     }
 
-    return userService.findByExternalId(userToRemoveId, correlationId)
-      .then(user => userService.delete(externalServiceId, removerId, userToRemoveId, correlationId).then(() => user.username))
+    return userService.findByExternalId(userToRemoveExternalId, correlationId)
+      .then(user => userService.delete(externalServiceId, removerExternalId, userToRemoveExternalId, correlationId).then(() => user.username))
       .then((username) => onSuccess(username))
       .catch(onError)
   },

--- a/app/services/clients/adminusers_client.js
+++ b/app/services/clients/adminusers_client.js
@@ -770,12 +770,12 @@ module.exports = function (clientOptions = {}) {
     return defer.promise
   }
 
-  const deleteUser = (serviceExternalId, removerId, userId) => {
+  const deleteUser = (serviceExternalId, removerExternalId, userExternalId) => {
     const params = {
       correlationId: correlationId,
       headers: {}
     }
-    const url = `${serviceResource}/${serviceExternalId}/users/${userId}`
+    const url = `${serviceResource}/${serviceExternalId}/users/${userExternalId}`
     const defer = q.defer()
     const startTime = new Date()
     const context = {
@@ -785,14 +785,14 @@ module.exports = function (clientOptions = {}) {
       correlationId: correlationId,
       method: 'DELETE',
       description: 'delete a user from a service',
-      userDelete: userId,
-      userRemover: removerId,
+      userDelete: userExternalId,
+      userRemover: removerExternalId,
       service: SERVICE_NAME
     }
     const callbackToPromiseConverter = createCallbackToPromiseConverter(context)
     requestLogger.logRequestStart(context)
 
-    params.headers[HEADER_USER_CONTEXT] = removerId
+    params.headers[HEADER_USER_CONTEXT] = removerExternalId
     baseClient.delete(url, params, callbackToPromiseConverter)
       .on('error', callbackToPromiseConverter)
 

--- a/app/services/user_service.js
+++ b/app/services/user_service.js
@@ -98,12 +98,12 @@ module.exports = {
   },
 
   /**
-   * @param serviceId
+   * @param externalServiceId
    * @param correlationId
    * @returns {Promise}
    */
-  getServiceUsers: function (serviceId, correlationId) {
-    return getAdminUsersClient({correlationId: correlationId}).getServiceUsers(serviceId)
+  getServiceUsers: function (externalServiceId, correlationId) {
+    return getAdminUsersClient({correlationId: correlationId}).getServiceUsers(externalServiceId)
   },
 
   /**
@@ -163,12 +163,13 @@ module.exports = {
 
   /**
    *
-   * @param serviceId
-   * @param removerId
-   * @param userId
+   * @param externalServiceId
+   * @param removerExternalId
+   * @param userExternalId
+   * @param correlationId
    */
-  delete: function (serviceId, removerId, userId, correlationId) {
-    return getAdminUsersClient({correlationId: correlationId}).deleteUser(serviceId, removerId, userId)
+  delete: function (externalServiceId, removerExternalId, userExternalId, correlationId) {
+    return getAdminUsersClient({correlationId: correlationId}).deleteUser(externalServiceId, removerExternalId, userExternalId)
   },
 
   /**


### PR DESCRIPTION
## WHAT

We removed the deprecated way to send service internal ids in adminusers,
this commit contains some small refactoring of the service external id names.

https://github.com/alphagov/pay-adminusers/pull/154