### PR TITLE
PP-4305 Handle Stripe gateway accounts

### DIFF
--- a/app/controllers/credentials_controller.js
+++ b/app/controllers/credentials_controller.js
@@ -41,7 +41,12 @@ function showSuccessView (viewMode, req, res) {
 
 function loadIndex (req, res, viewMode) {
   if (req.account) {
-    showSuccessView(viewMode, req, res)
+    if (req.account.payment_provider === 'stripe') {
+      res.status(404)
+      res.render('404')
+    } else {
+      showSuccessView(viewMode, req, res)
+    }
   } else {
     errorView(req, res)
   }

--- a/app/utils/display_converter.js
+++ b/app/utils/display_converter.js
@@ -95,10 +95,11 @@ module.exports = function (req, data, template) {
   convertedData.currentGatewayAccount = getAccount(account)
   convertedData.isTestGateway = _.get(convertedData, 'currentGatewayAccount.type') === 'test'
   convertedData.isSandbox = _.get(convertedData, 'currentGatewayAccount.payment_provider') === 'sandbox'
+  const paymentProvider = _.get(convertedData, 'currentGatewayAccount.payment_provider')
   convertedData.currentService = _.get(req, 'service')
   if (permissions) {
     convertedData.serviceNavigationItems = serviceNavigationItems(url.parse(originalUrl).pathname, permissions, paymentMethod)
-    convertedData.adminNavigationItems = adminNavigationItems(originalUrl, permissions, paymentMethod)
+    convertedData.adminNavigationItems = adminNavigationItems(originalUrl, permissions, paymentMethod, paymentProvider)
   }
   convertedData._features = {}
   if (req.user && req.user.features) {

--- a/app/utils/navBuilder.js
+++ b/app/utils/navBuilder.js
@@ -58,7 +58,7 @@ const serviceNavigationItems = (originalUrl, permissions, type) => {
   return navigationItems
 }
 
-const adminNavigationItems = (originalUrl, permissions, type) => {
+const adminNavigationItems = (originalUrl, permissions, type, paymentProvider) => {
   return [
     {
       id: 'navigation-menu-api-keys',
@@ -72,7 +72,7 @@ const adminNavigationItems = (originalUrl, permissions, type) => {
       name: 'Account credentials',
       url: paths.credentials.index,
       current: pathLookup(originalUrl, paths.credentials.index),
-      permissions: permissions.gateway_credentials_update && type === 'card'
+      permissions: permissions.gateway_credentials_update && type === 'card' && (paymentProvider !== 'stripe')
     },
     {
       id: 'navigation-menu-3d-secure',

--- a/test/ui/credentials_ui_tests.js
+++ b/test/ui/credentials_ui_tests.js
@@ -369,4 +369,25 @@ describe('The credentials view in edit mode', function () {
     body.should.not.containSelector('a#edit-credentials-link')
     body.should.not.containSelector('input#submitCredentials')
   })
+
+  it('should display error page for `stripe`', function () {
+    const templateData = {
+      currentGatewayAccount: {
+        'payment_provider': 'stripe',
+        'credentials': {}
+      },
+      'editMode': 'true',
+      permissions: {
+        gateway_credentials_update: true
+      }
+    }
+
+    const body = renderTemplate('404', templateData)
+
+    body.should.containSelector('h1:first-of-type').withExactText('Page not found')
+
+    body.should.not.containSelector('form#credentials-form')
+    body.should.not.containSelector('a#edit-credentials-link')
+    body.should.not.containSelector('input#submitCredentials')
+  })
 })

--- a/test/ui/navigation_ui_tests.js
+++ b/test/ui/navigation_ui_tests.js
@@ -75,7 +75,8 @@ describe('navigation menu', function () {
     body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('API keys')
   })
 
-  it('should render Accounts credentials navigation link when user have gateway credentials read permission', function () {
+  it('should render Accounts credentials navigation link when user have gateway credentials read permission' +
+    ' and payment provider is NOT `stripe` ', function () {
     const testPermissions = {
       tokens_update: false,
       gateway_credentials_update: true,
@@ -87,12 +88,33 @@ describe('navigation menu', function () {
     const templateData = {
       permissions: testPermissions,
       showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card')
+      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'worldpay')
     }
 
     const body = renderTemplate('api-keys/index', templateData)
 
     body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('Account credentials')
+  })
+
+  it('should not render Accounts credentials navigation link when user have gateway credentials read permission' +
+    ' and payment provider is `stripe`', function () {
+    const testPermissions = {
+      tokens_update: false,
+      gateway_credentials_update: true,
+      service_name_read: false,
+      payment_types_read: false,
+      toggle_3ds_read: true,
+      email_notification_template_read: false
+    }
+    const templateData = {
+      permissions: testPermissions,
+      showSettingsNav: true,
+      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'stripe')
+    }
+
+    const body = renderTemplate('api-keys/index', templateData)
+
+    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('3D Secure')
   })
 
   it('should render Card types navigation link when user have card Types read permission', function () {


### PR DESCRIPTION
## WHAT

For payment provider `Stripe`, users do not need to manage payment provider credentials as the accounts are procured centrally and possibly automated with Stripe Connect.

So account credentials menu and page are not relevant  if payment provider is 'Stripe'

Changes
- Account credentials - side menu not displayed if payment provider is Stripe
- Error page - 404 page is displayed when `[selfservice url]/credentials` link is accessed directly and when payment provider is Stripe



