### PR TITLE
PP-4181 - Add babel polyfill to help older browsers

### DIFF
--- a/app/browsered.js
+++ b/app/browsered.js
@@ -1,5 +1,7 @@
 'use strict'
 
+require('@babel/polyfill')
+
 // Local dependencies
 const multiSelects = require('./browsered/multi-select')
 const fieldValidation = require('./browsered/field-validation')

--- a/package-lock.json
+++ b/package-lock.json
@@ -797,6 +797,16 @@
         }
       }
     },
+    "@babel/polyfill": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0.tgz",
+      "integrity": "sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
+      }
+    },
     "@babel/preset-env": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",
+    "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.1.6",
     "@pact-foundation/pact-node": "6.16.4",
     "chai": "^4.1.2",


### PR DESCRIPTION
This increases the bundle from 138kB to 270kB. Sad times, but I am
having trouble making it apply just the polyfills we need. So this is a
stop gap to get partial refunds working again for older browsers.