### PR TITLE
PP-4949 Add non-linear navigation for VAT number and Company Number pages

### DIFF
--- a/app/controllers/stripe-setup/vat-number-company-number/check-your-answers/get.controller.js
+++ b/app/controllers/stripe-setup/vat-number-company-number/check-your-answers/get.controller.js
@@ -5,16 +5,20 @@ const lodash = require('lodash')
 
 // Local dependencies
 const { response } = require('../../../../utils/response')
+const { stripeSetup } = require('../../../../paths')
 
 module.exports = (req, res) => {
-  const vatNumberPageData = lodash.get(req, 'session.pageData.stripeSetup.vatNumberData')
-  const companyNumberPageData = lodash.get(req, 'session.pageData.stripeSetup.companyNumberData')
-  const pageData = {
-    vatNumber: vatNumberPageData.vatNumber,
-    companyNumber: 'None'
+  const vatNumber = lodash.get(req, 'session.pageData.stripeSetup.vatNumberData.vatNumber')
+  const companyNumberMode = lodash.get(req, 'session.pageData.stripeSetup.companyNumberData.companyNumberMode')
+  const companyNumber = lodash.get(req, 'session.pageData.stripeSetup.companyNumberData.companyNumber')
+
+  if (!vatNumber || !companyNumberMode) {
+    return res.redirect(303, stripeSetup.vatNumberCompanyNumber)
   }
-  if (companyNumberPageData && companyNumberPageData.companyNumber) {
-    pageData.companyNumber = companyNumberPageData.companyNumber
+
+  const pageData = {
+    vatNumber: vatNumber,
+    companyNumber: companyNumber || 'None'
   }
 
   return response(req, res, 'stripe-setup/vat-number-company-number/check-your-answers', pageData)

--- a/app/controllers/stripe-setup/vat-number-company-number/company-number/get.controller.js
+++ b/app/controllers/stripe-setup/vat-number-company-number/company-number/get.controller.js
@@ -5,8 +5,13 @@ const lodash = require('lodash')
 
 // Local dependencies
 const { response } = require('../../../../utils/response')
+const { stripeSetup } = require('../../../../paths')
 
 module.exports = (req, res) => {
+  if (lodash.isEmpty(lodash.get(req, 'session.pageData.stripeSetup.vatNumberData.vatNumber'))) {
+    return res.redirect(303, stripeSetup.vatNumberCompanyNumber)
+  }
+
   let pageData = lodash.get(req, 'session.pageData.stripeSetup.companyNumberData')
   if (pageData) {
     delete req.session.pageData.stripeSetup.companyNumberData

--- a/app/controllers/stripe-setup/vat-number-company-number/company-number/post.controller.js
+++ b/app/controllers/stripe-setup/vat-number-company-number/company-number/post.controller.js
@@ -16,6 +16,10 @@ module.exports = (req, res) => {
   const rawCompanyNumber = lodash.get(req.body, COMPANY_NUMBER_FIELD, '')
   const trimmedCompanyNumber = rawCompanyNumber.trim()
 
+  if (lodash.isEmpty(lodash.get(req, 'session.pageData.stripeSetup.vatNumberData.vatNumber'))) {
+    return res.redirect(303, stripeSetup.vatNumberCompanyNumber)
+  }
+
   const errors = validateCompanyNumberForm(rawCompanyNumberMode, trimmedCompanyNumber)
   if (!lodash.isEmpty(errors)) {
     lodash.set(req, 'session.pageData.stripeSetup.companyNumberData', {

--- a/app/controllers/stripe-setup/vat-number-company-number/get.controller.js
+++ b/app/controllers/stripe-setup/vat-number-company-number/get.controller.js
@@ -12,10 +12,11 @@ module.exports = (req, res) => {
     return res.redirect(303, stripeSetup.vatNumber)
   }
 
-  if (stripeSetupPageData.vatNumberData && stripeSetupPageData.companyNumberData) {
-    return res.redirect(303, stripeSetup.checkYourAnswers)
-  } else if (stripeSetupPageData.vatNumberData) {
+  if (lodash.isEmpty(lodash.get(req, 'session.pageData.stripeSetup.vatNumberData.vatNumber'))) {
+    return res.redirect(303, stripeSetup.vatNumber)
+  } else if (lodash.isEmpty(lodash.get(req, 'session.pageData.stripeSetup.companyNumberData.companyNumberMode'))) {
     return res.redirect(303, stripeSetup.companyNumber)
   }
-  return res.redirect(303, stripeSetup.vatNumber)
+
+  return res.redirect(303, stripeSetup.checkYourAnswers)
 }

--- a/app/controllers/stripe-setup/vat-number-company-number/vat-number/post.controller.js
+++ b/app/controllers/stripe-setup/vat-number-company-number/vat-number/post.controller.js
@@ -26,6 +26,12 @@ module.exports = (req, res) => {
       errors: {},
       vatNumber: displayVatNumber
     })
+
+    const companyNumberMode = lodash.get(req, 'session.pageData.stripeSetup.companyNumberData.companyNumberMode')
+
+    if (companyNumberMode) {
+      return res.redirect(303, stripeSetup.checkYourAnswers)
+    }
     return res.redirect(303, stripeSetup.companyNumber)
   }
 }

--- a/test/cypress/integration/stripe-setup/vat-number-company-number/check_your_answers_spec.js
+++ b/test/cypress/integration/stripe-setup/vat-number-company-number/check_your_answers_spec.js
@@ -85,7 +85,7 @@ describe('Stripe setup: "VAT number / company number - check your answers" page'
           .should('contain', 'None')
       })
 
-      it('should go to VAT number page when VAT number "change" button is clicked and change tbe value', () => {
+      it('should go to VAT number page when VAT number "change" button is clicked and change the value', () => {
         const newVatNumber = 'GBGD001'
 
         cy.visit('/vat-number-company-number/vat-number')
@@ -123,14 +123,6 @@ describe('Stripe setup: "VAT number / company number - check your answers" page'
 
             cy.get('input#vat-number[name="vat-number"]').clear()
             cy.get('input#vat-number[name="vat-number"]').type(newVatNumber)
-            cy.get('button[type=submit]').click()
-          })
-
-        cy.location().should((location) => {
-          expect(location.pathname).to.eq('/vat-number-company-number/company-number')
-        })
-        cy.get('#company-number-form').should('exist')
-          .within(() => {
             cy.get('button[type=submit]').click()
           })
 

--- a/test/cypress/integration/stripe-setup/vat-number-company-number/company_number_spec.js
+++ b/test/cypress/integration/stripe-setup/vat-number-company-number/company_number_spec.js
@@ -24,7 +24,9 @@ describe('Stripe setup: company number page', () => {
 
         cy.setEncryptedCookies(userExternalId, gatewayAccountId, {})
 
-        cy.visit('/vat-number-company-number/company-number')
+        cy.visit('/vat-number-company-number/vat-number')
+        cy.get('input#vat-number[name="vat-number"]').type('GB999 9999 73')
+        cy.get('#vat-number-form > button[type=submit]').click()
       })
 
       it('should display page correctly', () => {
@@ -143,11 +145,13 @@ describe('Stripe setup: company number page', () => {
         cy.task('setupStubs', [
           commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
-          stubStripeSetupGetForMultipleCalls(gatewayAccountId, false, true),
+          stubStripeSetupGetForMultipleCalls(gatewayAccountId, false, false, false, true),
           stubStripeAccountGet(gatewayAccountId, 'acct_123example123')
         ])
 
-        cy.visit('/vat-number-company-number/company-number')
+        cy.visit('/vat-number-company-number/vat-number')
+        cy.get('input#vat-number[name="vat-number"]').type('GB999 9999 73')
+        cy.get('#vat-number-form > button[type=submit]').click()
 
         cy.get('#company-number-form').should('exist')
           .within(() => {

--- a/test/cypress/integration/stripe-setup/vat-number-company-number/index_spec.js
+++ b/test/cypress/integration/stripe-setup/vat-number-company-number/index_spec.js
@@ -35,7 +35,9 @@ describe('Stripe setup: "VAT number / company number" index page', () => {
       it('should redirect to /company-number page when pageData has vatNumber only', () => {
         cy.setEncryptedCookies(userExternalId, gatewayAccountId, {
           stripeSetup: {
-            vatNumberData: {}
+            vatNumberData: {
+              vatNumber: 'GBGD001'
+            }
           }
         })
 
@@ -49,8 +51,12 @@ describe('Stripe setup: "VAT number / company number" index page', () => {
       it('should redirect to /check-your-answers page when pageData has vatNumber and companyNumber', () => {
         cy.setEncryptedCookies(userExternalId, gatewayAccountId, {
           stripeSetup: {
-            vatNumberData: {},
-            companyNumberData: {}
+            vatNumberData: {
+              vatNumber: 'GBGD001'
+            },
+            companyNumberData: {
+              companyNumberMode: 'no'
+            }
           }
         })
 
@@ -64,7 +70,9 @@ describe('Stripe setup: "VAT number / company number" index page', () => {
       it('should redirect to /vat-number page when pageData has companyNumber only (invalid cookie structure)', () => {
         cy.setEncryptedCookies(userExternalId, gatewayAccountId, {
           stripeSetup: {
-            companyNumberData: {}
+            companyNumberData: {
+              companyNumberMode: 'no'
+            }
           }
         })
 

--- a/test/cypress/integration/stripe-setup/vat-number-company-number/navigation_spec.js
+++ b/test/cypress/integration/stripe-setup/vat-number-company-number/navigation_spec.js
@@ -1,0 +1,267 @@
+'use strict'
+
+// Local dependencies
+const commonStubs = require('../../../utils/common_stubs')
+const {
+  stubGetGatewayAccountStripeSetupSuccess,
+  stubStripeAccountGet
+} = require('./support')
+
+describe('Stripe setup: "VAT number / company number" index page', () => {
+  const gatewayAccountId = 42
+  const userExternalId = 'userExternalId'
+  describe('when user is admin, account is Stripe and "VAT number / company number" is not already submitted', () => {
+    beforeEach(() => {
+      cy.task('setupStubs', [
+        commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
+        commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
+        stubGetGatewayAccountStripeSetupSuccess(gatewayAccountId, false),
+        stubStripeAccountGet(gatewayAccountId, 'acct_123example123')
+      ])
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId, {})
+    })
+
+    it('should allow the user to complete the journey', () => {
+      cy.visit('/vat-number-company-number')
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/vat-number')
+      })
+
+      cy.get('#vat-number-form').within(() => {
+        cy.get('#vat-number').type('GBGD001')
+        cy.get('button').click()
+      })
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/company-number')
+      })
+
+      cy.get('#company-number-form').within(() => {
+        cy.get('#company-number-mode-1').check()
+        cy.get('#company-number').type('01234567')
+        cy.get('button').click()
+      })
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/check-your-answers')
+      })
+    })
+
+    it('should allow the user to go back from company number to VAT number', () => {
+      cy.visit('/vat-number-company-number')
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/vat-number')
+      })
+
+      cy.get('#vat-number-form').within(() => {
+        cy.get('#vat-number').type('GBGD001')
+        cy.get('button').click()
+      })
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/company-number')
+      })
+
+      cy.visit('/vat-number-company-number/vat-number')
+
+      cy.get('#vat-number-form').should('exist')
+      cy.get('#vat-number').should('have.attr', 'value', 'GBGD001')
+    })
+
+    it('should allow the user to go back from check answers to VAT number', () => {
+      cy.visit('/vat-number-company-number')
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/vat-number')
+      })
+
+      cy.get('#vat-number-form').within(() => {
+        cy.get('#vat-number').type('GBGD001')
+        cy.get('button').click()
+      })
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/company-number')
+      })
+
+      cy.get('#company-number-form').within(() => {
+        cy.get('#company-number-mode-1').check()
+        cy.get('#company-number').type('01234567')
+        cy.get('button').click()
+      })
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/check-your-answers')
+      })
+
+      cy.visit('/vat-number-company-number/vat-number')
+
+      cy.get('#vat-number-form').should('exist')
+      cy.get('#vat-number').should('have.attr', 'value', 'GBGD001')
+    })
+
+    it('should allow the user to go back from check answers to company number (with number)', () => {
+      cy.visit('/vat-number-company-number')
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/vat-number')
+      })
+
+      cy.get('#vat-number-form').within(() => {
+        cy.get('#vat-number').type('GBGD001')
+        cy.get('button').click()
+      })
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/company-number')
+      })
+
+      cy.get('#company-number-form').within(() => {
+        cy.get('#company-number-mode-1').check()
+        cy.get('#company-number').type('01234567')
+        cy.get('button').click()
+      })
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/check-your-answers')
+      })
+
+      cy.visit('/vat-number-company-number/company-number')
+
+      cy.get('#company-number-form').should('exist')
+      cy.get('#company-number-mode-1').should('have.attr', 'checked')
+      cy.get('#company-number').should('be.visible')
+      cy.get('#company-number').should('have.attr', 'value', '01234567')
+    })
+
+    it('should allow the user to go back from check answers to company number (without number)', () => {
+      cy.visit('/vat-number-company-number')
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/vat-number')
+      })
+
+      cy.get('#vat-number-form').within(() => {
+        cy.get('#vat-number').type('GBGD001')
+        cy.get('button').click()
+      })
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/company-number')
+      })
+
+      cy.get('#company-number-form').within(() => {
+        cy.get('#company-number-mode-2').check()
+        cy.get('button').click()
+      })
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/check-your-answers')
+      })
+
+      cy.visit('/vat-number-company-number/company-number')
+
+      cy.get('#company-number-form').should('exist')
+      cy.get('#company-number-mode-2').should('have.attr', 'checked')
+      cy.get('#company-number').should('not.be.visible')
+      cy.get('#company-number').should('not.have.attr', 'value')
+    })
+
+    it('should redirect user from company number to VAT number if VAT number not already entered', () => {
+      cy.visit('/vat-number-company-number/company-number')
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/vat-number')
+      })
+    })
+
+    it('should redirect user from check answers to VAT number if VAT number not already entered', () => {
+      cy.visit('/vat-number-company-number/check-your-answers')
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/vat-number')
+      })
+
+      cy.get('#vat-number-form').should('exist')
+    })
+
+    it('should redirect user from check answers to VAT number if VAT number not already entered', () => {
+      cy.visit('/vat-number-company-number/check-your-answers')
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/vat-number')
+      })
+
+      cy.get('#vat-number-form').should('exist')
+    })
+
+    it('should redirect user from check answers to company number if company number not already entered', () => {
+      cy.visit('/vat-number-company-number')
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/vat-number')
+      })
+
+      cy.get('#vat-number-form').within(() => {
+        cy.get('#vat-number').type('GBGD001')
+        cy.get('button').click()
+      })
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/company-number')
+      })
+
+      cy.visit('/vat-number-company-number/check-your-answers')
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/company-number')
+      })
+
+      cy.get('#company-number-form').should('exist')
+    })
+
+    it('should redirect user immediately back to check your answers if changed VAT number', () => {
+      cy.visit('/vat-number-company-number')
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/vat-number')
+      })
+
+      cy.get('#vat-number-form').within(() => {
+        cy.get('#vat-number').type('GBGD001')
+        cy.get('button').click()
+      })
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/company-number')
+      })
+
+      cy.get('#company-number-form').within(() => {
+        cy.get('#company-number-mode-1').check()
+        cy.get('#company-number').type('01234567')
+        cy.get('button').click()
+      })
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/check-your-answers')
+      })
+
+      cy.get('dl.govuk-summary-list > div.govuk-summary-list__row:nth-child(1) > dd.govuk-summary-list__actions > a').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/vat-number')
+      })
+
+      cy.get('#vat-number-form').within(() => {
+        cy.get('#vat-number').clear().type('GBGD002')
+        cy.get('button').click()
+      })
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/vat-number-company-number/check-your-answers')
+      })
+    })
+  })
+})


### PR DESCRIPTION
## WHAT

- If user tries to go further forward than they should (e.g. go to company number page when not entered VAT number), take them back to the right place

- If user goes from check answers to change VAT number, take them directly back to check answers, skipping company number because they’ve already entered it

- Tests for the above navigation and also tests to make sure the user can go back to an earlier page in the flow

Co-Authored-By: Alex Bishop <alexbishop1@users.noreply.github.com>