### PR TITLE
PP-4976 Use controller errors on the edit merchant details page

### DIFF
--- a/app/controllers/edit_merchant_details/post-edit-controller.js
+++ b/app/controllers/edit_merchant_details/post-edit-controller.js
@@ -121,7 +121,6 @@ const submitForm = async function (form, serviceExternalId, correlationId, hasDi
   }
 
   const payload = serviceUpdateRequest.formatPayload()
-  console.log('PAYLOAD ' + JSON.stringify(payload))
   return serviceService.updateService(serviceExternalId, payload, correlationId)
 }
 

--- a/app/views/merchant_details/edit_merchant_details.njk
+++ b/app/views/merchant_details/edit_merchant_details.njk
@@ -63,7 +63,7 @@
     {% set nameError = false %}
     {% if errors["merchant-name"] %}
       {% set nameError = {
-        text: "Please enter a valid name"
+        text: errors["merchant-name"]
       } %}
     {% endif %}
 
@@ -93,7 +93,7 @@
       {% set phoneError = false %}
       {% if errors["telephone-number"] %}
         {% set phoneError = {
-          text: "Please enter a valid phone number"
+          text: errors["telephone-number"]
         } %}
       {% endif %}
 
@@ -114,7 +114,7 @@
       {% set emailError = false %}
       {% if errors["merchant-email"] %}
         {% set emailError = {
-          text: "Please enter a valid email"
+          text: errors["merchant-email"]
         } %}
       {% endif %}
 
@@ -136,28 +136,35 @@
     {% set addressLine1Error = false %}
     {% if errors["address-line1"] %}
       {% set addressLine1Error = {
-        text: "Please enter a valid address"
+        text: errors["address-line1"]
+      } %}
+    {% endif %}
+
+    {% set addressLine2Error = false %}
+    {% if errors["address-line2"] %}
+      {% set addressLine2Error = {
+        text: errors["address-line2"]
       } %}
     {% endif %}
 
     {% set cityError = false %}
     {% if errors["address-city"] %}
       {% set cityError = {
-        text: "Please enter a valid town or city"
+        text: errors["address-city"]
       } %}
     {% endif %}
 
     {% set postcodeError = false %}
     {% if errors["address-postcode"] %}
       {% set postcodeError = {
-        text: "Please enter a valid postcode"
+        text: errors["address-postcode"]
       } %}
     {% endif %}
 
     {% set countryError = false %}
     {% if errors["address-country"] %}
       {% set countryError = {
-        text: "Please enter a valid country"
+        text: errors["address-country"]
       } %}
     {% endif %}
 
@@ -187,6 +194,7 @@
         classes: "govuk-!-width-two-thirds",
         id: "address-line2",
         name: "address-line2",
+        errorMessage: addressLine2Error,
         value: merchant_details.address_line2
       }) }}
 

--- a/test/cypress/integration/settings/merchant_details_spec.js
+++ b/test/cypress/integration/settings/merchant_details_spec.js
@@ -49,7 +49,7 @@ describe('Dashboard', () => {
         .contains('Postcode')
         .should('have.attr', 'href', '#address-postcode')
       cy.get('.govuk-error-message')
-        .contains('Please enter a valid postcode')
+        .contains('Please enter a real postcode')
     })
   })
 })

--- a/test/unit/controller/edit_merchant_details_controller/get-edit.test.js
+++ b/test/unit/controller/edit_merchant_details_controller/get-edit.test.js
@@ -229,6 +229,13 @@ describe('edit merchant details controller - get', () => {
     })
   })
   describe('when errors and merchant details are set in the session (CREDIT CARD GATEWAY ACCOUNT)', () => {
+    const merchantNameError = 'merchant name error'
+    const addressLine1Error = 'address line 1 error'
+    const addressLine2Error = 'address line 2 error'
+    const addressCityError = 'address city error'
+    const addressPostcodeError = 'address postcode error'
+    const addressCountryError = 'address country error'
+
     before(done => {
       const user = buildUserResponse(['20'])
 
@@ -236,7 +243,7 @@ describe('edit merchant details controller - get', () => {
         .reply(200, user.getPlain())
       session = {
         csrfSecret: '123',
-        12345: {refunded_amount: 5},
+        12345: { refunded_amount: 5 },
         passport: {
           user: user.getAsObject()
         },
@@ -255,8 +262,12 @@ describe('edit merchant details controller - get', () => {
               address_country: 'GB'
             },
             errors: {
-              'merchant-name': true,
-              'address-country': true
+              'merchant-name': merchantNameError,
+              'address-line1': addressLine1Error,
+              'address-line2': addressLine2Error,
+              'address-city': addressCityError,
+              'address-postcode': addressPostcodeError,
+              'address-country': addressCountryError
             }
           }
         }
@@ -274,14 +285,24 @@ describe('edit merchant details controller - get', () => {
       expect(response.statusCode).to.be.equal(200)
     })
     it(`should show a list of errors`, () => {
-      expect($('.govuk-error-summary__list li').length).to.equal(2)
+      expect($('.govuk-error-summary__list li').length).to.equal(5)
       expect($('.govuk-error-summary__list li a[href$="#merchant-name"]').text()).to.equal('Name')
       expect($('.govuk-error-summary__list li a[href$="#address-country"]').text()).to.equal('Country')
     })
     it(`should show inline error messages`, () => {
-      expect($('.govuk-error-message').length).to.equal(2)
-      expect($('.govuk-error-message').eq(0).text()).to.contain('Please enter a valid name')
-      expect($('.govuk-error-message').eq(1).text()).to.contain('Please enter a valid country')
+      expect($('.govuk-error-message').length).to.equal(6)
+      expect($('.govuk-form-group--error > input#merchant-name').parent().find('.govuk-error-message').text())
+        .to.contain(merchantNameError)
+      expect($('.govuk-form-group--error > input#address-line1').parent().find('.govuk-error-message').text())
+        .to.contain(addressLine1Error)
+      expect($('.govuk-form-group--error > input#address-line2').parent().find('.govuk-error-message').text())
+        .to.contain(addressLine2Error)
+      expect($('.govuk-form-group--error > input#address-city').parent().find('.govuk-error-message').text())
+        .to.contain(addressCityError)
+      expect($('.govuk-form-group--error > input#address-postcode').parent().find('.govuk-error-message').text())
+        .to.contain(addressPostcodeError)
+      expect($('.govuk-form-group--error > select#address-country').parent().find('.govuk-error-message').text())
+        .to.contain(addressCountryError)
     })
     it(`should not show an updated successful banner`, () => {
       expect($('.notification').length).to.equal(0)
@@ -296,13 +317,17 @@ describe('edit merchant details controller - get', () => {
     })
   })
   describe('when errors and merchant details are set in the session (DIRECT DEBIT GATEWAY ACCOUNT)', () => {
+    const merchantNameError = 'merchant name error'
+    const telephoneNumberError = 'telephone number error'
+    const merchantEmailError = 'merchant email error'
+
     before(done => {
       const user = buildUserResponse(['DIRECT_DEBIT:somerandomidhere'])
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user.getPlain())
       session = {
         csrfSecret: '123',
-        12345: {refunded_amount: 5},
+        12345: { refunded_amount: 5 },
         passport: {
           user: user.getAsObject()
         },
@@ -324,10 +349,9 @@ describe('edit merchant details controller - get', () => {
             },
             has_direct_debit_gateway_account: true,
             errors: {
-              'merchant-name': true,
-              'telephone-number': true,
-              'merchant-email': true,
-              'address-country': true
+              'merchant-name': merchantNameError,
+              'telephone-number': telephoneNumberError,
+              'merchant-email': merchantEmailError
             }
           }
         }
@@ -345,18 +369,19 @@ describe('edit merchant details controller - get', () => {
       expect(response.statusCode).to.be.equal(200)
     })
     it(`should show a list of errors`, () => {
-      expect($('.govuk-error-summary__list li').length).to.equal(4)
+      expect($('.govuk-error-summary__list li').length).to.equal(3)
       expect($('.govuk-error-summary__list li a[href$="#merchant-name"]').text()).to.equal('Name')
       expect($('.govuk-error-summary__list li a[href$="#telephone-number"]').text()).to.equal('Phone number')
       expect($('.govuk-error-summary__list li a[href$="#merchant-email"]').text()).to.equal('Email')
-      expect($('.govuk-error-summary__list li a[href$="#address-country"]').text()).to.equal('Country')
     })
     it(`should show inline error messages`, () => {
-      expect($('.govuk-error-message').length).to.equal(4)
-      expect($('.govuk-error-message').eq(0).text()).to.contain('Please enter a valid name')
-      expect($('.govuk-error-message').eq(1).text()).to.contain('Please enter a valid phone number')
-      expect($('.govuk-error-message').eq(2).text()).to.contain('Please enter a valid email')
-      expect($('.govuk-error-message').eq(3).text()).to.contain('Please enter a valid country')
+      expect($('.govuk-error-message').length).to.equal(3)
+      expect($('.govuk-form-group--error > input#merchant-name').parent().find('.govuk-error-message').text())
+        .to.contain(merchantNameError)
+      expect($('.govuk-form-group--error > input#telephone-number').parent().find('.govuk-error-message').text())
+        .to.contain(telephoneNumberError)
+      expect($('.govuk-form-group--error > input#merchant-email').parent().find('.govuk-error-message').text())
+        .to.contain(merchantEmailError)
     })
     it(`should not show an updated successful banner`, () => {
       expect($('.notification').length).to.equal(0)


### PR DESCRIPTION
The 'errors' object returned by the post controller now contains error messages as the values, where previously there was just a boolean to indicate there was an error.
Use these error messages in the template rather than the existing static text.

This modifies some of the error messages, but makes them more consistent with the design system.

