### PR TITLE
PP-4462 Add bank details validation

### DIFF
--- a/app/browsered/field-validation-checks.js
+++ b/app/browsered/field-validation-checks.js
@@ -85,7 +85,7 @@ exports.isNaxsiSafe = function (value) {
 }
 
 exports.isNotAccountNumber = value => {
-  if (NUMBERS_ONLY.test(value) && (value.length >= 6 && value.length <= 8)) {
+  if (/^[0-9]{6,8}$/.test(value)) {
     return false
   } else {
     return validationErrors.invalidBankAccountNumber
@@ -93,7 +93,7 @@ exports.isNotAccountNumber = value => {
 }
 
 exports.isNotSortCode = value => {
-  if (/^[ -]*(?:[0-9][ -]*){6}$/.test(value)) {
+  if (/^(?:[ -]*[0-9][ -]*){6}$/.test(value)) {
     return false
   } else {
     return validationErrors.invalidSortCode

--- a/app/browsered/field-validation-checks.js
+++ b/app/browsered/field-validation-checks.js
@@ -16,7 +16,9 @@ const validationErrors = {
   isAboveMaxAmount: `Choose an amount under £${MAX_AMOUNT.toLocaleString()}`,
   isPasswordLessThanTenChars: `Choose a Password of 10 characters or longer`,
   isGreaterThanMaxLengthChars: `The text is too long`,
-  invalidCharacters: `You cannot use any of the following characters < > ; : \` ( ) " ' = | , ~ [ ]`
+  invalidCharacters: `You cannot use any of the following characters < > ; : \` ( ) " ' = | , ~ [ ]`,
+  invalidBankAccountNumber: 'Please enter a valid account number',
+  invalidSortCode: 'Please enter a valid sort code'
 }
 
 exports.isEmpty = function (value) {
@@ -79,5 +81,21 @@ exports.isNaxsiSafe = function (value) {
     return validationErrors.invalidCharacters
   } else {
     return false
+  }
+}
+
+exports.isNotAccountNumber = value => {
+  if (NUMBERS_ONLY.test(value) && (value.length >= 6 && value.length <= 8)) {
+    return false
+  } else {
+    return validationErrors.invalidBankAccountNumber
+  }
+}
+
+exports.isNotSortCode = value => {
+  if (/^[ -]*(?:[0-9][ -]*){6}$/.test(value)) {
+    return false
+  } else {
+    return validationErrors.invalidSortCode
   }
 }

--- a/app/browsered/field-validation.js
+++ b/app/browsered/field-validation.js
@@ -92,6 +92,12 @@ function validateField (form, field) {
       case 'isNaxsiSafe':
         result = checks.isNaxsiSafe(field.value)
         break
+      case 'accountNumber':
+        result = checks.isNotAccountNumber(field.value)
+        break
+      case 'sortCode':
+        result = checks.isNotSortCode(field.value)
+        break
       default:
         result = checks.isEmpty(field.value)
         break

--- a/app/controllers/live-account-setup/bank-details/bank-details-validations.js
+++ b/app/controllers/live-account-setup/bank-details/bank-details-validations.js
@@ -1,0 +1,50 @@
+'use strict'
+
+// Local dependencies
+const { isEmpty, isNotAccountNumber, isNotSortCode } = require('../../../browsered/field-validation-checks')
+
+exports.validateAccountNumber = (accountNumber) => {
+  const isEmptyErrorMessage = isEmpty(accountNumber)
+  if (isEmptyErrorMessage) {
+    return {
+      valid: false,
+      message: isEmptyErrorMessage
+    }
+  }
+
+  const isNotAccountNumberErrorMessage = isNotAccountNumber(accountNumber)
+  if (isNotAccountNumberErrorMessage) {
+    return {
+      valid: false,
+      message: isNotAccountNumberErrorMessage
+    }
+  }
+
+  return {
+    valid: true,
+    message: null
+  }
+}
+
+exports.validateSortCode = (sortCode) => {
+  const isEmptyErrorMessage = isEmpty(sortCode)
+  if (isEmptyErrorMessage) {
+    return {
+      valid: false,
+      message: isEmptyErrorMessage
+    }
+  }
+
+  const isNotSortCodeErrorMessage = isNotSortCode(sortCode)
+  if (isNotSortCodeErrorMessage) {
+    return {
+      valid: false,
+      message: isNotSortCodeErrorMessage
+    }
+  }
+
+  return {
+    valid: true,
+    message: null
+  }
+}

--- a/app/controllers/live-account-setup/bank-details/bank-details-validations.test.js
+++ b/app/controllers/live-account-setup/bank-details/bank-details-validations.test.js
@@ -1,0 +1,61 @@
+'use strict'
+
+// NPM dependencies
+const { expect } = require('chai')
+
+// Local dependencies
+const bankDetailsValidations = require('./bank-details-validations')
+
+describe('Bank details validations', () => {
+  describe('account number validations', () => {
+    it('should validate successfully', () => {
+      const bankAccountNumber = '00012345'
+
+      expect(bankDetailsValidations.validateAccountNumber(bankAccountNumber).valid).to.be.true // eslint-disable-line
+    })
+
+    it('should be not valid when is empty string', () => {
+      const bankAccountNumber = ''
+
+      expect(bankDetailsValidations.validateAccountNumber(bankAccountNumber)).to.deep.equal({
+        valid: false,
+        message: 'This field cannot be blank'
+      })
+    })
+
+    it('should be not valid for invalid account number', () => {
+      const bankAccountNumber = 'abcdefgh'
+
+      expect(bankDetailsValidations.validateAccountNumber(bankAccountNumber)).to.deep.equal({
+        valid: false,
+        message: 'Please enter a valid account number'
+      })
+    })
+  })
+
+  describe('sort code validations', () => {
+    it('should validate successfully', () => {
+      const sortCode = '108800'
+
+      expect(bankDetailsValidations.validateSortCode(sortCode).valid).to.be.true // eslint-disable-line
+    })
+
+    it('should be not valid when is empty string', () => {
+      const sortCode = ''
+
+      expect(bankDetailsValidations.validateSortCode(sortCode)).to.deep.equal({
+        valid: false,
+        message: 'This field cannot be blank'
+      })
+    })
+
+    it('should be not valid for invalid sort code', () => {
+      const sortCode = 'abcdef'
+
+      expect(bankDetailsValidations.validateSortCode(sortCode)).to.deep.equal({
+        valid: false,
+        message: 'Please enter a valid sort code'
+      })
+    })
+  })
+})

--- a/test/unit/browsered/field_validation_checks_test.js
+++ b/test/unit/browsered/field_validation_checks_test.js
@@ -110,6 +110,12 @@ describe('field validation checks', () => {
       expect(isNotSortCode(sortCode)).to.be.false // eslint-disable-line
     })
 
+    it('should validate successfully for 6 digits with random whitespace', () => {
+      const sortCode = '1 0 88 00'
+
+      expect(isNotSortCode(sortCode)).to.be.false // eslint-disable-line
+    })
+
     it('should be not valid when is not a number', () => {
       const sortCode = 'abcdef'
 

--- a/test/unit/browsered/field_validation_checks_test.js
+++ b/test/unit/browsered/field_validation_checks_test.js
@@ -1,10 +1,16 @@
 'use strict'
 
 // NPM dependencies
-const {expect} = require('chai')
+const { expect } = require('chai')
 
 // Local dependencies
-const {isAboveMaxAmount, isPasswordLessThanTenChars, isFieldGreaterThanMaxLengthChars} = require('../../../app/browsered/field-validation-checks')
+const {
+  isAboveMaxAmount,
+  isPasswordLessThanTenChars,
+  isFieldGreaterThanMaxLengthChars,
+  isNotAccountNumber,
+  isNotSortCode
+} = require('../../../app/browsered/field-validation-checks')
 
 describe('field validation checks', () => {
   describe('isAboveMaxAmount', () => {
@@ -39,6 +45,87 @@ describe('field validation checks', () => {
     })
     it('should return false, ignoring the validation if max length is not numeric', () => {
       expect(isFieldGreaterThanMaxLengthChars('123456ABC', 'que')).to.equal(false)
+    })
+  })
+  describe('isNotValidAccountNumber', () => {
+    it('should validate successfully for 8 digits', () => {
+      const accountNumber = '00012345'
+
+      expect(isNotAccountNumber(accountNumber)).to.be.false // eslint-disable-line
+    })
+
+    it('should validate successfully for 6 digits', () => {
+      const accountNumber = '012345'
+
+      expect(isNotAccountNumber(accountNumber)).to.be.false // eslint-disable-line
+    })
+
+    it('should validate successfully for 7 digits', () => {
+      const accountNumber = '0012345'
+
+      expect(isNotAccountNumber(accountNumber)).to.be.false // eslint-disable-line
+    })
+
+    it('should be not valid when is not a number', () => {
+      const accountNumber = 'abcdefgh'
+
+      expect(isNotAccountNumber(accountNumber)).to.be.equal('Please enter a valid account number')
+    })
+
+    it('should be not valid when is too short', () => {
+      const accountNumber = '12345'
+
+      expect(isNotAccountNumber(accountNumber)).to.be.equal('Please enter a valid account number')
+    })
+
+    it('should be not valid when is too long', () => {
+      const accountNumber = '123456789'
+
+      expect(isNotAccountNumber(accountNumber)).to.be.equal('Please enter a valid account number')
+    })
+  })
+
+  describe('isNotValidSortCode', () => {
+    it('should validate successfully for 6 digits', () => {
+      const sortCode = '108800'
+
+      expect(isNotSortCode(sortCode)).to.be.false // eslint-disable-line
+    })
+
+    it('should validate successfully for 6 digits with dashes', () => {
+      const sortCode = '10-88-00'
+
+      expect(isNotSortCode(sortCode)).to.be.false // eslint-disable-line
+    })
+
+    it('should validate successfully for 6 digits with spaces', () => {
+      const sortCode = '10 88 00'
+
+      expect(isNotSortCode(sortCode)).to.be.false // eslint-disable-line
+    })
+
+    it('should validate successfully for 6 digits with mix of dashes and spaces', () => {
+      const sortCode = '10-88 00'
+
+      expect(isNotSortCode(sortCode)).to.be.false // eslint-disable-line
+    })
+
+    it('should be not valid when is not a number', () => {
+      const sortCode = 'abcdef'
+
+      expect(isNotSortCode(sortCode)).to.be.equal('Please enter a valid sort code')
+    })
+
+    it('should be not valid when is too short', () => {
+      const sortCode = '12345'
+
+      expect(isNotSortCode(sortCode)).to.be.equal('Please enter a valid sort code')
+    })
+
+    it('should be not valid when is too long', () => {
+      const sortCode = '1234567'
+
+      expect(isNotSortCode(sortCode)).to.be.equal('Please enter a valid sort code')
     })
   })
 })


### PR DESCRIPTION
Add validation checks to be used by both the client-side javascript validation and the server side validation to validate the account number and sort code.

Add bank-details-validation.js which will be used by the controller to perform the server-side validation.

with @DanailMinchev

