### PR TITLE
PP-3377 change payment states as to new display states

### DIFF
--- a/app/controllers/transactions/transaction_detail_controller.js
+++ b/app/controllers/transactions/transaction_detail_controller.js
@@ -6,6 +6,7 @@ const auth = require('../../services/auth_service.js')
 const {response} = require('../../utils/response.js')
 const {renderErrorView} = require('../../utils/response.js')
 const {CORRELATION_HEADER} = require('../../utils/correlation_header.js')
+const NEW_CHARGE_STATUS_FEATURE_HEADER = 'NEW_CHARGE_STATUS_ENABLED'
 
 const defaultMsg = 'Error processing transaction view'
 const notFound = 'Charge not found'
@@ -14,9 +15,10 @@ module.exports = (req, res) => {
   const accountId = auth.getCurrentGatewayAccountId(req)
   const chargeId = req.params.chargeId
   const correlationId = req.headers[CORRELATION_HEADER]
+  const newChargeStatusEnabled = req.user.hasFeature(NEW_CHARGE_STATUS_FEATURE_HEADER)
 
   Charge(correlationId)
-    .findWithEvents(accountId, chargeId)
+    .findWithEvents(accountId, chargeId, newChargeStatusEnabled)
     .then(data => {
       data.indexFilters = req.session.filters
       response(req, res, 'transaction_detail/index', data)

--- a/app/controllers/transactions/transaction_download_controller.js
+++ b/app/controllers/transactions/transaction_download_controller.js
@@ -10,14 +10,16 @@ const auth = require('../../services/auth_service.js')
 const date = require('../../utils/dates.js')
 const {renderErrorView} = require('../../utils/response.js')
 const {CORRELATION_HEADER} = require('../../utils/correlation_header.js')
+const NEW_CHARGE_STATUS_FEATURE_HEADER = 'NEW_CHARGE_STATUS_ENABLED'
 
 module.exports = (req, res) => {
   const accountId = auth.getCurrentGatewayAccountId(req)
   const filters = req.query
   const name = `GOVUK Pay ${date.dateToDefaultFormat(new Date())}.csv`
   const correlationId = req.headers[CORRELATION_HEADER]
+  const newChargeStatusEnabled = req.user.hasFeature(NEW_CHARGE_STATUS_FEATURE_HEADER)
   transactionService.searchAll(accountId, filters, correlationId)
-    .then(json => jsonToCsv(json.results))
+    .then(json => jsonToCsv(json.results, newChargeStatusEnabled))
     .then(csv => {
       logger.debug('Sending csv attachment download -', {'filename': name})
       res.setHeader('Content-disposition', 'attachment; filename=' + name)

--- a/app/controllers/transactions/transaction_list_controller.js
+++ b/app/controllers/transactions/transaction_list_controller.js
@@ -52,7 +52,7 @@ module.exports = (req, res) => {
             model.filtersDescription = describeFilters(filters.result)
             model.eventStates = states.allDisplayStateSelectorObjects()
             model.eventStates.forEach(state => {
-              state.value.selected = filters.selectedStates.includes(state.name)
+              state.value.selected = filters.selectedStates && filters.selectedStates.includes(state.name)
             })
           }
 

--- a/app/controllers/transactions/transaction_list_controller.js
+++ b/app/controllers/transactions/transaction_list_controller.js
@@ -33,7 +33,7 @@ module.exports = (req, res) => {
           const model = buildPaymentList(transactions, allCards, accountId, filters.result)
           model.search_path = router.paths.transactions.index
           model.filtersDescription = describeFilters(filters.result)
-          model.eventStates = states.states()
+          model.eventStates = states.old_states()
           model.eventStates.forEach(state => {
             const relevantFilter = (state.type === 'payment' ? filters.result.payment_states : filters.result.refund_states) || []
             state.value.selected = relevantFilter.includes(state.name)

--- a/app/controllers/transactions/transaction_list_controller.js
+++ b/app/controllers/transactions/transaction_list_controller.js
@@ -52,7 +52,7 @@ module.exports = (req, res) => {
             model.filtersDescription = describeFilters(filters.result)
             model.eventStates = states.allDisplayStateSelectorObjects()
             model.eventStates.forEach(state => {
-              state.value.selected = filters.selectedStates && filters.selectedStates.includes(state.name)
+              state.value.selected = filters.result.selectedStates && filters.result.selectedStates.includes(state.name)
             })
           }
 

--- a/app/controllers/transactions/transaction_list_controller.js
+++ b/app/controllers/transactions/transaction_list_controller.js
@@ -12,19 +12,28 @@ const {ConnectorClient} = require('../../services/clients/connector_client.js')
 const {buildPaymentList} = require('../../utils/transaction_view.js')
 const {response} = require('../../utils/response.js')
 const {renderErrorView} = require('../../utils/response.js')
-const {getFilters, describeFilters} = require('../../utils/filters.js')
+const {old_getFilters, old_describeFilters, getFilters, describeFilters} = require('../../utils/filters.js')
 const states = require('../../utils/states')
 const client = new ConnectorClient(process.env.CONNECTOR_URL)
 
 const {CORRELATION_HEADER} = require('../../utils/correlation_header.js')
+const NEW_CHARGE_STATUS_FEATURE_HEADER = 'NEW_CHARGE_STATUS_ENABLED'
 
 module.exports = (req, res) => {
   const accountId = auth.getCurrentGatewayAccountId(req)
-  const filters = getFilters(req)
-  const correlationId = req.headers[CORRELATION_HEADER] || ''
+  const newChargeStatusEnabled = req.user.hasFeature(NEW_CHARGE_STATUS_FEATURE_HEADER)
+  let filters = {}
+  if (!newChargeStatusEnabled) {
+    filters = old_getFilters(req)
+  } else {
+    filters = getFilters(req)
+  }
+  filters.result.newChargeStatusEnabled = newChargeStatusEnabled
 
+  const correlationId = req.headers[CORRELATION_HEADER] || ''
   req.session.filters = url.parse(req.url).query
   if (!filters.valid) return error('Invalid search')
+
   transactionService
     .search(accountId, filters.result, correlationId)
     .then(transactions => {
@@ -32,12 +41,21 @@ module.exports = (req, res) => {
         .getAllCardTypes({correlationId}, allCards => {
           const model = buildPaymentList(transactions, allCards, accountId, filters.result)
           model.search_path = router.paths.transactions.index
-          model.filtersDescription = describeFilters(filters.result)
-          model.eventStates = states.old_states()
-          model.eventStates.forEach(state => {
-            const relevantFilter = (state.type === 'payment' ? filters.result.payment_states : filters.result.refund_states) || []
-            state.value.selected = relevantFilter.includes(state.name)
-          })
+          if (!filters.result.newChargeStatusEnabled) {
+            model.filtersDescription = old_describeFilters(filters.result)
+            model.eventStates = states.old_states()
+            model.eventStates.forEach(state => {
+              const relevantFilter = (state.type === 'payment' ? filters.result.payment_states : filters.result.refund_states) || []
+              state.value.selected = relevantFilter.includes(state.name)
+            })
+          } else {
+            model.filtersDescription = describeFilters(filters.result)
+            model.eventStates = states.allDisplayStateSelectorObjects()
+            model.eventStates.forEach(state => {
+              state.value.selected = filters.selectedStates.includes(state.name)
+            })
+          }
+
           model.stateFiltersFriendly = model.eventStates
             .filter(state => state.value.selected)
             .map(state => state.value.text)

--- a/app/models/TransactionEvent.class.js
+++ b/app/models/TransactionEvent.class.js
@@ -21,7 +21,7 @@ class TransactionEvent {
       message: lodash.get(eventData, 'state.message')
     }
 
-    this.state_friendly = states.getDescription(this.type, this.state.status)
+    this.state_friendly = states.old_getDescription(this.type, this.state.status)
     this.updated_friendly = dates.utcToDisplay(this.updated)
     this.amount_friendly = currencyFormatter.format((this.amount / 100).toFixed(2), {code: 'GBP'})
     if (this.amount && this.type.toLowerCase() === 'refund') {

--- a/app/models/TransactionEvent.class.js
+++ b/app/models/TransactionEvent.class.js
@@ -8,7 +8,7 @@ const states = require('../utils/states')
 const dates = require('../utils/dates')
 
 class TransactionEvent {
-  constructor (eventData) {
+  constructor (eventData, newChargeStatusEnabled = false) {
     this.type = eventData.type
     this.amount = eventData.amount
     this.updated = eventData.updated
@@ -21,7 +21,7 @@ class TransactionEvent {
       message: lodash.get(eventData, 'state.message')
     }
 
-    this.state_friendly = states.old_getDescription(this.type, this.state.status)
+    this.state_friendly = newChargeStatusEnabled ? '' : states.old_getDescription(this.type, this.state.status)
     this.updated_friendly = dates.utcToDisplay(this.updated)
     this.amount_friendly = currencyFormatter.format((this.amount / 100).toFixed(2), {code: 'GBP'})
     if (this.amount && this.type.toLowerCase() === 'refund') {

--- a/app/models/TransactionEvent.class.js
+++ b/app/models/TransactionEvent.class.js
@@ -21,7 +21,7 @@ class TransactionEvent {
       message: lodash.get(eventData, 'state.message')
     }
 
-    this.state_friendly = newChargeStatusEnabled ? '' : states.old_getDescription(this.type, this.state.status)
+    this.state_friendly = newChargeStatusEnabled ? states.getDisplayNameForConnectorState(this.state, this.type) : states.old_getDescription(this.type, this.state.status)
     this.updated_friendly = dates.utcToDisplay(this.updated)
     this.amount_friendly = currencyFormatter.format((this.amount / 100).toFixed(2), {code: 'GBP'})
     if (this.amount && this.type.toLowerCase() === 'refund') {

--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -11,7 +11,7 @@ const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 module.exports = function (correlationId) {
   correlationId = correlationId || ''
 
-  function findWithEvents (accountId, chargeId) {
+  function findWithEvents (accountId, chargeId, newChargeStatusEnabled = false) {
     var defer = q.defer()
     var params = {
       gatewayAccountId: accountId,
@@ -25,11 +25,11 @@ module.exports = function (correlationId) {
           .map(event => event.submitted_by)
         userIds = lodash.uniq(userIds)
         if (userIds.length <= 0) {
-          defer.resolve(transactionView.buildPaymentView(chargeData, eventsData))
+          defer.resolve(transactionView.buildPaymentView(chargeData, eventsData, [], newChargeStatusEnabled))
         } else {
           userService.findMultipleByExternalIds(userIds, correlationId)
             .then(users => {
-              defer.resolve(transactionView.buildPaymentView(chargeData, eventsData, users))
+              defer.resolve(transactionView.buildPaymentView(chargeData, eventsData, users, newChargeStatusEnabled))
             })
             .catch(err => findWithEventsError(err, undefined, defer))
         }

--- a/app/utils/filters.js
+++ b/app/utils/filters.js
@@ -17,6 +17,7 @@ function validateFilters (filters) {
 
 function getFilters (req) {
   let filters = qs.parse(req.query)
+  filters.selectedStates = []
   if (filters.state) {
     filters.selectedStates = typeof filters.state === 'string' ? [filters.state] : filters.state
     const result = states.displayStatesToConnectorStates(filters.selectedStates)
@@ -35,10 +36,8 @@ function describeFilters (filters) {
   if (filters.fromDate) description += ` from <strong>${filters.fromDate}</strong>`
   if (filters.toDate) description += ` to <strong>${filters.toDate}</strong>`
 
-  const paymentStates = filters.payment_states ? filters.payment_states.map(state => states.getDisplayNameForConnectorState(state, 'payment')) : []
-  const refundStates = filters.refund_states ? filters.refund_states.map(state => states.getDisplayNameForConnectorState(state, 'refund')) : []
-  const selectedStates = [...paymentStates, ...refundStates].map(state => `${state}`)
-  if (filters.state && selectedStates.length === 0) {
+  const selectedStates = filters.selectedStates || []
+  if (filters.state && filters.selectedStates.length === 0) {
     description += ` with <strong>${filters.state}</strong> state`
   } else if (selectedStates.length === 1) {
     description += ` with <strong>${selectedStates[0]}</strong> state`

--- a/app/utils/filters.js
+++ b/app/utils/filters.js
@@ -55,7 +55,7 @@ function describeFilters (filters) {
   return description
 }
 
-function old_describeFilters (filters) {
+function old_describeFilters (filters) { // eslint-disable-line
   let description = ``
   if (filters.fromDate) description += ` from <strong>${filters.fromDate}</strong>`
   if (filters.toDate) description += ` to <strong>${filters.toDate}</strong>`
@@ -81,7 +81,7 @@ function old_describeFilters (filters) {
   return description
 }
 
-function old_getFilters (req) {
+function old_getFilters (req) { // eslint-disable-line
   let filters = qs.parse(req.query)
 
   if (filters.state) {
@@ -97,8 +97,8 @@ function old_getFilters (req) {
 }
 
 module.exports = {
-  old_getFilters: old_getFilters,
-  old_describeFilters: old_describeFilters,
+  old_getFilters: old_getFilters, // eslint-disable-line
+  old_describeFilters: old_describeFilters, // eslint-disable-line
   getFilters: getFilters,
   describeFilters: describeFilters
 }

--- a/app/utils/states.js
+++ b/app/utils/states.js
@@ -4,6 +4,141 @@ const lodash = require('lodash')
 const changeCase = require('change-case')
 
 const PAYMENT_STATE_DESCRIPTIONS = {
+  'created': {
+    displayName: 'In progress'
+  },
+  'started': {
+    displayName: 'In progress'
+  },
+  'submitted': {
+    displayName: 'In progress'
+  },
+  'success': {
+    displayName: 'Success'
+  },
+  'error': {
+    displayName: 'Error',
+    errorCodes: ['P0050']
+  },
+  'failed': {
+    displayName: 'Failed',
+    errorCodes: ['P0010', 'P0020', 'P0030']
+  },
+  'cancelled': {
+    displayName: 'Cancelled',
+    errorCodes: ['P0040']
+  }
+}
+
+const REFUND_STATE_DESCRIPTIONS = {
+  'submitted': {
+    description: 'Refund submitted',
+    displayName: 'Refund submitted'
+  },
+  'error': {
+    description: 'Error processing refund',
+    displayName: 'Refund error'
+  },
+  'success': {
+    description: 'Refund successful',
+    displayName: 'Refund success'
+  }
+}
+
+const ERROR_CODE_TO_DISPLAY_STATE = {
+  'P0010': 'Declined',
+  'P0020': 'Timed out',
+  'P0030': 'Cancelled',
+  'P0040': 'Cancelled',
+  'P0050': 'Error'
+}
+
+exports.allDisplayStates = () => [... uniqueDisplayStates(PAYMENT_STATE_DESCRIPTIONS), ... uniqueDisplayStates(REFUND_STATE_DESCRIPTIONS)]
+exports.displayStatesToConnectorStates = (displayStatesArray) => toConnectorStates(displayStatesArray)
+exports.allDisplayStateSelectorObjects = () => exports.allDisplayStates().map(state => toSelectorObject(state))
+exports.getDisplayNameForConnectorState = (connectorState, type = 'payment') => {
+  return displayNameForConnectorState(connectorState, type)
+}
+
+// TODO: leaving this toSelector Object structure for backward compatibility.
+//       Simplify this when removing the feature flag for displaying the new payment states (PP-3377)
+function toSelectorObject (displayName = '') {
+  return {
+    type: displayName,
+    name: displayName,
+    key: `${displayName}`,
+    value: {
+      text: displayName
+    }
+  }
+}
+
+function uniqueDisplayStates (stateDescriptions) {
+  const result = lodash.flattenDeep(Object.keys(stateDescriptions).map(key => {
+    if (stateDescriptions[key].errorCodes) {
+      return stateDescriptions[key].errorCodes.map(errorCode => ERROR_CODE_TO_DISPLAY_STATE[errorCode])
+    }
+    return stateDescriptions[key].displayName
+  }))
+  return lodash.uniq(result)
+}
+
+function displayNameForConnectorState (connectorState, type) {
+  if (connectorState.code && ERROR_CODE_TO_DISPLAY_STATE[connectorState.code]) {
+    return ERROR_CODE_TO_DISPLAY_STATE[connectorState.code]
+  }
+  return getDisplayNameFromConnectorState(connectorState, type)
+}
+
+function getDisplayNameFromConnectorState (connectorState, type = 'payment') {
+  if (type === 'payment') {
+    const found = Object.keys(PAYMENT_STATE_DESCRIPTIONS).find(connectorPaymentState => connectorPaymentState === connectorState.status.toLowerCase())
+    if (found) {
+      return lodash.get(PAYMENT_STATE_DESCRIPTIONS, `${found}.displayName`, '')
+    }
+  } else {
+    const found = Object.keys(REFUND_STATE_DESCRIPTIONS).find(refundPaymentState => refundPaymentState === connectorState.status.toLowerCase())
+    if (found) {
+      return lodash.get(REFUND_STATE_DESCRIPTIONS, `${found}.displayName`, '')
+    }
+  }
+  return ''
+}
+
+function toConnectorStates (displayStates) {
+  const result = {
+    payment_states: [],
+    refund_states: [],
+  }
+  displayStates.forEach(displayState => {
+    Object.keys(PAYMENT_STATE_DESCRIPTIONS).forEach(connectorPaymentState => {
+      if (PAYMENT_STATE_DESCRIPTIONS[connectorPaymentState].errorCodes) {
+        const found = PAYMENT_STATE_DESCRIPTIONS[connectorPaymentState].errorCodes.find(errorCode => ERROR_CODE_TO_DISPLAY_STATE[errorCode] === displayState)
+        if (found) {
+          result.payment_states.push(connectorPaymentState)
+        }
+      } else {
+        if (PAYMENT_STATE_DESCRIPTIONS[connectorPaymentState].displayName === displayState) {
+          result.payment_states.push(connectorPaymentState)
+        }
+      }
+    })
+
+    Object.keys(REFUND_STATE_DESCRIPTIONS).forEach(refundPaymentState => {
+      if (REFUND_STATE_DESCRIPTIONS[refundPaymentState].displayName === displayState) {
+        result.refund_states.push(refundPaymentState)
+      }
+    })
+  })
+  result.payment_states = lodash.uniq(result.payment_states)
+  result.refund_states = lodash.uniq(result.refund_states)
+  return result
+}
+
+// OLD Status code logic from here onwards -- TO REMOVE once the feature flag is taken off (PP-3377)
+// ------------------------------------------------------------------------------------------
+
+const OLD_PAYMENT_STATE_DESCRIPTIONS = {
   'created': 'Service created payment',
   'started': 'User entering card details',
   'submitted': 'User submitted card details',
@@ -12,25 +147,25 @@ const PAYMENT_STATE_DESCRIPTIONS = {
   'failed': 'User failed to complete payment',
   'cancelled': 'Service cancelled payment'
 }
-const REFUND_STATE_DESCRIPTIONS = {
+const OLD_REFUND_STATE_DESCRIPTIONS = {
   'submitted': 'Refund submitted',
   'error': 'Error processing refund',
   'success': 'Refund successful'
 }
 
-exports.payment_states = () => Object.keys(PAYMENT_STATE_DESCRIPTIONS).map(key => toSelectorObject('PAYMENT', key))
-exports.refund_states = () => Object.keys(REFUND_STATE_DESCRIPTIONS).map(key => toSelectorObject('REFUND', key))
-exports.states = () => [...exports.payment_states(), ...exports.refund_states()]
-exports.getDisplayName = (type = 'payment', name = '') => {
-  const origin = exports.states().find(event => event.name === name.toLowerCase() && event.type === type.toLowerCase())
+exports.old_payment_states = () => Object.keys(OLD_PAYMENT_STATE_DESCRIPTIONS).map(key => old_toSelectorObject('PAYMENT', key))
+exports.old_refund_states = () => Object.keys(OLD_REFUND_STATE_DESCRIPTIONS).map(key => old_toSelectorObject('REFUND', key))
+exports.old_states = () => [...exports.old_payment_states(), ...exports.old_refund_states()]
+exports.old_getDisplayName = (type = 'payment', name = '') => {
+  const origin = exports.old_states().find(event => event.name === name.toLowerCase() && event.type === type.toLowerCase())
   return lodash.get(origin, `value.text`, changeCase.upperCaseFirst(name.toLowerCase()))
 }
-exports.getDescription = (type = '', name = '') => {
-  const origin = type.toLowerCase() === 'refund' ? REFUND_STATE_DESCRIPTIONS : PAYMENT_STATE_DESCRIPTIONS
+exports.old_getDescription = (type = '', name = '') => {
+  const origin = type.toLowerCase() === 'refund' ? OLD_REFUND_STATE_DESCRIPTIONS : OLD_PAYMENT_STATE_DESCRIPTIONS
   return origin[name.toLowerCase()]
 }
 
-function toSelectorObject (type = '', name = '') {
+function old_toSelectorObject (type = '', name = '') {
   return {
     type: type.toLowerCase(),
     name: name.toLowerCase(),

--- a/app/utils/states.js
+++ b/app/utils/states.js
@@ -57,7 +57,8 @@ exports.allDisplayStates = () => [... uniqueDisplayStates(PAYMENT_STATE_DESCRIPT
 exports.displayStatesToConnectorStates = (displayStatesArray) => toConnectorStates(displayStatesArray)
 exports.allDisplayStateSelectorObjects = () => exports.allDisplayStates().map(state => toSelectorObject(state))
 exports.getDisplayNameForConnectorState = (connectorState, type = 'payment') => {
-  return displayNameForConnectorState(connectorState, type)
+  const sanitisedType = (type.toLowerCase() === 'charge') ? 'payment' : type.toLowerCase();
+  return displayNameForConnectorState(connectorState, sanitisedType)
 }
 
 // TODO: leaving this toSelector Object structure for backward compatibility.

--- a/app/utils/states.js
+++ b/app/utils/states.js
@@ -91,13 +91,14 @@ function displayNameForConnectorState (connectorState, type) {
 }
 
 function getDisplayNameFromConnectorState (connectorState, type = 'payment') {
+  let stateToConvert = connectorState.status || connectorState
   if (type === 'payment') {
-    const found = Object.keys(PAYMENT_STATE_DESCRIPTIONS).find(connectorPaymentState => connectorPaymentState === connectorState.status.toLowerCase())
+    const found = Object.keys(PAYMENT_STATE_DESCRIPTIONS).find(connectorPaymentState => connectorPaymentState === stateToConvert.toLowerCase())
     if (found) {
       return lodash.get(PAYMENT_STATE_DESCRIPTIONS, `${found}.displayName`, '')
     }
   } else {
-    const found = Object.keys(REFUND_STATE_DESCRIPTIONS).find(refundPaymentState => refundPaymentState === connectorState.status.toLowerCase())
+    const found = Object.keys(REFUND_STATE_DESCRIPTIONS).find(refundPaymentState => refundPaymentState === stateToConvert.toLowerCase())
     if (found) {
       return lodash.get(REFUND_STATE_DESCRIPTIONS, `${found}.displayName`, '')
     }

--- a/app/utils/states.js
+++ b/app/utils/states.js
@@ -53,11 +53,11 @@ const ERROR_CODE_TO_DISPLAY_STATE = {
   'P0050': 'Error'
 }
 
-exports.allDisplayStates = () => [... uniqueDisplayStates(PAYMENT_STATE_DESCRIPTIONS), ... uniqueDisplayStates(REFUND_STATE_DESCRIPTIONS)]
+exports.allDisplayStates = () => [...uniqueDisplayStates(PAYMENT_STATE_DESCRIPTIONS), ...uniqueDisplayStates(REFUND_STATE_DESCRIPTIONS)]
 exports.displayStatesToConnectorStates = (displayStatesArray) => toConnectorStates(displayStatesArray)
 exports.allDisplayStateSelectorObjects = () => exports.allDisplayStates().map(state => toSelectorObject(state))
 exports.getDisplayNameForConnectorState = (connectorState, type = 'payment') => {
-  const sanitisedType = (type.toLowerCase() === 'charge') ? 'payment' : type.toLowerCase();
+  const sanitisedType = (type.toLowerCase() === 'charge') ? 'payment' : type.toLowerCase()
   return displayNameForConnectorState(connectorState, sanitisedType)
 }
 
@@ -65,9 +65,9 @@ exports.getDisplayNameForConnectorState = (connectorState, type = 'payment') => 
 //       Simplify this when removing the feature flag for displaying the new payment states (PP-3377)
 function toSelectorObject (displayName = '') {
   return {
-    type: displayName, //to remove
+    type: displayName, // to remove
     name: displayName,
-    key: `${displayName}`, //to remove
+    key: `${displayName}`, // to remove
     value: {
       text: displayName
     }
@@ -110,7 +110,7 @@ function getDisplayNameFromConnectorState (connectorState, type = 'payment') {
 function toConnectorStates (displayStates) {
   const result = {
     payment_states: [],
-    refund_states: [],
+    refund_states: []
   }
   displayStates.forEach(displayState => {
     Object.keys(PAYMENT_STATE_DESCRIPTIONS).forEach(connectorPaymentState => {
@@ -155,19 +155,19 @@ const OLD_REFUND_STATE_DESCRIPTIONS = {
   'success': 'Refund successful'
 }
 
-exports.old_payment_states = () => Object.keys(OLD_PAYMENT_STATE_DESCRIPTIONS).map(key => old_toSelectorObject('PAYMENT', key))
-exports.old_refund_states = () => Object.keys(OLD_REFUND_STATE_DESCRIPTIONS).map(key => old_toSelectorObject('REFUND', key))
-exports.old_states = () => [...exports.old_payment_states(), ...exports.old_refund_states()]
-exports.old_getDisplayName = (type = 'payment', name = '') => {
-  const origin = exports.old_states().find(event => event.name === name.toLowerCase() && event.type === type.toLowerCase())
+exports.old_payment_states = () => Object.keys(OLD_PAYMENT_STATE_DESCRIPTIONS).map(key => old_toSelectorObject('PAYMENT', key)) // eslint-disable-line
+exports.old_refund_states = () => Object.keys(OLD_REFUND_STATE_DESCRIPTIONS).map(key => old_toSelectorObject('REFUND', key)) // eslint-disable-line
+exports.old_states = () => [...exports.old_payment_states(), ...exports.old_refund_states()] // eslint-disable-line
+exports.old_getDisplayName = (type = 'payment', name = '') => {  // eslint-disable-line
+  const origin = exports.old_states().find(event => event.name === name.toLowerCase() && event.type === type.toLowerCase()) // eslint-disable-line
   return lodash.get(origin, `value.text`, changeCase.upperCaseFirst(name.toLowerCase()))
 }
-exports.old_getDescription = (type = '', name = '') => {
+exports.old_getDescription = (type = '', name = '') => {  // eslint-disable-line
   const origin = type.toLowerCase() === 'refund' ? OLD_REFUND_STATE_DESCRIPTIONS : OLD_PAYMENT_STATE_DESCRIPTIONS
   return origin[name.toLowerCase()]
 }
 
-function old_toSelectorObject (type = '', name = '') {
+function old_toSelectorObject (type = '', name = '') {  // eslint-disable-line
   return {
     type: type.toLowerCase(),
     name: name.toLowerCase(),

--- a/app/utils/states.js
+++ b/app/utils/states.js
@@ -64,9 +64,9 @@ exports.getDisplayNameForConnectorState = (connectorState, type = 'payment') => 
 //       Simplify this when removing the feature flag for displaying the new payment states (PP-3377)
 function toSelectorObject (displayName = '') {
   return {
-    type: displayName,
+    type: displayName, //to remove
     name: displayName,
-    key: `${displayName}`,
+    key: `${displayName}`, //to remove
     value: {
       text: displayName
     }

--- a/app/utils/transaction_view.js
+++ b/app/utils/transaction_view.js
@@ -43,7 +43,7 @@ module.exports = {
       })
 
     connectorData.results.forEach(element => {
-      element.state_friendly = states.getDisplayName(element.transaction_type, element.state.status)
+      element.state_friendly = states.old_getDisplayName(element.transaction_type, element.state.status)
       element.amount = asGBP(element.amount)
       element.email = (element.email && element.email.length > 20) ? element.email.substring(0, 20) + '...' : element.email
       element.updated = dates.utcToDisplay(element.updated)

--- a/app/utils/transaction_view.js
+++ b/app/utils/transaction_view.js
@@ -44,7 +44,7 @@ module.exports = {
 
     connectorData.results.forEach(element => {
       if (filtersResult.newChargeStatusEnabled) {
-        element.state_friendly = states.getDisplayNameForConnectorState(element.state.status, element.transaction_type)
+        element.state_friendly = states.getDisplayNameForConnectorState(element.state, element.transaction_type)
       } else {
         element.state_friendly = states.old_getDisplayName(element.transaction_type, element.state.status)
       }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "babel-preset-env": "^1.6.1",
     "babelify": "^8.0.0",
     "chai": "^4.0.2",
+    "chai-arrays": "^2.0.0",
     "chai-as-promised": "^7.0.0",
     "chai-string": "^1.4.0",
     "cheerio": "^1.0.0-rc.1",

--- a/test/fixtures/user_fixtures.js
+++ b/test/fixtures/user_fixtures.js
@@ -155,7 +155,8 @@ module.exports = {
       otp_key: opts.otp_key || randomOtpKey(),
       disabled: opts.disabled || false,
       login_counter: opts.login_counter || 0,
-      session_version: opts.session_version || 0
+      session_version: opts.session_version || 0,
+      features: opts.features || ''
     }
 
     return {

--- a/test/integration/json/transaction_download.json
+++ b/test/integration/json/transaction_download.json
@@ -1,9 +1,10 @@
 [
   {
     "amount": 12345,
+    "transaction_type": "charge",
     "state": {
-      "status": "succeeded",
-      "finished": false
+      "status": "success",
+      "finished": true
     },
     "card_brand": "Visa",
     "description": "desc-red",
@@ -33,8 +34,9 @@
   },
   {
     "amount": 999,
+    "transaction_type": "charge",
     "state": {
-      "status": "canceled",
+      "status": "cancelled",
       "finished": true,
       "code": "P01234",
       "message": "Something happened"

--- a/test/integration/json/transaction_download_refunds.json
+++ b/test/integration/json/transaction_download_refunds.json
@@ -2,7 +2,7 @@
   {
     "amount": 12345,
     "state": {
-      "status": "succeeded",
+      "status": "success",
       "finished": false
     },
     "card_brand": "Visa",

--- a/test/integration/json/transaction_download_spreadsheet_formula_injection.json
+++ b/test/integration/json/transaction_download_spreadsheet_formula_injection.json
@@ -2,7 +2,7 @@
   {
     "amount": 12345,
     "state": {
-      "status": "succeeded",
+      "status": "success",
       "finished": false
     },
     "card_brand": "Visa",
@@ -29,6 +29,7 @@
       "cardholder_name": "TEST01",
       "expiry_date": "12\/19",
       "last_digits_card_number": "4242"
-    }
+    },
+    "transaction_type": "charge"
   }
 ]

--- a/test/integration/old_transaction_details_ft_tests.js
+++ b/test/integration/old_transaction_details_ft_tests.js
@@ -40,9 +40,7 @@ describe('The transaction view scenarios', function () {
   beforeEach(function (done) {
     let permissions = 'transactions-details:read'
     let user = session.getUser({
-      gateway_account_ids: [gatewayAccountId],
-      permissions: [{name: permissions}],
-      features: 'NEW_CHARGE_STATUS_ENABLED'
+      gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
     })
     app = session.getAppWithLoggedInUser(getApp(), user)
 
@@ -56,7 +54,7 @@ describe('The transaction view scenarios', function () {
         'charge_id': chargeId,
         'events': [
           {
-            'type': 'payment',
+            'type': 'PAYMENT',
             'state': {
               'status': 'created',
               'finished': false
@@ -65,7 +63,7 @@ describe('The transaction view scenarios', function () {
             'updated': '2015-12-24 13:21:05'
           },
           {
-            'type': 'payment',
+            'type': 'PAYMENT',
             'state': {
               'status': 'started',
               'finished': false
@@ -74,7 +72,7 @@ describe('The transaction view scenarios', function () {
             'updated': '2015-12-24 13:23:12'
           },
           {
-            'type': 'payment',
+            'type': 'PAYMENT',
             'state': {
               'status': 'success',
               'finished': true
@@ -83,7 +81,7 @@ describe('The transaction view scenarios', function () {
             'updated': '2015-12-24 12:05:43'
           },
           {
-            'type': 'payment',
+            'type': 'PAYMENT',
             'state': {
               'status': 'cancelled',
               'finished': true,
@@ -94,7 +92,7 @@ describe('The transaction view scenarios', function () {
             'updated': '2015-12-24 12:05:43'
           },
           {
-            'type': 'payment',
+            'type': 'PAYMENT',
             'state': {
               'status': 'failed',
               'finished': true,
@@ -199,9 +197,9 @@ describe('The transaction view scenarios', function () {
               'message': 'Payment was cancelled by the user',
               'code': 'P0030'
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': '20000',
-            'state_friendly': 'Cancelled',
+            'state_friendly': 'User failed to complete payment',
             'updated': '2015-12-24 12:05:43',
             'amount_friendly': '£200.00',
             'updated_friendly': '24 Dec 2015 — 12:05:43'
@@ -213,9 +211,9 @@ describe('The transaction view scenarios', function () {
               'message': 'Payment was cancelled by the service',
               'code': 'P0040'
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': '20000',
-            'state_friendly': 'Cancelled',
+            'state_friendly': 'Service cancelled payment',
             'amount_friendly': '£200.00',
             'updated': '2015-12-24 12:05:43',
             'updated_friendly': '24 Dec 2015 — 12:05:43'
@@ -225,9 +223,9 @@ describe('The transaction view scenarios', function () {
               'status': 'success',
               'finished': true
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': '20000',
-            'state_friendly': 'Success',
+            'state_friendly': 'Payment successful',
             'amount_friendly': '£200.00',
             'updated': '2015-12-24 12:05:43',
             'updated_friendly': '24 Dec 2015 — 12:05:43'
@@ -237,9 +235,9 @@ describe('The transaction view scenarios', function () {
               'status': 'started',
               'finished': false
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': '20000',
-            'state_friendly': 'In progress',
+            'state_friendly': 'User entering card details',
             'amount_friendly': '£200.00',
             'updated': '2015-12-24 13:23:12',
             'updated_friendly': '24 Dec 2015 — 13:23:12'
@@ -249,9 +247,9 @@ describe('The transaction view scenarios', function () {
               'status': 'created',
               'finished': false
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': '20000',
-            'state_friendly': 'In progress',
+            'state_friendly': 'Service created payment',
             'amount_friendly': '£200.00',
             'updated': '2015-12-24 13:21:05',
             'updated_friendly': '24 Dec 2015 — 13:21:05'
@@ -279,7 +277,7 @@ describe('The transaction view scenarios', function () {
         'charge_id': chargeId,
         'events': [
           {
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'state': {
               'status': 'created',
@@ -288,7 +286,7 @@ describe('The transaction view scenarios', function () {
             'updated': '2015-12-24 13:21:05'
           },
           {
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'state': {
               'status': 'started',
@@ -365,26 +363,26 @@ describe('The transaction view scenarios', function () {
         'gateway_transaction_id': 'dsfh-34578fb-4und-8dhry',
         'events': [
           {
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'amount_friendly': '£50.00',
             'state': {
               'status': 'started',
               'finished': false
             },
-            'state_friendly': 'In progress',
+            'state_friendly': 'User entering card details',
             'updated': '2015-12-24 13:23:12',
             'updated_friendly': '24 Dec 2015 — 13:23:12'
           },
           {
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'amount_friendly': '£50.00',
             'state': {
               'status': 'created',
               'finished': false
             },
-            'state_friendly': 'In progress',
+            'state_friendly': 'Service created payment',
             'updated': '2015-12-24 13:21:05',
             'updated_friendly': '24 Dec 2015 — 13:21:05'
           }
@@ -411,7 +409,7 @@ describe('The transaction view scenarios', function () {
         'charge_id': chargeId,
         'events': [
           {
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'state': {
               'status': 'created',
@@ -420,7 +418,7 @@ describe('The transaction view scenarios', function () {
             'updated': '2015-12-24 13:21:05'
           },
           {
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'state': {
               'status': 'started',
@@ -509,10 +507,10 @@ describe('The transaction view scenarios', function () {
               'status': 'started',
               'finished': false
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'amount_friendly': '£50.00',
-            'state_friendly': 'In progress',
+            'state_friendly': 'User entering card details',
             'updated': '2015-12-24 13:23:12',
             'updated_friendly': '24 Dec 2015 — 13:23:12'
           },
@@ -521,10 +519,10 @@ describe('The transaction view scenarios', function () {
               'status': 'created',
               'finished': false
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'amount_friendly': '£50.00',
-            'state_friendly': 'In progress',
+            'state_friendly': 'Service created payment',
             'updated': '2015-12-24 13:21:05',
             'updated_friendly': '24 Dec 2015 — 13:21:05'
           }
@@ -555,7 +553,7 @@ describe('The transaction view scenarios', function () {
               'status': 'created',
               'finished': false
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'updated': '2015-12-24 13:21:05'
           },
@@ -564,7 +562,7 @@ describe('The transaction view scenarios', function () {
               'status': 'started',
               'finished': false
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'updated': '2015-12-24 13:23:12'
           },
@@ -573,7 +571,7 @@ describe('The transaction view scenarios', function () {
               'status': 'success',
               'finished': true
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'updated': '2015-12-24 12:05:43'
           },
@@ -584,7 +582,7 @@ describe('The transaction view scenarios', function () {
               'message': 'Payment was cancelled by the service',
               'code': 'P0040'
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'updated': '2015-12-24 12:05:43'
           },
@@ -595,7 +593,7 @@ describe('The transaction view scenarios', function () {
               'message': 'Payment was cancelled by the user',
               'code': 'P0030'
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'updated': '2015-12-24 12:05:43'
           }
@@ -694,10 +692,10 @@ describe('The transaction view scenarios', function () {
               'message': 'Payment was cancelled by the user',
               'code': 'P0030'
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'amount_friendly': '£50.00',
-            'state_friendly': 'Cancelled',
+            'state_friendly': 'User failed to complete payment',
             'updated': '2015-12-24 12:05:43',
             'updated_friendly': '24 Dec 2015 — 12:05:43'
           },
@@ -708,10 +706,10 @@ describe('The transaction view scenarios', function () {
               'message': 'Payment was cancelled by the service',
               'code': 'P0040'
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'amount_friendly': '£50.00',
-            'state_friendly': 'Cancelled',
+            'state_friendly': 'Service cancelled payment',
             'updated': '2015-12-24 12:05:43',
             'updated_friendly': '24 Dec 2015 — 12:05:43'
           },
@@ -720,10 +718,10 @@ describe('The transaction view scenarios', function () {
               'status': 'success',
               'finished': true
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'amount_friendly': '£50.00',
-            'state_friendly': 'Success',
+            'state_friendly': 'Payment successful',
             'updated': '2015-12-24 12:05:43',
             'updated_friendly': '24 Dec 2015 — 12:05:43'
           },
@@ -732,10 +730,10 @@ describe('The transaction view scenarios', function () {
               'status': 'started',
               'finished': false
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'amount_friendly': '£50.00',
-            'state_friendly': 'In progress',
+            'state_friendly': 'User entering card details',
             'updated': '2015-12-24 13:23:12',
             'updated_friendly': '24 Dec 2015 — 13:23:12'
           },
@@ -744,10 +742,10 @@ describe('The transaction view scenarios', function () {
               'status': 'created',
               'finished': false
             },
-            'type': 'payment',
+            'type': 'PAYMENT',
             'amount': 5000,
             'amount_friendly': '£50.00',
-            'state_friendly': 'In progress',
+            'state_friendly': 'Service created payment',
             'updated': '2015-12-24 13:21:05',
             'updated_friendly': '24 Dec 2015 — 13:21:05'
           }

--- a/test/integration/old_transaction_download_ft_tests.js
+++ b/test/integration/old_transaction_download_ft_tests.js
@@ -35,7 +35,7 @@ function downloadTransactionList (query) {
     .set('Accept', 'application/json')
 }
 
-describe('Transaction download endpoints', function () {
+describe('Old Transaction download endpoints', function () {
   afterEach(function () {
     nock.cleanAll()
     app = null
@@ -44,9 +44,7 @@ describe('Transaction download endpoints', function () {
   beforeEach(function (done) {
     let permissions = 'transactions-download:read'
     let user = session.getUser({
-      gateway_account_ids: [gatewayAccountId],
-      permissions: [{name: permissions}],
-      features: 'NEW_CHARGE_STATUS_ENABLED'
+      gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
     })
     app = session.getAppWithLoggedInUser(getApp(), user)
 
@@ -84,8 +82,8 @@ describe('Transaction download endpoints', function () {
           let csvContent = res.text
           let arrayOfLines = csvContent.split('\n')
           assert(5, arrayOfLines.length)
-          assert.equal('"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","Success",true,"","","transaction-1","charge1","12 May 2016 — 17:37:29"', arrayOfLines[1])
-          assert.equal('"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","Cancelled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"', arrayOfLines[2])
+          assert.equal('"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","success",true,"","","transaction-1","charge1","12 May 2016 — 17:37:29"', arrayOfLines[1])
+          assert.equal('"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","cancelled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"', arrayOfLines[2])
         })
         .end(function (err, res) {
           if (err) return done(err)
@@ -93,10 +91,10 @@ describe('Transaction download endpoints', function () {
           let arrayOfLines = csvContent.split('\n')
           expect(arrayOfLines.length).to.equal(5)
           expect(arrayOfLines[0]).to.equal('"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Date Created"')
-          expect(arrayOfLines[1]).to.equal('"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","Success",true,"","","transaction-1","charge1","12 May 2016 — 17:37:29"')
-          expect(arrayOfLines[2]).to.equal('"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","Cancelled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"')
-          expect(arrayOfLines[3]).to.equal('"red","desc-red","alice.111@mail.fake","12.34","Visa","TEST01","12/19","4242","Success",true,"","","transaction-1","charge1","12 May 2016 — 17:37:29"')
-          expect(arrayOfLines[4]).to.equal('"blue","desc-blue","alice.222@mail.fake","1.23","Mastercard","TEST02","12/19","4241","Cancelled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"')
+          expect(arrayOfLines[1]).to.equal('"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","success",true,"","","transaction-1","charge1","12 May 2016 — 17:37:29"')
+          expect(arrayOfLines[2]).to.equal('"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","cancelled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"')
+          expect(arrayOfLines[3]).to.equal('"red","desc-red","alice.111@mail.fake","12.34","Visa","TEST01","12/19","4242","success",true,"","","transaction-1","charge1","12 May 2016 — 17:37:29"')
+          expect(arrayOfLines[4]).to.equal('"blue","desc-blue","alice.222@mail.fake","1.23","Mastercard","TEST02","12/19","4241","cancelled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015 — 19:55:29"')
           done()
         })
     })
@@ -130,7 +128,7 @@ describe('Transaction download endpoints', function () {
           let csvContent = res.text
           let arrayOfLines = csvContent.split('\n')
           expect(arrayOfLines[0]).to.equal('"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Date Created"')
-          expect(arrayOfLines[1]).to.equal('"\'+red","\'=calc+z!A0","\'-alice.111@mail.fake","123.45","\'@Visa","TEST01","12/19","4242","Success",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"')
+          expect(arrayOfLines[1]).to.equal('"\'+red","\'=calc+z!A0","\'-alice.111@mail.fake","123.45","\'@Visa","TEST01","12/19","4242","success",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"')
           done()
         })
     })
@@ -152,10 +150,10 @@ describe('Transaction download endpoints', function () {
           results: results
         })
 
-      connectorMockResponds(200, mockJson, {refund_states: 'success'})
+      connectorMockResponds(200, mockJson, {state: 'success', refund_states: 'success'})
 
       request(app)
-        .get(paths.transactions.download + '?refund_states=success')
+        .get(paths.transactions.download + '?state=success&refund_states=success')
         .set('Accept', 'application/json')
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
@@ -187,10 +185,10 @@ describe('Transaction download endpoints', function () {
           results: results
         })
 
-      connectorMockResponds(200, mockJson, {payment_states: 'success'})
+      connectorMockResponds(200, mockJson, {state: 'success', payment_states: 'success'})
 
       request(app)
-        .get(paths.transactions.download + '?payment_states=success')
+        .get(paths.transactions.download + '?state=success&payment_states=success')
         .set('Accept', 'application/json')
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
@@ -200,7 +198,7 @@ describe('Transaction download endpoints', function () {
           let csvContent = res.text
           let arrayOfLines = csvContent.split('\n')
           expect(arrayOfLines[0]).to.equal('"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Date Created"')
-          expect(arrayOfLines[1]).to.equal('"\'+red","\'=calc+z!A0","\'-alice.111@mail.fake","123.45","\'@Visa","TEST01","12/19","4242","Success",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"')
+          expect(arrayOfLines[1]).to.equal('"\'+red","\'=calc+z!A0","\'-alice.111@mail.fake","123.45","\'@Visa","TEST01","12/19","4242","success",false,"","","transaction-1","charge1","12 May 2016 — 17:37:29"')
           done()
         })
     })

--- a/test/integration/old_transaction_list_ft_tests.js
+++ b/test/integration/old_transaction_list_ft_tests.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const chai = require('chai')
-const lodash = require('lodash')
 const chaiAsPromised = require('chai-as-promised')
 require('../test_helpers/serialize_mock.js')
 const userCreator = require('../test_helpers/user_creator.js')
@@ -16,7 +15,7 @@ const CONNECTOR_DATE = '2016-02-10T12:44:01.000Z'
 const DISPLAY_DATE = '10 Feb 2016 — 12:44:01'
 const gatewayAccountId = '651342'
 const {expect} = chai
-const connectorSearchParameters = {}
+const searchParameters = {}
 const CONNECTOR_CHARGES_API_PATH = '/v2/api/accounts/' + gatewayAccountId + '/charges'
 const CONNECTOR_ALL_CARD_TYPES_API_PATH = '/v1/api/card-types'
 const ALL_CARD_TYPES = {
@@ -45,9 +44,7 @@ describe('The /transactions endpoint', function () {
   beforeEach(function (done) {
     let permissions = 'transactions:read'
     let user = session.getUser({
-      gateway_account_ids: [gatewayAccountId],
-      permissions: [{name: permissions}],
-      features: 'NEW_CHARGE_STATUS_ENABLED'
+      gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
     })
     app = session.getAppWithLoggedInUser(getApp(), user)
 
@@ -66,9 +63,8 @@ describe('The /transactions endpoint', function () {
           'amount': 5000,
           'reference': 'ref1',
           'email': 'alice.222@mail.fake',
-          transaction_type: 'payment',
           'state': {
-            'status': 'created',
+            'status': 'testing',
             'finished': false
           },
           'card_brand': 'Visa',
@@ -82,10 +78,9 @@ describe('The /transactions endpoint', function () {
           'amount': 2000,
           'reference': 'ref2',
           'email': 'alice.111@mail.fake',
-          transaction_type: 'payment',
           'state': {
-            'status': 'success',
-            'finished': true
+            'status': 'testing2',
+            'finished': false
           },
           'card_brand': 'Visa',
           'updated': CONNECTOR_DATE,
@@ -96,7 +91,7 @@ describe('The /transactions endpoint', function () {
       total: 2
     }
 
-    connectorMockResponds(200, connectorData, connectorSearchParameters)
+    connectorMockResponds(200, connectorData, searchParameters)
 
     let expectedData = {
       'results': [
@@ -106,13 +101,12 @@ describe('The /transactions endpoint', function () {
           'amount': '£50.00',
           'reference': 'ref1',
           'email': 'alice.222@mail.fake',
-          transaction_type: 'payment',
           'state': {
-            'status': 'created',
+            'status': 'testing',
             'finished': false
           },
           'card_brand': 'Visa',
-          'state_friendly': 'In progress',
+          'state_friendly': 'Testing',
           'gateway_account_id': gatewayAccountId,
           'updated': DISPLAY_DATE,
           'created': DISPLAY_DATE,
@@ -124,13 +118,12 @@ describe('The /transactions endpoint', function () {
           'amount': '£20.00',
           'reference': 'ref2',
           'email': 'alice.111@mail.fake',
-          transaction_type: 'payment',
           'state': {
-            'status': 'success',
-            'finished': true
+            'status': 'testing2',
+            'finished': false
           },
           'card_brand': 'Visa',
-          'state_friendly': 'Success',
+          'state_friendly': 'Testing2',
           'gateway_account_id': gatewayAccountId,
           'updated': DISPLAY_DATE,
           'created': DISPLAY_DATE,
@@ -149,51 +142,47 @@ describe('The /transactions endpoint', function () {
       .end(done)
   })
 
-  it('should return a list of transactions for the gateway account with no csv download link', function (done) {
+  it('should return a list of transactions for the gateway account', function (done) {
     connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
       .reply(200, ALL_CARD_TYPES)
 
     let connectorData = {
-      results: [
+      'results': [
         {
-          charge_id: '100',
-          gateway_transaction_id: 'tnx-id-1',
-          amount: 5000,
-          reference: 'ref1',
-          email: 'alice.222@mail.fake',
-          transaction_type: 'payment',
-          state: {
-            status: 'failed',
-            finished: true,
-            code: 'P0030',
-            message: 'Payment was cancelled by the service'
+          'charge_id': '100',
+          'gateway_transaction_id': 'tnx-id-1',
+          'amount': 5000,
+          'reference': 'ref1',
+          'email': 'alice.222@mail.fake',
+          'state': {
+            'status': 'testing',
+            'finished': false
           },
-          card_brand: 'Visa',
-          updated: CONNECTOR_DATE,
-          created_date: CONNECTOR_DATE
+          'card_brand': 'Visa',
+          'updated': CONNECTOR_DATE,
+          'created_date': CONNECTOR_DATE
 
         },
         {
-          charge_id: '101',
-          gateway_transaction_id: 'tnx-id-2',
-          amount: 2000,
-          reference: 'ref2',
-          email: 'alice.111@mail.fake',
-          transaction_type: 'refund',
-          state: {
-            status: 'success',
-            finished: true
+          'charge_id': '101',
+          'gateway_transaction_id': 'tnx-id-2',
+          'amount': 2000,
+          'reference': 'ref2',
+          'email': 'alice.111@mail.fake',
+          'state': {
+            'status': 'testing2',
+            'finished': false
           },
-          card_brand: 'Visa',
-          updated: CONNECTOR_DATE,
-          created_date: CONNECTOR_DATE
+          'card_brand': 'Visa',
+          'updated': CONNECTOR_DATE,
+          'created_date': CONNECTOR_DATE
 
         }
       ],
       total: 10001
     }
 
-    connectorMockResponds(200, connectorData, connectorSearchParameters)
+    connectorMockResponds(200, connectorData, searchParameters)
 
     let expectedData = {
       'results': [
@@ -203,15 +192,12 @@ describe('The /transactions endpoint', function () {
           'amount': '£50.00',
           'reference': 'ref1',
           'email': 'alice.222@mail.fake',
-          transaction_type: 'payment',
           'state': {
-            'status': 'failed',
-            'finished': true,
-            'code': 'P0030',
-            'message': 'Payment was cancelled by the service'
+            'status': 'testing',
+            'finished': false
           },
           'card_brand': 'Visa',
-          'state_friendly': 'Cancelled',
+          'state_friendly': 'Testing',
           'gateway_account_id': gatewayAccountId,
           'updated': DISPLAY_DATE,
           'created': DISPLAY_DATE,
@@ -220,16 +206,15 @@ describe('The /transactions endpoint', function () {
         {
           'charge_id': '101',
           'gateway_transaction_id': 'tnx-id-2',
-          'amount': '–£20.00',
+          'amount': '£20.00',
           'reference': 'ref2',
           'email': 'alice.111@mail.fake',
-          transaction_type: 'refund',
           'state': {
-            'status': 'success',
-            'finished': true
+            'status': 'testing2',
+            'finished': false
           },
           'card_brand': 'Visa',
-          'state_friendly': 'Refund success',
+          'state_friendly': 'Testing2',
           'gateway_account_id': gatewayAccountId,
           'updated': DISPLAY_DATE,
           'created': DISPLAY_DATE,
@@ -249,7 +234,7 @@ describe('The /transactions endpoint', function () {
       .end(done)
   })
 
-  it('should return a list of transactions for the gateway account when some display states is selected', function (done) {
+  it('should return a list of transactions for the gateway account when a state is selected', function (done) {
     connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
       .reply(200, ALL_CARD_TYPES)
 
@@ -261,9 +246,8 @@ describe('The /transactions endpoint', function () {
           'amount': 5000,
           'reference': 'ref1',
           'email': 'alice.222@mail.fake',
-          transaction_type: 'payment',
           'state': {
-            'status': 'created',
+            'status': 'testing',
             'finished': false
           },
           'card_brand': 'Visa',
@@ -277,65 +261,26 @@ describe('The /transactions endpoint', function () {
           'amount': 2000,
           'reference': 'ref2',
           'email': 'alice.111@mail.fake',
-          transaction_type: 'payment',
           'state': {
-            'status': 'submitted',
+            'status': 'testing2',
             'finished': false
           },
           'card_brand': 'Visa',
           'updated': CONNECTOR_DATE,
           'created_date': CONNECTOR_DATE
-        },
-        {
-          'charge_id': '102',
-          'gateway_transaction_id': 'tnx-id-3',
-          'amount': 4500,
-          'reference': 'ref2',
-          'email': 'alice.111@mail.fake',
-          transaction_type: 'payment',
-          'state': {
-            'status': 'failed',
-            'finished': false,
-            'code': 'P0020',
-            'message': 'some error'
-          },
-          'card_brand': 'Visa',
-          'updated': CONNECTOR_DATE,
-          'created_date': CONNECTOR_DATE
-        },
-        {
-          'charge_id': '103',
-          'gateway_transaction_id': 'tnx-id-2',
-          'amount': 5000,
-          'reference': 'ref2',
-          'email': 'alice.111@mail.fake',
-          transaction_type: 'refund',
-          'state': {
-            'status': 'submitted',
-            'finished': true
-          },
-          'card_brand': 'Visa',
-          'updated': CONNECTOR_DATE,
-          'created_date': CONNECTOR_DATE
+
         }
       ]
     }
 
-    connectorMockResponds(200, connectorData, {
-      payment_states: 'created,started,submitted,failed',
-      refund_states: 'submitted'
-    })
+    connectorMockResponds(200, connectorData, {state: 'started', payment_states: 'started'})
     request(app)
-      .get(paths.transactions.index)
-      .query({state: ['In progress', 'Timed out', 'Refund submitted']})
+      .get(paths.transactions.index + '?state=started')
       .set('Accept', 'application/json')
       .set('x-request-id', requestId)
       .expect(200)
       .expect(function (res) {
-        expect(res.body.results.length).to.equal(4)
-        expect(res.body.results.map(row => row.charge_id)).to.deep.equal(['100', '101', '102', '103'])
-        expect(res.body.results.map(row => row.state_friendly)).to.deep.equal(['In progress', 'In progress', 'Timed out', 'Refund submitted'])
-        res.body.downloadTransactionLink.should.eql('/transactions/download?payment_states=created&payment_states=started&payment_states=submitted&payment_states=failed&refund_states=submitted')
+        res.body.downloadTransactionLink.should.eql('/transactions/download?payment_states=started')
       })
       .end(done)
   })
@@ -351,9 +296,8 @@ describe('The /transactions endpoint', function () {
           'gateway_transaction_id': 'tnx-id-1',
           'amount': 5000,
           'email': 'alice.111@mail.fake',
-          transaction_type: 'payment',
           'state': {
-            'status': 'created',
+            'status': 'testing',
             'finished': false
           },
           'card_brand': 'Visa',
@@ -367,9 +311,8 @@ describe('The /transactions endpoint', function () {
           'amount': 2000,
           'reference': 'ref2',
           'email': 'alice.111@mail.fake',
-          transaction_type: 'payment',
           'state': {
-            'status': 'success',
+            'status': 'testing2',
             'finished': false
           },
           'card_brand': 'Visa',
@@ -379,7 +322,7 @@ describe('The /transactions endpoint', function () {
       ]
     }
 
-    connectorMockResponds(200, connectorData, connectorSearchParameters)
+    connectorMockResponds(200, connectorData, searchParameters)
 
     var expectedData = {
       'results': [
@@ -388,13 +331,12 @@ describe('The /transactions endpoint', function () {
           'gateway_transaction_id': 'tnx-id-1',
           'amount': '£50.00',
           'email': 'alice.111@mail.fake',
-          transaction_type: 'payment',
           'state': {
-            'status': 'created',
+            'status': 'testing',
             'finished': false
           },
           'card_brand': 'Visa',
-          'state_friendly': 'In progress',
+          'state_friendly': 'Testing',
           'gateway_account_id': gatewayAccountId,
           'updated': DISPLAY_DATE,
           'created': DISPLAY_DATE,
@@ -407,13 +349,12 @@ describe('The /transactions endpoint', function () {
           'amount': '£20.00',
           'reference': 'ref2',
           'email': 'alice.111@mail.fake',
-          transaction_type: 'payment',
           'state': {
-            'status': 'success',
+            'status': 'testing2',
             'finished': false
           },
           'card_brand': 'Visa',
-          'state_friendly': 'Success',
+          'state_friendly': 'Testing2',
           'gateway_account_id': gatewayAccountId,
           'updated': DISPLAY_DATE,
           'created': DISPLAY_DATE,
@@ -437,7 +378,7 @@ describe('The /transactions endpoint', function () {
     let connectorData = {
       'results': []
     }
-    connectorMockResponds(200, connectorData, connectorSearchParameters)
+    connectorMockResponds(200, connectorData, searchParameters)
 
     getTransactionList()
       .expect(200)
@@ -449,7 +390,7 @@ describe('The /transactions endpoint', function () {
 
   it('should show error message on a bad request while retrieving the list of transactions', function (done) {
     let errorMessage = 'Unable to retrieve list of transactions.'
-    connectorMockResponds(400, {'message': errorMessage}, connectorSearchParameters)
+    connectorMockResponds(400, {'message': errorMessage}, searchParameters)
 
     getTransactionList()
       .expect(500, {'message': errorMessage})
@@ -457,7 +398,7 @@ describe('The /transactions endpoint', function () {
   })
 
   it('should show a generic error message on a connector service error while retrieving the list of transactions', function (done) {
-    connectorMockResponds(500, {'message': 'some error from connector'}, connectorSearchParameters)
+    connectorMockResponds(500, {'message': 'some error from connector'}, searchParameters)
 
     getTransactionList()
       .expect(500, {'message': 'Unable to retrieve list of transactions.'})
@@ -471,9 +412,64 @@ describe('The /transactions endpoint', function () {
       .expect(500, {'message': 'Unable to retrieve list of transactions.'})
       .end(done)
   })
+
+  //
+  // PP-1158 Fix 3 selfservice problematic tests in transaction_list_ft_tests
+  //
+  // These 3 tests have been commented out deliberately in selfservice due to a
+  // very obscure condition causing an Uncaught Error: Can't set headers
+  // after they are sent.
+  //
+  // This matter has already been investigate by a few team members but
+  // with no real solution so far!
+  //
+  // The problem seems to be around promises being resolved aggressively in
+  // tests resulting in the response being rendered more than once.
+  //
+
+  // it('should show error message on a bad request while retrieving the list of card brands', function (done) {
+  //  var connectorData = {
+  //    'results': []
+  //  };
+  //  connectorMockResponds(200, connectorData, searchParameters);
+  //
+  //  var errorMessage = 'Unable to retrieve list of card brands.';
+  //  connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
+  //    .reply(400, {'message': errorMessage});
+  //
+  //  getTransactionList()
+  //    .expect(500, {'message': errorMessage})
+  //    .end(done);
+  // });
+
+  // it('should show a generic error message on a connector service error while retrieving the list of card brands', function (done) {
+  //  var connectorData = {
+  //    'results': []
+  //  };
+  //  connectorMockResponds(200, connectorData, searchParameters);
+  //
+  //  connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
+  //    .reply(500, {'message': 'some error from connector'});
+  //
+  //  getTransactionList()
+  //    .expect(500, {'message': 'Unable to retrieve list of transactions.'})
+  //    .end(done);
+  // });
+
+  // it('should show internal error message if any error happens while retrieving the list of card brands', function (done) {
+  //
+  //  var connectorData = {
+  //    'results': []
+  //  };
+  //  connectorMockResponds(200, connectorData, searchParameters);
+  //
+  //  getTransactionList()
+  //    .expect(500, {'message': 'Unable to retrieve list of transactions.'})
+  //    .end(done);
+  // });
 })
 
-describe('The /transactions endpoint filtering by states)', () => {
+describe('The /transactions endpoint is enabled)', () => {
   afterEach(function () {
     nock.cleanAll()
     app = null
@@ -482,16 +478,14 @@ describe('The /transactions endpoint filtering by states)', () => {
   beforeEach(function (done) {
     let permissions = 'transactions:read'
     let user = session.getUser({
-      gateway_account_ids: [gatewayAccountId],
-      permissions: [{name: permissions}],
-      features: 'NEW_CHARGE_STATUS_ENABLED'
+      gateway_account_ids: [gatewayAccountId], permissions: [{name: permissions}]
     })
     app = session.getAppWithLoggedInUser(getApp(), user)
 
     userCreator.mockUserResponse(user.toJson(), done)
   })
 
-  it('should show all options in state filter', function (done) {
+  it('should allow filtering by charge and refund states', function (done) {
     connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
       .reply(200, ALL_CARD_TYPES)
 
@@ -499,18 +493,19 @@ describe('The /transactions endpoint filtering by states)', () => {
       'results': []
     }
 
-    connectorMockResponds(200, connectorData, connectorSearchParameters)
+    connectorMockResponds(200, connectorData, searchParameters)
 
     getTransactionList()
       .expect(200)
       .expect(function (res) {
-        expect(res.body.eventStates).property('length').to.equal(9)
+        expect(res.body.eventStates).property('length').to.equal(10)
         expect(res.body.eventStates.map(state => state.value.text)).to.deep.equal([
-          'In progress',
+          'Created',
+          'Started',
+          'Submitted',
           'Success',
           'Error',
-          'Declined',
-          'Timed out',
+          'Failed',
           'Cancelled',
           'Refund submitted',
           'Refund error',
@@ -528,28 +523,28 @@ describe('The /transactions endpoint filtering by states)', () => {
       'results': []
     }
 
-    connectorMockResponds(200, connectorData, {payment_states: 'created,started,submitted'})
+    connectorMockResponds(200, connectorData, {payment_states: 'started'})
 
     request(app)
-      .get(paths.transactions.index)
-      .query({state: 'In progress'})
+      .get(paths.transactions.index + '?state=payment-started')
       .set('Accept', 'application/json')
       .set('x-request-id', requestId)
       .expect(200)
       .expect(function (res) {
-        expect(res.body.eventStates).property('length').to.equal(9)
+        expect(res.body.eventStates).property('length').to.equal(10)
         expect(res.body.eventStates.map(state => state.value.text)).to.deep.equal([
-          'In progress',
+          'Created',
+          'Started',
+          'Submitted',
           'Success',
           'Error',
-          'Declined',
-          'Timed out',
+          'Failed',
           'Cancelled',
           'Refund submitted',
           'Refund error',
           'Refund success'
         ])
-        res.body.downloadTransactionLink.should.eql('/transactions/download?payment_states=created&payment_states=started&payment_states=submitted')
+        res.body.downloadTransactionLink.should.eql('/transactions/download?payment_states=started')
       })
       .end(done)
   })
@@ -562,28 +557,28 @@ describe('The /transactions endpoint filtering by states)', () => {
       'results': []
     }
 
-    connectorMockResponds(200, connectorData, {refund_states: 'submitted'})
+    connectorMockResponds(200, connectorData, {refund_states: 'started'})
 
     request(app)
-      .get(paths.transactions.index)
-      .query({state: 'Refund submitted'})
+      .get(paths.transactions.index + '?state=refund-started')
       .set('Accept', 'application/json')
       .set('x-request-id', requestId)
       .expect(200)
       .expect(function (res) {
-        expect(res.body.eventStates).property('length').to.equal(9)
+        expect(res.body.eventStates).property('length').to.equal(10)
         expect(res.body.eventStates.map(state => state.value.text)).to.deep.equal([
-          'In progress',
+          'Created',
+          'Started',
+          'Submitted',
           'Success',
           'Error',
-          'Declined',
-          'Timed out',
+          'Failed',
           'Cancelled',
           'Refund submitted',
           'Refund error',
           'Refund success'
         ])
-        res.body.downloadTransactionLink.should.eql('/transactions/download?refund_states=submitted')
+        res.body.downloadTransactionLink.should.eql('/transactions/download?refund_states=started')
       })
       .end(done)
   })

--- a/test/integration/transaction_list_ft_tests.js
+++ b/test/integration/transaction_list_ft_tests.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const chai = require('chai')
-const lodash = require('lodash')
 const chaiAsPromised = require('chai-as-promised')
 require('../test_helpers/serialize_mock.js')
 const userCreator = require('../test_helpers/user_creator.js')

--- a/test/integration/transaction_list_ft_tests.js
+++ b/test/integration/transaction_list_ft_tests.js
@@ -335,6 +335,13 @@ describe('The /transactions endpoint', function () {
         expect(res.body.results.length).to.equal(4)
         expect(res.body.results.map(row => row.charge_id)).to.deep.equal(['100', '101', '102', '103'])
         expect(res.body.results.map(row => row.state_friendly)).to.deep.equal(['In progress', 'In progress', 'Timed out', 'Refund submitted'])
+        expect(res.body.eventStates.length).to.equal(9)
+        const selectedStates = res.body.eventStates.filter(state => state.value.selected === true)
+        expect(selectedStates.length).to.equal(3)
+        selectedStates.forEach(state => {
+          expect(['In progress', 'Timed out', 'Refund submitted']).to.include(state.value.text)
+        })
+
         res.body.downloadTransactionLink.should.eql('/transactions/download?payment_states=created&payment_states=started&payment_states=submitted&payment_states=failed&refund_states=submitted')
       })
       .end(done)

--- a/test/ui/transaction_details_ui_tests.js
+++ b/test/ui/transaction_details_ui_tests.js
@@ -23,8 +23,9 @@ describe('The transaction details view', function () {
       'refunded': false,
       'charge_id': '1',
       'description': 'First ever',
+      'state_friendly': 'Declined',
       'state': {
-        'status': 'success',
+        'status': 'Failed',
         'finished': true
       },
       'card_details': {
@@ -33,21 +34,27 @@ describe('The transaction details view', function () {
         'expiry_date': 'Data unavailable',
         'last_digits_card_number': '****'
       },
-      'state_friendly': 'Success',
       'gateway_transaction_id': '938c54a7-4186-4506-bfbe-72a122da6528',
       'events': [
         {
           'chargeId': 1,
-          'state:': {'status': 'started', 'finished': false},
-          'state_friendly': 'User started payment of AMOUNT',
+          state: {
+            status: 'error', finished: true, message: 'Payment provider returned an error', code: 'P0050'
+          },
+          'state_friendly': '',
           'amount_friendly': '£10.00',
           'updated': '2015-12-24 13:21:05',
           'updated_friendly': '24 January 2015 13:21:05'
         },
         {
           'chargeId': 1,
-          'state:': {'status': 'created', 'finished': false},
-          'state_friendly': 'Service created payment',
+          state: {
+            status: 'failed',
+            finished: false,
+            message: 'Payment was cancelled by the user',
+            code: 'P0030'
+          },
+          'state_friendly': '',
           'amount_friendly': '£10.00',
           'updated': '2015-12-24 13:21:05',
           'updated_friendly': '24 January 2015 13:21:05'
@@ -81,10 +88,10 @@ describe('The transaction details view', function () {
     //
     templateData.events.forEach((transactionData, ix) => {
       body.should.containSelector('table.transaction-events')
-          .havingRowAt(ix + 1)
-          .withTableDataAt(1, templateData.events[ix].state_friendly)
-          .withTableDataAt(2, templateData.events[ix].amount_friendly)
-          .withTableDataAt(3, templateData.events[ix].updated_friendly)
+        .havingRowAt(ix + 1)
+        .withTableDataAt(1, `${templateData.events[ix].state.code} - ${templateData.events[ix].state.message}`)
+        .withTableDataAt(2, templateData.events[ix].amount_friendly)
+        .withTableDataAt(3, templateData.events[ix].updated_friendly)
     })
   })
 
@@ -184,10 +191,10 @@ describe('The transaction details view', function () {
 
     templateData.events.forEach(function (transactionData, ix) {
       body.should.containSelector('table.transaction-events')
-          .havingRowAt(ix + 1)
-          .withTableDataAt(1, templateData.events[ix].state_friendly)
-          .withTableDataAt(2, templateData.events[ix].amount_friendly)
-          .withTableDataAt(3, templateData.events[ix].updated_friendly)
+        .havingRowAt(ix + 1)
+        .withTableDataAt(1, templateData.events[ix].state_friendly)
+        .withTableDataAt(2, templateData.events[ix].amount_friendly)
+        .withTableDataAt(3, templateData.events[ix].updated_friendly)
     })
   })
 

--- a/test/ui/transaction_list_ui_tests.js
+++ b/test/ui/transaction_list_ui_tests.js
@@ -3,12 +3,12 @@
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-var path = require('path')
+const path = require('path')
 chai.use(chaiAsPromised)
 chai.should()
 
 require(path.join(__dirname, '/../test_helpers/html_assertions.js'))
-var renderTemplate = require(path.join(__dirname, '/../test_helpers/html_assertions.js')).render
+const renderTemplate = require(path.join(__dirname, '/../test_helpers/html_assertions.js')).render
 
 describe('The transaction list view', function () {
   it('should render all transactions', function () {
@@ -19,9 +19,9 @@ describe('The transaction list view', function () {
           'email': 'example1@mail.fake',
           'amount': '50.00',
           'reference': 'ref1',
-          'state_friendly': 'Testing',
+          'state_friendly': 'Declined',
           'state': {
-            'status': 'testing',
+            'status': 'failed',
             'finished': false
           },
           'card_details': {
@@ -44,10 +44,10 @@ describe('The transaction list view', function () {
           'email': 'example2@mail.fake',
           'amount': '20.00',
           'reference': 'ref1',
-          'state_friendly': 'Testing2',
+          'state_friendly': 'In progress',
           'state': {
-            'status': 'testing2',
-            'finished': true
+            'status': 'created',
+            'finished': false
           },
           'card_details': {
             'billing_address': {
@@ -69,9 +69,9 @@ describe('The transaction list view', function () {
           'email': 'example3@mail.fake',
           'amount': '20.00',
           'reference': 'ref1',
-          'state_friendly': 'Testing2',
+          'state_friendly': 'Refund success',
           'state': {
-            'status': 'testing2',
+            'status': 'success',
             'finished': true
           },
           'card_details': {
@@ -126,9 +126,9 @@ describe('The transaction list view', function () {
           'email': 'example1@mail.fake',
           'amount': '50.00',
           'reference': 'ref1',
-          'state_friendly': 'Testing',
+          'state_friendly': 'Declined',
           'state': {
-            'status': 'testing',
+            'status': 'failed',
             'finished': false
           },
           'card_details': {
@@ -151,10 +151,10 @@ describe('The transaction list view', function () {
           'email': 'example2@mail.fake',
           'amount': '20.00',
           'reference': 'ref1',
-          'state_friendly': 'Testing2',
+          'state_friendly': 'In progress',
           'state': {
-            'status': 'testing2',
-            'finished': true
+            'status': 'created',
+            'finished': false
           },
           'card_details': {
             'billing_address': {
@@ -176,9 +176,9 @@ describe('The transaction list view', function () {
           'email': 'example3@mail.fake',
           'amount': '20.00',
           'reference': 'ref1',
-          'state_friendly': 'Testing2',
+          'state_friendly': 'Refund success',
           'state': {
-            'status': 'testing2',
+            'status': 'success',
             'finished': true
           },
           'card_details': {
@@ -233,10 +233,10 @@ describe('The transaction list view', function () {
           'email': 'example1@mail.fake',
           'amount': '50.00',
           'reference': 'ref1',
-          'state_friendly': 'Testing',
+          'state_friendly': 'Success',
           'state': {
-            'status': 'testing',
-            'finished': false
+            'status': 'success',
+            'finished': true
           },
           'card_details': {
             'billing_address': {
@@ -258,9 +258,9 @@ describe('The transaction list view', function () {
           'email': 'example2@mail.fake',
           'amount': '20.00',
           'reference': 'ref1',
-          'state_friendly': 'Testing2',
+          'state_friendly': 'Refund error',
           'state': {
-            'status': 'testing2',
+            'status': 'error',
             'finished': true
           },
           'card_details': {
@@ -299,10 +299,10 @@ describe('The transaction list view', function () {
           'email': 'example1@mail.fake',
           'amount': '50.00',
           'reference': 'ref1',
-          'state_friendly': 'Testing',
+          'state_friendly': 'Timed out',
           'state': {
-            'status': 'testing',
-            'finished': false
+            'status': 'failed',
+            'finished': true
           },
           'card_details': {
             'billing_address': {
@@ -324,9 +324,9 @@ describe('The transaction list view', function () {
           'email': 'example2@mail.fake',
           'amount': '20.00',
           'reference': 'ref1',
-          'state_friendly': 'Testing2',
+          'state_friendly': 'Success',
           'state': {
-            'status': 'testing2',
+            'status': 'success',
             'finished': true
           },
           'card_details': {
@@ -365,10 +365,10 @@ describe('The transaction list view', function () {
           'email': 'example1@mail.fake',
           'amount': '50.00',
           'reference': 'ref1',
-          'state_friendly': 'Testing',
+          'state_friendly': 'Success',
           'state': {
-            'status': 'testing',
-            'finished': false
+            'status': 'success',
+            'finished': true
           },
           'card_details': {
             'billing_address': {
@@ -390,9 +390,9 @@ describe('The transaction list view', function () {
           'email': 'example2@mail.fake',
           'amount': '20.00',
           'reference': 'ref1',
-          'state_friendly': 'Testing2',
+          'state_friendly': 'Success',
           'state': {
-            'status': 'testing2',
+            'status': 'success',
             'finished': true
           },
           'card_details': {

--- a/test/ui/transaction_search_ui_tests.js
+++ b/test/ui/transaction_search_ui_tests.js
@@ -8,16 +8,16 @@ describe('The transaction list view', function () {
   it('should render all transactions', function () {
     var templateData = {
       'total': 2,
-      'filtersDescription': '  from 2015-01-11 01:01:01   to 2015-01-11 01:01:01   with \'Testing2\' state   with \'Visa\' card brand',
+      'filtersDescription': '  from 2015-01-11 01:01:01   to 2015-01-11 01:01:01   with <strong>\'Refund success\'</strong>, <strong>\'Success\'</strong> states   with \'Visa\' card brand',
       'results': [
         {
           'charge_id': '100',
           'email': 'example1@mail.fake',
           'amount': '50.00',
           'reference': 'ref1',
-          'state_friendly': 'Testing2',
+          'state_friendly': 'Refund success',
           'state': {
-            'status': 'testing2',
+            'status': 'success',
             'finished': true
           },
           'card_details': {
@@ -40,10 +40,10 @@ describe('The transaction list view', function () {
           'email': 'example2@mail.fake',
           'amount': '20.00',
           'reference': 'ref1',
-          'state_friendly': 'Testing2',
+          'state_friendly': 'Success',
           'state': {
-            'status': 'testing2',
-            'finished': false
+            'status': 'success',
+            'finished': true
           },
           'card_details': {
             'billing_address': {
@@ -84,7 +84,8 @@ describe('The transaction list view', function () {
     expect(totalResultsText).to.contain('2 transactions')
     expect(totalResultsText).to.contain('from 2015-01-11 01:01:01')
     expect(totalResultsText).to.contain('to 2015-01-11 01:01:01')
-    expect(totalResultsText).to.contain('with \'Testing2\' state')
+    expect(totalResultsText).to.contain('with \'Refund success\'')
+    expect(totalResultsText).to.contain('\'Success\' states')
     expect(totalResultsText).to.contain('with \'Visa\' card brand')
     expect($('input#reference').attr('value')).to.equal('ref1')
     expect($('input#fromDate').attr('value')).to.equal('2015-01-11 01:01:01')

--- a/test/unit/models/charge_test.js
+++ b/test/unit/models/charge_test.js
@@ -111,7 +111,7 @@ describe('charge model', function () {
         return chargeModel.findWithEvents(1, 2).then(function (data) {
           expect(buildPaymentView.called).to.equal(true)
           expect(buildPaymentView.args.length).to.equal(1)
-          expect(buildPaymentView.args[0].length).to.equal(3)
+          expect(buildPaymentView.args[0]).to.have.lengthOf.above(3)
           expect(buildPaymentView.args[0][0]).to.deep.equal({foo: 'bar'})
           expect(buildPaymentView.args[0][1]).to.deep.equal({events: [{submitted_by: user.external_id}]})
           expect(buildPaymentView.args[0][2]).to.deep.equal([new User(user)])

--- a/test/unit/utils/filters_test.js
+++ b/test/unit/utils/filters_test.js
@@ -6,17 +6,17 @@ const filters = require('../../../app/utils/filters')
 describe('filters', () => {
   describe('state filter', () => {
     it('should be unchanged if there is a single state does not contain \'-\' but should add it to the \'payment_states\' array for backward compatibility', () => {
-      const {result} = filters.getFilters({query: {state: 'started'}})
+      const {result} = filters.old_getFilters({query: {state: 'started'}})
       expect(result).to.have.property('payment_states').to.deep.equal(['started'])
       expect(result).not.to.have.property('refund_states')
     })
     it('should add state to the relevant filter array if there is a single state that contains \'-\' and replace the state property with just the state name', () => {
-      const {result} = filters.getFilters({query: {state: 'payment-started'}})
+      const {result} = filters.old_getFilters({query: {state: 'payment-started'}})
       expect(result).to.have.property('payment_states').to.deep.equal(['started'])
       expect(result).not.to.have.property('refund_states')
     })
     it('should states to their respective relevant filter array (defaulting to \'payment_states\') if there are multiple states and should set the state filter to the first item in the combined \'payment_states\' and \'refund_states\' arrays for backward compatibility', () => {
-      const {result} = filters.getFilters({query: {state: ['payment-started', 'payment-success', 'refund-created', 'complete']}})
+      const {result} = filters.old_getFilters({query: {state: ['payment-started', 'payment-success', 'refund-created', 'complete']}})
       expect(result).to.have.property('payment_states').to.deep.equal(['started', 'success', 'complete'])
       expect(result).to.have.property('refund_states').to.deep.equal(['created'])
     })

--- a/test/unit/utils/filters_test.js
+++ b/test/unit/utils/filters_test.js
@@ -60,21 +60,20 @@ describe('filters', () => {
         const testFilter = {
           fromDate: 'from-date',
           toDate: 'to-date',
-          payment_states: ['created', 'started', 'failed'],
-          refund_states: ['success', 'submitted']
+          selectedStates: ['In progress', 'Refund success', 'Refund submitted'],
         }
         const result = filters.describeFilters(testFilter)
-        expect(result.trim()).to.equal('from <strong>from-date</strong> to <strong>to-date</strong> with <strong>In progress</strong>, <strong>In progress</strong>, <strong>Failed</strong>, <strong>Refund success</strong> or <strong>Refund submitted</strong> states')
+        expect(result.trim()).to.equal('from <strong>from-date</strong> to <strong>to-date</strong> with <strong>In progress</strong>, <strong>Refund success</strong> or <strong>Refund submitted</strong> states')
       })
 
       it('should describe correctly when one state selected', function () {
         const testFilter = {
           fromDate: 'from-date',
           toDate: 'to-date',
-          payment_states: ['failed']
+          selectedStates: ['Cancelled']
         }
         const result = filters.describeFilters(testFilter)
-        expect(result.trim()).to.equal('from <strong>from-date</strong> to <strong>to-date</strong> with <strong>Failed</strong> state')
+        expect(result.trim()).to.equal('from <strong>from-date</strong> to <strong>to-date</strong> with <strong>Cancelled</strong> state')
       })
 
       it('should describe correctly when no state selected', function () {

--- a/test/unit/utils/filters_test.js
+++ b/test/unit/utils/filters_test.js
@@ -60,7 +60,7 @@ describe('filters', () => {
         const testFilter = {
           fromDate: 'from-date',
           toDate: 'to-date',
-          selectedStates: ['In progress', 'Refund success', 'Refund submitted'],
+          selectedStates: ['In progress', 'Refund success', 'Refund submitted']
         }
         const result = filters.describeFilters(testFilter)
         expect(result.trim()).to.equal('from <strong>from-date</strong> to <strong>to-date</strong> with <strong>In progress</strong>, <strong>Refund success</strong> or <strong>Refund submitted</strong> states')

--- a/test/unit/utils/filters_test.js
+++ b/test/unit/utils/filters_test.js
@@ -4,7 +4,7 @@ const {expect} = require('chai')
 const filters = require('../../../app/utils/filters')
 
 describe('filters', () => {
-  describe('state filter', () => {
+  describe('old state filter', () => {
     it('should be unchanged if there is a single state does not contain \'-\' but should add it to the \'payment_states\' array for backward compatibility', () => {
       const {result} = filters.old_getFilters({query: {state: 'started'}})
       expect(result).to.have.property('payment_states').to.deep.equal(['started'])
@@ -19,6 +19,73 @@ describe('filters', () => {
       const {result} = filters.old_getFilters({query: {state: ['payment-started', 'payment-success', 'refund-created', 'complete']}})
       expect(result).to.have.property('payment_states').to.deep.equal(['started', 'success', 'complete'])
       expect(result).to.have.property('refund_states').to.deep.equal(['created'])
+    })
+  })
+
+  describe('state filter', () => {
+    describe('getFilter', () => {
+      it('should transform In progress display states to connector states correctly', function () {
+        const {result} = filters.getFilters({query: {state: 'In progress'}})
+        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted'])
+        expect(result).to.not.have.property('refund_states')
+      })
+
+      it('should transform some payment display states to connector states correctly', function () {
+        const {result} = filters.getFilters({query: {state: ['In progress', 'Timed out', 'Cancelled']}})
+        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'failed', 'cancelled'])
+        expect(result).to.not.have.property('refund_states')
+      })
+
+      it('should transform all payment display states to connector states correctly', function () {
+        const {result} = filters.getFilters({query: {state: ['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined']}})
+        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'success', 'error', 'failed', 'cancelled'])
+        expect(result).to.not.have.property('refund_states')
+      })
+
+      it('should transform all refund display states to connector states correctly', function () {
+        const {result} = filters.getFilters({query: {state: ['Refund success', 'Refund error', 'Refund submitted']}})
+        expect(result).to.have.property('refund_states').to.deep.equal(['success', 'error', 'submitted'])
+        expect(result).to.not.have.property('payment_states')
+      })
+
+      it('should transform both payment and refund display states to connector states correctly', function () {
+        const {result} = filters.getFilters({query: {state: ['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined', 'Refund success', 'Refund error', 'Refund submitted']}})
+        expect(result).to.have.property('refund_states').to.deep.equal(['success', 'error', 'submitted'])
+        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'success', 'error', 'failed', 'cancelled'])
+      })
+    })
+
+    describe('describeFilter', () => {
+      it('should describe correctly when multiple states selected', function () {
+        const testFilter = {
+          fromDate: 'from-date',
+          toDate: 'to-date',
+          payment_states: ['created', 'started', 'failed'],
+          refund_states: ['success', 'submitted']
+        }
+        const result = filters.describeFilters(testFilter)
+        expect(result.trim()).to.equal('from <strong>from-date</strong> to <strong>to-date</strong> with <strong>In progress</strong>, <strong>In progress</strong>, <strong>Failed</strong>, <strong>Refund success</strong> or <strong>Refund submitted</strong> states')
+      })
+
+      it('should describe correctly when one state selected', function () {
+        const testFilter = {
+          fromDate: 'from-date',
+          toDate: 'to-date',
+          payment_states: ['failed']
+        }
+        const result = filters.describeFilters(testFilter)
+        expect(result.trim()).to.equal('from <strong>from-date</strong> to <strong>to-date</strong> with <strong>Failed</strong> state')
+      })
+
+      it('should describe correctly when no state selected', function () {
+        const testFilter = {
+          fromDate: 'from-date',
+          toDate: 'to-date',
+          state: ''
+        }
+        const result = filters.describeFilters(testFilter)
+        expect(result.trim()).to.equal('from <strong>from-date</strong> to <strong>to-date</strong>')
+      })
     })
   })
 })

--- a/test/unit/utils/states_test.js
+++ b/test/unit/utils/states_test.js
@@ -66,6 +66,10 @@ describe('states', function () {
       expect(states.getDisplayNameForConnectorState({status: 'failed', code: 'P0010', message: 'Bar'})).to.equal('Declined')
       expect(states.getDisplayNameForConnectorState({status: 'cancelled', code: 'P0040', message: 'Baz'})).to.equal('Cancelled')
       expect(states.getDisplayNameForConnectorState({status: 'cancelled', code: 'P0050', message: 'Kaz'})).to.equal('Error')
+
+      expect(states.getDisplayNameForConnectorState({status: 'submitted'}, 'charge')).to.equal('In progress')
+      expect(states.getDisplayNameForConnectorState({status: 'submitted'}, 'PAYMENT')).to.equal('In progress')
+      expect(states.getDisplayNameForConnectorState({status: 'submitted'}, 'refund')).to.equal('Refund submitted')
     })
   })
 

--- a/test/unit/utils/states_test.js
+++ b/test/unit/utils/states_test.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const chai = require('chai')
+const assertArrays = require('chai-arrays')
+let states = require('../../../app/utils/states')
+chai.use(assertArrays)
+const expect = chai.expect
+
+describe('states', function () {
+  describe('new states', function () {
+
+    it('should get unique display states for states dropdown', function () {
+      const allDisplayStates = states.allDisplayStates()
+      expect(allDisplayStates.length).to.be.equal(9)
+      expect(allDisplayStates).to.be.containingAllOf([
+        'In progress', 'Success', 'Error', 'Declined', 'Timed out', 'Cancelled',
+        'Refund submitted', 'Refund error', 'Refund success'])
+    })
+
+    it('should get connector states from In progress display state', function () {
+      const connectorStatesResult = states.displayStatesToConnectorStates(['In progress'])
+      expect(connectorStatesResult.payment_states.length).to.be.equal(3)
+      expect(connectorStatesResult.payment_states).to.be.containingAllOf(['created', 'started', 'submitted'])
+      expect(connectorStatesResult.refund_states.length).to.be.equal(0)
+    })
+
+    it('should get connector states from Cancelled display state', function () {
+      const connectorStatesResult = states.displayStatesToConnectorStates(['Cancelled'])
+      expect(connectorStatesResult.payment_states.length).to.be.equal(2)
+      expect(connectorStatesResult.payment_states).to.be.containingAllOf(['failed', 'cancelled'])
+      expect(connectorStatesResult.refund_states.length).to.be.equal(0)
+    })
+
+    it('should get connector states from refunds display states', function () {
+      const connectorStatesResult = states.displayStatesToConnectorStates(['Refund success', 'Refund error', 'Refund submitted'])
+      expect(connectorStatesResult.refund_states.length).to.be.equal(3)
+      expect(connectorStatesResult.refund_states).to.be.containingAllOf(['submitted', 'error', 'success'])
+      expect(connectorStatesResult.payment_states.length).to.be.equal(0)
+    })
+
+    it('should get connector states from all possible display states', function () {
+      const connectorStatesResult = states.displayStatesToConnectorStates(['In progress', 'Success', 'Error', 'Declined', 'Timed out', 'Cancelled', 'Refund success', 'Refund error', 'Refund submitted'])
+      expect(connectorStatesResult.payment_states.length).to.be.equal(7)
+      expect(connectorStatesResult.payment_states).to.be.containingAllOf(['created', 'started', 'submitted', 'success', 'error', 'failed', 'cancelled'])
+      expect(connectorStatesResult.refund_states.length).to.be.equal(3)
+      expect(connectorStatesResult.refund_states).to.be.containingAllOf(['submitted', 'error', 'success'])
+    })
+
+    it('should convert to correct display state selector objects', function () {
+      const allDisplayStates = states.allDisplayStates()
+      const allDisplayStateSelectors = states.allDisplayStateSelectorObjects()
+      expect(allDisplayStateSelectors.length).to.be.equal(9)
+      allDisplayStateSelectors.forEach(selectorObj => {
+        expect(allDisplayStates).to.include(selectorObj.value.text)
+      })
+    })
+
+    it('should get display name for connector state', function () {
+      expect(states.getDisplayNameForConnectorState({status: 'submitted'})).to.equal('In progress')
+      expect(states.getDisplayNameForConnectorState({status: 'created'})).to.equal('In progress')
+      expect(states.getDisplayNameForConnectorState({status: 'success'})).to.equal('Success')
+      expect(states.getDisplayNameForConnectorState({status: 'success'}, 'refund')).to.equal('Refund success')
+      expect(states.getDisplayNameForConnectorState({status: 'error'}, 'refund')).to.equal('Refund error')
+
+      expect(states.getDisplayNameForConnectorState({status: 'failed', code: 'P0030', message: 'Foo'})).to.equal('Cancelled')
+      expect(states.getDisplayNameForConnectorState({status: 'failed', code: 'P0010', message: 'Bar'})).to.equal('Declined')
+      expect(states.getDisplayNameForConnectorState({status: 'cancelled', code: 'P0040', message: 'Baz'})).to.equal('Cancelled')
+      expect(states.getDisplayNameForConnectorState({status: 'cancelled', code: 'P0050', message: 'Kaz'})).to.equal('Error')
+    })
+  })
+
+  describe('old states', function () {
+    it('should get all state selector objects', function () {
+      const oldStates = states.old_states()
+      expect(oldStates.length).to.equal(10)
+      const expectedOldStates = ['Created','Started','Submitted','Success','Error','Failed','Cancelled','Refund submitted','Refund success','Refund error']
+      oldStates.forEach(state => {
+        expect(expectedOldStates).to.include(state.value.text)
+      })
+    })
+
+    it('should get correct display name for a given connector state', function () {
+      expect(states.old_getDisplayName('payment','success')).to.equal('Success')
+      expect(states.old_getDisplayName('payment','failed')).to.equal('Failed')
+      expect(states.old_getDisplayName('payment','error')).to.equal('Error')
+      expect(states.old_getDisplayName('payment','cancelled')).to.equal('Cancelled')
+      expect(states.old_getDisplayName('refund','success')).to.equal('Refund success')
+      expect(states.old_getDisplayName('refund','submitted')).to.equal('Refund submitted')
+      expect(states.old_getDisplayName('refund','error')).to.equal('Refund error')
+    })
+
+    it('should get correct description for a given connector state', function () {
+      expect(states.old_getDescription('payment','success')).to.equal('Payment successful')
+      expect(states.old_getDescription('payment','failed')).to.equal('User failed to complete payment')
+      expect(states.old_getDescription('payment','error')).to.equal('Error processing payment')
+      expect(states.old_getDescription('payment','cancelled')).to.equal('Service cancelled payment')
+      expect(states.old_getDescription('refund','success')).to.equal('Refund successful')
+      expect(states.old_getDescription('refund','submitted')).to.equal('Refund submitted')
+      expect(states.old_getDescription('refund','error')).to.equal('Error processing refund')
+    })
+  })
+})

--- a/test/unit/utils/states_test.js
+++ b/test/unit/utils/states_test.js
@@ -8,7 +8,6 @@ const expect = chai.expect
 
 describe('states', function () {
   describe('new states', function () {
-
     it('should get unique display states for states dropdown', function () {
       const allDisplayStates = states.allDisplayStates()
       expect(allDisplayStates.length).to.be.equal(9)
@@ -62,10 +61,26 @@ describe('states', function () {
       expect(states.getDisplayNameForConnectorState({status: 'success'}, 'refund')).to.equal('Refund success')
       expect(states.getDisplayNameForConnectorState({status: 'error'}, 'refund')).to.equal('Refund error')
 
-      expect(states.getDisplayNameForConnectorState({status: 'failed', code: 'P0030', message: 'Foo'})).to.equal('Cancelled')
-      expect(states.getDisplayNameForConnectorState({status: 'failed', code: 'P0010', message: 'Bar'})).to.equal('Declined')
-      expect(states.getDisplayNameForConnectorState({status: 'cancelled', code: 'P0040', message: 'Baz'})).to.equal('Cancelled')
-      expect(states.getDisplayNameForConnectorState({status: 'cancelled', code: 'P0050', message: 'Kaz'})).to.equal('Error')
+      expect(states.getDisplayNameForConnectorState({
+        status: 'failed',
+        code: 'P0030',
+        message: 'Foo'
+      })).to.equal('Cancelled')
+      expect(states.getDisplayNameForConnectorState({
+        status: 'failed',
+        code: 'P0010',
+        message: 'Bar'
+      })).to.equal('Declined')
+      expect(states.getDisplayNameForConnectorState({
+        status: 'cancelled',
+        code: 'P0040',
+        message: 'Baz'
+      })).to.equal('Cancelled')
+      expect(states.getDisplayNameForConnectorState({
+        status: 'cancelled',
+        code: 'P0050',
+        message: 'Kaz'
+      })).to.equal('Error')
 
       expect(states.getDisplayNameForConnectorState({status: 'submitted'}, 'charge')).to.equal('In progress')
       expect(states.getDisplayNameForConnectorState({status: 'submitted'}, 'PAYMENT')).to.equal('In progress')
@@ -77,30 +92,30 @@ describe('states', function () {
     it('should get all state selector objects', function () {
       const oldStates = states.old_states()
       expect(oldStates.length).to.equal(10)
-      const expectedOldStates = ['Created','Started','Submitted','Success','Error','Failed','Cancelled','Refund submitted','Refund success','Refund error']
+      const expectedOldStates = ['Created', 'Started', 'Submitted', 'Success', 'Error', 'Failed', 'Cancelled', 'Refund submitted', 'Refund success', 'Refund error']
       oldStates.forEach(state => {
         expect(expectedOldStates).to.include(state.value.text)
       })
     })
 
     it('should get correct display name for a given connector state', function () {
-      expect(states.old_getDisplayName('payment','success')).to.equal('Success')
-      expect(states.old_getDisplayName('payment','failed')).to.equal('Failed')
-      expect(states.old_getDisplayName('payment','error')).to.equal('Error')
-      expect(states.old_getDisplayName('payment','cancelled')).to.equal('Cancelled')
-      expect(states.old_getDisplayName('refund','success')).to.equal('Refund success')
-      expect(states.old_getDisplayName('refund','submitted')).to.equal('Refund submitted')
-      expect(states.old_getDisplayName('refund','error')).to.equal('Refund error')
+      expect(states.old_getDisplayName('payment', 'success')).to.equal('Success')
+      expect(states.old_getDisplayName('payment', 'failed')).to.equal('Failed')
+      expect(states.old_getDisplayName('payment', 'error')).to.equal('Error')
+      expect(states.old_getDisplayName('payment', 'cancelled')).to.equal('Cancelled')
+      expect(states.old_getDisplayName('refund', 'success')).to.equal('Refund success')
+      expect(states.old_getDisplayName('refund', 'submitted')).to.equal('Refund submitted')
+      expect(states.old_getDisplayName('refund', 'error')).to.equal('Refund error')
     })
 
     it('should get correct description for a given connector state', function () {
-      expect(states.old_getDescription('payment','success')).to.equal('Payment successful')
-      expect(states.old_getDescription('payment','failed')).to.equal('User failed to complete payment')
-      expect(states.old_getDescription('payment','error')).to.equal('Error processing payment')
-      expect(states.old_getDescription('payment','cancelled')).to.equal('Service cancelled payment')
-      expect(states.old_getDescription('refund','success')).to.equal('Refund successful')
-      expect(states.old_getDescription('refund','submitted')).to.equal('Refund submitted')
-      expect(states.old_getDescription('refund','error')).to.equal('Error processing refund')
+      expect(states.old_getDescription('payment', 'success')).to.equal('Payment successful')
+      expect(states.old_getDescription('payment', 'failed')).to.equal('User failed to complete payment')
+      expect(states.old_getDescription('payment', 'error')).to.equal('Error processing payment')
+      expect(states.old_getDescription('payment', 'cancelled')).to.equal('Service cancelled payment')
+      expect(states.old_getDescription('refund', 'success')).to.equal('Refund successful')
+      expect(states.old_getDescription('refund', 'submitted')).to.equal('Refund submitted')
+      expect(states.old_getDescription('refund', 'error')).to.equal('Error processing refund')
     })
   })
 })

--- a/test/unit/utils_filters_test.js
+++ b/test/unit/utils_filters_test.js
@@ -13,7 +13,7 @@ describe('session', function () {
       toTime: '14:12:18'
     }
 
-    var filter = filters.getFilters({ query: query })
+    var filter = filters.old_getFilters({ query: query })
     expect(filter.valid).to.equal(true)
     expect(filter.result).to.not.equal(query)
     expect(filter.result).to.deep.equal({
@@ -39,7 +39,7 @@ describe('session', function () {
       page: '1'
     }
 
-    var filter = filters.getFilters({ query: query })
+    var filter = filters.old_getFilters({ query: query })
     delete query.state
     expect(filter.valid).to.equal(true)
     expect(filter.result).to.deep.equal(query)
@@ -50,7 +50,7 @@ describe('session', function () {
       pageSize: '1000'
     }
 
-    var filter = filters.getFilters({ query: query })
+    var filter = filters.old_getFilters({ query: query })
     expect(filter.valid).to.equal(false)
   })
 
@@ -61,7 +61,7 @@ describe('session', function () {
 
     }
 
-    var filter = filters.getFilters({ query: query })
+    var filter = filters.old_getFilters({ query: query })
     expect(filter.valid).to.equal(false)
   })
 
@@ -71,7 +71,7 @@ describe('session', function () {
       pageSize: '5000'
 
     }
-    var filter = filters.getFilters({ query: query })
+    var filter = filters.old_getFilters({ query: query })
     expect(filter.valid).to.equal(false)
   })
 
@@ -81,7 +81,7 @@ describe('session', function () {
       pageSize: '5'
 
     }
-    var filter = filters.getFilters({ query: query })
+    var filter = filters.old_getFilters({ query: query })
     expect(filter.valid).to.equal(false)
   })
 })


### PR DESCRIPTION
## WHAT
This might look like it contains a lot, but effectively all it does is transforming incoming connector states to the new display states and transform back the outgoing display states to connector states. 

The presentation logic of old display states and the new display states are very different therefore it needed a complete re-write. In order to make thing easier and more reasonable we've left the old states logic as is and prefixed with `old_`   in every function. Depending on the feature flag (to display new states) the core components call wither the new function or the `old_` function.

existing tests, didn't help much here either. They were not very reflective of the current state of the states and was very hard to reason about. So renamed all the existing tests to `old_` prefixed test files and added new tests (unit, ft ). 

So when we remove the feature flag hopefully its a matter of removing all the `old_`  stuff.

with  @chrisgrimble 

