### PR TITLE
PP-3813 Split connector contract tests

### DIFF
--- a/test/unit/clients/connector_client/connector_client_create_gateway_account_test.js
+++ b/test/unit/clients/connector_client/connector_client_create_gateway_account_test.js
@@ -22,7 +22,7 @@ chai.use(chaiAsPromised)
 
 describe('connector client - create gateway account', function () {
   const provider = Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'connector',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/connector_client/connector_get_card_types_test.js
+++ b/test/unit/clients/connector_client/connector_get_card_types_test.js
@@ -22,7 +22,7 @@ chai.use(chaiAsPromised)
 
 describe('connector client', function () {
   const provider = Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'connector',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/connector_client/connector_get_transactions_and_summary_test.js
+++ b/test/unit/clients/connector_client/connector_get_transactions_and_summary_test.js
@@ -51,7 +51,8 @@ describe('connector client', function () {
       provider.addInteraction(
         new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${params.gatewayAccountId}/transactions-summary`)
           .withUponReceiving('a valid transaction summary request')
-          .withState(`User ${params.gatewayAccountId} exists in the database and has available transactions`)
+          .withState(`User ${params.gatewayAccountId} exists in the database and has available transactions
+          between 2018-05-14T00:00:00 and 2018-05-15T00:00:00`)
           .withMethod('GET')
           .withQuery('from_date', params.fromDateTime)
           .withQuery('to_date', params.toDateTime)


### PR DESCRIPTION
We want to run the contract tests pertaining to
transactions as part of the pipeline, and build out
connector support for those. We don't want to worry
about other tests. I have marked all those tests we
don't want to worry about for now as `selfservice-to-be`
following precedent for adminusers.