### PR TITLE
PP-4463 Server-side responsible person date of birth validation

### DIFF
--- a/app/browsered/field-validation.js
+++ b/app/browsered/field-validation.js
@@ -98,9 +98,6 @@ function validateField (form, field) {
       case 'sortCode':
         result = checks.isNotSortCode(field.value)
         break
-      case 'postcode':
-        result = checks.isInvalidUkPostcode(field.value)
-        break
       default:
         result = checks.isEmpty(field.value)
         break

--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -7,7 +7,7 @@ const lodash = require('lodash')
 const paths = require('../../../paths')
 const response = require('../../../utils/response')
 const {
-  validateMandatoryField, validateOptionalField, validatePostcode
+  validateMandatoryField, validateOptionalField, validatePostcode, validateDateOfBirth
 } = require('./responsible-person-validations')
 
 const FIRST_NAME_FIELD = 'first-name'
@@ -61,6 +61,11 @@ module.exports = (req, res) => {
     return errors
   }, {})
 
+  const dateOfBirthErrorMessage = validateDoB(req)
+  if (dateOfBirthErrorMessage) {
+    errors['dob'] = dateOfBirthErrorMessage
+  }
+
   const pageData = {
     firstName: lodash.get(req.body, FIRST_NAME_FIELD),
     lastName: lodash.get(req.body, LAST_NAME_FIELD),
@@ -86,7 +91,7 @@ module.exports = (req, res) => {
 }
 
 const validate = (req, fieldName, fieldValidator, maxLength) => {
-  const field = getFieldValue(req, fieldName)
+  const field = lodash.get(req.body, fieldName)
   const isFieldValid = fieldValidator(field, maxLength)
   if (!isFieldValid.valid) {
     return isFieldValid.message
@@ -94,6 +99,13 @@ const validate = (req, fieldName, fieldValidator, maxLength) => {
   return null
 }
 
-const getFieldValue = (req, fieldNames) => {
-  return lodash.get(req.body, fieldNames)
+const validateDoB = (req) => {
+  const day = lodash.get(req.body, DOB_DAY_FIELD)
+  const month = lodash.get(req.body, DOB_MONTH_FIELD)
+  const year = lodash.get(req.body, DOB_YEAR_FIELD)
+  const dateOfBirthValidationResult = validateDateOfBirth(day, month, year)
+  if (!dateOfBirthValidationResult.valid) {
+    return dateOfBirthValidationResult.message
+  }
+  return null
 }

--- a/app/controllers/stripe-setup/responsible-person/responsible-person-validations.js
+++ b/app/controllers/stripe-setup/responsible-person/responsible-person-validations.js
@@ -1,11 +1,13 @@
 'use strict'
 
 // NPM dependencies
+const moment = require('moment-timezone')
 const ukPostcode = require('uk-postcode')
 
 // Local dependencies
 const {
-  isEmpty, isFieldGreaterThanMaxLengthChars, isInvalidUkPostcode
+  isEmpty,
+  isFieldGreaterThanMaxLengthChars
 } = require('../../../browsered/field-validation-checks')
 
 exports.validateOptionalField = (value, maxLength) => {
@@ -71,5 +73,92 @@ exports.validatePostcode = (postcode) => {
     valid: true,
     message: null
   }
+}
 
+exports.validateDateOfBirth = (day, month, year) => {
+  const dayIsEmptyErrorMessage = isEmpty(day)
+  const monthIsEmptyErrorMessage = isEmpty(month)
+  const yearIsEmptyErrorMessage = isEmpty(year)
+
+  if (dayIsEmptyErrorMessage && monthIsEmptyErrorMessage && yearIsEmptyErrorMessage) {
+    return {
+      valid: false,
+      message: 'Enter the date of birth'
+    }
+  }
+
+  if (dayIsEmptyErrorMessage && !monthIsEmptyErrorMessage && !yearIsEmptyErrorMessage) {
+    return {
+      valid: false,
+      message: 'Date of birth must include a day'
+    }
+  }
+
+  if (!dayIsEmptyErrorMessage && monthIsEmptyErrorMessage && !yearIsEmptyErrorMessage) {
+    return {
+      valid: false,
+      message: 'Date of birth must include a month'
+    }
+  }
+
+  if (!dayIsEmptyErrorMessage && !monthIsEmptyErrorMessage && yearIsEmptyErrorMessage) {
+    return {
+      valid: false,
+      message: 'Date of birth must include a year'
+    }
+  }
+
+  if (dayIsEmptyErrorMessage && monthIsEmptyErrorMessage && !yearIsEmptyErrorMessage) {
+    return {
+      valid: false,
+      message: 'Date of birth must include a day and month'
+    }
+  }
+
+  if (dayIsEmptyErrorMessage && !monthIsEmptyErrorMessage && yearIsEmptyErrorMessage) {
+    return {
+      valid: false,
+      message: 'Date of birth must include a day and year'
+    }
+  }
+
+  if (!dayIsEmptyErrorMessage && monthIsEmptyErrorMessage && yearIsEmptyErrorMessage) {
+    return {
+      valid: false,
+      message: 'Date of birth must include a month and year'
+    }
+  }
+
+  if (!/^[0-9]{1,2}$/.test(day) || !/^[0-9]{1,2}$/.test(month) || !/^[1-9][0-9]{3}$/.test(year)) {
+    return {
+      valid: false,
+      message: 'Enter a real date of birth'
+    }
+  }
+
+  const dateOfBirth = moment({
+    year: parseInt(year, 10),
+    month: parseInt(month, 10) - 1,
+    day: parseInt(day, 10)
+  })
+
+  if (!dateOfBirth.isValid()) {
+    return {
+      valid: false,
+      message: 'Enter a real date of birth'
+    }
+  }
+
+  const now = moment()
+  if (dateOfBirth.isAfter(now)) {
+    return {
+      valid: false,
+      message: 'Date of birth must be in the past'
+    }
+  }
+
+  return {
+    valid: true,
+    message: null
+  }
 }

--- a/app/controllers/stripe-setup/responsible-person/responsible-person-validations.test.js
+++ b/app/controllers/stripe-setup/responsible-person/responsible-person-validations.test.js
@@ -2,6 +2,7 @@
 
 // NPM dependencies
 const { expect } = require('chai')
+const moment = require('moment-timezone')
 
 // Local dependencies
 const responsiblePersonValidations = require('./responsible-person-validations')
@@ -64,6 +65,121 @@ describe('Responsible person page field validations', () => {
       expect(responsiblePersonValidations.validatePostcode('CA90210')).to.deep.equal({
         valid: false,
         message: 'Please enter a real postcode'
+      })
+    })
+  })
+
+  describe('date of birth validations', () => {
+    it('should be valid when date of birth in the past', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('10', '6', '2000').valid).to.be.true // eslint-disable-line
+    })
+
+    it('should be valid when day has leading zero', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('01', '6', '2000').valid).to.be.true // eslint-disable-line
+    })
+
+    it('should be valid when month has leading zero', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('10', '06', '2000').valid).to.be.true // eslint-disable-line
+    })
+
+    it('should not be valid nothing entered', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('', '', '')).to.deep.equal({
+        valid: false,
+        message: 'Enter the date of birth'
+      })
+    })
+
+    it('should not be valid when no day entered', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('', '6', '2000')).to.deep.equal({
+        valid: false,
+        message: 'Date of birth must include a day'
+      })
+    })
+
+    it('should not be valid when no month entered', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('10', '', '2000')).to.deep.equal({
+        valid: false,
+        message: 'Date of birth must include a month'
+      })
+    })
+
+    it('should not be valid when no year entered', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('10', '6', '')).to.deep.equal({
+        valid: false,
+        message: 'Date of birth must include a year'
+      })
+    })
+
+    it('should not be valid when no day and month entered', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('', '', '2000')).to.deep.equal({
+        valid: false,
+        message: 'Date of birth must include a day and month'
+      })
+    })
+
+    it('should not be valid when no day and year entered', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('', '6', '')).to.deep.equal({
+        valid: false,
+        message: 'Date of birth must include a day and year'
+      })
+    })
+
+    it('should not be valid when no month and year entered', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('10', '', '')).to.deep.equal({
+        valid: false,
+        message: 'Date of birth must include a month and year'
+      })
+    })
+
+    it('should not be valid when day does not contain numbers', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('cakeday', '6', '2000')).to.deep.equal({
+        valid: false,
+        message: 'Enter a real date of birth'
+      })
+    })
+
+    it('should not be valid when month does not contain numbers', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('10', 'Prairial', '2000')).to.deep.equal({
+        valid: false,
+        message: 'Enter a real date of birth'
+      })
+    })
+
+    it('should not be valid when year does not contain numbers', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('10', '6', 'dragon')).to.deep.equal({
+        valid: false,
+        message: 'Enter a real date of birth'
+      })
+    })
+
+    it('should not be valid when year does not have four digits', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('10', '6', '00')).to.deep.equal({
+        valid: false,
+        message: 'Enter a real date of birth'
+      })
+    })
+
+    it('should not be valid when day is a negative number', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('-10', '6', '2000')).to.deep.equal({
+        valid: false,
+        message: 'Enter a real date of birth'
+      })
+    })
+
+    it('should not be valid when date does not exist', () => {
+      expect(responsiblePersonValidations.validateDateOfBirth('29', '02', '1999')).to.deep.equal({
+        valid: false,
+        message: 'Enter a real date of birth'
+      })
+    })
+
+    it('should not be valid when date is in the future', () => {
+      const dateInTheMysteriousFuture = moment().add(1, 'days')
+
+      expect(responsiblePersonValidations.validateDateOfBirth(dateInTheMysteriousFuture.date(),
+        dateInTheMysteriousFuture.month() + 1, dateInTheMysteriousFuture.year())).to.deep.equal({
+        valid: false,
+        message: 'Date of birth must be in the past'
       })
     })
   })

--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -52,6 +52,13 @@
           href: '#stripe-setup-home-address-postcode-input'
         }), errorList) %}
       {% endif %}
+
+      {% if errors['dob'] %}
+        {% set errorList = (errorList.push({
+          text: 'Date of birth',
+          href: '#stripe-setup-dob-input-day'
+        }), errorList) %}
+      {% endif %}
       {{ govukErrorSummary({
         titleText: 'There was a problem with the details you gave for:',
         errorList: errorList
@@ -180,10 +187,10 @@
         classes: "govuk-input--width-10",
         errorMessage: homeAddressPostcodeError
       }) }}
-      {% set homeAddressPostcodeError = false %}
-      {% if errors['home-address-postcode'] %}
-        {% set homeAddressPostcodeError = {
-          text: errors['home-address-postcode']
+      {% set dobError = false %}
+      {% if errors['dob'] %}
+        {% set dobError = {
+          text: errors['dob']
         } %}
       {% endif %}
       {{ govukDateInput({


### PR DESCRIPTION
Add server-side validation for the date of the birth on the Stripe responsible person page. Requires a date of birth in past and uses the error messages described in the GOV.UK Design System at https://design-system.service.gov.uk/components/date-input/.