### PR TITLE
BAU Fix policy download page link styles

### DIFF
--- a/app/views/policy/policy.njk
+++ b/app/views/policy/policy.njk
@@ -6,7 +6,7 @@
 
 {% block mainContent %}
 <div class="govuk-grid-column-full">
-  <h1 class="govuk-heading-l page-title">
+  <h1 class="govuk-heading-l">
     {% block policyTitle %} {% endblock %}
   </h1>
 </div>
@@ -20,7 +20,7 @@
   </p>
   <ul class="govuk-list govuk-list--bullet">
     <li>
-      <a href="{{ link }}" download>{% block policyDownloadLinkDescription %}{% endblock %}</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ link }}" download>{% block policyDownloadLinkDescription %}{% endblock %}</a>
     </li>
   </ul>
   <p class="govuk-body">These terms are confidential and should not be shared outside of your organisation.</p>


### PR DESCRIPTION
Policy download pages had links styled by the default browser. This
ensures GOV.UK design system classes are applied.


