### PR TITLE
PP-4449 "Request to go live" index page implementation and testing

### DIFF
--- a/app/controllers/request-to-go-live/go-live-stage-to-next-page-path.js
+++ b/app/controllers/request-to-go-live/go-live-stage-to-next-page-path.js
@@ -2,20 +2,20 @@
 
 // Local dependencies
 const goLiveStage = require('../../models/go-live-stage')
-const paths = require('../../paths')
+const { requestToGoLive } = require('../../paths')
 
 const goLiveStageToNextPagePathMap = {}
-goLiveStageToNextPagePathMap[goLiveStage.NOT_STARTED] = paths.requestToGoLive.organisationName
-goLiveStageToNextPagePathMap[goLiveStage.ENTERED_ORGANISATION_NAME] = paths.requestToGoLive.chooseHowToProcessPayments
-goLiveStageToNextPagePathMap[goLiveStage.CHOSEN_PSP_STRIPE] = paths.requestToGoLive.agreement
-goLiveStageToNextPagePathMap[goLiveStage.CHOSEN_PSP_WORLDPAY] = paths.requestToGoLive.agreement
-goLiveStageToNextPagePathMap[goLiveStage.CHOSEN_PSP_SMARTPAY] = paths.requestToGoLive.agreement
-goLiveStageToNextPagePathMap[goLiveStage.CHOSEN_PSP_EPDQ] = paths.requestToGoLive.agreement
-goLiveStageToNextPagePathMap[goLiveStage.TERMS_AGREED_STRIPE] = paths.requestToGoLive.index
-goLiveStageToNextPagePathMap[goLiveStage.TERMS_AGREED_WORLDPAY] = paths.requestToGoLive.index
-goLiveStageToNextPagePathMap[goLiveStage.TERMS_AGREED_SMARTPAY] = paths.requestToGoLive.index
-goLiveStageToNextPagePathMap[goLiveStage.TERMS_AGREED_EPDQ] = paths.requestToGoLive.index
-goLiveStageToNextPagePathMap[goLiveStage.DENIED] = paths.requestToGoLive.index
-goLiveStageToNextPagePathMap[goLiveStage.LIVE] = paths.requestToGoLive.index
+goLiveStageToNextPagePathMap[goLiveStage.NOT_STARTED] = requestToGoLive.organisationName
+goLiveStageToNextPagePathMap[goLiveStage.ENTERED_ORGANISATION_NAME] = requestToGoLive.chooseHowToProcessPayments
+goLiveStageToNextPagePathMap[goLiveStage.CHOSEN_PSP_STRIPE] = requestToGoLive.agreement
+goLiveStageToNextPagePathMap[goLiveStage.CHOSEN_PSP_WORLDPAY] = requestToGoLive.agreement
+goLiveStageToNextPagePathMap[goLiveStage.CHOSEN_PSP_SMARTPAY] = requestToGoLive.agreement
+goLiveStageToNextPagePathMap[goLiveStage.CHOSEN_PSP_EPDQ] = requestToGoLive.agreement
+goLiveStageToNextPagePathMap[goLiveStage.TERMS_AGREED_STRIPE] = requestToGoLive.index
+goLiveStageToNextPagePathMap[goLiveStage.TERMS_AGREED_WORLDPAY] = requestToGoLive.index
+goLiveStageToNextPagePathMap[goLiveStage.TERMS_AGREED_SMARTPAY] = requestToGoLive.index
+goLiveStageToNextPagePathMap[goLiveStage.TERMS_AGREED_EPDQ] = requestToGoLive.index
+goLiveStageToNextPagePathMap[goLiveStage.DENIED] = requestToGoLive.index
+goLiveStageToNextPagePathMap[goLiveStage.LIVE] = requestToGoLive.index
 
 module.exports = goLiveStageToNextPagePathMap

--- a/app/controllers/request-to-go-live/go-live-stage-to-next-page-path.js
+++ b/app/controllers/request-to-go-live/go-live-stage-to-next-page-path.js
@@ -1,0 +1,21 @@
+'use strict'
+
+// Local dependencies
+const goLiveStage = require('../../models/go-live-stage')
+const paths = require('../../paths')
+
+const goLiveStageToNextPagePathMap = {}
+goLiveStageToNextPagePathMap[goLiveStage.NOT_STARTED] = paths.requestToGoLive.organisationName
+goLiveStageToNextPagePathMap[goLiveStage.ENTERED_ORGANISATION_NAME] = paths.requestToGoLive.chooseHowToProcessPayments
+goLiveStageToNextPagePathMap[goLiveStage.CHOSEN_PSP_STRIPE] = paths.requestToGoLive.agreement
+goLiveStageToNextPagePathMap[goLiveStage.CHOSEN_PSP_WORLDPAY] = paths.requestToGoLive.agreement
+goLiveStageToNextPagePathMap[goLiveStage.CHOSEN_PSP_SMARTPAY] = paths.requestToGoLive.agreement
+goLiveStageToNextPagePathMap[goLiveStage.CHOSEN_PSP_EPDQ] = paths.requestToGoLive.agreement
+goLiveStageToNextPagePathMap[goLiveStage.TERMS_AGREED_STRIPE] = paths.requestToGoLive.index
+goLiveStageToNextPagePathMap[goLiveStage.TERMS_AGREED_WORLDPAY] = paths.requestToGoLive.index
+goLiveStageToNextPagePathMap[goLiveStage.TERMS_AGREED_SMARTPAY] = paths.requestToGoLive.index
+goLiveStageToNextPagePathMap[goLiveStage.TERMS_AGREED_EPDQ] = paths.requestToGoLive.index
+goLiveStageToNextPagePathMap[goLiveStage.DENIED] = paths.requestToGoLive.index
+goLiveStageToNextPagePathMap[goLiveStage.LIVE] = paths.requestToGoLive.index
+
+module.exports = goLiveStageToNextPagePathMap

--- a/app/controllers/request-to-go-live/index/get.controller.js
+++ b/app/controllers/request-to-go-live/index/get.controller.js
@@ -1,10 +1,16 @@
 'use strict'
 
 // Local dependencies
+const goLiveStage = require('../../../models/go-live-stage')
 const response = require('../../../utils/response')
 
 module.exports = (req, res) => {
-  // TODO: finish the UI implementation and logic
-  const externalServiceId = req.service.externalId
-  return response.response(req, res, 'request-to-go-live/index', {externalServiceId})
+  return response.response(
+    req,
+    res,
+    'request-to-go-live/index',
+    {
+      goLiveStage
+    }
+  )
 }

--- a/app/controllers/request-to-go-live/index/post.controller.js
+++ b/app/controllers/request-to-go-live/index/post.controller.js
@@ -1,10 +1,11 @@
 'use strict'
 
 // Local dependencies
-const paths = require('../../../paths')
+const goLiveStageToNextPagePath = require('../go-live-stage-to-next-page-path')
 
 module.exports = (req, res) => {
-  // TODO: finish the UI implementation and logic
-  const externalServiceId = req.service.externalId
-  res.redirect(303, paths.requestToGoLive.index.replace(':externalServiceId', externalServiceId))
+  res.redirect(
+    303,
+    goLiveStageToNextPagePath[req.service.currentGoLiveStage].replace(':externalServiceId', req.service.externalId)
+  )
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -156,6 +156,9 @@ module.exports = {
   },
   generateRoute: require(path.join(__dirname, '/utils/generate_route.js')),
   requestToGoLive: {
-    index: '/service/:externalServiceId/request-to-go-live'
+    index: '/service/:externalServiceId/request-to-go-live',
+    organisationName: '/service/:externalServiceId/request-to-go-live/organisation-name',
+    chooseHowToProcessPayments: '/service/:externalServiceId/request-to-go-live/choose-how-to-process-payments',
+    agreement: '/service/:externalServiceId/request-to-go-live/agreement'
   }
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -1,5 +1,6 @@
 'use strict'
 
+// Node.js core dependencies
 const path = require('path')
 
 module.exports = {

--- a/app/views/request-to-go-live/index.njk
+++ b/app/views/request-to-go-live/index.njk
@@ -1,28 +1,113 @@
 {% extends "../layout.njk" %}
 {% from "components/button/macro.njk" import govukButton %}
+{% from "components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% block pageTitle %}
   Request to go live - {{ currentService.name }} - GOV.UK Pay
 {% endblock %}
 
 {% block mainContent %}
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l govuk-!-margin-top-6 govuk-!-margin-bottom-2">Request to go live</h1>
-    <p class="govuk-body-l intro">Complete these steps to start taking real payments.</p>
-
-    <div class="request-to-go-live-list">
-       <h3 class="govuk-heading-m">Add your organisation’s name</h3>
-      <p class="govuk-body-m">This information will appear on your payment pages.</p>
-      <h3 class="govuk-heading-m">Choose how to process payments</h3>
-      <p class="govuk-body-m">Use GOV.UK Pay’s preferred payment service provider (PSP). If you have already procured
-        your own PSP, you can enter their details instead.</p>
-      <h3 class="govuk-heading-m">Sign an agreement with GOV.UK Pay</h3>
-      <p class="govuk-body-m">GOV.UK Pay will contact you within one working day to confirm whether or not your
-        organisation has already signed an agreement. If not, we’ll send you the relevant documents.</p>
-      <form id="request-to-go-live-index-form" method="post" action="/service/{{externalServiceId}}/request-to-go-live">
-        <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
-        {{ govukButton({ text: "Start now" }) }}
-      </form>
+  {% if currentService.currentGoLiveStage === goLiveStage.LIVE %}
+    <div class="govuk-grid-column-full">
+      <div class="next-steps-panel">
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-0">Your service is live</h3>
+        <p class="govuk-body-l govuk-!-margin-bottom-4">You can now start taking payments.</p>
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Next steps:</h3>
+        <ul class="govuk-list govuk-list--bullet">
+          {% if currentService.hasCardGatewayAccount %}
+            <li><a class="govuk-link govuk-link--no-visited-state" href="/card-types/summary">manage the card types</a> your service accepts and turn on 3D Secure</li>
+          {% endif %}
+          <li><a class="govuk-link govuk-link--no-visited-state" href="/service/{{currentService.externalId}}">add team members</a> and edit their account permissions.</li>
+        </ul>
+      </div>
     </div>
-  </div>
+  {% endif %}
+  {% if currentService.currentGoLiveStage === goLiveStage.DENIED %}
+    <div class="govuk-grid-column-full govuk-!-margin-top-6">
+    {{ govukErrorSummary({
+      titleText: 'There is a problem',
+      errorList: [
+        {
+          html: '<a class="govuk-link" href="https://www.payments.service.gov.uk/support/" title="Contact the GOV.UK Pay Team">Please contact GOV.UK Pay support</a>'
+        }
+      ]
+    }) }}
+    </div>
+  {% else %}
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l govuk-!-margin-top-6 govuk-!-margin-bottom-2">Request to go live</h1>
+      <p class="govuk-body-l intro">Complete these steps to start taking real payments.</p>
+
+      <div class="request-to-go-live-list">
+        <div id="request-to-go-live-step-1">
+          <h3 class="govuk-heading-m">
+            Add your organisation’s name
+            {% if currentService.currentGoLiveStage in [
+              goLiveStage.ENTERED_ORGANISATION_NAME,
+              goLiveStage.CHOSEN_PSP_STRIPE,
+              goLiveStage.CHOSEN_PSP_WORLDPAY,
+              goLiveStage.CHOSEN_PSP_SMARTPAY,
+              goLiveStage.CHOSEN_PSP_EPDQ,
+              goLiveStage.TERMS_AGREED_STRIPE,
+              goLiveStage.TERMS_AGREED_WORLDPAY,
+              goLiveStage.TERMS_AGREED_SMARTPAY,
+              goLiveStage.TERMS_AGREED_EPDQ,
+              goLiveStage.LIVE
+            ] %}
+              <span class="status">COMPLETED</span>
+            {% endif %}
+          </h3>
+          <p class="govuk-body-m">This information will appear on your payment pages.</p>
+        </div>
+        <div id="request-to-go-live-step-2">
+          <h3 class="govuk-heading-m">
+            Choose how to process payments
+            {% if currentService.currentGoLiveStage in [
+              goLiveStage.CHOSEN_PSP_STRIPE,
+              goLiveStage.CHOSEN_PSP_WORLDPAY,
+              goLiveStage.CHOSEN_PSP_SMARTPAY,
+              goLiveStage.CHOSEN_PSP_EPDQ,
+              goLiveStage.TERMS_AGREED_STRIPE,
+              goLiveStage.TERMS_AGREED_WORLDPAY,
+              goLiveStage.TERMS_AGREED_SMARTPAY,
+              goLiveStage.TERMS_AGREED_EPDQ,
+              goLiveStage.LIVE
+            ] %}
+              <span class="status">COMPLETED</span>
+            {% endif %}
+          </h3>
+          <p class="govuk-body-m">Use GOV.UK Pay’s preferred payment service provider (PSP). If you have already procured your own PSP, you can enter their details instead.</p>
+        </div>
+        <div id="request-to-go-live-step-3">
+          <h3 class="govuk-heading-m">
+            Sign an agreement with GOV.UK Pay
+            {% if currentService.currentGoLiveStage in [
+              goLiveStage.TERMS_AGREED_STRIPE,
+              goLiveStage.TERMS_AGREED_WORLDPAY,
+              goLiveStage.TERMS_AGREED_SMARTPAY,
+              goLiveStage.TERMS_AGREED_EPDQ,
+              goLiveStage.LIVE
+            ] %}
+              <span class="status">COMPLETED</span>
+            {% endif %}
+          </h3>
+          <p class="govuk-body-m">GOV.UK Pay will contact you within one working day to confirm whether or not your organisation has already signed an agreement. If not, we’ll send you the relevant documents.</p>
+        </div>
+        <form id="request-to-go-live-index-form" method="post" action="/service/{{currentService.externalId}}/request-to-go-live">
+          <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+          {% if currentService.currentGoLiveStage === goLiveStage.NOT_STARTED %}
+            {{ govukButton({ text: "Start now" }) }}
+          {% elif currentService.currentGoLiveStage not in [
+            goLiveStage.TERMS_AGREED_STRIPE,
+            goLiveStage.TERMS_AGREED_WORLDPAY,
+            goLiveStage.TERMS_AGREED_SMARTPAY,
+            goLiveStage.TERMS_AGREED_EPDQ,
+            goLiveStage.LIVE
+          ] %}
+            {{ govukButton({ text: "Continue" }) }}
+          {% endif %}
+        </form>
+      </div>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/test/cypress/integration/user/request_to_go_live_index_spec.js
+++ b/test/cypress/integration/user/request_to_go_live_index_spec.js
@@ -1,0 +1,340 @@
+describe('Request to go live: Index', () => {
+  const selfServiceUsers = require('../../../fixtures/config/self_service_user.json')
+
+  describe('no permissions', () => {
+    beforeEach(() => {
+      cy.setCookie('session', Cypress.env('encryptedSessionRequestToGoLiveNoPermissionsCookie'))
+      cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveNoPermissionsCookie'))
+    })
+
+    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_NO_PERMISSIONS')[0]
+
+    it('should show an error when the user does not have enough permissions', () => {
+      const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
+      cy.visit(requestToGoLivePageUrl)
+      cy.get('h1').should('contain', 'An error occurred:')
+      cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+    })
+  })
+
+  describe('REQUEST_TO_GO_LIVE_STAGE_NOT_STARTED', () => {
+    beforeEach(() => {
+      cy.setCookie('session', Cypress.env('encryptedSessionRequestToGoLiveStageNotStartedCookie'))
+      cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageNotStartedCookie'))
+    })
+
+    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_NOT_STARTED')[0]
+
+    it('should show "Request to go live" page with correct progress indication', () => {
+      const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
+      cy.visit(requestToGoLivePageUrl)
+      cy.get('#request-to-go-live-step-1 > h3').should('exist')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('not.exist')
+
+      cy.get('#request-to-go-live-step-2 > h3').should('exist')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('not.exist')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
+
+      cy.get('#request-to-go-live-index-form > button').should('exist')
+      cy.get('#request-to-go-live-index-form > button').should('contain', 'Start now')
+      cy.get('#request-to-go-live-index-form > button').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/service/rtglnotstarted/request-to-go-live/organisation-name')
+      })
+    })
+  })
+
+  describe('REQUEST_TO_GO_LIVE_STAGE_ENTERED_ORGANISATION_NAME', () => {
+    beforeEach(() => {
+      cy.setCookie('session', Cypress.env('encryptedSessionRequestToGoLiveStageEnteredOrganisationNameCookie'))
+      cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageEnteredOrganisationNameCookie'))
+    })
+
+    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_ENTERED_ORGANISATION_NAME')[0]
+
+    it('should show "Request to go live" page with correct progress indication', () => {
+      const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
+      cy.visit(requestToGoLivePageUrl)
+      cy.get('#request-to-go-live-step-1 > h3').should('exist')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-2 > h3').should('exist')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('not.exist')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
+
+      cy.get('#request-to-go-live-index-form > button').should('exist')
+      cy.get('#request-to-go-live-index-form > button').should('contain', 'Continue')
+      cy.get('#request-to-go-live-index-form > button').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/service/rtglenteredorgname/request-to-go-live/choose-how-to-process-payments')
+      })
+    })
+  })
+
+  describe('REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_STRIPE', () => {
+    beforeEach(() => {
+      cy.setCookie('session', Cypress.env('encryptedSessionRequestToGoLiveStageChosenPspStripeCookie'))
+      cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageChosenPspStripeCookie'))
+    })
+
+    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_STRIPE')[0]
+
+    it('should show "Request to go live" page with correct progress indication', () => {
+      const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
+      cy.visit(requestToGoLivePageUrl)
+      cy.get('#request-to-go-live-step-1 > h3').should('exist')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-2 > h3').should('exist')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
+
+      cy.get('#request-to-go-live-index-form > button').should('exist')
+      cy.get('#request-to-go-live-index-form > button').should('contain', 'Continue')
+      cy.get('#request-to-go-live-index-form > button').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/service/rtglchosenpspstripe/request-to-go-live/agreement')
+      })
+    })
+  })
+
+  describe('REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_WORLDPAY', () => {
+    beforeEach(() => {
+      cy.setCookie('session', Cypress.env('encryptedSessionRequestToGoLiveStageChosenPspWorldPayCookie'))
+      cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageChosenPspWorldPayCookie'))
+    })
+
+    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_WORLDPAY')[0]
+
+    it('should show "Request to go live" page with correct progress indication', () => {
+      const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
+      cy.visit(requestToGoLivePageUrl)
+      cy.get('#request-to-go-live-step-1 > h3').should('exist')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-2 > h3').should('exist')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
+
+      cy.get('#request-to-go-live-index-form > button').should('exist')
+      cy.get('#request-to-go-live-index-form > button').should('contain', 'Continue')
+      cy.get('#request-to-go-live-index-form > button').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/service/rtglchosenpspworldpay/request-to-go-live/agreement')
+      })
+    })
+  })
+
+  describe('REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_SMARTPAY', () => {
+    beforeEach(() => {
+      cy.setCookie('session', Cypress.env('encryptedSessionRequestToGoLiveStageChosenPspSmartPayCookie'))
+      cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageChosenPspSmartPayCookie'))
+    })
+
+    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_SMARTPAY')[0]
+
+    it('should show "Request to go live" page with correct progress indication', () => {
+      const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
+      cy.visit(requestToGoLivePageUrl)
+      cy.get('#request-to-go-live-step-1 > h3').should('exist')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-2 > h3').should('exist')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
+
+      cy.get('#request-to-go-live-index-form > button').should('exist')
+      cy.get('#request-to-go-live-index-form > button').should('contain', 'Continue')
+      cy.get('#request-to-go-live-index-form > button').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/service/rtglchosenpspsmartpay/request-to-go-live/agreement')
+      })
+    })
+  })
+
+  describe('REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_EPDQ', () => {
+    beforeEach(() => {
+      cy.setCookie('session', Cypress.env('encryptedSessionRequestToGoLiveStageChosenPspEpdqCookie'))
+      cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageChosenPspEpdqCookie'))
+    })
+
+    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_EPDQ')[0]
+
+    it('should show "Request to go live" page with correct progress indication', () => {
+      const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
+      cy.visit(requestToGoLivePageUrl)
+      cy.get('#request-to-go-live-step-1 > h3').should('exist')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-2 > h3').should('exist')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
+
+      cy.get('#request-to-go-live-index-form > button').should('exist')
+      cy.get('#request-to-go-live-index-form > button').should('contain', 'Continue')
+      cy.get('#request-to-go-live-index-form > button').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/service/rtglchosenpspepdq/request-to-go-live/agreement')
+      })
+    })
+  })
+
+  describe('REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_STRIPE', () => {
+    beforeEach(() => {
+      cy.setCookie('session', Cypress.env('encryptedSessionRequestToGoLiveStageTermsAgreedStripeCookie'))
+      cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageTermsAgreedStripeCookie'))
+    })
+
+    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_STRIPE')[0]
+
+    it('should show "Request to go live" page with correct progress indication', () => {
+      const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
+      cy.visit(requestToGoLivePageUrl)
+      cy.get('#request-to-go-live-step-1 > h3').should('exist')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-2 > h3').should('exist')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-index-form > button').should('not.exist')
+    })
+  })
+
+  describe('REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_WORLDPAY', () => {
+    beforeEach(() => {
+      cy.setCookie('session', Cypress.env('encryptedSessionRequestToGoLiveStageTermsAgreedWorldPayCookie'))
+      cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageTermsAgreedWorldPayCookie'))
+    })
+
+    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_WORLDPAY')[0]
+
+    it('should show "Request to go live" page with correct progress indication', () => {
+      const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
+      cy.visit(requestToGoLivePageUrl)
+      cy.get('#request-to-go-live-step-1 > h3').should('exist')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-2 > h3').should('exist')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-index-form > button').should('not.exist')
+    })
+  })
+
+  describe('REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_SMARTPAY', () => {
+    beforeEach(() => {
+      cy.setCookie('session', Cypress.env('encryptedSessionRequestToGoLiveStageTermsAgreedSmartPayCookie'))
+      cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageTermsAgreedSmartPayCookie'))
+    })
+
+    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_SMARTPAY')[0]
+
+    it('should show "Request to go live" page with correct progress indication', () => {
+      const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
+      cy.visit(requestToGoLivePageUrl)
+      cy.get('#request-to-go-live-step-1 > h3').should('exist')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-2 > h3').should('exist')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-index-form > button').should('not.exist')
+    })
+  })
+
+  describe('REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_EPDQ', () => {
+    beforeEach(() => {
+      cy.setCookie('session', Cypress.env('encryptedSessionRequestToGoLiveStageTermsAgreedEpdqCookie'))
+      cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageTermsAgreedEpdqCookie'))
+    })
+
+    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_EPDQ')[0]
+
+    it('should show "Request to go live" page with correct progress indication', () => {
+      const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
+      cy.visit(requestToGoLivePageUrl)
+      cy.get('#request-to-go-live-step-1 > h3').should('exist')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-2 > h3').should('exist')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-index-form > button').should('not.exist')
+    })
+  })
+
+  describe('REQUEST_TO_GO_LIVE_STAGE_DENIED', () => {
+    beforeEach(() => {
+      cy.setCookie('session', Cypress.env('encryptedSessionRequestToGoLiveStageDeniedCookie'))
+      cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageDeniedCookie'))
+    })
+
+    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_DENIED')[0]
+
+    it('should show "Request to go live" page with an error', () => {
+      const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
+      cy.visit(requestToGoLivePageUrl)
+      cy.get('.govuk-error-summary h2').should('contain', 'There is a problem')
+      cy.get('.govuk-error-summary .govuk-error-summary__list a')
+        .should('contain', 'Please contact GOV.UK Pay support')
+        .and('have.attr', 'href')
+        .and('eq', 'https://www.payments.service.gov.uk/support/')
+    })
+  })
+
+  describe('REQUEST_TO_GO_LIVE_STAGE_LIVE', () => {
+    beforeEach(() => {
+      cy.setCookie('session', Cypress.env('encryptedSessionRequestToGoLiveStageLiveCookie'))
+      cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageLiveCookie'))
+    })
+
+    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_LIVE')[0]
+
+    it('should show "Request to go live" page with correct progress indication', () => {
+      const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
+      cy.visit(requestToGoLivePageUrl)
+      cy.get('#request-to-go-live-step-1 > h3').should('exist')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-2 > h3').should('exist')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'COMPLETED')
+
+      cy.get('#request-to-go-live-index-form > button').should('not.exist')
+
+      cy.get('.govuk-grid-column-full h3').should('contain', 'Your service is live')
+    })
+  })
+})

--- a/test/cypress/integration/user/request_to_go_live_index_spec.js
+++ b/test/cypress/integration/user/request_to_go_live_index_spec.js
@@ -7,7 +7,7 @@ describe('Request to go live: Index', () => {
       cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveNoPermissionsCookie'))
     })
 
-    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_NO_PERMISSIONS')[0]
+    const selfServiceUser = selfServiceUsers.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_NO_PERMISSIONS')
 
     it('should show an error when the user does not have enough permissions', () => {
       const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
@@ -23,7 +23,7 @@ describe('Request to go live: Index', () => {
       cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageNotStartedCookie'))
     })
 
-    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_NOT_STARTED')[0]
+    const selfServiceUser = selfServiceUsers.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_NOT_STARTED')
 
     it('should show "Request to go live" page with correct progress indication', () => {
       const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
@@ -53,7 +53,7 @@ describe('Request to go live: Index', () => {
       cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageEnteredOrganisationNameCookie'))
     })
 
-    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_ENTERED_ORGANISATION_NAME')[0]
+    const selfServiceUser = selfServiceUsers.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_ENTERED_ORGANISATION_NAME')
 
     it('should show "Request to go live" page with correct progress indication', () => {
       const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
@@ -83,7 +83,7 @@ describe('Request to go live: Index', () => {
       cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageChosenPspStripeCookie'))
     })
 
-    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_STRIPE')[0]
+    const selfServiceUser = selfServiceUsers.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_STRIPE')
 
     it('should show "Request to go live" page with correct progress indication', () => {
       const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
@@ -113,7 +113,7 @@ describe('Request to go live: Index', () => {
       cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageChosenPspWorldPayCookie'))
     })
 
-    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_WORLDPAY')[0]
+    const selfServiceUser = selfServiceUsers.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_WORLDPAY')
 
     it('should show "Request to go live" page with correct progress indication', () => {
       const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
@@ -143,7 +143,7 @@ describe('Request to go live: Index', () => {
       cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageChosenPspSmartPayCookie'))
     })
 
-    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_SMARTPAY')[0]
+    const selfServiceUser = selfServiceUsers.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_SMARTPAY')
 
     it('should show "Request to go live" page with correct progress indication', () => {
       const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
@@ -173,7 +173,7 @@ describe('Request to go live: Index', () => {
       cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageChosenPspEpdqCookie'))
     })
 
-    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_EPDQ')[0]
+    const selfServiceUser = selfServiceUsers.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_EPDQ')
 
     it('should show "Request to go live" page with correct progress indication', () => {
       const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
@@ -203,7 +203,7 @@ describe('Request to go live: Index', () => {
       cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageTermsAgreedStripeCookie'))
     })
 
-    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_STRIPE')[0]
+    const selfServiceUser = selfServiceUsers.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_STRIPE')
 
     it('should show "Request to go live" page with correct progress indication', () => {
       const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
@@ -227,7 +227,7 @@ describe('Request to go live: Index', () => {
       cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageTermsAgreedWorldPayCookie'))
     })
 
-    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_WORLDPAY')[0]
+    const selfServiceUser = selfServiceUsers.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_WORLDPAY')
 
     it('should show "Request to go live" page with correct progress indication', () => {
       const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
@@ -251,7 +251,7 @@ describe('Request to go live: Index', () => {
       cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageTermsAgreedSmartPayCookie'))
     })
 
-    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_SMARTPAY')[0]
+    const selfServiceUser = selfServiceUsers.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_SMARTPAY')
 
     it('should show "Request to go live" page with correct progress indication', () => {
       const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
@@ -275,7 +275,7 @@ describe('Request to go live: Index', () => {
       cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageTermsAgreedEpdqCookie'))
     })
 
-    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_EPDQ')[0]
+    const selfServiceUser = selfServiceUsers.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_EPDQ')
 
     it('should show "Request to go live" page with correct progress indication', () => {
       const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
@@ -299,7 +299,7 @@ describe('Request to go live: Index', () => {
       cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageDeniedCookie'))
     })
 
-    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_DENIED')[0]
+    const selfServiceUser = selfServiceUsers.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_DENIED')
 
     it('should show "Request to go live" page with an error', () => {
       const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`
@@ -318,7 +318,7 @@ describe('Request to go live: Index', () => {
       cy.setCookie('gateway_account', Cypress.env('encryptedGatewayAccountRequestToGoLiveStageLiveCookie'))
     })
 
-    const selfServiceUser = selfServiceUsers.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_LIVE')[0]
+    const selfServiceUser = selfServiceUsers.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_LIVE')
 
     it('should show "Request to go live" page with correct progress indication', () => {
       const requestToGoLivePageUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live`

--- a/test/cypress/integration/user/request_to_go_live_index_spec.js
+++ b/test/cypress/integration/user/request_to_go_live_index_spec.js
@@ -42,7 +42,7 @@ describe('Request to go live: Index', () => {
       cy.get('#request-to-go-live-index-form > button').click()
 
       cy.location().should((location) => {
-        expect(location.pathname).to.eq('/service/rtglnotstarted/request-to-go-live/organisation-name')
+        expect(location.pathname).to.eq('/service/rtglNotStarted/request-to-go-live/organisation-name')
       })
     })
   })
@@ -72,7 +72,7 @@ describe('Request to go live: Index', () => {
       cy.get('#request-to-go-live-index-form > button').click()
 
       cy.location().should((location) => {
-        expect(location.pathname).to.eq('/service/rtglenteredorgname/request-to-go-live/choose-how-to-process-payments')
+        expect(location.pathname).to.eq('/service/rtglEnteredOrgName/request-to-go-live/choose-how-to-process-payments')
       })
     })
   })
@@ -102,7 +102,7 @@ describe('Request to go live: Index', () => {
       cy.get('#request-to-go-live-index-form > button').click()
 
       cy.location().should((location) => {
-        expect(location.pathname).to.eq('/service/rtglchosenpspstripe/request-to-go-live/agreement')
+        expect(location.pathname).to.eq('/service/rtglChosenPspStripe/request-to-go-live/agreement')
       })
     })
   })
@@ -132,7 +132,7 @@ describe('Request to go live: Index', () => {
       cy.get('#request-to-go-live-index-form > button').click()
 
       cy.location().should((location) => {
-        expect(location.pathname).to.eq('/service/rtglchosenpspworldpay/request-to-go-live/agreement')
+        expect(location.pathname).to.eq('/service/rtglChosenPspWorldPay/request-to-go-live/agreement')
       })
     })
   })
@@ -162,7 +162,7 @@ describe('Request to go live: Index', () => {
       cy.get('#request-to-go-live-index-form > button').click()
 
       cy.location().should((location) => {
-        expect(location.pathname).to.eq('/service/rtglchosenpspsmartpay/request-to-go-live/agreement')
+        expect(location.pathname).to.eq('/service/rtglChosenPspSmartPay/request-to-go-live/agreement')
       })
     })
   })
@@ -192,7 +192,7 @@ describe('Request to go live: Index', () => {
       cy.get('#request-to-go-live-index-form > button').click()
 
       cy.location().should((location) => {
-        expect(location.pathname).to.eq('/service/rtglchosenpspepdq/request-to-go-live/agreement')
+        expect(location.pathname).to.eq('/service/rtglChosenPspEpdq/request-to-go-live/agreement')
       })
     })
   })

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -21,183 +21,183 @@ module.exports = (on, config) => {
   const selfServiceUserConfig = require('../../fixtures/config/self_service_user.json')
 
   // Default user
-  const selfServiceUser = selfServiceUserConfig.config.users.filter(fil => fil.isPrimary === 'true')[0]
+  const selfServiceUser = selfServiceUserConfig.config.users.find(fil => fil.isPrimary === 'true')
   const encryptedSessionCookie = generateEncryptedSessionCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
     selfServiceUser.external_id
   )
   const encryptedGatewayAccountCookie = generateEncryptedGatewayAccountCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
-    selfServiceUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+    selfServiceUser.gateway_accounts.find(fil => fil.isPrimary === 'true').id
   )
   config.env.encryptedSessionCookie = encryptedSessionCookie
   config.env.encryptedGatewayAccountCookie = encryptedGatewayAccountCookie
 
   // REQUEST_TO_GO_LIVE_NO_PERMISSIONS user
-  const selfServiceRequestToGoLiveNoPermissionsUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_NO_PERMISSIONS')[0]
+  const selfServiceRequestToGoLiveNoPermissionsUser = selfServiceUserConfig.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_NO_PERMISSIONS')
   const encryptedSessionRequestToGoLiveNoPermissionsCookie = generateEncryptedSessionCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
     selfServiceRequestToGoLiveNoPermissionsUser.external_id
   )
   const encryptedGatewayAccountRequestToGoLiveNoPermissionsCookie = generateEncryptedGatewayAccountCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
-    selfServiceRequestToGoLiveNoPermissionsUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+    selfServiceRequestToGoLiveNoPermissionsUser.gateway_accounts.find(fil => fil.isPrimary === 'true').id
   )
   config.env.encryptedSessionRequestToGoLiveNoPermissionsCookie = encryptedSessionRequestToGoLiveNoPermissionsCookie
   config.env.encryptedGatewayAccountRequestToGoLiveNoPermissionsCookie = encryptedGatewayAccountRequestToGoLiveNoPermissionsCookie
 
   // REQUEST_TO_GO_LIVE_STAGE_NOT_STARTED user
-  const selfServiceRequestToGoLiveStageNotStartedUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_NOT_STARTED')[0]
+  const selfServiceRequestToGoLiveStageNotStartedUser = selfServiceUserConfig.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_NOT_STARTED')
   const encryptedSessionRequestToGoLiveStageNotStartedCookie = generateEncryptedSessionCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
     selfServiceRequestToGoLiveStageNotStartedUser.external_id
   )
   const encryptedGatewayAccountRequestToGoLiveStageNotStartedCookie = generateEncryptedGatewayAccountCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
-    selfServiceRequestToGoLiveStageNotStartedUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+    selfServiceRequestToGoLiveStageNotStartedUser.gateway_accounts.find(fil => fil.isPrimary === 'true').id
   )
   config.env.encryptedSessionRequestToGoLiveStageNotStartedCookie = encryptedSessionRequestToGoLiveStageNotStartedCookie
   config.env.encryptedGatewayAccountRequestToGoLiveStageNotStartedCookie = encryptedGatewayAccountRequestToGoLiveStageNotStartedCookie
 
   // REQUEST_TO_GO_LIVE_STAGE_ENTERED_ORGANISATION_NAME user
-  const selfServiceRequestToGoLiveStageEnteredOrganisationNameUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_ENTERED_ORGANISATION_NAME')[0]
+  const selfServiceRequestToGoLiveStageEnteredOrganisationNameUser = selfServiceUserConfig.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_ENTERED_ORGANISATION_NAME')
   const encryptedSessionRequestToGoLiveStageEnteredOrganisationNameCookie = generateEncryptedSessionCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
     selfServiceRequestToGoLiveStageEnteredOrganisationNameUser.external_id
   )
   const encryptedGatewayAccountRequestToGoLiveStageEnteredOrganisationNameCookie = generateEncryptedGatewayAccountCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
-    selfServiceRequestToGoLiveStageEnteredOrganisationNameUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+    selfServiceRequestToGoLiveStageEnteredOrganisationNameUser.gateway_accounts.find(fil => fil.isPrimary === 'true').id
   )
   config.env.encryptedSessionRequestToGoLiveStageEnteredOrganisationNameCookie = encryptedSessionRequestToGoLiveStageEnteredOrganisationNameCookie
   config.env.encryptedGatewayAccountRequestToGoLiveStageEnteredOrganisationNameCookie = encryptedGatewayAccountRequestToGoLiveStageEnteredOrganisationNameCookie
 
   // REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_STRIPE user
-  const selfServiceRequestToGoLiveStageChosenPspStripeUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_STRIPE')[0]
+  const selfServiceRequestToGoLiveStageChosenPspStripeUser = selfServiceUserConfig.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_STRIPE')
   const encryptedSessionRequestToGoLiveStageChosenPspStripeCookie = generateEncryptedSessionCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
     selfServiceRequestToGoLiveStageChosenPspStripeUser.external_id
   )
   const encryptedGatewayAccountRequestToGoLiveStageChosenPspStripeCookie = generateEncryptedGatewayAccountCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
-    selfServiceRequestToGoLiveStageChosenPspStripeUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+    selfServiceRequestToGoLiveStageChosenPspStripeUser.gateway_accounts.find(fil => fil.isPrimary === 'true').id
   )
   config.env.encryptedSessionRequestToGoLiveStageChosenPspStripeCookie = encryptedSessionRequestToGoLiveStageChosenPspStripeCookie
   config.env.encryptedGatewayAccountRequestToGoLiveStageChosenPspStripeCookie = encryptedGatewayAccountRequestToGoLiveStageChosenPspStripeCookie
 
   // REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_WORLDPAY user
-  const selfServiceRequestToGoLiveStageChosenPspWorldPayUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_WORLDPAY')[0]
+  const selfServiceRequestToGoLiveStageChosenPspWorldPayUser = selfServiceUserConfig.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_WORLDPAY')
   const encryptedSessionRequestToGoLiveStageChosenPspWorldPayCookie = generateEncryptedSessionCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
     selfServiceRequestToGoLiveStageChosenPspWorldPayUser.external_id
   )
   const encryptedGatewayAccountRequestToGoLiveStageChosenPspWorldPayCookie = generateEncryptedGatewayAccountCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
-    selfServiceRequestToGoLiveStageChosenPspWorldPayUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+    selfServiceRequestToGoLiveStageChosenPspWorldPayUser.gateway_accounts.find(fil => fil.isPrimary === 'true').id
   )
   config.env.encryptedSessionRequestToGoLiveStageChosenPspWorldPayCookie = encryptedSessionRequestToGoLiveStageChosenPspWorldPayCookie
   config.env.encryptedGatewayAccountRequestToGoLiveStageChosenPspWorldPayCookie = encryptedGatewayAccountRequestToGoLiveStageChosenPspWorldPayCookie
 
   // REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_SMARTPAY user
-  const selfServiceRequestToGoLiveStageChosenPspSmartPayUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_SMARTPAY')[0]
+  const selfServiceRequestToGoLiveStageChosenPspSmartPayUser = selfServiceUserConfig.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_SMARTPAY')
   const encryptedSessionRequestToGoLiveStageChosenPspSmartPayCookie = generateEncryptedSessionCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
     selfServiceRequestToGoLiveStageChosenPspSmartPayUser.external_id
   )
   const encryptedGatewayAccountRequestToGoLiveStageChosenPspSmartPayCookie = generateEncryptedGatewayAccountCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
-    selfServiceRequestToGoLiveStageChosenPspSmartPayUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+    selfServiceRequestToGoLiveStageChosenPspSmartPayUser.gateway_accounts.find(fil => fil.isPrimary === 'true').id
   )
   config.env.encryptedSessionRequestToGoLiveStageChosenPspSmartPayCookie = encryptedSessionRequestToGoLiveStageChosenPspSmartPayCookie
   config.env.encryptedGatewayAccountRequestToGoLiveStageChosenPspSmartPayCookie = encryptedGatewayAccountRequestToGoLiveStageChosenPspSmartPayCookie
 
   // REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_EPDQ user
-  const selfServiceRequestToGoLiveStageChosenPspEpdqUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_EPDQ')[0]
+  const selfServiceRequestToGoLiveStageChosenPspEpdqUser = selfServiceUserConfig.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_EPDQ')
   const encryptedSessionRequestToGoLiveStageChosenPspEpdqCookie = generateEncryptedSessionCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
     selfServiceRequestToGoLiveStageChosenPspEpdqUser.external_id
   )
   const encryptedGatewayAccountRequestToGoLiveStageChosenPspEpdqCookie = generateEncryptedGatewayAccountCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
-    selfServiceRequestToGoLiveStageChosenPspEpdqUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+    selfServiceRequestToGoLiveStageChosenPspEpdqUser.gateway_accounts.find(fil => fil.isPrimary === 'true').id
   )
   config.env.encryptedSessionRequestToGoLiveStageChosenPspEpdqCookie = encryptedSessionRequestToGoLiveStageChosenPspEpdqCookie
   config.env.encryptedGatewayAccountRequestToGoLiveStageChosenPspEpdqCookie = encryptedGatewayAccountRequestToGoLiveStageChosenPspEpdqCookie
 
   // REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_STRIPE user
-  const selfServiceRequestToGoLiveStageTermsAgreedStripeUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_STRIPE')[0]
+  const selfServiceRequestToGoLiveStageTermsAgreedStripeUser = selfServiceUserConfig.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_STRIPE')
   const encryptedSessionRequestToGoLiveStageTermsAgreedStripeCookie = generateEncryptedSessionCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
     selfServiceRequestToGoLiveStageTermsAgreedStripeUser.external_id
   )
   const encryptedGatewayAccountRequestToGoLiveStageTermsAgreedStripeCookie = generateEncryptedGatewayAccountCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
-    selfServiceRequestToGoLiveStageTermsAgreedStripeUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+    selfServiceRequestToGoLiveStageTermsAgreedStripeUser.gateway_accounts.find(fil => fil.isPrimary === 'true').id
   )
   config.env.encryptedSessionRequestToGoLiveStageTermsAgreedStripeCookie = encryptedSessionRequestToGoLiveStageTermsAgreedStripeCookie
   config.env.encryptedGatewayAccountRequestToGoLiveStageTermsAgreedStripeCookie = encryptedGatewayAccountRequestToGoLiveStageTermsAgreedStripeCookie
 
   // REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_WORLDPAY user
-  const selfServiceRequestToGoLiveStageTermsAgreedWorldPayUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_WORLDPAY')[0]
+  const selfServiceRequestToGoLiveStageTermsAgreedWorldPayUser = selfServiceUserConfig.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_WORLDPAY')
   const encryptedSessionRequestToGoLiveStageTermsAgreedWorldPayCookie = generateEncryptedSessionCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
     selfServiceRequestToGoLiveStageTermsAgreedWorldPayUser.external_id
   )
   const encryptedGatewayAccountRequestToGoLiveStageTermsAgreedWorldPayCookie = generateEncryptedGatewayAccountCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
-    selfServiceRequestToGoLiveStageTermsAgreedWorldPayUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+    selfServiceRequestToGoLiveStageTermsAgreedWorldPayUser.gateway_accounts.find(fil => fil.isPrimary === 'true').id
   )
   config.env.encryptedSessionRequestToGoLiveStageTermsAgreedWorldPayCookie = encryptedSessionRequestToGoLiveStageTermsAgreedWorldPayCookie
   config.env.encryptedGatewayAccountRequestToGoLiveStageTermsAgreedWorldPayCookie = encryptedGatewayAccountRequestToGoLiveStageTermsAgreedWorldPayCookie
 
   // REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_SMARTPAY user
-  const selfServiceRequestToGoLiveStageTermsAgreedSmartPayUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_SMARTPAY')[0]
+  const selfServiceRequestToGoLiveStageTermsAgreedSmartPayUser = selfServiceUserConfig.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_SMARTPAY')
   const encryptedSessionRequestToGoLiveStageTermsAgreedSmartPayCookie = generateEncryptedSessionCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
     selfServiceRequestToGoLiveStageTermsAgreedSmartPayUser.external_id
   )
   const encryptedGatewayAccountRequestToGoLiveStageTermsAgreedSmartPayCookie = generateEncryptedGatewayAccountCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
-    selfServiceRequestToGoLiveStageTermsAgreedSmartPayUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+    selfServiceRequestToGoLiveStageTermsAgreedSmartPayUser.gateway_accounts.find(fil => fil.isPrimary === 'true').id
   )
   config.env.encryptedSessionRequestToGoLiveStageTermsAgreedSmartPayCookie = encryptedSessionRequestToGoLiveStageTermsAgreedSmartPayCookie
   config.env.encryptedGatewayAccountRequestToGoLiveStageTermsAgreedSmartPayCookie = encryptedGatewayAccountRequestToGoLiveStageTermsAgreedSmartPayCookie
 
   // REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_EPDQ user
-  const selfServiceRequestToGoLiveStageTermsAgreedEpdqUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_EPDQ')[0]
+  const selfServiceRequestToGoLiveStageTermsAgreedEpdqUser = selfServiceUserConfig.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_EPDQ')
   const encryptedSessionRequestToGoLiveStageTermsAgreedEpdqCookie = generateEncryptedSessionCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
     selfServiceRequestToGoLiveStageTermsAgreedEpdqUser.external_id
   )
   const encryptedGatewayAccountRequestToGoLiveStageTermsAgreedEpdqCookie = generateEncryptedGatewayAccountCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
-    selfServiceRequestToGoLiveStageTermsAgreedEpdqUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+    selfServiceRequestToGoLiveStageTermsAgreedEpdqUser.gateway_accounts.find(fil => fil.isPrimary === 'true').id
   )
   config.env.encryptedSessionRequestToGoLiveStageTermsAgreedEpdqCookie = encryptedSessionRequestToGoLiveStageTermsAgreedEpdqCookie
   config.env.encryptedGatewayAccountRequestToGoLiveStageTermsAgreedEpdqCookie = encryptedGatewayAccountRequestToGoLiveStageTermsAgreedEpdqCookie
 
   // REQUEST_TO_GO_LIVE_STAGE_DENIED user
-  const selfServiceRequestToGoLiveStageDeniedUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_DENIED')[0]
+  const selfServiceRequestToGoLiveStageDeniedUser = selfServiceUserConfig.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_DENIED')
   const encryptedSessionRequestToGoLiveStageDeniedCookie = generateEncryptedSessionCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
     selfServiceRequestToGoLiveStageDeniedUser.external_id
   )
   const encryptedGatewayAccountRequestToGoLiveStageDeniedCookie = generateEncryptedGatewayAccountCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
-    selfServiceRequestToGoLiveStageDeniedUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+    selfServiceRequestToGoLiveStageDeniedUser.gateway_accounts.find(fil => fil.isPrimary === 'true').id
   )
   config.env.encryptedSessionRequestToGoLiveStageDeniedCookie = encryptedSessionRequestToGoLiveStageDeniedCookie
   config.env.encryptedGatewayAccountRequestToGoLiveStageDeniedCookie = encryptedGatewayAccountRequestToGoLiveStageDeniedCookie
 
   // REQUEST_TO_GO_LIVE_STAGE_LIVE user
-  const selfServiceRequestToGoLiveStageLiveUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_LIVE')[0]
+  const selfServiceRequestToGoLiveStageLiveUser = selfServiceUserConfig.config.users.find(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_LIVE')
   const encryptedSessionRequestToGoLiveStageLiveCookie = generateEncryptedSessionCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
     selfServiceRequestToGoLiveStageLiveUser.external_id
   )
   const encryptedGatewayAccountRequestToGoLiveStageLiveCookie = generateEncryptedGatewayAccountCookie(
     config.env.TEST_SESSION_ENCRYPTION_KEY,
-    selfServiceRequestToGoLiveStageLiveUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+    selfServiceRequestToGoLiveStageLiveUser.gateway_accounts.find(fil => fil.isPrimary === 'true').id
   )
   config.env.encryptedSessionRequestToGoLiveStageLiveCookie = encryptedSessionRequestToGoLiveStageLiveCookie
   config.env.encryptedGatewayAccountRequestToGoLiveStageLiveCookie = encryptedGatewayAccountRequestToGoLiveStageLiveCookie

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -18,30 +18,210 @@ module.exports = (on, config) => {
 
   // The same fixed user config is used to generate pacts/contracts, so generating cookies from this config
   // ensures our pact-stub server is ready to return canned responses.
-  const ssUserConfig = require('../../fixtures/config/self_service_user.json')
+  const selfServiceUserConfig = require('../../fixtures/config/self_service_user.json')
 
-  const ssUser = ssUserConfig.config.users.filter(fil => fil.isPrimary === 'true')[0]
+  // Default user
+  const selfServiceUser = selfServiceUserConfig.config.users.filter(fil => fil.isPrimary === 'true')[0]
+  const encryptedSessionCookie = generateEncryptedSessionCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceUser.external_id
+  )
+  const encryptedGatewayAccountCookie = generateEncryptedGatewayAccountCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+  )
+  config.env.encryptedSessionCookie = encryptedSessionCookie
+  config.env.encryptedGatewayAccountCookie = encryptedGatewayAccountCookie
 
-  const encryptedSessionCookie = cookieMonster.getCookie('session', config.env.TEST_SESSION_ENCRYPTION_KEY,
+  // REQUEST_TO_GO_LIVE_NO_PERMISSIONS user
+  const selfServiceRequestToGoLiveNoPermissionsUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_NO_PERMISSIONS')[0]
+  const encryptedSessionRequestToGoLiveNoPermissionsCookie = generateEncryptedSessionCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveNoPermissionsUser.external_id
+  )
+  const encryptedGatewayAccountRequestToGoLiveNoPermissionsCookie = generateEncryptedGatewayAccountCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveNoPermissionsUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+  )
+  config.env.encryptedSessionRequestToGoLiveNoPermissionsCookie = encryptedSessionRequestToGoLiveNoPermissionsCookie
+  config.env.encryptedGatewayAccountRequestToGoLiveNoPermissionsCookie = encryptedGatewayAccountRequestToGoLiveNoPermissionsCookie
+
+  // REQUEST_TO_GO_LIVE_STAGE_NOT_STARTED user
+  const selfServiceRequestToGoLiveStageNotStartedUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_NOT_STARTED')[0]
+  const encryptedSessionRequestToGoLiveStageNotStartedCookie = generateEncryptedSessionCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageNotStartedUser.external_id
+  )
+  const encryptedGatewayAccountRequestToGoLiveStageNotStartedCookie = generateEncryptedGatewayAccountCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageNotStartedUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+  )
+  config.env.encryptedSessionRequestToGoLiveStageNotStartedCookie = encryptedSessionRequestToGoLiveStageNotStartedCookie
+  config.env.encryptedGatewayAccountRequestToGoLiveStageNotStartedCookie = encryptedGatewayAccountRequestToGoLiveStageNotStartedCookie
+
+  // REQUEST_TO_GO_LIVE_STAGE_ENTERED_ORGANISATION_NAME user
+  const selfServiceRequestToGoLiveStageEnteredOrganisationNameUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_ENTERED_ORGANISATION_NAME')[0]
+  const encryptedSessionRequestToGoLiveStageEnteredOrganisationNameCookie = generateEncryptedSessionCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageEnteredOrganisationNameUser.external_id
+  )
+  const encryptedGatewayAccountRequestToGoLiveStageEnteredOrganisationNameCookie = generateEncryptedGatewayAccountCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageEnteredOrganisationNameUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+  )
+  config.env.encryptedSessionRequestToGoLiveStageEnteredOrganisationNameCookie = encryptedSessionRequestToGoLiveStageEnteredOrganisationNameCookie
+  config.env.encryptedGatewayAccountRequestToGoLiveStageEnteredOrganisationNameCookie = encryptedGatewayAccountRequestToGoLiveStageEnteredOrganisationNameCookie
+
+  // REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_STRIPE user
+  const selfServiceRequestToGoLiveStageChosenPspStripeUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_STRIPE')[0]
+  const encryptedSessionRequestToGoLiveStageChosenPspStripeCookie = generateEncryptedSessionCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageChosenPspStripeUser.external_id
+  )
+  const encryptedGatewayAccountRequestToGoLiveStageChosenPspStripeCookie = generateEncryptedGatewayAccountCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageChosenPspStripeUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+  )
+  config.env.encryptedSessionRequestToGoLiveStageChosenPspStripeCookie = encryptedSessionRequestToGoLiveStageChosenPspStripeCookie
+  config.env.encryptedGatewayAccountRequestToGoLiveStageChosenPspStripeCookie = encryptedGatewayAccountRequestToGoLiveStageChosenPspStripeCookie
+
+  // REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_WORLDPAY user
+  const selfServiceRequestToGoLiveStageChosenPspWorldPayUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_WORLDPAY')[0]
+  const encryptedSessionRequestToGoLiveStageChosenPspWorldPayCookie = generateEncryptedSessionCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageChosenPspWorldPayUser.external_id
+  )
+  const encryptedGatewayAccountRequestToGoLiveStageChosenPspWorldPayCookie = generateEncryptedGatewayAccountCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageChosenPspWorldPayUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+  )
+  config.env.encryptedSessionRequestToGoLiveStageChosenPspWorldPayCookie = encryptedSessionRequestToGoLiveStageChosenPspWorldPayCookie
+  config.env.encryptedGatewayAccountRequestToGoLiveStageChosenPspWorldPayCookie = encryptedGatewayAccountRequestToGoLiveStageChosenPspWorldPayCookie
+
+  // REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_SMARTPAY user
+  const selfServiceRequestToGoLiveStageChosenPspSmartPayUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_SMARTPAY')[0]
+  const encryptedSessionRequestToGoLiveStageChosenPspSmartPayCookie = generateEncryptedSessionCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageChosenPspSmartPayUser.external_id
+  )
+  const encryptedGatewayAccountRequestToGoLiveStageChosenPspSmartPayCookie = generateEncryptedGatewayAccountCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageChosenPspSmartPayUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+  )
+  config.env.encryptedSessionRequestToGoLiveStageChosenPspSmartPayCookie = encryptedSessionRequestToGoLiveStageChosenPspSmartPayCookie
+  config.env.encryptedGatewayAccountRequestToGoLiveStageChosenPspSmartPayCookie = encryptedGatewayAccountRequestToGoLiveStageChosenPspSmartPayCookie
+
+  // REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_EPDQ user
+  const selfServiceRequestToGoLiveStageChosenPspEpdqUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_EPDQ')[0]
+  const encryptedSessionRequestToGoLiveStageChosenPspEpdqCookie = generateEncryptedSessionCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageChosenPspEpdqUser.external_id
+  )
+  const encryptedGatewayAccountRequestToGoLiveStageChosenPspEpdqCookie = generateEncryptedGatewayAccountCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageChosenPspEpdqUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+  )
+  config.env.encryptedSessionRequestToGoLiveStageChosenPspEpdqCookie = encryptedSessionRequestToGoLiveStageChosenPspEpdqCookie
+  config.env.encryptedGatewayAccountRequestToGoLiveStageChosenPspEpdqCookie = encryptedGatewayAccountRequestToGoLiveStageChosenPspEpdqCookie
+
+  // REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_STRIPE user
+  const selfServiceRequestToGoLiveStageTermsAgreedStripeUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_STRIPE')[0]
+  const encryptedSessionRequestToGoLiveStageTermsAgreedStripeCookie = generateEncryptedSessionCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageTermsAgreedStripeUser.external_id
+  )
+  const encryptedGatewayAccountRequestToGoLiveStageTermsAgreedStripeCookie = generateEncryptedGatewayAccountCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageTermsAgreedStripeUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+  )
+  config.env.encryptedSessionRequestToGoLiveStageTermsAgreedStripeCookie = encryptedSessionRequestToGoLiveStageTermsAgreedStripeCookie
+  config.env.encryptedGatewayAccountRequestToGoLiveStageTermsAgreedStripeCookie = encryptedGatewayAccountRequestToGoLiveStageTermsAgreedStripeCookie
+
+  // REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_WORLDPAY user
+  const selfServiceRequestToGoLiveStageTermsAgreedWorldPayUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_WORLDPAY')[0]
+  const encryptedSessionRequestToGoLiveStageTermsAgreedWorldPayCookie = generateEncryptedSessionCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageTermsAgreedWorldPayUser.external_id
+  )
+  const encryptedGatewayAccountRequestToGoLiveStageTermsAgreedWorldPayCookie = generateEncryptedGatewayAccountCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageTermsAgreedWorldPayUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+  )
+  config.env.encryptedSessionRequestToGoLiveStageTermsAgreedWorldPayCookie = encryptedSessionRequestToGoLiveStageTermsAgreedWorldPayCookie
+  config.env.encryptedGatewayAccountRequestToGoLiveStageTermsAgreedWorldPayCookie = encryptedGatewayAccountRequestToGoLiveStageTermsAgreedWorldPayCookie
+
+  // REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_SMARTPAY user
+  const selfServiceRequestToGoLiveStageTermsAgreedSmartPayUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_SMARTPAY')[0]
+  const encryptedSessionRequestToGoLiveStageTermsAgreedSmartPayCookie = generateEncryptedSessionCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageTermsAgreedSmartPayUser.external_id
+  )
+  const encryptedGatewayAccountRequestToGoLiveStageTermsAgreedSmartPayCookie = generateEncryptedGatewayAccountCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageTermsAgreedSmartPayUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+  )
+  config.env.encryptedSessionRequestToGoLiveStageTermsAgreedSmartPayCookie = encryptedSessionRequestToGoLiveStageTermsAgreedSmartPayCookie
+  config.env.encryptedGatewayAccountRequestToGoLiveStageTermsAgreedSmartPayCookie = encryptedGatewayAccountRequestToGoLiveStageTermsAgreedSmartPayCookie
+
+  // REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_EPDQ user
+  const selfServiceRequestToGoLiveStageTermsAgreedEpdqUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_EPDQ')[0]
+  const encryptedSessionRequestToGoLiveStageTermsAgreedEpdqCookie = generateEncryptedSessionCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageTermsAgreedEpdqUser.external_id
+  )
+  const encryptedGatewayAccountRequestToGoLiveStageTermsAgreedEpdqCookie = generateEncryptedGatewayAccountCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageTermsAgreedEpdqUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+  )
+  config.env.encryptedSessionRequestToGoLiveStageTermsAgreedEpdqCookie = encryptedSessionRequestToGoLiveStageTermsAgreedEpdqCookie
+  config.env.encryptedGatewayAccountRequestToGoLiveStageTermsAgreedEpdqCookie = encryptedGatewayAccountRequestToGoLiveStageTermsAgreedEpdqCookie
+
+  // REQUEST_TO_GO_LIVE_STAGE_DENIED user
+  const selfServiceRequestToGoLiveStageDeniedUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_DENIED')[0]
+  const encryptedSessionRequestToGoLiveStageDeniedCookie = generateEncryptedSessionCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageDeniedUser.external_id
+  )
+  const encryptedGatewayAccountRequestToGoLiveStageDeniedCookie = generateEncryptedGatewayAccountCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageDeniedUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+  )
+  config.env.encryptedSessionRequestToGoLiveStageDeniedCookie = encryptedSessionRequestToGoLiveStageDeniedCookie
+  config.env.encryptedGatewayAccountRequestToGoLiveStageDeniedCookie = encryptedGatewayAccountRequestToGoLiveStageDeniedCookie
+
+  // REQUEST_TO_GO_LIVE_STAGE_LIVE user
+  const selfServiceRequestToGoLiveStageLiveUser = selfServiceUserConfig.config.users.filter(element => element.cypressTestingCategory === 'REQUEST_TO_GO_LIVE_STAGE_LIVE')[0]
+  const encryptedSessionRequestToGoLiveStageLiveCookie = generateEncryptedSessionCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageLiveUser.external_id
+  )
+  const encryptedGatewayAccountRequestToGoLiveStageLiveCookie = generateEncryptedGatewayAccountCookie(
+    config.env.TEST_SESSION_ENCRYPTION_KEY,
+    selfServiceRequestToGoLiveStageLiveUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id
+  )
+  config.env.encryptedSessionRequestToGoLiveStageLiveCookie = encryptedSessionRequestToGoLiveStageLiveCookie
+  config.env.encryptedGatewayAccountRequestToGoLiveStageLiveCookie = encryptedGatewayAccountRequestToGoLiveStageLiveCookie
+
+  // send back the modified config object
+  return config
+}
+
+function generateEncryptedSessionCookie (sessionEncyptionKey, userExternalId) {
+  const encryptedSessionCookie = cookieMonster.getCookie('session', sessionEncyptionKey,
     {
-      passport: {user: ssUser.external_id},
+      passport: { user: userExternalId },
       secondFactor: 'totp',
       version: 0,
       icamefrom: 'cypress.io'
     })
+  return encryptedSessionCookie
+}
 
-  const encryptedGatewayAccountCookie = cookieMonster.getCookie('gateway_account', config.env.TEST_SESSION_ENCRYPTION_KEY,
+function generateEncryptedGatewayAccountCookie (sessionEncyptionKey, gatewayAccountId) {
+  const encryptedGatewayAccountCookie = cookieMonster.getCookie('gateway_account', sessionEncyptionKey,
     {
-      currentGatewayAccountId: ssUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id,
+      currentGatewayAccountId: gatewayAccountId,
       icamefrom: 'cypress.io'
     })
-
-  config.env.encryptedSessionCookie = encryptedSessionCookie
-  config.env.encryptedGatewayAccountCookie = encryptedGatewayAccountCookie
-
-  console.log(`test encrypted session cookie: ${encryptedSessionCookie}`)
-  console.log(`test encrypted gateway account cookie: ${encryptedGatewayAccountCookie}`)
-
-  // send back the modified config object
-  return config
+  return encryptedGatewayAccountCookie
 }

--- a/test/fixtures/config/self_service_user.json
+++ b/test/fixtures/config/self_service_user.json
@@ -1490,10 +1490,10 @@
         "invalid_passwordMatcher": "some-password",
         "valid_password": "some-valid-password",
         "valid_passwordMatcher": "some-valid-password",
-        "external_id": "rtglnotstarteduserextid",
-        "username": "some-user-rtglnotstarted@gov.uk",
-        "usernameMatcher": "some-user-rtglnotstarted@gov\\.uk",
-        "email": "some-user-rtglnotstarted@gov.uk",
+        "external_id": "rtglNotStartedUserExtId",
+        "username": "some-user-rtglNotStarted@gov.uk",
+        "usernameMatcher": "some-user-rtglNotStarted@gov\\.uk",
+        "email": "some-user-rtglNotStarted@gov.uk",
         "otp_key": "krb6fcianbdjkt01ecvi08jcln",
         "telephone_number": "9127979",
         "second_factor": "SMS",
@@ -1513,7 +1513,7 @@
           {
             "rel": "self",
             "method": "GET",
-            "href": "http://myconnector.local/v1/api/users/rtglnotstarteduserextid"
+            "href": "http://myconnector.local/v1/api/users/rtglNotStartedUserExtId"
           }
         ],
         "role": {
@@ -1671,12 +1671,12 @@
           ]
         },
         "service_ids": [
-          "rtglnotstarted"
+          "rtglNotStarted"
         ],
         "service_roles": [
           {
             "service": {
-              "external_id": "rtglnotstarted",
+              "external_id": "rtglNotStarted",
               "name": "System Generated",
               "gateway_account_ids": [
                 "666"
@@ -1844,7 +1844,7 @@
         ],
         "services": [
           {
-            "external_id": "rtglnotstarted",
+            "external_id": "rtglNotStarted",
             "name": "System Generated",
             "gateway_account_ids": [
               "666"
@@ -1902,10 +1902,10 @@
         "invalid_passwordMatcher": "some-password",
         "valid_password": "some-valid-password",
         "valid_passwordMatcher": "some-valid-password",
-        "external_id": "rtglenteredorgnameuserextid",
-        "username": "some-user-rtglenteredorgname@gov.uk",
-        "usernameMatcher": "some-user-rtglenteredorgname@gov\\.uk",
-        "email": "some-user-rtglenteredorgname@gov.uk",
+        "external_id": "rtglEnteredOrgNameUserExtId",
+        "username": "some-user-rtglEnteredOrgName@gov.uk",
+        "usernameMatcher": "some-user-rtglEnteredOrgName@gov\\.uk",
+        "email": "some-user-rtglEnteredOrgName@gov.uk",
         "otp_key": "krb6fcianbdjkt01ecvi08jcln",
         "telephone_number": "9127979",
         "second_factor": "SMS",
@@ -1925,7 +1925,7 @@
           {
             "rel": "self",
             "method": "GET",
-            "href": "http://myconnector.local/v1/api/users/rtglenteredorgnameuserextid"
+            "href": "http://myconnector.local/v1/api/users/rtglEnteredOrgNameUserExtId"
           }
         ],
         "role": {
@@ -2083,12 +2083,12 @@
           ]
         },
         "service_ids": [
-          "rtglenteredorgname"
+          "rtglEnteredOrgName"
         ],
         "service_roles": [
           {
             "service": {
-              "external_id": "rtglenteredorgname",
+              "external_id": "rtglEnteredOrgName",
               "name": "System Generated",
               "gateway_account_ids": [
                 "666"
@@ -2256,7 +2256,7 @@
         ],
         "services": [
           {
-            "external_id": "rtglenteredorgname",
+            "external_id": "rtglEnteredOrgName",
             "name": "System Generated",
             "gateway_account_ids": [
               "666"
@@ -2314,10 +2314,10 @@
         "invalid_passwordMatcher": "some-password",
         "valid_password": "some-valid-password",
         "valid_passwordMatcher": "some-valid-password",
-        "external_id": "rtglchosenpspstripeuserextid",
-        "username": "some-user-rtglchosenpspstripe@gov.uk",
-        "usernameMatcher": "some-user-rtglchosenpspstripe@gov\\.uk",
-        "email": "some-user-rtglchosenpspstripe@gov.uk",
+        "external_id": "rtglChosenPspStripeUserExtId",
+        "username": "some-user-rtglChosenPspStripe@gov.uk",
+        "usernameMatcher": "some-user-rtglChosenPspStripe@gov\\.uk",
+        "email": "some-user-rtglChosenPspStripe@gov.uk",
         "otp_key": "krb6fcianbdjkt01ecvi08jcln",
         "telephone_number": "9127979",
         "second_factor": "SMS",
@@ -2337,7 +2337,7 @@
           {
             "rel": "self",
             "method": "GET",
-            "href": "http://myconnector.local/v1/api/users/rtglchosenpspstripeuserextid"
+            "href": "http://myconnector.local/v1/api/users/rtglChosenPspStripeUserExtId"
           }
         ],
         "role": {
@@ -2495,12 +2495,12 @@
           ]
         },
         "service_ids": [
-          "rtglchosenpspstripe"
+          "rtglChosenPspStripe"
         ],
         "service_roles": [
           {
             "service": {
-              "external_id": "rtglchosenpspstripe",
+              "external_id": "rtglChosenPspStripe",
               "name": "System Generated",
               "gateway_account_ids": [
                 "666"
@@ -2668,7 +2668,7 @@
         ],
         "services": [
           {
-            "external_id": "rtglchosenpspstripe",
+            "external_id": "rtglChosenPspStripe",
             "name": "System Generated",
             "gateway_account_ids": [
               "666"
@@ -2726,10 +2726,10 @@
         "invalid_passwordMatcher": "some-password",
         "valid_password": "some-valid-password",
         "valid_passwordMatcher": "some-valid-password",
-        "external_id": "rtglchosenpspworldpayuserextid",
-        "username": "some-user-rtglchosenpspworldpay@gov.uk",
-        "usernameMatcher": "some-user-rtglchosenpspworldpay@gov\\.uk",
-        "email": "some-user-rtglchosenpspworldpay@gov.uk",
+        "external_id": "rtglChosenPspWorldPayUserExtId",
+        "username": "some-user-rtglChosenPspWorldPay@gov.uk",
+        "usernameMatcher": "some-user-rtglChosenPspWorldPay@gov\\.uk",
+        "email": "some-user-rtglChosenPspWorldPay@gov.uk",
         "otp_key": "krb6fcianbdjkt01ecvi08jcln",
         "telephone_number": "9127979",
         "second_factor": "SMS",
@@ -2749,7 +2749,7 @@
           {
             "rel": "self",
             "method": "GET",
-            "href": "http://myconnector.local/v1/api/users/rtglchosenpspworldpayuserextid"
+            "href": "http://myconnector.local/v1/api/users/rtglChosenPspWorldPayUserExtId"
           }
         ],
         "role": {
@@ -2907,12 +2907,12 @@
           ]
         },
         "service_ids": [
-          "rtglchosenpspworldpay"
+          "rtglChosenPspWorldPay"
         ],
         "service_roles": [
           {
             "service": {
-              "external_id": "rtglchosenpspworldpay",
+              "external_id": "rtglChosenPspWorldPay",
               "name": "System Generated",
               "gateway_account_ids": [
                 "666"
@@ -3080,7 +3080,7 @@
         ],
         "services": [
           {
-            "external_id": "rtglchosenpspworldpay",
+            "external_id": "rtglChosenPspWorldPay",
             "name": "System Generated",
             "gateway_account_ids": [
               "666"
@@ -3138,10 +3138,10 @@
         "invalid_passwordMatcher": "some-password",
         "valid_password": "some-valid-password",
         "valid_passwordMatcher": "some-valid-password",
-        "external_id": "rtglchosenpspsmartpayuserextid",
-        "username": "some-user-rtglchosenpspsmartpay@gov.uk",
-        "usernameMatcher": "some-user-rtglchosenpspsmartpay@gov\\.uk",
-        "email": "some-user-rtglchosenpspsmartpay@gov.uk",
+        "external_id": "rtglChosenPspSmartPayUserExtId",
+        "username": "some-user-rtglChosenPspSmartPay@gov.uk",
+        "usernameMatcher": "some-user-rtglChosenPspSmartPay@gov\\.uk",
+        "email": "some-user-rtglChosenPspSmartPay@gov.uk",
         "otp_key": "krb6fcianbdjkt01ecvi08jcln",
         "telephone_number": "9127979",
         "second_factor": "SMS",
@@ -3161,7 +3161,7 @@
           {
             "rel": "self",
             "method": "GET",
-            "href": "http://myconnector.local/v1/api/users/rtglchosenpspsmartpayuserextid"
+            "href": "http://myconnector.local/v1/api/users/rtglChosenPspSmartPayUserExtId"
           }
         ],
         "role": {
@@ -3319,12 +3319,12 @@
           ]
         },
         "service_ids": [
-          "rtglchosenpspsmartpay"
+          "rtglChosenPspSmartPay"
         ],
         "service_roles": [
           {
             "service": {
-              "external_id": "rtglchosenpspsmartpay",
+              "external_id": "rtglChosenPspSmartPay",
               "name": "System Generated",
               "gateway_account_ids": [
                 "666"
@@ -3492,7 +3492,7 @@
         ],
         "services": [
           {
-            "external_id": "rtglchosenpspsmartpay",
+            "external_id": "rtglChosenPspSmartPay",
             "name": "System Generated",
             "gateway_account_ids": [
               "666"
@@ -3550,10 +3550,10 @@
         "invalid_passwordMatcher": "some-password",
         "valid_password": "some-valid-password",
         "valid_passwordMatcher": "some-valid-password",
-        "external_id": "rtglchosenpspepdquserextid",
-        "username": "some-user-rtglchosenpspepdq@gov.uk",
-        "usernameMatcher": "some-user-rtglchosenpspepdq@gov\\.uk",
-        "email": "some-user-rtglchosenpspepdq@gov.uk",
+        "external_id": "rtglChosenPspEpdqUserExtId",
+        "username": "some-user-rtglChosenPspEpdq@gov.uk",
+        "usernameMatcher": "some-user-rtglChosenPspEpdq@gov\\.uk",
+        "email": "some-user-rtglChosenPspEpdq@gov.uk",
         "otp_key": "krb6fcianbdjkt01ecvi08jcln",
         "telephone_number": "9127979",
         "second_factor": "SMS",
@@ -3573,7 +3573,7 @@
           {
             "rel": "self",
             "method": "GET",
-            "href": "http://myconnector.local/v1/api/users/rtglchosenpspepdquserextid"
+            "href": "http://myconnector.local/v1/api/users/rtglChosenPspEpdqUserExtId"
           }
         ],
         "role": {
@@ -3731,12 +3731,12 @@
           ]
         },
         "service_ids": [
-          "rtglchosenpspepdq"
+          "rtglChosenPspEpdq"
         ],
         "service_roles": [
           {
             "service": {
-              "external_id": "rtglchosenpspepdq",
+              "external_id": "rtglChosenPspEpdq",
               "name": "System Generated",
               "gateway_account_ids": [
                 "666"
@@ -3904,7 +3904,7 @@
         ],
         "services": [
           {
-            "external_id": "rtglchosenpspepdq",
+            "external_id": "rtglChosenPspEpdq",
             "name": "System Generated",
             "gateway_account_ids": [
               "666"
@@ -3962,10 +3962,10 @@
         "invalid_passwordMatcher": "some-password",
         "valid_password": "some-valid-password",
         "valid_passwordMatcher": "some-valid-password",
-        "external_id": "rtgltermsokstripeuserextid",
-        "username": "some-user-rtgltermsokstripe@gov.uk",
-        "usernameMatcher": "some-user-rtgltermsokstripe@gov\\.uk",
-        "email": "some-user-rtgltermsokstripe@gov.uk",
+        "external_id": "rtglTermsOkStripeUserExtId",
+        "username": "some-user-rtglTermsOkStripe@gov.uk",
+        "usernameMatcher": "some-user-rtglTermsOkStripe@gov\\.uk",
+        "email": "some-user-rtglTermsOkStripe@gov.uk",
         "otp_key": "krb6fcianbdjkt01ecvi08jcln",
         "telephone_number": "9127979",
         "second_factor": "SMS",
@@ -3985,7 +3985,7 @@
           {
             "rel": "self",
             "method": "GET",
-            "href": "http://myconnector.local/v1/api/users/rtgltermsokstripeuserextid"
+            "href": "http://myconnector.local/v1/api/users/rtglTermsOkStripeUserExtId"
           }
         ],
         "role": {
@@ -4143,12 +4143,12 @@
           ]
         },
         "service_ids": [
-          "rtgltermsokstripe"
+          "rtglTermsOkStripe"
         ],
         "service_roles": [
           {
             "service": {
-              "external_id": "rtgltermsokstripe",
+              "external_id": "rtglTermsOkStripe",
               "name": "System Generated",
               "gateway_account_ids": [
                 "666"
@@ -4316,7 +4316,7 @@
         ],
         "services": [
           {
-            "external_id": "rtgltermsokstripe",
+            "external_id": "rtglTermsOkStripe",
             "name": "System Generated",
             "gateway_account_ids": [
               "666"
@@ -4374,10 +4374,10 @@
         "invalid_passwordMatcher": "some-password",
         "valid_password": "some-valid-password",
         "valid_passwordMatcher": "some-valid-password",
-        "external_id": "rtgltermsokworldpayuserextid",
-        "username": "some-user-rtgltermsokworldpay@gov.uk",
-        "usernameMatcher": "some-user-rtgltermsokworldpay@gov\\.uk",
-        "email": "some-user-rtgltermsokworldpay@gov.uk",
+        "external_id": "rtglTermsOkWorldPayUserExtId",
+        "username": "some-user-rtglTermsOkWorldPay@gov.uk",
+        "usernameMatcher": "some-user-rtglTermsOkWorldPay@gov\\.uk",
+        "email": "some-user-rtglTermsOkWorldPay@gov.uk",
         "otp_key": "krb6fcianbdjkt01ecvi08jcln",
         "telephone_number": "9127979",
         "second_factor": "SMS",
@@ -4397,7 +4397,7 @@
           {
             "rel": "self",
             "method": "GET",
-            "href": "http://myconnector.local/v1/api/users/rtgltermsokworldpayuserextid"
+            "href": "http://myconnector.local/v1/api/users/rtglTermsOkWorldPayUserExtId"
           }
         ],
         "role": {
@@ -4555,12 +4555,12 @@
           ]
         },
         "service_ids": [
-          "rtgltermsokworldpay"
+          "rtglTermsOkWorldPay"
         ],
         "service_roles": [
           {
             "service": {
-              "external_id": "rtgltermsokworldpay",
+              "external_id": "rtglTermsOkWorldPay",
               "name": "System Generated",
               "gateway_account_ids": [
                 "666"
@@ -4728,7 +4728,7 @@
         ],
         "services": [
           {
-            "external_id": "rtgltermsokworldpay",
+            "external_id": "rtglTermsOkWorldPay",
             "name": "System Generated",
             "gateway_account_ids": [
               "666"
@@ -4786,10 +4786,10 @@
         "invalid_passwordMatcher": "some-password",
         "valid_password": "some-valid-password",
         "valid_passwordMatcher": "some-valid-password",
-        "external_id": "rtgltermsoksmartpayuserextid",
-        "username": "some-user-rtgltermsoksmartpay@gov.uk",
-        "usernameMatcher": "some-user-rtgltermsoksmartpay@gov\\.uk",
-        "email": "some-user-rtgltermsoksmartpay@gov.uk",
+        "external_id": "rtglTermsOkSmartPayUserExtId",
+        "username": "some-user-rtglTermsOkSmartPay@gov.uk",
+        "usernameMatcher": "some-user-rtglTermsOkSmartPay@gov\\.uk",
+        "email": "some-user-rtglTermsOkSmartPay@gov.uk",
         "otp_key": "krb6fcianbdjkt01ecvi08jcln",
         "telephone_number": "9127979",
         "second_factor": "SMS",
@@ -4809,7 +4809,7 @@
           {
             "rel": "self",
             "method": "GET",
-            "href": "http://myconnector.local/v1/api/users/rtgltermsoksmartpayuserextid"
+            "href": "http://myconnector.local/v1/api/users/rtglTermsOkSmartPayUserExtId"
           }
         ],
         "role": {
@@ -4967,12 +4967,12 @@
           ]
         },
         "service_ids": [
-          "rtgltermsoksmartpay"
+          "rtglTermsOkSmartPay"
         ],
         "service_roles": [
           {
             "service": {
-              "external_id": "rtgltermsoksmartpay",
+              "external_id": "rtglTermsOkSmartPay",
               "name": "System Generated",
               "gateway_account_ids": [
                 "666"
@@ -5140,7 +5140,7 @@
         ],
         "services": [
           {
-            "external_id": "rtgltermsoksmartpay",
+            "external_id": "rtglTermsOkSmartPay",
             "name": "System Generated",
             "gateway_account_ids": [
               "666"
@@ -5198,10 +5198,10 @@
         "invalid_passwordMatcher": "some-password",
         "valid_password": "some-valid-password",
         "valid_passwordMatcher": "some-valid-password",
-        "external_id": "rtgltermsokepdquserextid",
-        "username": "some-user-rtgltermsokepdq@gov.uk",
-        "usernameMatcher": "some-user-rtgltermsokepdq@gov\\.uk",
-        "email": "some-user-rtgltermsokepdq@gov.uk",
+        "external_id": "rtglTermsOkEpdqUserExtId",
+        "username": "some-user-rtglTermsOkEpdq@gov.uk",
+        "usernameMatcher": "some-user-rtglTermsOkEpdq@gov\\.uk",
+        "email": "some-user-rtglTermsOkEpdq@gov.uk",
         "otp_key": "krb6fcianbdjkt01ecvi08jcln",
         "telephone_number": "9127979",
         "second_factor": "SMS",
@@ -5221,7 +5221,7 @@
           {
             "rel": "self",
             "method": "GET",
-            "href": "http://myconnector.local/v1/api/users/rtgltermsokepdquserextid"
+            "href": "http://myconnector.local/v1/api/users/rtglTermsOkEpdqUserExtId"
           }
         ],
         "role": {
@@ -5379,12 +5379,12 @@
           ]
         },
         "service_ids": [
-          "rtgltermsokepdq"
+          "rtglTermsOkEpdq"
         ],
         "service_roles": [
           {
             "service": {
-              "external_id": "rtgltermsokepdq",
+              "external_id": "rtglTermsOkEpdq",
               "name": "System Generated",
               "gateway_account_ids": [
                 "666"
@@ -5552,7 +5552,7 @@
         ],
         "services": [
           {
-            "external_id": "rtgltermsokepdq",
+            "external_id": "rtglTermsOkEpdq",
             "name": "System Generated",
             "gateway_account_ids": [
               "666"
@@ -5610,10 +5610,10 @@
         "invalid_passwordMatcher": "some-password",
         "valid_password": "some-valid-password",
         "valid_passwordMatcher": "some-valid-password",
-        "external_id": "rtgldenieduserextid",
-        "username": "some-user-rtgldenied@gov.uk",
-        "usernameMatcher": "some-user-rtgldenied@gov\\.uk",
-        "email": "some-user-rtgldenied@gov.uk",
+        "external_id": "rtglDeniedUserExtId",
+        "username": "some-user-rtglDenied@gov.uk",
+        "usernameMatcher": "some-user-rtglDenied@gov\\.uk",
+        "email": "some-user-rtglDenied@gov.uk",
         "otp_key": "krb6fcianbdjkt01ecvi08jcln",
         "telephone_number": "9127979",
         "second_factor": "SMS",
@@ -5633,7 +5633,7 @@
           {
             "rel": "self",
             "method": "GET",
-            "href": "http://myconnector.local/v1/api/users/rtgldenieduserextid"
+            "href": "http://myconnector.local/v1/api/users/rtglDeniedUserExtId"
           }
         ],
         "role": {
@@ -5791,12 +5791,12 @@
           ]
         },
         "service_ids": [
-          "rtgldenied"
+          "rtglDenied"
         ],
         "service_roles": [
           {
             "service": {
-              "external_id": "rtgldenied",
+              "external_id": "rtglDenied",
               "name": "System Generated",
               "gateway_account_ids": [
                 "666"
@@ -5964,7 +5964,7 @@
         ],
         "services": [
           {
-            "external_id": "rtgldenied",
+            "external_id": "rtglDenied",
             "name": "System Generated",
             "gateway_account_ids": [
               "666"
@@ -6022,10 +6022,10 @@
         "invalid_passwordMatcher": "some-password",
         "valid_password": "some-valid-password",
         "valid_passwordMatcher": "some-valid-password",
-        "external_id": "rtglliveuserextid",
-        "username": "some-user-rtgllive@gov.uk",
-        "usernameMatcher": "some-user-rtgllive@gov\\.uk",
-        "email": "some-user-rtgllive@gov.uk",
+        "external_id": "rtglLiveUserExtId",
+        "username": "some-user-rtglLive@gov.uk",
+        "usernameMatcher": "some-user-rtglLive@gov\\.uk",
+        "email": "some-user-rtglLive@gov.uk",
         "otp_key": "krb6fcianbdjkt01ecvi08jcln",
         "telephone_number": "9127979",
         "second_factor": "SMS",
@@ -6045,7 +6045,7 @@
           {
             "rel": "self",
             "method": "GET",
-            "href": "http://myconnector.local/v1/api/users/rtglliveuserextid"
+            "href": "http://myconnector.local/v1/api/users/rtglLiveUserExtId"
           }
         ],
         "role": {
@@ -6203,12 +6203,12 @@
           ]
         },
         "service_ids": [
-          "rtgllive"
+          "rtglLive"
         ],
         "service_roles": [
           {
             "service": {
-              "external_id": "rtgllive",
+              "external_id": "rtglLive",
               "name": "System Generated",
               "gateway_account_ids": [
                 "666"
@@ -6376,7 +6376,7 @@
         ],
         "services": [
           {
-            "external_id": "rtgllive",
+            "external_id": "rtglLive",
             "name": "System Generated",
             "gateway_account_ids": [
               "666"

--- a/test/fixtures/config/self_service_user.json
+++ b/test/fixtures/config/self_service_user.json
@@ -4,6 +4,7 @@
     "users": [
       {
         "isPrimary": "true",
+        "cypressTestingCategory": "DEFAULT",
         "invalid_password": "some-password",
         "invalid_passwordMatcher": "some-password",
         "valid_password": "some-valid-password",
@@ -193,7 +194,8 @@
               ],
               "_links": [],
               "redirect_to_service_immediately_on_terminal_state": false,
-              "collect_billing_address": true
+              "collect_billing_address": true,
+              "current_go_live_stage": "NOT_STARTED"
             },
             "role": {
               "name": "admin",
@@ -351,7 +353,8 @@
               "666"
             ],
             "redirect_to_service_immediately_on_terminal_state": false,
-            "collect_billing_address": true
+            "collect_billing_address": true,
+            "current_go_live_stage": "NOT_STARTED"
           }
         ],
         "permissions": [
@@ -1084,6 +1087,5344 @@
               }
             ]
           }
+        }
+      },
+      {
+        "isPrimary": "false",
+        "cypressTestingCategory": "REQUEST_TO_GO_LIVE_NO_PERMISSIONS",
+        "invalid_password": "some-password",
+        "invalid_passwordMatcher": "some-password",
+        "valid_password": "some-valid-password",
+        "valid_passwordMatcher": "some-valid-password",
+        "external_id": "7d19aff33f8948deb97ed16b2912dcd3",
+        "username": "some-user@gov.uk",
+        "usernameMatcher": "some-user@gov\\.uk",
+        "email": "some-user@gov.uk",
+        "otp_key": "krb6fcianbdjkt01ecvi08jcln",
+        "telephone_number": "9127979",
+        "second_factor": "SMS",
+        "provisional_otp_key": "NOTSET",
+        "provisional_otp_key_created_at": null,
+        "disabled": false,
+        "login_counter": 0,
+        "session_version": 0,
+        "gateway_accounts": [
+          {
+            "id": "666",
+            "isPrimary": "true",
+            "name": "sandbox"
+          }
+        ],
+        "_links": [
+          {
+            "rel": "self",
+            "method": "GET",
+            "href": "http://myconnector.local/v1/api/users/7d19aff33f8948deb97ed16b2912dcd3"
+          }
+        ],
+        "role": {
+          "name": "admin",
+          "description": "Administrator",
+          "permissions": [
+            {
+              "name": "users-service:read",
+              "description": "Viewusersinservice"
+            },
+            {
+              "name": "users-service:create",
+              "description": "Createuserinthisservice"
+            },
+            {
+              "name": "tokens-active:read",
+              "description": "Viewactivekeys"
+            },
+            {
+              "name": "tokens-revoked:read",
+              "description": "Viewrevokedkeys"
+            },
+            {
+              "name": "tokens:create",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:update",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:delete",
+              "description": "Revokekey"
+            },
+            {
+              "name": "transactions:read",
+              "description": "Viewtransactionslist"
+            },
+            {
+              "name": "transactions-by-date:read",
+              "description": "Searchtransactionsbydate"
+            },
+            {
+              "name": "transactions-by-fields:read",
+              "description": "Searchtransactionsbypaymentfields"
+            },
+            {
+              "name": "transactions-download:read",
+              "description": "Downloadtransactions"
+            },
+            {
+              "name": "transactions-details:read",
+              "description": "Viewtransactiondetails"
+            },
+            {
+              "name": "transactions-events:read",
+              "description": "Viewtransactionevents"
+            },
+            {
+              "name": "refunds:create",
+              "description": "Issuerefund"
+            },
+            {
+              "name": "transactions-amount:read",
+              "description": "Viewtransactionamounts"
+            },
+            {
+              "name": "transactions-description:read",
+              "description": "Viewtransactiondescription"
+            },
+            {
+              "name": "transactions-email:read",
+              "description": "Viewtransactionemail"
+            },
+            {
+              "name": "transactions-card-type:read",
+              "description": "Viewtransactioncardtype"
+            },
+            {
+              "name": "gateway-credentials:read",
+              "description": "Viewgatewayaccountcredentials"
+            },
+            {
+              "name": "gateway-credentials:update",
+              "description": "Editgatewayaccountcredentials"
+            },
+            {
+              "name": "service-name:read",
+              "description": "Viewservicename"
+            },
+            {
+              "name": "service-name:update",
+              "description": "Editservicename"
+            },
+            {
+              "name": "payment-types:read",
+              "description": "Viewpaymenttypes"
+            },
+            {
+              "name": "payment-types:update",
+              "description": "Editpaymenttypes"
+            },
+            {
+              "name": "email-notification-template:read",
+              "description": "Viewemailnotificationstemplate"
+            },
+            {
+              "name": "email-notification-paragraph:update",
+              "description": "Editemailnotificationsparagraph"
+            },
+            {
+              "name": "email-notification-toggle:update",
+              "description": "Turnemailnotificationson/off"
+            },
+            {
+              "name": "tokens:read",
+              "description": "View keys"
+            },
+            {
+              "name": "toggle-3ds:read",
+              "description": "View 3D Secure setting"
+            },
+            {
+              "name": "toggle-3ds:update",
+              "description": "Edit 3D Secure setting"
+            },
+            {
+              "name": "users-service:delete",
+              "description": "Remove user from a service"
+            },
+            {
+              "name": "merchant-details:read",
+              "description": "View Merchant Details setting"
+            },
+            {
+              "name": "merchant-details:update",
+              "description": "Edit Merchant Details setting"
+            },
+            {
+              "name": "toggle-billing-address:read",
+              "description": "View Billing Address setting"
+            },
+            {
+              "name": "toggle-billing-address:update",
+              "description": "Edit Billing Address setting"
+            }
+          ]
+        },
+        "service_ids": [
+          "cp5wa"
+        ],
+        "service_roles": [
+          {
+            "service": {
+              "external_id": "cp5wa",
+              "name": "System Generated",
+              "gateway_account_ids": [
+                "666"
+              ],
+              "_links": [],
+              "redirect_to_service_immediately_on_terminal_state": false,
+              "collect_billing_address": true,
+              "current_go_live_stage": "NOT_STARTED"
+            },
+            "role": {
+              "name": "admin",
+              "description": "Administrator",
+              "permissions": [
+                {
+                  "name": "users-service:read",
+                  "description": "Viewusersinservice"
+                },
+                {
+                  "name": "users-service:create",
+                  "description": "Createuserinthisservice"
+                },
+                {
+                  "name": "tokens-active:read",
+                  "description": "Viewactivekeys"
+                },
+                {
+                  "name": "tokens-revoked:read",
+                  "description": "Viewrevokedkeys"
+                },
+                {
+                  "name": "tokens:create",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:update",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:delete",
+                  "description": "Revokekey"
+                },
+                {
+                  "name": "transactions:read",
+                  "description": "Viewtransactionslist"
+                },
+                {
+                  "name": "transactions-by-date:read",
+                  "description": "Searchtransactionsbydate"
+                },
+                {
+                  "name": "transactions-by-fields:read",
+                  "description": "Searchtransactionsbypaymentfields"
+                },
+                {
+                  "name": "transactions-download:read",
+                  "description": "Downloadtransactions"
+                },
+                {
+                  "name": "transactions-details:read",
+                  "description": "Viewtransactiondetails"
+                },
+                {
+                  "name": "transactions-events:read",
+                  "description": "Viewtransactionevents"
+                },
+                {
+                  "name": "refunds:create",
+                  "description": "Issuerefund"
+                },
+                {
+                  "name": "transactions-amount:read",
+                  "description": "Viewtransactionamounts"
+                },
+                {
+                  "name": "transactions-description:read",
+                  "description": "Viewtransactiondescription"
+                },
+                {
+                  "name": "transactions-email:read",
+                  "description": "Viewtransactionemail"
+                },
+                {
+                  "name": "transactions-card-type:read",
+                  "description": "Viewtransactioncardtype"
+                },
+                {
+                  "name": "gateway-credentials:read",
+                  "description": "Viewgatewayaccountcredentials"
+                },
+                {
+                  "name": "gateway-credentials:update",
+                  "description": "Editgatewayaccountcredentials"
+                },
+                {
+                  "name": "service-name:read",
+                  "description": "Viewservicename"
+                },
+                {
+                  "name": "service-name:update",
+                  "description": "Editservicename"
+                },
+                {
+                  "name": "payment-types:read",
+                  "description": "Viewpaymenttypes"
+                },
+                {
+                  "name": "payment-types:update",
+                  "description": "Editpaymenttypes"
+                },
+                {
+                  "name": "email-notification-template:read",
+                  "description": "Viewemailnotificationstemplate"
+                },
+                {
+                  "name": "email-notification-paragraph:update",
+                  "description": "Editemailnotificationsparagraph"
+                },
+                {
+                  "name": "email-notification-toggle:update",
+                  "description": "Turnemailnotificationson/off"
+                },
+                {
+                  "name": "tokens:read",
+                  "description": "View keys"
+                },
+                {
+                  "name": "toggle-3ds:read",
+                  "description": "View 3D Secure setting"
+                },
+                {
+                  "name": "toggle-3ds:update",
+                  "description": "Edit 3D Secure setting"
+                },
+                {
+                  "name": "users-service:delete",
+                  "description": "Remove user from a service"
+                },
+                {
+                  "name": "merchant-details:read",
+                  "description": "View Merchant Details setting"
+                },
+                {
+                  "name": "merchant-details:update",
+                  "description": "Edit Merchant Details setting"
+                },
+                {
+                  "name": "toggle-billing-address:read",
+                  "description": "View Billing Address setting"
+                },
+                {
+                  "name": "toggle-billing-address:update",
+                  "description": "Edit Billing Address setting"
+                }
+              ]
+            }
+          }
+        ],
+        "services": [
+          {
+            "external_id": "cp5wa",
+            "name": "System Generated",
+            "gateway_account_ids": [
+              "666"
+            ],
+            "redirect_to_service_immediately_on_terminal_state": false,
+            "collect_billing_address": true,
+            "current_go_live_stage": "NOT_STARTED"
+          }
+        ],
+        "permissions": [
+          "users-service:read",
+          "users-service:create",
+          "tokens-active:read",
+          "tokens-revoked:read",
+          "tokens:create",
+          "tokens:update",
+          "tokens:delete",
+          "transactions:read",
+          "transactions-by-date:read",
+          "transactions-by-fields:read",
+          "transactions-download:read",
+          "transactions-details:read",
+          "transactions-events:read",
+          "refunds:create",
+          "transactions-amount:read",
+          "transactions-description:read",
+          "transactions-email:read",
+          "transactions-card-type:read",
+          "gateway-credentials:read",
+          "gateway-credentials:update",
+          "service-name:read",
+          "service-name:update",
+          "payment-types:read",
+          "payment-types:update",
+          "email-notification-template:read",
+          "email-notification-paragraph:update",
+          "email-notification-toggle:update",
+          "tokens:read",
+          "toggle-3ds:read",
+          "toggle-3ds:update",
+          "users-service:delete",
+          "merchant-details:read",
+          "merchant-details:update"
+        ],
+        "sections": {
+          "description": "Contains fixtures for data intended to be surfaced in various 'sections' of self-service"
+        }
+      },
+      {
+        "isPrimary": "false",
+        "cypressTestingCategory": "REQUEST_TO_GO_LIVE_STAGE_NOT_STARTED",
+        "invalid_password": "some-password",
+        "invalid_passwordMatcher": "some-password",
+        "valid_password": "some-valid-password",
+        "valid_passwordMatcher": "some-valid-password",
+        "external_id": "rtglnotstarteduserextid",
+        "username": "some-user-rtglnotstarted@gov.uk",
+        "usernameMatcher": "some-user-rtglnotstarted@gov\\.uk",
+        "email": "some-user-rtglnotstarted@gov.uk",
+        "otp_key": "krb6fcianbdjkt01ecvi08jcln",
+        "telephone_number": "9127979",
+        "second_factor": "SMS",
+        "provisional_otp_key": "NOTSET",
+        "provisional_otp_key_created_at": null,
+        "disabled": false,
+        "login_counter": 0,
+        "session_version": 0,
+        "gateway_accounts": [
+          {
+            "id": "666",
+            "isPrimary": "true",
+            "name": "sandbox"
+          }
+        ],
+        "_links": [
+          {
+            "rel": "self",
+            "method": "GET",
+            "href": "http://myconnector.local/v1/api/users/rtglnotstarteduserextid"
+          }
+        ],
+        "role": {
+          "name": "admin",
+          "description": "Administrator",
+          "permissions": [
+            {
+              "name": "users-service:read",
+              "description": "Viewusersinservice"
+            },
+            {
+              "name": "users-service:create",
+              "description": "Createuserinthisservice"
+            },
+            {
+              "name": "tokens-active:read",
+              "description": "Viewactivekeys"
+            },
+            {
+              "name": "tokens-revoked:read",
+              "description": "Viewrevokedkeys"
+            },
+            {
+              "name": "tokens:create",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:update",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:delete",
+              "description": "Revokekey"
+            },
+            {
+              "name": "transactions:read",
+              "description": "Viewtransactionslist"
+            },
+            {
+              "name": "transactions-by-date:read",
+              "description": "Searchtransactionsbydate"
+            },
+            {
+              "name": "transactions-by-fields:read",
+              "description": "Searchtransactionsbypaymentfields"
+            },
+            {
+              "name": "transactions-download:read",
+              "description": "Downloadtransactions"
+            },
+            {
+              "name": "transactions-details:read",
+              "description": "Viewtransactiondetails"
+            },
+            {
+              "name": "transactions-events:read",
+              "description": "Viewtransactionevents"
+            },
+            {
+              "name": "refunds:create",
+              "description": "Issuerefund"
+            },
+            {
+              "name": "transactions-amount:read",
+              "description": "Viewtransactionamounts"
+            },
+            {
+              "name": "transactions-description:read",
+              "description": "Viewtransactiondescription"
+            },
+            {
+              "name": "transactions-email:read",
+              "description": "Viewtransactionemail"
+            },
+            {
+              "name": "transactions-card-type:read",
+              "description": "Viewtransactioncardtype"
+            },
+            {
+              "name": "gateway-credentials:read",
+              "description": "Viewgatewayaccountcredentials"
+            },
+            {
+              "name": "gateway-credentials:update",
+              "description": "Editgatewayaccountcredentials"
+            },
+            {
+              "name": "service-name:read",
+              "description": "Viewservicename"
+            },
+            {
+              "name": "service-name:update",
+              "description": "Editservicename"
+            },
+            {
+              "name": "payment-types:read",
+              "description": "Viewpaymenttypes"
+            },
+            {
+              "name": "payment-types:update",
+              "description": "Editpaymenttypes"
+            },
+            {
+              "name": "email-notification-template:read",
+              "description": "Viewemailnotificationstemplate"
+            },
+            {
+              "name": "email-notification-paragraph:update",
+              "description": "Editemailnotificationsparagraph"
+            },
+            {
+              "name": "email-notification-toggle:update",
+              "description": "Turnemailnotificationson/off"
+            },
+            {
+              "name": "tokens:read",
+              "description": "View keys"
+            },
+            {
+              "name": "toggle-3ds:read",
+              "description": "View 3D Secure setting"
+            },
+            {
+              "name": "toggle-3ds:update",
+              "description": "Edit 3D Secure setting"
+            },
+            {
+              "name": "users-service:delete",
+              "description": "Remove user from a service"
+            },
+            {
+              "name": "merchant-details:read",
+              "description": "View Merchant Details setting"
+            },
+            {
+              "name": "merchant-details:update",
+              "description": "Edit Merchant Details setting"
+            },
+            {
+              "name": "toggle-billing-address:read",
+              "description": "View Billing Address setting"
+            },
+            {
+              "name": "toggle-billing-address:update",
+              "description": "Edit Billing Address setting"
+            },
+            {
+              "name": "go-live-stage:update",
+              "description": "Update Go Live stage"
+            },
+            {
+              "name": "go-live-stage:read",
+              "description": "View Go Live stage"
+            }
+          ]
+        },
+        "service_ids": [
+          "rtglnotstarted"
+        ],
+        "service_roles": [
+          {
+            "service": {
+              "external_id": "rtglnotstarted",
+              "name": "System Generated",
+              "gateway_account_ids": [
+                "666"
+              ],
+              "_links": [],
+              "redirect_to_service_immediately_on_terminal_state": false,
+              "collect_billing_address": true,
+              "current_go_live_stage": "NOT_STARTED"
+            },
+            "role": {
+              "name": "admin",
+              "description": "Administrator",
+              "permissions": [
+                {
+                  "name": "users-service:read",
+                  "description": "Viewusersinservice"
+                },
+                {
+                  "name": "users-service:create",
+                  "description": "Createuserinthisservice"
+                },
+                {
+                  "name": "tokens-active:read",
+                  "description": "Viewactivekeys"
+                },
+                {
+                  "name": "tokens-revoked:read",
+                  "description": "Viewrevokedkeys"
+                },
+                {
+                  "name": "tokens:create",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:update",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:delete",
+                  "description": "Revokekey"
+                },
+                {
+                  "name": "transactions:read",
+                  "description": "Viewtransactionslist"
+                },
+                {
+                  "name": "transactions-by-date:read",
+                  "description": "Searchtransactionsbydate"
+                },
+                {
+                  "name": "transactions-by-fields:read",
+                  "description": "Searchtransactionsbypaymentfields"
+                },
+                {
+                  "name": "transactions-download:read",
+                  "description": "Downloadtransactions"
+                },
+                {
+                  "name": "transactions-details:read",
+                  "description": "Viewtransactiondetails"
+                },
+                {
+                  "name": "transactions-events:read",
+                  "description": "Viewtransactionevents"
+                },
+                {
+                  "name": "refunds:create",
+                  "description": "Issuerefund"
+                },
+                {
+                  "name": "transactions-amount:read",
+                  "description": "Viewtransactionamounts"
+                },
+                {
+                  "name": "transactions-description:read",
+                  "description": "Viewtransactiondescription"
+                },
+                {
+                  "name": "transactions-email:read",
+                  "description": "Viewtransactionemail"
+                },
+                {
+                  "name": "transactions-card-type:read",
+                  "description": "Viewtransactioncardtype"
+                },
+                {
+                  "name": "gateway-credentials:read",
+                  "description": "Viewgatewayaccountcredentials"
+                },
+                {
+                  "name": "gateway-credentials:update",
+                  "description": "Editgatewayaccountcredentials"
+                },
+                {
+                  "name": "service-name:read",
+                  "description": "Viewservicename"
+                },
+                {
+                  "name": "service-name:update",
+                  "description": "Editservicename"
+                },
+                {
+                  "name": "payment-types:read",
+                  "description": "Viewpaymenttypes"
+                },
+                {
+                  "name": "payment-types:update",
+                  "description": "Editpaymenttypes"
+                },
+                {
+                  "name": "email-notification-template:read",
+                  "description": "Viewemailnotificationstemplate"
+                },
+                {
+                  "name": "email-notification-paragraph:update",
+                  "description": "Editemailnotificationsparagraph"
+                },
+                {
+                  "name": "email-notification-toggle:update",
+                  "description": "Turnemailnotificationson/off"
+                },
+                {
+                  "name": "tokens:read",
+                  "description": "View keys"
+                },
+                {
+                  "name": "toggle-3ds:read",
+                  "description": "View 3D Secure setting"
+                },
+                {
+                  "name": "toggle-3ds:update",
+                  "description": "Edit 3D Secure setting"
+                },
+                {
+                  "name": "users-service:delete",
+                  "description": "Remove user from a service"
+                },
+                {
+                  "name": "merchant-details:read",
+                  "description": "View Merchant Details setting"
+                },
+                {
+                  "name": "merchant-details:update",
+                  "description": "Edit Merchant Details setting"
+                },
+                {
+                  "name": "toggle-billing-address:read",
+                  "description": "View Billing Address setting"
+                },
+                {
+                  "name": "toggle-billing-address:update",
+                  "description": "Edit Billing Address setting"
+                },
+                {
+                  "name": "go-live-stage:update",
+                  "description": "Update Go Live stage"
+                },
+                {
+                  "name": "go-live-stage:read",
+                  "description": "View Go Live stage"
+                }
+              ]
+            }
+          }
+        ],
+        "services": [
+          {
+            "external_id": "rtglnotstarted",
+            "name": "System Generated",
+            "gateway_account_ids": [
+              "666"
+            ],
+            "redirect_to_service_immediately_on_terminal_state": false,
+            "collect_billing_address": true,
+            "current_go_live_stage": "NOT_STARTED"
+          }
+        ],
+        "permissions": [
+          "users-service:read",
+          "users-service:create",
+          "tokens-active:read",
+          "tokens-revoked:read",
+          "tokens:create",
+          "tokens:update",
+          "tokens:delete",
+          "transactions:read",
+          "transactions-by-date:read",
+          "transactions-by-fields:read",
+          "transactions-download:read",
+          "transactions-details:read",
+          "transactions-events:read",
+          "refunds:create",
+          "transactions-amount:read",
+          "transactions-description:read",
+          "transactions-email:read",
+          "transactions-card-type:read",
+          "gateway-credentials:read",
+          "gateway-credentials:update",
+          "service-name:read",
+          "service-name:update",
+          "payment-types:read",
+          "payment-types:update",
+          "email-notification-template:read",
+          "email-notification-paragraph:update",
+          "email-notification-toggle:update",
+          "tokens:read",
+          "toggle-3ds:read",
+          "toggle-3ds:update",
+          "users-service:delete",
+          "merchant-details:read",
+          "merchant-details:update",
+          "go-live-stage:update",
+          "go-live-stage:read"
+        ],
+        "sections": {
+          "description": "Contains fixtures for data intended to be surfaced in various 'sections' of self-service"
+        }
+      },
+      {
+        "isPrimary": "false",
+        "cypressTestingCategory": "REQUEST_TO_GO_LIVE_STAGE_ENTERED_ORGANISATION_NAME",
+        "invalid_password": "some-password",
+        "invalid_passwordMatcher": "some-password",
+        "valid_password": "some-valid-password",
+        "valid_passwordMatcher": "some-valid-password",
+        "external_id": "rtglenteredorgnameuserextid",
+        "username": "some-user-rtglenteredorgname@gov.uk",
+        "usernameMatcher": "some-user-rtglenteredorgname@gov\\.uk",
+        "email": "some-user-rtglenteredorgname@gov.uk",
+        "otp_key": "krb6fcianbdjkt01ecvi08jcln",
+        "telephone_number": "9127979",
+        "second_factor": "SMS",
+        "provisional_otp_key": "NOTSET",
+        "provisional_otp_key_created_at": null,
+        "disabled": false,
+        "login_counter": 0,
+        "session_version": 0,
+        "gateway_accounts": [
+          {
+            "id": "666",
+            "isPrimary": "true",
+            "name": "sandbox"
+          }
+        ],
+        "_links": [
+          {
+            "rel": "self",
+            "method": "GET",
+            "href": "http://myconnector.local/v1/api/users/rtglenteredorgnameuserextid"
+          }
+        ],
+        "role": {
+          "name": "admin",
+          "description": "Administrator",
+          "permissions": [
+            {
+              "name": "users-service:read",
+              "description": "Viewusersinservice"
+            },
+            {
+              "name": "users-service:create",
+              "description": "Createuserinthisservice"
+            },
+            {
+              "name": "tokens-active:read",
+              "description": "Viewactivekeys"
+            },
+            {
+              "name": "tokens-revoked:read",
+              "description": "Viewrevokedkeys"
+            },
+            {
+              "name": "tokens:create",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:update",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:delete",
+              "description": "Revokekey"
+            },
+            {
+              "name": "transactions:read",
+              "description": "Viewtransactionslist"
+            },
+            {
+              "name": "transactions-by-date:read",
+              "description": "Searchtransactionsbydate"
+            },
+            {
+              "name": "transactions-by-fields:read",
+              "description": "Searchtransactionsbypaymentfields"
+            },
+            {
+              "name": "transactions-download:read",
+              "description": "Downloadtransactions"
+            },
+            {
+              "name": "transactions-details:read",
+              "description": "Viewtransactiondetails"
+            },
+            {
+              "name": "transactions-events:read",
+              "description": "Viewtransactionevents"
+            },
+            {
+              "name": "refunds:create",
+              "description": "Issuerefund"
+            },
+            {
+              "name": "transactions-amount:read",
+              "description": "Viewtransactionamounts"
+            },
+            {
+              "name": "transactions-description:read",
+              "description": "Viewtransactiondescription"
+            },
+            {
+              "name": "transactions-email:read",
+              "description": "Viewtransactionemail"
+            },
+            {
+              "name": "transactions-card-type:read",
+              "description": "Viewtransactioncardtype"
+            },
+            {
+              "name": "gateway-credentials:read",
+              "description": "Viewgatewayaccountcredentials"
+            },
+            {
+              "name": "gateway-credentials:update",
+              "description": "Editgatewayaccountcredentials"
+            },
+            {
+              "name": "service-name:read",
+              "description": "Viewservicename"
+            },
+            {
+              "name": "service-name:update",
+              "description": "Editservicename"
+            },
+            {
+              "name": "payment-types:read",
+              "description": "Viewpaymenttypes"
+            },
+            {
+              "name": "payment-types:update",
+              "description": "Editpaymenttypes"
+            },
+            {
+              "name": "email-notification-template:read",
+              "description": "Viewemailnotificationstemplate"
+            },
+            {
+              "name": "email-notification-paragraph:update",
+              "description": "Editemailnotificationsparagraph"
+            },
+            {
+              "name": "email-notification-toggle:update",
+              "description": "Turnemailnotificationson/off"
+            },
+            {
+              "name": "tokens:read",
+              "description": "View keys"
+            },
+            {
+              "name": "toggle-3ds:read",
+              "description": "View 3D Secure setting"
+            },
+            {
+              "name": "toggle-3ds:update",
+              "description": "Edit 3D Secure setting"
+            },
+            {
+              "name": "users-service:delete",
+              "description": "Remove user from a service"
+            },
+            {
+              "name": "merchant-details:read",
+              "description": "View Merchant Details setting"
+            },
+            {
+              "name": "merchant-details:update",
+              "description": "Edit Merchant Details setting"
+            },
+            {
+              "name": "toggle-billing-address:read",
+              "description": "View Billing Address setting"
+            },
+            {
+              "name": "toggle-billing-address:update",
+              "description": "Edit Billing Address setting"
+            },
+            {
+              "name": "go-live-stage:update",
+              "description": "Update Go Live stage"
+            },
+            {
+              "name": "go-live-stage:read",
+              "description": "View Go Live stage"
+            }
+          ]
+        },
+        "service_ids": [
+          "rtglenteredorgname"
+        ],
+        "service_roles": [
+          {
+            "service": {
+              "external_id": "rtglenteredorgname",
+              "name": "System Generated",
+              "gateway_account_ids": [
+                "666"
+              ],
+              "_links": [],
+              "redirect_to_service_immediately_on_terminal_state": false,
+              "collect_billing_address": true,
+              "current_go_live_stage": "ENTERED_ORGANISATION_NAME"
+            },
+            "role": {
+              "name": "admin",
+              "description": "Administrator",
+              "permissions": [
+                {
+                  "name": "users-service:read",
+                  "description": "Viewusersinservice"
+                },
+                {
+                  "name": "users-service:create",
+                  "description": "Createuserinthisservice"
+                },
+                {
+                  "name": "tokens-active:read",
+                  "description": "Viewactivekeys"
+                },
+                {
+                  "name": "tokens-revoked:read",
+                  "description": "Viewrevokedkeys"
+                },
+                {
+                  "name": "tokens:create",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:update",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:delete",
+                  "description": "Revokekey"
+                },
+                {
+                  "name": "transactions:read",
+                  "description": "Viewtransactionslist"
+                },
+                {
+                  "name": "transactions-by-date:read",
+                  "description": "Searchtransactionsbydate"
+                },
+                {
+                  "name": "transactions-by-fields:read",
+                  "description": "Searchtransactionsbypaymentfields"
+                },
+                {
+                  "name": "transactions-download:read",
+                  "description": "Downloadtransactions"
+                },
+                {
+                  "name": "transactions-details:read",
+                  "description": "Viewtransactiondetails"
+                },
+                {
+                  "name": "transactions-events:read",
+                  "description": "Viewtransactionevents"
+                },
+                {
+                  "name": "refunds:create",
+                  "description": "Issuerefund"
+                },
+                {
+                  "name": "transactions-amount:read",
+                  "description": "Viewtransactionamounts"
+                },
+                {
+                  "name": "transactions-description:read",
+                  "description": "Viewtransactiondescription"
+                },
+                {
+                  "name": "transactions-email:read",
+                  "description": "Viewtransactionemail"
+                },
+                {
+                  "name": "transactions-card-type:read",
+                  "description": "Viewtransactioncardtype"
+                },
+                {
+                  "name": "gateway-credentials:read",
+                  "description": "Viewgatewayaccountcredentials"
+                },
+                {
+                  "name": "gateway-credentials:update",
+                  "description": "Editgatewayaccountcredentials"
+                },
+                {
+                  "name": "service-name:read",
+                  "description": "Viewservicename"
+                },
+                {
+                  "name": "service-name:update",
+                  "description": "Editservicename"
+                },
+                {
+                  "name": "payment-types:read",
+                  "description": "Viewpaymenttypes"
+                },
+                {
+                  "name": "payment-types:update",
+                  "description": "Editpaymenttypes"
+                },
+                {
+                  "name": "email-notification-template:read",
+                  "description": "Viewemailnotificationstemplate"
+                },
+                {
+                  "name": "email-notification-paragraph:update",
+                  "description": "Editemailnotificationsparagraph"
+                },
+                {
+                  "name": "email-notification-toggle:update",
+                  "description": "Turnemailnotificationson/off"
+                },
+                {
+                  "name": "tokens:read",
+                  "description": "View keys"
+                },
+                {
+                  "name": "toggle-3ds:read",
+                  "description": "View 3D Secure setting"
+                },
+                {
+                  "name": "toggle-3ds:update",
+                  "description": "Edit 3D Secure setting"
+                },
+                {
+                  "name": "users-service:delete",
+                  "description": "Remove user from a service"
+                },
+                {
+                  "name": "merchant-details:read",
+                  "description": "View Merchant Details setting"
+                },
+                {
+                  "name": "merchant-details:update",
+                  "description": "Edit Merchant Details setting"
+                },
+                {
+                  "name": "toggle-billing-address:read",
+                  "description": "View Billing Address setting"
+                },
+                {
+                  "name": "toggle-billing-address:update",
+                  "description": "Edit Billing Address setting"
+                },
+                {
+                  "name": "go-live-stage:update",
+                  "description": "Update Go Live stage"
+                },
+                {
+                  "name": "go-live-stage:read",
+                  "description": "View Go Live stage"
+                }
+              ]
+            }
+          }
+        ],
+        "services": [
+          {
+            "external_id": "rtglenteredorgname",
+            "name": "System Generated",
+            "gateway_account_ids": [
+              "666"
+            ],
+            "redirect_to_service_immediately_on_terminal_state": false,
+            "collect_billing_address": true,
+            "current_go_live_stage": "ENTERED_ORGANISATION_NAME"
+          }
+        ],
+        "permissions": [
+          "users-service:read",
+          "users-service:create",
+          "tokens-active:read",
+          "tokens-revoked:read",
+          "tokens:create",
+          "tokens:update",
+          "tokens:delete",
+          "transactions:read",
+          "transactions-by-date:read",
+          "transactions-by-fields:read",
+          "transactions-download:read",
+          "transactions-details:read",
+          "transactions-events:read",
+          "refunds:create",
+          "transactions-amount:read",
+          "transactions-description:read",
+          "transactions-email:read",
+          "transactions-card-type:read",
+          "gateway-credentials:read",
+          "gateway-credentials:update",
+          "service-name:read",
+          "service-name:update",
+          "payment-types:read",
+          "payment-types:update",
+          "email-notification-template:read",
+          "email-notification-paragraph:update",
+          "email-notification-toggle:update",
+          "tokens:read",
+          "toggle-3ds:read",
+          "toggle-3ds:update",
+          "users-service:delete",
+          "merchant-details:read",
+          "merchant-details:update",
+          "go-live-stage:update",
+          "go-live-stage:read"
+        ],
+        "sections": {
+          "description": "Contains fixtures for data intended to be surfaced in various 'sections' of self-service"
+        }
+      },
+      {
+        "isPrimary": "false",
+        "cypressTestingCategory": "REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_STRIPE",
+        "invalid_password": "some-password",
+        "invalid_passwordMatcher": "some-password",
+        "valid_password": "some-valid-password",
+        "valid_passwordMatcher": "some-valid-password",
+        "external_id": "rtglchosenpspstripeuserextid",
+        "username": "some-user-rtglchosenpspstripe@gov.uk",
+        "usernameMatcher": "some-user-rtglchosenpspstripe@gov\\.uk",
+        "email": "some-user-rtglchosenpspstripe@gov.uk",
+        "otp_key": "krb6fcianbdjkt01ecvi08jcln",
+        "telephone_number": "9127979",
+        "second_factor": "SMS",
+        "provisional_otp_key": "NOTSET",
+        "provisional_otp_key_created_at": null,
+        "disabled": false,
+        "login_counter": 0,
+        "session_version": 0,
+        "gateway_accounts": [
+          {
+            "id": "666",
+            "isPrimary": "true",
+            "name": "sandbox"
+          }
+        ],
+        "_links": [
+          {
+            "rel": "self",
+            "method": "GET",
+            "href": "http://myconnector.local/v1/api/users/rtglchosenpspstripeuserextid"
+          }
+        ],
+        "role": {
+          "name": "admin",
+          "description": "Administrator",
+          "permissions": [
+            {
+              "name": "users-service:read",
+              "description": "Viewusersinservice"
+            },
+            {
+              "name": "users-service:create",
+              "description": "Createuserinthisservice"
+            },
+            {
+              "name": "tokens-active:read",
+              "description": "Viewactivekeys"
+            },
+            {
+              "name": "tokens-revoked:read",
+              "description": "Viewrevokedkeys"
+            },
+            {
+              "name": "tokens:create",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:update",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:delete",
+              "description": "Revokekey"
+            },
+            {
+              "name": "transactions:read",
+              "description": "Viewtransactionslist"
+            },
+            {
+              "name": "transactions-by-date:read",
+              "description": "Searchtransactionsbydate"
+            },
+            {
+              "name": "transactions-by-fields:read",
+              "description": "Searchtransactionsbypaymentfields"
+            },
+            {
+              "name": "transactions-download:read",
+              "description": "Downloadtransactions"
+            },
+            {
+              "name": "transactions-details:read",
+              "description": "Viewtransactiondetails"
+            },
+            {
+              "name": "transactions-events:read",
+              "description": "Viewtransactionevents"
+            },
+            {
+              "name": "refunds:create",
+              "description": "Issuerefund"
+            },
+            {
+              "name": "transactions-amount:read",
+              "description": "Viewtransactionamounts"
+            },
+            {
+              "name": "transactions-description:read",
+              "description": "Viewtransactiondescription"
+            },
+            {
+              "name": "transactions-email:read",
+              "description": "Viewtransactionemail"
+            },
+            {
+              "name": "transactions-card-type:read",
+              "description": "Viewtransactioncardtype"
+            },
+            {
+              "name": "gateway-credentials:read",
+              "description": "Viewgatewayaccountcredentials"
+            },
+            {
+              "name": "gateway-credentials:update",
+              "description": "Editgatewayaccountcredentials"
+            },
+            {
+              "name": "service-name:read",
+              "description": "Viewservicename"
+            },
+            {
+              "name": "service-name:update",
+              "description": "Editservicename"
+            },
+            {
+              "name": "payment-types:read",
+              "description": "Viewpaymenttypes"
+            },
+            {
+              "name": "payment-types:update",
+              "description": "Editpaymenttypes"
+            },
+            {
+              "name": "email-notification-template:read",
+              "description": "Viewemailnotificationstemplate"
+            },
+            {
+              "name": "email-notification-paragraph:update",
+              "description": "Editemailnotificationsparagraph"
+            },
+            {
+              "name": "email-notification-toggle:update",
+              "description": "Turnemailnotificationson/off"
+            },
+            {
+              "name": "tokens:read",
+              "description": "View keys"
+            },
+            {
+              "name": "toggle-3ds:read",
+              "description": "View 3D Secure setting"
+            },
+            {
+              "name": "toggle-3ds:update",
+              "description": "Edit 3D Secure setting"
+            },
+            {
+              "name": "users-service:delete",
+              "description": "Remove user from a service"
+            },
+            {
+              "name": "merchant-details:read",
+              "description": "View Merchant Details setting"
+            },
+            {
+              "name": "merchant-details:update",
+              "description": "Edit Merchant Details setting"
+            },
+            {
+              "name": "toggle-billing-address:read",
+              "description": "View Billing Address setting"
+            },
+            {
+              "name": "toggle-billing-address:update",
+              "description": "Edit Billing Address setting"
+            },
+            {
+              "name": "go-live-stage:update",
+              "description": "Update Go Live stage"
+            },
+            {
+              "name": "go-live-stage:read",
+              "description": "View Go Live stage"
+            }
+          ]
+        },
+        "service_ids": [
+          "rtglchosenpspstripe"
+        ],
+        "service_roles": [
+          {
+            "service": {
+              "external_id": "rtglchosenpspstripe",
+              "name": "System Generated",
+              "gateway_account_ids": [
+                "666"
+              ],
+              "_links": [],
+              "redirect_to_service_immediately_on_terminal_state": false,
+              "collect_billing_address": true,
+              "current_go_live_stage": "CHOSEN_PSP_STRIPE"
+            },
+            "role": {
+              "name": "admin",
+              "description": "Administrator",
+              "permissions": [
+                {
+                  "name": "users-service:read",
+                  "description": "Viewusersinservice"
+                },
+                {
+                  "name": "users-service:create",
+                  "description": "Createuserinthisservice"
+                },
+                {
+                  "name": "tokens-active:read",
+                  "description": "Viewactivekeys"
+                },
+                {
+                  "name": "tokens-revoked:read",
+                  "description": "Viewrevokedkeys"
+                },
+                {
+                  "name": "tokens:create",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:update",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:delete",
+                  "description": "Revokekey"
+                },
+                {
+                  "name": "transactions:read",
+                  "description": "Viewtransactionslist"
+                },
+                {
+                  "name": "transactions-by-date:read",
+                  "description": "Searchtransactionsbydate"
+                },
+                {
+                  "name": "transactions-by-fields:read",
+                  "description": "Searchtransactionsbypaymentfields"
+                },
+                {
+                  "name": "transactions-download:read",
+                  "description": "Downloadtransactions"
+                },
+                {
+                  "name": "transactions-details:read",
+                  "description": "Viewtransactiondetails"
+                },
+                {
+                  "name": "transactions-events:read",
+                  "description": "Viewtransactionevents"
+                },
+                {
+                  "name": "refunds:create",
+                  "description": "Issuerefund"
+                },
+                {
+                  "name": "transactions-amount:read",
+                  "description": "Viewtransactionamounts"
+                },
+                {
+                  "name": "transactions-description:read",
+                  "description": "Viewtransactiondescription"
+                },
+                {
+                  "name": "transactions-email:read",
+                  "description": "Viewtransactionemail"
+                },
+                {
+                  "name": "transactions-card-type:read",
+                  "description": "Viewtransactioncardtype"
+                },
+                {
+                  "name": "gateway-credentials:read",
+                  "description": "Viewgatewayaccountcredentials"
+                },
+                {
+                  "name": "gateway-credentials:update",
+                  "description": "Editgatewayaccountcredentials"
+                },
+                {
+                  "name": "service-name:read",
+                  "description": "Viewservicename"
+                },
+                {
+                  "name": "service-name:update",
+                  "description": "Editservicename"
+                },
+                {
+                  "name": "payment-types:read",
+                  "description": "Viewpaymenttypes"
+                },
+                {
+                  "name": "payment-types:update",
+                  "description": "Editpaymenttypes"
+                },
+                {
+                  "name": "email-notification-template:read",
+                  "description": "Viewemailnotificationstemplate"
+                },
+                {
+                  "name": "email-notification-paragraph:update",
+                  "description": "Editemailnotificationsparagraph"
+                },
+                {
+                  "name": "email-notification-toggle:update",
+                  "description": "Turnemailnotificationson/off"
+                },
+                {
+                  "name": "tokens:read",
+                  "description": "View keys"
+                },
+                {
+                  "name": "toggle-3ds:read",
+                  "description": "View 3D Secure setting"
+                },
+                {
+                  "name": "toggle-3ds:update",
+                  "description": "Edit 3D Secure setting"
+                },
+                {
+                  "name": "users-service:delete",
+                  "description": "Remove user from a service"
+                },
+                {
+                  "name": "merchant-details:read",
+                  "description": "View Merchant Details setting"
+                },
+                {
+                  "name": "merchant-details:update",
+                  "description": "Edit Merchant Details setting"
+                },
+                {
+                  "name": "toggle-billing-address:read",
+                  "description": "View Billing Address setting"
+                },
+                {
+                  "name": "toggle-billing-address:update",
+                  "description": "Edit Billing Address setting"
+                },
+                {
+                  "name": "go-live-stage:update",
+                  "description": "Update Go Live stage"
+                },
+                {
+                  "name": "go-live-stage:read",
+                  "description": "View Go Live stage"
+                }
+              ]
+            }
+          }
+        ],
+        "services": [
+          {
+            "external_id": "rtglchosenpspstripe",
+            "name": "System Generated",
+            "gateway_account_ids": [
+              "666"
+            ],
+            "redirect_to_service_immediately_on_terminal_state": false,
+            "collect_billing_address": true,
+            "current_go_live_stage": "CHOSEN_PSP_STRIPE"
+          }
+        ],
+        "permissions": [
+          "users-service:read",
+          "users-service:create",
+          "tokens-active:read",
+          "tokens-revoked:read",
+          "tokens:create",
+          "tokens:update",
+          "tokens:delete",
+          "transactions:read",
+          "transactions-by-date:read",
+          "transactions-by-fields:read",
+          "transactions-download:read",
+          "transactions-details:read",
+          "transactions-events:read",
+          "refunds:create",
+          "transactions-amount:read",
+          "transactions-description:read",
+          "transactions-email:read",
+          "transactions-card-type:read",
+          "gateway-credentials:read",
+          "gateway-credentials:update",
+          "service-name:read",
+          "service-name:update",
+          "payment-types:read",
+          "payment-types:update",
+          "email-notification-template:read",
+          "email-notification-paragraph:update",
+          "email-notification-toggle:update",
+          "tokens:read",
+          "toggle-3ds:read",
+          "toggle-3ds:update",
+          "users-service:delete",
+          "merchant-details:read",
+          "merchant-details:update",
+          "go-live-stage:update",
+          "go-live-stage:read"
+        ],
+        "sections": {
+          "description": "Contains fixtures for data intended to be surfaced in various 'sections' of self-service"
+        }
+      },
+      {
+        "isPrimary": "false",
+        "cypressTestingCategory": "REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_WORLDPAY",
+        "invalid_password": "some-password",
+        "invalid_passwordMatcher": "some-password",
+        "valid_password": "some-valid-password",
+        "valid_passwordMatcher": "some-valid-password",
+        "external_id": "rtglchosenpspworldpayuserextid",
+        "username": "some-user-rtglchosenpspworldpay@gov.uk",
+        "usernameMatcher": "some-user-rtglchosenpspworldpay@gov\\.uk",
+        "email": "some-user-rtglchosenpspworldpay@gov.uk",
+        "otp_key": "krb6fcianbdjkt01ecvi08jcln",
+        "telephone_number": "9127979",
+        "second_factor": "SMS",
+        "provisional_otp_key": "NOTSET",
+        "provisional_otp_key_created_at": null,
+        "disabled": false,
+        "login_counter": 0,
+        "session_version": 0,
+        "gateway_accounts": [
+          {
+            "id": "666",
+            "isPrimary": "true",
+            "name": "sandbox"
+          }
+        ],
+        "_links": [
+          {
+            "rel": "self",
+            "method": "GET",
+            "href": "http://myconnector.local/v1/api/users/rtglchosenpspworldpayuserextid"
+          }
+        ],
+        "role": {
+          "name": "admin",
+          "description": "Administrator",
+          "permissions": [
+            {
+              "name": "users-service:read",
+              "description": "Viewusersinservice"
+            },
+            {
+              "name": "users-service:create",
+              "description": "Createuserinthisservice"
+            },
+            {
+              "name": "tokens-active:read",
+              "description": "Viewactivekeys"
+            },
+            {
+              "name": "tokens-revoked:read",
+              "description": "Viewrevokedkeys"
+            },
+            {
+              "name": "tokens:create",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:update",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:delete",
+              "description": "Revokekey"
+            },
+            {
+              "name": "transactions:read",
+              "description": "Viewtransactionslist"
+            },
+            {
+              "name": "transactions-by-date:read",
+              "description": "Searchtransactionsbydate"
+            },
+            {
+              "name": "transactions-by-fields:read",
+              "description": "Searchtransactionsbypaymentfields"
+            },
+            {
+              "name": "transactions-download:read",
+              "description": "Downloadtransactions"
+            },
+            {
+              "name": "transactions-details:read",
+              "description": "Viewtransactiondetails"
+            },
+            {
+              "name": "transactions-events:read",
+              "description": "Viewtransactionevents"
+            },
+            {
+              "name": "refunds:create",
+              "description": "Issuerefund"
+            },
+            {
+              "name": "transactions-amount:read",
+              "description": "Viewtransactionamounts"
+            },
+            {
+              "name": "transactions-description:read",
+              "description": "Viewtransactiondescription"
+            },
+            {
+              "name": "transactions-email:read",
+              "description": "Viewtransactionemail"
+            },
+            {
+              "name": "transactions-card-type:read",
+              "description": "Viewtransactioncardtype"
+            },
+            {
+              "name": "gateway-credentials:read",
+              "description": "Viewgatewayaccountcredentials"
+            },
+            {
+              "name": "gateway-credentials:update",
+              "description": "Editgatewayaccountcredentials"
+            },
+            {
+              "name": "service-name:read",
+              "description": "Viewservicename"
+            },
+            {
+              "name": "service-name:update",
+              "description": "Editservicename"
+            },
+            {
+              "name": "payment-types:read",
+              "description": "Viewpaymenttypes"
+            },
+            {
+              "name": "payment-types:update",
+              "description": "Editpaymenttypes"
+            },
+            {
+              "name": "email-notification-template:read",
+              "description": "Viewemailnotificationstemplate"
+            },
+            {
+              "name": "email-notification-paragraph:update",
+              "description": "Editemailnotificationsparagraph"
+            },
+            {
+              "name": "email-notification-toggle:update",
+              "description": "Turnemailnotificationson/off"
+            },
+            {
+              "name": "tokens:read",
+              "description": "View keys"
+            },
+            {
+              "name": "toggle-3ds:read",
+              "description": "View 3D Secure setting"
+            },
+            {
+              "name": "toggle-3ds:update",
+              "description": "Edit 3D Secure setting"
+            },
+            {
+              "name": "users-service:delete",
+              "description": "Remove user from a service"
+            },
+            {
+              "name": "merchant-details:read",
+              "description": "View Merchant Details setting"
+            },
+            {
+              "name": "merchant-details:update",
+              "description": "Edit Merchant Details setting"
+            },
+            {
+              "name": "toggle-billing-address:read",
+              "description": "View Billing Address setting"
+            },
+            {
+              "name": "toggle-billing-address:update",
+              "description": "Edit Billing Address setting"
+            },
+            {
+              "name": "go-live-stage:update",
+              "description": "Update Go Live stage"
+            },
+            {
+              "name": "go-live-stage:read",
+              "description": "View Go Live stage"
+            }
+          ]
+        },
+        "service_ids": [
+          "rtglchosenpspworldpay"
+        ],
+        "service_roles": [
+          {
+            "service": {
+              "external_id": "rtglchosenpspworldpay",
+              "name": "System Generated",
+              "gateway_account_ids": [
+                "666"
+              ],
+              "_links": [],
+              "redirect_to_service_immediately_on_terminal_state": false,
+              "collect_billing_address": true,
+              "current_go_live_stage": "CHOSEN_PSP_WORLDPAY"
+            },
+            "role": {
+              "name": "admin",
+              "description": "Administrator",
+              "permissions": [
+                {
+                  "name": "users-service:read",
+                  "description": "Viewusersinservice"
+                },
+                {
+                  "name": "users-service:create",
+                  "description": "Createuserinthisservice"
+                },
+                {
+                  "name": "tokens-active:read",
+                  "description": "Viewactivekeys"
+                },
+                {
+                  "name": "tokens-revoked:read",
+                  "description": "Viewrevokedkeys"
+                },
+                {
+                  "name": "tokens:create",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:update",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:delete",
+                  "description": "Revokekey"
+                },
+                {
+                  "name": "transactions:read",
+                  "description": "Viewtransactionslist"
+                },
+                {
+                  "name": "transactions-by-date:read",
+                  "description": "Searchtransactionsbydate"
+                },
+                {
+                  "name": "transactions-by-fields:read",
+                  "description": "Searchtransactionsbypaymentfields"
+                },
+                {
+                  "name": "transactions-download:read",
+                  "description": "Downloadtransactions"
+                },
+                {
+                  "name": "transactions-details:read",
+                  "description": "Viewtransactiondetails"
+                },
+                {
+                  "name": "transactions-events:read",
+                  "description": "Viewtransactionevents"
+                },
+                {
+                  "name": "refunds:create",
+                  "description": "Issuerefund"
+                },
+                {
+                  "name": "transactions-amount:read",
+                  "description": "Viewtransactionamounts"
+                },
+                {
+                  "name": "transactions-description:read",
+                  "description": "Viewtransactiondescription"
+                },
+                {
+                  "name": "transactions-email:read",
+                  "description": "Viewtransactionemail"
+                },
+                {
+                  "name": "transactions-card-type:read",
+                  "description": "Viewtransactioncardtype"
+                },
+                {
+                  "name": "gateway-credentials:read",
+                  "description": "Viewgatewayaccountcredentials"
+                },
+                {
+                  "name": "gateway-credentials:update",
+                  "description": "Editgatewayaccountcredentials"
+                },
+                {
+                  "name": "service-name:read",
+                  "description": "Viewservicename"
+                },
+                {
+                  "name": "service-name:update",
+                  "description": "Editservicename"
+                },
+                {
+                  "name": "payment-types:read",
+                  "description": "Viewpaymenttypes"
+                },
+                {
+                  "name": "payment-types:update",
+                  "description": "Editpaymenttypes"
+                },
+                {
+                  "name": "email-notification-template:read",
+                  "description": "Viewemailnotificationstemplate"
+                },
+                {
+                  "name": "email-notification-paragraph:update",
+                  "description": "Editemailnotificationsparagraph"
+                },
+                {
+                  "name": "email-notification-toggle:update",
+                  "description": "Turnemailnotificationson/off"
+                },
+                {
+                  "name": "tokens:read",
+                  "description": "View keys"
+                },
+                {
+                  "name": "toggle-3ds:read",
+                  "description": "View 3D Secure setting"
+                },
+                {
+                  "name": "toggle-3ds:update",
+                  "description": "Edit 3D Secure setting"
+                },
+                {
+                  "name": "users-service:delete",
+                  "description": "Remove user from a service"
+                },
+                {
+                  "name": "merchant-details:read",
+                  "description": "View Merchant Details setting"
+                },
+                {
+                  "name": "merchant-details:update",
+                  "description": "Edit Merchant Details setting"
+                },
+                {
+                  "name": "toggle-billing-address:read",
+                  "description": "View Billing Address setting"
+                },
+                {
+                  "name": "toggle-billing-address:update",
+                  "description": "Edit Billing Address setting"
+                },
+                {
+                  "name": "go-live-stage:update",
+                  "description": "Update Go Live stage"
+                },
+                {
+                  "name": "go-live-stage:read",
+                  "description": "View Go Live stage"
+                }
+              ]
+            }
+          }
+        ],
+        "services": [
+          {
+            "external_id": "rtglchosenpspworldpay",
+            "name": "System Generated",
+            "gateway_account_ids": [
+              "666"
+            ],
+            "redirect_to_service_immediately_on_terminal_state": false,
+            "collect_billing_address": true,
+            "current_go_live_stage": "CHOSEN_PSP_WORLDPAY"
+          }
+        ],
+        "permissions": [
+          "users-service:read",
+          "users-service:create",
+          "tokens-active:read",
+          "tokens-revoked:read",
+          "tokens:create",
+          "tokens:update",
+          "tokens:delete",
+          "transactions:read",
+          "transactions-by-date:read",
+          "transactions-by-fields:read",
+          "transactions-download:read",
+          "transactions-details:read",
+          "transactions-events:read",
+          "refunds:create",
+          "transactions-amount:read",
+          "transactions-description:read",
+          "transactions-email:read",
+          "transactions-card-type:read",
+          "gateway-credentials:read",
+          "gateway-credentials:update",
+          "service-name:read",
+          "service-name:update",
+          "payment-types:read",
+          "payment-types:update",
+          "email-notification-template:read",
+          "email-notification-paragraph:update",
+          "email-notification-toggle:update",
+          "tokens:read",
+          "toggle-3ds:read",
+          "toggle-3ds:update",
+          "users-service:delete",
+          "merchant-details:read",
+          "merchant-details:update",
+          "go-live-stage:update",
+          "go-live-stage:read"
+        ],
+        "sections": {
+          "description": "Contains fixtures for data intended to be surfaced in various 'sections' of self-service"
+        }
+      },
+      {
+        "isPrimary": "false",
+        "cypressTestingCategory": "REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_SMARTPAY",
+        "invalid_password": "some-password",
+        "invalid_passwordMatcher": "some-password",
+        "valid_password": "some-valid-password",
+        "valid_passwordMatcher": "some-valid-password",
+        "external_id": "rtglchosenpspsmartpayuserextid",
+        "username": "some-user-rtglchosenpspsmartpay@gov.uk",
+        "usernameMatcher": "some-user-rtglchosenpspsmartpay@gov\\.uk",
+        "email": "some-user-rtglchosenpspsmartpay@gov.uk",
+        "otp_key": "krb6fcianbdjkt01ecvi08jcln",
+        "telephone_number": "9127979",
+        "second_factor": "SMS",
+        "provisional_otp_key": "NOTSET",
+        "provisional_otp_key_created_at": null,
+        "disabled": false,
+        "login_counter": 0,
+        "session_version": 0,
+        "gateway_accounts": [
+          {
+            "id": "666",
+            "isPrimary": "true",
+            "name": "sandbox"
+          }
+        ],
+        "_links": [
+          {
+            "rel": "self",
+            "method": "GET",
+            "href": "http://myconnector.local/v1/api/users/rtglchosenpspsmartpayuserextid"
+          }
+        ],
+        "role": {
+          "name": "admin",
+          "description": "Administrator",
+          "permissions": [
+            {
+              "name": "users-service:read",
+              "description": "Viewusersinservice"
+            },
+            {
+              "name": "users-service:create",
+              "description": "Createuserinthisservice"
+            },
+            {
+              "name": "tokens-active:read",
+              "description": "Viewactivekeys"
+            },
+            {
+              "name": "tokens-revoked:read",
+              "description": "Viewrevokedkeys"
+            },
+            {
+              "name": "tokens:create",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:update",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:delete",
+              "description": "Revokekey"
+            },
+            {
+              "name": "transactions:read",
+              "description": "Viewtransactionslist"
+            },
+            {
+              "name": "transactions-by-date:read",
+              "description": "Searchtransactionsbydate"
+            },
+            {
+              "name": "transactions-by-fields:read",
+              "description": "Searchtransactionsbypaymentfields"
+            },
+            {
+              "name": "transactions-download:read",
+              "description": "Downloadtransactions"
+            },
+            {
+              "name": "transactions-details:read",
+              "description": "Viewtransactiondetails"
+            },
+            {
+              "name": "transactions-events:read",
+              "description": "Viewtransactionevents"
+            },
+            {
+              "name": "refunds:create",
+              "description": "Issuerefund"
+            },
+            {
+              "name": "transactions-amount:read",
+              "description": "Viewtransactionamounts"
+            },
+            {
+              "name": "transactions-description:read",
+              "description": "Viewtransactiondescription"
+            },
+            {
+              "name": "transactions-email:read",
+              "description": "Viewtransactionemail"
+            },
+            {
+              "name": "transactions-card-type:read",
+              "description": "Viewtransactioncardtype"
+            },
+            {
+              "name": "gateway-credentials:read",
+              "description": "Viewgatewayaccountcredentials"
+            },
+            {
+              "name": "gateway-credentials:update",
+              "description": "Editgatewayaccountcredentials"
+            },
+            {
+              "name": "service-name:read",
+              "description": "Viewservicename"
+            },
+            {
+              "name": "service-name:update",
+              "description": "Editservicename"
+            },
+            {
+              "name": "payment-types:read",
+              "description": "Viewpaymenttypes"
+            },
+            {
+              "name": "payment-types:update",
+              "description": "Editpaymenttypes"
+            },
+            {
+              "name": "email-notification-template:read",
+              "description": "Viewemailnotificationstemplate"
+            },
+            {
+              "name": "email-notification-paragraph:update",
+              "description": "Editemailnotificationsparagraph"
+            },
+            {
+              "name": "email-notification-toggle:update",
+              "description": "Turnemailnotificationson/off"
+            },
+            {
+              "name": "tokens:read",
+              "description": "View keys"
+            },
+            {
+              "name": "toggle-3ds:read",
+              "description": "View 3D Secure setting"
+            },
+            {
+              "name": "toggle-3ds:update",
+              "description": "Edit 3D Secure setting"
+            },
+            {
+              "name": "users-service:delete",
+              "description": "Remove user from a service"
+            },
+            {
+              "name": "merchant-details:read",
+              "description": "View Merchant Details setting"
+            },
+            {
+              "name": "merchant-details:update",
+              "description": "Edit Merchant Details setting"
+            },
+            {
+              "name": "toggle-billing-address:read",
+              "description": "View Billing Address setting"
+            },
+            {
+              "name": "toggle-billing-address:update",
+              "description": "Edit Billing Address setting"
+            },
+            {
+              "name": "go-live-stage:update",
+              "description": "Update Go Live stage"
+            },
+            {
+              "name": "go-live-stage:read",
+              "description": "View Go Live stage"
+            }
+          ]
+        },
+        "service_ids": [
+          "rtglchosenpspsmartpay"
+        ],
+        "service_roles": [
+          {
+            "service": {
+              "external_id": "rtglchosenpspsmartpay",
+              "name": "System Generated",
+              "gateway_account_ids": [
+                "666"
+              ],
+              "_links": [],
+              "redirect_to_service_immediately_on_terminal_state": false,
+              "collect_billing_address": true,
+              "current_go_live_stage": "CHOSEN_PSP_SMARTPAY"
+            },
+            "role": {
+              "name": "admin",
+              "description": "Administrator",
+              "permissions": [
+                {
+                  "name": "users-service:read",
+                  "description": "Viewusersinservice"
+                },
+                {
+                  "name": "users-service:create",
+                  "description": "Createuserinthisservice"
+                },
+                {
+                  "name": "tokens-active:read",
+                  "description": "Viewactivekeys"
+                },
+                {
+                  "name": "tokens-revoked:read",
+                  "description": "Viewrevokedkeys"
+                },
+                {
+                  "name": "tokens:create",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:update",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:delete",
+                  "description": "Revokekey"
+                },
+                {
+                  "name": "transactions:read",
+                  "description": "Viewtransactionslist"
+                },
+                {
+                  "name": "transactions-by-date:read",
+                  "description": "Searchtransactionsbydate"
+                },
+                {
+                  "name": "transactions-by-fields:read",
+                  "description": "Searchtransactionsbypaymentfields"
+                },
+                {
+                  "name": "transactions-download:read",
+                  "description": "Downloadtransactions"
+                },
+                {
+                  "name": "transactions-details:read",
+                  "description": "Viewtransactiondetails"
+                },
+                {
+                  "name": "transactions-events:read",
+                  "description": "Viewtransactionevents"
+                },
+                {
+                  "name": "refunds:create",
+                  "description": "Issuerefund"
+                },
+                {
+                  "name": "transactions-amount:read",
+                  "description": "Viewtransactionamounts"
+                },
+                {
+                  "name": "transactions-description:read",
+                  "description": "Viewtransactiondescription"
+                },
+                {
+                  "name": "transactions-email:read",
+                  "description": "Viewtransactionemail"
+                },
+                {
+                  "name": "transactions-card-type:read",
+                  "description": "Viewtransactioncardtype"
+                },
+                {
+                  "name": "gateway-credentials:read",
+                  "description": "Viewgatewayaccountcredentials"
+                },
+                {
+                  "name": "gateway-credentials:update",
+                  "description": "Editgatewayaccountcredentials"
+                },
+                {
+                  "name": "service-name:read",
+                  "description": "Viewservicename"
+                },
+                {
+                  "name": "service-name:update",
+                  "description": "Editservicename"
+                },
+                {
+                  "name": "payment-types:read",
+                  "description": "Viewpaymenttypes"
+                },
+                {
+                  "name": "payment-types:update",
+                  "description": "Editpaymenttypes"
+                },
+                {
+                  "name": "email-notification-template:read",
+                  "description": "Viewemailnotificationstemplate"
+                },
+                {
+                  "name": "email-notification-paragraph:update",
+                  "description": "Editemailnotificationsparagraph"
+                },
+                {
+                  "name": "email-notification-toggle:update",
+                  "description": "Turnemailnotificationson/off"
+                },
+                {
+                  "name": "tokens:read",
+                  "description": "View keys"
+                },
+                {
+                  "name": "toggle-3ds:read",
+                  "description": "View 3D Secure setting"
+                },
+                {
+                  "name": "toggle-3ds:update",
+                  "description": "Edit 3D Secure setting"
+                },
+                {
+                  "name": "users-service:delete",
+                  "description": "Remove user from a service"
+                },
+                {
+                  "name": "merchant-details:read",
+                  "description": "View Merchant Details setting"
+                },
+                {
+                  "name": "merchant-details:update",
+                  "description": "Edit Merchant Details setting"
+                },
+                {
+                  "name": "toggle-billing-address:read",
+                  "description": "View Billing Address setting"
+                },
+                {
+                  "name": "toggle-billing-address:update",
+                  "description": "Edit Billing Address setting"
+                },
+                {
+                  "name": "go-live-stage:update",
+                  "description": "Update Go Live stage"
+                },
+                {
+                  "name": "go-live-stage:read",
+                  "description": "View Go Live stage"
+                }
+              ]
+            }
+          }
+        ],
+        "services": [
+          {
+            "external_id": "rtglchosenpspsmartpay",
+            "name": "System Generated",
+            "gateway_account_ids": [
+              "666"
+            ],
+            "redirect_to_service_immediately_on_terminal_state": false,
+            "collect_billing_address": true,
+            "current_go_live_stage": "CHOSEN_PSP_SMARTPAY"
+          }
+        ],
+        "permissions": [
+          "users-service:read",
+          "users-service:create",
+          "tokens-active:read",
+          "tokens-revoked:read",
+          "tokens:create",
+          "tokens:update",
+          "tokens:delete",
+          "transactions:read",
+          "transactions-by-date:read",
+          "transactions-by-fields:read",
+          "transactions-download:read",
+          "transactions-details:read",
+          "transactions-events:read",
+          "refunds:create",
+          "transactions-amount:read",
+          "transactions-description:read",
+          "transactions-email:read",
+          "transactions-card-type:read",
+          "gateway-credentials:read",
+          "gateway-credentials:update",
+          "service-name:read",
+          "service-name:update",
+          "payment-types:read",
+          "payment-types:update",
+          "email-notification-template:read",
+          "email-notification-paragraph:update",
+          "email-notification-toggle:update",
+          "tokens:read",
+          "toggle-3ds:read",
+          "toggle-3ds:update",
+          "users-service:delete",
+          "merchant-details:read",
+          "merchant-details:update",
+          "go-live-stage:update",
+          "go-live-stage:read"
+        ],
+        "sections": {
+          "description": "Contains fixtures for data intended to be surfaced in various 'sections' of self-service"
+        }
+      },
+      {
+        "isPrimary": "false",
+        "cypressTestingCategory": "REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_EPDQ",
+        "invalid_password": "some-password",
+        "invalid_passwordMatcher": "some-password",
+        "valid_password": "some-valid-password",
+        "valid_passwordMatcher": "some-valid-password",
+        "external_id": "rtglchosenpspepdquserextid",
+        "username": "some-user-rtglchosenpspepdq@gov.uk",
+        "usernameMatcher": "some-user-rtglchosenpspepdq@gov\\.uk",
+        "email": "some-user-rtglchosenpspepdq@gov.uk",
+        "otp_key": "krb6fcianbdjkt01ecvi08jcln",
+        "telephone_number": "9127979",
+        "second_factor": "SMS",
+        "provisional_otp_key": "NOTSET",
+        "provisional_otp_key_created_at": null,
+        "disabled": false,
+        "login_counter": 0,
+        "session_version": 0,
+        "gateway_accounts": [
+          {
+            "id": "666",
+            "isPrimary": "true",
+            "name": "sandbox"
+          }
+        ],
+        "_links": [
+          {
+            "rel": "self",
+            "method": "GET",
+            "href": "http://myconnector.local/v1/api/users/rtglchosenpspepdquserextid"
+          }
+        ],
+        "role": {
+          "name": "admin",
+          "description": "Administrator",
+          "permissions": [
+            {
+              "name": "users-service:read",
+              "description": "Viewusersinservice"
+            },
+            {
+              "name": "users-service:create",
+              "description": "Createuserinthisservice"
+            },
+            {
+              "name": "tokens-active:read",
+              "description": "Viewactivekeys"
+            },
+            {
+              "name": "tokens-revoked:read",
+              "description": "Viewrevokedkeys"
+            },
+            {
+              "name": "tokens:create",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:update",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:delete",
+              "description": "Revokekey"
+            },
+            {
+              "name": "transactions:read",
+              "description": "Viewtransactionslist"
+            },
+            {
+              "name": "transactions-by-date:read",
+              "description": "Searchtransactionsbydate"
+            },
+            {
+              "name": "transactions-by-fields:read",
+              "description": "Searchtransactionsbypaymentfields"
+            },
+            {
+              "name": "transactions-download:read",
+              "description": "Downloadtransactions"
+            },
+            {
+              "name": "transactions-details:read",
+              "description": "Viewtransactiondetails"
+            },
+            {
+              "name": "transactions-events:read",
+              "description": "Viewtransactionevents"
+            },
+            {
+              "name": "refunds:create",
+              "description": "Issuerefund"
+            },
+            {
+              "name": "transactions-amount:read",
+              "description": "Viewtransactionamounts"
+            },
+            {
+              "name": "transactions-description:read",
+              "description": "Viewtransactiondescription"
+            },
+            {
+              "name": "transactions-email:read",
+              "description": "Viewtransactionemail"
+            },
+            {
+              "name": "transactions-card-type:read",
+              "description": "Viewtransactioncardtype"
+            },
+            {
+              "name": "gateway-credentials:read",
+              "description": "Viewgatewayaccountcredentials"
+            },
+            {
+              "name": "gateway-credentials:update",
+              "description": "Editgatewayaccountcredentials"
+            },
+            {
+              "name": "service-name:read",
+              "description": "Viewservicename"
+            },
+            {
+              "name": "service-name:update",
+              "description": "Editservicename"
+            },
+            {
+              "name": "payment-types:read",
+              "description": "Viewpaymenttypes"
+            },
+            {
+              "name": "payment-types:update",
+              "description": "Editpaymenttypes"
+            },
+            {
+              "name": "email-notification-template:read",
+              "description": "Viewemailnotificationstemplate"
+            },
+            {
+              "name": "email-notification-paragraph:update",
+              "description": "Editemailnotificationsparagraph"
+            },
+            {
+              "name": "email-notification-toggle:update",
+              "description": "Turnemailnotificationson/off"
+            },
+            {
+              "name": "tokens:read",
+              "description": "View keys"
+            },
+            {
+              "name": "toggle-3ds:read",
+              "description": "View 3D Secure setting"
+            },
+            {
+              "name": "toggle-3ds:update",
+              "description": "Edit 3D Secure setting"
+            },
+            {
+              "name": "users-service:delete",
+              "description": "Remove user from a service"
+            },
+            {
+              "name": "merchant-details:read",
+              "description": "View Merchant Details setting"
+            },
+            {
+              "name": "merchant-details:update",
+              "description": "Edit Merchant Details setting"
+            },
+            {
+              "name": "toggle-billing-address:read",
+              "description": "View Billing Address setting"
+            },
+            {
+              "name": "toggle-billing-address:update",
+              "description": "Edit Billing Address setting"
+            },
+            {
+              "name": "go-live-stage:update",
+              "description": "Update Go Live stage"
+            },
+            {
+              "name": "go-live-stage:read",
+              "description": "View Go Live stage"
+            }
+          ]
+        },
+        "service_ids": [
+          "rtglchosenpspepdq"
+        ],
+        "service_roles": [
+          {
+            "service": {
+              "external_id": "rtglchosenpspepdq",
+              "name": "System Generated",
+              "gateway_account_ids": [
+                "666"
+              ],
+              "_links": [],
+              "redirect_to_service_immediately_on_terminal_state": false,
+              "collect_billing_address": true,
+              "current_go_live_stage": "CHOSEN_PSP_EPDQ"
+            },
+            "role": {
+              "name": "admin",
+              "description": "Administrator",
+              "permissions": [
+                {
+                  "name": "users-service:read",
+                  "description": "Viewusersinservice"
+                },
+                {
+                  "name": "users-service:create",
+                  "description": "Createuserinthisservice"
+                },
+                {
+                  "name": "tokens-active:read",
+                  "description": "Viewactivekeys"
+                },
+                {
+                  "name": "tokens-revoked:read",
+                  "description": "Viewrevokedkeys"
+                },
+                {
+                  "name": "tokens:create",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:update",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:delete",
+                  "description": "Revokekey"
+                },
+                {
+                  "name": "transactions:read",
+                  "description": "Viewtransactionslist"
+                },
+                {
+                  "name": "transactions-by-date:read",
+                  "description": "Searchtransactionsbydate"
+                },
+                {
+                  "name": "transactions-by-fields:read",
+                  "description": "Searchtransactionsbypaymentfields"
+                },
+                {
+                  "name": "transactions-download:read",
+                  "description": "Downloadtransactions"
+                },
+                {
+                  "name": "transactions-details:read",
+                  "description": "Viewtransactiondetails"
+                },
+                {
+                  "name": "transactions-events:read",
+                  "description": "Viewtransactionevents"
+                },
+                {
+                  "name": "refunds:create",
+                  "description": "Issuerefund"
+                },
+                {
+                  "name": "transactions-amount:read",
+                  "description": "Viewtransactionamounts"
+                },
+                {
+                  "name": "transactions-description:read",
+                  "description": "Viewtransactiondescription"
+                },
+                {
+                  "name": "transactions-email:read",
+                  "description": "Viewtransactionemail"
+                },
+                {
+                  "name": "transactions-card-type:read",
+                  "description": "Viewtransactioncardtype"
+                },
+                {
+                  "name": "gateway-credentials:read",
+                  "description": "Viewgatewayaccountcredentials"
+                },
+                {
+                  "name": "gateway-credentials:update",
+                  "description": "Editgatewayaccountcredentials"
+                },
+                {
+                  "name": "service-name:read",
+                  "description": "Viewservicename"
+                },
+                {
+                  "name": "service-name:update",
+                  "description": "Editservicename"
+                },
+                {
+                  "name": "payment-types:read",
+                  "description": "Viewpaymenttypes"
+                },
+                {
+                  "name": "payment-types:update",
+                  "description": "Editpaymenttypes"
+                },
+                {
+                  "name": "email-notification-template:read",
+                  "description": "Viewemailnotificationstemplate"
+                },
+                {
+                  "name": "email-notification-paragraph:update",
+                  "description": "Editemailnotificationsparagraph"
+                },
+                {
+                  "name": "email-notification-toggle:update",
+                  "description": "Turnemailnotificationson/off"
+                },
+                {
+                  "name": "tokens:read",
+                  "description": "View keys"
+                },
+                {
+                  "name": "toggle-3ds:read",
+                  "description": "View 3D Secure setting"
+                },
+                {
+                  "name": "toggle-3ds:update",
+                  "description": "Edit 3D Secure setting"
+                },
+                {
+                  "name": "users-service:delete",
+                  "description": "Remove user from a service"
+                },
+                {
+                  "name": "merchant-details:read",
+                  "description": "View Merchant Details setting"
+                },
+                {
+                  "name": "merchant-details:update",
+                  "description": "Edit Merchant Details setting"
+                },
+                {
+                  "name": "toggle-billing-address:read",
+                  "description": "View Billing Address setting"
+                },
+                {
+                  "name": "toggle-billing-address:update",
+                  "description": "Edit Billing Address setting"
+                },
+                {
+                  "name": "go-live-stage:update",
+                  "description": "Update Go Live stage"
+                },
+                {
+                  "name": "go-live-stage:read",
+                  "description": "View Go Live stage"
+                }
+              ]
+            }
+          }
+        ],
+        "services": [
+          {
+            "external_id": "rtglchosenpspepdq",
+            "name": "System Generated",
+            "gateway_account_ids": [
+              "666"
+            ],
+            "redirect_to_service_immediately_on_terminal_state": false,
+            "collect_billing_address": true,
+            "current_go_live_stage": "CHOSEN_PSP_EPDQ"
+          }
+        ],
+        "permissions": [
+          "users-service:read",
+          "users-service:create",
+          "tokens-active:read",
+          "tokens-revoked:read",
+          "tokens:create",
+          "tokens:update",
+          "tokens:delete",
+          "transactions:read",
+          "transactions-by-date:read",
+          "transactions-by-fields:read",
+          "transactions-download:read",
+          "transactions-details:read",
+          "transactions-events:read",
+          "refunds:create",
+          "transactions-amount:read",
+          "transactions-description:read",
+          "transactions-email:read",
+          "transactions-card-type:read",
+          "gateway-credentials:read",
+          "gateway-credentials:update",
+          "service-name:read",
+          "service-name:update",
+          "payment-types:read",
+          "payment-types:update",
+          "email-notification-template:read",
+          "email-notification-paragraph:update",
+          "email-notification-toggle:update",
+          "tokens:read",
+          "toggle-3ds:read",
+          "toggle-3ds:update",
+          "users-service:delete",
+          "merchant-details:read",
+          "merchant-details:update",
+          "go-live-stage:update",
+          "go-live-stage:read"
+        ],
+        "sections": {
+          "description": "Contains fixtures for data intended to be surfaced in various 'sections' of self-service"
+        }
+      },
+      {
+        "isPrimary": "false",
+        "cypressTestingCategory": "REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_STRIPE",
+        "invalid_password": "some-password",
+        "invalid_passwordMatcher": "some-password",
+        "valid_password": "some-valid-password",
+        "valid_passwordMatcher": "some-valid-password",
+        "external_id": "rtgltermsokstripeuserextid",
+        "username": "some-user-rtgltermsokstripe@gov.uk",
+        "usernameMatcher": "some-user-rtgltermsokstripe@gov\\.uk",
+        "email": "some-user-rtgltermsokstripe@gov.uk",
+        "otp_key": "krb6fcianbdjkt01ecvi08jcln",
+        "telephone_number": "9127979",
+        "second_factor": "SMS",
+        "provisional_otp_key": "NOTSET",
+        "provisional_otp_key_created_at": null,
+        "disabled": false,
+        "login_counter": 0,
+        "session_version": 0,
+        "gateway_accounts": [
+          {
+            "id": "666",
+            "isPrimary": "true",
+            "name": "sandbox"
+          }
+        ],
+        "_links": [
+          {
+            "rel": "self",
+            "method": "GET",
+            "href": "http://myconnector.local/v1/api/users/rtgltermsokstripeuserextid"
+          }
+        ],
+        "role": {
+          "name": "admin",
+          "description": "Administrator",
+          "permissions": [
+            {
+              "name": "users-service:read",
+              "description": "Viewusersinservice"
+            },
+            {
+              "name": "users-service:create",
+              "description": "Createuserinthisservice"
+            },
+            {
+              "name": "tokens-active:read",
+              "description": "Viewactivekeys"
+            },
+            {
+              "name": "tokens-revoked:read",
+              "description": "Viewrevokedkeys"
+            },
+            {
+              "name": "tokens:create",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:update",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:delete",
+              "description": "Revokekey"
+            },
+            {
+              "name": "transactions:read",
+              "description": "Viewtransactionslist"
+            },
+            {
+              "name": "transactions-by-date:read",
+              "description": "Searchtransactionsbydate"
+            },
+            {
+              "name": "transactions-by-fields:read",
+              "description": "Searchtransactionsbypaymentfields"
+            },
+            {
+              "name": "transactions-download:read",
+              "description": "Downloadtransactions"
+            },
+            {
+              "name": "transactions-details:read",
+              "description": "Viewtransactiondetails"
+            },
+            {
+              "name": "transactions-events:read",
+              "description": "Viewtransactionevents"
+            },
+            {
+              "name": "refunds:create",
+              "description": "Issuerefund"
+            },
+            {
+              "name": "transactions-amount:read",
+              "description": "Viewtransactionamounts"
+            },
+            {
+              "name": "transactions-description:read",
+              "description": "Viewtransactiondescription"
+            },
+            {
+              "name": "transactions-email:read",
+              "description": "Viewtransactionemail"
+            },
+            {
+              "name": "transactions-card-type:read",
+              "description": "Viewtransactioncardtype"
+            },
+            {
+              "name": "gateway-credentials:read",
+              "description": "Viewgatewayaccountcredentials"
+            },
+            {
+              "name": "gateway-credentials:update",
+              "description": "Editgatewayaccountcredentials"
+            },
+            {
+              "name": "service-name:read",
+              "description": "Viewservicename"
+            },
+            {
+              "name": "service-name:update",
+              "description": "Editservicename"
+            },
+            {
+              "name": "payment-types:read",
+              "description": "Viewpaymenttypes"
+            },
+            {
+              "name": "payment-types:update",
+              "description": "Editpaymenttypes"
+            },
+            {
+              "name": "email-notification-template:read",
+              "description": "Viewemailnotificationstemplate"
+            },
+            {
+              "name": "email-notification-paragraph:update",
+              "description": "Editemailnotificationsparagraph"
+            },
+            {
+              "name": "email-notification-toggle:update",
+              "description": "Turnemailnotificationson/off"
+            },
+            {
+              "name": "tokens:read",
+              "description": "View keys"
+            },
+            {
+              "name": "toggle-3ds:read",
+              "description": "View 3D Secure setting"
+            },
+            {
+              "name": "toggle-3ds:update",
+              "description": "Edit 3D Secure setting"
+            },
+            {
+              "name": "users-service:delete",
+              "description": "Remove user from a service"
+            },
+            {
+              "name": "merchant-details:read",
+              "description": "View Merchant Details setting"
+            },
+            {
+              "name": "merchant-details:update",
+              "description": "Edit Merchant Details setting"
+            },
+            {
+              "name": "toggle-billing-address:read",
+              "description": "View Billing Address setting"
+            },
+            {
+              "name": "toggle-billing-address:update",
+              "description": "Edit Billing Address setting"
+            },
+            {
+              "name": "go-live-stage:update",
+              "description": "Update Go Live stage"
+            },
+            {
+              "name": "go-live-stage:read",
+              "description": "View Go Live stage"
+            }
+          ]
+        },
+        "service_ids": [
+          "rtgltermsokstripe"
+        ],
+        "service_roles": [
+          {
+            "service": {
+              "external_id": "rtgltermsokstripe",
+              "name": "System Generated",
+              "gateway_account_ids": [
+                "666"
+              ],
+              "_links": [],
+              "redirect_to_service_immediately_on_terminal_state": false,
+              "collect_billing_address": true,
+              "current_go_live_stage": "TERMS_AGREED_STRIPE"
+            },
+            "role": {
+              "name": "admin",
+              "description": "Administrator",
+              "permissions": [
+                {
+                  "name": "users-service:read",
+                  "description": "Viewusersinservice"
+                },
+                {
+                  "name": "users-service:create",
+                  "description": "Createuserinthisservice"
+                },
+                {
+                  "name": "tokens-active:read",
+                  "description": "Viewactivekeys"
+                },
+                {
+                  "name": "tokens-revoked:read",
+                  "description": "Viewrevokedkeys"
+                },
+                {
+                  "name": "tokens:create",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:update",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:delete",
+                  "description": "Revokekey"
+                },
+                {
+                  "name": "transactions:read",
+                  "description": "Viewtransactionslist"
+                },
+                {
+                  "name": "transactions-by-date:read",
+                  "description": "Searchtransactionsbydate"
+                },
+                {
+                  "name": "transactions-by-fields:read",
+                  "description": "Searchtransactionsbypaymentfields"
+                },
+                {
+                  "name": "transactions-download:read",
+                  "description": "Downloadtransactions"
+                },
+                {
+                  "name": "transactions-details:read",
+                  "description": "Viewtransactiondetails"
+                },
+                {
+                  "name": "transactions-events:read",
+                  "description": "Viewtransactionevents"
+                },
+                {
+                  "name": "refunds:create",
+                  "description": "Issuerefund"
+                },
+                {
+                  "name": "transactions-amount:read",
+                  "description": "Viewtransactionamounts"
+                },
+                {
+                  "name": "transactions-description:read",
+                  "description": "Viewtransactiondescription"
+                },
+                {
+                  "name": "transactions-email:read",
+                  "description": "Viewtransactionemail"
+                },
+                {
+                  "name": "transactions-card-type:read",
+                  "description": "Viewtransactioncardtype"
+                },
+                {
+                  "name": "gateway-credentials:read",
+                  "description": "Viewgatewayaccountcredentials"
+                },
+                {
+                  "name": "gateway-credentials:update",
+                  "description": "Editgatewayaccountcredentials"
+                },
+                {
+                  "name": "service-name:read",
+                  "description": "Viewservicename"
+                },
+                {
+                  "name": "service-name:update",
+                  "description": "Editservicename"
+                },
+                {
+                  "name": "payment-types:read",
+                  "description": "Viewpaymenttypes"
+                },
+                {
+                  "name": "payment-types:update",
+                  "description": "Editpaymenttypes"
+                },
+                {
+                  "name": "email-notification-template:read",
+                  "description": "Viewemailnotificationstemplate"
+                },
+                {
+                  "name": "email-notification-paragraph:update",
+                  "description": "Editemailnotificationsparagraph"
+                },
+                {
+                  "name": "email-notification-toggle:update",
+                  "description": "Turnemailnotificationson/off"
+                },
+                {
+                  "name": "tokens:read",
+                  "description": "View keys"
+                },
+                {
+                  "name": "toggle-3ds:read",
+                  "description": "View 3D Secure setting"
+                },
+                {
+                  "name": "toggle-3ds:update",
+                  "description": "Edit 3D Secure setting"
+                },
+                {
+                  "name": "users-service:delete",
+                  "description": "Remove user from a service"
+                },
+                {
+                  "name": "merchant-details:read",
+                  "description": "View Merchant Details setting"
+                },
+                {
+                  "name": "merchant-details:update",
+                  "description": "Edit Merchant Details setting"
+                },
+                {
+                  "name": "toggle-billing-address:read",
+                  "description": "View Billing Address setting"
+                },
+                {
+                  "name": "toggle-billing-address:update",
+                  "description": "Edit Billing Address setting"
+                },
+                {
+                  "name": "go-live-stage:update",
+                  "description": "Update Go Live stage"
+                },
+                {
+                  "name": "go-live-stage:read",
+                  "description": "View Go Live stage"
+                }
+              ]
+            }
+          }
+        ],
+        "services": [
+          {
+            "external_id": "rtgltermsokstripe",
+            "name": "System Generated",
+            "gateway_account_ids": [
+              "666"
+            ],
+            "redirect_to_service_immediately_on_terminal_state": false,
+            "collect_billing_address": true,
+            "current_go_live_stage": "TERMS_AGREED_STRIPE"
+          }
+        ],
+        "permissions": [
+          "users-service:read",
+          "users-service:create",
+          "tokens-active:read",
+          "tokens-revoked:read",
+          "tokens:create",
+          "tokens:update",
+          "tokens:delete",
+          "transactions:read",
+          "transactions-by-date:read",
+          "transactions-by-fields:read",
+          "transactions-download:read",
+          "transactions-details:read",
+          "transactions-events:read",
+          "refunds:create",
+          "transactions-amount:read",
+          "transactions-description:read",
+          "transactions-email:read",
+          "transactions-card-type:read",
+          "gateway-credentials:read",
+          "gateway-credentials:update",
+          "service-name:read",
+          "service-name:update",
+          "payment-types:read",
+          "payment-types:update",
+          "email-notification-template:read",
+          "email-notification-paragraph:update",
+          "email-notification-toggle:update",
+          "tokens:read",
+          "toggle-3ds:read",
+          "toggle-3ds:update",
+          "users-service:delete",
+          "merchant-details:read",
+          "merchant-details:update",
+          "go-live-stage:update",
+          "go-live-stage:read"
+        ],
+        "sections": {
+          "description": "Contains fixtures for data intended to be surfaced in various 'sections' of self-service"
+        }
+      },
+      {
+        "isPrimary": "false",
+        "cypressTestingCategory": "REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_WORLDPAY",
+        "invalid_password": "some-password",
+        "invalid_passwordMatcher": "some-password",
+        "valid_password": "some-valid-password",
+        "valid_passwordMatcher": "some-valid-password",
+        "external_id": "rtgltermsokworldpayuserextid",
+        "username": "some-user-rtgltermsokworldpay@gov.uk",
+        "usernameMatcher": "some-user-rtgltermsokworldpay@gov\\.uk",
+        "email": "some-user-rtgltermsokworldpay@gov.uk",
+        "otp_key": "krb6fcianbdjkt01ecvi08jcln",
+        "telephone_number": "9127979",
+        "second_factor": "SMS",
+        "provisional_otp_key": "NOTSET",
+        "provisional_otp_key_created_at": null,
+        "disabled": false,
+        "login_counter": 0,
+        "session_version": 0,
+        "gateway_accounts": [
+          {
+            "id": "666",
+            "isPrimary": "true",
+            "name": "sandbox"
+          }
+        ],
+        "_links": [
+          {
+            "rel": "self",
+            "method": "GET",
+            "href": "http://myconnector.local/v1/api/users/rtgltermsokworldpayuserextid"
+          }
+        ],
+        "role": {
+          "name": "admin",
+          "description": "Administrator",
+          "permissions": [
+            {
+              "name": "users-service:read",
+              "description": "Viewusersinservice"
+            },
+            {
+              "name": "users-service:create",
+              "description": "Createuserinthisservice"
+            },
+            {
+              "name": "tokens-active:read",
+              "description": "Viewactivekeys"
+            },
+            {
+              "name": "tokens-revoked:read",
+              "description": "Viewrevokedkeys"
+            },
+            {
+              "name": "tokens:create",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:update",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:delete",
+              "description": "Revokekey"
+            },
+            {
+              "name": "transactions:read",
+              "description": "Viewtransactionslist"
+            },
+            {
+              "name": "transactions-by-date:read",
+              "description": "Searchtransactionsbydate"
+            },
+            {
+              "name": "transactions-by-fields:read",
+              "description": "Searchtransactionsbypaymentfields"
+            },
+            {
+              "name": "transactions-download:read",
+              "description": "Downloadtransactions"
+            },
+            {
+              "name": "transactions-details:read",
+              "description": "Viewtransactiondetails"
+            },
+            {
+              "name": "transactions-events:read",
+              "description": "Viewtransactionevents"
+            },
+            {
+              "name": "refunds:create",
+              "description": "Issuerefund"
+            },
+            {
+              "name": "transactions-amount:read",
+              "description": "Viewtransactionamounts"
+            },
+            {
+              "name": "transactions-description:read",
+              "description": "Viewtransactiondescription"
+            },
+            {
+              "name": "transactions-email:read",
+              "description": "Viewtransactionemail"
+            },
+            {
+              "name": "transactions-card-type:read",
+              "description": "Viewtransactioncardtype"
+            },
+            {
+              "name": "gateway-credentials:read",
+              "description": "Viewgatewayaccountcredentials"
+            },
+            {
+              "name": "gateway-credentials:update",
+              "description": "Editgatewayaccountcredentials"
+            },
+            {
+              "name": "service-name:read",
+              "description": "Viewservicename"
+            },
+            {
+              "name": "service-name:update",
+              "description": "Editservicename"
+            },
+            {
+              "name": "payment-types:read",
+              "description": "Viewpaymenttypes"
+            },
+            {
+              "name": "payment-types:update",
+              "description": "Editpaymenttypes"
+            },
+            {
+              "name": "email-notification-template:read",
+              "description": "Viewemailnotificationstemplate"
+            },
+            {
+              "name": "email-notification-paragraph:update",
+              "description": "Editemailnotificationsparagraph"
+            },
+            {
+              "name": "email-notification-toggle:update",
+              "description": "Turnemailnotificationson/off"
+            },
+            {
+              "name": "tokens:read",
+              "description": "View keys"
+            },
+            {
+              "name": "toggle-3ds:read",
+              "description": "View 3D Secure setting"
+            },
+            {
+              "name": "toggle-3ds:update",
+              "description": "Edit 3D Secure setting"
+            },
+            {
+              "name": "users-service:delete",
+              "description": "Remove user from a service"
+            },
+            {
+              "name": "merchant-details:read",
+              "description": "View Merchant Details setting"
+            },
+            {
+              "name": "merchant-details:update",
+              "description": "Edit Merchant Details setting"
+            },
+            {
+              "name": "toggle-billing-address:read",
+              "description": "View Billing Address setting"
+            },
+            {
+              "name": "toggle-billing-address:update",
+              "description": "Edit Billing Address setting"
+            },
+            {
+              "name": "go-live-stage:update",
+              "description": "Update Go Live stage"
+            },
+            {
+              "name": "go-live-stage:read",
+              "description": "View Go Live stage"
+            }
+          ]
+        },
+        "service_ids": [
+          "rtgltermsokworldpay"
+        ],
+        "service_roles": [
+          {
+            "service": {
+              "external_id": "rtgltermsokworldpay",
+              "name": "System Generated",
+              "gateway_account_ids": [
+                "666"
+              ],
+              "_links": [],
+              "redirect_to_service_immediately_on_terminal_state": false,
+              "collect_billing_address": true,
+              "current_go_live_stage": "TERMS_AGREED_WORLDPAY"
+            },
+            "role": {
+              "name": "admin",
+              "description": "Administrator",
+              "permissions": [
+                {
+                  "name": "users-service:read",
+                  "description": "Viewusersinservice"
+                },
+                {
+                  "name": "users-service:create",
+                  "description": "Createuserinthisservice"
+                },
+                {
+                  "name": "tokens-active:read",
+                  "description": "Viewactivekeys"
+                },
+                {
+                  "name": "tokens-revoked:read",
+                  "description": "Viewrevokedkeys"
+                },
+                {
+                  "name": "tokens:create",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:update",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:delete",
+                  "description": "Revokekey"
+                },
+                {
+                  "name": "transactions:read",
+                  "description": "Viewtransactionslist"
+                },
+                {
+                  "name": "transactions-by-date:read",
+                  "description": "Searchtransactionsbydate"
+                },
+                {
+                  "name": "transactions-by-fields:read",
+                  "description": "Searchtransactionsbypaymentfields"
+                },
+                {
+                  "name": "transactions-download:read",
+                  "description": "Downloadtransactions"
+                },
+                {
+                  "name": "transactions-details:read",
+                  "description": "Viewtransactiondetails"
+                },
+                {
+                  "name": "transactions-events:read",
+                  "description": "Viewtransactionevents"
+                },
+                {
+                  "name": "refunds:create",
+                  "description": "Issuerefund"
+                },
+                {
+                  "name": "transactions-amount:read",
+                  "description": "Viewtransactionamounts"
+                },
+                {
+                  "name": "transactions-description:read",
+                  "description": "Viewtransactiondescription"
+                },
+                {
+                  "name": "transactions-email:read",
+                  "description": "Viewtransactionemail"
+                },
+                {
+                  "name": "transactions-card-type:read",
+                  "description": "Viewtransactioncardtype"
+                },
+                {
+                  "name": "gateway-credentials:read",
+                  "description": "Viewgatewayaccountcredentials"
+                },
+                {
+                  "name": "gateway-credentials:update",
+                  "description": "Editgatewayaccountcredentials"
+                },
+                {
+                  "name": "service-name:read",
+                  "description": "Viewservicename"
+                },
+                {
+                  "name": "service-name:update",
+                  "description": "Editservicename"
+                },
+                {
+                  "name": "payment-types:read",
+                  "description": "Viewpaymenttypes"
+                },
+                {
+                  "name": "payment-types:update",
+                  "description": "Editpaymenttypes"
+                },
+                {
+                  "name": "email-notification-template:read",
+                  "description": "Viewemailnotificationstemplate"
+                },
+                {
+                  "name": "email-notification-paragraph:update",
+                  "description": "Editemailnotificationsparagraph"
+                },
+                {
+                  "name": "email-notification-toggle:update",
+                  "description": "Turnemailnotificationson/off"
+                },
+                {
+                  "name": "tokens:read",
+                  "description": "View keys"
+                },
+                {
+                  "name": "toggle-3ds:read",
+                  "description": "View 3D Secure setting"
+                },
+                {
+                  "name": "toggle-3ds:update",
+                  "description": "Edit 3D Secure setting"
+                },
+                {
+                  "name": "users-service:delete",
+                  "description": "Remove user from a service"
+                },
+                {
+                  "name": "merchant-details:read",
+                  "description": "View Merchant Details setting"
+                },
+                {
+                  "name": "merchant-details:update",
+                  "description": "Edit Merchant Details setting"
+                },
+                {
+                  "name": "toggle-billing-address:read",
+                  "description": "View Billing Address setting"
+                },
+                {
+                  "name": "toggle-billing-address:update",
+                  "description": "Edit Billing Address setting"
+                },
+                {
+                  "name": "go-live-stage:update",
+                  "description": "Update Go Live stage"
+                },
+                {
+                  "name": "go-live-stage:read",
+                  "description": "View Go Live stage"
+                }
+              ]
+            }
+          }
+        ],
+        "services": [
+          {
+            "external_id": "rtgltermsokworldpay",
+            "name": "System Generated",
+            "gateway_account_ids": [
+              "666"
+            ],
+            "redirect_to_service_immediately_on_terminal_state": false,
+            "collect_billing_address": true,
+            "current_go_live_stage": "TERMS_AGREED_WORLDPAY"
+          }
+        ],
+        "permissions": [
+          "users-service:read",
+          "users-service:create",
+          "tokens-active:read",
+          "tokens-revoked:read",
+          "tokens:create",
+          "tokens:update",
+          "tokens:delete",
+          "transactions:read",
+          "transactions-by-date:read",
+          "transactions-by-fields:read",
+          "transactions-download:read",
+          "transactions-details:read",
+          "transactions-events:read",
+          "refunds:create",
+          "transactions-amount:read",
+          "transactions-description:read",
+          "transactions-email:read",
+          "transactions-card-type:read",
+          "gateway-credentials:read",
+          "gateway-credentials:update",
+          "service-name:read",
+          "service-name:update",
+          "payment-types:read",
+          "payment-types:update",
+          "email-notification-template:read",
+          "email-notification-paragraph:update",
+          "email-notification-toggle:update",
+          "tokens:read",
+          "toggle-3ds:read",
+          "toggle-3ds:update",
+          "users-service:delete",
+          "merchant-details:read",
+          "merchant-details:update",
+          "go-live-stage:update",
+          "go-live-stage:read"
+        ],
+        "sections": {
+          "description": "Contains fixtures for data intended to be surfaced in various 'sections' of self-service"
+        }
+      },
+      {
+        "isPrimary": "false",
+        "cypressTestingCategory": "REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_SMARTPAY",
+        "invalid_password": "some-password",
+        "invalid_passwordMatcher": "some-password",
+        "valid_password": "some-valid-password",
+        "valid_passwordMatcher": "some-valid-password",
+        "external_id": "rtgltermsoksmartpayuserextid",
+        "username": "some-user-rtgltermsoksmartpay@gov.uk",
+        "usernameMatcher": "some-user-rtgltermsoksmartpay@gov\\.uk",
+        "email": "some-user-rtgltermsoksmartpay@gov.uk",
+        "otp_key": "krb6fcianbdjkt01ecvi08jcln",
+        "telephone_number": "9127979",
+        "second_factor": "SMS",
+        "provisional_otp_key": "NOTSET",
+        "provisional_otp_key_created_at": null,
+        "disabled": false,
+        "login_counter": 0,
+        "session_version": 0,
+        "gateway_accounts": [
+          {
+            "id": "666",
+            "isPrimary": "true",
+            "name": "sandbox"
+          }
+        ],
+        "_links": [
+          {
+            "rel": "self",
+            "method": "GET",
+            "href": "http://myconnector.local/v1/api/users/rtgltermsoksmartpayuserextid"
+          }
+        ],
+        "role": {
+          "name": "admin",
+          "description": "Administrator",
+          "permissions": [
+            {
+              "name": "users-service:read",
+              "description": "Viewusersinservice"
+            },
+            {
+              "name": "users-service:create",
+              "description": "Createuserinthisservice"
+            },
+            {
+              "name": "tokens-active:read",
+              "description": "Viewactivekeys"
+            },
+            {
+              "name": "tokens-revoked:read",
+              "description": "Viewrevokedkeys"
+            },
+            {
+              "name": "tokens:create",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:update",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:delete",
+              "description": "Revokekey"
+            },
+            {
+              "name": "transactions:read",
+              "description": "Viewtransactionslist"
+            },
+            {
+              "name": "transactions-by-date:read",
+              "description": "Searchtransactionsbydate"
+            },
+            {
+              "name": "transactions-by-fields:read",
+              "description": "Searchtransactionsbypaymentfields"
+            },
+            {
+              "name": "transactions-download:read",
+              "description": "Downloadtransactions"
+            },
+            {
+              "name": "transactions-details:read",
+              "description": "Viewtransactiondetails"
+            },
+            {
+              "name": "transactions-events:read",
+              "description": "Viewtransactionevents"
+            },
+            {
+              "name": "refunds:create",
+              "description": "Issuerefund"
+            },
+            {
+              "name": "transactions-amount:read",
+              "description": "Viewtransactionamounts"
+            },
+            {
+              "name": "transactions-description:read",
+              "description": "Viewtransactiondescription"
+            },
+            {
+              "name": "transactions-email:read",
+              "description": "Viewtransactionemail"
+            },
+            {
+              "name": "transactions-card-type:read",
+              "description": "Viewtransactioncardtype"
+            },
+            {
+              "name": "gateway-credentials:read",
+              "description": "Viewgatewayaccountcredentials"
+            },
+            {
+              "name": "gateway-credentials:update",
+              "description": "Editgatewayaccountcredentials"
+            },
+            {
+              "name": "service-name:read",
+              "description": "Viewservicename"
+            },
+            {
+              "name": "service-name:update",
+              "description": "Editservicename"
+            },
+            {
+              "name": "payment-types:read",
+              "description": "Viewpaymenttypes"
+            },
+            {
+              "name": "payment-types:update",
+              "description": "Editpaymenttypes"
+            },
+            {
+              "name": "email-notification-template:read",
+              "description": "Viewemailnotificationstemplate"
+            },
+            {
+              "name": "email-notification-paragraph:update",
+              "description": "Editemailnotificationsparagraph"
+            },
+            {
+              "name": "email-notification-toggle:update",
+              "description": "Turnemailnotificationson/off"
+            },
+            {
+              "name": "tokens:read",
+              "description": "View keys"
+            },
+            {
+              "name": "toggle-3ds:read",
+              "description": "View 3D Secure setting"
+            },
+            {
+              "name": "toggle-3ds:update",
+              "description": "Edit 3D Secure setting"
+            },
+            {
+              "name": "users-service:delete",
+              "description": "Remove user from a service"
+            },
+            {
+              "name": "merchant-details:read",
+              "description": "View Merchant Details setting"
+            },
+            {
+              "name": "merchant-details:update",
+              "description": "Edit Merchant Details setting"
+            },
+            {
+              "name": "toggle-billing-address:read",
+              "description": "View Billing Address setting"
+            },
+            {
+              "name": "toggle-billing-address:update",
+              "description": "Edit Billing Address setting"
+            },
+            {
+              "name": "go-live-stage:update",
+              "description": "Update Go Live stage"
+            },
+            {
+              "name": "go-live-stage:read",
+              "description": "View Go Live stage"
+            }
+          ]
+        },
+        "service_ids": [
+          "rtgltermsoksmartpay"
+        ],
+        "service_roles": [
+          {
+            "service": {
+              "external_id": "rtgltermsoksmartpay",
+              "name": "System Generated",
+              "gateway_account_ids": [
+                "666"
+              ],
+              "_links": [],
+              "redirect_to_service_immediately_on_terminal_state": false,
+              "collect_billing_address": true,
+              "current_go_live_stage": "TERMS_AGREED_SMARTPAY"
+            },
+            "role": {
+              "name": "admin",
+              "description": "Administrator",
+              "permissions": [
+                {
+                  "name": "users-service:read",
+                  "description": "Viewusersinservice"
+                },
+                {
+                  "name": "users-service:create",
+                  "description": "Createuserinthisservice"
+                },
+                {
+                  "name": "tokens-active:read",
+                  "description": "Viewactivekeys"
+                },
+                {
+                  "name": "tokens-revoked:read",
+                  "description": "Viewrevokedkeys"
+                },
+                {
+                  "name": "tokens:create",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:update",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:delete",
+                  "description": "Revokekey"
+                },
+                {
+                  "name": "transactions:read",
+                  "description": "Viewtransactionslist"
+                },
+                {
+                  "name": "transactions-by-date:read",
+                  "description": "Searchtransactionsbydate"
+                },
+                {
+                  "name": "transactions-by-fields:read",
+                  "description": "Searchtransactionsbypaymentfields"
+                },
+                {
+                  "name": "transactions-download:read",
+                  "description": "Downloadtransactions"
+                },
+                {
+                  "name": "transactions-details:read",
+                  "description": "Viewtransactiondetails"
+                },
+                {
+                  "name": "transactions-events:read",
+                  "description": "Viewtransactionevents"
+                },
+                {
+                  "name": "refunds:create",
+                  "description": "Issuerefund"
+                },
+                {
+                  "name": "transactions-amount:read",
+                  "description": "Viewtransactionamounts"
+                },
+                {
+                  "name": "transactions-description:read",
+                  "description": "Viewtransactiondescription"
+                },
+                {
+                  "name": "transactions-email:read",
+                  "description": "Viewtransactionemail"
+                },
+                {
+                  "name": "transactions-card-type:read",
+                  "description": "Viewtransactioncardtype"
+                },
+                {
+                  "name": "gateway-credentials:read",
+                  "description": "Viewgatewayaccountcredentials"
+                },
+                {
+                  "name": "gateway-credentials:update",
+                  "description": "Editgatewayaccountcredentials"
+                },
+                {
+                  "name": "service-name:read",
+                  "description": "Viewservicename"
+                },
+                {
+                  "name": "service-name:update",
+                  "description": "Editservicename"
+                },
+                {
+                  "name": "payment-types:read",
+                  "description": "Viewpaymenttypes"
+                },
+                {
+                  "name": "payment-types:update",
+                  "description": "Editpaymenttypes"
+                },
+                {
+                  "name": "email-notification-template:read",
+                  "description": "Viewemailnotificationstemplate"
+                },
+                {
+                  "name": "email-notification-paragraph:update",
+                  "description": "Editemailnotificationsparagraph"
+                },
+                {
+                  "name": "email-notification-toggle:update",
+                  "description": "Turnemailnotificationson/off"
+                },
+                {
+                  "name": "tokens:read",
+                  "description": "View keys"
+                },
+                {
+                  "name": "toggle-3ds:read",
+                  "description": "View 3D Secure setting"
+                },
+                {
+                  "name": "toggle-3ds:update",
+                  "description": "Edit 3D Secure setting"
+                },
+                {
+                  "name": "users-service:delete",
+                  "description": "Remove user from a service"
+                },
+                {
+                  "name": "merchant-details:read",
+                  "description": "View Merchant Details setting"
+                },
+                {
+                  "name": "merchant-details:update",
+                  "description": "Edit Merchant Details setting"
+                },
+                {
+                  "name": "toggle-billing-address:read",
+                  "description": "View Billing Address setting"
+                },
+                {
+                  "name": "toggle-billing-address:update",
+                  "description": "Edit Billing Address setting"
+                },
+                {
+                  "name": "go-live-stage:update",
+                  "description": "Update Go Live stage"
+                },
+                {
+                  "name": "go-live-stage:read",
+                  "description": "View Go Live stage"
+                }
+              ]
+            }
+          }
+        ],
+        "services": [
+          {
+            "external_id": "rtgltermsoksmartpay",
+            "name": "System Generated",
+            "gateway_account_ids": [
+              "666"
+            ],
+            "redirect_to_service_immediately_on_terminal_state": false,
+            "collect_billing_address": true,
+            "current_go_live_stage": "TERMS_AGREED_SMARTPAY"
+          }
+        ],
+        "permissions": [
+          "users-service:read",
+          "users-service:create",
+          "tokens-active:read",
+          "tokens-revoked:read",
+          "tokens:create",
+          "tokens:update",
+          "tokens:delete",
+          "transactions:read",
+          "transactions-by-date:read",
+          "transactions-by-fields:read",
+          "transactions-download:read",
+          "transactions-details:read",
+          "transactions-events:read",
+          "refunds:create",
+          "transactions-amount:read",
+          "transactions-description:read",
+          "transactions-email:read",
+          "transactions-card-type:read",
+          "gateway-credentials:read",
+          "gateway-credentials:update",
+          "service-name:read",
+          "service-name:update",
+          "payment-types:read",
+          "payment-types:update",
+          "email-notification-template:read",
+          "email-notification-paragraph:update",
+          "email-notification-toggle:update",
+          "tokens:read",
+          "toggle-3ds:read",
+          "toggle-3ds:update",
+          "users-service:delete",
+          "merchant-details:read",
+          "merchant-details:update",
+          "go-live-stage:update",
+          "go-live-stage:read"
+        ],
+        "sections": {
+          "description": "Contains fixtures for data intended to be surfaced in various 'sections' of self-service"
+        }
+      },
+      {
+        "isPrimary": "false",
+        "cypressTestingCategory": "REQUEST_TO_GO_LIVE_STAGE_TERMS_AGREED_EPDQ",
+        "invalid_password": "some-password",
+        "invalid_passwordMatcher": "some-password",
+        "valid_password": "some-valid-password",
+        "valid_passwordMatcher": "some-valid-password",
+        "external_id": "rtgltermsokepdquserextid",
+        "username": "some-user-rtgltermsokepdq@gov.uk",
+        "usernameMatcher": "some-user-rtgltermsokepdq@gov\\.uk",
+        "email": "some-user-rtgltermsokepdq@gov.uk",
+        "otp_key": "krb6fcianbdjkt01ecvi08jcln",
+        "telephone_number": "9127979",
+        "second_factor": "SMS",
+        "provisional_otp_key": "NOTSET",
+        "provisional_otp_key_created_at": null,
+        "disabled": false,
+        "login_counter": 0,
+        "session_version": 0,
+        "gateway_accounts": [
+          {
+            "id": "666",
+            "isPrimary": "true",
+            "name": "sandbox"
+          }
+        ],
+        "_links": [
+          {
+            "rel": "self",
+            "method": "GET",
+            "href": "http://myconnector.local/v1/api/users/rtgltermsokepdquserextid"
+          }
+        ],
+        "role": {
+          "name": "admin",
+          "description": "Administrator",
+          "permissions": [
+            {
+              "name": "users-service:read",
+              "description": "Viewusersinservice"
+            },
+            {
+              "name": "users-service:create",
+              "description": "Createuserinthisservice"
+            },
+            {
+              "name": "tokens-active:read",
+              "description": "Viewactivekeys"
+            },
+            {
+              "name": "tokens-revoked:read",
+              "description": "Viewrevokedkeys"
+            },
+            {
+              "name": "tokens:create",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:update",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:delete",
+              "description": "Revokekey"
+            },
+            {
+              "name": "transactions:read",
+              "description": "Viewtransactionslist"
+            },
+            {
+              "name": "transactions-by-date:read",
+              "description": "Searchtransactionsbydate"
+            },
+            {
+              "name": "transactions-by-fields:read",
+              "description": "Searchtransactionsbypaymentfields"
+            },
+            {
+              "name": "transactions-download:read",
+              "description": "Downloadtransactions"
+            },
+            {
+              "name": "transactions-details:read",
+              "description": "Viewtransactiondetails"
+            },
+            {
+              "name": "transactions-events:read",
+              "description": "Viewtransactionevents"
+            },
+            {
+              "name": "refunds:create",
+              "description": "Issuerefund"
+            },
+            {
+              "name": "transactions-amount:read",
+              "description": "Viewtransactionamounts"
+            },
+            {
+              "name": "transactions-description:read",
+              "description": "Viewtransactiondescription"
+            },
+            {
+              "name": "transactions-email:read",
+              "description": "Viewtransactionemail"
+            },
+            {
+              "name": "transactions-card-type:read",
+              "description": "Viewtransactioncardtype"
+            },
+            {
+              "name": "gateway-credentials:read",
+              "description": "Viewgatewayaccountcredentials"
+            },
+            {
+              "name": "gateway-credentials:update",
+              "description": "Editgatewayaccountcredentials"
+            },
+            {
+              "name": "service-name:read",
+              "description": "Viewservicename"
+            },
+            {
+              "name": "service-name:update",
+              "description": "Editservicename"
+            },
+            {
+              "name": "payment-types:read",
+              "description": "Viewpaymenttypes"
+            },
+            {
+              "name": "payment-types:update",
+              "description": "Editpaymenttypes"
+            },
+            {
+              "name": "email-notification-template:read",
+              "description": "Viewemailnotificationstemplate"
+            },
+            {
+              "name": "email-notification-paragraph:update",
+              "description": "Editemailnotificationsparagraph"
+            },
+            {
+              "name": "email-notification-toggle:update",
+              "description": "Turnemailnotificationson/off"
+            },
+            {
+              "name": "tokens:read",
+              "description": "View keys"
+            },
+            {
+              "name": "toggle-3ds:read",
+              "description": "View 3D Secure setting"
+            },
+            {
+              "name": "toggle-3ds:update",
+              "description": "Edit 3D Secure setting"
+            },
+            {
+              "name": "users-service:delete",
+              "description": "Remove user from a service"
+            },
+            {
+              "name": "merchant-details:read",
+              "description": "View Merchant Details setting"
+            },
+            {
+              "name": "merchant-details:update",
+              "description": "Edit Merchant Details setting"
+            },
+            {
+              "name": "toggle-billing-address:read",
+              "description": "View Billing Address setting"
+            },
+            {
+              "name": "toggle-billing-address:update",
+              "description": "Edit Billing Address setting"
+            },
+            {
+              "name": "go-live-stage:update",
+              "description": "Update Go Live stage"
+            },
+            {
+              "name": "go-live-stage:read",
+              "description": "View Go Live stage"
+            }
+          ]
+        },
+        "service_ids": [
+          "rtgltermsokepdq"
+        ],
+        "service_roles": [
+          {
+            "service": {
+              "external_id": "rtgltermsokepdq",
+              "name": "System Generated",
+              "gateway_account_ids": [
+                "666"
+              ],
+              "_links": [],
+              "redirect_to_service_immediately_on_terminal_state": false,
+              "collect_billing_address": true,
+              "current_go_live_stage": "TERMS_AGREED_EPDQ"
+            },
+            "role": {
+              "name": "admin",
+              "description": "Administrator",
+              "permissions": [
+                {
+                  "name": "users-service:read",
+                  "description": "Viewusersinservice"
+                },
+                {
+                  "name": "users-service:create",
+                  "description": "Createuserinthisservice"
+                },
+                {
+                  "name": "tokens-active:read",
+                  "description": "Viewactivekeys"
+                },
+                {
+                  "name": "tokens-revoked:read",
+                  "description": "Viewrevokedkeys"
+                },
+                {
+                  "name": "tokens:create",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:update",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:delete",
+                  "description": "Revokekey"
+                },
+                {
+                  "name": "transactions:read",
+                  "description": "Viewtransactionslist"
+                },
+                {
+                  "name": "transactions-by-date:read",
+                  "description": "Searchtransactionsbydate"
+                },
+                {
+                  "name": "transactions-by-fields:read",
+                  "description": "Searchtransactionsbypaymentfields"
+                },
+                {
+                  "name": "transactions-download:read",
+                  "description": "Downloadtransactions"
+                },
+                {
+                  "name": "transactions-details:read",
+                  "description": "Viewtransactiondetails"
+                },
+                {
+                  "name": "transactions-events:read",
+                  "description": "Viewtransactionevents"
+                },
+                {
+                  "name": "refunds:create",
+                  "description": "Issuerefund"
+                },
+                {
+                  "name": "transactions-amount:read",
+                  "description": "Viewtransactionamounts"
+                },
+                {
+                  "name": "transactions-description:read",
+                  "description": "Viewtransactiondescription"
+                },
+                {
+                  "name": "transactions-email:read",
+                  "description": "Viewtransactionemail"
+                },
+                {
+                  "name": "transactions-card-type:read",
+                  "description": "Viewtransactioncardtype"
+                },
+                {
+                  "name": "gateway-credentials:read",
+                  "description": "Viewgatewayaccountcredentials"
+                },
+                {
+                  "name": "gateway-credentials:update",
+                  "description": "Editgatewayaccountcredentials"
+                },
+                {
+                  "name": "service-name:read",
+                  "description": "Viewservicename"
+                },
+                {
+                  "name": "service-name:update",
+                  "description": "Editservicename"
+                },
+                {
+                  "name": "payment-types:read",
+                  "description": "Viewpaymenttypes"
+                },
+                {
+                  "name": "payment-types:update",
+                  "description": "Editpaymenttypes"
+                },
+                {
+                  "name": "email-notification-template:read",
+                  "description": "Viewemailnotificationstemplate"
+                },
+                {
+                  "name": "email-notification-paragraph:update",
+                  "description": "Editemailnotificationsparagraph"
+                },
+                {
+                  "name": "email-notification-toggle:update",
+                  "description": "Turnemailnotificationson/off"
+                },
+                {
+                  "name": "tokens:read",
+                  "description": "View keys"
+                },
+                {
+                  "name": "toggle-3ds:read",
+                  "description": "View 3D Secure setting"
+                },
+                {
+                  "name": "toggle-3ds:update",
+                  "description": "Edit 3D Secure setting"
+                },
+                {
+                  "name": "users-service:delete",
+                  "description": "Remove user from a service"
+                },
+                {
+                  "name": "merchant-details:read",
+                  "description": "View Merchant Details setting"
+                },
+                {
+                  "name": "merchant-details:update",
+                  "description": "Edit Merchant Details setting"
+                },
+                {
+                  "name": "toggle-billing-address:read",
+                  "description": "View Billing Address setting"
+                },
+                {
+                  "name": "toggle-billing-address:update",
+                  "description": "Edit Billing Address setting"
+                },
+                {
+                  "name": "go-live-stage:update",
+                  "description": "Update Go Live stage"
+                },
+                {
+                  "name": "go-live-stage:read",
+                  "description": "View Go Live stage"
+                }
+              ]
+            }
+          }
+        ],
+        "services": [
+          {
+            "external_id": "rtgltermsokepdq",
+            "name": "System Generated",
+            "gateway_account_ids": [
+              "666"
+            ],
+            "redirect_to_service_immediately_on_terminal_state": false,
+            "collect_billing_address": true,
+            "current_go_live_stage": "TERMS_AGREED_EPDQ"
+          }
+        ],
+        "permissions": [
+          "users-service:read",
+          "users-service:create",
+          "tokens-active:read",
+          "tokens-revoked:read",
+          "tokens:create",
+          "tokens:update",
+          "tokens:delete",
+          "transactions:read",
+          "transactions-by-date:read",
+          "transactions-by-fields:read",
+          "transactions-download:read",
+          "transactions-details:read",
+          "transactions-events:read",
+          "refunds:create",
+          "transactions-amount:read",
+          "transactions-description:read",
+          "transactions-email:read",
+          "transactions-card-type:read",
+          "gateway-credentials:read",
+          "gateway-credentials:update",
+          "service-name:read",
+          "service-name:update",
+          "payment-types:read",
+          "payment-types:update",
+          "email-notification-template:read",
+          "email-notification-paragraph:update",
+          "email-notification-toggle:update",
+          "tokens:read",
+          "toggle-3ds:read",
+          "toggle-3ds:update",
+          "users-service:delete",
+          "merchant-details:read",
+          "merchant-details:update",
+          "go-live-stage:update",
+          "go-live-stage:read"
+        ],
+        "sections": {
+          "description": "Contains fixtures for data intended to be surfaced in various 'sections' of self-service"
+        }
+      },
+      {
+        "isPrimary": "false",
+        "cypressTestingCategory": "REQUEST_TO_GO_LIVE_STAGE_DENIED",
+        "invalid_password": "some-password",
+        "invalid_passwordMatcher": "some-password",
+        "valid_password": "some-valid-password",
+        "valid_passwordMatcher": "some-valid-password",
+        "external_id": "rtgldenieduserextid",
+        "username": "some-user-rtgldenied@gov.uk",
+        "usernameMatcher": "some-user-rtgldenied@gov\\.uk",
+        "email": "some-user-rtgldenied@gov.uk",
+        "otp_key": "krb6fcianbdjkt01ecvi08jcln",
+        "telephone_number": "9127979",
+        "second_factor": "SMS",
+        "provisional_otp_key": "NOTSET",
+        "provisional_otp_key_created_at": null,
+        "disabled": false,
+        "login_counter": 0,
+        "session_version": 0,
+        "gateway_accounts": [
+          {
+            "id": "666",
+            "isPrimary": "true",
+            "name": "sandbox"
+          }
+        ],
+        "_links": [
+          {
+            "rel": "self",
+            "method": "GET",
+            "href": "http://myconnector.local/v1/api/users/rtgldenieduserextid"
+          }
+        ],
+        "role": {
+          "name": "admin",
+          "description": "Administrator",
+          "permissions": [
+            {
+              "name": "users-service:read",
+              "description": "Viewusersinservice"
+            },
+            {
+              "name": "users-service:create",
+              "description": "Createuserinthisservice"
+            },
+            {
+              "name": "tokens-active:read",
+              "description": "Viewactivekeys"
+            },
+            {
+              "name": "tokens-revoked:read",
+              "description": "Viewrevokedkeys"
+            },
+            {
+              "name": "tokens:create",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:update",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:delete",
+              "description": "Revokekey"
+            },
+            {
+              "name": "transactions:read",
+              "description": "Viewtransactionslist"
+            },
+            {
+              "name": "transactions-by-date:read",
+              "description": "Searchtransactionsbydate"
+            },
+            {
+              "name": "transactions-by-fields:read",
+              "description": "Searchtransactionsbypaymentfields"
+            },
+            {
+              "name": "transactions-download:read",
+              "description": "Downloadtransactions"
+            },
+            {
+              "name": "transactions-details:read",
+              "description": "Viewtransactiondetails"
+            },
+            {
+              "name": "transactions-events:read",
+              "description": "Viewtransactionevents"
+            },
+            {
+              "name": "refunds:create",
+              "description": "Issuerefund"
+            },
+            {
+              "name": "transactions-amount:read",
+              "description": "Viewtransactionamounts"
+            },
+            {
+              "name": "transactions-description:read",
+              "description": "Viewtransactiondescription"
+            },
+            {
+              "name": "transactions-email:read",
+              "description": "Viewtransactionemail"
+            },
+            {
+              "name": "transactions-card-type:read",
+              "description": "Viewtransactioncardtype"
+            },
+            {
+              "name": "gateway-credentials:read",
+              "description": "Viewgatewayaccountcredentials"
+            },
+            {
+              "name": "gateway-credentials:update",
+              "description": "Editgatewayaccountcredentials"
+            },
+            {
+              "name": "service-name:read",
+              "description": "Viewservicename"
+            },
+            {
+              "name": "service-name:update",
+              "description": "Editservicename"
+            },
+            {
+              "name": "payment-types:read",
+              "description": "Viewpaymenttypes"
+            },
+            {
+              "name": "payment-types:update",
+              "description": "Editpaymenttypes"
+            },
+            {
+              "name": "email-notification-template:read",
+              "description": "Viewemailnotificationstemplate"
+            },
+            {
+              "name": "email-notification-paragraph:update",
+              "description": "Editemailnotificationsparagraph"
+            },
+            {
+              "name": "email-notification-toggle:update",
+              "description": "Turnemailnotificationson/off"
+            },
+            {
+              "name": "tokens:read",
+              "description": "View keys"
+            },
+            {
+              "name": "toggle-3ds:read",
+              "description": "View 3D Secure setting"
+            },
+            {
+              "name": "toggle-3ds:update",
+              "description": "Edit 3D Secure setting"
+            },
+            {
+              "name": "users-service:delete",
+              "description": "Remove user from a service"
+            },
+            {
+              "name": "merchant-details:read",
+              "description": "View Merchant Details setting"
+            },
+            {
+              "name": "merchant-details:update",
+              "description": "Edit Merchant Details setting"
+            },
+            {
+              "name": "toggle-billing-address:read",
+              "description": "View Billing Address setting"
+            },
+            {
+              "name": "toggle-billing-address:update",
+              "description": "Edit Billing Address setting"
+            },
+            {
+              "name": "go-live-stage:update",
+              "description": "Update Go Live stage"
+            },
+            {
+              "name": "go-live-stage:read",
+              "description": "View Go Live stage"
+            }
+          ]
+        },
+        "service_ids": [
+          "rtgldenied"
+        ],
+        "service_roles": [
+          {
+            "service": {
+              "external_id": "rtgldenied",
+              "name": "System Generated",
+              "gateway_account_ids": [
+                "666"
+              ],
+              "_links": [],
+              "redirect_to_service_immediately_on_terminal_state": false,
+              "collect_billing_address": true,
+              "current_go_live_stage": "DENIED"
+            },
+            "role": {
+              "name": "admin",
+              "description": "Administrator",
+              "permissions": [
+                {
+                  "name": "users-service:read",
+                  "description": "Viewusersinservice"
+                },
+                {
+                  "name": "users-service:create",
+                  "description": "Createuserinthisservice"
+                },
+                {
+                  "name": "tokens-active:read",
+                  "description": "Viewactivekeys"
+                },
+                {
+                  "name": "tokens-revoked:read",
+                  "description": "Viewrevokedkeys"
+                },
+                {
+                  "name": "tokens:create",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:update",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:delete",
+                  "description": "Revokekey"
+                },
+                {
+                  "name": "transactions:read",
+                  "description": "Viewtransactionslist"
+                },
+                {
+                  "name": "transactions-by-date:read",
+                  "description": "Searchtransactionsbydate"
+                },
+                {
+                  "name": "transactions-by-fields:read",
+                  "description": "Searchtransactionsbypaymentfields"
+                },
+                {
+                  "name": "transactions-download:read",
+                  "description": "Downloadtransactions"
+                },
+                {
+                  "name": "transactions-details:read",
+                  "description": "Viewtransactiondetails"
+                },
+                {
+                  "name": "transactions-events:read",
+                  "description": "Viewtransactionevents"
+                },
+                {
+                  "name": "refunds:create",
+                  "description": "Issuerefund"
+                },
+                {
+                  "name": "transactions-amount:read",
+                  "description": "Viewtransactionamounts"
+                },
+                {
+                  "name": "transactions-description:read",
+                  "description": "Viewtransactiondescription"
+                },
+                {
+                  "name": "transactions-email:read",
+                  "description": "Viewtransactionemail"
+                },
+                {
+                  "name": "transactions-card-type:read",
+                  "description": "Viewtransactioncardtype"
+                },
+                {
+                  "name": "gateway-credentials:read",
+                  "description": "Viewgatewayaccountcredentials"
+                },
+                {
+                  "name": "gateway-credentials:update",
+                  "description": "Editgatewayaccountcredentials"
+                },
+                {
+                  "name": "service-name:read",
+                  "description": "Viewservicename"
+                },
+                {
+                  "name": "service-name:update",
+                  "description": "Editservicename"
+                },
+                {
+                  "name": "payment-types:read",
+                  "description": "Viewpaymenttypes"
+                },
+                {
+                  "name": "payment-types:update",
+                  "description": "Editpaymenttypes"
+                },
+                {
+                  "name": "email-notification-template:read",
+                  "description": "Viewemailnotificationstemplate"
+                },
+                {
+                  "name": "email-notification-paragraph:update",
+                  "description": "Editemailnotificationsparagraph"
+                },
+                {
+                  "name": "email-notification-toggle:update",
+                  "description": "Turnemailnotificationson/off"
+                },
+                {
+                  "name": "tokens:read",
+                  "description": "View keys"
+                },
+                {
+                  "name": "toggle-3ds:read",
+                  "description": "View 3D Secure setting"
+                },
+                {
+                  "name": "toggle-3ds:update",
+                  "description": "Edit 3D Secure setting"
+                },
+                {
+                  "name": "users-service:delete",
+                  "description": "Remove user from a service"
+                },
+                {
+                  "name": "merchant-details:read",
+                  "description": "View Merchant Details setting"
+                },
+                {
+                  "name": "merchant-details:update",
+                  "description": "Edit Merchant Details setting"
+                },
+                {
+                  "name": "toggle-billing-address:read",
+                  "description": "View Billing Address setting"
+                },
+                {
+                  "name": "toggle-billing-address:update",
+                  "description": "Edit Billing Address setting"
+                },
+                {
+                  "name": "go-live-stage:update",
+                  "description": "Update Go Live stage"
+                },
+                {
+                  "name": "go-live-stage:read",
+                  "description": "View Go Live stage"
+                }
+              ]
+            }
+          }
+        ],
+        "services": [
+          {
+            "external_id": "rtgldenied",
+            "name": "System Generated",
+            "gateway_account_ids": [
+              "666"
+            ],
+            "redirect_to_service_immediately_on_terminal_state": false,
+            "collect_billing_address": true,
+            "current_go_live_stage": "DENIED"
+          }
+        ],
+        "permissions": [
+          "users-service:read",
+          "users-service:create",
+          "tokens-active:read",
+          "tokens-revoked:read",
+          "tokens:create",
+          "tokens:update",
+          "tokens:delete",
+          "transactions:read",
+          "transactions-by-date:read",
+          "transactions-by-fields:read",
+          "transactions-download:read",
+          "transactions-details:read",
+          "transactions-events:read",
+          "refunds:create",
+          "transactions-amount:read",
+          "transactions-description:read",
+          "transactions-email:read",
+          "transactions-card-type:read",
+          "gateway-credentials:read",
+          "gateway-credentials:update",
+          "service-name:read",
+          "service-name:update",
+          "payment-types:read",
+          "payment-types:update",
+          "email-notification-template:read",
+          "email-notification-paragraph:update",
+          "email-notification-toggle:update",
+          "tokens:read",
+          "toggle-3ds:read",
+          "toggle-3ds:update",
+          "users-service:delete",
+          "merchant-details:read",
+          "merchant-details:update",
+          "go-live-stage:update",
+          "go-live-stage:read"
+        ],
+        "sections": {
+          "description": "Contains fixtures for data intended to be surfaced in various 'sections' of self-service"
+        }
+      },
+      {
+        "isPrimary": "false",
+        "cypressTestingCategory": "REQUEST_TO_GO_LIVE_STAGE_LIVE",
+        "invalid_password": "some-password",
+        "invalid_passwordMatcher": "some-password",
+        "valid_password": "some-valid-password",
+        "valid_passwordMatcher": "some-valid-password",
+        "external_id": "rtglliveuserextid",
+        "username": "some-user-rtgllive@gov.uk",
+        "usernameMatcher": "some-user-rtgllive@gov\\.uk",
+        "email": "some-user-rtgllive@gov.uk",
+        "otp_key": "krb6fcianbdjkt01ecvi08jcln",
+        "telephone_number": "9127979",
+        "second_factor": "SMS",
+        "provisional_otp_key": "NOTSET",
+        "provisional_otp_key_created_at": null,
+        "disabled": false,
+        "login_counter": 0,
+        "session_version": 0,
+        "gateway_accounts": [
+          {
+            "id": "666",
+            "isPrimary": "true",
+            "name": "sandbox"
+          }
+        ],
+        "_links": [
+          {
+            "rel": "self",
+            "method": "GET",
+            "href": "http://myconnector.local/v1/api/users/rtglliveuserextid"
+          }
+        ],
+        "role": {
+          "name": "admin",
+          "description": "Administrator",
+          "permissions": [
+            {
+              "name": "users-service:read",
+              "description": "Viewusersinservice"
+            },
+            {
+              "name": "users-service:create",
+              "description": "Createuserinthisservice"
+            },
+            {
+              "name": "tokens-active:read",
+              "description": "Viewactivekeys"
+            },
+            {
+              "name": "tokens-revoked:read",
+              "description": "Viewrevokedkeys"
+            },
+            {
+              "name": "tokens:create",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:update",
+              "description": "Generatekey"
+            },
+            {
+              "name": "tokens:delete",
+              "description": "Revokekey"
+            },
+            {
+              "name": "transactions:read",
+              "description": "Viewtransactionslist"
+            },
+            {
+              "name": "transactions-by-date:read",
+              "description": "Searchtransactionsbydate"
+            },
+            {
+              "name": "transactions-by-fields:read",
+              "description": "Searchtransactionsbypaymentfields"
+            },
+            {
+              "name": "transactions-download:read",
+              "description": "Downloadtransactions"
+            },
+            {
+              "name": "transactions-details:read",
+              "description": "Viewtransactiondetails"
+            },
+            {
+              "name": "transactions-events:read",
+              "description": "Viewtransactionevents"
+            },
+            {
+              "name": "refunds:create",
+              "description": "Issuerefund"
+            },
+            {
+              "name": "transactions-amount:read",
+              "description": "Viewtransactionamounts"
+            },
+            {
+              "name": "transactions-description:read",
+              "description": "Viewtransactiondescription"
+            },
+            {
+              "name": "transactions-email:read",
+              "description": "Viewtransactionemail"
+            },
+            {
+              "name": "transactions-card-type:read",
+              "description": "Viewtransactioncardtype"
+            },
+            {
+              "name": "gateway-credentials:read",
+              "description": "Viewgatewayaccountcredentials"
+            },
+            {
+              "name": "gateway-credentials:update",
+              "description": "Editgatewayaccountcredentials"
+            },
+            {
+              "name": "service-name:read",
+              "description": "Viewservicename"
+            },
+            {
+              "name": "service-name:update",
+              "description": "Editservicename"
+            },
+            {
+              "name": "payment-types:read",
+              "description": "Viewpaymenttypes"
+            },
+            {
+              "name": "payment-types:update",
+              "description": "Editpaymenttypes"
+            },
+            {
+              "name": "email-notification-template:read",
+              "description": "Viewemailnotificationstemplate"
+            },
+            {
+              "name": "email-notification-paragraph:update",
+              "description": "Editemailnotificationsparagraph"
+            },
+            {
+              "name": "email-notification-toggle:update",
+              "description": "Turnemailnotificationson/off"
+            },
+            {
+              "name": "tokens:read",
+              "description": "View keys"
+            },
+            {
+              "name": "toggle-3ds:read",
+              "description": "View 3D Secure setting"
+            },
+            {
+              "name": "toggle-3ds:update",
+              "description": "Edit 3D Secure setting"
+            },
+            {
+              "name": "users-service:delete",
+              "description": "Remove user from a service"
+            },
+            {
+              "name": "merchant-details:read",
+              "description": "View Merchant Details setting"
+            },
+            {
+              "name": "merchant-details:update",
+              "description": "Edit Merchant Details setting"
+            },
+            {
+              "name": "toggle-billing-address:read",
+              "description": "View Billing Address setting"
+            },
+            {
+              "name": "toggle-billing-address:update",
+              "description": "Edit Billing Address setting"
+            },
+            {
+              "name": "go-live-stage:update",
+              "description": "Update Go Live stage"
+            },
+            {
+              "name": "go-live-stage:read",
+              "description": "View Go Live stage"
+            }
+          ]
+        },
+        "service_ids": [
+          "rtgllive"
+        ],
+        "service_roles": [
+          {
+            "service": {
+              "external_id": "rtgllive",
+              "name": "System Generated",
+              "gateway_account_ids": [
+                "666"
+              ],
+              "_links": [],
+              "redirect_to_service_immediately_on_terminal_state": false,
+              "collect_billing_address": true,
+              "current_go_live_stage": "LIVE"
+            },
+            "role": {
+              "name": "admin",
+              "description": "Administrator",
+              "permissions": [
+                {
+                  "name": "users-service:read",
+                  "description": "Viewusersinservice"
+                },
+                {
+                  "name": "users-service:create",
+                  "description": "Createuserinthisservice"
+                },
+                {
+                  "name": "tokens-active:read",
+                  "description": "Viewactivekeys"
+                },
+                {
+                  "name": "tokens-revoked:read",
+                  "description": "Viewrevokedkeys"
+                },
+                {
+                  "name": "tokens:create",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:update",
+                  "description": "Generatekey"
+                },
+                {
+                  "name": "tokens:delete",
+                  "description": "Revokekey"
+                },
+                {
+                  "name": "transactions:read",
+                  "description": "Viewtransactionslist"
+                },
+                {
+                  "name": "transactions-by-date:read",
+                  "description": "Searchtransactionsbydate"
+                },
+                {
+                  "name": "transactions-by-fields:read",
+                  "description": "Searchtransactionsbypaymentfields"
+                },
+                {
+                  "name": "transactions-download:read",
+                  "description": "Downloadtransactions"
+                },
+                {
+                  "name": "transactions-details:read",
+                  "description": "Viewtransactiondetails"
+                },
+                {
+                  "name": "transactions-events:read",
+                  "description": "Viewtransactionevents"
+                },
+                {
+                  "name": "refunds:create",
+                  "description": "Issuerefund"
+                },
+                {
+                  "name": "transactions-amount:read",
+                  "description": "Viewtransactionamounts"
+                },
+                {
+                  "name": "transactions-description:read",
+                  "description": "Viewtransactiondescription"
+                },
+                {
+                  "name": "transactions-email:read",
+                  "description": "Viewtransactionemail"
+                },
+                {
+                  "name": "transactions-card-type:read",
+                  "description": "Viewtransactioncardtype"
+                },
+                {
+                  "name": "gateway-credentials:read",
+                  "description": "Viewgatewayaccountcredentials"
+                },
+                {
+                  "name": "gateway-credentials:update",
+                  "description": "Editgatewayaccountcredentials"
+                },
+                {
+                  "name": "service-name:read",
+                  "description": "Viewservicename"
+                },
+                {
+                  "name": "service-name:update",
+                  "description": "Editservicename"
+                },
+                {
+                  "name": "payment-types:read",
+                  "description": "Viewpaymenttypes"
+                },
+                {
+                  "name": "payment-types:update",
+                  "description": "Editpaymenttypes"
+                },
+                {
+                  "name": "email-notification-template:read",
+                  "description": "Viewemailnotificationstemplate"
+                },
+                {
+                  "name": "email-notification-paragraph:update",
+                  "description": "Editemailnotificationsparagraph"
+                },
+                {
+                  "name": "email-notification-toggle:update",
+                  "description": "Turnemailnotificationson/off"
+                },
+                {
+                  "name": "tokens:read",
+                  "description": "View keys"
+                },
+                {
+                  "name": "toggle-3ds:read",
+                  "description": "View 3D Secure setting"
+                },
+                {
+                  "name": "toggle-3ds:update",
+                  "description": "Edit 3D Secure setting"
+                },
+                {
+                  "name": "users-service:delete",
+                  "description": "Remove user from a service"
+                },
+                {
+                  "name": "merchant-details:read",
+                  "description": "View Merchant Details setting"
+                },
+                {
+                  "name": "merchant-details:update",
+                  "description": "Edit Merchant Details setting"
+                },
+                {
+                  "name": "toggle-billing-address:read",
+                  "description": "View Billing Address setting"
+                },
+                {
+                  "name": "toggle-billing-address:update",
+                  "description": "Edit Billing Address setting"
+                },
+                {
+                  "name": "go-live-stage:update",
+                  "description": "Update Go Live stage"
+                },
+                {
+                  "name": "go-live-stage:read",
+                  "description": "View Go Live stage"
+                }
+              ]
+            }
+          }
+        ],
+        "services": [
+          {
+            "external_id": "rtgllive",
+            "name": "System Generated",
+            "gateway_account_ids": [
+              "666"
+            ],
+            "redirect_to_service_immediately_on_terminal_state": false,
+            "collect_billing_address": true,
+            "current_go_live_stage": "LIVE"
+          }
+        ],
+        "permissions": [
+          "users-service:read",
+          "users-service:create",
+          "tokens-active:read",
+          "tokens-revoked:read",
+          "tokens:create",
+          "tokens:update",
+          "tokens:delete",
+          "transactions:read",
+          "transactions-by-date:read",
+          "transactions-by-fields:read",
+          "transactions-download:read",
+          "transactions-details:read",
+          "transactions-events:read",
+          "refunds:create",
+          "transactions-amount:read",
+          "transactions-description:read",
+          "transactions-email:read",
+          "transactions-card-type:read",
+          "gateway-credentials:read",
+          "gateway-credentials:update",
+          "service-name:read",
+          "service-name:update",
+          "payment-types:read",
+          "payment-types:update",
+          "email-notification-template:read",
+          "email-notification-paragraph:update",
+          "email-notification-toggle:update",
+          "tokens:read",
+          "toggle-3ds:read",
+          "toggle-3ds:update",
+          "users-service:delete",
+          "merchant-details:read",
+          "merchant-details:update",
+          "go-live-stage:update",
+          "go-live-stage:read"
+        ],
+        "sections": {
+          "description": "Contains fixtures for data intended to be surfaced in various 'sections' of self-service"
         }
       }
     ]

--- a/test/fixtures/user_fixtures.js
+++ b/test/fixtures/user_fixtures.js
@@ -118,6 +118,7 @@ module.exports = {
     const defaultServiceId = opts.default_service_id || '193'
     const gatewayAccountIds = opts.gateway_account_ids || ['540']
     const collectBillingAddress = (opts.collect_billing_address && opts.collect_billing_address === true)
+    const currentGoLiveStage = opts.current_go_live_stage || goLiveStage.NOT_STARTED
 
     const data = {
       external_id: opts.external_id || newExternalId,
@@ -128,7 +129,8 @@ module.exports = {
           name: 'System Generated',
           external_id: defaultServiceId,
           gateway_account_ids: gatewayAccountIds,
-          collect_billing_address: collectBillingAddress
+          collect_billing_address: collectBillingAddress,
+          current_go_live_stage: currentGoLiveStage
         },
         role: opts.role || {
           name: 'admin',
@@ -178,7 +180,7 @@ module.exports = {
     const merchantAddressPostcode = merchantDetails.address_postcode || 'updated-merchant-details-postcode'
     const merchantAddressCountry = merchantDetails.address_country || 'updated-merchant-details-country'
     const collectBillingAddress = opts.collect_billing_address || false
-    const currentGoLiveStage = opts.current_go_live_stage || goLiveStage.LIVE
+    const currentGoLiveStage = opts.current_go_live_stage || goLiveStage.NOT_STARTED
 
     const data = {
       external_id: reqExternalId,

--- a/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
+++ b/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
@@ -11,7 +11,7 @@ const getAdminUsersClient = require('../../../../../app/services/clients/adminus
 const userFixtures = require('../../../../fixtures/user_fixtures')
 const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
 const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 const User = require('../../../../../app/models/User.class')
 
 // Constants
@@ -21,8 +21,8 @@ chai.use(chaiAsPromised)
 const expect = chai.expect
 
 // Note: the browser tests use values in the fixed config below, which match the defined interations
-const ssUserConfig = require('../../../../fixtures/config/self_service_user')
-const ssDefaultUser = ssUserConfig.config.users.filter(fil => fil.isPrimary === 'true')[0]
+const selfServiceUserConfig = require('../../../../fixtures/config/self_service_user')
+const selfServiceDefaultUser = selfServiceUserConfig.config.users.filter(fil => fil.isPrimary === 'true')[0]
 
 describe('adminusers client - authenticate', function () {
   let provider = Pact({
@@ -38,35 +38,37 @@ describe('adminusers client - authenticate', function () {
   before(() => provider.setup())
   after((done) => provider.finalize().then(done()))
 
-  describe('success', () => {
-    const validPasswordResponse = userFixtures.validPasswordAuthenticateResponse(ssDefaultUser)
-    const validPasswordRequestPactified = userFixtures
-      .validPasswordAuthenticateRequest({
-        username: ssDefaultUser.username,
-        usernameMatcher: ssDefaultUser.usernameMatcher,
-        password: ssDefaultUser.valid_password,
-        passwordMatcher: ssDefaultUser.valid_passwordMatcher
+  selfServiceUserConfig.config.users.forEach(currentUser => {
+    describe(`success "${currentUser.cypressTestingCategory}" user`, () => {
+      const validPasswordResponse = userFixtures.validPasswordAuthenticateResponse(currentUser)
+      const validPasswordRequestPactified = userFixtures
+        .validPasswordAuthenticateRequest({
+          username: currentUser.username,
+          usernameMatcher: currentUser.usernameMatcher,
+          password: currentUser.valid_password,
+          passwordMatcher: currentUser.valid_passwordMatcher
+        })
+
+      before((done) => {
+        provider.addInteraction(
+          new PactInteractionBuilder(`${AUTHENTICATE_PATH}`)
+            .withUponReceiving('a correct password for a user')
+            .withState(`user with email address ${currentUser.username} exists in the database with the correct with a correct password set to: ${currentUser.valid_password}`)
+            .withMethod('POST')
+            .withRequestBody(validPasswordRequestPactified)
+            .withResponseBody(validPasswordResponse.getPactified())
+            .withStatusCode(200)
+            .build()
+        ).then(() => done())
       })
 
-    before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${AUTHENTICATE_PATH}`)
-          .withUponReceiving('a correct password for a user')
-          .withState(`user with email address ${ssDefaultUser.username} exists in the database with the correct with a correct password set to: ${ssDefaultUser.valid_password}`)
-          .withMethod('POST')
-          .withRequestBody(validPasswordRequestPactified)
-          .withResponseBody(validPasswordResponse.getPactified())
-          .withStatusCode(200)
-          .build()
-      ).then(() => done())
-    })
+      afterEach(() => provider.verify())
 
-    afterEach(() => provider.verify())
-
-    it('should return the right authentication success response', done => {
-      adminusersClient.authenticateUser(ssDefaultUser.username, ssDefaultUser.valid_password).then((response) => {
-        expect(response).to.deep.equal(new User(validPasswordResponse.getPlain()))
-        done()
+      it('should return the right authentication success response', done => {
+        adminusersClient.authenticateUser(currentUser.username, currentUser.valid_password).then((response) => {
+          expect(response).to.deep.equal(new User(validPasswordResponse.getPlain()))
+          done()
+        })
       })
     })
   })
@@ -75,17 +77,17 @@ describe('adminusers client - authenticate', function () {
     const invalidPasswordResponse = userFixtures.invalidPasswordAuthenticateResponse()
     const invalidPasswordRequestPactified = userFixtures
       .invalidPasswordAuthenticateRequest({
-        username: ssDefaultUser.username,
-        usernameMatcher: ssDefaultUser.usernameMatcher,
-        password: ssDefaultUser.invalid_password,
-        passwordMatcher: ssDefaultUser.invalid_passwordMatcher
+        username: selfServiceDefaultUser.username,
+        usernameMatcher: selfServiceDefaultUser.usernameMatcher,
+        password: selfServiceDefaultUser.invalid_password,
+        passwordMatcher: selfServiceDefaultUser.invalid_passwordMatcher
       })
 
     before((done) => {
       provider.addInteraction(
         new PactInteractionBuilder(`${AUTHENTICATE_PATH}`)
           .withUponReceiving('an incorrect password for a user')
-          .withState(`user with email address ${ssDefaultUser.username} exists in the database with the correct with a correct password set to: ${ssDefaultUser.valid_password}`)
+          .withState(`user with email address ${selfServiceDefaultUser.username} exists in the database with the correct with a correct password set to: ${selfServiceDefaultUser.valid_password}`)
           .withMethod('POST')
           .withRequestBody(invalidPasswordRequestPactified)
           .withResponseBody(invalidPasswordResponse.getPactified())
@@ -97,7 +99,7 @@ describe('adminusers client - authenticate', function () {
     afterEach(() => provider.verify())
 
     it('should return the right authentication failure response', done => {
-      adminusersClient.authenticateUser(ssDefaultUser.username, ssDefaultUser.invalid_password).then(() => {
+      adminusersClient.authenticateUser(selfServiceDefaultUser.username, selfServiceDefaultUser.invalid_password).then(() => {
         done('should not resolve here')
       }).catch(err => {
         expect(err.errorCode).to.equal(401)

--- a/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
+++ b/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
@@ -24,8 +24,8 @@ const expect = chai.expect
 const selfServiceUserConfig = require('../../../../fixtures/config/self_service_user')
 const selfServiceDefaultUser = selfServiceUserConfig.config.users.filter(fil => fil.isPrimary === 'true')[0]
 
-describe('adminusers client - authenticate', function () {
-  let provider = Pact({
+describe('adminusers client - authenticate', () => {
+  const provider = Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/user/get_user_test.js
+++ b/test/unit/clients/adminusers_client/user/get_user_test.js
@@ -21,7 +21,7 @@ const selfServiceUserConfig = require('../../../../fixtures/config/self_service_
 chai.use(chaiAsPromised)
 
 describe('adminusers client - get user', () => {
-  let provider = Pact({
+  const provider = Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
@@ -32,7 +32,7 @@ describe('adminusers client - get user', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after(done => provider.finalize().then(done()))
 
   selfServiceUserConfig.config.users.forEach(currentUser => {
     describe(`success "${currentUser.cypressTestingCategory}" user`, () => {
@@ -44,7 +44,7 @@ describe('adminusers client - get user', () => {
 
       const getUserResponse = userFixtures.validPasswordAuthenticateResponse(currentUser)
 
-      before((done) => {
+      before(done => {
         provider.addInteraction(
           new PactInteractionBuilder(`${USER_PATH}/${params.external_id}`)
             .withState(`a user exists with the given external id ${existingExternalId}`)
@@ -56,10 +56,10 @@ describe('adminusers client - get user', () => {
 
       afterEach(() => provider.verify())
 
-      it('should find a user successfully', function (done) {
+      it('should find a user successfully', done => {
         const expectedUserData = getUserResponse.getPlain()
 
-        adminusersClient.getUserByExternalId(params.external_id).should.be.fulfilled.then(function (user) {
+        adminusersClient.getUserByExternalId(params.external_id).should.be.fulfilled.then(user => {
           expect(user.externalId).to.be.equal(expectedUserData.external_id)
           expect(user.username).to.be.equal(expectedUserData.username)
           expect(user.email).to.be.equal(expectedUserData.email)
@@ -80,7 +80,7 @@ describe('adminusers client - get user', () => {
       external_id: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' // non existent external id
     }
 
-    before((done) => {
+    before(done => {
       provider.addInteraction(
         new PactInteractionBuilder(`${USER_PATH}/${params.external_id}`)
           .withState('no user exists with the given external id')
@@ -93,8 +93,8 @@ describe('adminusers client - get user', () => {
 
     afterEach(() => provider.verify())
 
-    it('should respond 404 if user not found', function (done) {
-      adminusersClient.getUserByExternalId(params.external_id).should.be.rejected.then(function (response) {
+    it('should respond 404 if user not found', done => {
+      adminusersClient.getUserByExternalId(params.external_id).should.be.rejected.then(response => {
         expect(response.errorCode).to.equal(404)
       }).should.notify(done)
     })

--- a/test/unit/clients/adminusers_client/user/get_user_test.js
+++ b/test/unit/clients/adminusers_client/user/get_user_test.js
@@ -4,7 +4,7 @@
 const Pact = require('pact')
 const path = require('path')
 const chai = require('chai')
-const {expect} = chai
+const { expect } = chai
 const chaiAsPromised = require('chai-as-promised')
 
 // user dependencies
@@ -14,13 +14,13 @@ const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_bu
 
 // constants
 const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 const USER_PATH = '/v1/api/users'
-const ssUserConfig = require('../../../../fixtures/config/self_service_user.json')
+const selfServiceUserConfig = require('../../../../fixtures/config/self_service_user.json')
 
 chai.use(chaiAsPromised)
 
-describe('adminusers client - get user', function () {
+describe('adminusers client - get user', () => {
   let provider = Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
@@ -31,47 +31,47 @@ describe('adminusers client - get user', function () {
     pactfileWriteMode: 'merge'
   })
 
-  const ssDefaultUser = ssUserConfig.config.users.filter(fil => fil.isPrimary === 'true')[0]
-
   before(() => provider.setup())
   after((done) => provider.finalize().then(done()))
 
-  describe('success', () => {
-    const existingExternalId = ssDefaultUser.external_id
+  selfServiceUserConfig.config.users.forEach(currentUser => {
+    describe(`success "${currentUser.cypressTestingCategory}" user`, () => {
+      const existingExternalId = currentUser.external_id
 
-    const params = {
-      external_id: existingExternalId
-    }
+      const params = {
+        external_id: existingExternalId
+      }
 
-    const getUserResponse = userFixtures.validPasswordAuthenticateResponse(ssDefaultUser)
+      const getUserResponse = userFixtures.validPasswordAuthenticateResponse(currentUser)
 
-    before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${USER_PATH}/${params.external_id}`)
-          .withState(`a user exists with the given external id ${existingExternalId}`)
-          .withUponReceiving('a valid get user request')
-          .withResponseBody(getUserResponse.getPactified())
-          .build()
-      ).then(done())
-    })
+      before((done) => {
+        provider.addInteraction(
+          new PactInteractionBuilder(`${USER_PATH}/${params.external_id}`)
+            .withState(`a user exists with the given external id ${existingExternalId}`)
+            .withUponReceiving('a valid get user request')
+            .withResponseBody(getUserResponse.getPactified())
+            .build()
+        ).then(done())
+      })
 
-    afterEach(() => provider.verify())
+      afterEach(() => provider.verify())
 
-    it('should find a user successfully', function (done) {
-      const expectedUserData = getUserResponse.getPlain()
+      it('should find a user successfully', function (done) {
+        const expectedUserData = getUserResponse.getPlain()
 
-      adminusersClient.getUserByExternalId(params.external_id).should.be.fulfilled.then(function (user) {
-        expect(user.externalId).to.be.equal(expectedUserData.external_id)
-        expect(user.username).to.be.equal(expectedUserData.username)
-        expect(user.email).to.be.equal(expectedUserData.email)
-        expect(user.serviceRoles.length).to.be.equal(1)
-        expect(user.serviceRoles[0].service.gatewayAccountIds.length).to.be.equal(1)
-        expect(user.telephoneNumber).to.be.equal(expectedUserData.telephone_number)
-        expect(user.otpKey).to.be.equal(expectedUserData.otp_key)
-        expect(user.provisionalOtpKey).to.be.equal(expectedUserData.provisional_otp_key)
-        expect(user.secondFactor).to.be.equal(expectedUserData.second_factor)
-        expect(user.serviceRoles[0].role.permissions.length).to.be.equal(expectedUserData.service_roles[0].role.permissions.length)
-      }).should.notify(done)
+        adminusersClient.getUserByExternalId(params.external_id).should.be.fulfilled.then(function (user) {
+          expect(user.externalId).to.be.equal(expectedUserData.external_id)
+          expect(user.username).to.be.equal(expectedUserData.username)
+          expect(user.email).to.be.equal(expectedUserData.email)
+          expect(user.serviceRoles.length).to.be.equal(1)
+          expect(user.serviceRoles[0].service.gatewayAccountIds.length).to.be.equal(1)
+          expect(user.telephoneNumber).to.be.equal(expectedUserData.telephone_number)
+          expect(user.otpKey).to.be.equal(expectedUserData.otp_key)
+          expect(user.provisionalOtpKey).to.be.equal(expectedUserData.provisional_otp_key)
+          expect(user.secondFactor).to.be.equal(expectedUserData.second_factor)
+          expect(user.serviceRoles[0].role.permissions.length).to.be.equal(expectedUserData.service_roles[0].role.permissions.length)
+        }).should.notify(done)
+      })
     })
   })
 

--- a/test/unit/controller/request-to-go-live/go-live-stage-to-next-page-path.test.js
+++ b/test/unit/controller/request-to-go-live/go-live-stage-to-next-page-path.test.js
@@ -1,0 +1,69 @@
+'use strict'
+
+// NPM dependencies
+const chai = require('chai')
+
+// Local dependencies
+const goLiveStageToNextPagePath = require('../../../../app/controllers/request-to-go-live/go-live-stage-to-next-page-path')
+const goLiveStage = require('../../../../app/models/go-live-stage')
+
+// Constants
+const expect = chai.expect
+
+describe('go-live-stage-to-next-page-path tests', () => {
+  describe('should return "index" path', () => {
+    const path = '/service/:externalServiceId/request-to-go-live'
+
+    it('should resolve TERMS_AGREED_STRIPE stages correctly', () => {
+      expect(goLiveStageToNextPagePath[goLiveStage.TERMS_AGREED_STRIPE]).to.equal(path)
+    })
+    it('should resolve TERMS_AGREED_WORLDPAY stages correctly', () => {
+      expect(goLiveStageToNextPagePath[goLiveStage.TERMS_AGREED_WORLDPAY]).to.equal(path)
+    })
+    it('should resolve TERMS_AGREED_SMARTPAY stages correctly', () => {
+      expect(goLiveStageToNextPagePath[goLiveStage.TERMS_AGREED_SMARTPAY]).to.equal(path)
+    })
+    it('should resolve TERMS_AGREED_EPDQ stages correctly', () => {
+      expect(goLiveStageToNextPagePath[goLiveStage.TERMS_AGREED_EPDQ]).to.equal(path)
+    })
+    it('should resolve DENIED stages correctly', () => {
+      expect(goLiveStageToNextPagePath[goLiveStage.DENIED]).to.equal(path)
+    })
+    it('should resolve LIVE stages correctly', () => {
+      expect(goLiveStageToNextPagePath[goLiveStage.LIVE]).to.equal(path)
+    })
+  })
+
+  describe('should return "organisation-name" path', () => {
+    const path = '/service/:externalServiceId/request-to-go-live/organisation-name'
+
+    it('should resolve NOT_STARTED stage correctly', () => {
+      expect(goLiveStageToNextPagePath[goLiveStage.NOT_STARTED]).to.equal(path)
+    })
+  })
+
+  describe('should return "choose-how-to-process-payments" path', () => {
+    const path = '/service/:externalServiceId/request-to-go-live/choose-how-to-process-payments'
+
+    it('should resolve ENTERED_ORGANISATION_NAME stage correctly', () => {
+      expect(goLiveStageToNextPagePath[goLiveStage.ENTERED_ORGANISATION_NAME]).to.equal(path)
+    })
+  })
+
+  describe('should return "agreement" path', () => {
+    const path = '/service/:externalServiceId/request-to-go-live/agreement'
+
+    it('should resolve CHOSEN_PSP_STRIPE stages correctly', () => {
+      expect(goLiveStageToNextPagePath[goLiveStage.CHOSEN_PSP_STRIPE]).to.equal(path)
+    })
+    it('should resolve CHOSEN_PSP_WORLDPAY stages correctly', () => {
+      expect(goLiveStageToNextPagePath[goLiveStage.CHOSEN_PSP_WORLDPAY]).to.equal(path)
+    })
+    it('should resolve CHOSEN_PSP_SMARTPAY stages correctly', () => {
+      expect(goLiveStageToNextPagePath[goLiveStage.CHOSEN_PSP_SMARTPAY]).to.equal(path)
+    })
+    it('should resolve CHOSEN_PSP_EPDQ stages correctly', () => {
+      expect(goLiveStageToNextPagePath[goLiveStage.CHOSEN_PSP_EPDQ]).to.equal(path)
+    })
+  })
+})


### PR DESCRIPTION
## WHAT

This PR implements "Request to go live" index page and adds Cypress testing.
Routes were added for future workflow pages.
The content/design of the page can change in near future, but currently this implementation is the latest one.

## HOW 

- Add all "request-to-go-live" url paths
- Add "go-live-stage-to-next-page-path" utility
 Display `COMPLETED` label for each step depending on `GoLiveStage`
  returned from adminusers
- Redirect to the next step depending on `GoLiveStage` returned from
  adminusers
- Add "Your service is live" panel which will be removed later when the
  new mockup is ready
- Modified the template to have test CSS ids
- Add Cypress tests, including the static fixtures and
  modified related Pact tests

with @stephencdaly 
