### PR TITLE
PP-5185 - settings needs to be included within authenticated paths

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -204,6 +204,7 @@ module.exports.bind = function (app) {
     ...lodash.values(policyPages),
     ...lodash.values(stripeSetup),
     ...lodash.values(digitalWallet),
+    ...lodash.values(settings),
     paths.feedback
   ] // Extract all the authenticated paths as a single array
 


### PR DESCRIPTION
This stops the cookie message showing all the time, the route wasnt
accessible because the controller required things only accessible within
auth so it errored because it couldnt resolve