### PR TITLE
PP-4997: hide fee and net amounts for refund details

### DIFF
--- a/app/views/transaction_detail/_details.njk
+++ b/app/views/transaction_detail/_details.njk
@@ -90,13 +90,26 @@
   </tr>
   
   {% if isStripeAccount %}
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">PSP fee:</th>
-      <td class="govuk-table__cell govuk-!-font-size-16" data-cell-type="fee">{{ fee }}</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">Net amount:</th>
-      <td class="govuk-table__cell govuk-!-font-size-16" data-cell-type="net">{{ net_amount or total_amount or amount }}</td> </tr>
+    {# 
+      @TODO(sfount) with the current behaviour, self service will always go to the 
+      charge end point to get details -- this means a refund will have all of the 
+      same attributes as a charge (including fee and net amount). The fee and net 
+      amount have nothing to do with the refund and should only be shown for the charge. 
+      In future we should look at calling the /refunds end point to get the refund
+      (will not include additional charge details) -- this could look like 
+      /transactions/charges/${ID}
+      /transactions/refunds/${ID}
+    #}
+    {% if transaction_type !== 'refund' %}
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">PSP fee:</th>
+        <td class="govuk-table__cell govuk-!-font-size-16" data-cell-type="fee">{{ fee }}</td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">Net amount:</th>
+        <td class="govuk-table__cell govuk-!-font-size-16" data-cell-type="net">{{ net_amount or total_amount or amount }}</td> 
+      </tr>
+    {% endif %}
   {% endif %}
 
   <tr class="govuk-table__row">

--- a/test/cypress/integration/transactions/transaction_details_spec.js
+++ b/test/cypress/integration/transactions/transaction_details_spec.js
@@ -20,7 +20,7 @@ function formatDate (date) {
   return day + ' ' + monthNames[monthIndex] + ' ' + year + ' — '
 }
 
-function defaultChargeDetails (paymentProvider = 'sandbox') {
+function defaultChargeDetails (paymentProvider = 'sandbox', transactionType = 'charge') {
   return {
     charge: {
       charge_id: '12345',
@@ -38,6 +38,7 @@ function defaultChargeDetails (paymentProvider = 'sandbox') {
       expiry_date: '08/23',
       email: 'example@example.com',
       payment_provider: paymentProvider,
+      transaction_type: transactionType,
       delayed_capture: false,
       ...(paymentProvider === 'stripe' && { fee: 100 }),
       ...(paymentProvider === 'stripe' && { net_amount: 900 })
@@ -357,5 +358,13 @@ describe('Transaction details page', () => {
     cy.visit(`${transactionsUrl}/${chargeDetails.charge.charge_id}`)
     cy.get('.transaction-details tbody').find('[data-cell-type="fee"]').first().should('have.text', convertPenceToPoundsFormatted(chargeDetails.charge.fee))
     cy.get('.transaction-details tbody').find('[data-cell-type="net"]').first().should('have.text', convertPenceToPoundsFormatted(chargeDetails.charge.amount - chargeDetails.charge.fee))
+  })
+
+  it('should not show fee or net details for a refund transaction', () => {
+    const chargeDetails = defaultChargeDetails('stripe', 'refund')
+    cy.task('setupStubs', getStubs(chargeDetails))
+    cy.visit(`${transactionsUrl}/${chargeDetails.charge.charge_id}`)
+    cy.get('.transaction-details tbody').find('[data-cell-type="fee"]').should('not.exist')
+    cy.get('.transaction-details tbody').find('[data-cell-type="net"]').should('not.exist')
   })
 })

--- a/test/fixtures/transaction_fixtures.js
+++ b/test/fixtures/transaction_fixtures.js
@@ -57,6 +57,7 @@ const buildTransactionWithDefaults = (opts = {}) => {
       : 'https://demoservice.pymnt.localdomain:443/return/532aad2f833a3b8234921ca85a98ca5b/ref188888',
     email: opts.email || 'gds-payments-team-smoke@digital.cabinet-office.gov.uk',
     payment_provider: opts.payment_provider || 'sandbox',
+    transaction_type: opts.transaction_type || 'charge',
     created_date: opts.created_date || '2018-05-01T13:27:00.057Z',
     refund_summary: {
       status: opts.refund_summary_status || 'unavailable',


### PR DESCRIPTION
Self service currently just fetches the charge end point for any
transaction -- this means that refunds are displayed with the charges
`fee` and `net_amount` columns. This factors this in until a more
specific method of searching for refunds or charges is implemented.

