### PR TITLE
PP-4463 Add StripePerson model object for use with Stripe client

### DIFF
--- a/app/services/clients/stripe/stripePerson.model.js
+++ b/app/services/clients/stripe/stripePerson.model.js
@@ -1,0 +1,59 @@
+'use strict'
+
+// NPM dependencies
+const Joi = require('joi')
+
+const schema = {
+  first_name: Joi.string().required(),
+  last_name: Joi.string().required(),
+  address_line1: Joi.string().required(),
+  address_line2:  Joi.string(),
+  address_city: Joi.string().required(),
+  address_postcode: Joi.string().required(),
+  dob_day: Joi.number().integer().strict().min(1).max(31),
+  dob_month: Joi.number().integer().strict().min(1).max(12),
+  dob_year: Joi.number().integer().strict().min(1000).max(9999),
+}
+
+class StripePerson {
+  constructor (body) {
+    const params = Object.assign({}, body)
+    const { error, value: model } = Joi.validate(params, schema, { allowUnknown: true, stripUnknown: true })
+
+    if (error) {
+      throw new Error(`StripePerson ${error.details[0].message}`)
+    }
+
+    Object.assign(this, build(model))
+  }
+
+  basicObject () {
+    return Object.assign({}, this)
+  }
+}
+
+function build (params) {
+  const person = {
+    first_name: params.first_name,
+    last_name: params.last_name,
+    address: {
+      line1: params.address_line1,
+      city: params.address_city,
+      postal_code: params.address_postcode,
+      country: 'GB'
+    },
+    dob: {
+      day: params.dob_day,
+      month: params.dob_month,
+      year: params.dob_year
+    }
+  }
+
+  if (params.address_line2) {
+    person.address.line2 = params.address_line2
+  }
+
+  return person
+}
+
+module.exports = StripePerson

--- a/app/services/clients/stripe/stripePerson.model.test.js
+++ b/app/services/clients/stripe/stripePerson.model.test.js
@@ -1,0 +1,235 @@
+'use strict'
+
+// NPM dependencies
+const { expect } = require('chai')
+
+// Local dependencies
+const StripePerson = require('./stripePerson.model')
+
+const firstName = 'Carol'
+const lastName = 'Danvers'
+const addressLine1 = '10 Downing Street'
+const addressLine2 = 'Marvel Cinematic Universe'
+const addressCity = 'London'
+const addressPostcode = 'SW1A 2AA'
+const dobDay = 8
+const dobMonth = 3
+const dobYear = 2019
+
+describe('StripePerson', () => {
+  it('should successfully create a StripePerson object with a second address line', () => {
+    const stripePerson = new StripePerson({
+      first_name: firstName,
+      last_name: lastName,
+      address_line1: addressLine1,
+      address_line2: addressLine2,
+      address_city: addressCity,
+      address_postcode: addressPostcode,
+      dob_day: dobDay,
+      dob_month: dobMonth,
+      dob_year: dobYear
+    })
+
+    expect(stripePerson.basicObject()).to.deep.equal({
+      first_name: firstName,
+      last_name: lastName,
+      address: {
+        line1: addressLine1,
+        line2: addressLine2,
+        city: addressCity,
+        postal_code: addressPostcode,
+        country: 'GB'
+      },
+      dob: {
+        day: dobDay,
+        month: dobMonth,
+        year: dobYear
+      }
+    })
+  })
+
+  it('should successfully create a StripePerson object without a second address line', () => {
+    const stripePerson = new StripePerson({
+      first_name: firstName,
+      last_name: lastName,
+      address_line1: addressLine1,
+      address_city: addressCity,
+      address_postcode: addressPostcode,
+      dob_day: dobDay,
+      dob_month: dobMonth,
+      dob_year: dobYear
+    })
+
+    expect(stripePerson.basicObject()).to.deep.equal({
+      first_name: firstName,
+      last_name: lastName,
+      address: {
+        line1: addressLine1,
+        city: addressCity,
+        postal_code: addressPostcode,
+        country: 'GB'
+      },
+      dob: {
+        day: dobDay,
+        month: dobMonth,
+        year: dobYear
+      }
+    })
+  })
+
+  it('should fail when property that should be string is not string', () => {
+    expect(() => new StripePerson({
+      first_name: 12345,
+      last_name: lastName,
+      address_line1: addressLine1,
+      address_city: addressCity,
+      address_postcode: addressPostcode,
+      dob_day: dobDay,
+      dob_month: dobMonth,
+      dob_year: dobYear
+    })).to.throw('StripePerson "first_name" must be a string')
+  })
+
+  it('should fail when property that should be string is empty', () => {
+    expect(() => new StripePerson({
+      first_name: '',
+      last_name: lastName,
+      address_line1: addressLine1,
+      address_city: addressCity,
+      address_postcode: addressPostcode,
+      dob_day: dobDay,
+      dob_month: dobMonth,
+      dob_year: dobYear
+    })).to.throw('StripePerson "first_name" is not allowed to be empty')
+  })
+
+  it('should fail when property that should be string is null', () => {
+    expect(() => new StripePerson({
+      first_name: null,
+      last_name: lastName,
+      address_line1: addressLine1,
+      address_city: addressCity,
+      address_postcode: addressPostcode,
+      dob_day: dobDay,
+      dob_month: dobMonth,
+      dob_year: dobYear
+    })).to.throw('StripePerson "first_name" must be a string')
+  })
+
+  it('should fail when property that should be integer is a string that coerces to an integer', () => {
+    expect(() => new StripePerson({
+      first_name: firstName,
+      last_name: lastName,
+      address_line1: addressLine1,
+      address_city: addressCity,
+      address_postcode: addressPostcode,
+      dob_day: '8',
+      dob_month: dobMonth,
+      dob_year: dobYear
+    })).to.throw('StripePerson "dob_day" must be a number')
+  })
+
+  it('should fail when property that should be integer is number but not integer', () => {
+    expect(() => new StripePerson({
+      first_name: firstName,
+      last_name: lastName,
+      address_line1: addressLine1,
+      address_city: addressCity,
+      address_postcode: addressPostcode,
+      dob_day: 8.1,
+      dob_month: dobMonth,
+      dob_year: dobYear
+    })).to.throw('StripePerson "dob_day" must be an integer')
+  })
+
+  it('should fail when property that should be integer is null', () => {
+    expect(() => new StripePerson({
+      first_name: firstName,
+      last_name: lastName,
+      address_line1: addressLine1,
+      address_city: addressCity,
+      address_postcode: addressPostcode,
+      dob_day: null,
+      dob_month: dobMonth,
+      dob_year: dobYear
+    })).to.throw('StripePerson "dob_day" must be a number')
+  })
+
+  it('should fail when day is less than 1', () => {
+    expect(() => new StripePerson({
+      first_name: firstName,
+      last_name: lastName,
+      address_line1: addressLine1,
+      address_city: addressCity,
+      address_postcode: addressPostcode,
+      dob_day: 0,
+      dob_month: dobMonth,
+      dob_year: dobYear
+    })).to.throw('StripePerson "dob_day" must be larger than or equal to 1')
+  })
+
+  it('should fail when day is more than 31', () => {
+    expect(() => new StripePerson({
+      first_name: firstName,
+      last_name: lastName,
+      address_line1: addressLine1,
+      address_city: addressCity,
+      address_postcode: addressPostcode,
+      dob_day: 32,
+      dob_month: dobMonth,
+      dob_year: dobYear
+    })).to.throw('StripePerson "dob_day" must be less than or equal to 31')
+  })
+
+  it('should fail when month is less than 1', () => {
+    expect(() => new StripePerson({
+      first_name: firstName,
+      last_name: lastName,
+      address_line1: addressLine1,
+      address_city: addressCity,
+      address_postcode: addressPostcode,
+      dob_day: dobDay,
+      dob_month: 0,
+      dob_year: dobYear
+    })).to.throw('StripePerson "dob_month" must be larger than or equal to 1')
+  })
+
+  it('should fail when month is larger than 12', () => {
+    expect(() => new StripePerson({
+      first_name: firstName,
+      last_name: lastName,
+      address_line1: addressLine1,
+      address_city: addressCity,
+      address_postcode: addressPostcode,
+      dob_day: dobDay,
+      dob_month: 13,
+      dob_year: dobYear
+    })).to.throw('StripePerson "dob_month" must be less than or equal to 12')
+  })
+
+  it('should fail when year is less than 1000', () => {
+    expect(() => new StripePerson({
+      first_name: firstName,
+      last_name: lastName,
+      address_line1: addressLine1,
+      address_city: addressCity,
+      address_postcode: addressPostcode,
+      dob_day: dobDay,
+      dob_month: dobMonth,
+      dob_year: 999
+    })).to.throw('StripePerson "dob_year" must be larger than or equal to 1000')
+  })
+
+  it('should fail when year is more than 9999', () => {
+    expect(() => new StripePerson({
+      first_name: firstName,
+      last_name: lastName,
+      address_line1: addressLine1,
+      address_city: addressCity,
+      address_postcode: addressPostcode,
+      dob_day: dobDay,
+      dob_month: dobMonth,
+      dob_year: 10000
+    })).to.throw('StripePerson "dob_year" must be less than or equal to 9999')
+  })
+})

--- a/app/services/clients/stripe/stripe_client.js
+++ b/app/services/clients/stripe/stripe_client.js
@@ -6,6 +6,8 @@ const ProxyAgent = require('https-proxy-agent')
 
 // Local dependencies
 const StripeBankAccount = require('./stripeBankAccount.model')
+const StripePerson = require('./stripePerson.model')
+
 
 // Constants
 const STRIPE_HOST = process.env.STRIPE_HOST
@@ -28,5 +30,10 @@ module.exports = {
   updateBankAccount: function (stripeAccountId, body) {
     const bankAccount = new StripeBankAccount(body)
     return stripe.accounts.update(stripeAccountId, bankAccount.basicObject())
+  },
+
+  createPerson: function (stripeAccountId, body) {
+    const stripePerson = new StripePerson(body)
+    return stripe.accounts.createPerson(stripeAccountId, stripePerson.basicObject())
   }
 }


### PR DESCRIPTION
Add `StripePerson` model object, which represents the details about a responsible person in the format that the Stripe Connect Persons API expects.