### PR TITLE
bau: Rename selfservice consumer

### DIFF
--- a/test/unit/clients/product_client/payment/create_test.js
+++ b/test/unit/clients/product_client/payment/create_test.js
@@ -25,7 +25,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 
 describe('products client - creating a new payment', () => {
   let provider = Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/product_client/payment/get_by_payment_external_id_test.js
+++ b/test/unit/clients/product_client/payment/get_by_payment_external_id_test.js
@@ -25,7 +25,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 
 describe('products client - find a payment by it\'s own external id', function () {
   let provider = Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/product_client/payment/get_by_product_external_id_test.js
+++ b/test/unit/clients/product_client/payment/get_by_product_external_id_test.js
@@ -26,7 +26,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 
 describe('products client - find a payment by it\'s associated product external id', function () {
   let provider = Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/product_client/product/create_test.js
+++ b/test/unit/clients/product_client/product/create_test.js
@@ -27,7 +27,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 
 describe('products client - create a new product', () => {
   let provider = Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/product_client/product/delete_test.js
+++ b/test/unit/clients/product_client/product/delete_test.js
@@ -24,7 +24,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 
 describe('products client - delete a product', () => {
   let provider = Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/product_client/product/disable_test.js
+++ b/test/unit/clients/product_client/product/disable_test.js
@@ -24,7 +24,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 
 describe('products client - disable a product', () => {
   let provider = Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/product_client/product/get_by_gateway_account_id_test.js
+++ b/test/unit/clients/product_client/product/get_by_gateway_account_id_test.js
@@ -27,7 +27,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 
 describe('products client - find products associated with a particular gateway account id', function () {
   let provider = Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/product_client/product/get_by_product_external_id_test.js
+++ b/test/unit/clients/product_client/product/get_by_product_external_id_test.js
@@ -25,7 +25,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 
 describe('products client - find a product by it\'s external id', function () {
   let provider = Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/product_client/product/get_by_product_path_test.js
+++ b/test/unit/clients/product_client/product/get_by_product_path_test.js
@@ -25,7 +25,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`) {
 
 describe('products client - find a product by it\'s product path', function () {
   let provider = Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/product_client/product/update_service_name_by_gateway_account_id_test.js
+++ b/test/unit/clients/product_client/product/update_service_name_by_gateway_account_id_test.js
@@ -24,7 +24,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 
 describe('products client - update product service name by gateway account id', () => {
   let provider = Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),


### PR DESCRIPTION
We have a selfservice-products pact in the pact broker but there are no
provider tests in products to verify the pact yet. This is currently causing
selfservice deploys to fail as the deploy job asks the pact broker "can i deploy
selfservice?". The broker sees there's no compatibility between selfservice and
products and fails the build. Renaming selfservice -> selfservice-to-be will
unblock us for the moment.

@oswaldquek
