### PR TITLE
PP-4939 Fix error navigating to Organisation Details when name is set

### DIFF
--- a/app/controllers/edit_merchant_details/get-index-controller.js
+++ b/app/controllers/edit_merchant_details/get-index-controller.js
@@ -6,12 +6,17 @@ const lodash = require('lodash')
 // Local dependencies
 const paths = require('../../paths')
 const formatPath = require('../../utils/replace_params_in_path')
-const {response} = require('../../utils/response')
+const { response } = require('../../utils/response')
 
 module.exports = (req, res) => {
   const externalServiceId = req.service.externalId
   const merchantDetails = lodash.get(req, 'service.merchantDetails', undefined)
-  if (!merchantDetails) {
+  if (!merchantDetails ||
+    !merchantDetails.name ||
+    !merchantDetails.address_line1 ||
+    !merchantDetails.address_city ||
+    !merchantDetails.address_postcode ||
+    !merchantDetails.address_country) {
     return res.redirect(formatPath(paths.merchantDetails.edit, externalServiceId))
   }
 

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -10,36 +10,6 @@ const pactBase = require(path.join(__dirname, '/pact_base'))
 // Global setup
 const pactServices = pactBase({ array: ['service_ids'] })
 
-const buildMerchantDetailsWithDefaults = (opts = {}) => {
-  _.defaults(opts, {
-    name: 'name',
-    address_line1: 'line1',
-    address_city: 'City',
-    address_postcode: 'POSTCODE',
-    address_country: 'GB'
-  })
-
-  const merchantDetails = {
-    name: opts.name,
-    address_line1: opts.address_line1,
-    address_city: opts.address_city,
-    address_postcode: opts.address_postcode,
-    address_country: opts.address_country
-  }
-
-  if (opts.address_line2) {
-    merchantDetails.address_line2 = opts.address_line2
-  }
-  if (opts.telephone_number) {
-    merchantDetails.telephone_number = opts.telephone_number
-  }
-  if (opts.email) {
-    merchantDetails.email = opts.email
-  }
-
-  return merchantDetails
-}
-
 const buildServiceNameWithDefaults = (opts = {}) => {
   _.defaults(opts, {
     en: 'System Generated'
@@ -313,7 +283,16 @@ module.exports = {
     }
 
     if (opts.merchant_details) {
-      service.merchant_details = buildMerchantDetailsWithDefaults(opts.merchant_details)
+      service.merchant_details = _.pick(opts.merchant_details, [
+        'name',
+        'address_line1',
+        'address_line2',
+        'address_city',
+        'address_postcode',
+        'address_country',
+        'email',
+        'telephone_number'
+      ])
     }
 
     return {


### PR DESCRIPTION
When organisation details are incomplete, i.e. name or mandatory address fields are not present, take the user to the edit details page with existing details pre-filled rather than the view details page. This
fixes the 500 error thrown when the country code was not set on the view details page.


