### PR TITLE
PP-3521 Do not call products and connector when editing service name for a dd account

### DIFF
--- a/app/controllers/api_keys_controller.js
+++ b/app/controllers/api_keys_controller.js
@@ -4,7 +4,7 @@ var response = require('../utils/response.js').response
 var errorView = require('../utils/response.js').renderErrorView
 var auth = require('../services/auth_service.js')
 const publicAuthClient = require('../services/clients/public_auth_client')
-const {DIRECT_DEBIT_TOKEN_PREFIX} = require('../services/clients/direct_debit_connector_client.js')
+const {isADirectDebitAccount} = require('../services/clients/direct_debit_connector_client.js')
 // TODO remove these and make them proper i.e. show update destroy etc
 const API_KEYS_INDEX = 'tokens'
 const API_KEY_GENERATE = 'token_generate'
@@ -73,7 +73,7 @@ module.exports.show = function (req, res) {
 module.exports.create = function (req, res) {
   // current account id is either external (DIRECT_DEBIT) or internal (CARD) for now
   const currentAccountId = auth.getCurrentGatewayAccountId(req)
-  const tokenType = currentAccountId.startsWith(DIRECT_DEBIT_TOKEN_PREFIX) ? 'DIRECT_DEBIT' : 'CARD'
+  const tokenType = isADirectDebitAccount(currentAccountId) ? 'DIRECT_DEBIT' : 'CARD'
   const correlationId = req.correlationId
   const description = req.body.description
   const payload = {

--- a/app/controllers/dashboard/dashboard-activity-controller.js
+++ b/app/controllers/dashboard/dashboard-activity-controller.js
@@ -9,7 +9,7 @@ const moment = require('moment-timezone')
 const response = require('../../utils/response').response
 const CORRELATION_HEADER = require('../../utils/correlation_header').CORRELATION_HEADER
 const ConnectorClient = require('../../services/clients/connector_client').ConnectorClient
-const { DIRECT_DEBIT_TOKEN_PREFIX } = require('../../services/clients/direct_debit_connector_client.js')
+const { isADirectDebitAccount } = require('../../services/clients/direct_debit_connector_client.js')
 const auth = require('../../services/auth_service.js')
 const connectorClient = () => new ConnectorClient(process.env.CONNECTOR_URL)
 const datetime = require('../../utils/nunjucks-filters/datetime')
@@ -39,7 +39,7 @@ module.exports = (req, res) => {
 
   logger.info(`[${correlationId}] successfully logged in`)
 
-  if (gatewayAccountId.startsWith(DIRECT_DEBIT_TOKEN_PREFIX)) {
+  if (isADirectDebitAccount(gatewayAccountId)) {
     // todo implement transaction list for direct debit
     return response(req, res, 'dashboard/index', {
       name: req.user.username,

--- a/app/middleware/get_gateway_account.js
+++ b/app/middleware/get_gateway_account.js
@@ -12,7 +12,7 @@ module.exports = function (req, res, next) {
     gatewayAccountId: accountId,
     correlationId: req.correlationId
   }
-  if (accountId.startsWith(directDebitConnectorClient.DIRECT_DEBIT_TOKEN_PREFIX)) {
+  if (directDebitConnectorClient.isADirectDebitAccount(accountId)) {
     return directDebitConnectorClient.gatewayAccount.get(params)
       .then(gatewayAccount => {
         req.account = gatewayAccount

--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -1,5 +1,6 @@
 const _ = require('lodash')
 const {renderErrorView} = require('../utils/response.js')
+const {isADirectDebitAccount} = require('../services/clients/direct_debit_connector_client')
 /**
  * This middleware resolves the current service in context
  *
@@ -18,7 +19,7 @@ module.exports = function (req, res, next) {
   }
 
   req.service.hasDirectDebitGatewayAccount =
-    (req.service.gatewayAccountIds || []).some((gatewayAccountId) => gatewayAccountId.startsWith('DIRECT_DEBIT:'))
+    (req.service.gatewayAccountIds || []).some((gatewayAccountId) => isADirectDebitAccount(gatewayAccountId))
 
   next()
 }

--- a/app/services/clients/direct_debit_connector_client.js
+++ b/app/services/clients/direct_debit_connector_client.js
@@ -13,11 +13,15 @@ const SERVICE_NAME = 'directdebit-connector'
 
 // Exports
 module.exports = {
-  DIRECT_DEBIT_TOKEN_PREFIX,
+  isADirectDebitAccount,
   gatewayAccount: {
     create: createGatewayAccount,
     get: getGatewayAccountByExternalId
   }
+}
+
+function isADirectDebitAccount (accountId) {
+  return accountId.startsWith(DIRECT_DEBIT_TOKEN_PREFIX)
 }
 
 function createGatewayAccount (options) {


### PR DESCRIPTION
## WHAT
 - Edit service name was failing if a service has a dd gateway account, as we were making
   calls to products and connector, receiving a 404
 - We are currently not calling edit service name for dd connector, as the endpoint is not
   yet implemented

