### PR TITLE
PP-5366 - Suppress native browser validation

### DIFF
--- a/app/views/login/otp-login.njk
+++ b/app/views/login/otp-login.njk
@@ -27,7 +27,7 @@
   {% if authenticatorMethod === 'APP' %}
   <h1 class="govuk-heading-l page-title">Use your authenticator app</h1>
   {% endif %}
-  <form action="{{routes.user.otpLogIn}}" method="post" class="form submit-two-fa" id="otp-login-form">
+  <form action="{{routes.user.otpLogIn}}" method="post" class="form submit-two-fa" id="otp-login-form" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
     {% if authenticatorMethod === 'SMS' %}
     <p class="govuk-body">We have sent you a text message with a security code</p>

--- a/app/views/transactions/filter.njk
+++ b/app/views/transactions/filter.njk
@@ -3,7 +3,7 @@
 {% from "components/button/macro.njk" import govukButton %}
 
 <div class="transactions-filter govuk-grid-row">
-  <form class="govuk-clearfix" method="get" action="{{search_path}}">
+  <form class="govuk-clearfix" method="get" action="{{search_path}}" novalidate>
     <div class="govuk-grid-column-one-quarter inputs-less-margin">
       {{
         govukInput({

--- a/app/views/twoFactorAuth/configure.njk
+++ b/app/views/twoFactorAuth/configure.njk
@@ -46,7 +46,7 @@
     })
   }}
 {% endif %}
-  <form method="post" action="{{routes.user.twoFactorAuth.configure}}" data-validate>
+  <form method="post" action="{{routes.user.twoFactorAuth.configure}}" novalidate data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {% set codeError = false %}


### PR DESCRIPTION
In some modern browsers when a pattern attribute is added a native
browser message pops up and blocks form submission. They’re not helpful
and just suppress our more helpful error messages.

Thanks @nickcolley for the tip https://github.com/alphagov/govuk-design-system/issues/941#issuecomment-506286337
