### PR TITLE
PP-3493 Add issued by to csv export

### DIFF
--- a/app/controllers/transactions/transaction_download_controller.js
+++ b/app/controllers/transactions/transaction_download_controller.js
@@ -2,6 +2,7 @@
 
 // NPM Dependencies
 const logger = require('winston')
+const lodash = require('lodash')
 
 // Local Dependencies
 const transactionService = require('../../services/transaction_service')
@@ -10,6 +11,7 @@ const auth = require('../../services/auth_service.js')
 const date = require('../../utils/dates.js')
 const {renderErrorView} = require('../../utils/response.js')
 const {CORRELATION_HEADER} = require('../../utils/correlation_header.js')
+const userService = require('../../services/user_service')
 
 module.exports = (req, res) => {
   const accountId = auth.getCurrentGatewayAccountId(req)
@@ -17,7 +19,31 @@ module.exports = (req, res) => {
   const name = `GOVUK_Pay_${date.dateToDefaultFormat(new Date()).replace(' ', '_')}.csv`
   const correlationId = req.headers[CORRELATION_HEADER]
   transactionService.searchAll(accountId, filters, correlationId)
-    .then(json => jsonToCsv(json.results))
+    .then(json => {
+      let userIds = json.results
+        .filter(res => res.transaction_type === 'refund')
+        .map(res => res.refund_summary.user_external_id)
+      userIds = lodash.uniq(userIds)
+      if (userIds.length === 0) {
+        return jsonToCsv(json.results)
+      } else {
+        return userService.findMultipleByExternalIds(userIds, correlationId)
+          .then(users => {
+            const usersMap = userIds.reduce((map, userId, index) => {
+              map[userId] = users[index].username
+              return map
+            }, {})
+            const results = json.results
+              .map(res => {
+                if (res.transaction_type === 'refund') {
+                  res.refund_summary.user_external_id = usersMap[res.refund_summary.user_external_id]
+                }
+                return res
+              })
+            return jsonToCsv(results)
+          })
+      }
+    })
     .then(csv => {
       logger.debug('Sending csv attachment download -', {'filename': name})
       res.setHeader('Content-disposition', 'attachment; filename="' + name + '"')

--- a/app/utils/json_to_csv.js
+++ b/app/utils/json_to_csv.js
@@ -67,7 +67,8 @@ module.exports = function (data) {
           {label: 'Error Code', value: 'state.code'},
           {label: 'Error Message', value: 'state.message'},
           {label: 'Provider ID', value: 'gateway_transaction_id'},
-          {label: 'GOV.UK Payment ID', value: 'charge_id'}
+          {label: 'GOV.UK Payment ID', value: 'charge_id'},
+          {label: 'Issued By', value: 'refund_summary.user_external_id'}
         ]),
         {
           label: 'Date Created',

--- a/test/integration/json/transaction_download_refunds.json
+++ b/test/integration/json/transaction_download_refunds.json
@@ -30,6 +30,9 @@
       "expiry_date": "12\/19",
       "last_digits_card_number": "4242"
     },
+    "refund_summary": {
+      "user_external_id": "thisisauser"
+    },
     "transaction_type": "refund"
   }
 ]

--- a/test/unit/utils/json_to_csv_tests.js
+++ b/test/unit/utils/json_to_csv_tests.js
@@ -18,11 +18,11 @@ describe('json2csv module', function () {
 
     let csvDataPromise = jsonToCSV(jsonData)
 
-    let csvDataExpected = `"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Date Created","Time Created"
-"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","Success",false,"","","transaction-1","charge1","12 May 2016","17:37:29"
-"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","Cancelled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015","19:55:29"
-"red","desc-red","alice.111@mail.fake","12.34","Visa","TEST01","12/19","4242","Success",false,"","","transaction-1","charge1","12 May 2016","17:37:29"
-"blue","desc-blue","alice.222@mail.fake","1.23","Mastercard","TEST02","12/19","4241","Cancelled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015","19:55:29"`
+    let csvDataExpected = `"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Issued By","Date Created","Time Created"
+"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","Success",false,"","","transaction-1","charge1","","12 May 2016","17:37:29"
+"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","Cancelled",true,"P01234","Something happened","transaction-2","charge2","","12 Apr 2015","19:55:29"
+"red","desc-red","alice.111@mail.fake","12.34","Visa","TEST01","12/19","4242","Success",false,"","","transaction-1","charge1","","12 May 2016","17:37:29"
+"blue","desc-blue","alice.222@mail.fake","1.23","Mastercard","TEST02","12/19","4241","Cancelled",true,"P01234","Something happened","transaction-2","charge2","","12 Apr 2015","19:55:29"`
 
     return csvDataPromise.then(csvData => {
       return expect(csvData).to.deep.equal(csvDataExpected)
@@ -38,12 +38,12 @@ describe('json2csv module', function () {
 
     let csvDataPromise = jsonToCSV(jsonData)
 
-    let csvDataExpected = `"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Date Created","Time Created"
-"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","Success",false,"","","transaction-1","charge1","12 May 2016","17:37:29"
-"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","Cancelled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015","19:55:29"
-"red","desc-red","alice.111@mail.fake","12.34","Visa","TEST01","12/19","4242","Success",false,"","","transaction-1","charge1","12 May 2016","17:37:29"
-"refund_test","desc-refund","alice.111@mail.fake","-45.67","Visa","TEST01","12/19","4242","Refund success",false,"","","transaction-1","refund1","12 May 2016","17:37:29"
-"blue","desc-blue","alice.222@mail.fake","1.23","Mastercard","TEST02","12/19","4241","Cancelled",true,"P01234","Something happened","transaction-2","charge2","12 Apr 2015","19:55:29"`
+    let csvDataExpected = `"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Issued By","Date Created","Time Created"
+"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","Success",false,"","","transaction-1","charge1","","12 May 2016","17:37:29"
+"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","Cancelled",true,"P01234","Something happened","transaction-2","charge2","","12 Apr 2015","19:55:29"
+"red","desc-red","alice.111@mail.fake","12.34","Visa","TEST01","12/19","4242","Success",false,"","","transaction-1","charge1","","12 May 2016","17:37:29"
+"refund_test","desc-refund","alice.111@mail.fake","-45.67","Visa","TEST01","12/19","4242","Refund success",false,"","","transaction-1","refund1","","12 May 2016","17:37:29"
+"blue","desc-blue","alice.222@mail.fake","1.23","Mastercard","TEST02","12/19","4241","Cancelled",true,"P01234","Something happened","transaction-2","charge2","","12 Apr 2015","19:55:29"`
 
     return csvDataPromise.then(csvData => {
       return expect(csvData).to.deep.equal(csvDataExpected)


### PR DESCRIPTION
## WHAT
 - Connector now returns the user external id for refunds. Selfservice has to get that for each refund and map it to a username by calling adminusers. 

Apologies for the frankly fugly code, but it is necessary as there can be multiple refunds from the same user and adminusers will only return a single result, so we need to store that in a map in order to populate the csv list with correct results.


