### PR TITLE
PP-5560 Loosen payment link validation

### DIFF
--- a/app/browsered/field-validation-checks.js
+++ b/app/browsered/field-validation-checks.js
@@ -17,7 +17,7 @@ const validationErrors = {
   isAboveMaxAmount: `Choose an amount under £${MAX_AMOUNT.toLocaleString()}`,
   isPasswordLessThanTenChars: 'Choose a Password of 10 characters or longer',
   isGreaterThanMaxLengthChars: 'The text is too long',
-  invalidCharacters: `You cannot use any of the following characters < > ; : \` ( ) " ' = | , ~ [ ]`,
+  invalidCharacters: `You cannot use any of the following characters < > ; |`,
   invalidBankAccountNumber: 'Enter a valid account number',
   invalidSortCode: 'Enter a valid sort code',
   invalidVatNumber: 'Enter a valid VAT number',
@@ -83,7 +83,7 @@ exports.isFieldGreaterThanMaxLengthChars = (value, maxLength) => {
 exports.isPasswordLessThanTenChars = value => !value || value.length < 10 ? validationErrors.isPasswordLessThanTenChars : false
 
 exports.isNaxsiSafe = function (value) {
-  if (/[<>;:`()"'=|,~[\]]+/g.test(value)) {
+  if (/[<>;|]+/g.test(value)) {
     return validationErrors.invalidCharacters
   } else {
     return false

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -89,6 +89,7 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
           text: detailsHint
         },
         attributes: {
+          "data-validate": "isNaxsiSafe",
           "autofocus": change !== "payment-link-description",
           "rows": "5",
           "lang": lang


### PR DESCRIPTION
We were previously not allowing special characters which were whitelisted by NAXSI. Update the validation rule to only disallow characters that NAXSI will block, and update the error message
displayed to the user appropriately.

Also add the field validation to the "Details" field on the payment link information screen, as this would previously not warn if disallowed characters were entered and instead show a generic error page.
