### PR TITLE
PP-3204 Fix bug (headers not set by base_client)

### DIFF
--- a/app/services/clients/products_client.js
+++ b/app/services/clients/products_client.js
@@ -48,6 +48,7 @@ function createProduct (options) {
     json: true,
     body: {
       gateway_account_id: options.gatewayAccountId,
+      pay_api_token: options.payApiToken,
       name: options.name,
       price: options.price,
       description: options.description,


### PR DESCRIPTION
- removed payApiToken which is needed for publicauth. Placed it back



