### PR TITLE
PP-4157 - add valdation to check for max number of characters

### DIFF
--- a/app/views/email_notifications/edit.njk
+++ b/app/views/email_notifications/edit.njk
@@ -48,18 +48,23 @@ Change email notifications template - {{currentService.name}} {{currentGatewayAc
       <li>use redirects or tracking links</li>
   </ul>
 
-  <form method="post" action="{{routes.emailNotifications.confirm}}">
+  <form method="post" action="{{routes.emailNotifications.confirm}}" data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {{
       govukTextarea({
         name: "custom-email-text",
+        id: "custom-email-text",
         label: {
           text: "Enter a custom paragraph",
           classes: "govuk-label--s"
         },
         classes: "qa-custom-p",
-        value: customEmailText
+        value: customEmailText,
+        attributes: {
+          "data-validate": "isFieldGreaterThanMaxLengthChars",
+          "data-validate-max-length": "5000"
+        }
       })
     }}
     {{


### PR DESCRIPTION
The custom email paragraph let you put any amount of words in, when this
reaced ~10,000 it broke selfservice with non-descript error.

I’ve set the limit to 5000 characters which is around 800 words, which
seems a reasonable limit.