### PR TITLE
Capitalise the first letter of “Crown” in the footer

### DIFF
--- a/app/views/includes/footer-categories.njk
+++ b/app/views/includes/footer-categories.njk
@@ -44,10 +44,10 @@
     <h2 class="govuk-footer__heading govuk-heading-m">Legal Terms</h2>
     <ul class="govuk-footer__list">
       <li class="govuk-footer__list-item">
-        <a class="govuk-footer__link" href="/policy/download/memorandum-of-understanding-for-crown-bodies">Memorandum of understanding for crown bodies</a>
+        <a class="govuk-footer__link" href="/policy/download/memorandum-of-understanding-for-crown-bodies">Memorandum of understanding for Crown bodies</a>
       </li>
       <li class="govuk-footer__list-item">
-        <a class="govuk-footer__link" href="/policy/download/contract-for-non-crown-bodies">Contract for non-crown bodies</a>
+        <a class="govuk-footer__link" href="/policy/download/contract-for-non-crown-bodies">Contract for non-Crown bodies</a>
       </li>
       <li class="govuk-footer__list-item">
         <a class="govuk-footer__link" href="/policy/download/stripe-connected-account-agreement">Stripe Connected Account Agreement</a>


### PR DESCRIPTION
We’ve established that “Crown” should always begin with a capital letter (see https://www.gov.uk/bona-vacantia for example) and we use an initial capital elsewhere in the admin tool.