### PR TITLE
BAU - Excluding files that nodemon should ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,15 @@
     "prepublish": "npm run snyk-protect",
     "publish-pacts": "./bin/publish-pacts.js"
   },
+  "nodemonConfig": {
+    "ignore": [
+      "test/*",
+      "assets/*",
+      "browsered/*",
+      "Gruntfile.js",
+      "app/browsered.js"
+    ]
+  },
   "dependencies": {
     "accessible-autocomplete": "^1.6.1",
     "appmetrics": "3.x",


### PR DESCRIPTION
Nodemon was reloading when there were changes in these files and nothing
will happen if it does, so it might as well not reload on them.

These are are assets that require running npm run compile (to run Grunt)
then this will change, application.js which then will trigger nodemon to
do reload.