### PR TITLE
BAU - use an not a as word after is option

### DIFF
--- a/app/views/transactions/filter.njk
+++ b/app/views/transactions/filter.njk
@@ -108,7 +108,7 @@
             classes: 'govuk-label--s govuk-!-font-size-16 govuk-!-margin-bottom-0'
           },
           hint: {
-            text: "Select a option",
+            text: "Select an option",
             classes: 'govuk-!-font-size-14'
           },
           attributes: {


### PR DESCRIPTION
Small but embarrassing mistake