### PR TITLE
PP-5193 Check permission for link gocardless account

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -347,7 +347,7 @@ module.exports.bind = function (app) {
   app.post(paths.feedback, xraySegmentCls, hasServices, resolveService, getAccount, feedbackController.postIndex)
 
   // Partner app link GoCardless account
-  app.get(paths.partnerApp.linkAccount, xraySegmentCls, getAccount, goCardlessRedirect.index)
+  app.get(paths.partnerApp.linkAccount, xraySegmentCls, permission('connected-gocardless-account:update'), getAccount, goCardlessRedirect.index)
 
   // Request to go live: index
   app.get(requestToGoLive.index, xraySegmentCls, permission('go-live-stage:read'), getAccount, requestToGoLiveIndexController.get)

--- a/app/utils/navBuilder.js
+++ b/app/utils/navBuilder.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const _ = require('lodash')
 const paths = require('./../paths')
 const pathLookup = require('./pathLookup')
@@ -102,7 +104,7 @@ const adminNavigationItems = (originalUrl, permissions, type, paymentProvider) =
       name: 'Link GoCardless Merchant Account',
       url: paths.partnerApp.linkAccount,
       current: pathLookup(originalUrl, paths.partnerApp.linkAccount),
-      permissions: permissions.tokens_update && type === 'direct debit'
+      permissions: permissions.connected_gocardless_account_update && type === 'direct debit'
     },
     {
       id: 'navigation-menu-billing-address',

--- a/test/fixtures/user_fixtures.js
+++ b/test/fixtures/user_fixtures.js
@@ -178,6 +178,14 @@ const defaultPermissions = [
   {
     name: 'stripe-vat-number-company-number:read',
     description: 'View Stripe VAT number company number'
+  },
+  {
+    name: 'connected-gocardless-account:read',
+    description: 'View connected go cardless account'
+  },
+  {
+    name: 'connected-gocardless-account:update',
+    description: 'Update connected go cardless account'
   }
 ]
 

--- a/test/integration/partnerapp/handle_redirect_to_gocardless_connect_test.js
+++ b/test/integration/partnerapp/handle_redirect_to_gocardless_connect_test.js
@@ -3,7 +3,7 @@
 require('../../test_helpers/serialize_mock.js')
 const request = require('supertest')
 const sinon = require('sinon')
-const {getUser, getMockSession, getAppWithSessionAndGatewayAccountCookies} = require('../../test_helpers/mock_session.js')
+const { getUser, getMockSession, getAppWithSessionAndGatewayAccountCookies } = require('../../test_helpers/mock_session.js')
 const directDebitClient = require('../../../app/services/clients/direct_debit_connector_client')
 
 const paths = require('../../../app/paths.js')
@@ -21,8 +21,11 @@ describe('GET /link/account - GoCardless Connect partner app', function () {
 
   beforeEach(() => {
     let stubbedCreateState = directDebitClient.partnerApp.createState = sinon.stub()
-    stubbedCreateState.resolves({state: stateParam})
-    const user = getUser({external_id: 'DIRECT_DEBIT:121391373c1844dd99cb3416b70785c8'})
+    stubbedCreateState.resolves({ state: stateParam })
+    const user = getUser({
+      external_id: 'DIRECT_DEBIT:121391373c1844dd99cb3416b70785c8',
+      permissions: [{ name: 'connected-gocardless-account:update' }]
+    })
     const mockSession = getMockSession(user)
     app = getAppWithSessionAndGatewayAccountCookies(server.getApp(), mockSession, user)
   })
@@ -41,7 +44,7 @@ describe('GET /link/account - GoCardless Connect partner app', function () {
 
 describe('GET /link/account - GoCardless Connect partner app', function () {
   beforeEach(() => {
-    const user = getUser()
+    const user = getUser({ permissions: [{ name: 'connected-gocardless-account:update' }] })
     const mockSession = getMockSession(user)
     app = getAppWithSessionAndGatewayAccountCookies(server.getApp(), mockSession, user)
   })

--- a/test/ui/navigation_ui_tests.js
+++ b/test/ui/navigation_ui_tests.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const renderTemplate = require(path.join(__dirname, '/../test_helpers/html_assertions.js')).render
-const {serviceNavigationItems, adminNavigationItems} = require(path.join(__dirname, '../../app/utils/navBuilder'))
+const { serviceNavigationItems, adminNavigationItems } = require(path.join(__dirname, '../../app/utils/navBuilder'))
 
 describe('navigation menu', function () {
   it('should render only Home link when user does have any of the required permissions to show the navigation links', function () {
@@ -11,7 +11,7 @@ describe('navigation menu', function () {
       currentGatewayAccount: {
         full_type: 'test'
       },
-      currentService: {name: 'Service Name'},
+      currentService: { name: 'Service Name' },
       permissions: testPermissions,
       hideServiceNav: false,
       serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'card'),
@@ -32,7 +32,7 @@ describe('navigation menu', function () {
       currentGatewayAccount: {
         full_type: 'test'
       },
-      currentService: {name: 'Service Name'},
+      currentService: { name: 'Service Name' },
       permissions: testPermissions,
       hideServiceNav: false,
       serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'card'),
@@ -53,7 +53,7 @@ describe('navigation menu', function () {
       currentGatewayAccount: {
         full_type: 'test'
       },
-      currentService: {name: 'Service Name'},
+      currentService: { name: 'Service Name' },
       permissions: testPermissions,
       hideServiceNav: false,
       serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'direct debit'),
@@ -204,102 +204,16 @@ describe('navigation menu', function () {
     body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('Billing address')
   })
 
-  it('should not render Accounts credentials navigation link when user is using direct debit gateway account', function () {
+  it('should not render card navigation links when gateway account is direct debit', function () {
     const testPermissions = {
       tokens_update: true,
       gateway_credentials_update: true,
-      service_name_read: false,
-      merchant_details_read: false,
-      payment_types_read: false,
-      toggle_3ds_read: false,
-      email_notification_template_read: false
-    }
-    const templateData = {
-      permissions: testPermissions,
-      showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'direct debit')
-    }
-
-    const body = renderTemplate('api-keys/index', templateData)
-
-    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('API keys')
-    body.should.containSelector('.settings-navigation li:nth-child(2)').withExactText('Link GoCardless Merchant Account')
-  })
-
-  it('should not render Card types navigation link when user is using direct debit gateway account', function () {
-    const testPermissions = {
-      tokens_update: true,
-      gateway_credentials_update: false,
-      service_name_read: false,
-      merchant_details_read: false,
+      service_name_read: true,
+      merchant_details_read: true,
       payment_types_read: true,
-      toggle_3ds_read: false,
-      email_notification_template_read: false
-    }
-    const templateData = {
-      permissions: testPermissions,
-      showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'direct debit')
-    }
-
-    const body = renderTemplate('api-keys/index', templateData)
-
-    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('API keys')
-    body.should.containSelector('.settings-navigation li:nth-child(2)').withExactText('Link GoCardless Merchant Account')
-  })
-  it('should not render 3D Secure navigation link when user is using direct debit gateway account', function () {
-    const testPermissions = {
-      tokens_update: true,
-      gateway_credentials_update: false,
-      service_name_read: false,
-      merchant_details_read: false,
-      payment_types_read: false,
       toggle_3ds_read: true,
-      email_notification_template_read: false
-    }
-    const templateData = {
-      permissions: testPermissions,
-      showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'direct debit')
-    }
-
-    const body = renderTemplate('api-keys/index', templateData)
-
-    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('API keys')
-    body.should.containSelector('.settings-navigation li:nth-child(2)').withExactText('Link GoCardless Merchant Account')
-  })
-
-  it('should not render Email notifications navigation link when user is using direct debit gateway account', function () {
-    const testPermissions = {
-      tokens_update: true,
-      gateway_credentials_update: false,
-      service_name_read: false,
-      merchant_details_read: false,
-      payment_types_read: false,
-      toggle_3ds_read: false,
-      email_notification_template_read: true
-    }
-    const templateData = {
-      permissions: testPermissions,
-      showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'direct debit')
-    }
-
-    const body = renderTemplate('api-keys/index', templateData)
-
-    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('API keys')
-    body.should.containSelector('.settings-navigation li:nth-child(2)').withExactText('Link GoCardless Merchant Account')
-  })
-
-  it('should not render Billing address navigation link when user is using direct debit gateway account', function () {
-    const testPermissions = {
-      tokens_update: true,
-      gateway_credentials_update: false,
-      service_name_read: false,
-      merchant_details_read: false,
-      payment_types_read: false,
-      toggle_3ds_read: false,
-      email_notification_template_read: false,
+      email_notification_template_read: true,
+      connected_gocardless_account_update: true,
       toggle_billing_address_read: true
     }
     const templateData = {
@@ -312,11 +226,45 @@ describe('navigation menu', function () {
 
     body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('API keys')
     body.should.containSelector('.settings-navigation li:nth-child(2)').withExactText('Link GoCardless Merchant Account')
+    body.should.not.contain('Account credentials')
+    body.should.not.contain('3D Secure')
+    body.should.not.contain('Card types')
+    body.should.not.contain('Email notifications')
+    body.should.not.contain('Billing address')
   })
 
-  it('should render Link GoCardless Merchant Account navigation link when user have tokens read permission', function () {
+  it('should not render direct debit navigation links when gateway account is card', function () {
     const testPermissions = {
-      tokens_update: true
+      tokens_update: true,
+      gateway_credentials_update: true,
+      service_name_read: true,
+      merchant_details_read: true,
+      payment_types_read: true,
+      toggle_3ds_read: true,
+      email_notification_template_read: true,
+      connected_gocardless_account_update: true,
+      toggle_billing_address_read: true
+    }
+    const templateData = {
+      permissions: testPermissions,
+      showSettingsNav: true,
+      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card')
+    }
+
+    const body = renderTemplate('api-keys/index', templateData)
+
+    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('API keys')
+    body.should.containSelector('.settings-navigation li:nth-child(2)').withExactText('Account credentials')
+    body.should.containSelector('.settings-navigation li:nth-child(3)').withExactText('3D Secure')
+    body.should.containSelector('.settings-navigation li:nth-child(4)').withExactText('Card types')
+    body.should.containSelector('.settings-navigation li:nth-child(5)').withExactText('Email notifications')
+    body.should.containSelector('.settings-navigation li:nth-child(6)').withExactText('Billing address')
+    body.should.not.contain('Link GoCardless Merchant Account')
+  })
+
+  it('should render Link GoCardless Merchant Account navigation link when user has connected-gocardless-account:update', function () {
+    const testPermissions = {
+      connected_gocardless_account_update: true
     }
     const templateData = {
       permissions: testPermissions,
@@ -326,6 +274,20 @@ describe('navigation menu', function () {
 
     const body = renderTemplate('api-keys/index', templateData)
 
-    body.should.containSelector('.settings-navigation li:nth-child(2)').withExactText('Link GoCardless Merchant Account')
+    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('Link GoCardless Merchant Account')
+  })
+
+  it('should not render Link GoCardless Merchant Account naviagtion link when user does not have connected-gocardless-account:update', function () {
+    const testPermissions = {
+      connected_gocardless_account_update: false
+    }
+    const templateData = {
+      permission: testPermissions,
+      showSettingsNav: true,
+      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'direct debit')
+    }
+
+    const body = renderTemplate('api-keys/index', templateData)
+    body.should.not.containSelector('.settings-navigation li:nth-child(1)').withExactText('Link GoCardless Merchant Account')
   })
 })


### PR DESCRIPTION
- Resolving gateway account was failing when navigating to the link account page, as the get gateway account middleware was expecting the service to have already been resolved. It then ended up resolving the wrong gateway account. The permissions middleware resolves the service so adding this to the stack fixes the issue.
- Use a new specific permission that was added for accessing this setting.
- Simplify navigation_ui_tests by having just 2 tests to check that the correct links are shown for card/direct debit gateway accounts when the user has all permissions.

Co-authored-by: Rory Malcolm <rory.malcolm@digital.cabinet-office.gov.uk>


