### PR TITLE
PP-4472 Fix user access bug

### DIFF
--- a/app/controllers/edit_merchant_details/get-edit-controller.js
+++ b/app/controllers/edit_merchant_details/get-edit-controller.js
@@ -3,7 +3,7 @@ const responses = require('../../utils/response')
 const countries = require('../../services/countries.js')
 
 module.exports = (req, res) => {
-  const externalServiceId = req.params.externalServiceId
+  const externalServiceId = req.service.externalId
   let pageData = lodash.get(req, 'session.pageData.editMerchantDetails')
   if (pageData) {
     delete req.session.pageData.editMerchantDetails

--- a/app/controllers/edit_merchant_details/get-index-controller.js
+++ b/app/controllers/edit_merchant_details/get-index-controller.js
@@ -9,7 +9,7 @@ const formatPath = require('../../utils/replace_params_in_path')
 const {response} = require('../../utils/response')
 
 module.exports = (req, res) => {
-  const externalServiceId = req.params.externalServiceId
+  const externalServiceId = req.service.externalId
   const merchantDetails = lodash.get(req, 'service.merchantDetails', undefined)
   if (!merchantDetails) {
     return res.redirect(formatPath(paths.merchantDetails.edit, externalServiceId))

--- a/app/controllers/edit_merchant_details/post-edit-controller.js
+++ b/app/controllers/edit_merchant_details/post-edit-controller.js
@@ -18,7 +18,7 @@ const MERCHANT_EMAIL = 'merchant-email'
 
 module.exports = (req, res) => {
   const correlationId = lodash.get(req, 'correlationId')
-  const externalServiceId = req.params.externalServiceId
+  const externalServiceId = req.service.externalId
   const hasDirectDebitGatewayAccount = lodash.get(req, 'service.hasDirectDebitGatewayAccount') || lodash.get(req, 'service.hasCardAndDirectDebitGatewayAccount')
   const reqMerchantDetails = {
     name: req.body[MERCHANT_NAME],

--- a/app/controllers/invite_user_controller.js
+++ b/app/controllers/invite_user_controller.js
@@ -38,7 +38,7 @@ module.exports = {
 
   index: (req, res) => {
     let roles = rolesModule.roles
-    const externalServiceId = req.params.externalServiceId
+    const externalServiceId = req.service.externalId
     const teamMemberIndexLink = formattedPathFor(paths.teamMembers.index, externalServiceId)
     const teamMemberInviteSubmitLink = formattedPathFor(paths.teamMembers.invite, externalServiceId)
     const invitee = lodash.get(req, 'session.pageData.invitee', '')
@@ -62,7 +62,7 @@ module.exports = {
   invite: (req, res) => {
     const correlationId = req.correlationId
     const senderId = req.user.externalId
-    const externalServiceId = req.params.externalServiceId
+    const externalServiceId = req.service.externalId
     const invitee = req.body['invitee-email'].trim()
     const roleId = parseInt(req.body['role-input'])
 

--- a/app/controllers/service_roles_update_controller.js
+++ b/app/controllers/service_roles_update_controller.js
@@ -33,7 +33,7 @@ module.exports = {
   index: (req, res) => {
     let correlationId = req.correlationId
     let externalUserId = req.params.externalUserId
-    let serviceExternalId = req.params.externalServiceId
+    let serviceExternalId = req.service.externalId
 
     let viewData = user => {
       const editPermissionsLink = formattedPathFor(paths.teamMembers.permissions, serviceExternalId, user.externalId)
@@ -88,7 +88,7 @@ module.exports = {
    */
   update: (req, res) => {
     let externalUserId = req.params.externalUserId
-    let serviceExternalId = req.params.externalServiceId
+    let serviceExternalId = req.service.externalId
     let targetRoleExtId = parseInt(req.body['role-input'])
     let targetRole = getRole(targetRoleExtId)
     let correlationId = req.correlationId

--- a/app/controllers/service_users_controller.js
+++ b/app/controllers/service_users_controller.js
@@ -57,7 +57,7 @@ module.exports = {
    * @param res
    */
   index: (req, res) => {
-    const externalServiceId = req.params.externalServiceId
+    const externalServiceId = req.service.externalId
 
     const onSuccess = function ([members, invitedMembers]) {
       const teamMembers = mapByRoles(members, externalServiceId, req.user)
@@ -99,7 +99,7 @@ module.exports = {
    * @param res
    */
   show: (req, res) => {
-    const externalServiceId = req.params.externalServiceId
+    const externalServiceId = req.service.externalId
     const externalUserId = req.params.externalUserId
     if (externalUserId === req.user.externalId) {
       res.redirect(paths.user.profile)
@@ -138,7 +138,7 @@ module.exports = {
    */
   delete: (req, res) => {
     const userToRemoveExternalId = req.params.externalUserId
-    const externalServiceId = req.params.externalServiceId
+    const externalServiceId = req.service.externalId
     const removerExternalId = req.user.externalId
     const correlationId = req.correlationId
 

--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -30,6 +30,9 @@ module.exports = function (req, res, next) {
   if (!req.service) {
     return notAuthorised(req, res)
   }
+
+  delete req.params.externalServiceId
+
   req.service.hasDirectDebitGatewayAccount = gatewayAccountType(req) === 'has_direct_debit_gateway_account'
   req.service.hasCardGatewayAccount = gatewayAccountType(req) === 'has_card_gateway_account'
   req.service.hasCardAndDirectDebitGatewayAccount = gatewayAccountType(req) === 'has_card_and_dd_gateway_account'

--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -1,6 +1,11 @@
 const _ = require('lodash')
 const {renderErrorView} = require('../utils/response.js')
 const {isADirectDebitAccount} = require('../services/clients/direct_debit_connector_client')
+
+function notAuthorised (req, res) {
+  return renderErrorView(req, res, 'You do not have the rights to access this service.', 403)
+}
+
 /**
  * This middleware resolves the current service in context
  *
@@ -8,8 +13,12 @@ const {isADirectDebitAccount} = require('../services/clients/direct_debit_connec
 module.exports = function (req, res, next) {
   const externalServiceId = req.params.externalServiceId
   const gatewayAccountId = _.get(req, 'gateway_account.currentGatewayAccountId')
+
   if (externalServiceId) {
-    req.service = _.get(req.user.serviceRoles.find(serviceRole => serviceRole.service.externalId === externalServiceId), 'service')
+    req.service = getServiceFromUserByExternalId(req, externalServiceId)
+    if (!req.service) {
+      return notAuthorised(req, res)
+    }
   } else if (gatewayAccountId) {
     req.service = _.get(req.user.serviceRoles.find(serviceRole => serviceRole.service.gatewayAccountIds.includes(gatewayAccountId)), 'service')
   }
@@ -19,14 +28,17 @@ module.exports = function (req, res, next) {
   }
 
   if (!req.service) {
-    return renderErrorView(req, res, 'You do not have the rights to access this service.')
+    return notAuthorised(req, res)
   }
-
   req.service.hasDirectDebitGatewayAccount = gatewayAccountType(req) === 'has_direct_debit_gateway_account'
   req.service.hasCardGatewayAccount = gatewayAccountType(req) === 'has_card_gateway_account'
   req.service.hasCardAndDirectDebitGatewayAccount = gatewayAccountType(req) === 'has_card_and_dd_gateway_account'
 
   next()
+}
+
+function getServiceFromUserByExternalId (req, externalServiceId) {
+  return _.get(req.user.serviceRoles.find(serviceRole => serviceRole.service.externalId === externalServiceId), 'service')
 }
 
 function gatewayAccountType (req) {

--- a/test/integration/invite_users_controller_ft_test.js
+++ b/test/integration/invite_users_controller_ft_test.js
@@ -123,8 +123,8 @@ describe('invite user controller', function () {
         correlationId: 'blah',
         user: {externalId: 'some-ext-id', serviceIds: ['1']},
         body: {'invitee-email': invalidEmail, 'role-input': '200'},
-        params: {
-          externalServiceId: externalServiceId
+        service: {
+          externalId: externalServiceId
         }
       })
 

--- a/test/integration/service_users_ft_test.js
+++ b/test/integration/service_users_ft_test.js
@@ -116,7 +116,7 @@ describe('service users resource', function () {
       })
       .end(done)
   })
-  it.only('should error when accessing service use ris not a member of', function (done) {
+  it('should error when accessing a service that the user is not a member of', function (done) {
     const externalServiceId = '734rgw76jhka'
     const noAccessServiceId = 'no_access'
 
@@ -323,7 +323,7 @@ describe('service users resource', function () {
     supertest(app)
       .get(formattedPathFor(paths.teamMembers.show, externalServiceId2, EXTERNAL_ID_OTHER_USER))
       .set('Accept', 'application/json')
-      .expect(500)
+      .expect(403)
       .expect((res) => {
         expect(res.body.message).to.equal('You do not have the rights to access this service.')
       })


### PR DESCRIPTION
We discovered that in some cases it is possible for a logged in user to
view and modify data from other services. This PR fixes the bug. 
The basic cause of the bug is that for urls that contain the service id 
we were not correctly checking whether the user had access to that url.

fd93aa2d has a failing test describing the bug and the main fix.

881e48dd ensures that we won't repeat this mistake in future by ensuring
that all controllers use a service id that we have ensured is valid for 
current user.

This probably needs unit tests around the resolve service middleware,
but I think the high level test is enough to show the bug is fixed. I will
do further tests in a separate PR, which will better demonstrate what
resolve_service is supposed to do.