### PR TITLE
PP-3897 Re-enables contract tests for connector

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,7 @@ pipeline {
         }
         ws('contract-tests-wp') {
           runPactProviderTests("pay-adminusers", "${env.PACT_TAG}")
+          runPactProviderTests("pay-connector", "${env.PACT_TAG}")
         }
       }
       post {


### PR DESCRIPTION
## WHAT
As per description. This was disabled while some provider tests were fixed due to running red on master builds. This was due to the pact tag being different on a PR compared to master, so was only found out after the original PR was merged to enable it.


