### PR TITLE
PP-3813 Run cypress tests as part of build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,11 @@ pipeline {
         }
       }
     }
+    stage('Browser Tests') {
+      steps {
+        cypress('selfservice')
+      }
+    }
     stage('Contract Tests') {
       steps {
         script {

--- a/docker/build_and_test.sh
+++ b/docker/build_and_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ueo pipefail
 rm -rf node_modules
-ln -s /tmp/node_modules /app/node_modules
+cp -R /tmp/node_modules /app/node_modules
 npm run compile
 npm run lint
 npm test -- --forbid-only --forbid-pending


### PR DESCRIPTION
This commit adds `Browser Testing` stage to the build.
Most of the magic happens in https://github.com/alphagov/pay-jenkins-library/blob/master/vars/cypress.groovy

In order to have test node_modules available to other things (specifically
cypress test image), we have gone back to using cp -R for node modules,
rather than ln -s. The symbolic link meant that the node moules were not
available outside of the context of the container.