### PR TITLE
BAU - Details has title error label

### DIFF
--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -88,7 +88,6 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
         hint: {
           text: detailsHint
         },
-        errorMessage: titleError,
         attributes: {
           "autofocus": change !== "payment-link-description",
           "rows": "5",


### PR DESCRIPTION
Details shouldn’t have an error label because it’s optional