### PR TITLE
PP-3482: Enclose filename in quotes

### DIFF
--- a/app/controllers/transactions/transaction_download_controller.js
+++ b/app/controllers/transactions/transaction_download_controller.js
@@ -22,7 +22,7 @@ module.exports = (req, res) => {
     .then(json => jsonToCsv(json.results, newChargeStatusEnabled))
     .then(csv => {
       logger.debug('Sending csv attachment download -', {'filename': name})
-      res.setHeader('Content-disposition', 'attachment; filename=' + name)
+      res.setHeader('Content-disposition', 'attachment; filename="' + name + '"')
       res.setHeader('Content-Type', 'text/csv')
       res.send(csv)
     })

--- a/test/integration/old_transaction_download_ft_tests.js
+++ b/test/integration/old_transaction_download_ft_tests.js
@@ -77,7 +77,7 @@ describe('Old Transaction download endpoints', function () {
       downloadTransactionList()
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv"/)
         .expect(function (res) {
           let csvContent = res.text
           let arrayOfLines = csvContent.split('\n')
@@ -122,7 +122,7 @@ describe('Old Transaction download endpoints', function () {
       downloadTransactionList()
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv"/)
         .end(function (err, res) {
           if (err) return done(err)
           let csvContent = res.text
@@ -157,7 +157,7 @@ describe('Old Transaction download endpoints', function () {
         .set('Accept', 'application/json')
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv"/)
         .end(function (err, res) {
           if (err) return done(err)
           let csvContent = res.text
@@ -192,7 +192,7 @@ describe('Old Transaction download endpoints', function () {
         .set('Accept', 'application/json')
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv"/)
         .end(function (err, res) {
           if (err) return done(err)
           let csvContent = res.text

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -79,7 +79,7 @@ describe('Transaction download endpoints', function () {
       downloadTransactionList()
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv"/)
         .expect(function (res) {
           let csvContent = res.text
           let arrayOfLines = csvContent.split('\n')
@@ -124,7 +124,7 @@ describe('Transaction download endpoints', function () {
       downloadTransactionList()
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv"/)
         .end(function (err, res) {
           if (err) return done(err)
           let csvContent = res.text
@@ -159,7 +159,7 @@ describe('Transaction download endpoints', function () {
         .set('Accept', 'application/json')
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv"/)
         .end(function (err, res) {
           if (err) return done(err)
           let csvContent = res.text
@@ -194,7 +194,7 @@ describe('Transaction download endpoints', function () {
         .set('Accept', 'application/json')
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv"/)
         .end(function (err, res) {
           if (err) return done(err)
           let csvContent = res.text


### PR DESCRIPTION
We had a bug on firefox in windows where it ignored
the string after GOVUK.

Just enclose it in quotes.

https://stackoverflow.com/questions/21442903/firefox-has-problems-when-downloading-with-a-space-in-filename

