### PR TITLE
PP-4462 bank details page new permissions

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -336,13 +336,13 @@ module.exports.bind = function (app) {
   app.get(requestToGoLive.index, xraySegmentCls, permission('go-live-stage:read'), getAccount, requestToGoLiveIndexController.get)
   app.post(requestToGoLive.index, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveIndexController.post)
   // Request to go live: organisation name
-  app.get(requestToGoLive.organisationName, xraySegmentCls, permission('go-live-stage:read'), getAccount, requestToGoLiveOrganisationNameController.get)
+  app.get(requestToGoLive.organisationName, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveOrganisationNameController.get)
   app.post(requestToGoLive.organisationName, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveOrganisationNameController.post)
   // Request to go live: choose how to process payments
-  app.get(requestToGoLive.chooseHowToProcessPayments, xraySegmentCls, permission('go-live-stage:read'), getAccount, requestToGoLiveChooseHowToProcessPaymentsController.get)
+  app.get(requestToGoLive.chooseHowToProcessPayments, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveChooseHowToProcessPaymentsController.get)
   app.post(requestToGoLive.chooseHowToProcessPayments, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveChooseHowToProcessPaymentsController.post)
   // Request to go live: agreement
-  app.get(requestToGoLive.agreement, xraySegmentCls, permission('go-live-stage:read'), getAccount, requestToGoLiveAgreementController.get)
+  app.get(requestToGoLive.agreement, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveAgreementController.get)
   app.post(requestToGoLive.agreement, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveAgreementController.post)
 
   // Private policy document downloads

--- a/app/routes.js
+++ b/app/routes.js
@@ -349,8 +349,8 @@ module.exports.bind = function (app) {
   app.get(policyPages.download, xraySegmentCls, policyDocumentsController.download)
 
   // Stripe setup: bank details
-  app.get(stripeSetup.bankDetails, xraySegmentCls, permission('go-live-stage:read'), getAccount, paymentMethodIsCard, stripeSetupBankDetailsController.get)
-  app.post(stripeSetup.bankDetails, xraySegmentCls, permission('go-live-stage:update'), getAccount, paymentMethodIsCard, stripeSetupBankDetailsController.post)
+  app.get(stripeSetup.bankDetails, xraySegmentCls, permission('stripe-bank-details:update'), getAccount, paymentMethodIsCard, stripeSetupBankDetailsController.get)
+  app.post(stripeSetup.bankDetails, xraySegmentCls, permission('stripe-bank-details:update'), getAccount, paymentMethodIsCard, stripeSetupBankDetailsController.post)
 
   app.all('*', (req, res) => {
     res.status(404)

--- a/test/fixtures/user_fixtures.js
+++ b/test/fixtures/user_fixtures.js
@@ -154,6 +154,14 @@ const defaultPermissions = [
   {
     name: 'go-live-stage:read',
     description: 'View Go Live stage'
+  },
+  {
+    name: 'stripe-bank-details:update',
+    description: 'Update Stripe bank details'
+  },
+  {
+    name: 'stripe-bank-details:read',
+    description: 'View Stripe bank details'
   }
 ]
 


### PR DESCRIPTION
## WHAT

Use more granular permissions for Stripe setup pages and use `update` permission for all of the request to go live pages, except index page which makes sense to allow users with `read` permission to see the status

with @stephencdaly
