### PR TITLE
PP-4437 Update copy for GoCardless connect

### DIFF
--- a/app/controllers/partnerapp/handle_redirect_to_gocardless_connect.js
+++ b/app/controllers/partnerapp/handle_redirect_to_gocardless_connect.js
@@ -15,12 +15,12 @@ exports.index = (req, res) => {
       })
       .catch(err => {
         logger.info(`'There was an error getting a state token from Direct Debit Connector' ${JSON.stringify(err)}`)
-        req.flash('genericError', '<h2>There is a problem, please retry again</h2>')
+        req.flash('genericError', '<h2>There is a problem, please try again</h2>')
         res.redirect('/')
       })
   } else {
-    res.status(400)
-    res.end()
+    res.status(404)
+    res.render('404')
   }
 }
 

--- a/app/views/dashboard/_connected-to-gocardless.njk
+++ b/app/views/dashboard/_connected-to-gocardless.njk
@@ -1,6 +1,9 @@
 {% from "components/button/macro.njk" import govukButton %}
 
-<p class="govuk-body">This service is connected to GoCardless and able to take payments from users.</p>
-<p class="govuk-body">You can see a breakdown of your mandates and payments on your GoCardless dashboard.</p>
+<p class="govuk-body">
+Your service is connected to GoCardless and can accept Direct Debit payments.
+</p>
 
-<a class="govuk-link govuk-link--no-visited-state payment-links-list--item__link" href="https://manage.gocardless.com/sign-in">Go to your GoCardless account</a>.
+<p class="govuk-body">
+If you want to make any changes to your account, or create manual reports, you need to <a class="govuk-link govuk-link--no-visited-state payment-links-list--item__link" href="https://manage.gocardless.com/sign-in">go to the GoCardless website</a>.
+</p>

--- a/app/views/dashboard/_link-to-gocardless.njk
+++ b/app/views/dashboard/_link-to-gocardless.njk
@@ -1,30 +1,25 @@
 {% from "components/button/macro.njk" import govukButton %}
 
 <p class="govuk-body">
-You must connect to GoCardless, the direct debit provider GOV.UK Pay has procured, before you can take payments. You will be able to:
+GoCardless will collect and manage Direct Debit payments for GOV.UK Pay.
+</p>
+
+<p class="govuk-body">
+You need to connect to GoCardless before you can take Direct Debit payments. To do this, you’ll need to go to the GoCardless website. 
+</p>
+
+<p class="govuk-body">
+On the GoCardless website, you must either:
 </p>
 
 <ul class="govuk-list govuk-list--bullet">
     <li>create a new account</li>
-    <li>connect an existing account</li>
+    <li>authorise the connection to your existing GoCardless account</li>
 </ul>
 
-<p class="govuk-heading-m ">Before you start</p>
-
-<p class="govuk-body">It takes around 5 minutes. You will need to provide:</p>
-
-<ul class="govuk-list govuk-list--bullet">
-    <li>bank account details</li>
-    <li>support contact details</li>
-</ul>
-
-<p class="govuk-body">
-You will be sent to GoCardless's website to complete this step and then redirected back to Pay when you are finished.
-</p>
-
-    {{
-      govukButton({
-        text: "Connect to GoCardless",
-        href: "/link-account"
-      })
-    }}
+{{
+  govukButton({
+    text: "Connect to GoCardless",
+    href: "/link-account"
+  })
+}}

--- a/app/views/dashboard/index.njk
+++ b/app/views/dashboard/index.njk
@@ -7,13 +7,13 @@ Dashboard - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK
 {% block mainContent %}
   {% if account.paymentMethod === 'direct debit' and account.paymentProvider === 'gocardless' %}
     {% if account.isConnected === false %}
-      <div class="govuk-grid-column-full">
+      <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l first-steps__title">Connect to GoCardless</h1>
         {% include "./_link-to-gocardless.njk" %}
       </div>
     {% else %}
-      <div class="govuk-grid-column-full">
-        <h1 class="govuk-heading-l first-steps__title">Dashboard</h1>
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l first-steps__title">Connected to GoCardless</h1>
         {% include "./_connected-to-gocardless.njk" %}
       </div>
     {% endif %}

--- a/app/views/oauth/gocardless_complete.njk
+++ b/app/views/oauth/gocardless_complete.njk
@@ -1,4 +1,5 @@
 {% extends "../layout.njk" %}
+{% from "components/panel/macro.njk" import govukPanel %}
 
 {% block pageTitle %}
 GoCardless successfully connected - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
@@ -6,18 +7,38 @@ GoCardless successfully connected - {{currentService.name}} {{currentGatewayAcco
 
 {% block mainContent %}
 
-  <p class="govuk-body"></p>
-  
-  <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-panel govuk-panel--confirmation">
-      <h2 class="govuk-panel__title">Successfully connected to GoCardless</h2>
-    </div>
-  <div>
+<div class="govuk-grid-column-two-thirds">
+  {{ govukPanel({
+    titleText: "You’ve successfully connected to GoCardless",
+    classes: "govuk-!-margin-bottom-6"
+  }) }}
 
   <p class="govuk-body">
-    You can now take direct debit payments.
+    Before you can take Direct Debit payments, you need to complete your account details.
   </p>
 
-  <a class="govuk-link govuk-link--no-visited-state payment-links-list--item__link" href="/">Go to the dashboard</a>.
+  <p class="govuk-body">
+    Once completed, you’ll be ready to accept Direct Debit payments.
+  </p>
+
+  <p class="govuk-body">
+    Go to the GoCardless website to:
+  </p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>provide your account details, for example your organisation’s details and contact names</li>
+    <li>provide your bank details - so we know where to send payment</li>
+    <li>verify who you are - provide personal details to help confirm your identity</li>
+  </ul>
+
+  <p class="govuk-body">
+    API integration is handled by GOV.UK Pay, so don’t ‘Create an access token’ or use the ‘Developers’ section on the GoCardless website.
+  </p>
+
+  <p class="govuk-body">
+    <a class="govuk-link govuk-link--no-visited-state payment-links-list--item__link" href="/">Go to the dashboard</a>.
+  </p>
+
+</div>
 
 {% endblock %}

--- a/test/cypress/integration/dashboard/dashboard_gocardless_spec.js
+++ b/test/cypress/integration/dashboard/dashboard_gocardless_spec.js
@@ -47,7 +47,7 @@ describe('Dashboard', () => {
       setupDirectDebitGatewayAccount(true)
 
       cy.visit(dashboardUrl)
-      cy.get('h1').should('contain', 'Dashboard')
+      cy.get('h1').should('contain', 'Connected to GoCardless')
       cy.get('a[href="https://manage.gocardless.com/sign-in"').should('exist')
     })
 

--- a/test/cypress/integration/partnerapp/handle_redirect_from_gocardless_spec.js
+++ b/test/cypress/integration/partnerapp/handle_redirect_from_gocardless_spec.js
@@ -18,7 +18,7 @@ describe('Get request to complete Go Cardless linking', () => {
 
     it('should show success message', () => {
       cy.visit('/oauth/complete?state=blah&code=blahblah')
-      cy.get('.govuk-panel--confirmation > h2').should('contain', 'Successfully connected to GoCardless')
+      cy.get('.govuk-panel--confirmation > h1').should('contain', 'You’ve successfully connected to GoCardless')
     })
   })
 

--- a/test/cypress/integration/partnerapp/handle_redirect_to_gocardless_spec.js
+++ b/test/cypress/integration/partnerapp/handle_redirect_to_gocardless_spec.js
@@ -24,7 +24,7 @@ describe('Connect to Go Cardless', () => {
       cy.get('a[href="/link-account"').click()
       cy.visit('/link-account')
       cy.get('.notification').should('have.class', 'generic-error')
-      cy.get('h2').should('contain', 'There is a problem, please retry again')
+      cy.get('h2').should('contain', 'There is a problem, please try again')
       cy.get('h1').should('contain', 'Connect to GoCardless')
       cy.get('a[href="/link-account"').should('exist')
     })

--- a/test/integration/partnerapp/handle_redirect_to_gocardless_connect_test.js
+++ b/test/integration/partnerapp/handle_redirect_to_gocardless_connect_test.js
@@ -55,7 +55,7 @@ describe('GET /link/account - GoCardless Connect partner app', function () {
   it('does not allow access if authenticated and NOT DIRECT_DEBIT account', done => {
     request(app)
       .get(paths.partnerApp.linkAccount)
-      .expect(400)
+      .expect(404)
       .end(done)
   })
 })


### PR DESCRIPTION
Update the copy on the dashboard and the page we show when the connect process is complete for GoCardless accounts.

Return a 404 and render the 404 page if the account isn't a direct debit account rather than just returning a 400.

Specification for copy: https://docs.google.com/document/d/1cFX_-FjLW7aGEHm8XKL88ltVBmVd5_5wHHQhpmogMvk/edit?ts=5d025a82
