### PR TITLE
Prevent static assets from being included in passport user deserialisation

### DIFF
--- a/server.js
+++ b/server.js
@@ -151,12 +151,12 @@ function initialise () {
   app.disable('x-powered-by')
   app.use(flash())
   initialiseTLS(app)
+  initialisePublic(app)
   initialiseCookies(app)
   initialiseAuth(app)
   initialiseGlobalMiddleware(app)
   initialiseTemplateEngine(app)
   initialiseRoutes(app)
-  initialisePublic(app)
   initialiseErrorHandling(app)
 
   warnIfAnalyticsNotSet()


### PR DESCRIPTION
## WHAT
Moves the initialisation of static asset handling higher up in the express configuration, which will remove them from the passport user serialisation middleware flow.

Results in a 12x reduction in calls to adminusers on common page requests and smoke tests.


