### PR TITLE
PP-4462 Set Stripe API version in the client

### DIFF
--- a/app/services/clients/stripe/stripe_client.js
+++ b/app/services/clients/stripe/stripe_client.js
@@ -15,6 +15,7 @@ const STRIPE_PORT = process.env.STRIPE_PORT
 if (process.env.http_proxy) {
   stripe.setHttpAgent(new ProxyAgent(process.env.http_proxy))
 }
+stripe.setApiVersion('2019-02-19')
 // only expect host and port environment variables to be set when running tests
 if (STRIPE_HOST) {
   stripe.setHost(STRIPE_HOST)


### PR DESCRIPTION
## WHAT

- Set Stripe API version to latest `2019-02-19` version in the SDK client,
  because we want to use latest version and not the one which is currently
  set on a global account level (in the Stripe Dashboard).
- Later, once we have migrated to the new version (including `pay-connector` and `webhooks`)
  we should remove this header
