### PR TITLE
PP-4215 Remove flakey transaction filtering, end to end test, with browser/contract implementation

### DIFF
--- a/test/cypress/integration/user/transaction_search_spec.js
+++ b/test/cypress/integration/user/transaction_search_spec.js
@@ -93,5 +93,44 @@ describe('Transactions', () => {
       cy.get('#transactions-list tbody').find('tr').first().find('td').eq(1).should('have.text', convertAmounts(filteredTo.data[0].amount))
       cy.get('#transactions-list tbody').find('tr').eq(1).find('td').eq(1).should('have.text', convertAmounts(filteredTo.data[1].amount))
     })
+
+    // https://payments-platform.atlassian.net/browse/PP-4215
+    it('should have the right number of transactions when filtering by state = success, multiple card brands and a partial email', () => {
+
+      const filteredPartialEmail = selfServiceDefaultUser.sections.filteredTransactions.data.filter(fil => fil.filtering.kind === 'partialemail')[0]
+
+      cy.get('#card-brand').click()
+      filteredPartialEmail.filtering.card_brand.forEach(brand => {
+        cy.get(`#card-brand .multi-select-item[value=${brand}]`).click()
+      })
+      cy.get('#email').type(filteredPartialEmail.filtering.email)
+      cy.get('#filter').click()
+
+      // Ensure the right number of transactions is displayed
+      cy.get('#transactions-list tbody').find('tr').should('have.length', filteredPartialEmail.data.length)
+
+      // Ensure the values are displayed correctly
+      cy.get('#transactions-list tbody').find('tr').first().find('td').eq(1).should('have.text', convertAmounts(filteredPartialEmail.data[0].amount))
+    })
+
+    // https://payments-platform.atlassian.net/browse/PP-4215
+    it('should have the right number of transactions when filtering by multiple payment states, a start and end date and a partial reference', () => {
+      const filteredMultipleStates = selfServiceDefaultUser.sections.filteredTransactions.data.filter(fil => fil.filtering.kind === 'multiplestates-partialref-startenddate')[0]
+
+      cy.get('#state').click()
+      filteredMultipleStates.filtering.payment_states.forEach(state => {
+        cy.get(`#state .multi-select-item[value='${state}']`).click()
+      })
+      cy.get('#reference').type(filteredMultipleStates.filtering.reference)
+      cy.get('#fromDate').type(filteredMultipleStates.filtering.from_date_raw)
+      cy.get('#fromTime').type(filteredMultipleStates.filtering.from_time_raw)
+      cy.get('#toDate').type(filteredMultipleStates.filtering.to_date_raw)
+      cy.get('#toTime').type(filteredMultipleStates.filtering.to_time_raw)
+      cy.get('#filter').click()
+      // Ensure the right number of transactions is displayed
+      cy.get('#transactions-list tbody').find('tr').should('have.length', filteredMultipleStates.data.length)
+      // Ensure the values are displayed correctly
+      cy.get('#transactions-list tbody').find('tr').first().find('td').eq(1).should('have.text', convertAmounts(filteredMultipleStates.data[0].amount))
+    })
   })
 })

--- a/test/fixtures/config/self_service_user.json
+++ b/test/fixtures/config/self_service_user.json
@@ -569,7 +569,7 @@
                 ],
                 "charge_id": "12345",
                 "gateway_transaction_id": "4cddd970-cce9-4bf1-b087-f13db1e199bd",
-                "email": "gds-payments-team-smoke@digital.cabinet-office.gov.uk",
+                "email": "gds1-payments-team-smoke@digital.cabinet-office.gov.uk",
                 "created_date": "2018-05-01T13:27:00.057Z",
                 "card_details": {
                   "last_digits_card_number": "0002",
@@ -601,7 +601,7 @@
                 ],
                 "charge_id": "23456",
                 "gateway_transaction_id": "c4fa72f2-8b1a-4b55-a0c4-407c6c71851a",
-                "email": "gds-payments-team-smoke@digital.cabinet-office.gov.uk",
+                "email": "gds2-payments-team-smoke@digital.cabinet-office.gov.uk",
                 "created_date": "2018-05-02T13:27:00.057Z",
                 "card_details": {
                   "last_digits_card_number": "0002",
@@ -634,7 +634,7 @@
                 ],
                 "charge_id": "34567",
                 "gateway_transaction_id": "ad7ecae2-4942-4d7c-882c-8c3342b8b6f8",
-                "email": "gds-payments-team-smoke@digital.cabinet-office.gov.uk",
+                "email": "gds3-payments-team-smoke@digital.cabinet-office.gov.uk",
                 "created_date": "2018-05-03T13:27:00.057Z",
                 "card_details": {
                   "last_digits_card_number": "0002",
@@ -666,7 +666,7 @@
                 ],
                 "charge_id": "45678",
                 "gateway_transaction_id": "0cec51bd-5759-40ed-b946-96b5a0945fed",
-                "email": "gds-payments-team-smoke@digital.cabinet-office.gov.uk",
+                "email": "gds4-payments-team-smoke@digital.cabinet-office.gov.uk",
                 "created_date": "2018-05-04T13:27:00.057Z",
                 "card_details": {
                   "last_digits_card_number": "0002",
@@ -722,7 +722,7 @@
                     ],
                     "charge_id": "34567",
                     "gateway_transaction_id": "ad7ecae2-4942-4d7c-882c-8c3342b8b6f8",
-                    "email": "gds-payments-team-smoke@digital.cabinet-office.gov.uk",
+                    "email": "gds3-payments-team-smoke@digital.cabinet-office.gov.uk",
                     "created_date": "2018-05-03T13:27:00.057Z",
                     "card_details": {
                       "last_digits_card_number": "0002",
@@ -754,7 +754,7 @@
                     ],
                     "charge_id": "45678",
                     "gateway_transaction_id": "0cec51bd-5759-40ed-b946-96b5a0945fed",
-                    "email": "gds-payments-team-smoke@digital.cabinet-office.gov.uk",
+                    "email": "gds4-payments-team-smoke@digital.cabinet-office.gov.uk",
                     "created_date": "2018-05-04T13:27:00.057Z",
                     "card_details": {
                       "last_digits_card_number": "0002",
@@ -807,7 +807,7 @@
                     ],
                     "charge_id": "12345",
                     "gateway_transaction_id": "4cddd970-cce9-4bf1-b087-f13db1e199bd",
-                    "email": "gds-payments-team-smoke@digital.cabinet-office.gov.uk",
+                    "email": "gds1-payments-team-smoke@digital.cabinet-office.gov.uk",
                     "created_date": "2018-05-01T13:27:00.057Z",
                     "card_details": {
                       "last_digits_card_number": "0002",
@@ -839,7 +839,7 @@
                     ],
                     "charge_id": "23456",
                     "gateway_transaction_id": "c4fa72f2-8b1a-4b55-a0c4-407c6c71851a",
-                    "email": "gds-payments-team-smoke@digital.cabinet-office.gov.uk",
+                    "email": "gds2-payments-team-smoke@digital.cabinet-office.gov.uk",
                     "created_date": "2018-05-02T13:27:00.057Z",
                     "card_details": {
                       "last_digits_card_number": "0002",
@@ -859,6 +859,117 @@
                   },
                   "first_page": {
                     "href": "https://myconnector.local/v2/api/accounts/666/charges?email=&to_date=2018-05-03T00%3A00Z&page=1&display_size=100"
+                  }
+                }
+              },
+              {
+                "filtering": {
+                  "kind": "partialemail",
+                  "email": "gds4",
+                  "card_brand": ["visa"]
+                },
+                "data": [
+                  {
+                    "amount": 400,
+                    "state": {
+                      "finished": true,
+                      "status": "error"
+                    },
+                    "description": "ref4",
+                    "reference": "ref488888",
+                    "links": [
+                      {
+                        "rel": "self",
+                        "method": "GET",
+                        "href": "https://myconnector.local/v1/api/accounts/666/charges/45678"
+                      },
+                      {
+                        "rel": "refunds",
+                        "method": "GET",
+                        "href": "https://myconnector.local/v1/api/accounts/666/charges/45678/refunds"
+                      }
+                    ],
+                    "charge_id": "45678",
+                    "gateway_transaction_id": "0cec51bd-5759-40ed-b946-96b5a0945fed",
+                    "email": "gds4-payments-team-smoke@digital.cabinet-office.gov.uk",
+                    "created_date": "2018-05-04T13:27:00.057Z",
+                    "card_details": {
+                      "last_digits_card_number": "0002",
+                      "cardholder_name": "Test User",
+                      "expiry_date": "08/23",
+                      "card_brand": "Visa"
+                    },
+                    "transaction_type": "charge"
+                  }
+                ],
+                "links": {
+                  "self": {
+                    "href": "https://myconnector.local/v2/api/accounts/666/charges?email=gds4&page=1&display_size=100"
+                  },
+                  "last_page": {
+                    "href": "https://myconnector.local/v2/api/accounts/666/charges?email=gds4&page=1&display_size=100"
+                  },
+                  "first_page": {
+                    "href": "https://myconnector.local/v2/api/accounts/666/charges?email=gds4&page=1&display_size=100"
+                  }
+                }
+              },
+              {
+                "filtering": {
+                  "kind": "multiplestates-partialref-startenddate",
+                  "reference": "ref38",
+                  "payment_states": ["Success", "In progress"],
+                  "payment_states_expanded": ["created", "started", "submitted", "success"],
+                  "from_date": "2018-05-03T00:00:00.000Z",
+                  "from_date_raw": "03/5/2018",
+                  "from_time_raw": "01:00:00",
+                  "to_date": "2018-05-04T00:00:01.000Z",
+                  "to_date_raw": "04/5/2018",
+                  "to_time_raw": "01:00:00"
+                },
+                "data": [
+                  {
+                    "amount": 300,
+                    "state": {
+                      "finished": true,
+                      "status": "success"
+                    },
+                    "description": "ref3",
+                    "reference": "ref388888",
+                    "links": [
+                      {
+                        "rel": "self",
+                        "method": "GET",
+                        "href": "https://myconnector.local/v1/api/accounts/666/charges/34567"
+                      },
+                      {
+                        "rel": "refunds",
+                        "method": "GET",
+                        "href": "https://myconnector.local/v1/api/accounts/666/charges/34567/refunds"
+                      }
+                    ],
+                    "charge_id": "34567",
+                    "gateway_transaction_id": "ad7ecae2-4942-4d7c-882c-8c3342b8b6f8",
+                    "email": "gds3-payments-team-smoke@digital.cabinet-office.gov.uk",
+                    "created_date": "2018-05-03T13:27:00.057Z",
+                    "card_details": {
+                      "last_digits_card_number": "0002",
+                      "cardholder_name": "Test User",
+                      "expiry_date": "08/23",
+                      "card_brand": "Visa"
+                    },
+                    "transaction_type": "charge"
+                  }
+                ],
+                "links": {
+                  "self": {
+                    "href": "https://myconnector.local/v2/api/accounts/666/charges?xxxxxxxxxxxxxxxxxxxxxx&page=1&display_size=100"
+                  },
+                  "last_page": {
+                    "href": "https://myconnector.local/v2/api/accounts/666/charges?xxxxxxxxxxxxxxxxxxxxxx&page=1&display_size=100"
+                  },
+                  "first_page": {
+                    "href": "https://myconnector.local/v2/api/accounts/666/charges?xxxxxxxxxxxxxxxxxxxxxx&page=1&display_size=100"
                   }
                 }
               }

--- a/test/fixtures/config/self_service_user.json
+++ b/test/fixtures/config/self_service_user.json
@@ -963,13 +963,13 @@
                 ],
                 "links": {
                   "self": {
-                    "href": "https://myconnector.local/v2/api/accounts/666/charges?xxxxxxxxxxxxxxxxxxxxxx&page=1&display_size=100"
+                    "href": "https://myconnector.local/v2/api/accounts/666/charges?reference=ref38&cardholder_name=&last_digits_card_number=&email=&card_brand=&from_date=2018-05-03T00%3A00%3A00.000Z&to_date=2018-05-04T00%3A00%3A01.000Z&page=1&display_size=100&payment_states=created%2Cstarted%2Csubmitted%2Csuccess"
                   },
                   "last_page": {
-                    "href": "https://myconnector.local/v2/api/accounts/666/charges?xxxxxxxxxxxxxxxxxxxxxx&page=1&display_size=100"
+                    "href": "https://myconnector.local/v2/api/accounts/666/charges?reference=ref38&cardholder_name=&last_digits_card_number=&email=&card_brand=&from_date=2018-05-03T00%3A00%3A00.000Z&to_date=2018-05-04T00%3A00%3A01.000Z&page=1&display_size=100&payment_states=created%2Cstarted%2Csubmitted%2Csuccess"
                   },
                   "first_page": {
-                    "href": "https://myconnector.local/v2/api/accounts/666/charges?xxxxxxxxxxxxxxxxxxxxxx&page=1&display_size=100"
+                    "href": "https://myconnector.local/v2/api/accounts/666/charges?reference=ref38&cardholder_name=&last_digits_card_number=&email=&card_brand=&from_date=2018-05-03T00%3A00%3A00.000Z&to_date=2018-05-04T00%3A00%3A01.000Z&page=1&display_size=100&payment_states=created%2Cstarted%2Csubmitted%2Csuccess"
                   }
                 }
               }

--- a/test/fixtures/transaction_fixtures.js
+++ b/test/fixtures/transaction_fixtures.js
@@ -26,12 +26,12 @@ module.exports = {
   },
   validTransactionsResponse: (opts = {}) => {
     let data = {
-      total: opts.transactions.data.length,
-      count: opts.transactions.data.length,
+      total: opts.transactions.length,
+      count: opts.transactions.length,
       page: 1,
       results:
-        [...opts.transactions.data],
-      _links: opts.transactions.links
+        [...opts.transactions],
+      _links: opts.links
     }
 
     return {

--- a/test/unit/clients/connector_client/connector_get_transactions_and_summary_test.js
+++ b/test/unit/clients/connector_client/connector_get_transactions_and_summary_test.js
@@ -27,7 +27,7 @@ chai.use(chaiAsPromised)
 
 describe('connector client', function () {
   const provider = Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'connector',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/connector_client/connector_get_transactions_and_summary_test.js
+++ b/test/unit/clients/connector_client/connector_get_transactions_and_summary_test.js
@@ -41,9 +41,9 @@ describe('connector client', function () {
 
   describe('get transaction summary', () => {
     const params = {
-      gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id, // '666'
-      fromDateTime: ssDefaultUser.sections.dashboard.transaction_summary.from_date, // 2018-05-14T00:00:00+01:00
-      toDateTime: ssDefaultUser.sections.dashboard.transaction_summary.to_date // 2018-05-15T00:00:00+01:00
+      gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id,
+      fromDateTime: ssDefaultUser.sections.dashboard.transaction_summary.from_date,
+      toDateTime: ssDefaultUser.sections.dashboard.transaction_summary.to_date
     }
     const validGetTransactionSummaryResponse = transactionSummaryFixtures.validTransactionSummaryResponse()
 
@@ -77,8 +77,9 @@ describe('connector client', function () {
 
   describe('get transactions', () => {
     const params = {
-      gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id, // '666'
-      transactions: ssDefaultUser.sections.transactions
+      gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id,
+      transactions: ssDefaultUser.sections.transactions.data,
+      links: ssDefaultUser.sections.transactions.links
     }
     const validGetTransactionsResponse = transactionSummaryFixtures.validTransactionsResponse(params)
 
@@ -126,10 +127,11 @@ describe('connector client', function () {
     // cover scenarios where the UI will compute a date/time
     const filtered = ssDefaultUser.sections.filteredTransactions.data.filter(fil => fil.filtering.kind === 'fromdate')[0]
     const params = {
-      gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id, // '666'
+      gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id,
       fromDate: filtered.filtering.from_date_raw,
       fromTime: filtered.filtering.from_time_raw,
-      transactions: filtered
+      transactions: filtered.data,
+      links: filtered.links
     }
     const validGetFilteredTransactionsResponse = transactionSummaryFixtures.validTransactionsResponse(params)
 
@@ -174,10 +176,11 @@ describe('connector client', function () {
   describe('get filtered transactions with a \'to_date\' defined', () => {
     const filtered = ssDefaultUser.sections.filteredTransactions.data.filter(fil => fil.filtering.kind === 'todate')[0]
     const params = {
-      gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id, // '666'
+      gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id,
       toDate: filtered.filtering.to_date_raw,
       toTime: filtered.filtering.to_time_raw,
-      transactions: filtered
+      transactions: filtered.data,
+      links: filtered.links
     }
     const validGetFilteredTransactionsResponse = transactionSummaryFixtures.validTransactionsResponse(params)
 
@@ -210,6 +213,109 @@ describe('connector client', function () {
     afterEach(() => provider.verify())
 
     it('should get \'to_date\' filtered transactions successfully', function (done) {
+      const getFilteredTransactions = validGetFilteredTransactionsResponse.getPlain()
+      connectorClient.searchTransactions(params,
+        (connectorData, connectorResponse) => {
+          expect(connectorResponse.body).to.deep.equal(getFilteredTransactions)
+          done()
+        })
+    })
+  })
+
+  describe('get filtered transactions with multiple values for \'card_brand\' and a value for \'email\' defined', () => {
+    const filtered = ssDefaultUser.sections.filteredTransactions.data.filter(fil => fil.filtering.kind === 'partialemail')[0]
+    const params = {
+      gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id,
+      email: filtered.filtering.email,
+      brand: filtered.filtering.card_brand,
+      transactions: filtered.data,
+      links: filtered.links
+    }
+    const validGetFilteredTransactionsResponse = transactionSummaryFixtures.validTransactionsResponse(params)
+
+    // Stop the transactions data being flowed through into anything else
+    delete params.transactions
+
+    before((done) => {
+      const pactified = validGetFilteredTransactionsResponse.getPactified()
+      provider.addInteraction(
+        new PactInteractionBuilder(`${TRANSACTIONS_RESOURCE}/${params.gatewayAccountId}/charges`)
+          .withUponReceiving('a valid transactions request filtered by partial email and card_brand of visa')
+          .withState(`Account ${params.gatewayAccountId} exists in the database and has 1 available transaction with a card brand of ${filtered.filtering.card_brand[0]}, and a partial email matching ${filtered.filtering.email}`)
+          .withMethod('GET')
+          .withQuery('reference', '')
+          .withQuery('cardholder_name', '')
+          .withQuery('last_digits_card_number', '')
+          .withQuery('email', filtered.filtering.email)
+          .withQuery('card_brand', filtered.filtering.card_brand[0])
+          .withQuery('from_date', '')
+          .withQuery('to_date', '')
+          .withQuery('page', '1')
+          .withQuery('display_size', '100')
+          .withStatusCode(200)
+          .withResponseBody(pactified)
+          .build()
+      ).then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should get partial email filtered transactions successfully', function (done) {
+      const getFilteredTransactions = validGetFilteredTransactionsResponse.getPlain()
+      connectorClient.searchTransactions(params,
+        (connectorData, connectorResponse) => {
+          expect(connectorResponse.body).to.deep.equal(getFilteredTransactions)
+          done()
+        })
+    })
+  })
+
+  describe('get filtered transactions with multiple values for \'payment_states\', a partial value for \'reference\' and a to/from date defined', () => {
+    const filtered = ssDefaultUser.sections.filteredTransactions.data.filter(fil => fil.filtering.kind === 'multiplestates-partialref-startenddate')[0]
+    const params = {
+      gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id,
+      reference: filtered.filtering.reference,
+      payment_states: filtered.filtering.payment_states_expanded,
+      fromDate: filtered.filtering.from_date_raw,
+      fromTime: filtered.filtering.from_time_raw,
+      toDate: filtered.filtering.to_date_raw,
+      toTime: filtered.filtering.to_time_raw,
+      transactions: filtered.data,
+      links: filtered.links
+    }
+    const validGetFilteredTransactionsResponse = transactionSummaryFixtures.validTransactionsResponse(params)
+
+    // Stop the transactions data being flowed through into anything else
+    delete params.transactions
+
+    before((done) => {
+      const pactified = validGetFilteredTransactionsResponse.getPactified()
+      provider.addInteraction(
+        new PactInteractionBuilder(`${TRANSACTIONS_RESOURCE}/${params.gatewayAccountId}/charges`)
+          .withUponReceiving('a valid transactions request filtered by payment states, a date range and a partial reference')
+          .withState(`Account ${params.gatewayAccountId} exists in the database and has 1 available transaction with a payment state of success, a reference matching the partial search ${filtered.filtering.reference} and falls between the date range ${filtered.filtering.from_date} amd ${filtered.filtering.to_date}`)
+          .withMethod('GET')
+          .withQuery('reference', filtered.filtering.reference)
+          .withQuery('cardholder_name', '')
+          .withQuery('last_digits_card_number', '')
+          .withQuery('email', '')
+          .withQuery('card_brand', '')
+          .withQuery('from_date', filtered.filtering.from_date)
+          .withQuery('to_date', filtered.filtering.to_date)
+          .withQuery('page', '1')
+          .withQuery('display_size', '100')
+          .withQuery('payment_states', filtered.filtering.payment_states_expanded.join(','))
+          .withStatusCode(200)
+          .withResponseBody(pactified)
+          .build()
+      ).then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should get partial email filtered transactions successfully', function (done) {
       const getFilteredTransactions = validGetFilteredTransactionsResponse.getPlain()
       connectorClient.searchTransactions(params,
         (connectorData, connectorResponse) => {


### PR DESCRIPTION
Replaces the flakey tests in end to end:

https://github.com/alphagov/pay-endtoend/blob/master/src/test/java/uk/gov/pay/endtoend/tests/selfservice/TransactionSearchIT.java

These do not play nicely with Selenium, and frequently fail to select desired elements on thew page, causing intermittent failures.

This replaces the functionality with Cypress.io browser tests, which rely on contract tests and interactions which stub the self-service -> connector, calls.