### PR TITLE
PP-4462 Stripe setup middlewares

### DIFF
--- a/app/middleware/stripe-setup/check-bank-details-not-submitted.js
+++ b/app/middleware/stripe-setup/check-bank-details-not-submitted.js
@@ -1,0 +1,25 @@
+'use strict'
+
+// Local dependencies
+const ConnectorClient = require('../../services/clients/connector_client').ConnectorClient
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+const { renderErrorView } = require('../../utils/response')
+const paths = require('../../paths')
+
+module.exports = (req, res, next) => {
+  if (!req.account) {
+    renderErrorView(req, res, 'Internal server error')
+    return
+  }
+
+  connector.getStripeAccountSetup(req.account.gateway_account_id, req.correlationId).then(stripeSetupResponse => {
+    if (stripeSetupResponse.bankAccount) {
+      req.flash('genericError', 'Bank details flag already set')
+      res.redirect(303, paths.dashboard.index)
+    } else {
+      next()
+    }
+  }).catch(() => {
+    renderErrorView(req, res, 'Please try again or contact support team')
+  })
+}

--- a/app/middleware/stripe-setup/check-bank-details-not-submitted.js
+++ b/app/middleware/stripe-setup/check-bank-details-not-submitted.js
@@ -1,12 +1,12 @@
 'use strict'
 
 // Local dependencies
-const ConnectorClient = require('../../services/clients/connector_client').ConnectorClient
+const { ConnectorClient } = require('../../services/clients/connector_client')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 const { renderErrorView } = require('../../utils/response')
 const paths = require('../../paths')
 
-module.exports = (req, res, next) => {
+module.exports = function checkBankDetailsNotSubmitted (req, res, next) {
   if (!req.account) {
     renderErrorView(req, res, 'Internal server error')
     return

--- a/app/middleware/stripe-setup/check-bank-details-not-submitted.test.js
+++ b/app/middleware/stripe-setup/check-bank-details-not-submitted.test.js
@@ -1,0 +1,126 @@
+'use strict'
+
+// NPM dependencies
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+// Local dependencies
+const paths = require('../../paths')
+
+// Global setup
+chai.use(chaiAsPromised)
+const { expect } = chai // must be called after chai.use(chaiAsPromised) to use "should.eventually"
+
+describe('Check bank details not submitted middleware', () => {
+  let req
+  let res
+  let next
+
+  beforeEach(() => {
+    req = {
+      correlationId: 'correlation-id',
+      account: {
+        gateway_account_id: '1'
+      },
+      flash: sinon.spy()
+    }
+    res = {
+      setHeader: sinon.stub(),
+      status: sinon.spy(),
+      render: sinon.spy(),
+      redirect: sinon.spy()
+    }
+    next = sinon.spy()
+  })
+
+  it('should call next when bank account flag is false', done => {
+    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
+      bankAccount: false
+    })
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.calledOnce).to.be.true // eslint-disable-line
+      expect(req.flash.notCalled).to.be.true // eslint-disable-line
+      expect(res.redirect.notCalled).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should redirect to the dashboard with error message when bank account flag is true', done => {
+    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
+      bankAccount: true
+    })
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.notCalled).to.be.true // eslint-disable-line
+      expect(req.flash.calledWith('genericError', 'Bank details flag already set')).to.be.true // eslint-disable-line
+      expect(res.redirect.calledWith(303, paths.dashboard.index)).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should render an error page when req.account is undefined', done => {
+    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
+      bankAccount: false
+    })
+    req.account = undefined
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.notCalled).to.be.true // eslint-disable-line
+      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+      expect(res.render.calledWith('error', {message: 'Internal server error'})).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should render an error page when connector rejects the call', done => {
+    const middleware = getMiddlewareWithConnectorClientRejectedPromiseMock({
+      bankAccount: false
+    })
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.notCalled).to.be.true // eslint-disable-line
+      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+      expect(res.render.calledWith('error', {message: 'Please try again or contact support team'})).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+})
+
+function getMiddlewareWithConnectorClientResolvedPromiseMock (getStripeAccountSetupResponse) {
+  return proxyquire('./check-bank-details-not-submitted', {
+    '../../services/clients/connector_client': {
+      ConnectorClient: function () {
+        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => {
+          return new Promise(resolve => {
+            resolve(getStripeAccountSetupResponse)
+          })
+        }
+      }
+    }
+  })
+}
+
+function getMiddlewareWithConnectorClientRejectedPromiseMock (getStripeAccountSetupResponse) {
+  return proxyquire('./check-bank-details-not-submitted', {
+    '../../services/clients/connector_client': {
+      ConnectorClient: function () {
+        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => {
+          return new Promise((resolve, reject) => {
+            reject(new Error())
+          })
+        }
+      }
+    }
+  })
+}

--- a/app/middleware/stripe-setup/restrict-to-live-stripe-account.js
+++ b/app/middleware/stripe-setup/restrict-to-live-stripe-account.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = (req, res, next) => {
+  if (req.account &&
+    req.account.type &&
+    req.account.payment_provider &&
+    req.account.type.toLowerCase() === 'live' &&
+    req.account.payment_provider.toLowerCase() === 'stripe'
+  ) {
+    next()
+  } else {
+    res.status(404)
+    res.render('404')
+  }
+}

--- a/app/middleware/stripe-setup/restrict-to-live-stripe-account.js
+++ b/app/middleware/stripe-setup/restrict-to-live-stripe-account.js
@@ -1,14 +1,17 @@
 'use strict'
 
-module.exports = (req, res, next) => {
-  if (req.account &&
+module.exports = function restrictRequestsToLiveAccounts (req, res, next) {
+  const requestHasValidLiveStripeAccount = req.account &&
     req.account.type &&
     req.account.payment_provider &&
     req.account.type.toLowerCase() === 'live' &&
     req.account.payment_provider.toLowerCase() === 'stripe'
-  ) {
+
+  if (requestHasValidLiveStripeAccount) {
     next()
   } else {
+    // we display 404 error, because from user point of view this page should not exist
+    // if the user does not have a valid live Stripe account
     res.status(404)
     res.render('404')
   }

--- a/app/middleware/stripe-setup/restrict-to-live-stripe-account.test.js
+++ b/app/middleware/stripe-setup/restrict-to-live-stripe-account.test.js
@@ -1,0 +1,77 @@
+'use strict'
+
+// NPM dependencies
+const sinon = require('sinon')
+const { expect } = require('chai')
+
+// Local dependencies
+const restrictToLiveStripeAccount = require('./restrict-to-live-stripe-account')
+
+describe('Restrict to live stripe account middleware', () => {
+  let res
+  let next
+
+  beforeEach(() => {
+    res = {
+      setHeader: sinon.spy(),
+      status: sinon.spy(),
+      render: sinon.spy()
+    }
+    next = sinon.spy()
+  })
+
+  it('should call next when the gateway account is live and it is Stripe', () => {
+    const req = {
+      account: {
+        type: 'live',
+        payment_provider: 'stripe'
+      }
+    }
+
+    restrictToLiveStripeAccount(req, res, next)
+
+    expect(next.calledOnce).to.be.true // eslint-disable-line
+    expect(res.status.notCalled).to.be.true // eslint-disable-line
+    expect(res.render.notCalled).to.be.true // eslint-disable-line
+  })
+
+  it('should render 404 error when the gateway account is not in the request', () => {
+    const req = {}
+
+    restrictToLiveStripeAccount(req, res, next)
+
+    expect(next.notCalled).to.be.true // eslint-disable-line
+    expect(res.status.calledWith(404))
+    expect(res.render.calledWith('404'))
+  })
+
+  it('should render 404 error when the gateway account is not Stripe', () => {
+    const req = {
+      account: {
+        type: 'live',
+        payment_provider: 'sandbox'
+      }
+    }
+
+    restrictToLiveStripeAccount(req, res, next)
+
+    expect(next.notCalled).to.be.true // eslint-disable-line
+    expect(res.status.calledWith(404))
+    expect(res.render.calledWith('404'))
+  })
+
+  it('should render 404 error when the gateway account is not live', () => {
+    const req = {
+      account: {
+        type: 'test',
+        payment_provider: 'stripe'
+      }
+    }
+
+    restrictToLiveStripeAccount(req, res, next)
+
+    expect(next.notCalled).to.be.true // eslint-disable-line
+    expect(res.status.calledWith(404))
+    expect(res.render.calledWith('404'))
+  })
+})


### PR DESCRIPTION
## WHAT

This PR adds two middelwares which can be used for Stripe setup page validations:

- Restrict to live Stripe account middleware
- Check bank details not submitted middleware

with @stephencdaly
