### PR TITLE
PP-3686 remove nock from base client unit tests

### DIFF
--- a/test/unit/clients/base_client/base_client_test.js
+++ b/test/unit/clients/base_client/base_client_test.js
@@ -11,16 +11,16 @@ const config = require('../../../../app/utils/correlation_header')
 
 describe('baseClient', () => {
   const requestRetryStub = {
-    defaults: function() {
-      return function(options, callback) {
+    defaults: function () {
+      return function (options, callback) {
         callback(null, { statusCode: 200, request: options })
       }
     }
   }
   const baseClient = proxyquire('../../../../app/services/clients/base_client/base_client',
-  {
-    'requestretry': requestRetryStub
-  })
+    {
+      'requestretry': requestRetryStub
+    })
 
   describe('headers', () => {
     let correlationID, request

--- a/test/unit/clients/base_client/wrapper_arguments_test.js
+++ b/test/unit/clients/base_client/wrapper_arguments_test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 // NPM Dependencies
-const request = require('request')
 const {expect} = require('chai')
 const sinon = require('sinon')
 
@@ -11,36 +10,36 @@ const wrapper = require('../../../../app/services/clients/base_client/wrapper')
 describe('wrapper: arguments handling', () => {
   describe('wrapper arguments', () => {
     describe('when the verb argument is set', () => {
-      let method
-
+      const method = function (options, callback) {
+        callback(null, {statusCode: 200, request: options})
+      }
+      const methodSpy = sinon.spy(method)
       before(done => {
-        method = sinon.spy(request)
-        wrapper(method, 'get')('http://www.example.com')
+        wrapper(methodSpy, 'get')('http://www.example.com')
           .then(() => done())
           .catch(() => done())
       })
-
       it(`should set 'opts.method' to be the verb argument (in uppercase)`, () => {
-        expect(method.called).to.equal(true)
-        expect(method.callCount).to.equal(1)
-        expect(method.lastCall.args[0]).to.have.property('method').to.equal('GET')
+        expect(methodSpy.called).to.equal(true)
+        expect(methodSpy.callCount).to.equal(1)
+        expect(methodSpy.lastCall.args[0]).to.have.property('method').to.equal('GET')
       })
     })
 
     describe('when the verb argument is not set', () => {
-      let method
-
+      const method = function (options, callback) {
+        callback(null, {statusCode: 200, request: options})
+      }
+      const methodSpy = sinon.spy(method)
       before(done => {
-        method = sinon.spy(request)
-        wrapper(method)('http://www.example.com')
+        wrapper(methodSpy)('http://www.example.com')
           .then(() => done())
           .catch(() => done())
       })
-
       it(`should set 'opts.method' to be the verb argument (in uppercase)`, () => {
-        expect(method.called).to.equal(true)
-        expect(method.callCount).to.equal(1)
-        expect(method.lastCall.args[0]).not.to.have.property('method')
+        expect(methodSpy.called).to.equal(true)
+        expect(methodSpy.callCount).to.equal(1)
+        expect(methodSpy.lastCall.args[0]).not.to.have.property('method')
       })
     })
   })
@@ -48,61 +47,67 @@ describe('wrapper: arguments handling', () => {
   describe('wrapped function arguments', () => {
     describe('arguments', () => {
       describe('when it is passed a uri and an options object', () => {
-        let method
-        let uri
         let cb
+        let uri
+        const method = function (options, callback) {
+          callback(null, {statusCode: 200, request: options})
+        }
+        const methodSpy = sinon.spy(method)
         before(done => {
           uri = 'http://example.com/'
           cb = sinon.spy()
-          method = sinon.spy(request)
-          wrapper(method)(uri, {method: 'GET'}, cb)
+          wrapper(methodSpy)(uri, {method: 'GET'}, cb)
             .then(() => done())
             .catch(done)
         })
         it(`should set 'opts.uri' to be the url argument`, () => {
-          expect(method.called).to.equal(true)
-          expect(method.callCount).to.equal(1)
-          expect(method.lastCall.args[0]).to.have.property('uri').to.equal(uri)
+          expect(methodSpy.called).to.equal(true)
+          expect(methodSpy.callCount).to.equal(1)
+          expect(methodSpy.lastCall.args[0]).to.have.property('uri').to.equal(uri)
         })
         it(`should call the provided callback`, () => {
           expect(cb.called).to.equal(true)
         })
       })
       describe('when it is passed a uri and no options object', () => {
-        let method
         let uri
         let cb
+        const method = function (options, callback) {
+          callback(null, {statusCode: 200, request: options})
+        }
+        const methodSpy = sinon.spy(method)
         before(done => {
           uri = 'http://example.com'
           cb = sinon.spy()
-          method = sinon.spy(request)
-          wrapper(method, 'get')(uri, cb)
+          wrapper(methodSpy, 'get')(uri, cb)
             .then(() => done())
             .catch(done)
         })
         it(`should create an options object, and set it's uri property to be the passed uri`, () => {
-          expect(method.called).to.equal(true)
-          expect(method.lastCall.args[0]).to.have.property('uri').to.equal(uri)
+          expect(methodSpy.called).to.equal(true)
+          expect(methodSpy.lastCall.args[0]).to.have.property('uri').to.equal(uri)
         })
         it(`should call the provided callback`, () => {
           expect(cb.called).to.equal(true)
         })
       })
       describe('when it is only passed an options object', () => {
-        let method
         let opts
         let cb
+        const method = function (options, callback) {
+          callback(null, {statusCode: 200, request: options})
+        }
+        const methodSpy = sinon.spy(method)
         before(done => {
           opts = {uri: 'http://example.com/'}
           cb = sinon.spy()
-          method = sinon.spy(request)
-          wrapper(method, 'get')(opts, cb)
+          wrapper(methodSpy, 'get')(opts, cb)
             .then(() => done())
             .catch(done)
         })
         it(`should pass the options object to the wrapped request method as it's first argument`, () => {
-          expect(method.called).to.equal(true)
-          expect(method.lastCall.args[0]).to.equal(opts)
+          expect(methodSpy.called).to.equal(true)
+          expect(methodSpy.lastCall.args[0]).to.equal(opts)
         })
         it(`should call the provided callback`, () => {
           expect(cb.called).to.equal(true)

--- a/test/unit/clients/base_client/wrapper_arguments_test.js
+++ b/test/unit/clients/base_client/wrapper_arguments_test.js
@@ -1,20 +1,19 @@
 'use strict'
+
+// NPM Dependencies
 const request = require('request')
-const nock = require('nock')
 const {expect} = require('chai')
 const sinon = require('sinon')
+
+// Local Dependencies
 const wrapper = require('../../../../app/services/clients/base_client/wrapper')
 
 describe('wrapper: arguments handling', () => {
-  afterEach(() => {
-    nock.cleanAll()
-  })
   describe('wrapper arguments', () => {
     describe('when the verb argument is set', () => {
       let method
 
       before(done => {
-        nock('http://example.com').get('/').reply(200, 'success')
         method = sinon.spy(request)
         wrapper(method, 'get')('http://www.example.com')
           .then(() => done())
@@ -32,7 +31,6 @@ describe('wrapper: arguments handling', () => {
       let method
 
       before(done => {
-        nock('http://example.com').get('/').reply(200, 'success')
         method = sinon.spy(request)
         wrapper(method)('http://www.example.com')
           .then(() => done())
@@ -50,10 +48,10 @@ describe('wrapper: arguments handling', () => {
   describe('wrapped function arguments', () => {
     describe('arguments', () => {
       describe('when it is passed a uri and an options object', () => {
-        let method, uri, cb
-
+        let method
+        let uri
+        let cb
         before(done => {
-          nock('http://example.com').get('/').reply(200, 'success')
           uri = 'http://example.com/'
           cb = sinon.spy()
           method = sinon.spy(request)
@@ -61,23 +59,20 @@ describe('wrapper: arguments handling', () => {
             .then(() => done())
             .catch(done)
         })
-
         it(`should set 'opts.uri' to be the url argument`, () => {
           expect(method.called).to.equal(true)
           expect(method.callCount).to.equal(1)
           expect(method.lastCall.args[0]).to.have.property('uri').to.equal(uri)
         })
-        it(`should pass the results of the request to any provided callback`, () => {
+        it(`should call the provided callback`, () => {
           expect(cb.called).to.equal(true)
-          expect(cb.lastCall.args[2]).to.equal('success')
         })
       })
-
       describe('when it is passed a uri and no options object', () => {
-        let method, uri, cb
-
+        let method
+        let uri
+        let cb
         before(done => {
-          nock('http://example.com').get('/').reply(200, 'success')
           uri = 'http://example.com'
           cb = sinon.spy()
           method = sinon.spy(request)
@@ -85,22 +80,19 @@ describe('wrapper: arguments handling', () => {
             .then(() => done())
             .catch(done)
         })
-
         it(`should create an options object, and set it's uri property to be the passed uri`, () => {
           expect(method.called).to.equal(true)
           expect(method.lastCall.args[0]).to.have.property('uri').to.equal(uri)
         })
-        it(`should pass the results of the request to any provided callback`, () => {
+        it(`should call the provided callback`, () => {
           expect(cb.called).to.equal(true)
-          expect(cb.lastCall.args[2]).to.equal('success')
         })
       })
-
       describe('when it is only passed an options object', () => {
-        let method, opts, cb
-
+        let method
+        let opts
+        let cb
         before(done => {
-          nock('http://example.com').get('/').reply(200, 'success')
           opts = {uri: 'http://example.com/'}
           cb = sinon.spy()
           method = sinon.spy(request)
@@ -108,13 +100,11 @@ describe('wrapper: arguments handling', () => {
             .then(() => done())
             .catch(done)
         })
-
         it(`should pass the options object to the wrapped request method as it's first argument`, () => {
           expect(method.called).to.equal(true)
           expect(method.lastCall.args[0]).to.equal(opts)
         })
-
-        it(`should pass the results of the request to any provided callback`, () => {
+        it(`should call the provided callback`, () => {
           expect(cb.called).to.equal(true)
         })
       })

--- a/test/unit/clients/base_client/wrapper_request_callback_test.js
+++ b/test/unit/clients/base_client/wrapper_request_callback_test.js
@@ -1,28 +1,47 @@
 'use strict'
-const request = require('request')
-const nock = require('nock')
+
+// NPM Dependencies
+// const request = require('request')
 const {expect} = require('chai')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 const requestLogger = {}
+const events = require('events')
+const util = require('util')
+
+// Local Dependencies
 const wrapper = proxyquire('../../../../app/services/clients/base_client/wrapper', {
   '../../../utils/request_logger': requestLogger
 })
 
 describe('wrapper: request scenarios', () => {
-  afterEach(() => {
-    nock.cleanAll()
-  })
   describe('when the request returns successfully with statusCode 200', () => {
-    let cb, resolved, returnee
+    let cb
+    let resolved
+    let returnee
+    // Create a stubbed request object
+    function RequestStub () {
+      const self = this
+      events.EventEmitter.call(self)
+      return function (options, callback) {
+        setTimeout(() => {
+            // Emit a response that our test is checking for
+          self.emit('response', {statusCode: 200})
+            // And execute the callback
+          callback(null, {statusCode: 200, request: options, body: 'success'}, 'success')
+        }, 100)
+        return self
+      }
+    }
+    // Wire the EventEmitter into it, so we can emit the event specified above to any watchers
+    util.inherits(RequestStub, events.EventEmitter)
     before(done => {
       requestLogger.logRequestStart = sinon.spy()
       requestLogger.logRequestEnd = sinon.spy()
       requestLogger.logRequestFailure = sinon.spy()
       requestLogger.logRequestError = sinon.spy()
-      nock('http://example.com').get('/').reply(200, 'success')
       cb = sinon.spy()
-      returnee = wrapper(request, 'get')('http://example.com/', cb)
+      returnee = wrapper(new RequestStub(), 'get')('http://example.com/', cb)
       returnee
         .then(result => {
           resolved = result
@@ -36,11 +55,12 @@ describe('wrapper: request scenarios', () => {
     it('should return a promise that is resolved with the body of the successful request', () => {
       expect(resolved).to.equal('success')
     })
-    it('should call a supplied callback function with the results of the request', () => {
+    it('should call a supplied callback function', () => {
       expect(cb.lastCall.args[0]).to.equal(null)
       expect(cb.lastCall.args[1]).to.have.property('statusCode').to.equal(200)
       expect(cb.lastCall.args[1]).to.have.property('body').to.equal('success')
       expect(cb.lastCall.args[2]).to.equal('success')
+      expect(cb.called).to.equal(true)
     })
     it('should log the request start and request end but not a request failure or error', () => {
       expect(requestLogger.logRequestStart.called).to.equal(true)
@@ -50,15 +70,32 @@ describe('wrapper: request scenarios', () => {
     })
   })
   describe('when the request fails', () => {
-    let cb, rejected, returnee
+    let cb
+    let rejected
+    let returnee
+    // Create a stubbed request object
+    function RequestStub () {
+      const self = this
+      events.EventEmitter.call(self)
+      return function (options, callback) {
+        setTimeout(() => {
+          // Emit a response that our test is checking for
+          self.emit('response', {statusCode: 404})
+          // And execute the callback
+          callback(null, {statusCode: 404, request: options, body: 'not found'}, 'not found')
+        }, 100)
+        return self
+      }
+    }
+    // Wire the EventEmitter into it, so we can emit the event specified above to any watchers
+    util.inherits(RequestStub, events.EventEmitter)
     before(done => {
       requestLogger.logRequestStart = sinon.spy()
       requestLogger.logRequestEnd = sinon.spy()
       requestLogger.logRequestFailure = sinon.spy()
       requestLogger.logRequestError = sinon.spy()
-      nock('http://example.com').get('/').reply(404, 'not found')
       cb = sinon.spy()
-      returnee = wrapper(request, 'get')('http://example.com/', cb)
+      returnee = wrapper(new RequestStub(), 'get')('http://example.com/', cb)
       returnee
         .then(done)
         .catch(err => {
@@ -89,15 +126,33 @@ describe('wrapper: request scenarios', () => {
   })
 
   describe('when the request errors', () => {
-    let cb, rejected, returnee
+    let cb
+    let rejected
+    let returnee
+    // Create a stubbed request object
+    function RequestStub () {
+      const self = this
+      events.EventEmitter.call(self)
+      return function (options, callback) {
+        setTimeout(() => {
+          // Emit a response that our test is checking for
+          self.emit('error', new Error('something simply dreadful happened'))
+          // And execute the callback
+          callback(new Error('something simply dreadful happened'))
+        }, 100)
+        return self
+      }
+    }
+
+    // Wire the EventEmitter into it, so we can emit the event specified above to any watchers
+    util.inherits(RequestStub, events.EventEmitter)
     before(done => {
       requestLogger.logRequestStart = sinon.spy()
       requestLogger.logRequestEnd = sinon.spy()
       requestLogger.logRequestFailure = sinon.spy()
       requestLogger.logRequestError = sinon.spy()
-      nock('http://example.com').get('/').replyWithError(new Error('something simply dreadful happened'))
       cb = sinon.spy()
-      returnee = wrapper(request, 'get')('http://example.com/', cb)
+      returnee = wrapper(new RequestStub(), 'get')('http://example.com/', cb)
       returnee
         .then(done)
         .catch(err => {


### PR DESCRIPTION
## WHAT
Removes the use of nock from our base client unit tests.

