### PR TITLE
PP-4678 Make more adminusers pact tests run against provider

### DIFF
--- a/test/cypress/integration/user/login_spec.js
+++ b/test/cypress/integration/user/login_spec.js
@@ -1,7 +1,7 @@
 describe('Login Page', () => {
   const gatewayAccountId = 42
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
-  const validUsername = 'some-user@gov.uk'
+  const validUsername = 'some-user@example.com'
   const validPassword = 'some-valid-password'
   const invalidPassword = 'some-invalid-password'
 

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -48,7 +48,7 @@ const buildServiceNameWithDefaults = (opts = {}) => {
   const serviceName = {
     en: opts.en
   }
-  if (opts.cy) {
+  if (opts.cy !== undefined) {
     serviceName.cy = opts.cy
   }
 
@@ -56,13 +56,6 @@ const buildServiceNameWithDefaults = (opts = {}) => {
 }
 
 module.exports = {
-
-  getServiceUsersNotFoundResponse: () => {
-    let response = {
-      errors: ['service not found']
-    }
-    return pactServices.withPactified(response)
-  },
   /**
    * @param invites Array params override get invites for service response
    * @return {{getPactified: (function()) Pact response, getPlain: (function()) request with overrides applied}}
@@ -108,71 +101,28 @@ module.exports = {
     }
   },
 
-  validUpdateServiceNameRequestWithEnAndCy: (opts = {}) => {
+  validUpdateServiceNameRequest: (opts = {}) => {
+    _.defaults(opts, {
+      en: 'new-en-name',
+      cy: 'new-cy-name'
+    })
+
     const data = [
       {
         op: 'replace',
         path: 'service_name/en',
-        value: opts.en || 'new-en-name'
+        value: opts.en
       },
       {
         op: 'replace',
         path: 'service_name/cy',
-        value: opts.cy || 'new-cy-name'
+        value: opts.cy
       }
     ]
 
     return {
       getPactified: () => {
         return pactServices.pactifyNestedArray(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
-  },
-
-  validUpdateServiceNameRequestWithEn: (name = 'new-en-name') => {
-    const data = [
-      {
-        op: 'replace',
-        path: 'service_name/en',
-        value: name
-      },
-      {
-        op: 'replace',
-        path: 'service_name/cy',
-        value: ''
-      }
-    ]
-
-    return {
-      getPactified: () => {
-        return pactServices.pactifySimpleArray(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
-  },
-
-  validUpdateServiceNameRequestWithCy: (name = 'new-cy-name') => {
-    const data = [
-      {
-        op: 'replace',
-        path: 'service_name/en',
-        value: 'new-en-name'
-      },
-      {
-        op: 'replace',
-        path: 'service_name/cy',
-        value: name
-      }
-    ]
-
-    return {
-      getPactified: () => {
-        return pactServices.pactifySimpleArray(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -248,14 +198,11 @@ module.exports = {
     return pactServices.withPactified(response)
   },
 
-  addGatewayAccountsRequest: (opts) => {
-    opts = opts || {}
-    opts.gatewayAccountIds = opts.gatewayAccountIds || ['666']
-
+  addGatewayAccountsRequest: (gatewayAccountIds = ['666']) => {
     const data = {
       op: 'add',
       path: 'gateway_account_ids',
-      value: [].concat(opts.gatewayAccountIds)
+      value: gatewayAccountIds
     }
 
     return {
@@ -324,12 +271,11 @@ module.exports = {
   },
 
   validServiceResponse: (opts = {}) => {
-    _.defaultsDeep(opts, {
+    _.defaults(opts, {
       id: 857,
       external_id: 'cp5wa',
       name: 'System Generated',
       gateway_account_ids: ['666'],
-      links: [],
       service_name: {
         en: 'System Generated'
       },
@@ -343,7 +289,6 @@ module.exports = {
       external_id: opts.external_id,
       name: opts.name,
       gateway_account_ids: opts.gateway_account_ids,
-      _links: opts.links,
       service_name: buildServiceNameWithDefaults(opts.service_name),
       redirect_to_service_immediately_on_terminal_state: opts.redirect_to_service_immediately_on_terminal_state,
       collect_billing_address: opts.collect_billing_address,

--- a/test/fixtures/user_fixtures.js
+++ b/test/fixtures/user_fixtures.js
@@ -179,27 +179,41 @@ const buildRoleWithDefaults = (opts = {}) => {
 }
 
 function buildUserWithDefaults (opts) {
-  const serviceRoles = opts.service_roles ? lodash.flatMap(opts.service_roles, buildServiceRole) : [buildServiceRole()]
-  const data = {
-    external_id: opts.external_id || '7d19aff33f8948deb97ed16b2912dcd3',
-    username: opts.username || 'some-user@gov.uk',
-    email: opts.email || 'some-user@gov.uk',
-    otp_key: opts.otp_key || 'krb6fcianbdjkt01ecvi08jcln',
-    telephone_number: opts.telephone_number || '9127979',
-    service_roles: serviceRoles,
-    second_factor: opts.second_factor || 'SMS',
-    provisional_otp_key: opts.provisional_otp_key || 'a-provisional-key',
-    provisional_otp_key_created_at: opts.provisional_otp_key_created_at || null,
-    disabled: opts.disabled || false,
-    login_counter: opts.login_counter || 0,
-    session_version: opts.session_version || 0,
-    _links: opts._links || [{
+  lodash.defaults(opts, {
+    external_id: '7d19aff33f8948deb97ed16b2912dcd3',
+    username: 'some-user@gov.uk',
+    email: 'some-user@gov.uk',
+    otp_key: 'krb6fcianbdjkt01ecvi08jcln',
+    telephone_number: '9127979',
+    second_factor: 'SMS',
+    provisional_otp_key: 'a-provisional-key',
+    provisional_otp_key_created_at: null,
+    disabled: false,
+    login_counter: 0,
+    session_version: 0,
+    _links: [{
       rel: 'self',
       method: 'GET',
       href: 'http://localhost:8080/v1/api/users/09283568e105442da3928d1fa99fb0eb'
     }]
+  })
+
+  const serviceRoles = opts.service_roles ? lodash.flatMap(opts.service_roles, buildServiceRole) : [buildServiceRole()]
+  return {
+    external_id: opts.external_id,
+    username: opts.username,
+    email: opts.email,
+    otp_key: opts.otp_key,
+    telephone_number: opts.telephone_number,
+    service_roles: serviceRoles,
+    second_factor: opts.second_factor,
+    provisional_otp_key: opts.provisional_otp_key,
+    provisional_otp_key_created_at: opts.provisional_otp_key_created_at,
+    disabled: opts.disabled,
+    login_counter: opts.login_counter,
+    session_version: opts.session_version,
+    _links: opts._links
   }
-  return data
 }
 
 module.exports = {

--- a/test/fixtures/user_fixtures.js
+++ b/test/fixtures/user_fixtures.js
@@ -181,8 +181,8 @@ const buildRoleWithDefaults = (opts = {}) => {
 function buildUserWithDefaults (opts) {
   lodash.defaults(opts, {
     external_id: '7d19aff33f8948deb97ed16b2912dcd3',
-    username: 'some-user@gov.uk',
-    email: 'some-user@gov.uk',
+    username: 'some-user@example.com',
+    email: 'some-user@example.com',
     otp_key: 'krb6fcianbdjkt01ecvi08jcln',
     telephone_number: '9127979',
     second_factor: 'SMS',

--- a/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
+++ b/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
@@ -22,7 +22,7 @@ const expect = chai.expect
 
 describe('adminusers client - authenticate', () => {
   const provider = Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
@@ -34,8 +34,8 @@ describe('adminusers client - authenticate', () => {
   before(() => provider.setup())
   after((done) => provider.finalize().then(done()))
 
-  const existingUsername = 'some-user@gov.uk'
-  const validPassword = 'some-valid-password'
+  const existingUsername = 'existing-user'
+  const validPassword = 'password'
 
   describe('user is authenticated successfully', () => {
     const validPasswordResponse = userFixtures.validUserResponse({ username: existingUsername })
@@ -51,7 +51,7 @@ describe('adminusers client - authenticate', () => {
       provider.addInteraction(
         new PactInteractionBuilder(`${AUTHENTICATE_PATH}`)
           .withUponReceiving('a correct password for a user')
-          .withState(`user with email address ${existingUsername} exists in the database with the correct with a correct password set to: ${validPassword}`)
+          .withState(`a user exists with username ${existingUsername} and password ${validPassword}`)
           .withMethod('POST')
           .withRequestBody(validPasswordRequestPactified)
           .withResponseBody(validPasswordResponse.getPactified())
@@ -85,7 +85,7 @@ describe('adminusers client - authenticate', () => {
       provider.addInteraction(
         new PactInteractionBuilder(`${AUTHENTICATE_PATH}`)
           .withUponReceiving('an incorrect password for a user')
-          .withState(`user with email address ${existingUsername} exists in the database with the correct with a correct password set to: ${validPassword}`)
+          .withState(`a user exists with username ${existingUsername} and password ${validPassword}`)
           .withMethod('POST')
           .withRequestBody(invalidPasswordRequestPactified)
           .withResponseBody(invalidPasswordResponse.getPactified())

--- a/test/unit/clients/adminusers_client/forgotten_password/create_forgotten_password_test.js
+++ b/test/unit/clients/adminusers_client/forgotten_password/create_forgotten_password_test.js
@@ -13,7 +13,7 @@ const FORGOTTEN_PASSWORD_PATH = '/v1/api/forgotten-passwords'
 
 describe('adminusers client - create forgotten password', function () {
   let provider = Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
@@ -26,16 +26,18 @@ describe('adminusers client - create forgotten password', function () {
   after((done) => provider.finalize().then(done()))
 
   describe('success', () => {
-    let request = userFixtures.validForgottenPasswordCreateRequest('existing-user')
+    const username = 'existing-user'
+    let request = userFixtures.validForgottenPasswordCreateRequest(username)
 
     before((done) => {
       provider.addInteraction(
         new PactInteractionBuilder(FORGOTTEN_PASSWORD_PATH)
-          .withState('a user exist')
+          .withState(`a user exists with username ${username}`)
           .withUponReceiving('a valid forgotten password request')
           .withMethod('POST')
-          .withRequestBody(request.getPactified())
+          .withRequestBody(request.getPlain())
           .withStatusCode(200)
+          .withResponseHeaders({})
           .build()
       ).then(() => done())
     })

--- a/test/unit/clients/adminusers_client/forgotten_password/get_forgotten_password_test.js
+++ b/test/unit/clients/adminusers_client/forgotten_password/get_forgotten_password_test.js
@@ -13,7 +13,7 @@ const FORGOTTEN_PASSWORD_PATH = '/v1/api/forgotten-passwords'
 
 describe('adminusers client - get forgotten password', function () {
   let provider = Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/adminusers_client/service/create_service_test.js
+++ b/test/unit/clients/adminusers_client/service/create_service_test.js
@@ -22,7 +22,7 @@ chai.use(chaiAsPromised)
 
 describe('adminusers client - create a new service', function () {
   let provider = Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
@@ -139,35 +139,6 @@ describe('adminusers client - create a new service', function () {
         expect(service.external_id).to.equal(externalId)
         expect(service.name).to.equal(name)
         expect(service.gateway_account_ids).to.deep.equal(gatewayAccountIds)
-      }).should.notify(done)
-    })
-  })
-
-  describe('create a service - bad request', () => {
-    const invalidRequest = serviceFixtures.validCreateServiceRequest({gateway_account_ids: ['non-numeric-id']})
-    const errorResponse = serviceFixtures.badRequestResponseWhenNonNumericGatewayAccountIds(['non-numeric-id'])
-
-    before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(SERVICE_RESOURCE)
-          .withUponReceiving('an invalid create service request')
-          .withMethod('POST')
-          .withRequestBody(invalidRequest.getPactified())
-          .withStatusCode(400)
-          .withResponseBody(errorResponse.getPactified())
-          .build()
-      )
-        .then(() => done())
-        .catch(done)
-    })
-
-    afterEach(() => provider.verify())
-
-    it('should return 400 on invalid gateway account ids', function (done) {
-      adminusersClient.createService(null, null, ['non-numeric-id']).should.be.rejected.then(function (response) {
-        expect(response.errorCode).to.equal(400)
-        expect(response.message.errors.length).to.equal(1)
-        expect(response.message.errors).to.deep.equal(errorResponse.getPlain().errors)
       }).should.notify(done)
     })
   })

--- a/test/unit/clients/adminusers_client/service/get_service_users_test.js
+++ b/test/unit/clients/adminusers_client/service/get_service_users_test.js
@@ -8,7 +8,6 @@ const chaiAsPromised = require('chai-as-promised')
 
 // Local dependencies
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers_client')
-const serviceFixtures = require('../../../../fixtures/service_fixtures')
 const userServiceFixtures = require('../../../../fixtures/user_service_fixture')
 const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
 
@@ -21,32 +20,11 @@ const SERVICES_PATH = '/v1/api/services'
 const port = Math.floor(Math.random() * 48127) + 1024
 const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
 
-describe('adminusers client - service users', () => {
-  const serviceExternalId = '12345'
-  const nonExistingServiceId = '500'
-  const responseParams = {
-    service_roles: [{
-      service: {
-        name: 'System Generated',
-        external_id: serviceExternalId,
-        gateway_account_ids: []
-      },
-      role: {
-        name: 'admin',
-        description: 'Administrator',
-        permissions: ['perm-1', 'perm-2', 'perm-3'],
-        '_links': [{
-          'href': `http://adminusers.service/v1/api/users/${serviceExternalId}`,
-          'rel': 'self',
-          'method': 'GET'
-        }]
-      }
-    }]
-  }
-  const getServiceUsersResponse = userServiceFixtures.validServiceUsersResponse([responseParams])
+const existingServiceExternalId = 'cp5wa'
 
+describe('adminusers client - service users', () => {
   const provider = Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
@@ -58,12 +36,20 @@ describe('adminusers client - service users', () => {
   before(() => provider.setup())
   after(done => provider.finalize().then(done()))
 
-  describe('success', () => {
+  describe('single user is returned for service', () => {
+    const getServiceUsersResponse = userServiceFixtures.validServiceUsersResponse([{
+      service_roles: [{
+        service: {
+          external_id: existingServiceExternalId
+        }
+      }]
+    }])
+
     before(done => {
       provider.addInteraction(
-        new PactInteractionBuilder(`${SERVICES_PATH}/${serviceExternalId}/users`)
-          .withState('a service exists with external id 12345')
+        new PactInteractionBuilder(`${SERVICES_PATH}/${existingServiceExternalId}/users`)
           .withUponReceiving('a valid get service users request')
+          .withState(`a user exists with role for service with id ${existingServiceExternalId}`)
           .withResponseBody(getServiceUsersResponse.getPactified())
           .withStatusCode(200)
           .build()
@@ -73,24 +59,24 @@ describe('adminusers client - service users', () => {
     afterEach(() => provider.verify())
 
     it('should return service users successfully', done => {
-      adminusersClient.getServiceUsers(serviceExternalId).should.be.fulfilled.then(
+      adminusersClient.getServiceUsers(existingServiceExternalId).should.be.fulfilled.then(
         users => {
           const expectedResponse = getServiceUsersResponse.getPlain()
           expect(users[0].serviceRoles.length).to.be.equal(expectedResponse[0].service_roles.length)
-          expect(users[0].hasService(serviceExternalId)).to.be.equal(true)
+          expect(users[0].hasService(existingServiceExternalId)).to.be.equal(true)
         }
       ).should.notify(done)
     })
   })
 
-  describe('failure', () => {
+  describe('service does not exist', () => {
+    const nonExistingServiceId = '500'
     before(done => {
       provider.addInteraction(
         new PactInteractionBuilder(`${SERVICES_PATH}/${nonExistingServiceId}/users`)
-          .withState('a service doesnt exists with the given id')
           .withUponReceiving('a valid get service users request with non-existing service id')
-          .withResponseBody(serviceFixtures.getServiceUsersNotFoundResponse().getPactified())
           .withStatusCode(404)
+          .withResponseHeaders({})
           .build()
       ).then(() => done())
     })

--- a/test/unit/clients/adminusers_client/service/update_collect_billing_address_test.js
+++ b/test/unit/clients/adminusers_client/service/update_collect_billing_address_test.js
@@ -46,7 +46,7 @@ describe('adminusers client - patch collect billing address toggle', function ()
       provider.addInteraction(
         new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
           .withUponReceiving('a valid patch collect billing address toggle (disabled) request')
-          .withState(`a service exists with external id ${serviceExternalId} and billing address collection enabled`)
+          .withState(`a service exists with external id ${serviceExternalId}`)
           .withMethod('PATCH')
           .withRequestBody(validUpdateCollectBillingAddressRequest.getPactified())
           .withStatusCode(200)

--- a/test/unit/clients/adminusers_client/service/update_request_to_go_live_stage_test.js
+++ b/test/unit/clients/adminusers_client/service/update_request_to_go_live_stage_test.js
@@ -16,7 +16,7 @@ const SERVICE_RESOURCE = '/v1/api/services'
 const port = Math.floor(Math.random() * 48127) + 1024
 const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 const expect = chai.expect
-const serviceExternalId = 'rtglNotStarted'
+const serviceExternalId = 'cp5wa'
 
 // Global setup
 chai.use(chaiAsPromised)
@@ -47,7 +47,7 @@ describe('adminusers client - patch request to go live stage', function () {
       provider.addInteraction(
         new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
           .withUponReceiving('a valid patch current go live stage request')
-          .withState(`a service exists with external id ${serviceExternalId} and go live stage equals to NOT_STARTED`)
+          .withState(`a service exists with external id ${serviceExternalId}`)
           .withMethod('PATCH')
           .withRequestBody(validUpdateRequestToGoLiveRequest.getPlain())
           .withStatusCode(200)

--- a/test/unit/clients/adminusers_client/user/authenticate_test.js
+++ b/test/unit/clients/adminusers_client/user/authenticate_test.js
@@ -16,7 +16,7 @@ const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}
 
 describe('adminusers client - authenticate', function () {
   let provider = Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/adminusers_client/user/delete_user_test.js
+++ b/test/unit/clients/adminusers_client/user/delete_user_test.js
@@ -13,7 +13,7 @@ chai.use(chaiAsPromised)
 
 describe('adminusers client - delete user', function () {
   let provider = Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/adminusers_client/user/increment_session_version_test.js
+++ b/test/unit/clients/adminusers_client/user/increment_session_version_test.js
@@ -15,7 +15,7 @@ var adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`}
 
 describe('adminusers client - session', function () {
   let provider = Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/adminusers_client/user/second_factor_test.js
+++ b/test/unit/clients/adminusers_client/user/second_factor_test.js
@@ -13,6 +13,8 @@ const USER_PATH = '/v1/api/users'
 let port = Math.floor(Math.random() * 48127) + 1024
 let adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
 
+const existingExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
+
 describe('adminusers client', function () {
   let provider = Pact({
     consumer: 'selfservice-to-be',
@@ -28,8 +30,6 @@ describe('adminusers client', function () {
   after((done) => provider.finalize().then(done()))
 
   describe('send new second factor API - success', () => {
-    let existingExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
-
     before((done) => {
       provider.addInteraction(
         new PactInteractionBuilder(`${USER_PATH}/${existingExternalId}/second-factor`)
@@ -53,10 +53,10 @@ describe('adminusers client', function () {
     before((done) => {
       provider.addInteraction(
         new PactInteractionBuilder(`${USER_PATH}/${externalId}/second-factor`)
-          .withState('a user does not exist')
-          .withUponReceiving('a valid second factor post request')
+          .withUponReceiving('a second factor post request for a non-existent user')
           .withMethod('POST')
           .withStatusCode(404)
+          .withResponseHeaders({})
           .build()
       ).then(() => done())
     })
@@ -73,12 +73,11 @@ describe('adminusers client', function () {
   describe('authenticate a second factor API - success', () => {
     let token = '121212'
     let request = userFixtures.validAuthenticateSecondFactorRequest(token)
-    let response = userFixtures.validUserResponse()
-    let externalId = response.getPlain().external_id
+    let response = userFixtures.validUserResponse({ external_id: existingExternalId })
 
     before((done) => {
       provider.addInteraction(
-        new PactInteractionBuilder(`${USER_PATH}/${externalId}/second-factor/authenticate`)
+        new PactInteractionBuilder(`${USER_PATH}/${existingExternalId}/second-factor/authenticate`)
           .withState('a user exists')
           .withUponReceiving('a valid authenticate second factor token request')
           .withRequestBody(request.getPactified())
@@ -91,8 +90,8 @@ describe('adminusers client', function () {
     afterEach(() => provider.verify())
 
     it('authenticate a valid 2FA token successfully', function (done) {
-      adminusersClient.authenticateSecondFactor(externalId, token).should.be.fulfilled.then(function (createdUser) {
-        expect(createdUser.externalId).to.be.equal(externalId)
+      adminusersClient.authenticateSecondFactor(existingExternalId, token).should.be.fulfilled.then(function (createdUser) {
+        expect(createdUser.externalId).to.be.equal(existingExternalId)
       }).should.notify(done)
     })
   })
@@ -136,6 +135,7 @@ describe('adminusers client', function () {
           .withRequestBody(request.getPactified())
           .withMethod('POST')
           .withStatusCode(401)
+          .withResponseHeaders({})
           .build()
       ).then(() => done())
     })

--- a/test/unit/clients/adminusers_client/user/update_password_test.js
+++ b/test/unit/clients/adminusers_client/user/update_password_test.js
@@ -15,7 +15,7 @@ var adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`}
 
 describe('adminusers client - update password', function () {
   let provider = Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),

--- a/test/unit/clients/adminusers_client/user/update_servicerole_test.js
+++ b/test/unit/clients/adminusers_client/user/update_servicerole_test.js
@@ -13,9 +13,12 @@ const USER_PATH = '/v1/api/users'
 let port = Math.floor(Math.random() * 48127) + 1024
 let adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
 
+const existingUserExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
+const existingServiceExternalId = 'cp5wa'
+
 describe('adminusers client - update user service role', function () {
   let provider = Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
@@ -31,19 +34,20 @@ describe('adminusers client - update user service role', function () {
     let role = 'view-and-refund'
     let request = userFixtures.validUpdateServiceRoleRequest(role)
     let userFixture = userFixtures.validUserResponse({
+      external_id: existingUserExternalId,
       service_roles: [{
+        service: { external_id: existingServiceExternalId },
         role: { name: role, description: `${role}-description` }
       }]
     })
-    let user = userFixture.getPlain()
 
     before((done) => {
       provider.addInteraction(
-        new PactInteractionBuilder(`${USER_PATH}/${user.external_id}/services/${user.service_roles[0].service.external_id}`)
-          .withState('a user exist')
+        new PactInteractionBuilder(`${USER_PATH}/${existingUserExternalId}/services/${existingServiceExternalId}`)
+          .withState(`a service exists with external id ${existingServiceExternalId} with multiple admin users`)
           .withUponReceiving('a valid update service role request')
           .withMethod('PUT')
-          .withRequestBody(request.getPactified())
+          .withRequestBody(request.getPlain())
           .withStatusCode(200)
           .withResponseBody(userFixture.getPactified())
           .build()
@@ -54,8 +58,8 @@ describe('adminusers client - update user service role', function () {
 
     it('should update service role of a user successfully', function (done) {
       let requestData = request.getPlain()
-      adminusersClient.updateServiceRole(user.external_id, user.service_roles[0].service.external_id, requestData.role_name).should.be.fulfilled.then(function (updatedUser) {
-        const updatedServiceRole = updatedUser.serviceRoles.find(serviceRole => serviceRole.service.externalId === user.service_roles[0].service.external_id)
+      adminusersClient.updateServiceRole(existingUserExternalId, existingServiceExternalId, requestData.role_name).should.be.fulfilled.then(function (updatedUser) {
+        const updatedServiceRole = updatedUser.serviceRoles.find(serviceRole => serviceRole.service.externalId === existingServiceExternalId)
         expect(updatedServiceRole.role.name).to.be.equal(role)
       }).should.notify(done)
     })
@@ -65,16 +69,15 @@ describe('adminusers client - update user service role', function () {
     let role = 'view-and-refund'
     let request = userFixtures.validUpdateServiceRoleRequest(role)
     let externalId = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' // non existent external id
-    let serviceId = 1234
 
     before((done) => {
       provider.addInteraction(
-        new PactInteractionBuilder(`${USER_PATH}/${externalId}/services/${serviceId}`)
-          .withState('a user with external id does not exist')
-          .withUponReceiving('a valid update service role request')
+        new PactInteractionBuilder(`${USER_PATH}/${externalId}/services/${existingServiceExternalId}`)
+          .withUponReceiving('an update service role request for non-existent user')
           .withMethod('PUT')
-          .withRequestBody(request.getPactified())
+          .withRequestBody(request.getPlain())
           .withStatusCode(404)
+          .withResponseHeaders({})
           .build()
       ).then(() => done())
     })
@@ -83,36 +86,8 @@ describe('adminusers client - update user service role', function () {
 
     it('should error not found for non existent user when updating service role', function (done) {
       let requestData = request.getPlain()
-      adminusersClient.updateServiceRole(externalId, serviceId, requestData.role_name).should.be.rejected.then(function (response) {
+      adminusersClient.updateServiceRole(externalId, existingServiceExternalId, requestData.role_name).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(404)
-      }).should.notify(done)
-    })
-  })
-
-  describe('update user service role API - invalid role_name', () => {
-    let role = 'invalid-role'
-    let request = userFixtures.validUpdateServiceRoleRequest(role)
-    let existingExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
-    let serviceId = 1234
-
-    before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${USER_PATH}/${existingExternalId}/services/${serviceId}`)
-          .withState('a role with given name does not exist')
-          .withUponReceiving('a valid update service role request')
-          .withMethod('PUT')
-          .withRequestBody(request.getPactified())
-          .withStatusCode(400)
-          .build()
-      ).then(() => done())
-    })
-
-    afterEach(() => provider.verify())
-
-    it('should error bad request if an unknown role_name provided', function (done) {
-      let requestData = request.getPlain()
-      adminusersClient.updateServiceRole(existingExternalId, serviceId, requestData.role_name).should.be.rejected.then(function (response) {
-        expect(response.errorCode).to.equal(400)
       }).should.notify(done)
     })
   })
@@ -120,16 +95,14 @@ describe('adminusers client - update user service role', function () {
   describe('update user service role API - user does not belong to service', () => {
     let role = 'admin'
     let request = userFixtures.validUpdateServiceRoleRequest(role)
-    let existingExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
-    let serviceId = 1234
 
     before((done) => {
       provider.addInteraction(
-        new PactInteractionBuilder(`${USER_PATH}/${existingExternalId}/services/${serviceId}`)
-          .withState('a user exists with no access to service')
-          .withUponReceiving('a valid update service role request')
+        new PactInteractionBuilder(`${USER_PATH}/${existingUserExternalId}/services/${existingServiceExternalId}`)
+          .withState(`a user exists external id ${existingUserExternalId} and a service exists with external id ${existingServiceExternalId}`)
+          .withUponReceiving('an update service role request for user that does not belong to service')
           .withMethod('PUT')
-          .withRequestBody(request.getPactified())
+          .withRequestBody(request.getPlain())
           .withStatusCode(409)
           .build()
       ).then(() => done())
@@ -139,7 +112,7 @@ describe('adminusers client - update user service role', function () {
 
     it('should error conflict if user does not have access to the given service id', function (done) {
       let requestData = request.getPlain()
-      adminusersClient.updateServiceRole(existingExternalId, serviceId, requestData.role_name).should.be.rejected.then(function (response) {
+      adminusersClient.updateServiceRole(existingUserExternalId, existingServiceExternalId, requestData.role_name).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(409)
       }).should.notify(done)
     })
@@ -148,16 +121,14 @@ describe('adminusers client - update user service role', function () {
   describe('update user service role API - minimum no of admin limit reached', () => {
     let role = 'view-and-refund'
     let request = userFixtures.validUpdateServiceRoleRequest(role)
-    let existingExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
-    let serviceId = 1234
 
     before((done) => {
       provider.addInteraction(
-        new PactInteractionBuilder(`${USER_PATH}/${existingExternalId}/services/${serviceId}`)
-          .withState('only one user with admin role for the service')
-          .withUponReceiving('a valid update service role request')
+        new PactInteractionBuilder(`${USER_PATH}/${existingUserExternalId}/services/${existingServiceExternalId}`)
+          .withState(`a user exists with external id ${existingUserExternalId} with admin role for service with id ${existingServiceExternalId}`)
+          .withUponReceiving('an update service role request with minimum number of admins reached')
           .withMethod('PUT')
-          .withRequestBody(request.getPactified())
+          .withRequestBody(request.getPlain())
           .withStatusCode(412)
           .build()
       ).then(() => done())
@@ -167,7 +138,7 @@ describe('adminusers client - update user service role', function () {
 
     it('should error precondition failed, if number of remaining admins for the service is going to be less than 1', function (done) {
       let requestData = request.getPlain()
-      adminusersClient.updateServiceRole(existingExternalId, serviceId, requestData.role_name).should.be.rejected.then(function (response) {
+      adminusersClient.updateServiceRole(existingUserExternalId, existingServiceExternalId, requestData.role_name).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(412)
       }).should.notify(done)
     })


### PR DESCRIPTION
## WHAT
- lots of pact tests had consumer 'selfservice-to-be', which meant they
  were not published to the pact broker and so not verified against
  adminusers
- this commit gets a lot of those tests working against adminusers and
  changes the consumer to 'selfservice'
- some pact tests have been removed where they are over-testing
  validation which should be tested in adminusers itself, or are testing
  behaviour that does not exist



