### PR TITLE
PP-4976 Move server side validations so they can be reused

### DIFF
--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -11,7 +11,7 @@ const paths = require('../../../paths')
 const { response, renderErrorView } = require('../../../utils/response')
 const {
   validateMandatoryField, validateOptionalField, validatePostcode, validateDateOfBirth
-} = require('./responsible-person-validations')
+} = require('../../../utils/validation/server-side-form-validations')
 const { createPerson } = require('../../../services/clients/stripe/stripe_client')
 const { ConnectorClient } = require('../../../services/clients/connector_client')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)

--- a/app/utils/validation/server-side-form-validations.js
+++ b/app/utils/validation/server-side-form-validations.js
@@ -8,7 +8,13 @@ const ukPostcode = require('uk-postcode')
 const {
   isEmpty,
   isFieldGreaterThanMaxLengthChars
-} = require('../../../browsered/field-validation-checks')
+} = require('../../browsered/field-validation-checks')
+const { invalidTelephoneNumber } = require('./telephone-number-validation')
+
+const validReturnObject = {
+  valid: true,
+  message: null
+}
 
 exports.validateOptionalField = function validateOptionalField (value, maxLength) {
   if (!isEmpty(value)) {
@@ -22,10 +28,7 @@ exports.validateOptionalField = function validateOptionalField (value, maxLength
     }
   }
 
-  return {
-    valid: true,
-    message: null
-  }
+  return validReturnObject
 }
 
 exports.validateMandatoryField = function validateMandatoryField (value, maxLength) {
@@ -45,19 +48,41 @@ exports.validateMandatoryField = function validateMandatoryField (value, maxLeng
     }
   }
 
-  return {
-    valid: true,
-    message: null
-  }
+  return validReturnObject
 }
 
-exports.validatePostcode = function validatePostcode (postcode) {
+exports.validatePhoneNumber = function validatePhoneNumber (phoneNumber) {
+  const isEmptyErrorMessage = isEmpty(phoneNumber)
+  if (isEmptyErrorMessage) {
+    return {
+      valid: false,
+      message: isEmptyErrorMessage
+    }
+  }
+
+  const phoneNumberInvalid = invalidTelephoneNumber(phoneNumber)
+  if (phoneNumberInvalid) {
+    return {
+      valid: false,
+      message: 'Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192'
+    }
+  }
+
+  return validReturnObject
+}
+
+exports.validatePostcode = function validatePostcode (postcode, countryCode) {
   const isEmptyErrorMessage = isEmpty(postcode)
   if (isEmptyErrorMessage) {
     return {
       valid: false,
       message: isEmptyErrorMessage
     }
+  }
+
+  // only do proper validation on UK postcodes
+  if (countryCode && countryCode !== 'GB') {
+    return validReturnObject
   }
 
   if (!/^[A-z0-9 ]+$/.test(postcode)) {
@@ -75,10 +100,7 @@ exports.validatePostcode = function validatePostcode (postcode) {
     }
   }
 
-  return {
-    valid: true,
-    message: null
-  }
+  return validReturnObject
 }
 
 exports.validateDateOfBirth = function validateDateOfBirth (day, month, year) {
@@ -170,8 +192,5 @@ exports.validateDateOfBirth = function validateDateOfBirth (day, month, year) {
     }
   }
 
-  return {
-    valid: true,
-    message: null
-  }
+  return validReturnObject
 }

--- a/app/utils/validation/server-side-form-validations.test.js
+++ b/app/utils/validation/server-side-form-validations.test.js
@@ -5,7 +5,7 @@ const { expect } = require('chai')
 const moment = require('moment-timezone')
 
 // Local dependencies
-const responsiblePersonValidations = require('./responsible-person-validations')
+const validations = require('./server-side-form-validations')
 
 const BLANK_TEXT = ''
 const MAX_LENGTH = 25
@@ -14,15 +14,15 @@ const LOOOONG_TEXT = 'abcdefghijklmnopqrstuvwxyz'
 describe('Responsible person page field validations', () => {
   describe('optional text field validations', () => {
     it('should validate that optional text is valid', () => {
-      expect(responsiblePersonValidations.validateOptionalField('some text', MAX_LENGTH).valid).to.be.true // eslint-disable-line
+      expect(validations.validateOptionalField('some text', MAX_LENGTH).valid).to.be.true // eslint-disable-line
     })
 
     it('should validate that blank text is valid', () => {
-      expect(responsiblePersonValidations.validateOptionalField(BLANK_TEXT).valid).to.be.true // eslint-disable-line
+      expect(validations.validateOptionalField(BLANK_TEXT).valid).to.be.true // eslint-disable-line
     })
 
     it('should not be valid when optional text is too long', () => {
-      expect(responsiblePersonValidations.validateOptionalField(LOOOONG_TEXT, MAX_LENGTH)).to.deep.equal({
+      expect(validations.validateOptionalField(LOOOONG_TEXT, MAX_LENGTH)).to.deep.equal({
         valid: false,
         message: 'The text is too long'
       })
@@ -31,18 +31,18 @@ describe('Responsible person page field validations', () => {
 
   describe('mandatory text field validations', () => {
     it('should validate that mandatory text is valid', () => {
-      expect(responsiblePersonValidations.validateMandatoryField('some text', MAX_LENGTH).valid).to.be.true // eslint-disable-line
+      expect(validations.validateMandatoryField('some text', MAX_LENGTH).valid).to.be.true // eslint-disable-line
     })
 
     it('should not be valid when mandatory text is blank', () => {
-      expect(responsiblePersonValidations.validateMandatoryField(BLANK_TEXT, MAX_LENGTH)).to.deep.equal({
+      expect(validations.validateMandatoryField(BLANK_TEXT, MAX_LENGTH)).to.deep.equal({
         valid: false,
         message: 'This field cannot be blank'
       })
     })
 
     it('should not be valid when mandatory text is too long', () => {
-      expect(responsiblePersonValidations.validateMandatoryField(LOOOONG_TEXT, MAX_LENGTH)).to.deep.equal({
+      expect(validations.validateMandatoryField(LOOOONG_TEXT, MAX_LENGTH)).to.deep.equal({
         valid: false,
         message: 'The text is too long'
       })
@@ -51,142 +51,153 @@ describe('Responsible person page field validations', () => {
 
   describe('postcode validations', () => {
     it('should be valid when UK postcode', () => {
-      expect(responsiblePersonValidations.validatePostcode('NW1 5GH').valid).to.be.true // eslint-disable-line
+      expect(validations.validatePostcode('NW1 5GH').valid).to.be.true // eslint-disable-line
     })
 
     it('should be valid when UK postcode but all lower-case', () => {
-      expect(responsiblePersonValidations.validatePostcode('nw1 5gh').valid).to.be.true // eslint-disable-line
+      expect(validations.validatePostcode('nw1 5gh').valid).to.be.true // eslint-disable-line
     })
 
     it('should be valid when UK postcode but no space', () => {
-      expect(responsiblePersonValidations.validatePostcode('NW15GH').valid).to.be.true // eslint-disable-line
+      expect(validations.validatePostcode('NW15GH').valid).to.be.true // eslint-disable-line
     })
 
     it('should be valid when UK postcode but no space and all lower-case', () => {
-      expect(responsiblePersonValidations.validatePostcode('nw15gh').valid).to.be.true // eslint-disable-line
+      expect(validations.validatePostcode('nw15gh').valid).to.be.true // eslint-disable-line
     })
 
     it('should not be valid when postcode is blank', () => {
-      expect(responsiblePersonValidations.validatePostcode(BLANK_TEXT)).to.deep.equal({
+      expect(validations.validatePostcode(BLANK_TEXT)).to.deep.equal({
         valid: false,
         message: 'This field cannot be blank'
       })
     })
 
     it('should not be valid when postcode is UK postcode with extra punctuation', () => {
-      expect(responsiblePersonValidations.validatePostcode('NW1! 5GH')).to.deep.equal({
+      expect(validations.validatePostcode('NW1! 5GH')).to.deep.equal({
         valid: false,
         message: 'Please enter a real postcode'
       })
     })
 
-    it('should not be valid when postcode is not UK postcode', () => {
-      expect(responsiblePersonValidations.validatePostcode('CA90210')).to.deep.equal({
+    it('should not be valid when postcode is not UK postcode and country not provided', () => {
+      expect(validations.validatePostcode('CA90210')).to.deep.equal({
         valid: false,
         message: 'Please enter a real postcode'
       })
+    })
+
+    it('should not be valid when postcode is not UK postcode and country is GB', () => {
+      expect(validations.validatePostcode('CA90210', 'GB')).to.deep.equal({
+        valid: false,
+        message: 'Please enter a real postcode'
+      })
+    })
+
+    it('should be a valid postcode when postcode is not UK postcode and country is not GB', () => {
+      expect(validations.validatePostcode('CA90210', 'IE').valid).to.be.true // eslint-disable-line
     })
   })
 
   describe('date of birth validations', () => {
     it('should be valid when date of birth in the past', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('10', '6', '2000').valid).to.be.true // eslint-disable-line
+      expect(validations.validateDateOfBirth('10', '6', '2000').valid).to.be.true // eslint-disable-line
     })
 
     it('should be valid when day has leading zero', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('01', '6', '2000').valid).to.be.true // eslint-disable-line
+      expect(validations.validateDateOfBirth('01', '6', '2000').valid).to.be.true // eslint-disable-line
     })
 
     it('should be valid when month has leading zero', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('10', '06', '2000').valid).to.be.true // eslint-disable-line
+      expect(validations.validateDateOfBirth('10', '06', '2000').valid).to.be.true // eslint-disable-line
     })
 
     it('should not be valid nothing entered', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('', '', '')).to.deep.equal({
+      expect(validations.validateDateOfBirth('', '', '')).to.deep.equal({
         valid: false,
         message: 'Enter the date of birth'
       })
     })
 
     it('should not be valid when no day entered', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('', '6', '2000')).to.deep.equal({
+      expect(validations.validateDateOfBirth('', '6', '2000')).to.deep.equal({
         valid: false,
         message: 'Date of birth must include a day'
       })
     })
 
     it('should not be valid when no month entered', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('10', '', '2000')).to.deep.equal({
+      expect(validations.validateDateOfBirth('10', '', '2000')).to.deep.equal({
         valid: false,
         message: 'Date of birth must include a month'
       })
     })
 
     it('should not be valid when no year entered', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('10', '6', '')).to.deep.equal({
+      expect(validations.validateDateOfBirth('10', '6', '')).to.deep.equal({
         valid: false,
         message: 'Date of birth must include a year'
       })
     })
 
     it('should not be valid when no day and month entered', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('', '', '2000')).to.deep.equal({
+      expect(validations.validateDateOfBirth('', '', '2000')).to.deep.equal({
         valid: false,
         message: 'Date of birth must include a day and month'
       })
     })
 
     it('should not be valid when no day and year entered', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('', '6', '')).to.deep.equal({
+      expect(validations.validateDateOfBirth('', '6', '')).to.deep.equal({
         valid: false,
         message: 'Date of birth must include a day and year'
       })
     })
 
     it('should not be valid when no month and year entered', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('10', '', '')).to.deep.equal({
+      expect(validations.validateDateOfBirth('10', '', '')).to.deep.equal({
         valid: false,
         message: 'Date of birth must include a month and year'
       })
     })
 
     it('should not be valid when day does not contain numbers', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('cakeday', '6', '2000')).to.deep.equal({
+      expect(validations.validateDateOfBirth('cakeday', '6', '2000')).to.deep.equal({
         valid: false,
         message: 'Enter a real date of birth'
       })
     })
 
     it('should not be valid when month does not contain numbers', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('10', 'Prairial', '2000')).to.deep.equal({
+      expect(validations.validateDateOfBirth('10', 'Prairial', '2000')).to.deep.equal({
         valid: false,
         message: 'Enter a real date of birth'
       })
     })
 
     it('should not be valid when year does not contain numbers', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('10', '6', 'dragon')).to.deep.equal({
+      expect(validations.validateDateOfBirth('10', '6', 'dragon')).to.deep.equal({
         valid: false,
         message: 'Enter a real date of birth'
       })
     })
 
     it('should not be valid when year does not have four digits', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('10', '6', '00')).to.deep.equal({
+      expect(validations.validateDateOfBirth('10', '6', '00')).to.deep.equal({
         valid: false,
         message: 'Year must have 4 numbers'
       })
     })
 
     it('should not be valid when day is a negative number', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('-10', '6', '2000')).to.deep.equal({
+      expect(validations.validateDateOfBirth('-10', '6', '2000')).to.deep.equal({
         valid: false,
         message: 'Enter a real date of birth'
       })
     })
 
     it('should not be valid when date does not exist', () => {
-      expect(responsiblePersonValidations.validateDateOfBirth('29', '02', '1999')).to.deep.equal({
+      expect(validations.validateDateOfBirth('29', '02', '1999')).to.deep.equal({
         valid: false,
         message: 'Enter a real date of birth'
       })
@@ -195,10 +206,30 @@ describe('Responsible person page field validations', () => {
     it('should not be valid when date is in the future', () => {
       const dateInTheMysteriousFuture = moment().add(1, 'days')
 
-      expect(responsiblePersonValidations.validateDateOfBirth(dateInTheMysteriousFuture.date(),
+      expect(validations.validateDateOfBirth(dateInTheMysteriousFuture.date(),
         dateInTheMysteriousFuture.month() + 1, dateInTheMysteriousFuture.year())).to.deep.equal({
         valid: false,
         message: 'Date of birth must be in the past'
+      })
+    })
+  })
+
+  describe('phone number validation', () => {
+    it('should be valid for valid phone number', () => {
+      expect(validations.validatePhoneNumber('0113 496 0000').valid).to.be.true // eslint-disable-line
+    })
+
+    it('should not be valid for empty phone number', () => {
+      expect(validations.validatePhoneNumber('')).to.deep.equal({
+        valid: false,
+        message: 'This field cannot be blank'
+      })
+    })
+
+    it('should not be valid for invalid phone number', () => {
+      expect(validations.validatePhoneNumber('abd')).to.deep.equal({
+        valid: false,
+        message: 'Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192'
       })
     })
   })


### PR DESCRIPTION
- Move and rename responsible-person-validations to server-side-form-validations as most of these validations can be reused for the organisation address page.
- Add method to validate phone number field to server-side-form-validations
- Modify validate PostCode method to take a countryCode and only perform UK postcode validation for country code GB

with @SandorArpa

