### PR TITLE
PP-3438 Use new smoke tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,6 +100,14 @@ pipeline {
         }
       }
     }
+    stage('Deploy') {
+      when {
+        branch 'master'
+      }
+      steps {
+        deployEcs("selfservice", "test", null, false, false)
+      }
+    }
     stage('Smoke Tests') {
       failFast true
       parallel {


### PR DESCRIPTION
Deployment step was removed when new smoke, tag and trigger steps were
added. Changed the deployEcs arguments not to run tests and tag.

solo @belindac


