### PR TITLE
PP-4330 Use right url for switching to live docs link

### DIFF
--- a/app/views/dashboard/_links.njk
+++ b/app/views/dashboard/_links.njk
@@ -48,7 +48,7 @@
 
     {% if isTestGateway %}
     <article class="flex-grid--column-{% if isSandbox %}half{% else %}third{% endif %} links__box">
-      <a href="https://docs.payments.service.gov.uk/#switching-to-live">
+      <a href="https://docs.payments.service.gov.uk/switching_to_live/#switching-to-live">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Next steps to go live</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Read our documentation to see how your service can go live with GOV.UK&nbsp;Pay.</p>
       </a>


### PR DESCRIPTION
## WHAT
The url points to https://docs.payments.service.gov.uk/switching_to_live/#switching-to-live

