### PR TITLE
Support non-HTTPS URLs for confirmation pages during testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,20 @@ See [About Cypress tests in selfservice](./test/cypress/cypress_testing.md) for 
 
 ## Key environment variables
 
-| Variable                    | required | default value | Description                               |
-| --------------------------- |:--------:|:-------------:| ----------------------------------------- |
-| PORT                        | X | 9200 | The port number for the express server to be bound at runtime |
-| SESSION_ENCRYPTION_KEY      | X |      | Key to be used by the cookie encryption algorithm. Should be a large unguessable string ([More Info](https://www.npmjs.com/package/client-sessions)).  |
-| PUBLIC_AUTH_URL             | X |      | The publicauth endpoint to use when API Tokens. |
-| PUBLIC_AUTH_URL             | X |      | The endpoint to connector base URL. |
-| DISABLE_INTERNAL_HTTPS      |   | false/undefined | To switch off generating secure cookies. Set this to `true` only if you are running self service in a `non HTTPS` environment. |
-| HTTP_PROXY_ENABLED          |   | false/undefined | To enable proxying outbound traffic of HTTP(S) requests. If set to `true` make sure to set the following 3 variables |
-| HTTP_PROXY                  |   |      | HTTP proxy url |
-| HTTPS_PROXY                 |   |      | HTTPS proxy url |
-| NO_PROXY                    |   |      | host:port(s) that need to be by passed by the proxy. Supports comma separated list |
-| NODE_WORKER_COUNT           |   | 1 | The number of worker threads started by node cluster when run in production mode |
-| FEATURE_USE_LEDGER_PAYMENTS |   | false/undefined | Use the Ledger service as the source of payment data in favour of card connector |
+| Variable                      | required | default value | Description                               |
+| ----------------------------- |:--------:|:-------------:| ----------------------------------------- |
+| PORT                          | X | 9200 | The port number for the express server to be bound at runtime |
+| SESSION_ENCRYPTION_KEY        | X |      | Key to be used by the cookie encryption algorithm. Should be a large unguessable string ([More Info](https://www.npmjs.com/package/client-sessions)).  |
+| PUBLIC_AUTH_URL               | X |      | The publicauth endpoint to use when API Tokens. |
+| PUBLIC_AUTH_URL               | X |      | The endpoint to connector base URL. |
+| DISABLE_INTERNAL_HTTPS        |   | false/undefined | To switch off generating secure cookies. Set this to `true` only if you are running self service in a `non HTTPS` environment. |
+| ALLOW_HTTP_CONFIRMATION_PAGES |   | false/undefined | To permit non-HTTPS confirmation URLs. Set this to `true` only if you are running self service in a `non HTTPS` environment. |
+| HTTP_PROXY_ENABLED            |   | false/undefined | To enable proxying outbound traffic of HTTP(S) requests. If set to `true` make sure to set the following 3 variables |
+| HTTP_PROXY                    |   |      | HTTP proxy url |
+| HTTPS_PROXY                   |   |      | HTTPS proxy url |
+| NO_PROXY                      |   |      | host:port(s) that need to be by passed by the proxy. Supports comma separated list |
+| NODE_WORKER_COUNT             |   | 1 | The number of worker threads started by node cluster when run in production mode |
+| FEATURE_USE_LEDGER_PAYMENTS   |   | false/undefined | Use the Ledger service as the source of payment data in favour of card connector |
 
 ## Architecture Decision Records
 

--- a/app/browsered/field-validation-checks.js
+++ b/app/browsered/field-validation-checks.js
@@ -15,6 +15,7 @@ const validationErrors = {
   currency: 'Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”',
   phoneNumber: 'Must be a 11 digit phone number',
   validEmail: 'Please use a valid email address',
+  isURL: 'Please use a valid URL',
   isHttps: 'URL must begin with https://',
   isAboveMaxAmount: `Choose an amount under £${MAX_AMOUNT.toLocaleString()}`,
   isPasswordLessThanTenChars: 'Choose a Password of 10 characters or longer',
@@ -59,6 +60,14 @@ exports.isPhoneNumber = function (value) {
     return validationErrors.phoneNumber
   } else {
     return false
+  }
+}
+
+exports.isURL = function (value) {
+  try {
+    return new url.URL(value) ? validationErrors.isURL : false
+  } catch(err) {
+    return validationErrors.isURL
   }
 }
 

--- a/app/browsered/field-validation.js
+++ b/app/browsered/field-validation.js
@@ -77,6 +77,9 @@ function validateField (form, field) {
       case 'phone':
         result = checks.isPhoneNumber(field.value)
         break
+      case 'url':
+        result = checks.isURL(field.value)
+        break
       case 'https':
         result = checks.isHttps(field.value)
         break

--- a/app/controllers/test_with_your_users/submit_controller.js
+++ b/app/controllers/test_with_your_users/submit_controller.js
@@ -27,7 +27,9 @@ module.exports = (req, res) => {
     req.flash('genericError', `<h2>Use valid characters only</h2> ${isCurrency(paymentAmountInPence)}`)
   } else if (isAboveMaxAmount(penceToPounds(paymentAmountInPence))) {
     req.flash('genericError', `<h2>Enter a valid amount</h2> ${isAboveMaxAmount(penceToPounds(paymentAmountInPence))}`)
-  } else if (!confirmationPage || isHttps(confirmationPage)) {
+  } else if (process.env.ALLOW_HTTP_CONFIRMATION_PAGES === 'true' && (!confirmationPage || isURL(confirmationPage))) {
+    req.flash('genericError', `<h2>Enter a valid URL</h2>${isURL(confirmationPage)}`)
+  } else if (process.env.ALLOW_HTTP_CONFIRMATION_PAGES !== 'true' && (!confirmationPage || isHttps(confirmationPage))) {
     req.flash('genericError', `<h2>Enter a valid secure URL</h2>${isHttps(confirmationPage)}`)
   }
 


### PR DESCRIPTION
## WHAT
During testing we sometimes disable HTTPS but we require that confirmation page
URLs are HTTPS. Unfortunately, the `DISABLE_INTERNAL_HTTPS` environment
variable is set to true during tests and so if we key off that, we'll break the
test which checks for validation that URLs are HTTPS. Add an extra environment
variable to use during tests - `ALLOW_HTTP_CONFIRMATION_PAGES` to allow us to
bypass this validation check.