### PR TITLE
PP-4976 Fix cypress setupStubs task accidentally renamed

### DIFF
--- a/test/cypress/integration/dashboard/dashboard_go_live_link_spec.js
+++ b/test/cypress/integration/dashboard/dashboard_go_live_link_spec.js
@@ -135,7 +135,7 @@ describe('Go live link on dashboard', () => {
     it('should display next steps to go live link', () => {
       const directDebitGatewayAccountId = 'DIRECT_DEBIT:101'
 
-      cy.task('setupGetUserAndGatewayAccountStubs', [
+      cy.task('setupStubs', [
         commonStubs.getUserStub(userExternalId, [directDebitGatewayAccountId], serviceExternalId, 'NOT_STARTED'),
         commonStubs.getDirectDebitGatewayAccountStub(directDebitGatewayAccountId, 'test', 'sandbox')
       ])

--- a/test/cypress/integration/dashboard/dashboard_links_spec.js
+++ b/test/cypress/integration/dashboard/dashboard_links_spec.js
@@ -13,7 +13,7 @@ describe('the links are displayed correctly on the dashboard', () => {
     })
 
     it('should display 3 links for a live sandbox account', () => {
-      cy.task('setupGetUserAndGatewayAccountStubs', [
+      cy.task('setupStubs', [
         commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
         commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'sandbox')
       ])
@@ -35,7 +35,7 @@ describe('the links are displayed correctly on the dashboard', () => {
     })
 
     it('should display 2 links for a live non-sandbox account', () => {
-      cy.task('setupGetUserAndGatewayAccountStubs', [
+      cy.task('setupStubs', [
         commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
         commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'worldpay')
       ])
@@ -51,7 +51,7 @@ describe('the links are displayed correctly on the dashboard', () => {
     })
 
     it('should display 4 links for a test sandbox account', () => {
-      cy.task('setupGetUserAndGatewayAccountStubs', [
+      cy.task('setupStubs', [
         commonStubs.getUserStub(userExternalId, [gatewayAccountId], 'an-id', 'NOT_STARTED'),
         commonStubs.getGatewayAccountStub(gatewayAccountId, 'test', 'sandbox')
       ])
@@ -73,7 +73,7 @@ describe('the links are displayed correctly on the dashboard', () => {
     })
 
     it('should display 3 links for a test non-sandbox account', () => {
-      cy.task('setupGetUserAndGatewayAccountStubs', [
+      cy.task('setupStubs', [
         commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
         commonStubs.getGatewayAccountStub(gatewayAccountId, 'test', 'worldpay')
       ])
@@ -100,7 +100,7 @@ describe('the links are displayed correctly on the dashboard', () => {
     })
 
     it('should display 3 links for a live sandbox account', () => {
-      cy.task('setupGetUserAndGatewayAccountStubs', [
+      cy.task('setupStubs', [
         commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
         commonStubs.getDirectDebitGatewayAccountStub(gatewayAccountId, 'live', 'sandbox')
       ])
@@ -119,7 +119,7 @@ describe('the links are displayed correctly on the dashboard', () => {
     })
 
     it('should display 2 links for a live non-sandbox account', () => {
-      cy.task('setupGetUserAndGatewayAccountStubs', [
+      cy.task('setupStubs', [
         commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
         commonStubs.getDirectDebitGatewayAccountStub(gatewayAccountId, 'live', 'go-cardless')
       ])
@@ -135,7 +135,7 @@ describe('the links are displayed correctly on the dashboard', () => {
     })
 
     it('should display 4 links for a test sandbox account', () => {
-      cy.task('setupGetUserAndGatewayAccountStubs', [
+      cy.task('setupStubs', [
         commonStubs.getUserStub(userExternalId, [gatewayAccountId], 'an-id', 'NOT_STARTED'),
         commonStubs.getDirectDebitGatewayAccountStub(gatewayAccountId, 'test', 'sandbox')
       ])
@@ -157,7 +157,7 @@ describe('the links are displayed correctly on the dashboard', () => {
     })
 
     it('should display 3 links for a test non-sandbox account', () => {
-      cy.task('setupGetUserAndGatewayAccountStubs', [
+      cy.task('setupStubs', [
         commonStubs.getUserStub(userExternalId, [gatewayAccountId], 'an-id', 'NOT_STARTED'),
         commonStubs.getDirectDebitGatewayAccountStub(gatewayAccountId, 'test', 'go-cardless')
       ])

--- a/test/cypress/integration/dashboard/dashboard_spec.js
+++ b/test/cypress/integration/dashboard/dashboard_spec.js
@@ -6,7 +6,7 @@ describe('Dashboard', () => {
   beforeEach(() => {
     cy.setEncryptedCookies(userExternalId, gatewayAccountId)
 
-    cy.task('setupGetUserAndGatewayAccountStubs', [
+    cy.task('setupStubs', [
       {
         name: 'getUserSuccess',
         opts: {

--- a/test/cypress/integration/request-to-go-live/agreement_spec.js
+++ b/test/cypress/integration/request-to-go-live/agreement_spec.js
@@ -100,7 +100,7 @@ describe('Request to go live: agreement', () => {
       stubGovUkPayAgreement,
       stubStripeAgreement)
     beforeEach(() => {
-      cy.task('setupGetUserAndGatewayAccountStubs', stubPayload)
+      cy.task('setupStubs', stubPayload)
     })
 
     it('should display "Confirm that you accept our legal terms" page when in CHOSEN_PSP_STRIPE', () => {
@@ -153,7 +153,7 @@ describe('Request to go live: agreement', () => {
       utils.patchUpdateGoLiveStageSuccessStub('TERMS_AGREED_WORLDPAY'), stubGovUkPayAgreement)
 
     beforeEach(() => {
-      cy.task('setupGetUserAndGatewayAccountStubs', stubPayload)
+      cy.task('setupStubs', stubPayload)
     })
 
     it('should display "Confirm that you accept our legal terms" page when in CHOSEN_PSP_WORLDPAY', () => {
@@ -190,7 +190,7 @@ describe('Request to go live: agreement', () => {
       stubGovUkPayAgreement,
       utils.patchUpdateGoLiveStageErrorStub('TERMS_AGREED_STRIPE'))
     beforeEach(() => {
-      cy.task('setupGetUserAndGatewayAccountStubs', stubPayload)
+      cy.task('setupStubs', stubPayload)
     })
     it('should show "An error occurred: There is a problem with the payments platform"', () => {
       const requestToGoLiveChooseHowToProcessPaymentUrl = `/service/${serviceExternalId}/request-to-go-live/agreement`

--- a/test/cypress/integration/request-to-go-live/choose_how_to_process_payments_spec.js
+++ b/test/cypress/integration/request-to-go-live/choose_how_to_process_payments_spec.js
@@ -50,7 +50,7 @@ describe('Request to go live: choose how to process payments', () => {
     const stubPayload = lodash.concat(repeatGetUserSuccessStub,
       utils.patchUpdateGoLiveStageSuccessStub('CHOSEN_PSP_STRIPE'))
     beforeEach(() => {
-      cy.task('setupGetUserAndGatewayAccountStubs', stubPayload)
+      cy.task('setupStubs', stubPayload)
     })
 
     it('should patch adminusers then redirect to agreement when chosen Stripe', () => {
@@ -97,7 +97,7 @@ describe('Request to go live: choose how to process payments', () => {
     const stubPayload = lodash.concat(repeatGetUserSuccessStub,
       utils.patchUpdateGoLiveStageSuccessStub('CHOSEN_PSP_EPDQ'))
     beforeEach(() => {
-      cy.task('setupGetUserAndGatewayAccountStubs', stubPayload)
+      cy.task('setupStubs', stubPayload)
     })
 
     it('should patch choice and then redirect to agreement when chosen ePDQ', () => {
@@ -190,7 +190,7 @@ describe('Request to go live: choose how to process payments', () => {
     const stubPayload = lodash.concat(utils.getUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')),
       utils.patchUpdateGoLiveStageErrorStub('CHOSEN_PSP_STRIPE'))
     beforeEach(() => {
-      cy.task('setupGetUserAndGatewayAccountStubs', stubPayload)
+      cy.task('setupStubs', stubPayload)
     })
     it('should show "An error occurred: There is a problem with the payments platform"', () => {
       const requestToGoLiveChooseHowToProcessPaymentUrl = `/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`

--- a/test/cypress/integration/request-to-go-live/index_spec.js
+++ b/test/cypress/integration/request-to-go-live/index_spec.js
@@ -14,7 +14,7 @@ describe('Request to go live: index', () => {
   }
 
   const setupStubs = (serviceRole) => {
-    cy.task('setupGetUserAndGatewayAccountStubs', [
+    cy.task('setupStubs', [
       {
         name: 'getUserSuccess',
         opts: {

--- a/test/cypress/integration/request-to-go-live/organisation_name_spec.js
+++ b/test/cypress/integration/request-to-go-live/organisation_name_spec.js
@@ -75,7 +75,7 @@ describe('Request to go live: organisation name page', () => {
       stubPatchRequests('ENTERED_ORGANISATION_NAME', organisationName))
 
     beforeEach(() => {
-      cy.task('setupGetUserAndGatewayAccountStubs', stubPayload)
+      cy.task('setupStubs', stubPayload)
     })
 
     it('should allow users to type valid organisation name and submit', () => {
@@ -114,7 +114,7 @@ describe('Request to go live: organisation name page', () => {
       stubPatchRequests('ENTERED_ORGANISATION_NAME', changeOrganisationName))
 
     beforeEach(() => {
-      cy.task('setupGetUserAndGatewayAccountStubs', stubPayload)
+      cy.task('setupStubs', stubPayload)
     })
 
     it('should show page correctly and allow users to change pre-filled organisation name successfully', () => {

--- a/test/cypress/integration/settings/allow_apple_pay_spec.js
+++ b/test/cypress/integration/settings/allow_apple_pay_spec.js
@@ -6,7 +6,7 @@ describe('Apple Pay', () => {
   beforeEach(() => {
     cy.setEncryptedCookies(userExternalId, gatewayAccountId)
 
-    cy.task('setupGetUserAndGatewayAccountStubs', [
+    cy.task('setupStubs', [
       {
         name: 'getUserSuccess',
         opts: {

--- a/test/cypress/integration/settings/allow_google_pay_spec.js
+++ b/test/cypress/integration/settings/allow_google_pay_spec.js
@@ -7,7 +7,7 @@ describe('Google Pay', () => {
   beforeEach(() => {
     cy.setEncryptedCookies(userExternalId, gatewayAccountId)
 
-    cy.task('setupGetUserAndGatewayAccountStubs', [
+    cy.task('setupStubs', [
       {
         name: 'getUserSuccess',
         opts: {

--- a/test/cypress/integration/settings/email_notifications_spec.js
+++ b/test/cypress/integration/settings/email_notifications_spec.js
@@ -7,7 +7,7 @@ describe('Settings', () => {
   beforeEach(() => {
     cy.setEncryptedCookies(userExternalId, gatewayAccountId)
 
-    cy.task('setupGetUserAndGatewayAccountStubs', [
+    cy.task('setupStubs', [
       {
         name: 'getUserSuccess',
         opts: {

--- a/test/cypress/integration/settings/merchant_details_spec.js
+++ b/test/cypress/integration/settings/merchant_details_spec.js
@@ -5,7 +5,7 @@ describe('Dashboard', () => {
   beforeEach(() => {
     cy.setEncryptedCookies(userExternalId, gatewayAccountId)
 
-    cy.task('setupGetUserAndGatewayAccountStubs', [
+    cy.task('setupStubs', [
       {
         name: 'getUserSuccess',
         opts: {

--- a/test/cypress/integration/stripe-setup/bank_details_spec.js
+++ b/test/cypress/integration/stripe-setup/bank_details_spec.js
@@ -62,7 +62,7 @@ describe('Stripe setup: bank details page', () => {
 
     describe('Bank details page is shown', () => {
       beforeEach(() => {
-        cy.task('setupGetUserAndGatewayAccountStubs', [
+        cy.task('setupStubs', [
           commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
           stubGetGatewayAccountStripeSetupSuccess(false),
@@ -143,7 +143,7 @@ describe('Stripe setup: bank details page', () => {
 
     describe('Bank account flag already true', () => {
       it('should redirect to Dashboard with an error message when on Bank details page', () => {
-        cy.task('setupGetUserAndGatewayAccountStubs', [
+        cy.task('setupStubs', [
           commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
           stubGetGatewayAccountStripeSetupSuccess(true),
@@ -161,7 +161,7 @@ describe('Stripe setup: bank details page', () => {
       })
 
       it('should redirect to Dashboard with an error message when submitting Bank details page', () => {
-        cy.task('setupGetUserAndGatewayAccountStubs', [
+        cy.task('setupStubs', [
           commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
           stubGetGatewayAccountStripeSetupBankAccountFlagChanged(false, true),
@@ -183,7 +183,7 @@ describe('Stripe setup: bank details page', () => {
       })
 
       it('should redirect to Dashboard with an error message when submitting Check your answers page', () => {
-        cy.task('setupGetUserAndGatewayAccountStubs', [
+        cy.task('setupStubs', [
           commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
           stubGetGatewayAccountStripeSetupBankAccountFlagChanged(false, false, true),
@@ -212,7 +212,7 @@ describe('Stripe setup: bank details page', () => {
 
     describe('Not a Stripe gateway account', () => {
       it('should show a 404 error when gateway account is not Stripe', () => {
-        cy.task('setupGetUserAndGatewayAccountStubs', [
+        cy.task('setupStubs', [
           commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'sandbox'),
           stubGetGatewayAccountStripeSetupSuccess(false),
@@ -228,7 +228,7 @@ describe('Stripe setup: bank details page', () => {
 
     describe('Not a live gateway account', () => {
       it('should show a 404 error when gateway account is not live', () => {
-        cy.task('setupGetUserAndGatewayAccountStubs', [
+        cy.task('setupStubs', [
           commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'test', 'stripe'),
           stubGetGatewayAccountStripeSetupSuccess(false),
@@ -244,7 +244,7 @@ describe('Stripe setup: bank details page', () => {
 
     describe('User does not have the correct permissions', () => {
       it('should show a permission error when the user does not have enough permissions', () => {
-        cy.task('setupGetUserAndGatewayAccountStubs', [
+        cy.task('setupStubs', [
           commonStubs.getUserWithNoPermissionsStub(userExternalId, [gatewayAccountId]),
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe')
         ])
@@ -257,7 +257,7 @@ describe('Stripe setup: bank details page', () => {
 
     describe('Check your answers page', () => {
       beforeEach(() => {
-        cy.task('setupGetUserAndGatewayAccountStubs', [
+        cy.task('setupStubs', [
           commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
           stubGetGatewayAccountStripeSetupSuccess(false),
@@ -304,7 +304,7 @@ describe('Stripe setup: bank details page', () => {
     it('should show an error page', () => {
       cy.setEncryptedCookies(userExternalId, directDebitGatewayAccountId)
 
-      cy.task('setupGetUserAndGatewayAccountStubs', [
+      cy.task('setupStubs', [
         commonStubs.getUserStub(userExternalId, [directDebitGatewayAccountId]),
         commonStubs.getDirectDebitGatewayAccountStub(directDebitGatewayAccountId, 'live', 'go-cardless')
       ])

--- a/test/cypress/integration/stripe-setup/responsible_person_spec.js
+++ b/test/cypress/integration/stripe-setup/responsible_person_spec.js
@@ -70,7 +70,7 @@ describe('Stripe setup: responsible person page', () => {
 
   describe('when user is admin, account is Stripe and responsible person not already nominated', () => {
     beforeEach(() => {
-      cy.task('setupGetUserAndGatewayAccountStubs', [
+      cy.task('setupStubs', [
         commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
         commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
         stubStripeSetupGet(false),
@@ -415,7 +415,7 @@ describe('Stripe setup: responsible person page', () => {
 
   describe('trying to view form when responsible person already nominated', () => {
     beforeEach(() => {
-      cy.task('setupGetUserAndGatewayAccountStubs', [
+      cy.task('setupStubs', [
         commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
         commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
         stubStripeSetupGet(true),
@@ -436,7 +436,7 @@ describe('Stripe setup: responsible person page', () => {
 
   describe('trying to save details when responsible person already nominated', function () {
     beforeEach(() => {
-      cy.task('setupGetUserAndGatewayAccountStubs', [
+      cy.task('setupStubs', [
         commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
         commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
         stubStripeSetupGetForMultipleCalls(false, false, true),
@@ -474,7 +474,7 @@ describe('Stripe setup: responsible person page', () => {
 
   describe('when it’s not a Stripe gateway account', () => {
     beforeEach(() => {
-      cy.task('setupGetUserAndGatewayAccountStubs', [
+      cy.task('setupStubs', [
         commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
         commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'worldpay'),
         stubStripeSetupGet(false),
@@ -491,7 +491,7 @@ describe('Stripe setup: responsible person page', () => {
 
   describe('when user has incorrect permissions', () => {
     beforeEach(() => {
-      cy.task('setupGetUserAndGatewayAccountStubs', [
+      cy.task('setupStubs', [
         commonStubs.getUserWithNoPermissionsStub(userExternalId, [gatewayAccountId]),
         commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
         stubStripeSetupGet(false),

--- a/test/cypress/integration/transactions/transaction_details_spec.js
+++ b/test/cypress/integration/transactions/transaction_details_spec.js
@@ -96,7 +96,7 @@ describe('Transactions details page', () => {
   describe('page content', () => {
     it('should display transaction details correctly when delayed capture is OFF', () => {
       const chargeDetails = defaultChargeDetails()
-      cy.task('setupGetUserAndGatewayAccountStubs', getStubs(chargeDetails))
+      cy.task('setupStubs', getStubs(chargeDetails))
 
       cy.visit(`${transactionsUrl}/${chargeDetails.charge.charge_id}`)
 
@@ -150,7 +150,7 @@ describe('Transactions details page', () => {
     it('should display transaction details correctly when delayed capture is ON', () => {
       const aDelayedCaptureCharge = defaultChargeDetails()
       aDelayedCaptureCharge.charge.delayed_capture = true
-      cy.task('setupGetUserAndGatewayAccountStubs', getStubs(aDelayedCaptureCharge))
+      cy.task('setupStubs', getStubs(aDelayedCaptureCharge))
 
       cy.visit(`${transactionsUrl}/${aDelayedCaptureCharge.charge.charge_id}`)
 
@@ -207,7 +207,7 @@ describe('Transactions details page', () => {
       const aCorporateCardSurchargeCharge = defaultChargeDetails()
       aCorporateCardSurchargeCharge.charge.corporate_card_surcharge = 250
       aCorporateCardSurchargeCharge.charge.total_amount = 1250
-      cy.task('setupGetUserAndGatewayAccountStubs', getStubs(aCorporateCardSurchargeCharge))
+      cy.task('setupStubs', getStubs(aCorporateCardSurchargeCharge))
 
       cy.visit(`${transactionsUrl}/${aCorporateCardSurchargeCharge.charge.charge_id}`)
 
@@ -238,7 +238,7 @@ describe('Transactions details page', () => {
           }
         }
       ])
-      cy.task('setupGetUserAndGatewayAccountStubs', stubs)
+      cy.task('setupStubs', stubs)
 
       cy.visit(`${transactionsUrl}/${chargeDetails.charge.charge_id}`)
 
@@ -263,7 +263,7 @@ describe('Transactions details page', () => {
     it('should allow a refund to be re-attempted in the event of a failed refund', () => {
       const aFailedRefundCharge = defaultChargeDetails()
       aFailedRefundCharge.charge.refund_summary_status = 'error'
-      cy.task('setupGetUserAndGatewayAccountStubs', getStubs(aFailedRefundCharge))
+      cy.task('setupStubs', getStubs(aFailedRefundCharge))
 
       cy.visit(`${transactionsUrl}/${aFailedRefundCharge.charge.charge_id}`)
 
@@ -288,7 +288,7 @@ describe('Transactions details page', () => {
       const aCorporateCardSurchargeCharge = defaultChargeDetails()
       aCorporateCardSurchargeCharge.charge.corporate_card_surcharge = 250
       aCorporateCardSurchargeCharge.charge.total_amount = 1250
-      cy.task('setupGetUserAndGatewayAccountStubs', getStubs(aCorporateCardSurchargeCharge))
+      cy.task('setupStubs', getStubs(aCorporateCardSurchargeCharge))
 
       cy.visit(`${transactionsUrl}/${aCorporateCardSurchargeCharge.charge.charge_id}`)
 
@@ -301,7 +301,7 @@ describe('Transactions details page', () => {
 
     it('should display full refund amount without corporate card surcharge when there is no corporate card surcharge', () => {
       const chargeDetails = defaultChargeDetails()
-      cy.task('setupGetUserAndGatewayAccountStubs', getStubs(chargeDetails))
+      cy.task('setupStubs', getStubs(chargeDetails))
       cy.visit(`${transactionsUrl}/${chargeDetails.charge.charge_id}`)
 
       // Click the refund button
@@ -315,14 +315,14 @@ describe('Transactions details page', () => {
   it('should display Wallet Type where available', () => {
     const chargeDetails = defaultChargeDetails()
     chargeDetails.charge.wallet_type = 'APPLE_PAY'
-    cy.task('setupGetUserAndGatewayAccountStubs', getStubs(chargeDetails))
+    cy.task('setupStubs', getStubs(chargeDetails))
     cy.visit(`${transactionsUrl}/${chargeDetails.charge.charge_id}`)
     cy.get('th').contains('Wallet type').siblings().first().should('contain', 'Apple Pay')
   })
 
   it('should not display Wallet Type when not included in charge', () => {
     const chargeDetails = defaultChargeDetails()
-    cy.task('setupGetUserAndGatewayAccountStubs', getStubs(chargeDetails))
+    cy.task('setupStubs', getStubs(chargeDetails))
     cy.visit(`${transactionsUrl}/${chargeDetails.charge.charge_id}`)
     cy.get('.transaction-details tbody').should('not.contain', 'Wallet Type')
   })

--- a/test/cypress/integration/transactions/transaction_search_spec.js
+++ b/test/cypress/integration/transactions/transaction_search_spec.js
@@ -53,7 +53,7 @@ describe('Transactions', () => {
   beforeEach(() => {
     cy.setEncryptedCookies(userExternalId, gatewayAccountId)
 
-    cy.task('setupGetUserAndGatewayAccountStubs', [
+    cy.task('setupStubs', [
       {
         name: 'getUserSuccess',
         opts: {

--- a/test/cypress/integration/user/login_spec.js
+++ b/test/cypress/integration/user/login_spec.js
@@ -6,7 +6,7 @@ describe('Login Page', () => {
   const invalidPassword = 'some-invalid-password'
 
   beforeEach(() => {
-    cy.task('setupGetUserAndGatewayAccountStubs', [
+    cy.task('setupStubs', [
       {
         name: 'getUserSuccess',
         opts: {

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -43,7 +43,7 @@ module.exports = (on, config) => {
      * the name of a function defined in plugins/stubs.js, and the opts is an object passed to this function providing
      * the configuration options for building the stub predicates and responses.
      */
-    setupGetUserAndGatewayAccountStubs (stubSpecs) {
+    setupStubs (stubSpecs) {
       const stubsArray = lodash.flatMap(stubSpecs, spec => stubs[spec.name](spec.opts))
       return request({
         method: 'POST',

--- a/test/cypress/utils/request_to_go_live_utils.js
+++ b/test/cypress/utils/request_to_go_live_utils.js
@@ -98,7 +98,7 @@ const patchUpdateGoLiveStageErrorStub = (currentGoLiveStage) => {
 }
 
 const setupGetUserAndGatewayAccountStubs = (serviceRole) => {
-  cy.task('setupGetUserAndGatewayAccountStubs', getUserAndGatewayAccountStubs(serviceRole))
+  cy.task('setupStubs', getUserAndGatewayAccountStubs(serviceRole))
 }
 
 module.exports = {


### PR DESCRIPTION
Meant to just rename a method in request_to_go_live_utils but mistakenly propagated the rename too far. Fixed this.