### PR TITLE
BAU add last know healthy shrinkwrap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM govukpay/nodejs:6.12.2
 
 ADD package.json /tmp/package.json
+ADD npm-shrinkwrap.json /tmp/npm-shrinkwrap.json
 RUN cd /tmp && npm install --production
 
 ENV PORT 9000

--- a/docker/build_and_test.Dockerfile
+++ b/docker/build_and_test.Dockerfile
@@ -12,6 +12,7 @@ RUN apk del libc6-compat && apk add glibc-2.26-r0.apk
 
 # add package.json before source for node_module cache layer
 ADD package.json /tmp/package.json
+ADD npm-shrinkwrap.json /tmp/npm-shrinkwrap.json
 RUN cd /tmp && npm install
 WORKDIR /app
 ENV LD_LIBRARY_PATH /app/node_modules/appmetrics

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -494,9 +494,9 @@
       "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz"
     },
     "currency-formatter": {
-      "version": "1.4.1",
+      "version": "1.3.2",
       "from": "currency-formatter@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/currency-formatter/-/currency-formatter-1.4.1.tgz"
+      "resolved": "https://registry.npmjs.org/currency-formatter/-/currency-formatter-1.3.2.tgz"
     },
     "cycle": {
       "version": "1.0.3",
@@ -879,9 +879,9 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
     },
     "ipaddr.js": {
-      "version": "1.6.0",
-      "from": "ipaddr.js@1.6.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz"
+      "version": "1.5.2",
+      "from": "ipaddr.js@1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz"
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -1241,9 +1241,9 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
     },
     "nunjucks": {
-      "version": "3.1.0",
+      "version": "3.0.1",
       "from": "nunjucks@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.0.1.tgz"
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -1367,11 +1367,6 @@
       "from": "pkginfo@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
     },
-    "postinstall-build": {
-      "version": "5.0.1",
-      "from": "postinstall-build@>=5.0.1 <6.0.0",
-      "resolved": "https://registry.npmjs.org/postinstall-build/-/postinstall-build-5.0.1.tgz"
-    },
     "preserve": {
       "version": "0.2.0",
       "from": "preserve@>=0.2.0 <0.3.0",
@@ -1407,9 +1402,9 @@
       }
     },
     "proxy-addr": {
-      "version": "2.0.3",
+      "version": "2.0.2",
       "from": "proxy-addr@>=2.0.2 <2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz"
     },
     "ps-tree": {
       "version": "0.0.3",


### PR DESCRIPTION
## WHAT
Add the shrinkwrap from the last known healthy version of selfservice to master.
This should pin the dependencies to the versions as they were before we experienced problems.

