### PR TITLE
PP-5339 - remove account from phase tag so it's just live or test

### DIFF
--- a/app/views/includes/phase_banner.njk
+++ b/app/views/includes/phase_banner.njk
@@ -4,7 +4,7 @@
     <h4 class="service-info--name govuk-heading-s">
       {{currentService.name}}
       {% if currentGatewayAccount %}
-        <strong class="environment-tag environment-tag-{{currentGatewayAccount.type}}">{% if currentGatewayAccount.full_type === 'sandbox test' %}Test account{% else %}{{currentGatewayAccount.full_type | capitalize}}{% endif %} {% if currentGatewayAccount.full_type === 'live' %}account{% endif %}</strong>
+        <strong class="environment-tag environment-tag-{{currentGatewayAccount.type}}">{% if currentGatewayAccount.full_type === 'sandbox test' or currentGatewayAccount.full_type === 'SANDBOX test' %}Test{% else %}{{currentGatewayAccount.full_type | capitalize}}{% endif %}</strong>
       {% endif %}
     </h4>
   </div>


### PR DESCRIPTION
So right now it says 'Test Account' or 'Live account' can just be 'Test' and 'Live'
