### PR TITLE
PP-4819: do not display option to enable wallet for not supported gateways

### DIFF
--- a/app/views/digital-wallet/_digital_wallet_not_supported_message.njk
+++ b/app/views/digital-wallet/_digital_wallet_not_supported_message.njk
@@ -1,0 +1,3 @@
+    <aside class="pay-info-warning-box">
+      <p class="govuk-body">Sorry, we do not currently support Digital Wallets for your payment service provider.</p>
+    </aside>

--- a/app/views/digital-wallet/enable-apple-pay.njk
+++ b/app/views/digital-wallet/enable-apple-pay.njk
@@ -12,26 +12,30 @@
   </h1>
 </div>
 
-<div class="govuk-grid-column-two-thirds">
-  <h2 class="govuk-heading-m">
-    Are you sure?
-  </h2>
-  <p class="govuk-body">
-    Corporate card fees cannot be applied to payments made with Apple Pay.
-  </p>
+{% if isDigitalWalletSupported %}
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m">
+      Are you sure?
+    </h2>
+    <p class="govuk-body">
+      Corporate card fees cannot be applied to payments made with Apple Pay.
+    </p>
 
-  <form method="post" action="{{routes.digitalWallet.enableApplePay}}">
-    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-    {{
-      govukButton({
-        text: "Yes, turn on Apple Pay"
-      })
-    }}
-  </form>
-  <p class="govuk-body">
-    <a href="{{routes.digitalWallet.summary}}" class="govuk-link govuk-link--no-visited-state">
-      No, cancel
-    </a>
-  </p>
-</div>
+    <form method="post" action="{{routes.digitalWallet.enableApplePay}}">
+      <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+      {{
+        govukButton({
+          text: "Yes, turn on Apple Pay"
+        })
+      }}
+    </form>
+    <p class="govuk-body">
+      <a href="{{routes.digitalWallet.summary}}" class="govuk-link govuk-link--no-visited-state">
+        No, cancel
+      </a>
+    </p>
+  </div>
+  {% else %}
+    {% include('./_digital_wallet_not_supported_message.njk') %}
+  {% endif %}
 {% endblock %}

--- a/app/views/digital-wallet/enable-google-pay.njk
+++ b/app/views/digital-wallet/enable-google-pay.njk
@@ -6,56 +6,59 @@
 {% block pageTitle %}
    Enable Google Pay - GOV.UK Pay
 {% endblock %}
+  {% block mainContent %}
+  <div class="govuk-grid-column-full govuk-!-margin-top-6">
+    <h1 class="govuk-heading-l">
+      Enable Google Pay
+    </h1>
+  </div>
 
-{% block mainContent %}
-<div class="govuk-grid-column-full govuk-!-margin-top-6">
-  <h1 class="govuk-heading-l">
-    Enable Google Pay
-  </h1>
-</div>
+  {% if isDigitalWalletSupported %}
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m">
+        Are you sure?
+      </h2>
+        {{ govukInsetText({
+        text: "Your service will accept both credit and debit cards."
+        }) }}
+      <p class="govuk-body">
+        Corporate card fees cannot be applied to payments made with Google Pay.
+      </p>
 
-<div class="govuk-grid-column-two-thirds">
-  <h2 class="govuk-heading-m">
-    Are you sure?
-  </h2>
-    {{ govukInsetText({
-    text: "Your service will accept both credit and debit cards."
-    }) }}
-  <p class="govuk-body">
-    Corporate card fees cannot be applied to payments made with Google Pay.
-  </p>
+      <p class="govuk-body">
+        You’ll need a Google Pay merchant ID. Refer to the <a class="govuk-link" href="https://docs.payments.service.gov.uk/optional_features/digital_wallets/#enable-google-pay">GOV.UK Pay documentation on enabling Google Pay</a> to learn where to find your merchant ID.
+      </p>
 
-  <p class="govuk-body">
-    You’ll need a Google Pay merchant ID. Refer to the <a class="govuk-link" href="https://docs.payments.service.gov.uk/optional_features/digital_wallets/#enable-google-pay">GOV.UK Pay documentation on enabling Google Pay</a> to learn where to find your merchant ID.
-  </p>
+      <form method="post" action="{{routes.digitalWallet.enableGooglePay}}">
+        <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
-  <form method="post" action="{{routes.digitalWallet.enableGooglePay}}">
-    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-
-    {{
-      govukInput({
-        id: "merchantId",
-        name: "merchantId",
-        label: {
-          text: "Merchant ID",
-          classes: "govuk-label--s"
-        },
-        attributes: {
-          required: true
-        },
-        classes: "govuk-!-width-two-thirds"
-      })
-    }}
-    {{
-      govukButton({
-        text: "Yes, turn on Google Pay"
-      })
-    }}
-  </form>
-  <p class="govuk-body">
-    <a href="{{routes.digitalWallet.summary}}" class="govuk-link govuk-link--no-visited-state">
-      No, cancel
-    </a>
-  </p>
-</div>
+        {{
+          govukInput({
+            id: "merchantId",
+            name: "merchantId",
+            label: {
+              text: "Merchant ID",
+              classes: "govuk-label--s"
+            },
+            attributes: {
+              required: true
+            },
+            classes: "govuk-!-width-two-thirds"
+          })
+        }}
+        {{
+          govukButton({
+            text: "Yes, turn on Google Pay"
+          })
+        }}
+      </form>
+      <p class="govuk-body">
+        <a href="{{routes.digitalWallet.summary}}" class="govuk-link govuk-link--no-visited-state">
+          No, cancel
+        </a>
+      </p>
+    </div>
+  {% else %}
+    {% include ('./_digital_wallet_not_supported_message.njk') %}
+  {% endif %}
 {% endblock %}

--- a/app/views/digital-wallet/summary.njk
+++ b/app/views/digital-wallet/summary.njk
@@ -7,71 +7,74 @@ Manage digital wallet - {{currentService.name}} {{currentGatewayAccount.full_typ
 
 {% block page_content %}
   {% if permissions.payment_types_read %}
-    <div id="payment-types-card-summary">
-      <table class="govuk-table">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th class="govuk-table__header" scope="col">Provider</th>
-            <th class="govuk-table__header" scope="col" colspan="{{'2' if permissions.payment_types_update else '1'}}">Accepted</th>
-          </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell table-data-label govuk-!-padding-top-3 govuk-!-padding-bottom-2">
-              <img alt="Apple Pay logo" class="digital-wallet-provider-logo" src="/public/images/apple-pay-mark.svg"/>
-              Apple Pay
-            </td>
-            <td class="govuk-table__cell table-data-label">
-             {{ "Yes" if currentGatewayAccount.allow_apple_pay else "No" }}
-            </td>
-            {% if permissions.payment_types_update %}
-            <td class="govuk-table__cell table-data-label govuk-text-align-right">
-              {% if not currentGatewayAccount.allow_apple_pay %}
-              <a href="{{routes.digitalWallet.confirmApplePay}}" class="govuk-link govuk-link--no-visited-state">
-                Enable
-              </a> 
-              {% else %}
-              <form method="post" action="{{routes.digitalWallet.disableApplePay}}">
-                <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-                <button type="submit" class="govuk-button--as-link govuk-!-font-size-19">
-                Disable
-                </button>
-              </form>
-              {% endif %}
-            </td>
-            {% endif %}
-          </tr>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell table-data-label govuk-!-padding-top-3 govuk-!-padding-bottom-2">
-              <img alt="Google Pay logo" class="digital-wallet-provider-logo" src="public/images/google-pay-mark.svg"/>
-              Google Pay
-            </td>
-            <td class="govuk-table__cell table-data-label">
-              {{ "Yes" if currentGatewayAccount.allow_google_pay else "No" }}
-            </td>
-            {% if permissions.payment_types_update %}
-            <td class="govuk-table__cell table-data-label govuk-text-align-right">
-            {% if not currentGatewayAccount.allow_google_pay %}
-              <a href="{{routes.digitalWallet.confirmGooglePay}}" class="govuk-link govuk-link--no-visited-state">
-                Enable
-              </a>
-              {% else %}
-              <form method="post" action="{{routes.digitalWallet.disableGooglePay}}">
+    {% if isDigitalWalletSupported %}
+      <div id="payment-types-card-summary">
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header" scope="col">Provider</th>
+              <th class="govuk-table__header" scope="col" colspan="{{'2' if permissions.payment_types_update else '1'}}">Accepted</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell table-data-label govuk-!-padding-top-3 govuk-!-padding-bottom-2">
+                <img alt="Apple Pay logo" class="digital-wallet-provider-logo" src="/public/images/apple-pay-mark.svg"/>
+                Apple Pay
+              </td>
+              <td class="govuk-table__cell table-data-label">
+              {{ "Yes" if currentGatewayAccount.allow_apple_pay else "No" }}
+              </td>
+              {% if permissions.payment_types_update %}
+              <td class="govuk-table__cell table-data-label govuk-text-align-right">
+                {% if not currentGatewayAccount.allow_apple_pay %}
+                <a href="{{routes.digitalWallet.confirmApplePay}}" class="govuk-link govuk-link--no-visited-state">
+                  Enable
+                </a> 
+                {% else %}
+                <form method="post" action="{{routes.digitalWallet.disableApplePay}}">
                   <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
                   <button type="submit" class="govuk-button--as-link govuk-!-font-size-19">
                   Disable
                   </button>
-                </form>              
+                </form>
+                {% endif %}
+              </td>
               {% endif %}
-            </td>
-            {% endif %}
-          </tr>
-        </tbody>
-      </table>
-    </div>
-
+            </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell table-data-label govuk-!-padding-top-3 govuk-!-padding-bottom-2">
+                <img alt="Google Pay logo" class="digital-wallet-provider-logo" src="public/images/google-pay-mark.svg"/>
+                Google Pay
+              </td>
+              <td class="govuk-table__cell table-data-label">
+                {{ "Yes" if currentGatewayAccount.allow_google_pay else "No" }}
+              </td>
+              {% if permissions.payment_types_update %}
+              <td class="govuk-table__cell table-data-label govuk-text-align-right">
+              {% if not currentGatewayAccount.allow_google_pay %}
+                <a href="{{routes.digitalWallet.confirmGooglePay}}" class="govuk-link govuk-link--no-visited-state">
+                  Enable
+                </a>
+                {% else %}
+                <form method="post" action="{{routes.digitalWallet.disableGooglePay}}">
+                    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+                    <button type="submit" class="govuk-button--as-link govuk-!-font-size-19">
+                    Disable
+                    </button>
+                  </form>              
+                {% endif %}
+              </td>
+              {% endif %}
+            </tr>
+          </tbody>
+        </table>
+      </div>
     {{ govukInsetText({
       text: "Corporate card feeds cannot be applied to digital wallet payments."
     }) }}
+    {% else %}
+      {% include ('./_digital_wallet_not_supported_message.njk') %}
+    {% endif %}
   {% endif %}
 {% endblock %}

--- a/test/ui/digital_wallet_ui_tests.js
+++ b/test/ui/digital_wallet_ui_tests.js
@@ -1,0 +1,26 @@
+'use strict'
+
+// NPM dependencies
+const path = require('path')
+
+// Local dependencies
+const renderTemplate = require(path.join(__dirname, '/../test_helpers/html_assertions.js')).render
+
+describe('The digital wallet views', () => {
+  it('should not display options if gateway does not support digital wallet', () => {
+    const templateData = {
+      permissions: {
+        'payment_types_read': true,
+        'payment_types_update': true
+      }
+    }
+    const digitalWalletPages = ['digital-wallet/summary', 'digital-wallet/enable-google-pay', 'digital-wallet/enable-google-pay']
+    digitalWalletPages.forEach(page => {
+      const body = renderTemplate(page, templateData)
+      body.should.containSelector('.pay-info-warning-box').withText('Sorry, we do not currently support Digital Wallets for your payment service provider.')
+      body.should.containNoSelectorWithText('Apple Pay')
+      body.should.containNoSelectorWithText('Google Pay')
+      body.should.containNoSelectorWithText('Enable')
+    })
+  })
+})


### PR DESCRIPTION
## WHAT
Fixes an edge case whereby if a non-supported gateway user discovers the digital-wallet URL they can enable digital wallet. 

## HOW 
Go to `/digital-wallet` as a non worldpay user should show not supported message.

Note: The additional tests only test the negative path as we already have happy path Cypress tests for these routes.


