### PR TITLE
PP-4819: use async await to order Google Pay requests

### DIFF
--- a/app/controllers/digital-wallet/post-enable-google-pay-controller.js
+++ b/app/controllers/digital-wallet/post-enable-google-pay-controller.js
@@ -1,28 +1,26 @@
 'use strict'
 
 // Local dependencies
+const logger = require('winston')
 const paths = require('../../paths')
 const { ConnectorClient } = require('../../services/clients/connector_client')
 const { CORRELATION_HEADER } = require('../../utils/correlation_header.js')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
-module.exports = (req, res) => {
+module.exports = async function enableGooglePay (req, res) {
   const gatewayAccountId = req.account.gateway_account_id
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   const gatewayMerchantId = req.body.merchantId
-  const enableGooglePayBoolean = connector.toggleGooglePay(gatewayAccountId, true, correlationId)
-  const setGatewayMerchantId = connector.setGatewayMerchantId(gatewayAccountId, gatewayMerchantId, correlationId)
-
-  async function enableGooglePay () {
-    await setGatewayMerchantId
-    await enableGooglePayBoolean
-  }
-
-  enableGooglePay().then(() => {
+  try {
+    await connector.toggleGooglePay(gatewayAccountId, true, correlationId)
+    logger.info(`${correlationId} enabled google pay boolean for ${gatewayAccountId}`)
+    await connector.setGatewayMerchantId(gatewayAccountId, gatewayMerchantId, correlationId)
+    logger.info(`${correlationId} set google pay merchant ID for ${gatewayAccountId}`)
     req.flash('generic', '<h2>Google Pay successfully enabled.</h2>')
     return res.redirect(paths.digitalWallet.summary)
-  }).catch(err => {
+  } catch (err) {
+    logger.error(`${correlationId} error enabling google pay for ${gatewayAccountId}: ${err}`)
     req.flash('genericError', `<h2>Something went wrong</h2><p>${err}</p>`)
     return res.redirect(paths.digitalWallet.confirmGooglePay)
-  })
+  }
 }

--- a/app/controllers/digital-wallet/post-enable-google-pay-controller.js
+++ b/app/controllers/digital-wallet/post-enable-google-pay-controller.js
@@ -13,7 +13,12 @@ module.exports = (req, res) => {
   const enableGooglePayBoolean = connector.toggleGooglePay(gatewayAccountId, true, correlationId)
   const setGatewayMerchantId = connector.setGatewayMerchantId(gatewayAccountId, gatewayMerchantId, correlationId)
 
-  Promise.all([setGatewayMerchantId, enableGooglePayBoolean]).then(() => {
+  async function enableGooglePay () {
+    await setGatewayMerchantId
+    await enableGooglePayBoolean
+  }
+
+  enableGooglePay().then(() => {
     req.flash('generic', '<h2>Google Pay successfully enabled.</h2>')
     return res.redirect(paths.digitalWallet.summary)
   }).catch(err => {


### PR DESCRIPTION
## WHAT
use `async` `await` to order Google Pay PATCH requests 

Previously we were using `Promise.all` this caused a potential race condition where one PATCH happened before the other completed causing an exception in Connector.

## HOW 
Cypress tests should pass, functionality should work reliably on environment.