### PR TITLE
PP-4759 international phone number support backward compatablity

### DIFF
--- a/app/views/self_create_service/resend_otp.njk
+++ b/app/views/self_create_service/resend_otp.njk
@@ -22,7 +22,7 @@
             text: "Mobile number",
             classes: "govuk-label--s"
         },
-        value: telephoneNumber
+        value: telephoneNumber | replace("+", "00")
       })
     }}
     {{

--- a/test/ui/self_create_service_ui_tests.js
+++ b/test/ui/self_create_service_ui_tests.js
@@ -4,7 +4,7 @@
 const renderTemplate = require('../test_helpers/html_assertions').render
 const paths = require('../../app/paths')
 
-describe('Self-create service view', function () {
+describe.only('Self-create service view', function () {
   it('should render create an account form', function (done) {
     const templateData = {}
 
@@ -68,7 +68,7 @@ describe('Self-create service view', function () {
   })
 
   it('should render otp resend form with local telephone number', function (done) {
-    const telephoneNumber = '07812345678'
+    const telephoneNumber = '01134960000'
     const templateData = {
       telephoneNumber: telephoneNumber
     }
@@ -85,7 +85,7 @@ describe('Self-create service view', function () {
 
   it('should render otp resend form with international converted to numbers only telephone number', function (done) {
     const templateData = {
-      telephoneNumber: '+447812345678'
+      telephoneNumber: '+441134960000'
     }
 
     const body = renderTemplate('self_create_service/resend_otp', templateData)
@@ -93,7 +93,7 @@ describe('Self-create service view', function () {
     body.should.containSelector('h1').withExactText('Check your mobile number')
 
     body.should.containSelector('form#otp-resend-form').withAttribute('action', paths.selfCreateService.otpResend)
-    body.should.containInputField('telephone-number', 'tel').withAttribute('value', '00447812345678')
+    body.should.containInputField('telephone-number', 'tel').withAttribute('value', '00441134960000')
 
     done()
   })

--- a/test/ui/self_create_service_ui_tests.js
+++ b/test/ui/self_create_service_ui_tests.js
@@ -4,8 +4,8 @@
 const renderTemplate = require('../test_helpers/html_assertions').render
 const paths = require('../../app/paths')
 
-describe.only('Self-create service view', function () {
-  it('should render create an account form', function (done) {
+describe('Self-create service view', () => {
+  it('should render create an account form', done => {
     const templateData = {}
 
     const body = renderTemplate('self_create_service/register', templateData)
@@ -20,7 +20,7 @@ describe.only('Self-create service view', function () {
     done()
   })
 
-  it('should render email sent page', function (done) {
+  it('should render email sent page', done => {
     const email = 'bob@example.com'
     const templateData = {
       requesterEmail: email
@@ -35,7 +35,7 @@ describe.only('Self-create service view', function () {
     done()
   })
 
-  it('should render otp verify form', function (done) {
+  it('should render otp verify form', done => {
     const templateData = {}
 
     const body = renderTemplate('self_create_service/verify_otp', templateData)
@@ -51,7 +51,7 @@ describe.only('Self-create service view', function () {
     done()
   })
 
-  it('should render name your service form', function (done) {
+  it('should render name your service form', done => {
     const serviceName = 'My Service name'
     const templateData = {
       serviceName
@@ -67,7 +67,7 @@ describe.only('Self-create service view', function () {
     done()
   })
 
-  it('should render otp resend form with local telephone number', function (done) {
+  it('should render otp resend form with local telephone number', done => {
     const telephoneNumber = '01134960000'
     const templateData = {
       telephoneNumber: telephoneNumber
@@ -83,7 +83,7 @@ describe.only('Self-create service view', function () {
     done()
   })
 
-  it('should render otp resend form with international converted to numbers only telephone number', function (done) {
+  it('should render otp resend form with international converted to numbers only telephone number', done => {
     const templateData = {
       telephoneNumber: '+441134960000'
     }

--- a/test/ui/self_create_service_ui_tests.js
+++ b/test/ui/self_create_service_ui_tests.js
@@ -67,7 +67,7 @@ describe('Self-create service view', function () {
     done()
   })
 
-  it('should render otp resend form', function (done) {
+  it('should render otp resend form with local telephone number', function (done) {
     const telephoneNumber = '07812345678'
     const templateData = {
       telephoneNumber: telephoneNumber
@@ -79,6 +79,21 @@ describe('Self-create service view', function () {
 
     body.should.containSelector('form#otp-resend-form').withAttribute('action', paths.selfCreateService.otpResend)
     body.should.containInputField('telephone-number', 'tel').withAttribute('value', telephoneNumber)
+
+    done()
+  })
+
+  it('should render otp resend form with international converted to numbers only telephone number', function (done) {
+    const templateData = {
+      telephoneNumber: '+447812345678'
+    }
+
+    const body = renderTemplate('self_create_service/resend_otp', templateData)
+
+    body.should.containSelector('h1').withExactText('Check your mobile number')
+
+    body.should.containSelector('form#otp-resend-form').withAttribute('action', paths.selfCreateService.otpResend)
+    body.should.containInputField('telephone-number', 'tel').withAttribute('value', '00447812345678')
 
     done()
   })


### PR DESCRIPTION
## WHAT

Currently pay-adminusers saves and returns international telephone number format starting with `+44` (UK example).
The current validation in selfservice still expects numbers only telephone numbers.
This PR modifies the value of the input to be reformatted in numbers only international telephone number.
Once the validation of the selfservice can handle any format we need to remove this formatting.
