### PR TITLE
WIP PP-3482 Fix CSV download in firefox windows

### DIFF
--- a/app/controllers/transactions/transaction_download_controller.js
+++ b/app/controllers/transactions/transaction_download_controller.js
@@ -15,14 +15,14 @@ const NEW_CHARGE_STATUS_FEATURE_HEADER = 'NEW_CHARGE_STATUS_ENABLED'
 module.exports = (req, res) => {
   const accountId = auth.getCurrentGatewayAccountId(req)
   const filters = req.query
-  const name = `GOVUK Pay ${date.dateToDefaultFormat(new Date())}.csv`
+  const name = `GOVUK_Pay_${date.dateToDefaultFormat(new Date()).replace(' ', '_')}.csv`
   const correlationId = req.headers[CORRELATION_HEADER]
   const newChargeStatusEnabled = req.user.hasFeature(NEW_CHARGE_STATUS_FEATURE_HEADER)
   transactionService.searchAll(accountId, filters, correlationId)
     .then(json => jsonToCsv(json.results, newChargeStatusEnabled))
     .then(csv => {
       logger.debug('Sending csv attachment download -', {'filename': name})
-      res.setHeader('Content-disposition', 'attachment; filename=' + name)
+      res.setHeader('Content-disposition', 'attachment; filename="' + name + '"')
       res.setHeader('Content-Type', 'text/csv')
       res.send(csv)
     })

--- a/test/integration/old_transaction_download_ft_tests.js
+++ b/test/integration/old_transaction_download_ft_tests.js
@@ -77,7 +77,7 @@ describe('Old Transaction download endpoints', function () {
       downloadTransactionList()
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK_Pay_\d\d\d\d-\d\d-\d\d_\d\d:\d\d:\d\d.csv"/)
         .expect(function (res) {
           let csvContent = res.text
           let arrayOfLines = csvContent.split('\n')
@@ -122,7 +122,7 @@ describe('Old Transaction download endpoints', function () {
       downloadTransactionList()
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK_Pay_\d\d\d\d-\d\d-\d\d_\d\d:\d\d:\d\d.csv"/)
         .end(function (err, res) {
           if (err) return done(err)
           let csvContent = res.text
@@ -157,7 +157,7 @@ describe('Old Transaction download endpoints', function () {
         .set('Accept', 'application/json')
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK_Pay_\d\d\d\d-\d\d-\d\d_\d\d:\d\d:\d\d.csv"/)
         .end(function (err, res) {
           if (err) return done(err)
           let csvContent = res.text
@@ -192,7 +192,7 @@ describe('Old Transaction download endpoints', function () {
         .set('Accept', 'application/json')
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK_Pay_\d\d\d\d-\d\d-\d\d_\d\d:\d\d:\d\d.csv"/)
         .end(function (err, res) {
           if (err) return done(err)
           let csvContent = res.text

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -79,7 +79,7 @@ describe('Transaction download endpoints', function () {
       downloadTransactionList()
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK_Pay_\d\d\d\d-\d\d-\d\d_\d\d:\d\d:\d\d.csv"/)
         .expect(function (res) {
           let csvContent = res.text
           let arrayOfLines = csvContent.split('\n')
@@ -124,7 +124,7 @@ describe('Transaction download endpoints', function () {
       downloadTransactionList()
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK_Pay_\d\d\d\d-\d\d-\d\d_\d\d:\d\d:\d\d.csv"/)
         .end(function (err, res) {
           if (err) return done(err)
           let csvContent = res.text
@@ -159,7 +159,7 @@ describe('Transaction download endpoints', function () {
         .set('Accept', 'application/json')
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK_Pay_\d\d\d\d-\d\d-\d\d_\d\d:\d\d:\d\d.csv"/)
         .end(function (err, res) {
           if (err) return done(err)
           let csvContent = res.text
@@ -194,7 +194,7 @@ describe('Transaction download endpoints', function () {
         .set('Accept', 'application/json')
         .expect(200)
         .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-disposition', /attachment; filename=GOVUK Pay \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.csv/)
+        .expect('Content-disposition', /attachment; filename="GOVUK_Pay_\d\d\d\d-\d\d-\d\d_\d\d:\d\d:\d\d.csv"/)
         .end(function (err, res) {
           if (err) return done(err)
           let csvContent = res.text


### PR DESCRIPTION
Want to test this on a windows machine before deploying so do not merge for now.

The file name for the CSV file contains spaces so is not being handled
very well by Firefox on windows. Replaced spaces with _ and added
quotes around name in header.