### PR TITLE
PP-3897 Added connector contract tests to the Jenkins pipeline steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,7 @@ pipeline {
         }
         ws('contract-tests-wp') {
           runPactProviderTests("pay-adminusers", "${env.PACT_TAG}")
+          runPactProviderTests("pay-connector", "${env.PACT_TAG}")
         }
       }
       post {


### PR DESCRIPTION
## WHAT
Adds contract testing from the provider side, to the Jenkins pipeline for the consumer, which in this case is self-service.


