### PR TITLE
PP-5108 Use true booleans instead of strings

### DIFF
--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -520,7 +520,7 @@ ConnectorClient.prototype = {
         body: {
           op: 'replace',
           path: 'allow_apple_pay',
-          value: `${allowApplePay}`
+          value: allowApplePay
         },
         correlationId,
         description: 'toggle allow apple pay',
@@ -545,7 +545,7 @@ ConnectorClient.prototype = {
         body: {
           op: 'replace',
           path: 'allow_google_pay',
-          value: `${allowGooglePay}`
+          value: allowGooglePay
         },
         correlationId,
         description: 'toggle allow google pay',


### PR DESCRIPTION
## WHAT
Connector is already capable of handling Strings and Booleans. But we would like to use true booleans in place of "boolean strings". 

Solo: @cobainc0

