### PR TITLE
PP-4462 Add getStripeAccount() method to connector client

### DIFF
--- a/app/models/StripeAccount.class.js
+++ b/app/models/StripeAccount.class.js
@@ -1,0 +1,9 @@
+'use strict'
+
+class StripeAccount {
+  constructor (opts) {
+    this.stripeAccountId = opts.stripe_account_id
+  }
+}
+
+module.exports = StripeAccount

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -14,6 +14,7 @@ const requestLogger = require('../../utils/request_logger')
 const createCallbackToPromiseConverter = require('../../utils/response_converter').createCallbackToPromiseConverter
 const getQueryStringForParams = require('../../utils/get_query_string_for_params')
 const StripeAccountSetup = require('../../models/StripeAccountSetup.class')
+const StripeAccount = require('../../models/StripeAccount.class')
 
 // Constants
 const SERVICE_NAME = 'connector'
@@ -25,6 +26,7 @@ const CHARGE_API_PATH = CHARGES_API_PATH + '/{chargeId}'
 const CHARGE_REFUNDS_API_PATH = CHARGE_API_PATH + '/refunds'
 const CARD_TYPES_API_PATH = '/v1/api/card-types'
 const STRIPE_ACCOUNT_SETUP_PATH = ACCOUNT_API_PATH + '/stripe-setup'
+const STRIPE_ACCOUNT_PATH = ACCOUNT_API_PATH + '/stripe-account'
 
 const ACCOUNTS_FRONTEND_PATH = '/v1/frontend/accounts'
 const ACCOUNT_FRONTEND_PATH = ACCOUNTS_FRONTEND_PATH + '/{accountId}'
@@ -37,6 +39,7 @@ const TOGGLE_3DS_PATH = ACCOUNTS_FRONTEND_PATH + '/{accountId}/3ds-toggle'
 const TRANSACTIONS_SUMMARY = ACCOUNTS_API_PATH + '/{accountId}/transactions-summary'
 
 const responseBodyToStripeAccountSetupTransformer = body => new StripeAccountSetup(body)
+const responseBodyToStripeAccountTransformer = body => new StripeAccount(body)
 
 /**
  * @private
@@ -174,7 +177,7 @@ ConnectorClient.prototype = {
       url: url
     })
 
-    oldBaseClient.get(url, {correlationId: params.correlationId}, function (error, response, body) {
+    oldBaseClient.get(url, { correlationId: params.correlationId }, function (error, response, body) {
       logger.info(`[${params.correlationId}] - GET to %s ended - elapsed time: %s ms`, url, new Date() - startTime)
       responseHandler(error, response, body)
     })
@@ -227,7 +230,7 @@ ConnectorClient.prototype = {
       url: url,
       chargeId: params.chargeId
     })
-    oldBaseClient.get(url, {correlationId: params.correlationId}, this.responseHandler(successCallback))
+    oldBaseClient.get(url, { correlationId: params.correlationId }, this.responseHandler(successCallback))
     return this
   },
 
@@ -267,7 +270,7 @@ ConnectorClient.prototype = {
       let startTime = new Date()
       let context = {
         url: url,
-        defer: {resolve: resolve, reject: reject},
+        defer: { resolve: resolve, reject: reject },
         startTime: startTime,
         correlationId: params.correlationId,
         method: 'GET',
@@ -296,7 +299,7 @@ ConnectorClient.prototype = {
       let startTime = new Date()
       let context = {
         url: url,
-        defer: {resolve: resolve, reject: reject},
+        defer: { resolve: resolve, reject: reject },
         startTime: startTime,
         correlationId: params.correlationId,
         method: 'GET',
@@ -328,7 +331,7 @@ ConnectorClient.prototype = {
       const startTime = new Date()
       const context = {
         url: url,
-        defer: {resolve: resolve, reject: reject},
+        defer: { resolve: resolve, reject: reject },
         startTime: startTime,
         correlationId: correlationId,
         method: 'POST',
@@ -484,7 +487,7 @@ ConnectorClient.prototype = {
       const startTime = new Date()
       const context = {
         url: url,
-        defer: {resolve: resolve, reject: reject},
+        defer: { resolve: resolve, reject: reject },
         startTime: startTime,
         correlationId: correlationId,
         method: 'PATCH',
@@ -632,6 +635,21 @@ ConnectorClient.prototype = {
         correlationId,
         description: 'set stripe account setup flag to true for gateway account',
         service: SERVICE_NAME,
+        baseClientErrorHandler: 'old'
+      }
+    )
+  },
+
+  getStripeAccount: function (gatewayAccountId, correlationId) {
+    return baseClient.get(
+      {
+        baseUrl: this.connectorUrl,
+        url: STRIPE_ACCOUNT_PATH.replace('{accountId}', gatewayAccountId),
+        json: true,
+        correlationId,
+        description: 'get stripe account for gateway account',
+        service: SERVICE_NAME,
+        transform: responseBodyToStripeAccountTransformer,
         baseClientErrorHandler: 'old'
       }
     )

--- a/test/fixtures/stripe_account_fixtures.js
+++ b/test/fixtures/stripe_account_fixtures.js
@@ -1,0 +1,27 @@
+'use strict'
+
+// NPM dependencies
+const lodash = require('lodash')
+
+// Local dependencies
+const pactBase = require('./pact_base')
+
+// Global setup
+const pactRegister = pactBase()
+
+module.exports = {
+  buildGetStripeAccountResponse (opts = {}) {
+    const data = {
+      'stripe_account_id': opts.stripe_account_id
+    }
+
+    return {
+      getPactified: () => {
+        return pactRegister.pactify(data)
+      },
+      getPlain: () => {
+        return lodash.clone(data)
+      }
+    }
+  }
+}

--- a/test/unit/clients/connector_client/connector_get_stripe_account_test.js
+++ b/test/unit/clients/connector_client/connector_get_stripe_account_test.js
@@ -1,0 +1,68 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const path = require('path')
+
+// Local dependencies
+const PactInteractionBuilder = require('../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const Connector = require('../../../../app/services/clients/connector_client').ConnectorClient
+const stripeAccountFixtures = require('../../../fixtures/stripe_account_fixtures')
+
+// Constants
+const ACCOUNTS_RESOURCE = '/v1/api/accounts'
+const port = Math.floor(Math.random() * 48127) + 1024
+const connectorClient = new Connector(`http://localhost:${port}`)
+const expect = chai.expect
+
+// Global setup
+chai.use(chaiAsPromised)
+
+const existingGatewayAccountId = 42
+const defaultState = `a stripe gateway account with external id ${existingGatewayAccountId} exists in the database`
+
+describe('connector client - get stripe account', () => {
+  const provider = Pact({
+    consumer: 'selfservice',
+    provider: 'connector',
+    port: port,
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(() => provider.setup())
+  after(done => provider.finalize().then(done()))
+
+  describe('get stripe account setup success', () => {
+    const stripeAccountOpts = {
+      stripe_account_id: 'acct_123example123'
+    }
+    const response = stripeAccountFixtures.buildGetStripeAccountResponse(stripeAccountOpts)
+
+    before(done => {
+      provider.addInteraction(
+        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-account`)
+          .withUponReceiving('a valid get stripe account request')
+          .withState(defaultState)
+          .withMethod('GET')
+          .withStatusCode(200)
+          .withResponseBody(response.getPactified())
+          .build()
+      )
+        .then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should get successfully', done => {
+      connectorClient.getStripeAccount(existingGatewayAccountId, 'correlation-id').should.be.fulfilled.then(stripeAccount => {
+        expect(stripeAccount.stripeAccountId).to.equal(stripeAccountOpts.stripe_account_id)
+      }).should.notify(done)
+    })
+  })
+})


### PR DESCRIPTION
## WHAT

- Add `getStripeAccount()` method to connector client which is querying
  `/v1/api/accounts/{accountId}/stripe-account` endpoint to retrieve
  associated Stripe Account ID from the gateway account
- Add related Pact interactions
