### PR TITLE
PP-3928 Reduce the number of outbound requests to get gateway account information

### DIFF
--- a/app/services/clients/adminusers_client.js
+++ b/app/services/clients/adminusers_client.js
@@ -428,8 +428,6 @@ module.exports = function (clientOptions = {}) {
         correlationId: correlationId,
         description: 'submit otp code',
         service: SERVICE_NAME,
-        // TODO : Double check this
-        // transform: responseBodyToUserTransformer,
         baseClientErrorHandler: 'old'
       }
     )
@@ -511,8 +509,8 @@ module.exports = function (clientOptions = {}) {
           headers: {}
         },
         headers: headers,
-        userDelete: userExternalId, // TODO : Copied over from last implementation. Is this used anywhere?
-        userRemover: removerExternalId, // TODO : Copied over from last implementation. Is this used anywhere?
+        userDelete: userExternalId,
+        userRemover: removerExternalId,
         correlationId: correlationId,
         description: 'delete a user from a service',
         service: SERVICE_NAME,

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -76,6 +76,11 @@ function _accountUrlFor (gatewayAccountId, url) {
 }
 
 /** @private */
+function _accountsUrlFor (gatewayAccountIds, url) {
+  return url + ACCOUNTS_FRONTEND_PATH + '?accountIds=' + gatewayAccountIds.join(',')
+}
+
+/** @private */
 function _accountNotificationCredentialsUrlFor (gatewayAccountId, url) {
   return url + ACCOUNT_NOTIFICATION_CREDENTIALS_PATH.replace('{accountId}', gatewayAccountId)
 }
@@ -249,6 +254,35 @@ ConnectorClient.prototype = {
   getAccount: function (params) {
     return new Promise((resolve, reject) => {
       let url = _accountUrlFor(params.gatewayAccountId, this.connectorUrl)
+      let startTime = new Date()
+      let context = {
+        url: url,
+        defer: {resolve: resolve, reject: reject},
+        startTime: startTime,
+        correlationId: params.correlationId,
+        method: 'GET',
+        description: 'get an account',
+        service: SERVICE_NAME
+      }
+
+      let callbackToPromiseConverter = createCallbackToPromiseConverter(context)
+
+      baseClient.get(url, params, callbackToPromiseConverter)
+        .on('error', callbackToPromiseConverter)
+    })
+  },
+
+  /**
+   * Retrieves multiple gateway accounts for a given array of ids
+   * @param params
+   *          An object with the following elements;
+   *            gatewayAccountIds (required)
+   *            correlationId (optional)
+   *@return {Promise}
+   */
+  getAccounts: function (params) {
+    return new Promise((resolve, reject) => {
+      let url = _accountsUrlFor(params.gatewayAccountIds, this.connectorUrl)
       let startTime = new Date()
       let context = {
         url: url,

--- a/app/services/clients/direct_debit_connector_client.js
+++ b/app/services/clients/direct_debit_connector_client.js
@@ -58,7 +58,7 @@ function getGatewayAccountByExternalId (params) {
 function getGatewayAccountsByExternalIds (params) {
   return baseClient.get({
     baseUrl,
-    url: `/accounts?accountIds=${params.gatewayAccountIds.join(',')}`,
+    url: `/accounts?externalAccountIds=${params.gatewayAccountIds.join(',')}`,
     correlationId: params.correlationId,
     json: true,
     description: `find gateway accounts by external ids`,

--- a/app/services/clients/direct_debit_connector_client.js
+++ b/app/services/clients/direct_debit_connector_client.js
@@ -3,12 +3,11 @@
 // Local Dependencies
 const GatewayAccount = require('../../models/DirectDebitGatewayAccount.class')
 const baseClient = require('./base_client/base_client')
-const DIRECT_DEBIT_CONNECTOR_URL = process.env.DIRECT_DEBIT_CONNECTOR_URL
-const DIRECT_DEBIT_TOKEN_PREFIX = 'DIRECT_DEBIT:'
-// Use baseurl to create a baseclient for the direct debit microservice
-const baseUrl = `${DIRECT_DEBIT_CONNECTOR_URL}/v1/api`
 
 // Constants
+const DIRECT_DEBIT_CONNECTOR_URL = process.env.DIRECT_DEBIT_CONNECTOR_URL
+const DIRECT_DEBIT_TOKEN_PREFIX = 'DIRECT_DEBIT:'
+const baseUrl = `${DIRECT_DEBIT_CONNECTOR_URL}/v1/api`
 const SERVICE_NAME = 'directdebit-connector'
 
 // Exports
@@ -17,6 +16,9 @@ module.exports = {
   gatewayAccount: {
     create: createGatewayAccount,
     get: getGatewayAccountByExternalId
+  },
+  gatewayAccounts: {
+    get: getGatewayAccountsByExternalIds
   }
 }
 
@@ -51,4 +53,15 @@ function getGatewayAccountByExternalId (params) {
     description: `find a gateway account by external id`,
     service: SERVICE_NAME
   }).then(ga => new GatewayAccount(ga))
+}
+
+function getGatewayAccountsByExternalIds (params) {
+  return baseClient.get({
+    baseUrl,
+    url: `/accounts/?accountIds=${params.gatewayAccountIds.join(',')}`,
+    correlationId: params.correlationId,
+    json: true,
+    description: `find gateway accounts by external ids`,
+    service: SERVICE_NAME
+  })
 }

--- a/app/services/clients/direct_debit_connector_client.js
+++ b/app/services/clients/direct_debit_connector_client.js
@@ -58,7 +58,7 @@ function getGatewayAccountByExternalId (params) {
 function getGatewayAccountsByExternalIds (params) {
   return baseClient.get({
     baseUrl,
-    url: `/accounts/?accountIds=${params.gatewayAccountIds.join(',')}`,
+    url: `/accounts?accountIds=${params.gatewayAccountIds.join(',')}`,
     correlationId: params.correlationId,
     json: true,
     description: `find gateway accounts by external ids`,

--- a/app/services/service_service.js
+++ b/app/services/service_service.js
@@ -51,7 +51,9 @@ function getGatewayAccounts (gatewayAccountIds, correlationId) {
   return Promise.all([fetchCardGatewayAccounts, fetchDirectDebitGatewayAccounts])
     .then(results => {
       return results
-        .reduce((acc, cv) => {return acc.accounts ? cv.concat(acc.accounts) : cv})
+        .reduce((accumulator, currentValue) => {
+          return currentValue.accounts ? accumulator.concat(currentValue.accounts) : accumulator
+        }, [])
         .map(returnGatewayAccountVariant)
         .filter(p => !(p instanceof Error))
     })

--- a/app/utils/reflect.js
+++ b/app/utils/reflect.js
@@ -1,9 +1,0 @@
-'use strict'
-
-module.exports = {
-  reflect: promise => {
-    return promise.then(result => ({v: result, status: 'resolved'}),
-      error => ({e: error, status: 'rejected'})
-    )
-  }
-}

--- a/test/unit/controller/service_switch_controller_test.js
+++ b/test/unit/controller/service_switch_controller_test.js
@@ -32,24 +32,35 @@ describe('service switch controller: list of accounts', function () {
     const service2gatewayAccountIds = ['3', '6', '7']
     const service3gatewayAccountIds = ['4', '9']
     const directDebitGatewayAccountIds = ['DIRECT_DEBIT:6bugfqvub0isp3rqfknck5vq24', 'DIRECT_DEBIT:ksdfhjhfd;sfksd34']
-    const gatewayAccountIds = _.concat(service1gatewayAccountIds, service2gatewayAccountIds, service3gatewayAccountIds)
 
-    gatewayAccountIds.forEach(gid => {
-      connectorMock.get(ACCOUNTS_FRONTEND_PATH + `/${gid}`)
-        .reply(200, gatewayAccountFixtures.validGatewayAccountResponse({
-          gateway_account_id: gid,
-          service_name: `account ${gid}`,
-          type: _.sample(['test', 'live'])
-        }).getPlain())
-    })
-    directDebitGatewayAccountIds.forEach(gid => {
-      directDebitConnectorMock.get(DIRECT_DEBIT_ACCOUNTS_PATH + `/${gid}`)
-        .reply(200, gatewayAccountFixtures.validDirectDebitGatewayAccountResponse({
-          gateway_account_id: gid,
-          service_name: `account ${gid}`,
-          type: _.sample(['test', 'live'])
-        }).getPlain())
-    })
+    connectorMock.get(ACCOUNTS_FRONTEND_PATH + `?accountIds=${service1gatewayAccountIds.join(',')}`)
+      .reply(200, service1gatewayAccountIds.map(iter => gatewayAccountFixtures.validGatewayAccountResponse({
+        gateway_account_id: iter,
+        service_name: `account ${iter}`,
+        type: _.sample(['test', 'live'])
+      }).getPlain()))
+
+    connectorMock.get(ACCOUNTS_FRONTEND_PATH + `?accountIds=${service2gatewayAccountIds.join(',')}`)
+      .reply(200, service2gatewayAccountIds.map(iter => gatewayAccountFixtures.validGatewayAccountResponse({
+        gateway_account_id: iter,
+        service_name: `account ${iter}`,
+        type: _.sample(['test', 'live'])
+      }).getPlain()))
+
+    connectorMock.get(ACCOUNTS_FRONTEND_PATH + `accountIds=${service3gatewayAccountIds.join(',')}`)
+      .reply(200, service3gatewayAccountIds.map(iter => gatewayAccountFixtures.validGatewayAccountResponse({
+        gateway_account_id: iter,
+        service_name: `account ${iter}`,
+        type: _.sample(['test', 'live'])
+      }).getPlain()))
+
+    directDebitConnectorMock.get(DIRECT_DEBIT_ACCOUNTS_PATH + `/accountIds=${directDebitGatewayAccountIds.join(',')}`)
+      .reply(200, directDebitGatewayAccountIds.map(iter => gatewayAccountFixtures.validDirectDebitGatewayAccountResponse({
+        gateway_account_id: iter,
+        service_name: `account ${iter}`,
+        type: _.sample(['test', 'live'])
+      }).getPlain()))
+
     const req = {
       correlationId: 'correlationId',
       user: userFixtures.validUserResponse({

--- a/test/unit/controller/service_switch_controller_test.js
+++ b/test/unit/controller/service_switch_controller_test.js
@@ -33,7 +33,7 @@ describe('service switch controller: list of accounts', function () {
         type: _.sample(['test', 'live'])
       }).getPlain()) })
 
-    directDebitConnectorMock.get(DIRECT_DEBIT_ACCOUNTS_PATH + `?accountIds=${directDebitGatewayAccountIds.join(',')}`)
+    directDebitConnectorMock.get(DIRECT_DEBIT_ACCOUNTS_PATH + `?externalAccountIds=${directDebitGatewayAccountIds.join(',')}`)
       .reply(200, { accounts : directDebitGatewayAccountIds.map(iter => gatewayAccountFixtures.validDirectDebitGatewayAccountResponse({
         gateway_account_id: iter,
         service_name: `account ${iter}`,


### PR DESCRIPTION
## WHAT
Previously the services index/switcher page made an initial call to Adminusers to get a list of services with associated gateway ids against them. These were composed into a large collection of Promises which made individual calls to Connector or Direct Debit Connector to get information about external gateways.

In the case where a development/test system has a few services, with perhaps one test gateway account under each one, this resulted in an inefficient but still fairly fast response time. As the number of services/accounts increases, the page starts to considerably slow down, as evident in our production systems.

The new implementation aggregates all gateway ids across all services and requests them in one go, before matching these up against individual services and rendering them on the page. To support this, new logic was added to connector and direct debit connector for a modified API call. As a result the maximum number of requests to connector/dd-connector is 1 per page load.