### PR TITLE
PP-4336 transactions index migration to GOV.UK Frontend

### DIFF
--- a/app/assets/sass/application-new.scss
+++ b/app/assets/sass/application-new.scss
@@ -27,5 +27,7 @@
 @import "components/colour";
 @import "components/pay-checkbox";
 @import "components/currency-input";
+@import "components/transaction-list";
 @import "components/transaction-filter";
 @import "components/multi-select";
+@import "components/pagination";

--- a/app/assets/sass/application-new.scss
+++ b/app/assets/sass/application-new.scss
@@ -27,3 +27,5 @@
 @import "components/colour";
 @import "components/pay-checkbox";
 @import "components/currency-input";
+@import "components/transaction-filter";
+@import "components/multi-select";

--- a/app/assets/sass/components/button.scss
+++ b/app/assets/sass/components/button.scss
@@ -13,6 +13,7 @@
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
+    cursor: pointer;
 
     &:hover {
     color: $govuk-link-hover-colour;
@@ -45,5 +46,3 @@
     }
   }
 }
-
-

--- a/app/assets/sass/components/multi-select.scss
+++ b/app/assets/sass/components/multi-select.scss
@@ -6,15 +6,17 @@
 }
 
 .multi-select-title {
+  @include govuk-font($size: 19);
+
   border: 2px solid $govuk-text-colour;
-  padding: 8px;
+  padding: 6px 5px 5px;
   border-radius: 0;
   min-height: 34px;
   background-color: govuk-colour("white");
   text-align: left;
   background-image: url("/public/images/dd-arrow.svg");
   background-repeat: no-repeat;
-  background-position: right 13px top 4px;
+  background-position: right 10px top 6px;
   -webkit-appearance: none;
   appearance: none;
   max-width: 100%;
@@ -45,6 +47,7 @@
   z-index: 10;
   position: absolute;
   border: 2px solid $govuk-text-colour;
+  box-sizing: border-box;
   width: 100%;
   font-size: 16px;
 
@@ -67,7 +70,7 @@
     height: 100%;
     background-image: url("/public/images/dd-arrow.svg");
     background-repeat: no-repeat;
-    background-position: right 0px top 2px;
+    background-position: right -4px top 6px;
   }
 
   .govuk-checkboxes__item {

--- a/app/assets/sass/components/multi-select.scss
+++ b/app/assets/sass/components/multi-select.scss
@@ -1,0 +1,106 @@
+.multi-select {
+  @extend .govuk-clearfix;
+
+  position: relative;
+  width: 100%;
+}
+
+.multi-select-title {
+  border: 2px solid $govuk-text-colour;
+  padding: 8px;
+  border-radius: 0;
+  min-height: 34px;
+  background-color: govuk-colour("white");
+  text-align: left;
+  background-image: url("/public/images/dd-arrow.svg");
+  background-repeat: no-repeat;
+  background-position: right 13px top 4px;
+  -webkit-appearance: none;
+  appearance: none;
+  max-width: 100%;
+  font-size: 16px;
+
+  display: block;
+  cursor: pointer;
+
+  div {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 80%;
+    width: 15em;
+
+    @include govuk-media-query(tablet) {
+      width: 20em;
+    }
+  }
+}
+
+.multi-select-dropdown{
+  @extend .govuk-clearfix;
+
+  top: 0;
+  left: 0;
+  background-color: govuk-colour("white");
+  z-index: 10;
+  position: absolute;
+  border: 2px solid $govuk-text-colour;
+  width: 100%;
+  font-size: 16px;
+
+  .multi-select-dropdown-inner-container {
+    overflow-y: scroll;
+    overflow-x: hidden;
+  }
+
+  &:focus {
+    outline: 3px solid $govuk-focus-colour;
+    outline-offset: 0;
+  }
+
+  .multi-select-dropdown-close-area {
+    width: 15%;
+    top: 0;
+    right: 13px;
+    position: absolute;
+    z-index: 14;
+    height: 100%;
+    background-image: url("/public/images/dd-arrow.svg");
+    background-repeat: no-repeat;
+    background-position: right 0px top 2px;
+  }
+
+  .govuk-checkboxes__item {
+    width: 100%;
+    display: block;
+    text-align: left;
+    cursor: pointer;
+    margin: 0;
+
+    label {
+      padding: 10px 4px 4px;
+      width: 100%;
+    }
+
+    input {
+      z-index: 12;
+      width: 100%;
+    }
+  }
+  .govuk-checkboxes__item [type='checkbox'] + label::before,
+  .govuk-checkboxes__item [type='checkbox'] + label::after {
+    margin: auto;
+    height: 24px;
+    width: 24px;
+    top: 9px;
+    left: 8px;
+  }
+
+  .govuk-checkboxes__item [type=checkbox] + label::after {
+    top: 15px;
+    left: 12px;
+    height: 5px;
+    width: 13px;
+    border-width: 0 0 3px 3px;
+  }
+}

--- a/app/assets/sass/components/pagination.scss
+++ b/app/assets/sass/components/pagination.scss
@@ -1,0 +1,59 @@
+.pagination {
+  margin-bottom: govuk-spacing(3);
+
+  .paginationForm {
+    float: left;
+
+    button {
+      @include govuk-font($size: 14);
+
+      background: inherit;
+      border: 1px solid $govuk-border-colour;
+      border-right: none;
+      padding: govuk-spacing(1) govuk-spacing(2);
+      vertical-align: middle;
+      color: $govuk-link-colour;
+      cursor: pointer;
+
+      &:hover {
+        color: $govuk-text-colour;
+        background-color: $govuk-focus-colour;
+      }
+
+      &.active {
+        background-color: govuk-colour("blue");
+        border-color: govuk-colour("blue");
+        color: govuk-colour("white");
+
+        &:active {
+          color: govuk-colour("white");
+        }
+      }
+    }
+
+    &:last-child button {
+      border: 1px solid $govuk-border-colour;
+    }
+
+    /* Buttons for the next or previous set or either end of the whole lot */
+    &.first button:before {
+      content:"\00AB";
+      margin-right: 0.25em;
+    }
+
+    &.previous button:before {
+      content:"\2039";
+      margin-right: 0.25em;
+    }
+
+    &.next button:after {
+      content:"\203A";
+      margin-left: 0.25em;
+    }
+
+    &.last button:after {
+      content:"\00BB";
+      margin-left: 0.25em;
+    }
+  }
+}

--- a/app/assets/sass/components/transaction-filter.scss
+++ b/app/assets/sass/components/transaction-filter.scss
@@ -1,0 +1,67 @@
+.transactions-filter {
+  form {
+    margin: 0 govuk-spacing(3);
+    padding: govuk-spacing(3) 0;
+    background: govuk-colour("grey-3");
+  }
+
+  .govuk-hint {
+    color: $govuk-text-colour;
+  }
+}
+
+.datetime-filter {
+  float: left;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0 govuk-spacing(3);
+
+  @include govuk-media-query(tablet) {
+    width: 50%;
+  }
+
+  .govuk-form-group {
+    float: left;
+
+    width: 50%;
+    box-sizing: border-box;
+
+    &:first-of-type {
+      padding-right: govuk-spacing(1);
+    }
+
+    &:last-of-type {
+      padding-left: govuk-spacing(1);
+    }
+  }
+}
+
+.datetime-filter-to {
+  position: relative;
+}
+
+.datetime-separator {
+  @include govuk-font($size: 16)
+  margin-bottom: govuk-spacing(2);
+
+  @include govuk-media-query(tablet) {
+    @include govuk-font($size: 14)
+    position: absolute;
+    top: 50%;
+    left: -8px;
+    transform: translateY(-50%);
+  }
+}
+
+.inputs-less-margin .govuk-form-group {
+  margin-bottom: govuk-spacing(3);
+}
+
+.inputs-less-margin .govuk-button {
+  margin-bottom: govuk-spacing(0);
+}
+
+.clear-filter {
+  position: relative;
+  top: 10px;
+}

--- a/app/assets/sass/components/transaction-filter.scss
+++ b/app/assets/sass/components/transaction-filter.scss
@@ -58,7 +58,7 @@
 }
 
 .inputs-less-margin .govuk-button {
-  margin-bottom: govuk-spacing(0);
+  margin-bottom: govuk-spacing(1);
 }
 
 .clear-filter {

--- a/app/assets/sass/components/transaction-list.scss
+++ b/app/assets/sass/components/transaction-list.scss
@@ -1,0 +1,22 @@
+tr[data-follow-link]{
+  cursor: pointer;
+
+  &:hover {
+    background-color: govuk-colour("grey-4")
+  }
+}
+
+.display-size {
+  @include govuk-font($size: 19);
+  float: right;
+  margin-left: govuk-spacing(3);
+}
+
+.displaySizeForm:before {
+  content: '|';
+  margin: 0 govuk-spacing(1);
+}
+
+.capitalize {
+  text-transform: capitalize;
+}

--- a/app/browsered/multi-select.js
+++ b/app/browsered/multi-select.js
@@ -19,7 +19,7 @@ const OPEN_BUTTON_SELECTOR = '.multi-select-title'
 const CLOSE_BUTTON_SELECTOR = '.multi-select-dropdown-close-area'
 const DROPDOWN_SELECTOR = '.multi-select-dropdown'
 const SCROLL_CONTAINER_SELECTOR = '.multi-select-dropdown-inner-container'
-const ITEM_SELECTOR = '.multi-select-item'
+const ITEM_SELECTOR = '.govuk-checkboxes__input'
 const ALL_SELECTOR = `${ITEM_SELECTOR}[value=""]`
 const CURRENT_SELECTIONS = '.multi-select-current-selections'
 

--- a/app/controllers/transactions/transaction_list_controller.js
+++ b/app/controllers/transactions/transaction_list_controller.js
@@ -35,17 +35,22 @@ module.exports = (req, res) => {
           model.search_path = router.paths.transactions.index
           model.filtersDescription = describeFilters(filters.result)
           model.eventStates = states.allDisplayStateSelectorObjects()
-          model.eventStates.forEach(state => {
-            state.value.selected = filters.result.selectedStates && filters.result.selectedStates.includes(state.name)
+          .map(state => {
+            return {
+              value: state.key,
+              text: state.name,
+              selected: filters.result.selectedStates && filters.result.selectedStates.includes(state.name)
+            }
           })
+          model.eventStates.unshift({value: '', text: 'Any', selected: false})
 
           model.stateFiltersFriendly = model.eventStates
-            .filter(state => state.value.selected)
-            .map(state => state.value.text)
+            .filter(state => state.selected)
+            .map(state => state.text)
             .join(', ')
           if (_.has(filters.result, 'brand')) {
             model.cardBrands.forEach(brand => {
-              brand.value.selected = filters.result.brand.includes(brand.key)
+              brand.selected = filters.result.brand.includes(brand.value)
             })
           }
           response(req, res, 'transactions/index', model)

--- a/app/utils/filters.js
+++ b/app/utils/filters.js
@@ -47,6 +47,9 @@ function describeFilters (filters) {
 
   const brandStates = Array.isArray(filters.brand) ? filters.brand.map(brand => brand.replace('-', ' ')) : []
   if (brandStates.length === 0 && filters.brand) {
+    if (filters.brand === 'jcb') {
+      filters.brand = 'JCB'
+    }
     description += ` with <strong class="capitalize">‘${filters.brand.replace('-', ' ')}’</strong> card brand`
   } else if (brandStates.length > 1) {
     description += ` with <strong class="capitalize">‘${brandStates.join('</strong>, <strong class="capitalize">').replace(/,([^,]*)$/, ' or$1')}’</strong> card brands`

--- a/app/utils/transaction_view.js
+++ b/app/utils/transaction_view.js
@@ -33,14 +33,15 @@ module.exports = {
     connectorData.pageSizeLinks = getPageSizeLinks(connectorData)
 
     connectorData.cardBrands = lodash.uniqBy(allCards.card_types, 'brand')
-      .map((card) => {
-        let value = {}
-        value.text = card.label
-        if (card.brand === filtersResult.brand) {
-          value.selected = true
+      .map(card => {
+        return {
+          value: card.brand,
+          text: card.label,
+          selected: card.brand === filtersResult.brand
         }
-        return {'key': card.brand, 'value': value}
       })
+
+    connectorData.cardBrands.unshift({value: '', text: 'All brands', selected: false})
 
     connectorData.results.forEach(element => {
       element.state_friendly = states.getDisplayNameForConnectorState(element.state, element.transaction_type)

--- a/app/utils/transaction_view.js
+++ b/app/utils/transaction_view.js
@@ -36,7 +36,7 @@ module.exports = {
       .map(card => {
         return {
           value: card.brand,
-          text: card.label,
+          text: card.label === 'Jcb' ? card.label.toUpperCase() : card.label,
           selected: card.brand === filtersResult.brand
         }
       })

--- a/app/views/includes/multi-select.njk
+++ b/app/views/includes/multi-select.njk
@@ -1,18 +1,18 @@
 <div id="{{id}}" class="multi-select">
   <button type="button"
-    class="form-control large multi-select-title"
+    class="multi-select-title"
     id="option-select-title-{{name}}">
-    <div><span class="visually-hidden">Currently selected: </span><span class="multi-select-current-selections"></span></div>
+    <div><span class="govuk-visually-hidden">Currently selected: </span><span class="multi-select-current-selections"></span></div>
   </button>
   <div role="group" aria-labelledby="option-select-title-{{name}}"
      class="multi-select-dropdown"
      id="list-of-sectors-{{ name }}"
      style="visibility:hidden;">
-    <div class="multi-select-dropdown-inner-container">
+    <div class="multi-select-dropdown-inner-container govuk-checkboxes">
       {% for item in items %}
-      <div class="multiple-choice">
-        <input class="multi-select-item" name="{{name}}" value="{{ item.value }}" id="{{ item.id }}" type="checkbox" {% if item.checked %}checked{% endif %}>
-        <label for="{{ item.id }}" class="multi-select-label-{{ name }}">{{ item.text }}</label>
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input govuk-!-font-size-16" name="{{name}}" value="{{ item.value }}" id="{{ item.id }}" type="checkbox" {% if item.checked %}checked{% endif %}>
+        <label for="{{ item.id }}" class="govuk-label govuk-checkboxes__label govuk-!-font-size-16 multi-select-label-{{ name }}">{{ item.text }}</label>
       </div>
       {% endfor %}
     </div>

--- a/app/views/transactions/display_size.njk
+++ b/app/views/transactions/display_size.njk
@@ -1,21 +1,22 @@
   {% if hasPageSizeLinks %}
-
-  <div id="displaySize">
+  <div id="displaySize" class="display-size govuk-!-margin-top-3">
     <span>Results per page:</span>
     {% for pageSizeLink in pageSizeLinks %}
-    <form class="displaySizeForm {{pageSizeLink.type}}" method="get" action="{{pageSizeLink.search_path}}">
-      <div style="display:none">
-          <input class="state" name="state" type="text" value="{{pageSizeLink.filters.state}}"/>
-          <input class="reference" name="reference" type="text" value="{{pageSizeLink.filters.reference}}" />
-          <input class="fromDate" name="fromDate" type="text" value="{{pageSizeLink.filters.fromDate}}" />
-          <input class="toDate" name="toDate" type="text" value="{{pageSizeLink.filters.toDate}}"/>
-          <input class="page" name="page" type="text" value="1"/>
-          <input class="pageSize" name="pageSize" type="text" value="{{pageSizeLink.value}}"/>
-          <input class="fromTime" name="fromTime" type="text" value="{{pageSizeLink.filters.fromTime}}">
-          <input class="toTime" name="toTime" type="text" value="{{pageSizeLink.filters.toTime}}">
-        </div>
-        <input class="displaySize {% if pageSizeLink.active %}active{% endif %}" type="submit" value="{{pageSizeLink.name}}"/>
-    </form>
+    {% if pageSizeLink.active %}
+      {{pageSizeLink.name}}
+    {% else %}
+      <form class="displaySizeForm govuk-!-display-inline-block" method="get" action="{{pageSizeLink.search_path}}">
+        <input type="hidden" name="state" value="{{pageSizeLink.filters.state}}"/>
+        <input type="hidden" name="reference" value="{{pageSizeLink.filters.reference}}" />
+        <input type="hidden" name="fromDate" value="{{pageSizeLink.filters.fromDate}}" />
+        <input type="hidden" name="toDate" value="{{pageSizeLink.filters.toDate}}"/>
+        <input type="hidden" name="page" value="1"/>
+        <input type="hidden" name="pageSize" value="{{pageSizeLink.value}}"/>
+        <input type="hidden" name="fromTime" value="{{pageSizeLink.filters.fromTime}}">
+        <input type="hidden" name="toTime" value="{{pageSizeLink.filters.toTime}}">
+        <input class="govuk-button--as-link displaySize govuk-!-font-size-19" type="submit" value="{{pageSizeLink.name}}"/>
+      </form>
+    {% endif %}
     {% endfor %}
   </div>
   {% endif %}

--- a/app/views/transactions/filter.njk
+++ b/app/views/transactions/filter.njk
@@ -1,101 +1,207 @@
-<div class="grid-row transactions-filter">
-  <form class="form" method="get" action="{{search_path}}">
-    <fieldset>
-        <div class="column-quarter reference-number">
-          <label class="form-label form-label-small" for="reference">
-            <strong>Reference number</strong>
-            <span class="form-hint">Enter full or partial number</span>
-          </label>
-          <input class="form-control large" id="reference" name="reference" type="text" value="{{filters.reference}}" autofocus />
-        </div>
+{% from "components/input/macro.njk" import govukInput %}
+{% from "components/select/macro.njk" import govukSelect %}
+{% from "components/button/macro.njk" import govukButton %}
 
-        <div class="column-quarter email">
-          <label class="form-label form-label-small" for="email">
-            <strong>Email address</strong>
-            <span class="form-hint">Enter full or partial email</span>
-          </label>
-          <input class="form-control large" id="email" name="email" type="text" value="{{filters.email}}"/>
-        </div>
-
-        <div class="column-quarter">
-          <label class="form-label form-label-small" for="cardholderName">
-            <strong>Name on card</strong>
-            <span class="form-hint">Enter full or partial name</span>
-          </label>
-          <input class="form-control large" id="cardholderName" name="cardholderName" type="text" value="{{filters.cardholderName}}" autofocus />
-        </div>
-
-      <div class="column-quarter">
-        <label class="form-label form-label-small" for="lastDigitsCardNumber">
-          <strong>Last 4 card numbers</strong>
-          <span class="form-hint">Last 4 digits of associated card</span>
-        </label>
-        <input class="form-control large" id="cardholderName" name="lastDigitsCardNumber" type="text" value="{{filters.lastDigitsCardNumber}}" autofocus />
-      </div>
-
-        <div class="column-quarter">
-          <label class="form-label form-label-small" for="card-brand">
-            <strong>Card brand</strong>
-            <span class="form-hint">Select a brand</span>
-          </label>
-          <select class="form-control large" id="card-brand" name="brand" data-enhance-multiple>
-            <option value="">All brands</option>
-            {% for cardBrand in cardBrands %}
-              <option value="{{cardBrand.key}}" {% if cardBrand.value.selected %} selected {% endif %}>{{cardBrand.value.text}}</option>
-            {% endfor %}
-          </select>
-        </div>
-
-        <div class="column-quarter">
-          <label class="form-label form-label-small" for="state">
-            <strong>Payment status</strong>
-            <span class="form-hint">Select an option</span>
-          </label>
-          <select class="form-control large" id="state" name="state" data-enhance-multiple>
-            <option value="">Any</option>
-            {% for eventState in eventStates %}
-            <option value="{{eventState.key}}" {% if eventState.value.selected %} selected {% endif %}>{{eventState.value.text}}</option>
-            {% endfor %}
-          </select>
-        </div>
-
-      <fieldset class="column-half">
-        <legend class="form-label-small">
-          Date range
+<div class="transactions-filter govuk-grid-row">
+  <form class="govuk-clearfix" method="get" action="{{search_path}}">
+    <div class="govuk-grid-column-one-quarter inputs-less-margin">
+      {{
+        govukInput({
+          id: 'reference',
+          name: 'reference',
+          value: filters.reference,
+          label: {
+            text: 'Reference number',
+            classes: 'govuk-label--s govuk-!-font-size-16 govuk-!-margin-bottom-0'
+          },
+          hint: {
+            text: 'Enter full or partial number',
+            classes: 'govuk-!-font-size-14'
+          }
+        })
+      }}
+    </div>
+    <div class="govuk-grid-column-one-quarter inputs-less-margin">
+      {{
+        govukInput({
+          id: 'email',
+          name: 'email',
+          value: filters.email,
+          label: {
+            text: 'Email address',
+            classes: 'govuk-label--s govuk-!-font-size-16 govuk-!-margin-bottom-0'
+          },
+          hint: {
+            text: 'Enter full or partial email',
+            classes: 'govuk-!-font-size-14'
+          }
+        })
+      }}
+    </div>
+    <div class="govuk-grid-column-one-quarter inputs-less-margin">
+      {{
+        govukInput({
+          id: 'cardholderName',
+          name: 'cardholderName',
+          value: filters.cardholderName,
+          label: {
+            text: 'Name on card',
+            classes: 'govuk-label--s govuk-!-font-size-16 govuk-!-margin-bottom-0'
+          },
+          hint: {
+            text: 'Enter full or partial name',
+            classes: 'govuk-!-font-size-14'
+          }
+        })
+      }}
+    </div>
+    <div class="govuk-grid-column-one-quarter inputs-less-margin">
+      {{
+        govukInput({
+          id: 'lastDigitsCardNumber',
+          name: 'lastDigitsCardNumber',
+          value: filters.lastDigitsCardNumber,
+          label: {
+            text: 'Last 4 card numbers',
+            classes: 'govuk-label--s govuk-!-font-size-16 govuk-!-margin-bottom-0'
+          },
+          hint: {
+            text: 'Last 4 digits of associated card',
+            classes: 'govuk-!-font-size-14'
+          }
+        })
+      }}
+    </div>
+    <div class="govuk-grid-column-one-quarter">
+      {{
+        govukSelect({
+          id: "card-brand",
+          name: "brand",
+          label: {
+            text: "Card brand",
+            classes: 'govuk-label--s govuk-!-font-size-16 govuk-!-margin-bottom-0'
+          },
+          hint: {
+            text: "Select a brand",
+            classes: 'govuk-!-font-size-14'
+          },
+          attributes: {
+            'data-enhance-multiple': true
+          },
+          items: cardBrands
+        })
+      }}
+    </div>
+    <div class="govuk-grid-column-one-quarter">
+      {{
+        govukSelect({
+          id: "state",
+          name: "state",
+          label: {
+            text: "Payment status",
+            classes: 'govuk-label--s govuk-!-font-size-16 govuk-!-margin-bottom-0'
+          },
+          hint: {
+            text: "Select a option",
+            classes: 'govuk-!-font-size-14'
+          },
+          attributes: {
+            'data-enhance-multiple': true
+          },
+          items: eventStates
+        })
+      }}
+    </div>
+    <fieldset class="govuk-fieldset govuk-grid-one-half">
+      <legend class="govuk-fieldset__legend govuk-!-font-weight-bold govuk-!-font-size-16 govuk-!-margin-bottom-0 govuk-!-margin-left-3">
+        Date range
+      </legend>
+      <fieldset class="govuk-fieldset datetime-filter datetime-filter-from">
+        <legend class="govuk-visually-hidden">
+          From this date and time
         </legend>
-        <fieldset class="datetime-filter datetime-filter-from">
-          <legend class="visuallyhidden">
-            From this date and time
-          </legend>
-          <div class="date selector">
-            <label class="form-label" for="fromDate">Start date</label>
-            <input class="form-control large date-picker start" id="fromDate" name="fromDate" type="text" value="{{filters.fromDate}}" autocomplete="off">
-          </div>
-          <div class="time selector">
-            <label class="form-label" for="fromTime">Start time</label>
-            <input class="form-control large time-picker start" id="fromTime" name="fromTime" type="text" value="{{filters.fromTime}}" autocomplete="off">
-          </div>
-        </fieldset>
-        <fieldset class="datetime-filter datetime-filter-to">
-          <legend class="datetime-separator">
-            to<span class="visuallyhidden"> this date and time</span>
-          </legend>
-          <div class="date selector">
-            <label class="form-label" for="toDate">End date</label>
-            <input class="form-control large date-picker end" id="toDate" name="toDate" type="text" value="{{filters.toDate}}" autocomplete="off">
-          </div>
-          <div class="time selector">
-            <label class="form-label" for="toTime">End time</label>
-            <input class="form-control large time-picker end" id="toTime" name="toTime" type="text" value="{{filters.toTime}}" autocomplete="off">
-          </div>
-        </fieldset>
+        {{
+          govukInput({
+            id: 'fromDate',
+            name: 'fromDate',
+            value: filters.fromDate,
+            classes: 'date-picker start',
+            label: {
+              text: 'Start date',
+              classes: 'govuk-!-font-size-14 govuk-!-margin-bottom-2'
+            },
+            attributes: {
+              autocomplete: 'off'
+            }
+          })
+        }}
+        {{
+          govukInput({
+            id: 'fromTime',
+            name: 'fromTime',
+            value: filters.fromTime,
+            classes: 'time-picker start',
+            label: {
+              text: 'Start time',
+              classes: 'govuk-!-font-size-14 govuk-!-margin-bottom-2'
+            },
+            attributes: {
+              autocomplete: 'off'
+            }
+          })
+        }}
       </fieldset>
-      <div class="form-group filter-submit column-full">
-        <input class="button" type="submit" id="filter" value="Filter">
-        {% if hasFilters %}
-        <a href="{{routes.transactions.index}}" class="clear-filter"> Clear Filter </a>
-        {% endif %}
-      </div>
+      <fieldset class="govuk-fieldset datetime-filter datetime-filter-to">
+        <legend class="datetime-separator">
+          to<span class="govuk-visually-hidden"> this date and time</span>
+        </legend>
+        {{
+          govukInput({
+            id: 'toDate',
+            name: 'toDate',
+            value: filters.toDate,
+            classes: 'date-picker end',
+            label: {
+              text: 'End date',
+              classes: 'govuk-!-font-size-14 govuk-!-margin-bottom-2'
+            },
+            attributes: {
+              autocomplete: 'off'
+            }
+          })
+        }}
+        {{
+          govukInput({
+            id: 'toTime',
+            name: 'toTime',
+            value: filters.toTime,
+            classes: 'time-picker end',
+            label: {
+              text: 'End time',
+              classes: 'govuk-!-font-size-14 govuk-!-margin-bottom-2'
+            },
+            attributes: {
+              autocomplete: 'off'
+            }
+          })
+        }}
+      </fieldset>
     </fieldset>
+    <div class="govuk-grid-column-one-quarter inputs-less-margin">
+      {{
+        govukButton({
+          text: 'Filter',
+          classes: 'govuk-!-width-full',
+          attributes: {
+            id: "filter"
+          }
+        })
+      }}
+    </div>
+    <div class="govuk-grid-column-one-quarter inputs-less-margin">
+      {% if hasFilters %}
+      <a href="{{routes.transactions.index}}" class="govuk-link govuk-link--no-visited-state clear-filter">Clear Filter</a>
+      {% endif %}
+    </div>
   </form>
 </div>

--- a/app/views/transactions/index.njk
+++ b/app/views/transactions/index.njk
@@ -1,6 +1,6 @@
-{% extends "../layout.njk" %}
+{% extends "../layout-new.njk" %}
 
-{% block page_title %}
+{% block pageTitle %}
 Transactions - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
@@ -20,29 +20,28 @@ Transactions - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV
 {% endblock %}
 
 {% block mainContent %}
-<div class="column-full">
-  <h1 class="heading-large page-title">Transactions</h1>
-
+<div class="govuk-grid-column-full govuk-!-margin-top-6">
+  <h1 class="govuk-heading-l">Transactions</h1>
   {% include "transactions/filter.njk" %}
-
-
   <div>
-  <h3 class="heading-small" id="total-results">
-    {{totalFormatted}} transactions
-    {{ filtersDescription | safe }}
-  </h3>
+    <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-top-6" id="total-results">
+      {{totalFormatted}} transactions
+      {{ filtersDescription | safe }}
+    </h3>
 
-  {% include "transactions/display_size.njk" %}
+    {% include "transactions/display_size.njk" %}
 
-  {% if permissions.transactions_download_read %}
-    {% if (hasResults) %}
-      {% if showCsvDownload %}
-        <a href="{{downloadTransactionLink}}" id="download-transactions-link" class="push-bottom-sml"> Download all transaction details as a CSV file </a>
-      {% else %}
-        <p class="push-bottom-sml">You cannot download CSV over {{ csvMaxLimitFormatted }} transactions. Please refine your search</p>
+    {% if permissions.transactions_download_read %}
+      {% if (hasResults) %}
+        <p class="govuk-body">
+        {% if showCsvDownload %}
+          <a href="{{downloadTransactionLink}}" id="download-transactions-link" class="govuk-link govuk-link--no-visited-state"> Download all transaction details as a CSV file </a>
+        {% else %}
+          You cannot download CSV over {{ csvMaxLimitFormatted }} transactions. Please refine your search
+        {% endif %}
+        </p>
       {% endif %}
     {% endif %}
-  {% endif %}
   </div>
 
   {% include "transactions/paginator.njk" %}

--- a/app/views/transactions/index.njk
+++ b/app/views/transactions/index.njk
@@ -23,26 +23,25 @@ Transactions - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV
 <div class="govuk-grid-column-full govuk-!-margin-top-6">
   <h1 class="govuk-heading-l">Transactions</h1>
   {% include "transactions/filter.njk" %}
-  <div>
-    <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-top-6" id="total-results">
-      {{totalFormatted}} transactions
-      {{ filtersDescription | safe }}
-    </h3>
 
-    {% include "transactions/display_size.njk" %}
+  {% include "transactions/display_size.njk" %}
 
-    {% if permissions.transactions_download_read %}
-      {% if (hasResults) %}
-        <p class="govuk-body">
-        {% if showCsvDownload %}
-          <a href="{{downloadTransactionLink}}" id="download-transactions-link" class="govuk-link govuk-link--no-visited-state"> Download all transaction details as a CSV file </a>
-        {% else %}
-          You cannot download CSV over {{ csvMaxLimitFormatted }} transactions. Please refine your search
-        {% endif %}
-        </p>
+  <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-top-3" id="total-results">
+    {{totalFormatted}} transactions
+    {{ filtersDescription | safe }}
+  </h3>
+
+  {% if permissions.transactions_download_read %}
+    {% if (hasResults) %}
+      <p class="govuk-body">
+      {% if showCsvDownload %}
+        <a href="{{downloadTransactionLink}}" id="download-transactions-link" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-16"> Download all transaction details as a CSV file </a>
+      {% else %}
+        You cannot download CSV over {{ csvMaxLimitFormatted }} transactions. Please refine your search
       {% endif %}
+      </p>
     {% endif %}
-  </div>
+  {% endif %}
 
   {% include "transactions/paginator.njk" %}
 

--- a/app/views/transactions/list.njk
+++ b/app/views/transactions/list.njk
@@ -1,43 +1,44 @@
-<table id="transactions-list" class="transactions-list">
-  <thead>
-    <tr>
-      <th id="reference-header">Reference number</th>
+{% if results.length %}
+<table id="transactions-list" class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col" id="reference-header">Reference number</th>
       {% if permissions.transactions_email_read %}
-      <th id="email-header">Email</th>
+      <th class="govuk-table__header" scope="col" id="email-header">Email</th>
       {% endif %}
       {% if permissions.transactions_amount_read %}
-      <th id="amount-header">Amount</th>
+      <th class="govuk-table__header govuk-table__header--numeric" scope="col" id="amount-header">Amount</th>
       {% endif %}
       {% if permissions.transactions_card_type_read %}
-      <th id="brand-header">Card brand</th>
+      <th class="govuk-table__header" scope="col" id="brand-header">Card brand</th>
       {% endif %}
-      <th id="state-header">State</th>
-      <th id="time-header">Date created</th>
+      <th class="govuk-table__header" scope="col" id="state-header">State</th>
+      <th class="govuk-table__header govuk-table__header--numeric" scope="col" id="time-header">Date created</th>
     </tr>
   </thead>
-  <tbody>
+  <tbody class="govuk-table__body">
   {% for result in results %}
-    <tr data-follow-link data-link="{{result.link}}" class="transactions-list--row">
-      <th scope="row" class="charge-column reference transactions-list--item" data-gateway-transaction-id="{{result.gateway_transaction_id}}">
-        <a class="reference" id="charge-id-{{result.charge_id}}" data-charge-id="{{result.charge_id}}" href="{{result.link}}">
+    <tr data-follow-link data-link="{{result.link}}" class="transactions-list--row govuk-table__row">
+      <th scope="row" class="charge-column reference govuk-table__header" data-gateway-transaction-id="{{result.gateway_transaction_id}}">
+        <a class="govuk-link govuk-!-font-weight-regular govuk-!-font-size-14 reference" id="charge-id-{{result.charge_id}}" data-charge-id="{{result.charge_id}}" href="{{result.link}}">
           {{result.reference}}
         </a>
       </th>
       {% if permissions.transactions_email_read %}
-      <td class="transactions-list--item email">{{result.email}}</td>
+      <td class="govuk-table__cell transactions-list--item govuk-!-font-size-14 email">{{result.email}}</td>
       {% endif %}
       {% if permissions.transactions_amount_read %}
-      <td class="transactions-list--item amount">{{result.amount}}</td>
+      <td class="govuk-table__cell transactions-list--item govuk-!-font-size-14 govuk-table__cell--numeric amount">{{result.amount}}</td>
       {% endif %}
       {% if permissions.transactions_card_type_read %}
-      <td class="transactions-list--item brand">{{result.card_details.card_brand}}</td>
+      <td class="govuk-table__cell transactions-list--item govuk-!-font-size-14 brand">{{result.card_details.card_brand}}</td>
       {% endif %}
-      <td class="transactions-list--item state">{{result.state_friendly}}</td>
-      <td class="transactions-list--item time">{{result.created}}</td>
+      <td class="govuk-table__cell transactions-list--item govuk-!-font-size-14 state">{{result.state_friendly}}</td>
+      <td class="govuk-table__cell transactions-list--item govuk-!-font-size-14 govuk-table__cell--numeric time">{{result.created}}</td>
     </tr>
   {% endfor %}
   </tbody>
 </table>
-{% if not results.length %}
-  <p id="no-results">No results match the search criteria.</p>
+{% else %}
+  <p class="govuk-body" id="no-results">No results match the search criteria.</p>
 {% endif %}

--- a/app/views/transactions/paginator.njk
+++ b/app/views/transactions/paginator.njk
@@ -1,30 +1,30 @@
 {% if hasPaginationLinks %}
 <div class="pagination">
-	{% for paginationLink in paginationLinks %}
-    <form class="paginationForm {{paginationLink.pageName}}" method="get" action="{{paginationLink.search_path}}">
-        {% for state in filters.state %}
-          <input class="state" name="state" type="hidden" value="{{state}}"/>
-        {% endfor %}
-        {% for brand in filters.brand %}
-          <input class="brand" name="brand" type="hidden" value="{{brand}}"/>
-        {% endfor %}
-        <input class="reference" name="reference" type="hidden" value="{{filters.reference}}" />
-        <input class="email" name="email" type="hidden" value="{{filters.email}}" />
-        <input class="fromDate" name="fromDate" type="hidden" value="{{filters.fromDate}}" />
-        <input class="toDate" name="toDate" type="hidden" value="{{filters.toDate}}"/>
-        <input class="page" name="page" type="hidden" value="{{paginationLink.pageNumber}}"/>
-        <input class="pageSize" name="pageSize" type="hidden" value="{{filters.pageSize}}"/>
-        <input class="fromTime" name="fromTime" type="hidden" value="{{filters.fromTime}}">
-        <input class="toTime" name="toTime" type="hidden" value="{{filters.toTime}}">
+  {% for paginationLink in paginationLinks %}
+    <form class="paginationForm page-{{paginationLink.pageName}}" method="get" action="{{paginationLink.search_path}}">
+      {% for state in filters.state %}
+        <input class="state" name="state" type="hidden" value="{{state}}"/>
+      {% endfor %}
+      {% for brand in filters.brand %}
+        <input class="brand" name="brand" type="hidden" value="{{brand}}"/>
+      {% endfor %}
+      <input type="hidden" name="reference" value="{{filters.reference}}"/>
+      <input type="hidden" name="email" value="{{filters.email}}"/>
+      <input type="hidden" name="fromDate" value="{{filters.fromDate}}"/>
+      <input type="hidden" name="toDate" value="{{filters.toDate}}"/>
+      <input type="hidden" name="page" value="{{paginationLink.pageNumber}}"/>
+      <input type="hidden" name="pageSize" value="{{filters.pageSize}}"/>
+      <input type="hidden" name="fromTime" value="{{filters.fromTime}}">
+      <input type="hidden" name="toTime" value="{{filters.toTime}}">
 
-        <button class="pagination {{paginationLink.pageName}} {% if paginationLink.activePage %}active{% endif %}" type="submit">
-            {% if paginationLink.hasSymbolicName %}
-                {{paginationLink.pageName}}<span class="visuallyhidden"> page of results</span>
-            {% else %}
-                <span class="visuallyhidden">Results page </span>{{paginationLink.pageName}}
-            {% endif %}
-        </button>
+      <button class="pagination {{paginationLink.pageName}} {% if paginationLink.activePage %}active{% endif %}" type="submit">
+        {% if paginationLink.hasSymbolicName %}
+          {{paginationLink.pageName}}<span class="govuk-visually-hidden"> page of results</span>
+        {% else %}
+          <span class="govuk-visually-hidden">Results page </span>{{paginationLink.pageName}}
+        {% endif %}
+      </button>
     </form>
-	{% endfor %}
+  {% endfor %}
 </div>
 {% endif %}

--- a/test/cypress/integration/user/transaction_search_spec.js
+++ b/test/cypress/integration/user/transaction_search_spec.js
@@ -100,7 +100,7 @@ describe('Transactions', () => {
 
       cy.get('#card-brand').click()
       filteredPartialEmail.filtering.card_brand.forEach(brand => {
-        cy.get(`#card-brand .multi-select-item[value=${brand}]`).click()
+        cy.get(`#card-brand .govuk-checkboxes__input[value=${brand}]`).click()
       })
       cy.get('#email').type(filteredPartialEmail.filtering.email)
       cy.get('#filter').click()
@@ -118,7 +118,7 @@ describe('Transactions', () => {
 
       cy.get('#state').click()
       filteredMultipleStates.filtering.payment_states.forEach(state => {
-        cy.get(`#state .multi-select-item[value='${state}']`).click()
+        cy.get(`#state .govuk-checkboxes__input[value='${state}']`).click()
       })
       cy.get('#reference').type(filteredMultipleStates.filtering.reference)
       cy.get('#fromDate').type(filteredMultipleStates.filtering.from_date_raw)

--- a/test/integration/transaction_list_ft_tests.js
+++ b/test/integration/transaction_list_ft_tests.js
@@ -333,11 +333,11 @@ describe('The /transactions endpoint', function () {
         expect(res.body.results.length).to.equal(4)
         expect(res.body.results.map(row => row.charge_id)).to.deep.equal(['100', '101', '102', '103'])
         expect(res.body.results.map(row => row.state_friendly)).to.deep.equal(['In progress', 'In progress', 'Timed out', 'Refund submitted'])
-        expect(res.body.eventStates.length).to.equal(9)
-        const selectedStates = res.body.eventStates.filter(state => state.value.selected === true)
+        expect(res.body.eventStates.length).to.equal(10)
+        const selectedStates = res.body.eventStates.filter(state => state.selected === true)
         expect(selectedStates.length).to.equal(3)
         selectedStates.forEach(state => {
-          expect(['In progress', 'Timed out', 'Refund submitted']).to.include(state.value.text)
+          expect(['In progress', 'Timed out', 'Refund submitted']).to.include(state.text)
         })
 
         res.body.downloadTransactionLink.should.eql('/transactions/download?payment_states=created&payment_states=started&payment_states=submitted&payment_states=timedout&refund_states=submitted')
@@ -508,8 +508,9 @@ describe('The /transactions endpoint filtering by states)', () => {
     getTransactionList()
       .expect(200)
       .expect(function (res) {
-        expect(res.body.eventStates).property('length').to.equal(9)
-        expect(res.body.eventStates.map(state => state.value.text)).to.deep.equal([
+        expect(res.body.eventStates).property('length').to.equal(10)
+        expect(res.body.eventStates.map(state => state.text)).to.deep.equal([
+          'Any',
           'In progress',
           'Success',
           'Declined',
@@ -541,8 +542,9 @@ describe('The /transactions endpoint filtering by states)', () => {
       .set('x-request-id', requestId)
       .expect(200)
       .expect(function (res) {
-        expect(res.body.eventStates).property('length').to.equal(9)
-        expect(res.body.eventStates.map(state => state.value.text)).to.deep.equal([
+        expect(res.body.eventStates).property('length').to.equal(10)
+        expect(res.body.eventStates.map(state => state.text)).to.deep.equal([
+          'Any',
           'In progress',
           'Success',
           'Declined',
@@ -575,8 +577,9 @@ describe('The /transactions endpoint filtering by states)', () => {
       .set('x-request-id', requestId)
       .expect(200)
       .expect(function (res) {
-        expect(res.body.eventStates).property('length').to.equal(9)
-        expect(res.body.eventStates.map(state => state.value.text)).to.deep.equal([
+        expect(res.body.eventStates).property('length').to.equal(10)
+        expect(res.body.eventStates.map(state => state.text)).to.deep.equal([
+          'Any',
           'In progress',
           'Success',
           'Declined',

--- a/test/ui/pagination_ui_tests.js
+++ b/test/ui/pagination_ui_tests.js
@@ -52,18 +52,18 @@ describe('The pagination links', function () {
     var paginationLinks = templateData.paginationLinks
 
     for (var ctr = 0; ctr < paginationLinks.length; ctr++) {
-      body.should.containSelector('.paginationForm.' + paginationLinks[ctr].pageName)
-      body.should.containSelector('.paginationForm.' + paginationLinks[ctr].pageName + ' .state')
+      body.should.containSelector('.paginationForm.page-' + paginationLinks[ctr].pageName)
+      body.should.containSelector('.paginationForm.page-' + paginationLinks[ctr].pageName + '  [name="state"]')
         .withAttribute('value', 'Testing2')
-      body.should.containSelector('.paginationForm.' + paginationLinks[ctr].pageName + ' .reference')
+      body.should.containSelector('.paginationForm.page-' + paginationLinks[ctr].pageName + '  [name="reference"]')
         .withAttribute('value', 'ref1')
-      body.should.containSelector('.paginationForm.' + paginationLinks[ctr].pageName + ' .fromDate')
+      body.should.containSelector('.paginationForm.page-' + paginationLinks[ctr].pageName + '  [name="fromDate"]')
         .withAttribute('value', '2015-01-11 01:01:01')
-      body.should.containSelector('.paginationForm.' + paginationLinks[ctr].pageName + ' .toDate')
+      body.should.containSelector('.paginationForm.page-' + paginationLinks[ctr].pageName + ' [name="toDate"]')
         .withAttribute('value', '2015-01-11 01:01:01')
-      body.should.containSelector('.paginationForm.' + paginationLinks[ctr].pageName + ' .page')
+      body.should.containSelector('.paginationForm.page-' + paginationLinks[ctr].pageName + '  [name="page"]')
         .withAttribute('value', String(paginationLinks[ctr].pageNumber))
-      body.should.containSelector('.paginationForm.' + paginationLinks[ctr].pageName + ' .pageSize')
+      body.should.containSelector('.paginationForm.page-' + paginationLinks[ctr].pageName + '  [name="pageSize"]')
         .withAttribute('value', '100')
     }
   })

--- a/test/ui/transaction_list_ui_tests.js
+++ b/test/ui/transaction_list_ui_tests.js
@@ -222,7 +222,7 @@ describe('The transaction list view', function () {
         .withTableDataAt(5, templateData.results[ix].state_friendly)
         .withTableDataAt(6, templateData.results[ix].created)
     })
-    body.should.containSelector('.push-bottom-sml').withExactText('You cannot download CSV over 10,000 transactions. Please refine your search')
+    body.should.containSelector('.govuk-body').withExactText('You cannot download CSV over 10,000 transactions. Please refine your search')
   })
 
   it('should not render amount if no permission', function () {


### PR DESCRIPTION
- Migrated the Transaction filters over to GOV.UK Frontend
- Updated tests to work with new templates
  > The biggest change is supplying the states and card brands ready for the
nunjucks rather than doing another for loop in the template. This means
that tests and controllers had to be updated to match the new
object model.
- Finished migrating transactions list page to GOV.UK Frontend 
  > Converted the table, pagination and page display size components
  > Also put in a couple of checks to capitalise JCB so it doesn’t come out
as JCB or jcb