### PR TITLE
PP-3449 Fixed missing helper text for WorldPay

### DIFF
--- a/app/controllers/toggle_3ds_controller.js
+++ b/app/controllers/toggle_3ds_controller.js
@@ -26,7 +26,7 @@ module.exports.index = function (req, res) {
       requires3ds: req.account.requires3ds,
       hasAnyCardTypeRequiring3dsSelected: _.some(acceptedCards['card_types'], {'requires3ds': true}),
       justToggled: typeof req.query.toggled !== 'undefined',
-      showHelper3ds: req.payment_provider === 'worldpay'
+      showHelper3ds: req.account.payment_provider === 'worldpay'
     }
 
     show(req, res, 'index', model)

--- a/app/views/3d_secure/index.njk
+++ b/app/views/3d_secure/index.njk
@@ -39,7 +39,7 @@
 
       {% if permissions.toggle_3ds_update %}
         {% if showHelper3ds %}
-          <div class="panel panel-border-wide">
+          <div id="threeds-helper-text" class="panel panel-border-wide">
             <h2 class="heading-small">Activating 3D Secure</h2>
             <p>Check with your Worldpay account manager that your merchant code has been configured to support 3D
               Secure. Read more about this in our <a

--- a/test/ui/toggle_3ds_ui_tests.js
+++ b/test/ui/toggle_3ds_ui_tests.js
@@ -92,6 +92,23 @@ describe('The toggle 3D Secure page when 3D Secure is off', function () {
 
     body.should.containNoSelector('#3ds-toggled')
   })
+
+  it('should display helper test for worldpay', function () {
+    let templateData = {
+      'supports3ds': true,
+      'requires3ds': false,
+      'justToggled': false,
+      'showHelper3ds': true,
+      permissions: {
+        toggle_3ds_read: true,
+        toggle_3ds_update: true
+      }
+    }
+
+    let body = renderTemplate('3d_secure/index', templateData)
+
+    body.should.containSelector('#threeds-helper-text')
+  })
 })
 
 describe('The toggle 3D Secure page when 3D Secure is on', function () {


### PR DESCRIPTION
## WHAT
Fixed missing helper text for WorldPay

## HOW 
- Fixed getting the payment_provider from the correct object
- Added CSS id for the missing element for testing
- Added test to check that the element shows up for required permissions
and payment_provider


