### PR TITLE
PP-3441 Updated product client to reflect API changes

### DIFF
--- a/app/controllers/payment-links/get-disable-controller.js
+++ b/app/controllers/payment-links/get-disable-controller.js
@@ -6,9 +6,11 @@ const logger = require('winston')
 // Local dependencies
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products_client.js')
+const auth = require('../../services/auth_service.js')
 
 module.exports = (req, res) => {
-  productsClient.product.disable(req.params.productExternalId)
+  const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
+  productsClient.product.disable(gatewayAccountId, req.params.productExternalId)
     .then(() => {
       req.flash('generic', '<h2>The payment link was successfully deleted</h2><p>It will no longer be accessible</p>')
       res.redirect(paths.paymentLinks.manage)

--- a/app/controllers/test_with_your_users/disable_controller.js
+++ b/app/controllers/test_with_your_users/disable_controller.js
@@ -5,9 +5,11 @@ const logger = require('winston')
 // Local dependencies
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products_client.js')
+const auth = require('../../services/auth_service.js')
 
 module.exports = (req, res) => {
-  productsClient.product.disable(req.params.productExternalId)
+  const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
+  productsClient.product.disable(gatewayAccountId, req.params.productExternalId)
     .then(() => {
       req.flash('generic', '<p>Prototype link deleted</p>')
       res.redirect(paths.prototyping.demoService.links)

--- a/app/services/clients/products_client.js
+++ b/app/services/clients/products_client.js
@@ -65,10 +65,10 @@ function createProduct (options) {
  * @param {String} productExternalId: the external id of the product you wish to retrieve
  * @returns {Promise<Product>}
  */
-function getProductByExternalId (productExternalId) {
+function getProductByExternalId (gatewayAccountId, productExternalId) {
   return baseClient.get({
     baseUrl,
-    url: `/products/${productExternalId}`,
+    url: `/gateway-account/${gatewayAccountId}/products/${productExternalId}`,
     description: `find a product by it's external id`,
     service: SERVICE_NAME
   }).then(product => new Product(product))
@@ -81,10 +81,7 @@ function getProductByExternalId (productExternalId) {
 function getProductsByGatewayAccountId (gatewayAccountId) {
   return baseClient.get({
     baseUrl,
-    url: '/products',
-    qs: {
-      gatewayAccountId
-    },
+    url: `/gateway-account/${gatewayAccountId}/products`,
     description: 'find a list products associated with a gateway account',
     service: SERVICE_NAME
   }).then(products => products.map(product => new Product(product)))
@@ -113,10 +110,10 @@ function updateServiceNameOfProductsByGatewayAccountId (gatewayAccountId, servic
  * @param {String} productExternalId: the external id of the product you wish to disable
  * @returns Promise<undefined>
  */
-function disableProduct (productExternalId) {
+function disableProduct (gatewayAccountId, productExternalId) {
   return baseClient.patch({
     baseUrl,
-    url: `/products/${productExternalId}/disable`,
+    url: `/gateway-account/${gatewayAccountId}/products/${productExternalId}/disable`,
     description: `disable a product`,
     service: SERVICE_NAME
   })

--- a/test/unit/clients/product_client/product/disable_test.js
+++ b/test/unit/clients/product_client/product/disable_test.js
@@ -10,10 +10,10 @@ const pactProxy = require('../../../../test_helpers/pact_proxy')
 const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
 
 // Constants
-const PRODUCT_RESOURCE = '/v1/api/products'
+const API_RESOURCE = '/v1/api'
 const mockPort = Math.floor(Math.random() * 65535)
 const mockServer = pactProxy.create('localhost', mockPort)
-let productsMock, result, productExternalId
+let productsMock, result, productExternalId, gatewayAccountId
 
 function getProductsClient (baseUrl = `http://localhost:${mockPort}`, productsApiKey = 'ABC1234567890DEF') {
   return proxyquire('../../../../../app/services/clients/products_client', {
@@ -47,15 +47,16 @@ describe('products client - disable a product', () => {
   describe('when a product is successfully disabled', () => {
     before(done => {
       const productsClient = getProductsClient()
+      gatewayAccountId = '999'
       productExternalId = 'a_valid_external_id'
       productsMock.addInteraction(
-        new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}/disable`)
+        new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}/disable`)
           .withUponReceiving('a valid disable product request')
           .withMethod('PATCH')
           .withStatusCode(204)
           .build()
       )
-        .then(() => productsClient.product.disable(productExternalId))
+        .then(() => productsClient.product.disable(gatewayAccountId, productExternalId))
         .then(res => {
           result = res
           done()
@@ -77,13 +78,13 @@ describe('products client - disable a product', () => {
       const productsClient = getProductsClient()
       productExternalId = 'a_non_existant_external_id'
       productsMock.addInteraction(
-        new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}/disable`)
+        new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}/disable`)
           .withUponReceiving('an invalid create product request')
           .withMethod('PATCH')
           .withStatusCode(400)
           .build()
       )
-        .then(() => productsClient.product.disable(productExternalId), done)
+        .then(() => productsClient.product.disable(gatewayAccountId, productExternalId), done)
         .then(() => done(new Error('Promise unexpectedly resolved')))
         .catch((err) => {
           result = err

--- a/test/unit/clients/product_client/product/get_by_gateway_account_id_test.js
+++ b/test/unit/clients/product_client/product/get_by_gateway_account_id_test.js
@@ -11,7 +11,7 @@ const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_bu
 const productFixtures = require('../../../../fixtures/product_fixtures')
 
 // Constants
-const PRODUCT_RESOURCE = '/v1/api/products'
+const API_RESOURCE = '/v1/api'
 const mockPort = Math.floor(Math.random() * 65535)
 const mockServer = pactProxy.create('localhost', mockPort)
 let productsMock, response, result, gatewayAccountId
@@ -56,8 +56,7 @@ describe('products client - find products associated with a particular gateway a
         productFixtures.validCreateProductResponse({gateway_account_id: gatewayAccountId, price: randomPrice()}),
         productFixtures.validCreateProductResponse({gateway_account_id: gatewayAccountId, price: randomPrice()})
       ]
-      const interaction = new PactInteractionBuilder(PRODUCT_RESOURCE)
-        .withQuery('gatewayAccountId', String(gatewayAccountId))
+      const interaction = new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products`)
         .withUponReceiving('a valid get product by gateway account id request')
         .withMethod('GET')
         .withStatusCode(200)
@@ -99,8 +98,7 @@ describe('products client - find products associated with a particular gateway a
     before(done => {
       const productsClient = getProductsClient()
       gatewayAccountId = 98765
-      const interaction = new PactInteractionBuilder(PRODUCT_RESOURCE)
-        .withQuery('gatewayAccountId', String(gatewayAccountId))
+      const interaction = new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products`)
         .withUponReceiving('a valid get product by gateway account id where the gateway account has no products')
         .withMethod('GET')
         .withStatusCode(404)

--- a/test/unit/controller/payment-links/get-manage-controller.test.js
+++ b/test/unit/controller/payment-links/get-manage-controller.test.js
@@ -42,7 +42,7 @@ const PAYMENT_2 = {
 }
 
 function mockGetProductsByGatewayAccountEndpoint (gatewayAccountId) {
-  return nock(PRODUCTS_URL).get('/v1/api/products?gatewayAccountId=' + gatewayAccountId)
+  return nock(PRODUCTS_URL).get(`/v1/api/gateway-account/${gatewayAccountId}/products`)
 }
 
 describe('Manage payment links', () => {

--- a/test/unit/controller/payment-links/get_disable_controller_test.js
+++ b/test/unit/controller/payment-links/get_disable_controller_test.js
@@ -26,7 +26,7 @@ describe('Manage payment links - disable controller', () => {
       nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
         payment_provider: 'sandbox'
       })
-      nock(PRODUCTS_URL).patch(`/v1/api/products/${productExternalId}/disable`).reply(200)
+      nock(PRODUCTS_URL).patch(`/v1/api/gateway-account/${GATEWAY_ACCOUNT_ID}/products/${productExternalId}/disable`).reply(200)
       session = getMockSession(user)
       supertest(createAppWithSession(getApp(), session))
         .get(paths.paymentLinks.disable.replace(':productExternalId', productExternalId))
@@ -65,7 +65,7 @@ describe('Manage payment links - disable controller', () => {
       nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
         payment_provider: 'sandbox'
       })
-      nock(PRODUCTS_URL).patch(`/v1/api/products/${productExternalId}/disable`)
+      nock(PRODUCTS_URL).patch(`/v1/api/gateway-account/${GATEWAY_ACCOUNT_ID}/products/${productExternalId}/disable`)
         .replyWithError('Ruhroh! Something terrible has happened Shaggy!')
       session = getMockSession(user)
       supertest(createAppWithSession(getApp(), session))

--- a/test/unit/controller/test_with_your_users_controller/disable_controller_test.js
+++ b/test/unit/controller/test_with_your_users_controller/disable_controller_test.js
@@ -26,7 +26,7 @@ describe('test with your users - disable controller', () => {
       nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
         payment_provider: 'sandbox'
       })
-      nock(PRODUCTS_URL).patch(`/v1/api/products/${productExternalId}/disable`).reply(200)
+      nock(PRODUCTS_URL).patch(`/v1/api/gateway-account/${GATEWAY_ACCOUNT_ID}/products/${productExternalId}/disable`).reply(200)
       session = getMockSession(user)
       supertest(createAppWithSession(getApp(), session))
         .get(paths.prototyping.demoService.disable.replace(':productExternalId', productExternalId))

--- a/test/unit/controller/test_with_your_users_controller/links_controller_test.js
+++ b/test/unit/controller/test_with_your_users_controller/links_controller_test.js
@@ -57,7 +57,7 @@ const PAYMENT_3 = {
 }
 
 function mockGetProductsByGatewayAccountEndpoint (gatewayAccountId) {
-  return nock(PRODUCTS_URL).get('/v1/api/products?gatewayAccountId=' + gatewayAccountId)
+  return nock(PRODUCTS_URL).get(`/v1/api/gateway-account/${gatewayAccountId}/products`)
 }
 
 describe('Show the prototype links', () => {


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

`pay-products` was updated to force all product operations to supply the gateway account as a parameter for access control purposes and prevent insecure object reference. This change updates product client to reflect these api changes:

* Find a product by external id and by *gateway account id*,
  `/gateway-account/{gatewayAccountId}/products/{productExternalId}`
* Disable a product by external id and by *gateway account id*,
  `/gateway-account/{gatewayAccountId}/products/{productExternalId}/disable`
* Find all active products by *gateway account id*,
  `/gateway-account/{gatewayAccountId}/products`

