### PR TITLE
PP-4130 display surcharge on transaction details

### DIFF
--- a/app/utils/transaction_view.js
+++ b/app/utils/transaction_view.js
@@ -79,6 +79,12 @@ module.exports = {
     chargeData.state_friendly = states.getDisplayNameForConnectorState(chargeData.state, chargeData.transaction_type)
 
     chargeData.amount = asGBP(chargeData.amount)
+    if (chargeData.total_amount) {
+      chargeData.total_amount = asGBP(chargeData.total_amount)
+    }
+    if (chargeData.corporate_card_surcharge) {
+      chargeData.corporate_card_surcharge = asGBP(chargeData.corporate_card_surcharge)
+    }
 
     if (chargeData.card_details) {
       if (chargeData.card_details.card_brand == null) chargeData.card_details.card_brand = DATA_UNAVAILABLE

--- a/app/views/transaction_detail/_details.njk
+++ b/app/views/transaction_detail/_details.njk
@@ -21,7 +21,13 @@
   {% if permissions.transactions_amount_read %}
   <tr>
     <td>Payment amount:</td>
-    <td id="amount">{{amount}}</td>
+    <td id="amount">
+      {%- if total_amount and corporate_card_surcharge -%}
+        {{total_amount}} (including a corporate card fee of {{corporate_card_surcharge}})
+      {%- else -%}
+        {{amount}}
+      {%- endif -%}
+    </td>
   </tr>
 
   <tr>

--- a/app/views/transaction_detail/_details.njk
+++ b/app/views/transaction_detail/_details.njk
@@ -23,7 +23,7 @@
     <td>Payment amount:</td>
     <td id="amount">
       {%- if total_amount and corporate_card_surcharge -%}
-        {{total_amount}} (including a corporate card fee of {{corporate_card_surcharge}})
+        {{total_amount}} (including a card fee of {{corporate_card_surcharge}})
       {%- else -%}
         {{amount}}
       {%- endif -%}

--- a/test/cypress/integration/user/transaction_details_spec.js
+++ b/test/cypress/integration/user/transaction_details_spec.js
@@ -154,7 +154,7 @@ describe('Transactions details page', () => {
 
       // Amount
       cy.get('#amount').should('have.text',
-        `${convertAmounts(aCorporateCardSurchargeCharge.total_amount)} (including a corporate card fee of ${convertAmounts(aCorporateCardSurchargeCharge.corporate_card_surcharge)})`)
+        `${convertAmounts(aCorporateCardSurchargeCharge.total_amount)} (including a card fee of ${convertAmounts(aCorporateCardSurchargeCharge.corporate_card_surcharge)})`)
     })
   })
 

--- a/test/cypress/integration/user/transaction_details_spec.js
+++ b/test/cypress/integration/user/transaction_details_spec.js
@@ -153,7 +153,7 @@ describe('Transactions details page', () => {
       // Ensure page details match up
 
       // Amount
-      cy.get('.transaction-details tbody').find('tr').eq(3).find('td').eq(1).should('have.text',
+      cy.get('#amount').should('have.text',
         `${convertAmounts(aCorporateCardSurchargeCharge.total_amount)} (including a corporate card fee of ${convertAmounts(aCorporateCardSurchargeCharge.corporate_card_surcharge)})`)
     })
   })

--- a/test/cypress/integration/user/transaction_details_spec.js
+++ b/test/cypress/integration/user/transaction_details_spec.js
@@ -31,6 +31,8 @@ describe('Transactions details page', () => {
 
   const aFailedRefundCharge = selfServiceDefaultUser.sections.transactions.data.filter(fil => fil.state.status === 'error')[0]
 
+  const aCorporateCardSurchargeCharge = selfServiceDefaultUser.sections.transactions.data.filter(fil => fil.corporate_card_surcharge !== undefined)[0]
+
   beforeEach(() => {
     cy.setCookie('session', Cypress.env('encryptedSessionCookie'))
     cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountCookie'))
@@ -140,6 +142,19 @@ describe('Transactions details page', () => {
       // Email
       cy.get('.transaction-details tbody').find('tr').eq(14).find('td').eq(1).should('have.text',
         chargeWithDelayedCapture.email)
+    })
+
+    it('should display corporate card surcharge in the amount field correctly when there is a corporate card surcharge', () => {
+      cy.visit(`${transactionsUrl}/${aCorporateCardSurchargeCharge.charge_id}`)
+
+      // Ensure page title is correct
+      cy.title().should('eq', `Transaction details ${aCorporateCardSurchargeCharge.reference} - System Generated test - GOV.UK Pay`)
+
+      // Ensure page details match up
+
+      // Amount
+      cy.get('.transaction-details tbody').find('tr').eq(3).find('td').eq(1).should('have.text',
+        `${convertAmounts(aCorporateCardSurchargeCharge.total_amount)} (including a corporate card fee of ${convertAmounts(aCorporateCardSurchargeCharge.corporate_card_surcharge)})`)
     })
   })
 

--- a/test/fixtures/config/self_service_user.json
+++ b/test/fixtures/config/self_service_user.json
@@ -544,6 +544,61 @@
                     "refund_reference": null
                   }
                 ]
+              },
+              {
+                "charge_id": "52345",
+                "refund_summary": {
+                  "status": "available",
+                  "amount_available": 550,
+                  "amount_submitted": 0
+                },
+                "settlement_summary": {
+                  "capture_submit_time": "2018-05-01T13:27:00.057Z",
+                  "captured_date": "2018-05-01T13:27:00.057Z"
+                },
+                "billing_address": {
+                  "line1": "address line 1",
+                  "line2": "address line 2",
+                  "postcode": "AB1A 1AB",
+                  "city": "GB",
+                  "county": "somecounty",
+                  "country": "GB"
+                },
+                "charge_events": [
+                  {
+                    "type": "PAYMENT",
+                    "submitted_by": null,
+                    "state": {
+                      "status": "created",
+                      "finished": false
+                    },
+                    "amount": 550,
+                    "updated": "2018-05-01T13:27:00.063Z",
+                    "refund_reference": null
+                  },
+                  {
+                    "type": "PAYMENT",
+                    "submitted_by": null,
+                    "state": {
+                      "status": "started",
+                      "finished": false
+                    },
+                    "amount": 550,
+                    "updated": "2018-05-01T13:27:00.974Z",
+                    "refund_reference": null
+                  },
+                  {
+                    "type": "PAYMENT",
+                    "submitted_by": null,
+                    "state": {
+                      "status": "succeeded",
+                      "finished": true
+                    },
+                    "amount": 550,
+                    "updated": "2018-05-01T13:27:18.126Z",
+                    "refund_reference": null
+                  }
+                ]
               }
             ],
             "data": [
@@ -670,6 +725,40 @@
                 "created_date": "2018-05-04T13:27:00.057Z",
                 "card_details": {
                   "last_digits_card_number": "0002",
+                  "cardholder_name": "Test User",
+                  "expiry_date": "08/23",
+                  "card_brand": "Visa"
+                },
+                "transaction_type": "charge"
+              },
+              {
+                "amount": 500,
+                "corporate_card_surcharge": 50,
+                "total_amount": 550,
+                "state": {
+                  "finished": true,
+                  "status": "success"
+                },
+                "description": "ref5",
+                "reference": "ref588888",
+                "links": [
+                  {
+                    "rel": "self",
+                    "method": "GET",
+                    "href": "https://myconnector.local/v1/api/accounts/666/charges/52345"
+                  },
+                  {
+                    "rel": "refunds",
+                    "method": "GET",
+                    "href": "https://myconnector.local/v1/api/accounts/666/charges/52345/refunds"
+                  }
+                ],
+                "charge_id": "52345",
+                "gateway_transaction_id": "17be4b24-d308-4917-a9fe-8bc24c327415",
+                "email": "gds5-payments-team-smoke@digital.cabinet-office.gov.uk",
+                "created_date": "2018-05-01T13:27:00.057Z",
+                "card_details": {
+                  "last_digits_card_number": "0007",
                   "cardholder_name": "Test User",
                   "expiry_date": "08/23",
                   "card_brand": "Visa"

--- a/test/fixtures/transaction_fixtures.js
+++ b/test/fixtures/transaction_fixtures.js
@@ -44,7 +44,7 @@ module.exports = {
     }
   },
   validTransactionDetailsResponse: (opts = {}) => {
-    let data = {
+    const data = {
       amount: opts.summaryObject.amount || 20000,
       state: opts.summaryObject.state || {
         finished: true,
@@ -102,6 +102,12 @@ module.exports = {
         card_brand: opts.summaryObject.card_brand || 'Visa'
       },
       delayed_capture: opts.summaryObject.delayed_capture || false
+    }
+    if (opts.summaryObject.corporate_card_surcharge) {
+      data.corporate_card_surcharge = opts.summaryObject.corporate_card_surcharge
+    }
+    if (opts.summaryObject.total_amount) {
+      data.total_amount = opts.summaryObject.total_amount
     }
 
     return {

--- a/test/unit/clients/connector_client/connector_get_transaction_details_test.js
+++ b/test/unit/clients/connector_client/connector_get_transaction_details_test.js
@@ -62,7 +62,7 @@ describe('connector client', function () {
       provider.addInteraction(
         new PactInteractionBuilder(`${CHARGES_RESOURCE}/${params.gatewayAccountId}/charges/${params.chargeId}`)
           .withUponReceiving('a valid transaction details request with delayed capture OFF')
-          .withState(`User ${params.gatewayAccountId} exists in the database and has 4 transactions available`)
+          .withState(`User ${params.gatewayAccountId} exists in the database and has 5 transactions available`)
           .withMethod('GET')
           .withStatusCode(200)
           .withResponseBody(pactified)
@@ -108,7 +108,7 @@ describe('connector client', function () {
       provider.addInteraction(
         new PactInteractionBuilder(`${CHARGES_RESOURCE}/${params.gatewayAccountId}/charges/${params.chargeId}`)
           .withUponReceiving('a valid transaction details request with delayed capture ON')
-          .withState(`User ${params.gatewayAccountId} exists in the database and has 4 transactions available`)
+          .withState(`User ${params.gatewayAccountId} exists in the database and has 5 transactions available`)
           .withMethod('GET')
           .withStatusCode(200)
           .withResponseBody(pactified)
@@ -154,7 +154,7 @@ describe('connector client', function () {
       provider.addInteraction(
         new PactInteractionBuilder(`${CHARGES_RESOURCE}/${params.gatewayAccountId}/charges/${params.chargeId}`)
           .withUponReceiving('a valid transaction details request with corporate card surcharge')
-          .withState(`User ${params.gatewayAccountId} exists in the database and has 4 transactions available`)
+          .withState(`User ${params.gatewayAccountId} exists in the database and has 5 transactions available`)
           .withMethod('GET')
           .withStatusCode(200)
           .withResponseBody(pactified)
@@ -201,7 +201,7 @@ describe('connector client', function () {
       provider.addInteraction(
         new PactInteractionBuilder(`${CHARGES_RESOURCE}/${params.gatewayAccountId}/charges/${params.chargeId}`)
           .withUponReceiving('a valid failed refund transaction details request')
-          .withState(`User ${params.gatewayAccountId} exists in the database and has 4 transactions available`)
+          .withState(`User ${params.gatewayAccountId} exists in the database and has 5 transactions available`)
           .withMethod('GET')
           .withStatusCode(200)
           .withResponseBody(pactified)

--- a/test/unit/clients/connector_client/connector_get_transaction_details_test.js
+++ b/test/unit/clients/connector_client/connector_get_transaction_details_test.js
@@ -129,6 +129,52 @@ describe('connector client', function () {
     })
   })
 
+  describe('get transaction details with corporate card surcharge', () => {
+    const gatewayAccount = ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0]
+    const transactions = ssDefaultUser.sections.transactions
+    const corporateCardSurchargeCharge = transactions.data.filter(item => item.charge_id === '52345')[0]
+    const chargeDetails = transactions.details_data.filter(x => x.charge_id === corporateCardSurchargeCharge.charge_id)[0]
+    const params = {
+      gatewayAccountId: gatewayAccount.id,
+      chargeId: corporateCardSurchargeCharge.charge_id
+    }
+    const validGetTransactionDetailsResponse = transactionDetailsFixtures.validTransactionDetailsResponse(
+      {
+        summaryObject: corporateCardSurchargeCharge,
+        payment_provider: gatewayAccount.name,
+        gateway_account_id: params.gatewayAccountId,
+        refund_summary: chargeDetails.refund_summary,
+        settlement_summary: chargeDetails.settlement_summary,
+        billing_address: chargeDetails.billing_address
+      }
+    )
+
+    before((done) => {
+      const pactified = validGetTransactionDetailsResponse.getPactified()
+      provider.addInteraction(
+        new PactInteractionBuilder(`${CHARGES_RESOURCE}/${params.gatewayAccountId}/charges/${params.chargeId}`)
+          .withUponReceiving('a valid transaction details request with corporate card surcharge')
+          .withState(`User ${params.gatewayAccountId} exists in the database and has 4 transactions available`)
+          .withMethod('GET')
+          .withStatusCode(200)
+          .withResponseBody(pactified)
+          .build()
+      ).then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should get transaction details successfully', function (done) {
+      const getTransactionDetails = validGetTransactionDetailsResponse.getPlain()
+      connectorClient.getCharge(params,
+        (connectorData, connectorResponse) => {
+          expect(connectorResponse.body).to.deep.equal(getTransactionDetails)
+          done()
+        })
+    })
+  })
+
   describe('get failed refund transaction details', () => {
     // TODO : Added to support functionality added using browser testing. Could be a candidate for not being published to the pact broker
 
@@ -243,6 +289,44 @@ describe('connector client', function () {
     afterEach(() => provider.verify())
 
     it('should get charge events successfully for delayed_capture on', function (done) {
+      const getChargeEvents = validGetTransactionDetailsResponse.getPlain()
+      connectorClient.getChargeEvents(params,
+        (connectorData, connectorResponse) => {
+          expect(connectorResponse.body).to.deep.equal(getChargeEvents)
+          done()
+        })
+    })
+  })
+
+  describe('get charge events for corporate card surcharge', () => {
+    const firstCharge = ssDefaultUser.sections.transactions.data.filter(item => item.charge_id === '52345')[0]
+    const chargeDetails = ssDefaultUser.sections.transactions.details_data.filter(x => x.charge_id === firstCharge.charge_id)[0]
+    const params = {
+      gatewayAccountId: ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id, // '666'
+      chargeId: firstCharge.charge_id
+    }
+    const validGetTransactionDetailsResponse = transactionDetailsFixtures.validChargeEventsResponse({
+      chargeId: params.chargeId,
+      events: chargeDetails.charge_events
+    })
+
+    before((done) => {
+      const pactified = validGetTransactionDetailsResponse.getPactified()
+      provider.addInteraction(
+        new PactInteractionBuilder(`${CHARGES_RESOURCE}/${params.gatewayAccountId}/charges/${params.chargeId}/events`)
+          .withUponReceiving('a valid charge events request')
+          .withState(`User ${params.gatewayAccountId} exists in the database, has an available charge with id ${firstCharge.charge_id} and has available charge events`)
+          .withMethod('GET')
+          .withStatusCode(200)
+          .withResponseBody(pactified)
+          .build()
+      ).then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should get charge events successfully for corporate card surcharge', function (done) {
       const getChargeEvents = validGetTransactionDetailsResponse.getPlain()
       connectorClient.getChargeEvents(params,
         (connectorData, connectorResponse) => {

--- a/test/unit/clients/connector_client/connector_get_transactions_and_summary_test.js
+++ b/test/unit/clients/connector_client/connector_get_transactions_and_summary_test.js
@@ -91,7 +91,7 @@ describe('connector client', function () {
       provider.addInteraction(
         new PactInteractionBuilder(`${TRANSACTIONS_RESOURCE}/${params.gatewayAccountId}/charges`)
           .withUponReceiving('a valid transactions request')
-          .withState(`User ${params.gatewayAccountId} exists in the database and has 4 transactions available`)
+          .withState(`User ${params.gatewayAccountId} exists in the database and has 5 transactions available`)
           .withMethod('GET')
           .withQuery('reference', '')
           .withQuery('cardholder_name', '')


### PR DESCRIPTION
## WHAT

Display total_amount and corporate_card_surcharge properties in transaction details page

## HOW 

- Pass `total_amount` and `corporate_card_surcharge` properties in transaction details page and display appropriate message.
- Add Cypress tests and modified mocked Pact json files and fixtures.
- Update Pact charges state description.

with @stephencdaly and @brid 