### PR TITLE
PP-3061 Create/revoke direct debit API keys

### DIFF
--- a/app/controllers/api_keys_controller.js
+++ b/app/controllers/api_keys_controller.js
@@ -45,7 +45,7 @@ module.exports.revoked = function (req, res) {
     accountId: accountId
   })
       .then(publicAuthData => {
-        var revokedTokens = publicAuthData.tokens || []
+        const revokedTokens = publicAuthData.tokens || []
         revokedTokens.forEach(function (token) {
           token.csrfToken = csrf().create(req.session.csrfSecret)
         })
@@ -73,10 +73,10 @@ module.exports.show = function (req, res) {
 module.exports.create = function (req, res) {
   // current account id is either external (DIRECT_DEBIT) or internal (CARD) for now
   const currentAccountId = auth.getCurrentGatewayAccountId(req)
-  let tokenType = currentAccountId.startsWith(DIRECT_DEBIT_TOKEN_PREFIX) ? 'DIRECT_DEBIT' : 'CARD'
-  let correlationId = req.correlationId
-  let description = req.body.description
-  let payload = {
+  const tokenType = currentAccountId.startsWith(DIRECT_DEBIT_TOKEN_PREFIX) ? 'DIRECT_DEBIT' : 'CARD'
+  const correlationId = req.correlationId
+  const description = req.body.description
+  const payload = {
     'account_id': currentAccountId,
     'description': description,
     'created_by': req.user.email,

--- a/app/controllers/dashboard/dashboard-activity-controller.js
+++ b/app/controllers/dashboard/dashboard-activity-controller.js
@@ -9,7 +9,7 @@ const moment = require('moment-timezone')
 const response = require('../../utils/response').response
 const CORRELATION_HEADER = require('../../utils/correlation_header').CORRELATION_HEADER
 const ConnectorClient = require('../../services/clients/connector_client').ConnectorClient
-const directDebitConnectorClient = require('../../services/clients/direct_debit_connector_client.js')
+const { DIRECT_DEBIT_TOKEN_PREFIX } = require('../../services/clients/direct_debit_connector_client.js')
 const auth = require('../../services/auth_service.js')
 const connectorClient = () => new ConnectorClient(process.env.CONNECTOR_URL)
 const datetime = require('../../utils/nunjucks-filters/datetime')
@@ -39,7 +39,7 @@ module.exports = (req, res) => {
 
   logger.info(`[${correlationId}] successfully logged in`)
 
-  if (gatewayAccountId.startsWith(directDebitConnectorClient.DIRECT_DEBIT_TOKEN_PREFIX)) {
+  if (gatewayAccountId.startsWith(DIRECT_DEBIT_TOKEN_PREFIX)) {
     // todo implement transaction list for direct debit
     return response(req, res, 'dashboard/index', {
       name: req.user.username,

--- a/app/controllers/dashboard/dashboard-activity-controller.test.js
+++ b/app/controllers/dashboard/dashboard-activity-controller.test.js
@@ -12,7 +12,7 @@ const {getApp} = require('../../../server')
 const {getMockSession, createAppWithSession, getUser} = require('../../../test/test_helpers/mock_session')
 const paths = require('../../../app/paths')
 const {CONNECTOR_URL} = process.env
-const GATEWAY_ACCOUNT_ID = 929
+const GATEWAY_ACCOUNT_ID = '929'
 const DASHBOARD_RESPONSE = {
   successful_payments: {
     count: 10,

--- a/app/middleware/get_gateway_account.js
+++ b/app/middleware/get_gateway_account.js
@@ -1,13 +1,26 @@
 const auth = require('../services/auth_service.js')
 const Connector = require('../services/clients/connector_client.js').ConnectorClient
 const connectorClient = new Connector(process.env.CONNECTOR_URL)
+const directDebitConnectorClient = require('../services/clients/direct_debit_connector_client.js')
 const _ = require('lodash')
+const winston = require('winston')
 
 module.exports = function (req, res, next) {
   const accountId = auth.getCurrentGatewayAccountId(req)
   const params = {
     gatewayAccountId: accountId,
     correlationId: req.correlationId
+  }
+  if (accountId.startsWith(directDebitConnectorClient.DIRECT_DEBIT_TOKEN_PREFIX)) {
+    return directDebitConnectorClient.gatewayAccount.get(params)
+      .then(gatewayAccount => {
+        req.account = gatewayAccount
+        next()
+      })
+      .catch(err => {
+        winston.error(`${req.correlationId} - Error when attempting to retrieve direct debit gateway account: ${err}`)
+        next()
+      })
   }
   return connectorClient.getAccount(params)
     .then(data => {
@@ -16,7 +29,8 @@ module.exports = function (req, res, next) {
       })
       next()
     })
-    .catch(() => {
+    .catch(err => {
+      winston.error(`${req.correlationId} - Error when attempting to retrieve card gateway account: ${err}`)
       next()
     })
 }

--- a/app/models/DirectDebitGatewayAccount.class.js
+++ b/app/models/DirectDebitGatewayAccount.class.js
@@ -1,0 +1,52 @@
+'use strict'
+
+/**
+ * @class DirectDebitGatewayAccount
+ * @property {string} name - The name of the gateway account
+ * @property {string} id - The id of the gateway account
+ * @property {string} type - The type of the gateway account (e.g. test/live)
+ * @property {string} description - The description of the gateway account
+ * @property {string} analyticsId - Google analyticsId of the gateway account
+ * @property {boolean} externalId - external id of the gateway account
+ */
+class DirectDebitGatewayAccount {
+  /**
+   * Create an instance of Service
+   * @param {Object} gatewayAccountData - raw 'gateway account' object from server
+   * @param {string} gatewayAccountData.gateway_account_id - The external ID of the gateway account
+   * @param {string} gatewayAccountData.service_name - The name of the gateway account
+   * @param {string} gatewayAccountData.type - The type of the gateway account
+   * @param {string} gatewayAccountData.payment_provider - The payment provider of the gateway account
+   * @param {string} gatewayAccountData.description - The description of the gateway account
+   * @param {string} gatewayAccountData.analytics_id - Google analytics_id of the gateway account
+   * @param {boolean} gatewayAccountData.external_id - external id of the gateway account
+   **/
+  constructor (gatewayAccountData) {
+    this.id = gatewayAccountData.gateway_account_id
+    this.serviceName = gatewayAccountData.service_name
+    this.type = gatewayAccountData.type
+    this.description = gatewayAccountData.description
+    this.analyticsId = gatewayAccountData.analytics_id
+    this.externalId = gatewayAccountData.gateway_account_external_id
+
+    // compatibility with other parts of selfservice - recording as tech debt in jira
+    this.payment_provider = gatewayAccountData.payment_provider
+    this.service_name = gatewayAccountData.service_name
+  }
+
+  /**
+   * @method toJson
+   * @returns {Object} A minimal representation of the gateway account
+   */
+  toMinimalJson () {
+    return {
+      id: this.id,
+      external_id: this.externalId,
+      payment_provider: this.paymentProvider,
+      service_name: this.name,
+      type: this.type
+    }
+  }
+}
+
+module.exports = DirectDebitGatewayAccount

--- a/app/services/auth_service.js
+++ b/app/services/auth_service.js
@@ -149,7 +149,7 @@ function getCurrentGatewayAccountId (req) {
   }
   // save currentGatewayAccountId and return it
   req.gateway_account.currentGatewayAccountId = currentGatewayAccountId
-  return parseInt(req.gateway_account.currentGatewayAccountId)
+  return req.gateway_account.currentGatewayAccountId
 }
 
 function hasValidSession (req) {

--- a/app/services/clients/direct_debit_connector_client.js
+++ b/app/services/clients/direct_debit_connector_client.js
@@ -1,0 +1,50 @@
+'use strict'
+
+// Local Dependencies
+const GatewayAccount = require('../../models/DirectDebitGatewayAccount.class')
+const baseClient = require('./base_client/base_client')
+const DIRECT_DEBIT_CONNECTOR_URL = process.env.DIRECT_DEBIT_CONNECTOR_URL
+const DIRECT_DEBIT_TOKEN_PREFIX = 'DIRECT_DEBIT:'
+// Use baseurl to create a baseclient for the direct debit microservice
+const baseUrl = `${DIRECT_DEBIT_CONNECTOR_URL}/v1/api`
+
+// Constants
+const SERVICE_NAME = 'directdebit-connector'
+
+// Exports
+module.exports = {
+  DIRECT_DEBIT_TOKEN_PREFIX,
+  gatewayAccount: {
+    create: createGatewayAccount,
+    get: getGatewayAccountByExternalId
+  }
+}
+
+function createGatewayAccount (options) {
+  return baseClient.post({
+    baseUrl,
+    url: `/accounts`,
+    json: true,
+    body: {
+      payment_provider: options.paymentProvider,
+      service_name: options.serviceName,
+      type: options.type,
+      description: options.description,
+      analytics_id: options.analyticsId
+    },
+    correlationId: options.correlationId,
+    description: 'create a direct debit gateway account',
+    service: SERVICE_NAME
+  }).then(ga => new GatewayAccount(ga))
+}
+
+function getGatewayAccountByExternalId (params) {
+  return baseClient.get({
+    baseUrl,
+    url: `/accounts/${params.gatewayAccountId}`,
+    correlationId: params.correlationId,
+    json: true,
+    description: `find a gateway account by external id`,
+    service: SERVICE_NAME
+  }).then(ga => new GatewayAccount(ga))
+}

--- a/app/utils/display_converter.js
+++ b/app/utils/display_converter.js
@@ -99,7 +99,6 @@ const getAccount = account => {
       ? [account.payment_provider, account.type].join(' ')
       : account.type
   }
-
   return account
 }
 

--- a/test/fixtures/product_fixtures.js
+++ b/test/fixtures/product_fixtures.js
@@ -6,7 +6,7 @@ const pactProducts = pactBase()
 
 // Create random values if none provided
 const randomExternalId = () => Math.random().toString(36).substring(7)
-const randomGatewayAccountId = () => Math.round(Math.random() * 1000) + 1
+const randomGatewayAccountId = () => Math.random().toString(36).substring(7)
 const randomPrice = () => Math.round(Math.random() * 10000) + 1
 
 module.exports = {
@@ -103,6 +103,7 @@ module.exports = {
       price: opts.price || randomPrice(),
       _links: opts.links
     }
+
     if (opts.description) data.description = opts.description
     if (opts.return_url) data.return_url = opts.return_url
     if (!data._links) {

--- a/test/integration/credentials_ft_tests.js
+++ b/test/integration/credentials_ft_tests.js
@@ -9,7 +9,7 @@ var paths = require(path.join(__dirname, '/../../app/paths.js'))
 var app
 var mockSession = require('../test_helpers/mock_session.js')
 var {expect} = require('chai')
-var ACCOUNT_ID = 182364
+var ACCOUNT_ID = '182364'
 var CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts/' + ACCOUNT_ID
 var CONNECTOR_ACCOUNT_CREDENTIALS_PATH = CONNECTOR_ACCOUNT_PATH + '/credentials'
 var CONNECTOR_ACCOUNT_NOTIFICATION_CREDENTIALS_PATH = '/v1/api/accounts/' + ACCOUNT_ID + '/notification-credentials'

--- a/test/integration/get_gateway_account_ft_test.js
+++ b/test/integration/get_gateway_account_ft_test.js
@@ -66,7 +66,7 @@ describe('get account', function () {
       .end(done)
   })
 
-  it('s.onlyhould get a direct debit account', function (done) {
+  it('should get a direct debit account', function (done) {
     const user = session.getUser({
       service_roles: [
         {

--- a/test/integration/get_gateway_account_ft_test.js
+++ b/test/integration/get_gateway_account_ft_test.js
@@ -19,7 +19,7 @@ describe('get account', function () {
     done()
   })
 
-  it('should get account', function (done) {
+  it('should get a card account', function (done) {
     const user = session.getUser({
       service_roles: [
         {
@@ -60,6 +60,46 @@ describe('get account', function () {
           type: 'test',
           payment_provider: 'sandbox',
           supports3ds: false,
+          full_type: 'sandbox test'
+        })
+      })
+      .end(done)
+  })
+
+  it('s.onlyhould get a direct debit account', function (done) {
+    const user = session.getUser({
+      service_roles: [
+        {
+          service: {
+            external_id: '1234',
+            gateway_account_ids: ['DIRECT_DEBIT:1owehhserwr', '5']
+          },
+          role: {
+            permissions: [{name: 'transactions:read'}]
+          }
+        }
+      ]
+
+    })
+    const mockSession = session.getMockSession(user)
+    session.currentGatewayAccountId = 'DIRECT_DEBIT:1owehhserwr'
+    app = session.getAppWithSessionAndGatewayAccountCookies(getApp(), mockSession)
+    const directDebitConnectorMock = nock(process.env.DIRECT_DEBIT_CONNECTOR_URL)
+
+    directDebitConnectorMock.get('/v1/api/accounts/DIRECT_DEBIT:1owehhserwr').times(2).reply(200, {
+      bob: 'bob',
+      type: 'test',
+      payment_provider: 'sandbox'
+    })
+
+    supertest(app)
+      .get('/')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .expect(data => {
+        expect(data.body.currentGatewayAccount).to.deep.equal({
+          type: 'test',
+          payment_provider: 'sandbox',
           full_type: 'sandbox test'
         })
       })

--- a/test/integration/login_controller_test.js
+++ b/test/integration/login_controller_test.js
@@ -21,7 +21,7 @@ chai.use(chaiAsPromised)
 const expect = chai.expect
 
 var adminusersMock = nock(process.env.ADMINUSERS_URL)
-var ACCOUNT_ID = 182364
+var ACCOUNT_ID = '182364'
 const USER_RESOURCE = '/v1/api/users'
 const CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts'
 

--- a/test/integration/pagination_ft_tests.js
+++ b/test/integration/pagination_ft_tests.js
@@ -11,7 +11,7 @@ var querystring = require('querystring')
 const getQueryStringForParams = require('../../app/utils/get_query_string_for_params')
 var app
 
-var gatewayAccountId = 452345
+var gatewayAccountId = '452345'
 
 var CONNECTOR_CHARGES_SEARCH_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges'
 var CONNECTOR_ALL_CARD_TYPES_API_PATH = '/v1/api/card-types'

--- a/test/integration/payment_types_select_brand_ft_tests.js
+++ b/test/integration/payment_types_select_brand_ft_tests.js
@@ -14,7 +14,7 @@ var aCorrelationHeader = {
   reqheaders: {'x-request-id': requestId}
 }
 var {TYPES} = require(path.join(__dirname, '/../../app/controllers/payment_types_controller.js'))
-var ACCOUNT_ID = 182364
+var ACCOUNT_ID = '182364'
 var app
 var CONNECTOR_ALL_CARD_TYPES_API_PATH = '/v1/api/card-types'
 var CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts/' + ACCOUNT_ID

--- a/test/integration/payment_types_select_summary_ft_tests.js
+++ b/test/integration/payment_types_select_summary_ft_tests.js
@@ -12,7 +12,7 @@ var {expect} = require('chai')
 var NOT_AVAILABLE_BECAUSE_OF_TYPE_REQUIREMENT = 'Not available'
 var NOT_AVAILABLE_BECAUSE_OF_3DS_REQUIREMENT = 'You must <a href=\'/3ds\'>enable 3D Secure</a> to accept Maestro'
 
-var ACCOUNT_ID = 182364
+var ACCOUNT_ID = '182364'
 var app
 var requestId = 'unique-request-id'
 var aCorrelationHeader = {

--- a/test/integration/payment_types_select_type_ft_tests.js
+++ b/test/integration/payment_types_select_type_ft_tests.js
@@ -10,7 +10,7 @@ var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
 var expect = require('chai').expect
 var {TYPES} = require(path.join(__dirname, '/../../app/controllers/payment_types_controller.js'))
 
-var ACCOUNT_ID = 182364
+var ACCOUNT_ID = '182364'
 var app
 var requestId = 'unique-request-id'
 var aCorrelationHeader = {

--- a/test/integration/toggle_3ds_ft_tests.js
+++ b/test/integration/toggle_3ds_ft_tests.js
@@ -9,7 +9,7 @@ var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
 var csrf = require('csrf')
 var {expect} = require('chai')
 
-var ACCOUNT_ID = 182364
+var ACCOUNT_ID = '182364'
 
 var app
 

--- a/test/integration/transaction_details_ft_tests.js
+++ b/test/integration/transaction_details_ft_tests.js
@@ -8,7 +8,7 @@ var getApp = require('../../server.js').getApp
 var paths = require('../../app/paths.js')
 var session = require('../test_helpers/mock_session.js')
 var {expect} = require('chai')
-var gatewayAccountId = 15486734
+var gatewayAccountId = '15486734'
 
 var app
 

--- a/test/integration/transaction_details_refunds_ft_tests.js
+++ b/test/integration/transaction_details_refunds_ft_tests.js
@@ -8,7 +8,7 @@ var session = require('../test_helpers/mock_session.js')
 var userCreator = require('../test_helpers/user_creator.js')
 var expect = chai.expect
 
-var ACCOUNT_ID = 15486734
+var ACCOUNT_ID = '15486734'
 var USER_EXTERNAL_ID = 'efc2e588d92e42969d1fc32f61f5653b'
 var app
 var connectorMock = nock(process.env.CONNECTOR_URL)

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -13,7 +13,7 @@ var assert = require('chai').assert
 var expect = require('chai').expect
 var getQueryStringForParams = require('../../app/utils/get_query_string_for_params')
 
-var gatewayAccountId = 651342
+var gatewayAccountId = '651342'
 var app
 
 var CHARGES_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges'

--- a/test/integration/transaction_list_ft_tests.js
+++ b/test/integration/transaction_list_ft_tests.js
@@ -13,7 +13,7 @@ const getQueryStringForParams = require('../../app/utils/get_query_string_for_pa
 
 const CONNECTOR_DATE = '2016-02-10T12:44:01.000Z'
 const DISPLAY_DATE = '10 Feb 2016 — 12:44:01'
-const gatewayAccountId = 651342
+const gatewayAccountId = '651342'
 const {expect} = chai
 const searchParameters = {}
 const CONNECTOR_CHARGES_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges'

--- a/test/integration/transaction_search_ft_tests.js
+++ b/test/integration/transaction_search_ft_tests.js
@@ -17,7 +17,7 @@ var _ = require('lodash')
 chai.use(chaiAsPromised)
 chai.should()
 
-var gatewayAccountId = 452345
+var gatewayAccountId = '452345'
 
 var app
 
@@ -120,7 +120,7 @@ describe('The search transactions endpoint', function () {
           },
           'card_brand': 'Visa',
           'state_friendly': 'Testing',
-          'gateway_account_id': 452345,
+          'gateway_account_id': '452345',
           'updated': DISPLAY_DATE,
           'created': DISPLAY_DATE,
           'link': paths.generateRoute(paths.transactions.detail, {chargeId: 100})
@@ -138,7 +138,7 @@ describe('The search transactions endpoint', function () {
           },
           'card_brand': 'Visa',
           'state_friendly': 'Testing2',
-          'gateway_account_id': 452345,
+          'gateway_account_id': '452345',
           'updated': DISPLAY_DATE,
           'created': DISPLAY_DATE,
           'link': paths.generateRoute(paths.transactions.detail, {chargeId: 101})
@@ -192,7 +192,7 @@ describe('The search transactions endpoint', function () {
           },
           'card_brand': 'Visa',
           'state_friendly': 'Testing',
-          'gateway_account_id': 452345,
+          'gateway_account_id': '452345',
           'updated': DISPLAY_DATE,
           'created': DISPLAY_DATE,
           'link': paths.generateRoute(paths.transactions.detail, {chargeId: 100})
@@ -244,7 +244,7 @@ describe('The search transactions endpoint', function () {
           },
           'card_brand': 'Visa',
           'state_friendly': 'Testing',
-          'gateway_account_id': 452345,
+          'gateway_account_id': '452345',
           'updated': DISPLAY_DATE,
           'created': DISPLAY_DATE,
           'link': paths.generateRoute(paths.transactions.detail, {chargeId: 100})
@@ -298,7 +298,7 @@ describe('The search transactions endpoint', function () {
           },
           'card_brand': 'Visa',
           'state_friendly': 'Testing',
-          'gateway_account_id': 452345,
+          'gateway_account_id': '452345',
           'updated': DISPLAY_DATE,
           'created': DISPLAY_DATE,
           'link': paths.generateRoute(paths.transactions.detail, {chargeId: 100})
@@ -351,7 +351,7 @@ describe('The search transactions endpoint', function () {
           },
           'card_brand': 'Visa',
           'state_friendly': 'Testing',
-          'gateway_account_id': 452345,
+          'gateway_account_id': '452345',
           'updated': DISPLAY_DATE,
           'created': DISPLAY_DATE,
           'link': paths.generateRoute(paths.transactions.detail, {chargeId: 100})
@@ -404,7 +404,7 @@ describe('The search transactions endpoint', function () {
           },
           'card_brand': 'Visa',
           'state_friendly': 'Testing',
-          'gateway_account_id': 452345,
+          'gateway_account_id': '452345',
           'updated': DISPLAY_DATE,
           'created': DISPLAY_DATE,
           'link': paths.generateRoute(paths.transactions.detail, {chargeId: 100})
@@ -471,7 +471,7 @@ describe('The search transactions endpoint', function () {
           },
           'card_brand': 'Visa',
           'state_friendly': 'Testing',
-          'gateway_account_id': 452345,
+          'gateway_account_id': '452345',
           'updated': '11 Jan 2016 — 01:01:01',
           'created': '11 Jan 2016 — 01:01:01',
           'link': paths.generateRoute(paths.transactions.detail, {chargeId: 100})

--- a/test/test.env
+++ b/test/test.env
@@ -1,4 +1,5 @@
 CONNECTOR_URL=http://localhost:8001
+DIRECT_DEBIT_CONNECTOR_URL=http://localhost:8005
 PUBLIC_AUTH_BASE=http://localhost:8003
 PUBLIC_AUTH_URL=http://localhost:8003/v1/frontend/auth
 ADMINUSERS_URL=http://localhost:8002

--- a/test/test_helpers/mock_session.js
+++ b/test/test_helpers/mock_session.js
@@ -20,6 +20,7 @@ const createAppWithSession = function (app, sessionData, gatewayAccountData, reg
     req.gateway_account = gatewayAccountData || {
       currentGatewayAccountId: _.get(sessionData, 'passport.user.serviceRoles[0].service.gatewayAccountIds[0]')
     }
+    req.account = gatewayAccountData
     req.register_invite = registerInviteData || {}
     next()
   })

--- a/test/unit/controller/make_a_demo_payment_controller/edit_controller_test.js
+++ b/test/unit/controller/make_a_demo_payment_controller/edit_controller_test.js
@@ -12,7 +12,7 @@ const {getApp} = require('../../../../server')
 const {getMockSession, createAppWithSession, getUser} = require('../../../test_helpers/mock_session')
 const paths = require('../../../../app/paths')
 
-const GATEWAY_ACCOUNT_ID = 929
+const GATEWAY_ACCOUNT_ID = '929'
 const {CONNECTOR_URL} = process.env
 const VALID_USER = getUser({
   gateway_account_ids: [GATEWAY_ACCOUNT_ID],

--- a/test/unit/controller/make_a_demo_payment_controller/go_to_payment_controller_test.js
+++ b/test/unit/controller/make_a_demo_payment_controller/go_to_payment_controller_test.js
@@ -15,7 +15,7 @@ const {randomUuid} = require('../../../../app/utils/random')
 const {validCreateProductRequest, validCreateProductResponse} = require('../../../fixtures/product_fixtures')
 
 const {PUBLIC_AUTH_URL, PRODUCTS_URL, CONNECTOR_URL} = process.env
-const GATEWAY_ACCOUNT_ID = 929
+const GATEWAY_ACCOUNT_ID = '929'
 const PAYMENT_DESCRIPTION = 'Pay your window tax'
 const PAYMENT_AMOUNT = '20.00'
 const VALID_PAYLOAD = {

--- a/test/unit/controller/make_a_demo_payment_controller/index_controller_test.js
+++ b/test/unit/controller/make_a_demo_payment_controller/index_controller_test.js
@@ -13,7 +13,7 @@ const {getApp} = require('../../../../server')
 const {getMockSession, createAppWithSession, getUser} = require('../../../test_helpers/mock_session')
 const paths = require('../../../../app/paths')
 
-const GATEWAY_ACCOUNT_ID = 929
+const GATEWAY_ACCOUNT_ID = '929'
 const {CONNECTOR_URL} = process.env
 const VALID_USER = getUser({
   gateway_account_ids: [GATEWAY_ACCOUNT_ID],

--- a/test/unit/controller/make_a_demo_payment_controller/mock_card_details_controller_test.js
+++ b/test/unit/controller/make_a_demo_payment_controller/mock_card_details_controller_test.js
@@ -12,7 +12,7 @@ const {getApp} = require('../../../../server')
 const {getMockSession, createAppWithSession, getUser} = require('../../../test_helpers/mock_session')
 const paths = require('../../../../app/paths')
 const {CONNECTOR_URL} = process.env
-const GATEWAY_ACCOUNT_ID = 929
+const GATEWAY_ACCOUNT_ID = '929'
 
 describe('make a demo payment - mock card details controller', () => {
   describe('when both paymentDescription and paymentAmount exist in the session', () => {

--- a/test/unit/controller/test_with_your_users_controller/create_controller_test.js
+++ b/test/unit/controller/test_with_your_users_controller/create_controller_test.js
@@ -12,7 +12,7 @@ const {getApp} = require('../../../../server')
 const {getMockSession, createAppWithSession, getUser} = require('../../../test_helpers/mock_session')
 const paths = require('../../../../app/paths')
 const {CONNECTOR_URL} = process.env
-const GATEWAY_ACCOUNT_ID = 929
+const GATEWAY_ACCOUNT_ID = '929'
 
 describe('test with your users - create controller', () => {
   let result, $, session

--- a/test/unit/controller/test_with_your_users_controller/disable_controller_test.js
+++ b/test/unit/controller/test_with_your_users_controller/disable_controller_test.js
@@ -11,7 +11,7 @@ const {getMockSession, createAppWithSession, getUser} = require('../../../test_h
 const paths = require('../../../../app/paths')
 const {randomUuid} = require('../../../../app/utils/random')
 
-const GATEWAY_ACCOUNT_ID = 929
+const GATEWAY_ACCOUNT_ID = '929'
 const {PRODUCTS_URL, CONNECTOR_URL} = process.env
 
 describe('test with your users - disable controller', () => {

--- a/test/unit/controller/test_with_your_users_controller/links_controller_test.js
+++ b/test/unit/controller/test_with_your_users_controller/links_controller_test.js
@@ -10,7 +10,7 @@ const {expect} = require('chai')
 
 const {PRODUCTS_URL, CONNECTOR_URL} = process.env
 
-const GATEWAY_ACCOUNT_ID = 182364
+const GATEWAY_ACCOUNT_ID = '182364'
 const PAYMENT_1 = {
   external_id: 'product-external-id-1',
   gateway_account_id: 'product-gateway-account-id-1',

--- a/test/unit/controller/test_with_your_users_controller/submit_controller_test.js
+++ b/test/unit/controller/test_with_your_users_controller/submit_controller_test.js
@@ -15,7 +15,7 @@ const {randomUuid} = require('../../../../app/utils/random')
 const {validCreateProductRequest, validCreateProductResponse} = require('../../../fixtures/product_fixtures')
 
 const {PUBLIC_AUTH_URL, PRODUCTS_URL, CONNECTOR_URL} = process.env
-const GATEWAY_ACCOUNT_ID = 929
+const GATEWAY_ACCOUNT_ID = '929'
 const API_TOKEN = randomUuid()
 const VALID_USER = getUser({gateway_account_ids: [GATEWAY_ACCOUNT_ID], permissions: [{name: 'transactions:read'}]})
 const VALID_PAYLOAD = {

--- a/test/unit/middleware/get_gateway_account_test.js
+++ b/test/unit/middleware/get_gateway_account_test.js
@@ -34,8 +34,7 @@ var setupGetGatewayAccount = function (currentGatewayAccountID, paymentProvider)
     return Promise.resolve(new DirectDebitGatewayAccount({
       gateway_account_id: '3',
       gateway_account_external_id: params.gatewayAccountId,
-      payment_provider: paymentProvider,
-      payment_method: 'DIRECT_DEBIT'
+      payment_provider: paymentProvider
     }))
   })
   const directDebitConnectorMock = {
@@ -54,7 +53,7 @@ var setupGetGatewayAccount = function (currentGatewayAccountID, paymentProvider)
 describe('middleware: getGatewayAccount', () => {
   it('should call connectorClient.getAccount if it can resolve a currentGatewayAccountId', done => {
     lodash.set(req, 'user.serviceRoles[0]', {gatewayAccountIds: ['1', '2', '3']})
-    let getGatewayAccount = setupGetGatewayAccount('1', 'worldpay')
+    const getGatewayAccount = setupGetGatewayAccount('1', 'worldpay')
     getGatewayAccount(req, res, next).then(() => {
       expect(connectorGetAccountMock.called).to.equal(true)
       expect(connectorGetAccountMock.calledWith({gatewayAccountId: '1', correlationId: 'sdfghjk'})).to.equal(true)
@@ -65,7 +64,7 @@ describe('middleware: getGatewayAccount', () => {
   })
   it('should extend the account data with supports3ds set to true if the account type is worldpay', done => {
     lodash.set(req, 'user.serviceRoles[0]', {gatewayAccountIds: ['1', '2', '3']})
-    let getGatewayAccount = setupGetGatewayAccount('1', 'worldpay')
+    const getGatewayAccount = setupGetGatewayAccount('1', 'worldpay')
     getGatewayAccount(req, res, next).then(() => {
       expect(req.account).to.deep.equal({id: '1', payment_provider: 'worldpay', supports3ds: true})
       done()
@@ -73,7 +72,7 @@ describe('middleware: getGatewayAccount', () => {
   })
   it('should extend the account data with supports3ds set to false if the account type is not worldpay', done => {
     lodash.set(req, 'user.serviceRoles[0]', {gatewayAccountIds: ['1', '2', '3']})
-    let getGatewayAccount = setupGetGatewayAccount('1', 'epdq')
+    const getGatewayAccount = setupGetGatewayAccount('1', 'epdq')
     getGatewayAccount(req, res, next).then(() => {
       expect(req.account).to.deep.equal({id: '1', payment_provider: 'epdq', supports3ds: false})
       done()
@@ -81,7 +80,7 @@ describe('middleware: getGatewayAccount', () => {
   })
   it('should call direct debit connector if the token is a direct debit token', done => {
     lodash.set(req, 'user.serviceRoles[0]', {gatewayAccountIds: ['DIRECT_DEBIT:1sadasd']})
-    let getGatewayAccount = setupGetGatewayAccount('DIRECT_DEBIT:1sadasd', 'sandbox')
+    const getGatewayAccount = setupGetGatewayAccount('DIRECT_DEBIT:1sadasd', 'sandbox')
     getGatewayAccount(req, res, next).then(() => {
       expect(directDebitConnectorGetAccountMock.called).to.equal(true)
       expect(directDebitConnectorGetAccountMock.calledWith({gatewayAccountId: 'DIRECT_DEBIT:1sadasd', correlationId: 'sdfghjk'})).to.equal(true)

--- a/test/unit/middleware/get_gateway_account_test.js
+++ b/test/unit/middleware/get_gateway_account_test.js
@@ -7,14 +7,14 @@ const lodash = require('lodash')
 const sinon = require('sinon')
 const {expect} = require('chai')
 
+const DirectDebitGatewayAccount = require('../../../app/models/DirectDebitGatewayAccount.class')
+let req, res, next, connectorGetAccountMock, directDebitConnectorGetAccountMock
+
 const connectorMock = {
   ConnectorClient: function () {
     this.getAccount = connectorGetAccountMock
   }
 }
-
-let req, res, next, connectorGetAccountMock
-
 var setupGetGatewayAccount = function (currentGatewayAccountID, paymentProvider) {
   const authServiceMock = {getCurrentGatewayAccountId: () => currentGatewayAccountID}
   req = {
@@ -30,19 +30,34 @@ var setupGetGatewayAccount = function (currentGatewayAccountID, paymentProvider)
       payment_provider: paymentProvider
     })
   })
+  directDebitConnectorGetAccountMock = sinon.spy((params) => {
+    return Promise.resolve(new DirectDebitGatewayAccount({
+      gateway_account_id: '3',
+      gateway_account_external_id: params.gatewayAccountId,
+      payment_provider: paymentProvider,
+      payment_method: 'DIRECT_DEBIT'
+    }))
+  })
+  const directDebitConnectorMock = {
+    gatewayAccount: {
+      get: directDebitConnectorGetAccountMock
+    }
+  }
+
   return proxyquire(path.join(__dirname, '../../../app/middleware/get_gateway_account'), {
     '../services/auth_service.js': authServiceMock,
-    '../services/clients/connector_client.js': connectorMock
+    '../services/clients/connector_client.js': connectorMock,
+    '../services/clients/direct_debit_connector_client.js': directDebitConnectorMock
   })
 }
 
 describe('middleware: getGatewayAccount', () => {
   it('should call connectorClient.getAccount if it can resolve a currentGatewayAccountId', done => {
     lodash.set(req, 'user.serviceRoles[0]', {gatewayAccountIds: ['1', '2', '3']})
-    let getGatewayAccount = setupGetGatewayAccount(1, 'worldpay')
+    let getGatewayAccount = setupGetGatewayAccount('1', 'worldpay')
     getGatewayAccount(req, res, next).then(() => {
       expect(connectorGetAccountMock.called).to.equal(true)
-      expect(connectorGetAccountMock.calledWith({gatewayAccountId: 1, correlationId: 'sdfghjk'})).to.equal(true)
+      expect(connectorGetAccountMock.calledWith({gatewayAccountId: '1', correlationId: 'sdfghjk'})).to.equal(true)
       expect(next.called).to.equal(true)
       expect(res.redirect.called).to.equal(false)
       done()
@@ -50,17 +65,28 @@ describe('middleware: getGatewayAccount', () => {
   })
   it('should extend the account data with supports3ds set to true if the account type is worldpay', done => {
     lodash.set(req, 'user.serviceRoles[0]', {gatewayAccountIds: ['1', '2', '3']})
-    let getGatewayAccount = setupGetGatewayAccount(1, 'worldpay')
+    let getGatewayAccount = setupGetGatewayAccount('1', 'worldpay')
     getGatewayAccount(req, res, next).then(() => {
-      expect(req.account).to.deep.equal({id: 1, payment_provider: 'worldpay', supports3ds: true})
+      expect(req.account).to.deep.equal({id: '1', payment_provider: 'worldpay', supports3ds: true})
       done()
     })
   })
   it('should extend the account data with supports3ds set to false if the account type is not worldpay', done => {
     lodash.set(req, 'user.serviceRoles[0]', {gatewayAccountIds: ['1', '2', '3']})
-    let getGatewayAccount = setupGetGatewayAccount(1, 'epdq')
+    let getGatewayAccount = setupGetGatewayAccount('1', 'epdq')
     getGatewayAccount(req, res, next).then(() => {
-      expect(req.account).to.deep.equal({id: 1, payment_provider: 'epdq', supports3ds: false})
+      expect(req.account).to.deep.equal({id: '1', payment_provider: 'epdq', supports3ds: false})
+      done()
+    })
+  })
+  it('should call direct debit connector if the token is a direct debit token', done => {
+    lodash.set(req, 'user.serviceRoles[0]', {gatewayAccountIds: ['DIRECT_DEBIT:1sadasd']})
+    let getGatewayAccount = setupGetGatewayAccount('DIRECT_DEBIT:1sadasd', 'sandbox')
+    getGatewayAccount(req, res, next).then(() => {
+      expect(directDebitConnectorGetAccountMock.called).to.equal(true)
+      expect(directDebitConnectorGetAccountMock.calledWith({gatewayAccountId: 'DIRECT_DEBIT:1sadasd', correlationId: 'sdfghjk'})).to.equal(true)
+      expect(next.called).to.equal(true)
+      expect(res.redirect.called).to.equal(false)
       done()
     })
   })

--- a/test/unit/services/auth_service_test.js
+++ b/test/unit/services/auth_service_test.js
@@ -301,7 +301,7 @@ describe('auth service', function () {
       }
       const test = auth.getCurrentGatewayAccountId(req)
 
-      expect(test).to.equal(1)
+      expect(test).to.equal('1')
       expect(req.gateway_account.currentGatewayAccountId).to.equal('1')
 
       done()


### PR DESCRIPTION
## WHAT
- We can now generate api keys for direct debit. As we store now gateway accounts in many places, using
  internal account ids is not sufficient anymore. We need to support using external ids in lieu of internal ones.
- The `get_gateway_account` middleware will retrieve a direct debit gateway account if the api token is prefixed
  with `DIRECT_DEBIT:`
- When creating an api token, we send to publicauth either the internal or the external id. Publicauth supports already this.
- Changed tests to use not numeric account ids.

