### PR TITLE
PP-3943 Display invites in team members list

### DIFF
--- a/app/assets/sass/helpers/_admin_list.scss
+++ b/app/assets/sass/helpers/_admin_list.scss
@@ -1,4 +1,5 @@
 .admin-list-group {
+  margin-top: $gutter;
   .admin-list-group-heading:first-of-type {
     @include bold-24;
     margin: 0 0 $gutter;
@@ -75,4 +76,9 @@
 
 #edit-permissions-link {
   text-align: right;
+}
+
+#invite-team-member-link {
+  float: right;
+  margin-bottom: $gutter;
 }

--- a/app/services/clients/adminusers_client.js
+++ b/app/services/clients/adminusers_client.js
@@ -488,6 +488,42 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
+   *
+   * @param serviceExternalId
+   * @returns {Promise}
+   */
+  const getInvitedUsersList = (serviceExternalId) => {
+    console.log(inviteResource)
+    console.log(serviceExternalId)
+    const params = {
+      correlationId: correlationId,
+      qs: {
+        serviceId: serviceExternalId
+      }
+    }
+    const url = `${inviteResource}`
+    const defer = q.defer()
+    const startTime = new Date()
+    const context = {
+      url: url,
+      defer: defer,
+      startTime: startTime,
+      correlationId: correlationId,
+      method: 'GET',
+      description: 'get invited users for a service',
+      service: SERVICE_NAME
+    }
+
+    const callbackToPromiseConverter = createCallbackToPromiseConverter(context)
+    requestLogger.logRequestStart(context)
+
+    baseClient.get(url, params, callbackToPromiseConverter)
+      .on('error', callbackToPromiseConverter)
+
+    return defer.promise
+  }
+
+  /**
    * Get a valid invite or error if it's expired
    * @param inviteCode
    */
@@ -1020,6 +1056,7 @@ module.exports = function (clientOptions = {}) {
     // Invite-related Methods
     verifyOtpForServiceInvite,
     inviteUser,
+    getInvitedUsersList,
     getValidatedInvite,
     generateInviteOtpCode,
     completeInvite,

--- a/app/services/user_service.js
+++ b/app/services/user_service.js
@@ -173,6 +173,14 @@ module.exports = {
   },
 
   /**
+   * @param externalServiceId
+   * @param correlationId
+   */
+  getInvitedUsersList: function (externalServiceId, correlationId) {
+    return getAdminUsersClient({correlationId: correlationId}).getInvitedUsersList(externalServiceId)
+  },
+
+  /**
    *
    * @param externalServiceId
    * @param removerExternalId

--- a/app/views/services/team_members.njk
+++ b/app/views/services/team_members.njk
@@ -22,7 +22,12 @@ Team members - GOV.UK Pay
   </div>
 </div>
 <div class="grid-row">
-  <div class="column-two-thirds admin-list-group">
+  <div class="column-full admin-list-group">
+    {% if permissions.users_service_create %}
+      <a id="invite-team-member-link" class="button" href="{{inviteTeamMemberLink}}">
+        Invite a team member
+      </a>
+    {% endif %}
     <h2 id="active-team-members-heading" class="admin-list-group-heading">Active ({{number_active_members}})</h2>
     <div class="admin-list" id="team-members-admin-list">
       <h3 id="admin-role-header" class="admin-list-heading">Administrators ({{team_members["admin"].length}})</h3>
@@ -85,9 +90,42 @@ Team members - GOV.UK Pay
       </ul>
     </div>
   </div>
-    {% if permissions.users_service_create %}
-      <a id="invite-team-member-link" class="button" href="{{inviteTeamMemberLink}}">
-          Invite a team member
-      </a>
-    {% endif %}
+  <div class="column-full admin-list-group">
+    <h2 id="invited-team-members-heading" class="admin-list-group-heading">Invited ({{number_invited_members}})</h2>
+    <div class="admin-list" id="invited-team-members-admin-list">
+      <h3 id="invited-team-members-admin-role-header" class="admin-list-heading">Administrators ({{invited_team_members["admin"].length}})</h3>
+      <ul>
+        {% for admin in invited_team_members["admin"] %}
+          <li>
+              <span>
+                {{ admin.username }}
+            </span>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="admin-list" id="invited-team-members-view-and-refund-list">
+      <h3 id="invited-team-members-view-and-refund-role-header" class="admin-list-heading">View and refund ({{invited_team_members["view-and-refund"].length}})</h3>
+      <ul>
+        {% for team_member in invited_team_members["view-and-refund"] %}
+          <li>
+              <span>
+                {{ team_member.username }}
+            </span>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="admin-list" id="invited-team-members-view-only-list">
+      <h3 id="invited-team-members-view-only-role-header" class="admin-list-heading">View only ({{invited_team_members["view-only"].length}})</h3>
+      <ul>
+        {% for team_member in invited_team_members["view-only"] %}
+          <li>
+              <span>
+                {{ team_member.username }}
+            </span>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
 {% endblock %}

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -38,7 +38,29 @@ module.exports = {
     }
     return pactServices.withPactified(response)
   },
-
+  /**
+   * @param invites Array params override get invites for service response
+   * @return {{getPactified: (function()) Pact response, getPlain: (function()) request with overrides applied}}
+   */
+  validListInvitesForServiceResponse: (invites) => {
+    const data = invites || [{
+      email: 'esdfkjh@email.test',
+      telephone_number: '',
+      disabled: false,
+      role: 'admin',
+      expired: false,
+      user_exist: false,
+      attempt_counter: 0
+    }]
+    return {
+      getPactified: () => {
+        return pactServices.pactifyNestedArray(data)
+      },
+      getPlain: () => {
+        return data
+      }
+    }
+  },
   validCreateServiceRequest: (opts) => {
     opts = opts || {}
 

--- a/test/ui/team_member_list_ui_tests.js
+++ b/test/ui/team_member_list_ui_tests.js
@@ -52,7 +52,6 @@ describe('The team members view', function () {
     body.should.containSelector('div#team-members-view-and-refund-list ul').havingItemAt(1).withText('username6')
     body.should.containSelector('div#team-members-view-and-refund-list ul').havingItemAt(1).withALinkTo('view-username6-link')
   })
-
   it('should render all team members without links if user does not have read permissions', function () {
     let templateData = {
       'number_active_members': 2,
@@ -122,5 +121,71 @@ describe('The team members view', function () {
     let body = renderTemplate('services/team_members', templateData)
 
     body.should.not.containSelector('a#invite-team-member-link')
+  })
+  it('should render all invited team members grouped by role', function () {
+    let templateData = {
+      'number_invited_members': 5,
+      'number_admin_invited_members': 2,
+      'number_view-only_invited_members': 1,
+      'number_view-and-refund_invited_members': 2,
+      'invited_team_members': {
+        'admin': [
+          {username: 'username1'},
+          {username: 'username2'}
+        ],
+        'view-only': [
+          {username: 'username3'}
+        ],
+        'view-and-refund': [
+          {username: 'username6'},
+          {username: 'username5'}
+        ]
+      },
+      permissions: {
+        'users_service_read': true
+      }
+    }
+
+    let body = renderTemplate('services/team_members', templateData)
+
+    body.should.containSelector('h2#invited-team-members-heading').withExactText('Invited (5)')
+    body.should.containSelector('h3#invited-team-members-admin-role-header').withExactText('Administrators (2)')
+    body.should.containSelector('h3#invited-team-members-view-only-role-header').withExactText('View only (1)')
+    body.should.containSelector('h3#invited-team-members-view-and-refund-role-header').withExactText('View and refund (2)')
+
+    body.should.containSelector('div#invited-team-members-admin-list ul').havingNumberOfItems(2)
+    body.should.containSelector('div#invited-team-members-admin-list ul').havingItemAt(1).withText('username1')
+    body.should.containSelector('div#invited-team-members-admin-list ul').havingItemAt(2).withText('username2')
+
+    body.should.containSelector('div#invited-team-members-view-only-list ul').havingNumberOfItems(1)
+    body.should.containSelector('div#invited-team-members-view-only-list ul').havingItemAt(1).withText('username3')
+
+    body.should.containSelector('div#invited-team-members-view-and-refund-list ul').havingNumberOfItems(2)
+    body.should.containSelector('div#invited-team-members-view-and-refund-list ul').havingItemAt(1).withText('username6')
+    body.should.containSelector('div#invited-team-members-view-and-refund-list ul').havingItemAt(2).withText('username5')
+  })
+  it('should render number of invited members of a role as 0 if no users are grouped in that role', function () {
+    let templateData = {
+      'number_invited_members': 5,
+      'number_admin_invited_members': 2,
+      'number_view-only_invited_members': 0,
+      'number_view-and-refund_invited_members': 2,
+      'invited_team_members': {
+        'admin': [
+          {username: 'username1'},
+          {username: 'username2'}
+        ],
+        'view-only': [],
+        'view-and-refund': [
+          {username: 'username6'},
+          {username: 'username5'}
+        ]
+      }
+    }
+
+    let body = renderTemplate('services/team_members', templateData)
+
+    body.should.containSelector('h3#invited-team-members-view-only-role-header').withExactText('View only (0)')
+    body.should.containSelector('div#invited-team-members-view-only-list').havingNumberOfRows(0)
   })
 })


### PR DESCRIPTION
## WHAT
Listing invites for a service in the manage team members section. Also, make the page look a bit more like the prototype by floating the invite team members button and expanding the column from two thirds to full.

