### PR TITLE
PP 3980 replace smartpay refund fail e2e test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,4 @@ pacts/
 test/cypress/screenshots
 test/cypress/videos
 test/cypress/support
-# Stops 'headed' cypress auto generated directory in root
-cypress
+/cypress

--- a/test/cypress/integration/user/dashboard_spec.js
+++ b/test/cypress/integration/user/dashboard_spec.js
@@ -1,5 +1,5 @@
 describe('Dashboard', () => {
-  const selfServceUsers = require('../../../fixtures/config/self_service_user.json')
+  const selfServiceUsers = require('../../../fixtures/config/self_service_user.json')
 
   beforeEach(() => {
     cy.setCookie('session', Cypress.env('encryptedSessionCookie'))
@@ -9,7 +9,7 @@ describe('Dashboard', () => {
   describe('Homepage', () => {
     // Use a known configuration used to generate contracts/stubs.
     // This is also used to generate the session/gateway_account cookies
-    const ssUser = selfServceUsers.config.users.filter(fil => fil.isPrimary === 'true')[0]
+    const ssUser = selfServiceUsers.config.users.filter(fil => fil.isPrimary === 'true')[0]
 
     // Note : these from/to datetime strings exactly match those in the pact/contract, so are essential to match against stubs
     // Either change everything together, or map these do a single place like a .json document so the contracts/tests refer to one place

--- a/test/cypress/integration/user/transaction_details_spec.js
+++ b/test/cypress/integration/user/transaction_details_spec.js
@@ -1,0 +1,119 @@
+const capitalise = string => string[0].toUpperCase() + string.slice(1)
+const convertAmounts = val => '£' + (val / 100).toFixed(2)
+
+function formatDate (date) {
+
+  const monthNames = [
+    'January', 'February', 'March',
+    'April', 'May', 'June', 'July',
+    'August', 'September', 'October',
+    'November', 'December'
+  ]
+
+  let day = date.getDate();
+  day = day.toString().length > 1 ? day : '0' + day
+  const monthIndex = date.getMonth();
+  const year = date.getFullYear()
+
+  return day + ' ' + monthNames[monthIndex] + ' ' + year + ' — '
+}
+
+describe('Transactions details page', () => {
+
+  const transactionsUrl = `/transactions`
+
+  const selfServiceUsers = require('../../../fixtures/config/self_service_user.json')
+
+  const selfServiceDefaultUser = selfServiceUsers.config.users.filter(fil => fil.isPrimary === 'true')[0]
+
+  const aSmartpayCharge = selfServiceDefaultUser.sections.transactions.data[0]
+  const aSmartpayChargeDetails = selfServiceDefaultUser.sections.transactions.details_data[0]
+
+  beforeEach(() => {
+    cy.setCookie('session', Cypress.env('encryptedSessionCookie'))
+    cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountCookie'))
+
+    cy.visit(`${transactionsUrl}/${aSmartpayCharge.charge_id}`)
+  })
+
+  describe('page content', () => {
+
+    it('should display transaction details correctly', () => {
+
+      cy.visit(`${transactionsUrl}/${aSmartpayCharge.charge_id}`)
+
+      // Ensure page title is correct
+      cy.title().should('eq', `Transaction details ${aSmartpayCharge.reference} - System Generated test - GOV.UK Pay`)
+
+      // Ensure page details match up
+
+      // Reference number
+      cy.get('.transaction-details tbody').find('tr').first().find('td').eq(1).should('have.text',
+        aSmartpayCharge.reference)
+      // Status
+      cy.get('.transaction-details tbody').find('tr').eq(1).find('td').eq(1).should('have.text',
+        capitalise(aSmartpayCharge.state.status))
+      // Amount
+      cy.get('.transaction-details tbody').find('tr').eq(2).find('td').eq(1).should('have.text',
+        convertAmounts(aSmartpayCharge.amount))
+      // Refunded amount
+      cy.get('.transaction-details tbody').find('tr').eq(3).find('td').eq(1).should('have.text',
+        convertAmounts(aSmartpayChargeDetails.refund_summary.amount_submitted))
+      // Date created
+      cy.get('.transaction-details tbody').find('tr').eq(4).find('td').eq(1).should('contain',
+        formatDate(new Date(aSmartpayChargeDetails.charge_events[0].updated)))
+      // Provider
+      cy.get('.transaction-details tbody').find('tr').eq(5).find('td').eq(1).should('have.text',
+        capitalise(aSmartpayCharge.payment_provider))
+      // Provider ID
+      cy.get('.transaction-details tbody').find('tr').eq(6).find('td').eq(1).should('have.text',
+        aSmartpayCharge.gateway_transaction_id)
+      // GOVUK Payment ID
+      cy.get('.transaction-details tbody').find('tr').eq(7).find('td').eq(1).should('have.text',
+        aSmartpayCharge.charge_id)
+      // Payment method
+      cy.get('.transaction-details tbody').find('tr').eq(8).find('td').eq(1).should('have.text',
+        aSmartpayCharge.card_details.card_brand)
+      // Name on card
+      cy.get('.transaction-details tbody').find('tr').eq(9).find('td').eq(1).should('have.text',
+        aSmartpayCharge.card_details.cardholder_name)
+      // Card number
+      cy.get('.transaction-details tbody').find('tr').eq(10).find('td').eq(1).should('have.text',
+        `**** **** **** ${aSmartpayCharge.card_details.last_digits_card_number}`)
+      // Card expiry date
+      cy.get('.transaction-details tbody').find('tr').eq(11).find('td').eq(1).should('have.text',
+        aSmartpayCharge.card_details.expiry_date)
+      // Email
+      cy.get('.transaction-details tbody').find('tr').eq(12).find('td').eq(1).should('have.text',
+        aSmartpayCharge.email)
+
+    })
+
+  })
+
+  describe('refunds', () => {
+
+    it('should fail when an invalid refund amount is specified', () => {
+
+      // Click the refund button
+      cy.get('.refund__toggle').click()
+
+      // Select partial refund
+      cy.get('#partial').click()
+
+      // Select partial refund
+      cy.get('#refund-amount').type(aSmartpayCharge.amount + 1)
+
+      // Click the refund submit button
+      cy.get('.refund__submit-button').click()
+
+      // Ensure the flash container is showing
+      cy.get('.flash-container').should('be.visible')
+
+      cy.get('.flash-container').find('.error-summary').should('contain', 'The amount you tried to refund is greater than the transaction total')
+
+    })
+
+  })
+
+})

--- a/test/cypress/integration/user/transaction_details_spec.js
+++ b/test/cypress/integration/user/transaction_details_spec.js
@@ -26,6 +26,8 @@ describe('Transactions details page', () => {
 
   const selfServiceDefaultUser = selfServiceUsers.config.users.filter(fil => fil.isPrimary === 'true')[0]
 
+  const gatewayAccount = selfServiceDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0]
+
   const aSmartpayCharge = selfServiceDefaultUser.sections.transactions.data[0]
   const aSmartpayChargeDetails = selfServiceDefaultUser.sections.transactions.details_data[0]
 
@@ -64,7 +66,7 @@ describe('Transactions details page', () => {
         formatDate(new Date(aSmartpayChargeDetails.charge_events[0].updated)))
       // Provider
       cy.get('.transaction-details tbody').find('tr').eq(5).find('td').eq(1).should('have.text',
-        capitalise(aSmartpayCharge.payment_provider))
+        capitalise(gatewayAccount.name))
       // Provider ID
       cy.get('.transaction-details tbody').find('tr').eq(6).find('td').eq(1).should('have.text',
         aSmartpayCharge.gateway_transaction_id)

--- a/test/fixtures/config/self_service_user.json
+++ b/test/fixtures/config/self_service_user.json
@@ -30,6 +30,12 @@
           },
           {
             "name": "transactions-details:read"
+          },
+          {
+            "name": "refunds_create"
+          },
+          {
+            "name": "refunds:create"
           }
         ],
         "sections": {
@@ -41,10 +47,10 @@
           },
           "transactions": {
             "description": "a list of raw transactions as returned by connector, as well as available refunds",
-            "details_data" : [
+            "details_data": [
               {
                 "charge_id": "12345",
-                "refund_summary" : {
+                "refund_summary": {
                   "status": "available",
                   "amount_available": 100,
                   "amount_submitted": 0
@@ -60,7 +66,42 @@
                   "city": "GB",
                   "county": "somecounty",
                   "country": "GB"
-                }
+                },
+                "charge_events": [
+                  {
+                    "type": "PAYMENT",
+                    "submitted_by": null,
+                    "state": {
+                      "status": "created",
+                      "finished": false
+                    },
+                    "amount": 100,
+                    "updated": "2018-05-01T13:27:00.063Z",
+                    "refund_reference": null
+                  },
+                  {
+                    "type": "PAYMENT",
+                    "submitted_by": null,
+                    "state": {
+                      "status": "started",
+                      "finished": false
+                    },
+                    "amount": 100,
+                    "updated": "2018-05-01T13:27:00.974Z",
+                    "refund_reference": null
+                  },
+                  {
+                    "type": "PAYMENT",
+                    "submitted_by": null,
+                    "state": {
+                      "status": "succeeded",
+                      "finished": true
+                    },
+                    "amount": 100,
+                    "updated": "2018-05-01T13:27:18.126Z",
+                    "refund_reference": null
+                  }
+                ]
               }
             ],
             "data": [
@@ -94,7 +135,8 @@
                   "expiry_date": "08/23",
                   "card_brand": "Visa"
                 },
-                "transaction_type": "charge"
+                "transaction_type": "charge",
+                "payment_provider": "sandbox"
               },
               {
                 "amount": 200,
@@ -126,7 +168,8 @@
                   "expiry_date": "08/23",
                   "card_brand": "Visa"
                 },
-                "transaction_type": "charge"
+                "transaction_type": "charge",
+                "payment_provider": "sandbox"
               },
               {
                 "amount": 300,
@@ -158,7 +201,8 @@
                   "expiry_date": "08/23",
                   "card_brand": "Visa"
                 },
-                "transaction_type": "charge"
+                "transaction_type": "charge",
+                "payment_provider": "sandbox"
               },
               {
                 "amount": 400,
@@ -190,7 +234,8 @@
                   "expiry_date": "08/23",
                   "card_brand": "Visa"
                 },
-                "transaction_type": "charge"
+                "transaction_type": "charge",
+                "payment_provider": "sandbox"
               }
             ],
             "links": {

--- a/test/fixtures/config/self_service_user.json
+++ b/test/fixtures/config/self_service_user.json
@@ -8,11 +8,13 @@
         "gateway_accounts": [
           {
             "id": "666",
-            "isPrimary": "true"
+            "isPrimary": "true",
+            "name": "sandbox"
           },
           {
             "id": "7",
-            "isPrimary": "false"
+            "isPrimary": "false",
+            "name": "nonsandbox"
           }
         ],
         "permissions": [
@@ -135,8 +137,7 @@
                   "expiry_date": "08/23",
                   "card_brand": "Visa"
                 },
-                "transaction_type": "charge",
-                "payment_provider": "sandbox"
+                "transaction_type": "charge"
               },
               {
                 "amount": 200,
@@ -168,8 +169,7 @@
                   "expiry_date": "08/23",
                   "card_brand": "Visa"
                 },
-                "transaction_type": "charge",
-                "payment_provider": "sandbox"
+                "transaction_type": "charge"
               },
               {
                 "amount": 300,
@@ -201,8 +201,7 @@
                   "expiry_date": "08/23",
                   "card_brand": "Visa"
                 },
-                "transaction_type": "charge",
-                "payment_provider": "sandbox"
+                "transaction_type": "charge"
               },
               {
                 "amount": 400,
@@ -234,8 +233,7 @@
                   "expiry_date": "08/23",
                   "card_brand": "Visa"
                 },
-                "transaction_type": "charge",
-                "payment_provider": "sandbox"
+                "transaction_type": "charge"
               }
             ],
             "links": {

--- a/test/fixtures/config/self_service_user.json
+++ b/test/fixtures/config/self_service_user.json
@@ -27,6 +27,9 @@
           },
           {
             "name": "transactions_card_type_read"
+          },
+          {
+            "name": "transactions-details:read"
           }
         ],
         "sections": {
@@ -37,7 +40,29 @@
             }
           },
           "transactions": {
-            "description": "a list of raw transactions as returned by connector",
+            "description": "a list of raw transactions as returned by connector, as well as available refunds",
+            "details_data" : [
+              {
+                "charge_id": "12345",
+                "refund_summary" : {
+                  "status": "available",
+                  "amount_available": 100,
+                  "amount_submitted": 0
+                },
+                "settlement_summary": {
+                  "capture_submit_time": "2018-05-01T13:27:00.057Z",
+                  "captured_date": "2018-05-01T13:27:00.057Z"
+                },
+                "billing_address": {
+                  "line1": "address line 1",
+                  "line2": "address line 2",
+                  "postcode": "AB1A 1AB",
+                  "city": "GB",
+                  "county": "somecounty",
+                  "country": "GB"
+                }
+              }
+            ],
             "data": [
               {
                 "amount": 100,

--- a/test/fixtures/transaction_fixtures.js
+++ b/test/fixtures/transaction_fixtures.js
@@ -77,7 +77,7 @@ module.exports = {
         ? `https://demoservice.pymnt.localdomain:443/return/532aad2f833a3b8234921ca85a98ca5b/${opts.summaryObject.reference}`
         : 'https://demoservice.pymnt.localdomain:443/return/532aad2f833a3b8234921ca85a98ca5b/ref188888',
       email: opts.summaryObject.email || 'gds-payments-team-smoke@digital.cabinet-office.gov.uk',
-      payment_provider: opts.summaryObject.payment_provider || 'sandbox',
+      payment_provider: opts.payment_provider || 'sandbox',
       created_date: opts.summaryObject.created_data || '2018-05-01T13:27:00.057Z',
       refund_summary: opts.refund_summary || {
         status: 'unavailable',

--- a/test/fixtures/transaction_fixtures.js
+++ b/test/fixtures/transaction_fixtures.js
@@ -112,6 +112,74 @@ module.exports = {
         return data
       }
     }
-  }
+  },
+  validChargeEventsResponse: (opts = {}) => {
+    let data = {
+      "charge_id": opts.chargeId || "ht439nfg2l1e303k0dmifrn4fc",
+      "events": opts.events ||
+      [{
+        "type": "PAYMENT",
+        "submitted_by": null,
+        "state": {"status": "created", "finished": false},
+        "amount": 20000,
+        "updated": "2018-05-01T13:27:00.063Z",
+        "refund_reference": null
+      }, {
+        "type": "PAYMENT",
+        "submitted_by": null,
+        "state": {"status": "started", "finished": false},
+        "amount": 20000,
+        "updated": "2018-05-01T13:27:00.974Z",
+        "refund_reference": null
+      }, {
+        "type": "PAYMENT",
+        "submitted_by": null,
+        "state": {"status": "failed", "finished": true, "code": "P0010", "message": "Payment method rejected"},
+        "amount": 20000,
+        "updated": "2018-05-01T13:27:18.126Z",
+        "refund_reference": null
+      }]
+    }
 
+    return {
+      getPactified: () => {
+        return pactRegister.pactify(data)
+      },
+      getPlain: () => {
+        return data
+      }
+    }
+  },
+  invalidTransactionRefundRequest: (opts = {}) => {
+    const data = {
+        amount: opts.amount || 101,
+        refund_amount_available: opts.refund_amount_available || 100,
+        user_external_id: opts.user_external_id || '3b7b5f33-24ea-4405-88d2-0a1b13efb20c'
+    }
+
+    return {
+      getPactified: () => {
+        return pactRegister.pactify(data)
+      },
+      getPlain: () => {
+        return data
+      }
+    }
+
+  },
+  invalidTransactionRefundResponse : (opts = {}) => {
+    let data = {
+      reason : opts.reason || 'amount_not_available'
+    }
+
+    return {
+      getPactified: () => {
+        return pactRegister.pactify(data)
+      },
+      getPlain: () => {
+        return data
+      }
+    }
+
+  }
 }

--- a/test/fixtures/transaction_fixtures.js
+++ b/test/fixtures/transaction_fixtures.js
@@ -31,8 +31,77 @@ module.exports = {
       count: opts.transactions.data.length,
       page: 1,
       results:
-      [...opts.transactions.data],
+        [...opts.transactions.data],
       _links: opts.transactions.links
+    }
+
+    return {
+      getPactified: () => {
+        return pactRegister.pactify(data)
+      },
+      getPlain: () => {
+        return data
+      }
+    }
+  },
+  validTransactionDetailsResponse: (opts = {}) => {
+    let data = {
+      amount: opts.summaryObject.amount || 20000,
+      state: opts.summaryObject.state || {
+        finished: true,
+        code: 'P0010',
+        message: 'Payment method rejected',
+        status: 'failed'
+      },
+      description: opts.summaryObject.description || 'ref1',
+      reference: opts.summaryObject.reference || 'ref188888',
+      links: [
+        {
+          rel: 'self',
+          method: 'GET',
+          href: opts.summaryObject.charge_id
+            ? `https://connector.pymnt.localdomain/v1/api/accounts/${opts.gateway_account_id}/charges/${opts.summaryObject.charge_id}`
+            : 'https://connector.pymnt.localdomain/v1/api/accounts/2/charges/ht439nfg2l1e303k0dmifrn4fc'
+        },
+        {
+          rel: 'refunds',
+          method: 'GET',
+          href: opts.summaryObject.charge_id
+            ? `https://connector.pymnt.localdomain/v1/api/accounts/${opts.gateway_account_id}/charges/${opts.summaryObject.charge_id}/refunds`
+            : 'https://connector.pymnt.localdomain/v1/api/accounts/2/charges/ht439nfg2l1e303k0dmifrn4fc/refunds'
+        }
+      ],
+      charge_id: opts.summaryObject.charge_id || 'ht439nfg2l1e303k0dmifrn4fc',
+      gateway_transaction_id: opts.summaryObject.gateway_transaction_id || '4cddd970-cce9-4bf1-b087-f13db1e199bd',
+      return_url: opts.summaryObject
+        ? `https://demoservice.pymnt.localdomain:443/return/532aad2f833a3b8234921ca85a98ca5b/${opts.summaryObject.reference}`
+        : 'https://demoservice.pymnt.localdomain:443/return/532aad2f833a3b8234921ca85a98ca5b/ref188888',
+      email: opts.summaryObject.email || 'gds-payments-team-smoke@digital.cabinet-office.gov.uk',
+      payment_provider: opts.summaryObject.payment_provider || 'sandbox',
+      created_date: opts.summaryObject.created_data || '2018-05-01T13:27:00.057Z',
+      refund_summary: opts.refund_summary || {
+        status: 'unavailable',
+        amount_available: 20000,
+        amount_submitted: 0
+      },
+      settlement_summary: opts.settlement_summary ||{
+        capture_submit_time: null,
+        captured_date: null
+      },
+      card_details: {
+        last_digits_card_number: opts.summaryObject.last_digits_card_number ||'0002',
+        cardholder_name: opts.summaryObject.cardholder_name || 'Test User',
+        expiry_date: opts.summaryObject.expiry_data || '08/23',
+        billing_address: opts.billing_address || {
+          line1: 'address line 1',
+          line2: 'address line 2',
+          postcode: 'AB1A 1AB',
+          city: 'GB',
+          county: null,
+          country: 'GB'
+        },
+        card_brand: opts.summaryObject.card_brand || 'Visa'
+      }
     }
 
     return {

--- a/test/unit/clients/connector_client/connector_get_transaction_details_test.js
+++ b/test/unit/clients/connector_client/connector_get_transaction_details_test.js
@@ -9,7 +9,7 @@ const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
 const PactInteractionBuilder = require('../../../fixtures/pact_interaction_builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector_client').ConnectorClient
-const transactionSummaryFixtures = require('../../../fixtures/transaction_fixtures')
+const transactionDetailsFixtures = require('../../../fixtures/transaction_fixtures')
 
 // Constants
 const CHARGES_RESOURCE = '/v1/api/accounts'
@@ -26,7 +26,7 @@ chai.use(chaiAsPromised)
 
 describe('connector client', function () {
   const provider = Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'connector',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
@@ -46,7 +46,7 @@ describe('connector client', function () {
       gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id, // '666'
       chargeId: firstCharge.charge_id
     }
-    const validGetTransactionDetailsResponse = transactionSummaryFixtures.validTransactionDetailsResponse(
+    const validGetTransactionDetailsResponse = transactionDetailsFixtures.validTransactionDetailsResponse(
       {
         summaryObject: firstCharge,
         gateway_account_id: params.gatewayAccountId,
@@ -79,6 +79,96 @@ describe('connector client', function () {
           expect(connectorResponse.body).to.deep.equal(getTransactionDetails)
           done()
         })
+    })
+  })
+
+  describe('get charge events', () => {
+
+    const firstCharge = ssDefaultUser.sections.transactions.data[0]
+    const chargeDetails = ssDefaultUser.sections.transactions.details_data.filter(x => x.charge_id === firstCharge.charge_id)[0]
+    const params = {
+      gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id, // '666'
+      chargeId: firstCharge.charge_id
+    }
+    const validGetTransactionDetailsResponse = transactionDetailsFixtures.validChargeEventsResponse({
+      chargeId: params.chargeId,
+      events: chargeDetails.charge_events
+    })
+
+    before((done) => {
+      const pactified = validGetTransactionDetailsResponse.getPactified()
+      provider.addInteraction(
+        new PactInteractionBuilder(`${CHARGES_RESOURCE}/${params.gatewayAccountId}/charges/${params.chargeId}/events`)
+          .withUponReceiving('a valid charge events request')
+          .withState(`User ${params.gatewayAccountId} exists in the database, has an available charge with id ${firstCharge.charge_id} and has available charge events`)
+          .withMethod('GET')
+          .withStatusCode(200)
+          .withResponseBody(pactified)
+          .build()
+      ).then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should get charge events successfully', function (done) {
+      const getChargeEvents = validGetTransactionDetailsResponse.getPlain()
+      connectorClient.getChargeEvents(params,
+        (connectorData, connectorResponse) => {
+          expect(connectorResponse.body).to.deep.equal(getChargeEvents)
+          done()
+        })
+    })
+  })
+
+  describe('post refund', () => {
+
+    const firstCharge = ssDefaultUser.sections.transactions.data[0]
+    const chargeDetails = ssDefaultUser.sections.transactions.details_data.filter(x => x.charge_id === firstCharge.charge_id)[0]
+    const params = {
+      gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id, // '666'
+      chargeId: firstCharge.charge_id,
+      payload:
+        {
+          amount: chargeDetails.refund_summary.amount_available + 1, // 1 penny more than the available refund amount
+          refund_amount_available: chargeDetails.refund_summary.amount_available,
+          user_external_id: ssDefaultUser.external_id
+        }
+    }
+
+    const invalidTransactionRefundRequest = transactionDetailsFixtures.invalidTransactionRefundRequest(params.payload)
+    const invalidTransactionRefundResponse = transactionDetailsFixtures.invalidTransactionRefundResponse({ reason: 'amount_not_available'})
+
+    before((done) => {
+
+      const pactifiedRequest = invalidTransactionRefundRequest.getPactified()
+      const pactifiedResponse = invalidTransactionRefundResponse.getPactified()
+
+      provider.addInteraction(
+        new PactInteractionBuilder(`${CHARGES_RESOURCE}/${params.gatewayAccountId}/charges/${params.chargeId}/refunds`)
+          .withUponReceiving('an invalid transaction refund request')
+          .withState(`User ${params.gatewayAccountId} exists in the database, has an available charge with id ${firstCharge.charge_id}`)
+          .withMethod('POST')
+          .withRequestBody(pactifiedRequest)
+          .withStatusCode(400)
+          .withResponseBody(pactifiedResponse)
+          .build()
+      ).then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should fail with a refund amount greater than the refund amount available', function (done) {
+      const refundFailureResponse = invalidTransactionRefundResponse.getPlain()
+      connectorClient.postChargeRefund(params,
+        () => {
+          done('refund success callback should not be executed')
+        }).on('connectorError', (err, response) => {
+        expect(response.statusCode).to.equal(400)
+        expect(response.body).to.deep.equal(refundFailureResponse)
+        done()
+      })
     })
   })
 })

--- a/test/unit/clients/connector_client/connector_get_transaction_details_test.js
+++ b/test/unit/clients/connector_client/connector_get_transaction_details_test.js
@@ -40,15 +40,17 @@ describe('connector client', function () {
 
   describe('get transaction details', () => {
 
+    const gatewayAccount = ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0]
     const firstCharge = ssDefaultUser.sections.transactions.data[0]
     const chargeDetails = ssDefaultUser.sections.transactions.details_data.filter(x => x.charge_id === firstCharge.charge_id)[0]
     const params = {
-      gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id, // '666'
+      gatewayAccountId: gatewayAccount.id,
       chargeId: firstCharge.charge_id
     }
     const validGetTransactionDetailsResponse = transactionDetailsFixtures.validTransactionDetailsResponse(
       {
         summaryObject: firstCharge,
+        payment_provider: gatewayAccount.name,
         gateway_account_id: params.gatewayAccountId,
         refund_summary: chargeDetails.refund_summary,
         settlement_summary: chargeDetails.settlement_summary,

--- a/test/unit/clients/connector_client/connector_get_transaction_details_test.js
+++ b/test/unit/clients/connector_client/connector_get_transaction_details_test.js
@@ -1,0 +1,84 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+
+// Custom dependencies
+const path = require('path')
+const PactInteractionBuilder = require('../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const Connector = require('../../../../app/services/clients/connector_client').ConnectorClient
+const transactionSummaryFixtures = require('../../../fixtures/transaction_fixtures')
+
+// Constants
+const CHARGES_RESOURCE = '/v1/api/accounts'
+const port = Math.floor(Math.random() * 48127) + 1024
+const connectorClient = new Connector(`http://localhost:${port}`)
+const expect = chai.expect
+
+// Note: the browser tests use values in the fixed config below, which match the defined interations
+const ssUserConfig = require('../../../fixtures/config/self_service_user.json')
+const ssDefaultUser = ssUserConfig.config.users.filter(fil => fil.isPrimary === 'true')[0]
+
+// Global setup
+chai.use(chaiAsPromised)
+
+describe('connector client', function () {
+  const provider = Pact({
+    consumer: 'selfservice',
+    provider: 'connector',
+    port: port,
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(() => provider.setup())
+  after((done) => provider.finalize().then(done()))
+
+  describe('get transaction details', () => {
+
+    const firstCharge = ssDefaultUser.sections.transactions.data[0]
+    const chargeDetails = ssDefaultUser.sections.transactions.details_data.filter(x => x.charge_id === firstCharge.charge_id)[0]
+    const params = {
+      gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id, // '666'
+      chargeId: firstCharge.charge_id
+    }
+    const validGetTransactionDetailsResponse = transactionSummaryFixtures.validTransactionDetailsResponse(
+      {
+        summaryObject: firstCharge,
+        gateway_account_id: params.gatewayAccountId,
+        refund_summary: chargeDetails.refund_summary,
+        settlement_summary: chargeDetails.settlement_summary,
+        billing_address: chargeDetails.billing_address
+      }
+    )
+
+    before((done) => {
+      const pactified = validGetTransactionDetailsResponse.getPactified()
+      provider.addInteraction(
+        new PactInteractionBuilder(`${CHARGES_RESOURCE}/${params.gatewayAccountId}/charges/${params.chargeId}`)
+          .withUponReceiving('a valid transaction details request')
+          .withState(`User ${params.gatewayAccountId} exists in the database and has 4 transactions available`)
+          .withMethod('GET')
+          .withStatusCode(200)
+          .withResponseBody(pactified)
+          .build()
+      ).then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should get transaction details successfully', function (done) {
+      const getTransactionDetails = validGetTransactionDetailsResponse.getPlain()
+      connectorClient.getCharge(params,
+        (connectorData, connectorResponse) => {
+          expect(connectorResponse.body).to.deep.equal(getTransactionDetails)
+          done()
+        })
+    })
+  })
+})


### PR DESCRIPTION
## WHAT
Replaces the test in pay-endtoend which asserts that a refund attempt over the available refund amount, fails.

In order for this to work as a contract/browser test, the following needed do be done:

1. creating a pact interaction and unit test for:

a) viewing a transaction details page
b) posting an invalid refund request

2. creating Cypress browser tests to replicate the test from e2e


