### PR TITLE
Pp 4109 add delayed capture to transaction details

### DIFF
--- a/app/views/transaction_detail/_details.njk
+++ b/app/views/transaction_detail/_details.njk
@@ -53,7 +53,7 @@
   {% if delayed_capture %}
   <tr>
     <td>Delayed capture:</td>
-    <td id="delayed-capture-id">ON</td>
+    <td id="delayed-capture-id">On</td>
   </tr>
   {% endif %}
   </tbody>

--- a/app/views/transaction_detail/_details.njk
+++ b/app/views/transaction_detail/_details.njk
@@ -53,7 +53,7 @@
   {% if delayed_capture %}
   <tr>
     <td>Delayed capture:</td>
-    <td id="delayed-capture-id">On</td>
+    <td id="delayed-capture">On</td>
   </tr>
   {% endif %}
   </tbody>

--- a/app/views/transaction_detail/_details.njk
+++ b/app/views/transaction_detail/_details.njk
@@ -49,5 +49,12 @@
     <td>GOV.UK payment ID:</td>
     <td id="payment-id">{{charge_id}}</td>
   </tr>
+
+  {% if delayed_capture %}
+  <tr>
+    <td>Delayed capture:</td>
+    <td id="delayed-capture-id">ON</td>
+  </tr>
+  {% endif %}
   </tbody>
 </table>

--- a/test/cypress/integration/user/transaction_details_spec.js
+++ b/test/cypress/integration/user/transaction_details_spec.js
@@ -37,7 +37,7 @@ describe('Transactions details page', () => {
   })
 
   describe('page content', () => {
-    it('should display transaction details correctly', () => {
+    it('should display transaction details correctly when delayed capture is OFF', () => {
       cy.visit(`${transactionsUrl}/${aSmartpayCharge.charge_id}`)
 
       // Ensure page title is correct
@@ -84,6 +84,62 @@ describe('Transactions details page', () => {
       // Email
       cy.get('.transaction-details tbody').find('tr').eq(13).find('td').eq(1).should('have.text',
         aSmartpayCharge.email)
+      cy.get('#delayed-capture-id').should('not.exist')
+    })
+
+    it('should display transaction details correctly when delayed capture is ON', () => {
+      const chargeWithDelayedCapture = selfServiceDefaultUser.sections.transactions.data[1]
+      const chargeDetails = selfServiceDefaultUser.sections.transactions.details_data.filter(item => item.charge_id === chargeWithDelayedCapture.charge_id)[0]
+
+      cy.visit(`${transactionsUrl}/${chargeWithDelayedCapture.charge_id}`)
+
+      // Ensure page title is correct
+      cy.title().should('eq', `Transaction details ${chargeWithDelayedCapture.reference} - System Generated test - GOV.UK Pay`)
+
+      // Ensure page details match up
+
+      // Reference number
+      cy.get('.transaction-details tbody').find('tr').first().find('td').eq(1).should('have.text',
+        chargeWithDelayedCapture.reference)
+      // Status
+      cy.get('.transaction-details tbody').find('tr').eq(2).find('td').eq(1).should('have.text',
+        capitalise(chargeWithDelayedCapture.state.status))
+      // Amount
+      cy.get('.transaction-details tbody').find('tr').eq(3).find('td').eq(1).should('have.text',
+        convertAmounts(chargeWithDelayedCapture.amount))
+      // Refunded amount
+      cy.get('.transaction-details tbody').find('tr').eq(4).find('td').eq(1).should('have.text',
+        convertAmounts(chargeDetails.refund_summary.amount_submitted))
+      // Date created
+      cy.get('.transaction-details tbody').find('tr').eq(5).find('td').eq(1).should('contain',
+        formatDate(new Date(chargeDetails.charge_events[0].updated)))
+      // Provider
+      cy.get('.transaction-details tbody').find('tr').eq(6).find('td').eq(1).should('have.text',
+        capitalise(gatewayAccount.name))
+      // Provider ID
+      cy.get('.transaction-details tbody').find('tr').eq(7).find('td').eq(1).should('have.text',
+        chargeWithDelayedCapture.gateway_transaction_id)
+      // GOVUK Payment ID
+      cy.get('.transaction-details tbody').find('tr').eq(8).find('td').eq(1).should('have.text',
+        chargeWithDelayedCapture.charge_id)
+      // Delayed capture
+      cy.get('.transaction-details tbody').find('tr').eq(9).find('td').eq(1).should('have.text',
+        'ON')
+      // Payment method
+      cy.get('.transaction-details tbody').find('tr').eq(10).find('td').eq(1).should('have.text',
+        chargeWithDelayedCapture.card_details.card_brand)
+      // Name on card
+      cy.get('.transaction-details tbody').find('tr').eq(11).find('td').eq(1).should('have.text',
+        chargeWithDelayedCapture.card_details.cardholder_name)
+      // Card number
+      cy.get('.transaction-details tbody').find('tr').eq(12).find('td').eq(1).should('have.text',
+        `**** **** **** ${chargeWithDelayedCapture.card_details.last_digits_card_number}`)
+      // Card expiry date
+      cy.get('.transaction-details tbody').find('tr').eq(13).find('td').eq(1).should('have.text',
+        chargeWithDelayedCapture.card_details.expiry_date)
+      // Email
+      cy.get('.transaction-details tbody').find('tr').eq(14).find('td').eq(1).should('have.text',
+        chargeWithDelayedCapture.email)
     })
   })
 

--- a/test/cypress/integration/user/transaction_details_spec.js
+++ b/test/cypress/integration/user/transaction_details_spec.js
@@ -84,7 +84,7 @@ describe('Transactions details page', () => {
       // Email
       cy.get('.transaction-details tbody').find('tr').eq(13).find('td').eq(1).should('have.text',
         aSmartpayCharge.email)
-      cy.get('#delayed-capture-id').should('not.exist')
+      cy.get('#delayed-capture').should('not.exist')
     })
 
     it('should display transaction details correctly when delayed capture is ON', () => {

--- a/test/cypress/integration/user/transaction_details_spec.js
+++ b/test/cypress/integration/user/transaction_details_spec.js
@@ -124,7 +124,7 @@ describe('Transactions details page', () => {
         chargeWithDelayedCapture.charge_id)
       // Delayed capture
       cy.get('.transaction-details tbody').find('tr').eq(9).find('td').eq(1).should('have.text',
-        'ON')
+        'On')
       // Payment method
       cy.get('.transaction-details tbody').find('tr').eq(10).find('td').eq(1).should('have.text',
         chargeWithDelayedCapture.card_details.card_brand)

--- a/test/fixtures/config/self_service_user.json
+++ b/test/fixtures/config/self_service_user.json
@@ -489,6 +489,61 @@
                     "refund_reference": null
                   }
                 ]
+              },
+              {
+                "charge_id": "23456",
+                "refund_summary": {
+                  "status": "available",
+                  "amount_available": 500,
+                  "amount_submitted": 0
+                },
+                "settlement_summary": {
+                  "capture_submit_time": "2018-05-01T13:27:00.057Z",
+                  "captured_date": "2018-05-01T13:27:00.057Z"
+                },
+                "billing_address": {
+                  "line1": "address line 1",
+                  "line2": "address line 2",
+                  "postcode": "AB1A 1AB",
+                  "city": "GB",
+                  "county": "somecounty",
+                  "country": "GB"
+                },
+                "charge_events": [
+                  {
+                    "type": "PAYMENT",
+                    "submitted_by": null,
+                    "state": {
+                      "status": "created",
+                      "finished": false
+                    },
+                    "amount": 500,
+                    "updated": "2018-05-01T13:27:00.063Z",
+                    "refund_reference": null
+                  },
+                  {
+                    "type": "PAYMENT",
+                    "submitted_by": null,
+                    "state": {
+                      "status": "started",
+                      "finished": false
+                    },
+                    "amount": 500,
+                    "updated": "2018-05-01T13:27:00.974Z",
+                    "refund_reference": null
+                  },
+                  {
+                    "type": "PAYMENT",
+                    "submitted_by": null,
+                    "state": {
+                      "status": "succeeded",
+                      "finished": true
+                    },
+                    "amount": 500,
+                    "updated": "2018-05-01T13:27:18.126Z",
+                    "refund_reference": null
+                  }
+                ]
               }
             ],
             "data": [
@@ -554,7 +609,8 @@
                   "expiry_date": "08/23",
                   "card_brand": "Visa"
                 },
-                "transaction_type": "charge"
+                "transaction_type": "charge",
+                "delayed_capture": true
               },
               {
                 "amount": 300,

--- a/test/fixtures/transaction_fixtures.js
+++ b/test/fixtures/transaction_fixtures.js
@@ -100,7 +100,8 @@ module.exports = {
           country: 'GB'
         },
         card_brand: opts.summaryObject.card_brand || 'Visa'
-      }
+      },
+      delayed_capture: opts.summaryObject.delayed_capture || false
     }
 
     return {

--- a/test/ui/transaction_details_ui_tests.js
+++ b/test/ui/transaction_details_ui_tests.js
@@ -86,7 +86,7 @@ describe('The transaction details view', function () {
     $('#cardholder_name').text().should.equal('Data unavailable')
     $('#card_number').text().should.equal('**** **** **** ****')
     $('#card_expiry_date').text().should.equal('Data unavailable')
-    $('#delayed-capture-id').text().should.equal('On')
+    $('#delayed-capture').text().should.equal('On')
     //
     templateData.events.forEach((transactionData, ix) => {
       body.should.containSelector('table.transaction-events')
@@ -191,7 +191,7 @@ describe('The transaction details view', function () {
     $('#cardholder_name').text().should.equal(templateData.card_details.cardholder_name)
     $('#card_number').text().should.equal('**** **** **** ' + templateData.card_details.last_digits_card_number)
     $('#card_expiry_date').text().should.equal(templateData.card_details.expiry_date)
-    body.should.not.containSelector('#delayed-capture-id')
+    body.should.not.containSelector('#delayed-capture')
 
     templateData.events.forEach(function (transactionData, ix) {
       body.should.containSelector('table.transaction-events')

--- a/test/ui/transaction_details_ui_tests.js
+++ b/test/ui/transaction_details_ui_tests.js
@@ -86,7 +86,7 @@ describe('The transaction details view', function () {
     $('#cardholder_name').text().should.equal('Data unavailable')
     $('#card_number').text().should.equal('**** **** **** ****')
     $('#card_expiry_date').text().should.equal('Data unavailable')
-    $('#delayed-capture-id').text().should.equal('ON')
+    $('#delayed-capture-id').text().should.equal('On')
     //
     templateData.events.forEach((transactionData, ix) => {
       body.should.containSelector('table.transaction-events')

--- a/test/ui/transaction_details_ui_tests.js
+++ b/test/ui/transaction_details_ui_tests.js
@@ -60,6 +60,7 @@ describe('The transaction details view', function () {
           'updated_friendly': '24 January 2015 13:21:05'
         }
       ],
+      'delayed_capture': true,
       permissions: {
         'transactions_amount_read': true,
         'transactions_email_read': true,
@@ -85,6 +86,7 @@ describe('The transaction details view', function () {
     $('#cardholder_name').text().should.equal('Data unavailable')
     $('#card_number').text().should.equal('**** **** **** ****')
     $('#card_expiry_date').text().should.equal('Data unavailable')
+    $('#delayed-capture-id').text().should.equal('ON')
     //
     templateData.events.forEach((transactionData, ix) => {
       body.should.containSelector('table.transaction-events')
@@ -163,6 +165,7 @@ describe('The transaction details view', function () {
           'updated_friendly': '24 January 2015 13:21:05'
         }
       ],
+      'delayed_capture': false,
       permissions: {
         'transactions_amount_read': true,
         'transactions_email_read': true,
@@ -188,6 +191,7 @@ describe('The transaction details view', function () {
     $('#cardholder_name').text().should.equal(templateData.card_details.cardholder_name)
     $('#card_number').text().should.equal('**** **** **** ' + templateData.card_details.last_digits_card_number)
     $('#card_expiry_date').text().should.equal(templateData.card_details.expiry_date)
+    body.should.not.containSelector('#delayed-capture-id')
 
     templateData.events.forEach(function (transactionData, ix) {
       body.should.containSelector('table.transaction-events')


### PR DESCRIPTION
### What

- Added a label that displays 'Delayed capture: ON' when the charge has
delayed capture enabled. Otherwise it doesn't show anything different
- Added test data for Pact interactions
- Added cypress test and unit test

with @danworth



