### PR TITLE
[DO NOT MERGE] PP-4822 Add text explaining $reference in email custom paragraph

### DIFF
--- a/app/views/email_notifications/edit.njk
+++ b/app/views/email_notifications/edit.njk
@@ -48,6 +48,10 @@ Change email notifications template - {{currentService.name}} {{currentGatewayAc
       <li>use redirects or tracking links</li>
   </ul>
 
+   <p class="govuk-body">
+        Your service reference for the payment is already in the email. However, if you also want to include it in your custom paragraph, you can put $reference and it will be automatically replaced.
+   </p>
+
   <form method="post" action="{{routes.emailNotifications.confirm}}" data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 


### PR DESCRIPTION
Add some text to the page where the custom paragraph for email notification is configured, explaining that “$reference” will be replaced by the actual payment reference.
