### PR TITLE
PP-4451 Attempt to remedy browser test flakiness

### DIFF
--- a/test/cypress/integration/request-to-go-live/organisation_name_spec.js
+++ b/test/cypress/integration/request-to-go-live/organisation_name_spec.js
@@ -104,7 +104,6 @@ describe('Request to go live: organisation name page', () => {
 
       cy.get('#request-to-go-live-organisation-name-form > button').should('exist')
       cy.get('#request-to-go-live-organisation-name-form > button').should('contain', 'Continue')
-      cy.get('#request-to-go-live-organisation-name-form > button').click()
     })
 
     it('should show empty input box if organisation name is not pre-filled', () => {
@@ -145,7 +144,6 @@ describe('Request to go live: organisation name page', () => {
 
       cy.get('#request-to-go-live-organisation-name-form > button').should('exist')
       cy.get('#request-to-go-live-organisation-name-form > button').should('contain', 'Continue')
-      cy.get('#request-to-go-live-organisation-name-form > button').click()
     })
   })
 


### PR DESCRIPTION
- we suspect tests are flaky because they end on an action to click a
  button that will cause a redirect but doesn't do any asserts
- remove the click actions, they will be added back in in a subsequent
  commit along with assertions on the page redirected to


with @cobainc0 