### PR TITLE
PP-3133 - Adding a 404 page

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -272,4 +272,9 @@ module.exports.bind = function (app) {
   // Feedback
   app.get(paths.feedback, hasServices, resolveService, getAccount, feedbackCtrl.getIndex)
   app.post(paths.feedback, hasServices, resolveService, getAccount, feedbackCtrl.postIndex)
+
+  app.all('*', (req, res) => {
+    res.status(404)
+    res.render('404')
+  })
 }

--- a/app/views/404.njk
+++ b/app/views/404.njk
@@ -1,0 +1,18 @@
+{% extends "./layout_logged_out.njk" %}
+
+{% block page_title %}
+Page not found - GOV.UK Pay
+{% endblock %}
+
+{% block mainContent %}
+  <div class="column-two-thirds">
+    <h1 class="page-title">Page not found</h1>
+    <p>Sorry the page you requested was not found</p>
+    <p>Maybe try one of these:</p>
+    <ul class="list">
+      <li><a href="https://www.payments.service.gov.uk/">The GOV.UK Pay home page</a></li>
+      <li><a href="https://www.payments.service.gov.uk/getstarted/">Get started</a></li>
+      <li><a href="https://www.payments.service.gov.uk/support/">Support</a></li>
+    </ul>
+  </div>
+{% endblock %}

--- a/server.js
+++ b/server.js
@@ -158,8 +158,8 @@ function initialise () {
   initialiseAuth(app)
   initialiseGlobalMiddleware(app)
   initialiseTemplateEngine(app)
-  initialiseRoutes(app)
   initialiseErrorHandling(app)
+  initialiseRoutes(app) // This contains the 404 overrider and so should be last
 
   warnIfAnalyticsNotSet()
 

--- a/test/unit/middleware/404.test.js
+++ b/test/unit/middleware/404.test.js
@@ -1,0 +1,25 @@
+const request = require('supertest')
+const app = require('../../../server.js').getApp()
+
+describe('Invalid pages redirect to 404 page', () => {
+  it('should return 404', done => {
+    request(app)
+      .get('/notapage')
+      .expect(404)
+      .end(done)
+  })
+
+  it('should return 200 when path found', done => {
+    request(app)
+      .get('/login')
+      .expect(200)
+      .end(done)
+  })
+
+  it('should return 200 when static asset found', done => {
+    request(app)
+      .get('/public/images/crown.png')
+      .expect(200)
+      .end(done)
+  })
+})


### PR DESCRIPTION
Selfservice would error 500 before this, which is sad.

Because we’re using a wildcard, it has to be last otherwise it will
hijack everything else and that would be bad.


