### PR TITLE
PP-3378 Set css class to resend otp link view

### DIFF
--- a/app/views/self_create_service/verify_otp.njk
+++ b/app/views/self_create_service/verify_otp.njk
@@ -18,6 +18,6 @@
       <input class="button" type="submit" value="Continue">
     </div>
   </form>
-  <p><a href="{{routes.selfCreateService.otpResend}}">Not received a text message?</a></p>
+  <p><a href="{{routes.selfCreateService.otpResend}}" class="resend-otp-link">Not received a text message?</a></p>
 </div>
 {% endblock %}


### PR DESCRIPTION
## WHAT
- So it can be easily located my our end to end tests. Current tests visiting the pages via URL which is not ideal.



