### PR TITLE
swap order of Google Pay patches

### DIFF
--- a/app/controllers/digital-wallet/post-enable-google-pay-controller.js
+++ b/app/controllers/digital-wallet/post-enable-google-pay-controller.js
@@ -12,10 +12,10 @@ module.exports = async function enableGooglePay (req, res) {
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   const gatewayMerchantId = req.body.merchantId
   try {
-    await connector.toggleGooglePay(gatewayAccountId, true, correlationId)
-    logger.info(`${correlationId} enabled google pay boolean for ${gatewayAccountId}`)
     await connector.setGatewayMerchantId(gatewayAccountId, gatewayMerchantId, correlationId)
     logger.info(`${correlationId} set google pay merchant ID for ${gatewayAccountId}`)
+    await connector.toggleGooglePay(gatewayAccountId, true, correlationId)
+    logger.info(`${correlationId} enabled google pay boolean for ${gatewayAccountId}`)
     req.flash('generic', '<h2>Google Pay successfully enabled.</h2>')
     return res.redirect(paths.digitalWallet.summary)
   } catch (err) {


### PR DESCRIPTION
## WHAT
Bug fix after #1372 

PATCH requests were in the wrong order! We should PATCH the Gateway Account ID first so that if it is invalid the boolean is not enabled.

## HOW 
Tests should pass, ordering should make sense.


