### PR TITLE
PP-5012 Send language when creating product

### DIFF
--- a/app/controllers/payment-links/post-review-controller.js
+++ b/app/controllers/payment-links/post-review-controller.js
@@ -11,10 +11,20 @@ const productsClient = require('../../services/clients/products_client.js')
 const productTypes = require('../../utils/product_types')
 const publicAuthClient = require('../../services/clients/public_auth_client')
 const auth = require('../../services/auth_service.js')
+const supportedLanguage = require('../../models/supported-language')
 
 module.exports = (req, res) => {
   const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
-  const { paymentLinkTitle, paymentLinkDescription, paymentLinkAmount, serviceNamePath, productNamePath, paymentReferenceType, paymentReferenceLabel, paymentReferenceHint } = lodash.get(req, 'session.pageData.createPaymentLink', {})
+  const { paymentLinkTitle,
+    paymentLinkDescription,
+    paymentLinkAmount,
+    serviceNamePath,
+    productNamePath,
+    paymentReferenceType,
+    paymentReferenceLabel,
+    paymentReferenceHint,
+    isWelsh
+  } = lodash.get(req, 'session.pageData.createPaymentLink', {})
 
   if (!paymentLinkTitle) {
     return res.redirect(paths.paymentLinks.start)
@@ -36,7 +46,8 @@ module.exports = (req, res) => {
         name: paymentLinkTitle,
         type: productTypes.ADHOC,
         serviceNamePath,
-        productNamePath
+        productNamePath,
+        language: isWelsh ? supportedLanguage.WELSH : supportedLanguage.ENGLISH
       }
 
       if (paymentLinkDescription) {

--- a/app/services/clients/products_client.js
+++ b/app/services/clients/products_client.js
@@ -5,6 +5,7 @@ const Product = require('../../models/Product.class')
 const Payment = require('../../models/Payment.class')
 const baseClient = require('./base_client/base_client')
 const { PRODUCTS_URL } = require('../../../config')
+const supportedLanguage = require('../../models/supported-language')
 
 // Constants
 const SERVICE_NAME = 'products'
@@ -61,7 +62,8 @@ function createProduct (options) {
       product_name_path: options.productNamePath,
       reference_enabled: options.referenceEnabled,
       reference_label: options.referenceLabel,
-      reference_hint: options.referenceHint
+      reference_hint: options.referenceHint,
+      language: options.language || supportedLanguage.ENGLISH
     },
     description: 'create a product for a service',
     service: SERVICE_NAME

--- a/test/fixtures/product_fixtures.js
+++ b/test/fixtures/product_fixtures.js
@@ -14,7 +14,8 @@ module.exports = {
       gateway_account_id: opts.gatewayAccountId || 'd5gzn',
       pay_api_token: opts.payApiToken || 'pay-api-token',
       name: opts.name || 'A Product Name',
-      type: opts.type || 'DEMO'
+      type: opts.type || 'DEMO',
+      language: opts.language || 'en'
     }
     if (opts.type === 'ADHOC') data.reference_enabled = opts.reference_enabled || false
     if (opts.description) data.description = opts.description

--- a/test/unit/clients/product_client/product/create_test.js
+++ b/test/unit/clients/product_client/product/create_test.js
@@ -2,7 +2,7 @@
 
 // NPM dependencies
 const Pact = require('pact')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
 // Custom dependencies
@@ -40,12 +40,15 @@ describe('products client - create a new product', () => {
   after(() => provider.finalize())
 
   describe('when a product is successfully created', () => {
+    const language = 'cy'
+
     before(done => {
       const productsClient = getProductsClient()
       request = productFixtures.validCreateProductRequest({
         description: 'a test product',
         returnUrl: 'https://example.gov.uk/paid-for-somet',
-        price: randomPrice()
+        price: randomPrice(),
+        language
       })
       const requestPlain = request.getPlain()
       response = productFixtures.validCreateProductResponse(requestPlain)
@@ -65,7 +68,8 @@ describe('products client - create a new product', () => {
           price: requestPlain.price,
           description: requestPlain.description,
           returnUrl: requestPlain.return_url,
-          type: 'DEMO'
+          type: 'DEMO',
+          language
         }))
         .then(res => {
           result = res
@@ -85,6 +89,7 @@ describe('products client - create a new product', () => {
       expect(result.price).to.equal(plainRequest.price)
       expect(result.returnUrl).to.equal('https://example.gov.uk/paid-for-somet')
       expect(result.type).to.equal('DEMO')
+      expect(result.language).to.equal(language)
       expect(result).to.have.property('links')
       expect(Object.keys(result.links).length).to.equal(2)
       expect(result.links).to.have.property('self')
@@ -99,7 +104,7 @@ describe('products client - create a new product', () => {
   describe('create a product - bad request', () => {
     before(done => {
       const productsClient = getProductsClient()
-      request = productFixtures.validCreateProductRequest({pay_api_token: ''})
+      request = productFixtures.validCreateProductRequest({ pay_api_token: '' })
       const requestPlain = request.getPlain()
       provider.addInteraction(
         new PactInteractionBuilder(PRODUCT_RESOURCE)
@@ -116,7 +121,8 @@ describe('products client - create a new product', () => {
           price: requestPlain.price,
           description: requestPlain.description,
           returnUrl: requestPlain.return_url,
-          type: requestPlain.type
+          type: requestPlain.type,
+          language: requestPlain.language
         }), done)
         .then(() => done(new Error('Promise unexpectedly resolved')))
         .catch((err) => {

--- a/test/unit/controller/payment-links/post_review_controller.test.js
+++ b/test/unit/controller/payment-links/post_review_controller.test.js
@@ -2,19 +2,19 @@
 
 // NPM dependencies
 const supertest = require('supertest')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const lodash = require('lodash')
 const nock = require('nock')
 const csrf = require('csrf')
 
 // Local dependencies
-const {getApp} = require('../../../../server')
-const {getMockSession, createAppWithSession, getUser} = require('../../../test_helpers/mock_session')
+const { getApp } = require('../../../../server')
+const { getMockSession, createAppWithSession, getUser } = require('../../../test_helpers/mock_session')
 const paths = require('../../../../app/paths')
-const {randomUuid} = require('../../../../app/utils/random')
-const {validCreateProductRequest, validCreateProductResponse} = require('../../../fixtures/product_fixtures')
+const { randomUuid } = require('../../../../app/utils/random')
+const { validCreateProductRequest, validCreateProductResponse } = require('../../../fixtures/product_fixtures')
 
-const {PUBLIC_AUTH_URL, PRODUCTS_URL, CONNECTOR_URL} = process.env
+const { PUBLIC_AUTH_URL, PRODUCTS_URL, CONNECTOR_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '929'
 const PAYMENT_TITLE = 'Payment title'
 const PAYMENT_DESCRIPTION = 'Payment description'
@@ -24,7 +24,7 @@ const VALID_PAYLOAD = {
 }
 const VALID_USER = getUser({
   gateway_account_ids: [GATEWAY_ACCOUNT_ID],
-  permissions: [{name: 'tokens:create'}]
+  permissions: [{ name: 'tokens:create' }]
 })
 const VALID_CREATE_TOKEN_REQUEST = {
   account_id: GATEWAY_ACCOUNT_ID,
@@ -35,181 +35,229 @@ const VALID_CREATE_TOKEN_REQUEST = {
 const VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE = {
   payment_provider: 'sandbox'
 }
-const VALID_CREATE_TOKEN_RESPONSE = {token: randomUuid()}
-const VALID_CREATE_PRODUCT_REQUEST = validCreateProductRequest({
-  name: PAYMENT_TITLE,
-  description: PAYMENT_DESCRIPTION,
-  gatewayAccountId: GATEWAY_ACCOUNT_ID,
-  payApiToken: VALID_CREATE_TOKEN_RESPONSE.token,
-  serviceName: VALID_USER.serviceRoles[0].service.name,
-  price: PAYMENT_LINK_AMOUNT,
-  type: 'ADHOC',
-  reference_enabled: false
-}).getPlain()
+const VALID_CREATE_TOKEN_RESPONSE = { token: randomUuid() }
 
-const VALID_CREATE_PRODUCT_RESPONSE = validCreateProductResponse(VALID_CREATE_PRODUCT_REQUEST).getPlain()
+const buildCreateProductRequest = (language) => {
+  return validCreateProductRequest({
+    name: PAYMENT_TITLE,
+    description: PAYMENT_DESCRIPTION,
+    gatewayAccountId: GATEWAY_ACCOUNT_ID,
+    payApiToken: VALID_CREATE_TOKEN_RESPONSE.token,
+    serviceName: VALID_USER.serviceRoles[0].service.name,
+    price: PAYMENT_LINK_AMOUNT,
+    type: 'ADHOC',
+    reference_enabled: false,
+    language: language
+  }).getPlain()
+}
 
 describe('Create payment link review controller', () => {
-  describe(`when paymentDescription, paymentLinkTitle and paymentLinkAmount exist in the session`, () => {
-    describe(`when the API token is successfully created`, () => {
-      describe(`and the product is successfully created`, () => {
-        let result, session, app
-        before('Arrange', () => {
-          nock(PUBLIC_AUTH_URL).post('', VALID_CREATE_TOKEN_REQUEST).reply(201, VALID_CREATE_TOKEN_RESPONSE)
-          nock(PRODUCTS_URL).post('/v1/api/products', VALID_CREATE_PRODUCT_REQUEST).reply(201, VALID_CREATE_PRODUCT_RESPONSE)
-          nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
-          session = getMockSession(VALID_USER)
-          lodash.set(session, 'pageData.createPaymentLink.paymentLinkTitle', PAYMENT_TITLE)
-          lodash.set(session, 'pageData.createPaymentLink.paymentLinkDescription', PAYMENT_DESCRIPTION)
-          lodash.set(session, 'pageData.createPaymentLink.paymentLinkAmount', PAYMENT_LINK_AMOUNT)
-          app = createAppWithSession(getApp(), session)
-        })
-        before('Act', done => {
-          supertest(app)
-            .post(paths.paymentLinks.review)
-            .send(VALID_PAYLOAD)
-            .end((err, res) => {
-              result = res
-              done(err)
-            })
-        })
-        after(() => {
-          nock.cleanAll()
-        })
-
-        it('should redirect with status code 302', () => {
-          expect(result.statusCode).to.equal(302)
-        })
-
-        it('should redirect to the manage page with a success message', () => {
-          console.log(session.flash)
-          expect(session.flash).to.have.property('generic')
-          expect(session.flash.generic.length).to.equal(1)
-          expect(session.flash.generic[0]).to.equal('<h2>Your payment link is now live</h2><p>Give this link to your users to collect payments for your service.</p>')
-          expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.manage)
-        })
+  describe('successfull submission', () => {
+    let result, session, app
+    before('Arrange', () => {
+      const expectedProductRequest = buildCreateProductRequest('en')
+      const productResponse = validCreateProductResponse(expectedProductRequest).getPlain()
+      nock(PUBLIC_AUTH_URL).post('', VALID_CREATE_TOKEN_REQUEST).reply(201, VALID_CREATE_TOKEN_RESPONSE)
+      nock(PRODUCTS_URL).post('/v1/api/products', expectedProductRequest).reply(201, productResponse)
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+      session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.createPaymentLink', {
+        paymentLinkTitle: PAYMENT_TITLE,
+        paymentLinkDescription: PAYMENT_DESCRIPTION,
+        paymentLinkAmount: PAYMENT_LINK_AMOUNT,
+        isWelsh: false
       })
-      describe(`but the product creation fails`, () => {
-        let result, session, app
-
-        before('Arrange', () => {
-          nock(PUBLIC_AUTH_URL).post('', VALID_CREATE_TOKEN_REQUEST).reply(201, VALID_CREATE_TOKEN_RESPONSE)
-          nock(PRODUCTS_URL).post('/v1/api/products', VALID_CREATE_PRODUCT_REQUEST).replyWithError('Something went wrong')
-          nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
-          session = getMockSession(VALID_USER)
-          lodash.set(session, 'pageData.createPaymentLink.paymentLinkTitle', PAYMENT_TITLE)
-          lodash.set(session, 'pageData.createPaymentLink.paymentLinkDescription', PAYMENT_DESCRIPTION)
-          lodash.set(session, 'pageData.createPaymentLink.paymentLinkAmount', PAYMENT_LINK_AMOUNT)
-          app = createAppWithSession(getApp(), session)
-        })
-        before('Act', done => {
-          supertest(app)
-            .post(paths.paymentLinks.review)
-            .send(VALID_PAYLOAD)
-            .end((err, res) => {
-              result = res
-              done(err)
-            })
-        })
-        after(() => {
-          nock.cleanAll()
-        })
-
-        it('should redirect with status code 302', () => {
-          expect(result.statusCode).to.equal(302)
-        })
-
-        it('should redirect back to the review page', () => {
-          expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.review)
-        })
-
-        it('should add a relevant error message to the session \'flash\'', () => {
-          expect(session.flash).to.have.property('genericError')
-          expect(session.flash.genericError.length).to.equal(1)
-          expect(session.flash.genericError[0]).to.equal('<h2>There were errors</h2><p>Error while creating payment link</p>')
-        })
-      })
+      app = createAppWithSession(getApp(), session)
     })
-    describe(`when the API token creation fails`, () => {
-      let result, session, app
-      before('Arrange', () => {
-        nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
-        nock(PUBLIC_AUTH_URL).post('', VALID_CREATE_TOKEN_REQUEST).replyWithError('Something went wrong')
-        session = getMockSession(VALID_USER)
-        lodash.set(session, 'pageData.createPaymentLink.paymentLinkTitle', PAYMENT_TITLE)
-        lodash.set(session, 'pageData.createPaymentLink.paymentLinkDescription', PAYMENT_DESCRIPTION)
-        app = createAppWithSession(getApp(), session)
-      })
-      before('Act', done => {
-        supertest(app)
-          .post(paths.paymentLinks.review)
-          .send({
-            'csrfToken': csrf().create('123')
-          })
-          .end((err, res) => {
-            result = res
-            done(err)
-          })
-      })
-      after(() => {
-        nock.cleanAll()
-      })
+    before('Act', done => {
+      supertest(app)
+        .post(paths.paymentLinks.review)
+        .send(VALID_PAYLOAD)
+        .end((err, res) => {
+          result = res
+          done(err)
+        })
+    })
+    after(() => {
+      nock.cleanAll()
+    })
 
-      it('should redirect with status code 302', () => {
-        expect(result.statusCode).to.equal(302)
-      })
+    it('should redirect with status code 302', () => {
+      expect(result.statusCode).to.equal(302)
+    })
 
-      it('should redirect back to the index page', () => {
-        expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.review)
-      })
-
-      it('should add a relevant error message to the session \'flash\'', () => {
-        expect(session.flash).to.have.property('genericError')
-        expect(session.flash.genericError.length).to.equal(1)
-        expect(session.flash.genericError[0]).to.equal('<h2>There were errors</h2><p>Error while creating payment link</p>')
-      })
+    it('should redirect to the manage page with a success message', () => {
+      expect(session.flash).to.have.property('generic')
+      expect(session.flash.generic.length).to.equal(1)
+      expect(session.flash.generic[0]).to.equal('<h2>Your payment link is now live</h2><p>Give this link to your users to collect payments for your service.</p>')
+      expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.manage)
     })
   })
-  describe(`when paymentDescription in missing from the session`, () => {
-    describe(`when the API token is successfully created`, () => {
-      describe(`and the product is successfully created`, () => {
-        let result, session, app
-        before('Arrange', () => {
-          nock(PUBLIC_AUTH_URL).post('', VALID_CREATE_TOKEN_REQUEST).reply(201, VALID_CREATE_TOKEN_RESPONSE)
-          nock(PRODUCTS_URL).post('/v1/api/products', lodash.omit(VALID_CREATE_PRODUCT_REQUEST, 'description')).reply(201, VALID_CREATE_PRODUCT_RESPONSE)
-          nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
-          session = getMockSession(VALID_USER)
-          lodash.set(session, 'pageData.createPaymentLink.paymentLinkTitle', PAYMENT_TITLE)
-          lodash.set(session, 'pageData.createPaymentLink.paymentLinkAmount', PAYMENT_LINK_AMOUNT)
-          app = createAppWithSession(getApp(), session)
-        })
-        before('Act', done => {
-          supertest(app)
-            .post(paths.paymentLinks.review)
-            .send(VALID_PAYLOAD)
-            .end((err, res) => {
-              result = res
-              done(err)
-            })
-        })
-        after(() => {
-          nock.cleanAll()
-        })
-
-        it('should redirect with status code 302', () => {
-          expect(result.statusCode).to.equal(302)
-        })
-
-        it('should redirect to the manage page with a success message', () => {
-          expect(session.flash).to.have.property('generic')
-          expect(session.flash.generic.length).to.equal(1)
-          expect(session.flash.generic[0]).to.equal('<h2>Your payment link is now live</h2><p>Give this link to your users to collect payments for your service.</p>')
-          expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.manage)
-        })
+  describe('successful submission for a Welsh payment link', () => {
+    let result, session, app
+    before('Arrange', () => {
+      const expectedProductRequest = buildCreateProductRequest('cy')
+      const productResponse = validCreateProductResponse(expectedProductRequest).getPlain()
+      nock(PUBLIC_AUTH_URL).post('', VALID_CREATE_TOKEN_REQUEST).reply(201, VALID_CREATE_TOKEN_RESPONSE)
+      nock(PRODUCTS_URL).post('/v1/api/products', expectedProductRequest).reply(201, productResponse)
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+      session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.createPaymentLink', {
+        paymentLinkTitle: PAYMENT_TITLE,
+        paymentLinkDescription: PAYMENT_DESCRIPTION,
+        paymentLinkAmount: PAYMENT_LINK_AMOUNT,
+        isWelsh: true
       })
+      app = createAppWithSession(getApp(), session)
+    })
+    before('Act', done => {
+      supertest(app)
+        .post(paths.paymentLinks.review)
+        .send(VALID_PAYLOAD)
+        .end((err, res) => {
+          result = res
+          done(err)
+        })
+    })
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should redirect with status code 302', () => {
+      expect(result.statusCode).to.equal(302)
+    })
+
+    it('should redirect to the manage page', () => {
+      expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.manage)
     })
   })
-  describe(`when paymentLinkTitle is missing from the session`, () => {
+  describe('the product creation fails', () => {
+    let result, session, app
+
+    before('Arrange', () => {
+      const expectedProductRequest = buildCreateProductRequest('en')
+      nock(PUBLIC_AUTH_URL).post('', VALID_CREATE_TOKEN_REQUEST).reply(201, VALID_CREATE_TOKEN_RESPONSE)
+      nock(PRODUCTS_URL).post('/v1/api/products', expectedProductRequest).replyWithError('Something went wrong')
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+      session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.createPaymentLink', {
+        paymentLinkTitle: PAYMENT_TITLE,
+        paymentLinkDescription: PAYMENT_DESCRIPTION,
+        paymentLinkAmount: PAYMENT_LINK_AMOUNT,
+        isWelsh: false
+      })
+      app = createAppWithSession(getApp(), session)
+    })
+    before('Act', done => {
+      supertest(app)
+        .post(paths.paymentLinks.review)
+        .send(VALID_PAYLOAD)
+        .end((err, res) => {
+          result = res
+          done(err)
+        })
+    })
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should redirect with status code 302', () => {
+      expect(result.statusCode).to.equal(302)
+    })
+
+    it('should redirect back to the review page', () => {
+      expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.review)
+    })
+
+    it('should add a relevant error message to the session \'flash\'', () => {
+      expect(session.flash).to.have.property('genericError')
+      expect(session.flash.genericError.length).to.equal(1)
+      expect(session.flash.genericError[0]).to.equal('<h2>There were errors</h2><p>Error while creating payment link</p>')
+    })
+  })
+  describe('when the API token creation fails', () => {
+    let result, session, app
+    before('Arrange', () => {
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+      nock(PUBLIC_AUTH_URL).post('', VALID_CREATE_TOKEN_REQUEST).replyWithError('Something went wrong')
+      session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.createPaymentLink', {
+        paymentLinkTitle: PAYMENT_TITLE,
+        paymentLinkDescription: PAYMENT_DESCRIPTION,
+        isWelsh: false
+      })
+      app = createAppWithSession(getApp(), session)
+    })
+    before('Act', done => {
+      supertest(app)
+        .post(paths.paymentLinks.review)
+        .send({
+          'csrfToken': csrf().create('123')
+        })
+        .end((err, res) => {
+          result = res
+          done(err)
+        })
+    })
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should redirect with status code 302', () => {
+      expect(result.statusCode).to.equal(302)
+    })
+
+    it('should redirect back to the index page', () => {
+      expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.review)
+    })
+
+    it('should add a relevant error message to the session \'flash\'', () => {
+      expect(session.flash).to.have.property('genericError')
+      expect(session.flash.genericError.length).to.equal(1)
+      expect(session.flash.genericError[0]).to.equal('<h2>There were errors</h2><p>Error while creating payment link</p>')
+    })
+  })
+  describe('when paymentDescription in missing from the session', () => {
+    let result, session, app
+    before('Arrange', () => {
+      const expectedProductRequest = buildCreateProductRequest('en')
+      const productResponse = validCreateProductResponse(expectedProductRequest).getPlain()
+      nock(PUBLIC_AUTH_URL).post('', VALID_CREATE_TOKEN_REQUEST).reply(201, VALID_CREATE_TOKEN_RESPONSE)
+      nock(PRODUCTS_URL).post('/v1/api/products', lodash.omit(expectedProductRequest, 'description')).reply(201, productResponse)
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+      session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.createPaymentLink', {
+        paymentLinkTitle: PAYMENT_TITLE,
+        paymentLinkAmount: PAYMENT_LINK_AMOUNT,
+        isWelsh: false
+      })
+      app = createAppWithSession(getApp(), session)
+    })
+    before('Act', done => {
+      supertest(app)
+        .post(paths.paymentLinks.review)
+        .send(VALID_PAYLOAD)
+        .end((err, res) => {
+          result = res
+          done(err)
+        })
+    })
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should redirect with status code 302', () => {
+      expect(result.statusCode).to.equal(302)
+    })
+
+    it('should redirect to the manage page with a success message', () => {
+      expect(session.flash).to.have.property('generic')
+      expect(session.flash.generic.length).to.equal(1)
+      expect(session.flash.generic[0]).to.equal('<h2>Your payment link is now live</h2><p>Give this link to your users to collect payments for your service.</p>')
+      expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.manage)
+    })
+  })
+  describe('when paymentLinkTitle is missing from the session', () => {
     let result, app
 
     before('Arrange', () => {


### PR DESCRIPTION
Send language when creating a payment link, getting the language from whether the payment link is Welsh or not.
When no language is provided to the create product client, such as for creating a demo payment, default to English.

