### PR TITLE
BAU - remove extra margin from page content

### DIFF
--- a/app/views/dashboard/index.njk
+++ b/app/views/dashboard/index.njk
@@ -8,18 +8,18 @@ Dashboard - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK
   {% if account.paymentMethod === 'direct debit' and account.paymentProvider === 'gocardless' %}
     {% if account.isConnected === false %}
       <div class="govuk-grid-column-full">
-        <h1 class="govuk-heading-l govuk-!-margin-top-6 first-steps__title">Connect to GoCardless</h1>
+        <h1 class="govuk-heading-l first-steps__title">Connect to GoCardless</h1>
         {% include "./_link-to-gocardless.njk" %}
       </div>
-    {% else %}  
+    {% else %}
       <div class="govuk-grid-column-full">
-        <h1 class="govuk-heading-l govuk-!-margin-top-6 first-steps__title">Dashboard</h1>
+        <h1 class="govuk-heading-l first-steps__title">Dashboard</h1>
         {% include "./_connected-to-gocardless.njk" %}
       </div>
     {% endif %}
   {% else %}
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l govuk-!-margin-top-6 first-steps__title">Dashboard</h1>
+      <h1 class="govuk-heading-l first-steps__title">Dashboard</h1>
     </div>
     {% if paymentMethod === 'card' %}
       {% include "./_activity.njk" %}

--- a/app/views/digital-wallet/apple-pay.njk
+++ b/app/views/digital-wallet/apple-pay.njk
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       Apple Pay
     </h1>

--- a/app/views/digital-wallet/google-pay.njk
+++ b/app/views/digital-wallet/google-pay.njk
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       Google Pay
     </h1>

--- a/app/views/feedback/index.njk
+++ b/app/views/feedback/index.njk
@@ -9,7 +9,7 @@ Give feedback — GOV.UK Pay
 {% endblock %}
 
 {% block mainContent %}
-<div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+<div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">Give feedback</h1>
 
   <form method="POST" action="{{routes.feedback}}">

--- a/app/views/payment-links/_nav.njk
+++ b/app/views/payment-links/_nav.njk
@@ -1,6 +1,6 @@
 <aside class="govuk-grid-column-one-third navigation--pad-bottom">
   <nav role="navigation" class="navigation settings-navigation">
-    <ul class="govuk-list govuk-!-margin-top-6 govuk-!-margin-bottom-9">
+    <ul class="govuk-list govuk-!-margin-bottom-9">
        <li class="{% if createLink %}govuk-!-font-weight-bold {% endif %}govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline govuk-!-display-block" href="{{ routes.paymentLinks.start }}">Create a payment link</a></li>
       <li class="{% if not createLink %}govuk-!-font-weight-bold {% endif %}govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline govuk-!-display-block" href="{{ routes.paymentLinks.manage }}">Manage payment&nbsp;links</a></li>
     </ul>

--- a/app/views/payment-links/amount.njk
+++ b/app/views/payment-links/amount.njk
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block mainContent %}
-<section class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+<section class="govuk-grid-column-two-thirds">
   <form action="{{ nextPage }}" class="form" method="post">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 

--- a/app/views/payment-links/edit-amount.njk
+++ b/app/views/payment-links/edit-amount.njk
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block mainContent %}
-<section class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+<section class="govuk-grid-column-two-thirds">
   <form action="{{ self }}" class="form" method="post">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 

--- a/app/views/payment-links/edit-reference.njk
+++ b/app/views/payment-links/edit-reference.njk
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block mainContent %}
-<section class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+<section class="govuk-grid-column-two-thirds">
   <form action="{{ self }}" class="form" method="post" data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {% if change.length %}

--- a/app/views/payment-links/edit.njk
+++ b/app/views/payment-links/edit.njk
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block mainContent %}
-<section class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+<section class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">Edit your payment link</h1>
 
   {% set detailsHTML %}

--- a/app/views/payment-links/index.njk
+++ b/app/views/payment-links/index.njk
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block mainContent %}
-<section class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+<section class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">Create a payment link</h1>
   <p class="govuk-body">You can create a payment link so that users can make online payments to your service. Even if you don’t have a digital service, GOV.UK Pay can still take payments for you.</p>
   <p class="govuk-body">It’s quick and easy to create a payment link and you don’t need any technical knowledge.</p>

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -13,7 +13,7 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
 {% endblock %}
 
 {% block mainContent %}
-<section class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+<section class="govuk-grid-column-two-thirds">
   {% if isWelsh %}
     <h1 class="govuk-heading-l">Set Welsh payment link information</h1>
   {% else %}

--- a/app/views/payment-links/reference.njk
+++ b/app/views/payment-links/reference.njk
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block mainContent %}
-<section class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+<section class="govuk-grid-column-two-thirds">
   <form action="{{ routes.paymentLinks.reference }}" class="form" method="post" data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {% if change.length %}

--- a/app/views/payment-links/review.njk
+++ b/app/views/payment-links/review.njk
@@ -12,7 +12,7 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
 {% endblock %}
 
 {% block mainContent %}
-<section class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+<section class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">Review your payment link details</h1>
 
   {% set detailsHTML %}

--- a/app/views/payment-links/web-address.njk
+++ b/app/views/payment-links/web-address.njk
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block mainContent %}
-<section class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+<section class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">The website address is already taken</h1>
 
   <form action="{{ routes.paymentLinks.webAddress }}" class="form" method="post" data-validate>

--- a/app/views/request-to-go-live/agreement.njk
+++ b/app/views/request-to-go-live/agreement.njk
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+  <div class="govuk-grid-column-two-thirds">
 
     <span id="request-to-go-live-current-step" class="govuk-caption-l">Step 3 of 3</span>
 

--- a/app/views/request-to-go-live/choose-how-to-process-payments.njk
+++ b/app/views/request-to-go-live/choose-how-to-process-payments.njk
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+  <div class="govuk-grid-column-two-thirds">
 
     <span id="request-to-go-live-current-step" class="govuk-caption-l">Step 2 of 3</span>
 

--- a/app/views/request-to-go-live/index.njk
+++ b/app/views/request-to-go-live/index.njk
@@ -9,7 +9,7 @@
 
 {% block mainContent %}
   {% if showNextSteps %}
-    <div class="govuk-grid-column-full govuk-!-margin-top-6">
+    <div class="govuk-grid-column-full">
     {{ govukPanel({
       titleText: "Request submitted"
     }) }}
@@ -34,7 +34,7 @@
       <p class="govuk-body">Once that’s done, you can start taking payments.</p>
     </div>
   {% elif denied %}
-    <div class="govuk-grid-column-full govuk-!-margin-top-6">
+    <div class="govuk-grid-column-full">
     {{ govukErrorSummary({
       titleText: 'There is a problem',
       errorList: [

--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -10,7 +10,7 @@ Request a live account - {{ currentService.name }} - GOV.UK Pay
 {% endblock %}
 
 {% block mainContent %}
-<div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+<div class="govuk-grid-column-two-thirds">
   {% if errors %}
     {% set errorList = [] %}
 

--- a/app/views/request-to-go-live/organisation-name.njk
+++ b/app/views/request-to-go-live/organisation-name.njk
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+  <div class="govuk-grid-column-two-thirds">
     {% if errors %}
       {% set errorList = [] %}
       {% if errors['organisation-name'] %}

--- a/app/views/stripe-setup/bank-details/check-your-answers.njk
+++ b/app/views/stripe-setup/bank-details/check-your-answers.njk
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="govuk-grid-column-two-thirds-from-desktop govuk-!-margin-top-6">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
 
     <h1 class="govuk-heading-l">Check details before saving</h1>
 

--- a/app/views/stripe-setup/bank-details/index.njk
+++ b/app/views/stripe-setup/bank-details/index.njk
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+  <div class="govuk-grid-column-two-thirds">
     {% if errors | length %}
       {% set errorList = [] %}
       {% if errors['account-number'] %}

--- a/app/views/stripe-setup/responsible-person/check-your-answers.njk
+++ b/app/views/stripe-setup/responsible-person/check-your-answers.njk
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="govuk-grid-column-two-thirds-from-desktop govuk-!-margin-top-6">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
 
     <span id="request-to-go-live-current-step" class="govuk-caption-l">Before you can take payments</span>
     <h1 class="govuk-heading-l">Check details before saving</h1>

--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+  <div class="govuk-grid-column-two-thirds">
     {% if errors %}
       {% set errorList = [] %}
 

--- a/app/views/stripe-setup/vat-number-company-number/check-your-answers.njk
+++ b/app/views/stripe-setup/vat-number-company-number/check-your-answers.njk
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="govuk-grid-column-two-thirds-from-desktop govuk-!-margin-top-6">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">Check details before saving</h1>
 
     {{ govukSummaryList({

--- a/app/views/stripe-setup/vat-number-company-number/company-number.njk
+++ b/app/views/stripe-setup/vat-number-company-number/company-number.njk
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+  <div class="govuk-grid-column-two-thirds">
     {% if errors | length %}
       {% set errorList = [] %}
       {% if errors['company-number-declaration'] %}

--- a/app/views/stripe-setup/vat-number-company-number/vat-number.njk
+++ b/app/views/stripe-setup/vat-number-company-number/vat-number.njk
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+  <div class="govuk-grid-column-two-thirds">
     {% if errors | length %}
       {% set errorList = [] %}
       {% if errors['vat-number'] %}

--- a/app/views/transactions/index.njk
+++ b/app/views/transactions/index.njk
@@ -21,7 +21,7 @@ Transactions - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV
 {% endblock %}
 
 {% block mainContent %}
-<div class="govuk-grid-column-full govuk-!-margin-top-6">
+<div class="govuk-grid-column-full">
   <h1 class="govuk-heading-l">Transactions</h1>
   {% include "transactions/filter.njk" %}
 


### PR DESCRIPTION
As of PR #1555 we don’t need this extra margin between the body and the
phase banner as it’s handled automatically by the design system.
