### PR TITLE
PP-4976 Improve organisation details page post controller

### DIFF
--- a/app/controllers/edit_merchant_details/get-edit-controller.js
+++ b/app/controllers/edit_merchant_details/get-edit-controller.js
@@ -3,19 +3,17 @@ const responses = require('../../utils/response')
 const { countries } = require('@govuk-pay/pay-js-commons').utils
 
 module.exports = (req, res) => {
-  const externalServiceId = req.service.externalId
   let pageData = lodash.get(req, 'session.pageData.editMerchantDetails')
   if (pageData) {
     delete req.session.pageData.editMerchantDetails
   } else {
     pageData = {
-      merchant_details: lodash.get(req, 'service.merchantDetails'),
-      has_direct_debit_gateway_account: lodash.get(req, 'service.hasDirectDebitGatewayAccount'),
-      has_card_gateway_account: lodash.get(req, 'service.hasCardGatewayAccount'),
-      has_card_and_dd_gateway_account: lodash.get(req, 'service.hasCardAndDirectDebitGatewayAccount'),
-      externalServiceId
+      merchant_details: lodash.get(req, 'service.merchantDetails')
     }
   }
+  pageData.has_direct_debit_gateway_account = lodash.get(req, 'service.hasDirectDebitGatewayAccount')
+  pageData.has_card_gateway_account = lodash.get(req, 'service.hasCardGatewayAccount')
+  pageData.has_card_and_dd_gateway_account = lodash.get(req, 'service.hasCardAndDirectDebitGatewayAccount')
   pageData.countries = countries.govukFrontendFormatted(lodash.get(pageData.merchant_details, 'address_country'))
   return responses.response(req, res, 'merchant_details/edit_merchant_details', pageData)
 }

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.js
@@ -28,17 +28,17 @@ const validationRules = [
   {
     field: clientFieldNames.addressLine1,
     validator: validateMandatoryField,
-    maxLength: 200
+    maxLength: 255
   },
   {
     field: clientFieldNames.addressLine2,
     validator: validateOptionalField,
-    maxLength: 200
+    maxLength: 255
   },
   {
     field: clientFieldNames.addressCity,
     validator: validateMandatoryField,
-    maxLength: 100
+    maxLength: 255
   },
   {
     field: clientFieldNames.addressCountry,

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.js
@@ -15,7 +15,7 @@ const { updateService } = require('../../../services/service_service')
 const { renderErrorView } = require('../../../utils/response')
 const { validPaths, ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
 
-const clientFormIds = {
+const clientFieldNames = {
   addressLine1: 'address-line1',
   addressLine2: 'address-line2',
   addressCity: 'address-city',
@@ -26,27 +26,27 @@ const clientFormIds = {
 
 const validationRules = [
   {
-    field: clientFormIds.addressLine1,
+    field: clientFieldNames.addressLine1,
     validator: validateMandatoryField,
     maxLength: 200
   },
   {
-    field: clientFormIds.addressLine2,
+    field: clientFieldNames.addressLine2,
     validator: validateOptionalField,
     maxLength: 200
   },
   {
-    field: clientFormIds.addressCity,
+    field: clientFieldNames.addressCity,
     validator: validateMandatoryField,
     maxLength: 100
   },
   {
-    field: clientFormIds.addressCountry,
+    field: clientFieldNames.addressCountry,
     validator: validateMandatoryField,
     maxLength: 2
   },
   {
-    field: clientFormIds.telephoneNumber,
+    field: clientFieldNames.telephoneNumber,
     validator: validatePhoneNumber
   }
 ]
@@ -55,12 +55,12 @@ const trimField = (key, store) => lodash.get(store, key, '').trim()
 
 const normaliseForm = (formBody) => {
   const fields = [
-    clientFormIds.addressLine1,
-    clientFormIds.addressLine2,
-    clientFormIds.addressCity,
-    clientFormIds.addressCountry,
-    clientFormIds.addressPostcode,
-    clientFormIds.telephoneNumber
+    clientFieldNames.addressLine1,
+    clientFieldNames.addressLine2,
+    clientFieldNames.addressCity,
+    clientFieldNames.addressCountry,
+    clientFieldNames.addressPostcode,
+    clientFieldNames.telephoneNumber
   ]
   return fields.reduce((form, field) => {
     form[field] = trimField(field, formBody)
@@ -78,23 +78,23 @@ const validateForm = function validate (form) {
     return errors
   }, {})
 
-  const postCode = form[clientFormIds.addressPostcode]
-  const country = form[clientFormIds.addressCountry]
+  const postCode = form[clientFieldNames.addressPostcode]
+  const country = form[clientFieldNames.addressCountry]
   const postCodeValidResponse = validatePostcode(postCode, country)
   if (!postCodeValidResponse.valid) {
-    errors[clientFormIds.addressPostcode] = postCodeValidResponse.message
+    errors[clientFieldNames.addressPostcode] = postCodeValidResponse.message
   }
   return errors
 }
 
 const submitForm = async function (form, serviceExternalId, correlationId) {
   const updateRequest = new ServiceUpdateRequest()
-    .replace(validPaths.merchantDetails.addressLine1, form[clientFormIds.addressLine1])
-    .replace(validPaths.merchantDetails.addressLine2, form[clientFormIds.addressLine2])
-    .replace(validPaths.merchantDetails.addressCity, form[clientFormIds.addressCity])
-    .replace(validPaths.merchantDetails.addressPostcode, form[clientFormIds.addressPostcode])
-    .replace(validPaths.merchantDetails.addressCountry, form[clientFormIds.addressCountry])
-    .replace(validPaths.merchantDetails.telephoneNumber, form[clientFormIds.telephoneNumber])
+    .replace(validPaths.merchantDetails.addressLine1, form[clientFieldNames.addressLine1])
+    .replace(validPaths.merchantDetails.addressLine2, form[clientFieldNames.addressLine2])
+    .replace(validPaths.merchantDetails.addressCity, form[clientFieldNames.addressCity])
+    .replace(validPaths.merchantDetails.addressPostcode, form[clientFieldNames.addressPostcode])
+    .replace(validPaths.merchantDetails.addressCountry, form[clientFieldNames.addressCountry])
+    .replace(validPaths.merchantDetails.telephoneNumber, form[clientFieldNames.telephoneNumber])
     .replace(validPaths.currentGoLiveStage, goLiveStage.ENTERED_ORGANISATION_ADDRESS)
     .formatPayload()
 
@@ -105,12 +105,12 @@ const buildErrorsPageData = (form, errors) => {
   return {
     success: false,
     errors: errors,
-    address_line1: form[clientFormIds.addressLine1],
-    address_line2: form[clientFormIds.addressLine2],
-    address_city: form[clientFormIds.addressCity],
-    address_postcode: form[clientFormIds.addressPostcode],
-    address_country: form[clientFormIds.addressCountry],
-    telephone_number: form[clientFormIds.telephoneNumber]
+    address_line1: form[clientFieldNames.addressLine1],
+    address_line2: form[clientFieldNames.addressLine2],
+    address_city: form[clientFieldNames.addressCity],
+    address_postcode: form[clientFieldNames.addressPostcode],
+    address_country: form[clientFieldNames.addressCountry],
+    telephone_number: form[clientFieldNames.telephoneNumber]
   }
 }
 

--- a/app/utils/validation/server-side-form-validations.js
+++ b/app/utils/validation/server-side-form-validations.js
@@ -7,7 +7,8 @@ const ukPostcode = require('uk-postcode')
 // Local dependencies
 const {
   isEmpty,
-  isFieldGreaterThanMaxLengthChars
+  isFieldGreaterThanMaxLengthChars,
+  isValidEmail
 } = require('../../browsered/field-validation-checks')
 const { invalidTelephoneNumber } = require('./telephone-number-validation')
 
@@ -189,6 +190,26 @@ exports.validateDateOfBirth = function validateDateOfBirth (day, month, year) {
     return {
       valid: false,
       message: 'Date of birth must be in the past'
+    }
+  }
+
+  return validReturnObject
+}
+
+exports.validateEmail = function validateEmail (email) {
+  const isEmptyErrorMessage = isEmpty(email)
+  if (isEmptyErrorMessage) {
+    return {
+      valid: false,
+      message: isEmptyErrorMessage
+    }
+  }
+
+  const invalidEmailErrorMessage = isValidEmail(email)
+  if (invalidEmailErrorMessage) {
+    return {
+      valid: false,
+      message: invalidEmailErrorMessage
     }
   }
 

--- a/app/utils/validation/server-side-form-validations.test.js
+++ b/app/utils/validation/server-side-form-validations.test.js
@@ -233,4 +233,24 @@ describe('Responsible person page field validations', () => {
       })
     })
   })
+
+  describe('email validation', () => {
+    it('should be valid for valid email address', () => {
+      expect(validations.validateEmail('foo@example.com').valid).to.be.true // eslint-disable-line
+    })
+
+    it('should not be valid for empty email address', () => {
+      expect(validations.validateEmail('')).to.deep.equal({
+        valid: false,
+        message: 'This field cannot be blank'
+      })
+    })
+
+    it('should not be valid for an invalid email address', () => {
+      expect(validations.validateEmail('abd')).to.deep.equal({
+        valid: false,
+        message: 'Please use a valid email address'
+      })
+    })
+  })
 })

--- a/app/views/merchant_details/edit_merchant_details.njk
+++ b/app/views/merchant_details/edit_merchant_details.njk
@@ -57,7 +57,7 @@
     <p class="govuk-body" id="merchant-details-info">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
   {% endif %}
 
-  <form id="merchant-details-form" method="post" action="/organisation-details/edit/{{externalServiceId}}">
+  <form id="merchant-details-form" method="post" action="/organisation-details/edit/{{currentService.externalId}}">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
     {% set nameError = false %}

--- a/test/cypress/integration/request-to-go-live/organisation_address_spec.js
+++ b/test/cypress/integration/request-to-go-live/organisation_address_spec.js
@@ -6,8 +6,9 @@ const { userExternalId, gatewayAccountId, serviceExternalId } = utils.variables
 const pageUrl = `/service/${serviceExternalId}/request-to-go-live/organisation-address`
 
 describe('The organisation address page', () => {
-  const longText = 'This text is 201 ...............................................................................' +
-    '..........................................................................................characters long'
+  const longText = 'This text is 256 ...............................................................................' +
+    '...............................................................................................................' +
+    '..................................characters long'
 
   beforeEach(() => {
     cy.setEncryptedCookies(userExternalId, gatewayAccountId)


### PR DESCRIPTION
- Make validation pattern match that for the new request to go live organisation address page
- Use async/await in post-edit-controller and handle all errors
- Move the setting of some session variables for the get controller to a better place
- Modify tests to be unit tests rather than integration tests
- Add improved tests for checking the update of merchant details
