### PR TITLE
PP-3619 Removed contract test condition on not running when on the master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,11 +38,6 @@ pipeline {
       }
     }
     stage('Contract Tests') {
-      when {
-        not {
-          branch 'master'
-        }
-      }
       steps {
         script {
           env.PACT_TAG = gitBranchName()


### PR DESCRIPTION
##WHAT

Rather than contract tests running on PR and non master branches as they currently do, this removes that logic meaning master branch builds being triggers will cause contract tests to also run, and any associated interactions with the pact broker to execute.

I can't see any reasons why this would cause any unwanted side effects running on master currently.