### PR TITLE
PP-4607 Re-enable user pact tests

### DIFF
--- a/test/unit/clients/adminusers_client/user/get_user_test.js
+++ b/test/unit/clients/adminusers_client/user/get_user_test.js
@@ -22,7 +22,7 @@ chai.use(chaiAsPromised)
 
 describe('adminusers client - get user', () => {
   const provider = Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),


### PR DESCRIPTION
- These were temporarily disabled whilst unused fields were removed
  from the adminusers get user response

