### PR TITLE
PP-4678 Remove use of self_service_user.json from adminusers tests

### DIFF
--- a/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
+++ b/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
@@ -20,10 +20,6 @@ const AUTHENTICATE_PATH = '/v1/api/users/authenticate'
 chai.use(chaiAsPromised)
 const expect = chai.expect
 
-// Note: the browser tests use values in the fixed config below, which match the defined interations
-const selfServiceUserConfig = require('../../../../fixtures/config/self_service_user')
-const selfServiceDefaultUser = selfServiceUserConfig.config.users.filter(fil => fil.isPrimary === 'true')[0]
-
 describe('adminusers client - authenticate', () => {
   const provider = Pact({
     consumer: 'selfservice-to-be',
@@ -38,56 +34,58 @@ describe('adminusers client - authenticate', () => {
   before(() => provider.setup())
   after((done) => provider.finalize().then(done()))
 
-  selfServiceUserConfig.config.users.forEach(currentUser => {
-    describe(`success "${currentUser.cypressTestingCategory}" user`, () => {
-      const validPasswordResponse = userFixtures.validPasswordAuthenticateResponse(currentUser)
-      const validPasswordRequestPactified = userFixtures
-        .validPasswordAuthenticateRequest({
-          username: currentUser.username,
-          usernameMatcher: currentUser.usernameMatcher,
-          password: currentUser.valid_password,
-          passwordMatcher: currentUser.valid_passwordMatcher
-        })
+  const existingUsername = 'some-user@gov.uk'
+  const validPassword = 'some-valid-password'
 
-      before((done) => {
-        provider.addInteraction(
-          new PactInteractionBuilder(`${AUTHENTICATE_PATH}`)
-            .withUponReceiving('a correct password for a user')
-            .withState(`user with email address ${currentUser.username} exists in the database with the correct with a correct password set to: ${currentUser.valid_password}`)
-            .withMethod('POST')
-            .withRequestBody(validPasswordRequestPactified)
-            .withResponseBody(validPasswordResponse.getPactified())
-            .withStatusCode(200)
-            .build()
-        ).then(() => done())
+  describe('user is authenticated successfully', () => {
+    const validPasswordResponse = userFixtures.validPasswordAuthenticateResponse({ username: existingUsername })
+    const validPasswordRequestPactified = userFixtures
+      .validPasswordAuthenticateRequest({
+        username: existingUsername,
+        usernameMatcher: existingUsername,
+        password: validPassword,
+        passwordMatcher: validPassword
       })
 
-      afterEach(() => provider.verify())
+    before((done) => {
+      provider.addInteraction(
+        new PactInteractionBuilder(`${AUTHENTICATE_PATH}`)
+          .withUponReceiving('a correct password for a user')
+          .withState(`user with email address ${existingUsername} exists in the database with the correct with a correct password set to: ${validPassword}`)
+          .withMethod('POST')
+          .withRequestBody(validPasswordRequestPactified)
+          .withResponseBody(validPasswordResponse.getPactified())
+          .withStatusCode(200)
+          .build()
+      ).then(() => done())
+    })
 
-      it('should return the right authentication success response', done => {
-        adminusersClient.authenticateUser(currentUser.username, currentUser.valid_password).then((response) => {
-          expect(response).to.deep.equal(new User(validPasswordResponse.getPlain()))
-          done()
-        })
+    afterEach(() => provider.verify())
+
+    it('should return the right authentication success response', done => {
+      adminusersClient.authenticateUser(existingUsername, validPassword).then((response) => {
+        expect(response).to.deep.equal(new User(validPasswordResponse.getPlain()))
+        done()
       })
     })
   })
 
-  describe('failure', () => {
+  describe('user authentication fails', () => {
+    const invalidPassword = 'some-password'
     const invalidPasswordResponse = userFixtures.invalidPasswordAuthenticateResponse()
     const invalidPasswordRequestPactified = userFixtures
       .invalidPasswordAuthenticateRequest({
-        username: selfServiceDefaultUser.username,
-        usernameMatcher: selfServiceDefaultUser.usernameMatcher,
-        password: selfServiceDefaultUser.invalid_password,
-        passwordMatcher: selfServiceDefaultUser.invalid_passwordMatcher
+        username: existingUsername,
+        usernameMatcher: existingUsername,
+        password: invalidPassword,
+        passwordMatcher: invalidPassword
       })
 
     before((done) => {
       provider.addInteraction(
         new PactInteractionBuilder(`${AUTHENTICATE_PATH}`)
           .withUponReceiving('an incorrect password for a user')
-          .withState(`user with email address ${selfServiceDefaultUser.username} exists in the database with the correct with a correct password set to: ${selfServiceDefaultUser.valid_password}`)
+          .withState(`user with email address ${existingUsername} exists in the database with the correct with a correct password set to: ${validPassword}`)
           .withMethod('POST')
           .withRequestBody(invalidPasswordRequestPactified)
           .withResponseBody(invalidPasswordResponse.getPactified())
@@ -99,7 +97,7 @@ describe('adminusers client - authenticate', () => {
     afterEach(() => provider.verify())
 
     it('should return the right authentication failure response', done => {
-      adminusersClient.authenticateUser(selfServiceDefaultUser.username, selfServiceDefaultUser.invalid_password).then(() => {
+      adminusersClient.authenticateUser(existingUsername, invalidPassword).then(() => {
         done('should not resolve here')
       }).catch(err => {
         expect(err.errorCode).to.equal(401)

--- a/test/unit/clients/adminusers_client/service/update_collect_billing_address_test.js
+++ b/test/unit/clients/adminusers_client/service/update_collect_billing_address_test.js
@@ -10,14 +10,13 @@ const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers_client')
 const serviceFixtures = require('../../../../fixtures/service_fixtures')
-const ssUserConfig = require('../../../../fixtures/config/self_service_user')
 
 // Constants
 const SERVICE_RESOURCE = '/v1/api/services'
 const port = Math.floor(Math.random() * 48127) + 1024
 const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
 const expect = chai.expect
-const ssDefaultServiceId = ssUserConfig.config.users.filter(fil => fil.isPrimary === 'true')[0].service_roles[0].service.external_id
+const serviceExternalId = 'cp5wa'
 
 // Global setup
 chai.use(chaiAsPromised)
@@ -39,15 +38,15 @@ describe('adminusers client - patch collect billing address toggle', function ()
   describe('patch collect billing address toggle - disabled', () => {
     const validUpdateCollectBillingAddressRequest = serviceFixtures.validCollectBillingAddressToggleRequest({enabled: false})
     const validUpdateCollectBillingAddressResponse = serviceFixtures.validCollectBillingAddressToggleResponse({
-      external_id: ssDefaultServiceId,
+      external_id: serviceExternalId,
       collect_billing_address: false
     })
 
     before((done) => {
       provider.addInteraction(
-        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${ssDefaultServiceId}`)
+        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
           .withUponReceiving('a valid patch collect billing address toggle (disabled) request')
-          .withState(`a service exists with external id ${ssDefaultServiceId} and billing address collection enabled`)
+          .withState(`a service exists with external id ${serviceExternalId} and billing address collection enabled`)
           .withMethod('PATCH')
           .withRequestBody(validUpdateCollectBillingAddressRequest.getPactified())
           .withStatusCode(200)
@@ -61,9 +60,9 @@ describe('adminusers client - patch collect billing address toggle', function ()
     afterEach(() => provider.verify())
 
     it('should toggle successfully', function (done) {
-      adminusersClient.updateCollectBillingAddress(ssDefaultServiceId, false)
+      adminusersClient.updateCollectBillingAddress(serviceExternalId, false)
         .should.be.fulfilled.then(service => {
-          expect(service.external_id).to.equal(ssDefaultServiceId)
+          expect(service.external_id).to.equal(serviceExternalId)
           expect(service.collect_billing_address).to.equal(false)
         }).should.notify(done)
     })

--- a/test/unit/clients/adminusers_client/user/get_user_test.js
+++ b/test/unit/clients/adminusers_client/user/get_user_test.js
@@ -16,7 +16,6 @@ const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_bu
 const port = Math.floor(Math.random() * 48127) + 1024
 const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 const USER_PATH = '/v1/api/users'
-const selfServiceUserConfig = require('../../../../fixtures/config/self_service_user.json')
 
 chai.use(chaiAsPromised)
 
@@ -34,48 +33,41 @@ describe('adminusers client - get user', () => {
   before(() => provider.setup())
   after(done => provider.finalize().then(done()))
 
-  selfServiceUserConfig.config.users.forEach(currentUser => {
-    describe(`success "${currentUser.cypressTestingCategory}" user`, () => {
-      const existingExternalId = currentUser.external_id
+  describe('find a valid user', () => {
+    const existingExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
+    const getUserResponse = userFixtures.validPasswordAuthenticateResponse({ external_id: existingExternalId })
 
-      const params = {
-        external_id: existingExternalId
-      }
+    before(done => {
+      provider.addInteraction(
+        new PactInteractionBuilder(`${USER_PATH}/${existingExternalId}`)
+          .withState(`a user exists with the given external id ${existingExternalId}`)
+          .withUponReceiving('a valid get user request')
+          .withResponseBody(getUserResponse.getPactified())
+          .build()
+      ).then(done())
+    })
 
-      const getUserResponse = userFixtures.validPasswordAuthenticateResponse(currentUser)
+    afterEach(() => provider.verify())
 
-      before(done => {
-        provider.addInteraction(
-          new PactInteractionBuilder(`${USER_PATH}/${params.external_id}`)
-            .withState(`a user exists with the given external id ${existingExternalId}`)
-            .withUponReceiving('a valid get user request')
-            .withResponseBody(getUserResponse.getPactified())
-            .build()
-        ).then(done())
-      })
+    it('should find a user successfully', done => {
+      const expectedUserData = getUserResponse.getPlain()
 
-      afterEach(() => provider.verify())
-
-      it('should find a user successfully', done => {
-        const expectedUserData = getUserResponse.getPlain()
-
-        adminusersClient.getUserByExternalId(params.external_id).should.be.fulfilled.then(user => {
-          expect(user.externalId).to.be.equal(expectedUserData.external_id)
-          expect(user.username).to.be.equal(expectedUserData.username)
-          expect(user.email).to.be.equal(expectedUserData.email)
-          expect(user.serviceRoles.length).to.be.equal(1)
-          expect(user.serviceRoles[0].service.gatewayAccountIds.length).to.be.equal(1)
-          expect(user.telephoneNumber).to.be.equal(expectedUserData.telephone_number)
-          expect(user.otpKey).to.be.equal(expectedUserData.otp_key)
-          expect(user.provisionalOtpKey).to.be.equal(expectedUserData.provisional_otp_key)
-          expect(user.secondFactor).to.be.equal(expectedUserData.second_factor)
-          expect(user.serviceRoles[0].role.permissions.length).to.be.equal(expectedUserData.service_roles[0].role.permissions.length)
-        }).should.notify(done)
-      })
+      adminusersClient.getUserByExternalId(expectedUserData.external_id).should.be.fulfilled.then(user => {
+        expect(user.externalId).to.be.equal(expectedUserData.external_id)
+        expect(user.username).to.be.equal(expectedUserData.username)
+        expect(user.email).to.be.equal(expectedUserData.email)
+        expect(user.serviceRoles.length).to.be.equal(1)
+        expect(user.serviceRoles[0].service.gatewayAccountIds.length).to.be.equal(1)
+        expect(user.telephoneNumber).to.be.equal(expectedUserData.telephone_number)
+        expect(user.otpKey).to.be.equal(expectedUserData.otp_key)
+        expect(user.provisionalOtpKey).to.be.equal(expectedUserData.provisional_otp_key)
+        expect(user.secondFactor).to.be.equal(expectedUserData.second_factor)
+        expect(user.serviceRoles[0].role.permissions.length).to.be.equal(expectedUserData.service_roles[0].role.permissions.length)
+      }).should.notify(done)
     })
   })
 
-  describe('not found', () => {
+  describe('user not found', () => {
     const params = {
       external_id: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' // non existent external id
     }


### PR DESCRIPTION
## WHAT
- First steps towards removing self_service_user.json completely
- Remove pact tests to get service with each go live stage as these are unnecessary now that we don't use pacts to drive Cypress tests


