### PR TITLE
BAU: Jenkinsfile lib back in line with master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
   }
 
   libraries {
-    lib("pay-jenkins-library@PP-4678-updated-cypress-structure")
+    lib("pay-jenkins-library@master")
   }
 
   environment {


### PR DESCRIPTION
A feature branch of pay-jenkins-library was used to ensure updated
infrastructure was passing in CI, once
https://github.com/alphagov/pay-jenkins-library/pull/94 is merged this
should stay up to date with master.

Depends on https://github.com/alphagov/pay-jenkins-library/pull/94


