### PR TITLE
PP-5013 Add Welsh instructions on payment link reference and review pages

### DIFF
--- a/app/controllers/payment-links/get-information-controller.js
+++ b/app/controllers/payment-links/get-information-controller.js
@@ -14,8 +14,17 @@ module.exports = (req, res) => {
   const friendlyURL = process.env.PRODUCTS_FRIENDLY_BASE_URI
 
   const change = lodash.get(req, 'query.field', {})
-  const language = lodash.get(req, 'query.language', supportedLanguage.ENGLISH)
-  const isWelsh = language === supportedLanguage.WELSH
+
+  let isWelsh
+  if (pageData.hasOwnProperty('isWelsh')) {
+    isWelsh = pageData.isWelsh
+  } else {
+    isWelsh = lodash.get(req, 'query.language') === supportedLanguage.WELSH
+    lodash.set(req, 'session.pageData.createPaymentLink', {
+      ...pageData,
+      isWelsh
+    })
+  }
 
   return response(req, res, 'payment-links/information', {
     change,

--- a/app/controllers/payment-links/get-reference-controller.js
+++ b/app/controllers/payment-links/get-reference-controller.js
@@ -4,13 +4,14 @@
 const lodash = require('lodash')
 
 // Local dependencies
-const {response} = require('../../utils/response.js')
+const { response } = require('../../utils/response.js')
 
 module.exports = (req, res) => {
   const pageData = lodash.get(req, 'session.pageData.createPaymentLink', {})
   const paymentReferenceType = req.body['reference-type-group'] || pageData.paymentReferenceType || ''
   const paymentReferenceLabel = req.body['reference-label'] || pageData.paymentReferenceLabel || ''
   const paymentReferenceHint = req.body['reference-hint-text'] || pageData.paymentReferenceHint || ''
+  const isWelsh = pageData.isWelsh
 
   const change = lodash.get(req, 'query.change', {})
 
@@ -18,6 +19,7 @@ module.exports = (req, res) => {
     change,
     paymentReferenceType,
     paymentReferenceLabel,
-    paymentReferenceHint
+    paymentReferenceHint,
+    isWelsh
   })
 }

--- a/app/controllers/payment-links/post-information-controller.js
+++ b/app/controllers/payment-links/post-information-controller.js
@@ -27,11 +27,10 @@ module.exports = (req, res) => {
     return res.redirect(paths.paymentLinks.information)
   }
 
-  if (!lodash.isEmpty(pageData) && !lodash.isEqual(pageData, updatedPageData)) {
-    req.flash('generic', `<h2>The details have been updated</h2>`)
-  }
-
   if (req.body['change'] === 'true') {
+    if (!lodash.isEmpty(pageData) && !lodash.isEqual(pageData, updatedPageData)) {
+      req.flash('generic', `<h2>The details have been updated</h2>`)
+    }
     return res.redirect(paths.paymentLinks.review)
   }
 

--- a/app/views/payment-links/reference.njk
+++ b/app/views/payment-links/reference.njk
@@ -35,6 +35,16 @@
     } %}
     {% endif %}
 
+    {% if isWelsh %}
+      {% set referenceNameHint = 'For example, <span lang="cy">“rhif anfoneb”</span>' %}
+      {% set referenceHintHint = 'Explain in Welsh what the payment reference looks like and where to find it.' %}
+      {% set lang = 'cy' %}
+    {% else %}
+      {% set referenceNameHint = 'For example, “invoice number”' %}
+      {% set referenceHintHint = 'Tell users what the payment reference looks like and where they can find it.' %}
+      {% set lang = 'en' %}
+    {% endif %}
+
     {% set customReferenceHTML %}
       {{
         govukInput({
@@ -48,10 +58,11 @@
               classes: "govuk-label--s"
           },
           hint: {
-            text: "For example, 'invoice number'"
+            html: referenceNameHint
           },
           attributes: {
-            "data-validate": "isNaxsiSafe"
+            "data-validate": "isNaxsiSafe",
+            "lang": lang
           }
         })
       }}
@@ -68,12 +79,13 @@
               classes: "govuk-label--s"
           },
           hint: {
-            text: "Tell users what the payment reference looks like and where they can find it."
+            text: referenceHintHint
           },
           attributes: {
             "data-validate": "isFieldGreaterThanMaxLengthChars isNaxsiSafe",
             "maxlength": "255",
-            "data-validate-max-length": "255"
+            "data-validate-max-length": "255",
+            "lang": lang
           }
         })
       }}

--- a/app/views/payment-links/review.njk
+++ b/app/views/payment-links/review.njk
@@ -87,9 +87,16 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
         </dd>
       </div>
     </dl>
+
+    {% if pageData.isWelsh %}
+      {% set submitText = "Create Welsh payment link" %}
+    {% else %}
+      {% set submitText = "Create payment link" %}
+    {% endif %}
+
     {{
       govukButton({
-        text: "Create link",
+        text: submitText,
         attributes: {
           id: "create-payment-link-publish"
         }

--- a/test/cypress/integration/payment-links/create_payment_link_spec.js
+++ b/test/cypress/integration/payment-links/create_payment_link_spec.js
@@ -11,25 +11,30 @@ describe('The create payment link flow', () => {
     Cypress.Cookies.preserveOnce('session', 'gateway_account')
   })
 
-  describe('The create payment link start page', () => {
-    it('Should display page content', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit('/create-payment-link')
-
-      cy.get('h1').should('contain', 'Create a payment link')
-      cy.get('a#create-payment-link').should('exist')
-    })
-  })
-
   describe('A English payment link', () => {
-    it('Should navigate to create payment link in English information page', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit('/create-payment-link')
+    const name = 'Pay for a parking permit'
+    const description = 'Finish your application'
+    const referenceName = 'invoice number'
+    const referenceHint = 'Found in the email'
+    const amount = 10
 
-      cy.get('a#create-payment-link').click()
+    describe('The create payment link start page', () => {
+      it('Should display page content', () => {
+        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.visit('/create-payment-link')
 
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(`/create-payment-link/information`)
+        cy.get('h1').should('contain', 'Create a payment link')
+        cy.get('a#create-payment-link').should('exist')
+      })
+      it('Should navigate to create payment link in English information page', () => {
+        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.visit('/create-payment-link')
+
+        cy.get('a#create-payment-link').click()
+
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`/create-payment-link/information`)
+        })
       })
     })
 
@@ -56,19 +61,135 @@ describe('The create payment link flow', () => {
       })
 
       it('Should continue to the reference page', () => {
-        cy.get('input#payment-link-title').type('Pay for a parking permit')
-        cy.get('textarea#payment-link-description').type('A description')
-
-        cy.get('button[type=submit]').click()
+        cy.get('form[method=post][action="/create-payment-link/information"]').within(() => {
+          cy.get('input#payment-link-title').type(name)
+          cy.get('textarea#payment-link-description').type(description)
+          cy.get('button[type=submit]').click()
+        })
 
         cy.location().should((location) => {
           expect(location.pathname).to.eq(`/create-payment-link/reference`)
         })
       })
     })
+
+    describe('Reference page', () => {
+      it('should have instructions for an English patment link when "yes" is selected', () => {
+        cy.get('h1').should('contain', 'Do your users already have a payment reference?')
+
+        cy.get('form[method=post][action="/create-payment-link/reference"]').should('exist')
+          .within(() => {
+            cy.get('input[type=radio]#reference-type-custom').should('exist')
+            cy.get('input[type=radio]#reference-type-standard').should('exist')
+            cy.get('input[type=radio]#reference-type-custom').click()
+
+            cy.get('input#reference-label').should('exist')
+            cy.get('input#reference-label').should('have.attr', 'lang', 'en')
+            cy.get('input#reference-label').parent('.govuk-form-group').get('span')
+              .should('contain', 'For example, “invoice number”')
+
+            cy.get('textarea#reference-hint-text').should('exist')
+            cy.get('textarea#reference-hint-text').should('have.attr', 'lang', 'en')
+            cy.get('textarea#reference-hint-text').parent('.govuk-form-group').get('span')
+              .should('contain', 'Tell users what the')
+
+            cy.get('button[type=submit]').should('exist')
+          })
+      })
+
+      it('should continue to the amount page', () => {
+        cy.get('form[method=post][action="/create-payment-link/reference"]').should('exist')
+          .within(() => {
+            cy.get('input#reference-label').type(referenceName)
+            cy.get('textarea#reference-hint-text').type(referenceHint)
+            cy.get('button[type=submit]').click()
+          })
+
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`/create-payment-link/amount`)
+        })
+      })
+    })
+
+    describe('Amount page', () => {
+      it('should display content', () => {
+        cy.get('form[method=post][action="/create-payment-link/amount"]').should('exist')
+          .within(() => {
+            cy.get('input[type=radio]#amount-type-fixed').should('exist')
+            cy.get('input[type=radio]#amount-type-variable').should('exist')
+            cy.get('input#payment-amount').should('exist')
+            cy.get('button[type=submit]').should('exist')
+          })
+      })
+
+      it('should continue to the confirm page', () => {
+        cy.get('form[method=post][action="/create-payment-link/amount"]').should('exist')
+          .within(() => {
+            cy.get('input[type=radio]#amount-type-fixed').click()
+            cy.get('input#payment-amount').type(amount)
+            cy.get('button[type=submit]').click()
+          })
+
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`/create-payment-link/review`)
+        })
+      })
+    })
+
+    describe('Review page', () => {
+      it('should display entered values', () => {
+        cy.get('dl').find('div').eq(0).should('exist').within(() => {
+          cy.get('dt').should('contain', 'Title')
+          cy.get('dd.cya-answer').should('contain', name)
+          cy.get('dd.cya-change > a').should('have.attr', 'href', '/create-payment-link/information?field=payment-link-title')
+        })
+        cy.get('dl').find('div').eq(1).should('exist').within(() => {
+          cy.get('dt').should('contain', 'More details')
+          cy.get('dd.cya-answer').should('contain', description)
+          cy.get('dd.cya-change > a').should('have.attr', 'href', '/create-payment-link/information?field=payment-link-description')
+        })
+        cy.get('dl').find('div').eq(2).should('exist').within(() => {
+          cy.get('dt').should('contain', 'Reference number')
+          cy.get('dd.cya-answer').should('contain', referenceName)
+          cy.get('dd.cya-answer').get('span').should('contain', referenceHint)
+          cy.get('dd.cya-change > a').should('have.attr', 'href', '/create-payment-link/reference?change=true')
+        })
+        cy.get('dl').find('div').eq(3).should('exist').within(() => {
+          cy.get('dt').should('contain', 'Payment amount')
+          cy.get('dd.cya-answer').should('contain', '£10.00')
+          cy.get('dd.cya-change > a').should('have.attr', 'href', '/create-payment-link/amount')
+        })
+
+        cy.get('button[type=submit]').should('exist').should('contain', 'Create payment link')
+      })
+
+      it('should redirect to information page when "Change" clicked', () => {
+        cy.get('dl').find('div').eq(0).find('dd.cya-change > a').click()
+
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`/create-payment-link/information`)
+        })
+      })
+
+      it('should have details pre-filled', () => {
+        cy.get('input#payment-link-title').should('have.value', name)
+        cy.get('textarea#payment-link-description').should('have.value', description)
+      })
+
+      it('should have instructions for an English payment link', () => {
+        cy.get('input#payment-link-title').parent('.govuk-form-group').get('span')
+          .should('contain', 'For example, “Pay for a parking permit”')
+      })
+    })
   })
 
   describe('A Welsh payment link', () => {
+    const name = 'Talu am drwydded barcio'
+    const description = 'Disgrifiad yn Gymraeg'
+    const referenceName = 'rhif anfoneb'
+    const referenceHint = 'mewn e-bost'
+    const amount = 10
+
     describe('Information page', () => {
       it('Should display Welsh-specific instructions', () => {
         cy.setEncryptedCookies(userExternalId, gatewayAccountId)
@@ -98,14 +219,116 @@ describe('The create payment link flow', () => {
       })
 
       it('Should continue to the reference page', () => {
-        cy.get('input#payment-link-title').type('Talu am drwydded barcio')
-        cy.get('textarea#payment-link-description').type('Disgrifiad yn Gymraeg')
+        cy.get('input#payment-link-title').type(name)
+        cy.get('textarea#payment-link-description').type(description)
 
-        cy.get('button[type=submit]').click()
+        cy.get('form[method=post][action="/create-payment-link/information"]').within(() => {
+          cy.get('button[type=submit]').click()
+        })
 
         cy.location().should((location) => {
           expect(location.pathname).to.eq(`/create-payment-link/reference`)
         })
+      })
+    })
+
+    describe('Reference page', () => {
+      it('should have Welsh-specific instructions when "yes" is selected', () => {
+        cy.get('h1').should('contain', 'Do your users already have a payment reference?')
+
+        cy.get('form[method=post][action="/create-payment-link/reference"]').should('exist')
+          .within(() => {
+            cy.get('input[type=radio]#reference-type-custom').should('exist')
+            cy.get('input[type=radio]#reference-type-custom').click()
+
+            cy.get('input#reference-label').should('exist')
+            cy.get('input#reference-label').should('have.attr', 'lang', 'cy')
+            cy.get('input#reference-label').parent('.govuk-form-group').get('span')
+              .should('contain', 'For example, “rhif anfoneb”')
+
+            cy.get('textarea#reference-hint-text').should('exist')
+            cy.get('textarea#reference-hint-text').should('have.attr', 'lang', 'cy')
+            cy.get('textarea#reference-hint-text').parent('.govuk-form-group').get('span')
+              .should('contain', 'Explain in Welsh')
+
+            cy.get('button[type=submit]').should('exist')
+          })
+      })
+
+      it('should continue to the amount page', () => {
+        cy.get('form[method=post][action="/create-payment-link/reference"]').should('exist')
+          .within(() => {
+            cy.get('input#reference-label').type(referenceName)
+            cy.get('textarea#reference-hint-text').type(referenceHint)
+            cy.get('button[type=submit]').click()
+          })
+
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`/create-payment-link/amount`)
+        })
+      })
+    })
+
+    describe('Amount page', () => {
+      it('should display content', () => {
+        cy.get('form[method=post][action="/create-payment-link/amount"]').should('exist')
+          .within(() => {
+            cy.get('input[type=radio]#amount-type-fixed').should('exist')
+            cy.get('input[type=radio]#amount-type-variable').should('exist')
+            cy.get('input#payment-amount').should('exist')
+            cy.get('button[type=submit]').should('exist')
+          })
+      })
+
+      it('should continue to the confirm page', () => {
+        cy.get('form[method=post][action="/create-payment-link/amount"]').should('exist')
+          .within(() => {
+            cy.get('input[type=radio]#amount-type-fixed').click()
+            cy.get('input#payment-amount').type(amount)
+            cy.get('button[type=submit]').click()
+          })
+
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`/create-payment-link/review`)
+        })
+      })
+    })
+
+    describe('Review page', () => {
+      it('should have Welsh-specific instructions', () => {
+        cy.get('button[type=submit]').should('exist').should('contain', 'Create Welsh payment link')
+      })
+
+      it('should redirect to information page when "Change" clicked', () => {
+        cy.get('dl').find('div').eq(0).find('dd.cya-change > a').click()
+
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`/create-payment-link/information`)
+        })
+      })
+
+      it('should have details pre-filled', () => {
+        cy.get('input#payment-link-title').should('have.value', name)
+        cy.get('textarea#payment-link-description').should('have.value', description)
+      })
+
+      it('should have Welsh-specific instructions', () => {
+        cy.get('input#payment-link-title').parent('.govuk-form-group').get('span')
+          .should('contain', 'For example, “Talu am drwydded barcio”')
+      })
+
+      it('should redirect to the review page when "Continue" is clicked', () => {
+        cy.get('form[method=post][action="/create-payment-link/information"]').within(() => {
+          cy.get('button[type=submit]').click()
+        })
+
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`/create-payment-link/review`)
+        })
+      })
+
+      it('should have Welsh-specific instructions', () => {
+        cy.get('button[type=submit]').should('exist').should('contain', 'Create Welsh payment link')
       })
     })
   })

--- a/test/unit/controller/payment-links/get_reference_controller.test.js
+++ b/test/unit/controller/payment-links/get_reference_controller.test.js
@@ -2,16 +2,16 @@
 
 // NPM dependencies
 const supertest = require('supertest')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const cheerio = require('cheerio')
 const nock = require('nock')
 const lodash = require('lodash')
 
 // Local dependencies
-const {getApp} = require('../../../../server')
-const {getMockSession, createAppWithSession, getUser} = require('../../../test_helpers/mock_session')
+const { getApp } = require('../../../../server')
+const { getMockSession, createAppWithSession, getUser } = require('../../../test_helpers/mock_session')
 const paths = require('../../../../app/paths')
-const {CONNECTOR_URL} = process.env
+const { CONNECTOR_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '929'
 
 describe('Create payment link reference controller', () => {
@@ -20,12 +20,15 @@ describe('Create payment link reference controller', () => {
     before(done => {
       const user = getUser({
         gateway_account_ids: [GATEWAY_ACCOUNT_ID],
-        permissions: [{name: 'tokens:create'}]
+        permissions: [{ name: 'tokens:create' }]
       })
       nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
         payment_provider: 'sandbox'
       })
       session = getMockSession(user)
+      lodash.set(session, 'pageData.createPaymentLink', {
+        isWelsh: false
+      })
       supertest(createAppWithSession(getApp(), session))
         .get(paths.paymentLinks.reference)
         .end((err, res) => {
@@ -69,7 +72,7 @@ describe('Create payment link reference controller', () => {
       before(done => {
         const user = getUser({
           gateway_account_ids: [GATEWAY_ACCOUNT_ID],
-          permissions: [{name: 'tokens:create'}]
+          permissions: [{ name: 'tokens:create' }]
         })
         nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
           payment_provider: 'sandbox'
@@ -78,7 +81,8 @@ describe('Create payment link reference controller', () => {
         lodash.set(session, 'pageData.createPaymentLink', {
           paymentReferenceType: 'custom',
           paymentReferenceLabel: 'Hello world',
-          paymentReferenceHint: 'Some words'
+          paymentReferenceHint: 'Some words',
+          isWelsh: false
         })
         supertest(createAppWithSession(getApp(), session))
           .get(paths.paymentLinks.reference)
@@ -109,7 +113,7 @@ describe('Create payment link reference controller', () => {
       before(done => {
         const user = getUser({
           gateway_account_ids: [GATEWAY_ACCOUNT_ID],
-          permissions: [{name: 'tokens:create'}]
+          permissions: [{ name: 'tokens:create' }]
         })
         nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
           payment_provider: 'sandbox'
@@ -118,7 +122,8 @@ describe('Create payment link reference controller', () => {
         lodash.set(session, 'pageData.createPaymentLink', {
           paymentReferenceType: 'standard',
           paymentReferenceLabel: '',
-          paymentReferenceHint: ''
+          paymentReferenceHint: '',
+          isWelsh: false
         })
         supertest(createAppWithSession(getApp(), session))
           .get(paths.paymentLinks.reference)


### PR DESCRIPTION
- Store whether the payment link is Welsh in the session for the payment link flow.
- When displaying the "reference" page of the create payment link flow, get whether the payment link is Welsh from the session and use this to display Welsh-specific instructions if the value is true.
- Add cypress tests for the reference page.


