### PR TITLE
PP-4151 Changes copy on csv download link on transactions page

### DIFF
--- a/app/views/transactions/index.njk
+++ b/app/views/transactions/index.njk
@@ -37,7 +37,7 @@ Transactions - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV
   {% if permissions.transactions_download_read %}
     {% if (hasResults) %}
       {% if showCsvDownload %}
-        <a href="{{downloadTransactionLink}}" id="download-transactions-link" class="push-bottom-sml"> Download a spreadsheet of these transactions </a>
+        <a href="{{downloadTransactionLink}}" id="download-transactions-link" class="push-bottom-sml"> Download all transaction details as a CSV file </a>
       {% else %}
         <p class="push-bottom-sml">You cannot download CSV over {{ csvMaxLimitFormatted }} transactions. Please refine your search</p>
       {% endif %}


### PR DESCRIPTION
## WHAT
Changes the text on the CSV download link/button to something more intuitive.

As discussed in https://trello.com/c/sAgmvvK5/68-should-we-change-csv-download-link-in-the-admin-tool

