### PR TITLE
PP-5384 Change “login” to “sign in” on phone number change page

### DIFF
--- a/app/views/team-members/edit-phone-number.njk
+++ b/app/views/team-members/edit-phone-number.njk
@@ -13,7 +13,7 @@
 </div>
 <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
   <h1 class="govuk-heading-l">Change your phone number</h1>
-  <p class="govuk-body">Your phone number is used to send a text message code when you login to help verify your identity.</p>
+  <p class="govuk-body">Your phone number is used to send a text message code when you sign in to help verify your identity.</p>
 
   {% set phoneError = false %}
   {% if flash.genericError %}


### PR DESCRIPTION
Because http://notaverb.com/login and https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#sign-in-or-log-in