### PR TITLE
PP-3525 Show/hide 3DS helper text for Worldpay only

### DIFF
--- a/app/controllers/toggle_3ds_controller.js
+++ b/app/controllers/toggle_3ds_controller.js
@@ -50,7 +50,8 @@ module.exports.index = function (req, res) {
 }
 
 module.exports.onConfirm = (req, res) => {
-  show(req, res, 'on_confirm', {})
+  const model = {showHelper3ds: req.account.payment_provider === 'worldpay'}
+  show(req, res, 'on_confirm', model)
 }
 
 module.exports.on = function (req, res) {

--- a/app/middleware/get_gateway_account.js
+++ b/app/middleware/get_gateway_account.js
@@ -27,7 +27,7 @@ module.exports = function (req, res, next) {
   return connectorClient.getAccount(params)
     .then(data => {
       let SUPPORTS_3DS = ['worldpay']
-      // env var values are treated as text so the comparisaon is done for text
+      // env var values are treated as text so the comparison is done for text
       if (EPDQ_3DS_ENABLED === 'true') {
         SUPPORTS_3DS = _.concat(SUPPORTS_3DS, ['epdq'])
       }

--- a/app/views/3d_secure/index.njk
+++ b/app/views/3d_secure/index.njk
@@ -1,7 +1,7 @@
 {% extends "../credentials.njk" %}
 
 {% block page_title %}
-  3D Secure - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+  3D Secure - {{ currentServiceName }} {{ currentGatewayAccount.full_type }} - GOV.UK Pay
 {% endblock %}
 
 {% block side_navigation %}
@@ -9,94 +9,101 @@
 {% endblock %}
 
 {% block mainContent %}
-<div class="column-two-thirds">
-  {% if not permissions.toggle_3ds_update %}
-    {% include "../includes/settings-read-only.njk" %}
-  {% endif %}
-
-  {% if supports3ds %}
-    {% if permissions.toggle_3ds_read %}
-      {% if justToggled %}
-        <div id="3ds-toggled" class="govuk-box-highlight">
-        {% if requires3ds %}
-          <p>3D Secure is turned on for this service</p>
-        {% else %}
-          <p>3D Secure is turned off for this service</p>
-        {% endif %}
-        </div>
-      {% endif %}
+  <div class="column-two-thirds">
+    {% if not permissions.toggle_3ds_update %}
+      {% include "../includes/settings-read-only.njk" %}
     {% endif %}
 
-    <h1 class="page-title">3D Secure</h1>
-
-    <p id="threeds-supported">3D Secure (3DS) adds an extra layer of authentication to user payments. This can help reduce fraud, but also makes it <strong class="bold-small">harder for your service users to complete payments.</strong></p>
-    <p><strong class="bold-small">Verified by Visa</strong> and <strong class="bold-small">Mastercard SecureCode</strong> are common examples of 3D Secure.</p>
-
-    {% if not requires3ds %}
+    {% if supports3ds %}
       {% if permissions.toggle_3ds_read %}
-        <h2 id="3ds-status" class="heading-medium remove-top-margin">3D Secure is off</h2>
-      {% endif %}
-
-      {% if permissions.toggle_3ds_update %}
-        {% if showHelper3ds %}
-          <div id="threeds-helper-text" class="panel panel-border-wide">
-            <h2 class="heading-small">Activating 3D Secure</h2>
-            <p>Check with your Worldpay account manager that your merchant code has been configured to support 3D
-              Secure. Read more about this in our <a
-                href="https://docs.payments.service.gov.uk/#worldpay-setup-for-3d-secure">technical documentation</a>.
-            </p>
+        {% if justToggled %}
+          <div id="3ds-toggled" class="govuk-box-highlight">
+            {% if requires3ds %}
+              <p>3D Secure is turned on for this service</p>
+            {% else %}
+              <p>3D Secure is turned off for this service</p>
+            {% endif %}
           </div>
         {% endif %}
-
-        <p>Once that’s done, you can turn on 3D Secure for all payments to your service.</p>
-
-        <form class="permission-main" method="post" action="{{ routes.toggle3ds.onConfirm }}">
-          <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
-          <div class="form-group">
-            <input id="threeds-on-button" class="button" type="submit" value="Turn on 3D Secure">
-          </div>
-        </form>
       {% endif %}
-    {% endif %}
 
-    {% if requires3ds %}
-      {% if permissions.toggle_3ds_read %}
-        <h2 id="3ds-status" class="heading-medium remove-top-margin">3D Secure is activated</h2>
+      <h1 class="page-title">3D Secure</h1>
 
-        <div class="panel panel-border-wide">
+      <p id="threeds-supported">3D Secure (3DS) adds an extra layer of authentication to user payments. This can help
+        reduce fraud, but also makes it <strong class="bold-small">harder for your service users to complete
+          payments.</strong></p>
+      <p><strong class="bold-small">Verified by Visa</strong> and <strong class="bold-small">Mastercard
+          SecureCode</strong> are common examples of 3D Secure.</p>
+
+      {% if not requires3ds %}
+        {% if permissions.toggle_3ds_read %}
+          <h2 id="3ds-status" class="heading-medium remove-top-margin">3D Secure is off</h2>
+        {% endif %}
+
+        {% if permissions.toggle_3ds_update %}
+          {% if showHelper3ds %}
+            <div id="3ds-helper-text-worldpay">
+              <div class="panel panel-border-wide">
+                <h2 class="heading-small">Activating 3D Secure</h2>
+                <p>Check with your Worldpay account manager that your merchant code has been configured to support 3D
+                  Secure. Read more about this in our <a
+                    href="https://docs.payments.service.gov.uk/#worldpay-setup-for-3d-secure">technical
+                    documentation</a>.
+                </p>
+              </div>
+              <p>Once that’s done, you can turn on 3D Secure for all payments to your service.</p>
+            </div>
+          {% endif %}
+
+          <form class="permission-main" method="post" action="{{ routes.toggle3ds.onConfirm }}">
+            <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+            <div class="form-group">
+              <input id="threeds-on-button" class="button" type="submit" value="Turn on 3D Secure">
+            </div>
+          </form>
+        {% endif %}
+      {% endif %}
+
+      {% if requires3ds %}
+        {% if permissions.toggle_3ds_read %}
+          <h2 id="3ds-status" class="heading-medium remove-top-margin">3D Secure is activated</h2>
+
+          <div class="panel panel-border-wide">
             <h2 class="heading-small">Having problems with 3D Secure?</h2>
-            <p>If 3D Secure isn’t working on your service’s payment pages you’ll need to check with your Payment Gateway account manager that your merchant code has been configured to support 3D Secure.</p>
-        </div>
-      {% endif %}
+            <p>If 3D Secure isn’t working on your service’s payment pages you’ll need to check with your Payment Gateway
+              account manager that your merchant code has been configured to support 3D Secure.</p>
+          </div>
+        {% endif %}
 
-      {% if hasAnyCardTypeRequiring3dsSelected %}
-        <div id="info-message" class="notice">
+        {% if hasAnyCardTypeRequiring3dsSelected %}
+          <div id="info-message" class="notice">
             <i class="icon icon-important">
-                <span class="visually-hidden">Warning</span>
+              <span class="visually-hidden">Warning</span>
             </i>
 
             <strong class="bold-small">
-                You must disable Maestro to turn off 3D Secure
+              You must disable Maestro to turn off 3D Secure
             </strong>
-        </div>
-      {% endif %}
-
-      {% if permissions.toggle_3ds_update %}
-        <form class="permission-main" method="post" action="{{routes.toggle3ds.off}}">
-          <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-          <div class="form-group">
-            {% if hasAnyCardTypeRequiring3dsSelected %}
-              <input id="threeds-off-button-disabled" disabled class="button disabled" type="submit" value="Turn off 3D Secure">
-            {% else %}
-              <input id="threeds-off-button" class="button" type="submit" value="Turn off 3D Secure">
-            {% endif %}
           </div>
-        </form>
+        {% endif %}
+
+        {% if permissions.toggle_3ds_update %}
+          <form class="permission-main" method="post" action="{{ routes.toggle3ds.off }}">
+            <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+            <div class="form-group">
+              {% if hasAnyCardTypeRequiring3dsSelected %}
+                <input id="threeds-off-button-disabled" disabled class="button disabled" type="submit"
+                       value="Turn off 3D Secure">
+              {% else %}
+                <input id="threeds-off-button" class="button" type="submit" value="Turn off 3D Secure">
+              {% endif %}
+            </div>
+          </form>
+        {% endif %}
       {% endif %}
+    {% else %}
+      <h1 class="page-title">3D Secure</h1>
+      <p id="threeds-not-supported">3D Secure is not currently supported for this payment service provider (PSP).</p>
     {% endif %}
-  {% else %}
-    <h1 class="page-title">3D Secure</h1>
-    <p id="threeds-not-supported">3D Secure is not currently supported for this payment service provider (PSP).</p>
-  {% endif %}
-</div>
+  </div>
 {% endblock %}

--- a/app/views/3d_secure/on_confirm.njk
+++ b/app/views/3d_secure/on_confirm.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block page_title %}
-Confirm 3D Secure - {{currentServiceName}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+  Confirm 3D Secure - {{ currentServiceName }} {{ currentGatewayAccount.full_type }} - GOV.UK Pay
 {% endblock %}
 
 {% block side_navigation %}
@@ -12,15 +12,18 @@ Confirm 3D Secure - {{currentServiceName}} {{currentGatewayAccount.full_type}} -
   <h1 class="page-title">3D Secure</h1>
 
   {% if permissions.toggle_3ds_update %}
-    <h2 class="heading-medium remove-top-margin">Has your merchant code been configured to support 3D Secure?</h2>
-    <p>If you haven’t confirmed this with Worldpay, 3D Secure won’t work on your service’s payment pages.</p>
-
-    <form class="permission-main" method="post" action="{{routes.toggle3ds.on}}">
-      <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    {% if showHelper3ds %}
+      <div id="3ds-helper-text-worldpay">
+        <h2 class="heading-medium remove-top-margin">Has your merchant code been configured to support 3D Secure?</h2>
+        <p>If you haven’t confirmed this with Worldpay, 3D Secure won’t work on your service’s payment pages.</p>
+      </div>
+    {% endif %}
+    <form class="permission-main" method="post" action="{{ routes.toggle3ds.on }}">
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
       <div class="form-group">
         <input id="3ds-confirm-on-button" class="button" type="submit" value="Yes, turn on 3D Secure">
       </div>
-      <a href="{{routes.toggle3ds.index}}" class="remove-cancel">No, cancel</a>
+      <a href="{{ routes.toggle3ds.index }}" class="remove-cancel">No, cancel</a>
     </form>
   {% endif %}
 {% endblock %}

--- a/test/ui/toggle_3ds_ui_tests.js
+++ b/test/ui/toggle_3ds_ui_tests.js
@@ -107,7 +107,24 @@ describe('The toggle 3D Secure page when 3D Secure is off', function () {
 
     let body = renderTemplate('3d_secure/index', templateData)
 
-    body.should.containSelector('#threeds-helper-text')
+    body.should.containSelector('#3ds-helper-text-worldpay')
+  })
+
+  it('should not display helper test if not worldpay', function () {
+    let templateData = {
+      'supports3ds': true,
+      'requires3ds': false,
+      'justToggled': false,
+      'showHelper3ds': false,
+      permissions: {
+        toggle_3ds_read: true,
+        toggle_3ds_update: true
+      }
+    }
+
+    let body = renderTemplate('3d_secure/index', templateData)
+
+    body.should.containNoSelector('#3ds-helper-text-worldpay')
   })
 })
 
@@ -296,9 +313,38 @@ describe('The turn 3D Secure on confirmation page', function () {
         toggle_3ds_update: false
       }
     }
-
     let body = renderTemplate('3d_secure/on_confirm', templateData)
 
     body.should.containNoSelector('#3ds-confirm-on-button')
+  })
+
+  it('should not display helper test if not worldpay', function () {
+    let templateData = {
+      'supports3ds': true,
+      'showHelper3ds': false,
+      permissions: {
+        toggle_3ds_read: true,
+        toggle_3ds_update: true
+      }
+    }
+
+    let body = renderTemplate('3d_secure/on_confirm', templateData)
+
+    body.should.containNoSelector('#3ds-helper-text-worldpay')
+  })
+
+  it('should display helper test if worldpay', function () {
+    let templateData = {
+      'supports3ds': true,
+      'showHelper3ds': true,
+      permissions: {
+        toggle_3ds_read: true,
+        toggle_3ds_update: true
+      }
+    }
+
+    let body = renderTemplate('3d_secure/on_confirm', templateData)
+
+    body.should.containSelector('#3ds-helper-text-worldpay')
   })
 })

--- a/test/ui/toggle_3ds_ui_tests.js
+++ b/test/ui/toggle_3ds_ui_tests.js
@@ -92,40 +92,6 @@ describe('The toggle 3D Secure page when 3D Secure is off', function () {
 
     body.should.containNoSelector('#3ds-toggled')
   })
-
-  it('should display helper test for worldpay', function () {
-    let templateData = {
-      'supports3ds': true,
-      'requires3ds': false,
-      'justToggled': false,
-      'showHelper3ds': true,
-      permissions: {
-        toggle_3ds_read: true,
-        toggle_3ds_update: true
-      }
-    }
-
-    let body = renderTemplate('3d_secure/index', templateData)
-
-    body.should.containSelector('#3ds-helper-text-worldpay')
-  })
-
-  it('should not display helper test if not worldpay', function () {
-    let templateData = {
-      'supports3ds': true,
-      'requires3ds': false,
-      'justToggled': false,
-      'showHelper3ds': false,
-      permissions: {
-        toggle_3ds_read: true,
-        toggle_3ds_update: true
-      }
-    }
-
-    let body = renderTemplate('3d_secure/index', templateData)
-
-    body.should.containNoSelector('#3ds-helper-text-worldpay')
-  })
 })
 
 describe('The toggle 3D Secure page when 3D Secure is on', function () {
@@ -316,35 +282,5 @@ describe('The turn 3D Secure on confirmation page', function () {
     let body = renderTemplate('3d_secure/on_confirm', templateData)
 
     body.should.containNoSelector('#3ds-confirm-on-button')
-  })
-
-  it('should not display helper test if not worldpay', function () {
-    let templateData = {
-      'supports3ds': true,
-      'showHelper3ds': false,
-      permissions: {
-        toggle_3ds_read: true,
-        toggle_3ds_update: true
-      }
-    }
-
-    let body = renderTemplate('3d_secure/on_confirm', templateData)
-
-    body.should.containNoSelector('#3ds-helper-text-worldpay')
-  })
-
-  it('should display helper test if worldpay', function () {
-    let templateData = {
-      'supports3ds': true,
-      'showHelper3ds': true,
-      permissions: {
-        toggle_3ds_read: true,
-        toggle_3ds_update: true
-      }
-    }
-
-    let body = renderTemplate('3d_secure/on_confirm', templateData)
-
-    body.should.containSelector('#3ds-helper-text-worldpay')
   })
 })

--- a/test/unit/controller/toggle_3ds_controller/toggle_3ds_controller_test.js
+++ b/test/unit/controller/toggle_3ds_controller/toggle_3ds_controller_test.js
@@ -17,6 +17,7 @@ const CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts/' + ACCOUNT_ID
 const CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH = CONNECTOR_ACCOUNT_PATH + '/card-types'
 const connectorMock = nock(process.env.CONNECTOR_URL, aCorrelationHeader)
 const csrf = require('csrf')
+const ID_3DS_HELPER_TEXT = '#3ds-helper-text-worldpay'
 
 let app, response, $
 
@@ -25,162 +26,104 @@ function mockConnectorAcceptedCardTypesEndpoint (acceptedCardTypes) {
     .reply(200, acceptedCardTypes)
 }
 
-describe.only('The 3D Secure index endpoint', () => {
+function runConnectorMockGet (accountName) {
+  connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+    .reply(200, {
+      'payment_provider': accountName,
+      'requires3ds': false
+    })
+  mockConnectorAcceptedCardTypesEndpoint({'card_types': []})
+}
+
+function getToggle3DsIndex (accountName, done) {
+  runConnectorMockGet(accountName)
+
+  supertest(app)
+    .get(paths.toggle3ds.index)
+    .set('x-request-id', requestId)
+    .end((err, res) => {
+      response = res
+      $ = cheerio.load(res.text || '')
+      done(err)
+    })
+}
+
+function postToggle3DsIndexConfirm (accountName, done) {
+  runConnectorMockGet(accountName)
+
+  const csrfToken = csrf().create('123')
+  supertest(app)
+    .post(paths.toggle3ds.onConfirm)
+    .send({'csrfToken': csrfToken})
+    .set('x-request-id', requestId)
+    .end((err, res) => {
+      response = res
+      $ = cheerio.load(res.text || '')
+      done(err)
+    })
+}
+
+function assertStatusAndTitle () {
+  expect(response.statusCode).to.equal(200)
+  expect($('.page-title').text()).to.contain('3D Secure')
+}
+
+describe('The 3D Secure ', () => {
+  const permissions = [{name: 'toggle-3ds:update'}, {name: 'toggle-3ds:read'}]
+  const user = session.getUser({
+    gateway_account_ids: [ACCOUNT_ID], permissions: permissions
+  })
+
+  beforeEach(function () {
+    app = session.getAppWithLoggedInUser(getApp(), user)
+  })
+
   afterEach(function () {
     nock.cleanAll()
     app = null
   })
 
-  beforeEach(function (done) {
-    const permissions = [{name: 'toggle-3ds:update'}, {name: 'toggle-3ds:read'}]
-    const user = session.getUser({
-      gateway_account_ids: [ACCOUNT_ID], permissions: permissions
+  describe('index endpoint', () => {
+    describe('for WorldPay account', () => {
+      beforeEach(function (done) {
+        getToggle3DsIndex('worldpay', done)
+      })
+      it(`should display helper text`, () => {
+        assertStatusAndTitle()
+        expect($(ID_3DS_HELPER_TEXT).text()).to.contain('Activating 3D Secure')
+      })
     })
-    app = session.getAppWithLoggedInUser(getApp(), user)
 
-    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
-      .reply(200, {
-        'payment_provider': 'worldpay',
-        'requires3ds': false
+    describe('for non WorldPay account', () => {
+      beforeEach(function (done) {
+        getToggle3DsIndex('smartpay', done)
       })
-
-    mockConnectorAcceptedCardTypesEndpoint({'card_types': []})
-
-    supertest(app)
-      .get(paths.toggle3ds.index)
-      .set('x-request-id', requestId)
-      .end((err, res) => {
-        response = res
-        $ = cheerio.load(res.text || '')
-        done(err)
+      it(`should not display helper text`, () => {
+        assertStatusAndTitle()
+        expect($(ID_3DS_HELPER_TEXT).text()).to.equal('')
       })
-  })
-
-  it(`should display helper text for WordlPay 3DS`, () => {
-    expect(response.statusCode).to.equal(200)
-    expect($('.page-title').text()).to.contain('3D Secure')
-    expect($('#3ds-helper-text-worldpay').text()).to.contain('Activating 3D Secure')
-  })
-})
-
-describe.only('The 3D Secure index endpoint', () => {
-  afterEach(function () {
-    nock.cleanAll()
-    app = null
-  })
-
-  beforeEach(function (done) {
-    const permissions = [{name: 'toggle-3ds:update'}, {name: 'toggle-3ds:read'}]
-    const user = session.getUser({
-      gateway_account_ids: [ACCOUNT_ID], permissions: permissions
     })
-    app = session.getAppWithLoggedInUser(getApp(), user)
+  })
 
-    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
-      .reply(200, {
-        'payment_provider': 'smartpay',
-        'requires3ds': false
+  describe('confirmation page', () => {
+    describe('for WorldPay account', () => {
+      beforeEach((done) => {
+        postToggle3DsIndexConfirm('worldpay', done)
       })
-
-    mockConnectorAcceptedCardTypesEndpoint({'card_types': []})
-
-    supertest(app)
-      .get(paths.toggle3ds.index)
-      .set('x-request-id', requestId)
-      .end((err, res) => {
-        response = res
-        $ = cheerio.load(res.text || '')
-        done(err)
+      it(`should display helper text`, () => {
+        assertStatusAndTitle()
+        expect($(ID_3DS_HELPER_TEXT).text()).to.contain('If you haven’t confirmed this with Worldpay')
       })
-  })
-
-  it(`should not display helper text if not WordlPay 3DS`, () => {
-    expect(response.statusCode).to.equal(200)
-    expect($('.page-title').text()).to.contain('3D Secure')
-    expect($('#3ds-helper-text-worldpay').text()).to.equal('')
-  })
-})
-
-describe.only('The 3D Secure confirmation page for WorldPay account', () => {
-  afterEach(function () {
-    nock.cleanAll()
-    app = null
-  })
-
-  beforeEach(function (done) {
-    const permissions = [{name: 'toggle-3ds:update'}, {name: 'toggle-3ds:read'}]
-    const user = session.getUser({
-      gateway_account_ids: [ACCOUNT_ID], permissions: permissions
     })
-    app = session.getAppWithLoggedInUser(getApp(), user)
 
-    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
-      .reply(200, {
-        'payment_provider': 'worldpay',
-        'requires3ds': false
+    describe('for non WorldPay account', () => {
+      beforeEach((done) => {
+        postToggle3DsIndexConfirm('smartpay', done)
       })
-
-    mockConnectorAcceptedCardTypesEndpoint({'card_types': []})
-
-    const csrfToken = csrf().create('123')
-
-    supertest(app)
-      .post(paths.toggle3ds.onConfirm)
-      .send({'csrfToken': csrfToken})
-      .set('x-request-id', requestId)
-      .end((err, res) => {
-        response = res
-        $ = cheerio.load(res.text || '')
-        done(err)
+      it('should not display helper text', () => {
+        assertStatusAndTitle()
+        expect($(ID_3DS_HELPER_TEXT).text()).to.equal('')
       })
-  })
-
-  it(`should display helper text if WordlPay 3DS`, () => {
-    expect(response.statusCode).to.equal(200)
-    expect($('.page-title').text()).to.contain('3D Secure')
-    expect($('#3ds-helper-text-worldpay').text()).to.contain('If you haven’t confirmed this with Worldpay')
-  })
-})
-
-describe.only('The 3D Secure confirmation page for non WorldPay account', () => {
-  afterEach(function () {
-    nock.cleanAll()
-    app = null
-  })
-
-  beforeEach(function (done) {
-    const permissions = [{name: 'toggle-3ds:update'}, {name: 'toggle-3ds:read'}]
-    const user = session.getUser({
-      gateway_account_ids: [ACCOUNT_ID], permissions: permissions
     })
-    app = session.getAppWithLoggedInUser(getApp(), user)
-
-    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
-      .reply(200, {
-        'payment_provider': 'smartpay',
-        'requires3ds': false
-      })
-
-    mockConnectorAcceptedCardTypesEndpoint({'card_types': []})
-
-    const csrfToken = csrf().create('123')
-
-    supertest(app)
-      .post(paths.toggle3ds.onConfirm)
-      .send({'csrfToken': csrfToken})
-      // .set('Accept', 'application/json')
-      // .set('Content-Type', 'application/x-www-form-urlencoded')
-      .set('x-request-id', requestId)
-      .end((err, res) => {
-        response = res
-        $ = cheerio.load(res.text || '')
-        done(err)
-      })
-  })
-
-  it(`should not display helper text if not WordlPay 3DS`, () => {
-    expect(response.statusCode).to.equal(200)
-    expect($('.page-title').text()).to.contain('3D Secure')
-    expect($('#3ds-helper-text-worldpay').text()).to.equal('')
   })
 })

--- a/test/unit/controller/toggle_3ds_controller/toggle_3ds_controller_test.js
+++ b/test/unit/controller/toggle_3ds_controller/toggle_3ds_controller_test.js
@@ -1,0 +1,186 @@
+'use strict'
+
+const chai = require('chai')
+const cheerio = require('cheerio')
+const nock = require('nock')
+const getApp = require('../../../../server').getApp
+const supertest = require('supertest')
+const paths = require('../../../../app/paths')
+const expect = chai.expect
+const session = require('../../../test_helpers/mock_session')
+const requestId = 'unique-request-id'
+const aCorrelationHeader = {
+  reqheaders: {'x-request-id': requestId}
+}
+const ACCOUNT_ID = '182364'
+const CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts/' + ACCOUNT_ID
+const CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH = CONNECTOR_ACCOUNT_PATH + '/card-types'
+const connectorMock = nock(process.env.CONNECTOR_URL, aCorrelationHeader)
+const csrf = require('csrf')
+
+let app, response, $
+
+function mockConnectorAcceptedCardTypesEndpoint (acceptedCardTypes) {
+  connectorMock.get(CONNECTOR_ACCEPTED_CARD_TYPES_FRONTEND_PATH)
+    .reply(200, acceptedCardTypes)
+}
+
+describe.only('The 3D Secure index endpoint', () => {
+  afterEach(function () {
+    nock.cleanAll()
+    app = null
+  })
+
+  beforeEach(function (done) {
+    const permissions = [{name: 'toggle-3ds:update'}, {name: 'toggle-3ds:read'}]
+    const user = session.getUser({
+      gateway_account_ids: [ACCOUNT_ID], permissions: permissions
+    })
+    app = session.getAppWithLoggedInUser(getApp(), user)
+
+    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+      .reply(200, {
+        'payment_provider': 'worldpay',
+        'requires3ds': false
+      })
+
+    mockConnectorAcceptedCardTypesEndpoint({'card_types': []})
+
+    supertest(app)
+      .get(paths.toggle3ds.index)
+      .set('x-request-id', requestId)
+      .end((err, res) => {
+        response = res
+        $ = cheerio.load(res.text || '')
+        done(err)
+      })
+  })
+
+  it(`should display helper text for WordlPay 3DS`, () => {
+    expect(response.statusCode).to.equal(200)
+    expect($('.page-title').text()).to.contain('3D Secure')
+    expect($('#3ds-helper-text-worldpay').text()).to.contain('Activating 3D Secure')
+  })
+})
+
+describe.only('The 3D Secure index endpoint', () => {
+  afterEach(function () {
+    nock.cleanAll()
+    app = null
+  })
+
+  beforeEach(function (done) {
+    const permissions = [{name: 'toggle-3ds:update'}, {name: 'toggle-3ds:read'}]
+    const user = session.getUser({
+      gateway_account_ids: [ACCOUNT_ID], permissions: permissions
+    })
+    app = session.getAppWithLoggedInUser(getApp(), user)
+
+    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+      .reply(200, {
+        'payment_provider': 'smartpay',
+        'requires3ds': false
+      })
+
+    mockConnectorAcceptedCardTypesEndpoint({'card_types': []})
+
+    supertest(app)
+      .get(paths.toggle3ds.index)
+      .set('x-request-id', requestId)
+      .end((err, res) => {
+        response = res
+        $ = cheerio.load(res.text || '')
+        done(err)
+      })
+  })
+
+  it(`should not display helper text if not WordlPay 3DS`, () => {
+    expect(response.statusCode).to.equal(200)
+    expect($('.page-title').text()).to.contain('3D Secure')
+    expect($('#3ds-helper-text-worldpay').text()).to.equal('')
+  })
+})
+
+describe.only('The 3D Secure confirmation page for WorldPay account', () => {
+  afterEach(function () {
+    nock.cleanAll()
+    app = null
+  })
+
+  beforeEach(function (done) {
+    const permissions = [{name: 'toggle-3ds:update'}, {name: 'toggle-3ds:read'}]
+    const user = session.getUser({
+      gateway_account_ids: [ACCOUNT_ID], permissions: permissions
+    })
+    app = session.getAppWithLoggedInUser(getApp(), user)
+
+    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+      .reply(200, {
+        'payment_provider': 'worldpay',
+        'requires3ds': false
+      })
+
+    mockConnectorAcceptedCardTypesEndpoint({'card_types': []})
+
+    const csrfToken = csrf().create('123')
+
+    supertest(app)
+      .post(paths.toggle3ds.onConfirm)
+      .send({'csrfToken': csrfToken})
+      .set('x-request-id', requestId)
+      .end((err, res) => {
+        response = res
+        $ = cheerio.load(res.text || '')
+        done(err)
+      })
+  })
+
+  it(`should display helper text if WordlPay 3DS`, () => {
+    expect(response.statusCode).to.equal(200)
+    expect($('.page-title').text()).to.contain('3D Secure')
+    expect($('#3ds-helper-text-worldpay').text()).to.contain('If you haven’t confirmed this with Worldpay')
+  })
+})
+
+describe.only('The 3D Secure confirmation page for non WorldPay account', () => {
+  afterEach(function () {
+    nock.cleanAll()
+    app = null
+  })
+
+  beforeEach(function (done) {
+    const permissions = [{name: 'toggle-3ds:update'}, {name: 'toggle-3ds:read'}]
+    const user = session.getUser({
+      gateway_account_ids: [ACCOUNT_ID], permissions: permissions
+    })
+    app = session.getAppWithLoggedInUser(getApp(), user)
+
+    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+      .reply(200, {
+        'payment_provider': 'smartpay',
+        'requires3ds': false
+      })
+
+    mockConnectorAcceptedCardTypesEndpoint({'card_types': []})
+
+    const csrfToken = csrf().create('123')
+
+    supertest(app)
+      .post(paths.toggle3ds.onConfirm)
+      .send({'csrfToken': csrfToken})
+      // .set('Accept', 'application/json')
+      // .set('Content-Type', 'application/x-www-form-urlencoded')
+      .set('x-request-id', requestId)
+      .end((err, res) => {
+        response = res
+        $ = cheerio.load(res.text || '')
+        done(err)
+      })
+  })
+
+  it(`should not display helper text if not WordlPay 3DS`, () => {
+    expect(response.statusCode).to.equal(200)
+    expect($('.page-title').text()).to.contain('3D Secure')
+    expect($('#3ds-helper-text-worldpay').text()).to.equal('')
+  })
+})


### PR DESCRIPTION
## WHAT
- Moved all helper text for 3DS Worldpay into one div
- Show/hide 3DS helper text on 3DS confirmation page base don gateway
- Added tests for this cases


