### PR TITLE
WIP PP-3498 dropdown selects individual error states clean up

### DIFF
--- a/app/utils/states.js
+++ b/app/utils/states.js
@@ -16,17 +16,17 @@ const PAYMENT_STATE_DESCRIPTIONS = {
   'success': {
     displayName: 'Success'
   },
-  'error': {
-    displayName: 'Error',
-    errorCodes: ['P0050']
+  'declined': {
+    displayName: 'Declined'
   },
-  'failed': {
-    displayName: 'Failed',
-    errorCodes: ['P0010', 'P0020', 'P0030']
+  'timedout': {
+    displayName: 'Timed out'
   },
   'cancelled': {
-    displayName: 'Cancelled',
-    errorCodes: ['P0040']
+    displayName: 'Cancelled'
+  },
+  'error': {
+    displayName: 'Error'
   }
 }
 
@@ -48,9 +48,7 @@ const REFUND_STATE_DESCRIPTIONS = {
 const ERROR_CODE_TO_DISPLAY_STATE = {
   'P0010': 'Declined',
   'P0020': 'Timed out',
-  'P0030': 'Cancelled',
-  'P0040': 'Cancelled',
-  'P0050': 'Error'
+  'P0030': 'Cancelled'
 }
 
 exports.allDisplayStates = () => [...uniqueDisplayStates(PAYMENT_STATE_DESCRIPTIONS), ...uniqueDisplayStates(REFUND_STATE_DESCRIPTIONS)]
@@ -85,7 +83,7 @@ function uniqueDisplayStates (stateDescriptions) {
 }
 
 function displayNameForConnectorState (connectorState, type) {
-  if (connectorState.code && ERROR_CODE_TO_DISPLAY_STATE[connectorState.code]) {
+  if (connectorState.status === 'failed') {
     return ERROR_CODE_TO_DISPLAY_STATE[connectorState.code]
   }
   return getDisplayNameFromConnectorState(connectorState, type)

--- a/app/utils/states.js
+++ b/app/utils/states.js
@@ -45,18 +45,12 @@ const REFUND_STATE_DESCRIPTIONS = {
   }
 }
 
-const ERROR_CODE_TO_DISPLAY_STATE = {
-  'P0010': 'Declined',
-  'P0020': 'Timed out',
-  'P0030': 'Cancelled'
-}
-
 exports.allDisplayStates = () => [...uniqueDisplayStates(PAYMENT_STATE_DESCRIPTIONS), ...uniqueDisplayStates(REFUND_STATE_DESCRIPTIONS)]
 exports.displayStatesToConnectorStates = (displayStatesArray) => toConnectorStates(displayStatesArray)
 exports.allDisplayStateSelectorObjects = () => exports.allDisplayStates().map(state => toSelectorObject(state))
 exports.getDisplayNameForConnectorState = (connectorState, type = 'payment') => {
   const sanitisedType = (type.toLowerCase() === 'charge') ? 'payment' : type.toLowerCase()
-  return displayNameForConnectorState(connectorState, sanitisedType)
+  return getDisplayNameFromConnectorState(connectorState, sanitisedType)
 }
 
 // TODO: leaving this toSelector Object structure for backward compatibility.
@@ -74,19 +68,9 @@ function toSelectorObject (displayName = '') {
 
 function uniqueDisplayStates (stateDescriptions) {
   const result = lodash.flattenDeep(Object.keys(stateDescriptions).map(key => {
-    if (stateDescriptions[key].errorCodes) {
-      return stateDescriptions[key].errorCodes.map(errorCode => ERROR_CODE_TO_DISPLAY_STATE[errorCode])
-    }
     return stateDescriptions[key].displayName
   }))
   return lodash.uniq(result)
-}
-
-function displayNameForConnectorState (connectorState, type) {
-  if (connectorState.status === 'failed') {
-    return ERROR_CODE_TO_DISPLAY_STATE[connectorState.code]
-  }
-  return getDisplayNameFromConnectorState(connectorState, type)
 }
 
 function getDisplayNameFromConnectorState (connectorState, type = 'payment') {
@@ -112,15 +96,8 @@ function toConnectorStates (displayStates) {
   }
   displayStates.forEach(displayState => {
     Object.keys(PAYMENT_STATE_DESCRIPTIONS).forEach(connectorPaymentState => {
-      if (PAYMENT_STATE_DESCRIPTIONS[connectorPaymentState].errorCodes) {
-        const found = PAYMENT_STATE_DESCRIPTIONS[connectorPaymentState].errorCodes.find(errorCode => ERROR_CODE_TO_DISPLAY_STATE[errorCode] === displayState)
-        if (found) {
-          result.payment_states.push(connectorPaymentState)
-        }
-      } else {
-        if (PAYMENT_STATE_DESCRIPTIONS[connectorPaymentState].displayName === displayState) {
-          result.payment_states.push(connectorPaymentState)
-        }
+      if (PAYMENT_STATE_DESCRIPTIONS[connectorPaymentState].displayName === displayState) {
+        result.payment_states.push(connectorPaymentState)
       }
     })
 

--- a/test/integration/transaction_list_ft_tests.js
+++ b/test/integration/transaction_list_ft_tests.js
@@ -162,7 +162,7 @@ describe('The /transactions endpoint', function () {
           email: 'alice.222@mail.fake',
           transaction_type: 'payment',
           state: {
-            status: 'failed',
+            status: 'cancelled',
             finished: true,
             code: 'P0030',
             message: 'Payment was cancelled by the service'
@@ -204,7 +204,7 @@ describe('The /transactions endpoint', function () {
           'email': 'alice.222@mail.fake',
           transaction_type: 'payment',
           'state': {
-            'status': 'failed',
+            'status': 'cancelled',
             'finished': true,
             'code': 'P0030',
             'message': 'Payment was cancelled by the service'
@@ -293,7 +293,7 @@ describe('The /transactions endpoint', function () {
           'email': 'alice.111@mail.fake',
           transaction_type: 'payment',
           'state': {
-            'status': 'failed',
+            'status': 'timedout',
             'finished': false,
             'code': 'P0020',
             'message': 'some error'

--- a/test/integration/transaction_list_ft_tests.js
+++ b/test/integration/transaction_list_ft_tests.js
@@ -321,7 +321,7 @@ describe('The /transactions endpoint', function () {
     }
 
     connectorMockResponds(200, connectorData, {
-      payment_states: 'created,started,submitted,failed',
+      payment_states: 'created,started,submitted,timedout',
       refund_states: 'submitted'
     })
     request(app)
@@ -341,7 +341,7 @@ describe('The /transactions endpoint', function () {
           expect(['In progress', 'Timed out', 'Refund submitted']).to.include(state.value.text)
         })
 
-        res.body.downloadTransactionLink.should.eql('/transactions/download?payment_states=created&payment_states=started&payment_states=submitted&payment_states=failed&refund_states=submitted')
+        res.body.downloadTransactionLink.should.eql('/transactions/download?payment_states=created&payment_states=started&payment_states=submitted&payment_states=timedout&refund_states=submitted')
       })
       .end(done)
   })
@@ -514,10 +514,10 @@ describe('The /transactions endpoint filtering by states)', () => {
         expect(res.body.eventStates.map(state => state.value.text)).to.deep.equal([
           'In progress',
           'Success',
-          'Error',
           'Declined',
           'Timed out',
           'Cancelled',
+          'Error',
           'Refund submitted',
           'Refund error',
           'Refund success'
@@ -547,10 +547,10 @@ describe('The /transactions endpoint filtering by states)', () => {
         expect(res.body.eventStates.map(state => state.value.text)).to.deep.equal([
           'In progress',
           'Success',
-          'Error',
           'Declined',
           'Timed out',
           'Cancelled',
+          'Error',
           'Refund submitted',
           'Refund error',
           'Refund success'
@@ -581,10 +581,10 @@ describe('The /transactions endpoint filtering by states)', () => {
         expect(res.body.eventStates.map(state => state.value.text)).to.deep.equal([
           'In progress',
           'Success',
-          'Error',
           'Declined',
           'Timed out',
           'Cancelled',
+          'Error',
           'Refund submitted',
           'Refund error',
           'Refund success'

--- a/test/unit/utils/filters_test.js
+++ b/test/unit/utils/filters_test.js
@@ -32,13 +32,13 @@ describe('filters', () => {
 
       it('should transform some payment display states to connector states correctly', function () {
         const {result} = filters.getFilters({query: {state: ['In progress', 'Timed out', 'Cancelled']}})
-        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'failed', 'cancelled'])
+        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'timedout', 'cancelled'])
         expect(result).to.not.have.property('refund_states')
       })
 
       it('should transform all payment display states to connector states correctly', function () {
         const {result} = filters.getFilters({query: {state: ['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined']}})
-        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'success', 'error', 'failed', 'cancelled'])
+        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'success', 'error', 'cancelled', 'timedout', 'declined'])
         expect(result).to.not.have.property('refund_states')
       })
 
@@ -51,7 +51,7 @@ describe('filters', () => {
       it('should transform both payment and refund display states to connector states correctly', function () {
         const {result} = filters.getFilters({query: {state: ['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined', 'Refund success', 'Refund error', 'Refund submitted']}})
         expect(result).to.have.property('refund_states').to.deep.equal(['success', 'error', 'submitted'])
-        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'success', 'error', 'failed', 'cancelled'])
+        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'success', 'error', 'cancelled', 'timedout', 'declined'])
       })
     })
 

--- a/test/unit/utils/states_test.js
+++ b/test/unit/utils/states_test.js
@@ -58,38 +58,15 @@ describe('states', function () {
       expect(states.getDisplayNameForConnectorState({status: 'submitted'})).to.equal('In progress')
       expect(states.getDisplayNameForConnectorState({status: 'created'})).to.equal('In progress')
       expect(states.getDisplayNameForConnectorState({status: 'success'})).to.equal('Success')
+      expect(states.getDisplayNameForConnectorState({status: 'declined'})).to.equal('Declined')
+      expect(states.getDisplayNameForConnectorState({status: 'cancelled'})).to.equal('Cancelled')
+      expect(states.getDisplayNameForConnectorState({status: 'timedout'})).to.equal('Timed out')
+      expect(states.getDisplayNameForConnectorState({status: 'error'})).to.equal('Error')
+      expect(states.getDisplayNameForConnectorState({status: 'submitted'}, 'charge')).to.equal('In progress')
+
       expect(states.getDisplayNameForConnectorState({status: 'success'}, 'refund')).to.equal('Refund success')
       expect(states.getDisplayNameForConnectorState({status: 'error'}, 'refund')).to.equal('Refund error')
-      expect(states.getDisplayNameForConnectorState({status: 'timedout'})).to.equal('Timed out')
-      expect(states.getDisplayNameForConnectorState({status: 'declined'})).to.equal('Declined')
 
-      expect(states.getDisplayNameForConnectorState({
-        status: 'failed',
-        code: 'P0030',
-        message: 'Foo'
-      })).to.equal('Cancelled')
-      expect(states.getDisplayNameForConnectorState({
-        status: 'failed',
-        code: 'P0010',
-        message: 'Bar'
-      })).to.equal('Declined')
-      expect(states.getDisplayNameForConnectorState({
-        status: 'cancelled',
-        code: 'P0030',
-        message: 'Baz'
-      })).to.equal('Cancelled')
-      expect(states.getDisplayNameForConnectorState({
-        status: 'cancelled',
-        code: 'P0040',
-        message: 'Baz'
-      })).to.equal('Cancelled')
-      expect(states.getDisplayNameForConnectorState({
-        status: 'error',
-        code: 'P0050',
-        message: 'Kaz'
-      })).to.equal('Error')
-
-      expect(states.getDisplayNameForConnectorState({status: 'submitted'}, 'charge')).to.equal('In progress')
       expect(states.getDisplayNameForConnectorState({status: 'submitted'}, 'PAYMENT')).to.equal('In progress')
       expect(states.getDisplayNameForConnectorState({status: 'submitted'}, 'refund')).to.equal('Refund submitted')
     })

--- a/test/unit/utils/states_test.js
+++ b/test/unit/utils/states_test.js
@@ -25,8 +25,8 @@ describe('states', function () {
 
     it('should get connector states from Cancelled display state', function () {
       const connectorStatesResult = states.displayStatesToConnectorStates(['Cancelled'])
-      expect(connectorStatesResult.payment_states.length).to.be.equal(2)
-      expect(connectorStatesResult.payment_states).to.be.containingAllOf(['failed', 'cancelled'])
+      expect(connectorStatesResult.payment_states.length).to.be.equal(1)
+      expect(connectorStatesResult.payment_states).to.be.containingAllOf(['cancelled'])
       expect(connectorStatesResult.refund_states.length).to.be.equal(0)
     })
 
@@ -39,8 +39,8 @@ describe('states', function () {
 
     it('should get connector states from all possible display states', function () {
       const connectorStatesResult = states.displayStatesToConnectorStates(['In progress', 'Success', 'Error', 'Declined', 'Timed out', 'Cancelled', 'Refund success', 'Refund error', 'Refund submitted'])
-      expect(connectorStatesResult.payment_states.length).to.be.equal(7)
-      expect(connectorStatesResult.payment_states).to.be.containingAllOf(['created', 'started', 'submitted', 'success', 'error', 'failed', 'cancelled'])
+      expect(connectorStatesResult.payment_states.length).to.be.equal(8)
+      expect(connectorStatesResult.payment_states).to.be.containingAllOf(['created', 'started', 'submitted', 'success', 'error', 'declined', 'timedout', 'cancelled'])
       expect(connectorStatesResult.refund_states.length).to.be.equal(3)
       expect(connectorStatesResult.refund_states).to.be.containingAllOf(['submitted', 'error', 'success'])
     })
@@ -60,6 +60,8 @@ describe('states', function () {
       expect(states.getDisplayNameForConnectorState({status: 'success'})).to.equal('Success')
       expect(states.getDisplayNameForConnectorState({status: 'success'}, 'refund')).to.equal('Refund success')
       expect(states.getDisplayNameForConnectorState({status: 'error'}, 'refund')).to.equal('Refund error')
+      expect(states.getDisplayNameForConnectorState({status: 'timedout'})).to.equal('Timed out')
+      expect(states.getDisplayNameForConnectorState({status: 'declined'})).to.equal('Declined')
 
       expect(states.getDisplayNameForConnectorState({
         status: 'failed',
@@ -73,11 +75,16 @@ describe('states', function () {
       })).to.equal('Declined')
       expect(states.getDisplayNameForConnectorState({
         status: 'cancelled',
-        code: 'P0040',
+        code: 'P0030',
         message: 'Baz'
       })).to.equal('Cancelled')
       expect(states.getDisplayNameForConnectorState({
         status: 'cancelled',
+        code: 'P0040',
+        message: 'Baz'
+      })).to.equal('Cancelled')
+      expect(states.getDisplayNameForConnectorState({
+        status: 'error',
         code: 'P0050',
         message: 'Kaz'
       })).to.equal('Error')


### PR DESCRIPTION
Removing unneeded code. Previously we returned failed for the connector
state of a transaction and need to use the error code to map to the
state display value. Because we wanted to search by these states we
need to send different states for each one we displayed. This means we
no longer need to use the error code to map to display states so
removing the code.

