### PR TITLE
PP-5013 Display Welsh specific instructions on payment link information page

### DIFF
--- a/app/controllers/payment-links/get-information-controller.js
+++ b/app/controllers/payment-links/get-information-controller.js
@@ -4,19 +4,24 @@
 const lodash = require('lodash')
 
 // Local dependencies
-const {response} = require('../../utils/response.js')
+const { response } = require('../../utils/response')
+const supportedLanguage = require('../../models/supported-language')
 
 module.exports = (req, res) => {
   const pageData = lodash.get(req, 'session.pageData.createPaymentLink', {})
   const paymentLinkTitle = req.body['payment-description'] || pageData.paymentLinkTitle || ''
   const paymentLinkDescription = req.body['payment-amount'] || pageData.paymentLinkDescription || ''
-  const change = lodash.get(req, 'query.field', {})
   const friendlyURL = process.env.PRODUCTS_FRIENDLY_BASE_URI
+
+  const change = lodash.get(req, 'query.field', {})
+  const language = lodash.get(req, 'query.language', supportedLanguage.ENGLISH)
+  const isWelsh = language === supportedLanguage.WELSH
 
   return response(req, res, 'payment-links/information', {
     change,
     friendlyURL,
     paymentLinkTitle,
-    paymentLinkDescription
+    paymentLinkDescription,
+    isWelsh
   })
 }

--- a/app/models/supported-language.js
+++ b/app/models/supported-language.js
@@ -1,0 +1,6 @@
+'use strict'
+
+module.exports = {
+  ENGLISH: 'en',
+  WELSH: 'cy'
+}

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -14,7 +14,11 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
-  <h1 class="govuk-heading-l">Set payment link information</h1>
+  {% if isWelsh %}
+    <h1 class="govuk-heading-l">Set Welsh payment link information</h1>
+  {% else %}
+    <h1 class="govuk-heading-l">Set payment link information</h1>
+  {% endif %}
 
   <form action="{{ routes.paymentLinks.information }}" class="form" method="post" data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
@@ -31,6 +35,18 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
     {% endif %}
     {% set confirmationLabel %}{{friendlyURL}}/{{currentService.name | removeIndefiniteArticles | slugify}}/{% endset %}
 
+    {% if isWelsh %}
+      {% set titleLabel = 'Welsh title' %}
+      {% set titleHint = 'Briefly describe what the user is paying for. For example, <span lang="cy">“Talu am drwydded barcio”</span>. This will also be your website address.' %}
+      {% set detailsHint = 'Give your users more information in Welsh. For example, you could tell them how long it takes for their application to be processed.' %}
+      {% set lang = "cy" %}
+    {% else %}
+      {% set titleLabel = 'Title' %}
+      {% set titleHint = 'Briefly describe what the user is paying for. For example, “Pay for a parking permit”. This will also be your website address.' %}
+      {% set detailsHint = 'Give your users more information. For example, you could tell them how long it takes for their application to be processed.' %}
+      {% set lang = "en" %}
+    {% endif %}
+
     {{
       govukInput({
         id: 'payment-link-title',
@@ -38,13 +54,11 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
         value: paymentLinkTitle,
         classes: '',
         label: {
-            text: 'Title',
+            text: titleLabel,
             classes: 'govuk-label--s'
         },
         hint: {
-          text: 'Briefly describe what the user is paying for.
-          For example, “Pay for a parking permit”.
-          This will also be your website address.'
+          html: titleHint
         },
         errorMessage: titleError,
         attributes: {
@@ -55,7 +69,8 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
           "data-confirmation-title": "The website address for this payment link will look like:",
           "data-confirmation-label": confirmationLabel,
           "data-confirmation-filter": "slugify",
-          "data-confirmation-display": "onload" if change.length else false
+          "data-confirmation-display": "onload" if change.length else false,
+          "lang": lang
         }
       })
     }}
@@ -71,12 +86,13 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
             classes: 'govuk-label--s'
         },
         hint: {
-          text: 'Give your users more information. For example, you could tell them how long it takes for their application to be processed.'
+          text: detailsHint
         },
         errorMessage: titleError,
         attributes: {
           "autofocus": change !== "payment-link-description",
-          "rows": "5"
+          "rows": "5",
+          "lang": lang
         }
       })
     }}

--- a/test/cypress/integration/payment-links/create_payment_link_spec.js
+++ b/test/cypress/integration/payment-links/create_payment_link_spec.js
@@ -1,0 +1,112 @@
+const commonStubs = require('../../utils/common_stubs')
+const userExternalId = 'a-user-id'
+const gatewayAccountId = 42
+
+describe('The create payment link flow', () => {
+  beforeEach(() => {
+    cy.task('setupStubs', [
+      commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
+      commonStubs.getGatewayAccountStub(gatewayAccountId, 'test', 'worldpay')
+    ])
+    Cypress.Cookies.preserveOnce('session', 'gateway_account')
+  })
+
+  describe('The create payment link start page', () => {
+    it('Should display page content', () => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.visit('/create-payment-link')
+
+      cy.get('h1').should('contain', 'Create a payment link')
+      cy.get('a#create-payment-link').should('exist')
+    })
+  })
+
+  describe('A English payment link', () => {
+    it('Should navigate to create payment link in English information page', () => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.visit('/create-payment-link')
+
+      cy.get('a#create-payment-link').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq(`/create-payment-link/information`)
+      })
+    })
+
+    describe('Information page', () => {
+      it('Should display instructions for an English payment link', () => {
+        cy.get('h1').should('contain', 'Set payment link information')
+
+        cy.get('form[method=post][action="/create-payment-link/information"]').should('exist')
+          .within(() => {
+            cy.get('input#payment-link-title').should('exist')
+            cy.get('input#payment-link-title').should('have.attr', 'lang', 'en')
+            cy.get('label[for="payment-link-title"]').should('contain', 'Title')
+            cy.get('input#payment-link-title').parent('.govuk-form-group').get('span')
+              .should('contain', 'For example, “Pay for a parking permit”')
+
+            cy.get('textarea#payment-link-description').should('exist')
+            cy.get('textarea#payment-link-description').should('have.attr', 'lang', 'en')
+            cy.get('label[for="payment-link-description"]').should('exist')
+            cy.get('textarea#payment-link-description').parent('.govuk-form-group').get('span')
+              .should('contain', 'Give your users more information.')
+
+            cy.get('button[type=submit]').should('exist')
+          })
+      })
+
+      it('Should continue to the reference page', () => {
+        cy.get('input#payment-link-title').type('Pay for a parking permit')
+        cy.get('textarea#payment-link-description').type('A description')
+
+        cy.get('button[type=submit]').click()
+
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`/create-payment-link/reference`)
+        })
+      })
+    })
+  })
+
+  describe('A Welsh payment link', () => {
+    describe('Information page', () => {
+      it('Should display Welsh-specific instructions', () => {
+        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+
+        // TODO start the flow by clicking "Create payment link in Welsh" link when this
+        // exists
+        cy.visit('/create-payment-link/information?language=cy')
+
+        cy.get('h1').should('contain', 'Set Welsh payment link information')
+
+        cy.get('form[method=post][action="/create-payment-link/information"]').should('exist')
+          .within(() => {
+            cy.get('input#payment-link-title').should('exist')
+            cy.get('input#payment-link-title').should('have.attr', 'lang', 'cy')
+            cy.get('label[for="payment-link-title"]').should('contain', 'Welsh title')
+            cy.get('input#payment-link-title').parent('.govuk-form-group').get('span')
+              .should('contain', 'For example, “Talu am drwydded barcio”')
+
+            cy.get('textarea#payment-link-description').should('exist')
+            cy.get('textarea#payment-link-description').should('have.attr', 'lang', 'cy')
+            cy.get('label[for="payment-link-description"]').should('exist')
+            cy.get('textarea#payment-link-description').parent('.govuk-form-group').get('span')
+              .should('contain', 'Give your users more information in Welsh')
+
+            cy.get('button[type=submit]').should('exist')
+          })
+      })
+
+      it('Should continue to the reference page', () => {
+        cy.get('input#payment-link-title').type('Talu am drwydded barcio')
+        cy.get('textarea#payment-link-description').type('Disgrifiad yn Gymraeg')
+
+        cy.get('button[type=submit]').click()
+
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`/create-payment-link/reference`)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
- Add a supported-language enum to hold the supported language values.
- Display the "/create-payment-link/information" page with Welsh specific instructions if the query parameter "language=cy" is provided.
- Add Cypress tests covering the information page.


