### PR TITLE
PP-3602 Remove products and card payments smoke tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,28 +40,6 @@ pipeline {
     stage('Tests') {
       failFast true
       parallel {
-        stage('Card Payment End-to-End Tests') {
-            when {
-                anyOf {
-                  branch 'master'
-                  environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
-                }
-            }
-            steps {
-                runCardPaymentsE2E("selfservice")
-            }
-        }
-        stage('Products End-to-End Tests') {
-            when {
-                anyOf {
-                  branch 'master'
-                  environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
-                }
-            }
-            steps {
-                runProductsE2E("selfservice")
-            }
-        }
         stage('Direct-Debit End-to-End Tests') {
             when {
                 anyOf {


### PR DESCRIPTION
When doing the selenium tests for staging we decided selfservice should
only run DD smoke tests. Updating the Jenkinsfile so that there is
consistency across all the environments

solo @belindac