### PR TITLE
PP-4463 Remove responsible person client-side JavaScript validation

### DIFF
--- a/app/browsered/field-validation-checks.js
+++ b/app/browsered/field-validation-checks.js
@@ -1,6 +1,4 @@
 'use strict'
-// NPM dependencies
-const ukPostcode = require('uk-postcode')
 
 // Local dependencies
 const emailValidator = require('../utils/email_tools.js')
@@ -20,8 +18,7 @@ const validationErrors = {
   isGreaterThanMaxLengthChars: `The text is too long`,
   invalidCharacters: `You cannot use any of the following characters < > ; : \` ( ) " ' = | , ~ [ ]`,
   invalidBankAccountNumber: 'Please enter a valid account number',
-  invalidSortCode: 'Please enter a valid sort code',
-  invalidPostcode: 'Please enter a real postcode'
+  invalidSortCode: 'Please enter a valid sort code'
 }
 
 exports.isEmpty = function (value) {
@@ -100,13 +97,5 @@ exports.isNotSortCode = value => {
     return false
   } else {
     return validationErrors.invalidSortCode
-  }
-}
-
-exports.isInvalidUkPostcode = (value) => {
-  if (!ukPostcode.fromString(value).isComplete()) {
-    return validationErrors.invalidPostcode
-  } else {
-    return false
   }
 }

--- a/app/controllers/stripe-setup/responsible-person/responsible-person-validations.js
+++ b/app/controllers/stripe-setup/responsible-person/responsible-person-validations.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// NPM dependencies
+const ukPostcode = require('uk-postcode')
+
 // Local dependencies
 const {
   isEmpty, isFieldGreaterThanMaxLengthChars, isInvalidUkPostcode
@@ -56,11 +59,11 @@ exports.validatePostcode = (postcode) => {
     }
   }
 
-  const invalidPostcodeErrorMessage = isInvalidUkPostcode(postcode)
-  if (invalidPostcodeErrorMessage) {
+  const postcodeIsInvalid = !ukPostcode.fromString(postcode).isComplete()
+  if (postcodeIsInvalid) {
     return {
       valid: false,
-      message: invalidPostcodeErrorMessage
+      message: 'Please enter a real postcode'
     }
   }
 

--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -68,8 +68,7 @@
       <li>the head of finance</li>
       <li>the head of the organisation</li>
     </ul>
-    <form id="stripe-setup-responsible-person-form" method="post"
-          action="/responsible-person" data-validate="true">
+    <form id="stripe-setup-responsible-person-form" method="post" action="/responsible-person">
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {% set firstNameError = false %}
@@ -88,11 +87,7 @@
         type: "text",
         autocomplete: "given-name",
         errorMessage: firstNameError,
-        classes: "govuk-input--width-20",
-        attributes: {
-          "data-validate": "required isFieldGreaterThanMaxLengthChars",
-          "data-validate-max-length": "100"
-        }
+        classes: "govuk-input--width-20"
       }) }}
       {% set lastNameNameError = false %}
       {% if errors['last-name'] %}
@@ -110,11 +105,7 @@
         type: "text",
         autocomplete: "family-name",
         errorMessage: lastNameNameError,
-        classes: "govuk-input--width-20",
-        attributes: {
-          "data-validate": "required isFieldGreaterThanMaxLengthChars",
-          "data-validate-max-length": "100"
-        }
+        classes: "govuk-input--width-20"
       }) }}
       {% set homeAddressLine1Error = false %}
       {% if errors['home-address-line-1'] %}
@@ -131,11 +122,7 @@
         value: homeAddressLine1,
         type: "text",
         autocomplete: "address-line1",
-        errorMessage: homeAddressLine1Error,
-        attributes: {
-          "data-validate": "required isFieldGreaterThanMaxLengthChars",
-          "data-validate-max-length": "200"
-        }
+        errorMessage: homeAddressLine1Error
       }) }}
       {% set homeAddressLine2Error = false %}
       {% if errors['home-address-line-2'] %}
@@ -145,10 +132,7 @@
       {% endif %}
       {{ govukInput({
         label: {
-          html: '<span class="govuk-visually-hidden">Home address line 2 of 2</span>',
-          attributes: {
-            "data-validate-override-label": "stripe-setup-home-address-line-1-input"
-          }
+          html: '<span class="govuk-visually-hidden">Home address line 2 of 2</span>'
         },
         id: "stripe-setup-home-address-line-2-input",
         name: "home-address-line-2",
@@ -157,9 +141,7 @@
         autocomplete: "address-line2",
         errorMessage: homeAddressLine2Error,
         attributes: {
-          "aria-label": "Enter address line 2",
-          "data-validate": "isFieldGreaterThanMaxLengthChars",
-          "data-validate-max-length": "200"
+          "aria-label": "Enter address line 2"
         }
       }) }}
       {% set homeAddressCityError = false %}
@@ -178,11 +160,7 @@
         type: "text",
         autocomplete: "address-level2",
         errorMessage: homeAddressCityError,
-        classes: "govuk-input--width-20",
-        attributes: {
-          "data-validate": "required isFieldGreaterThanMaxLengthChars",
-          "data-validate-max-length": "100"
-        }
+        classes: "govuk-input--width-20"
       }) }}
       {% set homeAddressPostcodeError = false %}
       {% if errors['home-address-postcode'] %}
@@ -200,10 +178,7 @@
         type: "text",
         autocomplete: "postal-code",
         classes: "govuk-input--width-10",
-        errorMessage: homeAddressPostcodeError,
-        attributes: {
-          "data-validate": "required postcode"
-        }
+        errorMessage: homeAddressPostcodeError
       }) }}
       {% set homeAddressPostcodeError = false %}
       {% if errors['home-address-postcode'] %}
@@ -228,28 +203,19 @@
             value: dobDay,
             name: "day",
             classes: "govuk-input--width-2",
-            autocomplete: "bday-day",
-            attributes: {
-            "data-validate": "required dobDay"
-          }
+            autocomplete: "bday-day"
           },
           {
             value: dobMonth,
             name: "month",
             classes: "govuk-input--width-2",
-            autocomplete: "bday-month",
-            attributes: {
-            "data-validate": "required dobMonth"
-          }
+            autocomplete: "bday-month"
           },
           {
             value: dobYear,
             name: "year",
             classes: "govuk-input--width-4",
-            autocomplete: "bday-year",
-            attributes: {
-            "data-validate": "required dobYear"
-          }
+            autocomplete: "bday-year"
           }
         ]
       }) }}


### PR DESCRIPTION
Our current client-side (in-browser) validation framework isn’t flexible enough to support the level of date of birth validation we want on the Stripe responsible person page. If we had this date of birth validation only in the server-side code then the page would behave strangely if there were multiple errors (some would be caught client-side, others wouldn’t be caught until the form is actually POSTed to the server).

Remove the client-side validation for the responsible person page to avoid the issue. The validation was only applied when the user pressed the submit button (as opposed to when the focus leaves the field, for example), so the server-side validation offers the same experience, just a little slower.

Move the postcode validation logic out of JavaScript that gets served to browsers because it will only be required server-side now.