### PR TITLE
PP-3555 - Fix broken image path in stylesheet

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -15,6 +15,9 @@
 // Override New Transport font-stack from front-end toolkit
 $grey-8: #fff;
 
+// Set path for frontend toolkit because this isn’t rails
+$path: '/public/images/icons/';
+
 @mixin media-down($mobile) {
   @content;
 }


### PR DESCRIPTION
This is a weird one as we don't use any of the icons that are 404ing so
it doesnt really make sense that they are being compiled or fetched anyway.

But I can’t work out why they are being compiled to the stylesheet but I
can see why they are being compiled with the wrong path. If you don't
decalre the path, Frontend Toolkit assumes you're using Rails which
would be able to resolve the image. We're using Node so we need to
declare $path. So I've done that.

It’s weird that this in included in the stylesheet though as things
we're not using shouldnt be. But I'll fix this and think more about what
is going on.

