### PR TITLE
BAU - update old style docs links so they work

### DIFF
--- a/app/views/3d_secure/index.njk
+++ b/app/views/3d_secure/index.njk
@@ -52,7 +52,7 @@
               <h2 class="govuk-heading-s">Activating 3D Secure</h2>
               <p class="govuk-body">Check with your Worldpay account manager that your merchant code has been configured to support 3D
                 Secure. Read more about this in our <a
-                  href="https://docs.payments.service.gov.uk/#worldpay-setup-for-3d-secure">technical
+                  href="https://docs.payments.service.gov.uk/switching_to_live/set_up_a_live_worldpay_account/#set-up-3d-secure">technical
                   documentation</a>.
               </p>
               {% endset %}

--- a/app/views/credentials/sandbox.njk
+++ b/app/views/credentials/sandbox.njk
@@ -3,6 +3,6 @@
 {% block provider_content %}
   <div id="message">
     <p class="govuk-body">This is a test account. Account credentials only exist in live services, and relate to your payment service providers.</p>
-    <p class="govuk-body">See our guidance on <a class="govuk-link" href="https://docs.payments.service.gov.uk/#switching-to-live">switching to live</a> to go live.</p>
+    <p class="govuk-body">See our guidance on <a class="govuk-link" href="https://docs.payments.service.gov.uk/switching_to_live/#switching-to-live">switching to live</a> to go live.</p>
   </div>
 {% endblock %}

--- a/app/views/dashboard/_links.njk
+++ b/app/views/dashboard/_links.njk
@@ -28,7 +28,7 @@
     </article>
     {% else %}
     <article class="flex-grid--column-{% if isTestGateway %}third{% else %}half{% endif %} links__box">
-      <a href="https://docs.payments.service.gov.uk/#payment-flow-making-a-payment">
+      <a href="https://docs.payments.service.gov.uk/payment_flow_overview/#making-a-payment">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">See the payment flow</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Get an overview of payment pages in our documentation.</p>
       </a>

--- a/app/views/dashboard/demo-payment/mock-card-details.njk
+++ b/app/views/dashboard/demo-payment/mock-card-details.njk
@@ -20,7 +20,7 @@
   }}
 
   <p class="govuk-body">You can enter any valid value for the other details. For example, it doesn’t matter what expiry date you enter, but it must be in the future.</p>
-  <p class="govuk-body">You can also use other card types and see errors. <a class="govuk-link" href="https://docs.payments.service.gov.uk/#mock-card-numbers-for-testing-purposes">See more card types in our documentation</a>.</p>
+  <p class="govuk-body">You can also use other card types and see errors. <a class="govuk-link" href="https://docs.payments.service.gov.uk/testing_govuk_pay/#mock-card-numbers-for-testing-purposes">See more card types in our documentation</a>.</p>
 
   <form method="post" action="{{routes.prototyping.demoPayment.goToPaymentScreens}}" >
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>

--- a/app/views/dashboard/demo-service/index.njk
+++ b/app/views/dashboard/demo-service/index.njk
@@ -51,7 +51,7 @@ govuk-tabs__tab--selected{% endif %}" href="{{routes.prototyping.demoService.lin
     <p class="govuk-body">
     You can enter any valid value for the other details. For example, it doesn’t matter what expiry date you enter, but it must be in the future.
     </p>
-    <p class="govuk-body">You can also use other card types and see errors. <a class="govuk-link" href="https://docs.payments.service.gov.uk/#mock-card-numbers-for-testing-purposes">See more card types in our documentation</a>.</p>
+    <p class="govuk-body">You can also use other card types and see errors. <a class="govuk-link" href="https://docs.payments.service.gov.uk/testing_govuk_pay/#mock-card-numbers-for-testing-purposes">See more card types in our documentation</a>.</p>
   {% endif %}
 
   {% if productsTab %}


### PR DESCRIPTION
The links were just linking to the docs homepage, updated the links so they link directly to where they meant to