### PR TITLE
PP-4976 Add organisation address page

### DIFF
--- a/app/controllers/request-to-go-live/organisation-address/get.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/get.controller.js
@@ -1,0 +1,38 @@
+'use strict'
+
+// NPM dependencies
+const lodash = require('lodash')
+
+// Local dependencies
+const goLiveStage = require('../../../models/go-live-stage')
+const { requestToGoLive } = require('../../../paths')
+const response = require('../../../utils/response')
+const { countries } = require('@govuk-pay/pay-js-commons').utils
+
+module.exports = (req, res) => {
+  // redirect on wrong stage
+  if (req.service.currentGoLiveStage !== goLiveStage.ENTERED_ORGANISATION_NAME) {
+    return res.redirect(
+      303,
+      requestToGoLive.index.replace(':externalServiceId', req.service.externalId)
+    )
+  }
+  // initialise pageData
+  let pageData = lodash.get(req, 'session.pageData.requestToGoLive.organisationAddress')
+  if (pageData) {
+    delete req.session.pageData.requestToGoLive.organisationAddress
+  } else {
+    const merchantDetails = lodash.get(req, 'service.merchantDetails')
+    pageData = lodash.pick(merchantDetails, [
+      'address_line1',
+      'address_line2',
+      'address_city',
+      'address_postcode',
+      'address_country',
+      'telephone_number'
+    ])
+  }
+  pageData.countries = countries.govukFrontendFormatted(lodash.get(pageData, 'address_country'))
+  // render
+  return response.response(req, res, 'request-to-go-live/organisation-address', pageData)
+}

--- a/app/controllers/request-to-go-live/organisation-address/index.js
+++ b/app/controllers/request-to-go-live/organisation-address/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = {
+  get: require('./get.controller')
+}

--- a/app/paths.js
+++ b/app/paths.js
@@ -167,6 +167,7 @@ module.exports = {
   requestToGoLive: {
     index: '/service/:externalServiceId/request-to-go-live',
     organisationName: '/service/:externalServiceId/request-to-go-live/organisation-name',
+    organisationAddress: '/service/:externalServiceId/request-to-go-live/organisation-address',
     chooseHowToProcessPayments: '/service/:externalServiceId/request-to-go-live/choose-how-to-process-payments',
     agreement: '/service/:externalServiceId/request-to-go-live/agreement'
   },

--- a/app/routes.js
+++ b/app/routes.js
@@ -71,6 +71,7 @@ const feedbackController = require('./controllers/feedback')
 const toggleBillingAddressController = require('./controllers/billing-address/toggle-billing-address-controller')
 const requestToGoLiveIndexController = require('./controllers/request-to-go-live/index')
 const requestToGoLiveOrganisationNameController = require('./controllers/request-to-go-live/organisation-name')
+const requestToGoLiveOrganisationAddressController = require('./controllers/request-to-go-live/organisation-address')
 const requestToGoLiveChooseHowToProcessPaymentsController = require('./controllers/request-to-go-live/choose-how-to-process-payments')
 const requestToGoLiveAgreementController = require('./controllers/request-to-go-live/agreement')
 const policyDocumentsController = require('./controllers/policy')
@@ -354,6 +355,8 @@ module.exports.bind = function (app) {
   // Request to go live: organisation name
   app.get(requestToGoLive.organisationName, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveOrganisationNameController.get)
   app.post(requestToGoLive.organisationName, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveOrganisationNameController.post)
+  // Request to go live: organisation name
+  app.get(requestToGoLive.organisationAddress, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveOrganisationAddressController.get)
   // Request to go live: choose how to process payments
   app.get(requestToGoLive.chooseHowToProcessPayments, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveChooseHowToProcessPaymentsController.get)
   app.post(requestToGoLive.chooseHowToProcessPayments, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveChooseHowToProcessPaymentsController.post)

--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -1,0 +1,188 @@
+{% extends "../layout.njk" %}
+{% from "components/input/macro.njk" import govukInput %}
+{% from "components/button/macro.njk" import govukButton %}
+{% from "components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "components/select/macro.njk" import govukSelect %}
+{% from "components/fieldset/macro.njk" import govukFieldset %}
+
+{% block pageTitle %}
+Request a live account - {{ currentService.name }} - GOV.UK Pay
+{% endblock %}
+
+{% block mainContent %}
+<div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+  {% if errors %}
+    {% set errorList = [] %}
+
+    {% if errors['address-line1'] or errors['address-line2'] %}
+      {% if errors['address-line1'] %}
+        {% set href = '#address-line1' %}
+      {% else %}
+        {% set href = '#address-line2' %}
+      {% endif %}
+      {% set errorList = (errorList.push({
+      text: 'Building and street',
+      href: href
+      }), errorList) %}
+    {% endif %}
+
+    {% if errors['address-city'] %}
+      {% set errorList = (errorList.push({
+        text: 'Town or city',
+        href: '#address-city'
+      }), errorList) %}
+    {% endif %}
+
+    {% if errors['address-country'] %}
+      {% set errorList = (errorList.push({
+        text: 'Country',
+        href: '#address-country'
+      }), errorList) %}
+    {% endif %}
+
+    {% if errors['address-postcode'] %}
+      {% set errorList = (errorList.push({
+        text: 'Postcode',
+        href: '#address-postcode'
+      }), errorList) %}
+    {% endif %}
+
+    {% if errors['telephone-number'] %}
+      {% set errorList = (errorList.push({
+        text: 'Telephone number',
+        href: '#telephone-number'
+      }), errorList) %}
+    {% endif %}
+
+    {{ govukErrorSummary({
+    titleText: 'There was a problem with the details you gave for:',
+    errorList: errorList
+    }) }}
+  {% endif %}
+
+  <span id="request-to-go-live-current-step" class="govuk-caption-l">Step 1 of 3</span>
+
+  <form id="request-to-go-live-organisation-address-form" method="post"
+        action="/service/{{ currentService.externalId }}/request-to-go-live/organisation-address" data-validate="true">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+
+    {% call govukFieldset({
+    legend: {
+    text: "What is your organisation's address?",
+    classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-4",
+    isPageHeading: true
+    }
+    }) %}
+
+    <p class="govuk-body govuk-!-margin-bottom-6">Details of your organisation will appear on your payment pages. You can change them later if you need to.</p>
+
+    {% set addressLine1Error = false %}
+    {% if errors["address-line1"] %}
+      {% set addressLine1Error = {
+      text: "Please enter a valid address"
+      } %}
+    {% endif %}
+
+    {% set cityError = false %}
+    {% if errors["address-city"] %}
+      {% set cityError = {
+      text: "Please enter a valid town or city"
+      } %}
+    {% endif %}
+
+    {% set postcodeError = false %}
+    {% if errors["address-postcode"] %}
+      {% set postcodeError = {
+      text: "Please enter a valid postcode"
+      } %}
+    {% endif %}
+
+    {% set countryError = false %}
+    {% if errors["address-country"] %}
+      {% set countryError = {
+      text: "Please enter a valid country"
+      } %}
+    {% endif %}
+
+    {{ govukInput({
+      label: {
+        html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
+      },
+      classes: "govuk-!-width-two-thirds",
+      id: "address-line1",
+      name: "address-line1",
+      errorMessage: addressLine1Error,
+      value: address_line1
+    }) }}
+
+    {{ govukInput({
+      label: {
+        html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
+      },
+      classes: "govuk-!-width-two-thirds",
+      id: "address-line2",
+      name: "address-line2",
+      value: address_line2
+    }) }}
+
+    {{ govukInput({
+      label: {
+        text: "Town or city"
+      },
+      classes: "govuk-!-width-one-half",
+      id: "address-city",
+      name: "address-city",
+      errorMessage: cityError,
+      value: address_city
+    }) }}
+
+    {{ govukSelect({
+      id: "address-country",
+      classes: "govuk-!-width-one-half",
+      name: "address-country",
+      errorMessage: countryError,
+      label: {
+        text: "Country"
+      },
+      items: countries
+    }) }}
+
+    {{ govukInput({
+      label: {
+        text: "Postcode"
+      },
+      classes: "govuk-input--width-10",
+      id: "address-postcode",
+      name: "address-postcode",
+      errorMessage: postcodeError,
+      value: address_postcode
+    }) }}
+
+    {% set phoneError = false %}
+    {% if errors["telephone-number"] %}
+      {% set phoneError = {
+        text: "Please enter a valid phone number"
+      } %}
+    {% endif %}
+
+    {{ govukInput({
+      value: telephone_number,
+      label: {
+        text: "Telephone number"
+      },
+      hint: {
+        text: "For international numbers include the country code"
+      },
+      errorMessage: phoneError,
+      id: "telephone-number",
+      name: "telephone-number",
+      classes: "govuk-!-width-two-thirds",
+      type: "tel"
+    }) }}
+
+    {% endcall %}
+
+    {{ govukButton({ text: "Continue" }) }}
+  </form>
+</div>
+{% endblock %}

--- a/test/cypress/integration/request-to-go-live/organisation_address_spec.js
+++ b/test/cypress/integration/request-to-go-live/organisation_address_spec.js
@@ -1,0 +1,105 @@
+'use strict'
+
+const utils = require('../../utils/request_to_go_live_utils')
+const { userExternalId, gatewayAccountId, serviceExternalId } = utils.variables
+
+const pageUrl = `/service/${serviceExternalId}/request-to-go-live/organisation-address`
+
+describe('The organisation address page', () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+  })
+
+  describe('The go-live stage is ENTERED_ORGANISATION_NAME and there are no existing merchant details', () => {
+    const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')
+    beforeEach(() => {
+      utils.setupStubs(serviceRole)
+
+      cy.visit(pageUrl)
+    })
+
+    it('should display form', () => {
+      cy.get('h1').should('contain', `What is your organisation's address?`)
+
+      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
+        .should('exist')
+        .within(() => {
+          cy.get('label[for="address-line1"]').should('exist')
+          cy.get('input#address-line1[name="address-line1"]').should('exist')
+          cy.get('input#address-line2[name="address-line2"]').should('exist')
+
+          cy.get('label[for="address-city"]').should('exist')
+          cy.get('input#address-city[name="address-city"]').should('exist')
+
+          cy.get('label[for="address-country"]').should('exist')
+          cy.get('select#address-country[name="address-country"]').should('exist')
+
+          cy.get('label[for="address-postcode"]').should('exist')
+          cy.get('input#address-postcode[name="address-postcode"]').should('exist')
+
+          cy.get('label[for="telephone-number"]').should('exist')
+          cy.get('span#telephone-number-hint').should('exist')
+          cy.get('input#telephone-number[name="telephone-number"]').should('exist')
+        })
+    })
+  })
+
+  describe('There are existing organisation details', () => {
+    const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')
+    const merchantDetails = {
+      address_line1: 'A building',
+      address_line2: 'A street',
+      address_city: 'A city',
+      address_country: 'IE',
+      address_postcode: 'E8 4ER',
+      telephone_number: '01134960000'
+    }
+    serviceRole.service.merchant_details = merchantDetails
+
+    it('should display form with existing details pre-filled', () => {
+      utils.setupStubs(serviceRole)
+      cy.visit(`/service/${serviceExternalId}/request-to-go-live/organisation-address`)
+
+      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
+        .within(() => {
+          cy.get('#address-line1').should('have.value', merchantDetails.address_line1)
+          cy.get('#address-line2').should('have.value', merchantDetails.address_line2)
+          cy.get('#address-city').should('have.value', merchantDetails.address_city)
+          cy.get('#address-country').should('have.value', merchantDetails.address_country)
+          cy.get('#address-postcode').should('have.value', merchantDetails.address_postcode)
+          cy.get('#telephone-number').should('have.value', merchantDetails.telephone_number)
+        })
+    })
+  })
+
+  describe('User does not have the correct permissions', () => {
+    const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')
+    serviceRole.role = { permissions: [] }
+    beforeEach(() => {
+      utils.setupStubs(serviceRole)
+    })
+
+    it('should show an error when the user does not have enough permissions', () => {
+      cy.visit(pageUrl)
+      cy.get('h1').should('contain', 'An error occurred:')
+      cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+    })
+  })
+
+  describe('Service has invalid go live stage', () => {
+    const serviceRole = utils.buildServiceRoleForGoLiveStage('NOT_STARTED')
+    beforeEach(() => {
+      utils.setupStubs(serviceRole)
+    })
+
+    it('should redirect to "Request to go live: index" page when in wrong stage', () => {
+      cy.visit(pageUrl)
+
+      cy.get('h1').should('contain', 'Request a live account')
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live`)
+      })
+    })
+  })
+})


### PR DESCRIPTION
- Add get controller and route for organisation address page.
- Add template for page.
- Add cypress tests for the page rendering correctly and pre-filling
existing organisation details.

- The elements for validation errors have been added but server-side
validation has not been set up or tested as part of this commit.

with @SandorArpa


