### PR TITLE
PP-4448 Modify logic for displaying links on dashboard

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -10,6 +10,7 @@
 @import "components/dashboard-activity";
 @import "components/flex-grid";
 @import "components/links-box";
+@import "components/links-container";
 @import "components/flash";
 @import "components/text-align";
 @import "components/button";

--- a/app/assets/sass/components/links-box.scss
+++ b/app/assets/sass/components/links-box.scss
@@ -33,20 +33,4 @@
       color: $govuk-text-colour;
     }
   }
-
-  @include govuk-media-query(tablet) {
-    &.border-bottom {
-      margin-bottom: 45px;
-
-      &:after {
-        content: "";
-        position: absolute;
-        bottom: - govuk-spacing(6);
-        height: 1px;
-        background-color:  govuk-colour("grey-3");
-        right: govuk-spacing(3);
-        left: govuk-spacing(3);
-      }
-    }
-  }
 }

--- a/app/assets/sass/components/links-container.scss
+++ b/app/assets/sass/components/links-container.scss
@@ -1,0 +1,17 @@
+.links-container {
+  @include govuk-media-query(tablet) {
+    .flex-grid--column-half:nth-child(n+3) {
+      margin-top: 45px;
+
+      &:before {
+        content: "";
+        position: absolute;
+        top: - govuk-spacing(6);
+        height: 1px;
+        background-color: govuk-colour("grey-3");
+        right: govuk-spacing(3);
+        left: govuk-spacing(3);
+      }
+    }
+  }
+}

--- a/app/controllers/dashboard/dashboard-activity-controller.test.js
+++ b/app/controllers/dashboard/dashboard-activity-controller.test.js
@@ -11,6 +11,7 @@ const moment = require('moment-timezone')
 const {getApp} = require('../../../server')
 const {getMockSession, createAppWithSession, getUser} = require('../../../test/test_helpers/mock_session')
 const paths = require('../../../app/paths')
+const gatewayAccountFixtures = require('../../../test/fixtures/gateway_account_fixtures')
 const {CONNECTOR_URL} = process.env
 const GATEWAY_ACCOUNT_ID = '929'
 const DASHBOARD_RESPONSE = {
@@ -27,6 +28,12 @@ const DASHBOARD_RESPONSE = {
   }
 }
 
+const mockConnectorGetGatewayAccount = () => {
+  nock(CONNECTOR_URL)
+    .get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
+    .reply(200, gatewayAccountFixtures.validGatewayAccountResponse({ gateway_account_id: GATEWAY_ACCOUNT_ID }))
+}
+
 describe('dashboard-activity-controller', () => {
   describe('When the dashboard is successfully retrieved from connector', () => {
     describe('and the period is not set', () => {
@@ -38,6 +45,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         nock(CONNECTOR_URL)
           .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/transactions-summary`)
           .query(obj => {
@@ -100,7 +108,7 @@ describe('dashboard-activity-controller', () => {
           .to.contain(moment().tz('Europe/London').startOf('day').subtract(0, 'days').format('D MMMM YYYY h:mm:ssa z'))
       })
     })
-    describe('and the period is set to today explictly', () => {
+    describe('and the period is set to today explicitly', () => {
       let result, $, app
 
       before('Arrange', () => {
@@ -109,6 +117,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         nock(CONNECTOR_URL)
           .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/transactions-summary`)
           .query(obj => {
@@ -158,6 +167,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         nock(CONNECTOR_URL)
           .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/transactions-summary`)
           .query(obj => {
@@ -207,6 +217,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         nock(CONNECTOR_URL)
           .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/transactions-summary`)
           .query(obj => {
@@ -256,6 +267,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         nock(CONNECTOR_URL)
           .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/transactions-summary`)
           .query(obj => {
@@ -308,6 +320,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         nock(CONNECTOR_URL)
           .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/transactions-summary`)
           .query(obj => {
@@ -359,6 +372,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         nock(CONNECTOR_URL)
           .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/transactions-summary`)
           .query(obj => {
@@ -405,6 +419,7 @@ describe('dashboard-activity-controller', () => {
           permissions: [{name: 'transactions:read'}]
         }))
 
+        mockConnectorGetGatewayAccount()
         app = createAppWithSession(getApp(), session)
       })
 

--- a/app/views/dashboard/_links.njk
+++ b/app/views/dashboard/_links.njk
@@ -1,21 +1,32 @@
-<div class="govuk-grid-column-full flex-grid" data-click-events data-click-category="Dashboard" data-click-action="First steps link clicked">
+{% if linksToDisplay.length % 3 == 0 %}
+  {% set columnClass = "flex-grid--column-third" %}
+{% else %}
+  {% set columnClass = "flex-grid--column-half" %}
+{% endif %}
+
+<div class="govuk-grid-column-full flex-grid links-container" data-click-events data-click-category="Dashboard" data-click-action="First steps link clicked">
+  
   <div class="flex-grid--row">
-    {% if isSandbox %}
-    <article class="flex-grid--column-half links__box border-bottom">
+    {% if links.demoPayment in linksToDisplay %}
+    <article class="{{columnClass}} links__box" id="demo-payment-link">
       <a href="{{routes.prototyping.demoPayment.index}}">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Make a demo payment</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Try the payment experience as a user. Then view the completed payment as an administrator on GOV.UK&nbsp;Pay.</p>
       </a>
     </article>
+    {% endif %}
 
-    <article class="flex-grid--column-half links__box border-bottom">
+    {% if links.testPaymentLink in linksToDisplay %}
+    <article class="{{columnClass}} links__box" id="test-payment-link-link">
       <a href="{{routes.prototyping.demoService.index}}">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Test with your users</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Create a reusable link to integrate your service prototype with GOV.UK&nbsp;Pay and test with users.</p>
       </a>
     </article>
-    {% elif paymentMethod === 'card'%}
-    <article class="flex-grid--column-{% if isTestGateway %}third{% else %}half{% endif %} links__box">
+    {% endif %}
+
+    {% if links.paymentLinks in linksToDisplay %}
+    <article class="{{columnClass}} links__box" id="payment-links-link">
       {% if permissions.tokens_create %}
       <a href="{{routes.paymentLinks.start}}">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Create and manage payment links</h2>
@@ -26,15 +37,19 @@
         <p class="govuk-body govuk-!-margin-bottom-0">A payment link lets you take card payments online, even if you don't have a digital&nbsp;service.</p>
       </a>
     </article>
-    {% else %}
-    <article class="flex-grid--column-{% if isTestGateway %}third{% else %}half{% endif %} links__box">
+    {% endif %}
+
+    {% if links.directDebitPaymentFlow in linksToDisplay %}
+    <article class="{{columnClass}} links__box" id="payment-flow-link">
       <a href="https://docs.payments.service.gov.uk/payment_flow_overview/#making-a-payment">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">See the payment flow</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Get an overview of payment pages in our documentation.</p>
       </a>
     </article>
     {% endif %}
-    <article class="flex-grid--column-{% if isSandbox %}half{% else %}{% if isTestGateway %}third{% else %}half{% endif %}{% endif %} links__box">
+
+    {% if links.manageService in linksToDisplay %}
+    <article class="{{columnClass}} links__box" id="manage-service-link">
       <a href="/service/{{ currentService.externalId }}">
       {% if permissions.users_service_create %}
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Manage team members</h2>
@@ -45,9 +60,10 @@
       {% endif %}
       </a>
     </article>
+    {% endif %}
 
-    {% if isTestGateway %}
-    <article class="flex-grid--column-{% if isSandbox %}half{% else %}third{% endif %} links__box">
+    {% if links.goLive in linksToDisplay %}
+    <article class="{{columnClass}} links__box" id="request-to-go-live-link">
       <a href="https://docs.payments.service.gov.uk/switching_to_live/#switching-to-live">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Next steps to go live</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Read our documentation to see how your service can go live with GOV.UK&nbsp;Pay.</p>

--- a/test/cypress/integration/dashboard/dashboard_links_spec.js
+++ b/test/cypress/integration/dashboard/dashboard_links_spec.js
@@ -1,0 +1,178 @@
+'use strict'
+
+const commonStubs = require('../../utils/common_stubs')
+
+describe('the links are displayed correctly on the dashboard', () => {
+  const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+
+  describe('card gateway account', () => {
+    const gatewayAccountId = 42
+
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    })
+
+    it('should display 3 links for a live sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
+        commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'sandbox')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 3)
+
+      cy.get('#demo-payment-link').should('exist')
+      cy.get('#demo-payment-link').should('have.class', 'flex-grid--column-third')
+      cy.get('#demo-payment-link').should('not.have.class', 'border-bottom')
+
+      cy.get('#test-payment-link-link').should('exist')
+      cy.get('#test-payment-link-link').should('have.class', 'flex-grid--column-third')
+      cy.get('#test-payment-link-link').should('not.have.class', 'border-bottom')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-third')
+      cy.get('#manage-service-link').should('not.have.class', 'border-bottom')
+    })
+
+    it('should display 2 links for a live non-sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
+        commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'worldpay')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 2)
+
+      cy.get('#payment-links-link').should('exist')
+      cy.get('#payment-links-link').should('have.class', 'flex-grid--column-half')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-half')
+    })
+
+    it('should display 4 links for a test sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId], 'an-id', 'NOT_STARTED'),
+        commonStubs.getGatewayAccountStub(gatewayAccountId, 'test', 'sandbox')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 4)
+
+      cy.get('#demo-payment-link').should('exist')
+      cy.get('#demo-payment-link').should('have.class', 'flex-grid--column-half')
+
+      cy.get('#test-payment-link-link').should('exist')
+      cy.get('#test-payment-link-link').should('have.class', 'flex-grid--column-half')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-half')
+
+      cy.get('#request-to-go-live-link').should('exist')
+      cy.get('#request-to-go-live-link').should('have.class', 'flex-grid--column-half')
+    })
+
+    it('should display 3 links for a test non-sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
+        commonStubs.getGatewayAccountStub(gatewayAccountId, 'test', 'worldpay')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 3)
+
+      cy.get('#payment-links-link').should('exist')
+      cy.get('#payment-links-link').should('have.class', 'flex-grid--column-third')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-third')
+
+      cy.get('#request-to-go-live-link').should('exist')
+      cy.get('#request-to-go-live-link').should('have.class', 'flex-grid--column-third')
+    })
+  })
+
+  describe('direct debit gateway account', () => {
+    const gatewayAccountId = 'DIRECT_DEBIT:101'
+
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    })
+
+    it('should display 3 links for a live sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
+        commonStubs.getDirectDebitGatewayAccountStub(gatewayAccountId, 'live', 'sandbox')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 3)
+
+      cy.get('#demo-payment-link').should('exist')
+      cy.get('#demo-payment-link').should('have.class', 'flex-grid--column-third')
+
+      cy.get('#test-payment-link-link').should('exist')
+      cy.get('#test-payment-link-link').should('have.class', 'flex-grid--column-third')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-third')
+    })
+
+    it('should display 2 links for a live non-sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
+        commonStubs.getDirectDebitGatewayAccountStub(gatewayAccountId, 'live', 'go-cardless')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 2)
+
+      cy.get('#payment-flow-link').should('exist')
+      cy.get('#payment-flow-link').should('have.class', 'flex-grid--column-half')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-half')
+    })
+
+    it('should display 4 links for a test sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId], 'an-id', 'NOT_STARTED'),
+        commonStubs.getDirectDebitGatewayAccountStub(gatewayAccountId, 'test', 'sandbox')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 4)
+
+      cy.get('#demo-payment-link').should('exist')
+      cy.get('#demo-payment-link').should('have.class', 'flex-grid--column-half')
+
+      cy.get('#test-payment-link-link').should('exist')
+      cy.get('#test-payment-link-link').should('have.class', 'flex-grid--column-half')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-half')
+
+      cy.get('#request-to-go-live-link').should('exist')
+      cy.get('#request-to-go-live-link').should('have.class', 'flex-grid--column-half')
+    })
+
+    it('should display 3 links for a test non-sandbox account', () => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId], 'an-id', 'NOT_STARTED'),
+        commonStubs.getDirectDebitGatewayAccountStub(gatewayAccountId, 'test', 'go-cardless')
+      ])
+
+      cy.visit('/')
+      cy.get('.links__box').should('have.length', 3)
+
+      cy.get('#payment-flow-link').should('exist')
+      cy.get('#payment-flow-link').should('have.class', 'flex-grid--column-third')
+
+      cy.get('#manage-service-link').should('exist')
+      cy.get('#manage-service-link').should('have.class', 'flex-grid--column-third')
+
+      cy.get('#request-to-go-live-link').should('exist')
+      cy.get('#request-to-go-live-link').should('have.class', 'flex-grid--column-third')
+    })
+  })
+})

--- a/test/cypress/integration/dashboard/dashboard_spec.js
+++ b/test/cypress/integration/dashboard/dashboard_spec.js
@@ -30,7 +30,7 @@ describe('Dashboard', () => {
     const from = encodeURIComponent('2018-05-14T00:00:00+01:00')
     const to = encodeURIComponent('2018-05-15T00:00:00+01:00')
 
-    it(`should have the page title 'Dashboard - ${serviceName} test - GOV.UK Pay'`, () => {
+    it(`should have the page title 'Dashboard - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
       const dashboardUrl = `/?period=custom&fromDateTime=${from}&toDateTime=${to}`
       cy.visit(dashboardUrl)
       cy.title().should('eq', `Dashboard - ${serviceName} sandbox test - GOV.UK Pay`)

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -134,6 +134,31 @@ module.exports = {
       }
     ]
   },
+  getDirectDebitGatewayAccountSuccess: (opts = {}) => {
+    const aValidGetGatewayAccountResponse = gatewayAccountFixtures.validDirectDebitGatewayAccountResponse(opts).getPlain()
+    return [
+      {
+        predicates: [{
+          equals: {
+            method: 'GET',
+            path: '/v1/api/accounts/' + opts.gateway_account_id,
+            headers: {
+              'Accept': 'application/json'
+            }
+          }
+        }],
+        responses: [{
+          is: {
+            statusCode: 200,
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: aValidGetGatewayAccountResponse
+          }
+        }]
+      }
+    ]
+  },
   getAccountAuthSuccess: (opts = {}) => {
     const getServiceAuthResponse = gatewayAccountFixtures.validGatewayAccountTokensResponse(opts).getPlain()
     return [

--- a/test/cypress/utils/common_stubs.js
+++ b/test/cypress/utils/common_stubs.js
@@ -1,0 +1,38 @@
+'use strict'
+
+module.exports.getUserStub = (userExternalId, gatewayAccountIds, serviceExternalId = 'a-service-id', goLiveStage = 'NOT_STARTED') => {
+  return {
+    name: 'getUserSuccess',
+    opts: {
+      external_id: userExternalId,
+      service_roles: [{
+        service: {
+          gateway_account_ids: gatewayAccountIds,
+          current_go_live_stage: goLiveStage
+        }
+      }]
+    }
+  }
+}
+
+module.exports.getGatewayAccountStub = (gatewayAccountId, type = 'test', paymentProvider = 'sandbox') => {
+  return {
+    name: 'getGatewayAccountSuccess',
+    opts: {
+      gateway_account_id: gatewayAccountId,
+      type: type,
+      payment_provider: paymentProvider
+    }
+  }
+}
+
+module.exports.getDirectDebitGatewayAccountStub = (gatewayAccountId, type = 'test', paymentProvider = 'sandbox') => {
+  return {
+    name: 'getDirectDebitGatewayAccountSuccess',
+    opts: {
+      gateway_account_id: gatewayAccountId,
+      type: type,
+      payment_provider: paymentProvider
+    }
+  }
+}

--- a/test/fixtures/gateway_account_fixtures.js
+++ b/test/fixtures/gateway_account_fixtures.js
@@ -145,7 +145,7 @@ module.exports = {
       gateway_account_id: opts.gateway_account_id || 73,
       gateway_account_external_id: opts.gateway_account_external_id || 'DIRECT_DEBIT:' + 'a9c797ab271448bdba21359e15672076',
       service_name: opts.service_name || '8c0045d0664743c68e25489781e05b1d',
-      payment_provider: opts.service_name || 'sandbox',
+      payment_provider: opts.payment_provider || 'sandbox',
       type: opts.type || 'test',
       analytics_id: opts.analytics_id || 'd82dae5bcb024828bb686574a932b5a5'
     }

--- a/test/integration/login_controller_test.js
+++ b/test/integration/login_controller_test.js
@@ -1,24 +1,25 @@
 'use strict'
 
 const path = require('path')
-require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
 const request = require('supertest')
-const getApp = require(path.join(__dirname, '/../../server.js')).getApp
 const nock = require('nock')
 const assert = require('assert')
 const notp = require('notp')
 const chai = require('chai')
 const _ = require('lodash')
-const userFixtures = require('../fixtures/user_fixtures')
 const sinon = require('sinon')
+const chaiAsPromised = require('chai-as-promised')
 
+require(path.join(__dirname, '/../test_helpers/serialize_mock.js'))
+const getApp = require(path.join(__dirname, '/../../server.js')).getApp
+const userFixtures = require('../fixtures/user_fixtures')
+const gatewayAccountFixtures = require('../fixtures/gateway_account_fixtures')
 const paths = require(path.join(__dirname, '/../../app/paths.js'))
 const mockSession = require(path.join(__dirname, '/../test_helpers/mock_session.js'))
 const loginController = require(path.join(__dirname, '/../../app/controllers/login'))
 const mockRes = require('../fixtures/response')
-const {CONNECTOR_URL} = process.env
 
-const chaiAsPromised = require('chai-as-promised')
+const {CONNECTOR_URL} = process.env
 chai.use(chaiAsPromised)
 const expect = chai.expect
 
@@ -34,6 +35,9 @@ describe('The logged in endpoint', function () {
   it('should render ok when logged in', function (done) {
     const app = mockSession.getAppWithLoggedInUser(getApp(), user)
 
+    nock(CONNECTOR_URL)
+      .get(`/v1/frontend/accounts/${ACCOUNT_ID}`)
+      .reply(200, gatewayAccountFixtures.validGatewayAccountResponse({ gateway_account_id: ACCOUNT_ID }))
     nock(CONNECTOR_URL)
       .get(`/v1/api/accounts/${ACCOUNT_ID}/transactions-summary`)
       .query(() => true)

--- a/test/ui/navigation_ui_tests.js
+++ b/test/ui/navigation_ui_tests.js
@@ -14,7 +14,9 @@ describe('navigation menu', function () {
       currentService: {name: 'Service Name'},
       permissions: testPermissions,
       hideServiceNav: false,
-      serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'card')
+      serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'card'),
+      links: [],
+      linksToDisplay: []
     }
 
     const body = renderTemplate('dashboard/index', templateData)
@@ -33,7 +35,9 @@ describe('navigation menu', function () {
       currentService: {name: 'Service Name'},
       permissions: testPermissions,
       hideServiceNav: false,
-      serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'card')
+      serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'card'),
+      links: [],
+      linksToDisplay: []
     }
 
     const body = renderTemplate('dashboard/index', templateData)
@@ -52,7 +56,9 @@ describe('navigation menu', function () {
       currentService: {name: 'Service Name'},
       permissions: testPermissions,
       hideServiceNav: false,
-      serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'direct debit')
+      serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'direct debit'),
+      links: [],
+      linksToDisplay: []
     }
 
     const body = renderTemplate('dashboard/index', templateData)


### PR DESCRIPTION
Move logic for deciding which links will be displayed from the Nunjucks template to the controller. This allows us to know how many links will be displayed, and so format them correctly into either 2 or 3 columns with the correct borders on the links. This is required as the logic gets a bit more complicated when we add in the "request to go live" link

Move the decision for whether to display a bottom border on the links from the template, where we were conditionally adding a css class. We now have a css rule using the nth-child selector to decide whether a link box should have a border.

Add Cypress tests for displaying the links.