### PR TITLE
PP-5657 Map Payment fields to Refunds

### DIFF
--- a/app/services/clients/ledger_client.js
+++ b/app/services/clients/ledger_client.js
@@ -39,7 +39,7 @@ const events = function events (transactionId, gatewayAccountId, options = {}) {
 }
 
 const transactions = function transactions (gatewayAccountId, filters = {}, urlOverride, options = {}) {
-  const path = `/v1/transaction?account_id=${gatewayAccountId}&${getQueryStringForParams(filters, true, true)}`
+  const path = `/v1/transaction?with_parent_transaction=true&account_id=${gatewayAccountId}&${getQueryStringForParams(filters, true, true)}`
   const configuration = Object.assign({
     url: urlOverride ? url.parse(urlOverride).path : path,
     description: 'List transactions for a given gateway account ID',

--- a/app/services/clients/utils/ledger_legacy_connector_parity.js
+++ b/app/services/clients/utils/ledger_legacy_connector_parity.js
@@ -13,7 +13,21 @@ const legacyConnectorTransactionParity = (transaction) => {
   if (transaction.refund_summary && transaction.refund_summary.amount_refunded) {
     transaction.refund_summary.amount_submitted = transaction.refund_summary.amount_refunded
   }
+
   transaction.charge_id = transaction.transaction_id
+
+  if (transaction.transaction_type && transaction.transaction_type.toLowerCase() === 'refund') {
+    if (transaction.parent_transaction !== undefined && transaction.parent_transaction !== null) {
+      let charge = transaction.parent_transaction
+      transaction.charge_id = charge.transaction_id
+      transaction.gateway_transaction_id = charge.gateway_transaction_id
+      transaction.reference = charge.reference
+      transaction.description = charge.description
+      transaction.email = charge.email
+      transaction.card_details = charge.card_details
+    }
+  }
+
   return transaction
 }
 

--- a/test/unit/clients/ledger_client/ledger_search_transaction_test.js
+++ b/test/unit/clients/ledger_client/ledger_search_transaction_test.js
@@ -75,6 +75,7 @@ describe('ledger client', function () {
       return pactTestProvider.addInteraction(
         new PactInteractionBuilder(`${TRANSACTION_RESOURCE}`)
           .withQuery('account_id', params.account_id)
+          .withQuery('with_parent_transaction', 'true')
           .withQuery('page', '1')
           .withQuery('display_size', '100')
           .withUponReceiving('a valid search transaction details request')


### PR DESCRIPTION
## WHAT 
- When searching transactions, payment related fields (card details, reference, gateway_transaction_id, and so on) are displayed for refund transaction.
  Ledger now returns payment transaction as nested object for refund