### PR TITLE
PP-4564: Fix app metrics disabled flag equality

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@
 const path = require('path')
 
 // Please leave here even though it looks unused - this enables Node.js metrics to be pushed to Hosted Graphite
-if (!process.env.DISABLE_APPMETRICS) {
+if (process.env.DISABLE_APPMETRICS !== 'true') {
   require('./app/utils/metrics.js').metrics()
 }
 


### PR DESCRIPTION
This doesn't do what we think it does ™️

If any environment variable is set for `DIABLE_APP_METRICS` it will
result in `false`, this is because any defined string in JavaScript
converted to Boolean (`!`) will result in `true` - negating this will
always be false.

The current behaviour will disable app metrics if any value is set for
this environment variable (even if it's explicitly false).

Suggestion for extracting core functionality into shared modules made for upcoming work.

Note: This should be checked carefully before pushing to production - it may alter the way environments interpret or set flags