### PR TITLE
PP-3602 Reinstate incorrectly removed e2e config, remove products smoke test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,18 +108,9 @@ pipeline {
         deployEcs("selfservice")
       }
     }
-    stage('Smoke Tests') {
-      failFast true
-      parallel {
-        stage('Product Smoke Test') {
-          when { branch 'master' }
-          steps { runProductsSmokeTest() }
-        }
-        stage('Direct Debit Smoke Test') {
-          when { branch 'master' }
-          steps { runDirectDebitSmokeTest() }
-        }
-      }
+    stage('Direct Debit Smoke Test') {
+      when { branch 'master' }
+      steps { runDirectDebitSmokeTest() }
     }
     stage('Complete') {
       failFast true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,6 +40,28 @@ pipeline {
     stage('Tests') {
       failFast true
       parallel {
+        stage('Card Payment End-to-End Tests') {
+            when {
+                anyOf {
+                  branch 'master'
+                  environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
+                }
+            }
+            steps {
+                runCardPaymentsE2E("selfservice")
+            }
+        }
+        stage('Products End-to-End Tests') {
+            when {
+                anyOf {
+                  branch 'master'
+                  environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
+                }
+            }
+            steps {
+                runProductsE2E("selfservice")
+            }
+        }
         stage('Direct-Debit End-to-End Tests') {
             when {
                 anyOf {


### PR DESCRIPTION
Revert commit that amended e2e rather than smoke tests
Only products and products-ui should run products smoke tests

solo @belindac

