### PR TITLE
PP-3990 Prevents 'to-be' pacts from being published by changing their file extension before/after being published

### DIFF
--- a/docker/build_and_test.sh
+++ b/docker/build_and_test.sh
@@ -6,4 +6,6 @@ npm run compile
 # disabled while promise rejections not returning error objects need to be addressed
 # npm run lint
 npm test -- --forbid-only --forbid-pending
+# prevent publish of any pacts with 'to-be' in their name
+for i in ./pacts/*-to-be-*.json; do mv "$i" "${i%.json}.ignore"; done
 npm run publish-pacts


### PR DESCRIPTION
##WHAT

The naming convention 'to-be' is used in our contract testing pact/contract interaction stage to define an interaction where we don't quite have the provider contract tests ready so the two can be tested in unison.

This PR ensures that 'to-be' pacts are not published to the broker, which ensures they aren't ran on the provider as expectations, which would normally fail.

This is done by simply renaming the pact files with 'to-be' in their filename to a different file extension, publishing the pacts, and then changing them back.

