### PR TITLE
PP-5537 add Ledger get transaction events pact test

### DIFF
--- a/test/fixtures/ledger_transaction_fixtures.js
+++ b/test/fixtures/ledger_transaction_fixtures.js
@@ -26,7 +26,7 @@ const buildChargeEventWithDefaults = (opts = {}) => {
 
 const buildChargeEventStateWithDefaults = (opts = {}) => {
   let state
-  if (opts.status === 'failed') {
+  if (opts.status === 'declined') {
     state = {
       status: opts.status,
       finished: true,
@@ -41,6 +41,20 @@ const buildChargeEventStateWithDefaults = (opts = {}) => {
   }
 
   return state
+}
+
+const buildPaymentEvents = (opts = {}) => {
+  let events = []
+  if (opts.payment_states) {
+    opts.payment_states.forEach(paymentState => {
+      events.push({
+        state: buildChargeEventStateWithDefaults(paymentState),
+        resource_type: 'PAYMENT',
+        data: {}
+      })
+    })
+  }
+  return events
 }
 
 const buildTransactionDetails = (opts = {}) => {
@@ -77,6 +91,18 @@ const buildTransactionDetails = (opts = {}) => {
     }
   }
 
+  if (opts.card_brand) {
+    data.card_details = {
+      card_brand: opts.card_brand
+    }
+  }
+
+  if (opts.cardholder_name) {
+    data.card_details = {
+      cardholder_name: opts.cardholder_name
+    }
+  }
+
   if (opts.includeSearchResultCardDetails) {
     data.card_details = {
       last_digits_card_number: opts.last_digits_card_number || '0002',
@@ -91,7 +117,7 @@ const buildTransactionDetails = (opts = {}) => {
       status: opts.refund_summary_status || 'unavailable',
       user_external_id: opts.user_external_id || null,
       amount_available: opts.refund_summary_available || 20000,
-      amount_submitted: opts.refund_summary_submitted || 0
+      amount_submitted: opts.amount_submitted || 0
     }
   }
 
@@ -189,12 +215,8 @@ module.exports = {
     }
 
     return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
+      getPactified: () => pactRegister.pactify(data),
+      getPlain: () => data
     }
   },
   validTransactionRefundRequest: (opts = {}) => {
@@ -205,12 +227,8 @@ module.exports = {
     }
 
     return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
+      getPactified: () => pactRegister.pactify(data),
+      getPlain: () => data
     }
   },
   invalidTransactionRefundResponse: (opts = {}) => {
@@ -219,12 +237,19 @@ module.exports = {
     }
 
     return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
+      getPactified: () => pactRegister.pactify(data),
+      getPlain: () => data
+    }
+  },
+  validTransactionEventsResponse: (opts = {}) => {
+    const data = {
+      transaction_id: opts.transaction_id || 'ht439nfg2l1e303k0dmifrn4fc',
+      events: (opts.payment_states) ? buildPaymentEvents(opts) : []
+    }
+
+    return {
+      getPactified: () => pactRegister.pactify(data),
+      getPlain: () => data
     }
   }
 }

--- a/test/unit/clients/ledger_client/ledger_get_transaction_events_test.js
+++ b/test/unit/clients/ledger_client/ledger_get_transaction_events_test.js
@@ -20,31 +20,37 @@ chai.use(chaiAsPromised)
 
 const existingGatewayAccountId = '123456'
 const defaultTransactionId = 'ch_123abc456xyz'
-const defaultTransactionState = `a transaction with fee and net_amount exists`
+const defaultTransactionState = 'a transaction has CREATED and AUTHORISATION_REJECTED payment events'
 
 describe('ledger client', function () {
   before(() => pactTestProvider.setup())
   after(() => pactTestProvider.finalize())
 
-  describe('get transaction details', () => {
+  describe('get transaction events details', () => {
     const params = {
       account_id: existingGatewayAccountId,
       transaction_id: defaultTransactionId
     }
-    const validCreatedTransactionDetailsResponse = transactionDetailsFixtures.validTransactionCreatedDetailsResponse({
+    const validTransactionEventsResponse = transactionDetailsFixtures.validTransactionEventsResponse({
       transaction_id: params.transaction_id,
-      amount: 100,
-      fee: 5,
-      net_amount: 95,
-      refund_summary_available: 100
+      payment_states: [
+        {
+          status: 'created',
+          timestamp: '2019-08-06T10:34:43.487123Z'
+        },
+        {
+          status: 'declined',
+          timestamp: '2019-08-06T10:34:48.123456Z',
+          event_type: 'AUTHORISATION_REJECTED'
+        }
+      ]
     })
     before(() => {
-      const pactified = validCreatedTransactionDetailsResponse.getPactified()
+      const pactified = validTransactionEventsResponse.getPactified()
       return pactTestProvider.addInteraction(
-        new PactInteractionBuilder(`${TRANSACTION_RESOURCE}/${params.transaction_id}`)
-          .withQuery('account_id', params.account_id)
-          .withQuery('transaction_type', 'PAYMENT')
-          .withUponReceiving('a valid created transaction details request')
+        new PactInteractionBuilder(`${TRANSACTION_RESOURCE}/${params.transaction_id}/event`)
+          .withQuery('gateway_account_id', params.account_id)
+          .withUponReceiving('a valid transaction events details request')
           .withState(defaultTransactionState)
           .withMethod('GET')
           .withStatusCode(200)
@@ -55,11 +61,11 @@ describe('ledger client', function () {
 
     afterEach(() => pactTestProvider.verify())
 
-    it('should get transaction details successfully', function () {
-      const getCreatedTransactionDetails = legacyConnectorParityTransformer.legacyConnectorTransactionParity(validCreatedTransactionDetailsResponse.getPlain())
-      return ledgerClient.transaction(params.transaction_id, params.account_id, { transaction_type: 'PAYMENT' })
+    it('should get transaction events successfully', function () {
+      const getTransactionEventsDetails = legacyConnectorParityTransformer.legacyConnectorEventsParity(validTransactionEventsResponse.getPlain())
+      return ledgerClient.events(params.transaction_id, params.account_id)
         .then((ledgerResponse) => {
-          expect(ledgerResponse).to.deep.equal(getCreatedTransactionDetails)
+          expect(ledgerResponse).to.deep.equal(getTransactionEventsDetails)
         })
     })
   })

--- a/test/unit/clients/ledger_client/ledger_pact_test_provider.js
+++ b/test/unit/clients/ledger_client/ledger_pact_test_provider.js
@@ -1,0 +1,35 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+
+// Custom dependencies
+const path = require('path')
+const port = parseInt(process.env.LEDGER_URL.match(/\d+(\.\d+)?$/g)[0], 10)
+
+const pactProvider = Pact({
+  consumer: 'selfservice',
+  provider: 'ledger',
+  port: port,
+  log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+  dir: path.resolve(process.cwd(), 'pacts'),
+  spec: 2,
+  pactfileWriteMode: 'merge'
+})
+module.exports = {
+  getPort: function () {
+    return port
+  },
+  addInteraction: function (pact) {
+    return pactProvider.addInteraction(pact)
+  },
+  setup: function () {
+    return pactProvider.setup()
+  },
+  verify: function () {
+    return pactProvider.verify()
+  },
+  finalize: function () {
+    return pactProvider.finalize()
+  }
+}


### PR DESCRIPTION
## WHAT
- add pact test that verifies the interaction between ledger and selfservice for get transaction events
- add relevant methods to fixtures
- add a provider class (wrapper around Pact). We don't want to refactor ledger_client to make port configurable for tests' sake. Using this provider allow us to share the pre-configured port between Ledger pact tests.
- refactor get transaction details test to use the new provider class



