### PR TITLE
PP-4678 Remove self_service_user from email patch tests

### DIFF
--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -118,7 +118,7 @@ module.exports = {
     ]
   },
   patchAccountEmailCollectionModeSuccess: (opts = {}) => {
-    const validGatewayAccountEmailCollectionModeRequest = gatewayAccountFixtures.validGatewayAccountEmailCollectionModeRequest().getPlain()
+    const validGatewayAccountEmailCollectionModeRequest = gatewayAccountFixtures.validGatewayAccountEmailCollectionModeRequest(opts.collectionMode).getPlain()
     return [
       {
         predicates: [{
@@ -143,7 +143,7 @@ module.exports = {
     ]
   },
   patchConfirmationEmailToggleSuccess: (opts = {}) => {
-    const validGatewayAccountEmailConfirmationToggleRequest = gatewayAccountFixtures.validGatewayAccountEmailConfirmationToggleRequest(opts).getPlain()
+    const validGatewayAccountEmailConfirmationToggleRequest = gatewayAccountFixtures.validGatewayAccountEmailConfirmationToggleRequest(opts.enabled).getPlain()
     return [
       {
         predicates: [{
@@ -168,7 +168,7 @@ module.exports = {
     ]
   },
   patchRefundEmailToggleSuccess: (opts = {}) => {
-    const validGatewayAccountEmailRefundToggleRequest = gatewayAccountFixtures.validGatewayAccountEmailRefundToggleRequest(opts).getPlain()
+    const validGatewayAccountEmailRefundToggleRequest = gatewayAccountFixtures.validGatewayAccountEmailRefundToggleRequest(opts.enabled).getPlain()
     return [
       {
         predicates: [{

--- a/test/fixtures/gateway_account_fixtures.js
+++ b/test/fixtures/gateway_account_fixtures.js
@@ -9,11 +9,11 @@ const pactBase = require(path.join(__dirname, '/pact_base'))
 const pactRegister = pactBase()
 
 module.exports = {
-  validGatewayAccountEmailRefundToggleRequest: (opts = {}) => {
+  validGatewayAccountEmailRefundToggleRequest: (enabled = true) => {
     const data = {
-      op: opts.op || 'replace',
-      path: opts.path || '/refund/enabled',
-      value: opts.enabled || true
+      op: 'replace',
+      path: '/refund/enabled',
+      value: enabled
     }
 
     return {
@@ -25,11 +25,11 @@ module.exports = {
       }
     }
   },
-  validGatewayAccountEmailConfirmationToggleRequest: (opts = {}) => {
+  validGatewayAccountEmailConfirmationToggleRequest: (enabled = true) => {
     const data = {
-      op: opts.op || 'replace',
-      path: opts.path || '/confirmation/enabled',
-      value: opts.enabled || true
+      op: 'replace',
+      path: '/confirmation/enabled',
+      value: enabled
     }
 
     return {
@@ -41,11 +41,11 @@ module.exports = {
       }
     }
   },
-  validGatewayAccountEmailCollectionModeRequest: (opts = {}) => {
+  validGatewayAccountEmailCollectionModeRequest: (collectionMode = 'MANDATORY') => {
     const data = {
-      op: opts.op || 'replace',
-      path: opts.path || 'email_collection_mode',
-      value: opts.collectionMode || 'MANDATORY'
+      op: 'replace',
+      path: 'email_collection_mode',
+      value: collectionMode
     }
 
     return {

--- a/test/unit/clients/connector_client/connector_patch_email_collection_mode_test.js
+++ b/test/unit/clients/connector_client/connector_patch_email_collection_mode_test.js
@@ -20,9 +20,8 @@ const expect = chai.expect
 // Global setup
 chai.use(chaiAsPromised)
 
-// Note: the browser tests use values in the fixed config below, which match the defined interations
-const ssUserConfig = require('../../../fixtures/config/self_service_user.json')
-const ssDefaultUser = ssUserConfig.config.users.filter(fil => fil.isPrimary === 'true')[0]
+const existingGatewayAccountId = 42
+const defaultState = `Gateway account ${existingGatewayAccountId} exists in the database`
 
 describe('connector client - patch email collection mode', function () {
   let provider = Pact({
@@ -39,18 +38,14 @@ describe('connector client - patch email collection mode', function () {
   after((done) => provider.finalize().then(done()))
 
   describe('patch email collection mode - mandatory', () => {
-    const params = {
-      gatewayAccountId: parseInt(ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id), // 666
-      collectionMode: 'MANDATORY'
-    }
-
-    const validGatewayAccountEmailCollectionModeRequest = gatewayAccountFixtures.validGatewayAccountEmailCollectionModeRequest()
+    const validGatewayAccountEmailCollectionModeRequest =
+      gatewayAccountFixtures.validGatewayAccountEmailCollectionModeRequest('MANDATORY')
 
     before((done) => {
       provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${params.gatewayAccountId}`)
+        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
           .withUponReceiving('a valid patch email collection mode (mandatory) request')
-          .withState(`Gateway account ${params.gatewayAccountId} exists in the database`)
+          .withState(defaultState)
           .withMethod('PATCH')
           .withRequestBody(validGatewayAccountEmailCollectionModeRequest.getPactified())
           .withStatusCode(200)
@@ -63,8 +58,11 @@ describe('connector client - patch email collection mode', function () {
     afterEach(() => provider.verify())
 
     it('should set email collection mode to mandatory', function (done) {
-      const payload = {'op': 'replace', 'path': 'email_collection_mode', 'value': params.collectionMode}
-      connectorClient.updateEmailCollectionMode({gatewayAccountId: params.gatewayAccountId, payload: payload}, (connectorData, connectorResponse) => {
+      const params = {
+        gatewayAccountId: existingGatewayAccountId,
+        payload: validGatewayAccountEmailCollectionModeRequest.getPlain()
+      }
+      connectorClient.updateEmailCollectionMode(params, (connectorData, connectorResponse) => {
         expect(connectorResponse.statusCode).to.equal(200)
         done()
       })
@@ -72,18 +70,14 @@ describe('connector client - patch email collection mode', function () {
   })
 
   describe('patch email collection mode - optional', () => {
-    const params = {
-      gatewayAccountId: parseInt(ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id), // 666
-      collectionMode: 'OPTIONAL'
-    }
-
-    const validGatewayAccountEmailCollectionModeRequest = gatewayAccountFixtures.validGatewayAccountEmailCollectionModeRequest(params)
+    const validGatewayAccountEmailCollectionModeRequest =
+      gatewayAccountFixtures.validGatewayAccountEmailCollectionModeRequest('OPTIONAL')
 
     before((done) => {
       provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${params.gatewayAccountId}`)
+        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
           .withUponReceiving('a valid patch email collection mode (optional) request')
-          .withState(`Gateway account ${params.gatewayAccountId} exists in the database`)
+          .withState(defaultState)
           .withMethod('PATCH')
           .withRequestBody(validGatewayAccountEmailCollectionModeRequest.getPactified())
           .withStatusCode(200)
@@ -96,11 +90,11 @@ describe('connector client - patch email collection mode', function () {
     afterEach(() => provider.verify())
 
     it('should set email collection mode to optional', function (done) {
-      const payload = {'op': 'replace', 'path': 'email_collection_mode', 'value': params.collectionMode}
-      connectorClient.updateEmailCollectionMode({
-        gatewayAccountId: params.gatewayAccountId,
-        payload: payload
-      }, (connectorData, connectorResponse) => {
+      const params = {
+        gatewayAccountId: existingGatewayAccountId,
+        payload: validGatewayAccountEmailCollectionModeRequest.getPlain()
+      }
+      connectorClient.updateEmailCollectionMode(params, (connectorData, connectorResponse) => {
         expect(connectorResponse.statusCode).to.equal(200)
         done()
       })
@@ -108,18 +102,14 @@ describe('connector client - patch email collection mode', function () {
   })
 
   describe('patch email collection mode - off', () => {
-    const params = {
-      gatewayAccountId: parseInt(ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id), // 666
-      collectionMode: 'OFF'
-    }
-
-    const validGatewayAccountEmailCollectionModeRequest = gatewayAccountFixtures.validGatewayAccountEmailCollectionModeRequest(params)
+    const validGatewayAccountEmailCollectionModeRequest =
+      gatewayAccountFixtures.validGatewayAccountEmailCollectionModeRequest('OFF')
 
     before((done) => {
       provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${params.gatewayAccountId}`)
+        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
           .withUponReceiving('a valid patch email collection mode (off) request')
-          .withState(`Gateway account ${params.gatewayAccountId} exists in the database`)
+          .withState(`Gateway account ${existingGatewayAccountId} exists in the database`)
           .withMethod('PATCH')
           .withRequestBody(validGatewayAccountEmailCollectionModeRequest.getPactified())
           .withStatusCode(200)
@@ -132,11 +122,11 @@ describe('connector client - patch email collection mode', function () {
     afterEach(() => provider.verify())
 
     it('should set email collection mode to mandatory', function (done) {
-      const payload = {'op': 'replace', 'path': 'email_collection_mode', 'value': params.collectionMode}
-      connectorClient.updateEmailCollectionMode({
-        gatewayAccountId: params.gatewayAccountId,
-        payload: payload
-      }, (connectorData, connectorResponse) => {
+      const params = {
+        gatewayAccountId: existingGatewayAccountId,
+        payload: validGatewayAccountEmailCollectionModeRequest.getPlain()
+      }
+      connectorClient.updateEmailCollectionMode(params, (connectorData, connectorResponse) => {
         expect(connectorResponse.statusCode).to.equal(200)
         done()
       })

--- a/test/unit/clients/connector_client/connector_patch_email_confirmation_toggle_test.js
+++ b/test/unit/clients/connector_client/connector_patch_email_confirmation_toggle_test.js
@@ -20,9 +20,8 @@ const expect = chai.expect
 // Global setup
 chai.use(chaiAsPromised)
 
-// Note: the browser tests use values in the fixed config below, which match the defined interations
-const ssUserConfig = require('../../../fixtures/config/self_service_user.json')
-const ssDefaultUser = ssUserConfig.config.users.filter(fil => fil.isPrimary === 'true')[0]
+const existingGatewayAccountId = 42
+const defaultState = `Gateway account ${existingGatewayAccountId} exists in the database`
 
 describe('connector client - patch email confirmation toggle', function () {
   let provider = Pact({
@@ -39,18 +38,13 @@ describe('connector client - patch email confirmation toggle', function () {
   after((done) => provider.finalize().then(done()))
 
   describe('patch email confirmation toggle - enabled', () => {
-    const params = {
-      gatewayAccountId: parseInt(ssDefaultUser.gateway_accounts.filter(fil => fil.isPrimary === 'true')[0].id), // 666
-      enabled: true
-    }
-
-    const validGatewayAccountEmailConfirmationToggleRequest = gatewayAccountFixtures.validGatewayAccountEmailConfirmationToggleRequest(params)
+    const validGatewayAccountEmailConfirmationToggleRequest = gatewayAccountFixtures.validGatewayAccountEmailConfirmationToggleRequest(true)
 
     before((done) => {
       provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${params.gatewayAccountId}/email-notification`)
+        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/email-notification`)
           .withUponReceiving('a valid patch email confirmation toggle (enabled) request')
-          .withState(`Gateway account ${params.gatewayAccountId} exists in the database`)
+          .withState(defaultState)
           .withMethod('PATCH')
           .withRequestBody(validGatewayAccountEmailConfirmationToggleRequest.getPactified())
           .withStatusCode(200)
@@ -63,8 +57,11 @@ describe('connector client - patch email confirmation toggle', function () {
     afterEach(() => provider.verify())
 
     it('should toggle successfully', function (done) {
-      const payload = {'op': 'replace', 'path': '/confirmation/enabled', 'value': true}
-      connectorClient.updateConfirmationEmailEnabled({gatewayAccountId: params.gatewayAccountId, payload: payload}, (connectorData, connectorResponse) => {
+      const params = {
+        gatewayAccountId: existingGatewayAccountId,
+        payload: validGatewayAccountEmailConfirmationToggleRequest.getPlain()
+      }
+      connectorClient.updateConfirmationEmailEnabled(params, (connectorData, connectorResponse) => {
         expect(connectorResponse.statusCode).to.equal(200)
         done()
       })


### PR DESCRIPTION
## WHAT
- remove usages of static config file which will be removed in future
- modify fixtures for email setting patch requests to be stricter


