### PR TITLE
PP-5565 Fix refund summary not available CSV download

### DIFF
--- a/app/controllers/transactions/transaction_download_controller.js
+++ b/app/controllers/transactions/transaction_download_controller.js
@@ -41,11 +41,13 @@ module.exports = (req, res) => {
               return map
             }, {})
             const results = json.results
-              .map(res => {
-                if (res.transaction_type && res.transaction_type.toLowerCase() === 'refund') {
-                  res.refund_summary.user_username = userUsernameMap[res.refund_summary.user_external_id]
+              .map(transactionRow => {
+                if (transactionRow.transaction_type && transactionRow.transaction_type.toLowerCase() === 'refund') {
+                  if (transactionRow.refund_summary.user_external_id) {
+                    transactionRow.refund_summary.user_username = userUsernameMap[transactionRow.refund_summary.user_external_id]
+                  }
                 }
-                return res
+                return transactionRow
               })
             return jsonToCsv(results, isStripeAccount)
           })

--- a/app/services/clients/utils/ledger_legacy_connector_parity.js
+++ b/app/services/clients/utils/ledger_legacy_connector_parity.js
@@ -14,10 +14,11 @@ const legacyConnectorTransactionParity = (transaction) => {
     transaction.refund_summary.amount_submitted = transaction.refund_summary.amount_refunded
   }
 
+  if (transaction.refund_summary === undefined) {
+    transaction.refund_summary = {}
+  }
+
   if (transaction.refunded_by) {
-    if (transaction.refund_summary === undefined) {
-      transaction.refund_summary = {}
-    }
     transaction.refund_summary.user_external_id = transaction.refunded_by
   }
 


### PR DESCRIPTION
CSV downloads are breaking on ledger path, ledger does not always
provide refund summary (if external user didn't submit refund). This
checks for that.


