### PR TITLE
PP-4949 Disable client-side validation of company number

### DIFF
--- a/app/browsered/field-validation-checks.js
+++ b/app/browsered/field-validation-checks.js
@@ -125,12 +125,6 @@ exports.isNotVatNumber = value => {
 exports.isNotCompanyNumber = value => {
   const sanitisedCompanyNumber = value.replace(/\s/g, '').toUpperCase()
 
-  // Allow an empty string, as company number is not always required.
-  // If it is required, this will be flagged by the server side validation.
-  if (sanitisedCompanyNumber === '') {
-    return false
-  }
-
   if (/^[0-9]{7}$/.test(sanitisedCompanyNumber)) {
     return validationErrors.sevenDigitCompanyNumber
   } else if (!/^(?:0[0-9]|OC|LP|SC|SO|SL|NI|R0|NC|NL)[0-9]{6}$/.test(sanitisedCompanyNumber)) {

--- a/app/browsered/field-validation.js
+++ b/app/browsered/field-validation.js
@@ -101,9 +101,6 @@ function validateField (form, field) {
       case 'vatNumber':
         result = checks.isNotVatNumber(field.value)
         break
-      case 'companyNumber':
-        result = checks.isNotCompanyNumber(field.value)
-        break
       default:
         result = checks.isEmpty(field.value)
         break

--- a/app/views/stripe-setup/vat-number-company-number/company-number.njk
+++ b/app/views/stripe-setup/vat-number-company-number/company-number.njk
@@ -31,7 +31,7 @@
     {% endif %}
 
     <form id="company-number-form" method="post"
-          action="/vat-number-company-number/company-number" data-validate="true">
+          action="/vat-number-company-number/company-number">
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {% set companyNumberError = false %}
@@ -55,7 +55,6 @@
           type: "text",
           errorMessage: companyNumberError,
           attributes: {
-            "data-validate": "companyNumber",
             autocomplete: "off",
             spellcheck: "false"
           }

--- a/test/cypress/integration/stripe-setup/vat-number-company-number/company_number_spec.js
+++ b/test/cypress/integration/stripe-setup/vat-number-company-number/company_number_spec.js
@@ -86,7 +86,7 @@ describe('Stripe setup: company number page', () => {
         cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#company-number')
 
         cy.get('input#company-number[name="company-number"]').should('have.class', 'govuk-input--error')
-        cy.get('label[for=company-number] > span').should('contain', 'Enter a valid company number')
+        cy.get('#company-number-error').should('contain', 'Enter a valid company number')
       })
 
       it('should redirect to /check-your-answers page when company number is valid and "Yes" option is selected', () => {
@@ -107,7 +107,20 @@ describe('Stripe setup: company number page', () => {
         cy.get('#company-number-form').should('exist')
           .within(() => {
             cy.get('input#company-number-declaration-2[name="company-number-declaration"]').check()
-            cy.get('input#company-number[name="company-number"]').should('not.be.visible')
+            cy.get('button[type=submit]').click()
+          })
+
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq('/vat-number-company-number/check-your-answers')
+        })
+      })
+
+      it('should redirect to /check-your-answers page when "No" option is selected even if company number is invalid', () => {
+        cy.get('#company-number-form').should('exist')
+          .within(() => {
+            cy.get('input#company-number-declaration-1[name="company-number-declaration"]').check()
+            cy.get('input#company-number[name="company-number"]').type('(╯°□°)╯︵ ┻━┻')
+            cy.get('input#company-number-declaration-2[name="company-number-declaration"]').check()
 
             cy.get('button[type=submit]').click()
           })
@@ -115,6 +128,9 @@ describe('Stripe setup: company number page', () => {
         cy.location().should((location) => {
           expect(location.pathname).to.eq('/vat-number-company-number/check-your-answers')
         })
+
+        cy.get('dl.govuk-summary-list > div.govuk-summary-list__row:nth-child(2) > dd.govuk-summary-list__value')
+          .should('contain', 'None')
       })
     })
 


### PR DESCRIPTION
Disable client-side JavaScript validation of company number because it will validate the contents of the company number field even if the user has changed their mind and said they do not have a company number. The server-side validation, which remains in place, is more sophisticated and does not suffer from this deficiency.

Add a test for the above scenario.