### PR TITLE
PP-3943 Do not show invite list if empty and tweak ui

### DIFF
--- a/app/assets/sass/helpers/_admin_list.scss
+++ b/app/assets/sass/helpers/_admin_list.scss
@@ -1,13 +1,14 @@
 .admin-list-group {
-  margin-top: $gutter;
   .admin-list-group-heading:first-of-type {
     @include bold-24;
-    margin: 0 0 $gutter;
+    margin: 0 0 20px;
   }
 }
-
+.grid-row .admin-list-group:nth-child(n+2) {
+  margin-top: $gutter*2;
+}
 .admin-list {
-  margin-top: $gutter;
+  margin-top: 20px;
 
   .admin-list-heading {
     @include bold-16;

--- a/app/services/clients/adminusers_client.js
+++ b/app/services/clients/adminusers_client.js
@@ -493,8 +493,6 @@ module.exports = function (clientOptions = {}) {
    * @returns {Promise}
    */
   const getInvitedUsersList = (serviceExternalId) => {
-    console.log(inviteResource)
-    console.log(serviceExternalId)
     const params = {
       correlationId: correlationId,
       qs: {

--- a/app/views/services/team_members.njk
+++ b/app/views/services/team_members.njk
@@ -21,13 +21,13 @@ Team members - GOV.UK Pay
     {% endif %}
   </div>
 </div>
+{% if permissions.users_service_create %}
+  <a id="invite-team-member-link" class="button" href="{{inviteTeamMemberLink}}">
+    Invite a team member
+  </a>
+{% endif %}
 <div class="grid-row">
-  <div class="column-full admin-list-group">
-    {% if permissions.users_service_create %}
-      <a id="invite-team-member-link" class="button" href="{{inviteTeamMemberLink}}">
-        Invite a team member
-      </a>
-    {% endif %}
+  <div class="column-two-thirds admin-list-group">
     <h2 id="active-team-members-heading" class="admin-list-group-heading">Active ({{number_active_members}})</h2>
     <div class="admin-list" id="team-members-admin-list">
       <h3 id="admin-role-header" class="admin-list-heading">Administrators ({{team_members["admin"].length}})</h3>
@@ -90,7 +90,8 @@ Team members - GOV.UK Pay
       </ul>
     </div>
   </div>
-  <div class="column-full admin-list-group">
+  {% if number_invited_members > 0 %}
+  <div class="column-two-thirds admin-list-group">
     <h2 id="invited-team-members-heading" class="admin-list-group-heading">Invited ({{number_invited_members}})</h2>
     <div class="admin-list" id="invited-team-members-admin-list">
       <h3 id="invited-team-members-admin-role-header" class="admin-list-heading">Administrators ({{invited_team_members["admin"].length}})</h3>
@@ -128,4 +129,5 @@ Team members - GOV.UK Pay
         {% endfor %}
       </ul>
     </div>
+  {% endif %}
 {% endblock %}

--- a/test/ui/team_member_list_ui_tests.js
+++ b/test/ui/team_member_list_ui_tests.js
@@ -188,4 +188,27 @@ describe('The team members view', function () {
     body.should.containSelector('h3#invited-team-members-view-only-role-header').withExactText('View only (0)')
     body.should.containSelector('div#invited-team-members-view-only-list').havingNumberOfRows(0)
   })
+  it('should not render invited team members list if there are no invitations', function () {
+    let templateData = {
+      'number_invited_members': 0,
+      'number_admin_invited_members': 0,
+      'number_view-only_invited_members': 0,
+      'number_view-and-refund_invited_members': 0,
+      'invited_team_members': {
+        'admin': [],
+        'view-only': [],
+        'view-and-refund': []
+      }
+    }
+
+    let body = renderTemplate('services/team_members', templateData)
+    body.should.not.containSelector('h2#invited-team-members-heading')
+    body.should.not.containSelector('h3#invited-team-members-admin-role-header')
+    body.should.not.containSelector('h3#invited-team-members-view-only-role-header')
+    body.should.not.containSelector('h3#invited-team-members-view-and-refund-role-header')
+
+    body.should.not.containSelector('div#invited-team-members-admin-list')
+    body.should.not.containSelector('div#invited-team-members-view-only-list')
+    body.should.not.containSelector('div#invited-team-members-view-and-refund-list')
+  })
 })


### PR DESCRIPTION
## WHAT
- The invite list is shown only if there are invites
- Changed spacing between elements
- Also removed two `console.log`. Oooops.

