### PR TITLE
PP-3498 Results from 'State' dropdown on transactions filter should

### DIFF
--- a/app/utils/states.js
+++ b/app/utils/states.js
@@ -16,17 +16,17 @@ const PAYMENT_STATE_DESCRIPTIONS = {
   'success': {
     displayName: 'Success'
   },
-  'error': {
-    displayName: 'Error',
-    errorCodes: ['P0050']
+  'declined': {
+    displayName: 'Declined'
   },
-  'failed': {
-    displayName: 'Failed',
-    errorCodes: ['P0010', 'P0020', 'P0030']
+  'timedout': {
+    displayName: 'Timed out'
   },
   'cancelled': {
-    displayName: 'Cancelled',
-    errorCodes: ['P0040']
+    displayName: 'Cancelled'
+  },
+  'error': {
+    displayName: 'Error'
   }
 }
 
@@ -48,9 +48,7 @@ const REFUND_STATE_DESCRIPTIONS = {
 const ERROR_CODE_TO_DISPLAY_STATE = {
   'P0010': 'Declined',
   'P0020': 'Timed out',
-  'P0030': 'Cancelled',
-  'P0040': 'Cancelled',
-  'P0050': 'Error'
+  'P0030': 'Cancelled'
 }
 
 exports.allDisplayStates = () => [...uniqueDisplayStates(PAYMENT_STATE_DESCRIPTIONS), ...uniqueDisplayStates(REFUND_STATE_DESCRIPTIONS)]
@@ -85,7 +83,7 @@ function uniqueDisplayStates (stateDescriptions) {
 }
 
 function displayNameForConnectorState (connectorState, type) {
-  if (connectorState.code && ERROR_CODE_TO_DISPLAY_STATE[connectorState.code]) {
+  if (connectorState.status === 'failed') {
     return ERROR_CODE_TO_DISPLAY_STATE[connectorState.code]
   }
   return getDisplayNameFromConnectorState(connectorState, type)

--- a/test/integration/transaction_list_ft_tests.js
+++ b/test/integration/transaction_list_ft_tests.js
@@ -321,7 +321,7 @@ describe('The /transactions endpoint', function () {
     }
 
     connectorMockResponds(200, connectorData, {
-      payment_states: 'created,started,submitted,failed',
+      payment_states: 'created,started,submitted,timedout',
       refund_states: 'submitted'
     })
     request(app)
@@ -341,7 +341,7 @@ describe('The /transactions endpoint', function () {
           expect(['In progress', 'Timed out', 'Refund submitted']).to.include(state.value.text)
         })
 
-        res.body.downloadTransactionLink.should.eql('/transactions/download?payment_states=created&payment_states=started&payment_states=submitted&payment_states=failed&refund_states=submitted')
+        res.body.downloadTransactionLink.should.eql('/transactions/download?payment_states=created&payment_states=started&payment_states=submitted&payment_states=timedout&refund_states=submitted')
       })
       .end(done)
   })
@@ -514,10 +514,10 @@ describe('The /transactions endpoint filtering by states)', () => {
         expect(res.body.eventStates.map(state => state.value.text)).to.deep.equal([
           'In progress',
           'Success',
-          'Error',
           'Declined',
           'Timed out',
           'Cancelled',
+          'Error',
           'Refund submitted',
           'Refund error',
           'Refund success'
@@ -547,10 +547,10 @@ describe('The /transactions endpoint filtering by states)', () => {
         expect(res.body.eventStates.map(state => state.value.text)).to.deep.equal([
           'In progress',
           'Success',
-          'Error',
           'Declined',
           'Timed out',
           'Cancelled',
+          'Error',
           'Refund submitted',
           'Refund error',
           'Refund success'
@@ -581,10 +581,10 @@ describe('The /transactions endpoint filtering by states)', () => {
         expect(res.body.eventStates.map(state => state.value.text)).to.deep.equal([
           'In progress',
           'Success',
-          'Error',
           'Declined',
           'Timed out',
           'Cancelled',
+          'Error',
           'Refund submitted',
           'Refund error',
           'Refund success'

--- a/test/unit/utils/filters_test.js
+++ b/test/unit/utils/filters_test.js
@@ -32,13 +32,13 @@ describe('filters', () => {
 
       it('should transform some payment display states to connector states correctly', function () {
         const {result} = filters.getFilters({query: {state: ['In progress', 'Timed out', 'Cancelled']}})
-        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'failed', 'cancelled'])
+        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'timedout', 'cancelled'])
         expect(result).to.not.have.property('refund_states')
       })
 
       it('should transform all payment display states to connector states correctly', function () {
         const {result} = filters.getFilters({query: {state: ['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined']}})
-        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'success', 'error', 'failed', 'cancelled'])
+        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'success', 'error', 'cancelled', 'timedout', 'declined'])
         expect(result).to.not.have.property('refund_states')
       })
 
@@ -51,7 +51,7 @@ describe('filters', () => {
       it('should transform both payment and refund display states to connector states correctly', function () {
         const {result} = filters.getFilters({query: {state: ['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined', 'Refund success', 'Refund error', 'Refund submitted']}})
         expect(result).to.have.property('refund_states').to.deep.equal(['success', 'error', 'submitted'])
-        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'success', 'error', 'failed', 'cancelled'])
+        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'success', 'error', 'cancelled', 'timedout', 'declined'])
       })
     })
 

--- a/test/unit/utils/states_test.js
+++ b/test/unit/utils/states_test.js
@@ -25,8 +25,8 @@ describe('states', function () {
 
     it('should get connector states from Cancelled display state', function () {
       const connectorStatesResult = states.displayStatesToConnectorStates(['Cancelled'])
-      expect(connectorStatesResult.payment_states.length).to.be.equal(2)
-      expect(connectorStatesResult.payment_states).to.be.containingAllOf(['failed', 'cancelled'])
+      expect(connectorStatesResult.payment_states.length).to.be.equal(1)
+      expect(connectorStatesResult.payment_states).to.be.containingAllOf(['cancelled'])
       expect(connectorStatesResult.refund_states.length).to.be.equal(0)
     })
 
@@ -39,8 +39,8 @@ describe('states', function () {
 
     it('should get connector states from all possible display states', function () {
       const connectorStatesResult = states.displayStatesToConnectorStates(['In progress', 'Success', 'Error', 'Declined', 'Timed out', 'Cancelled', 'Refund success', 'Refund error', 'Refund submitted'])
-      expect(connectorStatesResult.payment_states.length).to.be.equal(7)
-      expect(connectorStatesResult.payment_states).to.be.containingAllOf(['created', 'started', 'submitted', 'success', 'error', 'failed', 'cancelled'])
+      expect(connectorStatesResult.payment_states.length).to.be.equal(8)
+      expect(connectorStatesResult.payment_states).to.be.containingAllOf(['created', 'started', 'submitted', 'success', 'error', 'declined', 'timedout', 'cancelled'])
       expect(connectorStatesResult.refund_states.length).to.be.equal(3)
       expect(connectorStatesResult.refund_states).to.be.containingAllOf(['submitted', 'error', 'success'])
     })
@@ -60,6 +60,8 @@ describe('states', function () {
       expect(states.getDisplayNameForConnectorState({status: 'success'})).to.equal('Success')
       expect(states.getDisplayNameForConnectorState({status: 'success'}, 'refund')).to.equal('Refund success')
       expect(states.getDisplayNameForConnectorState({status: 'error'}, 'refund')).to.equal('Refund error')
+      expect(states.getDisplayNameForConnectorState({status: 'timedout'})).to.equal('Timed out')
+      expect(states.getDisplayNameForConnectorState({status: 'declined'})).to.equal('Declined')
 
       expect(states.getDisplayNameForConnectorState({
         status: 'failed',
@@ -73,11 +75,16 @@ describe('states', function () {
       })).to.equal('Declined')
       expect(states.getDisplayNameForConnectorState({
         status: 'cancelled',
-        code: 'P0040',
+        code: 'P0030',
         message: 'Baz'
       })).to.equal('Cancelled')
       expect(states.getDisplayNameForConnectorState({
         status: 'cancelled',
+        code: 'P0040',
+        message: 'Baz'
+      })).to.equal('Cancelled')
+      expect(states.getDisplayNameForConnectorState({
+        status: 'error',
         code: 'P0050',
         message: 'Kaz'
       })).to.equal('Error')


### PR DESCRIPTION
only relate to the selected payment state

Previously the state dropdown was mapping all the errors to failed. We
want to be able to search by each type of error. Needed to map the
errors to their own code and pass this to connector. Connector has
already been updated to handle these new codes. Will come back and
remove old mappings once they have been removed from the connector
response. This had to be done in a number of steps to preserve
backwards compatibility.

with @kakumara


