### PR TITLE
PP-5266 Remove link Go Cardless account settings link

### DIFF
--- a/app/utils/navBuilder.js
+++ b/app/utils/navBuilder.js
@@ -75,13 +75,6 @@ const adminNavigationItems = (originalUrl, permissions, type, paymentProvider) =
       url: paths.paymentTypes.index,
       current: pathLookup(originalUrl, paths.paymentTypes.index) || pathLookup(originalUrl, paths.digitalWallet.summary),
       permissions: permissions.payment_types_read && type === 'card'
-    },
-    {
-      id: 'navigation-menu-link-gocardless-app',
-      name: 'Link GoCardless Merchant Account',
-      url: paths.partnerApp.linkAccount,
-      current: pathLookup(originalUrl, paths.partnerApp.linkAccount),
-      permissions: permissions.connected_gocardless_account_update && type === 'direct debit'
     }
   ]
 }

--- a/test/ui/navigation_ui_tests.js
+++ b/test/ui/navigation_ui_tests.js
@@ -163,7 +163,6 @@ describe('navigation menu', function () {
     const body = render('api-keys/index', templateData)
 
     body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('API keys')
-    body.should.containSelector('.settings-navigation li:nth-child(2)').withExactText('Link GoCardless Merchant Account')
     body.should.not.contain('Account credentials')
     body.should.not.contain('3D Secure')
     body.should.not.contain('Card types')
@@ -195,34 +194,5 @@ describe('navigation menu', function () {
     body.should.containSelector('.settings-navigation li:nth-child(2)').withExactText('API keys')
     body.should.containSelector('.settings-navigation li:nth-child(3)').withExactText('Account credentials')
     body.should.containSelector('.settings-navigation li:nth-child(4)').withExactText('Card types')
-  })
-
-  it('should render Link GoCardless Merchant Account navigation link when user has connected-gocardless-account:update', function () {
-    const testPermissions = {
-      connected_gocardless_account_update: true
-    }
-    const templateData = {
-      permissions: testPermissions,
-      showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'direct debit')
-    }
-
-    const body = render('api-keys/index', templateData)
-
-    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('Link GoCardless Merchant Account')
-  })
-
-  it('should not render Link GoCardless Merchant Account naviagtion link when user does not have connected-gocardless-account:update', function () {
-    const testPermissions = {
-      connected_gocardless_account_update: false
-    }
-    const templateData = {
-      permission: testPermissions,
-      showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'direct debit')
-    }
-
-    const body = render('api-keys/index', templateData)
-    body.should.not.containSelector('.settings-navigation li:nth-child(1)')
   })
 })


### PR DESCRIPTION
- Linking a Go Cardless account for a direct debit gateway account is now done by clicking a button on the dashboard, so remove the old link on the settings page to initiate this.

