### PR TITLE
PP-3575 payment link bugs

### DIFF
--- a/app/browsered/input-confirm.js
+++ b/app/browsered/input-confirm.js
@@ -8,6 +8,10 @@ module.exports = () => {
 
   inputs.forEach(input => {
     input.addEventListener('input', confirmInput, false)
+
+    if (input.dataset.confirmationDisplay === 'onload') {
+      confirmInput({target: input})
+    }
   })
 
   function confirmInput (e) {

--- a/app/controllers/payment-links/post-web-address-controller.js
+++ b/app/controllers/payment-links/post-web-address-controller.js
@@ -17,6 +17,11 @@ module.exports = (req, res) => {
   const pageData = lodash.get(req, 'session.pageData.createPaymentLink', {})
   let updatedPageData = lodash.cloneDeep(pageData)
 
+  if (updatedPageData.productNamePath === '') {
+    req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#payment-name-path">Please change the website address</a></li></ul>`)
+    return res.redirect(paths.paymentLinks.webAddress)
+  }
+
   updatedPageData.productNamePath = makeNiceURL(req.body['payment-name-path'])
   lodash.set(req, 'session.pageData.createPaymentLink', updatedPageData)
 

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -46,10 +46,16 @@ Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type
         data-validate="isFieldGreaterThanMaxLengthChars isNaxsiSafe"
         data-validate-max-length="254"
         value="{{ paymentLinkTitle }}"
-        {% if change !== 'payment-link-description' %}autofocus{% endif %} data-confirmation
+        {% if change !== 'payment-link-description' %}
+          autofocus
+        {% endif %}
+        data-confirmation
         data-confirmation-title="The website address for this payment link will look like:"
         data-confirmation-label="{{friendlyURL}}/{{currentServiceName | removeDefinateArticles | slugify}}/"
         data-confirmation-filter="slugify"
+        {% if change.length %}
+          data-confirmation-display="onload"
+        {% endif %}
       />
     </div>
     <div class="form-group">

--- a/app/views/payment-links/web-address.njk
+++ b/app/views/payment-links/web-address.njk
@@ -22,7 +22,7 @@ Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type
   <form action="{{ nextPage }}" class="form" method="post" data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <div class="form-group{% if flash.genericError %} error{% endif %}">
-      <label class="form-label-bold" for="payment-link-title">
+      <label class="form-label-bold" for="payment-name-path">
         Please change the website address
         <span class="form-hint">
           This will not change the title
@@ -43,6 +43,7 @@ Create a payment link - {{currentServiceName}} {{currentGatewayAccount.full_type
         type="text"
         value="{{ productNamePath }}"
         autofocus
+        data-validate
         data-slugify
       />
       <p class="create-payment-link-read-more"><a href="https://www.gov.uk/guidance/content-design/url-standards-for-gov-uk">Get guidance on writing a web address (URL)</a></p>


### PR DESCRIPTION
- if editing title then it shows the web address on load (before it only showed if you typed more characters in the title field, which is fine when first landing but not when returning to edit.
- Validate web address field so that blank web address can’t be submitted