### PR TITLE
PP-3295 Service name validation. Register user - add service name

### DIFF
--- a/app/utils/registration_validations.js
+++ b/app/utils/registration_validations.js
@@ -11,6 +11,7 @@ const emailValidator = require('../utils/email_tools.js')
 // Constants
 const MIN_PHONE_NUMBER_LENGTH = 11
 const MIN_PASSWORD_LENGTH = 10
+const MAX_SERVICE_NAME_LENGTH = 50
 const NUMBERS_ONLY = new RegExp('^[0-9]+$')
 
 // Global functions
@@ -116,10 +117,12 @@ module.exports = {
   validateServiceNamingInputs: (serviceName) => {
     const defer = q.defer()
 
-    if (hasValue(serviceName)) {
-      defer.resolve()
-    } else {
+    if (!hasValue(serviceName)) {
       defer.reject('Invalid service name')
+    } else if (_.trim(serviceName).length > MAX_SERVICE_NAME_LENGTH) {
+      defer.reject('Your service name is too long')
+    } else {
+      defer.resolve()
     }
 
     return defer.promise

--- a/test/unit/utils/registration_validations_test.js
+++ b/test/unit/utils/registration_validations_test.js
@@ -254,5 +254,13 @@ describe('registration_validation module', function () {
         expect(response).to.equal('Invalid service name')
       }).should.notify(done)
     })
+
+    it('should error if service name length is longer than 50 characters', function (done) {
+      const invalidServiceName = 'Wb7a9RbjhI0tDEkmZuuUuiblHhiNwiRyLwXPcQcbhSguFKjDOkh'
+
+      validation.validateServiceNamingInputs(invalidServiceName).should.be.rejected.then(response => {
+        expect(response).to.equal('Your service name is too long')
+      }).should.notify(done)
+    })
   })
 })


### PR DESCRIPTION
## WHAT
- Add 50 characters max length validation for service name when registering a new user. This has been added for consistency across all the microservices.


