### PR TITLE
PP-4491: Remove Chamber wrapper script

### DIFF
--- a/run-with-chamber.sh
+++ b/run-with-chamber.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -u
-
-AWS_REGION="$ECS_AWS_REGION" chamber exec "$ECS_SERVICE" -- npm start


### PR DESCRIPTION
Now that ECS supports retrieving secrets directly from Parameter Store, we no
longer use Chamber. This script is redundant.
