### PR TITLE
PP-4462 Add client methods to get and update Stripe setup flags

### DIFF
--- a/app/models/StripeAccountSetup.class.js
+++ b/app/models/StripeAccountSetup.class.js
@@ -1,0 +1,11 @@
+'use strict'
+
+class StripeAccountSetup {
+  constructor (opts) {
+    this.bankAccount = opts.bank_account
+    this.organisationDetails = opts.organisation_details
+    this.responsiblePerson = opts.responsible_person
+  }
+}
+
+module.exports = StripeAccountSetup

--- a/test/fixtures/stripe_account_setup_fixtures.js
+++ b/test/fixtures/stripe_account_setup_fixtures.js
@@ -1,0 +1,59 @@
+'use strict'
+
+// NPM dependencies
+const path = require('path')
+const _ = require('lodash')
+
+// Global setup
+const pactBase = require(path.join(__dirname, '/pact_base'))
+const pactRegister = pactBase()
+
+function buildUpdateStripeAccountSetupFlagRequest (path, completed) {
+  const data = [
+    {
+      op: 'replace',
+      path,
+      value: completed
+    }
+  ]
+
+  return {
+    getPactified: () => {
+      return pactRegister.pactify(data)
+    },
+    getPlain: () => {
+      return _.clone(data)
+    }
+  }
+}
+
+module.exports = {
+  buildUpdateBankAccountDetailsFlagRequest (completed) {
+    return buildUpdateStripeAccountSetupFlagRequest('bank_account', completed)
+  },
+
+  buildUpdateOrganisationDetailsFlagRequest (completed) {
+    return buildUpdateStripeAccountSetupFlagRequest('organisation_details', completed)
+  },
+
+  buildUpdateResponsiblePersonFlagRequest (completed) {
+    return buildUpdateStripeAccountSetupFlagRequest('responsible_person', completed)
+  },
+
+  buildGetStripeAccountSetupResponse (opts = {}) {
+    const data = {
+      'bank_account': opts.bank_account || false,
+      'organisation_details': opts.organisation_details || false,
+      'responsible_person': opts.responsible_person || false
+    }
+
+    return {
+      getPactified: () => {
+        return pactRegister.pactify(data)
+      },
+      getPlain: () => {
+        return _.clone(data)
+      }
+    }
+  }
+}

--- a/test/unit/clients/connector_client/connector_get_stripe_account_setup_test.js
+++ b/test/unit/clients/connector_client/connector_get_stripe_account_setup_test.js
@@ -1,0 +1,73 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const path = require('path')
+
+// Local dependencies
+const PactInteractionBuilder = require('../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const Connector = require('../../../../app/services/clients/connector_client').ConnectorClient
+const stripeAccountSetupFixtures = require('../../../fixtures/stripe_account_setup_fixtures')
+
+// Constants
+const ACCOUNTS_RESOURCE = '/v1/api/accounts'
+const port = Math.floor(Math.random() * 48127) + 1024
+const connectorClient = new Connector(`http://localhost:${port}`)
+const expect = chai.expect
+
+// Global setup
+chai.use(chaiAsPromised)
+
+const existingGatewayAccountId = 42
+const defaultState = `a stripe gateway account with external id ${existingGatewayAccountId} exists in the database`
+
+describe('connector client - get stripe account setup', () => {
+  const provider = Pact({
+    consumer: 'selfservice',
+    provider: 'connector',
+    port: port,
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(() => provider.setup())
+  after(done => provider.finalize().then(done()))
+
+  describe('get stripe account setup success', () => {
+    const stripeSetupOpts = {
+      bank_account: true,
+      organisation_details: false,
+      responsible_person: true
+    }
+    const response = stripeAccountSetupFixtures.buildGetStripeAccountSetupResponse(stripeSetupOpts)
+
+    before(done => {
+      provider.addInteraction(
+        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
+          .withUponReceiving('a valid get stripe account bank account flag request')
+          .withState(defaultState)
+          .withMethod('GET')
+          .withStatusCode(200)
+          .withResponseBody(response.getPactified())
+          .build()
+      )
+        .then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should update successfully', done => {
+      connectorClient.getStripeAccountSetup(existingGatewayAccountId)
+        .should.be.fulfilled.then(stripeAccountSetup => {
+          expect(stripeAccountSetup.bankAccount).to.equal(stripeSetupOpts.bank_account)
+          expect(stripeAccountSetup.organisationDetails).to.equal(stripeSetupOpts.organisation_details)
+          expect(stripeAccountSetup.responsiblePerson).to.equal(stripeSetupOpts.responsible_person)
+        }).should.notify(done)
+    })
+  })
+})

--- a/test/unit/clients/connector_client/connector_set_stripe_account_setup_flag_test.js
+++ b/test/unit/clients/connector_client/connector_set_stripe_account_setup_flag_test.js
@@ -1,0 +1,119 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const path = require('path')
+
+// Local dependencies
+const PactInteractionBuilder = require('../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const Connector = require('../../../../app/services/clients/connector_client').ConnectorClient
+const stripeAccountSetupFixtures = require('../../../fixtures/stripe_account_setup_fixtures')
+
+// Constants
+const ACCOUNTS_RESOURCE = '/v1/api/accounts'
+const port = Math.floor(Math.random() * 48127) + 1024
+const connectorClient = new Connector(`http://localhost:${port}`)
+
+// Global setup
+chai.use(chaiAsPromised)
+
+const existingGatewayAccountId = 42
+const defaultState = `a stripe gateway account with external id ${existingGatewayAccountId} exists in the database`
+
+describe('connector client - set stripe account setup flag', () => {
+  const provider = Pact({
+    consumer: 'selfservice',
+    provider: 'connector',
+    port: port,
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(() => provider.setup())
+  after(done => provider.finalize().then(done()))
+
+  describe('set bank account flag', () => {
+    const request = stripeAccountSetupFixtures.buildUpdateBankAccountDetailsFlagRequest(true).getPlain()
+
+    before(done => {
+      provider.addInteraction(
+        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
+          .withUponReceiving('a valid patch update stripe account bank account flag request')
+          .withState(defaultState)
+          .withMethod('PATCH')
+          .withRequestBody(request)
+          .withStatusCode(200)
+          .withResponseHeaders({})
+          .build()
+      )
+        .then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should update successfully', done => {
+      connectorClient.setStripeAccountSetupFlag(existingGatewayAccountId, 'bank_account')
+        .should.be.fulfilled
+        .notify(done)
+    })
+  })
+
+  describe('set organisation details flag', () => {
+    const request = stripeAccountSetupFixtures.buildUpdateOrganisationDetailsFlagRequest(true).getPlain()
+
+    before(done => {
+      provider.addInteraction(
+        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
+          .withUponReceiving('a valid patch update stripe account organisation details flag request')
+          .withState(defaultState)
+          .withMethod('PATCH')
+          .withRequestBody(request)
+          .withStatusCode(200)
+          .withResponseHeaders({})
+          .build()
+      )
+        .then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should update successfully', done => {
+      connectorClient.setStripeAccountSetupFlag(existingGatewayAccountId, 'organisation_details')
+        .should.be.fulfilled
+        .notify(done)
+    })
+  })
+
+  describe('set responsible person flag', () => {
+    const request = stripeAccountSetupFixtures.buildUpdateResponsiblePersonFlagRequest(true).getPlain()
+
+    before(done => {
+      provider.addInteraction(
+        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
+          .withUponReceiving('a valid patch update stripe account responsible person flag request')
+          .withState(defaultState)
+          .withMethod('PATCH')
+          .withRequestBody(request)
+          .withStatusCode(200)
+          .withResponseHeaders({})
+          .build()
+      )
+        .then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should update successfully', done => {
+      connectorClient.setStripeAccountSetupFlag(existingGatewayAccountId, 'responsible_person')
+        .should.be.fulfilled
+        .notify(done)
+    })
+  })
+})


### PR DESCRIPTION
Add method to connector_client to call the GET stripe account setup endpoint. The response of this request is mapped into a new StripeAccountSetup model.
Add method to call the PATCH stripe account setup endpoint to set a flag for an account setup task being completed.

Add pact tests for these interactions.


