### PR TITLE
PP-5012 Remove service-name field on edit payment link

### DIFF
--- a/app/views/payment-links/edit.njk
+++ b/app/views/payment-links/edit.njk
@@ -13,7 +13,6 @@
 <section class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
   <form action="{{ self }}" class="form" method="post">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-    <input name="service-name" type="hidden" value="{{currentService.name}}"/>
     <h1 class="govuk-heading-l">Edit your payment link</h1>
     <dl class="govuk-check-your-answers cya-questions-short">
       <div class="review-title">


### PR DESCRIPTION
This hidden field was not used and was causing NAXSI to block if there were any special characters in the service name, as the service name was not whitelisted for this URL


