### PR TITLE
PP-5755 Pass original logger.error arguments after Sentry

### DIFF
--- a/app/utils/sentry.js
+++ b/app/utils/sentry.js
@@ -16,11 +16,11 @@ function initialiseSentry () {
 
 const addSentryToErrorLevel = originalLogger => {
   const sentryLogger = Object.create(originalLogger)
-  sentryLogger.error = msg => {
+  sentryLogger.error = function () {
     try {
-      Sentry.captureException(new Error(msg))
+      Sentry.captureException(new Error(JSON.stringify(arguments)))
     } finally {
-      originalLogger.error(msg)
+      originalLogger.error(...arguments)
     }
   }
   return sentryLogger


### PR DESCRIPTION
When we enable Sentry we effectively override the original `error`
function on the logger so that we call `Sentry.captureException` before
proceeding to log the error by calling the original `error` function on
the logger. Since `logger.error` can be called with various arguments it
isn't sufficient to simple call `originalLogger.error(msg)` since this
can lose structured arguments of the form `logger.error( "some message",
{ key: "value" } )`. By passing the spread `arguments` that were
provided we should end up with the original log message had we not
inserted Sentry.

Furthermore, by creating the message for the `Error` we send to Sentry by
`JSON.stringify`'ing the arguments provided we capture richer
information than simplying taking only the message which would be
`arguments[0]`. Since the extra information is intended to be logged
(as we would anyway) it seems safe to send this to Sentry.

As a side note to make this work it is necessary to change the
overriding `error` function from an arrow function to a normal function,
this is so the `arguments` value pertains to the value of `arguments`
when the function is called, and not when the function is created (which
would be the arguments passed when loading the `app/utils/sentry.js`
script...I think).

## WHAT
Same change as per Frontend:
https://github.com/alphagov/pay-frontend/pull/1122/commits/6aedbd3e2a9d98a5ad73bc349c78ce81af1dffe2

