### PR TITLE
PP-3378 Add class to create new account link

### DIFF
--- a/app/views/login/login.njk
+++ b/app/views/login/login.njk
@@ -32,7 +32,7 @@ Sign in to GOV.UK Pay
 
   <h1 class="heading-large">Sign in</h1>
 
-  <p>If you do not have an account, you can <a href="{{ routes.selfCreateService.register }}">create one now</a>.</p>
+  <p>If you do not have an account, you can <a href="{{ routes.selfCreateService.register }}" class="register-link">create one now</a>.</p>
 
   <form action="/login" method="post" name="userLoginForm" class="push-bottom">
   <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>


### PR DESCRIPTION
## WHAT
- So it can be easily located by our end to end tests. Previous accepttests were navigating straight to the registration page rather than navigating users following page links (not convenient).

