### PR TITLE
PP-3510 - adding friendly url to the flow 

### DIFF
--- a/app/assets/sass/gov-uk-overrides/_forms.scss
+++ b/app/assets/sass/gov-uk-overrides/_forms.scss
@@ -29,6 +29,16 @@ textarea {
   }
 }
 
+.error-summary .error-summary-list {
+  li {
+    margin-bottom: 0;
+
+    &+ li {
+      margin-top: $gutter / 6;
+    }
+  }
+}
+
 .form-hint {
   margin-bottom: $gutter / 6;
 }

--- a/app/assets/sass/modules/_create-payment-link.scss
+++ b/app/assets/sass/modules/_create-payment-link.scss
@@ -69,4 +69,14 @@
   &-list {
     padding-bottom: $gutter / 2;
   }
+
+  &-read-more {
+    @include core-16;
+
+    margin-top: $gutter / 2;
+  }
+
+  &-url {
+    font-weight: normal;
+  }
 }

--- a/app/browsered.js
+++ b/app/browsered.js
@@ -10,6 +10,7 @@ const fieldValidation = require('./browsered/field-validation')
 const dashboardActivity = require('./browsered/dashboard-activity')
 const targetToShow = require('./browsered/target-to-show')
 const analytics = require('gaap-analytics')
+const inputConfirm = require('./browsered/input-confirm')
 
 // GOV.UK Frontend Toolkit dependencies
 require('../govuk_modules/govuk_frontend_toolkit/javascripts/govuk/show-hide-content')
@@ -20,6 +21,7 @@ dashboardActivity.init()
 targetToShow.init()
 analytics.eventTracking.init()
 analytics.virtualPageview.init()
+inputConfirm()
 
 $(document).ready($ => {
   const showHideContent = new window.GOVUK.ShowHideContent()

--- a/app/browsered.js
+++ b/app/browsered.js
@@ -11,6 +11,7 @@ const dashboardActivity = require('./browsered/dashboard-activity')
 const targetToShow = require('./browsered/target-to-show')
 const analytics = require('gaap-analytics')
 const inputConfirm = require('./browsered/input-confirm')
+const niceURL = require('./browsered/nice-url')
 
 // GOV.UK Frontend Toolkit dependencies
 require('../govuk_modules/govuk_frontend_toolkit/javascripts/govuk/show-hide-content')
@@ -22,6 +23,7 @@ targetToShow.init()
 analytics.eventTracking.init()
 analytics.virtualPageview.init()
 inputConfirm()
+niceURL()
 
 $(document).ready($ => {
   const showHideContent = new window.GOVUK.ShowHideContent()

--- a/app/browsered/input-confirm.js
+++ b/app/browsered/input-confirm.js
@@ -4,7 +4,7 @@ const slugify = require('../utils/nunjucks-filters/slugify')
 const removeDefinateArticles = require('../utils/nunjucks-filters/remove-definate-articles')
 
 module.exports = () => {
-  const inputs = document.querySelectorAll('[data-confirmation]')
+  const inputs = Array.prototype.slice.call(document.querySelectorAll('[data-confirmation]'))
 
   inputs.forEach(input => {
     input.addEventListener('input', confirmInput, false)

--- a/app/browsered/input-confirm.js
+++ b/app/browsered/input-confirm.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const slugify = require('../utils/nunjucks-filters/slugify')
+
+module.exports = () => {
+  const inputs = document.querySelectorAll('[data-confirmation]')
+
+  inputs.forEach(input => {
+    input.addEventListener('input', confirmInput, false)
+  })
+
+  function confirmInput (e) {
+    const input = e.target
+    // using slugify and also stripping out the (in)definite article (the/a/an)
+    let value = input.dataset.confirmationFilter === 'slugify' ? slugify(input.value.replace(/\ba\s|\ban\s|\bthe\b/gi, '')) : input.value
+    const confirmationId = `${input.id}-confirmation`
+    const confirmationPrepend = input.dataset.confirmationPrepend || ''
+    let confirmation = document.getElementById(confirmationId)
+
+    if (!confirmation) {
+      confirmation = document.createElement('div')
+      confirmation.innerHTML = `
+      <div id="${confirmationId}" class="form-group panel panel-border-wide input-confirm">
+        <h3 class="heading-small">${input.dataset.confirmationTitle}</h3>
+        <p class="">
+          ${input.dataset.confirmationLabel}<span class="input-confirmation"></span>
+        </p>
+      </div>`
+      input.closest('.form-group').after(confirmation)
+    }
+
+    if (value === '') {
+      confirmation.remove()
+    } else {
+      document
+        .querySelector(`#${confirmationId} .input-confirmation`)
+        .innerText = confirmationPrepend + value
+    }
+  }
+}

--- a/app/browsered/input-confirm.js
+++ b/app/browsered/input-confirm.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const slugify = require('../utils/nunjucks-filters/slugify')
+const removeDefinateArticles = require('../utils/nunjucks-filters/remove-definate-articles')
 
 module.exports = () => {
   const inputs = document.querySelectorAll('[data-confirmation]')
@@ -12,7 +13,7 @@ module.exports = () => {
   function confirmInput (e) {
     const input = e.target
     // using slugify and also stripping out the (in)definite article (the/a/an)
-    let value = input.dataset.confirmationFilter === 'slugify' ? slugify(input.value.replace(/\ba\s|\ban\s|\bthe\b/gi, '')) : input.value
+    let value = input.dataset.confirmationFilter === 'slugify' ? slugify(removeDefinateArticles(input.value)) : input.value
     const confirmationId = `${input.id}-confirmation`
     const confirmationPrepend = input.dataset.confirmationPrepend || ''
     let confirmation = document.getElementById(confirmationId)

--- a/app/browsered/nice-url.js
+++ b/app/browsered/nice-url.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const removeDefinateArticles = require('../utils/nunjucks-filters/remove-definate-articles')
+
+module.exports = () => {
+  const inputs = document.querySelectorAll('[data-slugify]')
+
+  inputs.forEach(input => {
+    input.addEventListener('input', niceURL, false)
+  })
+
+  function niceURL (e) {
+    const input = e.target
+    // stripping out the (in)definite article (the/a/an) and replacing spaces and other chars with a hyphen
+    input.value = removeDefinateArticles(input.value).replace(/[\s£&$*_+~.()'"!:@]+/g, '-').toLowerCase()
+  }
+}

--- a/app/browsered/nice-url.js
+++ b/app/browsered/nice-url.js
@@ -3,7 +3,7 @@
 const removeDefinateArticles = require('../utils/nunjucks-filters/remove-definate-articles')
 
 module.exports = () => {
-  const inputs = document.querySelectorAll('[data-slugify]')
+  const inputs = Array.prototype.slice.call(document.querySelectorAll('[data-slugify]'))
 
   inputs.forEach(input => {
     input.addEventListener('input', niceURL, false)

--- a/app/controllers/payment-links/get-disable-controller.js
+++ b/app/controllers/payment-links/get-disable-controller.js
@@ -12,7 +12,7 @@ module.exports = (req, res) => {
   const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
   productsClient.product.disable(gatewayAccountId, req.params.productExternalId)
     .then(() => {
-      req.flash('generic', '<h2>The payment link was successfully deleted</h2><p>It will no longer be accessible</p>')
+      req.flash('generic', '<h2>The payment link was successfully deleted</h2>')
       res.redirect(paths.paymentLinks.manage)
     })
     .catch((err) => {

--- a/app/controllers/payment-links/get-information-controller.js
+++ b/app/controllers/payment-links/get-information-controller.js
@@ -12,9 +12,11 @@ module.exports = (req, res) => {
   const paymentLinkTitle = req.body['payment-description'] || pageData.paymentLinkTitle || ''
   const paymentLinkDescription = req.body['payment-amount'] || pageData.paymentLinkDescription || ''
   const change = lodash.get(req, 'query.field', {})
+  const friendlyURL = process.env.PRODUCTS_FRIENDLY_BASE_URI
 
   return response(req, res, 'payment-links/information', {
     change,
+    friendlyURL,
     paymentLinkTitle,
     paymentLinkDescription,
     nextPage: paths.paymentLinks.information,

--- a/app/controllers/payment-links/get-web-address-controller.js
+++ b/app/controllers/payment-links/get-web-address-controller.js
@@ -10,7 +10,7 @@ const paths = require('../../paths')
 module.exports = (req, res) => {
   const friendlyURL = process.env.PRODUCTS_FRIENDLY_BASE_URI
   const pageData = lodash.get(req, 'session.pageData.createPaymentLink', {})
-  const productNamePath = req.body['payment-amount'] || pageData.productNamePath || ''
+  const productNamePath = pageData.productNamePath || ''
 
   return response(req, res, 'payment-links/web-address', {
     friendlyURL,

--- a/app/controllers/payment-links/get-web-address-controller.js
+++ b/app/controllers/payment-links/get-web-address-controller.js
@@ -1,0 +1,22 @@
+'use strict'
+
+// NPM dependencies
+const lodash = require('lodash')
+
+// Local dependencies
+const {response} = require('../../utils/response.js')
+const paths = require('../../paths')
+
+module.exports = (req, res) => {
+  const friendlyURL = process.env.PRODUCTS_FRIENDLY_BASE_URI
+  const pageData = lodash.get(req, 'session.pageData.createPaymentLink', {})
+  const productNamePath = req.body['payment-amount'] || pageData.productNamePath || ''
+
+  return response(req, res, 'payment-links/web-address', {
+    friendlyURL,
+    productNamePath,
+    nextPage: paths.paymentLinks.webAddress,
+    returnToStart: paths.paymentLinks.start,
+    manage: paths.paymentLinks.manage
+  })
+}

--- a/app/controllers/payment-links/index.js
+++ b/app/controllers/payment-links/index.js
@@ -3,6 +3,8 @@
 exports.getStart = require('./get-start-controller')
 exports.getInformation = require('./get-information-controller')
 exports.postInformation = require('./post-information-controller')
+exports.getWebAddress = require('./get-web-address-controller')
+exports.postWebAddress = require('./post-web-address-controller')
 exports.getAmount = require('./get-amount-controller')
 exports.postAmount = require('./post-amount-controller')
 exports.getReview = require('./get-review-controller')

--- a/app/controllers/payment-links/post-information-controller.js
+++ b/app/controllers/payment-links/post-information-controller.js
@@ -2,6 +2,7 @@
 
 // NPM dependencies
 const lodash = require('lodash')
+const slugify = require('../../utils/nunjucks-filters/slugify')
 
 // Local dependencies
 const paths = require('../../paths')
@@ -12,7 +13,11 @@ module.exports = (req, res) => {
 
   updatedPageData.paymentLinkTitle = req.body['payment-link-title']
   updatedPageData.paymentLinkDescription = req.body['payment-link-description']
+  updatedPageData.serviceNamePath = req.body['service-name-path']
+  updatedPageData.productNamePath = slugify(req.body['payment-link-title'].replace(/\ba\s|\ban\s|\bthe\b/gi, ''))
   lodash.set(req, 'session.pageData.createPaymentLink', updatedPageData)
+
+  console.log(updatedPageData)
 
   if (updatedPageData.paymentLinkTitle === '') {
     req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#payment-link-title">Title</a></li></ul>`)

--- a/app/controllers/payment-links/post-information-controller.js
+++ b/app/controllers/payment-links/post-information-controller.js
@@ -28,6 +28,14 @@ module.exports = (req, res) => {
     return res.redirect(paths.paymentLinks.information)
   }
 
+  if (!lodash.isEmpty(pageData) && !lodash.isEqual(pageData, updatedPageData)) {
+    req.flash('generic', `<h2>The details have been updated</h2>`)
+  }
+
+  if (req.body['change'] === 'true') {
+    return res.redirect(paths.paymentLinks.review)
+  }
+
   productsClient.product.getByProductPath(updatedPageData.serviceNamePath, updatedPageData.productNamePath)
   .then(product => {
     // if product exists we need to alert the user they must use a different URL
@@ -37,12 +45,4 @@ module.exports = (req, res) => {
     // if it errors then it means no product was found and that’s good
     return res.redirect(paths.paymentLinks.amount)
   })
-
-  if (!lodash.isEmpty(pageData) && !lodash.isEqual(pageData, updatedPageData)) {
-    req.flash('generic', `<h2>The details have been updated</h2>`)
-  }
-
-  if (req.body['change'] === 'true') {
-    return res.redirect(paths.paymentLinks.review)
-  }
 }

--- a/app/controllers/payment-links/post-information-controller.js
+++ b/app/controllers/payment-links/post-information-controller.js
@@ -7,9 +7,10 @@ const removeDefinateArticles = require('../../utils/nunjucks-filters/remove-defi
 
 // Local dependencies
 const paths = require('../../paths')
+const productsClient = require('../../services/clients/products_client.js')
 
 const makeNiceURL = string => {
-  slugify(removeDefinateArticles(string))
+  return slugify(removeDefinateArticles(string))
 }
 
 module.exports = (req, res) => {
@@ -27,6 +28,16 @@ module.exports = (req, res) => {
     return res.redirect(paths.paymentLinks.information)
   }
 
+  productsClient.product.getByProductPath(updatedPageData.serviceNamePath, updatedPageData.productNamePath)
+  .then(product => {
+    // if product exists we need to alert the user they must use a different URL
+    return res.redirect(paths.paymentLinks.webAddress)
+  })
+  .catch((err) => { // eslint-disable-line handle-callback-err
+    // if it errors then it means no product was found and that’s good
+    return res.redirect(paths.paymentLinks.amount)
+  })
+
   if (!lodash.isEmpty(pageData) && !lodash.isEqual(pageData, updatedPageData)) {
     req.flash('generic', `<h2>The details have been updated</h2>`)
   }
@@ -34,6 +45,4 @@ module.exports = (req, res) => {
   if (req.body['change'] === 'true') {
     return res.redirect(paths.paymentLinks.review)
   }
-
-  return res.redirect(paths.paymentLinks.amount)
 }

--- a/app/controllers/payment-links/post-information-controller.js
+++ b/app/controllers/payment-links/post-information-controller.js
@@ -3,9 +3,14 @@
 // NPM dependencies
 const lodash = require('lodash')
 const slugify = require('../../utils/nunjucks-filters/slugify')
+const removeDefinateArticles = require('../../utils/nunjucks-filters/remove-definate-articles')
 
 // Local dependencies
 const paths = require('../../paths')
+
+const makeNiceURL = string => {
+  slugify(removeDefinateArticles(string))
+}
 
 module.exports = (req, res) => {
   const pageData = lodash.get(req, 'session.pageData.createPaymentLink', {})
@@ -13,11 +18,9 @@ module.exports = (req, res) => {
 
   updatedPageData.paymentLinkTitle = req.body['payment-link-title']
   updatedPageData.paymentLinkDescription = req.body['payment-link-description']
-  updatedPageData.serviceNamePath = req.body['service-name-path']
-  updatedPageData.productNamePath = slugify(req.body['payment-link-title'].replace(/\ba\s|\ban\s|\bthe\b/gi, ''))
+  updatedPageData.serviceNamePath = makeNiceURL(req.body['service-name-path'])
+  updatedPageData.productNamePath = makeNiceURL(req.body['payment-link-title'])
   lodash.set(req, 'session.pageData.createPaymentLink', updatedPageData)
-
-  console.log(updatedPageData)
 
   if (updatedPageData.paymentLinkTitle === '') {
     req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#payment-link-title">Title</a></li></ul>`)

--- a/app/controllers/payment-links/post-review-controller.js
+++ b/app/controllers/payment-links/post-review-controller.js
@@ -12,13 +12,15 @@ const productTypes = require('../../utils/product_types')
 const publicAuthClient = require('../../services/clients/public_auth_client')
 const auth = require('../../services/auth_service.js')
 
-function buildProductPayload (payApiToken, gatewayAccountId, paymentLinkTitle, paymentLinkDescription, paymentLinkAmount, serviceName) {
+function buildProductPayload (payApiToken, gatewayAccountId, paymentLinkTitle, paymentLinkDescription, paymentLinkAmount, serviceName, serviceNamePath, productNamePath) {
   const productPayload = {
     payApiToken,
     gatewayAccountId,
     name: paymentLinkTitle,
     serviceName,
-    type: productTypes.ADHOC
+    type: productTypes.ADHOC,
+    serviceNamePath,
+    productNamePath
   }
 
   if (paymentLinkDescription) {
@@ -33,7 +35,7 @@ function buildProductPayload (payApiToken, gatewayAccountId, paymentLinkTitle, p
 
 module.exports = (req, res) => {
   const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
-  const {paymentLinkTitle, paymentLinkDescription, paymentLinkAmount} = lodash.get(req, 'session.pageData.createPaymentLink', {})
+  const {paymentLinkTitle, paymentLinkDescription, paymentLinkAmount, serviceNamePath, productNamePath} = lodash.get(req, 'session.pageData.createPaymentLink', {})
 
   if (!paymentLinkTitle) {
     return res.redirect(paths.paymentLinks.start)
@@ -54,7 +56,9 @@ module.exports = (req, res) => {
         paymentLinkTitle,
         paymentLinkDescription,
         paymentLinkAmount,
-        req.service.name
+        req.service.name,
+        serviceNamePath,
+        productNamePath
       )
     ))
     .then(product => {

--- a/app/controllers/payment-links/post-web-address-controller.js
+++ b/app/controllers/payment-links/post-web-address-controller.js
@@ -1,0 +1,33 @@
+'use strict'
+
+// NPM dependencies
+const lodash = require('lodash')
+
+// Local dependencies
+const paths = require('../../paths')
+const productsClient = require('../../services/clients/products_client.js')
+const slugify = require('../../utils/nunjucks-filters/slugify')
+const removeDefinateArticles = require('../../utils/nunjucks-filters/remove-definate-articles')
+
+const makeNiceURL = string => {
+  return slugify(removeDefinateArticles(string))
+}
+
+module.exports = (req, res) => {
+  const pageData = lodash.get(req, 'session.pageData.createPaymentLink', {})
+  let updatedPageData = lodash.cloneDeep(pageData)
+
+  updatedPageData.productNamePath = makeNiceURL(req.body['payment-name-path'])
+  lodash.set(req, 'session.pageData.createPaymentLink', updatedPageData)
+
+  productsClient.product.getByProductPath(updatedPageData.serviceNamePath, updatedPageData.productNamePath)
+  .then(product => {
+    // if product exists we need to alert the user they must use a different URL
+    req.flash('genericError', `<ul class="error-summary-list"><li><a href="#payment-name-path">The website address is already taken</a></li></ul>`)
+    return res.redirect(paths.paymentLinks.webAddress)
+  })
+  .catch((err) => { // eslint-disable-line handle-callback-err
+    // if it errors then it means no product was found and that’s good
+    return res.redirect(paths.paymentLinks.amount)
+  })
+}

--- a/app/paths.js
+++ b/app/paths.js
@@ -133,6 +133,7 @@ module.exports = {
   paymentLinks: {
     start: '/create-payment-link',
     information: '/create-payment-link/information',
+    webAddress: '/create-payment-link/web-address',
     amount: '/create-payment-link/amount',
     review: '/create-payment-link/review',
     manage: '/create-payment-link/manage',

--- a/app/routes.js
+++ b/app/routes.js
@@ -245,6 +245,8 @@ module.exports.bind = function (app) {
   app.get(paymentLinks.start, permission('transactions:read'), getAccount, paymentLinksCtrl.getStart)
   app.get(paymentLinks.information, permission('transactions:read'), getAccount, paymentLinksCtrl.getInformation)
   app.post(paymentLinks.information, permission('transactions:read'), getAccount, paymentLinksCtrl.postInformation)
+  app.get(paymentLinks.webAddress, permission('transactions:read'), getAccount, paymentLinksCtrl.getWebAddress)
+  app.post(paymentLinks.webAddress, permission('transactions:read'), getAccount, paymentLinksCtrl.postWebAddress)
   app.get(paymentLinks.amount, permission('transactions:read'), getAccount, paymentLinksCtrl.getAmount)
   app.post(paymentLinks.amount, permission('transactions:read'), getAccount, paymentLinksCtrl.postAmount)
   app.get(paymentLinks.review, permission('transactions:read'), getAccount, paymentLinksCtrl.getReview)

--- a/app/services/clients/products_client.js
+++ b/app/services/clients/products_client.js
@@ -39,6 +39,8 @@ module.exports = {
  * @param {string=} options.description - The description of the product
  * @param {string=} options.type - The type of the product
  * @param {string=} options.returnUrl - Where to redirect to upon completion of a charge for this product
+ * @param {string=} options.serviceNamePath - first part of friendly url derived from the service name
+ * @param {string=} options.productNamePath - second part of friendly url derived from the payment link title
  * @returns {Promise<Product>}
  */
 function createProduct (options) {
@@ -54,7 +56,9 @@ function createProduct (options) {
       description: options.description,
       service_name: options.serviceName,
       type: options.type,
-      return_url: options.returnUrl
+      return_url: options.returnUrl,
+      service_name_path: options.serviceNamePath,
+      product_name_path: options.productNamePath
     },
     description: 'create a product for a service',
     service: SERVICE_NAME

--- a/app/services/clients/products_client.js
+++ b/app/services/clients/products_client.js
@@ -19,7 +19,8 @@ module.exports = {
     disable: disableProduct,
     updateServiceNameOfProductsByGatewayAccountId: updateServiceNameOfProductsByGatewayAccountId,
     getByProductExternalId: getProductByExternalId,
-    getByGatewayAccountId: getProductsByGatewayAccountId
+    getByGatewayAccountId: getProductsByGatewayAccountId,
+    getByProductPath: getProductByPath
   },
   payment: {
     create: createPayment,
@@ -161,4 +162,18 @@ function getPaymentsByProductExternalId (productExternalId) {
     description: `find a payments associated with a particular product`,
     service: SERVICE_NAME
   }).then(payments => payments.map(payment => new Payment(payment)))
+}
+
+/**
+ * @param {String} serviceNamePath: the service name path of the product you wish to retrieve
+ * @param {String} productNamePath: the product name path of the product you wish to retrieve
+ * @returns {Promise<Product>}
+ */
+function getProductByPath (serviceNamePath, productNamePath) {
+  return baseClient.get({
+    baseUrl,
+    url: `/products?serviceNamePath=${serviceNamePath}&productNamePath=${productNamePath}`,
+    description: `find a product by it's product path`,
+    service: SERVICE_NAME
+  }).then(product => new Product(product))
 }

--- a/app/utils/nunjucks-filters/index.js
+++ b/app/utils/nunjucks-filters/index.js
@@ -1,3 +1,4 @@
 module.exports.currency = require('./currency')
 module.exports.datetime = require('./datetime')
 module.exports.slugify = require('./slugify')
+module.exports.removeDefinateArticles = require('./remove-definate-articles')

--- a/app/utils/nunjucks-filters/index.js
+++ b/app/utils/nunjucks-filters/index.js
@@ -1,2 +1,3 @@
 module.exports.currency = require('./currency')
 module.exports.datetime = require('./datetime')
+module.exports.slugify = require('./slugify')

--- a/app/utils/nunjucks-filters/remove-definate-articles.js
+++ b/app/utils/nunjucks-filters/remove-definate-articles.js
@@ -1,0 +1,6 @@
+// removes indefinate articles (a/an)
+// removes definate articles (the)
+
+module.exports = string => {
+  return string.replace(/\ba\s|\ban\s|\bthe\s/gi, '')
+}

--- a/app/utils/nunjucks-filters/remove-definate-articles.test.js
+++ b/app/utils/nunjucks-filters/remove-definate-articles.test.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const {expect} = require('chai')
+const slugify = require('./remove-definate-articles')
+
+describe('When a string is passed through the Nunjucks removeDefinateArticles filter', () => {
+  it('it should remove indefinate articles (a/an)', () => {
+    expect(slugify('Pay for an article')).to.equal('Pay for article')
+  })
+  it('it should remove definate articles (the)', () => {
+    expect(slugify('The Private Office of Jon Heslop')).to.equal('Private Office of Jon Heslop')
+  })
+})

--- a/app/utils/nunjucks-filters/slugify.js
+++ b/app/utils/nunjucks-filters/slugify.js
@@ -1,0 +1,11 @@
+const slugify = require('slugify')
+
+module.exports = string => {
+  return slugify(
+    string,
+    {
+      remove: /[$*_+~.()'"!\-:@]/g,
+      lower: true
+    }
+  )
+}

--- a/app/utils/nunjucks-filters/slugify.js
+++ b/app/utils/nunjucks-filters/slugify.js
@@ -4,7 +4,7 @@ module.exports = string => {
   return slugify(
     string,
     {
-      remove: /[$*_+~.()'"!\-:@]/g,
+      remove: /[$*_+~.()'"!:@?%=]/g,
       lower: true
     }
   )

--- a/app/utils/nunjucks-filters/slugify.test.js
+++ b/app/utils/nunjucks-filters/slugify.test.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const {expect} = require('chai')
+const slugify = require('./slugify')
+
+describe('When a string is passed through the Nunjucks slugify filter', () => {
+  it('it should make it url friendly', () => {
+    expect(slugify('Someones’s string')).to.equal('someoness-string')
+  })
+})

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -21,6 +21,7 @@ Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type
 
   <form action="{{ nextPage }}" class="form" method="post" data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    <input type="hidden" name="service-name-path" value="{{currentServiceName | slugify }}">
     {% if change.length %}
       <input name="change" type="hidden" value="true"/>
     {% endif %}
@@ -45,7 +46,7 @@ Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type
         data-validate value="{{ paymentLinkTitle }}"
         {% if change !== 'payment-link-description' %}autofocus{% endif %} data-confirmation
         data-confirmation-title="The website address for this payment link will look like:"
-        data-confirmation-label="http://www.gov.uk/payments/{{currentServiceName | slugify }}/"
+        data-confirmation-label="{{friendlyURL}}/{{currentServiceName | slugify }}/"
         data-confirmation-filter="slugify"
       />
     </div>

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -37,15 +37,17 @@ Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type
         </span>
         {% endif %}
       </label>
-      <input class="form-control form-control-full" id="payment-link-title" name="payment-link-title" type="text" data-validate value="{{ paymentLinkTitle }}" {% if change !== 'payment-link-description' %}autofocus{% endif %}>
-<!--       <div class="panel panel-border-wide create-payment-link-link-replay">
-        <h3 class="heading-small">
-          The website address for this payment link will look like:
-        </h3>
-        <p class="grey">
-          You haven’t entered a title yet.
-        </p>
-      </div> -->
+      <input
+        class="form-control form-control-full"
+        id="payment-link-title"
+        name="payment-link-title"
+        type="text"
+        data-validate value="{{ paymentLinkTitle }}"
+        {% if change !== 'payment-link-description' %}autofocus{% endif %} data-confirmation
+        data-confirmation-title="The website address for this payment link will look like:"
+        data-confirmation-label="http://www.gov.uk/payments/{{currentServiceName | slugify }}/"
+        data-confirmation-filter="slugify"
+      />
     </div>
     <div class="form-group">
       <label class="form-label-bold" for="payment-link-description">

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -21,7 +21,7 @@ Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type
 
   <form action="{{ nextPage }}" class="form" method="post" data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-    <input type="hidden" name="service-name-path" value="{{currentServiceName | slugify }}">
+    <input type="hidden" name="service-name-path" value="{{currentServiceName}}">
     {% if change.length %}
       <input name="change" type="hidden" value="true"/>
     {% endif %}
@@ -46,7 +46,7 @@ Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type
         data-validate value="{{ paymentLinkTitle }}"
         {% if change !== 'payment-link-description' %}autofocus{% endif %} data-confirmation
         data-confirmation-title="The website address for this payment link will look like:"
-        data-confirmation-label="{{friendlyURL}}/{{currentServiceName | slugify }}/"
+        data-confirmation-label="{{friendlyURL}}/{{currentServiceName | removeDefinateArticles | slugify}}/"
         data-confirmation-filter="slugify"
       />
     </div>

--- a/app/views/payment-links/manage.njk
+++ b/app/views/payment-links/manage.njk
@@ -33,8 +33,9 @@ Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type
     <li class="payment-links-list--item">
       <h2 class="heading-small payment-links-list--item__title">{{ product.name }}</h2>
       {% if product.links.friendly %}
-        <a class="payment-links-list--item__link" href="{{ product.links.friendly.href }}">{{ product.links.friendly.href }}</a>
-    {% else %}
+      {# Looks friendly but href is not friendly until we have it all set up with GOV.UK #}
+        <a class="payment-links-list--item__link" href="{{ product.links.pay.href }}">{{ product.links.friendly.href }}</a>
+      {% else %}
         <a class="payment-links-list--item__link" href="{{ product.links.pay.href }}">{{ product.links.pay.href }}</a>
       {% endif %}
        <div class="payment-links-list--item__actions">
@@ -51,10 +52,12 @@ Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type
             </div>
         </div>
       </div>
+      {# There’s no point in showing this until we have drafts
       <aside class="payment-links-list--item__status payment-links-list--item__status--live">
         Live
       </aside>
     </li>
+    #}
     {% endfor %}
   </ul>
   {% endif %}

--- a/app/views/payment-links/manage.njk
+++ b/app/views/payment-links/manage.njk
@@ -32,7 +32,11 @@ Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type
     {% for product in products %}
     <li class="payment-links-list--item">
       <h2 class="heading-small payment-links-list--item__title">{{ product.name }}</h2>
-      <a class="payment-links-list--item__link" href="{{ product.links.pay.href }}">{{ product.links.pay.href }}</a>
+      {% if product.links.friendly %}
+        <a class="payment-links-list--item__link" href="{{ product.links.friendly.href }}">{{ product.links.friendly.href }}</a>
+    {% else %}
+        <a class="payment-links-list--item__link" href="{{ product.links.pay.href }}">{{ product.links.pay.href }}</a>
+      {% endif %}
        <div class="payment-links-list--item__actions">
         <a class="payment-links-list--item__actions--toggle target-to-show--toggle" href="#delete-{{ product.externalId }}">Delete</a>
         <div class="target-to-show" id="delete-{{ product.externalId }}">

--- a/app/views/payment-links/review.njk
+++ b/app/views/payment-links/review.njk
@@ -40,7 +40,7 @@ Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type
         </dt>
         <dd class="cya-answer" id="create-payment-link-description">
           {% if paymentLinkDescription %}
-            {{ paymentLinkDescription }}
+            {{ paymentLinkDescription | striptags(true) | escape | nl2br }}
           {% else %}
             <span class="grey">None given</span>
           {% endif %}

--- a/app/views/payment-links/web-address.njk
+++ b/app/views/payment-links/web-address.njk
@@ -1,0 +1,56 @@
+{% extends "../layout.njk" %}
+
+{% block page_title %}
+Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+{% endblock %}
+
+{% block side_navigation %}
+<aside class="column-one-third pad-bottom">
+  <nav role="navigation" class="navigation settings-navigation">
+    <ul class="list">
+       <li class="active"><a href="{{ returnToStart }}">Create a payment link</a></li>
+      <li><a href="{{ manage }}">Manage payment&nbsp;links</a></li>
+    </ul>
+  </nav>
+</aside>
+{% endblock %}
+
+{% block mainContent %}
+<section class="column-two-thirds">
+  <h1 class="page-title">The website address is already taken</h1>
+
+  <form action="{{ nextPage }}" class="form" method="post" data-validate>
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    <div class="form-group{% if flash.genericError %} error{% endif %}">
+      <label class="form-label-bold" for="payment-link-title">
+        Please change the website address
+        <span class="form-hint">
+          This will not change the title
+        </span>
+        <span class="create-payment-link-url">
+          {{friendlyURL}}/{{currentServiceName | removeDefinateArticles | slugify}}/
+        </span>
+        {% if flash.genericError %}
+        <span class="error-message">
+          The website address is already taken
+        </span>
+        {% endif %}
+      </label>
+      <input
+        class="form-control"
+        id="payment-name-path"
+        name="payment-name-path"
+        type="text"
+        value="{{ productNamePath }}"
+        autofocus
+        data-slugify
+      />
+      <p class="create-payment-link-read-more"><a href="https://www.gov.uk/guidance/content-design/url-standards-for-gov-uk">Get guidance on writing a web address (URL)</a></p>
+    </div>
+    <div class="form-group">
+      <button class="button" type="submit">Continue</button>
+    </div>
+    <p><a class="cancel" href="{{ returnToStart }}">Cancel</a></p>
+  </form>
+</section>
+{% endblock %}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -764,6 +764,665 @@
       "from": "fs.realpath@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
     },
+    "fsevents": {
+      "version": "1.1.3",
+      "from": "fsevents@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "optional": true,
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "from": "abbrev@1.1.0",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "from": "ajv@4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "from": "ansi-regex@2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "from": "aproba@1.1.1",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "from": "are-we-there-yet@1.1.4",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "optional": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "from": "asn1@0.2.3",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "from": "assert-plus@0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "from": "asynckit@0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "from": "aws-sign2@0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "from": "aws4@1.6.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "from": "balanced-match@0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "from": "bcrypt-pbkdf@1.0.1",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "optional": true
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "from": "block-stream@0.0.9",
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+        },
+        "boom": {
+          "version": "2.10.1",
+          "from": "boom@2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "from": "brace-expansion@1.1.7",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "from": "buffer-shims@1.0.0",
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "from": "caseless@0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "from": "co@4.6.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "from": "code-point-at@1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "from": "combined-stream@1.0.5",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "from": "concat-map@0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "from": "console-control-strings@1.1.0",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "from": "core-util-is@1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "from": "cryptiles@2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "from": "dashdash@1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "from": "debug@2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "optional": true
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "from": "deep-extend@0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "from": "delayed-stream@1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "from": "delegates@1.0.0",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "from": "detect-libc@^1.0.2",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "from": "ecc-jsbn@0.1.1",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "optional": true
+        },
+        "extend": {
+          "version": "3.0.1",
+          "from": "extend@3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "from": "extsprintf@1.0.2",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "from": "forever-agent@0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "from": "form-data@2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "optional": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "from": "fs.realpath@1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "from": "fstream@1.0.11",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "from": "fstream-ignore@1.0.5",
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "from": "gauge@2.7.4",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "optional": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "from": "getpass@0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "from": "glob@7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "from": "graceful-fs@4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "from": "har-schema@1.0.5",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "from": "har-validator@4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "optional": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "from": "has-unicode@2.0.1",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "from": "hawk@3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "from": "hoek@2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "from": "http-signature@1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "optional": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "from": "inflight@1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "from": "inherits@2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+        },
+        "ini": {
+          "version": "1.3.4",
+          "from": "ini@1.3.4",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "from": "is-fullwidth-code-point@1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "from": "is-typedarray@1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "from": "isstream@0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "from": "jodid25519@1.0.2",
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "optional": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "from": "jsbn@0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "from": "json-schema@0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "from": "json-stable-stringify@1.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "optional": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "from": "json-stringify-safe@5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "from": "jsonify@0.0.0",
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "from": "jsprim@1.4.0",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "from": "mime-db@1.27.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "from": "mime-types@2.1.15",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "from": "minimatch@3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+        },
+        "ms": {
+          "version": "2.0.0",
+          "from": "ms@2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "from": "node-pre-gyp@^0.6.39",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+          "optional": true
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "from": "nopt@4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "optional": true
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "from": "npmlog@4.1.0",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+          "optional": true
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "from": "number-is-nan@1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "from": "oauth-sign@0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "object-assign@4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "from": "once@1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "from": "os-homedir@1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "from": "os-tmpdir@1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "from": "osenv@0.1.4",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "optional": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "from": "path-is-absolute@1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "from": "performance-now@0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "from": "process-nextick-args@1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "from": "punycode@1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "from": "qs@6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "from": "rc@1.2.1",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "optional": true,
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "from": "readable-stream@2.2.9",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
+        },
+        "request": {
+          "version": "2.81.0",
+          "from": "request@2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "optional": true
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "from": "rimraf@2.6.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "from": "safe-buffer@5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+        },
+        "semver": {
+          "version": "5.3.0",
+          "from": "semver@5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "from": "set-blocking@2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "from": "signal-exit@3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "from": "sntp@1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "from": "sshpk@1.13.0",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "from": "string_decoder@1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "from": "string-width@1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "from": "stringstream@0.0.5",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "from": "strip-ansi@3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "from": "strip-json-comments@2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "from": "tar@2.2.1",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "from": "tar-pack@3.4.0",
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+          "optional": true
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "from": "tough-cookie@2.3.2",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "optional": true
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "from": "tunnel-agent@0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "optional": true
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "from": "tweetnacl@0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "from": "uid-number@0.0.6",
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "from": "util-deprecate@1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "from": "uuid@3.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "from": "verror@1.3.6",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "from": "wide-align@1.1.2",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "optional": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "from": "wrappy@1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+        }
+      }
+    },
     "getpass": {
       "version": "0.1.7",
       "from": "getpass@>=0.1.1 <0.2.0",
@@ -1608,6 +2267,11 @@
       "version": "1.0.0",
       "from": "shush@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/shush/-/shush-1.0.0.tgz"
+    },
+    "slugify": {
+      "version": "1.2.9",
+      "from": "slugify@latest",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.2.9.tgz"
     },
     "snake-case": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "requestretry": "^1.12.0",
     "rfc822-validate": "^1.0.0",
     "serve-favicon": "2.4.5",
+    "slugify": "^1.2.9",
     "staticify": "0.0.9",
     "throng": "4.0.x",
     "tunnel": "0.0.5",

--- a/test/fixtures/product_fixtures.js
+++ b/test/fixtures/product_fixtures.js
@@ -51,6 +51,8 @@ module.exports = {
     if (opts.description) data.description = opts.description
     if (opts.returnUrl) data.return_url = opts.returnUrl
     if (opts.price) data.price = opts.price
+    if (opts.service_name_path) data.service_name_path = opts.service_name_path
+    if (opts.product_name_path) data.product_name_path = opts.product_name_path
     return {
       getPactified: () => {
         return pactProducts.pactify(data)
@@ -105,6 +107,8 @@ module.exports = {
     if (opts.description) data.description = opts.description
     if (opts.return_url) data.return_url = opts.return_url
     if (opts.price) data.price = opts.price
+    if (opts.service_name_path) data.service_name_path = opts.service_name_path
+    if (opts.product_name_path) data.product_name_path = opts.product_name_path
     if (!data._links) {
       data._links = [{
         href: `http://products.url/v1/api/products/${data.external_id}`,
@@ -115,6 +119,13 @@ module.exports = {
         rel: 'pay',
         method: 'GET'
       }]
+      if (opts.service_name_path && opts.product_name_path) {
+        data._links.push({
+          href: `http://products-ui.url/redirect/${opts.service_name_path}/${opts.product_name_path}`,
+          rel: 'friendly',
+          method: 'GET'
+        })
+      }
     }
 
     return {

--- a/test/fixtures/product_fixtures.js
+++ b/test/fixtures/product_fixtures.js
@@ -136,5 +136,20 @@ module.exports = {
         return data
       }
     }
+  },
+
+  validGetProductByPath: (opts = {}) => {
+    const data = {
+      serviceNamePath: opts.serviceNamePath || 'service-name',
+      productNamePath: opts.productNamePath || 'product-name'
+    }
+    return {
+      getPactified: () => {
+        return pactProducts.pactify(data)
+      },
+      getPlain: () => {
+        return data
+      }
+    }
   }
 }

--- a/test/unit/clients/product_client/product/get_by_product_path_test.js
+++ b/test/unit/clients/product_client/product/get_by_product_path_test.js
@@ -1,0 +1,136 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+const {expect} = require('chai')
+const proxyquire = require('proxyquire')
+
+// Custom dependencies
+const pactProxy = require('../../../../test_helpers/pact_proxy')
+const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const productFixtures = require('../../../../fixtures/product_fixtures')
+
+// Constants
+const PRODUCT_RESOURCE = '/v1/api/products'
+const mockPort = Math.floor(Math.random() * 65535)
+const mockServer = pactProxy.create('localhost', mockPort)
+let productsMock, response, result, productExternalId, serviceNamePath, productNamePath
+
+function getProductsClient (baseUrl = `http://localhost:${mockPort}`) {
+  return proxyquire('../../../../../app/services/clients/products_client', {
+    '../../../config': {
+      PRODUCTS_URL: baseUrl
+    }
+  })
+}
+
+describe('products client - find a product by it\'s product path', function () {
+  /**
+   * Start the server and set up Pact
+   */
+  before(function (done) {
+    this.timeout(5000)
+    mockServer.start().then(function () {
+      productsMock = Pact({consumer: 'Selfservice-find-product', provider: 'products', port: mockPort})
+      done()
+    })
+  })
+
+  /**
+   * Remove the server and publish pacts to broker
+   */
+  after(done => {
+    mockServer.delete()
+      .then(() => pactProxy.removeAll())
+      .then(() => done())
+  })
+
+  describe('when a product is successfully found', () => {
+    before(done => {
+      const productsClient = getProductsClient()
+      productExternalId = 'existing-id'
+      serviceNamePath = 'service-name-path'
+      productNamePath = 'product-name-path'
+      response = productFixtures.validCreateProductResponse({
+        external_id: productExternalId,
+        price: 1000,
+        name: 'A Product Name',
+        description: 'About this product',
+        return_url: 'https://example.gov.uk',
+        service_name_path: serviceNamePath,
+        product_name_path: productNamePath
+      })
+      productsMock.addInteraction(
+        new PactInteractionBuilder(`${PRODUCT_RESOURCE}`)
+          .withQuery('serviceNamePath', serviceNamePath)
+          .withQuery('productNamePath', productNamePath)
+          .withUponReceiving('a valid get product request')
+          .withMethod('GET')
+          .withStatusCode(200)
+          .withResponseBody(response.getPactified())
+          .build()
+      )
+        .then(() => productsClient.product.getByProductPath(serviceNamePath, productNamePath))
+        .then(res => {
+          result = res
+          done()
+        })
+        .catch(e => done(e))
+    })
+
+    after((done) => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should find an existing product', () => {
+      const plainResponse = response.getPlain()
+      expect(result.externalId).to.equal(productExternalId)
+      expect(result.name).to.exist.and.equal(plainResponse.name)
+      expect(result.description).to.exist.and.equal(plainResponse.description)
+      expect(result.price).to.exist.and.equal(plainResponse.price)
+      expect(result.returnUrl).to.exist.and.equal(plainResponse.return_url)
+      expect(result).to.have.property('links')
+      expect(Object.keys(result.links).length).to.equal(3)
+      expect(result.links).to.have.property('self')
+      expect(result.links.self).to.have.property('method').to.equal(plainResponse._links.find(link => link.rel === 'self').method)
+      expect(result.links.self).to.have.property('href').to.equal(plainResponse._links.find(link => link.rel === 'self').href)
+      expect(result.links).to.have.property('pay')
+      expect(result.links.pay).to.have.property('method').to.equal(plainResponse._links.find(link => link.rel === 'pay').method)
+      expect(result.links.pay).to.have.property('href').to.equal(plainResponse._links.find(link => link.rel === 'pay').href)
+      expect(result.links).to.have.property('friendly')
+      expect(result.links.friendly).to.have.property('method').to.equal(plainResponse._links.find(link => link.rel === 'friendly').method)
+      expect(result.links.friendly).to.have.property('href').to.equal(plainResponse._links.find(link => link.rel === 'friendly').href)
+    })
+  })
+
+  describe('when a product is not found', () => {
+    before(done => {
+      const productsClient = getProductsClient()
+      serviceNamePath = 'non-existing-service-name-path'
+      productNamePath = 'non-existing-product-name-path'
+      productsMock.addInteraction(
+        new PactInteractionBuilder(`${PRODUCT_RESOURCE}`)
+          .withQuery('serviceNamePath', serviceNamePath)
+          .withQuery('productNamePath', productNamePath)
+          .withUponReceiving('a valid find product request with non existing product path')
+          .withMethod('GET')
+          .withStatusCode(404)
+          .build()
+      )
+        .then(() => productsClient.product.getByProductPath(serviceNamePath, productNamePath), done)
+        .then(() => done(new Error('Promise unexpectedly resolved')))
+        .catch((err) => {
+          result = err
+          done()
+        })
+    })
+
+    after((done) => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should reject with error: 404 not found', () => {
+      expect(result.errorCode).to.equal(404)
+    })
+  })
+})

--- a/test/unit/controller/payment-links/get-web-address-controller.test.js
+++ b/test/unit/controller/payment-links/get-web-address-controller.test.js
@@ -1,0 +1,62 @@
+'use strict'
+
+// NPM dependencies
+const supertest = require('supertest')
+const {expect} = require('chai')
+const cheerio = require('cheerio')
+const nock = require('nock')
+const lodash = require('lodash')
+
+// Local dependencies
+const {getApp} = require('../../../../server')
+const {getMockSession, createAppWithSession, getUser} = require('../../../test_helpers/mock_session')
+const paths = require('../../../../app/paths')
+const {CONNECTOR_URL} = process.env
+const GATEWAY_ACCOUNT_ID = '929'
+
+describe('Create payment link web address controller', () => {
+  describe('if landing here for the first time', () => {
+    let result, $, session
+    before(done => {
+      const user = getUser({
+        gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+        permissions: [{name: 'transactions:read'}]
+      })
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
+        payment_provider: 'sandbox'
+      })
+      session = getMockSession(user)
+      lodash.set(session, 'pageData.createPaymentLink', {
+        paymentLinkTitle: 'Pay for an offline service',
+        paymentLinkDescription: 'Hello world',
+        productNamePath: 'pay-for-offline-service'
+      })
+      supertest(createAppWithSession(getApp(), session))
+        .get(paths.paymentLinks.webAddress)
+        .end((err, res) => {
+          result = res
+          $ = cheerio.load(res.text)
+          done(err)
+        })
+    })
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should return a statusCode of 200', () => {
+      expect(result.statusCode).to.equal(200)
+    })
+
+    it(`should include a cancel link linking to the Create payment link index`, () => {
+      expect($('.cancel').attr('href')).to.equal(paths.paymentLinks.start)
+    })
+
+    it(`should have itself as the form action`, () => {
+      expect($('form').attr('action')).to.equal(paths.paymentLinks.webAddress)
+    })
+
+    it(`should an input containing the product path`, () =>
+      expect($(`input[type="text"]`).val()).to.equal(session.pageData.createPaymentLink.productNamePath)
+    )
+  })
+})

--- a/test/unit/controller/payment-links/get_disable_controller_test.js
+++ b/test/unit/controller/payment-links/get_disable_controller_test.js
@@ -50,7 +50,7 @@ describe('Manage payment links - disable controller', () => {
     it('should add a relevant generic message to the session \'flash\'', () => {
       expect(session.flash).to.have.property('generic')
       expect(session.flash.generic.length).to.equal(1)
-      expect(session.flash.generic[0]).to.equal('<h2>The payment link was successfully deleted</h2><p>It will no longer be accessible</p>')
+      expect(session.flash.generic[0]).to.equal('<h2>The payment link was successfully deleted</h2>')
     })
   })
 

--- a/test/unit/controller/payment-links/post-information-controller.test.js
+++ b/test/unit/controller/payment-links/post-information-controller.test.js
@@ -4,19 +4,27 @@
 const supertest = require('supertest')
 const {expect} = require('chai')
 const lodash = require('lodash')
+const nock = require('nock')
 const csrf = require('csrf')
 
 // Local dependencies
 const {getApp} = require('../../../../server')
 const {getMockSession, createAppWithSession, getUser} = require('../../../test_helpers/mock_session')
 const paths = require('../../../../app/paths')
+const {validCreateProductResponse} = require('../../../fixtures/product_fixtures')
 
+const {PRODUCTS_URL} = process.env
+let product
 const GATEWAY_ACCOUNT_ID = '929'
+const SERVICE_NAME = 'Pay for an offline service'
+const SERVICE_NAME_SLUGIFIED = 'pay-for-offline-service'
 const PAYMENT_TITLE = 'Payment title'
+const PAYMENT_TITLE_SLUGIFIED = 'payment-title'
 const PAYMENT_DESCRIPTION = 'Payment description'
 const VALID_PAYLOAD = {
   'csrfToken': csrf().create('123'),
   'payment-link-title': PAYMENT_TITLE,
+  'service-name-path': SERVICE_NAME,
   'payment-link-description': PAYMENT_DESCRIPTION
 }
 const VALID_USER = getUser({
@@ -30,31 +38,90 @@ describe('Create payment link information controller', () => {
     before('Arrange', () => {
       session = getMockSession(VALID_USER)
       app = createAppWithSession(getApp(), session)
-    })
-    before('Act', done => {
-      supertest(app)
-        .post(paths.paymentLinks.information)
-        .send(VALID_PAYLOAD)
-        .end((err, res) => {
-          result = res
-          done(err)
-        })
+      product = validCreateProductResponse({
+        type: 'ADHOC',
+        service_name_path: SERVICE_NAME_SLUGIFIED,
+        product_name_path: PAYMENT_TITLE_SLUGIFIED
+      }).getPlain()
     })
 
-    it('should have paymentLinkTitle and paymentLinkDescription stored in the session', () => {
-      const sessionPageData = lodash.get(session, 'pageData.createPaymentLink', {})
-      expect(sessionPageData).to.have.property('paymentLinkTitle').to.equal(PAYMENT_TITLE)
-      expect(sessionPageData).to.have.property('paymentLinkDescription').to.equal(PAYMENT_DESCRIPTION)
+    describe(`and URL isnt taken already`, () => {
+      before('Arrange', () => {
+        nock(PRODUCTS_URL)
+          .get(`/v1/api/products`)
+          .query({'serviceNamePath': product.service_name_path, 'productNamePath': product.product_name_path})
+          .reply(404, product)
+      })
+      before('Act', done => {
+        supertest(app)
+          .post(paths.paymentLinks.information)
+          .send(VALID_PAYLOAD)
+          .end((err, res) => {
+            result = res
+            done(err)
+          })
+      })
+
+      it('should have paymentLinkTitle and paymentLinkDescription stored in the session', () => {
+        const sessionPageData = lodash.get(session, 'pageData.createPaymentLink', {})
+        expect(sessionPageData).to.have.property('paymentLinkTitle').to.equal(PAYMENT_TITLE)
+        expect(sessionPageData).to.have.property('paymentLinkDescription').to.equal(PAYMENT_DESCRIPTION)
+      })
+
+      it('should have serviceNamePath and productNamePath stored in the session', () => {
+        const sessionPageData = lodash.get(session, 'pageData.createPaymentLink', {})
+        expect(sessionPageData).to.have.property('serviceNamePath').to.equal(SERVICE_NAME_SLUGIFIED)
+        expect(sessionPageData).to.have.property('productNamePath').to.equal(PAYMENT_TITLE_SLUGIFIED)
+      })
+
+      it('should redirect with status code 302', () => {
+        expect(result.statusCode).to.equal(302)
+      })
+
+      it('should redirect to the amount page', () => {
+        expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.amount)
+      })
     })
 
-    it('should redirect with status code 302', () => {
-      expect(result.statusCode).to.equal(302)
-    })
+    describe(`and URL is taken already`, () => {
+      before('Arrange', () => {
+        nock(PRODUCTS_URL)
+          .get(`/v1/api/products`)
+          .query({'serviceNamePath': product.service_name_path, 'productNamePath': product.product_name_path})
+          .reply(200, product)
+      })
+      before('Act', done => {
+        supertest(app)
+          .post(paths.paymentLinks.information)
+          .send(VALID_PAYLOAD)
+          .end((err, res) => {
+            result = res
+            done(err)
+          })
+      })
 
-    it('should redirect to the amount page', () => {
-      expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.amount)
+      it('should have paymentLinkTitle and paymentLinkDescription stored in the session', () => {
+        const sessionPageData = lodash.get(session, 'pageData.createPaymentLink', {})
+        expect(sessionPageData).to.have.property('paymentLinkTitle').to.equal(PAYMENT_TITLE)
+        expect(sessionPageData).to.have.property('paymentLinkDescription').to.equal(PAYMENT_DESCRIPTION)
+      })
+
+      it('should have serviceNamePath and productNamePath stored in the session', () => {
+        const sessionPageData = lodash.get(session, 'pageData.createPaymentLink', {})
+        expect(sessionPageData).to.have.property('serviceNamePath').to.equal(SERVICE_NAME_SLUGIFIED)
+        expect(sessionPageData).to.have.property('productNamePath').to.equal(PAYMENT_TITLE_SLUGIFIED)
+      })
+
+      it('should redirect with status code 302', () => {
+        expect(result.statusCode).to.equal(302)
+      })
+
+      it('should redirect to the web address page', () => {
+        expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.webAddress)
+      })
     })
   })
+
   describe(`when no paymentLinkDescription is submitted`, () => {
     let result, session, app
     before('Arrange', () => {
@@ -79,6 +146,12 @@ describe('Create payment link information controller', () => {
     it('should have no paymentLinkDescription stored in the session', () => {
       const sessionPageData = lodash.get(session, 'pageData.createPaymentLink', {})
       expect(sessionPageData).to.have.property('paymentLinkDescription').to.equal('')
+    })
+
+    it('should have serviceNamePath and productNamePath stored in the session', () => {
+      const sessionPageData = lodash.get(session, 'pageData.createPaymentLink', {})
+      expect(sessionPageData).to.have.property('serviceNamePath').to.equal(SERVICE_NAME_SLUGIFIED)
+      expect(sessionPageData).to.have.property('productNamePath').to.equal(PAYMENT_TITLE_SLUGIFIED)
     })
 
     it('should redirect with status code 302', () => {

--- a/test/unit/controller/payment-links/post-web-address-controller.test.js
+++ b/test/unit/controller/payment-links/post-web-address-controller.test.js
@@ -1,0 +1,124 @@
+'use strict'
+
+// NPM dependencies
+const supertest = require('supertest')
+const {expect} = require('chai')
+const lodash = require('lodash')
+const nock = require('nock')
+const csrf = require('csrf')
+
+// Local dependencies
+const {getApp} = require('../../../../server')
+const {getMockSession, createAppWithSession, getUser} = require('../../../test_helpers/mock_session')
+const paths = require('../../../../app/paths')
+const {validCreateProductResponse} = require('../../../fixtures/product_fixtures')
+
+const {PRODUCTS_URL} = process.env
+let product
+const GATEWAY_ACCOUNT_ID = '929'
+const VALID_USER = getUser({
+  gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+  permissions: [{name: 'transactions:read'}]
+})
+const SERVICE_NAME_SLUGIFIED = 'pay-for-offline-service'
+const PAYMENT_TITLE_SLUGIFIED = 'payment-title'
+const VALID_PAYLOAD = {
+  'csrfToken': csrf().create('123'),
+  'payment-name-path': PAYMENT_TITLE_SLUGIFIED
+}
+
+describe('Create payment link web address post controller', () => {
+  describe(`when an available product path name is submitted`, () => {
+    let result, session, app
+    before('Arrange', () => {
+      session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.createPaymentLink', {
+        paymentLinkTitle: 'Payment title',
+        paymentLinkDescription: 'Hello world',
+        serviceNamePath: SERVICE_NAME_SLUGIFIED,
+        productNamePath: PAYMENT_TITLE_SLUGIFIED
+      })
+      app = createAppWithSession(getApp(), session)
+      product = validCreateProductResponse({
+        type: 'ADHOC',
+        service_name_path: SERVICE_NAME_SLUGIFIED,
+        product_name_path: PAYMENT_TITLE_SLUGIFIED
+      }).getPlain()
+      nock(PRODUCTS_URL)
+        .get(`/v1/api/products`)
+        .query({'serviceNamePath': product.service_name_path, 'productNamePath': product.product_name_path})
+        .reply(404, product)
+    })
+    before('Act', done => {
+      supertest(app)
+        .post(paths.paymentLinks.webAddress)
+        .send(VALID_PAYLOAD)
+        .end((err, res) => {
+          result = res
+          done(err)
+        })
+    })
+
+    it('should have productNamePath stored in the session', () => {
+      const sessionPageData = lodash.get(session, 'pageData.createPaymentLink', {})
+      expect(sessionPageData).to.have.property('productNamePath').to.equal(PAYMENT_TITLE_SLUGIFIED)
+    })
+
+    it('should redirect with status code 302', () => {
+      expect(result.statusCode).to.equal(302)
+    })
+
+    it('should redirect to the amount page', () => {
+      expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.amount)
+    })
+  })
+
+  describe(`when an unavailable product path name is submitted`, () => {
+    let result, session, app
+    before('Arrange', () => {
+      session = getMockSession(VALID_USER)
+      app = createAppWithSession(getApp(), session)
+      lodash.set(session, 'pageData.createPaymentLink', {
+        paymentLinkTitle: 'Payment title',
+        paymentLinkDescription: 'Hello world',
+        serviceNamePath: SERVICE_NAME_SLUGIFIED,
+        productNamePath: PAYMENT_TITLE_SLUGIFIED
+      })
+      product = validCreateProductResponse({
+        type: 'ADHOC',
+        service_name_path: SERVICE_NAME_SLUGIFIED,
+        product_name_path: PAYMENT_TITLE_SLUGIFIED
+      }).getPlain()
+      nock(PRODUCTS_URL)
+        .get(`/v1/api/products`)
+        .query({'serviceNamePath': product.service_name_path, 'productNamePath': product.product_name_path})
+        .reply(200, product)
+    })
+    before('Act', done => {
+      supertest(app)
+        .post(paths.paymentLinks.webAddress)
+        .send(VALID_PAYLOAD)
+        .end((err, res) => {
+          result = res
+          done(err)
+        })
+    })
+
+    it('should have productNamePath stored in the session', () => {
+      const sessionPageData = lodash.get(session, 'pageData.createPaymentLink', {})
+      expect(sessionPageData).to.have.property('productNamePath').to.equal(PAYMENT_TITLE_SLUGIFIED)
+    })
+
+    it('should redirect with status code 302', () => {
+      expect(result.statusCode).to.equal(302)
+    })
+
+    it('should redirect to the web address page', () => {
+      expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.webAddress)
+    })
+
+    it('should expect session to contain error message', () => {
+      expect(session.flash.genericError).to.have.property('length').to.equal(1)
+    })
+  })
+})


### PR DESCRIPTION
Only merge after EndToEnd: https://github.com/alphagov/pay-endtoend/pull/586

## 688433f - adding slugify package to format urls
This is a tiny package with no other dependencies that makes it easy for
us to consistently format urls client and server side.

## c36bdc3 - Adding url playback confirmation 
- slugify is accessible as a nunjucks filter for ease of use
- extending input confirm to be able to use slugify
- also removing indefinite article (a/an) from the url to keep the url
short.
- remove the definite article (the) too

## f6c4540 - Passed friendly URL to link creation 
- Added friendly URL to the session
- extended products client to include friendly URL bits
- prefer display of friendly URL on manage page

### NOTE: 
This also contains a backward compatible fix to make the JS work in PhantomJS