### PR TITLE
BAU Disable cypress videos

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -12,5 +12,6 @@
   "pluginsFile": "./test/cypress/plugins",
   "screenshotsFolder": "./test/cypress/screenshots",
   "supportFile": "./test/cypress/support",
-  "videosFolder": "./test/cypress/videos"
+  "videosFolder": "./test/cypress/videos",
+  "video": false
 }


### PR DESCRIPTION
Videos add a time overhead to test runs and we never look at them.
Disable them to speed up ci builds.

