### PR TITLE
PP-4678 Remove duplicated service fixtures

### DIFF
--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -425,7 +425,7 @@ module.exports = {
         responses: [{
           is: {
             statusCode: 200,
-            body: serviceFixtures.buildServiceWithDefaults(opts).getPlain(),
+            body: serviceFixtures.validServiceResponse(opts).getPlain(),
             headers: {
               'Content-Type': 'application/json'
             }

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -40,6 +40,21 @@ const buildMerchantDetailsWithDefaults = (opts = {}) => {
   return merchantDetails
 }
 
+const buildServiceNameWithDefaults = (opts = {}) => {
+  _.defaults(opts, {
+    en: 'System Generated'
+  })
+
+  const serviceName = {
+    en: opts.en
+  }
+  if (opts.cy) {
+    serviceName.cy = opts.cy
+  }
+
+  return serviceName
+}
+
 module.exports = {
 
   getServiceUsersNotFoundResponse: () => {
@@ -93,42 +108,17 @@ module.exports = {
     }
   },
 
-  validCreateServiceResponse: (opts) => {
-    opts = opts || {}
-
-    const externalId = opts.external_id || 'externalId'
-    const serviceName = opts.name || 'System Generated'
-    const gatewayAccountIds = opts.gateway_account_ids || []
-
-    const data = {
-      external_id: externalId,
-      name: serviceName,
-      gateway_account_ids: gatewayAccountIds
-    }
-
-    return {
-      getPactified: () => {
-        return pactServices.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
-    }
-  },
-
-  validUpdateServiceNameRequestWithEnAndCy: (opts) => {
-    opts = opts || {}
-
+  validUpdateServiceNameRequestWithEnAndCy: (opts = {}) => {
     const data = [
       {
         op: 'replace',
         path: 'service_name/en',
-        value: opts.name || 'new-en-name'
+        value: opts.en || 'new-en-name'
       },
       {
         op: 'replace',
         path: 'service_name/cy',
-        value: opts.nameCy || 'new-cy-name'
+        value: opts.cy || 'new-cy-name'
       }
     ]
 
@@ -142,40 +132,12 @@ module.exports = {
     }
   },
 
-  validUpdateServiceNameResponseWithEnAndCy: (opts) => {
-    opts = opts || {}
-
-    const externalId = opts.external_id || 'externalId'
-    const serviceName = opts.name || 'new-en-name'
-    const serviceNameCy = opts.nameCy || 'new-cy-name'
-
-    const data = {
-      external_id: externalId,
-      name: serviceName,
-      service_name: {
-        en: serviceName,
-        cy: serviceNameCy
-      }
-    }
-
-    return {
-      getPactified: () => {
-        return pactServices.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
-  },
-
-  validUpdateServiceNameRequestWithEn: (opts) => {
-    opts = opts || {}
-
+  validUpdateServiceNameRequestWithEn: (name = 'new-en-name') => {
     const data = [
       {
         op: 'replace',
         path: 'service_name/en',
-        value: opts.name || 'new-en-name'
+        value: name
       },
       {
         op: 'replace',
@@ -194,33 +156,7 @@ module.exports = {
     }
   },
 
-  validUpdateServiceNameResponseWithEn: (opts) => {
-    opts = opts || {}
-
-    const externalId = opts.external_id || 'externalId'
-    const serviceName = opts.name || 'new-en-name'
-
-    const data = {
-      external_id: externalId,
-      name: serviceName,
-      service_name: {
-        en: serviceName
-      }
-    }
-
-    return {
-      getPactified: () => {
-        return pactServices.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
-  },
-
-  validUpdateServiceNameRequestWithCy: (opts) => {
-    opts = opts || {}
-
+  validUpdateServiceNameRequestWithCy: (name = 'new-cy-name') => {
     const data = [
       {
         op: 'replace',
@@ -230,54 +166,7 @@ module.exports = {
       {
         op: 'replace',
         path: 'service_name/cy',
-        value: opts.name || 'new-cy-name'
-      }
-    ]
-
-    return {
-      getPactified: () => {
-        return pactServices.pactifySimpleArray(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
-  },
-
-  validUpdateServiceNameResponseWithCy: (opts) => {
-    opts = opts || {}
-
-    const externalId = opts.external_id || 'externalId'
-    const serviceName = opts.name || 'new-en-name'
-    const serviceNameCy = opts.nameCy || 'new-cy-name'
-
-    const data = {
-      external_id: externalId,
-      name: serviceName,
-      service_name: {
-        en: serviceName,
-        cy: serviceNameCy
-      }
-    }
-
-    return {
-      getPactified: () => {
-        return pactServices.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
-  },
-
-  badRequestWithInvalidPathWhenUpdateServiceNameRequest: (opts) => {
-    opts = opts || {}
-
-    const data = [
-      {
-        op: 'replace',
-        path: 'invalid-path',
-        value: opts.name || 'updated-service-name'
+        value: name
       }
     ]
 
@@ -300,44 +189,6 @@ module.exports = {
       address_city: opts.address_city || 'updated-merchant-details-city',
       address_postcode: opts.address_postcode || 'updated-merchant-details-postcode',
       address_country: opts.address_country || 'updated-merchant-details-country'
-    }
-
-    return {
-      getPactified: () => {
-        return pactServices.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
-  },
-  validUpdateMerchantDetailsResponse: (opts) => {
-    opts = opts || {}
-    const externalId = opts.external_id || 'externalId'
-    const serviceName = opts.name || 'updated-service-name'
-    const merchantDetails = opts.merchant_details || {}
-    const merchantName = merchantDetails.name || 'updated-merchant-details-name'
-    const merchantTelephoneNumber = merchantDetails.telephone_number || '03069990000'
-    const merchantEmail = merchantDetails.email || 'dd-merchant@example.com'
-    const merchantAddressLine1 = merchantDetails.address_line1 || 'updated-merchant-details-addressline1'
-    const merchantAddressLine2 = merchantDetails.address_line2 || 'updated-merchant-details-addressline2'
-    const merchantAddressCity = merchantDetails.address_city || 'updated-merchant-details-city'
-    const merchantAddressPostcode = merchantDetails.address_postcode || 'updated-merchant-details-postcode'
-    const merchantAddressCountry = merchantDetails.address_country || 'updated-merchant-details-country'
-
-    const data = {
-      external_id: externalId,
-      name: serviceName,
-      merchant_details: {
-        name: merchantName,
-        telephone_number: merchantTelephoneNumber,
-        email: merchantEmail,
-        address_line1: merchantAddressLine1,
-        address_line2: merchantAddressLine2,
-        address_city: merchantAddressCity,
-        address_postcode: merchantAddressPostcode,
-        address_country: merchantAddressCountry
-      }
     }
 
     return {
@@ -436,24 +287,6 @@ module.exports = {
     }
   },
 
-  validCollectBillingAddressToggleResponse: (opts) => {
-    opts = opts || {}
-
-    const data = {
-      external_id: opts.external_id || 'externalId',
-      collect_billing_address: opts.collect_billing_address || false
-    }
-
-    return {
-      getPactified: () => {
-        return pactServices.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
-  },
-
   validUpdateServiceRequest: (opts) => {
     opts = opts || {}
 
@@ -473,18 +306,31 @@ module.exports = {
     }
   },
 
-  buildServiceWithDefaults: (opts = {}) => {
+  validServiceResponse: (opts = {}) => {
+    _.defaultsDeep(opts, {
+      id: 857,
+      external_id: 'cp5wa',
+      name: 'System Generated',
+      gateway_account_ids: ['666'],
+      links: [],
+      service_name: {
+        en: 'System Generated'
+      },
+      redirect_to_service_immediately_on_terminal_state: false,
+      collect_billing_address: false,
+      current_go_live_stage: 'NOT_STARTED'
+    })
+
     const service = {
-      id: opts.id || 857,
-      external_id: opts.external_id || 'cp5wa',
-      name: opts.name || 'System Generated',
-      gateway_account_ids: opts.gateway_account_ids || [
-        '666'
-      ],
-      _links: opts.links || [],
-      redirect_to_service_immediately_on_terminal_state: opts.redirect_to_service_immediately_on_terminal_state || false,
-      collect_billing_address: opts.collect_billing_address || false,
-      current_go_live_stage: opts.current_go_live_stage || 'NOT_STARTED'
+      id: opts.id,
+      external_id: opts.external_id,
+      name: opts.name,
+      gateway_account_ids: opts.gateway_account_ids,
+      _links: opts.links,
+      service_name: buildServiceNameWithDefaults(opts.service_name),
+      redirect_to_service_immediately_on_terminal_state: opts.redirect_to_service_immediately_on_terminal_state,
+      collect_billing_address: opts.collect_billing_address,
+      current_go_live_stage: opts.current_go_live_stage
     }
 
     if (opts.merchant_details) {

--- a/test/fixtures/user_fixtures.js
+++ b/test/fixtures/user_fixtures.js
@@ -165,7 +165,7 @@ const pactUsers = pactBase({
 
 const buildServiceRole = (opts = {}) => {
   return {
-    service: serviceFixtures.buildServiceWithDefaults(opts.service).getPlain(),
+    service: serviceFixtures.validServiceResponse(opts.service).getPlain(),
     role: buildRoleWithDefaults(opts.role)
   }
 }

--- a/test/unit/clients/adminusers_client/service/create_service_test.js
+++ b/test/unit/clients/adminusers_client/service/create_service_test.js
@@ -35,7 +35,14 @@ describe('adminusers client - create a new service', function () {
   after((done) => provider.finalize().then(done()))
 
   describe('success', () => {
-    const validCreateServiceResponse = serviceFixtures.validCreateServiceResponse()
+    const name = 'Service name'
+    const externalId = 'externalId'
+    const gatewayAccountIds = []
+    const validCreateServiceResponse = serviceFixtures.validServiceResponse({
+      name: name,
+      external_id: externalId,
+      gateway_account_ids: gatewayAccountIds
+    })
 
     before((done) => {
       provider.addInteraction(
@@ -55,16 +62,25 @@ describe('adminusers client - create a new service', function () {
 
     it('should create a new service', function (done) {
       adminusersClient.createService().should.be.fulfilled.then(service => {
-        expect(service.external_id).to.equal('externalId')
-        expect(service.name).to.equal('System Generated')
-        expect(service.gateway_account_ids).to.deep.equal([])
+        expect(service.external_id).to.equal(externalId)
+        expect(service.name).to.equal(name)
+        expect(service.gateway_account_ids).to.deep.equal(gatewayAccountIds)
       }).should.notify(done)
     })
   })
 
   describe('create a service sending gateway account ids - success', () => {
-    const validRequest = serviceFixtures.validCreateServiceRequest({gateway_account_ids: ['1', '5']})
-    const validCreateServiceResponse = serviceFixtures.validCreateServiceResponse(validRequest.getPlain())
+    const name = 'Service name'
+    const externalId = 'externalId'
+    const gatewayAccountIds = ['1', '5']
+    const validRequest = serviceFixtures.validCreateServiceRequest({
+      gateway_account_ids: gatewayAccountIds
+    })
+    const validCreateServiceResponse = serviceFixtures.validServiceResponse({
+      name: name,
+      external_id: externalId,
+      gateway_account_ids: gatewayAccountIds
+    })
 
     before((done) => {
       provider.addInteraction(
@@ -84,16 +100,23 @@ describe('adminusers client - create a new service', function () {
 
     it('should create a new service', function (done) {
       adminusersClient.createService(null, null, validRequest.getPlain().gateway_account_ids).should.be.fulfilled.then(service => {
-        expect(service.external_id).to.equal('externalId')
-        expect(service.name).to.equal('System Generated')
+        expect(service.external_id).to.equal(externalId)
+        expect(service.name).to.equal(name)
         expect(service.gateway_account_ids).to.deep.equal(validCreateServiceResponse.getPlain().gateway_account_ids)
       }).should.notify(done)
     })
   })
 
   describe('create a service sending service name - success', () => {
-    const validRequest = serviceFixtures.validCreateServiceRequest({name: 'Service name'})
-    const validCreateServiceResponse = serviceFixtures.validCreateServiceResponse(validRequest.getPlain())
+    const name = 'Service name'
+    const externalId = 'externalId'
+    const gatewayAccountIds = []
+    const validRequest = serviceFixtures.validCreateServiceRequest({ name: name })
+    const validCreateServiceResponse = serviceFixtures.validServiceResponse({
+      name: name,
+      external_id: externalId,
+      gateway_account_ids: gatewayAccountIds
+    })
 
     before((done) => {
       provider.addInteraction(
@@ -113,9 +136,9 @@ describe('adminusers client - create a new service', function () {
 
     it('should create a new service', function (done) {
       adminusersClient.createService('Service name', null, null).should.be.fulfilled.then(service => {
-        expect(service.external_id).to.equal('externalId')
-        expect(service.name).to.equal('Service name')
-        expect(service.gateway_account_ids).to.deep.equal([])
+        expect(service.external_id).to.equal(externalId)
+        expect(service.name).to.equal(name)
+        expect(service.gateway_account_ids).to.deep.equal(gatewayAccountIds)
       }).should.notify(done)
     })
   })

--- a/test/unit/clients/adminusers_client/service/update_collect_billing_address_test.js
+++ b/test/unit/clients/adminusers_client/service/update_collect_billing_address_test.js
@@ -37,7 +37,7 @@ describe('adminusers client - patch collect billing address toggle', function ()
 
   describe('patch collect billing address toggle - disabled', () => {
     const validUpdateCollectBillingAddressRequest = serviceFixtures.validCollectBillingAddressToggleRequest({enabled: false})
-    const validUpdateCollectBillingAddressResponse = serviceFixtures.validCollectBillingAddressToggleResponse({
+    const validUpdateCollectBillingAddressResponse = serviceFixtures.validServiceResponse({
       external_id: serviceExternalId,
       collect_billing_address: false
     })

--- a/test/unit/clients/adminusers_client/service/update_merchant_details_test.js
+++ b/test/unit/clients/adminusers_client/service/update_merchant_details_test.js
@@ -37,10 +37,19 @@ describe('adminusers client - update merchant details', function () {
   describe('when updating merchant details with a valid request', () => {
     const existingServiceExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
     const serviceName = 'serviceName'
-    const validUpdateMerchantDetailsRequest = serviceFixtures.validUpdateMerchantDetailsRequest()
-    const validUpdateMerchantDetailsResponse = serviceFixtures.validUpdateMerchantDetailsResponse({
+    const merchantDetails = {
+      name: 'new-name',
+      address_line1: 'new-line1',
+      address_line2: 'new-line2',
+      address_city: 'new-city',
+      address_postcode: 'new-postcode',
+      address_country: 'new-country'
+    }
+    const validUpdateMerchantDetailsRequest = serviceFixtures.validUpdateMerchantDetailsRequest(merchantDetails)
+    const validUpdateMerchantDetailsResponse = serviceFixtures.validServiceResponse({
       external_id: existingServiceExternalId,
-      name: serviceName
+      name: serviceName,
+      merchant_details: merchantDetails
     })
     let result
 

--- a/test/unit/clients/adminusers_client/service/update_service_name_test.js
+++ b/test/unit/clients/adminusers_client/service/update_service_name_test.js
@@ -36,9 +36,15 @@ describe('adminusers client - update service name', function () {
 
   describe('success with en and cy', () => {
     const existingServiceExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
-    const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequestWithEnAndCy()
-    const validUpdateServiceNameResponse = serviceFixtures.validUpdateServiceNameResponseWithEnAndCy({
-      external_id: existingServiceExternalId
+    const serviceName = {
+      en: 'en-name',
+      cy: 'cy-name'
+    }
+    const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequestWithEnAndCy(serviceName)
+    const validUpdateServiceNameResponse = serviceFixtures.validServiceResponse({
+      name: serviceName.en,
+      external_id: existingServiceExternalId,
+      service_name: serviceName
     })
 
     before((done) => {
@@ -58,23 +64,24 @@ describe('adminusers client - update service name', function () {
     afterEach(() => provider.verify())
 
     it('should update service name for en and cy', function (done) {
-      const serviceNameEn = validUpdateServiceNameRequest.getPlain()[0].value
-      const serviceNameCy = validUpdateServiceNameRequest.getPlain()[1].value
-      adminusersClient.updateServiceName(existingServiceExternalId, serviceNameEn, serviceNameCy)
+      adminusersClient.updateServiceName(existingServiceExternalId, serviceName.en, serviceName.cy)
         .should.be.fulfilled.then(service => {
           expect(service.external_id).to.equal(existingServiceExternalId)
-          expect(service.name).to.equal(serviceNameEn)
-          expect(service.service_name.en).to.equal(serviceNameEn)
-          expect(service.service_name.cy).to.equal(serviceNameCy)
+          expect(service.name).to.equal(serviceName.en)
+          expect(service.service_name.en).to.equal(serviceName.en)
+          expect(service.service_name.cy).to.equal(serviceName.cy)
         }).should.notify(done)
     })
   })
 
   describe('success with en', () => {
     const existingServiceExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
-    const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequestWithEn()
-    const validUpdateServiceNameResponse = serviceFixtures.validUpdateServiceNameResponseWithEn({
-      external_id: existingServiceExternalId
+    const serviceNameEn = 'en-name'
+    const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequestWithEn(serviceNameEn)
+    const validUpdateServiceNameResponse = serviceFixtures.validServiceResponse({
+      name: serviceNameEn,
+      external_id: existingServiceExternalId,
+      service_name: { en: serviceNameEn }
     })
 
     before((done) => {
@@ -94,7 +101,6 @@ describe('adminusers client - update service name', function () {
     afterEach(() => provider.verify())
 
     it('should update service name for en', function (done) {
-      const serviceNameEn = validUpdateServiceNameRequest.getPlain()[0].value
       adminusersClient.updateServiceName(existingServiceExternalId, serviceNameEn).should.be.fulfilled.then(service => {
         expect(service.external_id).to.equal(existingServiceExternalId)
         expect(service.name).to.equal(serviceNameEn)
@@ -105,9 +111,11 @@ describe('adminusers client - update service name', function () {
 
   describe('success with cy', () => {
     const existingServiceExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
-    const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequestWithCy()
-    const validUpdateServiceNameResponse = serviceFixtures.validUpdateServiceNameResponseWithCy({
-      external_id: existingServiceExternalId
+    const serviceNameCy = 'cy-name'
+    const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequestWithCy(serviceNameCy)
+    const validUpdateServiceNameResponse = serviceFixtures.validServiceResponse({
+      external_id: existingServiceExternalId,
+      service_name: { cy: serviceNameCy }
     })
 
     before((done) => {
@@ -127,8 +135,6 @@ describe('adminusers client - update service name', function () {
     afterEach(() => provider.verify())
 
     it('should update service name for cy', function (done) {
-      const serviceNameCy = validUpdateServiceNameRequest.getPlain()[1].value
-
       adminusersClient.updateServiceName(existingServiceExternalId, null, serviceNameCy).should.be.fulfilled.then(service => {
         expect(service.external_id).to.equal(existingServiceExternalId)
         expect(service.service_name.cy).to.equal(serviceNameCy)
@@ -138,7 +144,11 @@ describe('adminusers client - update service name', function () {
 
   describe('not found', () => {
     const nonExistentServiceExternalId = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
-    const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequestWithEnAndCy()
+    const serviceName = {
+      en: 'en-name',
+      cy: 'cy-name'
+    }
+    const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequestWithEnAndCy(serviceName)
 
     before((done) => {
       provider.addInteraction(
@@ -156,9 +166,7 @@ describe('adminusers client - update service name', function () {
     afterEach(() => provider.verify())
 
     it('should return not found if service not exist', function (done) {
-      const serviceNameEn = validUpdateServiceNameRequest.getPlain()[0].value
-      const serviceNameCy = validUpdateServiceNameRequest.getPlain()[1].value
-      adminusersClient.updateServiceName(nonExistentServiceExternalId, serviceNameEn, serviceNameCy).should.be.rejected.then(response => {
+      adminusersClient.updateServiceName(nonExistentServiceExternalId, serviceName.en, serviceName.cy).should.be.rejected.then(response => {
         expect(response.errorCode).to.equal(404)
       }).should.notify(done)
     })

--- a/test/unit/controller/edit_merchant_details_controller/post-edit.test.js
+++ b/test/unit/controller/edit_merchant_details_controller/post-edit.test.js
@@ -44,7 +44,7 @@ describe('edit merchant details controller - post', () => {
   }]
   describe('when the update merchant details call is successful', () => {
     before(done => {
-      response = serviceFixtures.validUpdateMerchantDetailsResponse(serviceRoles[0].service.merchant_details).getPlain()
+      response = serviceFixtures.validServiceResponse(serviceRoles[0].service).getPlain()
       adminusersMock.put(`${SERVICE_RESOURCE}/${EXTERNAL_SERVICE_ID}/merchant-details`)
         .reply(200, response)
       const userInSession = mockSession.getUser({
@@ -90,7 +90,7 @@ describe('edit merchant details controller - post', () => {
   })
   describe('when the update merchant details call is missing mandatory fields', () => {
     before(done => {
-      response = serviceFixtures.validUpdateMerchantDetailsResponse(serviceRoles[0].service.merchant_details).getPlain()
+      response = serviceFixtures.validServiceResponse(serviceRoles[0].service).getPlain()
       adminusersMock.put(`${SERVICE_RESOURCE}/${EXTERNAL_SERVICE_ID}/merchant-details`)
         .reply(200, response)
       const userInSession = mockSession.getUser({
@@ -138,7 +138,7 @@ describe('edit merchant details controller - post', () => {
   })
   describe('when the update merchant details call has invalid postcode and the country is GB', () => {
     before(done => {
-      response = serviceFixtures.validUpdateMerchantDetailsResponse(serviceRoles[0].service.merchant_details).getPlain()
+      response = serviceFixtures.validServiceResponse(serviceRoles[0].service).getPlain()
       adminusersMock.put(`${SERVICE_RESOURCE}/${EXTERNAL_SERVICE_ID}/merchant-details`)
         .reply(200, response)
       const userInSession = mockSession.getUser({
@@ -187,7 +187,7 @@ describe('edit merchant details controller - post', () => {
   })
   describe('when the update merchant details call has invalid telephone number', () => {
     before(done => {
-      response = serviceFixtures.validUpdateMerchantDetailsResponse(serviceRoles[0].service.merchant_details).getPlain()
+      response = serviceFixtures.validServiceResponse(serviceRoles[0].service).getPlain()
       adminusersMock.put(`${SERVICE_RESOURCE}/${EXTERNAL_SERVICE_ID}/merchant-details`)
         .reply(200, response)
       const userInSession = mockSession.getUser({
@@ -236,7 +236,7 @@ describe('edit merchant details controller - post', () => {
   })
   describe('when the update merchant details call has invalid email', () => {
     before(done => {
-      response = serviceFixtures.validUpdateMerchantDetailsResponse(serviceRoles[0].service.merchant_details).getPlain()
+      response = serviceFixtures.validServiceResponse(serviceRoles[0].service).getPlain()
       adminusersMock.put(`${SERVICE_RESOURCE}/${EXTERNAL_SERVICE_ID}/merchant-details`)
         .reply(200, response)
       const userInSession = mockSession.getUser({
@@ -285,7 +285,7 @@ describe('edit merchant details controller - post', () => {
   })
   describe('when the update merchant details call has empty email', () => {
     before(done => {
-      response = serviceFixtures.validUpdateMerchantDetailsResponse(serviceRoles[0].service.merchant_details).getPlain()
+      response = serviceFixtures.validServiceResponse(serviceRoles[0].service).getPlain()
       adminusersMock.put(`${SERVICE_RESOURCE}/${EXTERNAL_SERVICE_ID}/merchant-details`)
         .reply(200, response)
       const userInSession = mockSession.getUser({
@@ -334,7 +334,7 @@ describe('edit merchant details controller - post', () => {
   })
   describe('when the update merchant details call is unsuccessful', () => {
     before(done => {
-      response = serviceFixtures.validUpdateMerchantDetailsResponse(serviceRoles[0].service.merchant_details).getPlain()
+      response = serviceFixtures.validServiceResponse(serviceRoles[0].service).getPlain()
       adminusersMock.put(`${SERVICE_RESOURCE}/${EXTERNAL_SERVICE_ID}/merchant-details`)
         .reply(400, 'Oops something went wrong')
       const userInSession = mockSession.getUser({


### PR DESCRIPTION
## WHAT
- All update service requests return a complete service in the body of the response. Use a single service fixture to build the response for all update requests.


