### PR TITLE
PP-3505 - Making template more straight forward

### DIFF
--- a/app/assets/sass/helpers/_headings.scss
+++ b/app/assets/sass/helpers/_headings.scss
@@ -9,8 +9,8 @@
   margin-top: 0;
 }
 
-.gutter-top {
-  margin-top: $gutter;
+.pad-bottom {
+  margin-bottom: $gutter * 4;
 }
 
 .heading-group {

--- a/app/assets/sass/modules/_create-payment-link.scss
+++ b/app/assets/sass/modules/_create-payment-link.scss
@@ -1,7 +1,3 @@
-.fullwidth .main-content {
-  display: none;
-}
-
 .payment-links-list {
 
   &--item {

--- a/app/assets/sass/modules/_flash.scss
+++ b/app/assets/sass/modules/_flash.scss
@@ -14,7 +14,7 @@
     }
   }
 
-  p:only-child {
+  p:last-of-type {
     margin-bottom: 0;
   }
 }
@@ -31,8 +31,4 @@
       list-style: none;
     }
   }
-}
-
-.full-width .main-content {
-  display: none;
 }

--- a/app/assets/sass/modules/_related_information.scss
+++ b/app/assets/sass/modules/_related_information.scss
@@ -1,8 +1,6 @@
 .related-information {
-  margin-top: $gutter * 2;
-  padding-top: $gutter-half;
   @include core-16;
-  margin-top: $gutter;
-  border-top: 10px solid $govuk-blue;
 
+  padding-top: $gutter-half;
+  border-top: 10px solid $govuk-blue;
 }

--- a/app/utils/display_converter.js
+++ b/app/utils/display_converter.js
@@ -2,27 +2,6 @@ let _ = require('lodash')
 const getHeldPermissions = require('./get_held_permissions')
 const {serviceNavigationItems, adminNavigationItems} = require('./navBuilder')
 
-const showSettingsNavTemplates = [
-  'tokens',
-  'tokens/generate',
-  'credentials',
-  'provider_credentials/epdq',
-  'provider_credentials/sandbox',
-  'provider_credentials/smartpay',
-  'provider_credentials/worldpay',
-  'service_name',
-  'merchant_details/edit_merchant_details',
-  'payment_types_summary',
-  'payment_types_select_type',
-  'payment_types_select_brand',
-  '3d_secure/index',
-  '3d_secure/on_confirm',
-  'email_notifications/index',
-  'email_notifications/off_confirm',
-  'email_notifications/edit',
-  'email_notifications/confirm'
-]
-
 const hideServiceHeaderTemplates = [
   'services/index',
   'services/edit_service_name',
@@ -68,10 +47,6 @@ const getPermissions = (user, service) => {
   }
 }
 
-const showSettingsNav = template => {
-  return showSettingsNavTemplates.indexOf(template) !== -1
-}
-
 const hideServiceHeader = template => {
   return hideServiceHeaderTemplates.indexOf(template) !== -1
 }
@@ -109,7 +84,6 @@ module.exports = function (req, data, template) {
   let originalUrl = req.originalUrl
   let permissions = getPermissions(user, req.service)
   convertedData.permissions = permissions
-  convertedData.showSettingsNav = showSettingsNav(template)
   convertedData.hideServiceHeader = hideServiceHeader(template)
   convertedData.hideServiceNav = hideServiceNav(template)
   addGatewayAccountProviderDisplayNames(convertedData)

--- a/app/views/3d_secure/index.njk
+++ b/app/views/3d_secure/index.njk
@@ -4,8 +4,12 @@
   3D Secure - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
-{% block mainContent %}
+{% block side_navigation %}
+  {% include "includes/side_navigation.njk" %}
+{% endblock %}
 
+{% block mainContent %}
+<div class="column-two-thirds">
   {% if not permissions.toggle_3ds_update %}
     {% include "../includes/settings-read-only.njk" %}
   {% endif %}
@@ -94,5 +98,5 @@
     <h1 class="page-title">3D Secure</h1>
     <p id="threeds-not-supported">3D Secure is not currently supported for this payment service provider (PSP).</p>
   {% endif %}
-
+</div>
 {% endblock %}

--- a/app/views/3d_secure/on_confirm.njk
+++ b/app/views/3d_secure/on_confirm.njk
@@ -4,6 +4,10 @@
 Confirm 3D Secure - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
+{% block side_navigation %}
+  {% include "includes/side_navigation.njk" %}
+{% endblock %}
+
 {% block mainContent %}
   <h1 class="page-title">3D Secure</h1>
 

--- a/app/views/credentials.njk
+++ b/app/views/credentials.njk
@@ -4,9 +4,15 @@
   Account credentials - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
+{% block side_navigation %}
+  {% include "includes/side_navigation.njk" %}
+{% endblock %}
+
 {% block mainContent %}
+<div class="column-two-thirds">
   <h1 class="page-title">Account credentials</h1>
 
   {% block provider_content %}
   {% endblock %}
+</div>
 {% endblock %}

--- a/app/views/dashboard/demo-payment/edit-amount.njk
+++ b/app/views/dashboard/demo-payment/edit-amount.njk
@@ -4,6 +4,7 @@ Edit payment amount for demo payment - {{currentServiceName}} {{currentGatewayAc
 {% endblock %}
 
 {% block mainContent %}
+<div class="column-two-thirds">
   <a href="{{nextPage}}" class="link-back">Back to make a demo payment</a>
   <h1 class="heading-large prototyping__heading">Edit payment amount</h1>
   <form method="post" action="{{nextPage}}" data-validate="true">
@@ -20,4 +21,5 @@ Edit payment amount for demo payment - {{currentServiceName}} {{currentGatewayAc
     </div>
     <input class="button" type="submit" value="Save changes">
   </form>
+</div>
 {% endblock %}

--- a/app/views/dashboard/demo-payment/edit-description.njk
+++ b/app/views/dashboard/demo-payment/edit-description.njk
@@ -4,6 +4,7 @@ Edit payment description for demo payment - {{currentServiceName}} {{currentGate
 {% endblock %}
 
 {% block mainContent %}
+<div class="column-two-thirds">
   <a href="{{nextPage}}" class="link-back">Back to make a demo payment</a>
   <h1 class="heading-large prototyping__heading">Edit payment description</h1>
   <form method="post" action="{{nextPage}}" data-validate="true">
@@ -17,4 +18,5 @@ Edit payment description for demo payment - {{currentServiceName}} {{currentGate
     </div>
     <input class="button" type="submit" value="Save changes">
   </form>
+</div>
 {% endblock %}

--- a/app/views/dashboard/demo-payment/index.njk
+++ b/app/views/dashboard/demo-payment/index.njk
@@ -5,35 +5,37 @@ Make a demo payment - {{currentServiceName}} {{currentGatewayAccount.full_type}}
 {% endblock %}
 
 {% block mainContent %}
-<a href="/" class="link-back">Back to dashboard</a>
-<h1 class="heading-large prototyping__heading">Make a demo payment</h1>
-<p>Try the payment experience as a user. Then view the completed payment as an administrator on GOV.UK Pay.</p>
-<table class="prototyping__settings-table">
-  <thead>
-  <tr>
-    <h2 class="heading-small">Payment description</h2>
-    <p class="prototyping__hint">Tell users what they are paying for</p>
-  </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <td id="payment-description">{{paymentDescription}}</td>
-    <td class="prototyping__edit-cell"><a class="prototyping__edit-button" href="{{editDescription}}">Edit</a></td>
-  </tr>
-  </tbody>
-</table>
-<table class="prototyping__settings-table">
-  <thead>
-  <tr>
-    <h2 class="heading-small">Payment amount</h2>
-  </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <td id="payment-amount">&pound;{{paymentAmount}}</td>
-    <td class="prototyping__edit-cell"><a class="prototyping__edit-button" href="{{editAmount}}">Edit</a></td>
-  </tr>
-  </tbody>
-</table>
-<a id="prototyping__continue" class="button" href="{{nextPage}}">Continue</a>
+<div class="column-two-thirds">
+  <a href="/" class="link-back">Back to dashboard</a>
+  <h1 class="heading-large prototyping__heading">Make a demo payment</h1>
+  <p>Try the payment experience as a user. Then view the completed payment as an administrator on GOV.UK Pay.</p>
+  <table class="prototyping__settings-table">
+    <thead>
+    <tr>
+      <h2 class="heading-small">Payment description</h2>
+      <p class="prototyping__hint">Tell users what they are paying for</p>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td id="payment-description">{{paymentDescription}}</td>
+      <td class="prototyping__edit-cell"><a class="prototyping__edit-button" href="{{editDescription}}">Edit</a></td>
+    </tr>
+    </tbody>
+  </table>
+  <table class="prototyping__settings-table">
+    <thead>
+    <tr>
+      <h2 class="heading-small">Payment amount</h2>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td id="payment-amount">&pound;{{paymentAmount}}</td>
+      <td class="prototyping__edit-cell"><a class="prototyping__edit-button" href="{{editAmount}}">Edit</a></td>
+    </tr>
+    </tbody>
+  </table>
+  <a id="prototyping__continue" class="button" href="{{nextPage}}">Continue</a>
+</div>
 {% endblock %}

--- a/app/views/dashboard/demo-payment/mock-card-details.njk
+++ b/app/views/dashboard/demo-payment/mock-card-details.njk
@@ -4,6 +4,7 @@ Mock card numbers for demo payment - {{currentServiceName}} {{currentGatewayAcco
 {% endblock %}
 
 {% block mainContent %}
+<div class="column-two-thirds">
   <a href="{{lastPage}}" class="link-back">Back to dashboard</a>
   <h1 class="heading-large prototyping__heading">Mock card numbers</h1>
   <p>Use this card number to test a successful payment. Don’t use real card numbers.</p>
@@ -18,4 +19,5 @@ Mock card numbers for demo payment - {{currentServiceName}} {{currentGatewayAcco
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <input id="prototyping__make-demo-payment" class="button" type="submit" value="Make a demo payment">
   </form>
+</div>
 {% endblock %}

--- a/app/views/dashboard/demo-service/confirm.njk
+++ b/app/views/dashboard/demo-service/confirm.njk
@@ -5,6 +5,7 @@ Your prototype link - {{currentServiceName}} {{currentGatewayAccount.full_type}}
 {% endblock %}
 
 {% block mainContent %}
+<div class="column-two-thirds">
   <a id="prototyping__links-link-back" href="{{linksPage}}" class="link-back">Back to prototype links</a>
   <h1 class="heading-large prototyping__heading">Your prototype link</h1>
   <p>This link will send the user to our payment pages. Use it in a “pay now” button, for example, to integrate it with your prototype.</p>
@@ -15,4 +16,5 @@ Your prototype link - {{currentServiceName}} {{currentGatewayAccount.full_type}}
   <p>Links will be saved for as long as you need them in the prototype links tab.</p>
 
   <a class="button links-page" href="{{linksPage}}">See prototype links</a>
+</div>
 {% endblock %}

--- a/app/views/dashboard/demo-service/create.njk
+++ b/app/views/dashboard/demo-service/create.njk
@@ -5,6 +5,7 @@ Create a prototype link - {{currentServiceName}} {{currentGatewayAccount.full_ty
 {% endblock %}
 
 {% block mainContent %}
+<div class="column-two-thirds">
   <a href="{{linksPage}}" class="link-back">Back to prototype links</a>
   <h1 class="heading-large prototyping__heading">Create a prototype link</h1>
   <form method="post" action="{{confirmPage}}" data-validate>
@@ -35,4 +36,5 @@ Create a prototype link - {{currentServiceName}} {{currentGatewayAccount.full_ty
     </div>
     <input id="prototyping__links-button-create-prototype-link" class="button" type="submit" value="Create prototype link">
   </form>
+</div>
 {% endblock %}

--- a/app/views/dashboard/demo-service/index.njk
+++ b/app/views/dashboard/demo-service/index.njk
@@ -5,6 +5,7 @@ Test with your users - {{currentServiceName}} {{currentGatewayAccount.full_type}
 {% endblock %}
 
 {% block mainContent %}
+<div class="column-two-thirds">
   <a href="/" class="link-back">Back to dashboard</a>
   <h1 class="heading-large prototyping__heading">Test with your users</h1>
   <p>Create a reusable link to integrate your service prototype with GOV.UK Pay and test with users.</p>
@@ -54,4 +55,5 @@ Test with your users - {{currentServiceName}} {{currentGatewayAccount.full_type}
       </div>
     {% endif %}
   </div>
+</div>
 {% endblock %}

--- a/app/views/dashboard/index.njk
+++ b/app/views/dashboard/index.njk
@@ -4,10 +4,11 @@
 Dashboard - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
-{% block full_width_content %}
+{% block mainContent %}
+<div class="column-full">
   <h1 class="page-title first-steps__title">Dashboard</h1>
 
   {% include "./_activity.njk" %}
   {% include "./_first-steps.njk" %}
-
+</div>
 {% endblock %}

--- a/app/views/email_notifications/confirm.njk
+++ b/app/views/email_notifications/confirm.njk
@@ -4,7 +4,12 @@
 Confirm email notifications - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
+{% block side_navigation %}
+  {% include "includes/side_navigation.njk" %}
+{% endblock %}
+
 {% block mainContent %}
+<div class="column-two-thirds">
   <h1 class="page-title">Confirm new email template</h1>
   <p>This email will be sent to users when they successfully complete a payment within your service.</p>
 
@@ -18,4 +23,5 @@ Confirm email notifications - {{currentServiceName}} {{currentGatewayAccount.ful
     <input name="email-confirm" type="submit" class="button push-top qa-confirm-submit" value="Confirm">
     <a class="push-top-sml" href="{{routes.emailNotifications.index}}">cancel</a>
   </form>
+</div>
 {% endblock %}

--- a/app/views/email_notifications/edit.njk
+++ b/app/views/email_notifications/edit.njk
@@ -4,7 +4,12 @@
 Change email notifications template - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
+{% block side_navigation %}
+  {% include "includes/side_navigation.njk" %}
+{% endblock %}
+
 {% block mainContent %}
+<div class="column-two-thirds">
   <h1 class="page-title heading-large">Add a custom paragraph to the email</h1>
   <h2 class="heading-medium">Current email template</h2>
   {% include "./email_body.njk" %}
@@ -36,4 +41,5 @@ Change email notifications template - {{currentServiceName}} {{currentGatewayAcc
     <input name="email-edit" type="submit" class="button push-top qa-edit-submit" value="Continue">
     <a class="push-top-sml" href="{{routes.emailNotifications.index}}">cancel</a>
   </form>
+</div>
 {% endblock %}

--- a/app/views/email_notifications/index.njk
+++ b/app/views/email_notifications/index.njk
@@ -4,7 +4,12 @@
   Email notifications - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
+{% block side_navigation %}
+  {% include "includes/side_navigation.njk" %}
+{% endblock %}
+
 {% block mainContent %}
+<div class="column-two-thirds">
   {% if not permissions.email_notification_toggle_update %}
     {% include "includes/settings-read-only.njk" %}
   {% endif %}
@@ -46,4 +51,5 @@
       {% endif %}
     {% endif %}
   {% endif %}
+</div>
 {% endblock %}

--- a/app/views/email_notifications/off_confirm.njk
+++ b/app/views/email_notifications/off_confirm.njk
@@ -4,7 +4,12 @@
 Turn off email notifications - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
+{% block side_navigation %}
+  {% include "includes/side_navigation.njk" %}
+{% endblock %}
+
 {% block mainContent %}
+<div class="column-two-thirds">
   <h1 class="heading-medium">
     Are you sure you want to turn off email notifications?
   </h1>
@@ -22,4 +27,5 @@ Turn off email notifications - {{currentServiceName}} {{currentGatewayAccount.fu
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
       <input name="email-off" type="submit" class="button push-top qa-off" value="Turn off email notifications">
   </form>
+</div>
 {% endblock %}

--- a/app/views/error_logged_in.njk
+++ b/app/views/error_logged_in.njk
@@ -8,11 +8,9 @@ An error occurred - GOV.UK Pay
   <script src="/public/js/components/link-follower.js"></script>
 {% endblock %}
 
-{% block mainClasses %}full-width{% endblock %}
-
-{% block full_width_content %}
+{% block mainContent %}
 <div class="column-two-thirds">
-    <h1 class="heading-large" id="error-title">{{error.title}}</h1>
+    <h1 class="heading-large page-title" id="error-title">{{error.title}}</h1>
 
     <p id="error-message">{{error.message}}</p>
 

--- a/app/views/forgotten_password/new_password.njk
+++ b/app/views/forgotten_password/new_password.njk
@@ -8,7 +8,7 @@ Create a new password - GOV.UK Pay
   <div class="column-two-thirds">
     <form action="/reset-password/{{id}}"method="post" class="form submit-new-password">
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
-      <h1 class="heading-large">
+      <h1 class="heading-large page-title">
         Create a new password
       </h1>
       <p>

--- a/app/views/forgotten_password/password_requested.njk
+++ b/app/views/forgotten_password/password_requested.njk
@@ -6,7 +6,7 @@ Reset password request - GOV.UK Pay
 
 {% block mainContent %}
   <div class="column-two-thirds">
-    <h1 class="heading-large">Now check your email</h1>
+    <h1 class="heading-large page-title">Now check your email</h1>
     <p>We’ve sent you an email with a link to reset your password.</p>
   </div>
 {% endblock %}

--- a/app/views/includes/flash.njk
+++ b/app/views/includes/flash.njk
@@ -1,18 +1,18 @@
 {% block flash %}
-<div class="grid-row">
-  {% if flash.genericError %}
-  <div class="column-full flash-container">
-    <div class="notification generic-error error-summary">
-      {{ flash.genericError | safe }}
+  <div class="column-two-thirds">
+    {% if flash.genericError %}
+    <div class="flash-container">
+      <div class="notification generic-error error-summary">
+        {{ flash.genericError | safe }}
+      </div>
     </div>
-  </div>
-  {% endif %}
-  {% if flash.generic %}
-  <div class="column-full flash-container">
-    <div class="notification generic-flash">
-      {{ flash.generic | safe }}
+    {% endif %}
+    {% if flash.generic %}
+    <div class="flash-container">
+      <div class="notification generic-flash">
+        {{ flash.generic | safe }}
+      </div>
     </div>
+    {% endif %}
   </div>
-  {% endif %}
-</div>
 {% endblock %}

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -30,15 +30,10 @@
     {% endif %}
 
     <main id="content" role="main" class="{% block mainClasses %}{% endblock %}">
-      {% block full_width_content %}{% endblock %}
       <div class="grid-row">
-        {% if showSettingsNav %}
-          {% include "includes/side_navigation.njk" %}
-        {% endif %}
-        <div class="column-two-thirds main-content">
-            {% include "includes/flash.njk" %}
-            {% block mainContent %}{% endblock %}
-        </div>
+        {% block side_navigation %}{% endblock %}
+        {% include "includes/flash.njk" %}
+        {% block mainContent %}{% endblock %}
       </div>
     </main>
   {% endblock %}

--- a/app/views/login/login.njk
+++ b/app/views/login/login.njk
@@ -30,7 +30,7 @@ Sign in to GOV.UK Pay
   </div>
   {% endif %}
 
-  <h1 class="heading-large">Sign in</h1>
+  <h1 class="heading-large page-title">Sign in</h1>
 
   <p>If you do not have an account, you can <a href="{{ routes.selfCreateService.register }}" class="register-link">create one now</a>.</p>
 

--- a/app/views/merchant_details/edit_merchant_details.njk
+++ b/app/views/merchant_details/edit_merchant_details.njk
@@ -4,7 +4,12 @@
   Merchant details - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
+{% block side_navigation %}
+  {% include "includes/side_navigation.njk" %}
+{% endblock %}
+
 {% block mainContent %}
+<div class="column-two-thirds">
   {% if success %}
   <div class="notification">
       Merchant details updated
@@ -120,4 +125,5 @@
         <input id="save-merchant-details" class="button" type="submit" value="Save">
     </div>
   </form>
+</div>
 {% endblock %}

--- a/app/views/payment-links/amount.njk
+++ b/app/views/payment-links/amount.njk
@@ -4,65 +4,63 @@
 Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
-{% block mainClasses %}fullwidth{% endblock %}
+{% block side_navigation %}
+<aside class="column-one-third pad-bottom">
+  <nav role="navigation" class="navigation settings-navigation">
+    <ul class="list">
+       <li class="active"><a href="{{ returnToStart }}">Create a payment link</a></li>
+      <li><a href="{{ manage }}">Manage payment&nbsp;links</a></li>
+    </ul>
+  </nav>
+</aside>
+{% endblock %}
 
-{% block full_width_content %}
-<div class="grid-row">
-  <aside class="column-one-third">
-    <nav role="navigation" class="navigation settings-navigation">
-      <ul class="list">
-        <li class="active"><a href="{{ returnToStart }}">Create a payment link</a></li>
-        <li><a href="{{ manage }}">Manage payment&nbsp;links</a></li>
-      </ul>
-    </nav>
-  </aside>
-  <section class="column-two-thirds">
-    {% include "includes/flash.njk" %}
-    <h1 class="page-title">Is the payment for a fixed amount?</h1>
-    <form action="{{ nextPage }}" class="form" method="post">
-      <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-      <div class="form-group{% if flash.genericError %} error{% endif %}">
-        {% if flash.errorType == 'paymentAmountType' %}
-        <span class="error-message">
-          Please choose an option
-        </span>
-        {% endif %}
-        <fieldset data-module="show-hide-content" id="fixed-or-variable">
-          <div class="multiple-choice" data-target="fixed-amount">
-            <input id="amount-type-fixed" type="radio" name="amount-type-group" value="fixed" {% if paymentAmountType == 'fixed' %}checked{% endif %}>
-            <label for="amount-type-fixed">Yes</label>
-          </div>
-          <div class="panel panel-border-wide {% if paymentAmountType == 'fixed' %}{% elif flash.genericError %}{% else %}js-hidden{% endif %}" id="fixed-amount">
-            <label class="form-label" for="contact-email">
-              Enter the amount
-              <span class="visually-hidden">in £</span>
-              {% if flash.errorType == 'paymentAmountFormat' %}
-              <span class="error-message">
-                Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”
-              </span>
-              {% endif %}
-            </label>
-           <div class="currency-input__inner">
-             <span class="currency-input__inner__unit">£</span>
-             <input class="form-control form-control-1-4" aria-label="Enter amount in pounds" name="payment-amount" data-non-numeric="" type="text" id="payment-amount" value="{{ paymentLinkAmount }}" {% if paymentAmountType == 'fixed' %}autofocus{% endif %}>
-           </div>
-          </div>
+{% block mainContent %}
+<section class="column-two-thirds">
+  <h1 class="page-title">Is the payment for a fixed amount?</h1>
+  <form action="{{ nextPage }}" class="form" method="post">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    <div class="form-group{% if flash.genericError %} error{% endif %}">
+      {% if flash.errorType == 'paymentAmountType' %}
+      <span class="error-message">
+        Please choose an option
+      </span>
+      {% endif %}
+      <fieldset data-module="show-hide-content" id="fixed-or-variable">
+        <div class="multiple-choice" data-target="fixed-amount">
+          <input id="amount-type-fixed" type="radio" name="amount-type-group" value="fixed" {% if paymentAmountType == 'fixed' %}checked{% endif %}>
+          <label for="amount-type-fixed">Yes</label>
+        </div>
+        <div class="panel panel-border-wide {% if paymentAmountType == 'fixed' %}{% elif flash.genericError %}{% else %}js-hidden{% endif %}" id="fixed-amount">
+          <label class="form-label" for="contact-email">
+            Enter the amount
+            <span class="visually-hidden">in £</span>
+            {% if flash.errorType == 'paymentAmountFormat' %}
+            <span class="error-message">
+              Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”
+            </span>
+            {% endif %}
+          </label>
+         <div class="currency-input__inner">
+           <span class="currency-input__inner__unit">£</span>
+           <input class="form-control form-control-1-4" aria-label="Enter amount in pounds" name="payment-amount" data-non-numeric="" type="text" id="payment-amount" value="{{ paymentLinkAmount }}" {% if paymentAmountType == 'fixed' %}autofocus{% endif %}>
+         </div>
+        </div>
 
-          <div class="multiple-choice">
-            <input id="amount-type-variable" type="radio" name="amount-type-group" value="variable" {% if paymentAmountType == 'variable' %}checked{% endif %}>
-            <label for="amount-type-variable">No, the user can choose the amount</label>
-          </div>
-        </fieldset>
-      </div>
-      <div class="form-group">
-        <button class="button" type="submit">Continue</button>
-      </div>
-      <p><a class="cancel" href="{{ returnToStart }}">Cancel</a></p>
-    </form>
-    <div>
-      <h3 class="heading-small">Example of what the user will see</h3>
-      <img class="create-payment-link-screenshot" src="/public/images/adhoc-2-amount.svg" alt="Screenshot of both possible payment link amount pages">
+        <div class="multiple-choice">
+          <input id="amount-type-variable" type="radio" name="amount-type-group" value="variable" {% if paymentAmountType == 'variable' %}checked{% endif %}>
+          <label for="amount-type-variable">No, the user can choose the amount</label>
+        </div>
+      </fieldset>
     </div>
-  </section>
-</div>
+    <div class="form-group">
+      <button class="button" type="submit">Continue</button>
+    </div>
+    <p><a class="cancel" href="{{ returnToStart }}">Cancel</a></p>
+  </form>
+  <div>
+    <h3 class="heading-small">Example of what the user will see</h3>
+    <img class="create-payment-link-screenshot" src="/public/images/adhoc-2-amount.svg" alt="Screenshot of both possible payment link amount pages">
+  </div>
+</section>
 {% endblock %}

--- a/app/views/payment-links/index.njk
+++ b/app/views/payment-links/index.njk
@@ -4,50 +4,51 @@
 Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
-{% block full_width_content %}
-<div class="grid-row">
-  <aside class="column-one-third">
-    <nav role="navigation" class="navigation settings-navigation">
-      <ul class="list">
-         <li class="active"><a href="{{ returnToStart }}">Create a payment link</a></li>
-        <li><a href="{{ manage }}">Manage payment&nbsp;links</a></li>
-      </ul>
-    </nav>
-  </aside>
-  <section class="column-two-thirds">
-    <h1 class="page-title">Create a payment link</h1>
-    <p>You can create a payment link so that users can make online payments to your service. Even if you don’t have a digital service, GOV.UK Pay can still take payments for you.</p>
-    <p>It's quick and easy to create a payment link and you don’t need any technical knowledge.</p>
-    <p>The same payment link can be used by all users of your service.</p>
-    <a id="create-payment-link" class="button" href="{{nextPage}}">Create a payment link</a>
-    <details role="group" class="create-payment-link-details">
-      <summary role="button" aria-controls="details-content" aria-expanded="false"><span class="summary">See an example</span></summary>
+{% block side_navigation %}
+<aside class="column-one-third pad-bottom">
+  <nav role="navigation" class="navigation settings-navigation">
+    <ul class="list">
+       <li class="active"><a href="{{ returnToStart }}">Create a payment link</a></li>
+      <li><a href="{{ manage }}">Manage payment&nbsp;links</a></li>
+    </ul>
+  </nav>
+</aside>
+{% endblock %}
 
-      <div class="panel panel-border-narrow" id="details-content" aria-hidden="true">
-        <ol class="list list-number">
-          <li>
-            <h4 class="heading-small">A user copies the payment link and enters it in a web browser.</h4>
-            <p>The url will be created from your service name. For example https://payment.service.gov.uk/pay/fishing-permit</p>
-          </li>
-          <li>
-            <h4 class="heading-small">They arrive at the start page, which tells them what they’re paying for. You choose the wording that goes here.</h4>
-            <img class="create-payment-link-screenshot" src="/public/images/adhoc-1-start.svg" alt="Screenshot of payment link landing page">
-          </li>
-          <li>
-            <h4 class="heading-small">They enter the amount they need to pay, or proceed with a set amount you’ve chosen.</h4>
-            <img class="create-payment-link-screenshot" src="/public/images/adhoc-2-amount.svg" alt="Screenshot of both possible payment link amount pages">
-          </li>
-          <li>
-            <h4 class="heading-small">They enter their payment information and make the payment.</h4>
-            <img class="create-payment-link-screenshot" src="/public/images/adhoc-3-start.svg" alt="Screenshot of payment information page">
-          </li>
-          <li>
-            <h4 class="heading-small">They receive a confirmation of successful payment. This is also emailed to them with a payment reference number.</h4>
-            <img class="create-payment-link-screenshot" src="/public/images/adhoc-4-confirm.svg" alt="Screenshot of confirmation page">
-          </li>
-        </ol>
-      </div>
-    </details>
-  </section>
-</div>
+{% block mainContent %}
+<section class="column-two-thirds">
+  <h1 class="page-title">Create a payment link</h1>
+  <p>You can create a payment link so that users can make online payments to your service. Even if you don’t have a digital service, GOV.UK Pay can still take payments for you.</p>
+  <p>It's quick and easy to create a payment link and you don’t need any technical knowledge.</p>
+  <p>The same payment link can be used by all users of your service.</p>
+  <a id="create-payment-link" class="button" href="{{nextPage}}">Create a payment link</a>
+  <details role="group" class="create-payment-link-details">
+    <summary role="button" aria-controls="details-content" aria-expanded="false"><span class="summary">See an example</span></summary>
+
+    <div class="panel panel-border-narrow" id="details-content" aria-hidden="true">
+      <ol class="list list-number">
+        <li>
+          <h4 class="heading-small">A user copies the payment link and enters it in a web browser.</h4>
+          <p>The url will be created from your service name. For example https://payment.service.gov.uk/pay/fishing-permit</p>
+        </li>
+        <li>
+          <h4 class="heading-small">They arrive at the start page, which tells them what they’re paying for. You choose the wording that goes here.</h4>
+          <img class="create-payment-link-screenshot" src="/public/images/adhoc-1-start.svg" alt="Screenshot of payment link landing page">
+        </li>
+        <li>
+          <h4 class="heading-small">They enter the amount they need to pay, or proceed with a set amount you’ve chosen.</h4>
+          <img class="create-payment-link-screenshot" src="/public/images/adhoc-2-amount.svg" alt="Screenshot of both possible payment link amount pages">
+        </li>
+        <li>
+          <h4 class="heading-small">They enter their payment information and make the payment.</h4>
+          <img class="create-payment-link-screenshot" src="/public/images/adhoc-3-start.svg" alt="Screenshot of payment information page">
+        </li>
+        <li>
+          <h4 class="heading-small">They receive a confirmation of successful payment. This is also emailed to them with a payment reference number.</h4>
+          <img class="create-payment-link-screenshot" src="/public/images/adhoc-4-confirm.svg" alt="Screenshot of confirmation page">
+        </li>
+      </ol>
+    </div>
+  </details>
+</section>
 {% endblock %}

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -4,70 +4,68 @@
 Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
-{% block mainClasses %}fullwidth{% endblock %}
+{% block side_navigation %}
+<aside class="column-one-third pad-bottom">
+  <nav role="navigation" class="navigation settings-navigation">
+    <ul class="list">
+       <li class="active"><a href="{{ returnToStart }}">Create a payment link</a></li>
+      <li><a href="{{ manage }}">Manage payment&nbsp;links</a></li>
+    </ul>
+  </nav>
+</aside>
+{% endblock %}
 
-{% block full_width_content %}
-<div class="grid-row">
-  <aside class="column-one-third">
-    <nav role="navigation" class="navigation settings-navigation">
-      <ul class="list">
-        <li class="active"><a href="{{ returnToStart }}">Create a payment link</a></li>
-        <li><a href="{{ manage }}">Manage payment&nbsp;links</a></li>
-      </ul>
-    </nav>
-  </aside>
-  <section class="column-two-thirds">
-    {% include "includes/flash.njk" %}
-    <h1 class="page-title">Set payment link information</h1>
+{% block mainContent %}
+<section class="column-two-thirds">
+  <h1 class="page-title">Set payment link information</h1>
 
-    <form action="{{ nextPage }}" class="form" method="post" data-validate>
-      <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-      {% if change.length %}
-        <input name="change" type="hidden" value="true"/>
-      {% endif %}
-      <div class="form-group{% if flash.genericError %} error{% endif %}">
-        <label class="form-label-bold" for="payment-link-title">
-          Title
-          <span class="form-hint">
-            Briefly describe what the user is paying for.
-            For example, “Pay for a parking permit”.
-          </span>
-          {% if flash.genericError %}
-          <span class="error-message">
-            This field cannot be blank
-          </span>
-          {% endif %}
-        </label>
-        <input class="form-control form-control-full" id="payment-link-title" name="payment-link-title" type="text" data-validate value="{{ paymentLinkTitle }}" {% if change !== 'payment-link-description' %}autofocus{% endif %}>
-        <div class="panel panel-border-wide create-payment-link-link-replay">
-          <h3 class="heading-small">
-            The website address for this payment link will look like:
-          </h3>
-          <p class="grey">
-            You haven’t entered a title yet.
-          </p>
-        </div>
+  <form action="{{ nextPage }}" class="form" method="post" data-validate>
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    {% if change.length %}
+      <input name="change" type="hidden" value="true"/>
+    {% endif %}
+    <div class="form-group{% if flash.genericError %} error{% endif %}">
+      <label class="form-label-bold" for="payment-link-title">
+        Title
+        <span class="form-hint">
+          Briefly describe what the user is paying for.
+          For example, “Pay for a parking permit”.
+        </span>
+        {% if flash.genericError %}
+        <span class="error-message">
+          This field cannot be blank
+        </span>
+        {% endif %}
+      </label>
+      <input class="form-control form-control-full" id="payment-link-title" name="payment-link-title" type="text" data-validate value="{{ paymentLinkTitle }}" {% if change !== 'payment-link-description' %}autofocus{% endif %}>
+      <div class="panel panel-border-wide create-payment-link-link-replay">
+        <h3 class="heading-small">
+          The website address for this payment link will look like:
+        </h3>
+        <p class="grey">
+          You haven’t entered a title yet.
+        </p>
       </div>
-      <div class="form-group">
-        <label class="form-label-bold" for="payment-link-description">
-          Details (optional)
-          <span class="form-hint">
-            Give your users more information. For example, you could tell them how long it takes for their application to be processed.
-          </span>
-        </label>
-
-        <textarea class="form-control form-control-full" name="payment-link-description" id="payment-link-description" rows="5" {% if change === 'payment-link-description' %}autofocus{% endif %}>{{ paymentLinkDescription }}</textarea>
-      </div>
-
-      <div class="form-group">
-        <button class="button" type="submit">Continue</button>
-      </div>
-      <p><a class="cancel" href="{{ returnToStart }}">Cancel</a></p>
-    </form>
-    <div>
-      <h3 class="heading-small">Example of what the user will see</h3>
-      <img class="create-payment-link-screenshot" src="/public/images/adhoc-1-start.svg" alt="Screenshot of payment link landing page">
     </div>
-  </section>
-</div>
+    <div class="form-group">
+      <label class="form-label-bold" for="payment-link-description">
+        Details (optional)
+        <span class="form-hint">
+          Give your users more information. For example, you could tell them how long it takes for their application to be processed.
+        </span>
+      </label>
+
+      <textarea class="form-control form-control-full" name="payment-link-description" id="payment-link-description" rows="5" {% if change === 'payment-link-description' %}autofocus{% endif %}>{{ paymentLinkDescription }}</textarea>
+    </div>
+
+    <div class="form-group">
+      <button class="button" type="submit">Continue</button>
+    </div>
+    <p><a class="cancel" href="{{ returnToStart }}">Cancel</a></p>
+  </form>
+  <div>
+    <h3 class="heading-small">Example of what the user will see</h3>
+    <img class="create-payment-link-screenshot" src="/public/images/adhoc-1-start.svg" alt="Screenshot of payment link landing page">
+  </div>
+</section>
 {% endblock %}

--- a/app/views/payment-links/manage.njk
+++ b/app/views/payment-links/manage.njk
@@ -4,57 +4,55 @@
 Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
-{% block mainClasses %}fullwidth{% endblock %}
-
-{% block full_width_content %}
-<div class="grid-row">
-  <aside class="column-one-third">
-    <nav role="navigation" class="navigation settings-navigation">
-      <ul class="list">
-        <li><a href="{{ returnToStart }}">Create a payment link</a></li>
-        <li class="active"><a href="{{ manage }}">Manage payment&nbsp;links</a></li>
-      </ul>
-    </nav>
-  </aside>
-  <section class="column-two-thirds">
-    {% include "includes/flash.njk" %}
-    <h1 class="page-title">Manage payment links</h1>
-    <p class="payment-links-list--header">
-      {% if productsLength === 1 %}
-        There is 1 payment link
-      {% elif productsLength > 1 %}
-        There are {{productsLength}} payment links
-      {% else %}
-        There are no payment links, you can <a href="{{ returnToStart }}">create one now</a>.
-      {% endif %}
-    </p>
-    {% if products.length %}
-    <ul class="payment-links-list">
-      {% for product in products %}
-      <li class="payment-links-list--item">
-        <h2 class="heading-small payment-links-list--item__title">{{ product.name }}</h2>
-        <a class="payment-links-list--item__link" href="{{ product.links.pay.href }}">{{ product.links.pay.href }}</a>
-         <div class="payment-links-list--item__actions">
-          <a class="payment-links-list--item__actions--toggle target-to-show--toggle" href="#delete-{{ product.externalId }}">Delete</a>
-          <div class="target-to-show" id="delete-{{ product.externalId }}">
-            <div class="error-summary" role="group" aria-labelledby="error-summary" tabindex="-1">
-                <h1 class="heading-medium error-summary-heading" id="error-summary">
-                    Are you sure you want to delete this link?
-                </h1>
-                <div class="button-group">
-                  <a class="button delete payment-links-list--item__actions--delete" href="manage/delete/{{ product.externalId }}">Yes, delete this link</a>
-                </div>
-                <a class="target-to-show--cancel" href="#main">Cancel</a>
-              </div>
-          </div>
-        </div>
-        <aside class="payment-links-list--item__status payment-links-list--item__status--live">
-          Live
-        </aside>
-      </li>
-      {% endfor %}
+{% block side_navigation %}
+<aside class="column-one-third pad-bottom">
+  <nav role="navigation" class="navigation settings-navigation">
+    <ul class="list">
+      <li><a href="{{ returnToStart }}">Create a payment link</a></li>
+      <li class="active"><a href="{{ manage }}">Manage payment&nbsp;links</a></li>
     </ul>
+  </nav>
+</aside>
+{% endblock %}
+
+{% block mainContent %}
+<section class="column-two-thirds">
+  <h1 class="page-title">Manage payment links</h1>
+  <p class="payment-links-list--header">
+    {% if productsLength === 1 %}
+      There is 1 payment link
+    {% elif productsLength > 1 %}
+      There are {{productsLength}} payment links
+    {% else %}
+      There are no payment links, you can <a href="{{ returnToStart }}">create one now</a>.
     {% endif %}
-  </section>
-</div>
+  </p>
+  {% if products.length %}
+  <ul class="payment-links-list">
+    {% for product in products %}
+    <li class="payment-links-list--item">
+      <h2 class="heading-small payment-links-list--item__title">{{ product.name }}</h2>
+      <a class="payment-links-list--item__link" href="{{ product.links.pay.href }}">{{ product.links.pay.href }}</a>
+       <div class="payment-links-list--item__actions">
+        <a class="payment-links-list--item__actions--toggle target-to-show--toggle" href="#delete-{{ product.externalId }}">Delete</a>
+        <div class="target-to-show" id="delete-{{ product.externalId }}">
+          <div class="error-summary" role="group" aria-labelledby="error-summary" tabindex="-1">
+              <h1 class="heading-medium error-summary-heading" id="error-summary">
+                  Are you sure you want to delete this link?
+              </h1>
+              <div class="button-group">
+                <a class="button delete payment-links-list--item__actions--delete" href="manage/delete/{{ product.externalId }}">Yes, delete this link</a>
+              </div>
+              <a class="target-to-show--cancel" href="#main">Cancel</a>
+            </div>
+        </div>
+      </div>
+      <aside class="payment-links-list--item__status payment-links-list--item__status--live">
+        Live
+      </aside>
+    </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+</section>
 {% endblock %}

--- a/app/views/payment-links/review.njk
+++ b/app/views/payment-links/review.njk
@@ -4,77 +4,75 @@
 Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
-{% block mainClasses %}fullwidth{% endblock %}
+{% block side_navigation %}
+<aside class="column-one-third pad-bottom">
+  <nav role="navigation" class="navigation settings-navigation">
+    <ul class="list">
+       <li class="active"><a href="{{ returnToStart }}">Create a payment link</a></li>
+      <li><a href="{{ manage }}">Manage payment&nbsp;links</a></li>
+    </ul>
+  </nav>
+</aside>
+{% endblock %}
 
-{% block full_width_content %}
-<div class="grid-row">
-  <aside class="column-one-third">
-    <nav role="navigation" class="navigation settings-navigation">
-      <ul class="list">
-        <li class="active"><a href="{{ returnToStart }}">Create a payment link</a></li>
-        <li><a href="{{ manage }}">Manage payment&nbsp;links</a></li>
-      </ul>
-    </nav>
-  </aside>
-  <section class="column-two-thirds">
-    {% include "includes/flash.njk" %}
-    <form action="{{ nextPage }}" class="form" method="post" data-validate>
-      <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-      <h1 class="page-title">Review your payment link details</h1>
-      <dl class="govuk-check-your-answers cya-questions-short">
-        <div class="review-title">
-          <dt class="cya-question">
-            Title
-          </dt>
-          <dd class="cya-answer" id="create-payment-link-title">
-            {{ paymentLinkTitle }}
-          </dd>
-          <dd class="cya-change">
-            <a href="{{ changeInformation }}?field=payment-link-title">
-              Change <span class="visuallyhidden">Title</span>
-            </a>
-          </dd>
-        </div>
-        <div class="review-details">
-          <dt class="cya-question">
-            More details
-          </dt>
-          <dd class="cya-answer" id="create-payment-link-description">
-            {% if paymentLinkDescription %}
-              {{ paymentLinkDescription }}
-            {% else %}
-              <span class="grey">None given</span>
-            {% endif %}
-          </dd>
-          <dd class="cya-change">
-            <a href="{{ changeInformation }}?field=payment-link-description">
-              Change <span class="visuallyhidden">More details</span>
-            </a>
-          </dd>
-        </div>
-        <div class="review-amount">
-          <dt class="cya-question">
-            Payment amount
-          </dt>
-          <dd class="cya-answer" id="create-payment-link-amount">
-            {% if paymentLinkAmount %}
-              £{{ paymentLinkAmount }}
-            {% else %}
-              <span class="grey">User can choose</span>
-            {% endif %}
-          </dd>
-          <dd class="cya-change">
-            <a href="{{ changeAmount }}">
-              Change <span class="visuallyhidden">payment amount</span>
-            </a>
-          </dd>
-        </div>
-      </dl>
-      <div class="form-group">
-        <button id="create-payment-link-publish" class="button" type="submit">Create link</button>
+{% block mainContent %}
+<section class="column-two-thirds">
+  <form action="{{ nextPage }}" class="form" method="post" data-validate>
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    <h1 class="page-title">Review your payment link details</h1>
+    <dl class="govuk-check-your-answers cya-questions-short">
+      <div class="review-title">
+        <dt class="cya-question">
+          Title
+        </dt>
+        <dd class="cya-answer" id="create-payment-link-title">
+          {{ paymentLinkTitle }}
+        </dd>
+        <dd class="cya-change">
+          <a href="{{ changeInformation }}?field=payment-link-title">
+            Change <span class="visuallyhidden">Title</span>
+          </a>
+        </dd>
       </div>
-      <p><a id="create-payment-link-cancel" class="cancel" href="{{ returnToStart }}">Cancel</a></p>
-    </form>
-  </section>
-</div>
+      <div class="review-details">
+        <dt class="cya-question">
+          More details
+        </dt>
+        <dd class="cya-answer" id="create-payment-link-description">
+          {% if paymentLinkDescription %}
+            {{ paymentLinkDescription }}
+          {% else %}
+            <span class="grey">None given</span>
+          {% endif %}
+        </dd>
+        <dd class="cya-change">
+          <a href="{{ changeInformation }}?field=payment-link-description">
+            Change <span class="visuallyhidden">More details</span>
+          </a>
+        </dd>
+      </div>
+      <div class="review-amount">
+        <dt class="cya-question">
+          Payment amount
+        </dt>
+        <dd class="cya-answer" id="create-payment-link-amount">
+          {% if paymentLinkAmount %}
+            £{{ paymentLinkAmount }}
+          {% else %}
+            <span class="grey">User can choose</span>
+          {% endif %}
+        </dd>
+        <dd class="cya-change">
+          <a href="{{ changeAmount }}">
+            Change <span class="visuallyhidden">payment amount</span>
+          </a>
+        </dd>
+      </div>
+    </dl>
+    <div class="form-group">
+      <button id="create-payment-link-publish" class="button" type="submit">Create link</button>
+    </div>
+    <p><a id="create-payment-link-cancel" class="cancel" href="{{ returnToStart }}">Cancel</a></p>
+  </form>
+</section>
 {% endblock %}

--- a/app/views/payment_types.njk
+++ b/app/views/payment_types.njk
@@ -8,7 +8,12 @@ Payment types - GOV.UK Pay
   <script src="/public/js/components/checkbox-row-selection.js"></script>
 {% endblock %}
 
+{% block side_navigation %}
+  {% include "includes/side_navigation.njk" %}
+{% endblock %}
+
 {% block mainContent %}
+<div class="column-two-thirds">
   {% if not permissions.payment_types_update %}
     {% include "includes/settings-read-only.njk" %}
   {% endif %}
@@ -23,4 +28,5 @@ Payment types - GOV.UK Pay
     {% block page_content %}
     {% endblock %}
   </div>
+</div>
 {% endblock %}

--- a/app/views/self_create_service/confirm.njk
+++ b/app/views/self_create_service/confirm.njk
@@ -6,7 +6,7 @@
 
 {% block mainContent %}
 <div id="display-email-sent" class="column-two-thirds">
-    <h1 class="heading-large">Check your email</h1>
+    <h1 class="heading-large page-title">Check your email</h1>
     <p>An email has been sent to {{requesterEmail}}.</p>
     <p>Click the link in the email to continue your registration.</p>
 </div>

--- a/app/views/self_create_service/register.njk
+++ b/app/views/self_create_service/register.njk
@@ -8,7 +8,7 @@
 <div class="column-two-thirds">
   <form action="{{routes.selfCreateService.register}}" method="post" id="submit-service-creation" class="form submit-registration">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-    <h1 class="heading-large">Create an account</h1>
+    <h1 class="heading-large page-title">Create an account</h1>
     <div class="form-group">
       <label class="form-label" for="email">
         Email

--- a/app/views/services/add_service.njk
+++ b/app/views/services/add_service.njk
@@ -4,54 +4,49 @@
 GOV.UK Pay - My services
 {% endblock %}
 
-{% block mainClasses %}full-width{% endblock %}
-
-{% block full_width_content %}
-  <div class="grid-row grid-row-align-to-edges">
-    <div class="column-two-thirds">
-      {% if errors %}
-      <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
-        <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
-            There was a problem with the details you gave for:
-        </h1>
-        <ul class="error-summary-list">
-          {% if errors.service_name %}
-          <li><a href="#service-name">Service name</a></li>
-          {% endif %}
-        </ul>
-      </div>
-      {% endif %}
-
-      <h1 class="heading-large">What service will you be taking payments for?</h1>
-      <p>
-        This is what your users will see when making a payment. You can change this later.
-      </p>
-
-      <form id="add-service-form" method="post" action="{{submit_link}}" data-validate="true">
-        <div class="form-group {% if errors.service_name %}error{% endif %}">
-          <label class="form-label" for="service-name">
-            Service name
-          </label>
-          {% if errors.service_name %}
-          <span class="error-message">
-            {{errors.service_name}}
-          </span>
-          {% endif %}
-          <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-          <input class="form-control" data-module="" id="service-name" name="service-name" type="text" value="{{current_name}}" data-validate="required isFieldGreaterThanMaxLengthChars" data-validate-max-length="50">
-        </div>
-
-        <div class="form-group call-to-action-group">
-            <input class="button" type="submit" value="Add Service">
-            <a id="service-name-cancel-link" href="{{my_services}}">
-                Cancel
-            </a>
-            <a id="service-nam-guidance" href="https://www.gov.uk/service-manual/design/naming-your-service">
-                Get guidance on choosing a name for your service
-            </a>
-        </div>
-      </form>
+{% block mainContent %}
+  <div class="column-two-thirds">
+    {% if errors %}
+    <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+      <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+          There was a problem with the details you gave for:
+      </h1>
+      <ul class="error-summary-list">
+        {% if errors.service_name %}
+        <li><a href="#service-name">Service name</a></li>
+        {% endif %}
+      </ul>
     </div>
-    <div class="column-one-third"></div>
+    {% endif %}
+
+    <h1 class="heading-large page-title">What service will you be taking payments for?</h1>
+    <p>
+      This is what your users will see when making a payment. You can change this later.
+    </p>
+
+    <form id="add-service-form" method="post" action="{{submit_link}}" data-validate="true">
+      <div class="form-group {% if errors.service_name %}error{% endif %}">
+        <label class="form-label" for="service-name">
+          Service name
+        </label>
+        {% if errors.service_name %}
+        <span class="error-message">
+          {{errors.service_name}}
+        </span>
+        {% endif %}
+        <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+        <input class="form-control" data-module="" id="service-name" name="service-name" type="text" value="{{current_name}}" data-validate="required isFieldGreaterThanMaxLengthChars" data-validate-max-length="50">
+      </div>
+
+      <div class="form-group call-to-action-group">
+          <input class="button" type="submit" value="Add Service">
+          <a id="service-name-cancel-link" href="{{my_services}}">
+              Cancel
+          </a>
+          <a id="service-nam-guidance" href="https://www.gov.uk/service-manual/design/naming-your-service">
+              Get guidance on choosing a name for your service
+          </a>
+      </div>
+    </form>
   </div>
 {% endblock %}

--- a/app/views/services/edit_service_name.njk
+++ b/app/views/services/edit_service_name.njk
@@ -4,44 +4,39 @@
 GOV.UK Pay - My services
 {% endblock %}
 
-{% block mainClasses %}full-width{% endblock %}
-
-{% block full_width_content %}
-  <div class="grid-row grid-row-align-to-edges">
-    <div class="column-two-thirds">
-      {% if errors %}
-      <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
-          <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
-              There was a problem with the details you gave for:
-          </h2>
-          <ul class="error-summary-list">
-              {% if errors.service_name %}
-              <li><a href="#service-name">Service name</a></li>
-              {% endif %}
-          </ul>
-      </div>
-      {% endif %}
-
-      <h1 class="heading-large">Edit service name</h1>
-      <p>
-          Changing your service name affects both live and test environments, including user-facing payment pages and emails.
-      </p>
-      <form id="edit-service-name-form" method="post" action="{{submit_link}}" data-validate="true">
-        <div class="form-group {% if errors.service_name %}error{% endif %}">
-          <label class="form-label" for="service-name">Service name</label>
-          {% if errors.service_name %}
-            <span class="error-message">{{errors.service_name}}</span>
-          {% endif %}
-          <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-          <input class="form-control" data-module="" id="service-name" name="service-name" type="text" value="{{current_name}}" data-validate="required isFieldGreaterThanMaxLengthChars" data-validate-max-length="50">
-        </div>
-        <div class="form-group call-to-action-group">
-          <input class="button" type="submit" value="Save">
-          <a id="service-name-cancel-link" href="{{my_services}}">Cancel</a>
-          <a id="service-nam-guidance" href="https://www.gov.uk/service-manual/design/naming-your-service">Get guidance on choosing a name for your service</a>
-        </div>
-      </form>
+{% block mainContent %}
+  <div class="column-two-thirds">
+    {% if errors %}
+    <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+        <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+            There was a problem with the details you gave for:
+        </h2>
+        <ul class="error-summary-list">
+            {% if errors.service_name %}
+            <li><a href="#service-name">Service name</a></li>
+            {% endif %}
+        </ul>
     </div>
-    <div class="column-one-third"></div>
+    {% endif %}
+
+    <h1 class="heading-large page-title">Edit service name</h1>
+    <p>
+        Changing your service name affects both live and test environments, including user-facing payment pages and emails.
+    </p>
+    <form id="edit-service-name-form" method="post" action="{{submit_link}}" data-validate="true">
+      <div class="form-group {% if errors.service_name %}error{% endif %}">
+        <label class="form-label" for="service-name">Service name</label>
+        {% if errors.service_name %}
+          <span class="error-message">{{errors.service_name}}</span>
+        {% endif %}
+        <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+        <input class="form-control" data-module="" id="service-name" name="service-name" type="text" value="{{current_name}}" data-validate="required isFieldGreaterThanMaxLengthChars" data-validate-max-length="50">
+      </div>
+      <div class="form-group call-to-action-group">
+        <input class="button" type="submit" value="Save">
+        <a id="service-name-cancel-link" href="{{my_services}}">Cancel</a>
+        <a id="service-nam-guidance" href="https://www.gov.uk/service-manual/design/naming-your-service">Get guidance on choosing a name for your service</a>
+      </div>
+    </form>
   </div>
 {% endblock %}

--- a/app/views/services/index.njk
+++ b/app/views/services/index.njk
@@ -4,14 +4,13 @@
 My services - GOV.UK Pay
 {% endblock %}
 
-{% block mainClasses %}full-width{% endblock %}
-
-{% block full_width_content %}
+{% block mainContent %}
+<div class="column-full">
   {% if new_service_name %}
-  <div class=“flash-container”><p id="new-service-name" class="notification generic-flash">You have been added to {{new_service_name}}</p></div>
+  <div class="flash-container"><p id="new-service-name" class="notification generic-flash">You have been added to {{new_service_name}}</p></div>
   {% endif %}
 
-  <h1 class="heading-large">My services</h1>
+  <h1 class="heading-large page-title">My services</h1>
   <div class="grid-row grid-row-align-to-edges">
       <div class="column-two-thirds">
         {% if services_singular %}
@@ -31,4 +30,5 @@ My services - GOV.UK Pay
         {% include "./_service_section.njk" %}
       {% endfor %}
   </div>
+</div>
 {% endblock %}

--- a/app/views/services/team_member_details.njk
+++ b/app/views/services/team_member_details.njk
@@ -4,50 +4,49 @@
 Team members details — GOV.UK Pay
 {% endblock %}
 
-{% block mainClasses %}full-width{% endblock %}
-
-{% block full_width_content %}
+{% block mainContent %}
+<div class="column-full">
   <a href="{{teamMemberIndexLink}}" class="link-back">See all team members</a>
-  <div class="grid-row">
-    <div class="column-two-thirds admin-list">
-      <h1 id="details-for" class="page-title gutter-top">
-          <span class="heading-secondary">Team members</span>
-          Details for {{username}}
+</div>
+<div class="column-two-thirds admin-list">
+  <h1 id="details-for" class="page-title">
+    <span class="heading-secondary">Team members</span>
+    Details for {{username}}
+  </h1>
+  <table>
+    <caption class="visually-hidden">Member details</caption>
+    <tbody>
+      <tr>
+        <th>Email:</th>
+        <td colspan="2" id="email">{{email}}</td>
+      </tr>
+      <tr>
+        <th>Permission level:</th>
+        <td id="role">{{role}}</td>
+        <td id="edit-permissions-link"><a href="{{editPermissionsLink}}">Edit permissions</a></td>
+      </tr>
+    </tbody>
+  </table>
+  {% if permissions.users_service_delete %}
+  <div class="js-confirm">
+    <p>
+      <a id="remove-team-member" href="#confirm-remove-user-dialog">Remove user</a>
+    </p>
+  </div>
+  <div id="confirm-remove-user-dialog" class="target-to-show">
+    <div class="error-summary" role="group" aria-labelledby="error-summary" tabindex="-1">
+      <h1 class="heading-medium error-summary-heading" id="error-summary">
+        Are you sure you want to remove {{username}}?
       </h1>
-      <table>
-          <caption class="visually-hidden">Member details</caption>
-          <tbody>
-          <tr>
-              <th>Email:</th>
-              <td colspan="2" id="email">{{email}}</td>
-          </tr>
-          <tr>
-              <th>Permission level:</th>
-              <td id="role">{{role}}</td>
-              <td id="edit-permissions-link"><a href="{{editPermissionsLink}}">Edit permissions</a></td>
-          </tr>
-          </tbody>
-      </table>
-      {% if permissions.users_service_delete %}
-      <div class="js-confirm">
-          <p>
-              <a id="remove-team-member" href="#confirm-remove-user-dialog">Remove user</a>
-          </p>
+      <div class="button-group">
+        <form id="remove-team-member-form" method="post" action="{{removeTeamMemberLink}}">
+          <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+          <input id="remove-team-member-confirm" type="submit" value="Yes, remove" class="button delete"/>
+          <a id="remove-team-member-cancel" href="#main">Cancel</a>
+        </form>
       </div>
-      <div id="confirm-remove-user-dialog" class="target-to-show">
-        <div class="error-summary" role="group" aria-labelledby="error-summary" tabindex="-1">
-            <h1 class="heading-medium error-summary-heading" id="error-summary">
-                Are you sure you want to remove {{username}}?
-            </h1>
-            <div class="button-group">
-                <form id="remove-team-member-form" method="post" action="{{removeTeamMemberLink}}">
-                    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-                    <input id="remove-team-member-confirm" type="submit" value="Yes, remove" class="button delete"/>
-                    <a id="remove-team-member-cancel" href="#main">Cancel</a>
-                </form>
-            </div>
-        </div>
-      </div>
-      {% endif %}
     </div>
+  </div>
+  {% endif %}
+</div>
 {% endblock %}

--- a/app/views/services/team_member_invite.njk
+++ b/app/views/services/team_member_invite.njk
@@ -8,21 +8,15 @@ Invite a new team member - GOV.UK Pay
   <script src="/public/js/components/link-follower.js"></script>
 {% endblock %}
 
-{% block mainClasses %}full-width{% endblock %}
-
-{% block full_width_content %}
-  <div class="grid-row">
-    <div class="column-two-thirds admin-list-group">
-      {% include "includes/flash.njk" %}
+{% block mainContent %}
+  <div class="column-two-thirds">
+    <a href="{{teamMemberIndexLink}}" class="link-back">See all team members</a>
+    <div>
+      <h1 class="heading-large underline">
+        <span class="heading-secondary">Team members</span>
+        Invite a team member</h1>
     </div>
   </div>
-  <a href="{{teamMemberIndexLink}}" class="link-back">See all team members</a>
-  <div>
-    <h1 class="heading-large underline">
-      <span class="heading-secondary">Team members</span>
-      Invite a team member</h1>
-  </div>
-
   <div class="column-full remove-left-margin">
     <form id="invite-member-form" method="post" action="{{teamMemberInviteSubmitLink}}">
       <div class="form-group">

--- a/app/views/services/team_member_permissions.njk
+++ b/app/views/services/team_member_permissions.njk
@@ -4,74 +4,74 @@
 Edit team member permissions - GOV.UK Pay
 {% endblock %}
 
-{% block mainClasses %}full-width{% endblock %}
-
-{% block full_width_content %}
+{% block mainContent %}
+<div class="column-full">
   <a href="{{teamMemberProfileLink}}" class="link-back">Back to team member profile</a>
-  <div>
-    <h1 class="heading-large underline">
-      <span class="heading-secondary">Team members</span>
-      Edit permissions</h1>
-  </div>
+</div>
+<div class="column-full">
+  <h1 class="heading-large underline">
+    <span class="heading-secondary">Team members</span>
+    Edit permissions</h1>
+</div>
 
-  <div class="column-full remove-left-margin">
-    <dl class="read-only-fields">
-      <dt class="heading-small">Email address</dt>
-      <dd id="email">{{email}}</dd>
-    </dl>
-    <form id="role-update-form" method="post" action="{{editPermissionsLink}}">
-      <div class="form-group">
-        <fieldset>
-          <legend class="heading-small">Permission level</legend>
-          <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-          <div class="multiple-choice">
-            <input id="role-admin-input" type="radio" name="role-input" value="{{admin.id}}" {{admin.checked}}>
-            <label for="role-admin-input">
-              <span class="heading-small">Administrator</span>
-              <ul class="question-advice form-hint">
-                <li>View transactions</li>
-                <li>Refund payments</li>
-                <li>Manage settings</li>
-              </ul>
-            </label>
-          </div>
-          <div class="multiple-choice">
-            <input id="role-view-and-refund-input" type="radio" name="role-input" value="{{viewAndRefund.id}}" {{viewAndRefund.checked}}>
-            <label for="role-view-and-refund-input">
-              <span class="heading-small">View and refund</span>
-              <ul class="question-advice form-hint">
-                <li>View transactions</li>
-                <li>Refund payments</li>
-                <li>Cannot manage settings</li>
-              </ul>
-            </label>
-          </div>
-          <div class="multiple-choice">
-            <input id="role-view-input" type="radio" name="role-input" value="{{view.id}}" {{view.checked}}>
-            <label for="role-view-input"><span class="heading-small">View only</span>
-              <ul class="question-advice form-hint">
-                <li>View transactions</li>
-                <li>Cannot refund payments</li>
-                <li>Cannot manage settings</li>
-              </ul>
-            </label>
-          </div>
-        </fieldset>
-        <div class="notice">
-          <i class="icon icon-important">
-            <span class="visually-hidden">Warning</span>
-          </i>
-          <strong class="bold-small">
-            This change affects both live and test environments
-          </strong>
+<div class="column-two-thirds">
+  <dl class="read-only-fields">
+    <dt class="heading-small">Email address</dt>
+    <dd id="email">{{email}}</dd>
+  </dl>
+  <form id="role-update-form" method="post" action="{{editPermissionsLink}}">
+    <div class="form-group">
+      <fieldset>
+        <legend class="heading-small">Permission level</legend>
+        <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+        <div class="multiple-choice">
+          <input id="role-admin-input" type="radio" name="role-input" value="{{admin.id}}" {{admin.checked}}>
+          <label for="role-admin-input">
+            <span class="heading-small">Administrator</span>
+            <ul class="question-advice form-hint">
+              <li>View transactions</li>
+              <li>Refund payments</li>
+              <li>Manage settings</li>
+            </ul>
+          </label>
         </div>
+        <div class="multiple-choice">
+          <input id="role-view-and-refund-input" type="radio" name="role-input" value="{{viewAndRefund.id}}" {{viewAndRefund.checked}}>
+          <label for="role-view-and-refund-input">
+            <span class="heading-small">View and refund</span>
+            <ul class="question-advice form-hint">
+              <li>View transactions</li>
+              <li>Refund payments</li>
+              <li>Cannot manage settings</li>
+            </ul>
+          </label>
+        </div>
+        <div class="multiple-choice">
+          <input id="role-view-input" type="radio" name="role-input" value="{{view.id}}" {{view.checked}}>
+          <label for="role-view-input"><span class="heading-small">View only</span>
+            <ul class="question-advice form-hint">
+              <li>View transactions</li>
+              <li>Cannot refund payments</li>
+              <li>Cannot manage settings</li>
+            </ul>
+          </label>
+        </div>
+      </fieldset>
+      <div class="notice">
+        <i class="icon icon-important">
+          <span class="visually-hidden">Warning</span>
+        </i>
+        <strong class="bold-small">
+          This change affects both live and test environments
+        </strong>
       </div>
-      <div class="form-group call-to-action-group">
-        <input type="submit" class="button" value="Save changes">
-        <a id="service-name-cancel-link" href="{{teamMemberIndexLink}}">
-          Cancel
-        </a>
-      </div>
-    </form>
-  </div>
+    </div>
+    <div class="form-group call-to-action-group">
+      <input type="submit" class="button" value="Save changes">
+      <a id="service-name-cancel-link" href="{{teamMemberIndexLink}}">
+        Cancel
+      </a>
+    </div>
+  </form>
+</div>
 {% endblock %}

--- a/app/views/services/team_member_profile.njk
+++ b/app/views/services/team_member_profile.njk
@@ -4,37 +4,34 @@
 My profile - GOV.UK Pay
 {% endblock %}
 
-{% block mainClasses %}full-width{% endblock %}
-
-{% block full_width_content %}
-<h1 id="details-for" class="heading-large">
-    My profile
-</h1>
-
-<div class="grid-row">
-    <div class="column-two-thirds admin-list">
-        <table>
-            <caption class="visually-hidden">Details for {{username}}</caption>
-            <tbody>
-                <tr>
-                    <td>Name:</td>
-                    <td id="name">{{username}}</td>
-                </tr>
-                <tr>
-                    <td>Email:</td>
-                    <td id="email">{{email}}</td>
-                </tr>
-                <tr>
-                    <td>Mobile number:</td>
-                    <td id="telephone-number">{{telephone_number}}</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-    <div class="column-one-third">
-        <div class="related-information">
-            <p>To change your permission level on a service you need to contact an administrator for that service.</p>
-        </div>
-    </div>
+{% block mainContent %}
+<div class="column-full">
+  <h1 id="details-for" class="heading-large page-title">
+      My profile
+  </h1>
+</div>
+<div class="column-two-thirds">
+  <table>
+    <caption class="visually-hidden">Details for {{username}}</caption>
+    <tbody>
+      <tr>
+        <td>Name:</td>
+        <td id="name">{{username}}</td>
+      </tr>
+      <tr>
+        <td>Email:</td>
+        <td id="email">{{email}}</td>
+      </tr>
+      <tr>
+        <td>Mobile number:</td>
+        <td id="telephone-number">{{telephone_number}}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="column-one-third">
+  <div class="related-information">
+    <p>To change your permission level on a service you need to contact an administrator for that service.</p>
+  </div>
 </div>
 {% endblock %}

--- a/app/views/services/team_members.njk
+++ b/app/views/services/team_members.njk
@@ -8,88 +8,86 @@ Team members - GOV.UK Pay
   <script src="/public/js/components/link-follower.js"></script>
 {% endblock %}
 
-{% block mainClasses %}full-width{% endblock %}
-{% block full_width_content %}
-  <div class="grid-row">
-    <div class="column-two-thirds admin-list-group">
-      {% include "includes/flash.njk" %}
+{% block mainContent %}
+  <div class="column-full">
+    <a href="/my-services" class="link-back">My services</a>
+  </div>
+  <div class="column-two-thirds">
+    <h1 class="page-title">Team members</h1>
+    {% if permissions.users_service_create %}
+      <p class="admin-lede">Team member changes affect both live and test environments.</p>
+    {% else %}
+      <p class="admin-lede">Contact an administrator to invite team members and change permissions.</p>
+    {% endif %}
+  </div>
+</div>
+<div class="grid-row">
+  <div class="column-two-thirds admin-list-group">
+    <h2 id="active-team-members-heading" class="admin-list-group-heading">Active ({{number_active_members}})</h2>
+    <div class="admin-list" id="team-members-admin-list">
+      <h3 id="admin-role-header" class="admin-list-heading">Administrators ({{team_members["admin"].length}})</h3>
+      <ul>
+        {% for admin in team_members["admin"] %}
+          <li>
+            {% if permissions.users_service_read %}
+              <a href="{{ admin.link }}">
+            {% else %}
+              <span>
+            {% endif %}
+            {{ admin.username }} {% if admin.is_current %}(you){% endif %}
+            {% if permissions.users_service_read %}
+              </a>
+            {% else %}
+              </span>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="admin-list" id="team-members-view-and-refund-list">
+      <h3 id="view-and-refund-role-header" class="admin-list-heading">View and refund ({{team_members["view-and-refund"].length}})</h3>
+      <ul>
+        {% for team_member in team_members["view-and-refund"] %}
+          <li>
+            {% if permissions.users_service_read %}
+              <a href="{{ team_member.link }}">
+            {% else %}
+              <span>
+            {% endif %}
+            {{ team_member.username }} {% if team_member.is_current %}(you){% endif %}
+            {% if permissions.users_service_read %}
+              </a>
+            {% else %}
+              </span>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="admin-list" id="team-members-view-only-list">
+      <h3 id="view-only-role-header" class="admin-list-heading">View only ({{team_members["view-only"].length}})</h3>
+      <ul>
+        {% for team_member in team_members["view-only"] %}
+          <li>
+            {% if permissions.users_service_read %}
+              <a href="{{ team_member.link }}">
+            {% else %}
+              <span>
+            {% endif %}
+            {{ team_member.username }} {% if team_member.is_current %}(you){% endif %}
+            {% if permissions.users_service_read %}
+              </a>
+            {% else %}
+              </span>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
     </div>
   </div>
-  <a href="/my-services" class="link-back">My services</a>
-  <h1 class="page-title gutter-top">Team members</h1>
-  {% if permissions.users_service_create %}
-    <p class="admin-lede">Team member changes affect both live and test environments.</p>
-  {% else %}
-    <p class="admin-lede">Contact an administrator to invite team members and change permissions.</p>
-  {% endif %}
-  <div class="grid-row">
-    <div class="column-two-thirds admin-list-group">
-      <h2 id="active-team-members-heading" class="admin-list-group-heading">Active ({{number_active_members}})</h2>
-      <div class="admin-list" id="team-members-admin-list">
-        <h3 id="admin-role-header" class="admin-list-heading">Administrators ({{team_members["admin"].length}})</h3>
-        <ul>
-          {% for admin in team_members["admin"] %}
-            <li>
-              {% if permissions.users_service_read %}
-                <a href="{{ admin.link }}">
-              {% else %}
-                <span>
-              {% endif %}
-              {{ admin.username }} {% if admin.is_current %}(you){% endif %}
-              {% if permissions.users_service_read %}
-                </a>
-              {% else %}
-                </span>
-              {% endif %}
-            </li>
-          {% endfor %}
-        </ul>
-      </div>
-      <div class="admin-list" id="team-members-view-and-refund-list">
-        <h3 id="view-and-refund-role-header" class="admin-list-heading">View and refund ({{team_members["view-and-refund"].length}})</h3>
-        <ul>
-          {% for team_member in team_members["view-and-refund"] %}
-            <li>
-              {% if permissions.users_service_read %}
-                <a href="{{ team_member.link }}">
-              {% else %}
-                <span>
-              {% endif %}
-              {{ team_member.username }} {% if team_member.is_current %}(you){% endif %}
-              {% if permissions.users_service_read %}
-                </a>
-              {% else %}
-                </span>
-              {% endif %}
-            </li>
-          {% endfor %}
-        </ul>
-      </div>
-      <div class="admin-list" id="team-members-view-only-list">
-        <h3 id="view-only-role-header" class="admin-list-heading">View only ({{team_members["view-only"].length}})</h3>
-        <ul>
-          {% for team_member in team_members["view-only"] %}
-            <li>
-              {% if permissions.users_service_read %}
-                <a href="{{ team_member.link }}">
-              {% else %}
-                <span>
-              {% endif %}
-              {{ team_member.username }} {% if team_member.is_current %}(you){% endif %}
-              {% if permissions.users_service_read %}
-                </a>
-              {% else %}
-                </span>
-              {% endif %}
-            </li>
-          {% endfor %}
-        </ul>
-      </div>
-    </div>
     {% if permissions.users_service_create %}
       <a id="invite-team-member-link" class="button" href="{{inviteTeamMemberLink}}">
           Invite a team member
       </a>
     {% endif %}
-  </div>
 {% endblock %}

--- a/app/views/token_generate.njk
+++ b/app/views/token_generate.njk
@@ -7,7 +7,12 @@ Generate API key - {{currentServiceName}} {{currentGatewayAccount.full_type}} - 
 <script src="/public/js/devtokens.js"></script>
 {% endblock %}
 
+{% block side_navigation %}
+  {% include "includes/side_navigation.njk" %}
+{% endblock %}
+
 {% block mainContent %}
+<div class="column-two-thirds">
   <h1 class="page-title">API keys</h1>
 
   {% if not token %}
@@ -42,4 +47,5 @@ Generate API key - {{currentServiceName}} {{currentGatewayAccount.full_type}} - 
       Finish
     </a>
   {% endif %}
+</div>
 {% endblock %}

--- a/app/views/tokens.njk
+++ b/app/views/tokens.njk
@@ -8,8 +8,12 @@ API Keys - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK P
 <script src="/public/js/devtokens.js"></script>
 {% endblock %}
 
-{% block mainContent %}
+{% block side_navigation %}
+  {% include "includes/side_navigation.njk" %}
+{% endblock %}
 
+{% block mainContent %}
+<div class="column-two-thirds">
   <h1 class="page-title">API Keys</h1>
   <ul class="tabs">
     {% if active %}
@@ -22,5 +26,5 @@ API Keys - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK P
   </ul>
 
   {% include "./includes/_token_list.njk" %}
-
+</div>
 {% endblock %}

--- a/app/views/transaction_detail/index.njk
+++ b/app/views/transaction_detail/index.njk
@@ -8,36 +8,32 @@ Transaction details {{reference}} - {{currentServiceName}} {{currentGatewayAccou
 <script src="/public/js/components/refund.js"></script>
 {% endblock %}
 
-{% block full_width_content %}
-  <div class="grid-row">
-    <div class="column-full">
-      <a href="{{routes.transactions.index}}?{{indexFilters}}" id="arrowed" class="link-back">Transactions list</a>
-    </div>
+{% block mainContent %}
+  <div class="column-full">
+    <a href="{{routes.transactions.index}}?{{indexFilters}}" id="arrowed" class="link-back">Transactions list</a>
   </div>
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">Transaction detail</h1>
-      {% include "./_details.njk" %}
+  <div class="column-two-thirds">
+    <h1 class="heading-large page-title">Transaction detail</h1>
+    {% include "./_details.njk" %}
 
-      <h2 class="heading-medium">Payment method</h2>
-      {% include "./_payment.njk" %}
+    <h2 class="heading-medium">Payment method</h2>
+    {% include "./_payment.njk" %}
 
-      {% if permissions.transactions_events_read %}
-        <h2 class="heading-medium">Transaction events</h2>
-        {% include "./_events.njk" %}
+    {% if permissions.transactions_events_read %}
+      <h2 class="heading-medium">Transaction events</h2>
+      {% include "./_events.njk" %}
+     {% endif %}
+  </div>
+
+  <div class="column-one-third">
+    {% if refundable %}
+      {% if permissions.refunds_create %}
+      <div class="refund__toggle-container {% if not flash.genericError %}active{% endif %}">
+        <a href="#refundForm" class="button refund__toggle delete">Refund Payment</a>
+        <p>You can also give partial&nbsp;refunds</p>
+      </div>
+      {% include "./_refund.njk" %}
        {% endif %}
-    </div>
-
-    <div class="column-one-third">
-      {% if refundable %}
-        {% if permissions.refunds_create %}
-        <div class="refund__toggle-container {% if not flash.genericError %}active{% endif %}">
-          <a href="#refundForm" class="button refund__toggle delete">Refund Payment</a>
-          <p>You can also give partial&nbsp;refunds</p>
-        </div>
-        {% include "./_refund.njk" %}
-         {% endif %}
-      {% endif %}
-    </div>
+    {% endif %}
   </div>
 {% endblock %}

--- a/app/views/transactions/index.njk
+++ b/app/views/transactions/index.njk
@@ -19,7 +19,8 @@ Transactions - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.
 <script src="/public/js/components/datetime-picker.js"></script>
 {% endblock %}
 
-{% block full_width_content %}
+{% block mainContent %}
+<div class="column-full">
   <h1 class="heading-large page-title">Transactions</h1>
 
   {% include "transactions/filter.njk" %}
@@ -49,4 +50,5 @@ Transactions - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.
   {% include "transactions/list.njk" %}
 
   {% include "transactions/paginator.njk" %}
+</div>
 {% endblock %}

--- a/app/views/user_registration/register.njk
+++ b/app/views/user_registration/register.njk
@@ -8,7 +8,7 @@
   <div class="column-two-thirds">
     <form action="{{routes.registerUser.registration}}" method="post" id="submit-registration" class="form submit-registration">
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-      <h1 class="heading-large">
+      <h1 class="heading-large page-title">
         Create an account
       </h1>
       <p id="email-display">Your account will be created with this email: {{email}}</p>


### PR DESCRIPTION
When selfservice was younger all pages except the transactions bit
showed the side settings navigation. Now we're adding more functionality
this is sort of breaking down and causing problems with resuable
elements. Such as the flash error/success banner appearing in the wrong
places.

### Summary of changes
- removed full_width_layout block
- added new side_navigation block for any side nav stuff
- removed display converter logic that controlled the display of the
settings navigation and dropped in side_navigation instead.
- added page-title class to page titles that didn’t have it, this reduces the top margin so there isn't a huge gap at the top of the page