### PR TITLE
PP-5537 add get events and search ledger transactions pact tests

### DIFF
--- a/test/fixtures/ledger_transaction_fixtures.js
+++ b/test/fixtures/ledger_transaction_fixtures.js
@@ -43,6 +43,20 @@ const buildChargeEventStateWithDefaults = (opts = {}) => {
   return state
 }
 
+const buildPaymentEvents = (opts = {}) => {
+  let events = []
+  if (opts.payment_states) {
+    opts.payment_states.forEach(paymentState => {
+      events.push({
+        state: buildChargeEventStateWithDefaults(paymentState),
+        resource_type: 'PAYMENT',
+        data: {}
+      })
+    })
+  }
+  return events
+}
+
 const buildTransactionDetails = (opts = {}) => {
   const data = {
     amount: opts.amount || 20000,
@@ -73,7 +87,7 @@ const buildTransactionDetails = (opts = {}) => {
         city: opts.billing_address_city || 'London',
         country: opts.billing_address_country || 'GB'
       },
-      card_brand: opts.card_brand || 'Visa'
+      card_brand: opts.card_brand || 'visa'
     }
   }
 
@@ -91,7 +105,7 @@ const buildTransactionDetails = (opts = {}) => {
       status: opts.refund_summary_status || 'unavailable',
       user_external_id: opts.user_external_id || null,
       amount_available: opts.refund_summary_available || 20000,
-      amount_submitted: opts.refund_summary_submitted || 0
+      amount_refunded: opts.amount_refunded || 0
     }
   }
 
@@ -112,6 +126,19 @@ const buildTransactionDetails = (opts = {}) => {
   if (opts.metadata) data.metadata = opts.metadata
 
   return data
+}
+
+const buildRefundDetails = (opts = {}) => {
+  return {
+    gateway_account_id: opts.gateway_account_id || '1',
+    amount: opts.amount || 10,
+    state: buildChargeEventStateWithDefaults(opts),
+    reference: opts.reference || 'aaba9756-15af-4ab0-b2c2-8696bc47655e',
+    created_date: opts.created_date || '2019-08-20T14:39:49.536Z',
+    transaction_type: 'REFUND',
+    transaction_id: opts.transaction_id || '1b5kia0u28ll2ic4obv26r5e4h',
+    parent_transaction_id: opts.parent_transaction_id || 'puuhl0gu7egigin7oh9c75p4m1'
+  }
 }
 
 module.exports = {
@@ -189,12 +216,8 @@ module.exports = {
     }
 
     return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
+      getPactified: () => pactRegister.pactify(data),
+      getPlain: () => data
     }
   },
   validTransactionRefundRequest: (opts = {}) => {
@@ -205,12 +228,8 @@ module.exports = {
     }
 
     return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
+      getPactified: () => pactRegister.pactify(data),
+      getPlain: () => data
     }
   },
   invalidTransactionRefundResponse: (opts = {}) => {
@@ -219,12 +238,44 @@ module.exports = {
     }
 
     return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return data
+      getPactified: () => pactRegister.pactify(data),
+      getPlain: () => data
+    }
+  },
+  validTransactionEventsResponse: (opts = {}) => {
+    const data = {
+      transaction_id: opts.transaction_id || 'ht439nfg2l1e303k0dmifrn4fc',
+      events: (opts.payment_states) ? buildPaymentEvents(opts) : []
+    }
+
+    return {
+      getPactified: () => pactRegister.pactify(data),
+      getPlain: () => data
+    }
+  },
+  validTransactionSearchResponse: (opts = {}) => {
+    let results = []
+    opts.transactions.forEach(transaction => {
+      transaction.gateway_account_id = opts.gateway_account_id
+      if (transaction.type === 'payment') {
+        transaction.includeCardDetails = true
+        transaction.includeRefundSummary = true
+        transaction.includeSettlementSummary = true
+        results.push(buildTransactionDetails(transaction))
+      } else if (transaction.type === 'refund') {
+        results.push(buildRefundDetails(transaction))
       }
+    })
+    const data = {
+      total: opts.transactions.length,
+      count: opts.transactions.length,
+      page: opts.page || 1,
+      results: results
+    }
+
+    return {
+      getPactified: () => pactRegister.pactify(data),
+      getPlain: () => data
     }
   }
 }

--- a/test/unit/clients/ledger_client/ledger_pact_test_provider.js
+++ b/test/unit/clients/ledger_client/ledger_pact_test_provider.js
@@ -1,0 +1,35 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+
+// Custom dependencies
+const path = require('path')
+const port = parseInt(process.env.LEDGER_URL.match(/\d+(\.\d+)?$/g)[0], 10)
+
+const pactProvider = Pact({
+  consumer: 'selfservice',
+  provider: 'ledger',
+  port: port,
+  log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+  dir: path.resolve(process.cwd(), 'pacts'),
+  spec: 2,
+  pactfileWriteMode: 'merge'
+})
+module.exports = {
+  getPort: function () {
+    return port
+  },
+  addInteraction: function (pact) {
+    return pactProvider.addInteraction(pact)
+  },
+  setup: function () {
+    return pactProvider.setup()
+  },
+  verify: function () {
+    return pactProvider.verify()
+  },
+  finalize: function () {
+    return pactProvider.finalize()
+  }
+}

--- a/test/unit/clients/ledger_client/ledger_search_transaction_test.js
+++ b/test/unit/clients/ledger_client/ledger_search_transaction_test.js
@@ -1,0 +1,113 @@
+'use strict'
+
+// NPM dependencies
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+
+// Custom dependencies
+const PactInteractionBuilder = require('../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const ledgerClient = require('../../../../app/services/clients/ledger_client')
+const transactionDetailsFixtures = require('../../../fixtures/ledger_transaction_fixtures')
+const legacyConnectorParityTransformer = require('../../../../app/services/clients/utils/ledger_legacy_connector_parity')
+const pactTestProvider = require('./ledger_pact_test_provider')
+
+// Constants
+const TRANSACTION_RESOURCE = '/v1/transaction'
+const expect = chai.expect
+
+// Global setup
+chai.use(chaiAsPromised)
+
+const existingGatewayAccountId = '123456'
+const defaultTransactionState = `refund transactions exists for a gateway account`
+
+describe('ledger client', function () {
+  before(() => pactTestProvider.setup())
+  after(() => pactTestProvider.finalize())
+
+  describe('search transactions', () => {
+    const params = {
+      account_id: existingGatewayAccountId
+    }
+    const validTransactionSearchResponse = transactionDetailsFixtures.validTransactionSearchResponse({
+      gateway_account_id: existingGatewayAccountId,
+      transactions: [
+        {
+          amount: 1000,
+          state: {
+            status: 'success',
+            finished: true
+          },
+          transaction_id: '111111',
+          created_date: '2018-09-21T10:14:16.067Z',
+          refund_summary_status: 'available',
+          refund_summary_available: 950,
+          amount_refunded: 50,
+          capture_submit_time: '2018-09-21T10:14:18.067Z',
+          captured_date: '2018-09-21T10:14:25.067Z',
+          type: 'payment'
+        },
+        {
+          amount: 2000,
+          state: {
+            status: 'success',
+            finished: true
+          },
+          transaction_id: '222222',
+          created_date: '2018-09-22T10:14:16.067Z',
+          refund_summary_status: 'available',
+          refund_summary_available: 1900,
+          amount_refunded: 100,
+          capture_submit_time: '2018-09-22T10:14:18.067Z',
+          captured_date: '2018-09-22T10:14:25.067Z',
+          type: 'payment'
+        },
+        {
+          amount: 50,
+          state: {
+            status: 'success',
+            finished: true
+          },
+          created_date: '2018-09-23T10:14:16.067Z',
+          parent_transaction_id: '111111',
+          type: 'refund'
+        },
+        {
+          amount: 100,
+          state: {
+            status: 'success',
+            finished: true
+          },
+          created_date: '2018-09-25T10:14:16.067Z',
+          parent_transaction_id: '222222',
+          type: 'refund'
+        }
+      ]
+    })
+    before(() => {
+      const pactified = validTransactionSearchResponse.getPactified()
+      return pactTestProvider.addInteraction(
+        new PactInteractionBuilder(`${TRANSACTION_RESOURCE}`)
+          .withQuery('account_id', params.account_id)
+          .withQuery('page', '1')
+          .withQuery('display_size', '100')
+          .withUponReceiving('a valid search transaction details request')
+          .withState(defaultTransactionState)
+          .withMethod('GET')
+          .withStatusCode(200)
+          .withResponseBody(pactified)
+          .build()
+      )
+    })
+
+    afterEach(() => pactTestProvider.verify())
+
+    it('should search transaction successfully', function () {
+      const searchTransactionDetails = legacyConnectorParityTransformer.legacyConnectorTransactionsParity(validTransactionSearchResponse.getPlain())
+      return ledgerClient.transactions(params.account_id)
+        .then((ledgerResponse) => {
+          expect(ledgerResponse).to.deep.equal(searchTransactionDetails)
+        })
+    })
+  })
+})


### PR DESCRIPTION
## WHAT
- add pact tests
- create a pact provider helper class. This is needed so the tests can share the pre-configured ledger_client's port.
- update transaction fixtures accordingly
