### PR TITLE
PP-4170 Revert to 'latest' version of pact-stub container

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint": "./node_modules/.bin/standard",
     "lint-sass": "./node_modules/.bin/sass-lint -v",
     "test": "npm run snyk-protect && rm -rf ./pacts && ./node_modules/mocha/bin/mocha '!(node_modules)/**/*+(.|_)+(test|tests)'.js",
-    "pact-stub": "docker run -t -p 8000:8000 -v \"$(pwd)/pacts/:/app/pacts\" pactfoundation/pact-stub-server:v0.0.10 -p 8000 -d pacts",
+    "pact-stub": "docker run -t -p 8000:8000 -v \"$(pwd)/pacts/:/app/pacts\" pactfoundation/pact-stub-server -p 8000 -d pacts",
     "cypress:server": "node --inspect -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
     "cypress:test": "cypress run",
     "cypress:test-headed": "cypress open",


### PR DESCRIPTION
## WHAT

The pact-stub version was pinned at a previous version while a regression was fixed that prevented things from working.

This has now been fixed, so we can track 'latest' again now.