### PR TITLE
PP-3493 Ignore undefined user id if refund issued by is not present

### DIFF
--- a/app/controllers/transactions/transaction_download_controller.js
+++ b/app/controllers/transactions/transaction_download_controller.js
@@ -23,6 +23,7 @@ module.exports = (req, res) => {
       let userIds = json.results
         .filter(res => res.transaction_type === 'refund')
         .map(res => res.refund_summary.user_external_id)
+        .filter(userId => userId)
       userIds = lodash.uniq(userIds)
       if (userIds.length === 0) {
         return jsonToCsv(json.results)

--- a/test/integration/json/transaction_download_refunds.json
+++ b/test/integration/json/transaction_download_refunds.json
@@ -34,5 +34,40 @@
       "user_external_id": "thisisauser"
     },
     "transaction_type": "refund"
+  },
+  {
+    "amount": 12345,
+    "state": {
+      "status": "success",
+      "finished": false
+    },
+    "card_brand": "Visa",
+    "description": "=calc+z!A0",
+    "reference": "+red",
+    "email": "-alice.111@mail.fake",
+    "links": [
+
+    ],
+    "charge_id": "charge2",
+    "gateway_transaction_id": "transaction-1",
+    "return_url": "https:\/\/demoservice.pymnt.localdomain:443\/return\/red",
+    "payment_provider": "sandbox",
+    "created_date": "2016-05-12T16:37:29.245Z",
+    "card_details": {
+      "billing_address": {
+        "city": "TEST01",
+        "country": "GB",
+        "line1": "TEST",
+        "line2": "TEST - DO NOT PROCESS",
+        "postcode": "SE1 3UZ"
+      },
+      "card_brand": "@Visa",
+      "cardholder_name": "TEST01",
+      "expiry_date": "12\/19",
+      "last_digits_card_number": "4242"
+    },
+    "refund_summary": {
+    },
+    "transaction_type": "refund"
   }
 ]

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -171,6 +171,7 @@ describe('Transaction download endpoints', function () {
           let arrayOfLines = csvContent.split('\n')
           expect(arrayOfLines[0]).to.equal('"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Issued By","Date Created","Time Created"')
           expect(arrayOfLines[1]).to.equal('"\'+red","\'=calc+z!A0","\'-alice.111@mail.fake","-123.45","\'@Visa","TEST01","12/19","4242","Refund success",false,"","","transaction-1","charge1","thisisausername","12 May 2016","17:37:29"')
+          expect(arrayOfLines[2]).to.equal('"\'+red","\'=calc+z!A0","\'-alice.111@mail.fake","-123.45","\'@Visa","TEST01","12/19","4242","Refund success",false,"","","transaction-1","charge2","","12 May 2016","17:37:29"')
           done()
         })
     })


### PR DESCRIPTION
## WHAT
- `user_external_id` is not always present (ie. for refunds coming from
   public api). Selfservice should handle this and not send undefined to
   adminusers


