### PR TITLE
BAU - Explicitly set APP is being configured

### DIFF
--- a/app/views/twoFactorAuth/index.njk
+++ b/app/views/twoFactorAuth/index.njk
@@ -18,6 +18,7 @@ Change sign-in method - GOV.UK Pay
     <p>You currently use text message codes to sign in to GOV.UK Pay.</p>
     <form method="post" action="{{routes.user.twoFactorAuth.index}}">
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+      <input name="two-fa-method" type="hidden" value="APP"/>
       <div class="form-group">
         <button class="button" type="submit">
           Use an authenticator app instead


### PR DESCRIPTION
This worked without this becuase if null it assumes app. But why not be
explicit.