### PR TITLE
PP-5266: Migrate getGatewayAccountByExternalId function

### DIFF
--- a/app/middleware/get_gateway_account.js
+++ b/app/middleware/get_gateway_account.js
@@ -11,6 +11,7 @@ const auth = require('../services/auth_service.js')
 const Connector = require('../services/clients/connector_client.js').ConnectorClient
 const connectorClient = new Connector(process.env.CONNECTOR_URL)
 const directDebitConnectorClient = require('../services/clients/direct_debit_connector_client.js')
+const directDebitConnectorClient2 = require('../services/clients/direct_debit_connector_client2')()
 
 // Constants
 const clsXrayConfig = require('../../config/xray-cls')
@@ -22,7 +23,7 @@ module.exports = function (req, res, next) {
     correlationId: req.correlationId
   }
   if (directDebitConnectorClient.isADirectDebitAccount(accountId)) {
-    return directDebitConnectorClient.gatewayAccount.get(params)
+    return directDebitConnectorClient2.getGatewayAccountByExternalId(params)
       .then(gatewayAccount => {
         req.account = gatewayAccount
         next()

--- a/app/services/clients/direct_debit_connector_client.js
+++ b/app/services/clients/direct_debit_connector_client.js
@@ -14,8 +14,7 @@ const SERVICE_NAME = 'directdebit-connector'
 module.exports = {
   isADirectDebitAccount,
   gatewayAccount: {
-    create: createGatewayAccount,
-    get: getGatewayAccountByExternalId
+    create: createGatewayAccount
   },
   gatewayAccounts: {
     get: getGatewayAccountsByExternalIds
@@ -43,17 +42,6 @@ function createGatewayAccount (options) {
     },
     correlationId: options.correlationId,
     description: 'create a direct debit gateway account',
-    service: SERVICE_NAME
-  }).then(ga => new GatewayAccount(ga))
-}
-
-function getGatewayAccountByExternalId (params) {
-  return baseClient.get({
-    baseUrl,
-    url: `/accounts/${params.gatewayAccountId}`,
-    correlationId: params.correlationId,
-    json: true,
-    description: `find a gateway account by external id`,
     service: SERVICE_NAME
   }).then(ga => new GatewayAccount(ga))
 }

--- a/test/unit/middleware/get_gateway_account_test.js
+++ b/test/unit/middleware/get_gateway_account_test.js
@@ -39,7 +39,7 @@ const setupGetGatewayAccount = function (currentGatewayAccountID, paymentProvide
       type: 'test'
     }))
   })
-  const directDebitConnectorMock = {
+  const directDebitConnectorMock2 = {
     gatewayAccount: {
       get: directDebitConnectorGetAccountMock
     }
@@ -48,7 +48,7 @@ const setupGetGatewayAccount = function (currentGatewayAccountID, paymentProvide
   return proxyquire(path.join(__dirname, '../../../app/middleware/get_gateway_account'), {
     '../services/auth_service.js': authServiceMock,
     '../services/clients/connector_client.js': connectorMock,
-    '../services/clients/direct_debit_connector_client.js': directDebitConnectorMock,
+    '../services/clients/direct_debit_connector_client2.js': directDebitConnectorMock2,
     'aws-xray-sdk': {
       captureAsyncFunc: function (name, callback) {
         callback(new AWSXRay.Segment('stub-subsegment'))


### PR DESCRIPTION
Migrate to direct_debit_connector_client2

This doesn't work. It fails with 
```
  10) middleware: getGatewayAccount
       middleware: getGatewayAccount - disableToggle3ds flag by payment provider
         should extend the account data with disableToggle3ds set to true if the account type is stripe:
     TypeError: require(...) is not a function
      at Object.<anonymous> (app/middleware/get_gateway_account.js:14:98)
```

Which is the error I saw very early and took me a day to figure out to no avail. I will leave this PR open and a ticket https://payments-platform.atlassian.net/browse/PP-5338 has been raised.