### PR TITLE
PP-2493 set up aws x ray in test environment

### DIFF
--- a/app/middleware/get_gateway_account.js
+++ b/app/middleware/get_gateway_account.js
@@ -3,6 +3,8 @@
 // npm dependencies
 const _ = require('lodash')
 const winston = require('winston')
+const AWSXRay = require('aws-xray-sdk')
+const getNamespace = require('continuation-local-storage').getNamespace
 
 // local dependencies
 const auth = require('../services/auth_service.js')
@@ -14,7 +16,11 @@ const directDebitConnectorClient = require('../services/clients/direct_debit_con
 const EPDQ_3DS_ENABLED = process.env.EPDQ_3DS_ENABLED
 const SMARTPAY_3DS_ENABLED = process.env.SMARTPAY_3DS_ENABLED || 'false'
 
+// Constants
+const clsXrayConfig = require('../../config/xray-cls')
+
 module.exports = function (req, res, next) {
+
   const accountId = auth.getCurrentGatewayAccountId(req)
   const params = {
     gatewayAccountId: accountId,
@@ -31,23 +37,31 @@ module.exports = function (req, res, next) {
         next()
       })
   }
-  return connectorClient.getAccount(params)
-    .then(data => {
-      let SUPPORTS_3DS = ['worldpay']
-      // env var values are treated as text so the comparison is done for text
-      if (EPDQ_3DS_ENABLED === 'true') {
-        SUPPORTS_3DS = _.concat(SUPPORTS_3DS, ['epdq'])
-      }
-      if (SMARTPAY_3DS_ENABLED === 'true') {
-        SUPPORTS_3DS = _.concat(SUPPORTS_3DS, ['smartpay'])
-      }
-      req.account = _.extend({}, data, {
-        supports3ds: SUPPORTS_3DS.includes(_.get(data, 'payment_provider'))
+
+  const namespace = getNamespace(clsXrayConfig.nameSpaceName)
+  const clsSegment = namespace.get(clsXrayConfig.segmentKeyName)
+
+  AWSXRay.captureAsyncFunc('connectorClient_getAccount', function (subsegment) {
+    return connectorClient.getAccount(params)
+      .then(data => {
+        subsegment.close()
+        let SUPPORTS_3DS = ['worldpay']
+        // env var values are treated as text so the comparison is done for text
+        if (EPDQ_3DS_ENABLED === 'true') {
+          SUPPORTS_3DS = _.concat(SUPPORTS_3DS, ['epdq'])
+        }
+        if (SMARTPAY_3DS_ENABLED === 'true') {
+          SUPPORTS_3DS = _.concat(SUPPORTS_3DS, ['smartpay'])
+        }
+        req.account = _.extend({}, data, {
+          supports3ds: SUPPORTS_3DS.includes(_.get(data, 'payment_provider'))
+        })
+        next()
       })
-      next()
-    })
-    .catch(err => {
-      winston.error(`${req.correlationId} - Error when attempting to retrieve card gateway account: ${err}`)
-      next()
-    })
+      .catch(err => {
+        subsegment.close(err)
+        winston.error(`${req.correlationId} - Error when attempting to retrieve card gateway account: ${err}`)
+        next()
+      })
+  }, clsSegment)
 }

--- a/app/middleware/x_ray.js
+++ b/app/middleware/x_ray.js
@@ -1,0 +1,13 @@
+'use strict'
+
+// NPM dependencies
+const getNamespace = require('continuation-local-storage').getNamespace
+
+// Local dependencies
+const clsXrayConfig = require('../../config/xray-cls')
+
+module.exports = (req, res, next) => {
+  const namespace = getNamespace(clsXrayConfig.nameSpaceName)
+  namespace.set(clsXrayConfig.segmentKeyName, req.segment)
+  next()
+}

--- a/app/services/clients/adminusers_client.js
+++ b/app/services/clients/adminusers_client.js
@@ -33,7 +33,8 @@ module.exports = function (clientOptions = {}) {
      * @param {string} externalId
      * @return {Promise<User>} A promise of a User
      */
-  const getUserByExternalId = (externalId) => {
+  const getUserByExternalId = (externalId, subSegment) => {
+
     return baseClient.get(
       {
         baseUrl,
@@ -43,7 +44,8 @@ module.exports = function (clientOptions = {}) {
         description: 'find a user',
         service: SERVICE_NAME,
         transform: responseBodyToUserTransformer,
-        baseClientErrorHandler: 'old'
+        baseClientErrorHandler: 'old',
+        subSegment: subSegment
       }
     )
   }

--- a/app/services/clients/base_client/wrapper.js
+++ b/app/services/clients/base_client/wrapper.js
@@ -88,8 +88,5 @@ module.exports = function (method, verb) {
       }
     })
     return call
-
-
-
   })
 }

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -6,8 +6,6 @@ const util = require('util')
 const EventEmitter = require('events').EventEmitter
 const logger = require('winston')
 const querystring = require('querystring')
-//const AWSXRay = require('aws-xray-sdk')
-const getNamespace = require('continuation-local-storage').getNamespace
 
 // Local dependencies
 const baseClient = require('./old_base_client')
@@ -34,8 +32,6 @@ const ACCOUNT_CREDENTIALS_PATH = ACCOUNT_FRONTEND_PATH + '/credentials'
 const EMAIL_NOTIFICATION__PATH = '/v1/api/accounts/{accountId}/email-notification'
 const TOGGLE_3DS_PATH = ACCOUNTS_FRONTEND_PATH + '/{accountId}/3ds-toggle'
 const TRANSACTIONS_SUMMARY = ACCOUNTS_API_PATH + '/{accountId}/transactions-summary'
-
-const clsXrayConfig = require('../../../config/xray-cls')
 
 /**
  * @private
@@ -261,7 +257,6 @@ ConnectorClient.prototype = {
         let startTime = new Date()
         let context = {
           url: url,
-          //subsegment: subsegment,
           defer: {resolve: resolve, reject: reject},
           startTime: startTime,
           correlationId: params.correlationId,

--- a/app/services/clients/old_base_client.js
+++ b/app/services/clients/old_base_client.js
@@ -1,23 +1,27 @@
 'use strict'
 
+// NPM dependences
 const path = require('path')
 const https = require('https')
-const httpAgent = require('http').globalAgent
+const http = require('http')
 const urlParse = require('url').parse
 const _ = require('lodash')
 const logger = require('winston')
 const request = require('requestretry')
+
+
+// Local dependencies
 const customCertificate = require('../../utils/custom_certificate')
 const getRequestContext = require('../../middleware/get_request_context').getRequestContext
 const CORRELATION_HEADER_NAME = require(path.join(__dirname, '/../../utils/correlation_header')).CORRELATION_HEADER
-const FEATURE_FLAGS_HEADER_NAME = 'features'
 
+// Constants
+const FEATURE_FLAGS_HEADER_NAME = 'features'
+const RETRIABLE_ERRORS = ['ECONNRESET']
 const agentOptions = {
   keepAlive: true,
   maxSockets: process.env.MAX_SOCKETS || 100
 }
-
-const RETRIABLE_ERRORS = ['ECONNRESET']
 
 function retryOnEconnreset (err) {
   return err && _.includes(RETRIABLE_ERRORS, err.code)
@@ -26,6 +30,7 @@ function retryOnEconnreset (err) {
 /**
  * @type {https.Agent}
  */
+const httpAgent = http.globalAgent
 const httpsAgent = new https.Agent(agentOptions)
 
 if (process.env.DISABLE_INTERNAL_HTTPS !== 'true') {

--- a/app/services/clients/old_base_client.js
+++ b/app/services/clients/old_base_client.js
@@ -8,7 +8,8 @@ const urlParse = require('url').parse
 const _ = require('lodash')
 const logger = require('winston')
 const request = require('requestretry')
-
+const getNamespace = require('continuation-local-storage').getNamespace
+const AWSXRay = require('aws-xray-sdk')
 
 // Local dependencies
 const customCertificate = require('../../utils/custom_certificate')
@@ -22,6 +23,7 @@ const agentOptions = {
   keepAlive: true,
   maxSockets: process.env.MAX_SOCKETS || 100
 }
+const clsXrayConfig = require('../../../config/xray-cls')
 
 function retryOnEconnreset (err) {
   return err && _.includes(RETRIABLE_ERRORS, err.code)
@@ -48,13 +50,18 @@ const client = request
     retryStrategy: retryOnEconnreset
   })
 
-const getHeaders = function getHeaders (args) {
+const getHeaders = function getHeaders (args, segmentData) {
   const requestContext = getRequestContext(args.correlationId || '') || {}
 
   let headers = {}
   headers['Content-Type'] = 'application/json'
   headers[CORRELATION_HEADER_NAME] = args.correlationId || ''
   headers[FEATURE_FLAGS_HEADER_NAME] = (requestContext.features || []).toString()
+
+  if (segmentData.clsSegment) {
+    const subSegment = segmentData.subSegment || new AWSXRay.Segment('_request', null, segmentData.clsSegment.trace_id)
+    headers['X-Amzn-Trace-Id'] = 'Root=' + segmentData.clsSegment.trace_id + ';Parent=' + subSegment.id + ';Sampled=1'
+  }
   _.merge(headers, args.headers)
 
   return headers
@@ -70,23 +77,23 @@ const getHeaders = function getHeaders (args) {
  *
  * @private
  */
-const _request = function request (methodName, url, args, callback) {
-  let agent = urlParse(url).protocol === 'http:' ? httpAgent : httpsAgent
+const _request = function request (methodName, url, args, callback, subSegment) {
+  const agent = urlParse(url).protocol === 'http:' ? httpAgent : httpsAgent
+  const namespace = getNamespace(clsXrayConfig.nameSpaceName)
+  const clsSegment = namespace ? namespace.get(clsXrayConfig.segmentKeyName) : null
 
   const requestOptions = {
     uri: url,
     method: methodName,
     agent: agent,
-    headers: getHeaders(args)
+    headers: getHeaders(args, { clsSegment: clsSegment, subSegment: subSegment})
   }
-
   if (args.qs) {
     requestOptions.qs = args.qs
   }
   if (args.payload) {
     requestOptions.body = args.payload
   }
-
   return client(requestOptions, callback)
 }
 
@@ -102,8 +109,8 @@ module.exports = {
    *
    * @returns {OutgoingMessage}
    */
-  get: function (url, args, callback) {
-    return _request('GET', url, args, callback)
+  get: function (url, args, callback, subsegment) {
+    return _request('GET', url, args, callback, subsegment)
   },
 
   /**

--- a/app/services/user_service.js
+++ b/app/services/user_service.js
@@ -47,8 +47,8 @@ module.exports = {
    * @param correlationId
    * @returns {Promise<User>}
    */
-  findByExternalId: (externalId, correlationId) => {
-    return getAdminUsersClient({correlationId: correlationId}).getUserByExternalId(externalId)
+  findByExternalId: (externalId, correlationId, subSegment) => {
+    return getAdminUsersClient({correlationId: correlationId}).getUserByExternalId(externalId, subSegment)
   },
 
   /**

--- a/app/utils/response_converter.js
+++ b/app/utils/response_converter.js
@@ -18,10 +18,14 @@ module.exports = {
       requestLogger.logRequestEnd(context)
 
       if (error) {
+        // TODO : Once anything using response converted has a segment passed, this can be removed.
+        if (context.subsegment) { context.subsegment.close(error) }
         requestLogger.logRequestError(context, error)
         defer.reject({error: error})
         return
       }
+      // TODO : Verify
+      if (context.subsegment) { context.subsegment.close() }
 
       if (response && SUCCESS_CODES.indexOf(response.statusCode) !== -1) {
         if (body && transformer && typeof transformer === 'function') {

--- a/aws-xray.rules
+++ b/aws-xray.rules
@@ -1,0 +1,25 @@
+{
+  "rules": [
+    {
+      "description": "Exclude healthchecks",
+      "service_name": "*",
+      "http_method": "*",
+      "url_path": "/healthcheck",
+      "fixed_target": 0,
+      "rate": 0.0
+    },
+    {
+      "description": "Exclude content",
+      "service_name": "*",
+      "http_method": "*",
+      "url_path": "/public",
+      "fixed_target": 0,
+      "rate": 0.0
+    }
+  ],
+  "default": {
+    "fixed_target": 1,
+    "rate": 0.1
+  },
+  "version": 1
+}

--- a/config/xray-cls.js
+++ b/config/xray-cls.js
@@ -1,0 +1,4 @@
+module.exports = {
+  nameSpaceName : 'sample',
+  segmentKeyName : 'sampleKey'
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -847,6 +847,15 @@
         "stack-chain": "1.3.7"
       }
     },
+    "async-listener": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.9.tgz",
+      "integrity": "sha512-E7Z2/QMs0EPt/o9wpYO/J3hmMCDdr1aVDS3ttlur5D5JlZtxhfuOwi4e7S8zbYIxA5qOOYdxfqGj97XAfdNvkQ==",
+      "requires": {
+        "semver": "5.5.0",
+        "shimmer": "1.2.0"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -861,6 +870,46 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws-xray-sdk": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk/-/aws-xray-sdk-1.2.0.tgz",
+      "integrity": "sha512-scFQzpAmuqtwQky2xhLqxJZrCcnJAhqg7gAbmWQlLzggjjuvrkQLkbnj2cpaQ1qFJ1G1w0XRsV0UGJTHGCAceQ==",
+      "requires": {
+        "aws-xray-sdk-core": "1.2.0",
+        "aws-xray-sdk-express": "1.2.0",
+        "aws-xray-sdk-mysql": "1.2.0",
+        "aws-xray-sdk-postgres": "1.2.0",
+        "pkginfo": "0.4.1"
+      }
+    },
+    "aws-xray-sdk-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-1.2.0.tgz",
+      "integrity": "sha512-HOSVn0O7ZXKTTgGErpG8GjFfSxhK5vfihqNAPoyi7GYMB16Y25BeWBkfpYVOEWWGYL/9bDcBcRAVc1NJwVJiHQ==",
+      "requires": {
+        "continuation-local-storage": "3.2.1",
+        "moment": "2.22.2",
+        "pkginfo": "0.4.1",
+        "semver": "5.5.0",
+        "underscore": "1.8.3",
+        "winston": "2.4.3"
+      }
+    },
+    "aws-xray-sdk-express": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-express/-/aws-xray-sdk-express-1.2.0.tgz",
+      "integrity": "sha512-YWzAy/J6LSJCu4957iTgb3UhBUw2E72xTbpiwLL3zNJTfz/oK1k/eV6UkGRlYwBOVSYy3wgSTiFPWn7KayQ4mQ=="
+    },
+    "aws-xray-sdk-mysql": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-mysql/-/aws-xray-sdk-mysql-1.2.0.tgz",
+      "integrity": "sha512-fId4DU8lZ4fcuYTRP0ll6j1mFYnwZU0TRlQt65CJfS3SEwiszD580BRIm+vyHLH8ZExOZ6OO0vfpC1H8hjVxrQ=="
+    },
+    "aws-xray-sdk-postgres": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-postgres/-/aws-xray-sdk-postgres-1.2.0.tgz",
+      "integrity": "sha512-P6lEAioryorEzvBuI8oGL29eeqtVqHpPnHauLsP+JEtX7T+BfBFVEcDzVHHcKofeSPzWrgom7pL++Mw60sMQMg=="
     },
     "aws4": {
       "version": "1.7.0",
@@ -3046,6 +3095,15 @@
       "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
       "integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
       "dev": true
+    },
+    "continuation-local-storage": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+      "requires": {
+        "async-listener": "0.6.9",
+        "emitter-listener": "1.1.1"
+      }
     },
     "convert-source-map": {
       "version": "1.5.1",
@@ -13019,8 +13077,7 @@
     "pkginfo": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
-      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
-      "dev": true
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
     },
     "pluralize": {
       "version": "1.2.1",
@@ -16519,8 +16576,7 @@
     "underscore": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-      "dev": true
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "underscore.string": {
       "version": "3.3.4",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "compile": "grunt generate-assets",
     "clean": "grunt clean",
     "start-local": "nodemon -e njk start.js",
+    "start-debug": "node start.js --inspect",
     "start": "node start.js",
     "watch": "chokidar app test *.js --initial -c 'npm run test'",
     "watch-live-reload": "./node_modules/.bin/grunt watch",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "accessible-autocomplete": "^1.6.1",
     "appmetrics": "3.x",
     "appmetrics-statsd": "2.0.x",
+    "aws-xray-sdk": "^1.2.0",
     "body-parser": "1.18.3",
     "change-case": "3.0.2",
     "check-types": "^7.3.x",

--- a/server.js
+++ b/server.js
@@ -7,6 +7,8 @@ if (!process.env.DISABLE_APPMETRICS) {
 }
 
 // NPM dependencies
+// TODO : Remove/enable
+// const AWSXRay = require('aws-xray-sdk')
 const express = require('express')
 const nunjucks = require('nunjucks')
 const httpsAgent = require('https').globalAgent
@@ -151,6 +153,14 @@ function listen () {
 function initialise () {
   const app = unconfiguredApp
   app.disable('x-powered-by')
+
+  // TODO : Remove/enable
+  // AWSXRay.enableManualMode()
+  // AWSXRay.setLogger(logger)
+  // AWSXRay.middleware.setSamplingRules('aws-xray.rules')
+  // AWSXRay.config([AWSXRay.plugins.ECSPlugin])
+  // app.use(AWSXRay.express.openSegment('pay_selfservice'))
+
   app.use(flash())
   initialiseTLS(app)
   initialisePublic(app)

--- a/server.js
+++ b/server.js
@@ -7,8 +7,6 @@ if (!process.env.DISABLE_APPMETRICS) {
 }
 
 // NPM dependencies
-// TODO : Remove/enable
-// const AWSXRay = require('aws-xray-sdk')
 const express = require('express')
 const nunjucks = require('nunjucks')
 const httpsAgent = require('https').globalAgent
@@ -152,16 +150,10 @@ function listen () {
  */
 function initialise () {
   const app = unconfiguredApp
+
   app.disable('x-powered-by')
-
-  // TODO : Remove/enable
-  // AWSXRay.enableManualMode()
-  // AWSXRay.setLogger(logger)
-  // AWSXRay.middleware.setSamplingRules('aws-xray.rules')
-  // AWSXRay.config([AWSXRay.plugins.ECSPlugin])
-  // app.use(AWSXRay.express.openSegment('pay_selfservice'))
-
   app.use(flash())
+
   initialiseTLS(app)
   initialisePublic(app)
   initialiseCookies(app)
@@ -170,7 +162,6 @@ function initialise () {
   initialiseTemplateEngine(app)
   initialiseErrorHandling(app)
   initialiseRoutes(app) // This contains the 404 overrider and so should be last
-
   warnIfAnalyticsNotSet()
 
   return app

--- a/test/unit/middleware/get_gateway_account_test.js
+++ b/test/unit/middleware/get_gateway_account_test.js
@@ -1,10 +1,12 @@
 'use strict'
 
+// NPM dependencies
 const path = require('path')
 const proxyquire = require('proxyquire')
 const lodash = require('lodash')
 const sinon = require('sinon')
 const {expect} = require('chai')
+const AWSXRay = require('aws-xray-sdk')
 
 const DirectDebitGatewayAccount = require('../../../app/models/DirectDebitGatewayAccount.class')
 let req, res, next, connectorGetAccountMock, directDebitConnectorGetAccountMock
@@ -46,7 +48,21 @@ const setupGetGatewayAccount = function (currentGatewayAccountID, paymentProvide
   return proxyquire(path.join(__dirname, '../../../app/middleware/get_gateway_account'), {
     '../services/auth_service.js': authServiceMock,
     '../services/clients/connector_client.js': connectorMock,
-    '../services/clients/direct_debit_connector_client.js': directDebitConnectorMock
+    '../services/clients/direct_debit_connector_client.js': directDebitConnectorMock,
+    'aws-xray-sdk': {
+      captureAsyncFunc: function (name, callback) {
+        callback(new AWSXRay.Segment('stub-subsegment'))
+      }
+    },
+    'continuation-local-storage': {
+      getNamespace: function () {
+        return {
+          get: function () {
+            return new AWSXRay.Segment('stub-segment')
+          }
+        }
+      }
+    }
   })
 }
 
@@ -54,65 +70,73 @@ describe('middleware: getGatewayAccount', () => {
   it('should call connectorClient.getAccount if it can resolve a currentGatewayAccountId', done => {
     lodash.set(req, 'user.serviceRoles[0]', {gatewayAccountIds: ['1', '2', '3']})
     const getGatewayAccount = setupGetGatewayAccount('1', 'worldpay')
-    getGatewayAccount(req, res, next).then(() => {
+    next = function () {
       expect(connectorGetAccountMock.called).to.equal(true)
       expect(connectorGetAccountMock.calledWith({gatewayAccountId: '1', correlationId: 'sdfghjk'})).to.equal(true)
-      expect(next.called).to.equal(true)
       expect(res.redirect.called).to.equal(false)
       done()
-    })
+    }
+    getGatewayAccount(req, res, next)
   })
   it('should extend the account data with supports3ds set to true if the account type is worldpay', done => {
     lodash.set(req, 'user.serviceRoles[0]', {gatewayAccountIds: ['1', '2', '3']})
     const getGatewayAccount = setupGetGatewayAccount('1', 'worldpay')
-    getGatewayAccount(req, res, next).then(() => {
+    next = function () {
       expect(req.account).to.deep.equal({id: '1', payment_provider: 'worldpay', supports3ds: true})
       done()
-    })
+    }
+    getGatewayAccount(req, res, next)
   })
   it('should extend the account data with supports3ds set to false if the account type is epdq and feature flag default disabled', done => {
     lodash.set(req, 'user.serviceRoles[0]', {gatewayAccountIds: ['1', '2', '3']})
     const getGatewayAccount = setupGetGatewayAccount('1', 'epdq')
-    getGatewayAccount(req, res, next).then(() => {
+    next = function () {
       expect(req.account).to.deep.equal({id: '1', payment_provider: 'epdq', supports3ds: false})
       done()
-    })
+    }
+    getGatewayAccount(req, res, next)
   })
   it('should extend the account data with supports3ds set to true if the account type is epdq and feature flag enabled', done => {
     process.env.EPDQ_3DS_ENABLED = 'true'
     lodash.set(req, 'user.serviceRoles[0]', {gatewayAccountIds: ['1', '2', '3']})
     const getGatewayAccount = setupGetGatewayAccount('1', 'epdq')
-    getGatewayAccount(req, res, next).then(() => {
+    next = function () {
       expect(req.account).to.deep.equal({id: '1', payment_provider: 'epdq', supports3ds: true})
       done()
-    })
+    }
+    getGatewayAccount(req, res, next)
   })
   it('should not extend the account data with supports3ds set to false if the account type is smartpay and feature flag disabled', done => {
     lodash.set(req, 'user.serviceRoles[0]', {gatewayAccountIds: ['1', '2', '3']})
     const getGatewayAccount = setupGetGatewayAccount('1', 'smartpay')
-    getGatewayAccount(req, res, next).then(() => {
+    next = function () {
       expect(req.account).to.deep.equal({id: '1', payment_provider: 'smartpay', supports3ds: false})
       done()
-    })
+    }
+    getGatewayAccount(req, res, next)
   })
   it('should extend the account data with supports3ds set to true if the account type is smartpay and feature flag enabled', done => {
     process.env.SMARTPAY_3DS_ENABLED = 'true'
     lodash.set(req, 'user.serviceRoles[0]', {gatewayAccountIds: ['1', '2', '3']})
     const getGatewayAccount = setupGetGatewayAccount('1', 'smartpay')
-    getGatewayAccount(req, res, next).then(() => {
+    next = function () {
       expect(req.account).to.deep.equal({id: '1', payment_provider: 'smartpay', supports3ds: true})
       done()
-    })
+    }
+    getGatewayAccount(req, res, next)
   })
   it('should call direct debit connector if the token is a direct debit token', done => {
     lodash.set(req, 'user.serviceRoles[0]', {gatewayAccountIds: ['DIRECT_DEBIT:1sadasd']})
     const getGatewayAccount = setupGetGatewayAccount('DIRECT_DEBIT:1sadasd', 'sandbox')
-    getGatewayAccount(req, res, next).then(() => {
+    next = function () {
       expect(directDebitConnectorGetAccountMock.called).to.equal(true)
-      expect(directDebitConnectorGetAccountMock.calledWith({gatewayAccountId: 'DIRECT_DEBIT:1sadasd', correlationId: 'sdfghjk'})).to.equal(true)
-      expect(next.called).to.equal(true)
+      expect(directDebitConnectorGetAccountMock.calledWith({
+        gatewayAccountId: 'DIRECT_DEBIT:1sadasd',
+        correlationId: 'sdfghjk'
+      })).to.equal(true)
       expect(res.redirect.called).to.equal(false)
       done()
-    })
+    }
+    getGatewayAccount(req, res, next)
   })
 })


### PR DESCRIPTION
Sets up configuration for fine grained instrumentation of inbound/outbound service calls using AWS x-ray.

This involves:
- Using the x-ray SDK express plugin to automatically create traces and segments on routes.
- Configuring our base clients to pass generated trace id's through to underlying microservices
- Uses 'continuation-local-storage' as a way of persisting segment information down through callback/async chains without having to modify every function in the chain.
- Manual segment creation on our passport/session implementation, as this occurs before/outside a route context

As a proof of concept and a first implementation, the service calls involved in loading the self service dashboard have been modified for x-ray tracing and sub-segment information. This pattern can be repeated depending on how/where we want to implement tracing.
