### PR TITLE
PP-3289 Make mocha fail builds on failed tests

### DIFF
--- a/app/controllers/credentials_controller.js
+++ b/app/controllers/credentials_controller.js
@@ -11,7 +11,7 @@ var auth = require('../services/auth_service.js')
 var router = require('../routes.js')
 const {CONNECTOR_URL} = process.env
 var CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
-const {isEmpty, isPasswordLessThanTenChars} = require('../browsered/field-validation-checks')
+const {isPasswordLessThanTenChars} = require('../browsered/field-validation-checks')
 
 var connectorClient = () => new ConnectorClient(CONNECTOR_URL)
 
@@ -31,7 +31,7 @@ function showSuccessView (viewMode, req, res) {
       responsePayload.editMode = false
       responsePayload.editNotificationCredentialsMode = false
   }
-  const invalidCreds = _.get(req,'session.pageData.editNotificationCredentials')
+  const invalidCreds = _.get(req, 'session.pageData.editNotificationCredentials')
   if (invalidCreds) {
     responsePayload.lastNotificationsData = invalidCreds
     delete req.session.pageData.editNotificationCredentials
@@ -91,7 +91,7 @@ module.exports = {
     const connectorUrl = CONNECTOR_URL + '/v1/api/accounts/{accountId}/notification-credentials'
     const {username, password} = _.get(req, 'body')
 
-    if(!username) {
+    if (!username) {
       req.flash('genericError', `<h2>Please enter a valid username</h2>`)
     } else if (!password) {
       req.flash('genericError', `<h2>Please enter a valid password</h2>`)
@@ -100,7 +100,7 @@ module.exports = {
     }
 
     if (_.get(req, 'session.flash.genericError.length')) {
-      _.set(req,'session.pageData.editNotificationCredentials', {username,password})
+      _.set(req, 'session.pageData.editNotificationCredentials', {username, password})
       return res.redirect(paths.notificationCredentials.edit)
     }
 

--- a/docker/build_and_test.sh
+++ b/docker/build_and_test.sh
@@ -4,7 +4,4 @@ rm -rf node_modules &&\
 ln -s /tmp/node_modules /app/node_modules &&\
 npm run compile &&\
 npm run lint &&\
-npm test -- --forbid-only --forbid-pending &&\
-rm -rf node_modules
-apk del glibc-2.26-r0 bash
-rm /glibc-2.26-r0.apk
+npm test -- --forbid-only --forbid-pending

--- a/test/fixtures/product_fixtures.js
+++ b/test/fixtures/product_fixtures.js
@@ -44,6 +44,7 @@ module.exports = {
   validCreateProductRequest: (opts = {}) => {
     const data = {
       gateway_account_id: opts.gatewayAccountId || randomGatewayAccountId(),
+      pay_api_token: opts.payApiToken || 'pay-api-token',
       name: opts.name || 'A Product Name',
       service_name: opts.serviceName || 'Example Service',
       price: opts.price || randomPrice(),

--- a/test/integration/credentials_ft_tests.js
+++ b/test/integration/credentials_ft_tests.js
@@ -553,12 +553,11 @@ describe('Credentials endpoints', () => {
     })
 
     it('should should flash a relevant error if no password is sent', function (done) {
-
       var sendData = {'password': 'a-notification-password'}
       var path = paths.notificationCredentials.update
       buildFormPostRequest(path, sendData, true, app)
         .end((err, res) => {
-          if(err) done(err)
+          if (err) done(err)
           expect(res.statusCode).to.equal(302)
           expect(res.headers.location).to.equal(paths.notificationCredentials.edit)
           expect(session.flash.genericError).to.have.property('length').to.equal(1)
@@ -567,12 +566,11 @@ describe('Credentials endpoints', () => {
         })
     })
     it('should should flash a relevant error if no password is sent', function (done) {
-
       var sendData = {'username': 'a-notification-username'}
       var path = paths.notificationCredentials.update
       buildFormPostRequest(path, sendData, true, app)
         .end((err, res) => {
-          if(err) done(err)
+          if (err) done(err)
           expect(res.statusCode).to.equal(302)
           expect(res.headers.location).to.equal(paths.notificationCredentials.edit)
           expect(session.flash.genericError).to.have.property('length').to.equal(1)
@@ -582,12 +580,11 @@ describe('Credentials endpoints', () => {
     })
 
     it('should should flash a relevant error if too short a password is sent', function (done) {
-
       var sendData = {'username': 'a-notification-username', 'password': '123456789'}
       var path = paths.notificationCredentials.update
       buildFormPostRequest(path, sendData, true, app)
         .end((err, res) => {
-          if(err) done(err)
+          if (err) done(err)
           expect(res.statusCode).to.equal(302)
           expect(res.headers.location).to.equal(paths.notificationCredentials.edit)
           expect(session.flash.genericError).to.have.property('length').to.equal(1)

--- a/test/unit/clients/product_client/product/create_test.js
+++ b/test/unit/clients/product_client/product/create_test.js
@@ -65,6 +65,7 @@ describe('products client - create a new product', () => {
       )
         .then(() => productsClient.product.create({
           gatewayAccountId: requestPlain.gateway_account_id,
+          payApiToken: requestPlain.pay_api_token,
           name: requestPlain.name,
           price: requestPlain.price,
           serviceName: requestPlain.service_name,
@@ -106,7 +107,7 @@ describe('products client - create a new product', () => {
   describe('create a product - bad request', () => {
     before(done => {
       const productsClient = getProductsClient()
-      request = productFixtures.validCreateProductRequest()
+      request = productFixtures.validCreateProductRequest({pay_api_token: ''})
       const requestPlain = request.getPlain()
       productsMock.addInteraction(
         new PactInteractionBuilder(PRODUCT_RESOURCE)
@@ -118,6 +119,7 @@ describe('products client - create a new product', () => {
       )
         .then(() => productsClient.product.create({
           gatewayAccountId: requestPlain.gateway_account_id,
+          payApiToken: requestPlain.pay_api_token,
           name: requestPlain.name,
           price: requestPlain.price,
           description: requestPlain.description,


### PR DESCRIPTION

## WHAT

* removed commands in `docker/build_and_test.sh` after test command because:
    * they weren't needed as we ditch the image after tests run
    * because they weren't strung on to the rest of the command with `&&\` they occurred even if the build failed
 * linting fixes to get build green
 * reverted changes in products tests that had removed pay_api_token

