### PR TITLE
PP-5560 - Yellow should only be used for focus

### DIFF
--- a/app/assets/sass/components/environment-tag.scss
+++ b/app/assets/sass/components/environment-tag.scss
@@ -4,12 +4,5 @@
   margin: 0 0 0 govuk-spacing(2);
   position: relative;
   top: -2px;
-
-  &-test {
-    background-color: govuk-colour("yellow");
-  }
-
-  &-live {
-    background-color: govuk-colour("light-grey");
-  }
+  background-color: govuk-colour("light-grey");
 }

--- a/app/assets/sass/components/header.scss
+++ b/app/assets/sass/components/header.scss
@@ -1,9 +1,5 @@
 .govuk-header__container {
   &--test {
-    border-color:  govuk-colour("blue");
-  }
-
-  &--test {
-    border-color:  govuk-colour("yellow");
+    border-color:  govuk-colour("mid-grey");
   }
 }


### PR DESCRIPTION
In the past we used yellow to denote test accounts but this was not
really kosher, but we got away with it. Now the yellow is way more
yellow it looks pretty out there so we’re switching to grey.

This will all get redesigned entirely soon so its just temporary
