### PR TITLE
PP-5199 Remove transaction type check for displaying psp fee

### DIFF
--- a/app/views/transaction_detail/_details.njk
+++ b/app/views/transaction_detail/_details.njk
@@ -90,17 +90,6 @@
   </tr>
   
   {% if isStripeAccount %}
-    {# 
-      @TODO(sfount) with the current behaviour, self service will always go to the 
-      charge end point to get details -- this means a refund will have all of the 
-      same attributes as a charge (including fee and net amount). The fee and net 
-      amount have nothing to do with the refund and should only be shown for the charge. 
-      In future we should look at calling the /refunds end point to get the refund
-      (will not include additional charge details) -- this could look like 
-      /transactions/charges/${ID}
-      /transactions/refunds/${ID}
-    #}
-    {% if transaction_type !== 'refund' %}
       <tr class="govuk-table__row">
         <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">PSP fee:</th>
         <td class="govuk-table__cell govuk-!-font-size-16" data-cell-type="fee">{{ fee }}</td>
@@ -109,7 +98,6 @@
         <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">Net amount:</th>
         <td class="govuk-table__cell govuk-!-font-size-16" data-cell-type="net">{{ net_amount or total_amount or amount }}</td> 
       </tr>
-    {% endif %}
   {% endif %}
 
   <tr class="govuk-table__row">

--- a/test/cypress/integration/transactions/transaction_details_spec.js
+++ b/test/cypress/integration/transactions/transaction_details_spec.js
@@ -359,12 +359,4 @@ describe('Transaction details page', () => {
     cy.get('.transaction-details tbody').find('[data-cell-type="fee"]').first().should('have.text', convertPenceToPoundsFormatted(chargeDetails.charge.fee))
     cy.get('.transaction-details tbody').find('[data-cell-type="net"]').first().should('have.text', convertPenceToPoundsFormatted(chargeDetails.charge.amount - chargeDetails.charge.fee))
   })
-
-  it('should not show fee or net details for a refund transaction', () => {
-    const chargeDetails = defaultChargeDetails('stripe', 'refund')
-    cy.task('setupStubs', getStubs(chargeDetails))
-    cy.visit(`${transactionsUrl}/${chargeDetails.charge.charge_id}`)
-    cy.get('.transaction-details tbody').find('[data-cell-type="fee"]').should('not.exist')
-    cy.get('.transaction-details tbody').find('[data-cell-type="net"]').should('not.exist')
-  })
 })


### PR DESCRIPTION
- On the transaction details page, we were checking whether the transaction_type of the charge was a 'refund' to decide whether to display the 'PSP fee' row. However, the connector charge endpoint does
not return this field, so this check always resolves as true.
- The cypress test for this was passing because it was using an incorrect fixture which was not validated by a pact test, which will be amended in a separate PR.

