### PR TITLE
Change “Direct debit” to “Direct Debit”

### DIFF
--- a/app/views/services/_service_section.njk
+++ b/app/views/services/_service_section.njk
@@ -20,7 +20,7 @@
     {% endif %}
 
     {% if service.gateway_accounts.directdebitAccounts.length %}
-    <h3 class="heading-small">Direct debit payments</h3>
+    <h3 class="heading-small">Direct Debit payments</h3>
     <ul class="list">
     {% for account in service.gateway_accounts.directdebitAccounts %}
       {% include "./_service_switch.njk" %}

--- a/app/views/services/_service_section_small.njk
+++ b/app/views/services/_service_section_small.njk
@@ -20,7 +20,7 @@
     {% endif %}
 
     {% if service.gateway_accounts.directdebitAccounts.length %}
-    <h3 class="heading-small">Direct debit payments</h3>
+    <h3 class="heading-small">Direct Debit payments</h3>
     <ul class="list service-list">
     {% for account in service.gateway_accounts.directdebitAccounts %}
       {% include "./_service_switch.njk" %}

--- a/test/unit/controller/service_switch_controller_test.js
+++ b/test/unit/controller/service_switch_controller_test.js
@@ -80,7 +80,7 @@ describe('service switch controller: list of accounts', function () {
           },
           {
             service: {
-              name: 'Direct debit service',
+              name: 'Direct Debit service',
               external_id: 'service-external-id-4',
               gateway_account_ids: directDebitGatewayAccountIds
             },
@@ -99,7 +99,7 @@ describe('service switch controller: list of accounts', function () {
         const renderData = arguments[1]
 
         expect(path).to.equal('services/index')
-        expect(renderData.services.map(service => service.name)).to.have.lengthOf(4).and.to.include('My Service 1', 'My Service 2', '', 'Direct debit service')
+        expect(renderData.services.map(service => service.name)).to.have.lengthOf(4).and.to.include('My Service 1', 'My Service 2', '', 'Direct Debit service')
         expect(cardGatewayAccountNamesOf(renderData, 'service-external-id-1')).to.have.lengthOf(2).and.to.include('account 2', 'account 5')
         expect(cardGatewayAccountNamesOf(renderData, 'service-external-id-2')).to.have.lengthOf(3).and.to.include('account 3', 'account 6', 'account 7')
         expect(cardGatewayAccountNamesOf(renderData, 'service-external-id-3')).to.have.lengthOf(2).and.to.include('account 4', 'account 9')


### PR DESCRIPTION
When talking about the Bacs scheme specifically, Direct Debit is a proper noun