### PR TITLE
PP-4846 Go live task list: show next steps box at right point

### DIFF
--- a/app/controllers/request-to-go-live/index/get.controller.js
+++ b/app/controllers/request-to-go-live/index/get.controller.js
@@ -1,16 +1,82 @@
 'use strict'
 
+// NPM dependencies
+const lodash = require('lodash')
+
 // Local dependencies
 const goLiveStage = require('../../../models/go-live-stage')
 const response = require('../../../utils/response')
 
+const {
+  NOT_STARTED,
+  ENTERED_ORGANISATION_NAME,
+  CHOSEN_PSP_STRIPE,
+  CHOSEN_PSP_WORLDPAY,
+  CHOSEN_PSP_SMARTPAY,
+  CHOSEN_PSP_EPDQ,
+  TERMS_AGREED_STRIPE,
+  TERMS_AGREED_WORLDPAY,
+  TERMS_AGREED_SMARTPAY,
+  TERMS_AGREED_EPDQ,
+  LIVE,
+  DENIED
+} = goLiveStage
+
+const live = [
+  LIVE
+]
+
+const agreedToTerms = [
+  TERMS_AGREED_STRIPE,
+  TERMS_AGREED_WORLDPAY,
+  TERMS_AGREED_SMARTPAY,
+  TERMS_AGREED_EPDQ
+].concat(live)
+
+const chosenHowToProcessPayments = [
+  CHOSEN_PSP_STRIPE,
+  CHOSEN_PSP_WORLDPAY,
+  CHOSEN_PSP_SMARTPAY,
+  CHOSEN_PSP_EPDQ
+].concat(agreedToTerms)
+
+const enteredOrganisationName = [
+  ENTERED_ORGANISATION_NAME
+].concat(chosenHowToProcessPayments)
+
+const startedButStillStepsToComplete = [
+  ENTERED_ORGANISATION_NAME,
+  CHOSEN_PSP_STRIPE,
+  CHOSEN_PSP_WORLDPAY,
+  CHOSEN_PSP_SMARTPAY,
+  CHOSEN_PSP_EPDQ
+]
+
+const showNextSteps = [
+  TERMS_AGREED_STRIPE,
+  TERMS_AGREED_WORLDPAY,
+  TERMS_AGREED_SMARTPAY,
+  TERMS_AGREED_EPDQ
+]
+
 module.exports = (req, res) => {
-  return response.response(
-    req,
-    res,
-    'request-to-go-live/index',
-    {
-      goLiveStage
-    }
-  )
+  const currentGoLiveStage = lodash.get(req, 'service.currentGoLiveStage', '')
+
+  let pageData = lodash.get(req, 'session.pageData.requestToGoLive.index')
+  if (pageData) {
+    delete req.session.pageData.requestToGoLive.index
+  }
+
+  pageData = {
+    notStarted: currentGoLiveStage === NOT_STARTED,
+    enteredOrganisationName: enteredOrganisationName.includes(currentGoLiveStage),
+    chosenHowToProcessPayments: chosenHowToProcessPayments.includes(currentGoLiveStage),
+    agreedToTerms: agreedToTerms.includes(currentGoLiveStage),
+    startedButStillStepsToComplete: startedButStillStepsToComplete.includes(currentGoLiveStage),
+    showNextSteps: showNextSteps.includes(currentGoLiveStage),
+    denied: currentGoLiveStage === DENIED
+  }
+
+  return response.response(req, res,'request-to-go-live/index', pageData)
+
 }

--- a/app/controllers/request-to-go-live/index/get.controller.js
+++ b/app/controllers/request-to-go-live/index/get.controller.js
@@ -30,19 +30,22 @@ const agreedToTerms = [
   TERMS_AGREED_STRIPE,
   TERMS_AGREED_WORLDPAY,
   TERMS_AGREED_SMARTPAY,
-  TERMS_AGREED_EPDQ
-].concat(live)
+  TERMS_AGREED_EPDQ,
+  ...live
+]
 
 const chosenHowToProcessPayments = [
   CHOSEN_PSP_STRIPE,
   CHOSEN_PSP_WORLDPAY,
   CHOSEN_PSP_SMARTPAY,
-  CHOSEN_PSP_EPDQ
-].concat(agreedToTerms)
+  CHOSEN_PSP_EPDQ,
+  ...agreedToTerms
+]
 
 const enteredOrganisationName = [
-  ENTERED_ORGANISATION_NAME
-].concat(chosenHowToProcessPayments)
+  ENTERED_ORGANISATION_NAME,
+  ...chosenHowToProcessPayments
+]
 
 const startedButStillStepsToComplete = [
   ENTERED_ORGANISATION_NAME,

--- a/app/views/policy/document-downloads/contract_for_non_crown_bodies.njk
+++ b/app/views/policy/document-downloads/contract_for_non_crown_bodies.njk
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block policyDescription %}
-  If you're a non-crown body, the contract terms apply when you use GOV.UK Pay.
+  If you’re a non-crown body, the contract terms apply when you use GOV.UK Pay.
 {% endblock %}
 
 {% block policyDownloadAction %}

--- a/app/views/policy/document-downloads/memorandum_of_understanding_for_crown_bodies.njk
+++ b/app/views/policy/document-downloads/memorandum_of_understanding_for_crown_bodies.njk
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block policyDescription %}
-  If you're a crown body, the memorandum of understanding terms apply when you use GOV.UK Pay.
+  If you’re a crown body, the memorandum of understanding terms apply when you use GOV.UK Pay.
 {% endblock %}
 
 {% block policyDownloadAction %}

--- a/app/views/request-to-go-live/index.njk
+++ b/app/views/request-to-go-live/index.njk
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  {% if currentService.currentGoLiveStage === goLiveStage.LIVE %}
+  {% if showNextSteps %}
     <div class="govuk-grid-column-full govuk-!-margin-top-6">
       <div class="next-steps-panel">
         <h3 class="govuk-heading-l govuk-!-margin-bottom-2">Thank you. We’re creating your live service</h3>
@@ -15,7 +15,7 @@
       </div>
     </div>
   {% endif %}
-  {% if currentService.currentGoLiveStage === goLiveStage.DENIED %}
+  {% if denied %}
     <div class="govuk-grid-column-full govuk-!-margin-top-6">
     {{ govukErrorSummary({
       titleText: 'There is a problem',
@@ -28,7 +28,7 @@
     </div>
   {% else %}
     <div class="govuk-grid-column-two-thirds">
-      {% if currentService.currentGoLiveStage !== goLiveStage.LIVE %}
+      {% if notStarted or startedButStillStepsToComplete %}
         <h1 class="govuk-heading-l govuk-!-margin-top-6 govuk-!-margin-bottom-2">Request to go live</h1>
         <p class="govuk-body-l intro">Complete these steps to start taking real payments.</p>
       {% endif %}
@@ -36,19 +36,8 @@
         <div id="request-to-go-live-step-1">
           <h3 class="govuk-heading-m">
             Add your organisation’s name
-            {% if currentService.currentGoLiveStage in [
-              goLiveStage.ENTERED_ORGANISATION_NAME,
-              goLiveStage.CHOSEN_PSP_STRIPE,
-              goLiveStage.CHOSEN_PSP_WORLDPAY,
-              goLiveStage.CHOSEN_PSP_SMARTPAY,
-              goLiveStage.CHOSEN_PSP_EPDQ,
-              goLiveStage.TERMS_AGREED_STRIPE,
-              goLiveStage.TERMS_AGREED_WORLDPAY,
-              goLiveStage.TERMS_AGREED_SMARTPAY,
-              goLiveStage.TERMS_AGREED_EPDQ,
-              goLiveStage.LIVE
-            ] %}
-              <span class="status">COMPLETED</span>
+            {% if enteredOrganisationName %}
+              <span class="status">Completed</span>
             {% endif %}
           </h3>
           <p class="govuk-body">We’ll use this to perform a security check.</p>
@@ -56,18 +45,8 @@
         <div id="request-to-go-live-step-2">
           <h3 class="govuk-heading-m">
             Choose how to process payments
-            {% if currentService.currentGoLiveStage in [
-              goLiveStage.CHOSEN_PSP_STRIPE,
-              goLiveStage.CHOSEN_PSP_WORLDPAY,
-              goLiveStage.CHOSEN_PSP_SMARTPAY,
-              goLiveStage.CHOSEN_PSP_EPDQ,
-              goLiveStage.TERMS_AGREED_STRIPE,
-              goLiveStage.TERMS_AGREED_WORLDPAY,
-              goLiveStage.TERMS_AGREED_SMARTPAY,
-              goLiveStage.TERMS_AGREED_EPDQ,
-              goLiveStage.LIVE
-            ] %}
-              <span class="status">COMPLETED</span>
+            {% if chosenHowToProcessPayments %}
+              <span class="status">Completed</span>
             {% endif %}
           </h3>
           <p class="govuk-body">Use GOV.UK Pay’s preferred payment service provider (PSP). If you have already procured your own PSP, you can enter their details instead.</p>
@@ -75,29 +54,17 @@
         <div id="request-to-go-live-step-3">
           <h3 class="govuk-heading-m">
             Confirm that you accept our legal terms
-            {% if currentService.currentGoLiveStage in [
-              goLiveStage.TERMS_AGREED_STRIPE,
-              goLiveStage.TERMS_AGREED_WORLDPAY,
-              goLiveStage.TERMS_AGREED_SMARTPAY,
-              goLiveStage.TERMS_AGREED_EPDQ,
-              goLiveStage.LIVE
-            ] %}
-              <span class="status">COMPLETED</span>
+            {% if agreedToTerms %}
+              <span class="status">Completed</span>
             {% endif %}
           </h3>
           <p class="govuk-body">To start using GOV.UK Pay your organisation must accept GOV.UK Pay’s legal terms.</p>
         </div>
         <form id="request-to-go-live-index-form" method="post" action="/service/{{currentService.externalId}}/request-to-go-live">
           <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
-          {% if currentService.currentGoLiveStage === goLiveStage.NOT_STARTED %}
+          {% if notStarted %}
             {{ govukButton({ text: "Start now" }) }}
-          {% elif currentService.currentGoLiveStage not in [
-            goLiveStage.TERMS_AGREED_STRIPE,
-            goLiveStage.TERMS_AGREED_WORLDPAY,
-            goLiveStage.TERMS_AGREED_SMARTPAY,
-            goLiveStage.TERMS_AGREED_EPDQ,
-            goLiveStage.LIVE
-          ] %}
+          {% elif startedButStillStepsToComplete %}
             {{ govukButton({ text: "Continue" }) }}
           {% endif %}
         </form>

--- a/app/views/request-to-go-live/index.njk
+++ b/app/views/request-to-go-live/index.njk
@@ -33,7 +33,7 @@
         <p class="govuk-body-l intro">Complete these steps to start taking real payments.</p>
       {% endif %}
       <div class="request-to-go-live-list">
-        <div id="request-to-go-live-step-1">
+        <div id="request-to-go-live-step-organisation-name">
           <h3 class="govuk-heading-m">
             Add your organisation’s name
             {% if enteredOrganisationName %}
@@ -42,7 +42,7 @@
           </h3>
           <p class="govuk-body">We’ll use this to perform a security check.</p>
         </div>
-        <div id="request-to-go-live-step-2">
+        <div id="request-to-go-live-step-choose-psp">
           <h3 class="govuk-heading-m">
             Choose how to process payments
             {% if chosenHowToProcessPayments %}
@@ -51,7 +51,7 @@
           </h3>
           <p class="govuk-body">Use GOV.UK Pay’s preferred payment service provider (PSP). If you have already procured your own PSP, you can enter their details instead.</p>
         </div>
-        <div id="request-to-go-live-step-3">
+        <div id="request-to-go-live-step-agree-terms">
           <h3 class="govuk-heading-m">
             Confirm that you accept our legal terms
             {% if agreedToTerms %}

--- a/test/cypress/integration/request-to-go-live/agreement_spec.js
+++ b/test/cypress/integration/request-to-go-live/agreement_spec.js
@@ -130,7 +130,6 @@ describe('Request to go live: agreement', () => {
       cy.location().should((location) => {
         expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live`)
       })
-      cy.get('#request-to-go-live-step-3').should('contain', 'COMPLETED')
     })
   })
 

--- a/test/cypress/integration/request-to-go-live/agreement_spec.js
+++ b/test/cypress/integration/request-to-go-live/agreement_spec.js
@@ -119,7 +119,6 @@ describe('Request to go live: agreement', () => {
 
       cy.get('#agreement-1').should('exist')
       cy.get('#agreement-1').should('not.be.checked')
-      cy.get('#request-to-go-live-step-3').should('not.contain', 'COMPLETED')
 
       cy.get('#request-to-go-live-agreement-form > button').should('exist')
       cy.get('#request-to-go-live-agreement-form > button').should('contain', 'Continue')
@@ -173,7 +172,6 @@ describe('Request to go live: agreement', () => {
 
       cy.get('#agreement-1').should('exist')
       cy.get('#agreement-1').should('not.be.checked')
-      cy.get('#request-to-go-live-step-3').should('not.contain', 'COMPLETED')
 
       cy.get('#request-to-go-live-agreement-form > button').should('exist')
       cy.get('#request-to-go-live-agreement-form > button').should('contain', 'Continue')
@@ -184,7 +182,6 @@ describe('Request to go live: agreement', () => {
       cy.location().should((location) => {
         expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live`)
       })
-      cy.get('#request-to-go-live-step-3').should('contain', 'COMPLETED')
     })
   })
 

--- a/test/cypress/integration/request-to-go-live/index_spec.js
+++ b/test/cypress/integration/request-to-go-live/index_spec.js
@@ -60,14 +60,15 @@ describe('Request to go live: index', () => {
       cy.visit(requestToGoLivePageUrl)
 
       cy.get('h1').should('contain', 'Request to go live')
+      cy.get('h1 + p').should('contain', 'Complete these steps to start taking real payments')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('exist')
+      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
       cy.get('#request-to-go-live-step-1 > h3 > span').should('not.exist')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('exist')
+      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
       cy.get('#request-to-go-live-step-2 > h3 > span').should('not.exist')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
       cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
 
       cy.get('#request-to-go-live-index-form > button').should('exist')
@@ -90,14 +91,15 @@ describe('Request to go live: index', () => {
       cy.visit(requestToGoLivePageUrl)
 
       cy.get('h1').should('contain', 'Request to go live')
+      cy.get('h1 + p').should('contain', 'Complete these steps to start taking real payments')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('exist')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('exist')
+      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
       cy.get('#request-to-go-live-step-2 > h3 > span').should('not.exist')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
       cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
 
       cy.get('#request-to-go-live-index-form > button').should('exist')
@@ -120,14 +122,15 @@ describe('Request to go live: index', () => {
       cy.visit(requestToGoLivePageUrl)
 
       cy.get('h1').should('contain', 'Request to go live')
+      cy.get('h1 + p').should('contain', 'Complete these steps to start taking real payments')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('exist')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('exist')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
       cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
 
       cy.get('#request-to-go-live-index-form > button').should('exist')
@@ -150,14 +153,15 @@ describe('Request to go live: index', () => {
       cy.visit(requestToGoLivePageUrl)
 
       cy.get('h1').should('contain', 'Request to go live')
+      cy.get('h1 + p').should('contain', 'Complete these steps to start taking real payments')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('exist')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('exist')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
       cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
 
       cy.get('#request-to-go-live-index-form > button').should('exist')
@@ -180,14 +184,15 @@ describe('Request to go live: index', () => {
       cy.visit(requestToGoLivePageUrl)
 
       cy.get('h1').should('contain', 'Request to go live')
+      cy.get('h1 + p').should('contain', 'Complete these steps to start taking real payments')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('exist')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('exist')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
       cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
 
       cy.get('#request-to-go-live-index-form > button').should('exist')
@@ -210,14 +215,15 @@ describe('Request to go live: index', () => {
       cy.visit(requestToGoLivePageUrl)
 
       cy.get('h1').should('contain', 'Request to go live')
+      cy.get('h1 + p').should('contain', 'Complete these steps to start taking real payments')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('exist')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('exist')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('exist')
+      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
       cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
 
       cy.get('#request-to-go-live-index-form > button').should('exist')
@@ -239,16 +245,18 @@ describe('Request to go live: index', () => {
       const requestToGoLivePageUrl = `/service/${serviceExternalId}/request-to-go-live`
       cy.visit(requestToGoLivePageUrl)
 
-      cy.get('h1').should('contain', 'Request to go live')
+      cy.get('h1').should('not.exist')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('exist')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('.next-steps-panel h3').should('contain', 'Thank you. We’re creating your live service')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('exist')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('exist')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'Completed')
 
       cy.get('#request-to-go-live-index-form > button').should('not.exist')
     })
@@ -263,16 +271,18 @@ describe('Request to go live: index', () => {
       const requestToGoLivePageUrl = `/service/${serviceExternalId}/request-to-go-live`
       cy.visit(requestToGoLivePageUrl)
 
-      cy.get('h1').should('contain', 'Request to go live')
+      cy.get('h1').should('not.exist')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('exist')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('.next-steps-panel h3').should('contain', 'Thank you. We’re creating your live service')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('exist')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('exist')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'Completed')
 
       cy.get('#request-to-go-live-index-form > button').should('not.exist')
     })
@@ -287,16 +297,18 @@ describe('Request to go live: index', () => {
       const requestToGoLivePageUrl = `/service/${serviceExternalId}/request-to-go-live`
       cy.visit(requestToGoLivePageUrl)
 
-      cy.get('h1').should('contain', 'Request to go live')
+      cy.get('h1').should('not.exist')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('exist')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('.next-steps-panel h3').should('contain', 'Thank you. We’re creating your live service')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('exist')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('exist')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'Completed')
 
       cy.get('#request-to-go-live-index-form > button').should('not.exist')
     })
@@ -311,16 +323,18 @@ describe('Request to go live: index', () => {
       const requestToGoLivePageUrl = `/service/${serviceExternalId}/request-to-go-live`
       cy.visit(requestToGoLivePageUrl)
 
-      cy.get('h1').should('contain', 'Request to go live')
+      cy.get('h1').should('not.exist')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('exist')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('.next-steps-panel h3').should('contain', 'Thank you. We’re creating your live service')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('exist')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('exist')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'Completed')
 
       cy.get('#request-to-go-live-index-form > button').should('not.exist')
     })
@@ -336,6 +350,8 @@ describe('Request to go live: index', () => {
       cy.visit(requestToGoLivePageUrl)
 
       cy.get('h1').should('not.exist')
+
+      cy.get('.next-steps-panel').should('not.exist')
 
       cy.get('.govuk-error-summary h2').should('contain', 'There is a problem')
       cy.get('.govuk-error-summary .govuk-error-summary__list a')
@@ -355,16 +371,17 @@ describe('Request to go live: index', () => {
       cy.visit(requestToGoLivePageUrl)
 
       cy.get('h1').should('not.exist')
-      cy.get('.govuk-grid-column-full h3').should('contain', 'Thank you. We’re creating your live service')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('exist')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('.next-steps-panel').should('not.exist')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('exist')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
+      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('exist')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'COMPLETED')
+      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
+      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
+
+      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
+      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'Completed')
 
       cy.get('#request-to-go-live-index-form > button').should('not.exist')
     })

--- a/test/cypress/integration/request-to-go-live/index_spec.js
+++ b/test/cypress/integration/request-to-go-live/index_spec.js
@@ -62,14 +62,14 @@ describe('Request to go live: index', () => {
       cy.get('h1').should('contain', 'Request to go live')
       cy.get('h1 + p').should('contain', 'Complete these steps to start taking real payments')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('not.exist')
+      cy.get('#request-to-go-live-step-organisation-name > h3').should('exist')
+      cy.get('#request-to-go-live-step-organisation-name > h3 > span').should('not.exist')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('not.exist')
+      cy.get('#request-to-go-live-step-choose-psp > h3').should('exist')
+      cy.get('#request-to-go-live-step-choose-psp > h3 > span').should('not.exist')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3').should('exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3 > span').should('not.exist')
 
       cy.get('#request-to-go-live-index-form > button').should('exist')
       cy.get('#request-to-go-live-index-form > button').should('contain', 'Start now')
@@ -93,14 +93,14 @@ describe('Request to go live: index', () => {
       cy.get('h1').should('contain', 'Request to go live')
       cy.get('h1 + p').should('contain', 'Complete these steps to start taking real payments')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-organisation-name > h3').should('exist')
+      cy.get('#request-to-go-live-step-organisation-name > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('not.exist')
+      cy.get('#request-to-go-live-step-choose-psp > h3').should('exist')
+      cy.get('#request-to-go-live-step-choose-psp > h3 > span').should('not.exist')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3').should('exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3 > span').should('not.exist')
 
       cy.get('#request-to-go-live-index-form > button').should('exist')
       cy.get('#request-to-go-live-index-form > button').should('contain', 'Continue')
@@ -124,14 +124,14 @@ describe('Request to go live: index', () => {
       cy.get('h1').should('contain', 'Request to go live')
       cy.get('h1 + p').should('contain', 'Complete these steps to start taking real payments')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-organisation-name > h3').should('exist')
+      cy.get('#request-to-go-live-step-organisation-name > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-choose-psp > h3').should('exist')
+      cy.get('#request-to-go-live-step-choose-psp > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3').should('exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3 > span').should('not.exist')
 
       cy.get('#request-to-go-live-index-form > button').should('exist')
       cy.get('#request-to-go-live-index-form > button').should('contain', 'Continue')
@@ -155,14 +155,14 @@ describe('Request to go live: index', () => {
       cy.get('h1').should('contain', 'Request to go live')
       cy.get('h1 + p').should('contain', 'Complete these steps to start taking real payments')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-organisation-name > h3').should('exist')
+      cy.get('#request-to-go-live-step-organisation-name > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-choose-psp > h3').should('exist')
+      cy.get('#request-to-go-live-step-choose-psp > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3').should('exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3 > span').should('not.exist')
 
       cy.get('#request-to-go-live-index-form > button').should('exist')
       cy.get('#request-to-go-live-index-form > button').should('contain', 'Continue')
@@ -186,14 +186,14 @@ describe('Request to go live: index', () => {
       cy.get('h1').should('contain', 'Request to go live')
       cy.get('h1 + p').should('contain', 'Complete these steps to start taking real payments')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-organisation-name > h3').should('exist')
+      cy.get('#request-to-go-live-step-organisation-name > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-choose-psp > h3').should('exist')
+      cy.get('#request-to-go-live-step-choose-psp > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3').should('exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3 > span').should('not.exist')
 
       cy.get('#request-to-go-live-index-form > button').should('exist')
       cy.get('#request-to-go-live-index-form > button').should('contain', 'Continue')
@@ -217,14 +217,14 @@ describe('Request to go live: index', () => {
       cy.get('h1').should('contain', 'Request to go live')
       cy.get('h1 + p').should('contain', 'Complete these steps to start taking real payments')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-organisation-name > h3').should('exist')
+      cy.get('#request-to-go-live-step-organisation-name > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-choose-psp > h3').should('exist')
+      cy.get('#request-to-go-live-step-choose-psp > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('not.exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3').should('exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3 > span').should('not.exist')
 
       cy.get('#request-to-go-live-index-form > button').should('exist')
       cy.get('#request-to-go-live-index-form > button').should('contain', 'Continue')
@@ -249,14 +249,14 @@ describe('Request to go live: index', () => {
 
       cy.get('.next-steps-panel h3').should('contain', 'Thank you. We’re creating your live service')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-organisation-name > h3').should('exist')
+      cy.get('#request-to-go-live-step-organisation-name > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-choose-psp > h3').should('exist')
+      cy.get('#request-to-go-live-step-choose-psp > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-agree-terms > h3').should('exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3 > span').should('contain', 'Completed')
 
       cy.get('#request-to-go-live-index-form > button').should('not.exist')
     })
@@ -275,14 +275,14 @@ describe('Request to go live: index', () => {
 
       cy.get('.next-steps-panel h3').should('contain', 'Thank you. We’re creating your live service')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-organisation-name > h3').should('exist')
+      cy.get('#request-to-go-live-step-organisation-name > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-choose-psp > h3').should('exist')
+      cy.get('#request-to-go-live-step-choose-psp > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-agree-terms > h3').should('exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3 > span').should('contain', 'Completed')
 
       cy.get('#request-to-go-live-index-form > button').should('not.exist')
     })
@@ -301,14 +301,14 @@ describe('Request to go live: index', () => {
 
       cy.get('.next-steps-panel h3').should('contain', 'Thank you. We’re creating your live service')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-organisation-name > h3').should('exist')
+      cy.get('#request-to-go-live-step-organisation-name > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-choose-psp > h3').should('exist')
+      cy.get('#request-to-go-live-step-choose-psp > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-agree-terms > h3').should('exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3 > span').should('contain', 'Completed')
 
       cy.get('#request-to-go-live-index-form > button').should('not.exist')
     })
@@ -327,14 +327,14 @@ describe('Request to go live: index', () => {
 
       cy.get('.next-steps-panel h3').should('contain', 'Thank you. We’re creating your live service')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-organisation-name > h3').should('exist')
+      cy.get('#request-to-go-live-step-organisation-name > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-choose-psp > h3').should('exist')
+      cy.get('#request-to-go-live-step-choose-psp > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-agree-terms > h3').should('exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3 > span').should('contain', 'Completed')
 
       cy.get('#request-to-go-live-index-form > button').should('not.exist')
     })
@@ -374,14 +374,14 @@ describe('Request to go live: index', () => {
 
       cy.get('.next-steps-panel').should('not.exist')
 
-      cy.get('#request-to-go-live-step-1 > h3').should('contain', 'Add your organisation’s name')
-      cy.get('#request-to-go-live-step-1 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-organisation-name > h3').should('exist')
+      cy.get('#request-to-go-live-step-organisation-name > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-2 > h3').should('contain', 'Choose how to process payments')
-      cy.get('#request-to-go-live-step-2 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-choose-psp > h3').should('exist')
+      cy.get('#request-to-go-live-step-choose-psp > h3 > span').should('contain', 'Completed')
 
-      cy.get('#request-to-go-live-step-3 > h3').should('contain', 'Confirm that you accept our legal terms')
-      cy.get('#request-to-go-live-step-3 > h3 > span').should('contain', 'Completed')
+      cy.get('#request-to-go-live-step-agree-terms > h3').should('exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3 > span').should('contain', 'Completed')
 
       cy.get('#request-to-go-live-index-form > button').should('not.exist')
     })

--- a/test/cypress/integration/request-to-go-live/organisation_name_spec.js
+++ b/test/cypress/integration/request-to-go-live/organisation_name_spec.js
@@ -50,7 +50,7 @@ describe('Request to go live: organisation name page', () => {
   })
 
   describe('Service has invalid go live stage', () => {
-    const serviceRole = utils.buildServiceRoleForGoLiveStage('INVALID_GO_LIVE_STAGE')
+    const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')
     beforeEach(() => {
       utils.setupStubs(serviceRole)
     })


### PR DESCRIPTION
Show the next steps box saying we are creating the live service when the current go live stage is `AGREED_TERMS_STRIPE`, `AGREED_TERMS_WORLDPAY`, `AGREED_TERMS_SMARTPAY` or `AGREED_TERMS_EPDQ` and not when it’s `LIVE`.