### PR TITLE
PP-4488 show corporate card surcharge on transaction list

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -32,6 +32,6 @@
 @import "components/multi-select";
 @import "components/pagination";
 @import "components/transaction-refund";
-@import "components/vetical-align";
+@import "components/vertical-align";
 @import "components/check-your-answers";
 @import "components/borders";

--- a/app/assets/sass/components/vertical-align.scss
+++ b/app/assets/sass/components/vertical-align.scss
@@ -1,3 +1,3 @@
-.vetical-align-top {
+.vertical-align-top {
   vertical-align: top;
 }

--- a/app/utils/transaction_view.js
+++ b/app/utils/transaction_view.js
@@ -46,6 +46,9 @@ module.exports = {
     connectorData.results.forEach(element => {
       element.state_friendly = states.getDisplayNameForConnectorState(element.state, element.transaction_type)
       element.amount = asGBP(element.amount)
+      if (element.total_amount && element.corporate_card_surcharge) {
+        element.total_amount = asGBP(element.total_amount)
+      }
       element.email = (element.email && element.email.length > 20) ? element.email.substring(0, 20) + '...' : element.email
       element.updated = dates.utcToDisplay(element.updated)
       element.created = dates.utcToDisplay(element.created_date)

--- a/app/views/transaction_detail/_details.njk
+++ b/app/views/transaction_detail/_details.njk
@@ -15,7 +15,7 @@
   {% endif %}
 
   <tr class="govuk-table__row">
-    <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16 vetical-align-top" scope="row">Payment status:</th>
+    <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16 vertical-align-top" scope="row">Payment status:</th>
     <td class="govuk-table__cell govuk-!-font-size-16" id="state">{{state_friendly}}
       {% if state_friendly === "Declined" %}
         {% set stateInfo %}

--- a/app/views/transactions/list.njk
+++ b/app/views/transactions/list.njk
@@ -7,7 +7,7 @@
       <th class="govuk-table__header" scope="col" id="email-header">Email</th>
       {% endif %}
       {% if permissions.transactions_amount_read %}
-      <th class="govuk-table__header govuk-table__header--numeric" scope="col" id="amount-header">Amount</th>
+      <th class="govuk-table__header" scope="col" id="amount-header">Amount</th>
       {% endif %}
       {% if permissions.transactions_card_type_read %}
       <th class="govuk-table__header" scope="col" id="brand-header">Card brand</th>
@@ -18,9 +18,9 @@
   </thead>
   <tbody class="govuk-table__body">
   {% for result in results %}
-    <tr data-follow-link data-link="{{result.link}}" class="transactions-list--row govuk-table__row">
+    <tr data-follow-link data-link="{{result.link}}" class="transactions-list--row govuk-table__row vertical-align-top">
       <th scope="row" class="charge-column reference govuk-table__header" data-gateway-transaction-id="{{result.gateway_transaction_id}}">
-        <a class="govuk-link govuk-!-font-weight-regular govuk-!-font-size-14 reference" id="charge-id-{{result.charge_id}}" data-charge-id="{{result.charge_id}}" href="{{result.link}}">
+        <a class="govuk-link govuk-!-font-weight-regular govuk-!-font-size-14 reference govuk-!-display-block" id="charge-id-{{result.charge_id}}" data-charge-id="{{result.charge_id}}" href="{{result.link}}">
           {{result.reference}}
         </a>
       </th>
@@ -28,7 +28,14 @@
       <td class="govuk-table__cell transactions-list--item govuk-!-font-size-14 email">{{result.email}}</td>
       {% endif %}
       {% if permissions.transactions_amount_read %}
-      <td class="govuk-table__cell transactions-list--item govuk-!-font-size-14 govuk-table__cell--numeric amount">{{result.amount}}</td>
+             <td class="govuk-table__cell transactions-list--item amount govuk-!-font-size-14" id="amount">
+                   {%- if result.total_amount and result.corporate_card_surcharge -%}
+                     {{result.total_amount}}
+                     <span class="govuk-!-display-block govuk-!-font-size-14">(with card fee)</span>
+                   {%- else -%}
+                     {{result.amount}}
+                   {%- endif -%}
+             </td>
       {% endif %}
       {% if permissions.transactions_card_type_read %}
       <td class="govuk-table__cell transactions-list--item govuk-!-font-size-14 brand">{{result.card_details.card_brand}}</td>

--- a/test/cypress/integration/user/transaction_search_spec.js
+++ b/test/cypress/integration/user/transaction_search_spec.js
@@ -3,6 +3,10 @@ describe('Transactions', () => {
 
   const selfServiceUsers = require('../../../fixtures/config/self_service_user.json')
 
+  const selfServiceDefaultUser = selfServiceUsers.config.users.filter(fil => fil.isPrimary === 'true')[0]
+
+  const aCorporateCardSurchargeCharge = selfServiceDefaultUser.sections.transactions.data.filter(fil => fil.corporate_card_surcharge !== undefined)[0]
+
   const convertAmounts = val => '£' + (val / 100).toFixed(2)
 
   beforeEach(() => {
@@ -130,6 +134,15 @@ describe('Transactions', () => {
       cy.get('#transactions-list tbody').find('tr').should('have.length', filteredMultipleStates.data.length)
       // Ensure the values are displayed correctly
       cy.get('#transactions-list tbody').find('tr').first().find('td').eq(1).should('have.text', convertAmounts(filteredMultipleStates.data[0].amount))
+    })
+
+    it('should display card fee with corporate card surcharge transaction', () => {
+      // Ensure the transactions list has the right number of items
+      const unfilteredTransactions = selfServiceDefaultUser.sections.transactions.data
+      cy.get('#transactions-list tbody').find('tr').should('have.length', unfilteredTransactions.length)
+
+      // Ensure the card fee is displayed correctly
+      cy.get('#transactions-list tbody').find('tr').eq(4).find('td').eq(1).should('contain', convertAmounts(aCorporateCardSurchargeCharge.total_amount)).and('contain', '(with card fee)')
     })
   })
 })

--- a/test/test_helpers/html_assertions.js
+++ b/test/test_helpers/html_assertions.js
@@ -194,4 +194,12 @@ chai.use(function (_chai, utils) {
       expectedValue, actualValue
     )
   })
+
+  chai.Assertion.addMethod('withTableDataTextAt', function (colIndex, expectedValue) {
+    const actualValue = this._obj.find('tr > :nth-child(' + colIndex + ')').text().replace(/\n/g, ' ').replace(/\s\s+/g, ' ').trim()
+    this.assert(actualValue.indexOf(expectedValue.toString()) > -1,
+      "Expected '" + actualValue + "' to be '" + expectedValue + "'.",
+      expectedValue, actualValue
+    )
+  })
 })

--- a/test/ui/transaction_list_ui_tests.js
+++ b/test/ui/transaction_list_ui_tests.js
@@ -12,7 +12,7 @@ const renderTemplate = require(path.join(__dirname, '/../test_helpers/html_asser
 
 describe('The transaction list view', function () {
   it('should render all transactions', function () {
-    var templateData = {
+    const templateData = {
       'results': [
         {
           'charge_id': 100,
@@ -103,7 +103,7 @@ describe('The transaction list view', function () {
       csvMaxLimitFormatted: '10,000'
     }
 
-    var body = renderTemplate('transactions/index', templateData)
+    const body = renderTemplate('transactions/index', templateData)
 
     templateData.results.forEach(function (transactionData, ix) {
       body.should.containSelector('table#transactions-list')
@@ -119,7 +119,7 @@ describe('The transaction list view', function () {
   })
 
   it('should render all transactions without download link', function () {
-    var templateData = {
+    const templateData = {
       'results': [
         {
           'charge_id': 100,
@@ -210,7 +210,7 @@ describe('The transaction list view', function () {
       csvMaxLimitFormatted: '10,000'
     }
 
-    var body = renderTemplate('transactions/index', templateData)
+    const body = renderTemplate('transactions/index', templateData)
 
     templateData.results.forEach(function (transactionData, ix) {
       body.should.containSelector('table#transactions-list')
@@ -226,7 +226,7 @@ describe('The transaction list view', function () {
   })
 
   it('should not render amount if no permission', function () {
-    var templateData = {
+    const templateData = {
       'results': [
         {
           'charge_id': 100,
@@ -285,14 +285,14 @@ describe('The transaction list view', function () {
       }
     }
 
-    var body = renderTemplate('transactions/index', templateData)
+    const body = renderTemplate('transactions/index', templateData)
 
     body.should.not.containSelector('#transactions-list .amount')
     body.should.not.containSelector('#amount-header')
   })
 
   it('should not render email if no permission', function () {
-    var templateData = {
+    const templateData = {
       'results': [
         {
           'charge_id': 100,
@@ -351,14 +351,14 @@ describe('The transaction list view', function () {
       }
     }
 
-    var body = renderTemplate('transactions/index', templateData)
+    const body = renderTemplate('transactions/index', templateData)
 
     body.should.not.containSelector('#transactions-list .email')
     body.should.not.containSelector('#email-header')
   })
 
   it('should not render card brand if no permission', function () {
-    var templateData = {
+    const templateData = {
       'results': [
         {
           'charge_id': 100,
@@ -417,9 +417,93 @@ describe('The transaction list view', function () {
       }
     }
 
-    var body = renderTemplate('transactions/index', templateData)
+    const body = renderTemplate('transactions/index', templateData)
 
     body.should.not.containSelector('#transactions-list .brand')
     body.should.not.containSelector('#brand-header')
+  })
+
+  it('should render all transactions with corporate surcharge', function () {
+    const templateData = {
+      'results': [
+        {
+          'charge_id': 102,
+          'email': 'example3@mail.fake',
+          'amount': '20.00',
+          'reference': 'ref1',
+          'state_friendly': 'Refund success',
+          'state': {
+            'status': 'success',
+            'finished': true
+          },
+          'card_details': {
+            'billing_address': {
+              'city': 'TEST',
+              'country': 'GB',
+              'line1': 'TEST',
+              'line2': 'TEST - DO NOT PROCESS',
+              'postcode': 'SE1 3UZ'
+            },
+            'card_brand': 'Amex',
+            'cardholder_name': 'TEST',
+            'expiry_date': '12/19',
+            'last_digits_card_number': '4242'
+          },
+          'created': '2016-01-11 01:01:01',
+          'corporate_card_surcharge': 100,
+          'total_amount': '£21.00'
+        },
+        {
+          'charge_id': 103,
+          'email': 'example3@mail.fake',
+          'amount': '£20.00',
+          'reference': 'ref1',
+          'state_friendly': 'Refund success',
+          'state': {
+            'status': 'success',
+            'finished': true
+          },
+          'card_details': {
+            'billing_address': {
+              'city': 'TEST',
+              'country': 'GB',
+              'line1': 'TEST',
+              'line2': 'TEST - DO NOT PROCESS',
+              'postcode': 'SE1 3UZ'
+            },
+            'card_brand': 'Amex',
+            'cardholder_name': 'TEST',
+            'expiry_date': '12/19',
+            'last_digits_card_number': '4242'
+          },
+          'created': '2016-01-11 01:01:01'
+        }
+      ],
+      permissions: {
+        'transactions_email_read': true,
+        'transactions_amount_read': true,
+        'transactions_card_type_read': true,
+        'transactions_download_read': true
+      },
+      hasResults: true,
+      total: 1,
+      showCsvDownload: true,
+      totalFormatted: '1',
+      csvMaxLimitFormatted: '10,000'
+    }
+
+    const body = renderTemplate('transactions/index', templateData)
+
+    templateData.results.forEach(function (transactionData, ix) {
+      body.should.containSelector('table#transactions-list')
+        .havingRowAt(ix + 1)
+        .withTableDataAt(1, templateData.results[ix].reference)
+        .withTableDataAt(2, templateData.results[ix].email)
+        .withTableDataTextAt(3, ix === 0 ? '£21.00 (with card fee)' : '£20.00')
+        .withTableDataAt(4, templateData.results[ix].card_details.card_brand)
+        .withTableDataAt(5, templateData.results[ix].state_friendly)
+        .withTableDataAt(6, templateData.results[ix].created)
+    })
+    body.should.containSelector('#download-transactions-link')
   })
 })


### PR DESCRIPTION
## WHAT

- show total amount and indicate that it includes a surcharge when relevant
- add ui test
- add Cypress test for transaction list and skip modifying the old `transaction_list_ft_tests.js` test as it is covered by Cypress and it is asserting on JSON response which is not good way to test integration and ui

    with @jonheslop and @DanailMinchev