### PR TITLE
PP-4523: Remove grunt-nodemon from Gruntfile build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -134,7 +134,6 @@ module.exports = function (grunt) {
     'grunt-contrib-copy',
     'grunt-contrib-uglify',
     'grunt-contrib-watch',
-    'grunt-nodemon',
     'grunt-sass'
   ].forEach(function (task) {
     grunt.loadNpmTasks(task)

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "grunt": "1.0.x",
     "grunt-babel": "^8.0.0",
     "grunt-browserify": "^5.3.0",
-    "grunt-cli": "1.3.x",
     "grunt-contrib-clean": "2.0.x",
     "grunt-contrib-copy": "1.0.x",
     "grunt-contrib-uglify": "^3.3.0",


### PR DESCRIPTION
`grunt-nodemon` was referenced from the Gruntfile build process, this threw
a warning as the dependency was removed and is no longer used.
The import for `grunt-nodemon` was removed.

A package.json dependency `grunt-cli` was also removed as it looks like this is
no longer used by any build process.

Previous behaviour: 
Error was thrown on `npm run compile` for the missing `grunt-nodemon` library

Expected: 
No error thrown as this library is not needed


