### PR TITLE
BAU - improve hover and focus styles for dashboard total links

### DIFF
--- a/app/assets/sass/components/dashboard-activity.scss
+++ b/app/assets/sass/components/dashboard-activity.scss
@@ -8,6 +8,7 @@
     }
 
     &__link {
+      display: block;
       text-decoration: none;
 
       &:link, &:visited {
@@ -16,14 +17,13 @@
 
       &:hover {
         .dashboard-total-group__values {
-          background-color: $govuk-border-colour;
+          background-color: govuk-colour("grey-3");
         }
       }
 
       &:focus {
-        .dashboard-total-group__values {
-          background-color: $govuk-focus-colour;
-        }
+        outline: 3px solid $govuk-focus-colour;
+        outline-offset: 0;
       }
     }
 


### PR DESCRIPTION
We were using greys to show hover and focus. This isnt great because the
contrast is low and also worsens the text contrast. Using a yellow
outline mimics the standard behaviour and increase contrast.
