### PR TITLE
PP-3498 Handle new states with old display value

### DIFF
--- a/app/utils/states.js
+++ b/app/utils/states.js
@@ -156,7 +156,13 @@ const OLD_REFUND_STATE_DESCRIPTIONS = {
 exports.old_payment_states = () => Object.keys(OLD_PAYMENT_STATE_DESCRIPTIONS).map(key => old_toSelectorObject('PAYMENT', key)) // eslint-disable-line
 exports.old_refund_states = () => Object.keys(OLD_REFUND_STATE_DESCRIPTIONS).map(key => old_toSelectorObject('REFUND', key)) // eslint-disable-line
 exports.old_states = () => [...exports.old_payment_states(), ...exports.old_refund_states()] // eslint-disable-line
-exports.old_getDisplayName = (type = 'payment', name = '') => {  // eslint-disable-line
+exports.old_getDisplayName = (type = 'payment', state = {}) => {  // eslint-disable-line
+  let name = state.status || ''
+  if (name.toLowerCase() === 'timedout' || name.toLowerCase() === 'declined') {
+    name = 'failed'
+  } else if (name.toLowerCase() === 'cancelled' && state.code === 'P0030') {
+    name = 'failed'
+  }
   const origin = exports.old_states().find(event => event.name === name.toLowerCase() && event.type === type.toLowerCase()) // eslint-disable-line
   return lodash.get(origin, `value.text`, changeCase.upperCaseFirst(name.toLowerCase()))
 }

--- a/app/utils/transaction_view.js
+++ b/app/utils/transaction_view.js
@@ -46,7 +46,7 @@ module.exports = {
       if (filtersResult.newChargeStatusEnabled) {
         element.state_friendly = states.getDisplayNameForConnectorState(element.state, element.transaction_type)
       } else {
-        element.state_friendly = states.old_getDisplayName(element.transaction_type, element.state.status)
+        element.state_friendly = states.old_getDisplayName(element.transaction_type, element.state)
       }
       element.amount = asGBP(element.amount)
       element.email = (element.email && element.email.length > 20) ? element.email.substring(0, 20) + '...' : element.email
@@ -83,7 +83,7 @@ module.exports = {
     if (newChargeStatusEnabled) {
       chargeData.state_friendly = states.getDisplayNameForConnectorState(chargeData.state, chargeData.transaction_type)
     } else {
-      chargeData.state_friendly = states.old_getDisplayName(chargeData.transaction_type, chargeData.state.status)
+      chargeData.state_friendly = states.old_getDisplayName(chargeData.transaction_type, chargeData.state)
     }
 
     chargeData.amount = asGBP(chargeData.amount)

--- a/test/unit/utils/states_test.js
+++ b/test/unit/utils/states_test.js
@@ -106,13 +106,16 @@ describe('states', function () {
     })
 
     it('should get correct display name for a given connector state', function () {
-      expect(states.old_getDisplayName('payment', 'success')).to.equal('Success')
-      expect(states.old_getDisplayName('payment', 'failed')).to.equal('Failed')
-      expect(states.old_getDisplayName('payment', 'error')).to.equal('Error')
-      expect(states.old_getDisplayName('payment', 'cancelled')).to.equal('Cancelled')
-      expect(states.old_getDisplayName('refund', 'success')).to.equal('Refund success')
-      expect(states.old_getDisplayName('refund', 'submitted')).to.equal('Refund submitted')
-      expect(states.old_getDisplayName('refund', 'error')).to.equal('Refund error')
+      expect(states.old_getDisplayName('payment', {status: 'success'})).to.equal('Success')
+      expect(states.old_getDisplayName('payment', {status: 'failed', code: ''})).to.equal('Failed')
+      expect(states.old_getDisplayName('payment', {status: 'timedout', code: 'P0020'})).to.equal('Failed')
+      expect(states.old_getDisplayName('payment', {status: 'declined', code: 'P0010'})).to.equal('Failed')
+      expect(states.old_getDisplayName('payment', {status: 'error', code: 'P0050'})).to.equal('Error')
+      expect(states.old_getDisplayName('payment', {status: 'cancelled', code: 'P0030'})).to.equal('Failed')
+      expect(states.old_getDisplayName('payment', {status: 'cancelled', code: 'P0040'})).to.equal('Cancelled')
+      expect(states.old_getDisplayName('refund', {status: 'success'})).to.equal('Refund success')
+      expect(states.old_getDisplayName('refund', {status: 'submitted'})).to.equal('Refund submitted')
+      expect(states.old_getDisplayName('refund', {status: 'error', code: 'P0050'})).to.equal('Refund error')
     })
 
     it('should get correct description for a given connector state', function () {


### PR DESCRIPTION
If the user does not have the new states feature flag enable they
should still see the old display values. As we have changed connector
to return the new states we need to map those new states to  the old
display values. Will all be deleted once we get rid of the feature flag.

with @kakumara