### PR TITLE
Use runAppE2E to run end to end tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,8 +72,8 @@ pipeline {
     }
     stage('Tests') {
       failFast true
-      parallel {
-        stage('Card Payment End-to-End Tests') {
+      stages {
+        stage('End-to-End Tests') {
             when {
                 anyOf {
                   branch 'master'
@@ -81,29 +81,7 @@ pipeline {
                 }
             }
             steps {
-                runCardPaymentsE2E("selfservice")
-            }
-        }
-        stage('Products End-to-End Tests') {
-            when {
-                anyOf {
-                  branch 'master'
-                  environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
-                }
-            }
-            steps {
-                runProductsE2E("selfservice")
-            }
-        }
-        stage('Direct-Debit End-to-End Tests') {
-            when {
-                anyOf {
-                  branch 'master'
-                  environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
-                }
-            }
-            steps {
-                runDirectDebitE2E("selfservice")
+                runAppE2E("selfservice", "card,products,directdebit")
             }
         }
       }


### PR DESCRIPTION
Let's deprecate the run{test}E2E groovy routines and use runAppE2E everywhere