### PR TITLE
PP-4678 Add documentation for new stubbing method for Cypress tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Run in two separate terminals:
 - `npm run cypress:test` to run headless 
 - `npm run cypress:test-headed` to run headed
 
+See [About Cypress tests in selfservice](./test/cypress/cypress_testing.md) for more information about running and writing Cypress tests.
+
 ## Key environment variables
 
 | Variable                    | required | default value | Description                               |

--- a/test/cypress/cypress_testing.md
+++ b/test/cypress/cypress_testing.md
@@ -1,0 +1,30 @@
+# About Cypress tests in selfservice
+
+## How external API requests are stubbed out
+
+We use a virtualisation server called [Mountebank](http://www.mbtest.org/) to stub out calls to external microservices. This is run alongside the Cypress server when the `npm run cypress:server` command is run locally.
+
+In the setup step of every Cypress test, we make a POST request to the running instance of Mountebank to initialise an `Imposter`, giving it an array of stubs to use. An Imposter intercepts all requests made to a particular port on localhost, and attempts to match a request to the stubs it has by matching on the `predicates` for the stub, responding with the `response` defined for the stub if there is a match.
+
+For running Cypress tests, we set the environment variables for the base URLs of all other microservices to use the same host and port as the Mountbank Imposter is initialised on. This means that requests to all microservices will be picked up by the single Imposter.
+
+When an Imposter has been set up on Mountebank, it cannot be modified. There is a global `beforeEach` defined in [support/index.js](./support/index.js) to delete the Imposter before each test runs so it can be initialised again.
+
+_If you get an error with message `Port 8000 is already in use` when running Cypress tests, you've probably tried to set up the imposter twice._
+
+#### Mountebank tips
+
+* Mountebank runs locally on port 2525 by default
+* You can see the Imposters currently loaded into Mountebank by making a `GET` request to `http://localhost:2525/imposters`
+* You can view the stubs for an imposter by making a `GET` request to `http://localhost:2525/imposters/8000` (replace 8000 if Imposter is initialised on a different port)
+* If Mountebank is run with the [`--debug` option](http://www.mbtest.org/docs/commandLine), the stubs array returned by the get imposter request includes a `matches` array, which can be useful for seeing which requests are matched on.
+
+## How we validate stubs used for Cypress tests
+
+All API stubs created for use in Cypress tests (defined in [plugins/stubs.js](./plugins/stubs.js)) must use the [fixture builders](../fixtures/fixture_builders.md) to generate the body in the request/response. 
+
+These fixture builders generate a well defined JSON structure which should be validated by a well defined suite of Pact tests. This means that if an API contract changes, there is one central place in test code that needs to be updated which will propogate through to the Cypress tests.
+
+## Custom Cypress commands
+
+We use custom Cypress commands for sharing code that is common between tests, such as to set cookies. These are defined in [support/commands.js](./support/commands.js). 

--- a/test/cypress/integration/user/dashboard_spec.js
+++ b/test/cypress/integration/user/dashboard_spec.js
@@ -27,8 +27,6 @@ describe('Dashboard', () => {
   })
 
   describe('Homepage', () => {
-    // Note : these from/to datetime strings exactly match those in the pact/contract, so are essential to match against stubs
-    // Either change everything together, or map these do a single place like a .json document so the contracts/tests refer to one place
     const from = encodeURIComponent('2018-05-14T00:00:00+01:00')
     const to = encodeURIComponent('2018-05-15T00:00:00+01:00')
 

--- a/test/cypress/integration/user/merchant_details_spec.js
+++ b/test/cypress/integration/user/merchant_details_spec.js
@@ -25,9 +25,6 @@ describe('Dashboard', () => {
   })
 
   describe('Homepage', () => {
-    // Use a known configuration used to generate contracts/stubs.
-    // This is also used to generate the session/gateway_account cookies
-
     it('should have the page title \'Choose service - GOV.UK Pay\'', () => {
       cy.visit('/my-services')
       cy.title().should('eq', 'Choose service - GOV.UK Pay')

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -33,6 +33,16 @@ module.exports = (on, config) => {
 
       return { encryptedSessionCookie, encryptedGatewayAccountCookie }
     },
+    /**
+     * Makes a post request to Mountebank to setup an Imposter with stubs built using the array of stub specifications
+     * provided.
+     *
+     * Note: this task can only be called once per test, so all stubs for a test must be set up in the same call.
+     *
+     * @param stubSpecs - an array of stub specification objects, each having a `name` and `opts`. The name refers to
+     * the name of a function defined in plugins/stubs.js, and the opts is an object passed to this function providing
+     * the configuration options for building the stub predicates and responses.
+     */
     setupStubs (stubSpecs) {
       const stubsArray = lodash.flatMap(stubSpecs, spec => stubs[spec.name](spec.opts))
       return request({
@@ -46,6 +56,9 @@ module.exports = (on, config) => {
         }
       })
     },
+    /**
+     * Makes a request to Mountebank to delete the existing Imposter along with all stubs that have been set up.
+     */
     clearStubs () {
       return request.delete(mountebankImpostersUrl)
     }

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -9,9 +9,11 @@ const gatewayAccountFixtures = require('../../fixtures/gateway_account_fixtures'
 const transactionDetailsFixtures = require('../../fixtures/transaction_fixtures')
 const cardFixtures = require('../../fixtures/card_fixtures')
 
-// Stub definitions added here should always use the fixture builders to generate request and response bodys.
-// The fixture builders used should be validated by also being used in the pact tests for the API endpoint, and they
-// should be written in a strict enough way the JSON they produce will adhere to a validated structure.
+/**
+ * Stub definitions added here should always use fixture builders to generate request and response bodys.
+ * The fixture builders used should be validated by also being used in the pact tests for the API endpoint, and they
+ * should be written in a strict enough way the JSON they produce will adhere to a validated structure.
+ */
 module.exports = {
   getUserSuccess: (opts = {}) => {
     const aValidUserResponse = userFixtures.validPasswordAuthenticateResponse(opts).getPlain()

--- a/test/fixtures/fixture_builders.md
+++ b/test/fixtures/fixture_builders.md
@@ -1,0 +1,17 @@
+# Test Fixture Builders
+
+## Purpose
+
+The purpose of the fixture builders is to build valid JSON for the body of requests made to, and responses expected by external APIs.
+
+These fixtures are used throughout test code in mocks and stubs, including in [Cypress tests](../cypress/cypress_testing.md).
+
+## Validation
+
+The validity of the fixture builders against the contract with external APIs is maintained by using them to construct Pacts which are validated by the Pact provider. All fixture builders should be thoroughly validated through use in Pact tests so we can have confidence that other tests create stubs with a valid structure.
+
+## Rules for writing fixture builders
+
+Fixture builders should produce a strictly defined JSON structure which can be validated. They should not substitute in entire JSON objects provided by parameters, but should just substitute values of individual fields. They can contain conditionals for building the JSON (i.e. omitting fields based on parameters they are given) but it should be ensured there are Pact tests which test all branches of the conditionals.
+
+Where there are shared JSON objects which appear in the request/response for multiple API endpoints, single fixture builders should be created for these, and duplication avoided to ensure they only need to be updated in a single place when the contract changes.


### PR DESCRIPTION
## WHAT
- Add readme for how Cypress tests interact with Mountebank and
  other Cypress tips
- Add readme for how fixture builders are used, validated and written
- Add some code comments explaining stubbing
- Remove some redundant code comments in Cypress tests that refer to the old method

