### PR TITLE
PP-4463 Minor content tweaks for Stripe responsible person page

### DIFF
--- a/app/middleware/stripe-setup/check-responsible-person-not-submitted.js
+++ b/app/middleware/stripe-setup/check-responsible-person-not-submitted.js
@@ -14,7 +14,7 @@ module.exports = function checkResponsiblePersonNotSubmitted (req, res, next) {
 
   connector.getStripeAccountSetup(req.account.gateway_account_id, req.correlationId).then(stripeSetupResponse => {
     if (stripeSetupResponse.responsiblePerson) {
-      req.flash('genericError', 'You’ve already nominated your responsible person.<br>Contact GOV.UK Pay support if you need to change them')
+      req.flash('genericError', 'You’ve already nominated your responsible person.<br>Contact GOV.UK Pay support if you need to change them.')
       res.redirect(303, paths.dashboard.index)
     } else {
       next()

--- a/app/middleware/stripe-setup/check-responsible-person-not-submitted.test.js
+++ b/app/middleware/stripe-setup/check-responsible-person-not-submitted.test.js
@@ -59,7 +59,7 @@ describe('Check responsible person not submitted middleware', () => {
 
     setTimeout(() => {
       expect(next.notCalled).to.be.true // eslint-disable-line
-      expect(req.flash.calledWith('genericError', 'You’ve already nominated your responsible person.<br>Contact GOV.UK Pay support if you need to change them')).to.be.true // eslint-disable-line
+      expect(req.flash.calledWith('genericError', 'You’ve already nominated your responsible person.<br>Contact GOV.UK Pay support if you need to change them.')).to.be.true // eslint-disable-line
       expect(res.redirect.calledWith(303, paths.dashboard.index)).to.be.true // eslint-disable-line
       done()
     }, 250)

--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -65,7 +65,6 @@
       }) }}
     {% endif %}
 
-    <span id="request-to-go-live-current-step" class="govuk-caption-l">Before you can take payments</span>
     <h1 class="govuk-heading-l">Nominate a responsible person</h1>
     <p class="govuk-body">Before you can take any payments, we need a named person in your organisation. It’s a legal
       requirement to provide this information. This person will be responsible for the management of payments.</p>


### PR DESCRIPTION
- Remove “Before you can take payments” heading from page
- Add period to end of error message shown if responsible person already nominated