### PR TITLE
PP-4976 Extract telephone number validation to its own module

### DIFF
--- a/app/controllers/register_service_controller.js
+++ b/app/controllers/register_service_controller.js
@@ -60,13 +60,13 @@ module.exports = {
       }
     }
 
-    const handleInvalidUserInput = (err) => {
+    const handleInvalidUserInput = (message) => {
       _.set(req, 'session.pageData.submitRegistration', {
         email,
         telephoneNumber
       })
       logger.debug(`[requestId=${correlationId}] invalid user input`)
-      req.flash('genericError', err)
+      req.flash('genericError', message)
       res.redirect(303, paths.selfCreateService.register)
     }
 
@@ -74,7 +74,7 @@ module.exports = {
       if (err.errorCode) {
         handleServerError(err)
       } else {
-        handleInvalidUserInput(err)
+        handleInvalidUserInput(err.message)
       }
     }
 
@@ -196,7 +196,7 @@ module.exports = {
       .then(resendOtpAndProceedToVerify)
       .catch(err => {
         logger.debug(`[requestId=${correlationId}] invalid user input - telephone number`)
-        req.flash('genericError', err)
+        req.flash('genericError', err.message)
         req.register_invite.telephone_number = telephoneNumber
         res.redirect(303, paths.selfCreateService.otpResend)
       })

--- a/app/controllers/register_user_controller.js
+++ b/app/controllers/register_user_controller.js
@@ -29,7 +29,7 @@ const withValidatedRegistrationCookie = (req, res, next) => {
   return shouldProceedWithRegistration(req.register_invite)
     .then(next)
     .catch(err => {
-      logger.warn(`[requestId=${correlationId}] unable to validate required cookie for registration - ${err.errorCode}`)
+      logger.warn(`[requestId=${correlationId}] unable to validate required cookie for registration - ${err.message}`)
       errorResponse(req, res, messages.missingCookie, 404)
     })
 }
@@ -80,7 +80,7 @@ module.exports = {
     const correlationId = req.correlationId
 
     if (!inviteCode) {
-      handleError(req, res, {errorCode: 404})
+      handleError(req, res, { errorCode: 404 })
       return
     }
 
@@ -111,7 +111,7 @@ module.exports = {
 
     const redirectToDetailEntry = (err) => {
       req.register_invite.telephone_number = telephoneNumber
-      req.flash('genericError', err)
+      req.flash('genericError', err.message)
       res.redirect(303, paths.registerUser.registration)
     }
 
@@ -177,7 +177,7 @@ module.exports = {
     return withValidatedRegistrationCookie(req, res, () => {
       validateOtp(verificationCode)
         .then(verifyOtpAndCreateUser)
-        .catch(err => handleInvalidOtp(err))
+        .catch(err => handleInvalidOtp(err.message))
     })
   },
 
@@ -223,7 +223,7 @@ module.exports = {
         .then(resendOtpAndProceedToVerify)
         .catch(err => {
           logger.debug(`[requestId=${correlationId}] invalid user input - telephone number`)
-          req.flash('genericError', err)
+          req.flash('genericError', err.message)
           req.register_invite.telephone_number = telephoneNumber
           res.redirect(303, paths.registerUser.reVerifyPhone)
         })

--- a/app/middleware/otp_verify.js
+++ b/app/middleware/otp_verify.js
@@ -7,7 +7,7 @@ const logger = require('winston')
 const paths = require('../paths')
 const errorResponse = require('../utils/response').renderErrorView
 const registrationService = require('../services/service_registration_service')
-const {validateOtp} = require('../utils/registration_validations')
+const { validateOtp } = require('../utils/registration_validations')
 
 // Exports
 module.exports = {
@@ -44,7 +44,7 @@ function verifyOtpForServiceInvite (req, res, next) {
       logger.warn(`[requestId=${req.correlationId}] Invalid invite code attempted ${req.code}, error = ${err.errorCode}`)
       switch (err.errorCode) {
         case undefined:
-          handleInvalidOtp(err)
+          handleInvalidOtp(err.message)
           break
         case 401:
           handleInvalidOtp('Invalid verification code')

--- a/app/middleware/validate_registration_invite_cookie.js
+++ b/app/middleware/validate_registration_invite_cookie.js
@@ -4,15 +4,15 @@
 const logger = require('winston')
 
 // Custom dependencies
-const {renderErrorView} = require('../utils/response')
-const {shouldProceedWithRegistration} = require('../utils/registration_validations')
+const { renderErrorView } = require('../utils/response')
+const { shouldProceedWithRegistration } = require('../utils/registration_validations')
 
 module.exports = function (req, res, next) {
   const correlationId = req.correlationId
   return shouldProceedWithRegistration(req.register_invite)
     .then(next)
     .catch(err => {
-      logger.warn(`[requestId=${correlationId}] unable to validate required cookie for registration - ${err}`)
+      logger.warn(`[requestId=${correlationId}] unable to validate required cookie for registration - ${err.message}`)
       renderErrorView(req, res, 'Unable to process registration at this time', 404)
     })
 }

--- a/app/utils/registration_validations.js
+++ b/app/utils/registration_validations.js
@@ -3,29 +3,16 @@
 // NPM dependencies
 const _ = require('lodash')
 const commonPassword = require('common-password')
-const { PhoneNumberUtil } = require('google-libphonenumber')
-const phoneNumberUtilInstance = PhoneNumberUtil.getInstance()
 
 // Local dependencies
 const emailValidator = require('../utils/email_tools.js')
+const { invalidTelephoneNumber } = require('../utils/validation/telephone-number-validation')
 
 // Constants
 const MIN_PASSWORD_LENGTH = 10
 const NUMBERS_ONLY = new RegExp('^[0-9]+$')
 
 // Global functions
-const invalidTelephoneNumber = telephoneNumber => {
-  if (!telephoneNumber) {
-    return true
-  }
-
-  try {
-    const parsedTelephoneNumber = phoneNumberUtilInstance.parseAndKeepRawInput(telephoneNumber, 'GB')
-    return !phoneNumberUtilInstance.isValidNumber(parsedTelephoneNumber)
-  } catch (e) {
-    return true
-  }
-}
 
 const hasValue = param => {
   return !_.isEmpty(_.trim(param))
@@ -41,7 +28,7 @@ module.exports = {
       if (hasValue(registerInviteCookie.email) && hasValue(registerInviteCookie.code)) {
         resolve()
       } else {
-        reject('registration cookie does not contain the email and/or code')
+        reject(new Error('registration cookie does not contain the email and/or code'))
       }
     })
   },
@@ -49,13 +36,13 @@ module.exports = {
   validateUserRegistrationInputs: (telephoneNumber, password) => {
     return new Promise((resolve, reject) => {
       if (invalidTelephoneNumber(telephoneNumber)) {
-        reject('Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
+        reject(new Error('Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192'))
       }
 
       if (!password || password.length < MIN_PASSWORD_LENGTH) {
-        reject('Your password must be at least 10 characters.')
+        reject(new Error('Your password must be at least 10 characters.'))
       } else if (commonPassword(password)) {
-        reject('The password you tried to create contains a common phrase or combination of characters. Choose something that’s harder to guess.')
+        reject(new Error('The password you tried to create contains a common phrase or combination of characters. Choose something that’s harder to guess.'))
       } else {
         resolve()
       }
@@ -65,7 +52,7 @@ module.exports = {
   validateRegistrationTelephoneNumber: (telephoneNumber) => {
     return new Promise((resolve, reject) => {
       if (invalidTelephoneNumber(telephoneNumber)) {
-        reject('Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
+        reject(new Error('Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192'))
       } else {
         resolve()
       }
@@ -75,7 +62,7 @@ module.exports = {
   validateOtp: (otp) => {
     return new Promise((resolve, reject) => {
       if (!otp || !NUMBERS_ONLY.test(otp)) {
-        reject('Invalid verification code')
+        reject(new Error('Invalid verification code'))
       } else {
         resolve()
       }
@@ -85,17 +72,17 @@ module.exports = {
   validateServiceRegistrationInputs: (email, telephoneNumber, password) => {
     return new Promise((resolve, reject) => {
       if (!emailValidator(email)) {
-        reject('Invalid email')
+        reject(new Error('Invalid email'))
       }
 
       if (invalidTelephoneNumber(telephoneNumber)) {
-        reject('Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
+        reject(new Error('Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192'))
       }
 
       if (!password || password.length < MIN_PASSWORD_LENGTH) {
-        reject('Your password must be at least 10 characters.')
+        reject(new Error('Your password must be at least 10 characters.'))
       } else if (commonPassword(password)) {
-        reject('The password you tried to create contains a common phrase or combination of characters. Choose something that’s harder to guess.')
+        reject(new Error('The password you tried to create contains a common phrase or combination of characters. Choose something that’s harder to guess.'))
       } else {
         resolve()
       }

--- a/app/utils/validation/telephone-number-validation.js
+++ b/app/utils/validation/telephone-number-validation.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const { PhoneNumberUtil } = require('google-libphonenumber')
+const phoneNumberUtilInstance = PhoneNumberUtil.getInstance()
+
+module.exports = {
+  invalidTelephoneNumber: telephoneNumber => {
+    if (!telephoneNumber) {
+      return true
+    }
+
+    try {
+      const parsedTelephoneNumber = phoneNumberUtilInstance.parseAndKeepRawInput(telephoneNumber, 'GB')
+      return !phoneNumberUtilInstance.isValidNumber(parsedTelephoneNumber)
+    } catch (e) {
+      return true
+    }
+  }
+}

--- a/app/utils/validation/telephone-number-validation.test.js
+++ b/app/utils/validation/telephone-number-validation.test.js
@@ -1,0 +1,39 @@
+'use strict'
+
+// NPM dependencies
+const { expect } = require('chai')
+
+// Local dependencies
+const { invalidTelephoneNumber } = require('./telephone-number-validation')
+
+describe('telephone number validation', () => {
+  it('should return false for telephone number with spaces', () => {
+    const validPhoneNumber = '0113 496 0000'
+    expect(invalidTelephoneNumber(validPhoneNumber)).to.be.false // eslint-disable-line
+  })
+
+  it('should return false for telephone number with dashes', () => {
+    const validPhoneNumber = '0113-496-0000'
+    expect(invalidTelephoneNumber(validPhoneNumber)).to.be.false // eslint-disable-line
+  })
+
+  it('should return false for telephone number with mixed format', () => {
+    const validPhoneNumber = '(0113) 496 / 0000'
+    expect(invalidTelephoneNumber(validPhoneNumber)).to.be.false // eslint-disable-line
+  })
+
+  it('should return false for telephone number with international mixed format', () => {
+    const validPhoneNumber = '+36 / (1) 496 - 0000'
+    expect(invalidTelephoneNumber(validPhoneNumber)).to.be.false // eslint-disable-line
+  })
+
+  it('should return true for invalid telephone number', () => {
+    const validPhoneNumber = 'abc'
+    expect(invalidTelephoneNumber(validPhoneNumber)).to.be.true // eslint-disable-line
+  })
+
+  it('should return true for telephone number is less than 9 digits', () => {
+    const validPhoneNumber = '12345678'
+    expect(invalidTelephoneNumber(validPhoneNumber)).to.be.true // eslint-disable-line
+  })
+})

--- a/test/unit/controller/register_service_controller/register_service_controller_test.js
+++ b/test/unit/controller/register_service_controller/register_service_controller_test.js
@@ -116,11 +116,11 @@ describe('Error handler register service', function () {
 
   it('should handle no error code as 303 redirect to index', function (done) {
     telephoneNumber = '0751234567'
-    const error = 'Invalid phone number'
+    const error = new Error('Invalid phone number')
 
     controller(error).submitRegistration(req, res).should.be.fulfilled
       .then(() => {
-        expect(flashStub.calledWith('genericError', error)).to.equal(true)
+        expect(flashStub.calledWith('genericError', error.message)).to.equal(true)
         expect(redirectStub.calledWith(303, paths.selfCreateService.register)).to.equal(true)
       }).should.notify(done)
   })
@@ -139,7 +139,7 @@ describe('Error handler register service', function () {
     controller(error).submitRegistration(req, res).should.be.fulfilled
       .then(() => {
         expect(statusStub.calledWith(errorCode)).to.eq(true)
-        expect(renderStub.calledWith('error', {message: 'Unable to process registration at this time'})).to.equal(true)
+        expect(renderStub.calledWith('error', { message: 'Unable to process registration at this time' })).to.equal(true)
       }).should.notify(done)
   })
 })

--- a/test/unit/utils/registration_validations_test.js
+++ b/test/unit/utils/registration_validations_test.js
@@ -25,86 +25,32 @@ describe('registration_validation module', () => {
         .notify(done)
     })
 
-    it('should find the provided details valid for telephone number with spaces', done => {
-      const validPhoneNumber = '0113 496 0000'
-      const validPassword = 'dnvlkHdPlfw8e_+@!'
-      validation.validateUserRegistrationInputs(validPhoneNumber, validPassword)
-        .should.be.fulfilled
-        .notify(done)
-    })
-
-    it('should find the provided details valid for telephone number with dashes', done => {
-      const validPhoneNumber = '0113-496-0000'
-      const validPassword = 'dnvlkHdPlfw8e_+@!'
-      validation.validateUserRegistrationInputs(validPhoneNumber, validPassword)
-        .should.be.fulfilled
-        .notify(done)
-    })
-
-    it('should find the provided details valid for telephone number with mixed format', done => {
-      const validPhoneNumber = '(0113) 496 / 0000'
-      const validPassword = 'dnvlkHdPlfw8e_+@!'
-      validation.validateUserRegistrationInputs(validPhoneNumber, validPassword)
-        .should.be.fulfilled
-        .notify(done)
-    })
-
-    it('should find the provided details valid for telephone number with international mixed format', done => {
-      const validPhoneNumber = '+44 / (113) 496 - 0000'
-      const validPassword = 'dnvlkHdPlfw8e_+@!'
-      validation.validateUserRegistrationInputs(validPhoneNumber, validPassword)
-        .should.be.fulfilled
-        .notify(done)
-    })
-
-    it('should find the provided telephone number invalid', done => {
-      const validPhoneNumber = 'abc'
-      const validPassword = 'dnvlkHdPlfw8e_+@!'
-      validation.validateUserRegistrationInputs(validPhoneNumber, validPassword)
-        .should.be.rejected.then((response) => {
-          expect(response).to.equal('Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
-        })
-        .should.notify(done)
-    })
-
-    it('should find the provided telephone number missing', done => {
+    it('should find the provided telephone number missing', () => {
       const validPhoneNumber = ''
       const validPassword = 'dnvlkHdPlfw8e_+@!'
-      validation.validateUserRegistrationInputs(validPhoneNumber, validPassword)
-        .should.be.rejected.then((response) => {
-          expect(response).to.equal('Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
-        })
-        .should.notify(done)
+      expect(validation.validateUserRegistrationInputs(validPhoneNumber, validPassword))
+        .to.be.rejectedWith('Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
     })
 
-    it('should invalidate if the provided password null/undefined', done => {
+    it('should invalidate if the provided password null/undefined', () => {
       const validPhoneNumber = '01134960000'
       const password = undefined
-      validation.validateUserRegistrationInputs(validPhoneNumber, password)
-        .should.be.rejected.then((response) => {
-          expect(response).to.equal('Your password must be at least 10 characters.')
-        })
-        .should.notify(done)
+      expect(validation.validateUserRegistrationInputs(validPhoneNumber, password))
+        .to.be.rejectedWith('Your password must be at least 10 characters.')
     })
 
-    it('should invalidate if the provided password a common password', done => {
+    it('should invalidate if the provided password a common password', () => {
       const validPhoneNumber = '01134960000'
       const password = '1234567890'
-      validation.validateUserRegistrationInputs(validPhoneNumber, password)
-        .should.be.rejected.then((response) => {
-          expect(response).to.equal('The password you tried to create contains a common phrase or combination of characters. Choose something that’s harder to guess.')
-        })
-        .should.notify(done)
+      expect(validation.validateUserRegistrationInputs(validPhoneNumber, password))
+        .to.be.rejectedWith('The password you tried to create contains a common phrase or combination of characters. Choose something that’s harder to guess.')
     })
 
-    it('should invalidate if the provided password invalid if its too short', done => {
+    it('should invalidate if the provided password invalid if its too short', () => {
       const validPhoneNumber = '01134960000'
       const validPassword = '2se45&s'
-      validation.validateUserRegistrationInputs(validPhoneNumber, validPassword)
-        .should.be.rejected.then((response) => {
-          expect(response).to.equal('Your password must be at least 10 characters.')
-        })
-        .should.notify(done)
+      expect(validation.validateUserRegistrationInputs(validPhoneNumber, validPassword))
+        .to.be.rejectedWith('Your password must be at least 10 characters.')
     })
   })
 
@@ -155,56 +101,18 @@ describe('registration_validation module', () => {
         .notify(done)
     })
 
-    it('should find the provided details valid for telephone number with spaces', done => {
-      const validPhoneNumber = '0113 496 0000'
-
-      validation.validateRegistrationTelephoneNumber(validPhoneNumber)
-        .should.be.fulfilled
-        .notify(done)
-    })
-
-    it('should find the provided details valid for telephone number with dashes', done => {
-      const validPhoneNumber = '0113-496-0000'
-
-      validation.validateRegistrationTelephoneNumber(validPhoneNumber)
-        .should.be.fulfilled
-        .notify(done)
-    })
-
-    it('should find the provided details valid for telephone number with mixed format', done => {
-      const validPhoneNumber = '(0113) 496 / 0000'
-
-      validation.validateRegistrationTelephoneNumber(validPhoneNumber)
-        .should.be.fulfilled
-        .notify(done)
-    })
-
-    it('should find the provided details valid for telephone number with international mixed format', done => {
-      const validPhoneNumber = '+44 / (113) 496 - 0000'
-
-      validation.validateRegistrationTelephoneNumber(validPhoneNumber)
-        .should.be.fulfilled
-        .notify(done)
-    })
-
-    it('should find the provided phone number invalid', done => {
+    it('should find the provided phone number invalid', () => {
       const validPhoneNumber = 'abc'
 
-      validation.validateRegistrationTelephoneNumber(validPhoneNumber)
-        .should.be.rejected.then((response) => {
-          expect(response).to.equal('Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
-        })
-        .should.notify(done)
+      expect(validation.validateRegistrationTelephoneNumber(validPhoneNumber))
+        .to.be.rejectedWith('Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
     })
 
-    it('should find the provided phone number missing', done => {
+    it('should find the provided phone number missing', () => {
       const validPhoneNumber = ''
 
-      validation.validateRegistrationTelephoneNumber(validPhoneNumber)
-        .should.be.rejected.then((response) => {
-          expect(response).to.equal('Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
-        })
-        .should.notify(done)
+      expect(validation.validateRegistrationTelephoneNumber(validPhoneNumber))
+        .to.be.rejectedWith('Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
     })
   })
 
@@ -217,22 +125,18 @@ describe('registration_validation module', () => {
         .notify(done)
     })
 
-    it('should error if otp is undefined', done => {
+    it('should error if otp is undefined', () => {
       const otp = undefined
 
-      validation.validateOtp(otp)
-        .should.be.rejected.then((response) => {
-          expect(response).to.equal('Invalid verification code')
-        }).should.notify(done)
+      expect(validation.validateOtp(otp))
+        .to.be.rejectedWith('Invalid verification code')
     })
 
-    it('should error if otp is not a number', done => {
+    it('should error if otp is not a number', () => {
       const otp = 'werb37'
 
-      validation.validateOtp(otp)
-        .should.be.rejected.then((response) => {
-          expect(response).to.equal('Invalid verification code')
-        }).should.notify(done)
+      expect(validation.validateOtp(otp))
+        .to.be.rejectedWith('Invalid verification code')
     })
   })
 


### PR DESCRIPTION
- Extract the phone number validation out of registration_validations into its own module telephone-number-validation so it can be re-used for validating other forms.
- Fix promise reject calls not returning an error in registration_validations which was rejected by linter.

We manually tested the following scenarios to check the errors are still displayed correctly to the user:
### Register service:
1. Enter invalid inputs for fields on register new service page
2. Enter invalid OTP code (not numbers) for validate OTP for service invite
3. Enter invalid telephone number on resend OTP code for service invite

### Invite user:
1. Enter invalid input on invite user form
2. Enter invalid OTP code (not numbers) for validate OTP for user invite
3. Enter invalid telephone number on resend OTP code for user invite

with @SandorArpa


