### PR TITLE
PP-4949 Company number validation

### DIFF
--- a/app/browsered/field-validation-checks.js
+++ b/app/browsered/field-validation-checks.js
@@ -19,7 +19,9 @@ const validationErrors = {
   invalidCharacters: `You cannot use any of the following characters < > ; : \` ( ) " ' = | , ~ [ ]`,
   invalidBankAccountNumber: 'Enter a valid account number',
   invalidSortCode: 'Enter a valid sort code',
-  invalidVatNumber: 'Enter a valid VAT number'
+  invalidVatNumber: 'Enter a valid VAT number',
+  invalidCompanyNumber: 'Enter a valid company number',
+  sevenDigitCompanyNumber: 'Company numbers in England and Wales have 8 digits and always start with 0'
 }
 
 exports.validationErrors = validationErrors
@@ -110,4 +112,14 @@ exports.isNotVatNumber = value => {
   } else {
     return validationErrors.invalidVatNumber
   }
+}
+
+exports.isNotCompanyNumber = value => {
+  const sanitisedCompanyNumber = value.replace(/\s/g, '').toUpperCase()
+  if (/^[0-9]{7}$/.test(sanitisedCompanyNumber)) {
+    return validationErrors.sevenDigitCompanyNumber
+  } else if (!/^(?:0[0-9]|OC|LP|SC|SO|SL|NI|R0|NC|NL)[0-9]{6}$/.test(sanitisedCompanyNumber)) {
+    return validationErrors.invalidCompanyNumber
+  }
+  return false
 }

--- a/app/browsered/field-validation.js
+++ b/app/browsered/field-validation.js
@@ -101,6 +101,9 @@ function validateField (form, field) {
       case 'vatNumber':
         result = checks.isNotVatNumber(field.value)
         break
+      case 'companyNumber':
+        result = checks.isNotCompanyNumber(field.value)
+        break
       default:
         result = checks.isEmpty(field.value)
         break

--- a/app/controllers/stripe-setup/vat-number-company-number/company-number/company-number-validations.js
+++ b/app/controllers/stripe-setup/vat-number-company-number/company-number/company-number-validations.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // Local dependencies
-const { isEmpty } = require('../../../../browsered/field-validation-checks')
+const { isEmpty, isNotCompanyNumber } = require('../../../../browsered/field-validation-checks')
 
 exports.validateCompanyNumber = function validateCompanyNumber (value) {
   const isEmptyErrorMessage = isEmpty(value)
@@ -12,8 +12,13 @@ exports.validateCompanyNumber = function validateCompanyNumber (value) {
     }
   }
 
-  // TODO
-  // implement "isNotCompanyNumber" in field-validation-checks
+  const isNotCompanyNumberErrorMessage = isNotCompanyNumber(value)
+  if (isNotCompanyNumberErrorMessage) {
+    return {
+      valid: false,
+      message: isNotCompanyNumberErrorMessage
+    }
+  }
 
   return {
     valid: true,

--- a/app/controllers/stripe-setup/vat-number-company-number/company-number/company-number-validations.test.js
+++ b/app/controllers/stripe-setup/vat-number-company-number/company-number/company-number-validations.test.js
@@ -6,14 +6,26 @@ const { expect } = require('chai')
 // Local dependencies
 const companyNumberValidations = require('./company-number-validations')
 
-describe('Company number validations', () => {
-  it('should not be valid when mandatory text is blank', () => {
+// Constants
+const validCompanyNumber = '01234567'
+const invalidCompanyNumber = '¯\\_(ツ)_/¯'
+
+describe('company number validations', () => {
+  it('should validate successfully', () => {
+    expect(companyNumberValidations.validateCompanyNumber(validCompanyNumber).valid).to.be.true // eslint-disable-line
+  })
+
+  it('should not be valid when blank', () => {
     expect(companyNumberValidations.validateCompanyNumber('')).to.deep.equal({
       valid: false,
       message: 'This field cannot be blank'
     })
   })
 
-  // TODO
-  // implement the rest of the tests once we have the validation implemented
+  it('should not be valid when company number is invalid', () => {
+    expect(companyNumberValidations.validateCompanyNumber(invalidCompanyNumber)).to.deep.equal({
+      valid: false,
+      message: 'Enter a valid company number'
+    })
+  })
 })

--- a/test/unit/browsered/field-validation-checks.company-number.test.js
+++ b/test/unit/browsered/field-validation-checks.company-number.test.js
@@ -1,0 +1,95 @@
+'use strict'
+
+// NPM dependencies
+const { expect } = require('chai')
+
+// Local dependencies
+const { isNotCompanyNumber } = require('../../../app/browsered/field-validation-checks')
+
+describe('isNotCompanyNumber', () => {
+  describe('UK company number validations', () => {
+    it('should validate that England and Wales limited company number is valid', () => {
+      expect(isNotCompanyNumber('01234567')).to.be.false // eslint-disable-line
+    })
+
+    it('should validate that England and Wales LLP number is valid', () => {
+      expect(isNotCompanyNumber('OC123456')).to.be.false // eslint-disable-line
+    })
+
+    it('should validate that England and Wales limited partnership number is valid', () => {
+      expect(isNotCompanyNumber('LP123456')).to.be.false // eslint-disable-line
+    })
+
+    it('should validate that Scotland limited company number is valid', () => {
+      expect(isNotCompanyNumber('SC123456')).to.be.false // eslint-disable-line
+    })
+
+    it('should validate that Scotland LLP number is valid', () => {
+      expect(isNotCompanyNumber('SO123456')).to.be.false // eslint-disable-line
+    })
+
+    it('should validate that Scotland limited partnership number is valid', () => {
+      expect(isNotCompanyNumber('SL123456')).to.be.false // eslint-disable-line
+    })
+
+    it('should validate that Northern Ireland limited company number is valid', () => {
+      expect(isNotCompanyNumber('NI123456')).to.be.false // eslint-disable-line
+    })
+
+    it('should validate that Northern Ireland pre-partition limited company number is valid', () => {
+      expect(isNotCompanyNumber('R0123456')).to.be.false // eslint-disable-line
+    })
+
+    it('should validate that Northern Ireland LLP number is valid', () => {
+      expect(isNotCompanyNumber('NC123456')).to.be.false // eslint-disable-line
+    })
+
+    it('should validate that Northern Ireland limited partnership number is valid', () => {
+      expect(isNotCompanyNumber('NL123456')).to.be.false // eslint-disable-line
+    })
+
+    it('should validate that company number with spaces is valid', () => {
+      expect(isNotCompanyNumber(' 0 123 45 67 ')).to.be.false // eslint-disable-line
+    })
+
+    it('should validate that company number with lower-case prefix is valid', () => {
+      expect(isNotCompanyNumber('sc123456')).to.be.false // eslint-disable-line
+    })
+
+    it('should validate that company number of 8 digits without leading 0 is invalid', () => {
+      expect(isNotCompanyNumber('12345678')).to.be.equal('Enter a valid company number') // eslint-disable-line
+    })
+
+    it('should validate that NI pre-partition company number without leading R0 is invalid', () => {
+      expect(isNotCompanyNumber('R1234567')).to.be.equal('Enter a valid company number') // eslint-disable-line
+    })
+
+    it('should validate that company number of 6 digits is invalid', () => {
+      expect(isNotCompanyNumber('123456')).to.be.equal('Enter a valid company number') // eslint-disable-line
+    })
+
+    it('should validate that company number of 7 digits is invalid (with special message)', () => {
+      expect(isNotCompanyNumber('1234567')).to.be.equal('Company numbers in England and Wales have 8 digits and always start with 0') // eslint-disable-line
+    })
+
+    it('should validate that company number of 9 digits is invalid', () => {
+      expect(isNotCompanyNumber('012345678')).to.be.equal('Enter a valid company number') // eslint-disable-line
+    })
+
+    it('should validate that company number of 9 digits is invalid', () => {
+      expect(isNotCompanyNumber('012345678')).to.be.equal('Enter a valid company number') // eslint-disable-line
+    })
+
+    it('should validate that company number with prefix and 5 digits is invalid', () => {
+      expect(isNotCompanyNumber('NI12345')).to.be.equal('Enter a valid company number') // eslint-disable-line
+    })
+
+    it('should validate that company number with prefix and 7 digits is invalid', () => {
+      expect(isNotCompanyNumber('NC1234567')).to.be.equal('Enter a valid company number') // eslint-disable-line
+    })
+
+    it('should validate that company number with unrecognised prefix is invalid', () => {
+      expect(isNotCompanyNumber('RC123456')).to.be.equal('Enter a valid company number') // eslint-disable-line
+    })
+  })
+})


### PR DESCRIPTION
Validation for company numbers, accepting these formats:

01234567 (England and Wales limited company: 0 then 7 digits)
OC123456 (England and Wales LLP: OC then 6 digits)
LP123456 (England and Wales limited partnership: LP then 6 digits)
SC123456 (Scotland limited company: SC then 6 digits)
SO123456 (Scotland LLP: SO then 6 digits)
SL123456 (Scotland limited partnership: SL then 6 digits)
NI123456 (Northern Ireland limited company: NI then 6 digits)
R0123456 (NI pre-partition limited company: R0 then 6 digits)
NC123456 (NI LLP: NC then 6 digits)
NL123456 (NI limited partnership: NL then 6 digits)

Any number of spaces are allowed anywhere and the case of the letters does not matter.

Certificates of incorporation for limited companies in England and Wales do not include the initial 0 in the company number, so we have a special error message for when the user enters 7 digits — possibly with whitespace — to remind them about the leading 0.