### PR TITLE
PP-4345 Fix refunds download to show correct username

### DIFF
--- a/app/controllers/transactions/transaction_download_controller.js
+++ b/app/controllers/transactions/transaction_download_controller.js
@@ -30,8 +30,10 @@ module.exports = (req, res) => {
       } else {
         return userService.findMultipleByExternalIds(userIds, correlationId)
           .then(users => {
-            const usersMap = userIds.reduce((map, userId, index) => {
-              map[userId] = users[index].username
+            const usersMap = userIds.reduce((map, userId) => {
+              map[userId] = users.find(user => {
+                return user.externalId === userId
+              }).username
               return map
             }, {})
             const results = json.results

--- a/test/fixtures/user_fixtures.js
+++ b/test/fixtures/user_fixtures.js
@@ -110,7 +110,7 @@ module.exports = {
     }
   },
   validUser: (opts = {}) => {
-    let newExternalId = '121391373c1844dd99cb3416b70785c8'
+    let newExternalId = opts.external_id || '121391373c1844dd99cb3416b70785c8'
     let newUsername = 'm87bmh'
     let defaultServiceId = opts.default_service_id || '193'
     let gatewayAccountIds = opts.gateway_account_ids || ['540']

--- a/test/integration/json/transaction_download_refunds.json
+++ b/test/integration/json/transaction_download_refunds.json
@@ -31,7 +31,7 @@
       "last_digits_card_number": "4242"
     },
     "refund_summary": {
-      "user_external_id": "thisisauser"
+      "user_external_id": "1stUserId"
     },
     "transaction_type": "refund"
   },
@@ -67,6 +67,42 @@
       "last_digits_card_number": "4242"
     },
     "refund_summary": {
+    },
+    "transaction_type": "refund"
+  },
+  {
+    "amount": 12345,
+    "state": {
+      "status": "success",
+      "finished": false
+    },
+    "card_brand": "Visa",
+    "description": "=calc+z!A0",
+    "reference": "+red",
+    "email": "-alice.111@mail.fake",
+    "links": [
+
+    ],
+    "charge_id": "charge3",
+    "gateway_transaction_id": "transaction-1",
+    "return_url": "https:\/\/demoservice.pymnt.localdomain:443\/return\/red",
+    "payment_provider": "sandbox",
+    "created_date": "2016-05-12T16:37:29.245Z",
+    "card_details": {
+      "billing_address": {
+        "city": "TEST01",
+        "country": "GB",
+        "line1": "TEST",
+        "line2": "TEST - DO NOT PROCESS",
+        "postcode": "SE1 3UZ"
+      },
+      "card_brand": "@Visa",
+      "cardholder_name": "TEST01",
+      "expiry_date": "12\/19",
+      "last_digits_card_number": "4242"
+    },
+    "refund_summary": {
+      "user_external_id": "2ndUserId"
     },
     "transaction_type": "refund"
   }

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -154,11 +154,19 @@ describe('Transaction download endpoints', function () {
           results: results
         })
       let user = userFixture.validUser({
-        username: 'thisisausername'
+        external_id: '1stUserId',
+        username: 'first_user_name'
+      }).getPlain()
+
+      let user2 = userFixture.validUser({
+        external_id: '2ndUserId',
+        username: 'second_user_name'
       }).getPlain()
 
       connectorMockResponds(200, mockJson, {refund_states: 'success'})
-      adminusersMock.get('/v1/api/users?ids=thisisauser').reply(200, [user])
+      adminusersMock.get('/v1/api/users')
+        .query({ids: '1stUserId,2ndUserId'})
+        .reply(200, [user2, user])
       request(app)
         .get(paths.transactions.download + '?refund_states=success')
         .set('Accept', 'application/json')
@@ -170,8 +178,9 @@ describe('Transaction download endpoints', function () {
           let csvContent = res.text
           let arrayOfLines = csvContent.split('\n')
           expect(arrayOfLines[0]).to.equal('"Reference","Description","Email","Amount","Card Brand","Cardholder Name","Card Expiry Date","Card Number","State","Finished","Error Code","Error Message","Provider ID","GOV.UK Payment ID","Issued By","Date Created","Time Created"')
-          expect(arrayOfLines[1]).to.equal('"\'+red","\'=calc+z!A0","\'-alice.111@mail.fake","-123.45","\'@Visa","TEST01","12/19","4242","Refund success",false,"","","transaction-1","charge1","thisisausername","12 May 2016","17:37:29"')
+          expect(arrayOfLines[1]).to.equal('"\'+red","\'=calc+z!A0","\'-alice.111@mail.fake","-123.45","\'@Visa","TEST01","12/19","4242","Refund success",false,"","","transaction-1","charge1","first_user_name","12 May 2016","17:37:29"')
           expect(arrayOfLines[2]).to.equal('"\'+red","\'=calc+z!A0","\'-alice.111@mail.fake","-123.45","\'@Visa","TEST01","12/19","4242","Refund success",false,"","","transaction-1","charge2","","12 May 2016","17:37:29"')
+          expect(arrayOfLines[3]).to.equal('"\'+red","\'=calc+z!A0","\'-alice.111@mail.fake","-123.45","\'@Visa","TEST01","12/19","4242","Refund success",false,"","","transaction-1","charge3","second_user_name","12 May 2016","17:37:29"')
           done()
         })
     })


### PR DESCRIPTION
- Change the logic within `transactions_download_controller` to not assume the
  order of the `Users` returned by `Adminusers` is the same as the ordering
  of the `external_user_ids` it sends in the GET query. This is necessary when
  converting the `external_user_id` to the `username` which is ultimately
  shown in the downloaded report. The previous implementation assumed the order
  of the `Users` which led to incorrect mapping between `exertnal_user_id` and
  `username`.
- Updated tests to catch this scenario and ensure correct username is used
  regardless of the order of the `Users` returned by `Adminusers`.

Related to support ticket:
https://govuk.zendesk.com/agent/tickets/3421777


