### PR TITLE
PP-4096 add welsh service name

### DIFF
--- a/app/assets/sass/helpers/_forms.scss
+++ b/app/assets/sass/helpers/_forms.scss
@@ -66,3 +66,22 @@ input[type='checkbox'].form-control {
     }
   }
 }
+
+.cf:before,
+.cf:after {
+    content: " "; /* 1 */
+    display: table; /* 2 */
+}
+
+.cf:after {
+    clear: both;
+}
+
+/**
+ * For IE 6/7 only
+ * Include this rule to trigger hasLayout and contain floats.
+ */
+.cf {
+    *zoom: 1;
+    margin-bottom: 30px;
+}

--- a/app/controllers/register_service_controller.js
+++ b/app/controllers/register_service_controller.js
@@ -225,16 +225,18 @@ module.exports = {
   submitYourServiceName: (req, res) => {
     const correlationId = req.correlationId
     const serviceName = req.body['service-name']
-    const validationErrors = validateServiceName(serviceName)
+    const serviceNameCy = req.body['service-name-cy']
+    const validationErrors = validateServiceName(serviceName, 'service-name-en', true)
+    const validationErrorsCy = validateServiceName(serviceNameCy, 'service-name-cy', false)
 
-    if (validationErrors) {
+    if (Object.keys(validationErrors).length || Object.keys(validationErrorsCy).length) {
       _.set(req, 'session.pageData.submitYourServiceName', {
         errors: validationErrors,
-        current_name: serviceName
+        current_name: _.merge({}, { en: serviceName, cy: serviceNameCy })
       })
       res.redirect(303, paths.selfCreateService.serviceNaming)
     } else {
-      return serviceService.updateServiceName(req.user.serviceRoles[0].service.externalId, serviceName, correlationId)
+      return serviceService.updateServiceName(req.user.serviceRoles[0].service.externalId, serviceName, serviceNameCy, correlationId)
         .then(() => {
           _.unset(req, 'session.pageData.submitYourServiceName')
           res.redirect(303, paths.dashboard.index)

--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -18,6 +18,7 @@ class Service {
   constructor (serviceData) {
     this.externalId = serviceData.external_id
     this.name = serviceData.name
+    this.serviceName = serviceData.service_name
     this.gatewayAccountIds = serviceData.gateway_account_ids
     this.merchantDetails = serviceData.merchant_details
   }
@@ -30,6 +31,7 @@ class Service {
     return {
       external_id: this.externalId,
       name: this.name,
+      serviceName: this.serviceName,
       gateway_account_ids: this.gatewayAccountIds,
       merchant_details: this.merchantDetails
     }

--- a/app/services/clients/adminusers_client.js
+++ b/app/services/clients/adminusers_client.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// NPM dependencies
+const lodash = require('lodash')
+
 // Local dependencies
 const baseClient = require('./base_client/base_client')
 const User = require('../../models/User.class')
@@ -527,7 +530,7 @@ module.exports = function (clientOptions = {}) {
      * @param gatewayAccountIds
      * @returns {*|promise|Constructor}
      */
-  const createService = (serviceName, gatewayAccountIds) => {
+  const createService = (serviceName, serviceNameCy, gatewayAccountIds) => {
     let postBody = {
       baseUrl,
       url: `${serviceResource}`,
@@ -541,11 +544,14 @@ module.exports = function (clientOptions = {}) {
 
     if (serviceName) {
       postBody.body.name = serviceName
+      postBody.body.service_name = lodash.merge(postBody.body.service_name, {en: serviceName})
+    }
+    if (serviceNameCy) {
+      postBody.body.service_name = lodash.merge(postBody.body.service_name, {cy: serviceNameCy})
     }
     if (gatewayAccountIds) {
       postBody.body.gateway_account_ids = gatewayAccountIds
     }
-
     return baseClient.post(
       postBody
     )
@@ -558,17 +564,24 @@ module.exports = function (clientOptions = {}) {
      * @param serviceName
      * @returns {*|Constructor|promise}
      */
-  const updateServiceName = (serviceExternalId, serviceName) => {
+  const updateServiceName = (serviceExternalId, serviceName, serviceNameCy) => {
+    const body = {
+      op: 'replace',
+      path: 'name',
+      value: serviceName
+    }
+    if (serviceNameCy) {
+      body.value = {
+        en: serviceName,
+        cy: serviceNameCy
+      }
+    }
     return baseClient.patch(
       {
         baseUrl,
         url: `${serviceResource}/${serviceExternalId}`,
         json: true,
-        body: {
-          op: 'replace',
-          path: 'name',
-          value: serviceName
-        },
+        body,
         correlationId: correlationId,
         description: 'update service name',
         service: SERVICE_NAME,

--- a/app/services/clients/adminusers_client.js
+++ b/app/services/clients/adminusers_client.js
@@ -565,16 +565,24 @@ module.exports = function (clientOptions = {}) {
      * @returns {*|Constructor|promise}
      */
   const updateServiceName = (serviceExternalId, serviceName, serviceNameCy) => {
-    const body = {
-      op: 'replace',
-      path: 'name',
-      value: serviceName
+    const body = []
+    if (serviceName) {
+       body.push(
+         {
+           op: 'replace',
+           path: 'service_name/en',
+           value: serviceName
+         }
+       )
     }
     if (serviceNameCy) {
-      body.value = {
-        en: serviceName,
-        cy: serviceNameCy
-      }
+      body.push(
+        {
+          op: 'replace',
+          path: 'service_name/cy',
+          value: serviceNameCy
+        }
+      )
     }
     return baseClient.patch(
       {

--- a/app/services/service_service.js
+++ b/app/services/service_service.js
@@ -69,12 +69,12 @@ function getGatewayAccounts (gatewayAccountIds, correlationId) {
  * @param correlationId
  * @returns {Promise<Service>} the updated service
  */
-function updateServiceName (serviceExternalId, serviceName, correlationId) {
+function updateServiceName(serviceExternalId, serviceName, serviceNameCy, correlationId) {
   return new Promise(function (resolve, reject) {
     if (!serviceExternalId) reject(new Error(`argument: 'serviceExternalId' cannot be undefined`))
     if (!serviceName) serviceName = 'System Generated'
 
-    getAdminUsersClient({correlationId}).updateServiceName(serviceExternalId, serviceName)
+    getAdminUsersClient({correlationId}).updateServiceName(serviceExternalId, serviceName, serviceNameCy)
       .then(result => {
         const gatewayAccountIds = lodash.get(result, 'gateway_account_ids', [])
 
@@ -121,11 +121,12 @@ function updateMerchantDetails (serviceExternalId, merchantDetails, correlationI
  * @param correlationId
  * @returns {*|Promise|Promise<Service>} the created service
  */
-function createService (serviceName, correlationId) {
+function createService (serviceName, serviceNameCy, correlationId) {
   if (!serviceName) serviceName = 'System Generated'
+  if (!serviceNameCy) serviceNameCy = ''
 
   return connectorClient.createGatewayAccount('sandbox', 'test', serviceName, null, correlationId)
     .then(gatewayAccount =>
-      getAdminUsersClient({correlationId}).createService(serviceName, [gatewayAccount.gateway_account_id])
+      getAdminUsersClient({ correlationId }).createService(serviceName, serviceNameCy, [gatewayAccount.gateway_account_id])
     )
 }

--- a/app/utils/service_name_validation.js
+++ b/app/utils/service_name_validation.js
@@ -4,16 +4,16 @@ const trim = require('lodash/trim')
 const {isEmpty, isFieldGreaterThanMaxLengthChars} = require('../browsered/field-validation-checks')
 const SERVICE_NAME_MAX_LENGTH = 50
 
-exports.validateServiceName = (serviceName) => {
-  let errors
-  let value = trim(serviceName)
-  if (isEmpty(value)) {
+exports.validateServiceName = (serviceNameValue, serviceName = 'service_name', required) => {
+  let errors = {}
+  let value = trim(serviceNameValue)
+  if (isEmpty(value) && required) {
     errors = {
-      service_name: isEmpty(value)
+      [serviceName]: isEmpty(value)
     }
-  } else if (isFieldGreaterThanMaxLengthChars(value, SERVICE_NAME_MAX_LENGTH)) {
+  } else if (!isEmpty(value) && isFieldGreaterThanMaxLengthChars(value, SERVICE_NAME_MAX_LENGTH)) {
     errors = {
-      service_name: isFieldGreaterThanMaxLengthChars(value, SERVICE_NAME_MAX_LENGTH)
+      [serviceName]: isFieldGreaterThanMaxLengthChars(value, SERVICE_NAME_MAX_LENGTH)
     }
   }
   return errors

--- a/app/views/services/add_service.njk
+++ b/app/views/services/add_service.njk
@@ -15,6 +15,9 @@ Add a new service - GOV.UK Pay
         {% if errors.service_name %}
         <li><a href="#service-name">Service name</a></li>
         {% endif %}
+        {% if errors.service_name_cy %}
+          <li><a href="#service-name">Welsh Service name</a></li>
+        {% endif %}
       </ul>
     </div>
     {% endif %}
@@ -36,6 +39,22 @@ Add a new service - GOV.UK Pay
         {% endif %}
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
         <input class="form-control" data-module="" id="service-name" name="service-name" type="text" value="{{current_name}}" data-validate="required isFieldGreaterThanMaxLengthChars" data-validate-max-length="50">
+      </div>
+
+      <div class="cf">
+        <div class="form-group multiple-choice {% if errors.service_name_cy %}error{% endif %}" data-target="welsh-service-name">
+          <input id="checkbox-service-name-cy" name="welsh-service-name-bool" type="checkbox" value="true">
+          <label for="checkbox-service-name-cy">Add a Welsh service name
+            <span class="form-hint">To translate your payment pages you need to <a href="https://docs.payments.service.gov.uk/integration_details/#creating-a-payment">integrate with our API</a></span>
+          </label>
+        </div>
+        <div class="form-group panel panel-border-narrow js-hidden" id="welsh-service-name">
+          <label class="form-label" for="service-name-cy">Welsh (Cymraeg) service name</label>
+          {% if errors.service_name_cy %}
+            <span class="error-message">{{errors.service_name_cy}}</span>
+          {% endif %}
+          <input class="form-control" data-module="" id="service-name-cy" name="service-name-cy" type="text" value="{{current_name_cy}}" data-validate="isFieldGreaterThanMaxLengthChars" data-validate-max-length="50" lang="cy">
+        </div>
       </div>
 
       <div class="form-group call-to-action-group">

--- a/app/views/services/edit_service_name.njk
+++ b/app/views/services/edit_service_name.njk
@@ -30,8 +30,25 @@ Edit service name - GOV.UK Pay
           <span class="error-message">{{errors.service_name}}</span>
         {% endif %}
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-        <input class="form-control" data-module="" id="service-name" name="service-name" type="text" value="{{current_name}}" data-validate="required isFieldGreaterThanMaxLengthChars" data-validate-max-length="50">
+        <input class="form-control" data-module="" id="service-name" name="service-name" type="text" value="{{current_name.en}}" data-validate="required isFieldGreaterThanMaxLengthChars" data-validate-max-length="50">
       </div>
+
+      <div class="cf">
+        <div class="form-group multiple-choice {% if errors.service_name_cy %}error{% endif %}" data-target="welsh-service-name">
+          <input id="checkbox-service-name-cy" name="welsh-service-name-bool" type="checkbox" value="true" {% if current_name.cy %}checked{% endif %}>
+          <label for="checkbox-service-name-cy">Add a Welsh service name
+            <span class="form-hint">To translate your payment pages you need to <a href="https://docs.payments.service.gov.uk/integration_details/#creating-a-payment">integrate with our API</a></span>
+          </label>
+        </div>
+        <div class="form-group panel panel-border-narrow js-hidden" id="welsh-service-name">
+          <label class="form-label" for="service-name-cy">Welsh (Cymraeg) service name</label>
+          {% if errors.service_name_cy %}
+            <span class="error-message">{{errors.service_name_cy}}</span>
+          {% endif %}
+          <input class="form-control" data-module="" id="service-name-cy" name="service-name-cy" type="text" value="{{current_name.cy}}" data-validate="isFieldGreaterThanMaxLengthChars" data-validate-max-length="50" lang="cy">
+        </div>
+      </div>
+
       <div class="form-group call-to-action-group">
         <input class="button" type="submit" value="Save">
         <a id="service-name-cancel-link" href="{{my_services}}">Cancel</a>

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint": "./node_modules/.bin/standard",
     "lint-sass": "./node_modules/.bin/sass-lint -v",
     "test": "npm run snyk-protect && rm -rf ./pacts && ./node_modules/mocha/bin/mocha '!(node_modules)/**/*+(.|_)+(test|tests)'.js",
-    "pact-stub": "docker run -t -p 8000:8000 -v \"$(pwd)/pacts/:/app/pacts\" pactfoundation/pact-stub-server -p 8000 -d pacts",
+    "pact-stub": "docker run -t -p 8000:8000 -v \"$(pwd)/pacts/:/app/pacts\" pactfoundation/pact-stub-server:v0.0.10 -p 8000 -d pacts",
     "cypress:server": "node --inspect -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
     "cypress:test": "cypress run",
     "cypress:test-headed": "cypress open",

--- a/test/fixtures/pact_base.js
+++ b/test/fixtures/pact_base.js
@@ -50,6 +50,7 @@ module.exports = function (options = {}) {
 
   return {
     pactifyMatch: pactifyMatch,
+    pactifySimpleArray: pactifySimpleArray,
     pactifyNestedArray: pactifyNestedArray,
     pactify: pactify,
     withPactified: withPactified

--- a/test/fixtures/self_register_fixtures.js
+++ b/test/fixtures/self_register_fixtures.js
@@ -69,7 +69,7 @@ module.exports = {
 
   invalidServiceNameRequest: (opts = {}) => {
     const data = {
-      service_name: opts.service_name || ' '
+      service_name: opts.service_name || ''
     }
 
     return {

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -67,6 +67,7 @@ module.exports = {
     const data = {}
     if (opts.name) {
       data.name = opts.name
+      data.service_name = { en: opts.name }
     }
     if (opts.gateway_account_ids) {
       data.gateway_account_ids = opts.gateway_account_ids
@@ -105,13 +106,46 @@ module.exports = {
     }
   },
 
-  validUpdateServiceNameRequest: (opts) => {
+  validUpdateServiceNameRequestWithEnAndCy: (opts) => {
     opts = opts || {}
 
+    const data = [
+      {
+        op: 'replace',
+        path: 'service_name/en',
+        value: opts.name || 'new-en-name'
+      },
+      {
+        op: 'replace',
+        path: 'service_name/cy',
+        value: opts.nameCy || 'new-cy-name'
+      }
+    ]
+
+    return {
+      getPactified: () => {
+        return pactServices.pactifyNestedArray(data)
+      },
+      getPlain: () => {
+        return _.clone(data)
+      }
+    }
+  },
+
+  validUpdateServiceNameResponseWithEnAndCy: (opts) => {
+    opts = opts || {}
+
+    const externalId = opts.external_id || 'externalId'
+    const serviceName = opts.name || 'new-en-name'
+    const serviceNameCy = opts.nameCy || 'new-cy-name'
+
     const data = {
-      op: 'replace',
-      path: 'name',
-      value: opts.name || 'updated-service-name'
+      external_id: externalId,
+      name: serviceName,
+      service_name: {
+        en: serviceName,
+        cy: serviceNameCy
+      }
     }
 
     return {
@@ -124,15 +158,82 @@ module.exports = {
     }
   },
 
-  validUpdateServiceNameResponse: (opts) => {
+  validUpdateServiceNameRequestWithEn: (opts) => {
+    opts = opts || {}
+
+    const data = [{
+        op: 'replace',
+        path: 'service_name/en',
+        value: opts.name || 'new-en-name'
+      }]
+
+    return {
+      getPactified: () => {
+        return pactServices.pactifySimpleArray(data)
+      },
+      getPlain: () => {
+        return _.clone(data)
+      }
+    }
+  },
+
+  validUpdateServiceNameResponseWithEn: (opts) => {
     opts = opts || {}
 
     const externalId = opts.external_id || 'externalId'
-    const serviceName = opts.name || 'updated-service-name'
+    const serviceName = opts.name || 'new-en-name'
 
     const data = {
       external_id: externalId,
-      name: serviceName
+      name: serviceName,
+      service_name: {
+        en: serviceName,
+      }
+    }
+
+    return {
+      getPactified: () => {
+        return pactServices.pactify(data)
+      },
+      getPlain: () => {
+        return _.clone(data)
+      }
+    }
+  },
+
+  validUpdateServiceNameRequestWithCy: (opts) => {
+    opts = opts || {}
+
+    const data = [{
+      op: 'replace',
+      path: 'service_name/cy',
+      value: opts.name || 'new-cy-name'
+    }]
+
+    return {
+      getPactified: () => {
+        return pactServices.pactifySimpleArray(data)
+      },
+      getPlain: () => {
+        return _.clone(data)
+      }
+    }
+  },
+
+  validUpdateServiceNameResponseWithCy: (opts) => {
+    opts = opts || {}
+
+    const externalId = opts.external_id || 'externalId'
+    const serviceName = opts.name || 'new-en-name'
+    const serviceNameCy = opts.nameCy || 'new-cy-name'
+
+    const data = {
+      external_id: externalId,
+      name: serviceName,
+      service_name: {
+        en: serviceName,
+        cy: serviceNameCy
+      }
     }
 
     return {
@@ -148,15 +249,17 @@ module.exports = {
   badRequestWithInvalidPathWhenUpdateServiceNameRequest: (opts) => {
     opts = opts || {}
 
-    const data = {
-      op: 'replace',
-      path: 'invalid-path',
-      value: opts.name || 'updated-service-name'
-    }
+    const data = [
+      {
+        op: 'replace',
+        path: 'invalid-path',
+        value: opts.name || 'updated-service-name'
+      }
+    ]
 
     return {
       getPactified: () => {
-        return pactServices.pactify(data)
+        return pactServices.pactifySimpleArray(data)
       },
       getPlain: () => {
         return _.clone(data)

--- a/test/integration/create_service_controller/create_service_controller_service_naming_ft_test.js
+++ b/test/integration/create_service_controller/create_service_controller_service_naming_ft_test.js
@@ -53,13 +53,13 @@ describe('create service - service naming', function () {
       .post(paths.selfCreateService.serviceNaming)
       .send({
         'service-name': request.service_name,
+        'service-name-cy': '',
         csrfToken: csrf().create('123')
       })
       .expect(303)
       .expect('Location', paths.dashboard.index)
       .end(done)
   })
-
   it('should redirect to name your service page if user input invalid', function (done) {
     const invalidServiceNameRequest = selfRegisterFixtures.invalidServiceNameRequest()
 
@@ -70,6 +70,7 @@ describe('create service - service naming', function () {
       .post(paths.selfCreateService.serviceNaming)
       .send({
         'service-name': request.service_name,
+        'service-name-cy': '',
         csrfToken: csrf().create('123')
       })
       .expect(303)

--- a/test/unit/clients/adminusers_client/service/create_service_test.js
+++ b/test/unit/clients/adminusers_client/service/create_service_test.js
@@ -63,7 +63,7 @@ describe('adminusers client - create a new service', function () {
   })
 
   describe('create a service sending gateway account ids - success', () => {
-    const validRequest = serviceFixtures.validCreateServiceRequest({gatewayAccountIds: ['1', '5']})
+    const validRequest = serviceFixtures.validCreateServiceRequest({gateway_account_ids: ['1', '5']})
     const validCreateServiceResponse = serviceFixtures.validCreateServiceResponse(validRequest.getPlain())
 
     before((done) => {
@@ -83,7 +83,7 @@ describe('adminusers client - create a new service', function () {
     afterEach(() => provider.verify())
 
     it('should create a new service', function (done) {
-      adminusersClient.createService(null, validRequest.getPlain().gateway_account_ids).should.be.fulfilled.then(service => {
+      adminusersClient.createService(null, null, validRequest.getPlain().gateway_account_ids).should.be.fulfilled.then(service => {
         expect(service.external_id).to.equal('externalId')
         expect(service.name).to.equal('System Generated')
         expect(service.gateway_account_ids).to.deep.equal(validCreateServiceResponse.getPlain().gateway_account_ids)
@@ -112,7 +112,7 @@ describe('adminusers client - create a new service', function () {
     afterEach(() => provider.verify())
 
     it('should create a new service', function (done) {
-      adminusersClient.createService('Service name', null).should.be.fulfilled.then(service => {
+      adminusersClient.createService('Service name', null, null).should.be.fulfilled.then(service => {
         expect(service.external_id).to.equal('externalId')
         expect(service.name).to.equal('Service name')
         expect(service.gateway_account_ids).to.deep.equal([])
@@ -141,9 +141,7 @@ describe('adminusers client - create a new service', function () {
     afterEach(() => provider.verify())
 
     it('should return 400 on invalid gateway account ids', function (done) {
-      adminusersClient.createService(
-        null, ['non-numeric-id']
-      ).should.be.rejected.then(function (response) {
+      adminusersClient.createService( null, null, ['non-numeric-id']).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(400)
         expect(response.message.errors.length).to.equal(1)
         expect(response.message.errors).to.deep.equal(errorResponse.getPlain().errors)

--- a/test/unit/clients/adminusers_client/service/update_service_name_test.js
+++ b/test/unit/clients/adminusers_client/service/update_service_name_test.js
@@ -34,17 +34,17 @@ describe('adminusers client - update service name', function () {
   before(() => provider.setup())
   after((done) => provider.finalize().then(done()))
 
-  describe('success', () => {
+  describe('success with en and cy', () => {
     const existingServiceExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
-    const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequest()
-    const validUpdateServiceNameResponse = serviceFixtures.validUpdateServiceNameResponse({
+    const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequestWithEnAndCy()
+    const validUpdateServiceNameResponse = serviceFixtures.validUpdateServiceNameResponseWithEnAndCy({
       external_id: existingServiceExternalId
     })
 
     before((done) => {
       provider.addInteraction(
         new PactInteractionBuilder(`${SERVICE_RESOURCE}/${existingServiceExternalId}`)
-          .withUponReceiving('a valid update service name request')
+          .withUponReceiving('a valid update service name request with en and cy')
           .withMethod('PATCH')
           .withRequestBody(validUpdateServiceNameRequest.getPactified())
           .withStatusCode(200)
@@ -57,17 +57,88 @@ describe('adminusers client - update service name', function () {
 
     afterEach(() => provider.verify())
 
-    it('should update service name', function (done) {
-      adminusersClient.updateServiceName(existingServiceExternalId, validUpdateServiceNameRequest.getPlain().value).should.be.fulfilled.then(service => {
+    it('should update service name for en and cy', function (done) {
+      const serviceNameEn = validUpdateServiceNameRequest.getPlain()[0].value
+      const serviceNameCy = validUpdateServiceNameRequest.getPlain()[1].value
+      adminusersClient.updateServiceName(existingServiceExternalId, serviceNameEn, serviceNameCy)
+        .should.be.fulfilled.then(service => {
         expect(service.external_id).to.equal(existingServiceExternalId)
-        expect(service.name).to.equal(validUpdateServiceNameRequest.getPlain().value)
+        expect(service.name).to.equal(serviceNameEn)
+        expect(service.service_name.en).to.equal(serviceNameEn)
+        expect(service.service_name.cy).to.equal(serviceNameCy)
+      }).should.notify(done)
+    })
+  })
+
+  describe('success with en', () => {
+    const existingServiceExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
+    const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequestWithEn()
+    const validUpdateServiceNameResponse = serviceFixtures.validUpdateServiceNameResponseWithEn({
+      external_id: existingServiceExternalId
+    })
+
+    before((done) => {
+      provider.addInteraction(
+        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${existingServiceExternalId}`)
+          .withUponReceiving('a valid update service name request with en')
+          .withMethod('PATCH')
+          .withRequestBody(validUpdateServiceNameRequest.getPactified())
+          .withStatusCode(200)
+          .withResponseBody(validUpdateServiceNameResponse.getPactified())
+          .build()
+      )
+        .then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should update service name for en', function (done) {
+      const serviceNameEn = validUpdateServiceNameRequest.getPlain()[0].value
+      adminusersClient.updateServiceName(existingServiceExternalId, serviceNameEn).should.be.fulfilled.then(service => {
+        expect(service.external_id).to.equal(existingServiceExternalId)
+        expect(service.name).to.equal(serviceNameEn)
+        expect(service.service_name.en).to.equal(serviceNameEn)
+      }).should.notify(done)
+    })
+  })
+
+  describe('success with cy', () => {
+    const existingServiceExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
+    const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequestWithCy()
+    const validUpdateServiceNameResponse = serviceFixtures.validUpdateServiceNameResponseWithCy({
+      external_id: existingServiceExternalId
+    })
+
+    before((done) => {
+      provider.addInteraction(
+        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${existingServiceExternalId}`)
+          .withUponReceiving('a valid update service name request with cy')
+          .withMethod('PATCH')
+          .withRequestBody(validUpdateServiceNameRequest.getPactified())
+          .withStatusCode(200)
+          .withResponseBody(validUpdateServiceNameResponse.getPactified())
+          .build()
+      )
+        .then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should update service name for cy', function (done) {
+      const serviceNameCy = validUpdateServiceNameRequest.getPlain()[0].value
+
+      adminusersClient.updateServiceName(existingServiceExternalId, null, serviceNameCy).should.be.fulfilled.then(service => {
+        expect(service.external_id).to.equal(existingServiceExternalId)
+        expect(service.service_name.cy).to.equal(serviceNameCy)
       }).should.notify(done)
     })
   })
 
   describe('not found', () => {
     const nonExistentServiceExternalId = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
-    const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequest()
+    const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequestWithEnAndCy()
 
     before((done) => {
       provider.addInteraction(
@@ -85,34 +156,10 @@ describe('adminusers client - update service name', function () {
     afterEach(() => provider.verify())
 
     it('should return not found if service not exist', function (done) {
-      adminusersClient.updateServiceName(nonExistentServiceExternalId, validUpdateServiceNameRequest.getPlain().value).should.be.rejected.then(response => {
+      const serviceNameEn = validUpdateServiceNameRequest.getPlain()[0].value
+      const serviceNameCy = validUpdateServiceNameRequest.getPlain()[1].value
+      adminusersClient.updateServiceName(nonExistentServiceExternalId, serviceNameEn, serviceNameCy).should.be.rejected.then(response => {
         expect(response.errorCode).to.equal(404)
-      }).should.notify(done)
-    })
-  })
-
-  describe('bad request', () => {
-    const existingServiceExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
-    const invalidUpdateServiceNameRequest = serviceFixtures.badRequestWithInvalidPathWhenUpdateServiceNameRequest()
-
-    before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${existingServiceExternalId}`)
-          .withUponReceiving('an invalid update service name request - bad request')
-          .withMethod('PATCH')
-          .withRequestBody(invalidUpdateServiceNameRequest.getPactified())
-          .withStatusCode(400)
-          .build()
-      )
-        .then(() => done())
-        .catch(done)
-    })
-
-    afterEach(() => provider.verify())
-
-    it('should return bad request if invalid request body', function (done) {
-      adminusersClient.updateServiceName(existingServiceExternalId, invalidUpdateServiceNameRequest.getPlain().value).should.be.rejected.then(response => {
-        expect(response.errorCode).to.equal(400)
       }).should.notify(done)
     })
   })

--- a/test/unit/controller/create_service_controller/get_test.js
+++ b/test/unit/controller/create_service_controller/get_test.js
@@ -9,7 +9,7 @@ const createServiceCtrl = proxyquire('../../../../app/controllers/create_service
 })
 let req, res
 
-describe('Controller: createService, Method: get', () => {
+describe.only('Controller: createService, Method: get', () => {
   describe('when there is no pre-existing pageData', () => {
     before(() => {
       mockResponses.response = sinon.spy()
@@ -32,6 +32,10 @@ describe('Controller: createService, Method: get', () => {
       expect(mockResponses.response.args[0][3]).to.have.property('current_name').to.equal('')
     })
 
+    it(`should pass pageData to the responses.response method with a 'current_name_cy' property equal to ''`, () => {
+      expect(mockResponses.response.args[0][3]).to.have.property('current_name_cy').to.equal('')
+    })
+
     it(`should pass pageData to the responses.response method that does not have an 'errors' property`, () => {
       expect(mockResponses.response.args[0][3]).to.not.have.property('errors')
     })
@@ -51,8 +55,12 @@ describe('Controller: createService, Method: get', () => {
           pageData: {
             createServiceName: {
               current_name: 'Blah',
+              current_name_cy: 'Some Cymraeg service name',
               errors: {
                 service_name: {
+                  'invalid': true
+                },
+                service_name_cy: {
                   'invalid': true
                 }
               }
@@ -71,9 +79,16 @@ describe('Controller: createService, Method: get', () => {
       expect(mockResponses.response.args[0][3]).to.have.property('current_name').to.equal('Blah')
     })
 
+    it(`should pass pageData to the responses.response method with a 'current_name_cy' property equal to the name in the pre-existing pageData`, () => {
+      expect(mockResponses.response.args[0][3]).to.have.property('current_name_cy').to.equal('Some Cymraeg service name')
+    })
+
     it(`should pass pageData to the responses.response method with 'errors' property equal to the 'errors' property of the pre-existing pageData`, () => {
       expect(mockResponses.response.args[0][3]).to.have.property('errors').to.deep.equal({
         service_name: {
+          'invalid': true
+        },
+        service_name_cy: {
           'invalid': true
         }
       })

--- a/test/unit/controller/create_service_controller/get_test.js
+++ b/test/unit/controller/create_service_controller/get_test.js
@@ -9,7 +9,7 @@ const createServiceCtrl = proxyquire('../../../../app/controllers/create_service
 })
 let req, res
 
-describe.only('Controller: createService, Method: get', () => {
+describe('Controller: createService, Method: get', () => {
   describe('when there is no pre-existing pageData', () => {
     before(() => {
       mockResponses.response = sinon.spy()

--- a/test/unit/controller/create_service_controller/post_test.js
+++ b/test/unit/controller/create_service_controller/post_test.js
@@ -14,7 +14,7 @@ const addServiceCtrl = proxyquire('../../../../app/controllers/create_service_co
 })
 let req, res
 
-describe.only('Controller: createService, Method: post', () => {
+describe('Controller: createService, Method: post', () => {
   describe('when the service name is not empty', () => {
     before(done => {
       mockServiceService.createService = sinon.stub().resolves({external_id: 'r378y387y8weriyi'})

--- a/test/unit/controller/create_service_controller/post_test.js
+++ b/test/unit/controller/create_service_controller/post_test.js
@@ -14,7 +14,7 @@ const addServiceCtrl = proxyquire('../../../../app/controllers/create_service_co
 })
 let req, res
 
-describe('Controller: createService, Method: post', () => {
+describe.only('Controller: createService, Method: post', () => {
   describe('when the service name is not empty', () => {
     before(done => {
       mockServiceService.createService = sinon.stub().resolves({external_id: 'r378y387y8weriyi'})
@@ -24,7 +24,8 @@ describe('Controller: createService, Method: post', () => {
         user: {externalId: '38475y38q4758ow4'},
         correlationId: random.randomUuid(),
         body: {
-          'service-name': 'A brand spanking new service name'
+          'service-name': 'A brand spanking new service name',
+          'service-name-cy': 'Some Cymraeg new service name'
         }
       }
       res = {
@@ -51,7 +52,8 @@ describe('Controller: createService, Method: post', () => {
       req = {
         correlationId: random.randomUuid(),
         body: {
-          'service-name': 'A brand spanking new service name'
+          'service-name': 'A brand spanking new service name',
+          'service-name-cy': 'Some Cymraeg new service name'
         }
       }
       res = {}
@@ -81,7 +83,8 @@ describe('Controller: createService, Method: post', () => {
         user: {externalId: '38475y38q4758ow4'},
         correlationId: random.randomUuid(),
         body: {
-          'service-name': 'A brand spanking new service name'
+          'service-name': 'A brand spanking new service name',
+          'service-name-cy': 'Some Cymraeg new service name'
         }
       }
       res = {}
@@ -133,6 +136,66 @@ describe('Controller: createService, Method: post', () => {
     it(`should set prexisting pageData that includes the 'current_name' and errors`, () => {
       expect(req.session.pageData.createServiceName).to.have.property('current_name').to.equal(req.body['service-name'])
       expect(req.session.pageData.createServiceName).to.have.property('errors').to.deep.equal({service_name: 'This field cannot be blank'})
+    })
+  })
+
+  describe('when the Welsh service name is empty', () => {
+    before(done => {
+      mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
+      mockUserService.assignServiceRole = sinon.stub().resolves()
+      mockResponses.response = sinon.spy()
+      req = {
+        user: { externalId: '38475y38q4758ow4' },
+        correlationId: random.randomUuid(),
+        body: {
+          'service-name': 'A brand spanking new service name',
+          'service-name-cy': ''
+        }
+      }
+      res = {
+        redirect: sinon.spy()
+      }
+      const result = addServiceCtrl.post(req, res)
+      if (result) {
+        result.then(() => done()).catch(done)
+      } else {
+        done(new Error('Didn\'t return a promise'))
+      }
+    })
+
+    it(`should call 'res.redirect' with '/my-service'`, () => {
+      expect(res.redirect.called).to.equal(true)
+      expect(res.redirect.args[0]).to.include('/my-services')
+    })
+  })
+
+  describe('when the Welsh service name is filled in', () => {
+    before(done => {
+      mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
+      mockUserService.assignServiceRole = sinon.stub().resolves()
+      mockResponses.response = sinon.spy()
+      req = {
+        user: { externalId: '38475y38q4758ow4' },
+        correlationId: random.randomUuid(),
+        body: {
+          'service-name': 'A brand spanking new service name',
+          'service-name-cy': ''
+        }
+      }
+      res = {
+        redirect: sinon.spy()
+      }
+      const result = addServiceCtrl.post(req, res)
+      if (result) {
+        result.then(() => done()).catch(done)
+      } else {
+        done(new Error('Didn\'t return a promise'))
+      }
+    })
+
+    it(`should call 'res.redirect' with '/my-service'`, () => {
+      expect(res.redirect.called).to.equal(true)
+      expect(res.redirect.args[0]).to.include('/my-services')
     })
   })
 })

--- a/test/unit/controller/edit_service_name/get_test.js
+++ b/test/unit/controller/edit_service_name/get_test.js
@@ -17,7 +17,7 @@ describe('Controller: editServiceName, Method: get', () => {
       mockResponses.response = sinon.spy()
       res = {}
       req = {
-        service: new Service({external_id: random.randomUuid(), name: 'Example Service'})
+        service: new Service({external_id: random.randomUuid(), name: 'Example Service', service_name: { en: 'Example En Service', cy: 'Example Cy Service'}})
       }
       editServiceNameCtrl.get(req, res)
     })
@@ -33,7 +33,7 @@ describe('Controller: editServiceName, Method: get', () => {
     })
 
     it(`should pass pageData to the responses.response method with a 'current_name' property equal to the name of 'req.service'`, () => {
-      expect(mockResponses.response.args[0][3]).to.have.property('current_name').to.equal(req.service.name)
+      expect(mockResponses.response.args[0][3]).to.have.property('current_name').to.equal(req.service.serviceName)
     })
 
     it(`should pass pageData to the responses.response method that does not have an 'errors' property`, () => {
@@ -51,7 +51,7 @@ describe('Controller: editServiceName, Method: get', () => {
       mockResponses.response = sinon.spy()
       res = {}
       req = {
-        service: new Service({external_id: random.randomUuid(), name: 'System Generated'})
+        service: new Service({external_id: random.randomUuid(), name: 'System Generated', serviceName: {en: 'System Generated', cy: ''}})
 
       }
       editServiceNameCtrl.get(req, res)
@@ -61,8 +61,8 @@ describe('Controller: editServiceName, Method: get', () => {
       expect(mockResponses.response.called).to.equal(true)
     })
 
-    it(`should pass pageData to the responses.response method with a 'current_name' property equal to the name of 'req.service'`, () => {
-      expect(mockResponses.response.args[0][3]).to.have.property('current_name').to.equal('')
+    it(`should pass pageData to the responses.response method with a 'current_name' property equal to the serviceName of 'req.service'`, () => {
+      expect(mockResponses.response.args[0][3]).to.have.property('current_name').to.equal(req.service.serviceName)
     })
   })
 

--- a/test/unit/controller/edit_service_name/post_test.js
+++ b/test/unit/controller/edit_service_name/post_test.js
@@ -22,7 +22,8 @@ describe('Controller: editServiceName, Method: get', () => {
         correlationId: random.randomUuid(),
         service: new Service({external_id: random.randomUuid(), name: 'Example Service'}),
         body: {
-          'service-name': 'A brand spanking new service name'
+          'service-name': 'A brand spanking new English service name',
+          'service-name-cy': 'A brand spanking new Welsh service name'
         }
       }
       res = {
@@ -50,7 +51,8 @@ describe('Controller: editServiceName, Method: get', () => {
         correlationId: random.randomUuid(),
         service: new Service({external_id: random.randomUuid(), name: 'Example Service'}),
         body: {
-          'service-name': 'A brand spanking new service name'
+          'service-name': 'A brand spanking new English service name',
+          'service-name-cy': 'A brand spanking new Welsh service name'
         }
       }
       res = {}
@@ -79,7 +81,8 @@ describe('Controller: editServiceName, Method: get', () => {
         correlationId: random.randomUuid(),
         service: new Service({external_id: random.randomUuid(), name: 'Example Service'}),
         body: {
-          'service-name': ''
+          'service-name': '',
+          'service-name-cy': ''
         }
       }
       res = {
@@ -99,7 +102,8 @@ describe('Controller: editServiceName, Method: get', () => {
     })
 
     it(`should set prexisting pageData that includes the 'current_name' and errors`, () => {
-      expect(req.session.pageData.editServiceName).to.have.property('current_name').to.equal(req.body['service-name'])
+      expect(req.session.pageData.editServiceName.current_name).to.have.property('en').to.equal(req.body['service-name'])
+      expect(req.session.pageData.editServiceName.current_name).to.have.property('cy').to.equal(req.body['service-name-cy'])
       expect(req.session.pageData.editServiceName).to.have.property('errors').to.deep.equal({service_name: 'This field cannot be blank'})
     })
   })


### PR DESCRIPTION
### 0f4519f  - PP-4096- Add Welsh service name to service add/edit

@georgeracu / @jonheslop

- service name validation has been changed to get a field name as well
as a value
- Added a field to the front end on create service and edit service
- Updated add service clients to pass through the welsh name (if
present)
- Updated the edit service clients to pass through the welsh name
- duplicated a few tests and tweaked for welsh, bit of a cop out, needs
work

### 4452f74 - PP-4096 - Update clients and tests to reflect update changes

@danworth

- Changed `updateServiceName` within `adminusers_client` to use path based
notation e.g. `service_name/cy`.
- Updated and created pact tests for `update_service_name_tests`.
- Updated tests for `create_service_tests`.
- Updated tests for `create_service_controller_service_naming_ft_tests` to
consider `cy`.
- Updated `register_service_controller` to work with `cy` including checking
for validation errors and setting into `session` upon error.
