### PR TITLE
PP-2984 Add `hasDirectDebitGatewayAccount` dynamic property to `req.service`

### DIFF
--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -17,5 +17,8 @@ module.exports = function (req, res, next) {
     return renderErrorView(req, res, 'You do not have the rights to access this service.')
   }
 
+  req.service.hasDirectDebitGatewayAccount =
+    (req.service.gatewayAccountIds || []).some((gatewayAccountId) => gatewayAccountId.startsWith('DIRECT_DEBIT:'))
+
   next()
 }

--- a/test/fixtures/user_fixtures.js
+++ b/test/fixtures/user_fixtures.js
@@ -50,6 +50,8 @@ function randomMerchantDetails () {
 
 module.exports = {
 
+  randomAccountId,
+
   validMinimalUser: () => {
     let newExternalId = random.randomUuid()
     let newUsername = randomUsername()

--- a/test/unit/middleware/resolve_service_test.js
+++ b/test/unit/middleware/resolve_service_test.js
@@ -6,7 +6,7 @@ const userFixtures = require('../../fixtures/user_fixtures')
 describe('resolve service', function () {
   it('resolve service from path param', function () {
     const res = {render: sinon.spy()}
-    let nextSpy = sinon.spy()
+    const nextSpy = sinon.spy()
 
     const user = userFixtures.validUser().getAsObject()
     const req = {user: user, params: {externalServiceId: user.serviceRoles[0].service.externalId}}
@@ -14,6 +14,34 @@ describe('resolve service', function () {
     resolveService(req, res, nextSpy)
 
     expect(req.service).to.deep.equal(user.serviceRoles[0].service)
+    expect(nextSpy.called).to.equal(true)
+  })
+
+  it('service.hasDirectDebitGatewayAccount is false when we do not have Direct Debit gateway accounts', function () {
+    const res = {render: sinon.spy()}
+    const nextSpy = sinon.spy()
+
+    const user = userFixtures.validUser().getAsObject()
+    const req = {user: user, params: {externalServiceId: user.serviceRoles[0].service.externalId}}
+
+    resolveService(req, res, nextSpy)
+
+    expect(req.service.hasDirectDebitGatewayAccount).to.be.equal(false)
+    expect(nextSpy.called).to.equal(true)
+  })
+
+  it('service.hasDirectDebitGatewayAccount is true when we have Direct Debit gateway accounts', function () {
+    const res = {render: sinon.spy()}
+    const nextSpy = sinon.spy()
+
+    const user = userFixtures.validUser({
+      gateway_account_ids: [userFixtures.randomAccountId(), 'DIRECT_DEBIT:randomidhere']
+    }).getAsObject()
+    const req = {user: user, params: {externalServiceId: user.serviceRoles[0].service.externalId}}
+
+    resolveService(req, res, nextSpy)
+
+    expect(req.service.hasDirectDebitGatewayAccount).to.be.equal(true)
     expect(nextSpy.called).to.equal(true)
   })
 })


### PR DESCRIPTION
## WHAT

Modified `resolve_service` middleware to add `hasDirectDebitGatewayAccount` property which calculates if we the current service has Direct Debit gateway account or not
