### PR TITLE
BAU - updating to new status page

### DIFF
--- a/app/views/includes/footer-categories.njk
+++ b/app/views/includes/footer-categories.njk
@@ -15,7 +15,7 @@
         <ul>
           <li><a href="https://ukgovernmentdigital.slack.com/messages/govuk-pay">Chat with GOV.UK Pay on Slack</a></li>
           <li><a href="https://docs.payments.service.gov.uk">Documentation</a></li>
-          <li><a href="http://stats.pingdom.com/ejtodj13fqqx">System status</a></li>
+          <li><a href="https://payments.statuspage.io/">System status</a></li>
           <li><a href="https://www.payments.service.gov.uk/support/">Support</a></li>
         </ul>
       </div>


### PR DESCRIPTION
Link on selfservice was out of date and doesn’t match pay-frontend