### PR TITLE
PP-4192 dashboard using GOV.UK Frontend

### DIFF
--- a/app/assets/sass/application-new.scss
+++ b/app/assets/sass/application-new.scss
@@ -6,3 +6,6 @@
 @import "components/navigation";
 @import "components/environment-tag";
 @import "components/feedback-banner";
+@import "components/dashboard-activity";
+@import "components/flex-grid";
+@import "components/links-box";

--- a/app/assets/sass/application-new.scss
+++ b/app/assets/sass/application-new.scss
@@ -1,5 +1,8 @@
 @import "govuk-frontend/all";
 
 @import "components/cookie-message";
-@import "components/navigation";
+@import "components/header";
 @import "components/phase-tag";
+@import "components/navigation";
+@import "components/environment-tag";
+@import "components/feedback-banner";

--- a/app/assets/sass/components/dashboard-activity.scss
+++ b/app/assets/sass/components/dashboard-activity.scss
@@ -1,0 +1,83 @@
+.dashboard-total {
+  &-group {
+    margin-bottom: govuk-spacing(6);
+
+    &__title {
+      @extend .govuk-heading-s;
+      margin: govuk-spacing(6) 0 govuk-spacing(1);
+    }
+
+    &__link {
+      text-decoration: none;
+
+      &:link, &:visited {
+        color: $govuk-text-colour;
+      }
+
+      &:hover {
+        .dashboard-total-group__values {
+          background-color: $govuk-border-colour;
+        }
+      }
+
+      &:focus {
+        .dashboard-total-group__values {
+          background-color: $govuk-focus-colour;
+        }
+      }
+    }
+
+    &__values {
+      display: flex;
+      position: relative;
+      margin: 0;
+      padding: govuk-spacing(3);
+      padding-left: govuk-spacing(5);
+      border: 1px solid $govuk-border-colour;
+      border-left: 0;
+      background-color: govuk-colour("grey-4");
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: baseline;
+
+      &::before {
+        content: "";
+        position: absolute;
+        top: -1px;
+        bottom: -1px;
+        left: 0;
+        width: .625rem;
+        background-color: govuk-colour("black");
+      }
+
+      &--red::before {
+        background-color: govuk-colour("red");
+      }
+
+      &--blue::before {
+        background-color: govuk-colour("blue");
+      }
+    }
+
+    &__count {
+      @include govuk-font($size: 24);
+      float: left;
+      margin-left: 0;
+    }
+
+    &__amount {
+      @include govuk-font($size: 24);
+      text-align: right;
+      flex: 1;
+      float: right;
+    }
+  }
+  &-explainer {
+    margin-top: govuk-spacing(2);
+    @include govuk-font($size: 16);
+  }
+}
+
+.nojs-update-button {
+  margin-left: govuk-spacing(3);
+}

--- a/app/assets/sass/components/environment-tag.scss
+++ b/app/assets/sass/components/environment-tag.scss
@@ -1,0 +1,16 @@
+.environment-tag {
+  @include govuk-font($size: 14, $weight: bold);
+  line-height: 1.25!important;
+  padding: 3px govuk-spacing(1) 1px;
+  margin: 0 0 0 govuk-spacing(6);
+  position: relative;
+  top: -2px;
+
+  &-sandbox {
+    background-color: govuk-colour("yellow");
+  }
+
+  &-live {
+    background-color: govuk-colour("blue");
+  }
+}

--- a/app/assets/sass/components/feedback-banner.scss
+++ b/app/assets/sass/components/feedback-banner.scss
@@ -1,0 +1,28 @@
+.feeback-banner {
+  @include govuk-font($size: 16);
+  border-bottom: govuk-spacing(2) solid govuk-colour("blue");
+
+  &--inner {
+    margin: govuk-spacing(6) govuk-spacing(3) 0;
+    padding: govuk-spacing(2) govuk-spacing(3) 0;
+    background-color: govuk-colour("blue");
+
+    @include govuk-media-query(tablet) {
+      margin: govuk-spacing(6) govuk-spacing(6) 0;
+    }
+
+ @media (min-width: 960px + govuk-spacing(9)) {
+      max-width: 960px;
+      margin: govuk-spacing(6) auto 0;
+    }
+  }
+
+  p {
+    margin: 0;
+  }
+
+  a:link, a:visited {
+    color: govuk-colour("white");
+  }
+
+}

--- a/app/assets/sass/components/flex-grid.scss
+++ b/app/assets/sass/components/flex-grid.scss
@@ -1,0 +1,52 @@
+.flex-grid {
+  &--row {
+    @extend .govuk-grid-row;
+    display: flex;
+    flex: 0 1 auto;
+    flex-flow: row wrap;
+    flex-direction: row;
+    flex-wrap: wrap;
+
+    & + & {
+      margin-top: 30px;
+    }
+  }
+
+  &--heading-group {
+    margin: 0 govuk-spacing(3);
+    flex: 2 100%;
+
+    &.marked {
+      border-top: solid 1px $govuk-border-colour;
+    }
+
+    h2 {
+      margin-top: 1.25em;
+    }
+  }
+
+  &--column-half {
+    @extend .govuk-grid-column-one-half;
+    margin-bottom: govuk-spacing(6);
+
+    @include govuk-media-query(tablet) {
+      flex: 0 0 auto;
+    }
+  }
+
+  &--column-third {
+    @extend .govuk-grid-column-one-third;
+    margin-bottom: govuk-spacing(6);
+  }
+
+  &--column-half,
+  &--column-third {
+    &.marked {
+      margin-bottom: 0;
+
+      &:nth-child(even) {
+        border-right: solid 1px $govuk-border-colour;
+      }
+    }
+  }
+}

--- a/app/assets/sass/components/header.scss
+++ b/app/assets/sass/components/header.scss
@@ -1,0 +1,9 @@
+.govuk-header__container {
+  &--test {
+    border-color:  govuk-colour("blue");
+  }
+
+  &--test {
+    border-color:  govuk-colour("yellow");
+  }
+}

--- a/app/assets/sass/components/links-box.scss
+++ b/app/assets/sass/components/links-box.scss
@@ -1,0 +1,52 @@
+.links__box {
+  position: relative;
+
+  a {
+    text-decoration: none;
+    display: inline-block;
+  }
+
+  a:link {
+    h2 {
+      color: $govuk-link-colour;
+      text-decoration: underline;
+    }
+  }
+
+  a:visited {
+    h2 {
+      color: $govuk-link-visited-colour;
+    }
+  }
+
+  a:hover {
+    h2 {
+      color: $govuk-link-hover-colour;
+    }
+  }
+
+  a:focus {
+    background-color: $govuk-focus-colour;
+    outline: 3px solid $govuk-focus-colour;
+
+    h2 {
+      color: $govuk-text-colour;
+    }
+  }
+
+  @include govuk-media-query(tablet) {
+    &.border-bottom {
+      margin-bottom: 45px;
+
+      &:after {
+        content: "";
+        position: absolute;
+        bottom: - govuk-spacing(6);
+        height: 1px;
+        background-color:  govuk-colour("grey-3");
+        right: govuk-spacing(3);
+        left: govuk-spacing(3);
+      }
+    }
+  }
+}

--- a/app/assets/sass/components/navigation.scss
+++ b/app/assets/sass/components/navigation.scss
@@ -1,3 +1,72 @@
 .govuk-header__content {
   text-align: right;
 }
+
+.govuk-phase-banner {
+  padding: 0;
+
+  @include govuk-media-query(tablet) {
+    margin-top: - govuk-spacing(5);
+  }
+}
+
+.service-info--name {
+  margin: govuk-spacing(2) 0 govuk-spacing(1);
+}
+
+.service-info {
+  float: left;
+}
+
+.service-navigation {
+  margin: 0;
+  float: left;
+
+  @include govuk-media-query(tablet) {
+    margin: 0;
+    float: right;
+  }
+
+  &--list {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+
+  &--list-item {
+    @include govuk-font($size: 16);
+    margin-top: govuk-spacing(2);
+
+    @include govuk-media-query(tablet) {
+      display: inline-block;
+      margin: 0 0 0 govuk-spacing(6);
+      border-bottom: 5px solid transparent;
+      border-left: 0;
+    }
+
+    a:link,
+    a:visited {
+      display: inline-block;
+      color: $govuk-link-colour;
+      text-decoration: none;
+      padding: govuk-spacing(2) 0;
+    }
+
+    a:focus {
+      color: $govuk-text-colour;
+      background-color: $govuk-focus-colour;
+      outline: 3px solid $govuk-focus-colour;
+    }
+
+    &-active {
+      padding-left: govuk-spacing(1);
+      border-left: 5px solid $govuk-text-colour;
+
+      @include govuk-media-query(tablet) {
+        padding-left: 0;
+        border-left: 0;
+        border-color: $govuk-text-colour;
+      }
+    }
+  }
+}

--- a/app/utils/display_converter.js
+++ b/app/utils/display_converter.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const url = require('url')
 const getHeldPermissions = require('./get_held_permissions')
 const {serviceNavigationItems, adminNavigationItems} = require('./navBuilder')
 
@@ -82,7 +83,7 @@ module.exports = function (req, data, template) {
   const convertedData = _.clone(data)
   const user = req.user
   const account = req.account
-  const originalUrl = req.originalUrl
+  const originalUrl = req.originalUrl || ''
   const permissions = getPermissions(user, req.service)
   const paymentMethod = _.get(account, 'paymentMethod', 'card')
   convertedData.paymentMethod = paymentMethod
@@ -96,7 +97,7 @@ module.exports = function (req, data, template) {
   convertedData.isSandbox = _.get(convertedData, 'currentGatewayAccount.payment_provider') === 'sandbox'
   convertedData.currentService = _.get(req, 'service')
   if (permissions) {
-    convertedData.serviceNavigationItems = serviceNavigationItems(originalUrl, permissions, paymentMethod)
+    convertedData.serviceNavigationItems = serviceNavigationItems(url.parse(originalUrl).pathname, permissions, paymentMethod)
     convertedData.adminNavigationItems = adminNavigationItems(originalUrl, permissions, paymentMethod)
   }
   convertedData._features = {}

--- a/app/views/dashboard/_activity.njk
+++ b/app/views/dashboard/_activity.njk
@@ -1,67 +1,97 @@
-<div class="grid-row">
-  <form class="column-half" action="/" method="get">
-    <fieldset class="form-group">
-      <label for="activity-period" class="visually-hidden">Select a date range</label>
-      <select id="activity-period" name="period" class="form-control">
-        <option {% if period === 'today' %}selected{% endif %} value="today">Today</option>
-        <option {% if period === 'yesterday' %}selected{% endif %} value="yesterday">Yesterday</option>
-        <option {% if period === 'previous-seven-days' %}selected{% endif %} value="previous-seven-days">Previous 7 days</option>
-        <option {% if period === 'previous-thirty-days' %}selected{% endif %} value="previous-thirty-days">Previous 30 days</option>
-      </select>
-      <noscript>
-        <button class="button nojs-update-button" type="submit">Update</button>
-      </noscript>
-    </fieldset>
-  </form>
-</div>
+{% from "components/select/macro.njk" import govukSelect %}
+{% from "components/button/macro.njk" import govukButton %}
+{% from "components/details/macro.njk" import govukDetails %}
 
-<div class="grid-row" data-click-events data-click-category="Dashboard" data-click-action="Activity link clicked">
+<form class="govuk-grid-column-full" action="/" method="get">
+
+  {{ govukSelect({
+    id: "activity-period",
+    name: "period",
+    label: {
+      text: "Select a date range",
+      classes: "govuk-visually-hidden"
+    },
+    items: [
+      {
+        value: "today",
+        text: "Today",
+        selected: period === 'today'
+      },
+      {
+        value: "yesterday",
+        text: "Yesterday",
+        selected: period === 'yesterday'
+      },
+      {
+        value: "previous-seven-days",
+        text: "Previous 7 days",
+        selected: period === 'previous-seven-days'
+      },
+      {
+        value: "previous-thirty-days",
+        text: "Previous 30 days",
+        selected: period === 'previous-thirty-days'
+      }
+    ]
+  }) }}
+
+  <noscript>
+    {{ govukButton({
+      classes: 'nojs-update-button',
+      text: "Update"
+    }) }}
+  </noscript>
+</form>
+
+<div data-click-events data-click-category="Dashboard" data-click-action="Activity link clicked">
 {% if not activityError %}
-  <article class="dashboard-total-group column-third">
+  <article class="dashboard-total-group govuk-grid-column-one-third">
     <header class="dashboard-total-group__heading">
       <h2 class="dashboard-total-group__title">Successful payments</h2>
     </header>
     <a class="dashboard-total-group__link" href="{{routes.transactions.index}}?state={{successfulTransactionsState}}&amp;{{ transactionsPeriodString }}" title="View successful payment transactions for chosen time period">
       <dl class="dashboard-total-group__values dashboard-total-group__values--blue">
-        <dt class="visually-hidden">Count</dt>
+        <dt class="govuk-visually-hidden">Count</dt>
         <dd class="dashboard-total-group__count">{{ activity.successful_payments.count }}</dd>
-        <dt class="visually-hidden">Amount</dt>
+        <dt class="govuk-visually-hidden">Amount</dt>
         <dd class="dashboard-total-group__amount">{{ activity.successful_payments.total_in_pence | currency }}</dd>
       </dl>
     </a>
   </article>
-  <article class="dashboard-total-group column-third">
+  <article class="dashboard-total-group govuk-grid-column-one-third">
     <header class="dashboard-total-group__heading">
       <h2 class="dashboard-total-group__title">Successful refunds</h2>
     </header>
     <a class="dashboard-total-group__link" href="{{routes.transactions.index}}?state=refund-success&amp;{{ transactionsPeriodString }}" title="View refunded transactions for chosen time period">
       <dl class="dashboard-total-group__values dashboard-total-group__values--red">
-        <dt class="visually-hidden">Count</dt>
+        <dt class="govuk-visually-hidden">Count</dt>
         <dd class="dashboard-total-group__count">{{ activity.refunded_payments.count }}</dd>
-        <dt class="visually-hidden">Amount</dt>
+        <dt class="govuk-visually-hidden">Amount</dt>
         <dd class="dashboard-total-group__amount">{{ activity.refunded_payments.total_in_pence | currency }}</dd>
       </dl>
     </a>
   </article>
-  <article class="dashboard-total-group column-third">
+  <article class="dashboard-total-group govuk-grid-column-one-third">
     <header class="dashboard-total-group__heading">
       <h2 class="dashboard-total-group__title">Net income</h2>
     </header>
     <a class="dashboard-total-group__link" href="{{routes.transactions.index}}?state=payment-success&amp;state=refund-success&amp;{{ transactionsPeriodString }}" title="View successful payments and refunded transactions for chosen time period">
       <dl class="dashboard-total-group__values">
-        <dt class="visually-hidden">Amount</dt>
+        <dt class="govuk-visually-hidden">Amount</dt>
         <dd class="dashboard-total-group__amount">{{ activity.net_income.total_in_pence | currency }}</dd>
       </dl>
     </a>
-    <details class="dashboard-total-explainer">
-      <summary>How these numbers are calculated</summary>
-      <div class="panel panel-border-narrow">
+    <details class="govuk-details dashboard-total-explainer">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">How these numbers are calculated</span>
+        </summary>
+      <div class="govuk-details__text">
         <p>Net income was calculated by subtracting the successful refunds from the successful payments for {{ fromDateTime | datetime('full') }} to {{ toDateTime | datetime('full') }}</p>
       </div>
     </details>
   </article>
 {% else %}
-  <article class="dashboard-total-group column-half">
+  <article class="dashboard-total-group govuk-grid-column-one-half">
     <header class="dashboard-total-group__heading">
       <h2 class="dashboard-total-group__title">Error fetching totals</h2>
     </header>

--- a/app/views/dashboard/_links.njk
+++ b/app/views/dashboard/_links.njk
@@ -1,47 +1,47 @@
-<div class="flex-grid" data-click-events data-click-category="Dashboard" data-click-action="First steps link clicked">
+<div class="govuk-grid-column-full flex-grid" data-click-events data-click-category="Dashboard" data-click-action="First steps link clicked">
   <div class="flex-grid--row">
     {% if isSandbox %}
     <article class="flex-grid--column-half links__box border-bottom">
       <a href="{{routes.prototyping.demoPayment.index}}">
-        <h2 class="heading-small">Make a demo payment</h2>
-        <p>Try the payment experience as a user. Then view the completed payment as an administrator on GOV.UK&nbsp;Pay.</p>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Make a demo payment</h2>
+        <p class="govuk-body govuk-!-margin-bottom-0">Try the payment experience as a user. Then view the completed payment as an administrator on GOV.UK&nbsp;Pay.</p>
       </a>
     </article>
 
     <article class="flex-grid--column-half links__box border-bottom">
       <a href="{{routes.prototyping.demoService.index}}">
-        <h2 class="heading-small">Test with your users</h2>
-        <p>Create a reusable link to integrate your service prototype with GOV.UK&nbsp;Pay and test with users.</p>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Test with your users</h2>
+        <p class="govuk-body govuk-!-margin-bottom-0">Create a reusable link to integrate your service prototype with GOV.UK&nbsp;Pay and test with users.</p>
       </a>
     </article>
     {% elif paymentMethod === 'card'%}
     <article class="flex-grid--column-{% if isTestGateway %}third{% else %}half{% endif %} links__box">
       {% if permissions.tokens_create %}
       <a href="{{routes.paymentLinks.start}}">
-        <h2 class="heading-small">Create and manage payment links</h2>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Create and manage payment links</h2>
       {% else %}
       <a href="{{routes.paymentLinks.manage}}">
-        <h2 class="heading-small">View payment links</h2>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">View payment links</h2>
       {% endif %}
-        <p>A payment link lets you take card payments online, even if you don't have a digital&nbsp;service.</p>
+        <p class="govuk-body govuk-!-margin-bottom-0">A payment link lets you take card payments online, even if you don't have a digital&nbsp;service.</p>
       </a>
     </article>
     {% else %}
     <article class="flex-grid--column-{% if isTestGateway %}third{% else %}half{% endif %} links__box">
       <a href="https://docs.payments.service.gov.uk/#payment-flow-making-a-payment">
-        <h2 class="heading-small">See the payment flow</h2>
-        <p>Get an overview of payment pages in our documentation.</p>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">See the payment flow</h2>
+        <p class="govuk-body govuk-!-margin-bottom-0">Get an overview of payment pages in our documentation.</p>
       </a>
     </article>
     {% endif %}
     <article class="flex-grid--column-{% if isSandbox %}half{% else %}{% if isTestGateway %}third{% else %}half{% endif %}{% endif %} links__box">
       <a href="/service/{{ currentService.externalId }}">
       {% if permissions.users_service_create %}
-        <h2 class="heading-small">Manage team members</h2>
-        <p>Administrators can manage team members in My&nbsp;services.</p>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Manage team members</h2>
+        <p class="govuk-body govuk-!-margin-bottom-0">Administrators can manage team members in My&nbsp;services.</p>
       {% else %}
-        <h2 class="heading-small">Manage your service</h2>
-        <p>Add a new service and view team members in My&nbsp;services.</p>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Manage your service</h2>
+        <p class="govuk-body govuk-!-margin-bottom-0">Add a new service and view team members in My&nbsp;services.</p>
       {% endif %}
       </a>
     </article>
@@ -49,8 +49,8 @@
     {% if isTestGateway %}
     <article class="flex-grid--column-{% if isSandbox %}half{% else %}third{% endif %} links__box">
       <a href="https://docs.payments.service.gov.uk/#switching-to-live">
-        <h2 class="heading-small">Next steps to go live</h2>
-        <p>Read our documentation to see how your service can go live with GOV.UK&nbsp;Pay.</p>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Next steps to go live</h2>
+        <p class="govuk-body govuk-!-margin-bottom-0">Read our documentation to see how your service can go live with GOV.UK&nbsp;Pay.</p>
       </a>
     </article>
     {% endif %}

--- a/app/views/dashboard/index.njk
+++ b/app/views/dashboard/index.njk
@@ -1,16 +1,16 @@
-{% extends "../layout.njk" %}
+{% extends "../layout-new.njk" %}
 
-{% block page_title %}
+{% block pageTitle %}
 Dashboard - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
 {% block mainContent %}
-<div class="column-full">
-  <h1 class="page-title first-steps__title">Dashboard</h1>
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l govuk-!-margin-top-6 first-steps__title">Dashboard</h1>
+  </div>
 
   {% if paymentMethod === 'card' %}
     {% include "./_activity.njk" %}
   {% endif %}
   {% include "./_links.njk" %}
-</div>
 {% endblock %}

--- a/app/views/includes/header.njk
+++ b/app/views/includes/header.njk
@@ -1,5 +1,5 @@
 <header class="govuk-header " role="banner" data-module="header">
-  <div class="govuk-header__container govuk-width-container">
+  <div class="govuk-header__container govuk-width-container govuk-header__container--{{accountType}}">
 
     <div class="govuk-header__logo">
       <a href="/" class="govuk-header__link govuk-header__link--homepage">
@@ -28,26 +28,49 @@
     <button role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
     <nav>
       <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-            <li class="govuk-header__navigation-item">
-              <a class="govuk-header__link" href="https://www.payments.service.gov.uk/#main">
-                About
-              </a>
-            </li>
-            <li class="govuk-header__navigation-item">
-              <a class="govuk-header__link" href="https://docs.payments.service.gov.uk">
-                Documentation
-              </a>
-            </li>
-            <li class="govuk-header__navigation-item">
-              <a class="govuk-header__link" href="https://www.payments.service.gov.uk/support/">
-                Support
-              </a>
-            </li>
-            <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
-              <a class="govuk-header__link" href="/login" id="login">
-                Sign in
-              </a>
-            </li>
+      {% if loggedIn %}
+        <li class="govuk-header__navigation-item">
+          <a class="govuk-header__link {% if services %}govuk-header__navigation-item--active{% endif %}" href="{{ routes.serviceSwitcher.index }}" title="Switch service" id="my-services">
+            Switch service
+          </a>
+        </li>
+        <li class="govuk-header__navigation-item">
+          <a class="govuk-header__link" href="{{ routes.user.profile }}" title="My profile" id="my-profile">
+            My profile
+          </a>
+        </li>
+        <li class="govuk-header__navigation-item">
+          <a class="govuk-header__link" href="https://docs.payments.service.gov.uk">
+            Documentation
+          </a>
+        </li>
+        <li class="govuk-header__navigation-item">
+          <a class="govuk-header__link" href="/logout" title="Log me out" id="logout">
+            Sign out
+          </a>
+        </li>
+      {% else %}
+        <li class="govuk-header__navigation-item">
+          <a class="govuk-header__link" href="https://www.payments.service.gov.uk/#main">
+            About
+          </a>
+        </li>
+        <li class="govuk-header__navigation-item">
+          <a class="govuk-header__link" href="https://docs.payments.service.gov.uk">
+            Documentation
+          </a>
+        </li>
+        <li class="govuk-header__navigation-item">
+          <a class="govuk-header__link" href="https://www.payments.service.gov.uk/support/">
+            Support
+          </a>
+        </li>
+        <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
+          <a class="govuk-header__link" href="/login" id="login">
+            Sign in
+          </a>
+        </li>
+      {% endif %}
       </ul>
     </nav>
     </div>

--- a/app/views/includes/phase_banner.njk
+++ b/app/views/includes/phase_banner.njk
@@ -1,27 +1,57 @@
-{% if currentService.name %}
-<div class="phase-banner">
-  <div class="service-info">
-    <h4 class="service-info--name heading-small">{{currentService.name}}</h4>
-    {% if currentGatewayAccount %}
-    <p>
-      <strong class="phase-tag">{{currentGatewayAccount.full_type}} {% if currentGatewayAccount.full_type === 'live' %}account{% endif %}</strong>
-    </p>
+{% if newLayout %}
+  {% if currentService.name %}
+  <div class="govuk-phase-banner govuk-clearfix">
+    <div class="service-info">
+      <h4 class="service-info--name govuk-heading-s">
+        {{currentService.name}}
+        {% if currentGatewayAccount %}
+          <strong class="environment-tag environment-tag-{{currentGatewayAccount.full_type}}">{{currentGatewayAccount.full_type | capitalize}} {% if currentGatewayAccount.full_type === 'live' %}account{% endif %}</strong>
+        {% endif %}
+      </h4>
+    </div>
+    {% if not hideServiceNav %}
+    <nav role="navigation" class="service-navigation">
+      <ul class="service-navigation--list">
+        {% for item in serviceNavigationItems %}
+          {% if item.permissions %}
+            {% if item.current %}
+              <li class="service-navigation--list-item service-navigation--list-item-active"><a id="{{item.id}}" href="{{item.url}}">{{item.name}}</a></li>
+            {% else %}
+              <li class="service-navigation--list-item"><a id="{{item.id}}" href="{{item.url}}">{{item.name}}</a></li>
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </nav>
     {% endif %}
   </div>
-  {% if not hideServiceNav %}
-  <nav role="navigation" class="service-navigation">
-    <ul class="service-navigation--list">
-      {% for item in serviceNavigationItems %}
-        {% if item.permissions %}
-          {% if item.current %}
-            <li class="service-navigation--list-item service-navigation--list-item-active"><a id="{{item.id}}" href="{{item.url}}">{{item.name}}</a></li>
-          {% else %}
-            <li class="service-navigation--list-item"><a id="{{item.id}}" href="{{item.url}}">{{item.name}}</a></li>
-          {% endif %}
-        {% endif %}
-      {% endfor %}
-    </ul>
-  </nav>
   {% endif %}
-</div>
+{% else %}
+  {% if currentService.name %}
+  <div class="phase-banner">
+    <div class="service-info">
+      <h4 class="service-info--name heading-small">{{currentService.name}}</h4>
+      {% if currentGatewayAccount %}
+      <p>
+        <strong class="phase-tag">{{currentGatewayAccount.full_type}} {% if currentGatewayAccount.full_type === 'live' %}account{% endif %}</strong>
+      </p>
+      {% endif %}
+    </div>
+    {% if not hideServiceNav %}
+    <nav role="navigation" class="service-navigation">
+      <ul class="service-navigation--list">
+        {% for item in serviceNavigationItems %}
+          {% if item.permissions %}
+            {% if item.current %}
+              <li class="service-navigation--list-item service-navigation--list-item-active"><a id="{{item.id}}" href="{{item.url}}">{{item.name}}</a></li>
+            {% else %}
+              <li class="service-navigation--list-item"><a id="{{item.id}}" href="{{item.url}}">{{item.name}}</a></li>
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </nav>
+    {% endif %}
+  </div>
+  {% endif %}
 {% endif %}

--- a/app/views/layout-new.njk
+++ b/app/views/layout-new.njk
@@ -1,0 +1,46 @@
+{% extends "template.njk" %}
+
+{% set newLayout = true %}
+{% set loggedIn = true %}
+{% set accountType = currentGatewayAccount.type %}
+
+{% block pageTitle %}GOV.UK Pay{% endblock %}
+
+{% block head %}
+  {% include "includes/head.njk" %}
+  {% block pageSpecificStyle %}
+  {% endblock %}
+{% endblock %}
+
+{% block bodyStart %}
+  {% include "includes/cookie-message.njk" %}
+{% endblock %}
+
+{% block header %}
+  {% include "includes/header.njk" %}
+{% endblock %}
+
+{% block content %}
+  {% if not hideServiceHeader %}
+    {% include "includes/phase_banner.njk" %}
+  {% endif %}
+
+  <div class="govuk-grid-row">
+    {% block side_navigation %}{% endblock %}
+      {% include "includes/flash.njk" %}
+    {% block mainContent %}{% endblock %}
+  </div>
+{% endblock %}
+
+{% block footer %}
+  {% if not hideFeedbackBanner %}
+    {% include "includes/feedback-banner.njk" %}
+  {% endif %}
+  {% include "includes/footer.njk" %}
+{% endblock %}
+
+{% block bodyEnd %}
+  {% include "includes/scripts.njk" %}
+  {% block pageSpecificJS %}
+  {% endblock %}
+{% endblock %}


### PR DESCRIPTION
d692d14  - Migrate logged in template components to GOV.UK Frontend
- Before starting on body of the Dashboard page need to update the header, nav and feedback  components.
- Also tweaked the spacing in the navigation bar to make it more uniform,
whilst I was there I increased the targets for the links from 23px to
40px which makes them easier to click.

### Before
<img width="418" alt="before" src="https://user-images.githubusercontent.com/440503/45488194-815a8b80-b758-11e8-882e-ea595f9b5c84.png">

### After
<img width="419" alt="after" src="https://user-images.githubusercontent.com/440503/45488197-8a4b5d00-b758-11e8-993f-6102c97c3e13.png">

a8f46b0  - Migrate Dashboard components to GOV.UK Frontend
- Ported styles across using new variables and mixins

159200a  - noticed Dashboard wasn’t highlighted when query on index
- The function that matches the current URL to the navigation link shouldn’t worry about the query string so stripping it out.
- This means Dashboard is highlighted even if you filter by a different time period