### PR TITLE
Add autocomplete="off" to OTP security code input elements

### DIFF
--- a/app/views/twoFactorAuth/configure.njk
+++ b/app/views/twoFactorAuth/configure.njk
@@ -65,7 +65,7 @@
           <span class="error-message">Please enter a valid security code</span>
         {% endif %}
       </label>
-      <input autofocus type="text" class="form-control" id="code" name="code" data-validate="required">
+      <input autofocus type="text" class="form-control" id="code" name="code" data-validate="required" autocomplete="off">
     </div>
     <div class="form-group">
       <button class="button" type="submit">

--- a/app/views/user_registration/verify_otp.njk
+++ b/app/views/user_registration/verify_otp.njk
@@ -14,7 +14,7 @@
       <p>We've sent you a text message with a security code</p>
       <div class="form-group">
         <label class="form-label" for="verify-code">Text message code</label>
-        <input class="form-control form-control-1-4" data-module="" id="verify-code" name="verify-code" rows="6" type="text" value="" autofocus>
+        <input class="form-control form-control-1-4" data-module="" id="verify-code" name="verify-code" rows="6" type="text" value="" autofocus autocomplete="off">
       </div>
       <div class="form-group">
         <input class="button" type="submit" value="Continue">


### PR DESCRIPTION
One-time passwords are by definition for one-time use, so there’s no point having browser autocomplete remember them or make suggestions based on past input.

We already had `autocomplete="off"` for the main sign in flow; this adds it for registration of a new user and configuring the sign-in method of an existing user.