### PR TITLE
PP-5153 Update existing Stripe person

### DIFF
--- a/app/services/clients/stripe/stripe_client.js
+++ b/app/services/clients/stripe/stripe_client.js
@@ -37,8 +37,12 @@ module.exports = {
     return stripe.accounts.update(stripeAccountId, company.basicObject())
   },
 
-  createPerson: function (stripeAccountId, body) {
+  listPersons: function (stripeAccountId) {
+    return stripe.accounts.listPersons(stripeAccountId)
+  },
+
+  updatePerson: function (stripeAccountId, stripePersonId, body) {
     const stripePerson = new StripePerson(body)
-    return stripe.accounts.createPerson(stripeAccountId, stripePerson.basicObject())
+    return stripe.accounts.updatePerson(stripeAccountId, stripePersonId, stripePerson.basicObject())
   }
 }


### PR DESCRIPTION
Stripe creates a blank "person" on a test account when it is created. Therefore rather than creating a new person, we need to update the existing person.
We update the final person returned when we call Stripe to list the persons as this will be the first person created.


