### PR TITLE
PP-3305 Fix validation mismatch for products creation

### DIFF
--- a/app/browsered/field-validation-checks.js
+++ b/app/browsered/field-validation-checks.js
@@ -5,7 +5,7 @@ const emailValidator = require('../utils/email_tools.js')
 
 // Constants
 const NUMBERS_ONLY = new RegExp('^[0-9]+$')
-const MAX_AMOUNT = 10000000
+const MAX_AMOUNT = 100000
 
 const validationErrors = {
   required: 'This is field cannot be blank',

--- a/test/unit/browsered/field_validation_checks_test.js
+++ b/test/unit/browsered/field_validation_checks_test.js
@@ -8,8 +8,8 @@ const {isBelowMaxAmount, isPasswordLessThanTenChars} = require('../../../app/bro
 
 describe('field validation checks', () => {
   describe('isBelowMaxAmount', () => {
-    it('should return an error string if it is passed an currency string exceeding £10 million', () => {
-      expect(isBelowMaxAmount('10000000.01')).to.equal(`Choose an amount under £10,000,000`)
+    it('should return an error string if it is passed an currency string exceeding £100 thousands', () => {
+      expect(isBelowMaxAmount('10000000.01')).to.equal(`Choose an amount under £100,000`)
     })
 
     it('should not return false if it is not passed an currency string', () => {

--- a/test/unit/controller/make_a_demo_payment_controller/index_controller_test.js
+++ b/test/unit/controller/make_a_demo_payment_controller/index_controller_test.js
@@ -236,7 +236,7 @@ describe('make a demo payment - index controller', () => {
           expect(session.flash.genericError[0]).to.equal('<h2>Use valid characters only</h2> Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”')
         })
       })
-      describe('because the value exceeds 10,000,000', () => {
+      describe('because the value exceeds 100,000', () => {
         let result, session, app
         before('Arrange', () => {
           nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
@@ -271,7 +271,7 @@ describe('make a demo payment - index controller', () => {
         it('should add a relevant error message to the session \'flash\'', () => {
           expect(session.flash).to.have.property('genericError')
           expect(session.flash.genericError.length).to.equal(1)
-          expect(session.flash.genericError[0]).to.equal('<h2>Enter a valid amount</h2> Choose an amount under £10,000,000')
+          expect(session.flash.genericError[0]).to.equal('<h2>Enter a valid amount</h2> Choose an amount under £100,000')
         })
       })
     })

--- a/test/unit/controller/test_with_your_users_controller/submit_controller_test.js
+++ b/test/unit/controller/test_with_your_users_controller/submit_controller_test.js
@@ -265,7 +265,7 @@ describe('test with your users - submit controller', () => {
           expect(session.flash.genericError[0]).to.equal('<h2>Use valid characters only</h2> Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”')
         })
       })
-      describe('because the value exceeds 10,000,000', () => {
+      describe('because the value exceeds 100,000', () => {
         let result, session, app
         before('Arrange', () => {
           nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
@@ -298,7 +298,7 @@ describe('test with your users - submit controller', () => {
         it('should add a relevant error message to the session \'flash\'', () => {
           expect(session.flash).to.have.property('genericError')
           expect(session.flash.genericError.length).to.equal(1)
-          expect(session.flash.genericError[0]).to.equal('<h2>Enter a valid amount</h2> Choose an amount under £10,000,000')
+          expect(session.flash.genericError[0]).to.equal('<h2>Enter a valid amount</h2> Choose an amount under £100,000')
         })
       })
     })


### PR DESCRIPTION
- At the point of payment creation the validator MAX_PRICE is set to pounds while
       the incoming payload's `price` field is in pence.

with @kakumara


