### PR TITLE
Fix broken link

### DIFF
--- a/app/views/provider_credentials/sandbox.njk
+++ b/app/views/provider_credentials/sandbox.njk
@@ -3,6 +3,6 @@
 {% block provider_content %}
   <div id="message">
     <p>This is a test account. Account credentials only exist in live services, and relate to your payment service providers.</p>
-    <p>See our guidance on <a href="https://docs.payments.service.gov.uk/#switching-to-production">switching to production</a> to go live.
+    <p>See our guidance on <a href="https://docs.payments.service.gov.uk/#switching-to-live">switching to live</a> to go live.
   </div>
 {% endblock %}


### PR DESCRIPTION
I also changed the terminology to match the `<h1>` in the documentation.