### PR TITLE
PP-2984 Add Phone number to Merchant details page

### DIFF
--- a/app/controllers/edit_merchant_details/get.js
+++ b/app/controllers/edit_merchant_details/get.js
@@ -8,7 +8,8 @@ exports.get = (req, res) => {
     delete req.session.pageData.editMerchantDetails
   } else {
     pageData = {
-      merchant_details: lodash.get(req, 'service.merchantDetails')
+      merchant_details: lodash.get(req, 'service.merchantDetails'),
+      has_direct_debit_gateway_account: lodash.get(req, 'service.hasDirectDebitGatewayAccount')
     }
   }
   pageData.countries = countries.retrieveCountries(lodash.get(pageData.merchant_details, 'address_country'))

--- a/app/controllers/edit_merchant_details/post.js
+++ b/app/controllers/edit_merchant_details/post.js
@@ -4,8 +4,10 @@ const ukPostcode = require('uk-postcode')
 const responses = require('../../utils/response')
 const paths = require('../../paths')
 const serviceService = require('../../services/service_service')
+const {isPhoneNumber} = require('../../browsered/field-validation-checks')
 
 const MERCHANT_NAME = 'merchant-name'
+const TELEPHONE_NUMBER = 'telephone-number'
 const ADDRESS_LINE1 = 'address-line1'
 const ADDRESS_LINE2 = 'address-line2'
 const ADDRESS_CITY = 'address-city'
@@ -15,21 +17,24 @@ const ADDRESS_COUNTRY = 'address-country'
 exports.post = (req, res) => {
   const correlationId = lodash.get(req, 'correlationId')
   const serviceExternalId = lodash.get(req, 'service.externalId')
+  const hasDirectDebitGatewayAccount = lodash.get(req, 'service.hasDirectDebitGatewayAccount')
   const reqMerchantDetails = {
     name: req.body[MERCHANT_NAME],
+    telephone_number: req.body[TELEPHONE_NUMBER] ? req.body[TELEPHONE_NUMBER].replace(/\s/g, '') : req.body[TELEPHONE_NUMBER],
     address_line1: req.body[ADDRESS_LINE1],
     address_line2: req.body[ADDRESS_LINE2],
     address_city: req.body[ADDRESS_CITY],
     address_postcode: req.body[ADDRESS_POSTCODE],
     address_country: req.body[ADDRESS_COUNTRY]
   }
-  const errors = isValidForm(req)
+  const errors = isValidForm(req, hasDirectDebitGatewayAccount)
   if (lodash.isEmpty(errors)) {
     return serviceService.updateMerchantDetails(serviceExternalId, reqMerchantDetails, correlationId)
       .then(() => {
         lodash.set(req, 'session.pageData.editMerchantDetails', {
           success: true,
-          merchant_details: reqMerchantDetails
+          merchant_details: reqMerchantDetails,
+          has_direct_debit_gateway_account: hasDirectDebitGatewayAccount
         })
         res.redirect(paths.merchantDetails.index)
       })
@@ -40,7 +45,8 @@ exports.post = (req, res) => {
     lodash.set(req, 'session.pageData.editMerchantDetails', {
       success: false,
       errors: errors,
-      merchant_details: reqMerchantDetails
+      merchant_details: reqMerchantDetails,
+      has_direct_debit_gateway_account: hasDirectDebitGatewayAccount
     })
     res.redirect(paths.merchantDetails.index)
   }
@@ -61,10 +67,20 @@ function isValidPostcode (postcode, countryCode) {
   return !(countryCode === 'GB' && !ukPostcode.fromString(postcode).isComplete())
 }
 
-function isValidForm (req) {
-  const errors = validateNotEmpty(req, [MERCHANT_NAME, ADDRESS_LINE1, ADDRESS_CITY, ADDRESS_POSTCODE, ADDRESS_COUNTRY])
+function isValidForm (req, isDirectDebitForm) {
+  const mandatoryFields = [MERCHANT_NAME, ADDRESS_LINE1, ADDRESS_CITY, ADDRESS_POSTCODE, ADDRESS_COUNTRY]
+  if (isDirectDebitForm) {
+    mandatoryFields.push(TELEPHONE_NUMBER)
+  }
+
+  const errors = validateNotEmpty(req, mandatoryFields)
+
+  if (isDirectDebitForm && req.body[TELEPHONE_NUMBER] && (isPhoneNumber(req.body[TELEPHONE_NUMBER]) !== false)) {
+    errors[TELEPHONE_NUMBER] = true
+  }
   if (!isValidPostcode(req.body[ADDRESS_POSTCODE], req.body[ADDRESS_COUNTRY])) {
     errors[ADDRESS_POSTCODE] = true
   }
+
   return errors
 }

--- a/app/views/merchant_details/edit_merchant_details.njk
+++ b/app/views/merchant_details/edit_merchant_details.njk
@@ -24,6 +24,9 @@
       {% if errors["merchant-name"] %}
       <li><a href="#merchant-name">Name</a></li>
       {% endif %}
+      {% if errors["telephone-number"] %}
+        <li><a href="#telephone-number">Phone number</a></li>
+      {% endif %}
       {% if errors["address-line1"] %}
       <li><a href="#address-line1">Address</a></li>
       {% endif %}
@@ -59,6 +62,22 @@
       {% endif %}
       <input class="form-control form-control-2-3" id="merchant-name" name="merchant-name" type="text" value="{{merchant_details.name}}">
     </div>
+    {% if has_direct_debit_gateway_account %}
+      <div class="form-group">
+        <label class="form-label" for="telephone-number">
+          <span class="heading-small">Phone number</span>
+          <span class="form-hint form-control-2-3">
+            Required for Direct Debit
+          </span>
+        </label>
+        {% if errors["telephone-number"] %}
+          <span class="error-message">
+            Please enter a valid phone number
+          </span>
+        {% endif %}
+        <input class="form-control form-control-2-3" id="telephone-number" name="telephone-number" type="text" value="{{merchant_details.telephone_number}}">
+      </div>
+    {% endif %}
     <div class="form-group">
       <h2 class="heading-small billing-address-label">Merchant address</h2>
       <div class="payment-type-intro">

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -168,6 +168,7 @@ module.exports = {
     const serviceName = opts.name || 'updated-service-name'
     const merchantDetails = opts.merchant_details || {}
     const merchantName = merchantDetails.name || 'updated-merchant-details-name'
+    const merchantTelephoneNumber = merchantDetails.telephone_number || '03069990000'
     const merchantAddressLine1 = merchantDetails.address_line1 || 'updated-merchant-details-addressline1'
     const merchantAddressLine2 = merchantDetails.address_line2 || 'updated-merchant-details-addressline2'
     const merchantAddressCity = merchantDetails.address_city || 'updated-merchant-details-city'
@@ -179,6 +180,7 @@ module.exports = {
       name: serviceName,
       merchant_details: {
         name: merchantName,
+        telephone_number: merchantTelephoneNumber,
         address_line1: merchantAddressLine1,
         address_line2: merchantAddressLine2,
         address_city: merchantAddressCity,

--- a/test/unit/controller/edit_merchant_details_controller/get_test.js
+++ b/test/unit/controller/edit_merchant_details_controller/get_test.js
@@ -34,7 +34,7 @@ describe('edit merchant details controller - get', () => {
     external_id: EXTERNAL_ID_IN_SESSION,
     service_roles: serviceRoles
   })
-  describe('when the merchant already has details', () => {
+  describe('when the merchant already has details (CREDIT CARD GATEWAY ACCOUNT)', () => {
     before(done => {
       let serviceRoles = [{
         service: {
@@ -43,6 +43,7 @@ describe('edit merchant details controller - get', () => {
           gateway_account_ids: ['20'],
           merchant_details: {
             name: 'name',
+            telephone_number: '',
             address_line1: 'line1',
             address_line2: 'line2',
             address_city: 'City',
@@ -63,7 +64,7 @@ describe('edit merchant details controller - get', () => {
       user = userFixtures.validUserWithMerchantDetails(userInSession)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user.getPlain())
-      let app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
       supertest(app)
         .get(paths.merchantDetails.index)
         .end((err, res) => {
@@ -84,12 +85,89 @@ describe('edit merchant details controller - get', () => {
       expect($('#address-country').val()).to.equal('AR')
     })
   })
-  describe('when the merchant has empty details', () => {
+  describe('when the merchant already has details (DIRECT DEBIT GATEWAY ACCOUNT)', () => {
     before(done => {
+      let serviceRoles = [{
+        service: {
+          name: 'System Generated',
+          external_id: EXTERNAL_SERVICE_ID,
+          gateway_account_ids: ['DIRECT_DEBIT:somerandomidhere'],
+          merchant_details: {
+            name: 'name',
+            telephone_number: '03069990000',
+            address_line1: 'line1',
+            address_line2: 'line2',
+            address_city: 'City',
+            address_postcode: 'POSTCODE',
+            address_country: 'AR'
+          }
+        },
+        role: {
+          name: 'admin',
+          description: 'Administrator',
+          permissions: [{name: 'merchant-details:read'}, {name: 'merchant-details:update'}]
+        }
+      }]
+      let userInSession = mockSession.getUser({
+        external_id: EXTERNAL_ID_IN_SESSION,
+        service_roles: serviceRoles
+      })
       user = userFixtures.validUserWithMerchantDetails(userInSession)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user.getPlain())
-      let app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
+      supertest(app)
+        .get(paths.merchantDetails.index)
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+    it(`should get a nice 200 status code`, () => {
+      expect(response.statusCode).to.equal(200)
+    })
+    it(`should pre-fill form values with the merchant details`, () => {
+      expect($('#merchant-name').val()).to.equal('name')
+      expect($('#telephone-number').val()).to.equal('03069990000')
+      expect($('#address-line1').val()).to.equal('line1')
+      expect($('#address-line2').val()).to.equal('line2')
+      expect($('#address-city').val()).to.equal('City')
+      expect($('#address-postcode').val()).to.equal('POSTCODE')
+      expect($('#address-country').val()).to.equal('AR')
+    })
+  })
+  describe('when the merchant has empty details (CREDIT CARD GATEWAY ACCOUNT)', () => {
+    before(done => {
+      let serviceRoles = [{
+        service: {
+          name: 'System Generated',
+          external_id: EXTERNAL_SERVICE_ID,
+          gateway_account_ids: ['20'],
+          merchant_details: {
+            name: '',
+            telephone_number: '',
+            address_line1: '',
+            address_line2: '',
+            address_city: '',
+            address_postcode: '',
+            address_country: ''
+          }
+        },
+        role: {
+          name: 'admin',
+          description: 'Administrator',
+          permissions: [{name: 'merchant-details:read'}, {name: 'merchant-details:update'}]
+        }
+      }]
+      let userInSession = mockSession.getUser({
+        external_id: EXTERNAL_ID_IN_SESSION,
+        service_roles: serviceRoles
+      })
+      user = userFixtures.validUserWithMerchantDetails(userInSession)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
+        .reply(200, user.getPlain())
+      const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
       supertest(app)
         .get(paths.merchantDetails.index)
         .end((err, res) => {
@@ -103,6 +181,58 @@ describe('edit merchant details controller - get', () => {
     })
     it(`should show empty inputs and GB selected as country`, () => {
       expect($('#merchant-name').val()).to.equal('')
+      expect($('#address-line1').val()).to.equal('')
+      expect($('#address-line2').val()).to.equal('')
+      expect($('#address-city').val()).to.equal('')
+      expect($('#address-postcode').val()).to.equal('')
+      expect($('#address-country').val()).to.equal('GB')
+    })
+  })
+  describe('when the merchant has empty details (DIRECT DEBIT GATEWAY ACCOUNT)', () => {
+    before(done => {
+      let serviceRoles = [{
+        service: {
+          name: 'System Generated',
+          external_id: EXTERNAL_SERVICE_ID,
+          gateway_account_ids: ['DIRECT_DEBIT:somerandomidhere'],
+          merchant_details: {
+            name: '',
+            telephone_number: '',
+            address_line1: '',
+            address_line2: '',
+            address_city: '',
+            address_postcode: '',
+            address_country: ''
+          }
+        },
+        role: {
+          name: 'admin',
+          description: 'Administrator',
+          permissions: [{name: 'merchant-details:read'}, {name: 'merchant-details:update'}]
+        }
+      }]
+      let userInSession = mockSession.getUser({
+        external_id: EXTERNAL_ID_IN_SESSION,
+        service_roles: serviceRoles
+      })
+      user = userFixtures.validUserWithMerchantDetails(userInSession)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
+        .reply(200, user.getPlain())
+      const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
+      supertest(app)
+        .get(paths.merchantDetails.index)
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+    it(`should get a nice 200 status code`, () => {
+      expect(response.statusCode).to.equal(200)
+    })
+    it(`should show empty inputs and GB selected as country`, () => {
+      expect($('#merchant-name').val()).to.equal('')
+      expect($('#telephone-number').val()).to.equal('')
       expect($('#address-line1').val()).to.equal('')
       expect($('#address-line2').val()).to.equal('')
       expect($('#address-city').val()).to.equal('')
@@ -130,7 +260,7 @@ describe('edit merchant details controller - get', () => {
           }
         }
       }
-      let app = mockSession.createAppWithSession(getApp(), session)
+      const app = mockSession.createAppWithSession(getApp(), session)
       supertest(app)
       .get(paths.merchantDetails.index)
       .end((err, res) => {
@@ -149,7 +279,7 @@ describe('edit merchant details controller - get', () => {
       expect($('.error-summary').length).to.equal(0)
     })
   })
-  describe('when errors and merchant details are set in the session', () => {
+  describe('when errors and merchant details are set in the session (CREDIT CARD GATEWAY ACCOUNT)', () => {
     before(done => {
       user = userFixtures.validUserWithMerchantDetails(userInSession)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
@@ -181,7 +311,7 @@ describe('edit merchant details controller - get', () => {
           }
         }
       }
-      let app = mockSession.createAppWithSession(getApp(), session)
+      const app = mockSession.createAppWithSession(getApp(), session)
       supertest(app)
       .get(paths.merchantDetails.index)
       .end((err, res) => {
@@ -208,6 +338,78 @@ describe('edit merchant details controller - get', () => {
     })
     it(`should show prefilled inputs`, () => {
       expect($('#merchant-name').val()).to.equal('name')
+      expect($('#address-line1').val()).to.equal('line1')
+      expect($('#address-line2').val()).to.equal('line2')
+      expect($('#address-city').val()).to.equal('City')
+      expect($('#address-postcode').val()).to.equal('POSTCODE')
+      expect($('#address-country').val()).to.equal('GB')
+    })
+  })
+  describe('when errors and merchant details are set in the session (DIRECT DEBIT GATEWAY ACCOUNT)', () => {
+    before(done => {
+      user = userFixtures.validUserWithMerchantDetails(userInSession)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
+        .reply(200, user.getPlain())
+      session = {
+        csrfSecret: '123',
+        12345: {refunded_amount: 5},
+        passport: {
+          user: userInSession
+        },
+        secondFactor: 'totp',
+        last_url: 'last_url',
+        version: 0,
+        pageData: {
+          editMerchantDetails: {
+            success: false,
+            merchant_details: {
+              name: 'name',
+              telephone_number: 'invalid-phone',
+              address_line1: 'line1',
+              address_line2: 'line2',
+              address_city: 'City',
+              address_postcode: 'POSTCODE',
+              address_country: 'GB'
+            },
+            has_direct_debit_gateway_account: true,
+            errors: {
+              'merchant-name': true,
+              'telephone-number': true,
+              'address-country': true
+            }
+          }
+        }
+      }
+      const app = mockSession.createAppWithSession(getApp(), session)
+      supertest(app)
+        .get(paths.merchantDetails.index)
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+    it(`should get a nice 200 status code`, () => {
+      expect(response.statusCode).to.be.equal(200)
+    })
+    it(`should show a list of errors`, () => {
+      expect($('.error-summary-list li').length).to.equal(3)
+      expect($('.error-summary-list li a[href$="#merchant-name"]').text()).to.equal('Name')
+      expect($('.error-summary-list li a[href$="#telephone-number"]').text()).to.equal('Phone number')
+      expect($('.error-summary-list li a[href$="#address-country"]').text()).to.equal('Country')
+    })
+    it(`should show inline error messages`, () => {
+      expect($('.error-message').length).to.equal(3)
+      expect($('.error-message').eq(0).text()).to.contain('Please enter a valid name')
+      expect($('.error-message').eq(1).text()).to.contain('Please enter a valid phone number')
+      expect($('.error-message').eq(2).text()).to.contain('Please enter a valid country')
+    })
+    it(`should not show an updated successful banner`, () => {
+      expect($('.notification').length).to.equal(0)
+    })
+    it(`should show prefilled inputs`, () => {
+      expect($('#merchant-name').val()).to.equal('name')
+      expect($('#telephone-number').val()).to.equal('invalid-phone')
       expect($('#address-line1').val()).to.equal('line1')
       expect($('#address-line2').val()).to.equal('line2')
       expect($('#address-city').val()).to.equal('City')

--- a/test/unit/controller/edit_merchant_details_controller/post_test.js
+++ b/test/unit/controller/edit_merchant_details_controller/post_test.js
@@ -24,9 +24,10 @@ describe('edit merchant details controller - post', () => {
     service: {
       name: 'System Generated',
       external_id: EXTERNAL_SERVICE_ID,
-      gateway_account_ids: ['20'],
+      gateway_account_ids: ['20', 'DIRECT_DEBIT:somerandomidhere'],
       merchant_details: {
         name: 'name',
+        telephone_number: '03069990000',
         address_line1: 'line1',
         address_line2: 'line2',
         address_city: 'City',
@@ -65,6 +66,7 @@ describe('edit merchant details controller - post', () => {
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({
           'merchant-name': 'new-name',
+          'telephone-number': '03069990001',
           'address-line1': 'new-line1',
           'address-city': 'new-city',
           'address-postcode': 'new-postcode',
@@ -131,6 +133,7 @@ describe('edit merchant details controller - post', () => {
       expect(session.pageData.editMerchantDetails.success).to.be.false // eslint-disable-line
       expect(session.pageData.editMerchantDetails.errors).to.deep.equal({
         'merchant-name': true,
+        'telephone-number': true,
         'address-line1': true
       })
     })
@@ -160,6 +163,7 @@ describe('edit merchant details controller - post', () => {
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({
           'merchant-name': 'new-name',
+          'telephone-number': '03069990001',
           'address-line1': 'new-line1',
           'address-city': 'new-city',
           'address-postcode': 'wrong',
@@ -197,6 +201,7 @@ describe('edit merchant details controller - post', () => {
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({
           'merchant-name': 'new-name',
+          'telephone-number': '03069990001',
           'address-line1': 'new-line1',
           'address-city': 'new-city',
           'address-postcode': 'new-postcode',


### PR DESCRIPTION
## WHAT

- Added `Phone number` to Merchant details page. The `Phone number` field is displayed when we have `Direct Debit` gateway account linked to the current service and also is mandatory in that case.
