### PR TITLE
PP-3637 - Subsequent paginations didnt include the filters

### DIFF
--- a/app/views/transactions/paginator.njk
+++ b/app/views/transactions/paginator.njk
@@ -2,8 +2,14 @@
 <div class="pagination">
 	{% for paginationLink in paginationLinks %}
     <form class="paginationForm {{paginationLink.pageName}}" method="get" action="{{paginationLink.search_path}}">
-        <input class="state" name="state" type="hidden" value="{{filters.state}}"/>
+        {% for state in filters.state %}
+          <input class="state" name="state" type="hidden" value="{{state}}"/>
+        {% endfor %}
+        {% for brand in filters.brand %}
+          <input class="brand" name="brand" type="hidden" value="{{brand}}"/>
+        {% endfor %}
         <input class="reference" name="reference" type="hidden" value="{{filters.reference}}" />
+        <input class="email" name="email" type="hidden" value="{{filters.email}}" />
         <input class="fromDate" name="fromDate" type="hidden" value="{{filters.fromDate}}" />
         <input class="toDate" name="toDate" type="hidden" value="{{filters.toDate}}"/>
         <input class="page" name="page" type="hidden" value="{{paginationLink.pageNumber}}"/>

--- a/test/ui/pagination_ui_tests.js
+++ b/test/ui/pagination_ui_tests.js
@@ -31,7 +31,7 @@ describe('The pagination links', function () {
           'created': '2016-01-11 01:01:01'
         }
       ],
-      'filters': {'reference': 'ref1', 'state': 'Testing2', 'fromDate': '2015-01-11 01:01:01', 'toDate': '2015-01-11 01:01:01', 'pageSize': '100'},
+      'filters': {'reference': 'ref1', 'state': ['Testing2'], 'fromDate': '2015-01-11 01:01:01', 'toDate': '2015-01-11 01:01:01', 'pageSize': '100'},
       'paginationLinks': [
         {pageNumber: 1, pageName: 1},
         {pageNumber: 2, pageName: 2},


### PR DESCRIPTION
Since we made it so that you can filter by multiple states/brands the
logic that passed these filters through pagination broke as it expected
a string not an array. I've changed this and updated the test.

I also noticed we didnt pass email through to pagination, this probably
wasn't picked up before because no one has ever searched so unrefined as
to return that many emails that pagination is necessary. But I've added
it anyway.
