### PR TITLE
PP-4463 Middleware to check responsible person flag not set

### DIFF
--- a/app/controllers/stripe-setup/responsible-person/get.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/get.controller.js
@@ -4,10 +4,5 @@
 const response = require('../../../utils/response')
 
 module.exports = (req, res) => {
-  if (req.account.payment_provider.toLowerCase() !== 'stripe') {
-    res.status(404)
-    res.render('404')
-    return
-  }
   return response.response(req, res, 'stripe-setup/responsible-person/index')
 }

--- a/app/middleware/stripe-setup/check-responsible-person-not-submitted.js
+++ b/app/middleware/stripe-setup/check-responsible-person-not-submitted.js
@@ -1,0 +1,25 @@
+'use strict'
+
+// Local dependencies
+const { ConnectorClient } = require('../../services/clients/connector_client')
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+const { renderErrorView } = require('../../utils/response')
+const paths = require('../../paths')
+
+module.exports = function checkResponsiblePersonNotSubmitted (req, res, next) {
+  if (!req.account) {
+    renderErrorView(req, res, 'Internal server error')
+    return
+  }
+
+  connector.getStripeAccountSetup(req.account.gateway_account_id, req.correlationId).then(stripeSetupResponse => {
+    if (stripeSetupResponse.responsiblePerson) {
+      req.flash('genericError', 'You’ve already nominated your responsible person.<br>Contact GOV.UK Pay support if you need to change them')
+      res.redirect(303, paths.dashboard.index)
+    } else {
+      next()
+    }
+  }).catch(() => {
+    renderErrorView(req, res, 'Please try again or contact support team')
+  })
+}

--- a/app/middleware/stripe-setup/check-responsible-person-not-submitted.test.js
+++ b/app/middleware/stripe-setup/check-responsible-person-not-submitted.test.js
@@ -1,0 +1,126 @@
+'use strict'
+
+// NPM dependencies
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+// Local dependencies
+const paths = require('../../paths')
+
+// Global setup
+chai.use(chaiAsPromised)
+const { expect } = chai // must be called after chai.use(chaiAsPromised) to use "should.eventually"
+
+describe('Check responsible person not submitted middleware', () => {
+  let req
+  let res
+  let next
+
+  beforeEach(() => {
+    req = {
+      correlationId: 'correlation-id',
+      account: {
+        gateway_account_id: '1'
+      },
+      flash: sinon.spy()
+    }
+    res = {
+      setHeader: sinon.stub(),
+      status: sinon.spy(),
+      render: sinon.spy(),
+      redirect: sinon.spy()
+    }
+    next = sinon.spy()
+  })
+
+  it('should call next when responsible person flag is false', done => {
+    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
+      responsiblePerson: false
+    })
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.calledOnce).to.be.true // eslint-disable-line
+      expect(req.flash.notCalled).to.be.true // eslint-disable-line
+      expect(res.redirect.notCalled).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should redirect to the dashboard with error message when responsible person flag is true', done => {
+    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
+      responsiblePerson: true
+    })
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.notCalled).to.be.true // eslint-disable-line
+      expect(req.flash.calledWith('genericError', 'You’ve already nominated your responsible person.<br>Contact GOV.UK Pay support if you need to change them')).to.be.true // eslint-disable-line
+      expect(res.redirect.calledWith(303, paths.dashboard.index)).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should render an error page when req.account is undefined', done => {
+    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
+      responsiblePerson: false
+    })
+    req.account = undefined
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.notCalled).to.be.true // eslint-disable-line
+      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+      expect(res.render.calledWith('error', {message: 'Internal server error'})).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should render an error page when connector rejects the call', done => {
+    const middleware = getMiddlewareWithConnectorClientRejectedPromiseMock({
+      responsiblePerson: false
+    })
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.notCalled).to.be.true // eslint-disable-line
+      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+      expect(res.render.calledWith('error', {message: 'Please try again or contact support team'})).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+})
+
+function getMiddlewareWithConnectorClientResolvedPromiseMock (getStripeAccountSetupResponse) {
+  return proxyquire('./check-responsible-person-not-submitted', {
+    '../../services/clients/connector_client': {
+      ConnectorClient: function () {
+        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => {
+          return new Promise(resolve => {
+            resolve(getStripeAccountSetupResponse)
+          })
+        }
+      }
+    }
+  })
+}
+
+function getMiddlewareWithConnectorClientRejectedPromiseMock (getStripeAccountSetupResponse) {
+  return proxyquire('./check-responsible-person-not-submitted', {
+    '../../services/clients/connector_client': {
+      ConnectorClient: function () {
+        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => {
+          return new Promise((resolve, reject) => {
+            reject(new Error())
+          })
+        }
+      }
+    }
+  })
+}


### PR DESCRIPTION
Middleware to check that the Stripe responsible person flag is not already set before allowing access to the page.

Heavily based on the equivalent middleware for the bank account details flag.