### PR TITLE
[DO NOT MERGE] PP-4448 Add request to go live link to dashboard

### DIFF
--- a/app/controllers/dashboard/dashboard-activity-controller.test.js
+++ b/app/controllers/dashboard/dashboard-activity-controller.test.js
@@ -11,6 +11,7 @@ const moment = require('moment-timezone')
 const {getApp} = require('../../../server')
 const {getMockSession, createAppWithSession, getUser} = require('../../../test/test_helpers/mock_session')
 const paths = require('../../../app/paths')
+const gatewayAccountFixtures = require('../../../test/fixtures/gateway_account_fixtures')
 const {CONNECTOR_URL} = process.env
 const GATEWAY_ACCOUNT_ID = '929'
 const DASHBOARD_RESPONSE = {
@@ -27,6 +28,12 @@ const DASHBOARD_RESPONSE = {
   }
 }
 
+const mockConnectorGetGatewayAccount = () => {
+  nock(CONNECTOR_URL)
+    .get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
+    .reply(200, gatewayAccountFixtures.validGatewayAccountResponse({ gateway_account_id: GATEWAY_ACCOUNT_ID }))
+}
+
 describe('dashboard-activity-controller', () => {
   describe('When the dashboard is successfully retrieved from connector', () => {
     describe('and the period is not set', () => {
@@ -38,6 +45,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         nock(CONNECTOR_URL)
           .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/transactions-summary`)
           .query(obj => {
@@ -100,7 +108,7 @@ describe('dashboard-activity-controller', () => {
           .to.contain(moment().tz('Europe/London').startOf('day').subtract(0, 'days').format('D MMMM YYYY h:mm:ssa z'))
       })
     })
-    describe('and the period is set to today explictly', () => {
+    describe('and the period is set to today explicitly', () => {
       let result, $, app
 
       before('Arrange', () => {
@@ -109,6 +117,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         nock(CONNECTOR_URL)
           .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/transactions-summary`)
           .query(obj => {
@@ -158,6 +167,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         nock(CONNECTOR_URL)
           .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/transactions-summary`)
           .query(obj => {
@@ -207,6 +217,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         nock(CONNECTOR_URL)
           .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/transactions-summary`)
           .query(obj => {
@@ -256,6 +267,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         nock(CONNECTOR_URL)
           .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/transactions-summary`)
           .query(obj => {
@@ -308,6 +320,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         nock(CONNECTOR_URL)
           .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/transactions-summary`)
           .query(obj => {
@@ -359,6 +372,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         nock(CONNECTOR_URL)
           .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/transactions-summary`)
           .query(obj => {
@@ -405,6 +419,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         app = createAppWithSession(getApp(), session)
       })
 

--- a/app/views/dashboard/_links.njk
+++ b/app/views/dashboard/_links.njk
@@ -1,21 +1,26 @@
+<script src="../../../test/cypress/integration/dashboard/dashboard_go_live_link_spec.js"></script>
 <div class="govuk-grid-column-full flex-grid" data-click-events data-click-category="Dashboard" data-click-action="First steps link clicked">
   <div class="flex-grid--row">
-    {% if isSandbox %}
-    <article class="flex-grid--column-half links__box border-bottom">
+    {% if 'demoPayment' in links %}
+    <article class="{{linkBoxClasses.shift()}} links__box" id="demo-payment-link">
       <a href="{{routes.prototyping.demoPayment.index}}">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Make a demo payment</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Try the payment experience as a user. Then view the completed payment as an administrator on GOV.UK&nbsp;Pay.</p>
       </a>
     </article>
+    {% endif %}
 
-    <article class="flex-grid--column-half links__box border-bottom">
+    {% if 'testPaymentLink' in links %}
+    <article class="{{linkBoxClasses.shift()}} links__box" id="test-payment-link-link">
       <a href="{{routes.prototyping.demoService.index}}">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Test with your users</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Create a reusable link to integrate your service prototype with GOV.UK&nbsp;Pay and test with users.</p>
       </a>
     </article>
-    {% elif paymentMethod === 'card'%}
-    <article class="flex-grid--column-{% if isTestGateway %}third{% else %}half{% endif %} links__box">
+    {% endif %}
+
+    {% if 'paymentLinks' in links %}
+    <article class="{{linkBoxClasses.shift()}} links__box" id="payment-links-link">
       {% if permissions.tokens_create %}
       <a href="{{routes.paymentLinks.start}}">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Create and manage payment links</h2>
@@ -26,15 +31,19 @@
         <p class="govuk-body govuk-!-margin-bottom-0">A payment link lets you take card payments online, even if you don't have a digital&nbsp;service.</p>
       </a>
     </article>
-    {% else %}
-    <article class="flex-grid--column-{% if isTestGateway %}third{% else %}half{% endif %} links__box">
+    {% endif %}
+
+    {% if 'directDebitPaymentFlow' in links %}
+    <article class="{{linkBoxClasses.shift()}} links__box" id="payment-flow-link">
       <a href="https://docs.payments.service.gov.uk/payment_flow_overview/#making-a-payment">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">See the payment flow</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Get an overview of payment pages in our documentation.</p>
       </a>
     </article>
     {% endif %}
-    <article class="flex-grid--column-{% if isSandbox %}half{% else %}{% if isTestGateway %}third{% else %}half{% endif %}{% endif %} links__box">
+
+    {% if 'manageService' in links %}
+    <article class="{{linkBoxClasses.shift()}} links__box" id="manage-service-link">
       <a href="/service/{{ currentService.externalId }}">
       {% if permissions.users_service_create %}
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Manage team members</h2>
@@ -45,13 +54,42 @@
       {% endif %}
       </a>
     </article>
+    {% endif %}
 
-    {% if isTestGateway %}
-    <article class="flex-grid--column-{% if isSandbox %}half{% else %}third{% endif %} links__box">
+    {% if 'goLive' in links %}
+    <article class="{{linkBoxClasses.shift()}} links__box" id="request-to-go-live-link">
+      {% if paymentMethod === 'direct debit' %}
       <a href="https://docs.payments.service.gov.uk/switching_to_live/#switching-to-live">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Next steps to go live</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Read our documentation to see how your service can go live with GOV.UK&nbsp;Pay.</p>
       </a>
+      {% elif currentService.currentGoLiveStage === goLiveStage.NOT_STARTED %}
+      <a href="/service/{{ currentService.externalId }}/request-to-go-live">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Request to go live</h2>
+        <p class="govuk-body govuk-!-margin-bottom-0">Complete the process of going live and start taking real payments.</p>
+      </a>
+      {% elif currentService.currentGoLiveStage in [
+      goLiveStage.ENTERED_ORGANISATION_NAME,
+      goLiveStage.CHOSEN_PSP_STRIPE,
+      goLiveStage.CHOSEN_PSP_WORLDPAY,
+      goLiveStage.CHOSEN_PSP_SMARTPAY,
+      goLiveStage.CHOSEN_PSP_EPDQ
+      ] %}
+      <a {% if currentService.currentGoLiveStage === goLiveStage.ENTERED_ORGANISATION_NAME -%}
+         href="/service/{{ currentService.externalId }}/request-to-go-live/choose-how-to-process-payments" {%- else -%}
+         href="/service/{{ currentService.externalId }}/request-to-go-live/agreement" {%- endif %}>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Continue request to go live</h2>
+        <p class="govuk-body govuk-!-margin-bottom-0">Complete the process of going live and start taking real payments.</p>
+      </a>
+      {% elif currentService.currentGoLiveStage in [
+      goLiveStage.TERMS_AGREED_STRIPE,
+      goLiveStage.TERMS_AGREED_WORLDPAY,
+      goLiveStage.TERMS_AGREED_SMARTPAY,
+      goLiveStage.TERMS_AGREED_EPDQ
+      ] %}
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">We are doing some checks</h2>
+        <p class="govuk-body govuk-!-margin-bottom-0">We are in the process of making your account live.</p>
+      {% endif %}
     </article>
     {% endif %}
   </div>

--- a/test/cypress/integration/dashboard/dashboard_go_live_link_spec.js
+++ b/test/cypress/integration/dashboard/dashboard_go_live_link_spec.js
@@ -1,0 +1,149 @@
+'use strict'
+
+const utils = require('../../utils/request_to_go_live_utils')
+const commonStubs = require('../../utils/common_stubs')
+const { userExternalId, gatewayAccountId, serviceExternalId } = utils.variables
+
+describe('Go live link on dashboard', () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+  })
+
+  describe('Card gateway account', () => {
+    describe('Go live link shown', () => {
+      beforeEach(() => {
+        utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('NOT_STARTED'))
+        cy.visit('/')
+      })
+
+      it('should show request to go live link when go-live stage is NOT_STARTED', () => {
+        cy.get('#request-to-go-live-link').should('exist')
+        cy.get('#request-to-go-live-link h2').should('contain', 'Request to go live')
+        cy.get('#request-to-go-live-link a').should('have.attr', 'href', `/service/${serviceExternalId}/request-to-go-live`)
+      })
+    })
+
+    describe('Continue link shown', () => {
+      it('should show continue link when go-live stage is ENTERED_ORGANISATION_NAME', () => {
+        utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME'))
+        cy.visit('/')
+
+        cy.get('#request-to-go-live-link').should('exist')
+        cy.get('#request-to-go-live-link h2').should('contain', 'Continue request to go live')
+        cy.get('#request-to-go-live-link a').should('have.attr', 'href', `/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`)
+      })
+
+      it('should show continue link when go-live stage is CHOSEN_PSP_STRIPE', () => {
+        utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_STRIPE'))
+        cy.visit('/')
+
+        cy.get('#request-to-go-live-link').should('exist')
+        cy.get('#request-to-go-live-link h2').should('contain', 'Continue request to go live')
+        cy.get('#request-to-go-live-link a').should('have.attr', 'href', `/service/${serviceExternalId}/request-to-go-live/agreement`)
+      })
+
+      it('should show continue link when go-live stage is CHOSEN_PSP_WORLDPAY', () => {
+        utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_WORLDPAY'))
+        cy.visit('/')
+
+        cy.get('#request-to-go-live-link').should('exist')
+        cy.get('#request-to-go-live-link h2').should('contain', 'Continue request to go live')
+        cy.get('#request-to-go-live-link a').should('have.attr', 'href', `/service/${serviceExternalId}/request-to-go-live/agreement`)
+      })
+
+      it('should show continue link when go-live stage is CHOSEN_PSP_SMARTPAY', () => {
+        utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_SMARTPAY'))
+        cy.visit('/')
+
+        cy.get('#request-to-go-live-link').should('exist')
+        cy.get('#request-to-go-live-link h2').should('contain', 'Continue request to go live')
+        cy.get('#request-to-go-live-link a').should('have.attr', 'href', `/service/${serviceExternalId}/request-to-go-live/agreement`)
+      })
+
+      it('should show continue link when go-live stage is CHOSEN_PSP_EPDQ', () => {
+        utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_EPDQ'))
+        cy.visit('/')
+
+        cy.get('#request-to-go-live-link').should('exist')
+        cy.get('#request-to-go-live-link h2').should('contain', 'Continue request to go live')
+        cy.get('#request-to-go-live-link a').should('have.attr', 'href', `/service/${serviceExternalId}/request-to-go-live/agreement`)
+      })
+    })
+
+    describe('Waiting to go live text shown', () => {
+      it('should show waiting to go live text when go-live stage is TERMS_AGREED_STRIPE', () => {
+        utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('TERMS_AGREED_STRIPE'))
+        cy.visit('/')
+
+        cy.get('#request-to-go-live-link').should('exist')
+        cy.get('#request-to-go-live-link h2').should('contain', 'We are doing some checks')
+      })
+
+      it('should show waiting to go live text when go-live stage is TERMS_AGREED_WORLDPAY', () => {
+        utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('TERMS_AGREED_WORLDPAY'))
+        cy.visit('/')
+
+        cy.get('#request-to-go-live-link').should('exist')
+        cy.get('#request-to-go-live-link h2').should('contain', 'We are doing some checks')
+      })
+
+      it('should show waiting to go live text when go-live stage is TERMS_AGREED_SMARTPAY', () => {
+        utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('TERMS_AGREED_SMARTPAY'))
+        cy.visit('/')
+
+        cy.get('#request-to-go-live-link').should('exist')
+        cy.get('#request-to-go-live-link h2').should('contain', 'We are doing some checks')
+      })
+
+      it('should show waiting to go live text when go-live stage is TERMS_AGREED_EPDQ', () => {
+        utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('TERMS_AGREED_EPDQ'))
+        cy.visit('/')
+
+        cy.get('#request-to-go-live-link').should('exist')
+        cy.get('#request-to-go-live-link h2').should('contain', 'We are doing some checks')
+      })
+    })
+
+    describe('Go live link not shown', () => {
+      it('should not show request to go live link when go-live stage is LIVE', () => {
+        utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('LIVE'))
+        cy.visit('/')
+
+        cy.get('#request-to-go-live-link').should('not.exist')
+      })
+
+      it('should not show request to go live link when go-live stage is DENIED', () => {
+        utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('DENIED'))
+        cy.visit('/')
+
+        cy.get('#request-to-go-live-link').should('not.exist')
+      })
+
+      it('should not show request to go live link when user is not an admin', () => {
+        const serviceRole = utils.buildServiceRoleForGoLiveStage('NOT_STARTED')
+        serviceRole.role = {
+          permissions: []
+        }
+        utils.setupSimpleGetUserAndGatewayAccountStubs(serviceRole)
+
+        cy.get('#request-to-go-live-link').should('not.exist')
+      })
+    })
+  })
+
+  describe('Direct debit gateway account', () => {
+    it('should display next steps to go live link', () => {
+      const directDebitGatewayAccountId = 'DIRECT_DEBIT:101'
+
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [directDebitGatewayAccountId], serviceExternalId, 'NOT_STARTED'),
+        commonStubs.getDirectDebitGatewayAccountStub(directDebitGatewayAccountId, 'test', 'sandbox')
+      ])
+      cy.visit('/')
+
+      cy.get('#request-to-go-live-link').should('exist')
+      cy.get('#request-to-go-live-link h2').should('contain', 'Next steps to go live')
+      cy.get('#request-to-go-live-link a').should('have.attr', 'href', 'https://docs.payments.service.gov.uk/switching_to_live/#switching-to-live')
+    })
+  })
+})

--- a/test/cypress/integration/dashboard/dashboard_links_spec.js
+++ b/test/cypress/integration/dashboard/dashboard_links_spec.js
@@ -1,0 +1,199 @@
+'use strict'
+
+const commonStubs = require('../../utils/common_stubs')
+
+describe('the links are displayed correctly on the dashboard', () => {
+  const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+
+  describe('card gateway account', () => {
+    const gatewayAccountId = 42
+
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    })
+
+    it('should display 3 links for a live sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
+        commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'sandbox')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 3)
+
+      cy.get('#demo-payment-link').should('exist')
+      cy.get('#demo-payment-link').should('have.class', 'flex-grid--column-third')
+      cy.get('#demo-payment-link').should('not.have.class', 'border-bottom')
+
+      cy.get('#test-payment-link-link').should('exist')
+      cy.get('#test-payment-link-link').should('have.class', 'flex-grid--column-third')
+      cy.get('#test-payment-link-link').should('not.have.class', 'border-bottom')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-third')
+      cy.get('#manage-service-link').should('not.have.class', 'border-bottom')
+    })
+
+    it('should display 2 links for a live non-sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
+        commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'worldpay')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 2)
+
+      cy.get('#payment-links-link').should('exist')
+      cy.get('#payment-links-link').should('have.class', 'flex-grid--column-half')
+      cy.get('#payment-links-link').should('not.have.class', 'border-bottom')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-half')
+      cy.get('#manage-service-link').should('not.have.class', 'border-bottom')
+    })
+
+    it('should display 4 links for a test sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId], 'an-id', 'NOT_STARTED'),
+        commonStubs.getGatewayAccountStub(gatewayAccountId, 'test', 'sandbox')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 4)
+
+      cy.get('#demo-payment-link').should('exist')
+      cy.get('#demo-payment-link').should('have.class', 'flex-grid--column-half')
+      cy.get('#demo-payment-link').should('have.class', 'border-bottom')
+
+      cy.get('#test-payment-link-link').should('exist')
+      cy.get('#test-payment-link-link').should('have.class', 'flex-grid--column-half')
+      cy.get('#test-payment-link-link').should('have.class', 'border-bottom')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-half')
+      cy.get('#manage-service-link').should('not.have.class', 'border-bottom')
+
+      cy.get('#request-to-go-live-link').should('exist')
+      cy.get('#request-to-go-live-link').should('have.class', 'flex-grid--column-half')
+      cy.get('#request-to-go-live-link').should('not.have.class', 'border-bottom')
+    })
+
+    it('should display 3 links for a test non-sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
+        commonStubs.getGatewayAccountStub(gatewayAccountId, 'test', 'worldpay')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 3)
+
+      cy.get('#payment-links-link').should('exist')
+      cy.get('#payment-links-link').should('have.class', 'flex-grid--column-third')
+      cy.get('#payment-links-link').should('not.have.class', 'border-bottom')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-third')
+      cy.get('#manage-service-link').should('not.have.class', 'border-bottom')
+
+      cy.get('#request-to-go-live-link').should('exist')
+      cy.get('#request-to-go-live-link').should('have.class', 'flex-grid--column-third')
+      cy.get('#request-to-go-live-link').should('not.have.class', 'border-bottom')
+    })
+  })
+
+  describe('direct debit gateway account', () => {
+    const gatewayAccountId = 'DIRECT_DEBIT:101'
+
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    })
+
+    it('should display 3 links for a live sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
+        commonStubs.getDirectDebitGatewayAccountStub(gatewayAccountId, 'live', 'sandbox')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 3)
+
+      cy.get('#demo-payment-link').should('exist')
+      cy.get('#demo-payment-link').should('have.class', 'flex-grid--column-third')
+      cy.get('#demo-payment-link').should('not.have.class', 'border-bottom')
+
+      cy.get('#test-payment-link-link').should('exist')
+      cy.get('#test-payment-link-link').should('have.class', 'flex-grid--column-third')
+      cy.get('#test-payment-link-link').should('not.have.class', 'border-bottom')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-third')
+      cy.get('#manage-service-link').should('not.have.class', 'border-bottom')
+    })
+
+    it('should display 2 links for a live non-sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
+        commonStubs.getDirectDebitGatewayAccountStub(gatewayAccountId, 'live', 'go-cardless')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 2)
+
+      cy.get('#payment-flow-link').should('exist')
+      cy.get('#payment-flow-link').should('have.class', 'flex-grid--column-half')
+      cy.get('#payment-flow-link').should('not.have.class', 'border-bottom')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-half')
+      cy.get('#manage-service-link').should('not.have.class', 'border-bottom')
+    })
+
+    it('should display 4 links for a test sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId], 'an-id', 'NOT_STARTED'),
+        commonStubs.getDirectDebitGatewayAccountStub(gatewayAccountId, 'test', 'sandbox')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 4)
+
+      cy.get('#demo-payment-link').should('exist')
+      cy.get('#demo-payment-link').should('have.class', 'flex-grid--column-half')
+      cy.get('#demo-payment-link').should('have.class', 'border-bottom')
+
+      cy.get('#test-payment-link-link').should('exist')
+      cy.get('#test-payment-link-link').should('have.class', 'flex-grid--column-half')
+      cy.get('#test-payment-link-link').should('have.class', 'border-bottom')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-half')
+      cy.get('#manage-service-link').should('not.have.class', 'border-bottom')
+
+      cy.get('#request-to-go-live-link').should('exist')
+      cy.get('#request-to-go-live-link').should('have.class', 'flex-grid--column-half')
+      cy.get('#request-to-go-live-link').should('not.have.class', 'border-bottom')
+    })
+
+    it('should display 3 links for a test non-sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId], 'an-id', 'NOT_STARTED'),
+        commonStubs.getDirectDebitGatewayAccountStub(gatewayAccountId, 'test', 'go-cardless')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 3)
+
+      cy.get('#payment-flow-link').should('exist')
+      cy.get('#payment-flow-link').should('have.class', 'flex-grid--column-third')
+      cy.get('#payment-flow-link').should('not.have.class', 'border-bottom')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-third')
+      cy.get('#manage-service-link').should('not.have.class', 'border-bottom')
+
+      cy.get('#request-to-go-live-link').should('exist')
+      cy.get('#request-to-go-live-link').should('have.class', 'flex-grid--column-third')
+      cy.get('#request-to-go-live-link').should('not.have.class', 'border-bottom')
+    })
+  })
+})

--- a/test/cypress/integration/dashboard/dashboard_spec.js
+++ b/test/cypress/integration/dashboard/dashboard_spec.js
@@ -30,7 +30,7 @@ describe('Dashboard', () => {
     const from = encodeURIComponent('2018-05-14T00:00:00+01:00')
     const to = encodeURIComponent('2018-05-15T00:00:00+01:00')
 
-    it(`should have the page title 'Dashboard - ${serviceName} test - GOV.UK Pay'`, () => {
+    it(`should have the page title 'Dashboard - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
       const dashboardUrl = `/?period=custom&fromDateTime=${from}&toDateTime=${to}`
       cy.visit(dashboardUrl)
       cy.title().should('eq', `Dashboard - ${serviceName} sandbox test - GOV.UK Pay`)

--- a/test/cypress/integration/request-to-go-live/agreement_spec.js
+++ b/test/cypress/integration/request-to-go-live/agreement_spec.js
@@ -23,7 +23,7 @@ describe('Request to go live: agreement', () => {
       serviceRole.role = {
         permissions: []
       }
-      utils.setupStubs(serviceRole)
+      utils.setupSimpleGetUserAndGatewayAccountStubs(serviceRole)
     })
 
     it('should show an error when the user does not have enough permissions', () => {
@@ -36,7 +36,7 @@ describe('Request to go live: agreement', () => {
 
   describe('REQUEST_TO_GO_LIVE_STAGE_WRONG_STAGE', () => {
     beforeEach(() => {
-      utils.setupStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME'))
+      utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME'))
     })
 
     it('should redirect to "Request to go live: index" page when in wrong stage', () => {
@@ -53,7 +53,7 @@ describe('Request to go live: agreement', () => {
 
   describe('REQUEST_TO_GO_LIVE_STAGE_NOT_STARTED_STAGE', () => {
     beforeEach(() => {
-      utils.setupStubs(utils.buildServiceRoleForGoLiveStage('NOT_STARTED'))
+      utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('NOT_STARTED'))
     })
 
     it('should redirect to "Request to go live: index" page when in not started stage', () => {
@@ -86,7 +86,7 @@ describe('Request to go live: agreement', () => {
     }]
 
     const stubPayload = lodash.concat(repeatGetUserSuccessStub,
-      utils.stubWithGoLiveStage('TERMS_AGREED_STRIPE'), stubGovUkPayAgreement)
+      utils.patchGoLiveStageStub('TERMS_AGREED_STRIPE'), stubGovUkPayAgreement)
     beforeEach(() => {
       cy.task('setupStubs', stubPayload)
     })
@@ -140,7 +140,7 @@ describe('Request to go live: agreement', () => {
     }]
 
     const stubPayload = lodash.concat(repeatGetUserSuccessStub,
-      utils.stubWithGoLiveStage('TERMS_AGREED_WORLDPAY'), stubGovUkPayAgreement)
+      utils.patchGoLiveStageStub('TERMS_AGREED_WORLDPAY'), stubGovUkPayAgreement)
 
     beforeEach(() => {
       cy.task('setupStubs', stubPayload)
@@ -178,8 +178,8 @@ describe('Request to go live: agreement', () => {
   })
 
   describe('adminusers error handlings', () => {
-    const stubPayload = lodash.concat(utils.simpleStub(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_STRIPE')),
-      utils.stubGoLiveStageError('TERMS_AGREED_STRIPE'))
+    const stubPayload = lodash.concat(utils.simpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_STRIPE')),
+      utils.patchGoLiveStageErrorStub('TERMS_AGREED_STRIPE'))
     beforeEach(() => {
       cy.task('setupStubs', stubPayload)
     })

--- a/test/cypress/integration/request-to-go-live/choose_how_to_process_payments_spec.js
+++ b/test/cypress/integration/request-to-go-live/choose_how_to_process_payments_spec.js
@@ -15,7 +15,7 @@ describe('Request to go live: choose how to process payments', () => {
 
   describe('Service has wrong go live stage', () => {
     beforeEach(() => {
-      utils.setupStubs(utils.buildServiceRoleForGoLiveStage('NOT_STARTED'))
+      utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('NOT_STARTED'))
     })
 
     it('should redirect to "Request to go live: index" page when in wrong stage', () => {
@@ -48,7 +48,7 @@ describe('Request to go live: choose how to process payments', () => {
     }]
 
     const stubPayload = lodash.concat(repeatGetUserSuccessStub,
-      utils.stubWithGoLiveStage('CHOSEN_PSP_STRIPE'))
+      utils.patchGoLiveStageStub('CHOSEN_PSP_STRIPE'))
     beforeEach(() => {
       cy.task('setupStubs', stubPayload)
     })
@@ -95,7 +95,7 @@ describe('Request to go live: choose how to process payments', () => {
     }]
 
     const stubPayload = lodash.concat(repeatGetUserSuccessStub,
-      utils.stubWithGoLiveStage('CHOSEN_PSP_EPDQ'))
+      utils.patchGoLiveStageStub('CHOSEN_PSP_EPDQ'))
     beforeEach(() => {
       cy.task('setupStubs', stubPayload)
     })
@@ -141,7 +141,7 @@ describe('Request to go live: choose how to process payments', () => {
       serviceRole.role = {
         permissions: []
       }
-      utils.setupStubs(serviceRole)
+      utils.setupSimpleGetUserAndGatewayAccountStubs(serviceRole)
     })
 
     it('should show an error when the user does not have enough permissions', () => {
@@ -154,7 +154,7 @@ describe('Request to go live: choose how to process payments', () => {
 
   describe('other tests', () => {
     beforeEach(() => {
-      utils.setupStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME'))
+      utils.setupSimpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME'))
     })
     describe('should show an error when no option selected', () => {
       it('should show "You need to select an option" error msg', () => {
@@ -187,8 +187,8 @@ describe('Request to go live: choose how to process payments', () => {
   })
 
   describe('adminusers error handlings', () => {
-    const stubPayload = lodash.concat(utils.simpleStub(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')),
-      utils.stubGoLiveStageError('CHOSEN_PSP_STRIPE'))
+    const stubPayload = lodash.concat(utils.simpleGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')),
+      utils.patchGoLiveStageErrorStub('CHOSEN_PSP_STRIPE'))
     beforeEach(() => {
       cy.task('setupStubs', stubPayload)
     })

--- a/test/cypress/integration/request-to-go-live/organisation_name_spec.js
+++ b/test/cypress/integration/request-to-go-live/organisation_name_spec.js
@@ -38,7 +38,7 @@ describe('Request to go live: organisation name page', () => {
     const serviceRole = utils.buildServiceRoleForGoLiveStage('NOT_STARTED')
     serviceRole.role = { permissions: [ ] }
     beforeEach(() => {
-      utils.setupStubs(serviceRole)
+      utils.setupSimpleGetUserAndGatewayAccountStubs(serviceRole)
     })
 
     it('should show an error when the user does not have enough permissions', () => {
@@ -52,7 +52,7 @@ describe('Request to go live: organisation name page', () => {
   describe('Service has invalid go live stage', () => {
     const serviceRole = utils.buildServiceRoleForGoLiveStage('INVALID_GO_LIVE_STAGE')
     beforeEach(() => {
-      utils.setupStubs(serviceRole)
+      utils.setupSimpleGetUserAndGatewayAccountStubs(serviceRole)
     })
     it('should redirect to "Request to go live: index" page when in wrong stage', () => {
       const requestToGoLivePageOrganisationNameUrl = `/service/${serviceExternalId}/request-to-go-live/organisation-name`
@@ -146,7 +146,7 @@ describe('Request to go live: organisation name page', () => {
   describe('Service has NOT_STARTED go live stage and there are validation errors on the page', () => {
     const serviceRole = utils.buildServiceRoleForGoLiveStage('NOT_STARTED')
     beforeEach(() => {
-      utils.setupStubs(serviceRole)
+      utils.setupSimpleGetUserAndGatewayAccountStubs(serviceRole)
     })
 
     it('should show errors on the page when no organisation name is submitted', () => {

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -134,6 +134,31 @@ module.exports = {
       }
     ]
   },
+  getDirectDebitGatewayAccountSuccess: (opts = {}) => {
+    const aValidGetGatewayAccountResponse = gatewayAccountFixtures.validDirectDebitGatewayAccountResponse(opts).getPlain()
+    return [
+      {
+        predicates: [{
+          equals: {
+            method: 'GET',
+            path: '/v1/api/accounts/' + opts.gateway_account_id,
+            headers: {
+              'Accept': 'application/json'
+            }
+          }
+        }],
+        responses: [{
+          is: {
+            statusCode: 200,
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: aValidGetGatewayAccountResponse
+          }
+        }]
+      }
+    ]
+  },
   getAccountAuthSuccess: (opts = {}) => {
     const getServiceAuthResponse = gatewayAccountFixtures.validGatewayAccountTokensResponse(opts).getPlain()
     return [

--- a/test/cypress/utils/common_stubs.js
+++ b/test/cypress/utils/common_stubs.js
@@ -1,0 +1,38 @@
+'use strict'
+
+module.exports.getUserStub = (userExternalId, gatewayAccountIds, serviceExternalId = 'a-service-id', goLiveStage = 'NOT_STARTED') => {
+  return {
+    name: 'getUserSuccess',
+    opts: {
+      external_id: userExternalId,
+      service_roles: [{
+        service: {
+          gateway_account_ids: gatewayAccountIds,
+          current_go_live_stage: goLiveStage
+        }
+      }]
+    }
+  }
+}
+
+module.exports.getGatewayAccountStub = (gatewayAccountId, type = 'test', paymentProvider = 'sandbox') => {
+  return {
+    name: 'getGatewayAccountSuccess',
+    opts: {
+      gateway_account_id: gatewayAccountId,
+      type: type,
+      payment_provider: paymentProvider
+    }
+  }
+}
+
+module.exports.getDirectDebitGatewayAccountStub = (gatewayAccountId, type = 'test', paymentProvider = 'sandbox') => {
+  return {
+    name: 'getDirectDebitGatewayAccountSuccess',
+    opts: {
+      gateway_account_id: gatewayAccountId,
+      type: type,
+      payment_provider: paymentProvider
+    }
+  }
+}

--- a/test/cypress/utils/request_to_go_live_utils.js
+++ b/test/cypress/utils/request_to_go_live_utils.js
@@ -27,7 +27,7 @@ const buildServiceRoleForMerchantDetailsField = (merchantDetails, goLiveStage) =
   }
 }
 
-const simpleStub = (serviceRole) => {
+const simpleGetUserAndGatewayAccountStubs = (serviceRole) => {
   return [
     {
       name: 'getUserSuccess',
@@ -38,12 +38,15 @@ const simpleStub = (serviceRole) => {
     },
     {
       name: 'getGatewayAccountSuccess',
-      opts: { gateway_account_id: variables.gatewayAccountId }
+      opts: {
+        gateway_account_id: variables.gatewayAccountId,
+        type: 'test'
+      }
     }
   ]
 }
 
-const stubWithGoLiveStage = (currentGoLiveStage) => {
+const patchGoLiveStageStub = (currentGoLiveStage) => {
   return {
     name: 'patchUpdateServiceSuccess',
     opts: {
@@ -54,7 +57,7 @@ const stubWithGoLiveStage = (currentGoLiveStage) => {
   }
 }
 
-const stubGoLiveStageError = (currentGoLiveStage) => {
+const patchGoLiveStageErrorStub = (currentGoLiveStage) => {
   return {
     name: 'patchGoLiveStageFailure',
     opts: {
@@ -67,8 +70,8 @@ const stubGoLiveStageError = (currentGoLiveStage) => {
   }
 }
 
-const setupStubs = (serviceRole) => {
-  cy.task('setupStubs', simpleStub(serviceRole))
+const setupSimpleGetUserAndGatewayAccountStubs = (serviceRole) => {
+  cy.task('setupStubs', simpleGetUserAndGatewayAccountStubs(serviceRole))
 }
 
 const stubUserSuccessResponse = (serviceRoleBefore, serviceRoleAfter) =>
@@ -92,9 +95,9 @@ module.exports = {
   variables,
   buildServiceRoleForMerchantDetailsField,
   buildServiceRoleForGoLiveStage,
-  simpleStub,
-  stubWithGoLiveStage,
-  stubGoLiveStageError,
-  setupStubs,
+  simpleGetUserAndGatewayAccountStubs,
+  patchGoLiveStageStub,
+  patchGoLiveStageErrorStub,
+  setupSimpleGetUserAndGatewayAccountStubs,
   stubUserSuccessResponse
 }

--- a/test/fixtures/gateway_account_fixtures.js
+++ b/test/fixtures/gateway_account_fixtures.js
@@ -145,7 +145,7 @@ module.exports = {
       gateway_account_id: opts.gateway_account_id || 73,
       gateway_account_external_id: opts.gateway_account_external_id || 'DIRECT_DEBIT:' + 'a9c797ab271448bdba21359e15672076',
       service_name: opts.service_name || '8c0045d0664743c68e25489781e05b1d',
-      payment_provider: opts.service_name || 'sandbox',
+      payment_provider: opts.payment_provider || 'sandbox',
       type: opts.type || 'test',
       analytics_id: opts.analytics_id || 'd82dae5bcb024828bb686574a932b5a5'
     }

--- a/test/integration/login_controller_test.js
+++ b/test/integration/login_controller_test.js
@@ -1,24 +1,25 @@
 'use strict'
 
 const path = require('path')
-require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
 const request = require('supertest')
-const getApp = require(path.join(__dirname, '/../../server.js')).getApp
 const nock = require('nock')
 const assert = require('assert')
 const notp = require('notp')
 const chai = require('chai')
 const _ = require('lodash')
-const userFixtures = require('../fixtures/user_fixtures')
 const sinon = require('sinon')
+const chaiAsPromised = require('chai-as-promised')
 
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+const getApp = require(path.join(__dirname, '/../../server.js')).getApp
+const userFixtures = require('../fixtures/user_fixtures')
+const gatewayAccountFixtures = require('../fixtures/gateway_account_fixtures')
 const paths = require(path.join(__dirname, '/../../app/paths.js'))
 const mockSession = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
 const loginController = require(path.join(__dirname, '/../../app/controllers/login'))
 const mockRes = require('../fixtures/response')
-const {CONNECTOR_URL} = process.env
 
-const chaiAsPromised = require('chai-as-promised')
+const {CONNECTOR_URL} = process.env
 chai.use(chaiAsPromised)
 const expect = chai.expect
 
@@ -34,6 +35,9 @@ describe('The logged in endpoint', function () {
   it('should render ok when logged in', function (done) {
     const app = mockSession.getAppWithLoggedInUser(getApp(), user)
 
+    nock(CONNECTOR_URL)
+      .get(`/v1/frontend/accounts/${ACCOUNT_ID}`)
+      .reply(200, gatewayAccountFixtures.validGatewayAccountResponse({ gateway_account_id: ACCOUNT_ID }))
     nock(CONNECTOR_URL)
       .get(`/v1/api/accounts/${ACCOUNT_ID}/transactions-summary`)
       .query(() => true)

--- a/test/ui/navigation_ui_tests.js
+++ b/test/ui/navigation_ui_tests.js
@@ -14,7 +14,8 @@ describe('navigation menu', function () {
       currentService: {name: 'Service Name'},
       permissions: testPermissions,
       hideServiceNav: false,
-      serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'card')
+      serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'card'),
+      links: []
     }
 
     const body = renderTemplate('dashboard/index', templateData)
@@ -33,7 +34,8 @@ describe('navigation menu', function () {
       currentService: {name: 'Service Name'},
       permissions: testPermissions,
       hideServiceNav: false,
-      serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'card')
+      serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'card'),
+      links: []
     }
 
     const body = renderTemplate('dashboard/index', templateData)
@@ -52,7 +54,8 @@ describe('navigation menu', function () {
       currentService: {name: 'Service Name'},
       permissions: testPermissions,
       hideServiceNav: false,
-      serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'direct debit')
+      serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'direct debit'),
+      links: []
     }
 
     const body = renderTemplate('dashboard/index', templateData)


### PR DESCRIPTION
Note: This should be ready to go, but we are waiting on the go-live request flow to be complete and the status of all services to be checked before this is deployed to production and made publicly available.
Also waiting on the wording of the link to be finalised.

## WHAT
- Move logic to decide whether to display each link on the dashboard and the css classes to apply into the controller as this has got a bit more complex
- Add Cypress tests for the links displayed on the dashboard for different gateway account types
- Add Cypress tests for the variant of the go-live link displayed on the dashboard
- Rename some methods in test/cypress/utils/request_to_go_live_utils.js to make them more descriptive

