### PR TITLE
PP-4889 Add metadata to transaction detail page.

### DIFF
--- a/app/views/transaction_detail/_metadata.njk
+++ b/app/views/transaction_detail/_metadata.njk
@@ -1,0 +1,10 @@
+<table class="transaction-details govuk-table">
+  <tbody class="govuk-table__body">
+    {% for key, value in metadata|dictsort %}
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">{{key}}:</th>
+      <td class="govuk-table__cell govuk-!-font-size-16" id="metadata-value">{{value}}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/app/views/transaction_detail/index.njk
+++ b/app/views/transaction_detail/index.njk
@@ -25,6 +25,11 @@
     <h2 class="govuk-heading-m govuk-!-margin-top-9">Payment method</h2>
     {% include "./_payment.njk" %}
 
+    {% if metadata %}
+    <h2 class="govuk-heading-m govuk-!-margin-top-9">Metadata</h2>
+        {% include "./_metadata.njk" %}
+    {% endif %}
+
     {% if permissions.transactions_events_read %}
       <h2 class="govuk-heading-m govuk-!-margin-top-9">Transaction events</h2>
       {% include "./_events.njk" %}

--- a/test/cypress/integration/transactions/transaction_details_spec.js
+++ b/test/cypress/integration/transactions/transaction_details_spec.js
@@ -326,4 +326,26 @@ describe('Transactions details page', () => {
     cy.visit(`${transactionsUrl}/${chargeDetails.charge.charge_id}`)
     cy.get('.transaction-details tbody').should('not.contain', 'Wallet Type')
   })
+
+  it('should display metadata when available', () => {
+    const chargeDetails = defaultChargeDetails()
+    chargeDetails.charge.metadata = {
+      key1: 123,
+      key2: true,
+      key3: 'some string'
+    }
+    cy.task('setupStubs', getStubs(chargeDetails))
+    cy.visit(`${transactionsUrl}/${chargeDetails.charge.charge_id}`)
+    cy.get('h2').should('contain', 'Metadata')
+    cy.get('th').contains('key1').siblings().first().should('contain', '123')
+    cy.get('th').contains('key2').siblings().first().should('contain', 'true')
+    cy.get('th').contains('key3').siblings().first().should('contain', 'some string')
+  })
+
+  it('should not display metadata when unavailable', () => {
+    const chargeDetails = defaultChargeDetails()
+    cy.task('setupStubs', getStubs(chargeDetails))
+    cy.visit(`${transactionsUrl}/${chargeDetails.charge.charge_id}`)
+    cy.get('h2').should('not.contain', 'Metadata')
+  })
 })

--- a/test/fixtures/transaction_fixtures.js
+++ b/test/fixtures/transaction_fixtures.js
@@ -82,7 +82,8 @@ const buildTransactionWithDefaults = (opts = {}) => {
       card_brand: opts.card_brand || 'Visa'
     },
     delayed_capture: opts.delayed_capture || false,
-    wallet_type: opts.wallet_type || null
+    wallet_type: opts.wallet_type || null,
+    metadata: opts.metadata || null
   }
 
   if (opts.corporate_card_surcharge) {


### PR DESCRIPTION
## WHAT
Add metadata to transactions details page, should not show if there is no metadata for the charge.


