### PR TITLE
PP-4463 Tidy up responsible person form

### DIFF
--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -53,29 +53,34 @@ const validationRules = [
 ]
 
 module.exports = (req, res) => {
+  const trimmedFormFields = {}
+  Object.entries(req.body).forEach(
+    ([name, value]) => trimmedFormFields[name] = value.trim()
+  );
+
   const errors = validationRules.reduce((errors, validationRule) => {
-    const errorMessage = validate(req.body, validationRule.field, validationRule.validator, validationRule.maxLength)
+    const errorMessage = validate(trimmedFormFields, validationRule.field, validationRule.validator, validationRule.maxLength)
     if (errorMessage) {
       errors[validationRule.field] = errorMessage
     }
     return errors
   }, {})
 
-  const dateOfBirthErrorMessage = validateDoB(req.body)
+  const dateOfBirthErrorMessage = validateDoB(trimmedFormFields)
   if (dateOfBirthErrorMessage) {
     errors['dob'] = dateOfBirthErrorMessage
   }
 
   const pageData = {
-    firstName: lodash.get(req.body, FIRST_NAME_FIELD),
-    lastName: lodash.get(req.body, LAST_NAME_FIELD),
-    homeAddressLine1: lodash.get(req.body, HOME_ADDRESS_LINE1_FIELD),
-    homeAddressLine2: lodash.get(req.body, HOME_ADDRESS_LINE2_FIELD),
-    homeAddressCity: lodash.get(req.body, HOME_ADDRESS_CITY_FIELD),
-    homeAddressPostcode: lodash.get(req.body, HOME_ADDRESS_POSTCODE_FIELD),
-    dobDay: lodash.get(req.body, DOB_DAY_FIELD),
-    dobMonth: lodash.get(req.body, DOB_MONTH_FIELD),
-    dobYear: lodash.get(req.body, DOB_YEAR_FIELD),
+    firstName: lodash.get(trimmedFormFields, FIRST_NAME_FIELD),
+    lastName: lodash.get(trimmedFormFields, LAST_NAME_FIELD),
+    homeAddressLine1: lodash.get(trimmedFormFields, HOME_ADDRESS_LINE1_FIELD),
+    homeAddressLine2: lodash.get(trimmedFormFields, HOME_ADDRESS_LINE2_FIELD),
+    homeAddressCity: lodash.get(trimmedFormFields, HOME_ADDRESS_CITY_FIELD),
+    homeAddressPostcode: lodash.get(trimmedFormFields, HOME_ADDRESS_POSTCODE_FIELD),
+    dobDay: lodash.get(trimmedFormFields, DOB_DAY_FIELD),
+    dobMonth: lodash.get(trimmedFormFields, DOB_MONTH_FIELD),
+    dobYear: lodash.get(trimmedFormFields, DOB_YEAR_FIELD),
   }
 
   if (!lodash.isEmpty(errors)) {
@@ -90,8 +95,8 @@ module.exports = (req, res) => {
   }
 }
 
-const validate = (formSubmission, fieldName, fieldValidator, maxLength) => {
-  const field = lodash.get(formSubmission, fieldName)
+const validate = (formFields, fieldName, fieldValidator, maxLength) => {
+  const field = lodash.get(formFields, fieldName)
   const isFieldValid = fieldValidator(field, maxLength)
   if (!isFieldValid.valid) {
     return isFieldValid.message
@@ -99,10 +104,10 @@ const validate = (formSubmission, fieldName, fieldValidator, maxLength) => {
   return null
 }
 
-const validateDoB = (formSubmission) => {
-  const day = lodash.get(formSubmission, DOB_DAY_FIELD)
-  const month = lodash.get(formSubmission, DOB_MONTH_FIELD)
-  const year = lodash.get(formSubmission, DOB_YEAR_FIELD)
+const validateDoB = (formFields) => {
+  const day = lodash.get(formFields, DOB_DAY_FIELD)
+  const month = lodash.get(formFields, DOB_MONTH_FIELD)
+  const year = lodash.get(formFields, DOB_YEAR_FIELD)
   const dateOfBirthValidationResult = validateDateOfBirth(day, month, year)
   if (!dateOfBirthValidationResult.valid) {
     return dateOfBirthValidationResult.message

--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -2,6 +2,7 @@
 
 // NPM dependencies
 const lodash = require('lodash')
+const moment = require('moment-timezone')
 
 // Local dependencies
 const paths = require('../../../paths')
@@ -101,14 +102,13 @@ module.exports = (req, res) => {
   } else if (lodash.get(req.body, 'answers-need-changing') === 'true') {
     return response.response(req, res, 'stripe-setup/responsible-person/index', pageData)
   } else {
+    const friendlyDob = formatDateOfBirth(formFields[DOB_DAY_FIELD], formFields[DOB_MONTH_FIELD] - 1, formFields[DOB_YEAR_FIELD])
+    pageData['friendlyDateOfBirth'] = friendlyDob
     return response.response(req, res, 'stripe-setup/responsible-person/check-your-answers', pageData)
   }
 }
 
 const validate = (formFields, fieldName, fieldValidator, maxLength) => {
-  console.log('field name ' + fieldName)
-  console.log('field value ' +  formFields[fieldName])
-
   const field = formFields[fieldName]
   const isFieldValid = fieldValidator(field, maxLength)
   if (!isFieldValid.valid) {
@@ -126,4 +126,12 @@ const validateDoB = (formFields) => {
     return dateOfBirthValidationResult.message
   }
   return null
+}
+
+const formatDateOfBirth = (day, month, year) => {
+  return moment({
+    day: day,
+    month: month - 1,
+    year: year,
+  }).format('D MMMM YYYY')
 }

--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -53,34 +53,44 @@ const validationRules = [
 ]
 
 module.exports = (req, res) => {
-  const trimmedFormFields = {}
-  Object.entries(req.body).forEach(
-    ([name, value]) => trimmedFormFields[name] = value.trim()
-  );
+  const normaliseField = (fieldName) => {
+    return lodash.get(req.body, fieldName, '').trim()
+  }
+
+  const formFields = {}
+  formFields[FIRST_NAME_FIELD] = normaliseField(FIRST_NAME_FIELD)
+  formFields[LAST_NAME_FIELD] = normaliseField(LAST_NAME_FIELD)
+  formFields[HOME_ADDRESS_LINE1_FIELD] = normaliseField(HOME_ADDRESS_LINE1_FIELD)
+  formFields[HOME_ADDRESS_LINE2_FIELD] = normaliseField(HOME_ADDRESS_LINE2_FIELD)
+  formFields[HOME_ADDRESS_CITY_FIELD] = normaliseField(HOME_ADDRESS_CITY_FIELD)
+  formFields[HOME_ADDRESS_POSTCODE_FIELD] = normaliseField(HOME_ADDRESS_POSTCODE_FIELD)
+  formFields[DOB_DAY_FIELD] = normaliseField(DOB_DAY_FIELD)
+  formFields[DOB_MONTH_FIELD] = normaliseField(DOB_MONTH_FIELD)
+  formFields[DOB_YEAR_FIELD] = normaliseField(DOB_YEAR_FIELD)
 
   const errors = validationRules.reduce((errors, validationRule) => {
-    const errorMessage = validate(trimmedFormFields, validationRule.field, validationRule.validator, validationRule.maxLength)
+    const errorMessage = validate(formFields, validationRule.field, validationRule.validator, validationRule.maxLength)
     if (errorMessage) {
       errors[validationRule.field] = errorMessage
     }
     return errors
   }, {})
 
-  const dateOfBirthErrorMessage = validateDoB(trimmedFormFields)
+  const dateOfBirthErrorMessage = validateDoB(formFields)
   if (dateOfBirthErrorMessage) {
     errors['dob'] = dateOfBirthErrorMessage
   }
 
   const pageData = {
-    firstName: lodash.get(trimmedFormFields, FIRST_NAME_FIELD),
-    lastName: lodash.get(trimmedFormFields, LAST_NAME_FIELD),
-    homeAddressLine1: lodash.get(trimmedFormFields, HOME_ADDRESS_LINE1_FIELD),
-    homeAddressLine2: lodash.get(trimmedFormFields, HOME_ADDRESS_LINE2_FIELD),
-    homeAddressCity: lodash.get(trimmedFormFields, HOME_ADDRESS_CITY_FIELD),
-    homeAddressPostcode: lodash.get(trimmedFormFields, HOME_ADDRESS_POSTCODE_FIELD),
-    dobDay: lodash.get(trimmedFormFields, DOB_DAY_FIELD),
-    dobMonth: lodash.get(trimmedFormFields, DOB_MONTH_FIELD),
-    dobYear: lodash.get(trimmedFormFields, DOB_YEAR_FIELD),
+    firstName: formFields[FIRST_NAME_FIELD],
+    lastName: formFields[LAST_NAME_FIELD],
+    homeAddressLine1: formFields[HOME_ADDRESS_LINE1_FIELD],
+    homeAddressLine2: formFields[HOME_ADDRESS_LINE2_FIELD],
+    homeAddressCity: formFields[HOME_ADDRESS_CITY_FIELD],
+    homeAddressPostcode: formFields[HOME_ADDRESS_POSTCODE_FIELD],
+    dobDay: formFields[DOB_DAY_FIELD],
+    dobMonth: formFields[DOB_MONTH_FIELD],
+    dobYear: formFields[DOB_YEAR_FIELD],
   }
 
   if (!lodash.isEmpty(errors)) {
@@ -96,7 +106,10 @@ module.exports = (req, res) => {
 }
 
 const validate = (formFields, fieldName, fieldValidator, maxLength) => {
-  const field = lodash.get(formFields, fieldName)
+  console.log('field name ' + fieldName)
+  console.log('field value ' +  formFields[fieldName])
+
+  const field = formFields[fieldName]
   const isFieldValid = fieldValidator(field, maxLength)
   if (!isFieldValid.valid) {
     return isFieldValid.message
@@ -105,9 +118,9 @@ const validate = (formFields, fieldName, fieldValidator, maxLength) => {
 }
 
 const validateDoB = (formFields) => {
-  const day = lodash.get(formFields, DOB_DAY_FIELD)
-  const month = lodash.get(formFields, DOB_MONTH_FIELD)
-  const year = lodash.get(formFields, DOB_YEAR_FIELD)
+  const day = formFields[DOB_DAY_FIELD]
+  const month = formFields[DOB_MONTH_FIELD]
+  const year = formFields[DOB_YEAR_FIELD]
   const dateOfBirthValidationResult = validateDateOfBirth(day, month, year)
   if (!dateOfBirthValidationResult.valid) {
     return dateOfBirthValidationResult.message

--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -54,14 +54,14 @@ const validationRules = [
 
 module.exports = (req, res) => {
   const errors = validationRules.reduce((errors, validationRule) => {
-    const errorMessage = validate(req, validationRule.field, validationRule.validator, validationRule.maxLength)
+    const errorMessage = validate(req.body, validationRule.field, validationRule.validator, validationRule.maxLength)
     if (errorMessage) {
       errors[validationRule.field] = errorMessage
     }
     return errors
   }, {})
 
-  const dateOfBirthErrorMessage = validateDoB(req)
+  const dateOfBirthErrorMessage = validateDoB(req.body)
   if (dateOfBirthErrorMessage) {
     errors['dob'] = dateOfBirthErrorMessage
   }
@@ -90,8 +90,8 @@ module.exports = (req, res) => {
   }
 }
 
-const validate = (req, fieldName, fieldValidator, maxLength) => {
-  const field = lodash.get(req.body, fieldName)
+const validate = (formSubmission, fieldName, fieldValidator, maxLength) => {
+  const field = lodash.get(formSubmission, fieldName)
   const isFieldValid = fieldValidator(field, maxLength)
   if (!isFieldValid.valid) {
     return isFieldValid.message
@@ -99,10 +99,10 @@ const validate = (req, fieldName, fieldValidator, maxLength) => {
   return null
 }
 
-const validateDoB = (req) => {
-  const day = lodash.get(req.body, DOB_DAY_FIELD)
-  const month = lodash.get(req.body, DOB_MONTH_FIELD)
-  const year = lodash.get(req.body, DOB_YEAR_FIELD)
+const validateDoB = (formSubmission) => {
+  const day = lodash.get(formSubmission, DOB_DAY_FIELD)
+  const month = lodash.get(formSubmission, DOB_MONTH_FIELD)
+  const year = lodash.get(formSubmission, DOB_YEAR_FIELD)
   const dateOfBirthValidationResult = validateDateOfBirth(day, month, year)
   if (!dateOfBirthValidationResult.valid) {
     return dateOfBirthValidationResult.message

--- a/app/controllers/stripe-setup/responsible-person/responsible-person-validations.js
+++ b/app/controllers/stripe-setup/responsible-person/responsible-person-validations.js
@@ -10,7 +10,7 @@ const {
   isFieldGreaterThanMaxLengthChars
 } = require('../../../browsered/field-validation-checks')
 
-exports.validateOptionalField = (value, maxLength) => {
+exports.validateOptionalField = function validateOptionalField (value, maxLength) {
   if (!isEmpty(value)) {
     const textTooLongErrorMessage = isFieldGreaterThanMaxLengthChars(value, maxLength)
 
@@ -28,7 +28,7 @@ exports.validateOptionalField = (value, maxLength) => {
   }
 }
 
-exports.validateMandatoryField = (value, maxLength) => {
+exports.validateMandatoryField = function validateMandatoryField (value, maxLength) {
   const isEmptyErrorMessage = isEmpty(value)
   if (isEmptyErrorMessage) {
     return {
@@ -52,7 +52,7 @@ exports.validateMandatoryField = (value, maxLength) => {
   }
 }
 
-exports.validatePostcode = (postcode) => {
+exports.validatePostcode = function validatePostcode (postcode) {
   const isEmptyErrorMessage = isEmpty(postcode)
   if (isEmptyErrorMessage) {
     return {
@@ -75,7 +75,7 @@ exports.validatePostcode = (postcode) => {
   }
 }
 
-exports.validateDateOfBirth = (day, month, year) => {
+exports.validateDateOfBirth = function validateDateOfBirth (day, month, year) {
   const dayIsEmptyErrorMessage = isEmpty(day)
   const monthIsEmptyErrorMessage = isEmpty(month)
   const yearIsEmptyErrorMessage = isEmpty(year)

--- a/app/controllers/stripe-setup/responsible-person/responsible-person-validations.js
+++ b/app/controllers/stripe-setup/responsible-person/responsible-person-validations.js
@@ -129,10 +129,17 @@ exports.validateDateOfBirth = (day, month, year) => {
     }
   }
 
-  if (!/^[0-9]{1,2}$/.test(day) || !/^[0-9]{1,2}$/.test(month) || !/^[1-9][0-9]{3}$/.test(year)) {
+  if (!/^[0-9]{1,2}$/.test(day) || !/^[0-9]{1,2}$/.test(month) || !/^[0-9]+$/.test(year)) {
     return {
       valid: false,
       message: 'Enter a real date of birth'
+    }
+  }
+
+  if (!/^[1-9][0-9]{3}$/.test(year)) {
+    return {
+      valid: false,
+      message: 'Date of birth must have a four-digit year'
     }
   }
 

--- a/app/controllers/stripe-setup/responsible-person/responsible-person-validations.test.js
+++ b/app/controllers/stripe-setup/responsible-person/responsible-person-validations.test.js
@@ -155,7 +155,7 @@ describe('Responsible person page field validations', () => {
     it('should not be valid when year does not have four digits', () => {
       expect(responsiblePersonValidations.validateDateOfBirth('10', '6', '00')).to.deep.equal({
         valid: false,
-        message: 'Enter a real date of birth'
+        message: 'Date of birth must have a four-digit year'
       })
     })
 

--- a/app/views/stripe-setup/responsible-person/check-your-answers.njk
+++ b/app/views/stripe-setup/responsible-person/check-your-answers.njk
@@ -61,8 +61,10 @@
           <dd class="govuk-summary-list__value">
             {{ homeAddressLine1 }}
             <br>
+            {%  if homeAddressLine2 %}
             {{ homeAddressLine2 }}
             <br>
+            {% endif %}
             {{ homeAddressCity }}
             <br>
             {{ homeAddressPostcode }}
@@ -79,7 +81,7 @@
             Date of birth
           </dt>
           <dd class="govuk-summary-list__value">
-            {{ dobDay }} {{ dobMonth }} {{ dobYear }}
+            {{ friendlyDateOfBirth }}
           </dd>
           <dd class="govuk-summary-list__actions">
             <button class="govuk-button--as-link" type="submit">


### PR DESCRIPTION
- On the Stripe responsible person page, make it so that if someone enters a date of birth that is otherwise valid but does not use a four-digit year, a specific “Date of birth must have a four-digit year” error message is shown.

- Name some anonymous functions.

- Trim whitespace from the beginning and the end of the responsible person form submission. This has the desired side-effect that all-whitespace fields will fail validation in the same way empty ones do.

- If a form submission to the Stripe responsible person page does not contain a field at all, default it to the empty string. If the field is mandatory, the existing validation will fail, which is what we want.

- On the check answers page, don’t show a blank line if there is no address line 2 and format the date of birth nicely (e.g. “10 June 2000”).

with @alan-gds

