### PR TITLE
PP-5185 - settings page redundant for direct debit gateways

### DIFF
--- a/app/controllers/settings/get.settings.controller.js
+++ b/app/controllers/settings/get.settings.controller.js
@@ -11,6 +11,10 @@ const humaniseEmailMode = mode => {
 }
 
 module.exports = (req, res) => {
+  if (req.account.paymentMethod === 'direct debit') {
+    return res.redirect('/api-keys')
+  }
+
   const pageData = {
     supports3ds: req.account.supports3ds,
     requires3ds: req.account.requires3ds,

--- a/app/middleware/get_email_notification.js
+++ b/app/middleware/get_email_notification.js
@@ -1,14 +1,18 @@
 'use strict'
-const errorView = require('../utils/response.js').renderErrorView
-const Email = require('../models/email.js')
+const { renderErrorView } = require('../utils/response')
+const Email = require('../models/email')
 const _ = require('lodash')
-const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
+const { CORRELATION_HEADER } = require('../utils/correlation_header')
 
 module.exports = function (req, res, next) {
-  return Email(req.headers[CORRELATION_HEADER]).get(req.account.gateway_account_id)
-    .then(emailData => {
-      req.account = _.merge(req.account, emailData)
-      next()
-    })
-    .catch(() => errorView(req, res))
+  if (req.account.paymentMethod !== 'direct debit') {
+    return Email(req.headers[CORRELATION_HEADER]).get(req.account.gateway_account_id)
+      .then(emailData => {
+        req.account = _.merge(req.account, emailData)
+        next()
+      })
+      .catch(() => renderErrorView(req, res))
+  } else {
+    next()
+  }
 }

--- a/app/utils/navBuilder.js
+++ b/app/utils/navBuilder.js
@@ -53,7 +53,7 @@ const adminNavigationItems = (originalUrl, permissions, type, paymentProvider) =
       name: 'Settings',
       url: paths.settings.index,
       current: pathLookup(originalUrl, paths.settings.index),
-      permissions: true
+      permissions: type === 'card'
     },
     {
       id: 'navigation-menu-api-keys',

--- a/test/cypress/integration/settings/settings-index.spec.js
+++ b/test/cypress/integration/settings/settings-index.spec.js
@@ -1,0 +1,43 @@
+describe('Settings page', () => {
+  const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+  const gatewayAccountId = 'DIRECT_DEBIT:42'
+  const serviceName = 'A Direct Debit Service'
+
+  describe('should redirect to API keys if Direct Debit gateway', () => {
+    beforeEach(() => {
+      cy.task('setupStubs', [
+        {
+          name: 'getUserSuccess',
+          opts: {
+            external_id: userExternalId,
+            service_roles: [{
+              service: {
+                gateway_account_ids: [gatewayAccountId],
+                name: serviceName
+              }
+            }]
+          }
+        },
+        {
+          name: 'getDirectDebitGatewayAccountSuccess',
+          opts: {
+            gateway_account_id: gatewayAccountId
+          }
+        }
+      ])
+    })
+
+    it('response should be a 302 pointing to /api-keys', () => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.request({
+        url: '/settings/',
+        followRedirect: false // turn off following redirects
+      })
+        .then((resp) => {
+          // redirect status code is 302
+          expect(resp.status).to.eq(302)
+          expect(resp.redirectedToUrl).to.contain('/api-keys')
+        })
+    })
+  })
+})

--- a/test/ui/navigation_ui_tests.js
+++ b/test/ui/navigation_ui_tests.js
@@ -162,8 +162,8 @@ describe('navigation menu', function () {
 
     const body = render('api-keys/index', templateData)
 
-    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('Settings')
-    body.should.containSelector('.settings-navigation li:nth-child(3)').withExactText('Link GoCardless Merchant Account')
+    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('API keys')
+    body.should.containSelector('.settings-navigation li:nth-child(2)').withExactText('Link GoCardless Merchant Account')
     body.should.not.contain('Account credentials')
     body.should.not.contain('3D Secure')
     body.should.not.contain('Card types')
@@ -209,7 +209,7 @@ describe('navigation menu', function () {
 
     const body = render('api-keys/index', templateData)
 
-    body.should.containSelector('.settings-navigation li:nth-child(2)').withExactText('Link GoCardless Merchant Account')
+    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('Link GoCardless Merchant Account')
   })
 
   it('should not render Link GoCardless Merchant Account naviagtion link when user does not have connected-gocardless-account:update', function () {

--- a/test/unit/middleware/get_email_notification_test.js
+++ b/test/unit/middleware/get_email_notification_test.js
@@ -34,7 +34,13 @@ describe('retrieve email notification template', function () {
 
   it('should call the error view if connector call fails', function (done) {
     const retrieveEmailNotification = require(path.join(__dirname, '/../../../app/middleware/get_email_notification.js'))
-    const req = {account: {gateway_account_id: 1}, headers: {}}
+    const req = {
+      account: {
+        gateway_account_id: 1,
+        paymentMethod: 'card'
+      },
+      headers: {}
+    }
     retrieveEmailNotification(req, response, next)
     setTimeout(function () {
       expect(next.notCalled).to.be.true // eslint-disable-line
@@ -56,12 +62,19 @@ describe('retrieve email notification template', function () {
     const retrieveEmailNotification = proxyquire(path.join(__dirname, '/../../../app/middleware/get_email_notification.js'), {
       '../models/email.js': emailStub
     })
-    const req = {account: {gateway_account_id: 1}, headers: {}}
+    const req = {
+      account: {
+        gateway_account_id: 1,
+        paymentMethod: 'card'
+      },
+      headers: {}
+    }
     retrieveEmailNotification(req, response, next).should.be.fulfilled.then(function () {
       expect(req.account).to.deep.equal({
         customEmailText: 'hello',
         'gateway_account_id': 1,
-        'emailEnabled': true
+        'emailEnabled': true,
+        paymentMethod: 'card'
       })
       expect(next.called).to.be.true // eslint-disable-line
     }).should.notify(done)


### PR DESCRIPTION
Settings page errored because it couldnt retrieve card only settings on a DD gateway, so redirect from this page to API Keys, which is basically what used to happen when you clicked settings