### PR TITLE
PP-5657 Fixes for CSV download from ledger

### DIFF
--- a/app/controllers/transactions/transaction_download_controller.js
+++ b/app/controllers/transactions/transaction_download_controller.js
@@ -25,7 +25,7 @@ module.exports = (req, res) => {
   transactionService.searchAll(accountId, filters, correlationId)
     .then(json => {
       let refundTransactionUserIds = json.results
-        .filter(res => res.transaction_type === 'refund')
+        .filter(res => res.transaction_type && res.transaction_type.toLowerCase() === 'refund')
         .map(res => res.refund_summary.user_external_id)
         .filter(userId => userId) // we call filter because we want to filter out all "falsy" values
       refundTransactionUserIds = lodash.uniq(refundTransactionUserIds)
@@ -42,7 +42,7 @@ module.exports = (req, res) => {
             }, {})
             const results = json.results
               .map(res => {
-                if (res.transaction_type === 'refund') {
+                if (res.transaction_type && res.transaction_type.toLowerCase() === 'refund') {
                   res.refund_summary.user_username = userUsernameMap[res.refund_summary.user_external_id]
                 }
                 return res

--- a/app/services/clients/utils/ledger_legacy_connector_parity.js
+++ b/app/services/clients/utils/ledger_legacy_connector_parity.js
@@ -14,6 +14,13 @@ const legacyConnectorTransactionParity = (transaction) => {
     transaction.refund_summary.amount_submitted = transaction.refund_summary.amount_refunded
   }
 
+  if (transaction.refunded_by) {
+    if (transaction.refund_summary === undefined) {
+      transaction.refund_summary = {}
+    }
+    transaction.refund_summary.user_external_id = transaction.refunded_by
+  }
+
   transaction.charge_id = transaction.transaction_id
 
   if (transaction.transaction_type && transaction.transaction_type.toLowerCase() === 'refund') {

--- a/app/utils/json_to_csv.js
+++ b/app/utils/json_to_csv.js
@@ -78,7 +78,7 @@ module.exports = function jsonToCSV (data, supportsGatewayFees = false) {
         {
           label: 'Amount',
           value: row => {
-            return (row.transaction_type === 'refund') ? penceToPounds(parseInt(row.amount) * -1) : penceToPounds(parseInt(row.amount))
+            return (row.transaction_type && row.transaction_type.toLowerCase() === 'refund') ? penceToPounds(parseInt(row.amount) * -1) : penceToPounds(parseInt(row.amount))
           }
         },
         ...getSanitisableFields([
@@ -124,7 +124,7 @@ module.exports = function jsonToCSV (data, supportsGatewayFees = false) {
           label: 'Total Amount',
           value: row => {
             const amountInPence = row.total_amount ? row.total_amount : row.amount
-            return (row.transaction_type === 'refund') ? penceToPounds(parseInt(amountInPence) * -1) : penceToPounds(parseInt(amountInPence))
+            return (row.transaction_type && row.transaction_type.toLowerCase() === 'refund') ? penceToPounds(parseInt(amountInPence) * -1) : penceToPounds(parseInt(amountInPence))
           }
         },
         {
@@ -139,7 +139,7 @@ module.exports = function jsonToCSV (data, supportsGatewayFees = false) {
             label: 'Net',
             value: row => {
               const amountInPence = row.net_amount || row.total_amount || row.amount
-              return (row.transaction_type === 'refund') ? penceToPounds(parseInt(amountInPence) * -1) : penceToPounds(parseInt(amountInPence))
+              return (row.transaction_type && row.transaction_type.toLowerCase() === 'refund') ? penceToPounds(parseInt(amountInPence) * -1) : penceToPounds(parseInt(amountInPence))
             }
           }
         ] : [],

--- a/test/unit/clients/ledger_client/legacy_connector_parity_util_test.js
+++ b/test/unit/clients/ledger_client/legacy_connector_parity_util_test.js
@@ -24,6 +24,7 @@ describe('Ledger service client legacy parity utilities', () => {
       const ledgerTransactionFixture = {
         transaction_id: 'some-transaction-id',
         transaction_type: 'REFUND',
+        refunded_by: 'f579410614654249987ad939f5ef53a1',
         refund_summary: {
           amount_refunded: 1000
         },
@@ -45,6 +46,7 @@ describe('Ledger service client legacy parity utilities', () => {
 
       const result = legacyConnectorTransactionParity(ledgerTransactionFixture)
       assert.strictEqual(result.charge_id, 'charge-id')
+      assert.strictEqual(result.refund_summary.user_external_id, 'f579410614654249987ad939f5ef53a1')
       assert.strictEqual(result.gateway_transaction_id, 'payment-gateway-transaction-id')
       assert.strictEqual(result.reference, 'payment-reference')
       assert.strictEqual(result.description, 'payment-descriptiom')
@@ -109,6 +111,7 @@ describe('Ledger service client legacy parity utilities', () => {
         {
           transaction_id: 'some-transaction-id',
           transaction_type: 'REFUND',
+          refunded_by: 'f579410614654249987ad939f5ef53a1',
           parent_transaction: {
             transaction_id: 'charge-id',
             reference: 'payment-reference'
@@ -119,6 +122,7 @@ describe('Ledger service client legacy parity utilities', () => {
 
       assert.strictEqual(transactions.results[0].charge_id, 'some-charge-id')
       assert.strictEqual(transactions.results[1].charge_id, 'charge-id')
+      assert.strictEqual(transactions.results[1].refund_summary.user_external_id, 'f579410614654249987ad939f5ef53a1')
       assert.strictEqual(transactions.results[1].reference, 'payment-reference')
     })
   })


### PR DESCRIPTION
## WHAT 
- Map `user_external_id` for refunds correctly for refund transactions from ledger
- Use `transaction_type`.toLowerCase() to make case insensitive comparison