### PR TITLE
PP-3432 - Renaming Payment types to Card types

### DIFF
--- a/app/paths.js
+++ b/app/paths.js
@@ -46,9 +46,9 @@ module.exports = {
     delete: '/tokens'
   },
   paymentTypes: {
-    selectType: '/payment-types/select-type',
-    selectBrand: '/payment-types/select-brand',
-    summary: '/payment-types/summary'
+    selectType: '/card-types/manage-type',
+    selectBrand: '/card-types/manage-brand',
+    summary: '/card-types/summary'
   },
   emailNotifications: {
     index: '/email-notifications',

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -352,7 +352,7 @@ ConnectorClient.prototype = {
   },
 
   /**
-   * Retrieves the accepted payment types for the given account
+   * Retrieves the accepted card Types for the given account
    * @param params
    *          An object with the following elements;
    *            gatewayAccountId (required)
@@ -372,7 +372,7 @@ ConnectorClient.prototype = {
   },
 
   /**
-   * Updates the accepted payment types for to the given gateway account
+   * Updates the accepted card Types for to the given gateway account
    * @param params
    *          An object with the following elements;
    *            gatewayAccountId (required)

--- a/app/utils/navBuilder.js
+++ b/app/utils/navBuilder.js
@@ -91,7 +91,7 @@ const adminNavigationItems = (originalUrl, permissions) => {
     },
     {
       id: 'navigation-menu-payment-types',
-      name: 'Payment types',
+      name: 'Card Types',
       url: paths.paymentTypes.summary,
       current: pathLookup(originalUrl, paths.paymentTypes.summary),
       permissions: permissions.payment_types_read

--- a/app/views/includes/settings-read-only.njk
+++ b/app/views/includes/settings-read-only.njk
@@ -1,3 +1,3 @@
 <aside class="info-box">
-  <p>You don’t have permission to manage settings. Contact your service admin if you would like to manage 3D secure, accepted payment types, or email notifications.</p>
+  <p>You don’t have permission to manage settings. Contact your service admin if you would like to manage 3D secure, accepted card Types, or email notifications.</p>
 </aside>

--- a/app/views/payment_types.njk
+++ b/app/views/payment_types.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block page_title %}
-Payment types - GOV.UK Pay
+Card Types - GOV.UK Pay
 {% endblock %}
 
 {% block pageSpecificJS %}
@@ -18,10 +18,10 @@ Payment types - GOV.UK Pay
     {% include "includes/settings-read-only.njk" %}
   {% endif %}
 
-  <h1 class="page-title">Payment types</h1>
+  <h1 class="page-title">Card Types</h1>
 
   {% if permissions.payment_types_update %}
-  <h2 class="heading-medium remove-top-margin">Manage accepted payment types</h2>
+  <h2 class="heading-medium remove-top-margin">Manage accepted cards</h2>
   {% endif %}
 
   <div id="payment-types">

--- a/app/views/payment_types_select_type.njk
+++ b/app/views/payment_types_select_type.njk
@@ -1,7 +1,7 @@
 {% extends "payment_types.njk" %}
 
 {% block page_title %}
-Manage payment types - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+Manage card Types - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
 {% block page_content %}

--- a/app/views/payment_types_summary.njk
+++ b/app/views/payment_types_summary.njk
@@ -1,7 +1,7 @@
 {% extends "payment_types.njk" %}
 
 {% block page_title %}
-Payment types - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+Card Types - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
 {% block page_content %}

--- a/test/integration/payment_types_select_brand_ft_tests.js
+++ b/test/integration/payment_types_select_brand_ft_tests.js
@@ -79,7 +79,7 @@ function buildFormPostRequest (path, sendData, sendCSRF, app) {
     .send(sendData)
 }
 
-describe('The payment types endpoint,', function () {
+describe('The card Types endpoint,', function () {
   describe('render select brand view,', function () {
     afterEach(function () {
       nock.cleanAll()

--- a/test/integration/payment_types_select_summary_ft_tests.js
+++ b/test/integration/payment_types_select_summary_ft_tests.js
@@ -65,7 +65,7 @@ function mockConnectorAcceptedCardTypesEndpoint (acceptedCardTypes) {
     .reply(200, acceptedCardTypes)
 }
 
-describe('The payment types endpoint,', function () {
+describe('The card Types endpoint,', function () {
   describe('render summary view,', function () {
     afterEach(function () {
       nock.cleanAll()

--- a/test/integration/payment_types_select_type_ft_tests.js
+++ b/test/integration/payment_types_select_type_ft_tests.js
@@ -41,7 +41,7 @@ function buildFormPostRequest (path, sendData, sendCSRF, baseApp) {
     .send(sendData)
 }
 
-describe('The payment types endpoint,', function () {
+describe('The card Types endpoint,', function () {
   describe('render select type view,', function () {
     afterEach(function () {
       nock.cleanAll()

--- a/test/ui/navigation_ui_tests.js
+++ b/test/ui/navigation_ui_tests.js
@@ -75,7 +75,7 @@ describe('navigation menu', function () {
     body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('Account credentials')
   })
 
-  it('should render Payment types navigation link when user have payment types read permission', function () {
+  it('should render Card Types navigation link when user have card Types read permission', function () {
     let testPermissions = {
       tokens_update: false,
       gateway_credentials_update: false,
@@ -93,7 +93,7 @@ describe('navigation menu', function () {
 
     let body = renderTemplate('tokens', templateData)
 
-    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('Payment types')
+    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('Card Types')
   })
 
   it('should render Merchant details navigation link when user have merchant details read permission', function () {

--- a/test/ui/payment_types_select_brand_ui_tests.js
+++ b/test/ui/payment_types_select_brand_ui_tests.js
@@ -30,7 +30,7 @@ describe('The payment select brand view', function () {
 
     body.should.containSelector('form#payment-types-card-brand-selection-form')
       .withAttribute('method', 'post')
-      .withAttribute('action', '/payment-types/select-brand')
+      .withAttribute('action', '/card-types/manage-brand')
 
     body.should.containSelector('input#accepted-card-type')
       .withAttribute('name', 'acceptedType')
@@ -38,7 +38,7 @@ describe('The payment select brand view', function () {
       .withAttribute('value', 'ALL')
 
     body.should.containSelector('a#payment-types-cancel-link')
-      .withAttribute('href', '/payment-types/summary')
+      .withAttribute('href', '/card-types/summary')
   })
 
   it('should display a message stating debit and credit cards have been chosen', function () {

--- a/test/ui/payment_types_select_type_ui_tests.js
+++ b/test/ui/payment_types_select_type_ui_tests.js
@@ -22,7 +22,7 @@ describe('The payment select type view', function () {
 
     var body = renderTemplate('payment_types_select_type', templateData)
 
-    body.should.containSelector('h1.page-title').withExactText('Payment types')
+    body.should.containSelector('h1.page-title').withExactText('Card Types')
 
     body.should.containSelector('input#payment-types-all-type')
       .withAttribute('name', 'payment-types-card-type')

--- a/test/ui/payment_types_summary_ui_tests.js
+++ b/test/ui/payment_types_summary_ui_tests.js
@@ -22,7 +22,7 @@ var templateData = {
   }
 }
 
-describe('The payment types summary view', function () {
+describe('The card Types summary view', function () {
   it('should display the manage button', function () {
     var model = _.extend({}, templateData)
 

--- a/test/ui/payment_types_summary_ui_tests.js
+++ b/test/ui/payment_types_summary_ui_tests.js
@@ -30,7 +30,7 @@ describe('The card Types summary view', function () {
 
     body.should.containSelector('a#payment-types-manage-button')
       .withAttribute('class', 'button')
-      .withAttribute('href', '/payment-types/select-type')
+      .withAttribute('href', '/card-types/manage-type')
       .withText('Manage')
   })
 


### PR DESCRIPTION
With direct debit coming soon we will have two payment types.

So we need to rename the current payment types to be card types,
so things aren’t confusing.

I went further a replaced every single instance of payment with card, including file names.
It worked but would have required a major e2e rewrite too and it didnt seem worth it.



