### PR TITLE
PP-4463 Better JS error summaries for fields with hidden labels

### DIFF
--- a/app/browsered/field-validation.js
+++ b/app/browsered/field-validation.js
@@ -120,14 +120,32 @@ function applyErrorMessaging (form, field, result) {
   }
 }
 
+function getLabel (field) {
+  if (field.hasAttribute('data-validate-override-label')) {
+    const overrideField = field.getAttribute('data-validate-override-label')
+    const overrideLabel = document.querySelector('label[for="' + overrideField + '"]')
+    if (overrideLabel) {
+      return overrideLabel
+    }
+  }
+  return field
+}
+
 function populateErrorSummary (form) {
-  const erroringFields = Array.prototype.slice.call(form.querySelectorAll(`${FORM_GROUP_WITH_ERROR} label`))
+  const erroringFieldLabels = Array.prototype.slice.call(form.querySelectorAll(`${FORM_GROUP_WITH_ERROR} label`))
+
+  const erroringFieldLabelsAndIds = erroringFieldLabels.map(field => {
+    const label = getLabel(field).innerHTML.split('<')[0].trim()
+    const id = field.getAttribute('for')
+    return {label, id}
+  })
+
+  const erroringFieldLabelsAndIdsDuplicateLabelsRemoved = erroringFieldLabelsAndIds.filter((field, index, fields) => {
+    return fields.indexOf(fields.find(f => f.label === field.label)) >= index
+  })
+
   const configuration = {
-    fields: erroringFields.map(field => {
-      const label = field.innerHTML.split('<')[0].trim()
-      const id = field.getAttribute('for')
-      return {label, id}
-    })
+    fields: erroringFieldLabelsAndIdsDuplicateLabelsRemoved
   }
 
   form.parentNode.insertAdjacentHTML(


### PR DESCRIPTION
Improve the error summary when it’s created by JavaScript running in the browser and there are errors with fields that have labels that are entirely visually hidden:

- Add support for a new `data-validate-override-label` attribute on a form field `label` element. The value of this attribute is the ID of another form field. When building the error summary, the label belonging to this other form field will be used instead of the original form field’s label. This is intended to be used when the original form field’s label is entirely visually hidden but another form field’s label accurately describes it (e.g. the second line of a postal address, where the label for the first line also works for the second).

- In the error summary, filter the list of field labels so that only the first field with an error is listed if there are multiple erroring fields with the same label (taking into account the new `data-validate-override-label` attribute).

This does not affect how the server-side validation works.