### PR TITLE
PP-4552 Fix transactions pagination when there is a single state filter

### DIFF
--- a/app/views/transactions/paginator.njk
+++ b/app/views/transactions/paginator.njk
@@ -2,7 +2,7 @@
 <div class="pagination">
   {% for paginationLink in paginationLinks %}
     <form class="paginationForm page-{{paginationLink.pageName}}" method="get" action="{{paginationLink.search_path}}">
-      {% for state in filters.state %}
+      {% for state in filters.selectedStates %}
         <input class="state" name="state" type="hidden" value="{{state}}"/>
       {% endfor %}
       {% for brand in filters.brand %}

--- a/test/ui/pagination_ui_tests.js
+++ b/test/ui/pagination_ui_tests.js
@@ -1,8 +1,7 @@
-// NPM dependencies
-const path = require('path')
+'use strict'
 
 // Local dependencies
-const renderTemplate = require(path.join(__dirname, '/../test_helpers/html_assertions.js')).render
+const {render} = require('../test_helpers/html_assertions.js')
 
 describe('The pagination links', function () {
   it('should display correct pagination links for all filters', () => {
@@ -24,7 +23,7 @@ describe('The pagination links', function () {
     }
 
     const templateData = transactionsTemplateData(filters)
-    const body = renderTemplate('transactions/paginator', templateData)
+    const body = render('transactions/paginator', templateData)
 
     body.should.containSelector('div.pagination')
 
@@ -68,7 +67,7 @@ describe('The pagination links', function () {
     }
 
     const templateData = transactionsTemplateData(filters)
-    const body = renderTemplate('transactions/paginator', templateData)
+    const body = render('transactions/paginator', templateData)
 
     body.should.containSelector('div.pagination')
 

--- a/test/ui/pagination_ui_tests.js
+++ b/test/ui/pagination_ui_tests.js
@@ -7,7 +7,7 @@ describe('The pagination links', function () {
   it('should display correct pagination links for all filters', () => {
     const filters = {
       'reference': 'ref1',
-      'email': 'abc@def.com',
+      'email': 'abc@example.com',
       'state': 'Cancelled',
       'selectedStates': [
         'Cancelled'
@@ -34,7 +34,7 @@ describe('The pagination links', function () {
       body.should.containSelector('.paginationForm.page-' + link.pageName + '  [name="reference"]')
         .withAttribute('value', 'ref1')
       body.should.containSelector('.paginationForm.page-' + link.pageName + ' [name="email"]')
-        .withAttribute('value', 'abc@def.com')
+        .withAttribute('value', 'abc@example.com')
       body.should.containSelector('.paginationForm.page-' + link.pageName + '  [name="fromDate"]')
         .withAttribute('value', '2015-01-11')
       body.should.containSelector('.paginationForm.page-' + link.pageName + ' [name="toDate"]')

--- a/test/ui/pagination_ui_tests.js
+++ b/test/ui/pagination_ui_tests.js
@@ -1,9 +1,90 @@
-var path = require('path')
-var renderTemplate = require(path.join(__dirname, '/../test_helpers/html_assertions.js')).render
+// NPM dependencies
+const path = require('path')
+
+// Local dependencies
+const renderTemplate = require(path.join(__dirname, '/../test_helpers/html_assertions.js')).render
 
 describe('The pagination links', function () {
-  it('should display correct pagination links', function () {
-    var templateData = {
+  it('should display correct pagination links for all filters', () => {
+    const filters = {
+      'reference': 'ref1',
+      'email': 'abc@def.com',
+      'state': 'Cancelled',
+      'selectedStates': [
+        'Cancelled'
+      ],
+      'payment_states': [
+        'cancelled'
+      ],
+      'fromDate': '2015-01-11',
+      'toDate': '2016-01-11',
+      'fromTime': '01:01:01',
+      'toTime': '02:02:02',
+      'pageSize': '100'
+    }
+
+    const templateData = transactionsTemplateData(filters)
+    const body = renderTemplate('transactions/paginator', templateData)
+
+    body.should.containSelector('div.pagination')
+
+    templateData.paginationLinks.forEach((link) => {
+      body.should.containSelector('.paginationForm.page-' + link.pageName)
+      body.should.containSelector('.paginationForm.page-' + link.pageName + '  [name="state"]')
+        .withAttribute('value', 'Cancelled')
+      body.should.containSelector('.paginationForm.page-' + link.pageName + '  [name="reference"]')
+        .withAttribute('value', 'ref1')
+      body.should.containSelector('.paginationForm.page-' + link.pageName + ' [name="email"]')
+        .withAttribute('value', 'abc@def.com')
+      body.should.containSelector('.paginationForm.page-' + link.pageName + '  [name="fromDate"]')
+        .withAttribute('value', '2015-01-11')
+      body.should.containSelector('.paginationForm.page-' + link.pageName + ' [name="toDate"]')
+        .withAttribute('value', '2016-01-11')
+      body.should.containSelector('.paginationForm.page-' + link.pageName + '  [name="page"]')
+        .withAttribute('value', String(link.pageNumber))
+      body.should.containSelector('.paginationForm.page-' + link.pageName + '  [name="pageSize"]')
+        .withAttribute('value', '100')
+      body.should.containSelector('.paginationForm.page-' + link.pageName + '  [name="fromTime"]')
+        .withAttribute('value', '01:01:01')
+      body.should.containSelector('.paginationForm.page-' + link.pageName + ' [name="toTime"]')
+        .withAttribute('value', '02:02:02')
+    })
+  })
+
+  it('should display correct pagination links for transactions filtered by multiple payment states', () => {
+    const filters = {
+      'state': ['Cancelled', 'In Progress'],
+      'selectedStates': [
+        'Cancelled',
+        'In Progress'
+      ],
+      'payment_states': [
+        'cancelled',
+        'created',
+        'started',
+        'submitted'
+      ],
+      'pageSize': '100'
+    }
+
+    const templateData = transactionsTemplateData(filters)
+    const body = renderTemplate('transactions/paginator', templateData)
+
+    body.should.containSelector('div.pagination')
+
+    templateData.paginationLinks.forEach((link) => {
+      body.should.containSelector('.paginationForm.page-' + link.pageName)
+      body.should.containSelector('.paginationForm.page-' + link.pageName + '  [name="state"][value="Cancelled"]')
+      body.should.containSelector('.paginationForm.page-' + link.pageName + '  [name="state"][value="In Progress"]')
+      body.should.containSelector('.paginationForm.page-' + link.pageName + '  [name="page"]')
+        .withAttribute('value', String(link.pageNumber))
+      body.should.containSelector('.paginationForm.page-' + link.pageName + '  [name="pageSize"]')
+        .withAttribute('value', '100')
+    })
+  })
+
+  const transactionsTemplateData = (filters = {}) => {
+    return {
       'total': 100,
       'results': [
         {
@@ -31,7 +112,7 @@ describe('The pagination links', function () {
           'created': '2016-01-11 01:01:01'
         }
       ],
-      'filters': {'reference': 'ref1', 'state': ['Testing2'], 'fromDate': '2015-01-11 01:01:01', 'toDate': '2015-01-11 01:01:01', 'pageSize': '100'},
+      'filters': filters,
       'paginationLinks': [
         {pageNumber: 1, pageName: 1},
         {pageNumber: 2, pageName: 2},
@@ -43,28 +124,7 @@ describe('The pagination links', function () {
       'selectedState': 'Testing2',
       'hasResults': true,
       'downloadTransactionLink':
-          '/transactions/download?reference=ref1&state=Testing2&from_date=2%2F0%2F2015%2001%3A01%3A01&&to_date=2%2F0%2F2015%2001%3A01%3A01'
+        '/transactions/download?reference=ref1&state=Testing2&from_date=2%2F0%2F2015%2001%3A01%3A01&&to_date=2%2F0%2F2015%2001%3A01%3A01'
     }
-
-    var body = renderTemplate('transactions/paginator', templateData)
-
-    body.should.containSelector('div.pagination')
-    var paginationLinks = templateData.paginationLinks
-
-    for (var ctr = 0; ctr < paginationLinks.length; ctr++) {
-      body.should.containSelector('.paginationForm.page-' + paginationLinks[ctr].pageName)
-      body.should.containSelector('.paginationForm.page-' + paginationLinks[ctr].pageName + '  [name="state"]')
-        .withAttribute('value', 'Testing2')
-      body.should.containSelector('.paginationForm.page-' + paginationLinks[ctr].pageName + '  [name="reference"]')
-        .withAttribute('value', 'ref1')
-      body.should.containSelector('.paginationForm.page-' + paginationLinks[ctr].pageName + '  [name="fromDate"]')
-        .withAttribute('value', '2015-01-11 01:01:01')
-      body.should.containSelector('.paginationForm.page-' + paginationLinks[ctr].pageName + ' [name="toDate"]')
-        .withAttribute('value', '2015-01-11 01:01:01')
-      body.should.containSelector('.paginationForm.page-' + paginationLinks[ctr].pageName + '  [name="page"]')
-        .withAttribute('value', String(paginationLinks[ctr].pageNumber))
-      body.should.containSelector('.paginationForm.page-' + paginationLinks[ctr].pageName + '  [name="pageSize"]')
-        .withAttribute('value', '100')
-    }
-  })
+  }
 })

--- a/test/unit/utils/filters_test.js
+++ b/test/unit/utils/filters_test.js
@@ -26,30 +26,35 @@ describe('filters', () => {
     describe('getFilter', () => {
       it('should transform In progress display states to connector states correctly', function () {
         const {result} = filters.getFilters({query: {state: 'In progress'}})
+        expect(result).to.have.property('selectedStates').to.deep.equal(['In progress'])
         expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted'])
         expect(result).to.not.have.property('refund_states')
       })
 
       it('should transform some payment display states to connector states correctly', function () {
         const {result} = filters.getFilters({query: {state: ['In progress', 'Timed out', 'Cancelled']}})
+        expect(result).to.have.property('selectedStates').to.deep.equal(['In progress', 'Timed out', 'Cancelled'])
         expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'timedout', 'cancelled'])
         expect(result).to.not.have.property('refund_states')
       })
 
       it('should transform all payment display states to connector states correctly', function () {
         const {result} = filters.getFilters({query: {state: ['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined']}})
+        expect(result).to.have.property('selectedStates').to.deep.equal(['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined'])
         expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'success', 'error', 'cancelled', 'timedout', 'declined'])
         expect(result).to.not.have.property('refund_states')
       })
 
       it('should transform all refund display states to connector states correctly', function () {
         const {result} = filters.getFilters({query: {state: ['Refund success', 'Refund error', 'Refund submitted']}})
+        expect(result).to.have.property('selectedStates').to.deep.equal(['Refund success', 'Refund error', 'Refund submitted'])
         expect(result).to.have.property('refund_states').to.deep.equal(['success', 'error', 'submitted'])
         expect(result).to.not.have.property('payment_states')
       })
 
       it('should transform both payment and refund display states to connector states correctly', function () {
         const {result} = filters.getFilters({query: {state: ['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined', 'Refund success', 'Refund error', 'Refund submitted']}})
+        expect(result).to.have.property('selectedStates').to.deep.equal(['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined', 'Refund success', 'Refund error', 'Refund submitted'])
         expect(result).to.have.property('refund_states').to.deep.equal(['success', 'error', 'submitted'])
         expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'success', 'error', 'cancelled', 'timedout', 'declined'])
       })


### PR DESCRIPTION
## WHAT
- Pagination template was using the wrong field in the template data
  meaning it was expecting to split an array but was actually splitting
  a string when there was a single payment state filter


