### PR TITLE
PP-5108 Add pact tests for wallet payments

### DIFF
--- a/test/fixtures/gateway_account_fixtures.js
+++ b/test/fixtures/gateway_account_fixtures.js
@@ -45,6 +45,22 @@ function validGatewayAccount (opts) {
 }
 
 module.exports = {
+  validGatewayAccountPatchRequest: (opts = {}) => {
+    const data = {
+      op: 'replace',
+      path: opts.path,
+      value: opts.value
+    }
+
+    return {
+      getPactified: () => {
+        return pactRegister.pactify(data)
+      },
+      getPlain: () => {
+        return _.clone(data)
+      }
+    }
+  },
   validGatewayAccountEmailRefundToggleRequest: (enabled = true) => {
     const data = {
       op: 'replace',

--- a/test/unit/clients/connector_client/connector_patch_apple_pay_toggle_test.js
+++ b/test/unit/clients/connector_client/connector_patch_apple_pay_toggle_test.js
@@ -1,0 +1,89 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+
+// Custom dependencies
+const path = require('path')
+const PactInteractionBuilder = require('../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const Connector = require('../../../../app/services/clients/connector_client').ConnectorClient
+const gatewayAccountFixtures = require('../../../fixtures/gateway_account_fixtures')
+
+// Constants
+const ACCOUNTS_RESOURCE = '/v1/api/accounts'
+const port = Math.floor(Math.random() * 48127) + 1024
+const connectorClient = new Connector(`http://localhost:${port}`)
+const expect = chai.expect
+const existingGatewayAccountId = 666
+
+// Global setup
+chai.use(chaiAsPromised)
+
+describe('connector client - patch apple pay toggle (enabled) request', () => {
+  const patchRequestParams = { path: 'allow_apple_pay', value: true }
+  const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams).getPlain()
+
+  let provider = Pact({
+    consumer: 'selfservice',
+    provider: 'connector',
+    port: port,
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(() => provider.setup())
+  after(() => provider.finalize())
+
+  describe('apple pay toggle - supported payment provider request', () => {
+    const applePayToggleSupportedPaymentProviderState =
+      `a gateway account supporting digital wallet with external id ${existingGatewayAccountId} exists in the database`
+
+    before(() => {
+      return provider.addInteraction(
+        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
+          .withUponReceiving('a valid patch apple pay toggle (enabled) request')
+          .withState(applePayToggleSupportedPaymentProviderState)
+          .withMethod('PATCH')
+          .withRequestBody(request)
+          .withStatusCode(200)
+          .withResponseHeaders({})
+          .build())
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should toggle successfully', done => {
+      connectorClient.toggleApplePay(existingGatewayAccountId, true, null)
+        .should.be.fulfilled
+        .notify(done)
+    })
+  })
+
+  describe('apple pay toggle with unsupported payment provider request', () => {
+    const applePayToggleUnsupportedPaymentProviderState = `User ${existingGatewayAccountId} exists in the database`
+
+    before(() => {
+      return provider.addInteraction(
+        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
+          .withUponReceiving('a valid patch apple pay toggle (enabled) request')
+          .withState(applePayToggleUnsupportedPaymentProviderState)
+          .withMethod('PATCH')
+          .withRequestBody(request)
+          .withStatusCode(400)
+          .build())
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should respond bad request for unsupported payment provider', done => {
+      connectorClient.toggleApplePay(existingGatewayAccountId, true, null)
+        .should.be.rejected.then(response => {
+          expect(response.errorCode).to.equal(400)
+        }).should.notify(done)
+    })
+  })
+})

--- a/test/unit/clients/connector_client/connector_patch_google_pay_toggle_test.js
+++ b/test/unit/clients/connector_client/connector_patch_google_pay_toggle_test.js
@@ -1,0 +1,89 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+
+// Custom dependencies
+const path = require('path')
+const PactInteractionBuilder = require('../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const Connector = require('../../../../app/services/clients/connector_client').ConnectorClient
+const gatewayAccountFixtures = require('../../../fixtures/gateway_account_fixtures')
+
+// Constants
+const ACCOUNTS_RESOURCE = '/v1/api/accounts'
+const port = Math.floor(Math.random() * 48127) + 1024
+const connectorClient = new Connector(`http://localhost:${port}`)
+const expect = chai.expect
+const existingGatewayAccountId = 666
+
+// Global setup
+chai.use(chaiAsPromised)
+
+describe('connector client - patch google pay toggle (enabled) request', () => {
+  const patchRequestParams = { path: 'allow_google_pay', value: true }
+  const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams).getPlain()
+
+  let provider = Pact({
+    consumer: 'selfservice',
+    provider: 'connector',
+    port: port,
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(() => provider.setup())
+  after(() => provider.finalize())
+
+  describe('google pay toggle - supported payment provider request', () => {
+    const googlePayToggleSupportedPaymentProviderState =
+      `a gateway account supporting digital wallet with external id ${existingGatewayAccountId} exists in the database`
+
+    before(() => {
+      return provider.addInteraction(
+        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
+          .withUponReceiving('a valid patch google pay toggle (enabled) request')
+          .withState(googlePayToggleSupportedPaymentProviderState)
+          .withMethod('PATCH')
+          .withRequestBody(request)
+          .withStatusCode(200)
+          .withResponseHeaders({})
+          .build())
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should toggle successfully', done => {
+      connectorClient.toggleGooglePay(existingGatewayAccountId, true, null)
+        .should.be.fulfilled
+        .notify(done)
+    })
+  })
+
+  describe('google pay toggle with unsupported payment provider request', () => {
+    const googlePayToggleUnsupportedPaymentProviderState = `User ${existingGatewayAccountId} exists in the database`
+
+    before(() => {
+      return provider.addInteraction(
+        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
+          .withUponReceiving('a valid patch google pay toggle (enabled) request')
+          .withState(googlePayToggleUnsupportedPaymentProviderState)
+          .withMethod('PATCH')
+          .withRequestBody(request)
+          .withStatusCode(400)
+          .build())
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should respond bad request for unsupported payment provider', done => {
+      connectorClient.toggleGooglePay(existingGatewayAccountId, true, null)
+        .should.be.rejected.then(response => {
+          expect(response.errorCode).to.equal(400)
+        }).should.notify(done)
+    })
+  })
+})


### PR DESCRIPTION
## WHAT
Add pact tests for gateway accounts supporting digital wallets
- connector now expects boolean values for `allow_google_pay` & `allow_apple_pay` flags

Solo: @cobainc0 
