### PR TITLE
PP-5199 Enable transactions pact tests

### DIFF
--- a/test/cypress/integration/transactions/transaction_details_spec.js
+++ b/test/cypress/integration/transactions/transaction_details_spec.js
@@ -26,8 +26,10 @@ function defaultChargeDetails (paymentProvider = 'sandbox', transactionType = 'c
       charge_id: '12345',
       reference: 'ref123',
       amount: defaultAmount,
-      state_finished: true,
-      state_status: 'success',
+      state: {
+        finished: true,
+        status: 'success'
+      },
       refund_summary_status: 'available',
       refund_summary_available: 1000,
       refund_summary_submitted: 0,
@@ -113,7 +115,7 @@ describe('Transaction details page', () => {
         chargeDetails.charge.reference)
       // Status
       cy.get('.transaction-details tbody').find('tr').eq(2).find('td').first().should('contain',
-        capitalise(chargeDetails.charge.state_status))
+        capitalise(chargeDetails.charge.state.status))
       // Amount
       cy.get('.transaction-details tbody').find('tr').eq(3).find('td').first().should('have.text',
         convertPenceToPoundsFormatted(chargeDetails.charge.amount))
@@ -167,7 +169,7 @@ describe('Transaction details page', () => {
         aDelayedCaptureCharge.charge.reference)
       // Status
       cy.get('.transaction-details tbody').find('tr').eq(2).find('td').first().should('contain',
-        capitalise(aDelayedCaptureCharge.charge.state_status))
+        capitalise(aDelayedCaptureCharge.charge.state.status))
       // Amount
       cy.get('.transaction-details tbody').find('tr').eq(3).find('td').first().should('have.text',
         convertPenceToPoundsFormatted(aDelayedCaptureCharge.charge.amount))

--- a/test/fixtures/transaction_fixtures.js
+++ b/test/fixtures/transaction_fixtures.js
@@ -38,26 +38,16 @@ const buildChargeEventStateWithDefaults = (opts = {}) => {
   return state
 }
 
-const buildTransactionWithDefaults = (opts = {}) => {
+const buildTransactionDetailsWithDefaults = (opts = {}) => {
   const data = {
     amount: opts.amount || 20000,
-    state: {
-      finished: opts.state_finished || false,
-      code: opts.state_code || 'P0010',
-      message: opts.state_message || 'Payment method rejected',
-      status: opts.state_status || 'failed'
-    },
+    state: buildChargeEventStateWithDefaults(opts.state),
     description: opts.description || 'ref1',
     reference: opts.reference || 'ref188888',
-    links: [],
     charge_id: opts.charge_id || 'ht439nfg2l1e303k0dmifrn4fc',
     gateway_transaction_id: opts.gateway_transaction_id || '4cddd970-cce9-4bf1-b087-f13db1e199bd',
-    return_url: opts.reference
-      ? `https://demoservice.pymnt.localdomain:443/return/532aad2f833a3b8234921ca85a98ca5b/${opts.reference}`
-      : 'https://demoservice.pymnt.localdomain:443/return/532aad2f833a3b8234921ca85a98ca5b/ref188888',
     email: opts.email || 'gds-payments-team-smoke@digital.cabinet-office.gov.uk',
     payment_provider: opts.payment_provider || 'sandbox',
-    transaction_type: opts.transaction_type || 'charge',
     created_date: opts.created_date || '2018-05-01T13:27:00.057Z',
     refund_summary: {
       status: opts.refund_summary_status || 'unavailable',
@@ -76,15 +66,12 @@ const buildTransactionWithDefaults = (opts = {}) => {
         line1: opts.billing_address_line1 || 'address line 1',
         line2: opts.billing_address_line2 || 'address line 2',
         postcode: opts.billing_address_postcode || 'AB1A 1AB',
-        city: opts.billing_address_city || 'GB',
-        county: opts.billing_address_county || null,
+        city: opts.billing_address_city || 'London',
         country: opts.billing_address_country || 'GB'
       },
       card_brand: opts.card_brand || 'Visa'
     },
-    delayed_capture: opts.delayed_capture || false,
-    wallet_type: opts.wallet_type || null,
-    metadata: opts.metadata || null
+    delayed_capture: opts.delayed_capture || false
   }
 
   if (opts.corporate_card_surcharge) {
@@ -93,6 +80,41 @@ const buildTransactionWithDefaults = (opts = {}) => {
   }
   if (opts.fee) data.fee = opts.fee
   if (opts.net_amount) data.net_amount = opts.net_amount
+  if (opts.wallet_type) data.wallet_type = opts.wallet_type
+  if (opts.metadata) data.metadata = opts.metadata
+
+  return data
+}
+
+const buildTransactionSearchResultWithDefaults = (opts = {}) => {
+  const data = {
+    amount: opts.amount || 20000,
+    state: buildChargeEventStateWithDefaults(opts.state),
+    description: opts.description || 'ref1',
+    reference: opts.reference || 'ref188888',
+    links: [],
+    charge_id: opts.charge_id || 'ht439nfg2l1e303k0dmifrn4fc',
+    gateway_transaction_id: opts.gateway_transaction_id || '4cddd970-cce9-4bf1-b087-f13db1e199bd',
+    email: opts.email || 'gds-payments-team-smoke@digital.cabinet-office.gov.uk',
+    transaction_type: opts.transaction_type || 'charge',
+    created_date: opts.created_date || '2018-05-01T13:27:00.057Z',
+    card_details: {
+      last_digits_card_number: opts.last_digits_card_number || '0002',
+      cardholder_name: opts.cardholder_name || 'Test User',
+      expiry_date: opts.expiry_date || '08/23',
+      card_brand: opts.card_brand || 'Visa'
+    },
+    delayed_capture: opts.delayed_capture || false
+  }
+
+  if (opts.corporate_card_surcharge) {
+    data.corporate_card_surcharge = opts.corporate_card_surcharge
+    data.total_amount = opts.total_amount
+  }
+  if (opts.fee) data.fee = opts.fee
+  if (opts.net_amount) data.net_amount = opts.net_amount
+  if (opts.wallet_type) data.wallet_type = opts.wallet_type
+  if (opts.metadata) data.metadata = opts.metadata
 
   return data
 }
@@ -115,14 +137,13 @@ module.exports = {
     }
   },
   validTransactionsResponse: (opts = {}) => {
-    const results = lodash.flatMap(opts.transactions, buildTransactionWithDefaults)
+    const results = lodash.flatMap(opts.transactions, buildTransactionSearchResultWithDefaults)
 
     const data = {
       total: opts.transactions.length,
       count: opts.transactions.length,
       page: opts.page || 1,
-      results: results,
-      _links: opts.links || []
+      results: results
     }
 
     return {
@@ -135,7 +156,7 @@ module.exports = {
     }
   },
   validTransactionDetailsResponse: (opts = {}) => {
-    const data = buildTransactionWithDefaults(opts)
+    const data = buildTransactionDetailsWithDefaults(opts)
 
     return {
       getPactified: () => {

--- a/test/unit/clients/connector_client/connector_get_transaction_details_test.js
+++ b/test/unit/clients/connector_client/connector_get_transaction_details_test.js
@@ -26,7 +26,7 @@ const defaultChargeState = `Gateway account ${existingGatewayAccountId} exists a
 
 describe('connector client', function () {
   const provider = Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'connector',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
@@ -76,7 +76,7 @@ describe('connector client', function () {
   describe('get transaction details with corporate card surcharge', () => {
     const params = {
       gatewayAccountId: existingGatewayAccountId,
-      chargeId: 'charge-with-corporate-charge'
+      chargeId: defaultChargeId
     }
     const validGetTransactionDetailsResponse = transactionDetailsFixtures.validTransactionDetailsResponse({
       charge_id: params.chargeId,
@@ -113,7 +113,7 @@ describe('connector client', function () {
   describe('get transaction details with metadata', () => {
     const params = {
       gatewayAccountId: '42',
-      chargeId: '100'
+      chargeId: defaultChargeId
     }
     const validGetTransactionDetailsResponse = transactionDetailsFixtures.validTransactionDetailsResponse({
       charge_id: params.chargeId,
@@ -171,7 +171,7 @@ describe('connector client', function () {
       provider.addInteraction(
         new PactInteractionBuilder(`${CHARGES_RESOURCE}/${params.gatewayAccountId}/charges/${params.chargeId}/events`)
           .withUponReceiving('a valid charge events request')
-          .withState(defaultChargeState)
+          .withState(`Gateway account ${params.gatewayAccountId} exists and has a charge with id ${params.chargeId} and has CREATED and AUTHORISATION_REJECTED charge events`)
           .withMethod('GET')
           .withStatusCode(200)
           .withResponseBody(pactified)
@@ -239,7 +239,7 @@ describe('connector client', function () {
 
       const params = {
         gatewayAccountId: 42,
-        chargeId: 'refund-success',
+        chargeId: defaultChargeId,
         payload: invalidTransactionRefundRequest.getPlain()
       }
 

--- a/test/unit/clients/connector_client/connector_get_transactions_and_summary_test.js
+++ b/test/unit/clients/connector_client/connector_get_transactions_and_summary_test.js
@@ -23,7 +23,7 @@ chai.use(chaiAsPromised)
 
 describe('connector client', function () {
   const provider = Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'connector',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
@@ -234,7 +234,7 @@ describe('connector client', function () {
       provider.addInteraction(
         new PactInteractionBuilder(`${TRANSACTIONS_RESOURCE}/${params.gatewayAccountId}/charges`)
           .withUponReceiving('a valid transactions request filtered by partial email and card_brand of visa')
-          .withState(`Account ${params.gatewayAccountId} exists in the database and has 1 available transaction with a card brands visa and mastercard and a partial email matching ${params.email}`)
+          .withState(`Account ${params.gatewayAccountId} exists in the database and has 1 available transaction with a card brand visa and a partial email matching ${params.email}`)
           .withMethod('GET')
           .withQuery('reference', '')
           .withQuery('cardholder_name', '')


### PR DESCRIPTION
* Set the provider to "selfservice" and make the Pact states match the states that exist in connector.
* Modify test fixtures so they produce the correct pacts.
* Modify Cypress tests to work with the modified fixtures.