### PR TITLE
PP-4949 Check VAT number company number not submitted middleware

### DIFF
--- a/app/middleware/stripe-setup/check-vat-number-company-number-not-submitted.js
+++ b/app/middleware/stripe-setup/check-vat-number-company-number-not-submitted.js
@@ -1,0 +1,25 @@
+'use strict'
+
+// Local dependencies
+const { ConnectorClient } = require('../../services/clients/connector_client')
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+const { renderErrorView } = require('../../utils/response')
+const paths = require('../../paths')
+
+module.exports = function checkVatNumberCompanyNumberNotSubmitted (req, res, next) {
+  if (!req.account) {
+    renderErrorView(req, res, 'Internal server error')
+    return
+  }
+
+  connector.getStripeAccountSetup(req.account.gateway_account_id, req.correlationId).then(stripeSetupResponse => {
+    if (stripeSetupResponse.vatNumberCompanyNumber) {
+      req.flash('genericError', 'You’ve already provided your VAT number or company registration number.<br />Contact GOV.UK Pay support if you need to update them.')
+      res.redirect(303, paths.dashboard.index)
+    } else {
+      next()
+    }
+  }).catch(() => {
+    renderErrorView(req, res, 'Please try again or contact support team')
+  })
+}

--- a/app/middleware/stripe-setup/check-vat-number-company-number-not-submitted.test.js
+++ b/app/middleware/stripe-setup/check-vat-number-company-number-not-submitted.test.js
@@ -1,0 +1,126 @@
+'use strict'
+
+// NPM dependencies
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+// Local dependencies
+const paths = require('../../paths')
+
+// Global setup
+chai.use(chaiAsPromised)
+const { expect } = chai // must be called after chai.use(chaiAsPromised) to use "should.eventually"
+
+describe('Check VAT number company number not submitted middleware', () => {
+  let req
+  let res
+  let next
+
+  beforeEach(() => {
+    req = {
+      correlationId: 'correlation-id',
+      account: {
+        gateway_account_id: '1'
+      },
+      flash: sinon.spy()
+    }
+    res = {
+      setHeader: sinon.stub(),
+      status: sinon.spy(),
+      render: sinon.spy(),
+      redirect: sinon.spy()
+    }
+    next = sinon.spy()
+  })
+
+  it('should call next when VAT number company number flag is false', done => {
+    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
+      vatNumberCompanyNumber: false
+    })
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.calledOnce).to.be.true // eslint-disable-line
+      expect(req.flash.notCalled).to.be.true // eslint-disable-line
+      expect(res.redirect.notCalled).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should redirect to the dashboard with error message when VAT number company number flag is true', done => {
+    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
+      vatNumberCompanyNumber: true
+    })
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.notCalled).to.be.true // eslint-disable-line
+      expect(req.flash.calledWith('genericError', 'You’ve already provided your VAT number or company registration number.<br />Contact GOV.UK Pay support if you need to update them.')).to.be.true // eslint-disable-line
+      expect(res.redirect.calledWith(303, paths.dashboard.index)).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should render an error page when req.account is undefined', done => {
+    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
+      vatNumberCompanyNumber: false
+    })
+    req.account = undefined
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.notCalled).to.be.true // eslint-disable-line
+      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+      expect(res.render.calledWith('error', { message: 'Internal server error' })).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should render an error page when connector rejects the call', done => {
+    const middleware = getMiddlewareWithConnectorClientRejectedPromiseMock({
+      vatNumberCompanyNumber: false
+    })
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.notCalled).to.be.true // eslint-disable-line
+      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+      expect(res.render.calledWith('error', { message: 'Please try again or contact support team' })).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+})
+
+function getMiddlewareWithConnectorClientResolvedPromiseMock (getStripeAccountSetupResponse) {
+  return proxyquire('./check-vat-number-company-number-not-submitted', {
+    '../../services/clients/connector_client': {
+      ConnectorClient: function () {
+        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => {
+          return new Promise(resolve => {
+            resolve(getStripeAccountSetupResponse)
+          })
+        }
+      }
+    }
+  })
+}
+
+function getMiddlewareWithConnectorClientRejectedPromiseMock (getStripeAccountSetupResponse) {
+  return proxyquire('./check-vat-number-company-number-not-submitted', {
+    '../../services/clients/connector_client': {
+      ConnectorClient: function () {
+        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => {
+          return new Promise((resolve, reject) => {
+            reject(new Error())
+          })
+        }
+      }
+    }
+  })
+}


### PR DESCRIPTION
## WHAT

- Add `check-vat-number-company-number-not-submitted` middleware which checks [vat_number_company_number](https://github.com/alphagov/pay-connector/blob/20c4e66c45f96d2663884596c2be8ce24b9c1074/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetup.java#L18) flag is not `true` when querying [/v1/api/accounts/{accountId}/stripe-setup](https://github.com/alphagov/pay-connector/blob/20c4e66c45f96d2663884596c2be8ce24b9c1074/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupResource.java#L42) endpoint.
