### PR TITLE
BAU: Reduce calls to adminusers/api/users

### DIFF
--- a/server.js
+++ b/server.js
@@ -159,8 +159,8 @@ function initialise () {
   initialiseTLS()
   initialisePublic(app)
   initialiseCookies(app)
-  initialiseAuth(app)
   initialiseGlobalMiddleware(app)
+  initialiseAuth(app)
   initialiseTemplateEngine(app)
   initialiseErrorHandling(app)
   initialiseRoutes(app) // This contains the 404 overrider and so should be last


### PR DESCRIPTION
All static assets (JS/ CSS) are currently served behind our
authorisation middlware, this requires making a request and
deserialising the user for these resources.

Bump up the middleware so that it is no longer private.

With @stephencdaly, @SandorArpa

Edit: do not merge - sanity check Auth corner cases 

