### PR TITLE
PP-3489 Temporary fix for failing smoke tests

### DIFF
--- a/app/browsered/field-validation.js
+++ b/app/browsered/field-validation.js
@@ -3,6 +3,9 @@
 // NPM Dependencies
 const every = require('lodash/every')
 
+// Polyfills introduced as a temporary fix to make Smoketests pass. See PP-3489
+require('./polyfills')
+
 // Local Dependencies
 const checks = require('./field-validation-checks')
 
@@ -25,7 +28,7 @@ function initValidation (e) {
   clearPreviousErrors()
 
   let validatedFields = findFields(form)
-  .map(field => validateField(form, field))
+    .map(field => validateField(form, field))
 
   if (every(validatedFields)) {
     form.submit()

--- a/app/browsered/polyfills.js
+++ b/app/browsered/polyfills.js
@@ -1,0 +1,31 @@
+(function (ElementProto) {
+  if (typeof ElementProto.matches !== 'function') {
+    ElementProto.matches = ElementProto.msMatchesSelector || ElementProto.mozMatchesSelector || ElementProto.webkitMatchesSelector || function matches (selector) {
+      var element = this
+      var elements = (element.document || element.ownerDocument).querySelectorAll(selector)
+      var index = 0
+
+      while (elements[index] && elements[index] !== element) {
+        ++index
+      }
+
+      return Boolean(elements[index])
+    }
+  }
+
+  if (typeof ElementProto.closest !== 'function') {
+    ElementProto.closest = function closest (selector) {
+      var element = this
+
+      while (element && element.nodeType === 1) {
+        if (element.matches(selector)) {
+          return element
+        }
+
+        element = element.parentNode
+      }
+
+      return null
+    }
+  }
+})(window.Element.prototype)


### PR DESCRIPTION
## WHAT
Temporary fix for failing smoke tests because of the use the `closest` element not supported in PhantomJS.

A Polyfill for `closest` element has been embedded in the code which can be removed once smoke tests stop relying on phantomjs.

