### PR TITLE
PP-5295 Dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,16 @@
+version: 1
+
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    allowed_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "security"
+      - match:
+          dependency_type: "production"
+          update_type: "all"
+  - package_manager: "docker"
+    directory: "/"
+    update_schedule: "weekly"


### PR DESCRIPTION
## WHAT 
Based on the options available https://dependabot.com/docs/config-file, configured
- Security only updates for development libraries
- Allowed all updates for production libraries / docker
- Scheduled dependabot updates to weekly

No options available to configure major/minor/patch versions. Can be done once feature is added by dependabot:feedback/issues/256