### PR TITLE
PP-5670: Specify consumer when running provider test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,11 +56,11 @@ pipeline {
           env.PACT_TAG = gitBranchName()
         }
         ws('contract-tests-wp') {
-          runPactProviderTests("pay-adminusers", "${env.PACT_TAG}")
-          runPactProviderTests("pay-connector", "${env.PACT_TAG}")
-          runPactProviderTests("pay-products", "${env.PACT_TAG}")
-          runPactProviderTests("pay-direct-debit-connector", "${env.PACT_TAG}")
-          runPactProviderTests("pay-ledger", "${env.PACT_TAG}")
+          runPactProviderTests("pay-adminusers", "${env.PACT_TAG}", "selfservice")
+          runPactProviderTests("pay-connector", "${env.PACT_TAG}", "selfservice")
+          runPactProviderTests("pay-products", "${env.PACT_TAG}", "selfservice")
+          runPactProviderTests("pay-direct-debit-connector", "${env.PACT_TAG}", "selfservice")
+          runPactProviderTests("pay-ledger", "${env.PACT_TAG}", "selfservice")
         }
       }
       post {


### PR DESCRIPTION
This will cause only the
selfservice->{adminusers,direct-debit-connector,connector,products,ledger}
test to run on a selfservice build during the provider test runs.

## WHAT
_A brief description of the pull request:_

## HOW 
_Steps to test or reproduce:_


