### PR TITLE
PP-3191 - adding virtual pageview so we can track signups

### DIFF
--- a/app/browsered.js
+++ b/app/browsered.js
@@ -13,5 +13,5 @@ window.$ = window.jQuery = $
 multiSelects.enableMultiSelects()
 fieldValidation.enableFieldValidation()
 dashboardActivity.init()
-dashboardActivity.init()
 analytics.eventTracking.init()
+analytics.virtualPageview.init()

--- a/app/views/self_create_service/set_name.njk
+++ b/app/views/self_create_service/set_name.njk
@@ -6,7 +6,7 @@
 
 {% block mainContent %}
 <div id="display-name-your-service" class="column-two-thirds">
-  <form action="{{routes.selfCreateService.serviceNaming}}" method="post" class="form submit-two-fa" id="name-your-service-form">
+  <form action="{{routes.selfCreateService.serviceNaming}}" method="post" class="form submit-two-fa" id="name-your-service-form" data-virtual-pageview="/service/registration-complete" data-parameters="dimension1:service-name">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
     <h1 class="form-title heading-large">What service will you be taking payments for?</h1>
     <div class="form-group">

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "eslint": "^3.0.0",
     "express-writer": "0.0.4",
     "fresh-require": "^1.0.3",
-    "gaap-analytics": "^2.2.1",
+    "gaap-analytics": "^3.0.0",
     "govuk-elements-sass": "3.1.2",
     "govuk_frontend_toolkit": "7.2.0",
     "govuk_template_jinja": "^0.23.0",


### PR DESCRIPTION
We want to be able to track signups as a goal to see if people are dropping off through the journey, but to do this we need a definitive end, so over on [GaaP Analytics](https://github.com/alphagov/gaap-analytics/pull/4) I added the ability to do so. This PR just updates our version of the npm module and inserts the markup