### PR TITLE
PP-4463 Send responsible person details to Stripe

### DIFF
--- a/app/controllers/stripe-setup/responsible-person/post.controller.test.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.test.js
@@ -1,0 +1,255 @@
+'use strict'
+
+// NPM dependencies
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+// Local dependencies
+const paths = require('../../../paths')
+
+// Global setup
+chai.use(chaiAsPromised)
+const { expect } = chai // must be called after chai.use(chaiAsPromised) to use "should.eventually"
+
+describe('Responsible person POST controller', () => {
+  const firstName = 'Chesney '
+  const firstNameNormalised = 'Chesney'
+  const lastName = ' Hawkes '
+  const lastNameNormalised = 'Hawkes'
+  const addressLine1 = ' 1 and Only'
+  const addressLine1Normalised = '1 and Only'
+  const addressLine2 = 'Call me by my name '
+  const addressLine2Normalised = 'Call me by my name'
+  const addressCity = ' Nobody I’d rather be '
+  const addressCityNormalised = 'Nobody I’d rather be'
+  const addressPostcode = 'im10ny '
+  const addressPostcodeNormalised = 'IM1 0NY'
+  const dobDay = '22 '
+  const dobDayNormalised = 22
+  const dobMonth = ' 09'
+  const dobMonthNormalised = 9
+  const dobYear = '1971 '
+  const dobYearNormalised = 1971
+
+  let req
+  let res
+  let setStripeAccountSetupFlagMock
+  let createPersonMock
+
+  beforeEach(() => {
+    req = {
+      correlationId: 'correlation-id',
+      account: {
+        gateway_account_id: '1'
+      }
+    }
+    res = {
+      setHeader: sinon.stub(),
+      status: sinon.spy(),
+      redirect: sinon.spy(),
+      render: sinon.spy(),
+      locals: {
+        stripeAccount: {
+          stripeAccountId: 'acct_123example123'
+        }
+      }
+    }
+  })
+
+  it('should call Stripe with normalised details (with second address line), then connector, then redirect to the dashboard', done => {
+    createPersonMock = sinon.spy((stripeAccountId, body) => {
+      return new Promise(resolve => {
+        resolve()
+      })
+    })
+    setStripeAccountSetupFlagMock = sinon.spy((gatewayAccountId, stripeAccountSetupFlag, correlationId) => {
+      return new Promise(resolve => {
+        resolve()
+      })
+    })
+    const controller = getControllerWithMocks()
+
+    req.body = {
+      'first-name': firstName,
+      'last-name': lastName,
+      'home-address-line-1': addressLine1,
+      'home-address-line-2': addressLine2,
+      'home-address-city': addressCity,
+      'home-address-postcode': addressPostcode,
+      'dob-day': dobDay,
+      'dob-month': dobMonth,
+      'dob-year': dobYear,
+      'answers-checked': 'true'
+    }
+
+    controller(req, res)
+
+    setTimeout(() => {
+      expect(createPersonMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+        first_name: firstNameNormalised,
+        last_name: lastNameNormalised,
+        address_line1: addressLine1Normalised,
+        address_line2: addressLine2Normalised,
+        address_city: addressCityNormalised,
+        address_postcode: addressPostcodeNormalised,
+        dob_day: dobDayNormalised,
+        dob_month: dobMonthNormalised,
+        dob_year: dobYearNormalised
+      })).to.be.true
+      expect(setStripeAccountSetupFlagMock.calledWith(req.account.gateway_account_id, 'responsible_person', req.correlationId)).to.be.true // eslint-disable-line
+      expect(res.redirect.calledWith(303, paths.dashboard.index)).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should call Stripe with normalised details (no second address line), then connector, then redirect to the dashboard', done => {
+    createPersonMock = sinon.spy((stripeAccountId, body) => {
+      return new Promise(resolve => {
+        resolve()
+      })
+    })
+    setStripeAccountSetupFlagMock = sinon.spy((gatewayAccountId, stripeAccountSetupFlag, correlationId) => {
+      return new Promise(resolve => {
+        resolve()
+      })
+    })
+    const controller = getControllerWithMocks()
+
+    req.body = {
+      'first-name': firstName,
+      'last-name': lastName,
+      'home-address-line-1': addressLine1,
+      'home-address-city': addressCity,
+      'home-address-postcode': addressPostcode,
+      'dob-day': dobDay,
+      'dob-month': dobMonth,
+      'dob-year': dobYear,
+      'answers-checked': 'true'
+    }
+
+    controller(req, res)
+
+    setTimeout(() => {
+      expect(createPersonMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+        first_name: firstNameNormalised,
+        last_name: lastNameNormalised,
+        address_line1: addressLine1Normalised,
+        address_city: addressCityNormalised,
+        address_postcode: addressPostcodeNormalised,
+        dob_day: dobDayNormalised,
+        dob_month: dobMonthNormalised,
+        dob_year: dobYearNormalised
+      })).to.be.true
+      expect(setStripeAccountSetupFlagMock.calledWith(req.account.gateway_account_id, 'responsible_person', req.correlationId)).to.be.true // eslint-disable-line
+      expect(res.redirect.calledWith(303, paths.dashboard.index)).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should render error when Stripe returns error, not call connector, and not redirect', done => {
+    createPersonMock = sinon.spy((stripeAccountId, body) => {
+      return new Promise((resolve, reject) => {
+        reject(new Error())
+      })
+    })
+    setStripeAccountSetupFlagMock = sinon.spy((gatewayAccountId, stripeAccountSetupFlag, correlationId) => {
+      return new Promise(resolve => {
+        resolve()
+      })
+    })
+    const controller = getControllerWithMocks()
+
+    req.body = {
+      'first-name': firstName,
+      'last-name': lastName,
+      'home-address-line-1': addressLine1,
+      'home-address-city': addressCity,
+      'home-address-postcode': addressPostcode,
+      'dob-day': dobDay,
+      'dob-month': dobMonth,
+      'dob-year': dobYear,
+      'answers-checked': 'true'
+    }
+
+    controller(req, res)
+
+    setTimeout(() => {
+      expect(createPersonMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+        first_name: firstNameNormalised,
+        last_name: lastNameNormalised,
+        address_line1: addressLine1Normalised,
+        address_city: addressCityNormalised,
+        address_postcode: addressPostcodeNormalised,
+        dob_day: dobDayNormalised,
+        dob_month: dobMonthNormalised,
+        dob_year: dobYearNormalised
+      })).to.be.true
+      expect(setStripeAccountSetupFlagMock.notCalled).to.be.true // eslint-disable-line
+      expect(res.redirect.notCalled).to.be.true // eslint-disable-line
+      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+      expect(res.render.calledWith('error', { message: 'Please try again or contact support team' })).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should render error when connector returns error', done => {
+    createPersonMock = sinon.spy((stripeAccountId, body) => {
+      return new Promise(resolve => {
+        resolve()
+      })
+    })
+    setStripeAccountSetupFlagMock = sinon.spy((gatewayAccountId, stripeAccountSetupFlag, correlationId) => {
+      return new Promise((resolve, reject) => {
+        reject(new Error())
+      })
+    })
+    const controller = getControllerWithMocks()
+
+    req.body = {
+      'first-name': firstName,
+      'last-name': lastName,
+      'home-address-line-1': addressLine1,
+      'home-address-city': addressCity,
+      'home-address-postcode': addressPostcode,
+      'dob-day': dobDay,
+      'dob-month': dobMonth,
+      'dob-year': dobYear,
+      'answers-checked': 'true'
+    }
+
+    controller(req, res)
+
+    setTimeout(() => {
+      expect(createPersonMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+        first_name: firstNameNormalised,
+        last_name: lastNameNormalised,
+        address_line1: addressLine1Normalised,
+        address_city: addressCityNormalised,
+        address_postcode: addressPostcodeNormalised,
+        dob_day: dobDayNormalised,
+        dob_month: dobMonthNormalised,
+        dob_year: dobYearNormalised
+      })).to.be.true
+      expect(setStripeAccountSetupFlagMock.calledWith(req.account.gateway_account_id, 'responsible_person', req.correlationId)).to.be.true // eslint-disable-line
+      expect(res.redirect.notCalled).to.be.true // eslint-disable-line
+      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+      expect(res.render.calledWith('error', { message: 'Please try again or contact support team' })).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  function getControllerWithMocks () {
+    return proxyquire('./post.controller', {
+      '../../../services/clients/stripe/stripe_client': {
+        createPerson: createPersonMock
+      },
+      '../../../services/clients/connector_client': {
+        ConnectorClient: function () {
+          this.setStripeAccountSetupFlag = setStripeAccountSetupFlagMock
+        }
+      }
+    })
+  }
+})


### PR DESCRIPTION
When the user successfully fills in the responsible person form, send the details to Stripe via the Stripe SDK (2019-02-19 API version) and tell connector to flip the flag saying that the details have been submitted for this gateway account.

Add tests for this part of the controller (other parts of the controller — validation, navigation back and forth between the form and the check answers page etc. — will be tested by Cypress tests).