### PR TITLE
PP-3686 Refactored charge_test in models unit tests, to remove nock http mocks

### DIFF
--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -91,8 +91,6 @@ module.exports = function (correlationId) {
     const code = (response || {}).statusCode || (err || {}).errorCode
     if (code === 404) return defer.reject('NOT_FOUND')
     if (code > 200) return defer.reject('GET_FAILED')
-    if (err) defer.reject('CLIENT_UNAVAILABLE')
-
     defer.reject('CLIENT_UNAVAILABLE')
   }
 

--- a/app/models/email.js
+++ b/app/models/email.js
@@ -1,7 +1,7 @@
 var q = require('q')
 var logger = require('winston')
 var EMAIL_NOTIFICATION_API_PATH = '/v1/api/accounts/{accountId}/email-notification'
-var ConnectorClient = require('../services/clients/connector_client').ConnectorClient
+var ConnectorClient = require('../services/clients/connector_client.js').ConnectorClient
 
 var connectorUrl = function (accountID) {
   return process.env.CONNECTOR_URL + EMAIL_NOTIFICATION_API_PATH.replace('{accountId}', accountID)
@@ -17,7 +17,6 @@ module.exports = function (correlationId) {
   var get = function (accountID) {
     var defer = q.defer()
     var startTime = new Date()
-
     connectorClient().getNotificationEmail({
       gatewayAccountId: accountID,
       correlationId: correlationId

--- a/test/unit/models/charge_test.js
+++ b/test/unit/models/charge_test.js
@@ -1,114 +1,147 @@
 'use strict'
 
+// NPM Dependencies
 const path = require('path')
-require(path.join(__dirname, '/../../test_helpers/html_assertions.js'))
-const assert = require('assert')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const expect = require('chai').expect
+const EventEmitter = require('events').EventEmitter
+
+// Local Dependencies
 const userFixtures = require('../../fixtures/user_fixtures')
-const nock = require('nock')
 const User = require('../../../app/models/User.class')
-const wrongPromise = function (data) {
-  throw new Error('Promise was unexpectedly fulfilled.')
-}
-let Charge, buildPaymentView, user
 
 describe('charge model', function () {
-  beforeEach(() => {
-    buildPaymentView = sinon.spy()
-    Charge = proxyquire(path.join(__dirname, '/../../../app/models/charge.js'), {
-      '../utils/transaction_view.js': {buildPaymentView}
-    })
-  })
   describe('findWithEvents', function () {
     describe('when connector is unavailable', function () {
-      before(function () {
-        nock.cleanAll()
-      })
-
-      after(function () {
-        nock.cleanAll()
-      })
-
       it('should return client unavailable', function () {
+          // Create a class that inherits from EventEmitter and emit a 'connectorError' event which is handled by the service
+        class StubConnectorChargeFunctions extends EventEmitter {
+          getCharge () {
+            setTimeout(() => {
+              this.emit('connectorError', {thisIs: 'anErrorObject'})
+            }, 100)
+            return this
+          }
+          getChargeEvents () {
+            return this
+          }
+          }
+        let sCCFinst = new StubConnectorChargeFunctions()
+        let connectorClientStub = {
+          ConnectorClient: function () {
+            return sCCFinst
+          }
+        }
+        let Charge = proxyquire(path.join(__dirname, '/../../../app/models/charge.js'), {
+          '../services/clients/connector_client.js': connectorClientStub
+        })
         const chargeModel = Charge('correlation-id')
-        return chargeModel.findWithEvents(1, 1).then(wrongPromise,
-            function rejected (error) {
-              assert.equal(error, 'CLIENT_UNAVAILABLE')
-            }
-          )
+        return expect(chargeModel.findWithEvents(1, 1))
+            .to.be.rejectedWith('CLIENT_UNAVAILABLE')
       }
       )
     })
 
     describe('when connector returns incorrect response code', function () {
-      const defaultCorrelationHeader = {
-        reqheaders: {'x-request-id': 'some-unique-id'}
-      }
-
-      before(function () {
-        nock.cleanAll()
-
-        nock(process.env.CONNECTOR_URL, defaultCorrelationHeader)
-          .get('/v1/api/accounts/1/charges/2')
-          .reply(405, '')
-      })
-
       it('should return get_failed', function () {
+        // Create a class that inherits from EventEmitter and emit a 'connectorError' event which is handled by the service
+        class StubConnectorChargeFunctions extends EventEmitter {
+          getCharge () {
+            setTimeout(() => {
+              this.emit('connectorError', {thisIs: 'anErrorObject'}, {statusCode: 201})
+            }, 100)
+            return this
+          }
+          getChargeEvents () {
+            return this
+          }
+        }
+        let sCCFinst = new StubConnectorChargeFunctions()
+        let connectorClientStub = {
+          ConnectorClient: function () {
+            return sCCFinst
+          }
+        }
+        let Charge = proxyquire(path.join(__dirname, '/../../../app/models/charge.js'), {
+          '../services/clients/connector_client.js': connectorClientStub
+        })
         const chargeModel = Charge('some-unique-id')
-        return chargeModel.findWithEvents(1, 2).then(wrongPromise,
-          function rejected (error) {
-            assert.equal(error, 'GET_FAILED')
-          })
+        return expect(chargeModel.findWithEvents(1, 1))
+          .to.be.rejectedWith('GET_FAILED')
       })
     })
 
     describe('when adminusers returns incorrect response code', function () {
-      before(function () {
-        nock.cleanAll()
-
-        nock(process.env.CONNECTOR_URL)
-          .get('/v1/api/accounts/1/charges/2')
-          .reply(200, { foo: 'bar' })
-
-        nock(process.env.CONNECTOR_URL)
-          .get('/v1/api/accounts/1/charges/2/events')
-          .reply(200, {events: [{ submitted_by: 'abc123' }]})
-
-        nock(process.env.ADMINUSERS_URL)
-          .get('/v1/api/users?ids=abc123')
-          .reply(405)
-      })
-
       it('should return get_failed', function () {
+        // Create a class that inherits from EventEmitter
+        class StubConnectorChargeFunctions extends EventEmitter {
+          getCharge (params, callback) {
+            callback({foo: 'bar'}) // eslint-disable-line
+            return this
+          }
+          getChargeEvents (params, callback) {
+            callback({events: [{submitted_by: 'abc123'}]}) // eslint-disable-line
+            return this
+          }
+        }
+        let sCCFinst = new StubConnectorChargeFunctions()
+        let connectorClientStub = {
+          ConnectorClient: function () {
+            return sCCFinst
+          }
+        }
+        let userServiceStub = {
+          findMultipleByExternalIds: function () {
+            return new Promise(function (resolve, reject) {
+              reject({errorCode: 405, iam: 'anError'}) // eslint-disable-line
+            })
+          }
+        }
+        let Charge = proxyquire(path.join(__dirname, '/../../../app/models/charge.js'), {
+          '../services/clients/connector_client.js': connectorClientStub,
+          '../services/user_service': userServiceStub
+        })
         const chargeModel = Charge('some-unique-id')
-        return chargeModel.findWithEvents(1, 2).then(wrongPromise,
-          function rejected (error) {
-            assert.equal(error, 'GET_FAILED')
-          })
+        return expect(chargeModel.findWithEvents(1, 1))
+          .to.be.rejectedWith('GET_FAILED')
       })
     })
 
     describe('when connector returns correctly', function () {
-      before(function () {
-        nock.cleanAll()
-        user = userFixtures.validUser().getPlain()
-
-        nock(process.env.CONNECTOR_URL)
-          .get('/v1/api/accounts/1/charges/2')
-          .reply(200, {foo: 'bar'})
-
-        nock(process.env.CONNECTOR_URL)
-          .get('/v1/api/accounts/1/charges/2/events')
-          .reply(200, {events: [{submitted_by: user.external_id}]})
-
-        nock(process.env.ADMINUSERS_URL)
-          .get(`/v1/api/users?ids=${user.external_id}`)
-          .reply(200, [user])
-      })
-
       it('should return the correct promise', function () {
+        let user = userFixtures.validUser().getPlain()
+        // Create a class that inherits from EventEmitter and emit a 'connectorError' event which is handled by the service
+        class StubConnectorChargeFunctions extends EventEmitter {
+          getCharge (params, callback) {
+            callback({foo: 'bar'}) // eslint-disable-line
+            return this
+          }
+          getChargeEvents (params, callback) {
+            callback({events: [{submitted_by: user.external_id}]}) // eslint-disable-line
+            return this
+          }
+        }
+        let sCCFinst = new StubConnectorChargeFunctions()
+        let connectorClientStub = {
+          ConnectorClient: function () {
+            return sCCFinst
+          }
+        }
+        let userServiceStub = {
+          findMultipleByExternalIds: function () {
+            return new Promise(function (resolve, reject) {
+              resolve([new User(user)])
+            })
+          }
+        }
+        let buildPaymentView = sinon.spy()
+        let Charge = proxyquire(path.join(__dirname, '/../../../app/models/charge.js'), {
+          '../services/clients/connector_client.js': connectorClientStub,
+          '../services/user_service': userServiceStub,
+          '../utils/transaction_view.js': {buildPaymentView}
+        })
+
         const chargeModel = Charge('correlation-id')
         return chargeModel.findWithEvents(1, 2).then(function () {
           expect(buildPaymentView.called).to.equal(true)
@@ -117,7 +150,7 @@ describe('charge model', function () {
           expect(buildPaymentView.args[0][0]).to.deep.equal({foo: 'bar'})
           expect(buildPaymentView.args[0][1]).to.deep.equal({events: [{submitted_by: user.external_id}]})
           expect(buildPaymentView.args[0][2]).to.deep.equal([new User(user)])
-        }, wrongPromise)
+        })
       })
     })
   })

--- a/test/unit/models/email_test.js
+++ b/test/unit/models/email_test.js
@@ -1,132 +1,168 @@
-var path = require('path')
-require(path.join(__dirname, '/../../test_helpers/html_assertions.js'))
-var assert = require('assert')
-var Email = require(path.join(__dirname, '/../../../app/models/email.js'))
-var nock = require('nock')
-var expect = require('chai').expect
-var _ = require('lodash')
+'use strict'
 
-var wrongPromise = function (data) {
-  throw new Error('Promise was unexpectedly fulfilled.')
-}
-
-var aCorrelationHeader = {
-  reqheaders: {
-    'x-request-id': 'some-unique-id'
-  }
-}
+// NPM Dependencies
+const path = require('path')
+const expect = require('chai').expect
+const _ = require('lodash')
+const EventEmitter = require('events').EventEmitter
+const proxyquire = require('proxyquire')
 
 describe('email notification', function () {
   describe('getting the template body', function () {
     describe('when connector is unavailable', function () {
-      before(function () {
-        nock.cleanAll()
-      })
-
-      after(function () {
-        nock.cleanAll()
-      })
-
       it('should return client unavailable', function () {
-        var emailModel = Email('some-unique-id')
-        return emailModel.get(123).then(wrongPromise,
-            function rejected (error) {
-              assert.equal(error.message, 'CLIENT_UNAVAILABLE')
-            }
-          )
+          // Create a class that inherits from EventEmitter and emit a 'connectorError' event which is handled by the service
+        class StubConnectorEmailFunctions extends EventEmitter {
+          getNotificationEmail () {
+            setTimeout(() => {
+              this.emit('connectorError')
+            }, 100)
+            return this
+          }
+          }
+        let sCEFinst = new StubConnectorEmailFunctions()
+        let connectorClientStub = {
+          ConnectorClient: function () {
+            return sCEFinst
+          }
+        }
+        let Email = proxyquire(path.join(__dirname, '/../../../app/models/email.js'), {
+          '../services/clients/connector_client.js': connectorClientStub
+        })
+        const emailModel = Email('some-unique-id')
+        return expect(emailModel.get(123))
+            .to.be.rejectedWith('CLIENT_UNAVAILABLE')
       }
       )
     })
 
     describe('when connector returns incorrect response code', function () {
-      before(function () {
-        nock.cleanAll()
-
-        nock(process.env.CONNECTOR_URL, aCorrelationHeader)
-          .get('/v1/api/accounts/123/email-notification')
-          .reply(404, '')
-      })
-
       it('should return get_failed', function () {
-        var emailModel = Email('some-unique-id')
-        return emailModel.get(123).then(wrongPromise,
-          function rejected (error) {
-            assert.equal(error.message, 'GET_FAILED')
-          })
+        // Create a class that inherits from EventEmitter and emit a 'connectorError' event which is handled by the service
+        class StubConnectorEmailFunctions extends EventEmitter {
+          getNotificationEmail () {
+            setTimeout(() => {
+              this.emit('connectorError', {thisIs: 'anErrorObject'}, {thisIs: 'aConnectorResponse'})
+            }, 100)
+            return this
+          }
+        }
+        let sCEFinst = new StubConnectorEmailFunctions()
+        let connectorClientStub = {
+          ConnectorClient: function () {
+            return sCEFinst
+          }
+        }
+        let Email = proxyquire(path.join(__dirname, '/../../../app/models/email.js'), {
+          '../services/clients/connector_client.js': connectorClientStub
+        })
+        const emailModel = Email('some-unique-id')
+        return expect(emailModel.get(123))
+          .to.be.rejectedWith('GET_FAILED')
       })
     })
 
     describe('when connector returns correctly', function () {
-      before(function () {
-        nock.cleanAll()
-
-        nock(process.env.CONNECTOR_URL)
-          .get('/v1/api/accounts/123/email-notification')
-          .reply(200, {'template_body': 'hello', 'enabled': true})
-      })
-
       it('should return the correct promise', function () {
-        var emailModel = Email('some-unique-id')
-        return emailModel.get(123).then(function (data) {
-          expect(data).to.deep.equal({'customEmailText': 'hello', 'emailEnabled': true})
-        }, wrongPromise)
+        // Create a class that inherits from EventEmitter
+        class StubConnectorEmailFunctions extends EventEmitter {
+          getNotificationEmail (params, callback) {
+            callback({template_body: 'some template here', enabled: true}) // eslint-disable-line
+            return this
+          }
+        }
+        let sCEFinst = new StubConnectorEmailFunctions()
+        let connectorClientStub = {
+          ConnectorClient: function () {
+            return sCEFinst
+          }
+        }
+        let Email = proxyquire(path.join(__dirname, '/../../../app/models/email.js'), {
+          '../services/clients/connector_client.js': connectorClientStub
+        })
+        const emailModel = Email('some-unique-id')
+        return expect(emailModel.get(123))
+          .to.be.fulfilled.then(function (response) {
+            expect(response).to.deep.equal({customEmailText: 'some template here', emailEnabled: true})
+          })
       })
     })
   })
 
   describe('updating the email notification template body', function () {
     describe('when connector is unavailable', function () {
-      before(function () {
-        nock.cleanAll()
-      })
-
-      after(function () {
-        nock.cleanAll()
-      })
-
       it('should return client unavailable', function () {
-        var emailModel = Email('some-unique-id')
-        return emailModel.update(123).then(wrongPromise,
-            function rejected (error) {
-              assert.equal(error.message, 'CLIENT_UNAVAILABLE')
-            }
-          )
+          // Create a class that inherits from EventEmitter and emit a 'connectorError' event which is handled by the service
+        class StubConnectorEmailFunctions extends EventEmitter {
+          updateNotificationEmail () {
+            setTimeout(() => {
+              this.emit('connectorError', {thisIs: 'anErrorObject'})
+            }, 100)
+            return this
+          }
+          }
+        let sCEFinst = new StubConnectorEmailFunctions()
+        let connectorClientStub = {
+          ConnectorClient: function () {
+            return sCEFinst
+          }
+        }
+        let Email = proxyquire(path.join(__dirname, '/../../../app/models/email.js'), {
+          '../services/clients/connector_client.js': connectorClientStub
+        })
+        const emailModel = Email('some-unique-id')
+        return expect(emailModel.update(123))
+            .to.be.rejectedWith('CLIENT_UNAVAILABLE')
       }
       )
     })
 
     describe('when connector returns incorrect response code', function () {
-      before(function () {
-        nock.cleanAll()
-
-        nock(process.env.CONNECTOR_URL)
-          .post('/v1/api/accounts/123/email-notification')
-          .reply(404, '')
-      })
-
       it('should return POST_FAILED', function () {
-        var emailModel = Email('some-unique-id')
-        return emailModel.update(123, 'hello')
-        .then(wrongPromise, function rejected (error) {
-          assert.equal(error.message, 'POST_FAILED')
+        // Create a class that inherits from EventEmitter and emit a 'connectorError' event which is handled by the service
+        class StubConnectorEmailFunctions extends EventEmitter {
+          updateNotificationEmail () {
+            setTimeout(() => {
+              this.emit('connectorError', {thisIs: 'anErrorObject'}, {thisIs: 'aConnectorResponse'})
+            }, 100)
+            return this
+          }
+        }
+        let sCEFinst = new StubConnectorEmailFunctions()
+        let connectorClientStub = {
+          ConnectorClient: function () {
+            return sCEFinst
+          }
+        }
+        let Email = proxyquire(path.join(__dirname, '/../../../app/models/email.js'), {
+          '../services/clients/connector_client.js': connectorClientStub
         })
+        const emailModel = Email('some-unique-id')
+        return expect(emailModel.update(123))
+          .to.be.rejectedWith('POST_FAILED')
       })
     })
 
     describe('when connector returns correctly', function () {
-      before(function () {
-        nock.cleanAll()
-
-        nock(process.env.CONNECTOR_URL)
-          .post('/v1/api/accounts/123/email-notification')
-          .reply(200, {})
-      })
-
       it('should update the email notification template body', function () {
-        var emailModel = Email('some-unique-id')
-        return emailModel.update(123, 'hello').then(function (data) {
-          assert.equal(1, 1)
-        }, wrongPromise)
+        class StubConnectorEmailFunctions extends EventEmitter {
+          updateNotificationEmail (params, callback) {
+            console.log('BOOM!')
+            callback()
+            return this
+          }
+        }
+        let sCEFinst = new StubConnectorEmailFunctions()
+        let connectorClientStub = {
+          ConnectorClient: function () {
+            return sCEFinst
+          }
+        }
+        let Email = proxyquire(path.join(__dirname, '/../../../app/models/email.js'), {
+          '../services/clients/connector_client.js': connectorClientStub
+        })
+        const emailModel = Email('some-unique-id')
+        return expect(emailModel.update(123)).to.be.fulfilled
       })
     })
   })
@@ -134,55 +170,78 @@ describe('email notification', function () {
   describe('enabling/disabling email notifications', function () {
     _.each([true, false], function (toggle) {
       describe('when connector is unavailable', function () {
-        before(function () {
-          nock.cleanAll()
-        })
-
-        after(function () {
-          nock.cleanAll()
-        })
-
         it('should return client unavailable', function () {
-          var emailModel = Email('some-unique-id')
-          return emailModel.setEnabled(123, toggle).then(wrongPromise,
-              function rejected (error) {
-                assert.equal(error.message, 'CLIENT_UNAVAILABLE')
-              }
-            )
+            // Create a class that inherits from EventEmitter and emit a 'connectorError' event which is handled by the service
+          class StubConnectorEmailFunctions extends EventEmitter {
+            updateNotificationEmailEnabled () {
+              setTimeout(() => {
+                this.emit('connectorError', {thisIs: 'anErrorObject'})
+              }, 100)
+              return this
+            }
+            }
+          let sCEFinst = new StubConnectorEmailFunctions()
+          let connectorClientStub = {
+            ConnectorClient: function () {
+              return sCEFinst
+            }
+          }
+          let Email = proxyquire(path.join(__dirname, '/../../../app/models/email.js'), {
+            '../services/clients/connector_client.js': connectorClientStub
+          })
+          const emailModel = Email('some-unique-id')
+          return expect(emailModel.setEnabled(123, toggle))
+              .to.be.rejectedWith('CLIENT_UNAVAILABLE')
         }
         )
       })
 
       describe('when connector returns incorrect response code', function () {
-        before(function () {
-          nock.cleanAll()
-          nock(process.env.CONNECTOR_URL)
-            .patch('/v1/api/accounts/123/email-notification', {'op': 'replace', 'path': 'enabled', 'value': toggle})
-            .reply(404, '')
-        })
-
         it('should return PATCH_FAILED', function () {
-          var emailModel = Email('some-unique-id')
-          return emailModel.setEnabled(123, toggle)
-          .then(wrongPromise, function rejected (error) {
-            assert.equal(error.message, 'PATCH_FAILED')
+          // Create a class that inherits from EventEmitter and emit a 'connectorError' event which is handled by the service
+          class StubConnectorEmailFunctions extends EventEmitter {
+            updateNotificationEmailEnabled () {
+              setTimeout(() => {
+                this.emit('connectorError', {thisIs: 'anErrorObject'}, {thisIs: 'aConnectorResponse'})
+              }, 100)
+              return this
+            }
+          }
+          let sCEFinst = new StubConnectorEmailFunctions()
+          let connectorClientStub = {
+            ConnectorClient: function () {
+              return sCEFinst
+            }
+          }
+          let Email = proxyquire(path.join(__dirname, '/../../../app/models/email.js'), {
+            '../services/clients/connector_client.js': connectorClientStub
           })
+          const emailModel = Email('some-unique-id')
+          return expect(emailModel.setEnabled(123, true))
+            .to.be.rejectedWith('PATCH_FAILED')
         })
       })
 
       describe('when connector returns correctly', function () {
-        before(function () {
-          nock.cleanAll()
-          nock(process.env.CONNECTOR_URL)
-            .patch('/v1/api/accounts/123/email-notification', {'op': 'replace', 'path': 'enabled', 'value': toggle})
-            .reply(200, {})
-        })
-
         it('should disable email notifications', function () {
-          var emailModel = Email('some-unique-id')
-          return emailModel.setEnabled(123, toggle).then(function (data) {
-            assert.equal(1, 1)
-          }, wrongPromise)
+          // Create a class that inherits from EventEmitter
+          class StubConnectorEmailFunctions extends EventEmitter {
+            updateNotificationEmailEnabled (params, callback) {
+              callback()
+              return this
+            }
+          }
+          let sCEFinst = new StubConnectorEmailFunctions()
+          let connectorClientStub = {
+            ConnectorClient: function () {
+              return sCEFinst
+            }
+          }
+          let Email = proxyquire(path.join(__dirname, '/../../../app/models/email.js'), {
+            '../services/clients/connector_client.js': connectorClientStub
+          })
+          const emailModel = Email('some-unique-id')
+          return expect(emailModel.setEnabled(123, true)).to.be.fulfilled
         })
       })
     })

--- a/test/unit/services/service_service_test.js
+++ b/test/unit/services/service_service_test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const proxyquire = require('proxyquire')
-const sinon = require('sinon')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 chai.use(chaiAsPromised)
@@ -44,7 +43,7 @@ getDDGatewayAccount = function (id) {
         }
       })
     } else {
-      reject()
+      reject() // eslint-disable-line
     }
   })
 }
@@ -60,7 +59,7 @@ getGatewayAccount = function () {
           resolve(gatewayAccountFixtures.validGatewayAccountResponse(
             {gateway_account_id: gatewayAccountId2, service_name: 'ga 2'}).getPlain())
         } else {
-          reject()
+          reject() // eslint-disable-line
         }
       })
     }
@@ -165,7 +164,7 @@ describe('service service', function () {
       const newServiceName = 'blabla'
 
       connectorClientStub = {
-        ConnectorClient: function() {
+        ConnectorClient: function () {
           return {
             patchServiceName: () => {
               return new Promise(resolve => {
@@ -186,7 +185,7 @@ describe('service service', function () {
       }
       productsClientStub = {
         product: {
-          updateServiceNameOfProductsByGatewayAccountId : () => {
+          updateServiceNameOfProductsByGatewayAccountId: () => {
             return new Promise(resolve => {
               resolve()
             })

--- a/test/unit/services/transaction_service_test.js
+++ b/test/unit/services/transaction_service_test.js
@@ -11,15 +11,14 @@ chai.use(chaiAsPromised)
 describe('transaction service', () => {
   describe('search', () => {
     describe('when connector returns correctly', () => {
-
       // Create a class that inherits from EventEmitter so we can replicate the .on('xxxx') functionality the code expects
-      class sTransactions extends EventEmitter {
-        searchTransactions(params, callback) {
+      class STransactions extends EventEmitter {
+        searchTransactions (params, callback) {
           callback(null, {statusCode: 200})
           return this
         }
       }
-      let sTranInst = new sTransactions()
+      let sTranInst = new STransactions()
       let connectorClientStub = {
         ConnectorClient: function () {
           return sTranInst
@@ -37,17 +36,16 @@ describe('transaction service', () => {
     })
 
     describe('when connector is unavailable', () => {
-
       // Create a class that inherits from EventEmitter and emit a 'connectorError' event which is handled by the service
-      class sTransactions extends EventEmitter {
-        searchTransactions() {
+      class STransactions extends EventEmitter {
+        searchTransactions () {
           setTimeout(() => {
             this.emit('connectorError')
           }, 100)
           return this
         }
       }
-      let sTranInst = new sTransactions()
+      let sTranInst = new STransactions()
       let connectorClientStub = {
         ConnectorClient: function () {
           return sTranInst
@@ -59,22 +57,21 @@ describe('transaction service', () => {
         })
 
       it('should return client unavailable', () => {
-          return expect(transactionService.search(123, {}, 'some-unique-id'))
+        return expect(transactionService.search(123, {}, 'some-unique-id'))
             .to.be.rejectedWith(Error, 'CLIENT_UNAVAILABLE')
-        }
+      }
       )
     })
 
     describe('when connector returns incorrect response code while retrieving the list of transactions', () => {
-
       // Create a class that inherits from EventEmitter so we can replicate the .on('xxxx') functionality the code expects
-      class sTransactions extends EventEmitter {
-        searchTransactions(params, callback) {
+      class STransactions extends EventEmitter {
+        searchTransactions (params, callback) {
           callback(null, {statusCode: 201})
           return this
         }
       }
-      let sTranInst = new sTransactions()
+      let sTranInst = new STransactions()
       let connectorClientStub = {
         ConnectorClient: function () {
           return sTranInst
@@ -94,14 +91,13 @@ describe('transaction service', () => {
 
   describe('searchAll', () => {
     describe('when connector returns correctly', () => {
-
-      class gaTransactions extends EventEmitter {
-        getAllTransactions(params, callback) {
+      class GaTransactions extends EventEmitter {
+        getAllTransactions (params, callback) {
           callback(null, {statusCode: 200})
           return this
         }
       }
-      let gaTranInst = new gaTransactions()
+      let gaTranInst = new GaTransactions()
       let connectorClientStub = {
         ConnectorClient: function () {
           return gaTranInst
@@ -144,16 +140,15 @@ describe('transaction service', () => {
     })
 
     describe('when connector is unavailable', () => {
-
-      class gaTransactions extends EventEmitter {
-        getAllTransactions(params, callback) {
+      class GaTransactions extends EventEmitter {
+        getAllTransactions (params, callback) {
           setTimeout(() => {
             this.emit('connectorError')
           }, 100)
           return this
         }
       }
-      let gaTranInst = new gaTransactions()
+      let gaTranInst = new GaTransactions()
       let connectorClientStub = {
         ConnectorClient: function () {
           return gaTranInst
@@ -165,23 +160,22 @@ describe('transaction service', () => {
         })
 
       it('should return client unavailable', () => {
-          return expect(transactionService.searchAll(123, {pageSize: 1, page: 100}, 'some-unique-id'))
+        return expect(transactionService.searchAll(123, {pageSize: 1, page: 100}, 'some-unique-id'))
             .to.be.rejectedWith(Error, 'CLIENT_UNAVAILABLE')
-        }
+      }
       )
     })
 
     describe('when connector returns incorrect response code', () => {
-
-      class gaTransactions extends EventEmitter {
-        getAllTransactions(params, callback) {
+      class GaTransactions extends EventEmitter {
+        getAllTransactions (params, callback) {
           setTimeout(() => {
             this.emit('connectorError', null, {iam: 'an-object'})
           }, 100)
           return this
         }
       }
-      let gaTranInst = new gaTransactions()
+      let gaTranInst = new GaTransactions()
       let connectorClientStub = {
         ConnectorClient: function () {
           return gaTranInst

--- a/test/unit/utils/util_correlation_header_test.js
+++ b/test/unit/utils/util_correlation_header_test.js
@@ -1,4 +1,3 @@
-var path = require('path')
 var assert = require('assert')
 var withCorrelationHeader = require('../../../app/utils/correlation_header.js').withCorrelationHeader
 

--- a/test/unit/utils/utils_filters_test.js
+++ b/test/unit/utils/utils_filters_test.js
@@ -1,4 +1,3 @@
-var path = require('path')
 var filters = require('../../../app/utils/filters.js')
 var expect = require('chai').expect
 


### PR DESCRIPTION
## WHAT
Removes use of 'nock' to mock http endpoints from the /test/unit/models directory. This is part of our ongoing consolidation work to prepare for contract/pact and browser tests.

Where nock http mocks have been removed, correctly stubbed functions from dependencies have been created, rather than the 'integration' like solution that we had beforehand.


