### PR TITLE
BAU Run e2e by default on PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
   agent any
 
   parameters {
-    booleanParam(defaultValue: false, description: '', name: 'runEndToEndOnPR')
+    booleanParam(defaultValue: true, description: '', name: 'runEndToEndOnPR')
   }
 
   options {


### PR DESCRIPTION
There is a perception that disabling e2e by default is causing
too many problems in master. This flips the deafult behaviour to run
e2e on PRs, but it is still possible to disable them.