### PR TITLE
PP-5382 - move beta tag from header to footer

### DIFF
--- a/app/assets/sass/components/phase-tag.scss
+++ b/app/assets/sass/components/phase-tag.scss
@@ -1,8 +1,6 @@
 .govuk-phase-banner__content__tag {
   @include govuk-font($size: 14, $weight: bold);
-  line-height: 1.25!important;
   padding: 3px 5px 1px;
-  margin: 0 0 0 5px;
+  margin-right: govuk-spacing(1);
   position: relative;
-  top: -2px;
 }

--- a/app/views/includes/feedback-banner.njk
+++ b/app/views/includes/feedback-banner.njk
@@ -1,5 +1,8 @@
 <div class="govuk-!-padding-bottom-3 pay-!-border-bottom govuk-!-margin-bottom-6 pay-!-negative-margin-t-2 pay-!-negative-margin-t-5-ns">
   <p class="govuk-body-s govuk-!-margin-bottom-0">
+    <strong class="govuk-tag govuk-phase-banner__content__tag">
+      beta
+    </strong>
     This is a new service — your <a class="govuk-link" href="{{routes.feedback}}">feedback</a> will help us to improve.
   </p>
 </div>

--- a/app/views/includes/header.njk
+++ b/app/views/includes/header.njk
@@ -16,9 +16,6 @@
         </span>
         <span class="govuk-header__product-name">
           Pay
-          <strong class="govuk-tag govuk-phase-banner__content__tag">
-            beta
-          </strong>
         </span>
       </a>
     </div>


### PR DESCRIPTION
Having it up top raises more questions than it answers. This way gives
in a little more context

![Screen Shot 2019-07-01 at 15 40 25](https://user-images.githubusercontent.com/440503/60445156-908ec500-9c16-11e9-9d45-f2e0fb83d9b4.png)