### PR TITLE
BAU Increase timeout for mocha tests

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,5 @@
 --reporter spec
 --require ./test/test_helpers/test_env.js
 --require ./test/test_helpers/supress_logs.js
+--timeout 5000
 --exit


### PR DESCRIPTION
We get the docker build stage of CI builds failing regularly due to a timeout when running tests which use pact interactions.
Increasing the timeout from the default of 2s to 5s to hopefully avoid this happening so regularly.


