### PR TITLE
PP-3382 Delete REFUNDS_IN_TX_LIST feature flag

### DIFF
--- a/app/controllers/transactions/transaction_download_controller.js
+++ b/app/controllers/transactions/transaction_download_controller.js
@@ -10,14 +10,12 @@ const auth = require('../../services/auth_service.js')
 const date = require('../../utils/dates.js')
 const {renderErrorView} = require('../../utils/response.js')
 const {CORRELATION_HEADER} = require('../../utils/correlation_header.js')
-const REFUNDS_IN_TRANSACTION_LIST_FEATURE_HEADER = 'REFUNDS_IN_TX_LIST'
 
 module.exports = (req, res) => {
   const accountId = auth.getCurrentGatewayAccountId(req)
   const filters = req.query
   const name = `GOVUK Pay ${date.dateToDefaultFormat(new Date())}.csv`
   const correlationId = req.headers[CORRELATION_HEADER]
-  filters.refundReportingEnabled = req.user.hasFeature(REFUNDS_IN_TRANSACTION_LIST_FEATURE_HEADER)
   transactionService.searchAll(accountId, filters, correlationId)
     .then(json => jsonToCsv(json.results))
     .then(csv => {

--- a/app/controllers/transactions/transaction_list_controller.js
+++ b/app/controllers/transactions/transaction_list_controller.js
@@ -17,7 +17,6 @@ const states = require('../../utils/states')
 const client = new ConnectorClient(process.env.CONNECTOR_URL)
 
 const {CORRELATION_HEADER} = require('../../utils/correlation_header.js')
-const REFUNDS_IN_TRANSACTION_LIST_FEATURE_HEADER = 'REFUNDS_IN_TX_LIST'
 
 module.exports = (req, res) => {
   const accountId = auth.getCurrentGatewayAccountId(req)
@@ -26,7 +25,6 @@ module.exports = (req, res) => {
 
   req.session.filters = url.parse(req.url).query
   if (!filters.valid) return error('Invalid search')
-  filters.result.refundReportingEnabled = req.user.hasFeature(REFUNDS_IN_TRANSACTION_LIST_FEATURE_HEADER)
   transactionService
     .search(accountId, filters.result, correlationId)
     .then(transactions => {
@@ -35,7 +33,7 @@ module.exports = (req, res) => {
           const model = buildPaymentList(transactions, allCards, accountId, filters.result)
           model.search_path = router.paths.transactions.index
           model.filtersDescription = describeFilters(filters.result)
-          model.eventStates = req.user.hasFeature(REFUNDS_IN_TRANSACTION_LIST_FEATURE_HEADER) ? states.states() : states.payment_states()
+          model.eventStates = states.states()
           model.eventStates.forEach(state => {
             const relevantFilter = (state.type === 'payment' ? filters.result.payment_states : filters.result.refund_states) || []
             state.value.selected = relevantFilter.includes(state.name)

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -1,9 +1,9 @@
 'use strict'
-var _ = require('lodash')
-var util = require('util')
-var EventEmitter = require('events').EventEmitter
-var logger = require('winston')
-var querystring = require('querystring')
+const _ = require('lodash')
+const util = require('util')
+const EventEmitter = require('events').EventEmitter
+const logger = require('winston')
+const querystring = require('querystring')
 const q = require('q')
 
 const baseClient = require('./old_base_client')
@@ -12,22 +12,23 @@ const createCallbackToPromiseConverter = require('../../utils/response_converter
 const getQueryStringForParams = require('../../utils/get_query_string_for_params')
 
 const SERVICE_NAME = 'connector'
-var ACCOUNTS_API_PATH = '/v1/api/accounts'
-var ACCOUNT_API_PATH = ACCOUNTS_API_PATH + '/{accountId}'
-var CHARGES_API_PATH = ACCOUNT_API_PATH + '/charges'
-var CHARGE_API_PATH = CHARGES_API_PATH + '/{chargeId}'
-var CHARGE_REFUNDS_API_PATH = CHARGE_API_PATH + '/refunds'
-var CARD_TYPES_API_PATH = '/v1/api/card-types'
+const ACCOUNTS_API_PATH = '/v1/api/accounts'
+const ACCOUNT_API_PATH = ACCOUNTS_API_PATH + '/{accountId}'
+const CHARGES_API_PATH = ACCOUNT_API_PATH + '/charges'
+const V2_CHARGES_API_PATH = '/v2/api/accounts/{accountId}/charges'
+const CHARGE_API_PATH = CHARGES_API_PATH + '/{chargeId}'
+const CHARGE_REFUNDS_API_PATH = CHARGE_API_PATH + '/refunds'
+const CARD_TYPES_API_PATH = '/v1/api/card-types'
 
-var ACCOUNTS_FRONTEND_PATH = '/v1/frontend/accounts'
-var ACCOUNT_FRONTEND_PATH = ACCOUNTS_FRONTEND_PATH + '/{accountId}'
-var SERVICE_NAME_FRONTEND_PATH = ACCOUNT_FRONTEND_PATH + '/servicename'
-var ACCEPTED_CARD_TYPES_FRONTEND_PATH = ACCOUNT_FRONTEND_PATH + '/card-types'
-var ACCOUNT_NOTIFICATION_CREDENTIALS_PATH = '/v1/api/accounts' + '/{accountId}' + '/notification-credentials'
-var ACCOUNT_CREDENTIALS_PATH = ACCOUNT_FRONTEND_PATH + '/credentials'
-var EMAIL_NOTIFICATION__PATH = '/v1/api/accounts/{accountId}/email-notification'
-var TOGGLE_3DS_PATH = ACCOUNTS_FRONTEND_PATH + '/{accountId}/3ds-toggle'
-var TRANSACTIONS_SUMMARY = ACCOUNTS_API_PATH + '/{accountId}/transactions-summary'
+const ACCOUNTS_FRONTEND_PATH = '/v1/frontend/accounts'
+const ACCOUNT_FRONTEND_PATH = ACCOUNTS_FRONTEND_PATH + '/{accountId}'
+const SERVICE_NAME_FRONTEND_PATH = ACCOUNT_FRONTEND_PATH + '/servicename'
+const ACCEPTED_CARD_TYPES_FRONTEND_PATH = ACCOUNT_FRONTEND_PATH + '/card-types'
+const ACCOUNT_NOTIFICATION_CREDENTIALS_PATH = '/v1/api/accounts' + '/{accountId}' + '/notification-credentials'
+const ACCOUNT_CREDENTIALS_PATH = ACCOUNT_FRONTEND_PATH + '/credentials'
+const EMAIL_NOTIFICATION__PATH = '/v1/api/accounts/{accountId}/email-notification'
+const TOGGLE_3DS_PATH = ACCOUNTS_FRONTEND_PATH + '/{accountId}/3ds-toggle'
+const TRANSACTIONS_SUMMARY = ACCOUNTS_API_PATH + '/{accountId}/transactions-summary'
 
 /**
  * @private
@@ -122,7 +123,7 @@ var _getTransactionSummaryUrlFor = function (accountID, period) {
 }
 
 function searchUrl (baseUrl, params) {
-  return baseUrl + CHARGES_API_PATH.replace('{accountId}', params.gatewayAccountId) + '?' + getQueryStringForParams(params)
+  return baseUrl + V2_CHARGES_API_PATH.replace('{accountId}', params.gatewayAccountId) + '?' + getQueryStringForParams(params)
 }
 
 /**
@@ -172,6 +173,7 @@ ConnectorClient.prototype = {
   getAllTransactions (params, successCallback) {
     var results = []
     var connectorClient = this
+    params.pageSize = params.pageSize || 500
     var recursiveRetrieve = function (recursiveParams) {
       connectorClient.searchTransactions(recursiveParams, function (data) {
         var next = _.get(data, '_links.next_page')
@@ -200,7 +202,7 @@ ConnectorClient.prototype = {
    * @returns {ConnectorClient}
    */
   getCharge: function (params, successCallback) {
-    var url = _chargeUrlFor(params.gatewayAccountId, params.chargeId, this.connectorUrl)
+    let url = _chargeUrlFor(params.gatewayAccountId, params.chargeId, this.connectorUrl)
     logger.debug('Calling connector to get charge -', {
       service: 'connector',
       method: 'GET',
@@ -222,7 +224,7 @@ ConnectorClient.prototype = {
    * @returns {ConnectorClient}
    */
   getChargeEvents: function (params, successCallback) {
-    var url = _chargeUrlFor(params.gatewayAccountId, params.chargeId, this.connectorUrl) + '/events'
+    let url = _chargeUrlFor(params.gatewayAccountId, params.chargeId, this.connectorUrl) + '/events'
     logger.debug('Calling connector to get events -', {
       service: 'connector',
       method: 'GET',
@@ -242,7 +244,7 @@ ConnectorClient.prototype = {
    *@return {Promise}
    */
   getAccount: function (params) {
-    var url = _accountUrlFor(params.gatewayAccountId, this.connectorUrl)
+    let url = _accountUrlFor(params.gatewayAccountId, this.connectorUrl)
     let defer = q.defer()
     let startTime = new Date()
     let context = {
@@ -318,7 +320,7 @@ ConnectorClient.prototype = {
    * @returns {ConnectorClient}
    */
   patchAccountCredentials: function (params, successCallback) {
-    var url = _accountCredentialsUrlFor(params.gatewayAccountId, this.connectorUrl)
+    let url = _accountCredentialsUrlFor(params.gatewayAccountId, this.connectorUrl)
 
     logger.debug('Calling connector to get account -', {
       service: 'connector',
@@ -337,7 +339,7 @@ ConnectorClient.prototype = {
    * @returns {ConnectorClient}
    */
   postAccountNotificationCredentials: function (params, successCallback) {
-    var url = _accountNotificationCredentialsUrlFor(params.gatewayAccountId, this.connectorUrl)
+    let url = _accountNotificationCredentialsUrlFor(params.gatewayAccountId, this.connectorUrl)
 
     logger.debug('Calling connector to get account -', {
       service: 'connector',
@@ -359,7 +361,7 @@ ConnectorClient.prototype = {
    *          Callback function upon retrieving accepted cards successfully
    */
   getAcceptedCardsForAccount: function (params, successCallback) {
-    var url = _accountAcceptedCardTypesUrlFor(params.gatewayAccountId, this.connectorUrl)
+    let url = _accountAcceptedCardTypesUrlFor(params.gatewayAccountId, this.connectorUrl)
     logger.debug('Calling connector to get accepted card types for account -', {
       service: 'connector',
       method: 'GET',
@@ -380,7 +382,7 @@ ConnectorClient.prototype = {
    *          Callback function upon saving accepted cards successfully
    */
   postAcceptedCardsForAccount: function (params, successCallback) {
-    var url = _accountAcceptedCardTypesUrlFor(params.gatewayAccountId, this.connectorUrl)
+    let url = _accountAcceptedCardTypesUrlFor(params.gatewayAccountId, this.connectorUrl)
     logger.debug('Calling connector to post accepted card types for account -', {
       service: 'connector',
       method: 'POST',
@@ -404,7 +406,7 @@ ConnectorClient.prototype = {
       successCallback = params
     }
 
-    var url = _cardTypesUrlFor(this.connectorUrl)
+    let url = _cardTypesUrlFor(this.connectorUrl)
     logger.debug('Calling connector to get all card types -', {
       service: 'connector',
       method: 'GET',
@@ -464,7 +466,7 @@ ConnectorClient.prototype = {
    *          Callback function for successful refunds
    */
   postChargeRefund: function (params, successCallback) {
-    var url = _chargeRefundsUrlFor(params.gatewayAccountId, params.chargeId, this.connectorUrl)
+    let url = _chargeRefundsUrlFor(params.gatewayAccountId, params.chargeId, this.connectorUrl)
     logger.debug('Calling connector to post a refund for payment -', {
       service: 'connector',
       method: 'POST',
@@ -483,7 +485,7 @@ ConnectorClient.prototype = {
    * @param {Function} successCallback
    */
   getNotificationEmail: function (params, successCallback) {
-    var url = _getNotificationEmailUrlFor(params.gatewayAccountId)
+    let url = _getNotificationEmailUrlFor(params.gatewayAccountId)
     baseClient.get(url, params, this.responseHandler(successCallback))
 
     return this
@@ -495,7 +497,7 @@ ConnectorClient.prototype = {
    * @param {Function} successCallback
    */
   updateNotificationEmail: function (params, successCallback) {
-    var url = _getNotificationEmailUrlFor(params.gatewayAccountId)
+    let url = _getNotificationEmailUrlFor(params.gatewayAccountId)
     baseClient.post(url, params, this.responseHandler(successCallback))
 
     return this
@@ -507,7 +509,7 @@ ConnectorClient.prototype = {
    * @param {Function} successCallback
    */
   updateNotificationEmailEnabled: function (params, successCallback) {
-    var url = _getNotificationEmailUrlFor(params.gatewayAccountId)
+    let url = _getNotificationEmailUrlFor(params.gatewayAccountId)
     baseClient.patch(url, params, this.responseHandler(successCallback))
 
     return this
@@ -519,7 +521,7 @@ ConnectorClient.prototype = {
    * @param {Function} successCallback
    */
   update3dsEnabled: function (params, successCallback) {
-    var url = _getToggle3dsUrlFor(params.gatewayAccountId)
+    let url = _getToggle3dsUrlFor(params.gatewayAccountId)
     baseClient.patch(url, params, this.responseHandler(successCallback))
     return this
   },
@@ -535,7 +537,7 @@ ConnectorClient.prototype = {
       to_date: params.toDateTime
     }
     const period = querystring.stringify(queryStrings)
-    var url = _getTransactionSummaryUrlFor(params.gatewayAccountId, period)
+    let url = _getTransactionSummaryUrlFor(params.gatewayAccountId, period)
     baseClient.get(url, params, this.responseHandler(successCallback))
 
     return this

--- a/app/services/clients/old_base_client.js
+++ b/app/services/clients/old_base_client.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const path = require('path')
 const https = require('https')
 const httpAgent = require('http').globalAgent

--- a/app/utils/filters.js
+++ b/app/utils/filters.js
@@ -1,13 +1,15 @@
-var qs = require('qs')
-var check = require('check-types')
-var Paginator = require('../utils/paginator.js')
-var _ = require('lodash')
+'use strict'
+
+const qs = require('qs')
+const check = require('check-types')
+const Paginator = require('../utils/paginator.js')
+const _ = require('lodash')
 
 function validateFilters (filters) {
-  var pageSizeIsNull = !check.assigned(filters.pageSize)
-  var pageSizeInRange = check.inRange(Number(filters.pageSize), 1, Paginator.MAX_PAGE_SIZE)
-  var pageIsNull = !check.assigned(filters.page)
-  var pageIsPositive = check.positive(Number(filters.page))
+  let pageSizeIsNull = !check.assigned(filters.pageSize)
+  let pageSizeInRange = check.inRange(Number(filters.pageSize), 1, Paginator.MAX_PAGE_SIZE)
+  let pageIsNull = !check.assigned(filters.page)
+  let pageIsPositive = check.positive(Number(filters.page))
   return (pageSizeIsNull || pageSizeInRange) &&
     (pageIsNull || pageIsPositive)
 }
@@ -45,9 +47,7 @@ function getFilters (req) {
     const states = typeof filters.state === 'string' ? [filters.state] : filters.state
     filters.payment_states = states.filter(state => !state.includes('refund-')).map(state => state.replace('payment-', ''))
     filters.refund_states = states.filter(state => state.includes('refund-')).map(state => state.replace('refund-', ''))
-    filters.state = [...filters.payment_states, ...filters.refund_states][0]
   }
-
   filters = _.omitBy(filters, _.isEmpty)
   return {
     valid: validateFilters(filters),

--- a/app/utils/get_query_string_for_params.js
+++ b/app/utils/get_query_string_for_params.js
@@ -14,16 +14,11 @@ function getQueryStringForParams (params = {}) {
     display_size: params.pageSize || 100
   }
 
-  if (params.refundReportingEnabled) {
-    if (params.payment_states) {
-      queryStrings.payment_states = params.payment_states instanceof Array ? params.payment_states.join(',') : params.payment_states
-    }
-    if (params.refund_states) {
-      queryStrings.refund_states = params.refund_states instanceof Array ? params.refund_states.join(',') : params.refund_states
-    }
-    queryStrings.state = ''
-  } else {
-    queryStrings.state = params.state
+  if (params.payment_states) {
+    queryStrings.payment_states = params.payment_states instanceof Array ? params.payment_states.join(',') : params.payment_states
+  }
+  if (params.refund_states) {
+    queryStrings.refund_states = params.refund_states instanceof Array ? params.refund_states.join(',') : params.refund_states
   }
 
   return querystring.stringify(queryStrings)

--- a/app/utils/transaction_view.js
+++ b/app/utils/transaction_view.js
@@ -1,4 +1,4 @@
-'usr strict'
+'use strict'
 
 const lodash = require('lodash')
 const changeCase = require('change-case')
@@ -34,7 +34,7 @@ module.exports = {
 
     connectorData.cardBrands = lodash.uniqBy(allCards.card_types, 'brand')
       .map((card) => {
-        var value = {}
+        let value = {}
         value.text = card.label
         if (card.brand === filters.brand) {
           value.selected = true
@@ -63,7 +63,6 @@ module.exports = {
       router.paths.transactions.download, {
         reference: filters.reference,
         email: filters.email,
-        state: filters.state,
         payment_states: filters.payment_states,
         refund_states: filters.refund_states,
         brand: filters.brand,
@@ -121,14 +120,14 @@ function asGBP (amountInPence) {
 
 function getPaginationLinks (connectorData) {
   if (connectorData.total) {
-    var paginator = new Paginator(connectorData.total, getCurrentPageSize(connectorData), getCurrentPageNumber(connectorData))
+    let paginator = new Paginator(connectorData.total, getCurrentPageSize(connectorData), getCurrentPageNumber(connectorData))
     return paginator.getLast() > 1 ? paginator.getNamedCentredRange(PAGINATION_SPREAD, true, true) : null
   }
 }
 
 function getPageSizeLinks (connectorData) {
   if (getCurrentPageSize(connectorData)) {
-    var paginator = new Paginator(connectorData.total, getCurrentPageSize(connectorData), getCurrentPageNumber(connectorData))
+    let paginator = new Paginator(connectorData.total, getCurrentPageSize(connectorData), getCurrentPageNumber(connectorData))
     return paginator.getDisplaySizeOptions()
   }
 }
@@ -138,9 +137,9 @@ function getCurrentPageNumber (connectorData) {
 }
 
 function getCurrentPageSize (connectorData) {
-  var selfLink = connectorData._links && connectorData._links.self
-  var queryString
-  var limit
+  let selfLink = connectorData._links && connectorData._links.self
+  let queryString
+  let limit
 
   if (selfLink) {
     queryString = url.parse(selfLink.href).query
@@ -152,6 +151,6 @@ function getCurrentPageSize (connectorData) {
 }
 
 function hasPageSizeLinks (connectorData) {
-  var paginator = new Paginator(connectorData.total, getCurrentPageSize(connectorData), getCurrentPageNumber(connectorData))
+  let paginator = new Paginator(connectorData.total, getCurrentPageSize(connectorData), getCurrentPageNumber(connectorData))
   return paginator.showDisplaySizeLinks()
 }

--- a/app/views/dashboard/_activity.njk
+++ b/app/views/dashboard/_activity.njk
@@ -34,18 +34,14 @@
     <header class="dashboard-total-group__heading">
       <h2 class="dashboard-total-group__title">Successful refunds</h2>
     </header>
-    {% if _features.REFUNDS_IN_TX_LIST %}
     <a class="dashboard-total-group__link" href="/transactions?state=refund-success&{{ transactionsPeriodString }}" title="View refunded transactions for chosen time period">
-    {% endif %}
       <dl class="dashboard-total-group__values dashboard-total-group__values--red">
         <dt class="visually-hidden">Count</dt>
         <dd class="dashboard-total-group__count">{{ activity.refunded_payments.count }}</dd>
         <dt class="visually-hidden">Amount</dt>
         <dd class="dashboard-total-group__amount">{{ activity.refunded_payments.total_in_pence | currency }}</dd>
       </dl>
-    {% if _features.REFUNDS_IN_TX_LIST %}
     </a>
-    {% endif %}
   </article>
   <article class="dashboard-total-group column-third">
     <header class="dashboard-total-group__heading">

--- a/app/views/transactions/filter.njk
+++ b/app/views/transactions/filter.njk
@@ -16,7 +16,6 @@
           </label>
           <input class="form-control large" id="email" name="email" type="text" value="{{filters.email}}"/>
         </div>
-      {% if _features.REFUNDS_IN_TX_LIST %}
         <div class="column-quarter">
           <label class="form-label" for="state">
             <strong>State</strong>
@@ -29,38 +28,18 @@
             {% endfor %}
           </select>
         </div>
-      {% endif %}
         <div class="column-quarter">
           <label class="form-label" for="card-brand">
             <strong>Card brand</strong>
             <span class="form-hint">Select a brand</span>
           </label>
-        {% if _features.REFUNDS_IN_TX_LIST %}
           <select class="form-control large" id="card-brand" name="brand" data-enhance-multiple>
-        {% else %}
-          <select class="form-control large" id="card-brand" name="brand">
-        {% endif %}
             <option value="">All brands</option>
             {% for cardBrand in cardBrands %}
               <option value="{{cardBrand.key}}" {% if cardBrand.value.selected %} selected {% endif %}>{{cardBrand.value.text}}</option>
             {% endfor %}
           </select>
         </div>
-      {% if not _features.REFUNDS_IN_TX_LIST %}
-        <div class="column-quarter">
-          <label class="form-label" for="state">
-            <strong>State</strong>
-            <span class="form-hint">Select an option</span>
-          </label>
-          <select class="form-control large" id="state" name="state">
-            <option value="">Any</option>
-            {% for eventState in eventStates %}
-            <option value="{{eventState.key}}" {% if eventState.value.selected %} selected {% endif %}>{{eventState.value.text}}</option>
-            {% endfor %}
-          </select>
-        </div>
-      {% endif %}
-
       <fieldset class="column-half datetime-pair">
         <legend>
           Date range

--- a/test/integration/pagination_ft_tests.js
+++ b/test/integration/pagination_ft_tests.js
@@ -1,24 +1,26 @@
-var path = require('path')
+'use strict'
+
+const path = require('path')
 require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
-var userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
-var request = require('supertest')
-var nock = require('nock')
-var getApp = require(path.join(__dirname, '/../../server.js')).getApp
-var paths = require(path.join(__dirname, '/../../app/paths.js'))
-var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
-var assert = require('assert')
-var querystring = require('querystring')
+const userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
+const request = require('supertest')
+const nock = require('nock')
+const getApp = require(path.join(__dirname, '/../../server.js')).getApp
+const paths = require(path.join(__dirname, '/../../app/paths.js'))
+const session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+const assert = require('assert')
+const querystring = require('querystring')
 const getQueryStringForParams = require('../../app/utils/get_query_string_for_params')
-var app
+let app
 
-var gatewayAccountId = '452345'
+const gatewayAccountId = '452345'
 
-var CONNECTOR_CHARGES_SEARCH_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges'
-var CONNECTOR_ALL_CARD_TYPES_API_PATH = '/v1/api/card-types'
+const CONNECTOR_CHARGES_SEARCH_API_PATH = '/v2/api/accounts/' + gatewayAccountId + '/charges'
+const CONNECTOR_ALL_CARD_TYPES_API_PATH = '/v1/api/card-types'
 
-var connectorMock = nock(process.env.CONNECTOR_URL)
+const connectorMock = nock(process.env.CONNECTOR_URL)
 
-var ALL_CARD_TYPES = {
+const ALL_CARD_TYPES = {
   'card_types': [
     {'id': '1', 'brand': 'mastercard', 'label': 'Mastercard', 'type': 'CREDIT'},
     {'id': '2', 'brand': 'mastercard', 'label': 'Mastercard', 'type': 'DEBIT'},
@@ -27,14 +29,14 @@ var ALL_CARD_TYPES = {
 }
 
 function connectorMockResponds (data, searchParameters) {
-  var queryStr = '?' + getQueryStringForParams(searchParameters)
+  let queryStr = '?' + getQueryStringForParams(searchParameters)
 
   return connectorMock.get(CONNECTOR_CHARGES_SEARCH_API_PATH + queryStr)
     .reply(200, data)
 }
 
 function searchTransactions (data) {
-  var query = querystring.stringify(data)
+  let query = querystring.stringify(data)
 
   return request(app)
     .get(paths.transactions.index + '?' + query)
@@ -63,8 +65,8 @@ describe('Pagination', function () {
 
   describe('Pagination', function () {
     it('should generate correct pagination data when no page number passed', function (done) {
-      var connectorData = {}
-      var data = {'display_size': 5}
+      let connectorData = {}
+      let data = {'display_size': 5}
       connectorData.total = 30
       connectorData.results = []
       connectorData._links = {self: {'href': '/v1/api/accounts/111/charges?&page=&display_size=5&state='}}
@@ -86,8 +88,8 @@ describe('Pagination', function () {
     })
 
     it('should generate correct pagination data when page number passed', function (done) {
-      var connectorData = {}
-      var data = {'display_size': 5}
+      let connectorData = {}
+      let data = {'display_size': 5}
       connectorData.total = 30
       connectorData.results = []
       connectorData.page = 3
@@ -113,8 +115,8 @@ describe('Pagination', function () {
     })
 
     it('should generate correct pagination data with different display size', function (done) {
-      var connectorData = {}
-      var data = {'display_size': 5}
+      let connectorData = {}
+      let data = {'display_size': 5}
       connectorData.total = 30
       connectorData.results = []
       connectorData.page = 3
@@ -140,8 +142,8 @@ describe('Pagination', function () {
     })
 
     it('should default to page 1 and display_size 100', function (done) {
-      var connectorData = {}
-      var data = {'display_size': 5}
+      let connectorData = {}
+      let data = {'display_size': 5}
       connectorData.total = 600
       connectorData.results = []
       connectorData._links = {self: {'href': '/v1/api/accounts/111/charges?&page=&display_size=&state='}}
@@ -163,8 +165,8 @@ describe('Pagination', function () {
     })
 
     it('should return correct display size options when total over 500', function (done) {
-      var connectorData = {}
-      var data = {'display_size': 100}
+      let connectorData = {}
+      let data = {'display_size': 100}
       connectorData.total = 600
       connectorData.results = []
       connectorData._links = {self: {'href': '/v1/api/accounts/111/charges?&page=1&display_size=100&state='}}
@@ -183,8 +185,8 @@ describe('Pagination', function () {
     })
 
     it('should return correct display size options when total between 100 and 500', function (done) {
-      var connectorData = {}
-      var data = {'display_size': 100}
+      let connectorData = {}
+      let data = {'display_size': 100}
       connectorData.total = 400
       connectorData.results = []
       connectorData.page = 1
@@ -204,8 +206,8 @@ describe('Pagination', function () {
     })
 
     it('should return correct display size options when total under 100', function (done) {
-      var connectorData = {}
-      var data = {'display_size': 100}
+      let connectorData = {}
+      let data = {'display_size': 100}
       connectorData.total = 50
       connectorData.results = []
       connectorData._links = {self: {'href': '/v1/api/accounts/111/charges?&page=1&display_size=100&state='}}
@@ -221,8 +223,8 @@ describe('Pagination', function () {
     })
 
     it('should return correct display size options when total under 100', function (done) {
-      var connectorData = {}
-      var data = {'display_size': 500}
+      let connectorData = {}
+      let data = {'display_size': 500}
       connectorData.total = 150
       connectorData.results = []
       connectorData._links = {self: {'href': '/v1/api/accounts/111/charges?&page=1&display_size=500&state='}}
@@ -238,21 +240,21 @@ describe('Pagination', function () {
     })
 
     it('should return return error if page out of bounds', function (done) {
-      var data = {'page': -1}
+      let data = {'page': -1}
 
       searchTransactions(data)
         .expect(500, {'message': 'Invalid search'}).end(done)
     })
 
     it('should return return error if pageSize out of bounds 1', function (done) {
-      var data = {'pageSize': 600}
+      let data = {'pageSize': 600}
 
       searchTransactions(data)
         .expect(500, {'message': 'Invalid search'}).end(done)
     })
 
     it('should return return error if pageSize out of bounds 2', function (done) {
-      var data = {'pageSize': 0}
+      let data = {'pageSize': 0}
 
       searchTransactions(data)
         .expect(500, {'message': 'Invalid search'}).end(done)

--- a/test/integration/transaction_details_ft_tests.js
+++ b/test/integration/transaction_details_ft_tests.js
@@ -1,19 +1,20 @@
+'use strict'
 
-var request = require('supertest')
-var nock = require('nock')
+const request = require('supertest')
+const nock = require('nock')
 
 require('../test_helpers/serialize_mock.js')
-var userCreator = require('../test_helpers/user_creator.js')
-var getApp = require('../../server.js').getApp
-var paths = require('../../app/paths.js')
-var session = require('../test_helpers/mock_session.js')
-var {expect} = require('chai')
-var gatewayAccountId = '15486734'
+const userCreator = require('../test_helpers/user_creator.js')
+const getApp = require('../../server.js').getApp
+const paths = require('../../app/paths.js')
+const session = require('../test_helpers/mock_session.js')
+const {expect} = require('chai')
+const gatewayAccountId = '15486734'
 
-var app
+let app
 
-var CONNECTOR_CHARGE_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges/{chargeId}'
-var connectorMock = nock(process.env.CONNECTOR_URL)
+const CONNECTOR_CHARGE_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges/{chargeId}'
+const connectorMock = nock(process.env.CONNECTOR_URL)
 
 function connectorMockResponds (path, data) {
   return connectorMock.get(path)
@@ -38,7 +39,7 @@ describe('The transaction view scenarios', function () {
 
   beforeEach(function (done) {
     let permissions = 'transactions-details:read'
-    var user = session.getUser({
+    let user = session.getUser({
       gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
     })
     app = session.getAppWithLoggedInUser(getApp(), user)
@@ -48,8 +49,8 @@ describe('The transaction view scenarios', function () {
 
   describe('The transaction history endpoint', function () {
     it('should return a list of transaction history for a given charge id', function (done) {
-      var chargeId = 452345
-      var mockEventsResponse = {
+      let chargeId = 452345
+      let mockEventsResponse = {
         'charge_id': chargeId,
         'events': [
           {
@@ -104,7 +105,7 @@ describe('The transaction view scenarios', function () {
         ]
       }
 
-      var mockChargeResponse = {
+      let mockChargeResponse = {
         'charge_id': chargeId,
         'description': 'Breathing licence',
         'reference': 'Ref-1234',
@@ -150,7 +151,7 @@ describe('The transaction view scenarios', function () {
         ]
       }
 
-      var expectedEventsView = {
+      let expectedEventsView = {
         'charge_id': chargeId,
         'description': 'Breathing licence',
         'reference': 'Ref-1234',
@@ -271,8 +272,8 @@ describe('The transaction view scenarios', function () {
     })
 
     it('should show a transaction when no card details are present', function (done) {
-      var chargeId = 452345
-      var mockEventsResponse = {
+      let chargeId = 452345
+      let mockEventsResponse = {
         'charge_id': chargeId,
         'events': [
           {
@@ -296,7 +297,7 @@ describe('The transaction view scenarios', function () {
         ]
       }
 
-      var mockChargeResponse = {
+      let mockChargeResponse = {
         'charge_id': chargeId,
         'description': 'Breathing licence',
         'reference': 'Ref-1234',
@@ -329,7 +330,7 @@ describe('The transaction view scenarios', function () {
         ]
       }
 
-      var expectedEventsView = {
+      let expectedEventsView = {
         'charge_id': chargeId,
         'description': 'Breathing licence',
         'reference': 'Ref-1234',
@@ -403,8 +404,8 @@ describe('The transaction view scenarios', function () {
     })
 
     it('should show a transaction when legacy cards details are present', function (done) {
-      var chargeId = 452345
-      var mockEventsResponse = {
+      let chargeId = 452345
+      let mockEventsResponse = {
         'charge_id': chargeId,
         'events': [
           {
@@ -428,7 +429,7 @@ describe('The transaction view scenarios', function () {
         ]
       }
 
-      var mockChargeResponse = {
+      let mockChargeResponse = {
         'charge_id': chargeId,
         'description': 'Breathing licence',
         'reference': 'Ref-1234',
@@ -468,7 +469,7 @@ describe('The transaction view scenarios', function () {
         ]
       }
 
-      var expectedEventsView = {
+      let expectedEventsView = {
         'charge_id': chargeId,
         'description': 'Breathing licence',
         'reference': 'Ref-1234',
@@ -543,8 +544,8 @@ describe('The transaction view scenarios', function () {
     })
 
     it('should return a list of transaction history for a given charge id and show refunded', function (done) {
-      var chargeWithRefund = 12345
-      var mockEventsResponse = {
+      let chargeWithRefund = 12345
+      let mockEventsResponse = {
         'charge_id': chargeWithRefund,
         'events': [
           {
@@ -599,7 +600,7 @@ describe('The transaction view scenarios', function () {
         ]
       }
 
-      var mockChargeResponse = {
+      let mockChargeResponse = {
         'charge_id': chargeWithRefund,
         'description': 'Breathing licence',
         'reference': 'Ref-1234',
@@ -645,7 +646,7 @@ describe('The transaction view scenarios', function () {
         ]
       }
 
-      var expectedEventsView = {
+      let expectedEventsView = {
         'charge_id': chargeWithRefund,
         'description': 'Breathing licence',
         'reference': 'Ref-1234',
@@ -754,7 +755,7 @@ describe('The transaction view scenarios', function () {
         }
       }
 
-      var events = '/v1/api/accounts/' + gatewayAccountId + '/charges/' + chargeWithRefund + '/events'
+      let events = '/v1/api/accounts/' + gatewayAccountId + '/charges/' + chargeWithRefund + '/events'
       connectorMockResponds(connectorChargePathFor(chargeWithRefund), mockChargeResponse)
       connectorMockResponds(events, mockEventsResponse)
 
@@ -767,8 +768,8 @@ describe('The transaction view scenarios', function () {
     })
 
     it('should return charge not found if a non existing charge id requested', function (done) {
-      var nonExistentChargeId = 888
-      var connectorError = {'message': 'Charge not found'}
+      let nonExistentChargeId = 888
+      let connectorError = {'message': 'Charge not found'}
       connectorMock.get(connectorChargePathFor(nonExistentChargeId))
         .reply(404, connectorError)
 
@@ -778,8 +779,8 @@ describe('The transaction view scenarios', function () {
     })
 
     it('should return a generic if connector responds with an error', function (done) {
-      var nonExistentChargeId = 888
-      var connectorError = {'message': 'Internal server error'}
+      let nonExistentChargeId = 888
+      let connectorError = {'message': 'Internal server error'}
       connectorMock.get(connectorChargePathFor(nonExistentChargeId))
         .reply(500, connectorError)
 
@@ -789,7 +790,7 @@ describe('The transaction view scenarios', function () {
     })
 
     it('should return a generic if unable to communicate with connector', function (done) {
-      var chargeId = 452345
+      let chargeId = 452345
       whenGetTransactionHistory(chargeId, app)
         .expect(500, {'message': 'Error processing transaction view'})
         .end(done)

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -1,26 +1,29 @@
-var path = require('path')
+'use strict'
+
+const path = require('path')
 process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
 require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
-var userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
-var request = require('supertest')
-var nock = require('nock')
-var _ = require('lodash')
-var getApp = require(path.join(__dirname, '/../../server.js')).getApp
-var querystring = require('querystring')
-var paths = require(path.join(__dirname, '/../../app/paths.js'))
-var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
-var assert = require('chai').assert
-var expect = require('chai').expect
-var getQueryStringForParams = require('../../app/utils/get_query_string_for_params')
+const userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
+const request = require('supertest')
+const nock = require('nock')
+const _ = require('lodash')
+const getApp = require(path.join(__dirname, '/../../server.js')).getApp
+const querystring = require('querystring')
+const paths = require(path.join(__dirname, '/../../app/paths.js'))
+const session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+const assert = require('chai').assert
+const expect = require('chai').expect
+const getQueryStringForParams = require('../../app/utils/get_query_string_for_params')
 
-var gatewayAccountId = '651342'
-var app
+const gatewayAccountId = '651342'
+let app
 
-var CHARGES_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges'
-var connectorMock = nock(process.env.CONNECTOR_URL)
+const CHARGES_API_PATH = '/v2/api/accounts/' + gatewayAccountId + '/charges'
+const connectorMock = nock(process.env.CONNECTOR_URL)
 
 function connectorMockResponds (code, data, searchParameters) {
-  var queryStr = '?' + getQueryStringForParams(searchParameters)
+  searchParameters.pageSize = searchParameters.pageSize || 500
+  let queryStr = '?' + getQueryStringForParams(searchParameters)
 
   return connectorMock.get(CHARGES_API_PATH + queryStr)
     .reply(code, data)
@@ -40,7 +43,7 @@ describe('Transaction download endpoints', function () {
 
   beforeEach(function (done) {
     let permissions = 'transactions-download:read'
-    var user = session.getUser({
+    let user = session.getUser({
       gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
     })
     app = session.getAppWithLoggedInUser(getApp(), user)
@@ -50,17 +53,17 @@ describe('Transaction download endpoints', function () {
 
   describe('The /transactions/download endpoint', function () {
     it('should download a csv file comprising a list of transactions for the gateway account', function (done) {
-      var results = require('./json/transaction_download.json')
+      let results = require('./json/transaction_download.json')
 
-      var mockJson = {
+      let mockJson = {
         results: results,
         _links: {
           next_page: {href: 'http://localhost:8000/bar'}
         }
       }
 
-      var secondPageMock = nock('http://localhost:8000')
-      var secondResults = _.cloneDeep(results)
+      let secondPageMock = nock('http://localhost:8000')
+      let secondResults = _.cloneDeep(results)
       secondResults[0].amount = 1234
       secondResults[1].amount = 123
 
@@ -76,16 +79,16 @@ describe('Transaction download endpoints', function () {
         .expect('Content-Type', 'text/csv; charset=utf-8')
         .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
         .expect(function (res) {
-          var csvContent = res.text
-          var arrayOfLines = csvContent.split('\n')
+          let csvContent = res.text
+          let arrayOfLines = csvContent.split('\n')
           assert(5, arrayOfLines.length)
           assert.equal('"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"', arrayOfLines[1])
           assert.equal('"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","canceled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"', arrayOfLines[2])
         })
         .end(function (err, res) {
           if (err) return done(err)
-          var csvContent = res.text
-          var arrayOfLines = csvContent.split('\n')
+          let csvContent = res.text
+          let arrayOfLines = csvContent.split('\n')
           expect(arrayOfLines.length).to.equal(5)
           expect(arrayOfLines[0]).to.equal('"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Date Created"')
           expect(arrayOfLines[1]).to.equal('"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"')
@@ -98,16 +101,16 @@ describe('Transaction download endpoints', function () {
 
     // @see https://payments-platform.atlassian.net/browse/PP-2254
     it('should download a csv file comprising a list of transactions and preventing Spreadsheet Formula Injection', function (done) {
-      var results = require('./json/transaction_download_spreadsheet_formula_injection.json')
+      let results = require('./json/transaction_download_spreadsheet_formula_injection.json')
 
-      var mockJson = {
+      let mockJson = {
         results: results,
         _links: {
           next_page: {href: 'http://localhost:8000/bar'}
         }
       }
 
-      var secondPageMock = nock('http://localhost:8000')
+      let secondPageMock = nock('http://localhost:8000')
 
       secondPageMock.get('/bar')
         .reply(200, {
@@ -122,8 +125,8 @@ describe('Transaction download endpoints', function () {
         .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
         .end(function (err, res) {
           if (err) return done(err)
-          var csvContent = res.text
-          var arrayOfLines = csvContent.split('\n')
+          let csvContent = res.text
+          let arrayOfLines = csvContent.split('\n')
           expect(arrayOfLines[0]).to.equal('"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Date Created"')
           expect(arrayOfLines[1]).to.equal('"\'+red","\'=calc+z!A0","\'-alice.111@mail.fake","123.45","\'@Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"')
           done()
@@ -131,16 +134,16 @@ describe('Transaction download endpoints', function () {
     })
 
     it('should download a csv file with expected refund states filtering', function (done) {
-      var results = require('./json/transaction_download_refunds.json')
+      let results = require('./json/transaction_download_refunds.json')
 
-      var mockJson = {
+      let mockJson = {
         results: results,
         _links: {
           next_page: {href: 'http://localhost:8000/bar'}
         }
       }
 
-      var secondPageMock = nock('http://localhost:8000')
+      let secondPageMock = nock('http://localhost:8000')
 
       secondPageMock.get('/bar')
         .reply(200, {
@@ -157,8 +160,8 @@ describe('Transaction download endpoints', function () {
         .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
         .end(function (err, res) {
           if (err) return done(err)
-          var csvContent = res.text
-          var arrayOfLines = csvContent.split('\n')
+          let csvContent = res.text
+          let arrayOfLines = csvContent.split('\n')
           expect(arrayOfLines[0]).to.equal('"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Date Created"')
           expect(arrayOfLines[1]).to.equal('"\'+red","\'=calc+z!A0","\'-alice.111@mail.fake","-123.45","\'@Visa","TEST01","12/19","4242","Refund succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"')
           done()
@@ -166,16 +169,16 @@ describe('Transaction download endpoints', function () {
     })
 
     it('should download a csv file with expected payment states filtering', function (done) {
-      var results = require('./json/transaction_download_spreadsheet_formula_injection.json')
+      let results = require('./json/transaction_download_spreadsheet_formula_injection.json')
 
-      var mockJson = {
+      let mockJson = {
         results: results,
         _links: {
           next_page: {href: 'http://localhost:8000/bar'}
         }
       }
 
-      var secondPageMock = nock('http://localhost:8000')
+      let secondPageMock = nock('http://localhost:8000')
 
       secondPageMock.get('/bar')
         .reply(200, {
@@ -192,8 +195,8 @@ describe('Transaction download endpoints', function () {
         .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
         .end(function (err, res) {
           if (err) return done(err)
-          var csvContent = res.text
-          var arrayOfLines = csvContent.split('\n')
+          let csvContent = res.text
+          let arrayOfLines = csvContent.split('\n')
           expect(arrayOfLines[0]).to.equal('"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Date Created"')
           expect(arrayOfLines[1]).to.equal('"\'+red","\'=calc+z!A0","\'-alice.111@mail.fake","123.45","\'@Visa","TEST01","12/19","4242","succeeded",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"')
           done()
@@ -201,7 +204,7 @@ describe('Transaction download endpoints', function () {
     })
 
     it('should show error message on a bad request', function (done) {
-      var errorMessage = 'Unable to download list of transactions.'
+      let errorMessage = 'Unable to download list of transactions.'
       connectorMockResponds(400, {'message': errorMessage}, {})
 
       downloadTransactionList()

--- a/test/integration/transaction_list_ft_tests.js
+++ b/test/integration/transaction_list_ft_tests.js
@@ -16,7 +16,7 @@ const DISPLAY_DATE = '10 Feb 2016 — 12:44:01'
 const gatewayAccountId = '651342'
 const {expect} = chai
 const searchParameters = {}
-const CONNECTOR_CHARGES_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges'
+const CONNECTOR_CHARGES_API_PATH = '/v2/api/accounts/' + gatewayAccountId + '/charges'
 const CONNECTOR_ALL_CARD_TYPES_API_PATH = '/v1/api/card-types'
 const ALL_CARD_TYPES = {
   'card_types': [
@@ -43,7 +43,7 @@ describe('The /transactions endpoint', function () {
 
   beforeEach(function (done) {
     let permissions = 'transactions:read'
-    var user = session.getUser({
+    let user = session.getUser({
       gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
     })
     app = session.getAppWithLoggedInUser(getApp(), user)
@@ -55,7 +55,7 @@ describe('The /transactions endpoint', function () {
     connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
       .reply(200, ALL_CARD_TYPES)
 
-    var connectorData = {
+    let connectorData = {
       'results': [
         {
           'charge_id': '100',
@@ -93,7 +93,7 @@ describe('The /transactions endpoint', function () {
 
     connectorMockResponds(200, connectorData, searchParameters)
 
-    var expectedData = {
+    let expectedData = {
       'results': [
         {
           'charge_id': '100',
@@ -146,7 +146,7 @@ describe('The /transactions endpoint', function () {
     connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
       .reply(200, ALL_CARD_TYPES)
 
-    var connectorData = {
+    let connectorData = {
       'results': [
         {
           'charge_id': '100',
@@ -184,7 +184,7 @@ describe('The /transactions endpoint', function () {
 
     connectorMockResponds(200, connectorData, searchParameters)
 
-    var expectedData = {
+    let expectedData = {
       'results': [
         {
           'charge_id': '100',
@@ -238,7 +238,7 @@ describe('The /transactions endpoint', function () {
     connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
       .reply(200, ALL_CARD_TYPES)
 
-    var connectorData = {
+    let connectorData = {
       'results': [
         {
           'charge_id': '100',
@@ -280,7 +280,7 @@ describe('The /transactions endpoint', function () {
       .set('x-request-id', requestId)
       .expect(200)
       .expect(function (res) {
-        res.body.downloadTransactionLink.should.eql('/transactions/download?state=started&payment_states=started')
+        res.body.downloadTransactionLink.should.eql('/transactions/download?payment_states=started')
       })
       .end(done)
   })
@@ -375,7 +375,7 @@ describe('The /transactions endpoint', function () {
     connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
       .reply(200, ALL_CARD_TYPES)
 
-    var connectorData = {
+    let connectorData = {
       'results': []
     }
     connectorMockResponds(200, connectorData, searchParameters)
@@ -389,7 +389,7 @@ describe('The /transactions endpoint', function () {
   })
 
   it('should show error message on a bad request while retrieving the list of transactions', function (done) {
-    var errorMessage = 'Unable to retrieve list of transactions.'
+    let errorMessage = 'Unable to retrieve list of transactions.'
     connectorMockResponds(400, {'message': errorMessage}, searchParameters)
 
     getTransactionList()
@@ -410,33 +410,6 @@ describe('The /transactions endpoint', function () {
 
     getTransactionList()
       .expect(500, {'message': 'Unable to retrieve list of transactions.'})
-      .end(done)
-  })
-
-  it('should only allow filtering by charge states', function (done) {
-    connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
-      .reply(200, ALL_CARD_TYPES)
-
-    var connectorData = {
-      'results': []
-    }
-
-    connectorMockResponds(200, connectorData, searchParameters)
-
-    getTransactionList()
-      .expect(200)
-      .expect(function (res) {
-        expect(res.body.eventStates).property('length').to.equal(7)
-        expect(res.body.eventStates.map(state => state.value.text)).to.deep.equal([
-          'Created',
-          'Started',
-          'Submitted',
-          'Success',
-          'Error',
-          'Failed',
-          'Cancelled'
-        ])
-      })
       .end(done)
   })
 
@@ -496,7 +469,7 @@ describe('The /transactions endpoint', function () {
   // });
 })
 
-describe('The /transactions endpoint (when feature flag: \'REFUNDS_IN_TX_LIST\' is enabled)', () => {
+describe('The /transactions endpoint is enabled)', () => {
   afterEach(function () {
     nock.cleanAll()
     app = null
@@ -504,10 +477,9 @@ describe('The /transactions endpoint (when feature flag: \'REFUNDS_IN_TX_LIST\' 
 
   beforeEach(function (done) {
     let permissions = 'transactions:read'
-    var user = session.getUser({
+    let user = session.getUser({
       gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
     })
-    user.features = ['REFUNDS_IN_TX_LIST']
     app = session.getAppWithLoggedInUser(getApp(), user)
 
     userCreator.mockUserResponse(user.toJson(), done)
@@ -517,7 +489,7 @@ describe('The /transactions endpoint (when feature flag: \'REFUNDS_IN_TX_LIST\' 
     connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
       .reply(200, ALL_CARD_TYPES)
 
-    var connectorData = {
+    let connectorData = {
       'results': []
     }
 
@@ -547,11 +519,11 @@ describe('The /transactions endpoint (when feature flag: \'REFUNDS_IN_TX_LIST\' 
     connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
       .reply(200, ALL_CARD_TYPES)
 
-    var connectorData = {
+    let connectorData = {
       'results': []
     }
 
-    connectorMockResponds(200, connectorData, {state: 'started', payment_states: 'started', refundReportingEnabled: true})
+    connectorMockResponds(200, connectorData, {payment_states: 'started'})
 
     request(app)
       .get(paths.transactions.index + '?state=payment-started')
@@ -572,7 +544,7 @@ describe('The /transactions endpoint (when feature flag: \'REFUNDS_IN_TX_LIST\' 
           'Refund error',
           'Refund success'
         ])
-        res.body.downloadTransactionLink.should.eql('/transactions/download?state=started&payment_states=started')
+        res.body.downloadTransactionLink.should.eql('/transactions/download?payment_states=started')
       })
       .end(done)
   })
@@ -581,11 +553,11 @@ describe('The /transactions endpoint (when feature flag: \'REFUNDS_IN_TX_LIST\' 
     connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
       .reply(200, ALL_CARD_TYPES)
 
-    var connectorData = {
+    let connectorData = {
       'results': []
     }
 
-    connectorMockResponds(200, connectorData, {state: 'started', refund_states: 'started', refundReportingEnabled: true})
+    connectorMockResponds(200, connectorData, {refund_states: 'started'})
 
     request(app)
       .get(paths.transactions.index + '?state=refund-started')
@@ -606,14 +578,14 @@ describe('The /transactions endpoint (when feature flag: \'REFUNDS_IN_TX_LIST\' 
           'Refund error',
           'Refund success'
         ])
-        res.body.downloadTransactionLink.should.eql('/transactions/download?state=started&refund_states=started')
+        res.body.downloadTransactionLink.should.eql('/transactions/download?refund_states=started')
       })
       .end(done)
   })
 })
 
 function connectorMockResponds (code, data, searchParameters) {
-  var queryString = getQueryStringForParams(searchParameters)
+  let queryString = getQueryStringForParams(searchParameters)
 
   return connectorMock.get(CONNECTOR_CHARGES_API_PATH + '?' + queryString)
     .reply(code, data)

--- a/test/integration/transaction_search_ft_tests.js
+++ b/test/integration/transaction_search_ft_tests.js
@@ -2,33 +2,33 @@
 
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
-var path = require('path')
+const path = require('path')
 require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
-var userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
-var request = require('supertest')
-var nock = require('nock')
-var getApp = require(path.join(__dirname, '/../../server.js')).getApp
-var dates = require('../../app/utils/dates.js')
-var paths = require(path.join(__dirname, '/../../app/paths.js'))
-var session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
-var querystring = require('querystring')
-var getQueryStringForParams = require('../../app/utils/get_query_string_for_params')
-var _ = require('lodash')
+const userCreator = require(path.join(__dirname, '/../test_helpers/user_creator.js'))
+const request = require('supertest')
+const nock = require('nock')
+const getApp = require(path.join(__dirname, '/../../server.js')).getApp
+const dates = require('../../app/utils/dates.js')
+const paths = require(path.join(__dirname, '/../../app/paths.js'))
+const session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+const querystring = require('querystring')
+const getQueryStringForParams = require('../../app/utils/get_query_string_for_params')
+const _ = require('lodash')
 chai.use(chaiAsPromised)
 chai.should()
 
-var gatewayAccountId = '452345'
+const gatewayAccountId = '452345'
 
-var app
+let app
 
-var CONNECTOR_CHARGES_SEARCH_API_PATH = '/v1/api/accounts/' + gatewayAccountId + '/charges'
-var CONNECTOR_ALL_CARD_TYPES_API_PATH = '/v1/api/card-types'
+const CONNECTOR_CHARGES_SEARCH_API_PATH = '/v2/api/accounts/' + gatewayAccountId + '/charges'
+const CONNECTOR_ALL_CARD_TYPES_API_PATH = '/v1/api/card-types'
 
-var connectorMock = nock(process.env.CONNECTOR_URL)
-var CONNECTOR_DATE = new Date()
-var DISPLAY_DATE = dates.utcToDisplay(CONNECTOR_DATE)
+const connectorMock = nock(process.env.CONNECTOR_URL)
+const CONNECTOR_DATE = new Date()
+const DISPLAY_DATE = dates.utcToDisplay(CONNECTOR_DATE)
 
-var ALL_CARD_TYPES = {
+const ALL_CARD_TYPES = {
   'card_types': [
     {'id': '1', 'brand': 'mastercard', 'label': 'Mastercard', 'type': 'CREDIT'},
     {'id': '2', 'brand': 'mastercard', 'label': 'Mastercard', 'type': 'DEBIT'},
@@ -37,14 +37,14 @@ var ALL_CARD_TYPES = {
 }
 
 function connectorMockResponds (data, searchParameters) {
-  var queryString = '?' + getQueryStringForParams(searchParameters)
+  let queryString = '?' + getQueryStringForParams(searchParameters)
 
   return connectorMock.get(CONNECTOR_CHARGES_SEARCH_API_PATH + queryString)
     .reply(200, data)
 }
 
 function searchTransactions (data) {
-  var query = querystring.stringify(data)
+  let query = querystring.stringify(data)
 
   return request(app).get(paths.transactions.index + '?' + query)
     .set('Accept', 'application/json').send()
@@ -58,7 +58,7 @@ describe('The search transactions endpoint', function () {
 
   beforeEach(function (done) {
     let permissions = 'transactions:read'
-    var user = session.getUser({
+    let user = session.getUser({
       gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
     })
     app = session.getAppWithLoggedInUser(getApp(), user)
@@ -70,7 +70,7 @@ describe('The search transactions endpoint', function () {
   })
 
   it('should return a list of transactions for the gateway account when searching by partial reference', function (done) {
-    var connectorData = {
+    let connectorData = {
       'results': [
         {
           'charge_id': '100',
@@ -103,10 +103,10 @@ describe('The search transactions endpoint', function () {
         }
       ]
     }
-    var searchParameters = {'reference': 'ref'}
+    let searchParameters = {'reference': 'ref'}
     connectorMockResponds(connectorData, searchParameters)
 
-    var expectedData = {
+    let expectedData = {
       'results': [
         {
           'charge_id': '100',
@@ -156,7 +156,7 @@ describe('The search transactions endpoint', function () {
   })
 
   it('should return a list of transactions for the gateway account when searching by full reference', function (done) {
-    var connectorData = {
+    let connectorData = {
       'results': [
         {
           'charge_id': '100',
@@ -175,10 +175,10 @@ describe('The search transactions endpoint', function () {
         }
       ]
     }
-    var data = {'reference': 'ref1'}
+    let data = {'reference': 'ref1'}
     connectorMockResponds(connectorData, data)
 
-    var expectedData = {
+    let expectedData = {
       'results': [
         {
           'charge_id': '100',
@@ -209,7 +209,7 @@ describe('The search transactions endpoint', function () {
   })
 
   it('should return a list of transactions for the gateway account when searching by partial email', function (done) {
-    var connectorData = {
+    let connectorData = {
       'results': [
         {
           'charge_id': '100',
@@ -227,10 +227,10 @@ describe('The search transactions endpoint', function () {
         }
       ]
     }
-    var data = {'email': 'alice'}
+    let data = {'email': 'alice'}
     connectorMockResponds(connectorData, data)
 
-    var expectedData = {
+    let expectedData = {
       'results': [
         {
           'charge_id': '100',
@@ -262,7 +262,7 @@ describe('The search transactions endpoint', function () {
   })
 
   it('should return a list of transactions for the gateway account when searching by full email', function (done) {
-    var connectorData = {
+    let connectorData = {
       'results': [
         {
           'charge_id': '100',
@@ -281,10 +281,10 @@ describe('The search transactions endpoint', function () {
         }
       ]
     }
-    var data = {'email': 'alice.111@mail.fake'}
+    let data = {'email': 'alice.111@mail.fake'}
     connectorMockResponds(connectorData, data)
 
-    var expectedData = {
+    let expectedData = {
       'results': [
         {
           'charge_id': '100',
@@ -315,7 +315,7 @@ describe('The search transactions endpoint', function () {
   })
 
   it('should return a list of transactions for the gateway account when searching by card brand', function (done) {
-    var connectorData = {
+    let connectorData = {
       'results': [
         {
           'charge_id': '100',
@@ -334,10 +334,10 @@ describe('The search transactions endpoint', function () {
         }
       ]
     }
-    var data = {'brand': 'visa'}
+    let data = {'brand': 'visa'}
     connectorMockResponds(connectorData, data)
 
-    var expectedData = {
+    let expectedData = {
       'results': [
         {
           'charge_id': '100',
@@ -368,7 +368,7 @@ describe('The search transactions endpoint', function () {
   })
 
   it('should return a list of transactions for the gateway account when searching by partial reference, status and brand', function (done) {
-    var connectorData = {
+    let connectorData = {
       'results': [
         {
           'charge_id': '100',
@@ -387,10 +387,10 @@ describe('The search transactions endpoint', function () {
         }
       ]
     }
-    var data = {'reference': 'ref1', 'state': 'TEST_STATUS', 'brand': 'visa'}
+    let data = { 'reference': 'ref1', 'payment_states': 'TEST_STATUS', 'brand': 'visa' }
     connectorMockResponds(connectorData, data)
 
-    var expectedData = {
+    let expectedData = {
       'results': [
         {
           'charge_id': '100',
@@ -412,7 +412,8 @@ describe('The search transactions endpoint', function () {
       ]
     }
 
-    searchTransactions(data)
+    let formData = _.omit(_.merge({'state': data.payment_states}, data), 'payment_states')
+    searchTransactions(formData)
       .expect(200)
       .expect(function (res) {
         res.body.results.should.eql(expectedData.results)
@@ -421,7 +422,7 @@ describe('The search transactions endpoint', function () {
   })
 
   it('should return a list of transactions for the gateway account when searching by partial reference, status, fromDate and toDate', function (done) {
-    var connectorData = {
+    let connectorData = {
       'results': [
         {
           'charge_id': '100',
@@ -440,9 +441,9 @@ describe('The search transactions endpoint', function () {
       ]
     }
 
-    var data = {
+    let data = {
       'reference': 'ref1',
-      'state': 'TEST_STATUS',
+      'payment_states': 'TEST_STATUS',
       'brand': 'visa',
       'fromDate': '21/01/2016',
       'fromTime': '13:04:45',
@@ -450,14 +451,14 @@ describe('The search transactions endpoint', function () {
       'toTime': '14:12:18'
     }
 
-    var queryStringParams = _.extend({}, data, {
+    let queryStringParams = _.extend({}, data, {
       'from_date': '2016-01-21T13:04:45.000Z',
       'to_date': '2016-01-22T14:12:19.000Z'
     })
 
     connectorMockResponds(connectorData, queryStringParams)
 
-    var expectedData = {
+    let expectedData = {
       'results': [
         {
           'charge_id': '100',
@@ -479,7 +480,8 @@ describe('The search transactions endpoint', function () {
       ]
     }
 
-    searchTransactions(data)
+    let formData = _.omit(_.merge({'state': data.payment_states}, data), 'payment_states')
+    searchTransactions(formData)
       .expect(200)
       .expect(function (res) {
         res.body.results.should.eql(expectedData.results)
@@ -488,14 +490,14 @@ describe('The search transactions endpoint', function () {
   })
 
   it('should return no transactions', function (done) {
-    var connectorData = {
+    let connectorData = {
       'results': []
     }
 
-    var data = {'reference': 'test'}
+    let data = {'reference': 'test'}
     connectorMockResponds(connectorData, data)
 
-    var expectedData = {
+    let expectedData = {
       'results': []
     }
 

--- a/test/unit/services/transaction_service_test.js
+++ b/test/unit/services/transaction_service_test.js
@@ -7,7 +7,9 @@ const chaiAsPromised = require('chai-as-promised')
 
 // Local Dependencies
 const transactionService = require('../../../app/services/transaction_service')
-var getQueryStringForParams = require('../../../app/utils/get_query_string_for_params')
+const getQueryStringForParams = require('../../../app/utils/get_query_string_for_params')
+
+const V2_CHARGES_API_PATH = '/v2/api/accounts/123/charges?'
 
 const {expect} = chai
 chai.use(chaiAsPromised)
@@ -21,7 +23,7 @@ describe('transaction service', () => {
         nock.cleanAll()
 
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams()}`)
+          .get(`${V2_CHARGES_API_PATH + getQueryStringForParams()}`)
           .reply(200, {})
       })
 
@@ -42,7 +44,7 @@ describe('transaction service', () => {
     describe('when connector returns incorrect response code while retrieving the list of transactions', () => {
       before(() => {
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams()}`)
+          .get(`${V2_CHARGES_API_PATH + getQueryStringForParams()}`)
           .reply(404, '')
       })
 
@@ -57,7 +59,7 @@ describe('transaction service', () => {
     describe('when connector returns correctly', () => {
       it('should return into the correct promise when it uses the legacy \'state\' method of querying states', () => {
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams({pageSize: 100, page: 1, state: 'success'})}`)
+          .get(`${V2_CHARGES_API_PATH + getQueryStringForParams({pageSize: 100, page: 1, state: 'success'})}`)
           .reply(200, {})
         return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, state: 'success'}, 'some-unique-id'))
           .to.eventually.be.fulfilled
@@ -65,7 +67,7 @@ describe('transaction service', () => {
 
       it('should return into the correct promise when it uses the new  \'refund_states\' method of querying refund states and multiple have been selected', () => {
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams({pageSize: 100, page: 1, refund_states: ['refund_success', 'refund_error'], refundReportingEnabled: true})}`)
+          .get(`${V2_CHARGES_API_PATH + getQueryStringForParams({pageSize: 100, page: 1, refund_states: ['refund_success', 'refund_error'], refundReportingEnabled: true})}`)
           .reply(200, {})
         return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, refund_states: ['refund_success', 'refund_error'], refundReportingEnabled: true}, 'some-unique-id'))
           .to.eventually.be.fulfilled
@@ -73,7 +75,7 @@ describe('transaction service', () => {
 
       it('should return into the correct promise when it uses the new  \'refund_states\' method of querying refund states and only one has been selected', () => {
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams({pageSize: 100, page: 1, refund_states: 'refund_success', refundReportingEnabled: true})}`)
+          .get(`${V2_CHARGES_API_PATH + getQueryStringForParams({pageSize: 100, page: 1, refund_states: 'refund_success', refundReportingEnabled: true})}`)
           .reply(200, {})
         return expect(transactionService.searchAll(123, {pageSize: 100, page: 1, refund_states: 'refund_success', refundReportingEnabled: true}, 'some-unique-id'))
           .to.eventually.be.fulfilled
@@ -81,7 +83,7 @@ describe('transaction service', () => {
 
       it('should return into the correct promise', () => {
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams()}`)
+          .get(`${V2_CHARGES_API_PATH + getQueryStringForParams()}`)
           .reply(200, {})
         return expect(transactionService.searchAll(123, {pageSize: 100, page: 1}, 'some-unique-id'))
           .to.eventually.be.fulfilled
@@ -99,7 +101,7 @@ describe('transaction service', () => {
     describe('when connector returns incorrect response code', () => {
       before(() => {
         nock(process.env.CONNECTOR_URL)
-          .get(`/v1/api/accounts/123/charges?${getQueryStringForParams()}`)
+          .get(`${V2_CHARGES_API_PATH + getQueryStringForParams()}`)
           .reply(404, '')
       })
 

--- a/test/unit/utils/filters_test.js
+++ b/test/unit/utils/filters_test.js
@@ -7,13 +7,11 @@ describe('filters', () => {
   describe('state filter', () => {
     it('should be unchanged if there is a single state does not contain \'-\' but should add it to the \'payment_states\' array for backward compatibility', () => {
       const {result} = filters.getFilters({query: {state: 'started'}})
-      expect(result).to.have.property('state').to.equal('started')
       expect(result).to.have.property('payment_states').to.deep.equal(['started'])
       expect(result).not.to.have.property('refund_states')
     })
     it('should add state to the relevant filter array if there is a single state that contains \'-\' and replace the state property with just the state name', () => {
       const {result} = filters.getFilters({query: {state: 'payment-started'}})
-      expect(result).to.have.property('state').to.equal('started')
       expect(result).to.have.property('payment_states').to.deep.equal(['started'])
       expect(result).not.to.have.property('refund_states')
     })
@@ -21,7 +19,6 @@ describe('filters', () => {
       const {result} = filters.getFilters({query: {state: ['payment-started', 'payment-success', 'refund-created', 'complete']}})
       expect(result).to.have.property('payment_states').to.deep.equal(['started', 'success', 'complete'])
       expect(result).to.have.property('refund_states').to.deep.equal(['created'])
-      expect(result).to.have.property('state').to.equal('started')
     })
   })
 })


### PR DESCRIPTION
## WHAT
Delete REFUNDS_IN_TX_LIST feature flag

## HOW 
- Removed refund reporting enabled check from query string
- Returning both sets of statuses for Refund and Charge
- Removed conditional display of statuses from njk templates
- Updated connector client to use the new v2 version of the API
- Updated filters not to pass `state` back to connector anymore
- Fixed tests to use the new v2 endpoint
- Fixed tests not to check for `state` in the url sent to connector
as this is not happening anymore. Anyone can have multiple state select
- Added missing 'use strict' to files, replaced `var` with `const` or
`let`

with @kakumar

