### PR TITLE
PP-3495 Do something about transaction event having "in progress"

### DIFF
--- a/app/models/TransactionEvent.class.js
+++ b/app/models/TransactionEvent.class.js
@@ -21,7 +21,7 @@ class TransactionEvent {
       message: lodash.get(eventData, 'state.message')
     }
 
-    this.state_friendly = newChargeStatusEnabled ? states.getDisplayNameForConnectorState(this.state, this.type) : states.old_getDescription(this.type, this.state.status)
+    this.state_friendly = newChargeStatusEnabled ? states.getEventDisplayNameForConnectorState(this.state, this.type) : states.old_getDescription(this.type, this.state.status)
     this.updated_friendly = dates.utcToDisplay(this.updated)
     this.amount_friendly = currencyFormatter.format((this.amount / 100).toFixed(2), {code: 'GBP'})
     if (this.amount && this.type.toLowerCase() === 'refund') {

--- a/test/integration/transaction_details_ft_tests.js
+++ b/test/integration/transaction_details_ft_tests.js
@@ -239,7 +239,7 @@ describe('The transaction view scenarios', function () {
             },
             'type': 'payment',
             'amount': '20000',
-            'state_friendly': 'In progress',
+            'state_friendly': 'Started',
             'amount_friendly': '£200.00',
             'updated': '2015-12-24 13:23:12',
             'updated_friendly': '24 Dec 2015 — 13:23:12'
@@ -251,7 +251,7 @@ describe('The transaction view scenarios', function () {
             },
             'type': 'payment',
             'amount': '20000',
-            'state_friendly': 'In progress',
+            'state_friendly': 'Created',
             'amount_friendly': '£200.00',
             'updated': '2015-12-24 13:21:05',
             'updated_friendly': '24 Dec 2015 — 13:21:05'
@@ -372,7 +372,7 @@ describe('The transaction view scenarios', function () {
               'status': 'started',
               'finished': false
             },
-            'state_friendly': 'In progress',
+            'state_friendly': 'Started',
             'updated': '2015-12-24 13:23:12',
             'updated_friendly': '24 Dec 2015 — 13:23:12'
           },
@@ -384,7 +384,7 @@ describe('The transaction view scenarios', function () {
               'status': 'created',
               'finished': false
             },
-            'state_friendly': 'In progress',
+            'state_friendly': 'Created',
             'updated': '2015-12-24 13:21:05',
             'updated_friendly': '24 Dec 2015 — 13:21:05'
           }
@@ -512,7 +512,7 @@ describe('The transaction view scenarios', function () {
             'type': 'payment',
             'amount': 5000,
             'amount_friendly': '£50.00',
-            'state_friendly': 'In progress',
+            'state_friendly': 'Started',
             'updated': '2015-12-24 13:23:12',
             'updated_friendly': '24 Dec 2015 — 13:23:12'
           },
@@ -524,7 +524,7 @@ describe('The transaction view scenarios', function () {
             'type': 'payment',
             'amount': 5000,
             'amount_friendly': '£50.00',
-            'state_friendly': 'In progress',
+            'state_friendly': 'Created',
             'updated': '2015-12-24 13:21:05',
             'updated_friendly': '24 Dec 2015 — 13:21:05'
           }
@@ -735,7 +735,7 @@ describe('The transaction view scenarios', function () {
             'type': 'payment',
             'amount': 5000,
             'amount_friendly': '£50.00',
-            'state_friendly': 'In progress',
+            'state_friendly': 'Started',
             'updated': '2015-12-24 13:23:12',
             'updated_friendly': '24 Dec 2015 — 13:23:12'
           },
@@ -747,7 +747,7 @@ describe('The transaction view scenarios', function () {
             'type': 'payment',
             'amount': 5000,
             'amount_friendly': '£50.00',
-            'state_friendly': 'In progress',
+            'state_friendly': 'Created',
             'updated': '2015-12-24 13:21:05',
             'updated_friendly': '24 Dec 2015 — 13:21:05'
           }

--- a/test/unit/utils/states_test.js
+++ b/test/unit/utils/states_test.js
@@ -93,6 +93,46 @@ describe('states', function () {
       expect(states.getDisplayNameForConnectorState({status: 'submitted'}, 'PAYMENT')).to.equal('In progress')
       expect(states.getDisplayNameForConnectorState({status: 'submitted'}, 'refund')).to.equal('Refund submitted')
     })
+
+    it('should get event display name for connector state', function () {
+      expect(states.getEventDisplayNameForConnectorState({status: 'submitted'}, 'payment')).to.equal('Submitted')
+      expect(states.getEventDisplayNameForConnectorState({status: 'submitted'}, 'PAYMENT')).to.equal('Submitted')
+      expect(states.getEventDisplayNameForConnectorState({status: 'submitted'}, 'refund')).to.equal('Refund submitted')
+
+      expect(states.getEventDisplayNameForConnectorState({status: 'started'}, 'payment')).to.equal('Started')
+      expect(states.getEventDisplayNameForConnectorState({status: 'created'}, 'payment')).to.equal('Created')
+      expect(states.getEventDisplayNameForConnectorState({status: 'success'}, 'payment')).to.equal('Success')
+      expect(states.getEventDisplayNameForConnectorState({status: 'success'}, 'refund')).to.equal('Refund success')
+      expect(states.getEventDisplayNameForConnectorState({status: 'error'}, 'refund')).to.equal('Refund error')
+      expect(states.getEventDisplayNameForConnectorState({status: 'timedout'}, 'payment')).to.equal('Timed out')
+      expect(states.getEventDisplayNameForConnectorState({status: 'declined'}, 'payment')).to.equal('Declined')
+
+      expect(states.getEventDisplayNameForConnectorState({
+        status: 'failed',
+        code: 'P0030',
+        message: 'Foo'
+      }, 'payment')).to.equal('Cancelled')
+      expect(states.getEventDisplayNameForConnectorState({
+        status: 'failed',
+        code: 'P0010',
+        message: 'Bar'
+      }, 'payment')).to.equal('Declined')
+      expect(states.getEventDisplayNameForConnectorState({
+        status: 'cancelled',
+        code: 'P0030',
+        message: 'Baz'
+      }, 'payment')).to.equal('Cancelled')
+      expect(states.getEventDisplayNameForConnectorState({
+        status: 'cancelled',
+        code: 'P0040',
+        message: 'Baz'
+      }, 'payment')).to.equal('Cancelled')
+      expect(states.getEventDisplayNameForConnectorState({
+        status: 'error',
+        code: 'P0050',
+        message: 'Kaz'
+      }, 'payment')).to.equal('Error')
+    })
   })
 
   describe('old states', function () {


### PR DESCRIPTION
repeated three times

Changed the transaction events to display 'Created', 'Started' and
'Submitted' instead of 'In progress'