### PR TITLE
PP-5061 Don’t send "name" property to adminusers for new service

### DIFF
--- a/app/services/clients/adminusers_client.js
+++ b/app/services/clients/adminusers_client.js
@@ -543,7 +543,6 @@ module.exports = function (clientOptions = {}) {
     }
 
     if (serviceName) {
-      postBody.body.name = serviceName
       postBody.body.service_name = lodash.merge(postBody.body.service_name, { en: serviceName })
     }
     if (serviceNameCy) {

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -54,7 +54,6 @@ module.exports = {
 
     const data = {}
     if (opts.name) {
-      data.name = opts.name
       data.service_name = { en: opts.name }
     }
     if (opts.gateway_account_ids) {


### PR DESCRIPTION
When creating a new service, don’t send the `"name"` property in the JSON payload. Continue sending an appropriate `"service_name"` property, which adminusers will also pick up.