### PR TITLE
PP-3975 Filter gatewayAccountIds by external and internal ids

### DIFF
--- a/app/controllers/my-services/get-index-controller.js
+++ b/app/controllers/my-services/get-index-controller.js
@@ -35,7 +35,12 @@ module.exports = (req, res) => {
   serviceService.getGatewayAccounts(aggregatedGatewayAccountIds, req.correlationId)
     .then(aggregatedGatewayAccounts => {
       return servicesRoles.map(serviceRole => {
-        const gatewayAccounts = aggregatedGatewayAccounts.filter(gatewayAccount => serviceRole.service.gatewayAccountIds.includes(gatewayAccount.id.toString()))
+        // For Direct Debit currently we initialise req.user.serviceRoles[].service.gatewayAccountIds with external ids,
+        // but for Cards we initialise with internal ids.
+        // We check the gateway accounts' external id first as not to overlap/skip between card payment and direct debit gateway accounts.
+        const gatewayAccounts =
+          aggregatedGatewayAccounts.filter(gatewayAccount => serviceRole.service.gatewayAccountIds.includes(gatewayAccount.external_id.toString()) ||
+            serviceRole.service.gatewayAccountIds.includes(gatewayAccount.id.toString()))
         return {
           name: serviceRole.service.name === 'System Generated' ? 'Temporary Service Name' : serviceRole.service.name,
           external_id: serviceRole.service.externalId,

--- a/app/models/DirectDebitGatewayAccount.class.js
+++ b/app/models/DirectDebitGatewayAccount.class.js
@@ -19,7 +19,7 @@ class DirectDebitGatewayAccount {
    * @param {string} gatewayAccountData.payment_provider - The payment provider of the gateway account
    * @param {string} gatewayAccountData.description - The description of the gateway account
    * @param {string} gatewayAccountData.analytics_id - Google analytics_id of the gateway account
-   * @param {boolean} gatewayAccountData.external_id - external id of the gateway account
+   * @param {boolean} gatewayAccountData.gateway_account_external_id - external id of the gateway account
    **/
   constructor (gatewayAccountData) {
     this.id = gatewayAccountData.gateway_account_id

--- a/app/services/service_service.js
+++ b/app/services/service_service.js
@@ -44,7 +44,7 @@ function getGatewayAccounts (gatewayAccountIds, correlationId) {
       correlationId: correlationId
     }) : Promise.resolve([])
 
-  const returnGatewayAccountVariant = ga => isADirectDebitAccount(ga.gateway_account_id)
+  const returnGatewayAccountVariant = ga => isADirectDebitAccount(ga.gateway_account_external_id)
     ? new DirectDebitGatewayAccount(ga).toMinimalJson()
     : new CardGatewayAccount(ga).toMinimalJson()
 

--- a/test/unit/services/service_service_test.js
+++ b/test/unit/services/service_service_test.js
@@ -59,34 +59,37 @@ const getDDGatewayAccounts = function (obj) {
 
 describe('service service', function () {
   describe('when getting gateway accounts', function () {
-    it('should return gateway accounts for the valid ids', function (done) {
-
-      directDebitClientStub = {
-        gatewayAccounts: {
-          get: getDDGatewayAccounts
-        },
-        isADirectDebitAccount: function (isDd) {
-          return isDd.startsWith('DIRECT_DEBIT:')
-        }
-      }
-
-      connectorClientStub = {
-        ConnectorClient: getGatewayAccounts
-      }
-
-      serviceService = proxyquire('../../../app/services/service_service',
-        {
-          '../services/clients/connector_client': connectorClientStub,
-          '../services/clients/direct_debit_connector_client': directDebitClientStub
-        })
-
-      serviceService.getGatewayAccounts([gatewayAccountId1, gatewayAccountId2, nonExistentId, directDebitAccountId1, nonExistentDirectDebitId], correlationId).then(gatewayAccounts => {
-        expect(gatewayAccounts).to.have.lengthOf(3)
-        expect(gatewayAccounts.map(accountObj => accountObj.id || accountObj.gateway_account_external_id))
-          .to.have.all.members(['1', '2', 'DIRECT_DEBIT:adashdkjlq3434lk'])
-        done()
-      })
-    })
+    // TODO:
+    // Uncomment and fix or rewrite the test for Direct Debit gateway accounts
+    //
+    // it('should return gateway accounts for the valid ids', function (done) {
+    //
+    //   directDebitClientStub = {
+    //     gatewayAccounts: {
+    //       get: getDDGatewayAccounts
+    //     },
+    //     isADirectDebitAccount: function (isDd) {
+    //       return isDd.startsWith('DIRECT_DEBIT:')
+    //     }
+    //   }
+    //
+    //   connectorClientStub = {
+    //     ConnectorClient: getGatewayAccounts
+    //   }
+    //
+    //   serviceService = proxyquire('../../../app/services/service_service',
+    //     {
+    //       '../services/clients/connector_client': connectorClientStub,
+    //       '../services/clients/direct_debit_connector_client': directDebitClientStub
+    //     })
+    //
+    //   serviceService.getGatewayAccounts([gatewayAccountId1, gatewayAccountId2, nonExistentId, directDebitAccountId1, nonExistentDirectDebitId], correlationId).then(gatewayAccounts => {
+    //     expect(gatewayAccounts).to.have.lengthOf(3)
+    //     expect(gatewayAccounts.map(accountObj => accountObj.id || accountObj.gateway_account_external_id))
+    //       .to.have.all.members(['1', '2', 'DIRECT_DEBIT:adashdkjlq3434lk'])
+    //     done()
+    //   })
+    // })
 
     it('should not call connector for retrieving direct debit accounts', function (done) {
       directDebitClientStub = {


### PR DESCRIPTION
## WHAT

We were missing filtering gateway accounts for Direct Debit when we list services.
For Direct Debit currently we initialise `req.user.serviceRoles[].service.gatewayAccountIds` with external ids, but for Cards we initialise with internal ids.
We check the gateway accounts' external id first as not to overlap/skip between card payment and direct debit gateway accounts.

with @SandorArpa

Commented out temporary failing test as agreed on the standup we need to merge that to unblock the current work and @brid will fix it.
