### PR TITLE
PP-4949 Rename companyNumberMode to companyNumberDeclaration

### DIFF
--- a/app/controllers/stripe-setup/vat-number-company-number/check-your-answers/get.controller.js
+++ b/app/controllers/stripe-setup/vat-number-company-number/check-your-answers/get.controller.js
@@ -9,10 +9,10 @@ const { stripeSetup } = require('../../../../paths')
 
 module.exports = (req, res) => {
   const vatNumber = lodash.get(req, 'session.pageData.stripeSetup.vatNumberData.vatNumber')
-  const companyNumberMode = lodash.get(req, 'session.pageData.stripeSetup.companyNumberData.companyNumberMode')
+  const companyNumberDeclaration = lodash.get(req, 'session.pageData.stripeSetup.companyNumberData.companyNumberDeclaration')
   const companyNumber = lodash.get(req, 'session.pageData.stripeSetup.companyNumberData.companyNumber')
 
-  if (!vatNumber || !companyNumberMode) {
+  if (!vatNumber || !companyNumberDeclaration) {
     return res.redirect(303, stripeSetup.vatNumberCompanyNumber)
   }
 

--- a/app/controllers/stripe-setup/vat-number-company-number/check-your-answers/post.controller.test.js
+++ b/app/controllers/stripe-setup/vat-number-company-number/check-your-answers/post.controller.test.js
@@ -39,7 +39,7 @@ describe('"VAT number / company number - check your answers" post controller', (
             },
             companyNumberData: {
               errors: {},
-              companyNumberMode: 'yes',
+              companyNumberDeclaration: 'true',
               companyNumber: rawCompanyNumber
             }
           }
@@ -88,7 +88,7 @@ describe('"VAT number / company number - check your answers" post controller', (
   it('should call stripe and connector with VAT number only and redirect to the dashboard', done => {
     req.session.pageData.stripeSetup.companyNumberData = {
       errors: {},
-      companyNumberMode: '',
+      companyNumberDeclaration: '',
       companyNumber: ''
     }
     updateCompanyMock = sinon.spy((stripeAccountId, body) => {

--- a/app/controllers/stripe-setup/vat-number-company-number/company-number/company-number-validations.js
+++ b/app/controllers/stripe-setup/vat-number-company-number/company-number/company-number-validations.js
@@ -7,7 +7,7 @@ const {
   isNotCompanyNumber
 } = require('../../../../browsered/field-validation-checks')
 
-exports.validateCompanyNumberMode = function validateCompanyNumberMode (value) {
+exports.validateCompanyNumberDeclaration = function validateCompanyNumberDeclaration (value) {
   if (!value) {
     return {
       valid: false,

--- a/app/controllers/stripe-setup/vat-number-company-number/company-number/get.controller.js
+++ b/app/controllers/stripe-setup/vat-number-company-number/company-number/get.controller.js
@@ -18,7 +18,7 @@ module.exports = (req, res) => {
   } else {
     pageData = {
       errors: {},
-      companyNumberMode: '',
+      companyNumberDeclaration: '',
       companyNumber: ''
     }
   }

--- a/app/controllers/stripe-setup/vat-number-company-number/company-number/post.controller.js
+++ b/app/controllers/stripe-setup/vat-number-company-number/company-number/post.controller.js
@@ -8,11 +8,11 @@ const { stripeSetup } = require('../../../../paths')
 const companyNumberValidations = require('./company-number-validations')
 
 // Constants
-const COMPANY_NUMBER_MODE_FIELD = 'company-number-mode'
+const COMPANY_NUMBER_DECLARATION_FIELD = 'company-number-declaration'
 const COMPANY_NUMBER_FIELD = 'company-number'
 
 module.exports = (req, res) => {
-  const rawCompanyNumberMode = lodash.get(req.body, COMPANY_NUMBER_MODE_FIELD, '')
+  const companyNumberDeclaration = lodash.get(req.body, COMPANY_NUMBER_DECLARATION_FIELD, '')
   const rawCompanyNumber = lodash.get(req.body, COMPANY_NUMBER_FIELD, '')
   const trimmedCompanyNumber = rawCompanyNumber.trim()
 
@@ -20,32 +20,32 @@ module.exports = (req, res) => {
     return res.redirect(303, stripeSetup.vatNumberCompanyNumber)
   }
 
-  const errors = validateCompanyNumberForm(rawCompanyNumberMode, trimmedCompanyNumber)
+  const errors = validateCompanyNumberForm(companyNumberDeclaration, trimmedCompanyNumber)
   if (!lodash.isEmpty(errors)) {
     lodash.set(req, 'session.pageData.stripeSetup.companyNumberData', {
       errors: errors,
-      companyNumberMode: rawCompanyNumberMode,
+      companyNumberDeclaration: companyNumberDeclaration,
       companyNumber: rawCompanyNumber
     })
     return res.redirect(303, stripeSetup.companyNumber)
   } else {
-    const sessionCompanyNumber = (rawCompanyNumberMode === 'no') ? '' : trimmedCompanyNumber
+    const sessionCompanyNumber = (companyNumberDeclaration === 'false') ? '' : trimmedCompanyNumber
     lodash.set(req, 'session.pageData.stripeSetup.companyNumberData', {
       errors: {},
-      companyNumberMode: rawCompanyNumberMode,
+      companyNumberDeclaration: companyNumberDeclaration,
       companyNumber: sessionCompanyNumber
     })
     return res.redirect(303, stripeSetup.checkYourAnswers)
   }
 }
 
-function validateCompanyNumberForm (companyNumberMode, companyNumber) {
+function validateCompanyNumberForm (companyNumberDeclaration, companyNumber) {
   const errors = {}
 
-  const companyNumberModeValidationResult = companyNumberValidations.validateCompanyNumberMode(companyNumberMode)
-  if (!companyNumberModeValidationResult.valid) {
-    errors[COMPANY_NUMBER_MODE_FIELD] = companyNumberModeValidationResult.message
-  } else if (companyNumberMode === 'yes') {
+  const companyNumberDeclarationValidationResult = companyNumberValidations.validateCompanyNumberDeclaration(companyNumberDeclaration)
+  if (!companyNumberDeclarationValidationResult.valid) {
+    errors[COMPANY_NUMBER_DECLARATION_FIELD] = companyNumberDeclarationValidationResult.message
+  } else if (companyNumberDeclaration === 'true') {
     const companyNumberValidationResult = companyNumberValidations.validateCompanyNumber(companyNumber)
     if (!companyNumberValidationResult.valid) {
       errors[COMPANY_NUMBER_FIELD] = companyNumberValidationResult.message

--- a/app/controllers/stripe-setup/vat-number-company-number/get.controller.js
+++ b/app/controllers/stripe-setup/vat-number-company-number/get.controller.js
@@ -14,7 +14,7 @@ module.exports = (req, res) => {
 
   if (lodash.isEmpty(lodash.get(req, 'session.pageData.stripeSetup.vatNumberData.vatNumber'))) {
     return res.redirect(303, stripeSetup.vatNumber)
-  } else if (lodash.isEmpty(lodash.get(req, 'session.pageData.stripeSetup.companyNumberData.companyNumberMode'))) {
+  } else if (lodash.isEmpty(lodash.get(req, 'session.pageData.stripeSetup.companyNumberData.companyNumberDeclaration'))) {
     return res.redirect(303, stripeSetup.companyNumber)
   }
 

--- a/app/controllers/stripe-setup/vat-number-company-number/vat-number/post.controller.js
+++ b/app/controllers/stripe-setup/vat-number-company-number/vat-number/post.controller.js
@@ -27,9 +27,9 @@ module.exports = (req, res) => {
       vatNumber: displayVatNumber
     })
 
-    const companyNumberMode = lodash.get(req, 'session.pageData.stripeSetup.companyNumberData.companyNumberMode')
+    const companyNumberDeclaration = lodash.get(req, 'session.pageData.stripeSetup.companyNumberData.companyNumberDeclaration')
 
-    if (companyNumberMode) {
+    if (companyNumberDeclaration) {
       return res.redirect(303, stripeSetup.checkYourAnswers)
     }
     return res.redirect(303, stripeSetup.companyNumber)

--- a/app/views/stripe-setup/vat-number-company-number/company-number.njk
+++ b/app/views/stripe-setup/vat-number-company-number/company-number.njk
@@ -12,10 +12,10 @@
   <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
     {% if errors | length %}
       {% set errorList = [] %}
-      {% if errors['company-number-mode'] %}
+      {% if errors['company-number-declaration'] %}
         {% set errorList = (errorList.push({
           text: 'Company registration number',
-          href: '#company-number-mode-1'
+          href: '#company-number-declaration-1'
         }), errorList) %}
       {% endif %}
       {% if errors['company-number'] %}
@@ -40,7 +40,7 @@
           text: errors['company-number']
         } %}
       {% endif %}
-      {% set companyHouseMode %}
+      {% set companyNumberInput %}
         {{ govukInput({
           name: "company-number",
           id: "company-number",
@@ -61,15 +61,15 @@
         }) }}
       {% endset %}
 
-      {% set companyNumberModeError = false %}
-      {% if errors['company-number-mode'] %}
-        {% set companyNumberModeError = {
-          text: errors['company-number-mode']
+      {% set companyNumberDeclarationError = false %}
+      {% if errors['company-number-declaration'] %}
+        {% set companyNumberDeclarationError = {
+          text: errors['company-number-declaration']
         } %}
       {% endif %}
       {{ govukRadios({
-        idPrefix: 'company-number-mode',
-        name: 'company-number-mode',
+        idPrefix: 'company-number-declaration',
+        name: 'company-number-declaration',
         fieldset: {
           legend: {
             text: 'Does your organisation have a company registration number?',
@@ -77,26 +77,26 @@
             classes: 'govuk-fieldset__legend--l'
           }
         },
-        errorMessage: companyNumberModeError,
+        errorMessage: companyNumberDeclarationError,
         items: [
           {
             text: 'Yes',
-            value: 'yes',
+            value: 'true',
             label: {
               classes: "govuk-label--s"
             },
             conditional: {
-              html: companyHouseMode
+              html: companyNumberInput
             },
-            checked: (companyNumberMode === 'yes')
+            checked: (companyNumberDeclaration === 'true')
           },
           {
             text: 'No',
-            value: 'no',
+            value: 'false',
             label: {
               classes: "govuk-label--s"
             },
-            checked: (companyNumberMode === 'no')
+            checked: (companyNumberDeclaration === 'false')
           }
         ]
       }) }}

--- a/test/cypress/integration/stripe-setup/vat-number-company-number/check_your_answers_spec.js
+++ b/test/cypress/integration/stripe-setup/vat-number-company-number/check_your_answers_spec.js
@@ -41,7 +41,7 @@ describe('Stripe setup: "VAT number / company number - check your answers" page'
         })
         cy.get('#company-number-form').should('exist')
           .within(() => {
-            cy.get('input#company-number-mode-1[name="company-number-mode"]').check()
+            cy.get('input#company-number-declaration-1[name="company-number-declaration"]').check()
             cy.get('input#company-number[name="company-number"]').type(validCompanyNumber)
 
             cy.get('button[type=submit]').click()
@@ -70,7 +70,7 @@ describe('Stripe setup: "VAT number / company number - check your answers" page'
         })
         cy.get('#company-number-form').should('exist')
           .within(() => {
-            cy.get('input#company-number-mode-2[name="company-number-mode"]').check()
+            cy.get('input#company-number-declaration-2[name="company-number-declaration"]').check()
             cy.get('input#company-number[name="company-number"]').should('not.be.visible')
 
             cy.get('button[type=submit]').click()
@@ -101,7 +101,7 @@ describe('Stripe setup: "VAT number / company number - check your answers" page'
         })
         cy.get('#company-number-form').should('exist')
           .within(() => {
-            cy.get('input#company-number-mode-1[name="company-number-mode"]').check()
+            cy.get('input#company-number-declaration-1[name="company-number-declaration"]').check()
             cy.get('input#company-number[name="company-number"]').type(validCompanyNumber)
 
             cy.get('button[type=submit]').click()
@@ -149,7 +149,7 @@ describe('Stripe setup: "VAT number / company number - check your answers" page'
         })
         cy.get('#company-number-form').should('exist')
           .within(() => {
-            cy.get('input#company-number-mode-1[name="company-number-mode"]').check()
+            cy.get('input#company-number-declaration-1[name="company-number-declaration"]').check()
             cy.get('input#company-number[name="company-number"]').type(validCompanyNumber)
 
             cy.get('button[type=submit]').click()
@@ -165,7 +165,7 @@ describe('Stripe setup: "VAT number / company number - check your answers" page'
         })
         cy.get('#company-number-form').should('exist')
           .within(() => {
-            cy.get('input#company-number-mode-1[name="company-number-mode"]').should('be.checked')
+            cy.get('input#company-number-declaration-1[name="company-number-declaration"]').should('be.checked')
             cy.get('input#company-number[name="company-number"]').should('have.value', validCompanyNumber)
             cy.get('button[type=submit]').should('exist')
             cy.get('button[type=submit]').should('contain', 'Continue')
@@ -227,7 +227,7 @@ describe('Stripe setup: "VAT number / company number - check your answers" page'
         })
         cy.get('#company-number-form').should('exist')
           .within(() => {
-            cy.get('input#company-number-mode-1[name="company-number-mode"]').check()
+            cy.get('input#company-number-declaration-1[name="company-number-declaration"]').check()
             cy.get('input#company-number[name="company-number"]').type(validCompanyNumber)
 
             cy.get('button[type=submit]').click()

--- a/test/cypress/integration/stripe-setup/vat-number-company-number/company_number_spec.js
+++ b/test/cypress/integration/stripe-setup/vat-number-company-number/company_number_spec.js
@@ -34,10 +34,10 @@ describe('Stripe setup: company number page', () => {
 
         cy.get('#company-number-form').should('exist')
           .within(() => {
-            cy.get('input#company-number-mode-1[name="company-number-mode"]').check()
+            cy.get('input#company-number-declaration-1[name="company-number-declaration"]').check()
             cy.get('input#company-number[name="company-number"]').should('be.visible')
 
-            cy.get('input#company-number-mode-2[name="company-number-mode"]').check()
+            cy.get('input#company-number-declaration-2[name="company-number-declaration"]').check()
             cy.get('input#company-number[name="company-number"]').should('not.be.visible')
 
             cy.get('button[type=submit]').should('exist')
@@ -50,15 +50,15 @@ describe('Stripe setup: company number page', () => {
 
         cy.get('h2').should('contain', 'There was a problem with the details you gave for:')
         cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'Company registration number')
-        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#company-number-mode-1')
+        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#company-number-declaration-1')
 
-        cy.get('#company-number-mode-error').should('contain', 'You must answer this question')
+        cy.get('#company-number-declaration-error').should('contain', 'You must answer this question')
       })
 
       it('should display an error when company number input is blank and "Yes" option is selected', () => {
         cy.get('#company-number-form').should('exist')
           .within(() => {
-            cy.get('input#company-number-mode-1[name="company-number-mode"]').check()
+            cy.get('input#company-number-declaration-1[name="company-number-declaration"]').check()
             cy.get('input#company-number[name="company-number"]').type('        ')
 
             cy.get('button[type=submit]').click()
@@ -75,7 +75,7 @@ describe('Stripe setup: company number page', () => {
       it('should display an error when company number is invalid and "Yes" option is selected', () => {
         cy.get('#company-number-form').should('exist')
           .within(() => {
-            cy.get('input#company-number-mode-1[name="company-number-mode"]').check()
+            cy.get('input#company-number-declaration-1[name="company-number-declaration"]').check()
             cy.get('input#company-number[name="company-number"]').type('(╯°□°)╯︵ ┻━┻')
 
             cy.get('button[type=submit]').click()
@@ -92,7 +92,7 @@ describe('Stripe setup: company number page', () => {
       it('should redirect to /check-your-answers page when company number is valid and "Yes" option is selected', () => {
         cy.get('#company-number-form').should('exist')
           .within(() => {
-            cy.get('input#company-number-mode-1[name="company-number-mode"]').check()
+            cy.get('input#company-number-declaration-1[name="company-number-declaration"]').check()
             cy.get('input#company-number[name="company-number"]').type('01234567')
 
             cy.get('button[type=submit]').click()
@@ -106,7 +106,7 @@ describe('Stripe setup: company number page', () => {
       it('should redirect to /check-your-answers page when "No" option is selected', () => {
         cy.get('#company-number-form').should('exist')
           .within(() => {
-            cy.get('input#company-number-mode-2[name="company-number-mode"]').check()
+            cy.get('input#company-number-declaration-2[name="company-number-declaration"]').check()
             cy.get('input#company-number[name="company-number"]').should('not.be.visible')
 
             cy.get('button[type=submit]').click()
@@ -155,7 +155,7 @@ describe('Stripe setup: company number page', () => {
 
         cy.get('#company-number-form').should('exist')
           .within(() => {
-            cy.get('input#company-number-mode-2[name="company-number-mode"]').check()
+            cy.get('input#company-number-declaration-2[name="company-number-declaration"]').check()
             cy.get('input#company-number[name="company-number"]').should('not.be.visible')
 
             cy.get('button[type=submit]').click()

--- a/test/cypress/integration/stripe-setup/vat-number-company-number/index_spec.js
+++ b/test/cypress/integration/stripe-setup/vat-number-company-number/index_spec.js
@@ -55,7 +55,7 @@ describe('Stripe setup: "VAT number / company number" index page', () => {
               vatNumber: 'GBGD001'
             },
             companyNumberData: {
-              companyNumberMode: 'no'
+              companyNumberDeclaration: 'false'
             }
           }
         })
@@ -71,7 +71,7 @@ describe('Stripe setup: "VAT number / company number" index page', () => {
         cy.setEncryptedCookies(userExternalId, gatewayAccountId, {
           stripeSetup: {
             companyNumberData: {
-              companyNumberMode: 'no'
+              companyNumberDeclaration: 'false'
             }
           }
         })

--- a/test/cypress/integration/stripe-setup/vat-number-company-number/navigation_spec.js
+++ b/test/cypress/integration/stripe-setup/vat-number-company-number/navigation_spec.js
@@ -38,7 +38,7 @@ describe('Stripe setup: "VAT number / company number" index page', () => {
       })
 
       cy.get('#company-number-form').within(() => {
-        cy.get('#company-number-mode-1').check()
+        cy.get('#company-number-declaration-1').check()
         cy.get('#company-number').type('01234567')
         cy.get('button').click()
       })
@@ -87,7 +87,7 @@ describe('Stripe setup: "VAT number / company number" index page', () => {
       })
 
       cy.get('#company-number-form').within(() => {
-        cy.get('#company-number-mode-1').check()
+        cy.get('#company-number-declaration-1').check()
         cy.get('#company-number').type('01234567')
         cy.get('button').click()
       })
@@ -119,7 +119,7 @@ describe('Stripe setup: "VAT number / company number" index page', () => {
       })
 
       cy.get('#company-number-form').within(() => {
-        cy.get('#company-number-mode-1').check()
+        cy.get('#company-number-declaration-1').check()
         cy.get('#company-number').type('01234567')
         cy.get('button').click()
       })
@@ -131,7 +131,7 @@ describe('Stripe setup: "VAT number / company number" index page', () => {
       cy.visit('/vat-number-company-number/company-number')
 
       cy.get('#company-number-form').should('exist')
-      cy.get('#company-number-mode-1').should('have.attr', 'checked')
+      cy.get('#company-number-declaration-1').should('have.attr', 'checked')
       cy.get('#company-number').should('be.visible')
       cy.get('#company-number').should('have.attr', 'value', '01234567')
     })
@@ -153,7 +153,7 @@ describe('Stripe setup: "VAT number / company number" index page', () => {
       })
 
       cy.get('#company-number-form').within(() => {
-        cy.get('#company-number-mode-2').check()
+        cy.get('#company-number-declaration-2').check()
         cy.get('button').click()
       })
 
@@ -164,7 +164,7 @@ describe('Stripe setup: "VAT number / company number" index page', () => {
       cy.visit('/vat-number-company-number/company-number')
 
       cy.get('#company-number-form').should('exist')
-      cy.get('#company-number-mode-2').should('have.attr', 'checked')
+      cy.get('#company-number-declaration-2').should('have.attr', 'checked')
       cy.get('#company-number').should('not.be.visible')
       cy.get('#company-number').should('not.have.attr', 'value')
     })
@@ -239,7 +239,7 @@ describe('Stripe setup: "VAT number / company number" index page', () => {
       })
 
       cy.get('#company-number-form').within(() => {
-        cy.get('#company-number-mode-1').check()
+        cy.get('#company-number-declaration-1').check()
         cy.get('#company-number').type('01234567')
         cy.get('button').click()
       })


### PR DESCRIPTION
Rename `companyNumberMode` (and variants) to `companyNumberDeclaration` to better reflect its purpose (storing the service’s answer — or declaration — of whether they have a company number or not).

Also change the possible values from the strings `"yes"` or `"no"` to the strings `"true"` or `"false"`.

Co-Authored-By: Yancoba Thompson <yancoba.thompson@digital.cabinet-office.gov.uk>