### PR TITLE
PP-3250 Run products e2e test as part of selfservice build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
       }
       steps {
         runEndToEnd("selfservice")
+        runParameterisedEndToEnd("selfservice", null, "end2end-tagged", false, false, "uk.gov.pay.endtoend.categories.End2EndProducts")
       }
     }
     stage('Docker Tag') {


### PR DESCRIPTION
This needs to wait till https://github.com/alphagov/pay-selfservice/pull/640 being merged.

## WHAT
As the way currently setup we are at a risk of releasing selfservice with broken products functionality given that the products e2e tests are not part of the selfseervice build.
This adds the products e2e tests as part of the `test` phase of selfservice.
