### PR TITLE
PP-4678 Remove duplicated user fixtures

### DIFF
--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -17,7 +17,7 @@ const serviceFixtures = require('../../fixtures/service_fixtures')
  */
 module.exports = {
   getUserSuccess: (opts = {}) => {
-    const aValidUserResponse = userFixtures.validPasswordAuthenticateResponse(opts).getPlain()
+    const aValidUserResponse = userFixtures.validUserResponse(opts).getPlain()
     return [
       {
         predicates: [{
@@ -194,7 +194,7 @@ module.exports = {
   },
   postUserAuthenticateSuccess: (opts = {}) => {
     const aValidAuthenticateRequest = userFixtures.validAuthenticateRequest(opts).getPlain()
-    const aValidAuthenticateResponse = userFixtures.validPasswordAuthenticateResponse(opts).getPlain()
+    const aValidAuthenticateResponse = userFixtures.validUserResponse(opts).getPlain()
     return [
       {
         predicates: [{

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -11,12 +11,20 @@ const pactBase = require(path.join(__dirname, '/pact_base'))
 const pactServices = pactBase({ array: ['service_ids'] })
 
 const buildMerchantDetailsWithDefaults = (opts = {}) => {
+  _.defaults(opts, {
+    name: 'name',
+    address_line1: 'line1',
+    address_city: 'City',
+    address_postcode: 'POSTCODE',
+    address_country: 'GB'
+  })
+
   const merchantDetails = {
-    name: opts.name || 'name',
-    address_line1: opts.address_line1 || 'line1',
-    address_city: opts.address_city || 'City',
-    address_postcode: opts.address_postcode || 'POSTCODE',
-    address_country: opts.address_country || 'GB'
+    name: opts.name,
+    address_line1: opts.address_line1,
+    address_city: opts.address_city,
+    address_postcode: opts.address_postcode,
+    address_country: opts.address_country
   }
 
   if (opts.address_line2) {

--- a/test/fixtures/user_fixtures.js
+++ b/test/fixtures/user_fixtures.js
@@ -163,21 +163,6 @@ const pactUsers = pactBase({
   length: [{ key: 'permissions', length: 1 }]
 })
 
-function validPassword () {
-  return 'G0VUkPay2017Rocks'
-}
-
-function merchantDetailsFixture () {
-  return {
-    name: 'name',
-    address_line1: 'line1',
-    address_line2: 'line2',
-    address_city: 'City',
-    address_postcode: 'POSTCODE',
-    address_country: 'GB'
-  }
-}
-
 const buildServiceRole = (opts = {}) => {
   return {
     service: serviceFixtures.buildServiceWithDefaults(opts.service).getPlain(),
@@ -187,94 +172,40 @@ const buildServiceRole = (opts = {}) => {
 
 const buildRoleWithDefaults = (opts = {}) => {
   return {
-    name: opts.role_name || 'admin',
+    name: opts.name || 'admin',
     description: opts.role_description || 'Administrator',
     permissions: opts.permissions || defaultPermissions
   }
 }
 
+function buildUserWithDefaults (opts) {
+  const serviceRoles = opts.service_roles ? lodash.flatMap(opts.service_roles, buildServiceRole) : [buildServiceRole()]
+  const data = {
+    external_id: opts.external_id || '7d19aff33f8948deb97ed16b2912dcd3',
+    username: opts.username || 'some-user@gov.uk',
+    email: opts.email || 'some-user@gov.uk',
+    otp_key: opts.otp_key || 'krb6fcianbdjkt01ecvi08jcln',
+    telephone_number: opts.telephone_number || '9127979',
+    service_roles: serviceRoles,
+    second_factor: opts.second_factor || 'SMS',
+    provisional_otp_key: opts.provisional_otp_key || 'a-provisional-key',
+    provisional_otp_key_created_at: opts.provisional_otp_key_created_at || null,
+    disabled: opts.disabled || false,
+    login_counter: opts.login_counter || 0,
+    session_version: opts.session_version || 0,
+    _links: opts._links || [{
+      rel: 'self',
+      method: 'GET',
+      href: 'http://localhost:8080/v1/api/users/09283568e105442da3928d1fa99fb0eb'
+    }]
+  }
+  return data
+}
+
 module.exports = {
-
-  validMinimalUser: () => {
-    const newExternalId = '8e1a29e4f66e409693d6e530bff7a642'
-    const newUsername = '5nxja'
-    const defaultServiceId = '535'
-    const accountIds = ['507']
-
-    const data = {
-      external_id: newExternalId,
-      username: newUsername,
-      email: `${newUsername}@example.com`,
-      service_roles: [{
-        service: {
-          name: 'System Generated',
-          external_id: defaultServiceId,
-          gateway_account_ids: accountIds
-        },
-        role: {
-          name: 'admin',
-          description: 'Administrator',
-          permissions: ['perm-1']
-        }
-      }],
-      telephone_number: '07700 95665',
-      secondFactor: 'SMS'
-    }
-
-    return {
-      getPactified: () => {
-        return pactUsers.pactify(data)
-      },
-      getAsObject: () => {
-        return new User(data)
-      },
-      getPlain: () => {
-        return data
-      }
-    }
-  },
-  validUserWithMerchantDetails: (opts = {}) => {
-    const newExternalId = '79d686ec43bc4768b2600d2e1e41e54e'
-    const newUsername = '6fu6kr'
-    const defaultServiceId = opts.default_service_id || '946'
-    const gatewayAccountIds = opts.gateway_account_ids || ['218']
-    const merchantDetails = opts.merchant_details || merchantDetailsFixture()
-
-    const data = {
-      external_id: opts.external_id || newExternalId,
-      username: opts.username || newUsername,
-      email: opts.email || `${newUsername}@example.com`,
-      service_roles: opts.service_roles || [{
-        service: {
-          name: 'System Generated',
-          external_id: defaultServiceId,
-          gateway_account_ids: gatewayAccountIds,
-          merchant_details: merchantDetails
-        },
-        role: opts.role || {
-          name: 'admin',
-          description: 'Administrator',
-          permissions: opts.permissions || [{ name: 'perm-1' }]
-        }
-      }],
-      telephone_number: opts.telephone_number || '922037',
-      otp_key: opts.otp_key || '56609',
-      disabled: opts.disabled || false,
-      login_counter: opts.login_counter || 0,
-      session_version: opts.session_version || 0
-    }
-    return {
-      getPactified: () => {
-        return pactUsers.pactify(data)
-      },
-      getAsObject: () => {
-        return new User(data)
-      },
-      getPlain: () => {
-        return data
-      }
-    }
-  },
+  /**
+   * @deprecated - use {@link validUserResponse}
+   */
   validUser: (opts = {}) => {
     const newExternalId = opts.external_id || '121391373c1844dd99cb3416b70785c8'
     const newUsername = 'm87bmh'
@@ -283,7 +214,7 @@ module.exports = {
     const collectBillingAddress = (opts.collect_billing_address && opts.collect_billing_address === true)
     const currentGoLiveStage = opts.current_go_live_stage || goLiveStage.NOT_STARTED
 
-    const data = {
+    const userOpts = {
       external_id: opts.external_id || newExternalId,
       username: opts.username || newUsername,
       email: opts.email || `${newUsername}@example.com`,
@@ -309,83 +240,9 @@ module.exports = {
       second_factor: opts.second_factor || 'SMS',
       provisional_otp_key: opts.provisional_otp_key || '60400'
     }
-    return {
-      getPactified: () => {
-        return pactUsers.pactify(data)
-      },
-      getAsObject: () => {
-        return new User(data)
-      },
-      getPlain: () => {
-        return data
-      }
-    }
-  },
 
-  /**
-   * @param opts Params override response
-   * @return {{getPactified: (function()) Pact response, getAsObject: (function()) User, getPlain: (function()) request with overrides applied}}
-   */
-  validUserResponse: (opts = {}) => {
-    const existingExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
-    const reqExternalId = opts.external_id || existingExternalId
-    const reqEmail = opts.email || `${opts.username || 'existing-user'}@example.com`
-    const defaultServiceId = 'cp5wa'
-    const defaultServiceName = 'System Generated'
-    const gatewayAccountIds = opts.gateway_account_ids || [758, 772]
-    const merchantDetails = opts.merchant_details || {}
-    const merchantName = merchantDetails.name || 'updated-merchant-details-name'
-    const merchantTelephoneNumber = merchantDetails.telephone_number || '03069990000'
-    const merchantEmail = merchantDetails.email || 'dd-merchant@example.com'
-    const merchantAddressLine1 = merchantDetails.address_line1 || 'updated-merchant-details-addressline1'
-    const merchantAddressLine2 = merchantDetails.address_line2 || 'updated-merchant-details-addressline2'
-    const merchantAddressCity = merchantDetails.address_city || 'updated-merchant-details-city'
-    const merchantAddressPostcode = merchantDetails.address_postcode || 'updated-merchant-details-postcode'
-    const merchantAddressCountry = merchantDetails.address_country || 'updated-merchant-details-country'
-    const collectBillingAddress = opts.collect_billing_address || false
-    const currentGoLiveStage = opts.current_go_live_stage || goLiveStage.NOT_STARTED
-
-    const data = {
-      external_id: reqExternalId,
-      username: reqEmail,
-      email: reqEmail,
-      service_roles: opts.service_roles || [{
-        service: {
-          name: defaultServiceName,
-          external_id: defaultServiceId,
-          gateway_account_ids: gatewayAccountIds,
-          service_name: {
-            en: defaultServiceName
-          },
-          merchant_details: {
-            name: merchantName,
-            telephone_number: merchantTelephoneNumber,
-            email: merchantEmail,
-            address_line1: merchantAddressLine1,
-            address_line2: merchantAddressLine2,
-            address_city: merchantAddressCity,
-            address_postcode: merchantAddressPostcode,
-            address_country: merchantAddressCountry
-          },
-          collect_billing_address: collectBillingAddress,
-          current_go_live_stage: currentGoLiveStage
-        },
-        role: {
-          name: 'admin',
-          description: 'Administrator',
-          permissions: [{ name: 'perm-1' }, { name: 'perm-2' }, { name: 'perm-3' }]
-        }
-      }],
-      otp_key: opts.otp_key || '43c3c4t',
-      telephone_number: opts.telephone_number || '0123441',
-      '_links': [{
-        'href': `http://adminusers.service/v1/api/users/${reqExternalId}`,
-        'rel': 'self',
-        'method': 'GET'
-      }],
-      second_factor: opts.second_factor || 'SMS',
-      provisional_otp_key: opts.provisional_otp_key || '55970'
-    }
+    // pass this through the known valid structure builder to ensure structure is correct
+    const data = buildUserWithDefaults(userOpts)
 
     return {
       getPactified: () => {
@@ -405,40 +262,7 @@ module.exports = {
    * @return {{getPactified: (function()) Pact response, getAsObject: (function()) User, getPlain: (function()) request with overrides applied}}
    */
   validMultipleUserResponse: (opts = []) => {
-    if (opts.length === 0) opts.push({})
-    const data = []
-
-    opts.forEach(intendedUser => {
-      const externalId = intendedUser.external_id || '8d8db4f2ad7d4c0c8373a09d9e95468b'
-      const username = intendedUser.username || 'b9g0vm'
-      const gatewayAccountIds = intendedUser.gateway_account_ids || ['213', '270']
-
-      data.push({
-        external_id: externalId,
-        username: username,
-        email: intendedUser.email || `${username}@example.com`,
-        service_roles: intendedUser.service_roles || [{
-          service: {
-            name: 'System Generated',
-            external_id: '0a9aa1216b93460a963f125b3f12e530',
-            gateway_account_ids: gatewayAccountIds
-          },
-          role: {
-            name: 'admin',
-            description: 'Administrator',
-            permissions: intendedUser.permissions || [{ name: 'perm-1' }, { name: 'perm-2' }, { name: 'perm-3' }]
-          }
-        }],
-        otp_key: intendedUser.otp_key || '7200b91bc4ba4eac958d3d7c33f119b1',
-        telephone_number: intendedUser.telephone_number || '07700 91044',
-        '_links': [{
-          'href': `http://adminusers.service/v1/api/users/${externalId}`,
-          'rel': 'self',
-          'method': 'GET'
-        }]
-      })
-    })
-
+    const data = opts.map(buildUserWithDefaults)
     return {
       getPactified: () => {
         return data.map(pactUsers.pactify)
@@ -498,7 +322,7 @@ module.exports = {
   validUpdatePasswordRequest: (token, newPassword) => {
     const request = {
       forgotten_password_code: token || '5ylaem',
-      new_password: newPassword || validPassword()
+      new_password: newPassword || 'G0VUkPay2017Rocks'
     }
 
     return pactUsers.withPactified(request)
@@ -547,29 +371,20 @@ module.exports = {
     }
   },
 
-  validPasswordAuthenticateResponse: (opts = {}) => {
-    const serviceRoles = opts.service_roles ? lodash.flatMap(opts.service_roles, buildServiceRole) : [buildServiceRole()]
-    const response = {
-      external_id: opts.external_id || '7d19aff33f8948deb97ed16b2912dcd3',
-      username: opts.username || 'some-user@gov.uk',
-      email: opts.email || 'some-user@gov.uk',
-      otp_key: opts.otp_key || 'krb6fcianbdjkt01ecvi08jcln',
-      telephone_number: opts.telephone_number || '9127979',
-      service_roles: serviceRoles,
-      second_factor: opts.second_factor || 'SMS',
-      provisional_otp_key: opts.provisional_otp_key || 'a-provisional-key',
-      provisional_otp_key_created_at: opts.provisional_otp_key_created_at || null,
-      disabled: opts.disabled || false,
-      login_counter: opts.login_counter || 0,
-      session_version: opts.session_version || 0,
-      _links: opts._links || [{
-        rel: 'self',
-        method: 'GET',
-        href: 'http://localhost:8080/v1/api/users/09283568e105442da3928d1fa99fb0eb'
-      }]
-    }
+  validUserResponse: (opts = {}) => {
+    const data = buildUserWithDefaults(opts)
 
-    return pactUsers.withPactified(response)
+    return {
+      getPactified: () => {
+        return pactUsers.pactify(data)
+      },
+      getAsObject: () => {
+        return new User(data)
+      },
+      getPlain: () => {
+        return data
+      }
+    }
   },
 
   invalidPasswordAuthenticateResponse: () => {

--- a/test/integration/login_controller_test.js
+++ b/test/integration/login_controller_test.js
@@ -300,8 +300,14 @@ describe('direct login after user registration', function () {
 
     let userResponse = userFixtures.validUserResponse({
       external_id: userExternalId,
+      username: email,
       email: email,
-      gateway_account_ids: [gatewayAccountId]}).getPlain()
+      service_roles: [{
+        service: {
+          gateway_account_ids: [gatewayAccountId]
+        }
+      }]
+    }).getPlain()
 
     adminusersMock.get(`${USER_RESOURCE}/${userExternalId}`)
       .reply(200, userResponse)

--- a/test/integration/service_users_ft_test.js
+++ b/test/integration/service_users_ft_test.js
@@ -41,22 +41,27 @@ describe('service users resource', () => {
 
   it('get list of service users should link to my profile for my user', done => {
     const externalServiceId = '734rgw76jhka'
-    const serviceRoles = [{
-      service: {
-        name: 'System Generated',
-        external_id: externalServiceId
-      },
-      role: {name: 'admin', description: 'Administrator', permissions: [{name: 'users-service:create'}]}
-    }]
-    const user = session.getUser({
+    let userOpts = {
       external_id: EXTERNAL_ID_LOGGED_IN,
       username: USERNAME_LOGGED_IN,
       email: USERNAME_LOGGED_IN,
-      service_roles: serviceRoles
-    })
-
-    const serviceUsersRes = userServiceFixtures.validServiceUsersResponse([{service_roles: serviceRoles}])
+      service_roles: [{
+        service: {
+          name: 'System Generated',
+          external_id: externalServiceId
+        },
+        role: {
+          name: 'admin',
+          description: 'Administrator',
+          permissions: [{
+            name: 'users-service:create'
+          }]
+        }
+      }]
+    }
+    const serviceUsersRes = userServiceFixtures.validServiceUsersResponse([userOpts])
     const getInvitesRes = serviceFixtures.validListInvitesForServiceResponse()
+    const user = userFixtures.validUserResponse(userOpts).getAsObject()
 
     adminusersMock.get(`${SERVICE_RESOURCE}/${externalServiceId}/users`)
       .reply(200, serviceUsersRes.getPlain())

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -158,12 +158,12 @@ describe('Transaction download endpoints', function () {
         .reply(200, {
           results: results
         })
-      const user = userFixture.validUser({
+      const user = userFixture.validUserResponse({
         external_id: '1stUserId',
         username: 'first_user_name'
       }).getPlain()
 
-      const user2 = userFixture.validUser({
+      const user2 = userFixture.validUserResponse({
         external_id: '2ndUserId',
         username: 'second_user_name'
       }).getPlain()

--- a/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
+++ b/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
@@ -38,7 +38,7 @@ describe('adminusers client - authenticate', () => {
   const validPassword = 'some-valid-password'
 
   describe('user is authenticated successfully', () => {
-    const validPasswordResponse = userFixtures.validPasswordAuthenticateResponse({ username: existingUsername })
+    const validPasswordResponse = userFixtures.validUserResponse({ username: existingUsername })
     const validPasswordRequestPactified = userFixtures
       .validPasswordAuthenticateRequest({
         username: existingUsername,

--- a/test/unit/clients/adminusers_client/user/assign_servicerole_test.js
+++ b/test/unit/clients/adminusers_client/user/assign_servicerole_test.js
@@ -32,7 +32,7 @@ describe('adminusers client - assign service role to user', function () {
     let userExternalId = 'existing-user'
     let serviceExternalId = 'random-service-id'
     let request = userFixtures.validAssignServiceRoleRequest(serviceExternalId, role)
-    let userFixture = userFixtures.validUser({
+    let userFixture = userFixtures.validUserResponse({
       external_id: userExternalId,
       service_roles: [{
         service: {
@@ -48,8 +48,6 @@ describe('adminusers client - assign service role to user', function () {
       }]
     })
 
-    let userResponse = userFixture.getPlain()
-
     before((done) => {
       provider.addInteraction(
         new PactInteractionBuilder(`${USER_PATH}/${userExternalId}/services`)
@@ -58,7 +56,7 @@ describe('adminusers client - assign service role to user', function () {
           .withMethod('POST')
           .withRequestBody(request.getPactified())
           .withStatusCode(200)
-          .withResponseBody(userFixtures.validUserResponse(userResponse).getPactified())
+          .withResponseBody(userFixture.getPactified())
           .build()
       ).then(() => done())
     })

--- a/test/unit/clients/adminusers_client/user/authenticate_test.js
+++ b/test/unit/clients/adminusers_client/user/authenticate_test.js
@@ -30,7 +30,7 @@ describe('adminusers client - authenticate', function () {
 
   describe('authenticate user API - success', () => {
     let request = userFixtures.validAuthenticateRequest({username: 'existing-user'})
-    let validUserResponse = userFixtures.validUserResponse(request.getPlain())
+    let validUserResponse = userFixtures.validUserResponse()
 
     before((done) => {
       provider.addInteraction(

--- a/test/unit/clients/adminusers_client/user/get_multiple_users_test.js
+++ b/test/unit/clients/adminusers_client/user/get_multiple_users_test.js
@@ -36,7 +36,11 @@ describe('adminusers client - get users', function () {
     let params = existingExternalIds.map(existingExternalId => {
       return {
         external_id: existingExternalId,
-        gateway_account_ids: ['666', '7']
+        service_roles: [{
+          service: {
+            gateway_account_ids: ['666', '7']
+          }
+        }]
       }
     })
 

--- a/test/unit/clients/adminusers_client/user/get_user_test.js
+++ b/test/unit/clients/adminusers_client/user/get_user_test.js
@@ -35,7 +35,7 @@ describe('adminusers client - get user', () => {
 
   describe('find a valid user', () => {
     const existingExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
-    const getUserResponse = userFixtures.validPasswordAuthenticateResponse({ external_id: existingExternalId })
+    const getUserResponse = userFixtures.validUserResponse({ external_id: existingExternalId })
 
     before(done => {
       provider.addInteraction(

--- a/test/unit/clients/adminusers_client/user/second_factor_test.js
+++ b/test/unit/clients/adminusers_client/user/second_factor_test.js
@@ -73,8 +73,8 @@ describe('adminusers client', function () {
   describe('authenticate a second factor API - success', () => {
     let token = '121212'
     let request = userFixtures.validAuthenticateSecondFactorRequest(token)
-    let minimalUser = userFixtures.validMinimalUser()
-    let externalId = minimalUser.getPlain().external_id
+    let response = userFixtures.validUserResponse()
+    let externalId = response.getPlain().external_id
 
     before((done) => {
       provider.addInteraction(
@@ -82,7 +82,7 @@ describe('adminusers client', function () {
           .withState('a user exists')
           .withUponReceiving('a valid authenticate second factor token request')
           .withRequestBody(request.getPactified())
-          .withResponseBody(userFixtures.validUserResponse(minimalUser.getPlain()).getPactified())
+          .withResponseBody(response.getPactified())
           .withMethod('POST')
           .build()
       ).then(() => done())

--- a/test/unit/clients/adminusers_client/user/update_servicerole_test.js
+++ b/test/unit/clients/adminusers_client/user/update_servicerole_test.js
@@ -30,7 +30,11 @@ describe('adminusers client - update user service role', function () {
   describe('update user service role API - success', () => {
     let role = 'view-and-refund'
     let request = userFixtures.validUpdateServiceRoleRequest(role)
-    let userFixture = userFixtures.validUser({role: {name: role, description: `${role}-description`}})
+    let userFixture = userFixtures.validUserResponse({
+      service_roles: [{
+        role: { name: role, description: `${role}-description` }
+      }]
+    })
     let user = userFixture.getPlain()
 
     before((done) => {
@@ -41,7 +45,7 @@ describe('adminusers client - update user service role', function () {
           .withMethod('PUT')
           .withRequestBody(request.getPactified())
           .withStatusCode(200)
-          .withResponseBody(userFixtures.validUserResponse(user).getPactified())
+          .withResponseBody(userFixture.getPactified())
           .build()
       ).then(() => done())
     })

--- a/test/unit/clients/connector_client/connector_get_transaction_details_test.js
+++ b/test/unit/clients/connector_client/connector_get_transaction_details_test.js
@@ -125,7 +125,6 @@ describe('connector client', function () {
         }
       ]
     })
-    console.log('RESPONSE: ' + JSON.stringify(validGetChargeEventsResponse));
 
     before((done) => {
       const pactified = validGetChargeEventsResponse.getPactified()

--- a/test/unit/controller/billing-address-controller/toggle-billing-address-controller.test.js
+++ b/test/unit/controller/billing-address-controller/toggle-billing-address-controller.test.js
@@ -27,14 +27,21 @@ describe('Toggle billing address collection controller', () => {
   })
   const EXTERNAL_ID_IN_SESSION = 'exsfjpwoi34op23i4'
   const EXTERNAL_SERVICE_ID = 'dsfkbskjalksjdlk342'
-  let userFixtureOpts = {
-    default_service_id: EXTERNAL_SERVICE_ID,
-    collect_billing_address: true,
-    permissions: [{name: 'toggle-billing-address:read'}, {name: 'toggle-billing-address:update'}]
+
+  const buildUserWithCollectBillingAddress = (collectBillingAddress) => {
+    return userFixtures.validUserResponse({
+      service_roles: [{
+        service: {
+          external_id: EXTERNAL_SERVICE_ID,
+          collect_billing_address: collectBillingAddress
+        }
+      }]
+    })
   }
+
   describe('should get index with billing address on', () => {
     before(done => {
-      user = userFixtures.validUser(userFixtureOpts)
+      user = buildUserWithCollectBillingAddress(true)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user.getPlain())
       const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
@@ -55,8 +62,7 @@ describe('Toggle billing address collection controller', () => {
   })
   describe('should get index with billing address off', () => {
     before(done => {
-      userFixtureOpts.collect_billing_address = false
-      user = userFixtures.validUser(userFixtureOpts)
+      user = buildUserWithCollectBillingAddress(false)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user.getPlain())
       const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
@@ -77,8 +83,7 @@ describe('Toggle billing address collection controller', () => {
   })
   describe('should get warning with billing address off', () => {
     before(done => {
-      userFixtureOpts.collect_billing_address = true
-      user = userFixtures.validUser(userFixtureOpts)
+      user = buildUserWithCollectBillingAddress(true)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user.getPlain())
       const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
@@ -103,8 +108,7 @@ describe('Toggle billing address collection controller', () => {
   })
   describe('should redirect to index on enable billing address', () => {
     before(done => {
-      userFixtureOpts.collect_billing_address = true
-      user = userFixtures.validUser(userFixtureOpts)
+      user = buildUserWithCollectBillingAddress(true)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user.getPlain())
       adminusersMock.patch(`${SERVICES_RESOURCE}/${EXTERNAL_SERVICE_ID}`)
@@ -133,8 +137,7 @@ describe('Toggle billing address collection controller', () => {
   })
   describe('should redirect to index on disable billing address', () => {
     before(done => {
-      userFixtureOpts.collect_billing_address = false
-      user = userFixtures.validUser(userFixtureOpts)
+      user = buildUserWithCollectBillingAddress(false)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user.getPlain())
       adminusersMock.patch(`${SERVICES_RESOURCE}/${EXTERNAL_SERVICE_ID}`)

--- a/test/unit/controller/edit_merchant_details_controller/get-index.test.js
+++ b/test/unit/controller/edit_merchant_details_controller/get-index.test.js
@@ -46,7 +46,7 @@ describe('Organisation details controller - get', () => {
         external_id: EXTERNAL_ID_IN_SESSION,
         service_roles: serviceRoles
       })
-      user = userFixtures.validUserWithMerchantDetails(userInSession)
+      user = userFixtures.validUserResponse(userInSession)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user.getPlain())
       const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
@@ -98,7 +98,7 @@ describe('Organisation details controller - get', () => {
         external_id: EXTERNAL_ID_IN_SESSION,
         service_roles: serviceRoles
       })
-      user = userFixtures.validUserWithMerchantDetails(userInSession)
+      user = userFixtures.validUserResponse(userInSession)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user.getPlain())
       const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
@@ -143,7 +143,7 @@ describe('Organisation details controller - get', () => {
         external_id: EXTERNAL_ID_IN_SESSION,
         service_roles: serviceRoles
       })
-      user = userFixtures.validUserWithMerchantDetails(userInSession)
+      user = userFixtures.validUserResponse(userInSession)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user.getPlain())
       const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
@@ -182,7 +182,7 @@ describe('Organisation details controller - get', () => {
         external_id: EXTERNAL_ID_IN_SESSION,
         service_roles: serviceRoles
       })
-      user = userFixtures.validUserWithMerchantDetails(userInSession)
+      user = userFixtures.validUserResponse(userInSession)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user.getPlain())
       const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)
@@ -221,7 +221,7 @@ describe('Organisation details controller - get', () => {
         external_id: EXTERNAL_ID_IN_SESSION,
         service_roles: serviceRoles
       })
-      user = userFixtures.validUserWithMerchantDetails(userInSession)
+      user = userFixtures.validUserResponse(userInSession)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user.getPlain())
       const app = mockSession.getAppWithLoggedInUser(getApp(), userInSession)

--- a/test/unit/controller/service_switch_controller_test.js
+++ b/test/unit/controller/service_switch_controller_test.js
@@ -147,7 +147,11 @@ describe('service switch controller: switching', function () {
       originalUrl: 'http://bob.com?accountId=6',
       user: userFixtures.validUserResponse({
         username: 'bob',
-        gateway_account_ids: ['6', '5']
+        service_roles: [{
+          service: {
+            gateway_account_ids: ['6', '5']
+          }
+        }]
       }).getAsObject(),
       session: session,
       gateway_account: gatewayAccount,

--- a/test/unit/middleware/has_services_test.js
+++ b/test/unit/middleware/has_services_test.js
@@ -23,8 +23,8 @@ describe('user has services middleware', function () {
   })
 
   it('should call next when user has services', function (done) {
-    const user = userFixtures.validUser({
-      services_roles: [{service: {external_id: '1'}}],
+    const user = userFixtures.validUserResponse({
+      services_roles: [{ service: { external_id: '1' } }],
       external_id: 'external-id'
     }).getAsObject()
 

--- a/test/unit/middleware/resolve_service_test.js
+++ b/test/unit/middleware/resolve_service_test.js
@@ -8,13 +8,23 @@ const {expect} = require('chai')
 const resolveService = require('../../../app/middleware/resolve_service')
 const userFixtures = require('../../fixtures/user_fixtures')
 
+const buildUserWithGatewayAccountIds = (gatewayAccountIds) => {
+  return userFixtures.validUserResponse({
+    service_roles: [{
+      service: {
+        gateway_account_ids: gatewayAccountIds
+      }
+    }]
+  }).getAsObject()
+}
+
 describe('resolve service middleware', () => {
   let res, nextSpy, user
 
   beforeEach(() => {
     res = { setHeader: sinon.spy(), status: sinon.spy(), render: sinon.spy() }
     nextSpy = sinon.spy()
-    user = userFixtures.validUser().getAsObject()
+    user = userFixtures.validUserResponse().getAsObject()
   })
 
   it('from externalServiceId in path param then remove it', () => {
@@ -90,9 +100,7 @@ describe('resolve types of gateway within a service', () => {
   })
 
   it('service.hasDirectDebitGatewayAccount is true and service.hasCardGatewayAccount is false when we have Direct Debit gateway accounts only', () => {
-    const user = userFixtures.validUser({
-      gateway_account_ids: ['DIRECT_DEBIT:randomidhere']
-    }).getAsObject()
+    const user = buildUserWithGatewayAccountIds(['DIRECT_DEBIT:randomidhere'])
     const req = {user: user, params: {externalServiceId: user.serviceRoles[0].service.externalId}}
 
     resolveService(req, res, nextSpy)
@@ -104,9 +112,7 @@ describe('resolve types of gateway within a service', () => {
   })
 
   it('service.hasCardGatewayAccount is true and service.hasDirectDebitGatewayAccount is false when we have Card gateway accounts only', () => {
-    const user = userFixtures.validUser({
-      gateway_account_ids: ['7127217']
-    }).getAsObject()
+    const user = buildUserWithGatewayAccountIds(['7127217'])
     const req = {user: user, params: {externalServiceId: user.serviceRoles[0].service.externalId}}
 
     resolveService(req, res, nextSpy)
@@ -118,9 +124,7 @@ describe('resolve types of gateway within a service', () => {
   })
 
   it('service.hasCardAndDirectDebitGatewayAccount is true when we have Direct Debit and Card gateway accounts', () => {
-    const user = userFixtures.validUser({
-      gateway_account_ids: ['7127217', 'DIRECT_DEBIT:randomidhere']
-    }).getAsObject()
+    const user = buildUserWithGatewayAccountIds(['7127217', 'DIRECT_DEBIT:randomidhere'])
     const req = {user: user, params: {externalServiceId: user.serviceRoles[0].service.externalId}}
 
     resolveService(req, res, nextSpy)

--- a/test/unit/models/User.class_test.js
+++ b/test/unit/models/User.class_test.js
@@ -61,7 +61,7 @@ describe('Class: User', () => {
   describe('Method: getPermissionsForService', () => {
     it('should return flattened permissions from a serviceRole of a user', () => {
       result = user.getPermissionsForService(service.externalId)
-      expect(result).to.include('perm-1')
+      expect(result).to.include(permission)
     })
   })
 })

--- a/test/unit/models/charge_test.js
+++ b/test/unit/models/charge_test.js
@@ -110,7 +110,7 @@ describe('charge model', function () {
 
     describe('when connector returns correctly', function () {
       it('should return the correct promise', function () {
-        let user = userFixtures.validUser().getPlain()
+        let user = userFixtures.validUserResponse().getPlain()
         // Create a class that inherits from EventEmitter and emit a 'connectorError' event which is handled by the service
         class StubConnectorChargeFunctions extends EventEmitter {
           getCharge (params, callback) {


### PR DESCRIPTION
## WHAT
- get closer to only having a single fixture to create a user for test purposes, this means that if the user model changes, it only needs to be updated in a single place for all tests
- replace most duplicated fixtures by use of getUserResponse fixture
- deprecate user_fixtures#getUser, this isn't removed yet as it has a lot of usages

## HOW
Viewing as side-by-side diff might be easier than unified

