### PR TITLE
PP-4983 Include organisation address in request to go live flow

### DIFF
--- a/app/controllers/request-to-go-live/choose-how-to-process-payments/get.controller.js
+++ b/app/controllers/request-to-go-live/choose-how-to-process-payments/get.controller.js
@@ -10,7 +10,7 @@ const response = require('../../../utils/response')
 
 module.exports = (req, res) => {
   // redirect on wrong stage
-  if (req.service.currentGoLiveStage !== goLiveStage.ENTERED_ORGANISATION_NAME) {
+  if (req.service.currentGoLiveStage !== goLiveStage.ENTERED_ORGANISATION_ADDRESS) {
     return res.redirect(
       303,
       requestToGoLive.index.replace(':externalServiceId', req.service.externalId)

--- a/app/controllers/request-to-go-live/go-live-stage-to-next-page-path.js
+++ b/app/controllers/request-to-go-live/go-live-stage-to-next-page-path.js
@@ -6,7 +6,7 @@ const { requestToGoLive } = require('../../paths')
 
 const goLiveStageToNextPagePathMap = {}
 goLiveStageToNextPagePathMap[goLiveStage.NOT_STARTED] = requestToGoLive.organisationName
-goLiveStageToNextPagePathMap[goLiveStage.ENTERED_ORGANISATION_NAME] = requestToGoLive.chooseHowToProcessPayments
+goLiveStageToNextPagePathMap[goLiveStage.ENTERED_ORGANISATION_NAME] = requestToGoLive.organisationAddress
 goLiveStageToNextPagePathMap[goLiveStage.ENTERED_ORGANISATION_ADDRESS] = requestToGoLive.chooseHowToProcessPayments
 goLiveStageToNextPagePathMap[goLiveStage.CHOSEN_PSP_STRIPE] = requestToGoLive.agreement
 goLiveStageToNextPagePathMap[goLiveStage.CHOSEN_PSP_WORLDPAY] = requestToGoLive.agreement

--- a/app/controllers/request-to-go-live/index/get.controller.js
+++ b/app/controllers/request-to-go-live/index/get.controller.js
@@ -43,10 +43,14 @@ const chosenHowToProcessPayments = [
   ...agreedToTerms
 ]
 
-const enteredOrganisationName = [
-  ENTERED_ORGANISATION_NAME,
+const enteredOrganisationAddress = [
   ENTERED_ORGANISATION_ADDRESS,
   ...chosenHowToProcessPayments
+]
+
+const enteredOrganisationName = [
+  ENTERED_ORGANISATION_NAME,
+  ...enteredOrganisationAddress
 ]
 
 const startedButStillStepsToComplete = [
@@ -81,6 +85,7 @@ module.exports = (req, res) => {
   pageData = {
     notStarted: currentGoLiveStage === NOT_STARTED,
     enteredOrganisationName: enteredOrganisationName.includes(currentGoLiveStage),
+    enteredOrganisationAddress: enteredOrganisationAddress.includes(currentGoLiveStage),
     chosenHowToProcessPayments: chosenHowToProcessPayments.includes(currentGoLiveStage),
     agreedToTerms: agreedToTerms.includes(currentGoLiveStage),
     startedButStillStepsToComplete: startedButStillStepsToComplete.includes(currentGoLiveStage),

--- a/app/views/request-to-go-live/index.njk
+++ b/app/views/request-to-go-live/index.njk
@@ -53,12 +53,14 @@
       <div class="request-to-go-live-list">
         <div id="request-to-go-live-step-organisation-name">
           <h3 class="govuk-heading-m">
-            Add your organisation’s name
-            {% if enteredOrganisationName %}
+            Add your organisation’s name and address
+            {% if enteredOrganisationAddress %}
               <span class="status">Completed</span>
+            {% elif enteredOrganisationName %}
+              <span class="status">In Progress</span>
             {% endif %}
           </h3>
-          <p class="govuk-body">We’ll use this information to help us set up your live account.</p>
+          <p class="govuk-body">These details will appear on your payment pages.</p>
         </div>
         <div id="request-to-go-live-step-choose-psp">
           <h3 class="govuk-heading-m">

--- a/test/cypress/integration/request-to-go-live/choose_how_to_process_payments_spec.js
+++ b/test/cypress/integration/request-to-go-live/choose_how_to_process_payments_spec.js
@@ -35,7 +35,7 @@ describe('Request to go live: choose how to process payments', () => {
       name: 'getUserSuccessRepeatFirstResponseNTimes',
       opts: [{
         external_id: userExternalId,
-        service_roles: [utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')],
+        service_roles: [utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS')],
         repeat: 2
       }, {
         external_id: userExternalId,
@@ -82,7 +82,7 @@ describe('Request to go live: choose how to process payments', () => {
       name: 'getUserSuccessRepeatFirstResponseNTimes',
       opts: [{
         external_id: userExternalId,
-        service_roles: [utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')],
+        service_roles: [utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS')],
         repeat: 2
       }, {
         external_id: userExternalId,
@@ -137,7 +137,7 @@ describe('Request to go live: choose how to process payments', () => {
 
   describe('User does not have the correct permissions', () => {
     beforeEach(() => {
-      const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')
+      const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS')
       serviceRole.role = {
         permissions: []
       }
@@ -154,7 +154,7 @@ describe('Request to go live: choose how to process payments', () => {
 
   describe('other tests', () => {
     beforeEach(() => {
-      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME'))
+      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS'))
     })
     describe('should show an error when no option selected', () => {
       it('should show "You need to select an option" error msg', () => {
@@ -187,7 +187,7 @@ describe('Request to go live: choose how to process payments', () => {
   })
 
   describe('adminusers error handlings', () => {
-    const stubPayload = lodash.concat(utils.getUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')),
+    const stubPayload = lodash.concat(utils.getUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS')),
       utils.patchUpdateGoLiveStageErrorStub('CHOSEN_PSP_STRIPE'))
     beforeEach(() => {
       cy.task('setupStubs', stubPayload)

--- a/test/cypress/integration/request-to-go-live/index_spec.js
+++ b/test/cypress/integration/request-to-go-live/index_spec.js
@@ -94,6 +94,37 @@ describe('Request to go live: index', () => {
       cy.get('h1 + p').should('contain', 'Complete these steps to request a live account')
 
       cy.get('#request-to-go-live-step-organisation-name > h3').should('exist')
+      cy.get('#request-to-go-live-step-organisation-name > h3 > span').should('contain', 'In Progress')
+
+      cy.get('#request-to-go-live-step-choose-psp > h3').should('exist')
+      cy.get('#request-to-go-live-step-choose-psp > h3 > span').should('not.exist')
+
+      cy.get('#request-to-go-live-step-agree-terms > h3').should('exist')
+      cy.get('#request-to-go-live-step-agree-terms > h3 > span').should('not.exist')
+
+      cy.get('#request-to-go-live-index-form > button').should('exist')
+      cy.get('#request-to-go-live-index-form > button').should('contain', 'Continue')
+      cy.get('#request-to-go-live-index-form > button').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live/organisation-address`)
+      })
+    })
+  })
+
+  describe('Request to go live stage ENTERED_ORGANISATION_ADDRESS', () => {
+    beforeEach(() => {
+      setupStubs(buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS'))
+    })
+
+    it('should show "Request to go live" page with correct progress indication', () => {
+      const requestToGoLivePageUrl = `/service/${serviceExternalId}/request-to-go-live`
+      cy.visit(requestToGoLivePageUrl)
+
+      cy.get('h1').should('contain', 'Request a live account')
+      cy.get('h1 + p').should('contain', 'Complete these steps to request a live account')
+
+      cy.get('#request-to-go-live-step-organisation-name > h3').should('exist')
       cy.get('#request-to-go-live-step-organisation-name > h3 > span').should('contain', 'Completed')
 
       cy.get('#request-to-go-live-step-choose-psp > h3').should('exist')

--- a/test/cypress/integration/request-to-go-live/organisation_name_spec.js
+++ b/test/cypress/integration/request-to-go-live/organisation_name_spec.js
@@ -99,7 +99,7 @@ describe('Request to go live: organisation name page', () => {
       cy.get('#request-to-go-live-organisation-name-form > button').click()
 
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`)
+        expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live/organisation-address`)
       })
     })
   })
@@ -139,7 +139,7 @@ describe('Request to go live: organisation name page', () => {
       cy.get('#request-to-go-live-organisation-name-form > button').click()
 
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`)
+        expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live/organisation-address`)
       })
     })
   })

--- a/test/unit/controller/request-to-go-live/go-live-stage-to-next-page-path.test.js
+++ b/test/unit/controller/request-to-go-live/go-live-stage-to-next-page-path.test.js
@@ -42,11 +42,19 @@ describe('go-live-stage-to-next-page-path tests', () => {
     })
   })
 
-  describe('should return "choose-how-to-process-payments" path', () => {
-    const path = '/service/:externalServiceId/request-to-go-live/choose-how-to-process-payments'
+  describe('should return "organisation-address" path', () => {
+    const path = '/service/:externalServiceId/request-to-go-live/organisation-address'
 
     it('should resolve ENTERED_ORGANISATION_NAME stage correctly', () => {
       expect(goLiveStageToNextPagePath[goLiveStage.ENTERED_ORGANISATION_NAME]).to.equal(path)
+    })
+  })
+
+  describe('should return "choose-how-to-process-payments" path', () => {
+    const path = '/service/:externalServiceId/request-to-go-live/choose-how-to-process-payments'
+
+    it('should resolve ENTERED_ORGANISATION_ADDRESS stage correctly', () => {
+      expect(goLiveStageToNextPagePath[goLiveStage.ENTERED_ORGANISATION_ADDRESS]).to.equal(path)
     })
   })
 


### PR DESCRIPTION
- Completing the "Organisation Name" page will now direct the user to
  the "Organisation Address" page.
- The "Choose How To Process Payments" page now expects the go live
  stage to be "ENTERED_ORGANISATION_ADDRESS"
- When the user has entered the organisation name, but not the address,
  the progress label in the task list is "IN PROGRESS"