### PR TITLE
[REVIEW-ONLY] PP-3239 migrating to transactions search API

### DIFF
--- a/app/controllers/transactions/transaction_download_controller.js
+++ b/app/controllers/transactions/transaction_download_controller.js
@@ -10,14 +10,12 @@ const auth = require('../../services/auth_service.js')
 const date = require('../../utils/dates.js')
 const {renderErrorView} = require('../../utils/response.js')
 const {CORRELATION_HEADER} = require('../../utils/correlation_header.js')
-const REFUNDS_IN_TRANSACTION_LIST_FEATURE_HEADER = 'REFUNDS_IN_TX_LIST'
 
 module.exports = (req, res) => {
   const accountId = auth.getCurrentGatewayAccountId(req)
   const filters = req.query
   const name = `GOVUK Pay ${date.dateToDefaultFormat(new Date())}.csv`
   const correlationId = req.headers[CORRELATION_HEADER]
-  filters.refundReportingEnabled = req.user.hasFeature(REFUNDS_IN_TRANSACTION_LIST_FEATURE_HEADER)
   transactionService.searchAll(accountId, filters, correlationId)
     .then(json => jsonToCsv(json.results))
     .then(csv => {

--- a/app/controllers/transactions/transaction_list_controller.js
+++ b/app/controllers/transactions/transaction_list_controller.js
@@ -17,7 +17,6 @@ const states = require('../../utils/states')
 const client = new ConnectorClient(process.env.CONNECTOR_URL)
 
 const {CORRELATION_HEADER} = require('../../utils/correlation_header.js')
-const REFUNDS_IN_TRANSACTION_LIST_FEATURE_HEADER = 'REFUNDS_IN_TX_LIST'
 
 module.exports = (req, res) => {
   const accountId = auth.getCurrentGatewayAccountId(req)
@@ -34,7 +33,7 @@ module.exports = (req, res) => {
           const model = buildPaymentList(transactions, allCards, accountId, filters.result)
           model.search_path = router.paths.transactions.index
           model.filtersDescription = describeFilters(filters.result)
-          model.eventStates = req.user.hasFeature(REFUNDS_IN_TRANSACTION_LIST_FEATURE_HEADER) ? states.states() : states.payment_states()
+          model.eventStates = states.states()
           model.eventStates.forEach(state => {
             const relevantFilter = (state.type === 'payment' ? filters.result.payment_states : filters.result.refund_states) || []
             state.value.selected = relevantFilter.includes(state.name)

--- a/app/controllers/transactions/transaction_list_controller.js
+++ b/app/controllers/transactions/transaction_list_controller.js
@@ -26,7 +26,6 @@ module.exports = (req, res) => {
 
   req.session.filters = url.parse(req.url).query
   if (!filters.valid) return error('Invalid search')
-  filters.result.refundReportingEnabled = req.user.hasFeature(REFUNDS_IN_TRANSACTION_LIST_FEATURE_HEADER)
   transactionService
     .search(accountId, filters.result, correlationId)
     .then(transactions => {

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -18,6 +18,7 @@ var CHARGES_API_PATH = ACCOUNT_API_PATH + '/charges'
 var CHARGE_API_PATH = CHARGES_API_PATH + '/{chargeId}'
 var CHARGE_REFUNDS_API_PATH = CHARGE_API_PATH + '/refunds'
 var CARD_TYPES_API_PATH = '/v1/api/card-types'
+const TRANSACTIONS_API_PATH = ACCOUNT_API_PATH + '/transactions'
 
 var ACCOUNTS_FRONTEND_PATH = '/v1/frontend/accounts'
 var ACCOUNT_FRONTEND_PATH = ACCOUNTS_FRONTEND_PATH + '/{accountId}'
@@ -122,7 +123,7 @@ var _getTransactionSummaryUrlFor = function (accountID, period) {
 }
 
 function searchUrl (baseUrl, params) {
-  return baseUrl + CHARGES_API_PATH.replace('{accountId}', params.gatewayAccountId) + '?' + getQueryStringForParams(params)
+  return baseUrl + TRANSACTIONS_API_PATH.replace('{accountId}', params.gatewayAccountId) + '?' + getQueryStringForParams(params)
 }
 
 /**

--- a/app/utils/filters.js
+++ b/app/utils/filters.js
@@ -47,7 +47,6 @@ function getFilters (req) {
     filters.refund_states = states.filter(state => state.includes('refund-')).map(state => state.replace('refund-', ''))
     filters.state = [...filters.payment_states, ...filters.refund_states][0]
   }
-
   filters = _.omitBy(filters, _.isEmpty)
   return {
     valid: validateFilters(filters),

--- a/app/utils/get_query_string_for_params.js
+++ b/app/utils/get_query_string_for_params.js
@@ -14,16 +14,11 @@ function getQueryStringForParams (params = {}) {
     display_size: params.pageSize || 100
   }
 
-  if (params.refundReportingEnabled) {
-    if (params.payment_states) {
-      queryStrings.payment_states = params.payment_states instanceof Array ? params.payment_states.join(',') : params.payment_states
-    }
-    if (params.refund_states) {
-      queryStrings.refund_states = params.refund_states instanceof Array ? params.refund_states.join(',') : params.refund_states
-    }
-    queryStrings.state = ''
-  } else {
-    queryStrings.state = params.state
+  if (params.payment_states) {
+    queryStrings.payment_states = params.payment_states
+  }
+  if (params.refund_states) {
+    queryStrings.refund_states = params.refund_states
   }
 
   return querystring.stringify(queryStrings)

--- a/test/integration/pagination_ft_tests.js
+++ b/test/integration/pagination_ft_tests.js
@@ -13,7 +13,7 @@ var app
 
 var gatewayAccountId = '452345'
 
-var CONNECTOR_CHARGES_SEARCH_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges'
+var CONNECTOR_CHARGES_SEARCH_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/transactions'
 var CONNECTOR_ALL_CARD_TYPES_API_PATH = '/v1/api/card-types'
 
 var connectorMock = nock(process.env.CONNECTOR_URL)

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -16,7 +16,7 @@ var getQueryStringForParams = require('../../app/utils/get_query_string_for_para
 var gatewayAccountId = '651342'
 var app
 
-var CHARGES_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges'
+var CHARGES_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/transactions'
 var connectorMock = nock(process.env.CONNECTOR_URL)
 
 function connectorMockResponds (code, data, searchParameters) {

--- a/test/integration/transaction_list_ft_tests.js
+++ b/test/integration/transaction_list_ft_tests.js
@@ -318,33 +318,6 @@ describe('The /transactions endpoint', function () {
       .end(done)
   })
 
-  it('should only allow filtering by charge states', function (done) {
-    connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-      .reply(200, ALL_CARD_TYPES)
-
-    var connectorData = {
-      'results': []
-    }
-
-    connectorMockResponds(200, connectorData, searchParameters)
-
-    getTransactionList()
-      .expect(200)
-      .expect(function (res) {
-        expect(res.body.eventStates).property('length').to.equal(7)
-        expect(res.body.eventStates.map(state => state.value.text)).to.deep.equal([
-          'Created',
-          'Started',
-          'Submitted',
-          'Success',
-          'Error',
-          'Failed',
-          'Cancelled'
-        ])
-      })
-      .end(done)
-  })
-
   //
   // PP-1158 Fix 3 selfservice problematic tests in transaction_list_ft_tests
   //
@@ -456,7 +429,7 @@ describe('The /transactions endpoint (when feature flag: \'REFUNDS_IN_TX_LIST\' 
       'results': []
     }
 
-    connectorMockResponds(200, connectorData, {state: 'started', payment_states: 'started', refundReportingEnabled: true})
+    connectorMockResponds(200, connectorData, {state: 'started', payment_states: 'started'})
 
     request(app)
       .get(paths.transactions.index + '?state=payment-started')
@@ -490,7 +463,7 @@ describe('The /transactions endpoint (when feature flag: \'REFUNDS_IN_TX_LIST\' 
       'results': []
     }
 
-    connectorMockResponds(200, connectorData, {state: 'started', refund_states: 'started', refundReportingEnabled: true})
+    connectorMockResponds(200, connectorData, {state: 'started', refund_states: 'started'})
 
     request(app)
       .get(paths.transactions.index + '?state=refund-started')

--- a/test/integration/transaction_list_ft_tests.js
+++ b/test/integration/transaction_list_ft_tests.js
@@ -16,7 +16,7 @@ const DISPLAY_DATE = '10 Feb 2016 — 12:44:01'
 const gatewayAccountId = '651342'
 const {expect} = chai
 const searchParameters = {}
-const CONNECTOR_CHARGES_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges'
+const CONNECTOR_CHARGES_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/transactions'
 const CONNECTOR_ALL_CARD_TYPES_API_PATH = '/v1/api/card-types'
 const ALL_CARD_TYPES = {
   'card_types': [

--- a/test/unit/services/transaction_service_test.js
+++ b/test/unit/services/transaction_service_test.js
@@ -67,17 +67,17 @@ describe('transaction service', () => {
 
       it('should return into the correct promise when it uses the new  \'refund_states\' method of querying refund states and multiple have been selected', () => {
         nock(process.env.CONNECTOR_URL)
-          .get(`${TRANSACTION_SEARCH_PATH}?${getQueryStringForParams({pageSize: 100, page: 1, refund_states: ['refund_success', 'refund_error'], refundReportingEnabled: true})}`)
+          .get(`${TRANSACTION_SEARCH_PATH}?${getQueryStringForParams({pageSize: 100, page: 1, refund_states: ['refund_success', 'refund_error']})}`)
           .reply(200, {})
-        return expect(transactionService.searchAll(TEST_ACCOUNT_ID, {pageSize: 100, page: 1, refund_states: ['refund_success', 'refund_error'], refundReportingEnabled: true}, 'some-unique-id'))
+        return expect(transactionService.searchAll(TEST_ACCOUNT_ID, {pageSize: 100, page: 1, refund_states: ['refund_success', 'refund_error']}, 'some-unique-id'))
           .to.eventually.be.fulfilled
       })
 
       it('should return into the correct promise when it uses the new  \'refund_states\' method of querying refund states and only one has been selected', () => {
         nock(process.env.CONNECTOR_URL)
-          .get(`${TRANSACTION_SEARCH_PATH}?${getQueryStringForParams({pageSize: 100, page: 1, refund_states: 'refund_success', refundReportingEnabled: true})}`)
+          .get(`${TRANSACTION_SEARCH_PATH}?${getQueryStringForParams({pageSize: 100, page: 1, refund_states: 'refund_success'})}`)
           .reply(200, {})
-        return expect(transactionService.searchAll(TEST_ACCOUNT_ID, {pageSize: 100, page: 1, refund_states: 'refund_success', refundReportingEnabled: true}, 'some-unique-id'))
+        return expect(transactionService.searchAll(TEST_ACCOUNT_ID, {pageSize: 100, page: 1, refund_states: 'refund_success'}, 'some-unique-id'))
           .to.eventually.be.fulfilled
       })
 

--- a/test/unit/services/transaction_service_test.js
+++ b/test/unit/services/transaction_service_test.js
@@ -8,6 +8,8 @@ const chaiAsPromised = require('chai-as-promised')
 // Local Dependencies
 const transactionService = require('../../../app/services/transaction_service')
 var getQueryStringForParams = require('../../../app/utils/get_query_string_for_params')
+const TEST_ACCOUNT_ID = 123
+const TRANSACTION_SEARCH_PATH = `/v1/api/accounts/${TEST_ACCOUNT_ID}/transactions`
 
 const {expect} = chai
 chai.use(chaiAsPromised)
@@ -21,19 +23,19 @@ describe('transaction service', () => {
         nock.cleanAll()
 
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams()}`)
+          .get(`${TRANSACTION_SEARCH_PATH}?${getQueryStringForParams()}`)
           .reply(200, {})
       })
 
       it('should return the correct promise', () => {
-        return expect(transactionService.search(123, {}, 'some-unique-id'))
+        return expect(transactionService.search(TEST_ACCOUNT_ID, {}, 'some-unique-id'))
           .to.eventually.be.fulfilled
       })
     })
 
     describe('when connector is unavailable', () => {
       it('should return client unavailable', () => {
-        return expect(transactionService.search(123, {}, 'some-unique-id'))
+        return expect(transactionService.search(TEST_ACCOUNT_ID, {}, 'some-unique-id'))
             .to.be.rejectedWith(Error, 'CLIENT_UNAVAILABLE')
       }
       )
@@ -42,12 +44,12 @@ describe('transaction service', () => {
     describe('when connector returns incorrect response code while retrieving the list of transactions', () => {
       before(() => {
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams()}`)
+          .get(`${TRANSACTION_SEARCH_PATH}?${getQueryStringForParams()}`)
           .reply(404, '')
       })
 
       it('should return get_failed', () => {
-        return expect(transactionService.search(123, {}, 'some-unique-id'))
+        return expect(transactionService.search(TEST_ACCOUNT_ID, {}, 'some-unique-id'))
           .to.be.rejectedWith(Error, 'GET_FAILED')
       })
     })
@@ -57,40 +59,40 @@ describe('transaction service', () => {
     describe('when connector returns correctly', () => {
       it('should return into the correct promise when it uses the legacy \'state\' method of querying states', () => {
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams({pageSize: 100, page: 1, state: 'success'})}`)
+          .get(`${TRANSACTION_SEARCH_PATH}?${getQueryStringForParams({pageSize: 100, page: 1, state: 'success'})}`)
           .reply(200, {})
-        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, state: 'success'}, 'some-unique-id'))
+        return expect(transactionService.searchAll(TEST_ACCOUNT_ID, {pageSize: 100, page: 1, state: 'success'}, 'some-unique-id'))
           .to.eventually.be.fulfilled
       })
 
       it('should return into the correct promise when it uses the new  \'refund_states\' method of querying refund states and multiple have been selected', () => {
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams({pageSize: 100, page: 1, refund_states: ['refund_success', 'refund_error'], refundReportingEnabled: true})}`)
+          .get(`${TRANSACTION_SEARCH_PATH}?${getQueryStringForParams({pageSize: 100, page: 1, refund_states: ['refund_success', 'refund_error'], refundReportingEnabled: true})}`)
           .reply(200, {})
-        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, refund_states: ['refund_success', 'refund_error'], refundReportingEnabled: true}, 'some-unique-id'))
+        return expect(transactionService.searchAll(TEST_ACCOUNT_ID, {pageSize: 100, page: 1, refund_states: ['refund_success', 'refund_error'], refundReportingEnabled: true}, 'some-unique-id'))
           .to.eventually.be.fulfilled
       })
 
       it('should return into the correct promise when it uses the new  \'refund_states\' method of querying refund states and only one has been selected', () => {
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams({pageSize: 100, page: 1, refund_states: 'refund_success', refundReportingEnabled: true})}`)
+          .get(`${TRANSACTION_SEARCH_PATH}?${getQueryStringForParams({pageSize: 100, page: 1, refund_states: 'refund_success', refundReportingEnabled: true})}`)
           .reply(200, {})
-        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, refund_states: 'refund_success', refundReportingEnabled: true}, 'some-unique-id'))
+        return expect(transactionService.searchAll(TEST_ACCOUNT_ID, {pageSize: 100, page: 1, refund_states: 'refund_success', refundReportingEnabled: true}, 'some-unique-id'))
           .to.eventually.be.fulfilled
       })
 
       it('should return into the correct promise', () => {
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams()}`)
+          .get(`${TRANSACTION_SEARCH_PATH}?${getQueryStringForParams()}`)
           .reply(200, {})
-        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1}, 'some-unique-id'))
+        return expect(transactionService.searchAll(TEST_ACCOUNT_ID, {pageSize: 100, page: 1}, 'some-unique-id'))
           .to.eventually.be.fulfilled
       })
     })
 
     describe('when connector is unavailable', () => {
       it('should return client unavailable', () => {
-        return expect(transactionService.searchAll(123, {pageSize: 1, page: 100}, 'some-unique-id'))
+        return expect(transactionService.searchAll(TEST_ACCOUNT_ID, {pageSize: 1, page: 100}, 'some-unique-id'))
             .to.be.rejectedWith(Error, 'CLIENT_UNAVAILABLE')
       }
       )
@@ -99,12 +101,12 @@ describe('transaction service', () => {
     describe('when connector returns incorrect response code', () => {
       before(() => {
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams()}`)
+          .get(`${TRANSACTION_SEARCH_PATH}?${getQueryStringForParams()}`)
           .reply(404, '')
       })
 
       it('should return GET_FAILED', () => {
-        return expect(transactionService.searchAll(123, {pageSize: 100, page: 1}, 'some-unique-id'))
+        return expect(transactionService.searchAll(TEST_ACCOUNT_ID, {pageSize: 100, page: 1}, 'some-unique-id'))
           .to.be.rejectedWith(Error, 'GET_FAILED')
       })
     })


### PR DESCRIPTION
[DO-NOT_MERGE] 
_Just review and keep it ready, as we are still debating to use this new API or keep the old API. If all boxes ticks, we can merge this later_

## WHAT
Until now we've been searching using the search charges API (with the feature flag enabling to search for refunds using a UNION query).
We now have a new API for transactions search (using `/transactions` endpoint) which uses the refactored data structures. This PR migrates the selfservice search transactions/download CSV features to use the new endpoint.

- Updated connector_client to user the new endpoint
- removed the need for feature flag
- Updated tests to depict the changes as well as a new test to test multi select `state` query

Not sure if `state` param still needs sending to connector (Possibly not). Leaving it for now to remove in a later PR.