### PR TITLE
PP-5537 add get events and search ledger transactions pact test

### DIFF
--- a/test/fixtures/ledger_transaction_fixtures.js
+++ b/test/fixtures/ledger_transaction_fixtures.js
@@ -97,6 +97,12 @@ const buildTransactionDetails = (opts = {}) => {
     }
   }
 
+  if (opts.cardholder_name) {
+    data.card_details = {
+      cardholder_name: opts.cardholder_name
+    }
+  }
+
   if (opts.includeSearchResultCardDetails) {
     data.card_details = {
       last_digits_card_number: opts.last_digits_card_number || '0002',
@@ -111,7 +117,7 @@ const buildTransactionDetails = (opts = {}) => {
       status: opts.refund_summary_status || 'unavailable',
       user_external_id: opts.user_external_id || null,
       amount_available: opts.refund_summary_available || 20000,
-      amount_refunded: opts.amount_refunded || 0
+      amount_submitted: opts.amount_submitted || 0
     }
   }
 

--- a/test/unit/clients/ledger_client/ledger_search_transaction_test.js
+++ b/test/unit/clients/ledger_client/ledger_search_transaction_test.js
@@ -33,6 +33,20 @@ describe('ledger client', function () {
       gateway_account_id: existingGatewayAccountId,
       transactions: [
         {
+          amount: 2000,
+          state: {
+            status: 'success',
+            finished: true
+          },
+          transaction_id: '222222',
+          created_date: '2018-09-22T10:14:15.067Z',
+          refund_summary_status: 'available',
+          refund_summary_available: 1850,
+          amount_submitted: 150,
+          type: 'payment',
+          card_brand: 'visa'
+        },
+        {
           amount: 1000,
           state: {
             status: 'started',
@@ -42,25 +56,7 @@ describe('ledger client', function () {
           created_date: '2018-09-21T10:14:16.067Z',
           refund_summary_status: 'available',
           refund_summary_available: 1000,
-          capture_submit_time: '2018-09-21T10:14:18.067Z',
-          captured_date: '2018-09-21T10:14:25.067Z',
           type: 'payment'
-        },
-        {
-          amount: 2000,
-          state: {
-            status: 'success',
-            finished: true
-          },
-          transaction_id: '222222',
-          created_date: '2018-09-22T10:14:16.067Z',
-          refund_summary_status: 'available',
-          refund_summary_available: 1850,
-          amount_refunded: 150,
-          capture_submit_time: '2018-09-22T10:14:18.067Z',
-          captured_date: '2018-09-22T10:14:25.067Z',
-          type: 'payment',
-          card_brand: 'visa'
         },
         {
           amount: 150,
@@ -68,7 +64,7 @@ describe('ledger client', function () {
             status: 'success',
             finished: true
           },
-          created_date: '2018-09-25T10:14:16.067Z',
+          created_date: '2018-09-26T10:14:16.067Z',
           parent_transaction_id: '222222',
           type: 'refund'
         }


### PR DESCRIPTION
## WHAT

- add pact tests
- create a pact provider helper class. This is needed so the tests can
  share the pre-configured ledger_client port.
- update transaction fixtures


