### PR TITLE
PP-3888 merchant details improvements 

### DIFF
--- a/app/assets/sass/helpers/_tables.scss
+++ b/app/assets/sass/helpers/_tables.scss
@@ -19,11 +19,23 @@ table {
     }
   }
 
-  tr:first-of-type {
-    border-top: 1px solid $grey-2;
-  }
-
   tbody tr th {
     font-weight: normal;
   }
+}
+
+.large-type {
+  * {
+    @include core-19;
+  }
+}
+
+
+.align-right {
+  text-align: right;
+}
+
+.row-heading {
+  @include bold-19;
+  vertical-align: top;
 }

--- a/app/controllers/edit_merchant_details/get-edit-controller.js
+++ b/app/controllers/edit_merchant_details/get-edit-controller.js
@@ -2,7 +2,7 @@ const lodash = require('lodash')
 const responses = require('../../utils/response')
 const countries = require('../../services/countries.js')
 
-exports.get = (req, res) => {
+module.exports = (req, res) => {
   const externalServiceId = req.params.externalServiceId
   let pageData = lodash.get(req, 'session.pageData.editMerchantDetails')
   if (pageData) {

--- a/app/controllers/edit_merchant_details/get-index-controller.js
+++ b/app/controllers/edit_merchant_details/get-index-controller.js
@@ -1,0 +1,27 @@
+'use strict'
+
+// NPM dependencies
+const lodash = require('lodash')
+
+// Local dependencies
+const paths = require('../../paths')
+const formatPath = require('../../utils/replace_params_in_path')
+const {response} = require('../../utils/response')
+
+module.exports = (req, res) => {
+  const externalServiceId = req.params.externalServiceId
+  const merchantDetails = lodash.get(req, 'service.merchantDetails', undefined)
+  if (!merchantDetails) {
+    return res.redirect(formatPath(paths.merchantDetails.edit, externalServiceId))
+  }
+
+  const pageData = {
+    merchant_details: merchantDetails,
+    has_direct_debit_gateway_account: lodash.get(req, 'service.hasDirectDebitGatewayAccount'),
+    has_card_gateway_account: lodash.get(req, 'service.hasCardGatewayAccount'),
+    has_card_and_dd_gateway_account: lodash.get(req, 'service.hasCardAndDirectDebitGatewayAccount'),
+    externalServiceId,
+    editPath: formatPath(paths.merchantDetails.edit, externalServiceId)
+  }
+  return response(req, res, 'merchant_details/merchant_details', pageData)
+}

--- a/app/controllers/edit_merchant_details/index.js
+++ b/app/controllers/edit_merchant_details/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+exports.getIndex = require('./get-index-controller')
+exports.getEdit = require('./get-edit-controller')
+exports.postEdit = require('./post-edit-controller')

--- a/app/controllers/edit_merchant_details/post-edit-controller.js
+++ b/app/controllers/edit_merchant_details/post-edit-controller.js
@@ -16,7 +16,7 @@ const ADDRESS_POSTCODE = 'address-postcode'
 const ADDRESS_COUNTRY = 'address-country'
 const MERCHANT_EMAIL = 'merchant-email'
 
-exports.post = (req, res) => {
+module.exports = (req, res) => {
   const correlationId = lodash.get(req, 'correlationId')
   const externalServiceId = req.params.externalServiceId
   const hasDirectDebitGatewayAccount = lodash.get(req, 'service.hasDirectDebitGatewayAccount') || lodash.get(req, 'service.hasCardAndDirectDebitGatewayAccount')
@@ -34,12 +34,7 @@ exports.post = (req, res) => {
   if (lodash.isEmpty(errors)) {
     return serviceService.updateMerchantDetails(externalServiceId, reqMerchantDetails, correlationId)
       .then(() => {
-        lodash.set(req, 'session.pageData.editMerchantDetails', {
-          success: true,
-          merchant_details: reqMerchantDetails,
-          has_direct_debit_gateway_account: hasDirectDebitGatewayAccount,
-          externalServiceId
-        })
+        req.flash('generic', `<h2>Organisation details updated</h2>`)
         res.redirect(formattedPathFor(paths.merchantDetails.index, externalServiceId))
       })
       .catch(err => {
@@ -53,7 +48,7 @@ exports.post = (req, res) => {
       has_direct_debit_gateway_account: hasDirectDebitGatewayAccount,
       externalServiceId
     })
-    res.redirect(formattedPathFor(paths.merchantDetails.index, externalServiceId))
+    res.redirect(formattedPathFor(paths.merchantDetails.edit, externalServiceId))
   }
 }
 

--- a/app/middleware/has_services.js
+++ b/app/middleware/has_services.js
@@ -2,7 +2,7 @@ const logger = require('winston')
 const _ = require('lodash')
 const paths = require('../paths')
 
-module.exports = function (req, res, next) {
+module.exports = (req, res, next) => {
   const serviceRoles = _.get(req, 'user.serviceRoles', [])
   if (req.url !== paths.serviceSwitcher.index && serviceRoles.length === 0) {
     logger.info('User does not belong to any service user_external_id=', _.get(req, 'user.externalId'))

--- a/app/paths.js
+++ b/app/paths.js
@@ -70,8 +70,8 @@ module.exports = {
     update: '/service/:externalServiceId/edit-name'
   },
   merchantDetails: {
-    index: '/merchant-details/:externalServiceId',
-    update: '/merchant-details/:externalServiceId'
+    index: '/organisation-details/:externalServiceId',
+    edit: '/organisation-details/edit/:externalServiceId'
   },
   teamMembers: {
     index: '/service/:externalServiceId',

--- a/app/routes.js
+++ b/app/routes.js
@@ -43,8 +43,7 @@ const forgotPassword = require('./controllers/forgotten_password_controller')
 const myServicesCtrl = require('./controllers/my-services')
 const editServiceNameCtrl = require('./controllers/edit_service_name_controller')
 const serviceUsersController = require('./controllers/service_users_controller')
-const editMerchantDetailsCtrlGet = require('./controllers/edit_merchant_details/get')
-const editMerchantDetailsCtrlPost = require('./controllers/edit_merchant_details/post')
+const merchantDetailsCtrl = require('./controllers/edit_merchant_details')
 const inviteUserController = require('./controllers/invite_user_controller')
 const registerCtrl = require('./controllers/register_user_controller')
 const serviceRolesUpdateController = require('./controllers/service_roles_update_controller')
@@ -171,8 +170,9 @@ module.exports.bind = function (app) {
   app.post(nc.update, permission('gateway-credentials:update'), getAccount, paymentMethodIsCard, credentialsCtrl.updateNotificationCredentials)
 
   // MERCHANT DETAILS
-  app.get(merchantDetails.index, permission('merchant-details:read'), editMerchantDetailsCtrlGet.get)
-  app.post(merchantDetails.update, permission('merchant-details:update'), editMerchantDetailsCtrlPost.post)
+  app.get(merchantDetails.index, permission('merchant-details:read'), merchantDetailsCtrl.getIndex)
+  app.get(merchantDetails.edit, permission('merchant-details:update'), merchantDetailsCtrl.getEdit)
+  app.post(merchantDetails.edit, permission('merchant-details:update'), merchantDetailsCtrl.postEdit)
 
   // API KEYS
   app.get(apiKeys.index, permission('tokens-active:read'), getAccount, apiKeysCtrl.getIndex)

--- a/app/views/merchant_details/edit_merchant_details.njk
+++ b/app/views/merchant_details/edit_merchant_details.njk
@@ -1,7 +1,7 @@
 {% extends "../layout.njk" %}
 
 {% block page_title %}
-  Merchant details - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+  Organisation details - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
 {% block mainContent %}
@@ -11,7 +11,7 @@
 <div class="column-two-thirds">
   {% if success %}
   <div class="notification">
-      Merchant details updated
+      Organisation details updated
   </div>
   {% endif %}
   {% if errors %}
@@ -44,25 +44,24 @@
     </ul>
   </div>
   {% endif %}
-  <h1 class="page-title">Merchant details</h1>
-
+  <h1 class="page-title">Organisation details</h1>
   {% if has_direct_debit_gateway_account %}
-    <p id="merchant-details-info">Direct Debit requires the details of the merchant taking payment to be shown to the payer. This information is
+    <p id="merchant-details-info">Direct Debit requires the details of the organisation taking payment to be shown to the payer. This information is
       displayed in emails and on payment pages.</p>
   {% endif %}
   {% if has_card_gateway_account %}
-    <p id="merchant-details-info">Payment card schemes require the details of the merchant taking payment to be shown on payment pages.</p>
+    <p id="merchant-details-info">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
   {% endif %}
   {% if has_card_and_dd_gateway_account %}
-    <p id="merchant-details-info">Payment card schemes and Direct Debit require the details of the merchant taking payment to be shown to the
+    <p id="merchant-details-info">Payment card schemes and Direct Debit require the details of the organisation taking payment to be shown to the
       payer. This information is displayed in emails and on payment pages.</p>
   {% endif %}
 
-  <form id="merchant-details-form" method="post" action="/merchant-details/{{externalServiceId}}">
+  <form id="merchant-details-form" method="post" action="/organisation-details/edit/{{externalServiceId}}">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
     <div class="form-group">
       <label class="form-label" for="merchant-name">
-        <span class="heading-small">Merchant name</span>
+        <span class="heading-small">Name</span>
         <span class="form-hint form-control-2-3">
           Organisation or department that holds the bank account with payment service provider
         </span>
@@ -88,7 +87,7 @@
       </div>
       <div class="form-group">
         <label class="form-label" for="merchant-email">
-          <span class="heading-small">Merchant email</span>
+          <span class="heading-small">Email</span>
         </label>
         {% if errors["merchant-email"] %}
           <span class="error-message">
@@ -99,7 +98,7 @@
       </div>
     {% endif %}
     <div class="form-group">
-      <h2 class="heading-small billing-address-label">Merchant address</h2>
+      <h2 class="heading-small billing-address-label">Address</h2>
       <div class="payment-type-intro">
       </div>
       <fieldset>
@@ -161,7 +160,9 @@
       </fieldset>
     </div>
     <div class="form-group">
-        <input id="save-merchant-details" class="button" type="submit" value="Save">
+        <button id="save-merchant-details" class="button" type="submit">
+          Save organisation details
+        </button>
     </div>
   </form>
 </div>

--- a/app/views/merchant_details/edit_merchant_details.njk
+++ b/app/views/merchant_details/edit_merchant_details.njk
@@ -45,16 +45,14 @@
   </div>
   {% endif %}
   <h1 class="page-title">Organisation details</h1>
-  {% if has_direct_debit_gateway_account %}
-    <p id="merchant-details-info">Direct Debit requires the details of the organisation taking payment to be shown to the payer. This information is
-      displayed in emails and on payment pages.</p>
-  {% endif %}
-  {% if has_card_gateway_account %}
-    <p id="merchant-details-info">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
-  {% endif %}
   {% if has_card_and_dd_gateway_account %}
     <p id="merchant-details-info">Payment card schemes and Direct Debit require the details of the organisation taking payment to be shown to the
       payer. This information is displayed in emails and on payment pages.</p>
+  {% elif has_direct_debit_gateway_account %}
+    <p id="merchant-details-info">Direct Debit requires the details of the organisation taking payment to be shown to the payer. This information is
+      displayed in emails and on payment pages.</p>
+  {% elif has_card_gateway_account %}
+    <p id="merchant-details-info">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
   {% endif %}
 
   <form id="merchant-details-form" method="post" action="/organisation-details/edit/{{externalServiceId}}">

--- a/app/views/merchant_details/merchant_details.njk
+++ b/app/views/merchant_details/merchant_details.njk
@@ -10,16 +10,14 @@
 </div>
 <div class="column-two-thirds">
   <h1 class="page-title">Organisation details</h1>
-  {% if has_direct_debit_gateway_account %}
-    <p id="merchant-details-info">Direct Debit requires the details of the organisation taking payment to be shown to the payer. This information is
-      displayed in emails and on payment pages.</p>
-  {% endif %}
-  {% if has_card_gateway_account %}
-    <p id="merchant-details-info">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
-  {% endif %}
   {% if has_card_and_dd_gateway_account %}
     <p id="merchant-details-info">Payment card schemes and Direct Debit require the details of the organisation taking payment to be shown to the
       payer. This information is displayed in emails and on payment pages.</p>
+  {% elif has_direct_debit_gateway_account %}
+    <p id="merchant-details-info">Direct Debit requires the details of the organisation taking payment to be shown to the payer. This information is
+      displayed in emails and on payment pages.</p>
+  {% elif has_card_gateway_account %}
+    <p id="merchant-details-info">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
   {% endif %}
 
   <table class="large-type">

--- a/app/views/merchant_details/merchant_details.njk
+++ b/app/views/merchant_details/merchant_details.njk
@@ -1,0 +1,80 @@
+{% extends "../layout.njk" %}
+
+{% block page_title %}
+  Organisation details - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+{% endblock %}
+
+{% block mainContent %}
+<div class="column-full">
+  <a href="/my-services" class="link-back">Back to services</a>
+</div>
+<div class="column-two-thirds">
+  <h1 class="page-title">Organisation details</h1>
+  {% if has_direct_debit_gateway_account %}
+    <p id="merchant-details-info">Direct Debit requires the details of the organisation taking payment to be shown to the payer. This information is
+      displayed in emails and on payment pages.</p>
+  {% endif %}
+  {% if has_card_gateway_account %}
+    <p id="merchant-details-info">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
+  {% endif %}
+  {% if has_card_and_dd_gateway_account %}
+    <p id="merchant-details-info">Payment card schemes and Direct Debit require the details of the organisation taking payment to be shown to the
+      payer. This information is displayed in emails and on payment pages.</p>
+  {% endif %}
+
+  <table class="large-type">
+    <tr>
+      <th class="row-heading">
+        Name
+      </th>
+      <td id="merchant-name">
+        {{merchant_details.name}}
+      </td>
+      <td class="align-right">
+        <a href="{{editPath}}">Change<span class="visuallyhidden">organisation name</span></a>
+      </td>
+    </tr>
+    <tr>
+      <th class="row-heading">
+        Address
+      </th>
+      <td id="merchant-address">
+        {{merchant_details.address_line1}}<br/>
+        {{merchant_details.address_line2}}<br/>
+        {{merchant_details.address_city}}<br/>
+        {{merchant_details.address_postcode}}<br/>
+        {{merchant_details.address_country}}
+      </td>
+      <td class="align-right">
+        <a href="{{editPath}}">Change<span class="visuallyhidden"> organisation address</span></a>
+      </td>
+    </tr>
+    {% if merchant_details.telephone_number %}
+    <tr>
+      <th class="row-heading">
+        Phone number
+      </th>
+      <td id="telephone-number">
+        {{merchant_details.telephone_number}}
+      </td>
+      <td class="align-right">
+        <a href="{{editPath}}">Change<span class="visuallyhidden"> organisation phone number</span></a>
+      </td>
+    </tr>
+    {% endif %}
+    {% if merchant_details.email %}
+    <tr>
+      <th class="row-heading">
+        Email
+      </th>
+      <td id="merchant-email">
+        {{merchant_details.email}}
+      </td>
+      <td class="align-right">
+        <a href="{{editPath}}">Change<span class="visuallyhidden"> organisation email</span></a>
+      </td>
+    </tr>
+    {% endif %}
+  </table>
+</div>
+{% endblock %}

--- a/app/views/services/_service_section.njk
+++ b/app/views/services/_service_section.njk
@@ -40,8 +40,8 @@
       </li>
       <li>
       {% if service.permissions.merchant_details_read %}
-        <a href="/merchant-details/{{ service.external_id }}" class="edit-merchant-details">Edit merchant details</a>
-        <p class="font-xsmall">Payment schemes require the details of the merchant taking payment to be shown to paying users.</p>
+        <a href="/organisation-details/{{ service.external_id }}" class="edit-merchant-details">Organisation details</a>
+        <p class="font-xsmall">Payment schemes require the details of the organisation taking payment to be shown to paying users.</p>
       {% endif %}
       </li>
     </ul>

--- a/test/unit/controller/edit_merchant_details_controller/get-edit.test.js
+++ b/test/unit/controller/edit_merchant_details_controller/get-edit.test.js
@@ -67,7 +67,7 @@ describe('edit merchant details controller - get', () => {
         .reply(200, user.getPlain())
       const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
       supertest(app)
-        .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+        .get(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
           response = res
           $ = cheerio.load(res.text || '')
@@ -119,7 +119,7 @@ describe('edit merchant details controller - get', () => {
         .reply(200, user.getPlain())
       const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
       supertest(app)
-        .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+        .get(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
           response = res
           $ = cheerio.load(res.text || '')
@@ -173,7 +173,7 @@ describe('edit merchant details controller - get', () => {
         .reply(200, user.getPlain())
       const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
       supertest(app)
-        .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+        .get(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
           response = res
           $ = cheerio.load(res.text || '')
@@ -228,7 +228,7 @@ describe('edit merchant details controller - get', () => {
         .reply(200, user.getPlain())
       const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
       supertest(app)
-        .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+        .get(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
           response = res
           $ = cheerio.load(res.text || '')
@@ -285,7 +285,7 @@ describe('edit merchant details controller - get', () => {
         .reply(200, user.getPlain())
       const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
       supertest(app)
-        .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+        .get(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
           response = res
           $ = cheerio.load(res.text || '')
@@ -307,45 +307,6 @@ describe('edit merchant details controller - get', () => {
     })
     it(`should display the merchant details info`, () => {
       expect($('#merchant-details-info').text()).to.include('Payment card schemes and Direct Debit require the details')
-    })
-  })
-  describe('when success is set in the session', () => {
-    before(done => {
-      user = userFixtures.validUserWithMerchantDetails(userInSession)
-      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
-      session = {
-        csrfSecret: '123',
-        12345: {refunded_amount: 5},
-        passport: {
-          user: userInSession
-        },
-        secondFactor: 'totp',
-        last_url: 'last_url',
-        version: 0,
-        pageData: {
-          editMerchantDetails: {
-            success: true
-          }
-        }
-      }
-      const app = mockSession.createAppWithSession(getApp(), session)
-      supertest(app)
-        .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
-        .end((err, res) => {
-          response = res
-          $ = cheerio.load(res.text || '')
-          done(err)
-        })
-    })
-    it(`should get a nice 200 status code`, () => {
-      expect(response.statusCode).to.equal(200)
-    })
-    it(`should show an updated successful banner`, () => {
-      expect($('.notification').text()).to.contain('Merchant details updated')
-    })
-    it(`should not show any error`, () => {
-      expect($('.error-summary').length).to.equal(0)
     })
   })
   describe('when errors and merchant details are set in the session (CREDIT CARD GATEWAY ACCOUNT)', () => {
@@ -382,7 +343,7 @@ describe('edit merchant details controller - get', () => {
       }
       const app = mockSession.createAppWithSession(getApp(), session)
       supertest(app)
-        .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+        .get(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
           response = res
           $ = cheerio.load(res.text || '')
@@ -453,7 +414,7 @@ describe('edit merchant details controller - get', () => {
       }
       const app = mockSession.createAppWithSession(getApp(), session)
       supertest(app)
-        .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+        .get(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
           response = res
           $ = cheerio.load(res.text || '')

--- a/test/unit/controller/edit_merchant_details_controller/get-index.test.js
+++ b/test/unit/controller/edit_merchant_details_controller/get-index.test.js
@@ -1,0 +1,243 @@
+const chai = require('chai')
+const cheerio = require('cheerio')
+const nock = require('nock')
+const mockSession = require('../../../test_helpers/mock_session.js')
+const getApp = require('../../../../server.js').getApp
+const supertest = require('supertest')
+const userFixtures = require('../../../fixtures/user_fixtures')
+const paths = require('../../../../app/paths.js')
+const formattedPathFor = require('../../../../app/utils/replace_params_in_path')
+const expect = chai.expect
+const adminusersMock = nock(process.env.ADMINUSERS_URL)
+const USER_RESOURCE = '/v1/api/users'
+let response, user, $
+
+describe('Organisation details controller - get', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+  const EXTERNAL_ID_IN_SESSION = 'exsfjpwoi34op23i4'
+  const EXTERNAL_SERVICE_ID = 'dsfkbskjalksjdlk342'
+  describe('when the organisation already has details (CREDIT CARD GATEWAY ACCOUNT)', () => {
+    before(done => {
+      let serviceRoles = [{
+        service: {
+          name: 'System Generated',
+          external_id: EXTERNAL_SERVICE_ID,
+          gateway_account_ids: ['20'],
+          merchant_details: {
+            name: 'name',
+            telephone_number: '',
+            address_line1: 'line1',
+            address_line2: 'line2',
+            address_city: 'City',
+            address_postcode: 'POSTCODE',
+            address_country: 'AR',
+            email: ''
+          }
+        },
+        role: {
+          name: 'admin',
+          description: 'Administrator',
+          permissions: [{name: 'merchant-details:read'}, {name: 'merchant-details:update'}]
+        }
+      }]
+      let userInSession = mockSession.getUser({
+        external_id: EXTERNAL_ID_IN_SESSION,
+        service_roles: serviceRoles
+      })
+      user = userFixtures.validUserWithMerchantDetails(userInSession)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
+        .reply(200, user.getPlain())
+      const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
+      supertest(app)
+        .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+    it(`should get a nice 200 status code`, () => {
+      expect(response.statusCode).to.equal(200)
+    })
+    it(`should show table with the organisation details`, () => {
+      expect($('#merchant-name').text()).to.contain('name')
+      expect($('#merchant-address').text()).to.contain('line1')
+      expect($('#merchant-address').text()).to.contain('line2')
+      expect($('#merchant-address').text()).to.contain('City')
+      expect($('#merchant-address').text()).to.contain('POSTCODE')
+      expect($('#merchant-address').text()).to.contain('AR')
+    })
+  })
+  describe('when the merchant already has details (DIRECT DEBIT GATEWAY ACCOUNT)', () => {
+    before(done => {
+      let serviceRoles = [{
+        service: {
+          name: 'System Generated',
+          external_id: EXTERNAL_SERVICE_ID,
+          gateway_account_ids: ['DIRECT_DEBIT:somerandomidhere'],
+          merchant_details: {
+            name: 'name',
+            telephone_number: '03069990000',
+            address_line1: 'line1',
+            address_line2: 'line2',
+            address_city: 'City',
+            address_postcode: 'POSTCODE',
+            address_country: 'AR',
+            email: 'dd-merchant@example.com'
+          }
+        },
+        role: {
+          name: 'admin',
+          description: 'Administrator',
+          permissions: [{name: 'merchant-details:read'}, {name: 'merchant-details:update'}]
+        }
+      }]
+      let userInSession = mockSession.getUser({
+        external_id: EXTERNAL_ID_IN_SESSION,
+        service_roles: serviceRoles
+      })
+      user = userFixtures.validUserWithMerchantDetails(userInSession)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
+        .reply(200, user.getPlain())
+      const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
+      supertest(app)
+        .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+    it(`should get a nice 200 status code`, () => {
+      expect(response.statusCode).to.equal(200)
+    })
+    it(`should show table with the organisation details`, () => {
+      expect($('#merchant-name').text()).to.contain('name')
+      expect($('#telephone-number').text()).to.contain('03069990000')
+      expect($('#merchant-email').text()).to.contain('dd-merchant@example.com')
+      expect($('#merchant-address').text()).to.contain('line1')
+      expect($('#merchant-address').text()).to.contain('line2')
+      expect($('#merchant-address').text()).to.contain('City')
+      expect($('#merchant-address').text()).to.contain('POSTCODE')
+      expect($('#merchant-address').text()).to.contain('AR')
+    })
+  })
+  describe('when the merchant has empty details (CREDIT CARD GATEWAY ACCOUNT)', () => {
+    before(done => {
+      let serviceRoles = [{
+        service: {
+          name: 'System Generated',
+          external_id: EXTERNAL_SERVICE_ID,
+          gateway_account_ids: ['20'],
+          merchant_details: undefined
+        },
+        role: {
+          name: 'admin',
+          description: 'Administrator',
+          permissions: [{name: 'merchant-details:read'}, {name: 'merchant-details:update'}]
+        }
+      }]
+      let userInSession = mockSession.getUser({
+        external_id: EXTERNAL_ID_IN_SESSION,
+        service_roles: serviceRoles
+      })
+      user = userFixtures.validUserWithMerchantDetails(userInSession)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
+        .reply(200, user.getPlain())
+      const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
+      supertest(app)
+        .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+    it(`should get a nice 302 status code`, () => {
+      expect(response.statusCode).to.equal(302)
+    })
+    it('should redirect to the edit page', () => {
+      expect(response.headers).to.have.property('location').to.equal(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
+    })
+  })
+  describe('when the merchant has empty details (DIRECT DEBIT GATEWAY ACCOUNT)', () => {
+    before(done => {
+      let serviceRoles = [{
+        service: {
+          name: 'System Generated',
+          external_id: EXTERNAL_SERVICE_ID,
+          gateway_account_ids: ['DIRECT_DEBIT:somerandomidhere'],
+          merchant_details: undefined
+
+        },
+        role: {
+          name: 'admin',
+          description: 'Administrator',
+          permissions: [{name: 'merchant-details:read'}, {name: 'merchant-details:update'}]
+        }
+      }]
+      let userInSession = mockSession.getUser({
+        external_id: EXTERNAL_ID_IN_SESSION,
+        service_roles: serviceRoles
+      })
+      user = userFixtures.validUserWithMerchantDetails(userInSession)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
+        .reply(200, user.getPlain())
+      const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
+      supertest(app)
+        .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+    it(`should get a nice 302 status code`, () => {
+      expect(response.statusCode).to.equal(302)
+    })
+    it('should redirect to the edit page', () => {
+      expect(response.headers).to.have.property('location').to.equal(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
+    })
+  })
+  describe('when the merchant has empty details (DIRECT DEBIT GATEWAY ACCOUNT and CREDIT CARD GATEWAY ACCOUNT)', () => {
+    before(done => {
+      let serviceRoles = [{
+        service: {
+          name: 'System Generated',
+          external_id: EXTERNAL_SERVICE_ID,
+          gateway_account_ids: ['DIRECT_DEBIT:somerandomidhere', '12345'],
+          merchant_details: undefined
+
+        },
+        role: {
+          name: 'admin',
+          description: 'Administrator',
+          permissions: [{name: 'merchant-details:read'}, {name: 'merchant-details:update'}]
+        }
+      }]
+      let userInSession = mockSession.getUser({
+        external_id: EXTERNAL_ID_IN_SESSION,
+        service_roles: serviceRoles
+      })
+      user = userFixtures.validUserWithMerchantDetails(userInSession)
+      adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
+        .reply(200, user.getPlain())
+      const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
+      supertest(app)
+        .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+    it(`should get a nice 302 status code`, () => {
+      expect(response.statusCode).to.equal(302)
+    })
+    it('should redirect to the edit page', () => {
+      expect(response.headers).to.have.property('location').to.equal(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
+    })
+  })
+})

--- a/test/unit/controller/edit_merchant_details_controller/post-edit.test.js
+++ b/test/unit/controller/edit_merchant_details_controller/post-edit.test.js
@@ -63,7 +63,7 @@ describe('edit merchant details controller - post', () => {
       }
       let app = mockSession.createAppWithSession(getApp(), session)
       supertest(app)
-        .post(formattedPathFor(paths.merchantDetails.update, EXTERNAL_SERVICE_ID))
+        .post(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({
           'merchant-name': 'new-name',
@@ -80,17 +80,12 @@ describe('edit merchant details controller - post', () => {
           done(err)
         })
     })
-    it(`should redirect back to the page`, () => {
+    it(`should redirect back to the index page`, () => {
       expect(response.statusCode).to.equal(302)
       expect(response.headers.location).to.equal(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
     })
     it(`should set the success notification in the session`, () => {
-      expect(session.pageData.editMerchantDetails.success).to.be.true // eslint-disable-line
-      expect(session.pageData.editMerchantDetails).not.to.have.property('errors')
-    })
-    it(`should set the success notification in the session`, () => {
-      expect(session.pageData.editMerchantDetails.success).to.be.true // eslint-disable-line
-      expect(session.pageData.editMerchantDetails).not.to.have.property('errors')
+      expect(session.flash.generic).to.have.property('length').to.equal(1)
     })
   })
   describe('when the update merchant details call is missing mandatory fields', () => {
@@ -114,7 +109,7 @@ describe('edit merchant details controller - post', () => {
       }
       let app = mockSession.createAppWithSession(getApp(), session)
       supertest(app)
-        .post(formattedPathFor(paths.merchantDetails.update, EXTERNAL_SERVICE_ID))
+        .post(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({
           'address-city': 'new-city',
@@ -129,7 +124,7 @@ describe('edit merchant details controller - post', () => {
     })
     it(`should redirect back to the page`, () => {
       expect(response.statusCode).to.equal(302)
-      expect(response.headers.location).to.equal(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+      expect(response.headers.location).to.equal(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
     })
     it(`should the errors in the session`, () => {
       expect(session.pageData.editMerchantDetails.success).to.be.false // eslint-disable-line
@@ -162,7 +157,7 @@ describe('edit merchant details controller - post', () => {
       }
       let app = mockSession.createAppWithSession(getApp(), session)
       supertest(app)
-        .post(formattedPathFor(paths.merchantDetails.update, EXTERNAL_SERVICE_ID))
+        .post(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({
           'merchant-name': 'new-name',
@@ -181,7 +176,7 @@ describe('edit merchant details controller - post', () => {
     })
     it(`should redirect back to the page`, () => {
       expect(response.statusCode).to.equal(302)
-      expect(response.headers.location).to.equal(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+      expect(response.headers.location).to.equal(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
     })
     it(`should set errors in the session`, () => {
       expect(session.pageData.editMerchantDetails.success).to.be.false // eslint-disable-line
@@ -211,7 +206,7 @@ describe('edit merchant details controller - post', () => {
       }
       const app = mockSession.createAppWithSession(getApp(), session)
       supertest(app)
-        .post(formattedPathFor(paths.merchantDetails.update, EXTERNAL_SERVICE_ID))
+        .post(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({
           'merchant-name': 'new-name',
@@ -230,7 +225,7 @@ describe('edit merchant details controller - post', () => {
     })
     it(`should redirect back to the page`, () => {
       expect(response.statusCode).to.equal(302)
-      expect(response.headers.location).to.equal(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+      expect(response.headers.location).to.equal(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
     })
     it(`should set errors in the session`, () => {
       expect(session.pageData.editMerchantDetails.success).to.be.false // eslint-disable-line
@@ -260,7 +255,7 @@ describe('edit merchant details controller - post', () => {
       }
       const app = mockSession.createAppWithSession(getApp(), session)
       supertest(app)
-        .post(formattedPathFor(paths.merchantDetails.update, EXTERNAL_SERVICE_ID))
+        .post(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({
           'merchant-name': 'new-name',
@@ -279,7 +274,7 @@ describe('edit merchant details controller - post', () => {
     })
     it(`should redirect back to the page`, () => {
       expect(response.statusCode).to.equal(302)
-      expect(response.headers.location).to.equal(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+      expect(response.headers.location).to.equal(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
     })
     it(`should set errors in the session`, () => {
       expect(session.pageData.editMerchantDetails.success).to.be.false // eslint-disable-line
@@ -309,7 +304,7 @@ describe('edit merchant details controller - post', () => {
       }
       const app = mockSession.createAppWithSession(getApp(), session)
       supertest(app)
-        .post(formattedPathFor(paths.merchantDetails.update, EXTERNAL_SERVICE_ID))
+        .post(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({
           'merchant-name': 'new-name',
@@ -328,7 +323,7 @@ describe('edit merchant details controller - post', () => {
     })
     it(`should redirect back to the page`, () => {
       expect(response.statusCode).to.equal(302)
-      expect(response.headers.location).to.equal(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
+      expect(response.headers.location).to.equal(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
     })
     it(`should set errors in the session`, () => {
       expect(session.pageData.editMerchantDetails.success).to.be.false // eslint-disable-line
@@ -348,7 +343,7 @@ describe('edit merchant details controller - post', () => {
       })
       const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
       supertest(app)
-        .post(formattedPathFor(paths.merchantDetails.update, EXTERNAL_SERVICE_ID))
+        .post(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({
           'merchant-name': 'new-name',


### PR DESCRIPTION
_This is a clone of https://github.com/alphagov/pay-selfservice/pull/835 but without the Pact/Cypress stuff which broke things, that we will come back to later_

Rather than showing the form filled in which is U G L Y, no offence, we
now show a summary page if the details have been entered already.

Also Merchant is jargon so renamed it to Organisation, but only for users, still called merchant in the background. I did start renaming it there too, but it got crazy! Especially seeing as to do it properly would have to rename in the java projects and on the DB too

