### PR TITLE
PP-4949 Minor Stripe VAT number and company number page changes

### DIFF
--- a/app/views/stripe-setup/vat-number-company-number/company-number.njk
+++ b/app/views/stripe-setup/vat-number-company-number/company-number.njk
@@ -48,7 +48,7 @@
             text: "Company registration number"
           },
           hint: {
-            text: "For example, '01234567'"
+            text: "For example, ‘01234567’"
           },
           value: companyNumber,
           classes: "govuk-input--width-30",
@@ -56,7 +56,8 @@
           errorMessage: companyNumberError,
           attributes: {
             "data-validate": "companyNumber",
-            "autocomplete": "off"
+            autocomplete: "off",
+            spellcheck: "false"
           }
         }) }}
       {% endset %}

--- a/app/views/stripe-setup/vat-number-company-number/vat-number.njk
+++ b/app/views/stripe-setup/vat-number-company-number/vat-number.njk
@@ -42,7 +42,7 @@
           text: "VAT number"
         },
         hint: {
-          text: "For example, 'GBGD001'"
+          text: "For example, ‘GBGD001’"
         },
         classes: "govuk-input--width-30",
         value: vatNumber,
@@ -50,7 +50,8 @@
         errorMessage: vatNumberError,
         attributes: {
           "data-validate": "required vatNumber",
-          "autocomplete": "off"
+          autocomplete: "off",
+          spellcheck: "false"
         }
       }) }}
 


### PR DESCRIPTION
- Use curly quotes around example input next to form fields
- Don’t quote attribute names in Nunjucks macros unless necessary
- Add `spellcheck="false"` to VAT number and company number inputs

Co-Authored-By: Yancoba Thompson <yancoba.thompson@digital.cabinet-office.gov.uk>