### PR TITLE
PP-4759 international phone number support backward compatibility - part 2

### DIFF
--- a/app/views/user_registration/re_verify_phone.njk
+++ b/app/views/user_registration/re_verify_phone.njk
@@ -24,7 +24,7 @@
               text: "Mobile number",
               classes: "govuk-label--s"
           },
-          value: telephone_number,
+          value: telephone_number | replace("+", "00"),
           hint: {
             text: "We’ll send you a security code by text message"
           }

--- a/app/views/user_registration/register.njk
+++ b/app/views/user_registration/register.njk
@@ -22,7 +22,7 @@
               text: "Mobile number",
               classes: "govuk-label--s"
           },
-          value: telephone_number,
+          value: telephone_number | replace("+", "00"),
           hint: {
             text: "We’ll send you a security code by text message"
           }

--- a/test/ui/register_user_ui_tests.js
+++ b/test/ui/register_user_ui_tests.js
@@ -17,10 +17,10 @@ describe('Register user view', function () {
     done()
   })
 
-  it('should render create an account form with telephone number pre-populated', function (done) {
+  it('should render create an account form with local telephone number pre-populated', function (done) {
     let templateData = {
       email: 'invitee@example.com',
-      telephone_number: '0328534765'
+      telephone_number: '01134960000'
     }
 
     let body = renderTemplate('user_registration/register', templateData)
@@ -28,7 +28,22 @@ describe('Register user view', function () {
     body.should.containSelector('form#submit-registration').withAttribute('action', paths.registerUser.registration)
     body.should.containSelector('p#email-display').withExactText('Your account will be created with this email: invitee@example.com')
     body.should.containSelector('input#telephone-number')
-      .withAttribute('value', '0328534765')
+      .withAttribute('value', '01134960000')
+    done()
+  })
+
+  it('should render create an account form with international converted to numbers only telephone number pre-populated', function (done) {
+    let templateData = {
+      email: 'invitee@example.com',
+      telephone_number: '+441134960000'
+    }
+
+    let body = renderTemplate('user_registration/register', templateData)
+
+    body.should.containSelector('form#submit-registration').withAttribute('action', paths.registerUser.registration)
+    body.should.containSelector('p#email-display').withExactText('Your account will be created with this email: invitee@example.com')
+    body.should.containSelector('input#telephone-number')
+      .withAttribute('value', '00441134960000')
     done()
   })
 
@@ -44,8 +59,8 @@ describe('Register user view', function () {
     done()
   })
 
-  it('should render resend otp code view', function (done) {
-    let telephoneNumber = '012345678901'
+  it('should render resend otp code view with local telephone number', function (done) {
+    let telephoneNumber = '01134960000'
 
     let templateData = {
       telephone_number: telephoneNumber
@@ -55,6 +70,18 @@ describe('Register user view', function () {
 
     body.should.containSelector('form#otp-send-again').withAttribute('action', paths.registerUser.reVerifyPhone)
     body.should.containSelector('input#telephone-number').withAttribute('value', telephoneNumber)
+    done()
+  })
+
+  it('should render resend otp code view with international converted to numbers only telephone number', function (done) {
+    let templateData = {
+      telephone_number: '+441134960000'
+    }
+
+    let body = renderTemplate('user_registration/re_verify_phone', templateData)
+
+    body.should.containSelector('form#otp-send-again').withAttribute('action', paths.registerUser.reVerifyPhone)
+    body.should.containSelector('input#telephone-number').withAttribute('value', '00441134960000')
     done()
   })
 })

--- a/test/ui/register_user_ui_tests.js
+++ b/test/ui/register_user_ui_tests.js
@@ -1,14 +1,19 @@
-let path = require('path')
-let renderTemplate = require(path.join(__dirname, '/../test_helpers/html_assertions.js')).render
-let paths = require('../../app/paths.js')
+'use strict'
 
-describe('Register user view', function () {
-  it('should render create an account form', function (done) {
-    let templateData = {
+// NPM dependencies
+const path = require('path')
+
+// Custom dependencies
+const renderTemplate = require(path.join(__dirname, '/../test_helpers/html_assertions.js')).render
+const paths = require('../../app/paths.js')
+
+describe('Register user view', () => {
+  it('should render create an account form', done => {
+    const templateData = {
       email: 'invitee@example.com'
     }
 
-    let body = renderTemplate('user_registration/register', templateData)
+    const body = renderTemplate('user_registration/register', templateData)
 
     body.should.containSelector('form#submit-registration').withAttribute('action', paths.registerUser.registration)
     body.should.containSelector('p#email-display').withExactText('Your account will be created with this email: invitee@example.com')
@@ -17,13 +22,13 @@ describe('Register user view', function () {
     done()
   })
 
-  it('should render create an account form with local telephone number pre-populated', function (done) {
-    let templateData = {
+  it('should render create an account form with local telephone number pre-populated', done => {
+    const templateData = {
       email: 'invitee@example.com',
       telephone_number: '01134960000'
     }
 
-    let body = renderTemplate('user_registration/register', templateData)
+    const body = renderTemplate('user_registration/register', templateData)
 
     body.should.containSelector('form#submit-registration').withAttribute('action', paths.registerUser.registration)
     body.should.containSelector('p#email-display').withExactText('Your account will be created with this email: invitee@example.com')
@@ -32,13 +37,13 @@ describe('Register user view', function () {
     done()
   })
 
-  it('should render create an account form with international converted to numbers only telephone number pre-populated', function (done) {
-    let templateData = {
+  it('should render create an account form with international converted to numbers only telephone number pre-populated', done => {
+    const templateData = {
       email: 'invitee@example.com',
       telephone_number: '+441134960000'
     }
 
-    let body = renderTemplate('user_registration/register', templateData)
+    const body = renderTemplate('user_registration/register', templateData)
 
     body.should.containSelector('form#submit-registration').withAttribute('action', paths.registerUser.registration)
     body.should.containSelector('p#email-display').withExactText('Your account will be created with this email: invitee@example.com')
@@ -47,38 +52,38 @@ describe('Register user view', function () {
     done()
   })
 
-  it('should render verify telephone number view', function (done) {
-    let templateData = {
+  it('should render verify telephone number view', done => {
+    const templateData = {
       email: 'invitee@example.com'
     }
 
-    let body = renderTemplate('user_registration/verify_otp', templateData)
+    const body = renderTemplate('user_registration/verify_otp', templateData)
 
     body.should.containSelector('form#verify-phone-form').withAttribute('action', paths.registerUser.otpVerify)
     body.should.containSelector('input#verify-code')
     done()
   })
 
-  it('should render resend otp code view with local telephone number', function (done) {
-    let telephoneNumber = '01134960000'
+  it('should render resend otp code view with local telephone number', done => {
+    const telephoneNumber = '01134960000'
 
-    let templateData = {
+    const templateData = {
       telephone_number: telephoneNumber
     }
 
-    let body = renderTemplate('user_registration/re_verify_phone', templateData)
+    const body = renderTemplate('user_registration/re_verify_phone', templateData)
 
     body.should.containSelector('form#otp-send-again').withAttribute('action', paths.registerUser.reVerifyPhone)
     body.should.containSelector('input#telephone-number').withAttribute('value', telephoneNumber)
     done()
   })
 
-  it('should render resend otp code view with international converted to numbers only telephone number', function (done) {
-    let templateData = {
+  it('should render resend otp code view with international converted to numbers only telephone number', done => {
+    const templateData = {
       telephone_number: '+441134960000'
     }
 
-    let body = renderTemplate('user_registration/re_verify_phone', templateData)
+    const body = renderTemplate('user_registration/re_verify_phone', templateData)
 
     body.should.containSelector('form#otp-send-again').withAttribute('action', paths.registerUser.reVerifyPhone)
     body.should.containSelector('input#telephone-number').withAttribute('value', '00441134960000')


### PR DESCRIPTION
## WHAT

Currently pay-adminusers saves and returns international telephone number format starting with `+44` (UK example).
The current validation in selfservice still expects numbers only telephone numbers.
This commit modifies the value of the input to be reformatted in numbers only international telephone number.
Once the validation of the selfservice can handle any format we need to remove this formatting.
