### PR TITLE
Correct inequality test

### DIFF
--- a/server.js
+++ b/server.js
@@ -49,7 +49,7 @@ function initialiseGlobalMiddleware (app) {
       logger.info(message)
     }
   }
-  if (!process.env.DISABLE_REQUEST_LOGGING === 'true') {
+  if (process.env.DISABLE_REQUEST_LOGGING !== 'true') {
     app.use(/\/((?!public|favicon.ico).)*/, loggingMiddleware(
       ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" - total time :response-time ms'))
   }


### PR DESCRIPTION
I think a strict inequality test was intended on this line. However, because the negation operator (`!`) [takes precedence](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence) over the strict equality test, the following will have happened:

1. `process.env.DISABLE_REQUEST_LOGGING` is a string
2. `!process.env.DISABLE_REQUEST_LOGGING` will be `true` if the string is non-empty, or `false` if the string is empty.
3. the left-hand side _boolean_ (`true` or `false`) is then compared using a *strict* comparison to the _string_ `'true'`, which will always yield `false`.

I found this problem using [LGTM.com](https://lgtm.com/projects/g/alphagov/pay-selfservice/). If you like, you can enable automated code review for pull requests to make sure this sort of problem and critical security vulnerabilities are flagged up during code review. You can enable it here: https://lgtm.com/projects/g/alphagov/pay-selfservice/ci/

(Full disclosure: I'm part of the team that's responsible for LGTM.com)