### PR TITLE
Fix link to documentation about Worldpay 3D Secure setup

### DIFF
--- a/app/views/3d_secure/index.njk
+++ b/app/views/3d_secure/index.njk
@@ -36,7 +36,7 @@
       {% if permissions.toggle_3ds_update %}
       <div class="panel panel-border-wide">
           <h2 class="heading-small">Activating 3D Secure</h2>
-          <p>Check with your Worldpay account manager that your merchant code has been configured to support 3D Secure. Read more about this in our <a href="https://govukpay-docs.cloudapps.digital/switching-to-production#worldpay-setup-for-3d-secure">technical documentation</a>.</p>
+          <p>Check with your Worldpay account manager that your merchant code has been configured to support 3D Secure. Read more about this in our <a href="https://govukpay-docs.cloudapps.digital/#worldpay-setup-for-3d-secure">technical documentation</a>.</p>
       </div>
 
       <p>Once that’s done, you can turn on 3D Secure for all payments to your service.</p>


### PR DESCRIPTION
Change link from https://govukpay-docs.cloudapps.digital/switching-to-production#worldpay-setup-for-3d-secure to https://govukpay-docs.cloudapps.digital/#worldpay-setup-for-3d-secure


