### PR TITLE
PP-4997 Negative net amount following standard

### DIFF
--- a/app/utils/json_to_csv.js
+++ b/app/utils/json_to_csv.js
@@ -109,7 +109,7 @@ module.exports = function jsonToCSV (data, supportsGatewayFees = false) {
           { label: 'Net',
             value: row => {
               const amountInPence = row.net_amount || row.total_amount || row.amount
-              return penceToPounds(parseInt(amountInPence))
+              return (row.transaction_type === 'refund') ? penceToPounds(parseInt(amountInPence) * -1) : penceToPounds(parseInt(amountInPence))
             } }
         ] : []
       ]


### PR DESCRIPTION
Ensure net amount is negative for CSV downloads if the transaction is a
refund. Not how it could potentially be best represented but done this
way for consistency.