### PR TITLE
PP-3510 - redirect is live so friendly URL can be used

### DIFF
--- a/app/views/payment-links/manage.njk
+++ b/app/views/payment-links/manage.njk
@@ -33,8 +33,7 @@ Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type
     <li class="payment-links-list--item">
       <h2 class="heading-small payment-links-list--item__title">{{ product.name }}</h2>
       {% if product.links.friendly %}
-      {# Looks friendly but href is not friendly until we have it all set up with GOV.UK #}
-        <a class="payment-links-list--item__link" href="{{ product.links.pay.href }}">{{ product.links.friendly.href }}</a>
+        <a class="payment-links-list--item__link" href="{{ product.links.friendly.href }}">{{ product.links.friendly.href }}</a>
       {% else %}
         <a class="payment-links-list--item__link" href="{{ product.links.pay.href }}">{{ product.links.pay.href }}</a>
       {% endif %}


### PR DESCRIPTION
Earlier the gov.uk redirect wasn’t live so it would have broken e2e.

Now it’s live we can use the friendly URL, IRL