### PR TITLE
PP-4462 Add bank details confirm your answers page

### DIFF
--- a/app/views/stripe-setup/bank-details/check-your-answers.njk
+++ b/app/views/stripe-setup/bank-details/check-your-answers.njk
@@ -1,0 +1,62 @@
+{% extends "../../layout.njk" %}
+{% from "components/summary-list/macro.njk" import govukSummaryList %}
+{% from "components/button/macro.njk" import govukButton %}
+
+{% block pageTitle %}
+  Add bank details - {{ currentService.name }} - GOV.UK Pay
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-column-two-thirds-from-desktop govuk-!-margin-top-6">
+
+    <h1 class="govuk-heading-l">Check details before saving</h1>
+
+    <form id="stripe-setup-bank-details-check-display-form" method="post" action="/bank-details" novalidate>
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+      <input name="answers-need-changing" type="hidden" value="true"/>
+      <input name="account-number" type="hidden" value="{{ accountNumber }}"/>
+      <input name="sort-code" type="hidden" value="{{ sortCode }}"/>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Account number
+          </dt>
+          <dd id="stripe-setup-account-number-value" class="govuk-summary-list__value">
+            {{ accountNumber }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <button id="stripe-setup-account-number-change-button" class="govuk-button--as-link" type="submit">
+              Change
+              <span class="govuk-visually-hidden">account number</span>
+            </button>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Sort code
+          </dt>
+          <dd id="stripe-setup-sort-code-value" class="govuk-summary-list__value">
+            {{ sortCode }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <button id="stripe-setup-sort-code-change-button" class="govuk-button--as-link" type="submit">
+              Change
+              <span class="govuk-visually-hidden">sort code</span>
+            </button>
+          </dd>
+        </div>
+      </dl>
+    </form>
+
+    <form id="stripe-setup-bank-details-check-submit-form" method="post" action="/bank-details" novalidate>
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+      <input name="answers-checked" type="hidden" value="true"/>
+      <input name="account-number" type="hidden" value="{{ accountNumber }}"/>
+      <input name="sort-code" type="hidden" value="{{ sortCode }}"/>
+
+      {{ govukButton({ text: "Save details" }) }}
+    </form>
+
+  </div>
+{% endblock %}

--- a/app/views/stripe-setup/bank-details/index.njk
+++ b/app/views/stripe-setup/bank-details/index.njk
@@ -9,7 +9,7 @@
 
 {% block mainContent %}
   <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
-    {% if errors %}
+    {% if errors.length > 0 %}
       {% set errorList = [] %}
       {% if errors['account-number'] %}
         {% set errorList = (errorList.push({
@@ -48,6 +48,7 @@
         },
         id: "stripe-setup-account-number-input",
         name: "account-number",
+        classes: "govuk-input--width-10",
         value: accountNumber,
         type: "text",
         errorMessage: accountNumberError,
@@ -69,6 +70,7 @@
         },
         id: "stripe-setup-sort-code-input",
         name: "sort-code",
+        classes: "govuk-input--width-10",
         value: sortCode,
         type: "text",
         errorMessage: sortCodeError,

--- a/test/cypress/integration/stripe-setup/bank_details_spec.js
+++ b/test/cypress/integration/stripe-setup/bank_details_spec.js
@@ -148,6 +148,58 @@ describe('Stripe setup: bank details page', () => {
         cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
       })
     })
+
+    describe('Check your answers page', () => {
+      const accountNumber = '00012345'
+      const sortCode = '108800'
+
+      beforeEach(() => {
+        cy.task('setupStubs', [
+          commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
+          commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
+          getStripeSetupStub(false)
+        ])
+
+        cy.visit('/bank-details')
+
+        cy.get('#stripe-setup-account-number-input').type(accountNumber)
+        cy.get('#stripe-setup-sort-code-input').type(sortCode)
+        cy.get('#stripe-setup-bank-details-form > button[type=submit]').click()
+      })
+
+      it('should go to check your answers page when inputs are valid', () => {
+        cy.get('#stripe-setup-account-number-value').should('contain', accountNumber)
+        cy.get('#stripe-setup-sort-code-value').should('contain', sortCode)
+
+        cy.get('h1').should('contain', 'Check details before saving')
+      })
+
+      it('should go to the dashboard page when save details button clicked', () => {
+        cy.get('#stripe-setup-bank-details-check-submit-form > button[type=submit]').click()
+
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`/`)
+        })
+      })
+
+      it('should go back to index page when change account number link clicked', () => {
+        cy.get('#stripe-setup-account-number-change-button').click()
+        cy.get('.govuk-error-summary').should('not.exist')
+
+        cy.get('h1').should('contain', 'Add bank details')
+        cy.get('#stripe-setup-account-number-input').should('have.value', accountNumber)
+        cy.get('#stripe-setup-sort-code-input').should('have.value', sortCode)
+      })
+
+      it('should go back to index page when change sort code link clicked', () => {
+        cy.get('#stripe-setup-sort-code-change-button').click()
+        cy.get('.govuk-error-summary').should('not.exist')
+
+        cy.get('h1').should('contain', 'Add bank details')
+        cy.get('#stripe-setup-account-number-input').should('have.value', accountNumber)
+        cy.get('#stripe-setup-sort-code-input').should('have.value', sortCode)
+      })
+    })
   })
 
   describe('Direct Debit gateway account', () => {


### PR DESCRIPTION
Add template for the confirm your answers page.

Add logic to the bank details post controller to handle navigation
back to the index page to change bank details or to submit the details
based on a hidden form field.

with @DanailMinchev

