### PR TITLE
PP-3707: Tag consumer pact on deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,6 +119,9 @@ pipeline {
       steps { runDirectDebitSmokeTest() }
     }
     stage('Pact Tag') {
+      when {
+        branch 'master'
+      }
       steps {
         echo 'Tagging consumer pact with "test"'
         tagPact("selfservice", gitCommit(), "test")


### PR DESCRIPTION
A deploy only happens on master branch so adding the conditional is required.

@oswaldquek
