### PR TITLE
PP-4194 - add/edit name using GOV.UK Frontend

### DIFF
--- a/app/browsered.js
+++ b/app/browsered.js
@@ -18,6 +18,9 @@ const accessibleAutocomplete = require('./browsered/autocomplete')
 // GOV.UK Frontend Toolkit dependencies
 require('../govuk_modules/govuk_frontend_toolkit/javascripts/govuk/show-hide-content')
 
+// GOV.UK Frontend js bundle
+const GOVUKFrontend = require('govuk-frontend')
+
 multiSelects.enableMultiSelects()
 fieldValidation.enableFieldValidation()
 dashboardActivity.init()
@@ -28,6 +31,7 @@ inputConfirm()
 niceURL()
 copyText()
 accessibleAutocomplete()
+GOVUKFrontend.initAll()
 
 $(document).ready($ => {
   const showHideContent = new window.GOVUK.ShowHideContent()

--- a/app/views/includes/validation-errors.njk
+++ b/app/views/includes/validation-errors.njk
@@ -1,5 +1,5 @@
 {% if newLayout %}
-  <div id="error-summary-{{form.id}}" class="govuk-error-summary" role="group" aria-labelledby="error-summary-heading-{{form.id}}" tabindex="-1">
+  <div id="error-summary-{{form.id}}" class="govuk-error-summary error-summary" role="group" aria-labelledby="error-summary-heading-{{form.id}}" tabindex="-1">
     <h2 class="govuk-error-summary__title" id="error-summary-heading-{{form.id}}">
       There was a problem with the details you gave for:
     </h2>

--- a/app/views/services/add_service.njk
+++ b/app/views/services/add_service.njk
@@ -1,70 +1,118 @@
-{% extends "../layout.njk" %}
+{% extends "../layout-new.njk" %}
+{% from "components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "components/input/macro.njk" import govukInput %}
+{% from "components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "components/button/macro.njk" import govukButton %}
 
-{% block page_title %}
-Add a new service - GOV.UK Pay
+{% block pageTitle %}
+  Add a new service - GOV.UK Pay
 {% endblock %}
 
 {% block mainContent %}
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
+
     {% if errors %}
-    <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
-      <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+      <div class="govuk-error-summary hidden" aria-labelledby="error-summary-heading-example-1" role="alert" tabindex="-1" data-module="error-summary">
+        <h2 class="govuk-error-summary__title" id="error-summary-heading-example-1">
           There was a problem with the details you gave for:
-      </h1>
-      <ul class="error-summary-list">
-        {% if errors.service_name %}
-        <li><a href="#service-name">Service name</a></li>
-        {% endif %}
-        {% if errors.service_name_cy %}
-          <li><a href="#service-name">Welsh Service name</a></li>
-        {% endif %}
-      </ul>
-    </div>
+        </h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            {% if errors.service_name %}
+            <li><a href="#service-name">Service name</a></li>
+            {% endif %}
+            {% if errors.service_name_cy %}
+              <li><a href="#service-name">Welsh Service name</a></li>
+            {% endif %}
+          </ul>
+        </div>
+      </div>
     {% endif %}
 
-    <h1 class="heading-large page-title">What service will you be taking payments for?</h1>
-    <p>
-      This is what your users will see when making a payment. You can change this later.
+    <h1 class="govuk-heading-l">What service will you be taking payments for?</h1>
+    <p class="govuk-body">
+      This is what your users will see when making a payment. You can change this&nbsp;later.
     </p>
 
     <form id="add-service-form" method="post" action="{{submit_link}}" data-validate="true">
-      <div class="form-group {% if errors.service_name %}error{% endif %}">
-        <label class="form-label" for="service-name">
-          Service name
-        </label>
-        {% if errors.service_name %}
-        <span class="error-message">
-          {{errors.service_name}}
-        </span>
-        {% endif %}
-        <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-        <input class="form-control" data-module="" id="service-name" name="service-name" type="text" value="{{current_name}}" data-validate="required isFieldGreaterThanMaxLengthChars" data-validate-max-length="50">
-      </div>
+      <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
-      <div class="cf">
-        <div class="form-group multiple-choice {% if errors.service_name_cy %}error{% endif %}" data-target="welsh-service-name">
-          <input id="checkbox-service-name-cy" name="welsh-service-name-bool" type="checkbox" value="true">
-          <label for="checkbox-service-name-cy">Add a Welsh (Cymraeg) service name</label>
-        </div>
-        <div class="form-group panel panel-border-narrow js-hidden" id="welsh-service-name">
-          <label class="form-label" for="service-name-cy">Welsh service name</label>
-          {% if errors.service_name_cy %}
-            <span class="error-message">{{errors.service_name_cy}}</span>
-          {% endif %}
-          <input class="form-control" data-module="" id="service-name-cy" name="service-name-cy" type="text" value="{{current_name_cy}}" data-validate="isFieldGreaterThanMaxLengthChars" data-validate-max-length="50" lang="cy">
-          <p class="form-hint">To turn on Welsh translations, follow the instructions in our&nbsp;documentation</p>
-        </div>
-      </div>
+      {% set enNameError = false %}
+      {% if errors.service_name %}
+        {% set enNameError = {
+          text: errors.service_name
+        } %}
+      {% endif %}
 
-      <div class="form-group call-to-action-group">
-          <input class="button" type="submit" value="Add Service">
-          <a id="service-name-cancel-link" href="{{my_services}}">
-              Cancel
-          </a>
-          <a id="service-nam-guidance" href="https://www.gov.uk/service-manual/design/naming-your-service">
-              Get guidance on choosing a name for your service
-          </a>
-      </div>
+      {{ govukInput({
+          label: {
+            text: "Service name"
+          },
+          errorMessage: enNameError,
+          id: "service-name",
+          name: "service-name",
+          value: current_name,
+          classes: "govuk-!-width-one-half",
+          type: "text",
+          attributes: {
+            "data-validate": "required isFieldGreaterThanMaxLengthChars",
+            "data-validate-max-length": "50"
+          }
+        })
+      }}
+
+      {% set cyNameError = false %}
+      {% if errors.service_name %}
+        {% set cyNameError = {
+          text: errors.service_name_cy
+        } %}
+      {% endif %}
+
+      {% set welshServiceNameHTML %}
+        {{ govukInput({
+          id: "service-name-cy",
+          name: "service-name-cy",
+          type: "text",
+          value: current_name_cy,
+          errorMessage: cyNameError,
+          classes: "govuk-!-width-two-thirds",
+          label: {
+            text: "Welsh service name"
+          },
+          attributes: {
+            "data-validate": "isFieldGreaterThanMaxLengthChars",
+            "data-validate-max-length": "50",
+            "lang": "cy"
+          }
+        }) }}
+        <p class="govuk-hint">To turn on Welsh translations, follow the instructions in our&nbsp;documentation</p>
+      {% endset -%}
+
+      {{ govukCheckboxes({
+        idPrefix: "checkbox-service-name-cy",
+        name: "welsh-service-name-bool",
+        items: [
+          {
+            value: "true",
+            text: "Add a Welsh (Cymraeg) service name",
+            conditional: {
+              html: welshServiceNameHTML
+            }
+          }
+        ]
+      }) }}
+
+      {{ govukButton({ text: "Add Service" })}}
+      <p class="govuk-body">
+        <a class="govuk-link govuk-link--no-visited-state" id="service-name-cancel-link" href="{{my_services}}">
+            Cancel
+        </a>
+      </p>
+      <p class="govuk-body">
+        <a class="govuk-link" id="service-nam-guidance" href="https://www.gov.uk/service-manual/design/naming-your-service">
+          Get guidance on choosing a name for your service
+        </a>
+      </p>
     </form>
   </div>
 {% endblock %}

--- a/app/views/services/edit_service_name.njk
+++ b/app/views/services/edit_service_name.njk
@@ -1,11 +1,15 @@
-{% extends "../layout.njk" %}
+{% extends "../layout-new.njk" %}
+{% from "components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "components/input/macro.njk" import govukInput %}
+{% from "components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "components/button/macro.njk" import govukButton %}
 
-{% block page_title %}
-Edit service name - GOV.UK Pay
+{% block pageTitle %}
+  Edit service name - GOV.UK Pay
 {% endblock %}
 
 {% block mainContent %}
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     {% if errors %}
     <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
         <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
@@ -19,51 +23,93 @@ Edit service name - GOV.UK Pay
     </div>
     {% endif %}
 
-    <h1 class="heading-large page-title">Edit service name</h1>
-    <p>
+    <h1 class="govuk-heading-l">Edit service name</h1>
+    <p class="govuk-body">
         Changing your service name affects both live and test environments, including user-facing payment pages and emails.
     </p>
     <form id="edit-service-name-form" method="post" action="{{submit_link}}" data-validate="true">
-      <div class="form-group {% if errors.service_name %}error{% endif %}">
-        <label class="form-label" for="service-name">Service name</label>
-        {% if errors.service_name %}
-          <span class="error-message">{{errors.service_name}}</span>
-        {% endif %}
-        <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-        <input class="form-control" data-module="" id="service-name" name="service-name" type="text" value="{{current_name.en}}" data-validate="required isFieldGreaterThanMaxLengthChars" data-validate-max-length="50">
-      </div>
+      <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
-      {% if current_name.cy %}
-      <div class="form-group {% if errors.service_name %}error{% endif %}">
-        <label class="form-label" for="service-name">Welsh (Cymraeg) service name</label>
-        {% if errors.service_name %}
-          <span class="error-message">{{errors.service_name}}</span>
-        {% endif %}
-        <input class="form-control" data-module="" id="service-name-cy" name="service-name-cy" type="text" value="{{current_name.cy}}" data-validate="isFieldGreaterThanMaxLengthChars" data-validate-max-length="50" lang="cy">
-        <p class="form-hint margin-top">To turn on Welsh translations, follow the instructions in our&nbsp;documentation</p>
-      </div>
-      {% else %}
-      <div class="cf">
-        <div class="form-group multiple-choice {% if errors.service_name_cy %}error{% endif %}" data-target="welsh-service-name">
-          <input id="checkbox-service-name-cy" name="welsh-service-name-bool" type="checkbox" value="true" {% if current_name.cy %}checked{% endif %}>
-          <label for="checkbox-service-name-cy">Add a Welsh (Cymraeg) service name</label>
-        </div>
-        <div class="form-group panel panel-border-narrow js-hidden" id="welsh-service-name">
-          <label class="form-label" for="service-name-cy">Welsh service name</label>
-          {% if errors.service_name_cy %}
-            <span class="error-message">{{errors.service_name_cy}}</span>
-          {% endif %}
-          <input class="form-control" data-module="" id="service-name-cy" name="service-name-cy" type="text" value="{{current_name.cy}}" data-validate="isFieldGreaterThanMaxLengthChars" data-validate-max-length="50" lang="cy">
-          <p class="form-hint">To turn on Welsh translations, follow the instructions in our&nbsp;documentation</p>
-        </div>
-      </div>
+      {% set enNameError = false %}
+      {% if errors.service_name %}
+        {% set enNameError = {
+          text: errors.service_name
+        } %}
       {% endif %}
 
-      <div class="form-group call-to-action-group">
-        <input class="button" type="submit" value="Save">
-        <a id="service-name-cancel-link" href="{{my_services}}">Cancel</a>
-        <a id="service-nam-guidance" href="https://www.gov.uk/service-manual/design/naming-your-service">Get guidance on choosing a name for your service</a>
-      </div>
+      {{ govukInput({
+          label: {
+            text: "Service name"
+          },
+          errorMessage: enNameError,
+          id: "service-name",
+          name: "service-name",
+          value: current_name.en,
+          classes: "govuk-!-width-one-half",
+          type: "text",
+          attributes: {
+            "data-validate": "required isFieldGreaterThanMaxLengthChars",
+            "data-validate-max-length": "50"
+          }
+        })
+      }}
+
+      {% set cyNameError = false %}
+      {% if errors.service_name %}
+        {% set cyNameError = {
+          text: errors.service_name_cy
+        } %}
+      {% endif %}
+
+      {% set welshServiceNameHTML %}
+        {{ govukInput({
+          id: "service-name-cy",
+          name: "service-name-cy",
+          type: "text",
+          value: current_name.cy,
+          errorMessage: cyNameError,
+          classes: "govuk-!-width-two-thirds",
+          label: {
+            text: "Welsh service name"
+          },
+          attributes: {
+            "data-validate": "isFieldGreaterThanMaxLengthChars",
+            "data-validate-max-length": "50",
+            "lang": "cy"
+          }
+        }) }}
+        <p class="govuk-hint">To turn on Welsh translations, follow the instructions in our&nbsp;documentation</p>
+      {% endset -%}
+
+      {% if current_name.cy %}
+        {{ welshServiceNameHTML | safe }}
+      {% else %}
+        {{ govukCheckboxes({
+          idPrefix: "checkbox-service-name-cy",
+          name: "welsh-service-name-bool",
+          items: [
+            {
+              value: "true",
+              text: "Add a Welsh (Cymraeg) service name",
+              conditional: {
+                html: welshServiceNameHTML
+              }
+            }
+          ]
+        }) }}
+      {% endif %}
+
+      {{ govukButton({ text: "Add Service" })}}
+      <p class="govuk-body">
+        <a class="govuk-link govuk-link--no-visited-state" id="service-name-cancel-link" href="{{my_services}}">
+            Cancel
+        </a>
+      </p>
+      <p class="govuk-body">
+        <a class="govuk-link" id="service-nam-guidance" href="https://www.gov.uk/service-manual/design/naming-your-service">
+          Get guidance on choosing a name for your service
+        </a>
+      </p>
     </form>
   </div>
 {% endblock %}


### PR DESCRIPTION
### 974bcec - New markup for add/edit service name pages

Migrated to GOV.UK Frontend new selectors and added in GOV.UK Frontend’s
JS bundle which gives us a bunch of nice polyfills and also makes the
conditionally revealing checkboxes work all nice.