### PR TITLE
PP-3928 Ensured the search box on service switcher only shows up when there are 8 services or more

### DIFF
--- a/app/views/services/index.njk
+++ b/app/views/services/index.njk
@@ -26,7 +26,7 @@ Choose service - GOV.UK Pay
       </a>
     </div>
   </div>
-  {% if services.length > 0 %}
+  {% if services.length > 7 %}
   <div class="js-show flex-grid--row">
     <div class="flex-grid--column-half tight">
       <label class="form-label-bold" for="service-filter">Filter services</label>


### PR DESCRIPTION
## WHAT
The service switch filter should only show (and only start to work correctly) when there are 8 services or more.

This adds a small fix to the nunjucks template to ensure this happens.

