### PR TITLE
PP-3494 - Dashboard succesful transaction link fix

### DIFF
--- a/app/controllers/dashboard/dashboard-activity-controller.js
+++ b/app/controllers/dashboard/dashboard-activity-controller.js
@@ -13,11 +13,12 @@ const { isADirectDebitAccount } = require('../../services/clients/direct_debit_c
 const auth = require('../../services/auth_service.js')
 const connectorClient = () => new ConnectorClient(process.env.CONNECTOR_URL)
 const datetime = require('../../utils/nunjucks-filters/datetime')
+const NEW_CHARGE_STATUS_FEATURE_HEADER = 'NEW_CHARGE_STATUS_ENABLED'
 
 module.exports = (req, res) => {
   const correlationId = _.get(req, 'headers.' + CORRELATION_HEADER, '')
   const gatewayAccountId = auth.getCurrentGatewayAccountId((req))
-
+  const newChargeStatusEnabled = req.user.hasFeature(NEW_CHARGE_STATUS_FEATURE_HEADER)
   let toDateTime = moment().tz('Europe/London').format() // Today is the default
   let daysAgo = 0
   let period = _.get(req, 'query.period', 'today')
@@ -59,6 +60,7 @@ module.exports = (req, res) => {
       name: req.user.username,
       serviceId: req.service.externalId,
       activity: activityResults,
+      successfulTransactionsState: newChargeStatusEnabled ? 'payment-success' : 'success',
       fromDateTime,
       toDateTime,
       period,

--- a/app/views/dashboard/_activity.njk
+++ b/app/views/dashboard/_activity.njk
@@ -21,7 +21,7 @@
     <header class="dashboard-total-group__heading">
       <h2 class="dashboard-total-group__title">Successful payments</h2>
     </header>
-    <a class="dashboard-total-group__link" href="/transactions?state=payment-success&amp;{{ transactionsPeriodString }}" title="View successful payment transactions for chosen time period">
+    <a class="dashboard-total-group__link" href="/transactions?state={{successfulTransactionsState}}&amp;{{ transactionsPeriodString }}" title="View successful payment transactions for chosen time period">
       <dl class="dashboard-total-group__values dashboard-total-group__values--blue">
         <dt class="visually-hidden">Count</dt>
         <dd class="dashboard-total-group__count">{{ activity.successful_payments.count }}</dd>


### PR DESCRIPTION
The dashboard was hardcoded with a filter link that used the new payment
state "payment-success".

If a user does not have the flag then the filter was ignored.

So this checks for the flag and if it’s not present will use "success".

