### PR TITLE
PP-3816 Create and delete a products token with payment links

### DIFF
--- a/app/controllers/payment-links/get-delete-controller.js
+++ b/app/controllers/payment-links/get-delete-controller.js
@@ -6,14 +6,29 @@ const logger = require('winston')
 // Local dependencies
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products_client.js')
+const publicAuthClient = require('../../services/clients/public_auth_client.js')
 const auth = require('../../services/auth_service.js')
 
 module.exports = (req, res) => {
   const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
-  productsClient.product.delete(gatewayAccountId, req.params.productExternalId)
-    .then(() => {
-      req.flash('generic', '<h2>The payment link was successfully deleted</h2>')
-      res.redirect(paths.paymentLinks.manage)
+  productsClient.product.getByProductExternalId(gatewayAccountId, req.params.productExternalId)
+    .then(product => {
+      const deleteToken = publicAuthClient.deleteTokenForAccount({
+        accountId: gatewayAccountId,
+        correlationId: req.correlationId,
+        payload: {
+          token: product.apiToken
+        }
+      })
+      const deleteProduct = productsClient.product.delete(gatewayAccountId, req.params.productExternalId)
+      return Promise.all([
+        deleteToken,
+        deleteProduct
+      ])
+        .then(() => {
+          req.flash('generic', '<h2>The payment link was successfully deleted</h2>')
+          res.redirect(paths.paymentLinks.manage)
+        })
     })
     .catch((err) => {
       logger.error(`[requestId=${req.correlationId}] Delete product failed - ${err.message}`)

--- a/app/controllers/payment-links/post-review-controller.js
+++ b/app/controllers/payment-links/post-review-controller.js
@@ -25,6 +25,7 @@ module.exports = (req, res) => {
     payload: {
       account_id: gatewayAccountId,
       created_by: req.user.email,
+      type: 'PRODUCTS',
       description: `Token for “${paymentLinkTitle}” payment link`
     }
   })

--- a/app/models/Product.class.js
+++ b/app/models/Product.class.js
@@ -28,6 +28,7 @@ class Product {
    * @param {Object} opts - raw 'product' object from server
    * @param {string} opts.external_id - The external ID of the product
    * @param {string} opts.gateway_account_id - The id of the product's associated gateway account
+   * @param {string} opts.pay_api_token - The token used to make payments on behalf of the service
    * @param {string} opts.name - The name of the product
    * @param {number} opts.price - price of the product in pence
    * @param {string} opts.govuk_status - the current status of the gov.uk pay charge
@@ -46,6 +47,7 @@ class Product {
     this.name = opts.name
     this.price = opts.price
     this.govukStatus = opts.govuk_status
+    this.apiToken = opts.pay_api_token
     this.serviceName = opts.service_name
     this.description = opts.description
     this.type = opts.type

--- a/app/services/clients/public_auth_client.js
+++ b/app/services/clients/public_auth_client.js
@@ -162,7 +162,8 @@ module.exports = {
    *  accountId: accountId,
    *  correlationId: correlationId,
    *  payload: {
-   *    token_link: token_link,
+   *    <token_link>: token_link,
+   *    <token_hash>: token_hash
    *  }
    * }
    *

--- a/test/unit/controller/payment-links/get_delete_controller_test.js
+++ b/test/unit/controller/payment-links/get_delete_controller_test.js
@@ -12,10 +12,25 @@ const paths = require('../../../../app/paths')
 const {randomUuid} = require('../../../../app/utils/random')
 
 const GATEWAY_ACCOUNT_ID = '929'
-const {PRODUCTS_URL, CONNECTOR_URL} = process.env
+const {PRODUCTS_URL, CONNECTOR_URL, PUBLIC_AUTH_URL} = process.env
+const PAYMENT = {
+  external_id: 'product-external-id-1',
+  gateway_account_id: 'product-gateway-account-id-1',
+  description: 'product-description-1',
+  name: 'payment-name-1',
+  price: '150',
+  pay_api_token: 'blatoken',
+  type: 'ADHOC',
+  return_url: 'http://return.url',
+  _links: [{
+    rel: 'pay',
+    href: 'http://pay.url',
+    method: 'GET'
+  }]
+}
 
 describe('Manage payment links - delete controller', () => {
-  describe('when the payment link is successfully deleted', () => {
+  describe('when the payment link and api token are successfully deleted', () => {
     let response, session
     before(done => {
       const productExternalId = randomUuid()
@@ -26,6 +41,10 @@ describe('Manage payment links - delete controller', () => {
       nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
         payment_provider: 'sandbox'
       })
+      nock(PUBLIC_AUTH_URL).delete(`/${GATEWAY_ACCOUNT_ID}`).reply(200, {
+        revoked: '07/09/2018'
+      })
+      nock(PRODUCTS_URL).get(`/v1/api/gateway-account/${GATEWAY_ACCOUNT_ID}/products/${productExternalId}`).reply(200, PAYMENT)
       nock(PRODUCTS_URL).delete(`/v1/api/gateway-account/${GATEWAY_ACCOUNT_ID}/products/${productExternalId}`).reply(204)
       session = getMockSession(user)
       supertest(createAppWithSession(getApp(), session))
@@ -54,7 +73,7 @@ describe('Manage payment links - delete controller', () => {
     })
   })
 
-  describe('when deleting the payment link fails', () => {
+  describe('when deleting the payment link fails but deleting token succeeds', () => {
     let response, session
     before(done => {
       const productExternalId = randomUuid()
@@ -65,8 +84,96 @@ describe('Manage payment links - delete controller', () => {
       nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
         payment_provider: 'sandbox'
       })
+      nock(PUBLIC_AUTH_URL).delete(`/${GATEWAY_ACCOUNT_ID}`).reply(200, {
+        revoked: '07/09/2018'
+      })
+      nock(PRODUCTS_URL).get(`/v1/api/gateway-account/${GATEWAY_ACCOUNT_ID}/products/${productExternalId}`).reply(200, PAYMENT)
       nock(PRODUCTS_URL).delete(`/v1/api/gateway-account/${GATEWAY_ACCOUNT_ID}/products/${productExternalId}`)
         .replyWithError('Ruhroh! Something terrible has happened Shaggy!')
+      session = getMockSession(user)
+      supertest(createAppWithSession(getApp(), session))
+        .get(paths.paymentLinks.delete.replace(':productExternalId', productExternalId))
+        .end((err, res) => {
+          response = res
+          done(err)
+        })
+    })
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should redirect with code 302', () => {
+      expect(response.statusCode).to.equal(302)
+    })
+
+    it('should redirect to the manage page', () => {
+      expect(response.header).to.have.property('location').to.equal(paths.paymentLinks.manage)
+    })
+
+    it('should add a relevant error message to the session \'flash\'', () => {
+      expect(session.flash).to.have.property('genericError')
+      expect(session.flash.genericError.length).to.equal(1)
+      expect(session.flash.genericError[0]).to.equal('<h2>There were errors</h2><p>Unable to delete the payment link</p>')
+    })
+  })
+
+  describe('when deleting the payment link succeeds but deleting token fails', () => {
+    let response, session
+    before(done => {
+      const productExternalId = randomUuid()
+      const user = getUser({
+        gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+        permissions: [{name: 'tokens:create'}]
+      })
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
+        payment_provider: 'sandbox'
+      })
+      nock(PRODUCTS_URL).get(`/v1/api/gateway-account/${GATEWAY_ACCOUNT_ID}/products/${productExternalId}`).reply(200, PAYMENT)
+      nock(PUBLIC_AUTH_URL).delete(`/${GATEWAY_ACCOUNT_ID}`).replyWithError('Ruhroh! Something terrible has happened Shaggy!')
+      nock(PRODUCTS_URL).delete(`/v1/api/gateway-account/${GATEWAY_ACCOUNT_ID}/products/${productExternalId}`).reply(204)
+      session = getMockSession(user)
+      supertest(createAppWithSession(getApp(), session))
+        .get(paths.paymentLinks.delete.replace(':productExternalId', productExternalId))
+        .end((err, res) => {
+          response = res
+          done(err)
+        })
+    })
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should redirect with code 302', () => {
+      expect(response.statusCode).to.equal(302)
+    })
+
+    it('should redirect to the manage page', () => {
+      expect(response.header).to.have.property('location').to.equal(paths.paymentLinks.manage)
+    })
+
+    it('should add a relevant error message to the session \'flash\'', () => {
+      expect(session.flash).to.have.property('genericError')
+      expect(session.flash.genericError.length).to.equal(1)
+      expect(session.flash.genericError[0]).to.equal('<h2>There were errors</h2><p>Unable to delete the payment link</p>')
+    })
+  })
+
+  describe('when failing to fetch information about a product', () => {
+    let response, session
+    before(done => {
+      const productExternalId = randomUuid()
+      const user = getUser({
+        gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+        permissions: [{name: 'tokens:create'}]
+      })
+      nock(PRODUCTS_URL).get(`/v1/api/gateway-account/${GATEWAY_ACCOUNT_ID}/products/${productExternalId}`).replyWithError('Ruhroh! Something terrible has happened Shaggy!')
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
+        payment_provider: 'sandbox'
+      })
+      nock(PUBLIC_AUTH_URL).delete(`/${GATEWAY_ACCOUNT_ID}`).reply(200, {
+        revoked: '07/09/2018'
+      })
+      nock(PRODUCTS_URL).delete(`/v1/api/gateway-account/${GATEWAY_ACCOUNT_ID}/products/${productExternalId}`).reply(204)
       session = getMockSession(user)
       supertest(createAppWithSession(getApp(), session))
         .get(paths.paymentLinks.delete.replace(':productExternalId', productExternalId))

--- a/test/unit/controller/payment-links/post_review_controller.test.js
+++ b/test/unit/controller/payment-links/post_review_controller.test.js
@@ -29,6 +29,7 @@ const VALID_USER = getUser({
 const VALID_CREATE_TOKEN_REQUEST = {
   account_id: GATEWAY_ACCOUNT_ID,
   created_by: VALID_USER.email,
+  type: 'PRODUCTS',
   description: `Token for “${PAYMENT_TITLE}” payment link`
 }
 const VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE = {


### PR DESCRIPTION
## WHAT
 - when creating a payment link, we now create a special token of type `PRODUCTS`. This will not be displayed in the API tokens section of selfservice so it won't be possible to manually revoke it
 - The only way to revoke this token is deleting the payment link

