### PR TITLE
PP-4976 Add validation for organisation address page

### DIFF
--- a/app/controllers/request-to-go-live/organisation-address/index.js
+++ b/app/controllers/request-to-go-live/organisation-address/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
 module.exports = {
-  get: require('./get.controller')
+  get: require('./get.controller'),
+  post: require('./post.controller')
 }

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.js
@@ -1,0 +1,97 @@
+'use strict'
+
+// NPM dependencies
+const lodash = require('lodash')
+
+// Local dependencies
+const { requestToGoLive } = require('../../../paths')
+const {
+  validateMandatoryField, validateOptionalField, validatePostcode, validatePhoneNumber
+} = require('../../../utils/validation/server-side-form-validations')
+const { renderErrorView } = require('../../../utils/response')
+
+const ADDRESS_LINE1_FIELD = 'address-line1'
+const ADDRESS_LINE2_FIELD = 'address-line2'
+const ADDRESS_CITY_FIELD = 'address-city'
+const ADDRESS_COUNTRY_FIELD = 'address-country'
+const ADDRESS_POSTCODE_FIELD = 'address-postcode'
+const TELEPHONE_NUMBER_FIELD = 'telephone-number'
+
+const validationRules = [
+  {
+    field: ADDRESS_LINE1_FIELD,
+    validator: validateMandatoryField,
+    maxLength: 200
+  },
+  {
+    field: ADDRESS_LINE2_FIELD,
+    validator: validateOptionalField,
+    maxLength: 200
+  },
+  {
+    field: ADDRESS_CITY_FIELD,
+    validator: validateMandatoryField,
+    maxLength: 100
+  },
+  {
+    field: ADDRESS_COUNTRY_FIELD,
+    validator: validateMandatoryField,
+    maxLength: 2
+  },
+  {
+    field: TELEPHONE_NUMBER_FIELD,
+    validator: validatePhoneNumber
+  }
+]
+
+const validate = function validate (formFields) {
+  const errors = {}
+  validationRules.forEach(validationRule => {
+    const value = formFields[validationRule.field]
+    const validationResponse = validationRule.validator(value, validationRule.maxLength)
+    if (!validationResponse.valid) {
+      errors[validationRule.field] = validationResponse.message
+    }
+  })
+
+  const postCode = formFields[ADDRESS_POSTCODE_FIELD]
+  const country = formFields[ADDRESS_COUNTRY_FIELD]
+  const postCodeValidResponse = validatePostcode(postCode, country)
+  if (!postCodeValidResponse.valid) {
+    errors[ADDRESS_POSTCODE_FIELD] = postCodeValidResponse.message
+  }
+  return errors
+}
+
+module.exports = (req, res) => {
+  const trimField = (fieldName) => {
+    return lodash.get(req.body, fieldName, '').trim()
+  }
+
+  const formFields = {}
+  formFields[ADDRESS_LINE1_FIELD] = trimField(ADDRESS_LINE1_FIELD)
+  formFields[ADDRESS_LINE2_FIELD] = trimField(ADDRESS_LINE2_FIELD)
+  formFields[ADDRESS_CITY_FIELD] = trimField(ADDRESS_CITY_FIELD)
+  formFields[ADDRESS_COUNTRY_FIELD] = trimField(ADDRESS_COUNTRY_FIELD)
+  formFields[ADDRESS_POSTCODE_FIELD] = trimField(ADDRESS_POSTCODE_FIELD)
+  formFields[TELEPHONE_NUMBER_FIELD] = trimField(TELEPHONE_NUMBER_FIELD)
+
+  const errors = validate(formFields)
+
+  if (lodash.isEmpty(errors)) {
+    // TODO: handle submission
+    renderErrorView(req, res)
+  } else {
+    lodash.set(req, 'session.pageData.requestToGoLive.organisationAddress', {
+      success: false,
+      errors: errors,
+      address_line1: formFields[ADDRESS_LINE1_FIELD],
+      address_line2: formFields[ADDRESS_LINE2_FIELD],
+      address_city: formFields[ADDRESS_CITY_FIELD],
+      address_postcode: formFields[ADDRESS_POSTCODE_FIELD],
+      address_country: formFields[ADDRESS_COUNTRY_FIELD],
+      telephone_number: formFields[TELEPHONE_NUMBER_FIELD]
+    })
+    return res.redirect(303, requestToGoLive.organisationAddress.replace(':externalServiceId', req.service.externalId))
+  }
+}

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.js
@@ -44,15 +44,17 @@ const validationRules = [
   }
 ]
 
+const trimField = (key, store) => lodash.get(store, key, '').trim()
+
 const validate = function validate (formFields) {
-  const errors = {}
-  validationRules.forEach(validationRule => {
+  const errors = validationRules.reduce((errors, validationRule) => {
     const value = formFields[validationRule.field]
     const validationResponse = validationRule.validator(value, validationRule.maxLength)
     if (!validationResponse.valid) {
       errors[validationRule.field] = validationResponse.message
     }
-  })
+    return errors
+  }, {})
 
   const postCode = formFields[ADDRESS_POSTCODE_FIELD]
   const country = formFields[ADDRESS_COUNTRY_FIELD]
@@ -64,17 +66,18 @@ const validate = function validate (formFields) {
 }
 
 module.exports = (req, res) => {
-  const trimField = (fieldName) => {
-    return lodash.get(req.body, fieldName, '').trim()
-  }
-
-  const formFields = {}
-  formFields[ADDRESS_LINE1_FIELD] = trimField(ADDRESS_LINE1_FIELD)
-  formFields[ADDRESS_LINE2_FIELD] = trimField(ADDRESS_LINE2_FIELD)
-  formFields[ADDRESS_CITY_FIELD] = trimField(ADDRESS_CITY_FIELD)
-  formFields[ADDRESS_COUNTRY_FIELD] = trimField(ADDRESS_COUNTRY_FIELD)
-  formFields[ADDRESS_POSTCODE_FIELD] = trimField(ADDRESS_POSTCODE_FIELD)
-  formFields[TELEPHONE_NUMBER_FIELD] = trimField(TELEPHONE_NUMBER_FIELD)
+  const fields = [
+    ADDRESS_LINE1_FIELD,
+    ADDRESS_LINE2_FIELD,
+    ADDRESS_CITY_FIELD,
+    ADDRESS_COUNTRY_FIELD,
+    ADDRESS_POSTCODE_FIELD,
+    TELEPHONE_NUMBER_FIELD
+  ]
+  const formFields = fields.reduce((form, field) => {
+    form[field] = trimField(field, req.body)
+    return form
+  }, {})
 
   const errors = validate(formFields)
 

--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -58,21 +58,24 @@ const validationRules = [
   }
 ]
 
-module.exports = (req, res) => {
-  const trimField = (fieldName) => {
-    return lodash.get(req.body, fieldName, '').trim()
-  }
+const trimField = (key, store) => lodash.get(store, key, '').trim()
 
-  const formFields = {}
-  formFields[FIRST_NAME_FIELD] = trimField(FIRST_NAME_FIELD)
-  formFields[LAST_NAME_FIELD] = trimField(LAST_NAME_FIELD)
-  formFields[HOME_ADDRESS_LINE1_FIELD] = trimField(HOME_ADDRESS_LINE1_FIELD)
-  formFields[HOME_ADDRESS_LINE2_FIELD] = trimField(HOME_ADDRESS_LINE2_FIELD)
-  formFields[HOME_ADDRESS_CITY_FIELD] = trimField(HOME_ADDRESS_CITY_FIELD)
-  formFields[HOME_ADDRESS_POSTCODE_FIELD] = trimField(HOME_ADDRESS_POSTCODE_FIELD)
-  formFields[DOB_DAY_FIELD] = trimField(DOB_DAY_FIELD)
-  formFields[DOB_MONTH_FIELD] = trimField(DOB_MONTH_FIELD)
-  formFields[DOB_YEAR_FIELD] = trimField(DOB_YEAR_FIELD)
+module.exports = (req, res) => {
+  const fields = [
+    FIRST_NAME_FIELD,
+    LAST_NAME_FIELD,
+    HOME_ADDRESS_LINE1_FIELD,
+    HOME_ADDRESS_LINE2_FIELD,
+    HOME_ADDRESS_CITY_FIELD,
+    HOME_ADDRESS_POSTCODE_FIELD,
+    DOB_DAY_FIELD,
+    DOB_MONTH_FIELD,
+    DOB_YEAR_FIELD
+  ]
+  const formFields = fields.reduce((form, field) => {
+    form[field] = trimField(field, req.body)
+    return form
+  }, {})
 
   const errors = validationRules.reduce((errors, validationRule) => {
     const errorMessage = validate(formFields, validationRule.field, validationRule.validator, validationRule.maxLength)

--- a/app/routes.js
+++ b/app/routes.js
@@ -355,8 +355,9 @@ module.exports.bind = function (app) {
   // Request to go live: organisation name
   app.get(requestToGoLive.organisationName, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveOrganisationNameController.get)
   app.post(requestToGoLive.organisationName, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveOrganisationNameController.post)
-  // Request to go live: organisation name
+  // Request to go live: organisation address
   app.get(requestToGoLive.organisationAddress, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveOrganisationAddressController.get)
+  app.post(requestToGoLive.organisationAddress, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveOrganisationAddressController.post)
   // Request to go live: choose how to process payments
   app.get(requestToGoLive.chooseHowToProcessPayments, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveChooseHowToProcessPaymentsController.get)
   app.post(requestToGoLive.chooseHowToProcessPayments, xraySegmentCls, permission('go-live-stage:update'), getAccount, requestToGoLiveChooseHowToProcessPaymentsController.post)

--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -79,28 +79,7 @@ Request a live account - {{ currentService.name }} - GOV.UK Pay
     {% set addressLine1Error = false %}
     {% if errors["address-line1"] %}
       {% set addressLine1Error = {
-      text: "Please enter a valid address"
-      } %}
-    {% endif %}
-
-    {% set cityError = false %}
-    {% if errors["address-city"] %}
-      {% set cityError = {
-      text: "Please enter a valid town or city"
-      } %}
-    {% endif %}
-
-    {% set postcodeError = false %}
-    {% if errors["address-postcode"] %}
-      {% set postcodeError = {
-      text: "Please enter a valid postcode"
-      } %}
-    {% endif %}
-
-    {% set countryError = false %}
-    {% if errors["address-country"] %}
-      {% set countryError = {
-      text: "Please enter a valid country"
+        text: errors["address-line1"]
       } %}
     {% endif %}
 
@@ -115,6 +94,13 @@ Request a live account - {{ currentService.name }} - GOV.UK Pay
       value: address_line1
     }) }}
 
+    {% set addressLine2Error = false %}
+    {% if errors["address-line2"] %}
+      {% set addressLine2Error = {
+        text: errors["address-line2"]
+      } %}
+    {% endif %}
+
     {{ govukInput({
       label: {
         html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
@@ -122,8 +108,16 @@ Request a live account - {{ currentService.name }} - GOV.UK Pay
       classes: "govuk-!-width-two-thirds",
       id: "address-line2",
       name: "address-line2",
+      errorMessage: addressLine2Error,
       value: address_line2
     }) }}
+
+    {% set cityError = false %}
+    {% if errors["address-city"] %}
+      {% set cityError = {
+        text: errors["address-city"]
+      } %}
+    {% endif %}
 
     {{ govukInput({
       label: {
@@ -136,6 +130,13 @@ Request a live account - {{ currentService.name }} - GOV.UK Pay
       value: address_city
     }) }}
 
+    {% set countryError = false %}
+    {% if errors["address-country"] %}
+      {% set countryError = {
+        text: errors["address-country"]
+      } %}
+    {% endif %}
+
     {{ govukSelect({
       id: "address-country",
       classes: "govuk-!-width-one-half",
@@ -146,6 +147,13 @@ Request a live account - {{ currentService.name }} - GOV.UK Pay
       },
       items: countries
     }) }}
+
+    {% set postcodeError = false %}
+    {% if errors["address-postcode"] %}
+      {% set postcodeError = {
+        text: errors["address-postcode"]
+      } %}
+    {% endif %}
 
     {{ govukInput({
       label: {
@@ -161,7 +169,7 @@ Request a live account - {{ currentService.name }} - GOV.UK Pay
     {% set phoneError = false %}
     {% if errors["telephone-number"] %}
       {% set phoneError = {
-        text: "Please enter a valid phone number"
+        text: errors["telephone-number"]
       } %}
     {% endif %}
 

--- a/test/cypress/integration/request-to-go-live/organisation_address_spec.js
+++ b/test/cypress/integration/request-to-go-live/organisation_address_spec.js
@@ -6,6 +6,9 @@ const { userExternalId, gatewayAccountId, serviceExternalId } = utils.variables
 const pageUrl = `/service/${serviceExternalId}/request-to-go-live/organisation-address`
 
 describe('The organisation address page', () => {
+  const longText = 'This text is 201 ...............................................................................' +
+    '..........................................................................................characters long'
+
   beforeEach(() => {
     cy.setEncryptedCookies(userExternalId, gatewayAccountId)
   })
@@ -40,6 +43,109 @@ describe('The organisation address page', () => {
           cy.get('label[for="telephone-number"]').should('exist')
           cy.get('span#telephone-number-hint').should('exist')
           cy.get('input#telephone-number[name="telephone-number"]').should('exist')
+        })
+    })
+
+    it('should display errors when validation fails', () => {
+      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
+        .within(() => {
+          // create errors for all fields except country by leaving them blank or inputting invalid values
+          cy.get('#address-line2').type(longText, { delay: 0 })
+          cy.get('button[type=submit]').click()
+        })
+
+      cy.get('.govuk-error-summary').find('a').should('have.length', 4)
+      cy.get('.govuk-error-summary').should('exist').within(() => {
+        cy.get('a[href="#address-line1"]').should('contain', 'Building and street')
+        cy.get('a[href="#address-city"]').should('contain', 'Town or city')
+        cy.get('a[href="#address-postcode"]').should('contain', 'Postcode')
+        cy.get('a[href="#telephone-number"]').should('contain', 'Telephone number')
+      })
+
+      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
+        .within(() => {
+          cy.get('.govuk-form-group--error > input#address-line1').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('contain', 'This field cannot be blank')
+          })
+          cy.get('.govuk-form-group--error > input#address-line2').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('contain', 'The text is too long')
+            cy.get('input#address-line2').should('have.value', longText)
+          })
+          cy.get('.govuk-form-group--error > input#address-city').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('contain', 'This field cannot be blank')
+          })
+          cy.get('.govuk-form-group--error > input#address-postcode').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('contain', 'This field cannot be blank')
+          })
+          cy.get('.govuk-form-group--error > input#telephone-number').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('contain', 'This field cannot be blank')
+          })
+        })
+    })
+
+    it('should keep entered responses when validation fails', () => {
+      const validLine1 = 'A building'
+      const validLine2 = 'A street'
+      const validCity = 'A city'
+      const country = 'IE'
+      const validPostcode = 'D01 F5P2'
+      const invalidTelephoneNumber = 'abd'
+
+      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
+        .within(() => {
+          cy.get('#address-line1').type(validLine1)
+          cy.get('#address-line2').type(validLine2)
+          cy.get('#address-city').type(validCity)
+          cy.get('#address-country').select(country)
+          cy.get('#address-postcode').type(validPostcode)
+          cy.get('#telephone-number').type(invalidTelephoneNumber)
+          cy.get('button[type=submit]').click()
+        })
+
+      cy.get('.govuk-error-summary').find('a').should('have.length', 1)
+      cy.get('.govuk-error-summary').should('exist').within(() => {
+        cy.get('a[href="#telephone-number"]').should('contain', 'Telephone number')
+      })
+
+      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
+        .within(() => {
+          cy.get('.govuk-form-group--error > input#telephone-number').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('contain', 'Invalid telephone number')
+          })
+
+          cy.get('#address-line1').should('have.value', validLine1)
+          cy.get('#address-line2').should('have.value', validLine2)
+          cy.get('#address-city').should('have.value', validCity)
+          cy.get('#address-country').should('have.value', country)
+          cy.get('#address-postcode').should('have.value', validPostcode)
+          cy.get('#telephone-number').should('have.value', invalidTelephoneNumber)
+        })
+    })
+
+    it('should show errors for invalid postcode', () => {
+      const invalidPostcode = '123'
+
+      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
+        .within(() => {
+          cy.get('#address-line1').type('A building')
+          cy.get('#address-line2').type('A street')
+          cy.get('#address-city').type('A city')
+          cy.get('#address-country').select('GB')
+          cy.get('#address-postcode').type(invalidPostcode)
+          cy.get('#telephone-number').type('01134960000')
+          cy.get('button[type=submit]').click()
+        })
+
+      cy.get('.govuk-error-summary').find('a').should('have.length', 1)
+      cy.get('.govuk-error-summary').should('exist').within(() => {
+        cy.get('a[href="#address-postcode"]').should('contain', 'Postcode')
+      })
+
+      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
+        .within(() => {
+          cy.get('.govuk-form-group--error > input#address-postcode').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('contain', 'Please enter a real postcode')
+          })
         })
     })
   })


### PR DESCRIPTION
## WHAT

Add post controller for the organisation page with server-side validation. Currently this will not submit the organisation details if validation is not successful.
Use error messages produced by the validation in the template, rather than error messages hardcoded in the template.

Co-authored-by: @SandorArpa 


