### PR TITLE
PP-4451 Validate Organisation name maximum character length

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -36,3 +36,4 @@
 @import "components/check-your-answers";
 @import "components/borders";
 @import "components/request-to-go-live";
+@import "components/error-label";

--- a/app/assets/sass/components/error-label.scss
+++ b/app/assets/sass/components/error-label.scss
@@ -1,0 +1,5 @@
+.govuk-label--l {
+  .govuk-error-message {
+    margin-top: govuk-spacing(3);
+  }
+}

--- a/app/controllers/request-to-go-live/organisation-name/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-name/post.controller.js
@@ -6,12 +6,15 @@ const lodash = require('lodash')
 // Local dependencies
 const goLiveStageToNextPagePath = require('../go-live-stage-to-next-page-path')
 const { requestToGoLive } = require('../../../paths')
+const { validateOrganisationName } = require('../../../utils/organisation_name_validation')
 
 // Constants
 const REQUEST_ORGANISATION_NAME_FIELD = 'organisation-name'
 
 module.exports = (req, res) => {
-  const errors = validateRequest(req)
+  const organisationName = lodash.get(req, 'body.organisation-name')
+  const errors = validateOrganisationName(organisationName, REQUEST_ORGANISATION_NAME_FIELD, true)
+
   if (lodash.isEmpty(errors)) {
     // TODO: handle submission
     res.redirect(
@@ -29,21 +32,4 @@ module.exports = (req, res) => {
       requestToGoLive.organisationName.replace(':externalServiceId', req.service.externalId)
     )
   }
-}
-
-function validateRequest (req) {
-  const mandatoryFields = [REQUEST_ORGANISATION_NAME_FIELD]
-
-  return validateNotEmpty(req, mandatoryFields)
-}
-
-function validateNotEmpty (req, fieldNames) {
-  const errors = {}
-  fieldNames.forEach(fieldName => {
-    let field = req.body[fieldName]
-    if (!field || typeof field !== 'string') {
-      errors[fieldName] = true
-    }
-  })
-  return errors
 }

--- a/app/utils/organisation_name_validation.js
+++ b/app/utils/organisation_name_validation.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const trim = require('lodash/trim')
+const { isEmpty, isFieldGreaterThanMaxLengthChars } = require('../browsered/field-validation-checks')
+const ORGANISATION_NAME_MAX_LENGTH = 255
+
+exports.validateOrganisationName = (organisationValue, organisationName = 'organisation_name', required) => {
+  let errors = {}
+  let value = trim(organisationValue)
+  if (isEmpty(value) && required) {
+    errors = {
+      [organisationName]: isEmpty(value)
+    }
+  } else if (!isEmpty(value) && isFieldGreaterThanMaxLengthChars(value, ORGANISATION_NAME_MAX_LENGTH)) {
+    errors = {
+      [organisationName]: isFieldGreaterThanMaxLengthChars(value, ORGANISATION_NAME_MAX_LENGTH)
+    }
+  }
+  return errors
+}

--- a/app/views/request-to-go-live/organisation-name.njk
+++ b/app/views/request-to-go-live/organisation-name.njk
@@ -25,7 +25,8 @@
 
     <span id="request-to-go-live-current-step" class="govuk-caption-l">Step 1 of 3</span>
 
-    <form id="request-to-go-live-organisation-name-form" method="post" action="/service/{{currentService.externalId}}/request-to-go-live/organisation-name">
+    <form id="request-to-go-live-organisation-name-form" method="post"
+          action="/service/{{ currentService.externalId }}/request-to-go-live/organisation-name" data-validate="true" >
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {% set organisationNameError = false %}
@@ -49,7 +50,8 @@
         type: "text",
         errorMessage: organisationNameError,
         attributes: {
-          "data-validate": "required"
+          "data-validate": "required isFieldGreaterThanMaxLengthChars",
+          "data-validate-max-length": "255"
         }
       }) }}
 

--- a/test/cypress/integration/request-to-go-live/organisation_name_spec.js
+++ b/test/cypress/integration/request-to-go-live/organisation_name_spec.js
@@ -69,7 +69,37 @@ describe('Request to go live: organisation name', () => {
       cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#request-to-go-live-organisation-name-input')
 
       cy.get('input#request-to-go-live-organisation-name-input').should('have.class', 'govuk-input--error')
-      cy.get('span#request-to-go-live-organisation-name-input-error').should('contain', 'Please enter a valid name')
+      cy.get('#request-to-go-live-organisation-name-form > div > h1 > label > span').should('contain', 'This field cannot be blank')
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq(`/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live/organisation-name`)
+      })
+    })
+
+    it('should show an error when name submitted exceeds max character length on "Request to go live: organisation name" page', () => {
+      const requestToGoLivePageOrganisationNameUrl = `/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live/organisation-name`
+      const maxLengthOrganisationNameAllowed = 255
+      const exceedMaxLengthOrganisationName = 'Lorem ipsum dolor sit ametf consectetuer adipiscing elitf Aenean commodo ligula eget dolorf Aenean massaf ' +
+        'Cum sociis natoque penatibus et magnis dis parturient montesf nascetur ridiculus musl Donec quam felisf ultricies necf pellentesque eue pretium quislk'
+
+      cy.visit(requestToGoLivePageOrganisationNameUrl)
+
+      cy.get('h1').should('contain', 'What is the name of your organisation?')
+
+      cy.get('input#request-to-go-live-organisation-name-input').should('exist')
+      cy.get('input#request-to-go-live-organisation-name-input').type(exceedMaxLengthOrganisationName)
+      cy.get('input#request-to-go-live-organisation-name-input').invoke('val').then(val => val.length).should('be.gt', maxLengthOrganisationNameAllowed)
+
+      cy.get('#request-to-go-live-organisation-name-form > button').should('exist')
+      cy.get('#request-to-go-live-organisation-name-form > button').should('contain', 'Continue')
+      cy.get('#request-to-go-live-organisation-name-form > button').click()
+
+      cy.get('h2').should('contain', 'There was a problem with the details you gave for:')
+      cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'What is the name of your organisation?')
+      cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#request-to-go-live-organisation-name-input')
+
+      cy.get('input#request-to-go-live-organisation-name-input').should('have.class', 'govuk-input--error')
+      cy.get('#request-to-go-live-organisation-name-form > div > h1 > label > span').should('contain', 'The text is too long')
 
       cy.location().should((location) => {
         expect(location.pathname).to.eq(`/service/${selfServiceUser.service_roles[0].service.external_id}/request-to-go-live/organisation-name`)


### PR DESCRIPTION
## WHAT
- prevents `organisation-name` characters from exceeding the upper limit of 255-characters, currently set in the db
 - removes organisation name default value from user fixture `self_service_user.json`to allow us to simulate realistic user behaviour
 - re-use validation provided in `field-validation-checks`
 - updates cypress tests to clear cookies prior to running tests to avoid persisting state
 - adds new cypress test for validating `organisation-name` character length
 - adds margin above error message because its visually more appealing

solo: @cobainc0 
