### PR TITLE
PP-2705 - conditionally adding multi-select for card brands

### DIFF
--- a/app/assets/sass/helpers/_headings.scss
+++ b/app/assets/sass/helpers/_headings.scss
@@ -33,3 +33,7 @@
 .pad-top {
   margin-top: $gutter * 2;
 }
+
+.capitalize {
+  text-transform: capitalize;
+}

--- a/app/browsered/multi-select.js
+++ b/app/browsered/multi-select.js
@@ -30,6 +30,7 @@ function progressivelyEnhanceSelects () {
     select = $(select)
     const configuration = {
       id: select.id || randomElementId(),
+      name: select[0].name,
       items: [...select.find('option')].map(option => {
         option = $(option)
         const text = option.text()

--- a/app/controllers/transactions/transaction_list_controller.js
+++ b/app/controllers/transactions/transaction_list_controller.js
@@ -2,6 +2,7 @@
 
 // Core Dependencies
 const url = require('url')
+const _ = require('lodash')
 
 // Local Dependencies
 const auth = require('../../services/auth_service.js')
@@ -43,6 +44,11 @@ module.exports = (req, res) => {
             .filter(state => state.value.selected)
             .map(state => state.value.text)
             .join(', ')
+          if (_.has(filters.result, 'brand')) {
+            model.cardBrands.forEach(brand => {
+              brand.value.selected = filters.result.brand.includes(brand.key)
+            })
+          }
           response(req, res, 'transactions/index', model)
         })
         .on('connectorError', () => error('Unable to retrieve card types.'))

--- a/app/utils/filters.js
+++ b/app/utils/filters.js
@@ -28,7 +28,12 @@ function describeFilters (filters) {
     description += ` with <strong>${selectedStates.join('</strong>, <strong>').replace(/,([^,]*)$/, ' or$1')}</strong> states`
   }
 
-  if (filters.brand) description += ` with <strong>'${filters.brand}'</strong> card brand`
+  const brandStates = Array.isArray(filters.brand) ? filters.brand.map(brand => brand.replace('-', ' ')) : []
+  if (brandStates.length === 0 && filters.brand) {
+    description += ` with <strong class="capitalize">‘${filters.brand.replace('-', ' ')}’</strong> card brand`
+  } else if (brandStates.length > 1) {
+    description += ` with <strong class="capitalize">‘${brandStates.join('</strong>, <strong class="capitalize">').replace(/,([^,]*)$/, ' or$1')}’</strong> card brands`
+  }
 
   return description
 }

--- a/app/views/includes/multi-select.njk
+++ b/app/views/includes/multi-select.njk
@@ -1,18 +1,17 @@
 <div id="{{id}}" class="multi-select">
   <button type="button"
     class="form-control large multi-select-title"
-    aria-describedby="state-select-box"
-    id="option-select-title-state">
+    id="option-select-title-{{name}}">
     <div><span class="visually-hidden">Currently selected: </span><span class="multi-select-current-selections"></span></div>
   </button>
-  <div role="group" aria-labelledby="option-select-title-state"
+  <div role="group" aria-labelledby="option-select-title-{{name}}"
      class="multi-select-dropdown"
      id="list_of_sectors"
      style="visibility:hidden;">
     <div class="multi-select-dropdown-inner-container">
       {% for item in items %}
       <div class="multiple-choice">
-        <input class="multi-select-item" name="state" value="{{ item.value }}" id="{{ item.id }}" type="checkbox" {% if item.checked %}checked{% endif %}>
+        <input class="multi-select-item" name="{{name}}" value="{{ item.value }}" id="{{ item.id }}" type="checkbox" {% if item.checked %}checked{% endif %}>
         <label for="{{ item.id }}">{{ item.text }}</label>
       </div>
       {% endfor %}

--- a/app/views/transactions/filter.njk
+++ b/app/views/transactions/filter.njk
@@ -35,7 +35,11 @@
             <strong>Card brand</strong>
             <span class="form-hint">Select a brand</span>
           </label>
+        {% if _features.REFUNDS_IN_TX_LIST %}
+          <select class="form-control large" id="card-brand" name="brand" data-enhance-multiple>
+        {% else %}
           <select class="form-control large" id="card-brand" name="brand">
+        {% endif %}
             <option value="">All brands</option>
             {% for cardBrand in cardBrands %}
               <option value="{{cardBrand.key}}" {% if cardBrand.value.selected %} selected {% endif %}>{{cardBrand.value.text}}</option>


### PR DESCRIPTION
Showing the multi-select for card brands if showing multi-select for
refunds, once everyone has refunds reporting will show both for
everyone.

Refactored the multi-select to work agnostically for different multi-selects

Added in logic so that filter can display a list of card brands and not
just one
