### PR TITLE
PP-4949 Various code improvements

### DIFF
--- a/app/services/clients/stripe/stripeBankAccount.model.js
+++ b/app/services/clients/stripe/stripeBankAccount.model.js
@@ -32,8 +32,8 @@ function build (params) {
       country: 'GB',
       currency: 'GBP',
       account_holder_type: 'company',
-      routing_number: params.bank_account_sort_code.replace(/\D/g, ''),
-      account_number: params.bank_account_number.replace(/\D/g, '')
+      routing_number: params.bank_account_sort_code,
+      account_number: params.bank_account_number
     }
   }
 }

--- a/app/services/clients/stripe/stripeBankAccount.model.test.js
+++ b/app/services/clients/stripe/stripeBankAccount.model.test.js
@@ -28,24 +28,6 @@ describe('StripeBankAccount', () => {
     })
   })
 
-  it('should successfully create a StripeBankAccount object with normalised fields', () => {
-    const stripeBankAccount = new StripeBankAccount({
-      bank_account_sort_code: ' 00 - 00 00 ',
-      bank_account_number: ' 000 123 45 '
-    })
-
-    expect(stripeBankAccount.basicObject()).to.deep.equal({
-      external_account: {
-        object: 'bank_account',
-        country: 'GB',
-        currency: 'GBP',
-        account_holder_type: 'company',
-        routing_number: '000000',
-        account_number: '00012345'
-      }
-    })
-  })
-
   it('should fail when sort code is numeric', () => {
     const bankAccountSortCode = 108800
     const bankAccountNumber = '00012345'

--- a/app/services/clients/stripe/stripePerson.model.js
+++ b/app/services/clients/stripe/stripePerson.model.js
@@ -7,12 +7,12 @@ const schema = {
   first_name: Joi.string().required(),
   last_name: Joi.string().required(),
   address_line1: Joi.string().required(),
-  address_line2:  Joi.string(),
+  address_line2: Joi.string().optional(),
   address_city: Joi.string().required(),
   address_postcode: Joi.string().required(),
   dob_day: Joi.number().integer().strict().min(1).max(31),
   dob_month: Joi.number().integer().strict().min(1).max(12),
-  dob_year: Joi.number().integer().strict().min(1000).max(9999),
+  dob_year: Joi.number().integer().strict().min(1000).max(9999)
 }
 
 class StripePerson {

--- a/app/views/stripe-setup/bank-details/check-your-answers.njk
+++ b/app/views/stripe-setup/bank-details/check-your-answers.njk
@@ -11,7 +11,7 @@
 
     <h1 class="govuk-heading-l">Check details before saving</h1>
 
-    <form id="stripe-setup-bank-details-check-display-form" method="post" action="/bank-details" novalidate>
+    <form id="bank-details-check-display-form" method="post" action="/bank-details" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
       <input name="answers-need-changing" type="hidden" value="true"/>
       <input name="account-number" type="hidden" value="{{ accountNumber }}"/>
@@ -22,11 +22,11 @@
           <dt class="govuk-summary-list__key">
             Account number
           </dt>
-          <dd id="stripe-setup-account-number-value" class="govuk-summary-list__value">
+          <dd id="account-number-value" class="govuk-summary-list__value">
             {{ accountNumber }}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <button id="stripe-setup-account-number-change-button" class="govuk-button--as-link" type="submit">
+            <button id="account-number-change-button" class="govuk-button--as-link" type="submit">
               Change
               <span class="govuk-visually-hidden">account number</span>
             </button>
@@ -36,11 +36,11 @@
           <dt class="govuk-summary-list__key">
             Sort code
           </dt>
-          <dd id="stripe-setup-sort-code-value" class="govuk-summary-list__value">
+          <dd id="sort-code-value" class="govuk-summary-list__value">
             {{ sortCode }}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <button id="stripe-setup-sort-code-change-button" class="govuk-button--as-link" type="submit">
+            <button id="sort-code-change-button" class="govuk-button--as-link" type="submit">
               Change
               <span class="govuk-visually-hidden">sort code</span>
             </button>
@@ -49,7 +49,7 @@
       </dl>
     </form>
 
-    <form id="stripe-setup-bank-details-check-submit-form" method="post" action="/bank-details" novalidate>
+    <form id="bank-details-check-submit-form" method="post" action="/bank-details" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
       <input name="answers-checked" type="hidden" value="true"/>
       <input name="account-number" type="hidden" value="{{ accountNumber }}"/>

--- a/app/views/stripe-setup/bank-details/index.njk
+++ b/app/views/stripe-setup/bank-details/index.njk
@@ -14,13 +14,13 @@
       {% if errors['account-number'] %}
         {% set errorList = (errorList.push({
           text: 'Account number',
-          href: '#stripe-setup-account-number-input'
+          href: '#account-number-input'
         }), errorList) %}
       {% endif %}
       {% if errors['sort-code'] %}
         {% set errorList = (errorList.push({
           text: 'Sort code',
-          href: '#stripe-setup-sort-code-input'
+          href: '#sort-code-input'
         }), errorList) %}
       {% endif %}
       {{ govukErrorSummary({
@@ -31,7 +31,7 @@
     <h1 class="govuk-heading-l govuk-!-margin-top-6 govuk-!-margin-bottom-2">Add bank details</h1>
     <p class="govuk-body govuk-!-margin-bottom-6">This is the bank account payments will go into.</p>
 
-    <form id="stripe-setup-bank-details-form" method="post"
+    <form id="bank-details-form" method="post"
           action="/bank-details" data-validate="true">
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
@@ -46,7 +46,7 @@
         label: {
           text: "Account number"
         },
-        id: "stripe-setup-account-number-input",
+        id: "account-number-input",
         name: "account-number",
         classes: "govuk-input--width-10",
         value: accountNumber,
@@ -69,7 +69,7 @@
         label: {
           text: "Sort code"
         },
-        id: "stripe-setup-sort-code-input",
+        id: "sort-code-input",
         name: "sort-code",
         classes: "govuk-input--width-10",
         value: sortCode,

--- a/app/views/stripe-setup/responsible-person/check-your-answers.njk
+++ b/app/views/stripe-setup/responsible-person/check-your-answers.njk
@@ -12,7 +12,7 @@
     <span id="request-to-go-live-current-step" class="govuk-caption-l">Before you can take payments</span>
     <h1 class="govuk-heading-l">Check details before saving</h1>
 
-    <form action="/responsible-person" method="POST" novalidate>
+    <form id="responsible-person-check-display-form" method="post" action="/responsible-person" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}">
       <input name="answers-need-changing" type="hidden" value="true">
       <input name="first-name" type="hidden" value="{{ firstName }}">
@@ -34,7 +34,7 @@
             {{ firstName }}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <button class="govuk-button--as-link" type="submit">
+            <button id="first-name-change-button" class="govuk-button--as-link" type="submit">
               Change
               <span class="govuk-visually-hidden">first name</span>
             </button>
@@ -48,7 +48,7 @@
             {{ lastName }}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <button class="govuk-button--as-link" type="submit">
+            <button id="last-name-change-button" class="govuk-button--as-link" type="submit">
               Change
               <span class="govuk-visually-hidden">last name</span>
             </button>
@@ -70,7 +70,7 @@
             {{ homeAddressPostcode }}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <button class="govuk-button--as-link" type="submit">
+            <button id="home-address-change-button" class="govuk-button--as-link" type="submit">
               Change
               <span class="govuk-visually-hidden">home address</span>
             </button>
@@ -84,7 +84,7 @@
             {{ friendlyDateOfBirth }}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <button class="govuk-button--as-link" type="submit">
+            <button id="date-of-birth-change-button" class="govuk-button--as-link" type="submit">
               Change
               <span class="govuk-visually-hidden">date of birth</span>
             </button>
@@ -93,7 +93,7 @@
       </dl>
     </form>
 
-    <form method="post" action="/responsible-person" novalidate>
+    <form id="responsible-person-check-submit-form" method="post" action="/responsible-person" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}">
       <input name="answers-checked" type="hidden" value="true">
       <input name="first-name" type="hidden" value="{{ firstName }}">

--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -74,7 +74,7 @@
       <li>the head of finance</li>
       <li>the head of the organisation</li>
     </ul>
-    <form method="post" action="/responsible-person">
+    <form id="responsible-person-form" method="post" action="/responsible-person" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {% set firstNameError = false %}

--- a/test/cypress/integration/stripe-setup/responsible_person_spec.js
+++ b/test/cypress/integration/stripe-setup/responsible_person_spec.js
@@ -25,7 +25,7 @@ describe('Stripe setup: responsible person page', () => {
   const dobYear = '1971'
   const typedDobYear = '1971 '
   const friendlyDob = '25 February 1971'
-  const longText = 'This text is 300 ...............................................................................' +
+  const longText = 'This text is 300 ................................................................................' +
     '...............................................................................................................' +
     '............................................................................ characters long'
 
@@ -83,7 +83,7 @@ describe('Stripe setup: responsible person page', () => {
     it('should display form', () => {
       cy.get('h1').should('contain', 'Nominate a responsible person')
 
-      cy.get('form[method=post][action="/responsible-person"]').should('exist')
+      cy.get('#responsible-person-form').should('exist')
         .within(() => {
           cy.get('label[for="first-name"]').should('exist')
           cy.get('input#first-name[name="first-name"][autocomplete="given-name"]').should('exist')
@@ -118,7 +118,7 @@ describe('Stripe setup: responsible person page', () => {
     })
 
     it('should display check answers page with second address line', () => {
-      cy.get('form[method=post][action="/responsible-person"]').within(() => {
+      cy.get('#responsible-person-form').within(() => {
         cy.get('#first-name').type(typedFirstName)
         cy.get('#last-name').type(typedLastName)
         cy.get('#home-address-line-1').type(typedAddressLine1)
@@ -133,10 +133,7 @@ describe('Stripe setup: responsible person page', () => {
 
       cy.get('h1').should('contain', 'Check details before saving')
 
-      const hiddenFieldIdentifyingSummaryForm = cy.get('form[method=post][action="/responsible-person"] > ' +
-        'input[type=hidden][name="answers-need-changing"][value="true"]')
-
-      hiddenFieldIdentifyingSummaryForm.parent().within(() => {
+      cy.get('#responsible-person-check-display-form').within(() => {
         cy.get('input[type=hidden][name="first-name"]').should('have.attr', 'value', firstName)
         cy.get('input[type=hidden][name="last-name"]').should('have.attr', 'value', lastName)
 
@@ -162,10 +159,7 @@ describe('Stripe setup: responsible person page', () => {
         })
       })
 
-      const hiddenFieldIdentifyingSaveForm = cy.get('form[method=post][action="/responsible-person"] > ' +
-        'input[type=hidden][name="answers-checked"][value="true"]')
-
-      hiddenFieldIdentifyingSaveForm.parent().within(() => {
+      cy.get('#responsible-person-check-submit-form').within(() => {
         cy.get('input[type=hidden][name="first-name"]').should('have.attr', 'value', firstName)
         cy.get('input[type=hidden][name="last-name"]').should('have.attr', 'value', lastName)
 
@@ -183,7 +177,7 @@ describe('Stripe setup: responsible person page', () => {
     })
 
     it('should display check answers page without second address line', () => {
-      cy.get('form[method=post][action="/responsible-person"]').within(() => {
+      cy.get('#responsible-person-form').within(() => {
         cy.get('#first-name').type(typedFirstName)
         cy.get('#last-name').type(typedLastName)
         cy.get('#home-address-line-1').type(typedAddressLine1)
@@ -197,10 +191,7 @@ describe('Stripe setup: responsible person page', () => {
 
       cy.get('h1').should('contain', 'Check details before saving')
 
-      const hiddenFieldIdentifyingSummaryForm = cy.get('form[method=post][action="/responsible-person"] ' +
-        'input[type=hidden][name="answers-need-changing"][value="true"]')
-
-      hiddenFieldIdentifyingSummaryForm.parent().within(() => {
+      cy.get('#responsible-person-check-display-form').within(() => {
         cy.get('input[type=hidden][name="first-name"]').should('have.attr', 'value', firstName)
         cy.get('input[type=hidden][name="last-name"]').should('have.attr', 'value', lastName)
 
@@ -224,10 +215,7 @@ describe('Stripe setup: responsible person page', () => {
         })
       })
 
-      const hiddenFieldIdentifyingSaveForm = cy.get('form[method=post][action="/responsible-person"] ' +
-        'input[type=hidden][name="answers-checked"][value="true"]')
-
-      hiddenFieldIdentifyingSaveForm.parent().within(() => {
+      cy.get('#responsible-person-check-submit-form').within(() => {
         cy.get('input[type=hidden][name="first-name"]').should('have.attr', 'value', firstName)
         cy.get('input[type=hidden][name="last-name"]').should('have.attr', 'value', lastName)
 
@@ -244,7 +232,7 @@ describe('Stripe setup: responsible person page', () => {
     })
 
     it('should allow going back to change answers', () => {
-      cy.get('form[method=post][action="/responsible-person"]').within(() => {
+      cy.get('#responsible-person-form').within(() => {
         cy.get('#first-name').type(typedFirstName)
         cy.get('#last-name').type(typedLastName)
         cy.get('#home-address-line-1').type(typedAddressLine1)
@@ -259,12 +247,16 @@ describe('Stripe setup: responsible person page', () => {
 
       cy.get('h1').should('contain', 'Check details before saving')
 
-      cy.get('form[method=post][action="/responsible-person"] >  input[type=hidden][name="answers-need-changing"][value="true"]')
-        .parent().get('button[type=submit]').first().click()
+      cy.get('#first-name-change-button[type=submit]').should('exist')
+      cy.get('#last-name-change-button[type=submit]').should('exist')
+      cy.get('#home-address-change-button[type=submit]').should('exist')
+      cy.get('#date-of-birth-change-button[type=submit]').should('exist')
+
+      cy.get('#first-name-change-button[type=submit]').click()
 
       cy.get('h1').should('contain', 'Nominate a responsible person')
 
-      cy.get('form[method=post][action="/responsible-person"]').should('exist').within(() => {
+      cy.get('#responsible-person-form').should('exist').within(() => {
         cy.get('input#first-name[name="first-name"][autocomplete="given-name"]').should('have.attr', 'value', firstName)
         cy.get('input#last-name[name="last-name"][autocomplete="family-name"]').should('have.attr', 'value', lastName)
 
@@ -285,7 +277,7 @@ describe('Stripe setup: responsible person page', () => {
     })
 
     it('should show errors when validation fails', () => {
-      cy.get('form[method=post][action="/responsible-person"]').within(() => {
+      cy.get('#responsible-person-form').within(() => {
         cy.get('#first-name').type(typedFirstName)
         // No last name, which is an error
         cy.get('#home-address-line-1').type(typedAddressLine1)
@@ -306,7 +298,7 @@ describe('Stripe setup: responsible person page', () => {
         cy.get('a[href="#home-address-postcode"]').should('contain', 'Postcode')
       })
 
-      cy.get('form[method=post][action="/responsible-person"]').should('exist').within(() => {
+      cy.get('#responsible-person-form').should('exist').within(() => {
         cy.get('.govuk-form-group--error > input#last-name').parent().should('exist').within(() => {
           cy.get('.govuk-error-message').should('exist')
           cy.get('input#last-name[name=last-name][autocomplete=family-name]').should('exist')
@@ -334,7 +326,7 @@ describe('Stripe setup: responsible person page', () => {
     })
 
     it('should show error for second address line using first address line label', () => {
-      cy.get('form[method=post][action="/responsible-person"]').within(() => {
+      cy.get('#responsible-person-form').within(() => {
         cy.get('#first-name').type(typedLastName)
         cy.get('#last-name').type(typedLastName)
         cy.get('#home-address-line-1').type(typedAddressLine1)
@@ -351,7 +343,7 @@ describe('Stripe setup: responsible person page', () => {
         cy.get('a[href="#home-address-line-2"]').should('contain', 'Home address')
       })
 
-      cy.get('form[method=post][action="/responsible-person"]').should('exist').within(() => {
+      cy.get('#responsible-person-form').should('exist').within(() => {
         cy.get('.govuk-form-group--error > input#home-address-line-2').parent().should('exist').within(() => {
           cy.get('.govuk-error-message').should('exist')
           cy.get('input#home-address-line-2').should('have.attr', 'value', longText)
@@ -360,7 +352,7 @@ describe('Stripe setup: responsible person page', () => {
     })
 
     it('should only show address once in error summary if error in both address lines', () => {
-      cy.get('form[method=post][action="/responsible-person"]').within(() => {
+      cy.get('#responsible-person-form').within(() => {
         cy.get('#first-name').type(typedLastName)
         cy.get('#last-name').type(typedLastName)
         cy.get('#home-address-line-1').type(longText)
@@ -378,7 +370,7 @@ describe('Stripe setup: responsible person page', () => {
         cy.get('a[href="#home-address-line-2"]').should('not.exist')
       })
 
-      cy.get('form[method=post][action="/responsible-person"]').should('exist').within(() => {
+      cy.get('#responsible-person-form').should('exist').within(() => {
         cy.get('.govuk-form-group--error > input#home-address-line-1').parent().should('exist').within(() => {
           cy.get('.govuk-error-message').should('exist')
           cy.get('input#home-address-line-1').should('have.attr', 'value', longText)
@@ -391,7 +383,7 @@ describe('Stripe setup: responsible person page', () => {
     })
 
     it('should error when validation for the date of birth fails', () => {
-      cy.get('form[method=post][action="/responsible-person"]').within(() => {
+      cy.get('#responsible-person-form').within(() => {
         cy.get('#first-name').type(typedLastName)
         cy.get('#last-name').type(typedLastName)
         cy.get('#home-address-line-1').type(typedAddressLine1)
@@ -410,7 +402,7 @@ describe('Stripe setup: responsible person page', () => {
         cy.get('a[href="#dob-year"]').should('not.exist')
       })
 
-      cy.get('form[method=post][action="/responsible-person"]').should('exist').within(() => {
+      cy.get('#responsible-person-form').should('exist').within(() => {
         cy.get('.govuk-form-group--error > fieldset > #dob-error').parent().parent().should('exist').within(() => {
           cy.get('.govuk-error-message').should('exist')
           cy.get('input#dob-day').should('have.attr', 'value', '29')
@@ -455,7 +447,7 @@ describe('Stripe setup: responsible person page', () => {
     })
 
     it('should redirect to dashboard with error message instead of saving details', () => {
-      cy.get('form[method=post][action="/responsible-person"]').within(() => {
+      cy.get('#responsible-person-form').within(() => {
         cy.get('#first-name').type(typedFirstName)
         cy.get('#last-name').type(typedLastName)
         cy.get('#home-address-line-1').type(typedAddressLine1)
@@ -470,8 +462,7 @@ describe('Stripe setup: responsible person page', () => {
 
       cy.get('h1').should('contain', 'Check details before saving')
 
-      cy.get('form[method=post][action="/responsible-person"] > input[type=hidden][name="answers-checked"][value="true"]')
-        .parent().get('button[type=submit]').first().click()
+      cy.get('#responsible-person-check-submit-form > button[type=submit]').click()
 
       cy.get('h1').should('contain', 'Dashboard')
       cy.location().should((location) => {


### PR DESCRIPTION
## WHAT

- Modified Stripe setup Cypress tests to use `within` function and use `ids` for forms
- Changed bank details Cypress test to use rest parameter syntax as in responsible person tests
- Removed `stripe-setup-` prefix from template ids, because it was too long
- Use `optional()` explicitly to document that the field is optional in models
- Remove normalisation from the models as it is handled in the controllers
- Other cosmetic changes

Co-authored-by: Yancoba Thompson <yancoba.thompson@digital.cabinet-office.gov.uk> / @cobainc0 
