### PR TITLE
PP-4451 organisation name page

### DIFF
--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -475,6 +475,31 @@ module.exports = {
       }
     ]
   },
+  patchSingleMerchantDetailsSuccess: (opts = {}) => {
+    return [
+      {
+        predicates: [{
+          equals: {
+            method: 'PATCH',
+            path: `/v1/api/services/${opts.external_id}`,
+            headers: {
+              'Accept': 'application/json'
+            },
+            body: serviceFixtures.validUpdateMerchantNameRequest(opts.value).getPlain()
+          }
+        }],
+        responses: [{
+          is: {
+            statusCode: 200,
+            body: serviceFixtures.validServiceResponse(opts).getPlain(),
+            headers: {
+              'Content-Type': 'application/json'
+            }
+          }
+        }]
+      }
+    ]
+  },
   patchGoLiveStageFailure: (opts = {}) => {
     return [
       {

--- a/test/cypress/utils/request_to_go_live_utils.js
+++ b/test/cypress/utils/request_to_go_live_utils.js
@@ -16,6 +16,17 @@ const buildServiceRoleForGoLiveStage = (goLiveStage) => {
   }
 }
 
+const buildServiceRoleForMerchantDetailsField = (merchantDetails, goLiveStage) => {
+  return {
+    service: {
+      external_id: variables.serviceExternalId,
+      gateway_account_ids: [variables.gatewayAccountId],
+      merchant_details: merchantDetails,
+      current_go_live_stage: goLiveStage
+    }
+  }
+}
+
 const simpleStub = (serviceRole) => {
   return [
     {
@@ -60,11 +71,30 @@ const setupStubs = (serviceRole) => {
   cy.task('setupStubs', simpleStub(serviceRole))
 }
 
+const stubUserSuccessResponse = (serviceRoleBefore, serviceRoleAfter) =>
+  [{
+    name: 'getUserSuccessRepeatFirstResponseNTimes',
+    opts: [{
+      external_id: variables.userExternalId,
+      service_roles: [serviceRoleBefore],
+      repeat: 2
+    }, {
+      external_id: variables.userExternalId,
+      service_roles: [serviceRoleAfter],
+      repeat: 2
+    }]
+  }, {
+    name: 'getGatewayAccountSuccess',
+    opts: { gateway_account_id: variables.gatewayAccountId }
+  }]
+
 module.exports = {
   variables,
+  buildServiceRoleForMerchantDetailsField,
   buildServiceRoleForGoLiveStage,
   simpleStub,
   stubWithGoLiveStage,
   stubGoLiveStageError,
-  setupStubs
+  setupStubs,
+  stubUserSuccessResponse
 }

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -251,6 +251,48 @@ module.exports = {
     }
   },
 
+  validUpdateMerchantNameRequest: (value) => {
+    const data = {
+      op: 'replace',
+      path: 'merchant_details/name',
+      value: value
+    }
+
+    return {
+      getPactified: () => {
+        return pactServices.pactify(data)
+      },
+      getPlain: () => {
+        return _.clone(data)
+      }
+    }
+  },
+
+  validUpdateMerchantNameResponse: opts => {
+    opts = opts || {}
+    const externalId = opts.external_id || 'externalId'
+    const serviceName = opts.name || 'updated-service-name'
+    const merchantDetails = opts.merchant_details || {}
+    const merchantName = merchantDetails.name || 'updated-merchant-details-name'
+
+    const data = {
+      external_id: externalId,
+      name: serviceName,
+      merchant_details: {
+        name: merchantName
+      }
+    }
+
+    return {
+      getPactified: () => {
+        return pactServices.pactify(data)
+      },
+      getPlain: () => {
+        return _.clone(data)
+      }
+    }
+  },
+
   validUpdateServiceRequest: (opts) => {
     opts = opts || {}
 

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -268,31 +268,6 @@ module.exports = {
     }
   },
 
-  validUpdateMerchantNameResponse: opts => {
-    opts = opts || {}
-    const externalId = opts.external_id || 'externalId'
-    const serviceName = opts.name || 'updated-service-name'
-    const merchantDetails = opts.merchant_details || {}
-    const merchantName = merchantDetails.name || 'updated-merchant-details-name'
-
-    const data = {
-      external_id: externalId,
-      name: serviceName,
-      merchant_details: {
-        name: merchantName
-      }
-    }
-
-    return {
-      getPactified: () => {
-        return pactServices.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
-  },
-
   validUpdateServiceRequest: (opts) => {
     opts = opts || {}
 

--- a/test/unit/clients/adminusers_client/service/update_merchant_name_test.js
+++ b/test/unit/clients/adminusers_client/service/update_merchant_name_test.js
@@ -1,0 +1,72 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+
+// Custom dependencies
+const path = require('path')
+const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const getAdminUsersClient = require('../../../../../app/services/clients/adminusers_client')
+const serviceFixtures = require('../../../../fixtures/service_fixtures')
+
+// Constants
+const SERVICE_RESOURCE = '/v1/api/services'
+const port = Math.floor(Math.random() * 48127) + 1024
+const adminUsersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
+const expect = chai.expect
+
+// Global setup
+chai.use(chaiAsPromised)
+
+describe('adminusers client - patch request to update merchant name', function () {
+  let provider = Pact({
+    consumer: 'selfservice',
+    provider: 'adminusers',
+    port: port,
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(() => provider.setup())
+  after(done => provider.finalize().then(done()))
+
+  describe('a valid update merchant name patch request', () => {
+    const serviceExternalId = 'cp5wa'
+    const serviceName = 'serviceName'
+    const validUpdateMerchantNameRequest = serviceFixtures.validUpdateMerchantNameRequest('updated-merchant-details-name')
+    const validUpdateMerchantNameResponse = serviceFixtures.validUpdateMerchantNameResponse({
+      external_id: serviceExternalId,
+      name: serviceName
+    })
+
+    before(done => {
+      provider.addInteraction(
+        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
+          .withUponReceiving('a valid update merchant name request')
+          .withState(`a service exists with external id ${serviceExternalId}`)
+          .withMethod('PATCH')
+          .withRequestBody(validUpdateMerchantNameRequest.getPactified())
+          .withStatusCode(200)
+          .withResponseBody(validUpdateMerchantNameResponse.getPactified())
+          .build()
+      )
+        .then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should update a merchant name successfully', (done) => {
+      adminUsersClient.updateMerchantName(serviceExternalId, 'updated-merchant-details-name')
+        .should.be.fulfilled.then(service => {
+          expect(service.externalId).to.equal(serviceExternalId)
+          expect(service.name).to.equal(serviceName)
+          expect(service.merchantDetails.name).to.equal(validUpdateMerchantNameRequest.getPlain().value)
+        }).should.notify(done)
+    })
+  })
+})

--- a/test/unit/clients/adminusers_client/service/update_merchant_name_test.js
+++ b/test/unit/clients/adminusers_client/service/update_merchant_name_test.js
@@ -36,11 +36,13 @@ describe('adminusers client - patch request to update merchant name', function (
 
   describe('a valid update merchant name patch request', () => {
     const serviceExternalId = 'cp5wa'
-    const serviceName = 'serviceName'
-    const validUpdateMerchantNameRequest = serviceFixtures.validUpdateMerchantNameRequest('updated-merchant-details-name')
-    const validUpdateMerchantNameResponse = serviceFixtures.validUpdateMerchantNameResponse({
+    const merchantName = 'updated-merchant-details-name'
+    const validUpdateMerchantNameRequest = serviceFixtures.validUpdateMerchantNameRequest(merchantName)
+    const validUpdateMerchantNameResponse = serviceFixtures.validServiceResponse({
       external_id: serviceExternalId,
-      name: serviceName
+      merchant_details: {
+        name: merchantName
+      }
     })
 
     before(done => {
@@ -61,10 +63,9 @@ describe('adminusers client - patch request to update merchant name', function (
     afterEach(() => provider.verify())
 
     it('should update a merchant name successfully', (done) => {
-      adminUsersClient.updateMerchantName(serviceExternalId, 'updated-merchant-details-name')
+      adminUsersClient.updateMerchantName(serviceExternalId, merchantName)
         .should.be.fulfilled.then(service => {
           expect(service.externalId).to.equal(serviceExternalId)
-          expect(service.name).to.equal(serviceName)
           expect(service.merchantDetails.name).to.equal(validUpdateMerchantNameRequest.getPlain().value)
         }).should.notify(done)
     })


### PR DESCRIPTION
## WHAT
Add contract test for merchant details PATCH request
 - new pact test `update_merchant_name_test` verifies that a
 request to the PATCH endpoint in adminUsers updates the merchant name
 successfully

Fixes flaky browser tests
 - adds missing assertions to the end of tests where previous flaky behaviour was exhibited. See SHA: 143a9b2
 - refactors `organisation_name_spec` to incorporate new utils in `request_to_go_live_utils`.


