### PR TITLE
PP-5537 add search ledger transactions pact test

### DIFF
--- a/test/fixtures/ledger_transaction_fixtures.js
+++ b/test/fixtures/ledger_transaction_fixtures.js
@@ -140,6 +140,19 @@ const buildTransactionDetails = (opts = {}) => {
   return data
 }
 
+const buildRefundDetails = (opts = {}) => {
+  return {
+    gateway_account_id: opts.gateway_account_id || '1',
+    amount: opts.amount || 10,
+    state: buildChargeEventStateWithDefaults(opts),
+    reference: opts.reference || 'aaba9756-15af-4ab0-b2c2-8696bc47655e',
+    created_date: opts.created_date || '2019-08-20T14:39:49.536Z',
+    transaction_type: 'REFUND',
+    transaction_id: opts.transaction_id || '1b5kia0u28ll2ic4obv26r5e4h',
+    parent_transaction_id: opts.parent_transaction_id || 'puuhl0gu7egigin7oh9c75p4m1'
+  }
+}
+
 module.exports = {
   validTransactionSummaryResponse: () => {
     let data = {
@@ -245,6 +258,30 @@ module.exports = {
     const data = {
       transaction_id: opts.transaction_id || 'ht439nfg2l1e303k0dmifrn4fc',
       events: (opts.payment_states) ? buildPaymentEvents(opts) : []
+    }
+
+    return {
+      getPactified: () => pactRegister.pactify(data),
+      getPlain: () => data
+    }
+  },
+  validTransactionSearchResponse: (opts = {}) => {
+    let results = []
+    opts.transactions.forEach(transaction => {
+      transaction.gateway_account_id = opts.gateway_account_id
+      if (transaction.type === 'payment') {
+        transaction.includeRefundSummary = true
+        transaction.includeSettlementSummary = true
+        results.push(buildTransactionDetails(transaction))
+      } else if (transaction.type === 'refund') {
+        results.push(buildRefundDetails(transaction))
+      }
+    })
+    const data = {
+      total: opts.transactions.length,
+      count: opts.transactions.length,
+      page: opts.page || 1,
+      results: results
     }
 
     return {

--- a/test/unit/clients/ledger_client/ledger_search_transaction_test.js
+++ b/test/unit/clients/ledger_client/ledger_search_transaction_test.js
@@ -1,0 +1,99 @@
+'use strict'
+
+// NPM dependencies
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+
+// Custom dependencies
+const PactInteractionBuilder = require('../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const ledgerClient = require('../../../../app/services/clients/ledger_client')
+const transactionDetailsFixtures = require('../../../fixtures/ledger_transaction_fixtures')
+const legacyConnectorParityTransformer = require('../../../../app/services/clients/utils/ledger_legacy_connector_parity')
+const pactTestProvider = require('./ledger_pact_test_provider')
+
+// Constants
+const TRANSACTION_RESOURCE = '/v1/transaction'
+const expect = chai.expect
+
+// Global setup
+chai.use(chaiAsPromised)
+
+const existingGatewayAccountId = '123456'
+const defaultTransactionState = `two payments and a refund transactions exist for selfservice search`
+
+describe('ledger client', function () {
+  before(() => pactTestProvider.setup())
+  after(() => pactTestProvider.finalize())
+
+  describe('search transactions', () => {
+    const params = {
+      account_id: existingGatewayAccountId
+    }
+    const validTransactionSearchResponse = transactionDetailsFixtures.validTransactionSearchResponse({
+      gateway_account_id: existingGatewayAccountId,
+      transactions: [
+        {
+          amount: 2000,
+          state: {
+            status: 'success',
+            finished: true
+          },
+          transaction_id: '222222',
+          created_date: '2018-09-22T10:14:15.067Z',
+          refund_summary_status: 'available',
+          refund_summary_available: 1850,
+          amount_submitted: 150,
+          type: 'payment',
+          card_brand: 'visa'
+        },
+        {
+          amount: 1000,
+          state: {
+            status: 'started',
+            finished: false
+          },
+          transaction_id: '111111',
+          created_date: '2018-09-21T10:14:16.067Z',
+          refund_summary_status: 'available',
+          refund_summary_available: 1000,
+          type: 'payment'
+        },
+        {
+          amount: 150,
+          state: {
+            status: 'success',
+            finished: true
+          },
+          created_date: '2018-09-26T10:14:16.067Z',
+          parent_transaction_id: '222222',
+          type: 'refund'
+        }
+      ]
+    })
+    before(() => {
+      const pactified = validTransactionSearchResponse.getPactified()
+      return pactTestProvider.addInteraction(
+        new PactInteractionBuilder(`${TRANSACTION_RESOURCE}`)
+          .withQuery('account_id', params.account_id)
+          .withQuery('page', '1')
+          .withQuery('display_size', '100')
+          .withUponReceiving('a valid search transaction details request')
+          .withState(defaultTransactionState)
+          .withMethod('GET')
+          .withStatusCode(200)
+          .withResponseBody(pactified)
+          .build()
+      )
+    })
+
+    afterEach(() => pactTestProvider.verify())
+
+    it('should search transaction successfully', function () {
+      const searchTransactionDetails = legacyConnectorParityTransformer.legacyConnectorTransactionsParity(validTransactionSearchResponse.getPlain())
+      return ledgerClient.transactions(params.account_id)
+        .then((ledgerResponse) => {
+          expect(ledgerResponse).to.deep.equal(searchTransactionDetails)
+        })
+    })
+  })
+})


### PR DESCRIPTION
## WHAT
- add pact test to cover a transaction search between selfservice and ledger
- add new methods to fixtures
