### PR TITLE
PP-4462 Stripe setup: apply restrictToLiveStripeAccount and checkBankDetailsNotSubmitted middelwares

### DIFF
--- a/app/controllers/stripe-setup/bank-details/get.controller.js
+++ b/app/controllers/stripe-setup/bank-details/get.controller.js
@@ -2,23 +2,7 @@
 
 // Local dependencies
 const response = require('../../../utils/response')
-const ConnectorClient = require('../../../services/clients/connector_client').ConnectorClient
-const connector = new ConnectorClient(process.env.CONNECTOR_URL)
-const paths = require('../../../paths')
 
 module.exports = (req, res) => {
-  if (req.account.payment_provider.toLowerCase() !== 'stripe' ||
-    req.account.type.toLowerCase() !== 'live') {
-    res.status(404)
-    res.render('404')
-    return
-  }
-
-  connector.getStripeAccountSetup(req.account.gateway_account_id, req.correlationId).then(stripeSetupResponse => {
-    if (stripeSetupResponse.bankAccount) {
-      req.flash('genericError', 'Bank details flag already set')
-      return res.redirect(303, paths.dashboard.index)
-    }
-    return response.response(req, res, 'stripe-setup/bank-details/index')
-  })
+  return response.response(req, res, 'stripe-setup/bank-details/index')
 }

--- a/app/controllers/stripe-setup/bank-details/post.controller.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.js
@@ -15,13 +15,6 @@ const ANSWERS_NEED_CHANGING_FIELD = 'answers-need-changing'
 const ANSWERS_CHECKED_FIELD = 'answers-checked'
 
 module.exports = (req, res) => {
-  if (req.account.payment_provider.toLowerCase() !== 'stripe' ||
-    req.account.type.toLowerCase() !== 'live') {
-    res.status(404)
-    res.render('404')
-    return
-  }
-
   const accountNumber = req.body[ACCOUNT_NUMBER_FIELD]
   const sortCode = req.body[SORT_CODE_FIELD]
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -30,6 +30,8 @@ const xraySegmentCls = require('./middleware/x_ray')
 const goCardlessRedirect = require('./middleware/partnerapp/handle_redirect_to_gocardless_connect')
 const goCardlessOAuthGet = require('./middleware/partnerapp/handle_gocardless_connect_get')
 const cookieMessage = require('./middleware/cookie_message')
+const restrictToLiveStripeAccount = require('./middleware/stripe-setup/restrict-to-live-stripe-account')
+const checkBankDetailsNotSubmitted = require('./middleware/stripe-setup/check-bank-details-not-submitted')
 
 // Controllers
 const staticController = require('./controllers/static_controller')
@@ -349,8 +351,8 @@ module.exports.bind = function (app) {
   app.get(policyPages.download, xraySegmentCls, policyDocumentsController.download)
 
   // Stripe setup: bank details
-  app.get(stripeSetup.bankDetails, xraySegmentCls, permission('stripe-bank-details:update'), getAccount, paymentMethodIsCard, stripeSetupBankDetailsController.get)
-  app.post(stripeSetup.bankDetails, xraySegmentCls, permission('stripe-bank-details:update'), getAccount, paymentMethodIsCard, stripeSetupBankDetailsController.post)
+  app.get(stripeSetup.bankDetails, xraySegmentCls, permission('stripe-bank-details:update'), getAccount, paymentMethodIsCard, restrictToLiveStripeAccount, checkBankDetailsNotSubmitted, stripeSetupBankDetailsController.get)
+  app.post(stripeSetup.bankDetails, xraySegmentCls, permission('stripe-bank-details:update'), getAccount, paymentMethodIsCard, restrictToLiveStripeAccount, checkBankDetailsNotSubmitted, stripeSetupBankDetailsController.post)
 
   app.all('*', (req, res) => {
     res.status(404)

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -134,6 +134,35 @@ module.exports = {
       }
     ]
   },
+  getGatewayAccountStripeSetupBankAccountFlagChanged: (opts = {}) => {
+    const responses = []
+    opts.data.forEach(item => {
+      responses.push({
+        is: {
+          statusCode: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: stripeAccountSetupFixtures.buildGetStripeAccountSetupResponse(item).getPlain()
+        }
+      })
+    })
+
+    return [
+      {
+        predicates: [{
+          equals: {
+            method: 'GET',
+            path: `/v1/api/accounts/${opts.gateway_account_id}/stripe-setup`,
+            headers: {
+              'Accept': 'application/json'
+            }
+          }
+        }],
+        responses
+      }
+    ]
+  },
   getGatewayAccountQueryParamsSuccess: (opts = {}) => {
     const aValidGetGatewayAccountResponse = gatewayAccountFixtures.validGatewayAccountResponse(opts).getPlain()
     return [


### PR DESCRIPTION
## WHAT

Stripe setup: apply restrictToLiveStripeAccount and checkBankDetailsNotSubmitted middelwares

- Apply restrictToLiveStripeAccount middleware which is restricting the access to only live Stripe accounts
- Apply checkBankDetailsNotSubmitted middelware which is checking if the bank details were already submitted

with @stephencdaly
