### PR TITLE
PP-4463 Responsible person page copy changes

### DIFF
--- a/app/controllers/stripe-setup/responsible-person/responsible-person-validations.js
+++ b/app/controllers/stripe-setup/responsible-person/responsible-person-validations.js
@@ -139,7 +139,7 @@ exports.validateDateOfBirth = function validateDateOfBirth (day, month, year) {
   if (!/^[1-9][0-9]{3}$/.test(year)) {
     return {
       valid: false,
-      message: 'Date of birth must have a four-digit year'
+      message: 'Year must have 4 numbers'
     }
   }
 

--- a/app/controllers/stripe-setup/responsible-person/responsible-person-validations.test.js
+++ b/app/controllers/stripe-setup/responsible-person/responsible-person-validations.test.js
@@ -155,7 +155,7 @@ describe('Responsible person page field validations', () => {
     it('should not be valid when year does not have four digits', () => {
       expect(responsiblePersonValidations.validateDateOfBirth('10', '6', '00')).to.deep.equal({
         valid: false,
-        message: 'Date of birth must have a four-digit year'
+        message: 'Year must have 4 numbers'
       })
     })
 

--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -67,7 +67,7 @@
 
     <span id="request-to-go-live-current-step" class="govuk-caption-l">Before you can take payments</span>
     <h1 class="govuk-heading-l">Nominate a responsible person</h1>
-    <p class="govuk-body">Before you can make any payments, we need a named person in your organisation. It’s a legal
+    <p class="govuk-body">Before you can take any payments, we need a named person in your organisation. It’s a legal
       requirement to provide this information. This person will be responsible for the management of payments.</p>
     <p class="govuk-body">The responsible person can be:</p>
     <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
- On the form, change “Before you can make any payments” to “Before you can take any payments”
- Change the error message when the user does not enter a four-digit date of birth from “Date of birth must have a four-digit year” to “Year must have 4 numbers”