### PR TITLE
PP-4678 Allow for null values in pact fixtures

### DIFF
--- a/test/fixtures/pact_base.js
+++ b/test/fixtures/pact_base.js
@@ -18,7 +18,9 @@ module.exports = function (options = {}) {
   let pactify = (object) => {
     let pactified = {}
     _.forIn(object, (value, key) => {
-      if (options.array && options.array.indexOf(key) !== -1) {
+      if (value === null) {
+        pactified[key] = null
+      } else if (options.array && options.array.indexOf(key) !== -1) {
         let length
         if (options.length && options.length.find(lengthKey => lengthKey.key === key)) {
           length = options.length.find(lengthKey => lengthKey.key === key).length

--- a/test/fixtures/user_fixtures.js
+++ b/test/fixtures/user_fixtures.js
@@ -417,6 +417,7 @@ module.exports = {
         ],
         second_factor: opts.second_factor || 'SMS',
         provisional_otp_key: opts.provisional_otp_key || null,
+        provisional_otp_key_created_at: opts.provisional_otp_key_created_at || null,
         disabled: opts.disabled || false,
         login_counter: opts.login_counter || 0,
         session_version: opts.session_version || 0,


### PR DESCRIPTION
## WHAT
Fixes exception thrown if we try to pactify a JSON object which has null values. Currently we weren't building any pacts with null values but we should be able to


