### PR TITLE
PP-3654 fix whitespace around email bug

### DIFF
--- a/app/controllers/invite_user_controller.js
+++ b/app/controllers/invite_user_controller.js
@@ -1,10 +1,11 @@
+const lodash = require('lodash')
 const logger = require('winston')
-let response = require('../utils/response.js')
-let userService = require('../services/user_service.js')
-let paths = require('../paths.js')
-let successResponse = response.response
-let errorResponse = response.renderErrorView
-let rolesModule = require('../utils/roles')
+const response = require('../utils/response.js')
+const userService = require('../services/user_service.js')
+const paths = require('../paths.js')
+const successResponse = response.response
+const errorResponse = response.renderErrorView
+const rolesModule = require('../utils/roles')
 const emailValidator = require('../utils/email_tools.js')
 
 const formattedPathFor = require('../../app/utils/replace_params_in_path')
@@ -40,12 +41,14 @@ module.exports = {
     const externalServiceId = req.params.externalServiceId
     const teamMemberIndexLink = formattedPathFor(paths.teamMembers.index, externalServiceId)
     const teamMemberInviteSubmitLink = formattedPathFor(paths.teamMembers.invite, externalServiceId)
+    const invitee = lodash.get(req, 'session.pageData.invitee', '')
     let data = {
       teamMemberIndexLink: teamMemberIndexLink,
       teamMemberInviteSubmitLink: teamMemberInviteSubmitLink,
       admin: {id: roles['admin'].extId},
       viewAndRefund: {id: roles['view-and-refund'].extId},
-      view: {id: roles['view-only'].extId}
+      view: {id: roles['view-only'].extId},
+      invitee
     }
 
     return successResponse(req, res, 'services/team_member_invite', data)
@@ -60,12 +63,13 @@ module.exports = {
     let correlationId = req.correlationId
     let senderId = req.user.externalId
     let externalServiceId = req.params.externalServiceId
-    let invitee = req.body['invitee-email']
+    let invitee = req.body['invitee-email'].trim()
     let roleId = parseInt(req.body['role-input'])
 
     let role = rolesModule.getRoleByExtId(roleId)
 
     let onSuccess = () => {
+      delete req.session.pageData.invitee
       req.flash('generic', `Invite sent to ${invitee}`)
       res.redirect(303, formattedPathFor(paths.teamMembers.index, externalServiceId))
     }
@@ -84,6 +88,7 @@ module.exports = {
 
     if (!emailValidator(invitee)) {
       req.flash('genericError', `Invalid email address`)
+      lodash.set(req, 'session.pageData', {invitee})
       res.redirect(303, formattedPathFor(paths.teamMembers.invite, externalServiceId))
       return
     }

--- a/app/utils/display_converter.js
+++ b/app/utils/display_converter.js
@@ -1,4 +1,4 @@
-let _ = require('lodash')
+const _ = require('lodash')
 const getHeldPermissions = require('./get_held_permissions')
 const {serviceNavigationItems, adminNavigationItems} = require('./navBuilder')
 

--- a/app/utils/navBuilder.js
+++ b/app/utils/navBuilder.js
@@ -1,4 +1,4 @@
-let _ = require('lodash')
+const _ = require('lodash')
 const paths = require('./../paths')
 const pathLookup = require('./pathLookup')
 

--- a/app/utils/pathLookup.js
+++ b/app/utils/pathLookup.js
@@ -1,6 +1,6 @@
 // function to see if current url matches another URL,
 // useful for navigation.
-let _ = require('lodash')
+const _ = require('lodash')
 
 module.exports = function (currentURL, url) {
   if (_.isArray(url)) {

--- a/app/utils/response.js
+++ b/app/utils/response.js
@@ -1,5 +1,5 @@
 let logger = require('winston')
-let _ = require('lodash')
+const _ = require('lodash')
 
 let displayConverter = require('./display_converter')
 

--- a/app/utils/roles.js
+++ b/app/utils/roles.js
@@ -1,4 +1,4 @@
-let _ = require('lodash')
+const _ = require('lodash')
 
 const roles = {
   'admin': {extId: 200, name: 'admin', description: 'Administrator'},

--- a/app/views/services/team_member_invite.njk
+++ b/app/views/services/team_member_invite.njk
@@ -23,7 +23,7 @@ Invite a new team member - GOV.UK Pay
         <label class="form-label" for="invitee-email">
             Email address
         </label>
-        <input type="text" class="form-control" id="invitee-email" name="invitee-email">
+        <input type="text" class="form-control" id="invitee-email" name="invitee-email" value="{{invitee}}">
       </div>
       <div class="form-group">
         <fieldset>

--- a/test/integration/invite_users_controller_ft_test.js
+++ b/test/integration/invite_users_controller_ft_test.js
@@ -1,19 +1,19 @@
-let path = require('path')
-let nock = require('nock')
-let getApp = require(path.join(__dirname, '/../../server.js')).getApp
-let supertest = require('supertest')
-let session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
-let csrf = require('csrf')
-let chai = require('chai')
-let roles = require('../../app/utils/roles').roles
-let paths = require(path.join(__dirname, '/../../app/paths.js'))
-let inviteFixtures = require(path.join(__dirname, '/../fixtures/invite_fixtures'))
-let sinon = require('sinon')
-let _ = require('lodash')
-let inviteUserController = require('../../app/controllers/invite_user_controller')
+const path = require('path')
+const nock = require('nock')
+const getApp = require(path.join(__dirname, '/../../server.js')).getApp
+const supertest = require('supertest')
+const session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+const csrf = require('csrf')
+const chai = require('chai')
+const roles = require('../../app/utils/roles').roles
+const paths = require(path.join(__dirname, '/../../app/paths.js'))
+const inviteFixtures = require(path.join(__dirname, '/../fixtures/invite_fixtures'))
+const sinon = require('sinon')
+const _ = require('lodash')
+const inviteUserController = require('../../app/controllers/invite_user_controller')
 
-let expect = chai.expect
-let adminusersMock = nock(process.env.ADMINUSERS_URL)
+const expect = chai.expect
+const adminusersMock = nock(process.env.ADMINUSERS_URL)
 
 const formattedPathFor = require('../../app/utils/replace_params_in_path')
 

--- a/test/integration/invite_users_controller_ft_test.js
+++ b/test/integration/invite_users_controller_ft_test.js
@@ -67,7 +67,7 @@ describe('invite user controller', function () {
     it('should error if the user is already invited/exists', function (done) {
       let existingUser = 'existing-user@example.com'
       adminusersMock.post(INVITE_RESOURCE)
-        .reply(409, inviteFixtures.conflictingInviteResponseWhenEmailUserAlreadyCreated(existingUser).getPlain())
+        .reply(412, inviteFixtures.conflictingInviteResponseWhenEmailUserAlreadyCreated(existingUser).getPlain())
       const app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       supertest(app)

--- a/test/integration/service_roles_update_ft_test.js
+++ b/test/integration/service_roles_update_ft_test.js
@@ -1,15 +1,15 @@
-let path = require('path')
-let nock = require('nock')
-let session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
-let getApp = require(path.join(__dirname, '/../../server.js')).getApp
-let supertest = require('supertest')
-let csrf = require('csrf')
-let userFixtures = require(path.join(__dirname, '/../fixtures/user_fixtures'))
-let paths = require(path.join(__dirname, '/../../app/paths.js'))
-let roles = require('../../app/utils/roles').roles
-let chai = require('chai')
-let _ = require('lodash')
-let chaiAsPromised = require('chai-as-promised')
+const path = require('path')
+const nock = require('nock')
+const session = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
+const getApp = require(path.join(__dirname, '/../../server.js')).getApp
+const supertest = require('supertest')
+const csrf = require('csrf')
+const userFixtures = require(path.join(__dirname, '/../fixtures/user_fixtures'))
+const paths = require(path.join(__dirname, '/../../app/paths.js'))
+const roles = require('../../app/utils/roles').roles
+const chai = require('chai')
+const _ = require('lodash')
+const chaiAsPromised = require('chai-as-promised')
 let app
 
 chai.use(chaiAsPromised)


### PR DESCRIPTION
- Strip whitespace automatically
- If an invalid email is put it, pass it back rather than clearing it
- update tests because they weren’t working at all because they expected a `409` when it was a `412`

(also spotted some embarrassing let usage so updated them to const, this is no by exhaustive but y'know. I’ve marked the actual meaningful changes)