### PR TITLE
PP-4976 Use a model to construct update service requests

### DIFF
--- a/app/controllers/edit_merchant_details/post-edit-controller.js
+++ b/app/controllers/edit_merchant_details/post-edit-controller.js
@@ -6,7 +6,7 @@ const paths = require('../../paths')
 const serviceService = require('../../services/service_service')
 const { isPhoneNumber, isValidEmail } = require('../../browsered/field-validation-checks')
 const formattedPathFor = require('../../utils/replace_params_in_path')
-const { validPaths, validOps, ServiceUpdateRequest } = require('../../services/ServiceUpdateRequest.class')
+const { validPaths, ServiceUpdateRequest } = require('../../models/ServiceUpdateRequest.class')
 
 const MERCHANT_NAME = 'merchant-name'
 const TELEPHONE_NUMBER = 'telephone-number'
@@ -42,14 +42,14 @@ module.exports = (req, res) => {
   formFields[TELEPHONE_NUMBER] = formFields[TELEPHONE_NUMBER].replace(/\s/g, '')
 
   const serviceUpdateRequest = new ServiceUpdateRequest()
-    .addUpdate(validOps.replace, validPaths.merchantDetails.name, formFields[MERCHANT_NAME])
-    .addUpdate(validOps.replace, validPaths.merchantDetails.telephoneNumber, formFields[TELEPHONE_NUMBER])
-    .addUpdate(validOps.replace, validPaths.merchantDetails.email, formFields[MERCHANT_EMAIL])
-    .addUpdate(validOps.replace, validPaths.merchantDetails.addressLine1, formFields[ADDRESS_LINE1])
-    .addUpdate(validOps.replace, validPaths.merchantDetails.addressLine2, formFields[ADDRESS_LINE2])
-    .addUpdate(validOps.replace, validPaths.merchantDetails.addressCity, formFields[ADDRESS_CITY])
-    .addUpdate(validOps.replace, validPaths.merchantDetails.addressPostcode, formFields[ADDRESS_POSTCODE])
-    .addUpdate(validOps.replace, validPaths.merchantDetails.addressCountry, formFields[ADDRESS_COUNTRY])
+    .replace(validPaths.merchantDetails.name, formFields[MERCHANT_NAME])
+    .replace(validPaths.merchantDetails.telephoneNumber, formFields[TELEPHONE_NUMBER])
+    .replace(validPaths.merchantDetails.email, formFields[MERCHANT_EMAIL])
+    .replace(validPaths.merchantDetails.addressLine1, formFields[ADDRESS_LINE1])
+    .replace(validPaths.merchantDetails.addressLine2, formFields[ADDRESS_LINE2])
+    .replace(validPaths.merchantDetails.addressCity, formFields[ADDRESS_CITY])
+    .replace(validPaths.merchantDetails.addressPostcode, formFields[ADDRESS_POSTCODE])
+    .replace(validPaths.merchantDetails.addressCountry, formFields[ADDRESS_COUNTRY])
     .formatPayload()
 
   const errors = isValidForm(formFields, hasDirectDebitGatewayAccount)

--- a/app/controllers/request-to-go-live/organisation-name/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-name/post.controller.js
@@ -8,8 +8,10 @@ const goLiveStageToNextPagePath = require('../go-live-stage-to-next-page-path')
 const goLiveStage = require('../../../models/go-live-stage')
 const { requestToGoLive } = require('../../../paths')
 const { validateOrganisationName } = require('../../../utils/organisation_name_validation')
-const { updateCurrentGoLiveStage, updateMerchantDetails } = require('../../../services/service_service')
+const { updateCurrentGoLiveStage, updateService } = require('../../../services/service_service')
 const { renderErrorView } = require('../../../utils/response')
+const { validPaths, validOps, ServiceUpdateRequest } = require('../../../services/ServiceUpdateRequest.class')
+
 // Constants
 const ORGANISATION_NAME_FIELD = 'organisation-name'
 
@@ -17,8 +19,11 @@ module.exports = (req, res) => {
   const organisationName = lodash.get(req.body, ORGANISATION_NAME_FIELD)
   const errors = validateOrganisationName(organisationName, ORGANISATION_NAME_FIELD, true)
   if (lodash.isEmpty(errors)) {
-    const merchantDetails = { name: organisationName }
-    return updateMerchantDetails(req.service.externalId, merchantDetails, req.correlationId)
+    const updateServiceRequest = new ServiceUpdateRequest()
+      .addUpdate(validOps.replace, validPaths.merchantDetails.name, organisationName)
+      .formatPayload()
+
+    return updateService(req.service.externalId, updateServiceRequest, req.correlationId)
       .then(service => {
         return updateCurrentGoLiveStage(service.externalId, goLiveStage.ENTERED_ORGANISATION_NAME, req.correlationId)
       })

--- a/app/controllers/request-to-go-live/organisation-name/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-name/post.controller.js
@@ -10,7 +10,7 @@ const { requestToGoLive } = require('../../../paths')
 const { validateOrganisationName } = require('../../../utils/organisation_name_validation')
 const { updateCurrentGoLiveStage, updateService } = require('../../../services/service_service')
 const { renderErrorView } = require('../../../utils/response')
-const { validPaths, validOps, ServiceUpdateRequest } = require('../../../services/ServiceUpdateRequest.class')
+const { validPaths, ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
 
 // Constants
 const ORGANISATION_NAME_FIELD = 'organisation-name'
@@ -20,7 +20,7 @@ module.exports = (req, res) => {
   const errors = validateOrganisationName(organisationName, ORGANISATION_NAME_FIELD, true)
   if (lodash.isEmpty(errors)) {
     const updateServiceRequest = new ServiceUpdateRequest()
-      .addUpdate(validOps.replace, validPaths.merchantDetails.name, organisationName)
+      .replace(validPaths.merchantDetails.name, organisationName)
       .formatPayload()
 
     return updateService(req.service.externalId, updateServiceRequest, req.correlationId)

--- a/app/models/ServiceUpdateRequest.class.js
+++ b/app/models/ServiceUpdateRequest.class.js
@@ -13,19 +13,40 @@ const validPaths = {
   }
 }
 
-const validOps = {
+const ops = {
   add: 'add',
   replace: 'replace'
 }
 
-class ServiceUpdateRequestClass {
+class ServiceUpdateRequest {
   constructor () {
     this.updates = []
   }
 
-  addUpdate (op, path, value) {
+  /**
+   * Adds an update with op "replace" to the request
+   * @param path
+   * @param value
+   */
+  add (path, value) {
     this.updates.push({
-      op, path, value
+      'op': ops.add,
+      path,
+      value
+    })
+    return this
+  }
+
+  /**
+   * Adds an update with op "add" to the request
+   * @param path
+   * @param value
+   */
+  replace (path, value) {
+    this.updates.push({
+      'op': ops.replace,
+      path,
+      value
     })
     return this
   }
@@ -35,4 +56,4 @@ class ServiceUpdateRequestClass {
   }
 }
 
-module.exports = { validPaths, validOps, ServiceUpdateRequest: ServiceUpdateRequestClass }
+module.exports = { validPaths, ServiceUpdateRequest }

--- a/app/models/ServiceUpdateRequest.class.test.js
+++ b/app/models/ServiceUpdateRequest.class.test.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const { expect } = require('chai')
+const { ServiceUpdateRequest } = require('./ServiceUpdateRequest.class')
+
+describe('the ServiceUpdateRequest model', () => {
+  it('should successfully add a "replace" request', () => {
+    const payload = new ServiceUpdateRequest().replace('foo', 'bar').formatPayload()
+    expect(payload).to.deep.equal([{
+      'op': 'replace',
+      'path': 'foo',
+      'value': 'bar'
+    }])
+  })
+
+  it('should successfully add an "add" request', () => {
+    const payload = new ServiceUpdateRequest().add('foo', 'bar').formatPayload()
+    expect(payload).to.deep.equal([{
+      'op': 'add',
+      'path': 'foo',
+      'value': 'bar'
+    }])
+  })
+
+  it('should successfully add multiple requests', () => {
+    const payload = new ServiceUpdateRequest()
+      .replace('replace-path-1', 'replace-value-1')
+      .replace('replace-path-2', 'replace-value-2')
+      .add('add-path', 'add-value')
+      .formatPayload()
+
+    expect(payload).to.deep.equal([
+      {
+        'op': 'replace',
+        'path': 'replace-path-1',
+        'value': 'replace-value-1'
+      },
+      {
+        'op': 'replace',
+        'path': 'replace-path-2',
+        'value': 'replace-value-2'
+      },
+      {
+        'op': 'add',
+        'path': 'add-path',
+        'value': 'add-value'
+      }
+    ])
+  })
+})

--- a/app/services/ServiceUpdateRequest.class.js
+++ b/app/services/ServiceUpdateRequest.class.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const validPaths = {
+  merchantDetails: {
+    name: 'merchant_details/name',
+    addressLine1: 'merchant_details/address_line1',
+    addressLine2: 'merchant_details/address_line2',
+    addressCity: 'merchant_details/address_city',
+    addressPostcode: 'merchant_details/address_postcode',
+    addressCountry: 'merchant_details/address_country',
+    telephoneNumber: 'merchant_details/telephone_number',
+    email: 'merchant_details/email'
+  }
+}
+
+const validOps = {
+  add: 'add',
+  replace: 'replace'
+}
+
+class ServiceUpdateRequestClass {
+  constructor () {
+    this.updates = []
+  }
+
+  addUpdate (op, path, value) {
+    this.updates.push({
+      op, path, value
+    })
+    return this
+  }
+
+  formatPayload () {
+    return this.updates
+  }
+}
+
+module.exports = { validPaths, validOps, ServiceUpdateRequest: ServiceUpdateRequestClass }

--- a/app/services/clients/adminusers_client.js
+++ b/app/services/clients/adminusers_client.js
@@ -558,6 +558,27 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
+   * Update service
+   *
+   * @param serviceExternalId
+   * @param body
+   * @returns {*|Constructor|promise}
+   */
+  const updateService = (serviceExternalId, body) => {
+    return baseClient.patch({
+      baseUrl,
+      url: `${serviceResource}/${serviceExternalId}`,
+      json: true,
+      body,
+      correlationId: correlationId,
+      description: 'update service',
+      transform: responseBodyToServiceTransformer,
+      service: SERVICE_NAME,
+      baseClientErrorHandler: 'old'
+    })
+  }
+
+  /**
      * Update service name
      *
      * @param serviceExternalId
@@ -611,37 +632,6 @@ module.exports = function (clientOptions = {}) {
           },
         correlationId: correlationId,
         description: 'update collect billing address',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
-      }
-    )
-  }
-
-  /**
-     * Update merchant details
-     *
-     * @param serviceExternalId
-     * @param merchantDetails
-     * @returns {*|Constructor|promise}
-     */
-  const updateMerchantDetails = (serviceExternalId, merchantDetails) => {
-    const patchData = Object.keys(merchantDetails).map(key => {
-      return {
-        op: 'replace',
-        path: `merchant_details/${key}`,
-        value: merchantDetails[key]
-      }
-    })
-
-    return baseClient.patch(
-      {
-        baseUrl,
-        url: `${serviceResource}/${serviceExternalId}`,
-        json: true,
-        body: patchData,
-        correlationId: correlationId,
-        description: 'update merchant details',
-        transform: responseBodyToServiceTransformer,
         service: SERVICE_NAME,
         baseClientErrorHandler: 'old'
       }
@@ -804,8 +794,8 @@ module.exports = function (clientOptions = {}) {
 
     // Service-related Methods
     createService,
+    updateService,
     updateServiceName,
-    updateMerchantDetails,
     updateCollectBillingAddress,
     addGatewayAccountsToService,
     updateCurrentGoLiveStage,

--- a/app/services/service_service.js
+++ b/app/services/service_service.js
@@ -13,17 +13,6 @@ const DirectDebitGatewayAccount = require('../models/DirectDebitGatewayAccount.c
 const Service = require('../models/Service.class')
 const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 
-module.exports = {
-  getGatewayAccounts,
-  updateServiceName,
-  updateMerchantDetails,
-  createService,
-  toggleCollectBillingAddress,
-  updateCurrentGoLiveStage,
-  addStripeAgreementIpAddress,
-  addGovUkAgreementEmailAddress
-}
-
 /**
  * @method getServicesForUser
  * @param {string[]} gatewayAccountIds - The ids of interested gateway accounts.
@@ -95,16 +84,15 @@ function updateServiceName (serviceExternalId, serviceName, serviceNameCy, corre
 }
 
 /**
- * Update the merchant details
+ * Update the service
  *
  * @param serviceExternalId
  * @param merchantDetails
  * @param correlationId
  * @returns {Promise<Service>} the updated service
  */
-
-function updateMerchantDetails (serviceExternalId, merchantDetails, correlationId) {
-  return getAdminUsersClient({ correlationId }).updateMerchantDetails(serviceExternalId, merchantDetails)
+function updateService (serviceExternalId, serviceUpdateRequest, correlationId) {
+  return getAdminUsersClient({ correlationId }).updateService(serviceExternalId, serviceUpdateRequest)
 }
 
 /**
@@ -169,4 +157,15 @@ function addStripeAgreementIpAddress (serviceExternalId, ipAddress, correlationI
  */
 function addGovUkAgreementEmailAddress (serviceExternalId, userExternalId, correlationId) {
   return getAdminUsersClient({ correlationId }).addGovUkAgreementEmailAddress(serviceExternalId, userExternalId)
+}
+
+module.exports = {
+  getGatewayAccounts,
+  updateService,
+  updateServiceName,
+  createService,
+  toggleCollectBillingAddress,
+  updateCurrentGoLiveStage,
+  addStripeAgreementIpAddress,
+  addGovUkAgreementEmailAddress
 }

--- a/test/unit/clients/adminusers_client/service/update_service_test.js
+++ b/test/unit/clients/adminusers_client/service/update_service_test.js
@@ -10,6 +10,7 @@ const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers_client')
 const serviceFixtures = require('../../../../fixtures/service_fixtures')
+const { validPaths, validOps, ServiceUpdateRequest } = require('../../../../../app/services/ServiceUpdateRequest.class')
 
 // Constants
 const SERVICE_RESOURCE = '/v1/api/services'
@@ -22,7 +23,7 @@ chai.use(chaiAsPromised)
 
 const existingServiceExternalId = 'cp5wa'
 
-describe('adminusers client - patch request to update details', function () {
+describe('adminusers client - patch request to update service', function () {
   let provider = Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
@@ -36,23 +37,28 @@ describe('adminusers client - patch request to update details', function () {
   before(() => provider.setup())
   after(done => provider.finalize().then(done()))
 
-  describe('a valid update merchant details patch request to update only the name', () => {
-    const merchantDetails = { name: 'updated-merchant-details-name' }
-    const validUpdateMerchantNameRequest = serviceFixtures.validUpdateMerchantDetailsRequest(merchantDetails)
-    const validUpdateMerchantNameResponse = serviceFixtures.validServiceResponse({
+  describe('a valid update service patch request to update single field', () => {
+    const merchantDetailsName = 'updated-name'
+    const validUpdateServiceRequest = new ServiceUpdateRequest()
+      .addUpdate(validOps.replace, validPaths.merchantDetails.name, merchantDetailsName)
+      .formatPayload()
+
+    const validUpdateServiceResponse = serviceFixtures.validServiceResponse({
       external_id: existingServiceExternalId,
-      merchant_details: merchantDetails
+      merchant_details: {
+        name: merchantDetailsName
+      }
     })
 
     before(done => {
       provider.addInteraction(
         new PactInteractionBuilder(`${SERVICE_RESOURCE}/${existingServiceExternalId}`)
-          .withUponReceiving('a valid update merchant name request')
+          .withUponReceiving('a valid update single service field request')
           .withState(`a service exists with external id ${existingServiceExternalId}`)
           .withMethod('PATCH')
-          .withRequestBody(validUpdateMerchantNameRequest.getPlain())
+          .withRequestBody(validUpdateServiceRequest)
           .withStatusCode(200)
-          .withResponseBody(validUpdateMerchantNameResponse.getPactified())
+          .withResponseBody(validUpdateServiceResponse.getPactified())
           .build()
       )
         .then(() => done())
@@ -62,16 +68,16 @@ describe('adminusers client - patch request to update details', function () {
     afterEach(() => provider.verify())
 
     it('should update a merchant name successfully', (done) => {
-      adminUsersClient.updateMerchantDetails(existingServiceExternalId, merchantDetails)
+      adminUsersClient.updateService(existingServiceExternalId, validUpdateServiceRequest)
         .should.be.fulfilled
         .then(service => {
           expect(service.externalId).to.equal(existingServiceExternalId)
-          expect(service.merchantDetails.name).to.equal(merchantDetails.name)
+          expect(service.merchantDetails.name).to.equal(merchantDetailsName)
         }).should.notify(done)
     })
   })
 
-  describe('a valid update merchant details patch request to update all fields', () => {
+  describe('a valid update service patch request to update all fields', () => {
     const merchantDetails = {
       name: 'new-name',
       address_line1: 'new-line1',
@@ -82,8 +88,19 @@ describe('adminusers client - patch request to update details', function () {
       telephone_number: '07700 900 982',
       email: 'foo@example.com'
     }
-    const validUpdateMerchantDetailsRequest = serviceFixtures.validUpdateMerchantDetailsRequest(merchantDetails)
-    const validUpdateMerchantDetailsResponse = serviceFixtures.validServiceResponse({
+
+    const validUpdateServiceRequest = new ServiceUpdateRequest()
+      .addUpdate(validOps.replace, validPaths.merchantDetails.name, merchantDetails.name)
+      .addUpdate(validOps.replace, validPaths.merchantDetails.addressLine1, merchantDetails.address_line1)
+      .addUpdate(validOps.replace, validPaths.merchantDetails.addressLine2, merchantDetails.address_line2)
+      .addUpdate(validOps.replace, validPaths.merchantDetails.addressCity, merchantDetails.address_city)
+      .addUpdate(validOps.replace, validPaths.merchantDetails.addressCountry, merchantDetails.address_country)
+      .addUpdate(validOps.replace, validPaths.merchantDetails.addressPostcode, merchantDetails.address_postcode)
+      .addUpdate(validOps.replace, validPaths.merchantDetails.telephoneNumber, merchantDetails.telephone_number)
+      .addUpdate(validOps.replace, validPaths.merchantDetails.email, merchantDetails.email)
+      .formatPayload()
+
+    const validUpdateServiceResponse = serviceFixtures.validServiceResponse({
       external_id: existingServiceExternalId,
       merchant_details: merchantDetails
     })
@@ -91,12 +108,12 @@ describe('adminusers client - patch request to update details', function () {
     before(done => {
       provider.addInteraction(
         new PactInteractionBuilder(`${SERVICE_RESOURCE}/${existingServiceExternalId}`)
-          .withUponReceiving('a valid update merchant details request to update all fields')
+          .withUponReceiving('a valid update service request to update all fields')
           .withState(`a service exists with external id ${existingServiceExternalId}`)
           .withMethod('PATCH')
-          .withRequestBody(validUpdateMerchantDetailsRequest.getPlain())
+          .withRequestBody(validUpdateServiceRequest)
           .withStatusCode(200)
-          .withResponseBody(validUpdateMerchantDetailsResponse.getPactified())
+          .withResponseBody(validUpdateServiceResponse.getPactified())
           .build()
       )
         .then(() => done())
@@ -105,8 +122,8 @@ describe('adminusers client - patch request to update details', function () {
 
     afterEach(() => provider.verify())
 
-    it('should update a merchant details successfully', (done) => {
-      adminUsersClient.updateMerchantDetails(existingServiceExternalId, merchantDetails)
+    it('should update service successfully', (done) => {
+      adminUsersClient.updateService(existingServiceExternalId, validUpdateServiceRequest)
         .should.be.fulfilled
         .then(service => {
           expect(service.externalId).to.equal(existingServiceExternalId)
@@ -115,17 +132,20 @@ describe('adminusers client - patch request to update details', function () {
     })
   })
 
-  describe('an invalid update merchant details patch request', () => {
-    const merchantDetails = { 'non-existent-path': 'foo' }
-    const invalidRequest = serviceFixtures.validUpdateMerchantDetailsRequest(merchantDetails)
+  describe('an invalid update service patch request', () => {
+    const invalidRequest = [{
+      'op': 'replace',
+      'non-existent-path': 'foo',
+      'value': 'bar'
+    }]
 
     before(done => {
       provider.addInteraction(
         new PactInteractionBuilder(`${SERVICE_RESOURCE}/${existingServiceExternalId}`)
-          .withUponReceiving('an invalid update merchant details request')
+          .withUponReceiving('an invalid update service patch request')
           .withState(`a service exists with external id ${existingServiceExternalId}`)
           .withMethod('PATCH')
-          .withRequestBody(invalidRequest.getPlain())
+          .withRequestBody(invalidRequest)
           .withStatusCode(400)
           .build()
       )
@@ -136,7 +156,7 @@ describe('adminusers client - patch request to update details', function () {
     afterEach(() => provider.verify())
 
     it('should return a 400 response', (done) => {
-      adminUsersClient.updateMerchantDetails(existingServiceExternalId, merchantDetails)
+      adminUsersClient.updateService(existingServiceExternalId, invalidRequest)
         .should.be.rejected
         .then(response => {
           expect(response.errorCode).to.equal(400)

--- a/test/unit/clients/adminusers_client/service/update_service_test.js
+++ b/test/unit/clients/adminusers_client/service/update_service_test.js
@@ -10,7 +10,7 @@ const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers_client')
 const serviceFixtures = require('../../../../fixtures/service_fixtures')
-const { validPaths, validOps, ServiceUpdateRequest } = require('../../../../../app/services/ServiceUpdateRequest.class')
+const { validPaths, ServiceUpdateRequest } = require('../../../../../app/models/ServiceUpdateRequest.class')
 
 // Constants
 const SERVICE_RESOURCE = '/v1/api/services'
@@ -40,7 +40,7 @@ describe('adminusers client - patch request to update service', function () {
   describe('a valid update service patch request to update single field', () => {
     const merchantDetailsName = 'updated-name'
     const validUpdateServiceRequest = new ServiceUpdateRequest()
-      .addUpdate(validOps.replace, validPaths.merchantDetails.name, merchantDetailsName)
+      .replace(validPaths.merchantDetails.name, merchantDetailsName)
       .formatPayload()
 
     const validUpdateServiceResponse = serviceFixtures.validServiceResponse({
@@ -90,14 +90,14 @@ describe('adminusers client - patch request to update service', function () {
     }
 
     const validUpdateServiceRequest = new ServiceUpdateRequest()
-      .addUpdate(validOps.replace, validPaths.merchantDetails.name, merchantDetails.name)
-      .addUpdate(validOps.replace, validPaths.merchantDetails.addressLine1, merchantDetails.address_line1)
-      .addUpdate(validOps.replace, validPaths.merchantDetails.addressLine2, merchantDetails.address_line2)
-      .addUpdate(validOps.replace, validPaths.merchantDetails.addressCity, merchantDetails.address_city)
-      .addUpdate(validOps.replace, validPaths.merchantDetails.addressCountry, merchantDetails.address_country)
-      .addUpdate(validOps.replace, validPaths.merchantDetails.addressPostcode, merchantDetails.address_postcode)
-      .addUpdate(validOps.replace, validPaths.merchantDetails.telephoneNumber, merchantDetails.telephone_number)
-      .addUpdate(validOps.replace, validPaths.merchantDetails.email, merchantDetails.email)
+      .replace(validPaths.merchantDetails.name, merchantDetails.name)
+      .replace(validPaths.merchantDetails.addressLine1, merchantDetails.address_line1)
+      .replace(validPaths.merchantDetails.addressLine2, merchantDetails.address_line2)
+      .replace(validPaths.merchantDetails.addressCity, merchantDetails.address_city)
+      .replace(validPaths.merchantDetails.addressCountry, merchantDetails.address_country)
+      .replace(validPaths.merchantDetails.addressPostcode, merchantDetails.address_postcode)
+      .replace(validPaths.merchantDetails.telephoneNumber, merchantDetails.telephone_number)
+      .replace(validPaths.merchantDetails.email, merchantDetails.email)
       .formatPayload()
 
     const validUpdateServiceResponse = serviceFixtures.validServiceResponse({


### PR DESCRIPTION
Replace updateMerchantDetails method with a more general updateService method. This updateService method can be used for all service update patch requests, and should replace other methods that make these requests.

Add a ServiceUpdateRequest model to construct the request payload with ops and paths defined as constants.



