### PR TITLE
PP-3686 Remove nock from middleware tests

### DIFF
--- a/test/unit/middleware/has_services_test.js
+++ b/test/unit/middleware/has_services_test.js
@@ -2,7 +2,6 @@
 
 const path = require('path')
 const sinon = require('sinon')
-const nock = require('nock')
 const chai = require('chai')
 const {expect} = chai
 const chaiAsPromised = require('chai-as-promised')
@@ -21,7 +20,6 @@ describe('user has services middleware', function () {
       status: sinon.spy()
     }
     next = sinon.spy()
-    nock.cleanAll()
   })
 
   it('should call next when user has services', function (done) {

--- a/test/unit/middleware/payment_method_card.test.js
+++ b/test/unit/middleware/payment_method_card.test.js
@@ -1,13 +1,13 @@
 'use strict'
 
 const sinon = require('sinon')
-const nock = require('nock')
 const chai = require('chai')
 const {expect} = chai
 const chaiAsPromised = require('chai-as-promised')
 const paymentMethodIsCard = require('../../../app/middleware/payment-method-card.js')
 
-let res, next
+let res
+let next
 
 chai.use(chaiAsPromised)
 
@@ -19,7 +19,6 @@ describe('user has payment-method-card middleware', () => {
       render: sinon.spy()
     }
     next = sinon.spy()
-    nock.cleanAll()
   })
 
   it('should call next when user is within card payment service', done => {


### PR DESCRIPTION
## WHAT
Either replaces uses of nock, and uses properly stubbed functions, or replaces nock references that were not used

This is part of a wider story to entirely remove nock, and implement pact stub based http mocks in contract tests, and remove http mocks from unit tests.
