### PR TITLE
PP-4970: Ensure function is passed to test promise

### DIFF
--- a/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
+++ b/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
@@ -32,7 +32,7 @@ describe('adminusers client - authenticate', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   const existingUsername = 'existing-user'
   const validPassword = 'password'

--- a/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
+++ b/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
@@ -32,7 +32,7 @@ describe('adminusers client - authenticate', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   const existingUsername = 'existing-user'
   const validPassword = 'password'

--- a/test/unit/clients/adminusers_client/forgotten_password/create_forgotten_password_test.js
+++ b/test/unit/clients/adminusers_client/forgotten_password/create_forgotten_password_test.js
@@ -23,7 +23,7 @@ describe('adminusers client - create forgotten password', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('success', () => {
     const username = 'existing-user'

--- a/test/unit/clients/adminusers_client/forgotten_password/create_forgotten_password_test.js
+++ b/test/unit/clients/adminusers_client/forgotten_password/create_forgotten_password_test.js
@@ -23,7 +23,7 @@ describe('adminusers client - create forgotten password', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('success', () => {
     const username = 'existing-user'

--- a/test/unit/clients/adminusers_client/forgotten_password/get_forgotten_password_test.js
+++ b/test/unit/clients/adminusers_client/forgotten_password/get_forgotten_password_test.js
@@ -23,7 +23,7 @@ describe('adminusers client - get forgotten password', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('success', () => {
     let code = 'existing-code'

--- a/test/unit/clients/adminusers_client/forgotten_password/get_forgotten_password_test.js
+++ b/test/unit/clients/adminusers_client/forgotten_password/get_forgotten_password_test.js
@@ -23,7 +23,7 @@ describe('adminusers client - get forgotten password', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('success', () => {
     let code = 'existing-code'

--- a/test/unit/clients/adminusers_client/invite/complete_service_invite_test.js
+++ b/test/unit/clients/adminusers_client/invite/complete_service_invite_test.js
@@ -32,7 +32,7 @@ describe('adminusers client - complete an invite', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('success', () => {
     const inviteCode = '7d19aff33f8948deb97ed16b2912dcd3'

--- a/test/unit/clients/adminusers_client/invite/complete_service_invite_test.js
+++ b/test/unit/clients/adminusers_client/invite/complete_service_invite_test.js
@@ -32,7 +32,7 @@ describe('adminusers client - complete an invite', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('success', () => {
     const inviteCode = '7d19aff33f8948deb97ed16b2912dcd3'

--- a/test/unit/clients/adminusers_client/invite/complete_user_invite_test.js
+++ b/test/unit/clients/adminusers_client/invite/complete_user_invite_test.js
@@ -32,7 +32,7 @@ describe('adminusers client - complete a user invite', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('success', () => {
     const inviteCode = '7d19aff33f8948deb97ed16b2912dcd3'

--- a/test/unit/clients/adminusers_client/invite/complete_user_invite_test.js
+++ b/test/unit/clients/adminusers_client/invite/complete_user_invite_test.js
@@ -32,7 +32,7 @@ describe('adminusers client - complete a user invite', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('success', () => {
     const inviteCode = '7d19aff33f8948deb97ed16b2912dcd3'

--- a/test/unit/clients/adminusers_client/invite/generate_invite_otp_code_service_test.js
+++ b/test/unit/clients/adminusers_client/invite/generate_invite_otp_code_service_test.js
@@ -31,7 +31,7 @@ describe('adminusers client - generate otp code for service invite', function ()
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('success', () => {
     const inviteCode = '7d19aff33f8948deb97ed16b2912dcd3'

--- a/test/unit/clients/adminusers_client/invite/generate_invite_otp_code_service_test.js
+++ b/test/unit/clients/adminusers_client/invite/generate_invite_otp_code_service_test.js
@@ -31,7 +31,7 @@ describe('adminusers client - generate otp code for service invite', function ()
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('success', () => {
     const inviteCode = '7d19aff33f8948deb97ed16b2912dcd3'

--- a/test/unit/clients/adminusers_client/invite/generate_invite_otp_code_user_test.js
+++ b/test/unit/clients/adminusers_client/invite/generate_invite_otp_code_user_test.js
@@ -32,7 +32,7 @@ describe('adminusers client - generate otp code for user invite', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('success', () => {
     const inviteCode = '7d19aff33f8948deb97ed16b2912dcd3'

--- a/test/unit/clients/adminusers_client/invite/generate_invite_otp_code_user_test.js
+++ b/test/unit/clients/adminusers_client/invite/generate_invite_otp_code_user_test.js
@@ -32,7 +32,7 @@ describe('adminusers client - generate otp code for user invite', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('success', () => {
     const inviteCode = '7d19aff33f8948deb97ed16b2912dcd3'

--- a/test/unit/clients/adminusers_client/invite/get_invite_test.js
+++ b/test/unit/clients/adminusers_client/invite/get_invite_test.js
@@ -28,7 +28,7 @@ describe('adminusers client - get a validated invite', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('success', () => {
     const inviteCode = '7d19aff33f8948deb97ed16b2912dcd3'

--- a/test/unit/clients/adminusers_client/invite/get_invite_test.js
+++ b/test/unit/clients/adminusers_client/invite/get_invite_test.js
@@ -28,7 +28,7 @@ describe('adminusers client - get a validated invite', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('success', () => {
     const inviteCode = '7d19aff33f8948deb97ed16b2912dcd3'

--- a/test/unit/clients/adminusers_client/invite/invite_user_test.js
+++ b/test/unit/clients/adminusers_client/invite/invite_user_test.js
@@ -26,7 +26,7 @@ describe('adminusers client - invite user', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('success', function () {
     let validInvite = inviteFixtures.validInviteRequest({externalServiceId: externalServiceId})

--- a/test/unit/clients/adminusers_client/invite/invite_user_test.js
+++ b/test/unit/clients/adminusers_client/invite/invite_user_test.js
@@ -26,7 +26,7 @@ describe('adminusers client - invite user', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('success', function () {
     let validInvite = inviteFixtures.validInviteRequest({externalServiceId: externalServiceId})

--- a/test/unit/clients/adminusers_client/invite/resend_otp_code_test.js
+++ b/test/unit/clients/adminusers_client/invite/resend_otp_code_test.js
@@ -32,7 +32,7 @@ describe('submit resend otp code API', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('success', () => {
     const validOtpResend = inviteFixtures.validResendOtpCodeRequest()

--- a/test/unit/clients/adminusers_client/invite/resend_otp_code_test.js
+++ b/test/unit/clients/adminusers_client/invite/resend_otp_code_test.js
@@ -32,7 +32,7 @@ describe('submit resend otp code API', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('success', () => {
     const validOtpResend = inviteFixtures.validResendOtpCodeRequest()

--- a/test/unit/clients/adminusers_client/invite/submit_service_registration_test.js
+++ b/test/unit/clients/adminusers_client/invite/submit_service_registration_test.js
@@ -35,7 +35,7 @@ describe('adminusers client - self register service', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('success', () => {
     const validRegistration = registerFixtures.validRegisterRequest()

--- a/test/unit/clients/adminusers_client/invite/submit_service_registration_test.js
+++ b/test/unit/clients/adminusers_client/invite/submit_service_registration_test.js
@@ -35,7 +35,7 @@ describe('adminusers client - self register service', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('success', () => {
     const validRegistration = registerFixtures.validRegisterRequest()

--- a/test/unit/clients/adminusers_client/invite/verify_otp_code_test.js
+++ b/test/unit/clients/adminusers_client/invite/verify_otp_code_test.js
@@ -25,7 +25,7 @@ describe('adminusers client - submit verification details', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   context('verify otp code - success', () => {
     let validRequest = registrationFixtures.validVerifyOtpCodeRequest()

--- a/test/unit/clients/adminusers_client/invite/verify_otp_code_test.js
+++ b/test/unit/clients/adminusers_client/invite/verify_otp_code_test.js
@@ -25,7 +25,7 @@ describe('adminusers client - submit verification details', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   context('verify otp code - success', () => {
     let validRequest = registrationFixtures.validVerifyOtpCodeRequest()

--- a/test/unit/clients/adminusers_client/invite/verify_service_otp_code_test.js
+++ b/test/unit/clients/adminusers_client/invite/verify_service_otp_code_test.js
@@ -25,7 +25,7 @@ describe('adminusers client - validate otp code for a service', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('success', () => {
     let validRequest = registrationFixtures.validVerifyOtpCodeRequest({code: 'aValidCode'})

--- a/test/unit/clients/adminusers_client/invite/verify_service_otp_code_test.js
+++ b/test/unit/clients/adminusers_client/invite/verify_service_otp_code_test.js
@@ -11,7 +11,7 @@ chai.use(chaiAsPromised)
 const expect = chai.expect
 const OTP_VALIDATE_RESOURCE = '/v1/api/invites/otp/validate/service'
 const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 describe('adminusers client - validate otp code for a service', function () {
   let provider = Pact({
@@ -28,7 +28,7 @@ describe('adminusers client - validate otp code for a service', function () {
   after(() => provider.finalize())
 
   describe('success', () => {
-    let validRequest = registrationFixtures.validVerifyOtpCodeRequest({code: 'aValidCode'})
+    let validRequest = registrationFixtures.validVerifyOtpCodeRequest({ code: 'aValidCode' })
 
     before((done) => {
       let pactified = validRequest.getPactified()
@@ -62,7 +62,7 @@ describe('adminusers client - validate otp code for a service', function () {
       let pactified = verifyCodeRequest.getPactified()
       provider.addInteraction(
         new PactInteractionBuilder(`${OTP_VALIDATE_RESOURCE}`)
-          .withUponReceiving('a verify otp code request with missing code')
+          .withUponReceiving('a verify service otp code request with missing code')
           .withMethod('POST')
           .withRequestBody(pactified)
           .withStatusCode(400)
@@ -91,7 +91,7 @@ describe('adminusers client - validate otp code for a service', function () {
       let pactified = verifyCodeRequest.getPactified()
       provider.addInteraction(
         new PactInteractionBuilder(`${OTP_VALIDATE_RESOURCE}`)
-          .withUponReceiving('a verify otp code request with non existent code')
+          .withUponReceiving('a verify service otp code request with non existent code')
           .withMethod('POST')
           .withRequestBody(pactified)
           .withStatusCode(404)
@@ -117,7 +117,7 @@ describe('adminusers client - validate otp code for a service', function () {
       let pactified = verifyCodeRequest.getPactified()
       provider.addInteraction(
         new PactInteractionBuilder(`${OTP_VALIDATE_RESOURCE}`)
-          .withUponReceiving('a registration details submission for locked code')
+          .withUponReceiving('a service registration details submission for locked code')
           .withMethod('POST')
           .withRequestBody(pactified)
           .withStatusCode(410)

--- a/test/unit/clients/adminusers_client/invite/verify_service_otp_code_test.js
+++ b/test/unit/clients/adminusers_client/invite/verify_service_otp_code_test.js
@@ -25,7 +25,7 @@ describe('adminusers client - validate otp code for a service', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('success', () => {
     let validRequest = registrationFixtures.validVerifyOtpCodeRequest({code: 'aValidCode'})

--- a/test/unit/clients/adminusers_client/service/add_gateway_accounts_to_services_test.js
+++ b/test/unit/clients/adminusers_client/service/add_gateway_accounts_to_services_test.js
@@ -36,7 +36,7 @@ describe('admin users client - add gateway accounts to service', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('a successful add gateway account to service request', () => {
     const gatewayAccountsIdsToAdd = ['42']

--- a/test/unit/clients/adminusers_client/service/add_gateway_accounts_to_services_test.js
+++ b/test/unit/clients/adminusers_client/service/add_gateway_accounts_to_services_test.js
@@ -36,7 +36,7 @@ describe('admin users client - add gateway accounts to service', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('a successful add gateway account to service request', () => {
     const gatewayAccountsIdsToAdd = ['42']

--- a/test/unit/clients/adminusers_client/service/create_service_test.js
+++ b/test/unit/clients/adminusers_client/service/create_service_test.js
@@ -32,7 +32,7 @@ describe('adminusers client - create a new service', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('success', () => {
     const name = 'Service name'

--- a/test/unit/clients/adminusers_client/service/create_service_test.js
+++ b/test/unit/clients/adminusers_client/service/create_service_test.js
@@ -32,7 +32,7 @@ describe('adminusers client - create a new service', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('success', () => {
     const name = 'Service name'

--- a/test/unit/clients/adminusers_client/service/get_service_users_test.js
+++ b/test/unit/clients/adminusers_client/service/get_service_users_test.js
@@ -34,7 +34,7 @@ describe('adminusers client - service users', () => {
   })
 
   before(() => provider.setup())
-  after(done => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('single user is returned for service', () => {
     const getServiceUsersResponse = userServiceFixtures.validServiceUsersResponse([{

--- a/test/unit/clients/adminusers_client/service/get_service_users_test.js
+++ b/test/unit/clients/adminusers_client/service/get_service_users_test.js
@@ -34,7 +34,7 @@ describe('adminusers client - service users', () => {
   })
 
   before(() => provider.setup())
-  after(done => provider.finalize().then(done()))
+  after(done => provider.finalize().then(() => { done() }))
 
   describe('single user is returned for service', () => {
     const getServiceUsersResponse = userServiceFixtures.validServiceUsersResponse([{

--- a/test/unit/clients/adminusers_client/service/govuk_pay_agreement_post_email_address_test.js
+++ b/test/unit/clients/adminusers_client/service/govuk_pay_agreement_post_email_address_test.js
@@ -33,7 +33,7 @@ describe('adminusers client - post govuk pay agreement - email address', () => {
   })
 
   before(() => provider.setup())
-  after(done => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('post email address', () => {
     const payload = { user_external_id: userExternalId }

--- a/test/unit/clients/adminusers_client/service/govuk_pay_agreement_post_email_address_test.js
+++ b/test/unit/clients/adminusers_client/service/govuk_pay_agreement_post_email_address_test.js
@@ -33,7 +33,7 @@ describe('adminusers client - post govuk pay agreement - email address', () => {
   })
 
   before(() => provider.setup())
-  after(done => provider.finalize().then(done()))
+  after(done => provider.finalize().then(() => { done() }))
 
   describe('post email address', () => {
     const payload = { user_external_id: userExternalId }
@@ -50,7 +50,7 @@ describe('adminusers client - post govuk pay agreement - email address', () => {
           .withResponseHeaders({})
           .build()
       )
-        .then(done())
+        .then(() => { done() })
     })
 
     afterEach(() => provider.verify())

--- a/test/unit/clients/adminusers_client/service/stripe_agreement_post_ip_address_test.js
+++ b/test/unit/clients/adminusers_client/service/stripe_agreement_post_ip_address_test.js
@@ -32,7 +32,7 @@ describe('adminusers client - post stripe agreement - ip address', () => {
   })
 
   before(() => provider.setup())
-  after(done => provider.finalize().then(done()))
+  after(done => provider.finalize().then(() => { done() }))
 
   describe('post ip address', () => {
     const ipAddress = '93.184.216.34' // example.org
@@ -50,7 +50,7 @@ describe('adminusers client - post stripe agreement - ip address', () => {
           .withResponseHeaders({})
           .build()
       )
-        .then(done())
+        .then(() => { done() })
     })
 
     afterEach(() => provider.verify())

--- a/test/unit/clients/adminusers_client/service/stripe_agreement_post_ip_address_test.js
+++ b/test/unit/clients/adminusers_client/service/stripe_agreement_post_ip_address_test.js
@@ -32,7 +32,7 @@ describe('adminusers client - post stripe agreement - ip address', () => {
   })
 
   before(() => provider.setup())
-  after(done => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('post ip address', () => {
     const ipAddress = '93.184.216.34' // example.org

--- a/test/unit/clients/adminusers_client/service/update_collect_billing_address_test.js
+++ b/test/unit/clients/adminusers_client/service/update_collect_billing_address_test.js
@@ -33,7 +33,7 @@ describe('adminusers client - patch collect billing address toggle', function ()
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('patch collect billing address toggle - disabled', () => {
     const validUpdateCollectBillingAddressRequest = serviceFixtures.validCollectBillingAddressToggleRequest({enabled: false})

--- a/test/unit/clients/adminusers_client/service/update_collect_billing_address_test.js
+++ b/test/unit/clients/adminusers_client/service/update_collect_billing_address_test.js
@@ -33,7 +33,7 @@ describe('adminusers client - patch collect billing address toggle', function ()
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('patch collect billing address toggle - disabled', () => {
     const validUpdateCollectBillingAddressRequest = serviceFixtures.validCollectBillingAddressToggleRequest({enabled: false})

--- a/test/unit/clients/adminusers_client/service/update_request_to_go_live_stage_test.js
+++ b/test/unit/clients/adminusers_client/service/update_request_to_go_live_stage_test.js
@@ -33,7 +33,7 @@ describe('adminusers client - patch request to go live stage', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('patch request to go live stage', () => {
     const value = 'ENTERED_ORGANISATION_NAME'

--- a/test/unit/clients/adminusers_client/service/update_request_to_go_live_stage_test.js
+++ b/test/unit/clients/adminusers_client/service/update_request_to_go_live_stage_test.js
@@ -33,7 +33,7 @@ describe('adminusers client - patch request to go live stage', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('patch request to go live stage', () => {
     const value = 'ENTERED_ORGANISATION_NAME'

--- a/test/unit/clients/adminusers_client/service/update_service_name_test.js
+++ b/test/unit/clients/adminusers_client/service/update_service_name_test.js
@@ -34,7 +34,7 @@ describe('adminusers client - update service name', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('success with en and cy', () => {
     const serviceName = {

--- a/test/unit/clients/adminusers_client/service/update_service_name_test.js
+++ b/test/unit/clients/adminusers_client/service/update_service_name_test.js
@@ -34,7 +34,7 @@ describe('adminusers client - update service name', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('success with en and cy', () => {
     const serviceName = {

--- a/test/unit/clients/adminusers_client/user/assign_servicerole_test.js
+++ b/test/unit/clients/adminusers_client/user/assign_servicerole_test.js
@@ -28,7 +28,7 @@ describe('adminusers client - assign service role to user', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('assign user service role API - success', () => {
     let role = 'view-and-refund'

--- a/test/unit/clients/adminusers_client/user/assign_servicerole_test.js
+++ b/test/unit/clients/adminusers_client/user/assign_servicerole_test.js
@@ -28,7 +28,7 @@ describe('adminusers client - assign service role to user', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('assign user service role API - success', () => {
     let role = 'view-and-refund'

--- a/test/unit/clients/adminusers_client/user/authenticate_test.js
+++ b/test/unit/clients/adminusers_client/user/authenticate_test.js
@@ -26,7 +26,7 @@ describe('adminusers client - authenticate', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('authenticate user API - success', () => {
     let request = userFixtures.validAuthenticateRequest({username: 'existing-user'})

--- a/test/unit/clients/adminusers_client/user/authenticate_test.js
+++ b/test/unit/clients/adminusers_client/user/authenticate_test.js
@@ -26,7 +26,7 @@ describe('adminusers client - authenticate', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('authenticate user API - success', () => {
     let request = userFixtures.validAuthenticateRequest({username: 'existing-user'})

--- a/test/unit/clients/adminusers_client/user/delete_user_test.js
+++ b/test/unit/clients/adminusers_client/user/delete_user_test.js
@@ -23,7 +23,7 @@ describe('adminusers client - delete user', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   const serviceId = 'pact-delete-service-id'
   const removerId = 'pact-delete-remover-id'

--- a/test/unit/clients/adminusers_client/user/delete_user_test.js
+++ b/test/unit/clients/adminusers_client/user/delete_user_test.js
@@ -23,7 +23,7 @@ describe('adminusers client - delete user', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   const serviceId = 'pact-delete-service-id'
   const removerId = 'pact-delete-remover-id'

--- a/test/unit/clients/adminusers_client/user/get_multiple_users_test.js
+++ b/test/unit/clients/adminusers_client/user/get_multiple_users_test.js
@@ -25,7 +25,7 @@ describe('adminusers client - get users', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('success', () => {
     let existingExternalIds = [

--- a/test/unit/clients/adminusers_client/user/get_multiple_users_test.js
+++ b/test/unit/clients/adminusers_client/user/get_multiple_users_test.js
@@ -25,7 +25,7 @@ describe('adminusers client - get users', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('success', () => {
     let existingExternalIds = [

--- a/test/unit/clients/adminusers_client/user/get_user_test.js
+++ b/test/unit/clients/adminusers_client/user/get_user_test.js
@@ -31,7 +31,7 @@ describe('adminusers client - get user', () => {
   })
 
   before(() => provider.setup())
-  after(done => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('find a valid user', () => {
     const existingExternalId = '7d19aff33f8948deb97ed16b2912dcd3'

--- a/test/unit/clients/adminusers_client/user/get_user_test.js
+++ b/test/unit/clients/adminusers_client/user/get_user_test.js
@@ -31,7 +31,7 @@ describe('adminusers client - get user', () => {
   })
 
   before(() => provider.setup())
-  after(done => provider.finalize().then(done()))
+  after(done => provider.finalize().then(() => { done() }))
 
   describe('find a valid user', () => {
     const existingExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
@@ -44,7 +44,7 @@ describe('adminusers client - get user', () => {
           .withUponReceiving('a valid get user request')
           .withResponseBody(getUserResponse.getPactified())
           .build()
-      ).then(done())
+      ).then(() => { done() })
     })
 
     afterEach(() => provider.verify())
@@ -80,7 +80,7 @@ describe('adminusers client - get user', () => {
           .withStatusCode(404)
           .withResponseHeaders({})
           .build()
-      ).then(done())
+      ).then(() => { done() })
     })
 
     afterEach(() => provider.verify())

--- a/test/unit/clients/adminusers_client/user/increment_session_version_test.js
+++ b/test/unit/clients/adminusers_client/user/increment_session_version_test.js
@@ -25,7 +25,7 @@ describe('adminusers client - session', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('increment session version  API - success', () => {
     let request = userFixtures.validIncrementSessionVersionRequest()

--- a/test/unit/clients/adminusers_client/user/increment_session_version_test.js
+++ b/test/unit/clients/adminusers_client/user/increment_session_version_test.js
@@ -25,7 +25,7 @@ describe('adminusers client - session', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('increment session version  API - success', () => {
     let request = userFixtures.validIncrementSessionVersionRequest()

--- a/test/unit/clients/adminusers_client/user/second_factor_test.js
+++ b/test/unit/clients/adminusers_client/user/second_factor_test.js
@@ -27,7 +27,7 @@ describe('adminusers client', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('send new second factor API - success', () => {
     before((done) => {

--- a/test/unit/clients/adminusers_client/user/second_factor_test.js
+++ b/test/unit/clients/adminusers_client/user/second_factor_test.js
@@ -27,7 +27,7 @@ describe('adminusers client', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('send new second factor API - success', () => {
     before((done) => {

--- a/test/unit/clients/adminusers_client/user/update_password_test.js
+++ b/test/unit/clients/adminusers_client/user/update_password_test.js
@@ -25,7 +25,7 @@ describe('adminusers client - update password', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('update password for user API - success', () => {
     let request = userFixtures.validUpdatePasswordRequest('avalidforgottenpasswordtoken')

--- a/test/unit/clients/adminusers_client/user/update_password_test.js
+++ b/test/unit/clients/adminusers_client/user/update_password_test.js
@@ -25,7 +25,7 @@ describe('adminusers client - update password', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('update password for user API - success', () => {
     let request = userFixtures.validUpdatePasswordRequest('avalidforgottenpasswordtoken')

--- a/test/unit/clients/adminusers_client/user/update_servicerole_test.js
+++ b/test/unit/clients/adminusers_client/user/update_servicerole_test.js
@@ -28,7 +28,7 @@ describe('adminusers client - update user service role', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('update user service role API - success', () => {
     let role = 'view-and-refund'

--- a/test/unit/clients/adminusers_client/user/update_servicerole_test.js
+++ b/test/unit/clients/adminusers_client/user/update_servicerole_test.js
@@ -28,7 +28,7 @@ describe('adminusers client - update user service role', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('update user service role API - success', () => {
     let role = 'view-and-refund'

--- a/test/unit/clients/connector_client/connector_client_create_gateway_account_test.js
+++ b/test/unit/clients/connector_client/connector_client_create_gateway_account_test.js
@@ -32,7 +32,7 @@ describe('connector client - create gateway account', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('create gateway account - success', () => {
     const validCreateGatewayAccountRequest = gatewayAccountFixtures.validCreateGatewayAccountRequest()

--- a/test/unit/clients/connector_client/connector_client_create_gateway_account_test.js
+++ b/test/unit/clients/connector_client/connector_client_create_gateway_account_test.js
@@ -32,7 +32,7 @@ describe('connector client - create gateway account', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('create gateway account - success', () => {
     const validCreateGatewayAccountRequest = gatewayAccountFixtures.validCreateGatewayAccountRequest()

--- a/test/unit/clients/connector_client/connector_get_card_types_test.js
+++ b/test/unit/clients/connector_client/connector_get_card_types_test.js
@@ -32,7 +32,7 @@ describe('connector client', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('get card types', () => {
     const validCardTypesResponse = cardFixtures.validCardTypesResponse()

--- a/test/unit/clients/connector_client/connector_get_card_types_test.js
+++ b/test/unit/clients/connector_client/connector_get_card_types_test.js
@@ -32,7 +32,7 @@ describe('connector client', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('get card types', () => {
     const validCardTypesResponse = cardFixtures.validCardTypesResponse()

--- a/test/unit/clients/connector_client/connector_get_gateway_account_test.js
+++ b/test/unit/clients/connector_client/connector_get_gateway_account_test.js
@@ -34,7 +34,7 @@ describe('connector client - get gateway account', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('get single gateway account - success', () => {
     const validGetGatewayAccountResponse = gatewayAccountFixtures.validGatewayAccountResponse({

--- a/test/unit/clients/connector_client/connector_get_gateway_account_test.js
+++ b/test/unit/clients/connector_client/connector_get_gateway_account_test.js
@@ -34,7 +34,7 @@ describe('connector client - get gateway account', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('get single gateway account - success', () => {
     const validGetGatewayAccountResponse = gatewayAccountFixtures.validGatewayAccountResponse({

--- a/test/unit/clients/connector_client/connector_get_multiple_gateway_accounts_test.js
+++ b/test/unit/clients/connector_client/connector_get_multiple_gateway_accounts_test.js
@@ -32,7 +32,7 @@ describe('connector client - get multiple gateway accounts', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('get multiple gateway accounts - success', () => {
     const validGetGatewayAccountsResponse = gatewayAccountFixtures.validGatewayAccountsResponse({

--- a/test/unit/clients/connector_client/connector_get_multiple_gateway_accounts_test.js
+++ b/test/unit/clients/connector_client/connector_get_multiple_gateway_accounts_test.js
@@ -32,7 +32,7 @@ describe('connector client - get multiple gateway accounts', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('get multiple gateway accounts - success', () => {
     const validGetGatewayAccountsResponse = gatewayAccountFixtures.validGatewayAccountsResponse({

--- a/test/unit/clients/connector_client/connector_get_stripe_account_setup_test.js
+++ b/test/unit/clients/connector_client/connector_get_stripe_account_setup_test.js
@@ -35,7 +35,7 @@ describe('connector client - get stripe account setup', () => {
   })
 
   before(() => provider.setup())
-  after(done => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('get stripe account setup success', () => {
     const stripeSetupOpts = {

--- a/test/unit/clients/connector_client/connector_get_stripe_account_setup_test.js
+++ b/test/unit/clients/connector_client/connector_get_stripe_account_setup_test.js
@@ -35,7 +35,7 @@ describe('connector client - get stripe account setup', () => {
   })
 
   before(() => provider.setup())
-  after(done => provider.finalize().then(done()))
+  after(done => provider.finalize().then(() => { done() }))
 
   describe('get stripe account setup success', () => {
     const stripeSetupOpts = {

--- a/test/unit/clients/connector_client/connector_get_stripe_account_test.js
+++ b/test/unit/clients/connector_client/connector_get_stripe_account_test.js
@@ -35,7 +35,7 @@ describe('connector client - get stripe account', () => {
   })
 
   before(() => provider.setup())
-  after(done => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('get stripe account setup success', () => {
     const stripeAccountOpts = {

--- a/test/unit/clients/connector_client/connector_get_stripe_account_test.js
+++ b/test/unit/clients/connector_client/connector_get_stripe_account_test.js
@@ -35,7 +35,7 @@ describe('connector client - get stripe account', () => {
   })
 
   before(() => provider.setup())
-  after(done => provider.finalize().then(done()))
+  after(done => provider.finalize().then(() => { done() }))
 
   describe('get stripe account setup success', () => {
     const stripeAccountOpts = {

--- a/test/unit/clients/connector_client/connector_get_transaction_details_test.js
+++ b/test/unit/clients/connector_client/connector_get_transaction_details_test.js
@@ -36,7 +36,7 @@ describe('connector client', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('get transaction details', () => {
     const params = {

--- a/test/unit/clients/connector_client/connector_get_transaction_details_test.js
+++ b/test/unit/clients/connector_client/connector_get_transaction_details_test.js
@@ -36,7 +36,7 @@ describe('connector client', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('get transaction details', () => {
     const params = {

--- a/test/unit/clients/connector_client/connector_get_transactions_and_summary_test.js
+++ b/test/unit/clients/connector_client/connector_get_transactions_and_summary_test.js
@@ -33,7 +33,7 @@ describe('connector client', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('get transaction summary', () => {
     const params = {

--- a/test/unit/clients/connector_client/connector_get_transactions_and_summary_test.js
+++ b/test/unit/clients/connector_client/connector_get_transactions_and_summary_test.js
@@ -33,7 +33,7 @@ describe('connector client', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('get transaction summary', () => {
     const params = {

--- a/test/unit/clients/connector_client/connector_patch_email_collection_mode_test.js
+++ b/test/unit/clients/connector_client/connector_patch_email_collection_mode_test.js
@@ -35,7 +35,7 @@ describe('connector client - patch email collection mode', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('patch email collection mode - mandatory', () => {
     const validGatewayAccountEmailCollectionModeRequest =

--- a/test/unit/clients/connector_client/connector_patch_email_collection_mode_test.js
+++ b/test/unit/clients/connector_client/connector_patch_email_collection_mode_test.js
@@ -35,7 +35,7 @@ describe('connector client - patch email collection mode', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('patch email collection mode - mandatory', () => {
     const validGatewayAccountEmailCollectionModeRequest =

--- a/test/unit/clients/connector_client/connector_patch_email_confirmation_toggle_test.js
+++ b/test/unit/clients/connector_client/connector_patch_email_confirmation_toggle_test.js
@@ -35,7 +35,7 @@ describe('connector client - patch email confirmation toggle', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('patch email confirmation toggle - enabled', () => {
     const validGatewayAccountEmailConfirmationToggleRequest = gatewayAccountFixtures.validGatewayAccountEmailConfirmationToggleRequest(true)

--- a/test/unit/clients/connector_client/connector_patch_email_confirmation_toggle_test.js
+++ b/test/unit/clients/connector_client/connector_patch_email_confirmation_toggle_test.js
@@ -35,7 +35,7 @@ describe('connector client - patch email confirmation toggle', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('patch email confirmation toggle - enabled', () => {
     const validGatewayAccountEmailConfirmationToggleRequest = gatewayAccountFixtures.validGatewayAccountEmailConfirmationToggleRequest(true)

--- a/test/unit/clients/connector_client/connector_patch_email_refund_toggle_test.js
+++ b/test/unit/clients/connector_client/connector_patch_email_refund_toggle_test.js
@@ -35,7 +35,7 @@ describe('connector client - patch email refund toggle', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('patch email refund toggle - enabled', () => {
     const validGatewayAccountEmailRefundToggleRequest = gatewayAccountFixtures.validGatewayAccountEmailRefundToggleRequest(true)

--- a/test/unit/clients/connector_client/connector_patch_email_refund_toggle_test.js
+++ b/test/unit/clients/connector_client/connector_patch_email_refund_toggle_test.js
@@ -35,7 +35,7 @@ describe('connector client - patch email refund toggle', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('patch email refund toggle - enabled', () => {
     const validGatewayAccountEmailRefundToggleRequest = gatewayAccountFixtures.validGatewayAccountEmailRefundToggleRequest(true)

--- a/test/unit/clients/connector_client/connector_set_stripe_account_setup_flag_test.js
+++ b/test/unit/clients/connector_client/connector_set_stripe_account_setup_flag_test.js
@@ -34,7 +34,7 @@ describe('connector client - set stripe account setup flag', () => {
   })
 
   before(() => provider.setup())
-  after(done => provider.finalize().then(done()))
+  after(done => provider.finalize().then(() => { done() }))
 
   describe('set bank account flag', () => {
     const request = stripeAccountSetupFixtures.buildUpdateBankAccountDetailsFlagRequest(true).getPlain()

--- a/test/unit/clients/connector_client/connector_set_stripe_account_setup_flag_test.js
+++ b/test/unit/clients/connector_client/connector_set_stripe_account_setup_flag_test.js
@@ -34,7 +34,7 @@ describe('connector client - set stripe account setup flag', () => {
   })
 
   before(() => provider.setup())
-  after(done => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('set bank account flag', () => {
     const request = stripeAccountSetupFixtures.buildUpdateBankAccountDetailsFlagRequest(true).getPlain()

--- a/test/unit/clients/product_client/payment/create_test.js
+++ b/test/unit/clients/product_client/payment/create_test.js
@@ -35,7 +35,7 @@ describe('products client - creating a new payment', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('when a charge is successfully created', () => {
     before((done) => {

--- a/test/unit/clients/product_client/payment/create_test.js
+++ b/test/unit/clients/product_client/payment/create_test.js
@@ -35,7 +35,7 @@ describe('products client - creating a new payment', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('when a charge is successfully created', () => {
     before((done) => {

--- a/test/unit/clients/product_client/payment/get_by_payment_external_id_test.js
+++ b/test/unit/clients/product_client/payment/get_by_payment_external_id_test.js
@@ -35,7 +35,7 @@ describe('products client - find a payment by it\'s own external id', function (
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('when a product is successfully found', () => {
     before(done => {

--- a/test/unit/clients/product_client/payment/get_by_payment_external_id_test.js
+++ b/test/unit/clients/product_client/payment/get_by_payment_external_id_test.js
@@ -35,7 +35,7 @@ describe('products client - find a payment by it\'s own external id', function (
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('when a product is successfully found', () => {
     before(done => {

--- a/test/unit/clients/product_client/payment/get_by_payment_external_id_test.js
+++ b/test/unit/clients/product_client/payment/get_by_payment_external_id_test.js
@@ -2,7 +2,7 @@
 
 // NPM dependencies
 const Pact = require('pact')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
 // Custom dependencies
@@ -41,7 +41,7 @@ describe('products client - find a payment by it\'s own external id', function (
     before(done => {
       const productsClient = getProductsClient()
       paymentExternalId = 'existing-id'
-      response = productFixtures.validCreatePaymentResponse({external_id: paymentExternalId})
+      response = productFixtures.validCreatePaymentResponse({ external_id: paymentExternalId })
       const interaction = new PactInteractionBuilder(`${PAYMENT_RESOURCE}/${paymentExternalId}`)
         .withUponReceiving('a valid get payment request')
         .withMethod('GET')
@@ -82,7 +82,7 @@ describe('products client - find a payment by it\'s own external id', function (
       paymentExternalId = 'non-existing-id'
       provider.addInteraction(
         new PactInteractionBuilder(`${PAYMENT_RESOURCE}/${paymentExternalId}`)
-          .withUponReceiving('a valid find product request with non existing id')
+          .withUponReceiving('a valid find payment request with non existing id')
           .withMethod('GET')
           .withStatusCode(404)
           .build()

--- a/test/unit/clients/product_client/payment/get_by_product_external_id_test.js
+++ b/test/unit/clients/product_client/payment/get_by_product_external_id_test.js
@@ -36,7 +36,7 @@ describe('products client - find a payment by it\'s associated product external 
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('when a product is successfully found', () => {
     before(done => {

--- a/test/unit/clients/product_client/payment/get_by_product_external_id_test.js
+++ b/test/unit/clients/product_client/payment/get_by_product_external_id_test.js
@@ -36,7 +36,7 @@ describe('products client - find a payment by it\'s associated product external 
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('when a product is successfully found', () => {
     before(done => {

--- a/test/unit/clients/product_client/payment/get_by_product_external_id_test.js
+++ b/test/unit/clients/product_client/payment/get_by_product_external_id_test.js
@@ -2,7 +2,7 @@
 
 // NPM dependencies
 const Pact = require('pact')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
 // Custom dependencies
@@ -43,12 +43,12 @@ describe('products client - find a payment by it\'s associated product external 
       const productsClient = getProductsClient()
       productExternalId = 'existing-id'
       response = [
-        productFixtures.validCreatePaymentResponse({product_external_id: productExternalId}),
-        productFixtures.validCreatePaymentResponse({product_external_id: productExternalId}),
-        productFixtures.validCreatePaymentResponse({product_external_id: productExternalId})
+        productFixtures.validCreatePaymentResponse({ product_external_id: productExternalId }),
+        productFixtures.validCreatePaymentResponse({ product_external_id: productExternalId }),
+        productFixtures.validCreatePaymentResponse({ product_external_id: productExternalId })
       ]
       const interaction = new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}/payments`)
-        .withUponReceiving('a valid get payment request')
+        .withUponReceiving('a valid get payment by product request')
         .withMethod('GET')
         .withStatusCode(200)
         .withResponseBody(response.map(item => item.getPactified()))
@@ -91,7 +91,7 @@ describe('products client - find a payment by it\'s associated product external 
       productExternalId = 'non-existing-id'
       provider.addInteraction(
         new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}/payments`)
-          .withUponReceiving('a valid find product request with non existing id')
+          .withUponReceiving('a valid find product payments request with non existing id')
           .withMethod('GET')
           .withStatusCode(404)
           .build()

--- a/test/unit/clients/product_client/product/create_test.js
+++ b/test/unit/clients/product_client/product/create_test.js
@@ -37,7 +37,7 @@ describe('products client - create a new product', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('when a product is successfully created', () => {
     before(done => {

--- a/test/unit/clients/product_client/product/create_test.js
+++ b/test/unit/clients/product_client/product/create_test.js
@@ -37,7 +37,7 @@ describe('products client - create a new product', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('when a product is successfully created', () => {
     before(done => {

--- a/test/unit/clients/product_client/product/delete_test.js
+++ b/test/unit/clients/product_client/product/delete_test.js
@@ -34,7 +34,7 @@ describe('products client - delete a product', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('when a product is successfully deleted', () => {
     before(done => {

--- a/test/unit/clients/product_client/product/delete_test.js
+++ b/test/unit/clients/product_client/product/delete_test.js
@@ -2,7 +2,7 @@
 
 // NPM dependencies
 const Pact = require('pact')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
 // Custom dependencies
@@ -43,7 +43,7 @@ describe('products client - delete a product', () => {
       productExternalId = 'a_valid_external_id'
       provider.addInteraction(
         new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}`)
-          .withUponReceiving('a valid disable product request')
+          .withUponReceiving('a valid delete product request')
           .withMethod('DELETE')
           .withStatusCode(204)
           .build()

--- a/test/unit/clients/product_client/product/delete_test.js
+++ b/test/unit/clients/product_client/product/delete_test.js
@@ -34,7 +34,7 @@ describe('products client - delete a product', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('when a product is successfully deleted', () => {
     before(done => {

--- a/test/unit/clients/product_client/product/disable_test.js
+++ b/test/unit/clients/product_client/product/disable_test.js
@@ -34,7 +34,7 @@ describe('products client - disable a product', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('when a product is successfully disabled', () => {
     before(done => {

--- a/test/unit/clients/product_client/product/disable_test.js
+++ b/test/unit/clients/product_client/product/disable_test.js
@@ -2,7 +2,7 @@
 
 // NPM dependencies
 const Pact = require('pact')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
 // Custom dependencies
@@ -69,7 +69,7 @@ describe('products client - disable a product', () => {
       productExternalId = 'a_non_existant_external_id'
       provider.addInteraction(
         new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}/disable`)
-          .withUponReceiving('an invalid create product request')
+          .withUponReceiving('an invalid disable product request')
           .withMethod('PATCH')
           .withStatusCode(400)
           .build()

--- a/test/unit/clients/product_client/product/disable_test.js
+++ b/test/unit/clients/product_client/product/disable_test.js
@@ -34,7 +34,7 @@ describe('products client - disable a product', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('when a product is successfully disabled', () => {
     before(done => {

--- a/test/unit/clients/product_client/product/get_by_gateway_account_id_test.js
+++ b/test/unit/clients/product_client/product/get_by_gateway_account_id_test.js
@@ -37,7 +37,7 @@ describe('products client - find products associated with a particular gateway a
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('when products are successfully found', () => {
     before(done => {

--- a/test/unit/clients/product_client/product/get_by_gateway_account_id_test.js
+++ b/test/unit/clients/product_client/product/get_by_gateway_account_id_test.js
@@ -37,7 +37,7 @@ describe('products client - find products associated with a particular gateway a
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('when products are successfully found', () => {
     before(done => {

--- a/test/unit/clients/product_client/product/get_by_product_external_id_test.js
+++ b/test/unit/clients/product_client/product/get_by_product_external_id_test.js
@@ -35,7 +35,7 @@ describe('products client - find a product by it\'s external id', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('when a product is successfully found', () => {
     before(done => {

--- a/test/unit/clients/product_client/product/get_by_product_external_id_test.js
+++ b/test/unit/clients/product_client/product/get_by_product_external_id_test.js
@@ -2,7 +2,7 @@
 
 // NPM dependencies
 const Pact = require('pact')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
 // Custom dependencies
@@ -52,7 +52,7 @@ describe('products client - find a product by it\'s external id', function () {
       })
       provider.addInteraction(
         new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}`)
-          .withUponReceiving('a valid get product request')
+          .withUponReceiving('a valid get product request by external id')
           .withMethod('GET')
           .withStatusCode(200)
           .withResponseBody(response.getPactified())

--- a/test/unit/clients/product_client/product/get_by_product_external_id_test.js
+++ b/test/unit/clients/product_client/product/get_by_product_external_id_test.js
@@ -35,7 +35,7 @@ describe('products client - find a product by it\'s external id', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('when a product is successfully found', () => {
     before(done => {

--- a/test/unit/clients/product_client/product/get_by_product_path_test.js
+++ b/test/unit/clients/product_client/product/get_by_product_path_test.js
@@ -35,7 +35,7 @@ describe('products client - find a product by it\'s product path', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   describe('when a product is successfully found', () => {
     before(done => {

--- a/test/unit/clients/product_client/product/get_by_product_path_test.js
+++ b/test/unit/clients/product_client/product/get_by_product_path_test.js
@@ -35,7 +35,7 @@ describe('products client - find a product by it\'s product path', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   describe('when a product is successfully found', () => {
     before(done => {

--- a/test/unit/clients/product_client/product/get_by_product_path_test.js
+++ b/test/unit/clients/product_client/product/get_by_product_path_test.js
@@ -2,7 +2,7 @@
 
 // NPM dependencies
 const Pact = require('pact')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
 // Custom dependencies
@@ -56,7 +56,7 @@ describe('products client - find a product by it\'s product path', function () {
         new PactInteractionBuilder(`${PRODUCT_RESOURCE}`)
           .withQuery('serviceNamePath', serviceNamePath)
           .withQuery('productNamePath', productNamePath)
-          .withUponReceiving('a valid get product request')
+          .withUponReceiving('a valid get product request by product path')
           .withMethod('GET')
           .withStatusCode(200)
           .withResponseBody(response.getPactified())

--- a/test/unit/clients/publicauth_client/get_tokens_test.js
+++ b/test/unit/clients/publicauth_client/get_tokens_test.js
@@ -4,17 +4,17 @@
 const Pact = require('pact')
 const path = require('path')
 const chai = require('chai')
-const {expect} = chai
+const { expect } = chai
 const chaiAsPromised = require('chai-as-promised')
-
-// user dependencies
-const gatewayAccountFixtures = require('../../../fixtures/gateway_account_fixtures')
-const publicauthClient = require('../../../../app/services/clients/public_auth_client')
-const PactInteractionBuilder = require('../../../fixtures/pact_interaction_builder').PactInteractionBuilder
 
 // constants
 const port = Math.floor(Math.random() * 48127) + 1024
 const TOKENS_PATH = '/v1/frontend/auth'
+process.env.PUBLIC_AUTH_URL = `http://localhost:${port}${TOKENS_PATH}`
+
+const gatewayAccountFixtures = require('../../../fixtures/gateway_account_fixtures')
+const publicauthClient = require('../../../../app/services/clients/public_auth_client')
+const PactInteractionBuilder = require('../../../fixtures/pact_interaction_builder').PactInteractionBuilder
 
 chai.use(chaiAsPromised)
 
@@ -31,8 +31,6 @@ describe('publicauth client - get tokens', function () {
 
   before(() => provider.setup())
   after(() => provider.finalize())
-
-  process.env.PUBLIC_AUTH_URL = `http://localhost:${port}${TOKENS_PATH}`
 
   describe('success', () => {
     const params = {
@@ -51,7 +49,7 @@ describe('publicauth client - get tokens', function () {
       ).then(() => { done() })
     })
 
-    afterEach(() => provider.finalize())
+    afterEach(() => provider.verify())
 
     it('should return service tokens information successfully', function (done) {
       const expectedTokensData = getServiceAuthResponse.getPlain()

--- a/test/unit/clients/publicauth_client/get_tokens_test.js
+++ b/test/unit/clients/publicauth_client/get_tokens_test.js
@@ -30,7 +30,7 @@ describe('publicauth client - get tokens', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(() => { done() }))
+  after(() => provider.finalize())
 
   process.env.PUBLIC_AUTH_URL = `http://localhost:${port}${TOKENS_PATH}`
 
@@ -51,7 +51,7 @@ describe('publicauth client - get tokens', function () {
       ).then(() => { done() })
     })
 
-    afterEach((done) => provider.verify().then(() => { done() }))
+    afterEach(() => provider.finalize())
 
     it('should return service tokens information successfully', function (done) {
       const expectedTokensData = getServiceAuthResponse.getPlain()

--- a/test/unit/clients/publicauth_client/get_tokens_test.js
+++ b/test/unit/clients/publicauth_client/get_tokens_test.js
@@ -30,7 +30,7 @@ describe('publicauth client - get tokens', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after((done) => provider.finalize().then(() => { done() }))
 
   process.env.PUBLIC_AUTH_URL = `http://localhost:${port}${TOKENS_PATH}`
 
@@ -48,10 +48,10 @@ describe('publicauth client - get tokens', function () {
           .withUponReceiving('a valid service auth request')
           .withResponseBody(getServiceAuthResponse.getPactified())
           .build()
-      ).then(done())
+      ).then(() => { done() })
     })
 
-    afterEach((done) => provider.verify().then(done()))
+    afterEach((done) => provider.verify().then(() => { done() }))
 
     it('should return service tokens information successfully', function (done) {
       const expectedTokensData = getServiceAuthResponse.getPlain()


### PR DESCRIPTION
All promise chains replaced in this PR immediately execute the method
being passed in (even before the original method will have run). This
impacts sequencing and is suspected to be causing flakeyness in build
environments.

This should make sure that all defined contracts are actually published and don't silently fail.

Updates duplicated contract descriptions to make sure they can be published.

Issue found investigating https://github.com/alphagov/pay-selfservice/pull/1271