### PR TITLE
PP-4228 - Remember gateway account from last login

### DIFF
--- a/app/controllers/service_users_controller.js
+++ b/app/controllers/service_users_controller.js
@@ -122,7 +122,7 @@ module.exports = {
           removeTeamMemberLink: removeTeamMemberLink
         })
       } else {
-        errorResponse(req, res, 'Error displaying this user of the current service')
+        errorResponse(req, res, 'You do not have the rights to access this service.')
       }
     }
 

--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -13,6 +13,11 @@ module.exports = function (req, res, next) {
   } else if (gatewayAccountId) {
     req.service = _.get(req.user.serviceRoles.find(serviceRole => serviceRole.service.gatewayAccountIds.includes(gatewayAccountId)), 'service')
   }
+
+  if (!req.service && req.user.serviceRoles.length) {
+    req.service = _.get(req.user.serviceRoles[0], 'service')
+  }
+
   if (!req.service) {
     return renderErrorView(req, res, 'You do not have the rights to access this service.')
   }

--- a/app/routes.js
+++ b/app/routes.js
@@ -128,7 +128,7 @@ module.exports.bind = function (app) {
 
   // LOGIN
   app.get(user.logIn, xraySegmentCls, cookieMessage, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, redirectLoggedInUser, loginCtrl.loginGet)
-  app.post(user.logIn, xraySegmentCls, cookieMessage, validateAndRefreshCsrf, trimUsername, loginCtrl.loginUser, getAccount, loginCtrl.postLogin)
+  app.post(user.logIn, xraySegmentCls, cookieMessage, validateAndRefreshCsrf, trimUsername, loginCtrl.loginUser, hasServices, resolveService, getAccount, loginCtrl.postLogin)
   app.get(dashboard.index, xraySegmentCls, cookieMessage, enforceUserAuthenticated, validateAndRefreshCsrf, hasServices, resolveService, getAccount, dashboardCtrl.dashboardActivity)
   app.get(user.noAccess, xraySegmentCls, cookieMessage, loginCtrl.noAccess)
   app.get(user.logOut, xraySegmentCls, cookieMessage, loginCtrl.logout)


### PR DESCRIPTION
The `getCurrentGatewayAccountId()` function in `auth_service.js` looks up
the users Gateway account from the cookie. This cookie persists even
when logged out (for up to 30 days), so when you log back in you end up
on the same service.

But when you login it checks that you’re still a part of that service as
whilst you were gone you could have been removed.

This check was happening without the service middleware before it so it
couldnt find the service and so kicked you back to the first service in
the list.

So I added the missing middlewares and this made it work OK for users
that had the cookie.

For users with no cookies this meant the `currentGatewayAccountId` was set
to an empty object. Which the `resolve_service` middleware skipped over
and assumed meant you shouldn't be here and locked you out.

So I have added another if else statement so that when there is no
cookie it defaults back to the first account in the users `serviceRoles`
object.

If however they happen to have no serviceRoles or are somehow trying to
access one they’re not part of they get the no rights error.

Phew