### PR TITLE
PP-4463 Responsible person home address postcode tweaks

### DIFF
--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -3,6 +3,7 @@
 // NPM dependencies
 const lodash = require('lodash')
 const moment = require('moment-timezone')
+const ukPostcode = require('uk-postcode')
 
 // Local dependencies
 const paths = require('../../../paths')
@@ -91,7 +92,7 @@ module.exports = (req, res) => {
     homeAddressPostcode: formFields[HOME_ADDRESS_POSTCODE_FIELD],
     dobDay: formFields[DOB_DAY_FIELD],
     dobMonth: formFields[DOB_MONTH_FIELD],
-    dobYear: formFields[DOB_YEAR_FIELD],
+    dobYear: formFields[DOB_YEAR_FIELD]
   }
 
   if (!lodash.isEmpty(errors)) {
@@ -100,10 +101,11 @@ module.exports = (req, res) => {
   } else if (lodash.get(req.body, 'answers-checked') === 'true') {
     return res.redirect(303, paths.dashboard.index)
   } else if (lodash.get(req.body, 'answers-need-changing') === 'true') {
+    pageData.homeAddressPostcode = ukPostcode.fromString(formFields[HOME_ADDRESS_POSTCODE_FIELD]).toString()
     return response.response(req, res, 'stripe-setup/responsible-person/index', pageData)
   } else {
-    const friendlyDob = formatDateOfBirth(formFields[DOB_DAY_FIELD], formFields[DOB_MONTH_FIELD] - 1, formFields[DOB_YEAR_FIELD])
-    pageData['friendlyDateOfBirth'] = friendlyDob
+    pageData.homeAddressPostcode = ukPostcode.fromString(formFields[HOME_ADDRESS_POSTCODE_FIELD]).toString()
+    pageData.friendlyDateOfBirth = formatDateOfBirth(formFields[DOB_DAY_FIELD], formFields[DOB_MONTH_FIELD] - 1, formFields[DOB_YEAR_FIELD])
     return response.response(req, res, 'stripe-setup/responsible-person/check-your-answers', pageData)
   }
 }
@@ -132,6 +134,6 @@ const formatDateOfBirth = (day, month, year) => {
   return moment({
     day: day,
     month: month - 1,
-    year: year,
+    year: year
   }).format('D MMMM YYYY')
 }

--- a/app/controllers/stripe-setup/responsible-person/responsible-person-validations.js
+++ b/app/controllers/stripe-setup/responsible-person/responsible-person-validations.js
@@ -39,7 +39,6 @@ exports.validateMandatoryField = function validateMandatoryField (value, maxLeng
 
   const textTooLongErrorMessage = isFieldGreaterThanMaxLengthChars(value, maxLength)
   if (textTooLongErrorMessage) {
-
     return {
       valid: false,
       message: textTooLongErrorMessage
@@ -58,6 +57,13 @@ exports.validatePostcode = function validatePostcode (postcode) {
     return {
       valid: false,
       message: isEmptyErrorMessage
+    }
+  }
+
+  if (!/^[A-z0-9 ]+$/.test(postcode)) {
+    return {
+      valid: false,
+      message: 'Please enter a real postcode'
     }
   }
 

--- a/app/controllers/stripe-setup/responsible-person/responsible-person-validations.test.js
+++ b/app/controllers/stripe-setup/responsible-person/responsible-person-validations.test.js
@@ -54,10 +54,29 @@ describe('Responsible person page field validations', () => {
       expect(responsiblePersonValidations.validatePostcode('NW1 5GH').valid).to.be.true // eslint-disable-line
     })
 
+    it('should be valid when UK postcode but all lower-case', () => {
+      expect(responsiblePersonValidations.validatePostcode('nw1 5gh').valid).to.be.true // eslint-disable-line
+    })
+
+    it('should be valid when UK postcode but no space', () => {
+      expect(responsiblePersonValidations.validatePostcode('NW15GH').valid).to.be.true // eslint-disable-line
+    })
+
+    it('should be valid when UK postcode but no space and all lower-case', () => {
+      expect(responsiblePersonValidations.validatePostcode('nw15gh').valid).to.be.true // eslint-disable-line
+    })
+
     it('should not be valid when postcode is blank', () => {
       expect(responsiblePersonValidations.validatePostcode(BLANK_TEXT)).to.deep.equal({
         valid: false,
         message: 'This field cannot be blank'
+      })
+    })
+
+    it('should not be valid when postcode is UK postcode with extra punctuation', () => {
+      expect(responsiblePersonValidations.validatePostcode('NW1! 5GH')).to.deep.equal({
+        valid: false,
+        message: 'Please enter a real postcode'
       })
     })
 
@@ -183,5 +202,4 @@ describe('Responsible person page field validations', () => {
       })
     })
   })
-
 })


### PR DESCRIPTION
• The `uk-postcode` package we use strips all non-alphanumeric characters from postcodes, so if someone enters “AB!1 2CD” (trying to enter “AB11” but holds down the shift key too long), `uk-postcode` will treat like as “AB1 2CD”, which will validate successfully even though the user made a mistake. Work around this by checking that the input consists only of alphanumeric characters and spaces before passing to `uk-postcode`.

• When presenting the postcode to the user on the check answers page, normalise it (so “ab112cd” will become “AB11 2CD”).