### PR TITLE
Add autocomplete="new-password" attribute where appropriate

### DIFF
--- a/app/views/forgotten_password/new_password.njk
+++ b/app/views/forgotten_password/new_password.njk
@@ -24,7 +24,8 @@
         id: "password",
         name: "password",
         classes: "govuk-!-width-two-thirds",
-        type: "password"
+        type: "password",
+        autocomplete: "new-password"
       })
     }}
 

--- a/app/views/self_create_service/register.njk
+++ b/app/views/self_create_service/register.njk
@@ -52,6 +52,7 @@
         id: "password",
         name: "password",
         type: "password",
+        autocomplete: "new-password",
         classes: "govuk-input--width-20",
         label: {
             text: "Password",

--- a/app/views/user_registration/register.njk
+++ b/app/views/user_registration/register.njk
@@ -34,6 +34,7 @@
           id: "password",
           name: "password",
           type: "password",
+          autocomplete: "new-password",
           classes: "govuk-input--width-20",
           label: {
               text: "Password",


### PR DESCRIPTION
Add the `autocomplete="new-password"` attribute where the user enters a new password. This gives a hint to web browsers and password managers that they shouldn’t automatically fill in a new password but that they might want to suggest a new randomly- generated new password.

References:
https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-new-password
https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands
https://hacks.mozilla.org/2019/10/firefox-70-a-bountiful-release-for-all/