### PR TITLE
PP-4448 Add payment_provider field to gateway account fixture

### DIFF
--- a/test/cypress/integration/dashboard/dashboard_spec.js
+++ b/test/cypress/integration/dashboard/dashboard_spec.js
@@ -33,7 +33,7 @@ describe('Dashboard', () => {
     it(`should have the page title 'Dashboard - ${serviceName} test - GOV.UK Pay'`, () => {
       const dashboardUrl = `/?period=custom&fromDateTime=${from}&toDateTime=${to}`
       cy.visit(dashboardUrl)
-      cy.title().should('eq', `Dashboard - ${serviceName} test - GOV.UK Pay`)
+      cy.title().should('eq', `Dashboard - ${serviceName} sandbox test - GOV.UK Pay`)
     })
   })
 })

--- a/test/cypress/integration/settings/email_notifications_spec.js
+++ b/test/cypress/integration/settings/email_notifications_spec.js
@@ -55,18 +55,18 @@ describe('Settings', () => {
   })
 
   describe('Settings default page', () => {
-    it(`should have the page title 'API Keys - ${serviceName} test - GOV.UK Pay'`, () => {
-      cy.title().should('eq', `API Keys - ${serviceName} test - GOV.UK Pay`)
+    it(`should have the page title 'API Keys - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
+      cy.title().should('eq', `API Keys - ${serviceName} sandbox test - GOV.UK Pay`)
     })
   })
 
   describe('Email notifications home page', () => {
-    it(`should have the page title 'Email notifications - ${serviceName} test - GOV.UK Pay'`, () => {
+    it(`should have the page title 'Email notifications - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
       const emailNotificationsUrl = `/email-notifications`
 
       // Default notifications page and confirmation email tab contents
       cy.visit(emailNotificationsUrl)
-      cy.title().should('eq', `Email notifications - ${serviceName} test - GOV.UK Pay`)
+      cy.title().should('eq', `Email notifications - ${serviceName} sandbox test - GOV.UK Pay`)
       cy.get('#confirmation-email-template').should('contain', 'Confirmation email template')
 
       // Click the 'Refund email' tab
@@ -77,13 +77,13 @@ describe('Settings', () => {
   })
 
   describe('Email collection mode page', () => {
-    it(`should have the page title 'Email notifications - ${serviceName} test - GOV.UK Pay'`, () => {
+    it(`should have the page title 'Email notifications - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
       const emailNotificationsUrl = `/email-notifications`
       cy.visit(emailNotificationsUrl)
 
       // Access the collection mode page
       cy.get('#email-notifications-toggle-collection').click()
-      cy.title().should('eq', `Email notifications - ${serviceName} test - GOV.UK Pay`)
+      cy.title().should('eq', `Email notifications - ${serviceName} sandbox test - GOV.UK Pay`)
       cy.url().should('include', '/email-settings-collection')
 
       cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to ask users for an email address on the card payment page?')
@@ -101,13 +101,13 @@ describe('Settings', () => {
   })
 
   describe('Confirmation email toggle page', () => {
-    it(`should have the page title 'Email notifications - ${serviceName} test - GOV.UK Pay'`, () => {
+    it(`should have the page title 'Email notifications - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
       const emailNotificationsUrl = `/email-notifications`
       cy.visit(emailNotificationsUrl)
 
       // Access the confirmation toggle page
       cy.get('#email-notifications-toggle-confirmation').click()
-      cy.title().should('eq', `Email notifications - ${serviceName} test - GOV.UK Pay`)
+      cy.title().should('eq', `Email notifications - ${serviceName} sandbox test - GOV.UK Pay`)
 
       cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to send payment confirmation emails?')
 
@@ -123,13 +123,13 @@ describe('Settings', () => {
   })
 
   describe('Refund email toggle page', () => {
-    it(`should have the page title 'Email notifications - ${serviceName} test - GOV.UK Pay'`, () => {
+    it(`should have the page title 'Email notifications - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
       const emailNotificationsUrl = `/email-notifications`
       cy.visit(emailNotificationsUrl)
 
       // Access the refund toggle page
       cy.get('#email-notifications-toggle-refund').click()
-      cy.title().should('eq', `Email notifications - ${serviceName} test - GOV.UK Pay`)
+      cy.title().should('eq', `Email notifications - ${serviceName} sandbox test - GOV.UK Pay`)
 
       cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to send refund emails?')
 

--- a/test/cypress/integration/transactions/transaction_details_spec.js
+++ b/test/cypress/integration/transactions/transaction_details_spec.js
@@ -101,7 +101,7 @@ describe('Transactions details page', () => {
       cy.visit(`${transactionsUrl}/${chargeDetails.charge.charge_id}`)
 
       // Ensure page title is correct
-      cy.title().should('eq', `Transaction details ${chargeDetails.charge.reference} - ${serviceName} test - GOV.UK Pay`)
+      cy.title().should('eq', `Transaction details ${chargeDetails.charge.reference} - ${serviceName} sandbox test - GOV.UK Pay`)
 
       // Ensure page details match up
 
@@ -155,7 +155,7 @@ describe('Transactions details page', () => {
       cy.visit(`${transactionsUrl}/${aDelayedCaptureCharge.charge.charge_id}`)
 
       // Ensure page title is correct
-      cy.title().should('eq', `Transaction details ${aDelayedCaptureCharge.charge.reference} - ${serviceName} test - GOV.UK Pay`)
+      cy.title().should('eq', `Transaction details ${aDelayedCaptureCharge.charge.reference} - ${serviceName} sandbox test - GOV.UK Pay`)
 
       // Ensure page details match up
 
@@ -212,7 +212,7 @@ describe('Transactions details page', () => {
       cy.visit(`${transactionsUrl}/${aCorporateCardSurchargeCharge.charge.charge_id}`)
 
       // Ensure page title is correct
-      cy.title().should('eq', `Transaction details ${aCorporateCardSurchargeCharge.charge.reference} - ${serviceName} test - GOV.UK Pay`)
+      cy.title().should('eq', `Transaction details ${aCorporateCardSurchargeCharge.charge.reference} - ${serviceName} sandbox test - GOV.UK Pay`)
 
       // Ensure page details match up
 

--- a/test/cypress/integration/transactions/transaction_search_spec.js
+++ b/test/cypress/integration/transactions/transaction_search_spec.js
@@ -136,8 +136,8 @@ describe('Transactions', () => {
   })
 
   describe('Transactions List', () => {
-    it(`should have the page title 'Transactions - ${serviceName} test - GOV.UK Pay'`, () => {
-      cy.title().should('eq', `Transactions - ${serviceName} test - GOV.UK Pay`)
+    it(`should have the page title 'Transactions - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
+      cy.title().should('eq', `Transactions - ${serviceName} sandbox test - GOV.UK Pay`)
     })
 
     describe('Filtering', () => {

--- a/test/fixtures/gateway_account_fixtures.js
+++ b/test/fixtures/gateway_account_fixtures.js
@@ -10,6 +10,7 @@ const pactRegister = pactBase()
 
 function validGatewayAccount (opts) {
   const gatewayAccount = {
+    payment_provider: opts.payment_provider || 'sandbox',
     gateway_account_id: opts.gateway_account_id || 31,
     service_name: opts.service_name || '8b9370c1a83c4d71a538a1691236acc2',
     type: opts.type || 'test',


### PR DESCRIPTION
## WHAT
- Add `payment_provider` field to gateway account fixture so we can set it to different values for Cypress tests.
- Update existing Cypress tests that assert on page title, as test accounts contain the payment provider in the page title. It wasn't previously there because the stubbed gateway account response wasn't returning a `payment_provider`