### PR TITLE
PP-5185 - Settings link is set dependent on payment Type

### DIFF
--- a/app/utils/navBuilder.js
+++ b/app/utils/navBuilder.js
@@ -25,7 +25,7 @@ const serviceNavigationItems = (originalUrl, permissions, type) => {
   navigationItems.push({
     id: 'navigation-menu-settings',
     name: 'Settings',
-    url: paths.settings.index,
+    url: type === 'card' ? paths.settings.index : paths.apiKeys.index,
     current: pathLookup(originalUrl, [
       paths.credentials,
       paths.notificationCredentials,
@@ -53,7 +53,7 @@ const adminNavigationItems = (originalUrl, permissions, type, paymentProvider) =
       name: 'Settings',
       url: paths.settings.index,
       current: pathLookup(originalUrl, paths.settings.index),
-      permissions: true
+      permissions: type === 'card'
     },
     {
       id: 'navigation-menu-api-keys',

--- a/test/ui/navigation_ui_tests.js
+++ b/test/ui/navigation_ui_tests.js
@@ -162,8 +162,8 @@ describe('navigation menu', function () {
 
     const body = render('api-keys/index', templateData)
 
-    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('Settings')
-    body.should.containSelector('.settings-navigation li:nth-child(3)').withExactText('Link GoCardless Merchant Account')
+    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('API keys')
+    body.should.containSelector('.settings-navigation li:nth-child(2)').withExactText('Link GoCardless Merchant Account')
     body.should.not.contain('Account credentials')
     body.should.not.contain('3D Secure')
     body.should.not.contain('Card types')
@@ -209,7 +209,7 @@ describe('navigation menu', function () {
 
     const body = render('api-keys/index', templateData)
 
-    body.should.containSelector('.settings-navigation li:nth-child(2)').withExactText('Link GoCardless Merchant Account')
+    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('Link GoCardless Merchant Account')
   })
 
   it('should not render Link GoCardless Merchant Account naviagtion link when user does not have connected-gocardless-account:update', function () {
@@ -223,6 +223,6 @@ describe('navigation menu', function () {
     }
 
     const body = render('api-keys/index', templateData)
-    body.should.not.containSelector('.settings-navigation li:nth-child(2)')
+    body.should.not.containSelector('.settings-navigation li:nth-child(1)')
   })
 })


### PR DESCRIPTION
There is no settings index for Direct Debit so we need to link to the
first available setting, API keys.
