### PR TITLE
BAU - add function that can format PSP names nicely

### DIFF
--- a/app/utils/display_converter.js
+++ b/app/utils/display_converter.js
@@ -2,6 +2,7 @@ const _ = require('lodash')
 const url = require('url')
 const getHeldPermissions = require('./get_held_permissions')
 const { serviceNavigationItems, adminNavigationItems } = require('./navBuilder')
+const formatPSPname = require('./format-PSP-name')
 
 const hideServiceHeaderTemplates = [
   'services/index',
@@ -73,7 +74,7 @@ const addGatewayAccountProviderDisplayNames = data => {
 const getAccount = account => {
   if (account) {
     account.full_type = account.type === 'test'
-      ? [account.payment_provider, account.type].join(' ')
+      ? [formatPSPname(account.payment_provider), account.type].join(' ')
       : account.type
   }
   return account

--- a/app/utils/format-PSP-name.js
+++ b/app/utils/format-PSP-name.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = paymentProvider => {
+  switch (paymentProvider) {
+    case 'epdq': // epqd => ePDQ
+      return paymentProvider.charAt(0) + paymentProvider.slice(1).toUpperCase()
+
+    default: // worldpay => Worldpay
+      return paymentProvider.charAt(0).toUpperCase() + paymentProvider.slice(1)
+  }
+}

--- a/app/views/includes/phase_banner.njk
+++ b/app/views/includes/phase_banner.njk
@@ -4,7 +4,7 @@
     <h4 class="service-info--name govuk-heading-s">
       {{currentService.name}}
       {% if currentGatewayAccount %}
-        <strong class="environment-tag environment-tag-{{currentGatewayAccount.type}}">{% if currentGatewayAccount.full_type === 'sandbox test' or currentGatewayAccount.full_type === 'SANDBOX test' %}Test{% else %}{{currentGatewayAccount.full_type | capitalize}}{% endif %}</strong>
+        <strong class="environment-tag environment-tag-{{currentGatewayAccount.type}}">{% if currentGatewayAccount.full_type === 'Sandbox test' %}Test{% else %}{{currentGatewayAccount.full_type}}{% endif %}</strong>
       {% endif %}
     </h4>
   </div>

--- a/server.js
+++ b/server.js
@@ -25,6 +25,7 @@ const errorHandler = require('./app/middleware/express_unhandled_error_handler')
 const { nunjucksFilters } = require('@govuk-pay/pay-js-commons')
 const logger = require('./app/utils/logger')(__filename)
 const Sentry = require('./app/utils/sentry.js').initialiseSentry()
+const formatPSPname = require('./app/utils/format-PSP-name')
 
 // Global constants
 const port = (process.env.PORT || 3000)
@@ -100,6 +101,7 @@ function initialiseTemplateEngine (app) {
     let filter = nunjucksFilters[name]
     nunjucksEnvironment.addFilter(name, filter)
   }
+  nunjucksEnvironment.addFilter('formatPSPname', formatPSPname)
 }
 
 function initialisePublic (app) {

--- a/test/cypress/integration/dashboard/dashboard_spec.js
+++ b/test/cypress/integration/dashboard/dashboard_spec.js
@@ -37,7 +37,7 @@ describe('Dashboard', () => {
     it(`should have the page title 'Dashboard - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
       const dashboardUrl = `/?period=today&fromDateTime=${from}&toDateTime=${to}`
       cy.visit(dashboardUrl)
-      cy.title().should('eq', `Dashboard - ${serviceName} sandbox test - GOV.UK Pay`)
+      cy.title().should('eq', `Dashboard - ${serviceName} Sandbox test - GOV.UK Pay`)
     })
   })
 })

--- a/test/cypress/integration/settings/email_notifications_spec.js
+++ b/test/cypress/integration/settings/email_notifications_spec.js
@@ -70,9 +70,9 @@ describe('Settings', () => {
     })
 
     describe('Email notifications home page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
+      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
         cy.get('#templates-link').click()
-        cy.title().should('eq', `Email notifications - ${serviceName} sandbox test - GOV.UK Pay`)
+        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
         cy.get('#confirmation-email-template').should('contain', 'Confirmation email template')
 
         // Click the 'Refund email' tab
@@ -83,12 +83,12 @@ describe('Settings', () => {
     })
 
     describe('Email collection mode page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
+      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
         // Access the collection mode page
         cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Enter an email address')
         cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On (mandatory)')
         cy.get('.email-notifications-toggle-collection').contains('Change enter an email address settings').click()
-        cy.title().should('eq', `Email notifications - ${serviceName} sandbox test - GOV.UK Pay`)
+        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
         cy.url().should('include', '/email-settings-collection')
 
         cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to ask users for an email address on the card payment page?')
@@ -106,12 +106,12 @@ describe('Settings', () => {
     })
 
     describe('Confirmation email toggle page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
+      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
         // Access the confirmation toggle page
         cy.get('.govuk-summary-list__key').eq(2).should('contain', 'Payment confirmation emails')
         cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
         cy.get('.email-notifications-toggle-confirmation').contains('Change payment confirmation emails settings').click()
-        cy.title().should('eq', `Email notifications - ${serviceName} sandbox test - GOV.UK Pay`)
+        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
 
         cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to send payment confirmation emails?')
 
@@ -127,12 +127,12 @@ describe('Settings', () => {
     })
 
     describe('Refund email toggle page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
+      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
         // Access the refund toggle page
         cy.get('.govuk-summary-list__key').eq(3).should('contain', 'Refund emails')
         cy.get('.govuk-summary-list__value').eq(3).should('contain', 'On')
         cy.get('.email-notifications-toggle-refund').contains('Change refund emails settings').click()
-        cy.title().should('eq', `Email notifications - ${serviceName} sandbox test - GOV.UK Pay`)
+        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
 
         cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to send refund emails?')
 
@@ -212,10 +212,10 @@ describe('Settings', () => {
     })
 
     describe('Email notifications home page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
+      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
         // Default notifications page and confirmation email tab contents
         cy.get('#templates-link').click()
-        cy.title().should('eq', `Email notifications - ${serviceName} sandbox test - GOV.UK Pay`)
+        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
         cy.get('#confirmation-email-template').should('contain', 'Confirmation email template')
 
         // Click the 'Refund email' tab
@@ -226,12 +226,12 @@ describe('Settings', () => {
     })
 
     describe('Email collection mode page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
+      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
         // Access the collection mode page
         cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Enter an email address')
         cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On (mandatory)')
         cy.get('.email-notifications-toggle-collection').contains('View enter an email address settings').click()
-        cy.title().should('eq', `Email notifications - ${serviceName} sandbox test - GOV.UK Pay`)
+        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
         cy.url().should('include', '/email-settings-collection')
 
         cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to ask users for an email address on the card payment page?')
@@ -245,12 +245,12 @@ describe('Settings', () => {
     })
 
     describe('Confirmation email toggle page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
+      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
         // Access the confirmation toggle page
         cy.get('.govuk-summary-list__key').eq(2).should('contain', 'Payment confirmation emails')
         cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
         cy.get('.email-notifications-toggle-confirmation').contains('View payment confirmation emails settings').click()
-        cy.title().should('eq', `Email notifications - ${serviceName} sandbox test - GOV.UK Pay`)
+        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
 
         cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to send payment confirmation emails?')
 
@@ -263,12 +263,12 @@ describe('Settings', () => {
     })
 
     describe('Refund email toggle page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
+      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
         // Access the refund toggle page
         cy.get('.govuk-summary-list__key').eq(3).should('contain', 'Refund emails')
         cy.get('.govuk-summary-list__value').eq(3).should('contain', 'On')
         cy.get('.email-notifications-toggle-refund').contains('View refund emails settings').click()
-        cy.title().should('eq', `Email notifications - ${serviceName} sandbox test - GOV.UK Pay`)
+        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
 
         cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to send refund emails?')
 

--- a/test/cypress/integration/transactions/transaction_details_spec.js
+++ b/test/cypress/integration/transactions/transaction_details_spec.js
@@ -120,7 +120,7 @@ describe('Transaction details page', () => {
       cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
 
       // Ensure page title is correct
-      cy.title().should('eq', `Transaction details ${transactionDetails.reference} - ${serviceName} sandbox test - GOV.UK Pay`)
+      cy.title().should('eq', `Transaction details ${transactionDetails.reference} - ${serviceName} Sandbox test - GOV.UK Pay`)
 
       // Ensure page details match up
       // Reference number
@@ -173,7 +173,7 @@ describe('Transaction details page', () => {
       cy.visit(`${transactionsUrl}/${aDelayedCaptureTransaction.transaction_id}`)
 
       // Ensure page title is correct
-      cy.title().should('eq', `Transaction details ${aDelayedCaptureTransaction.reference} - ${serviceName} sandbox test - GOV.UK Pay`)
+      cy.title().should('eq', `Transaction details ${aDelayedCaptureTransaction.reference} - ${serviceName} Sandbox test - GOV.UK Pay`)
 
       // Ensure page details match up
       // Reference number
@@ -229,7 +229,7 @@ describe('Transaction details page', () => {
       cy.visit(`${transactionsUrl}/${aCorporateCardSurchargeTransaction.transaction_id}`)
 
       // Ensure page title is correct
-      cy.title().should('eq', `Transaction details ${aCorporateCardSurchargeTransaction.reference} - ${serviceName} sandbox test - GOV.UK Pay`)
+      cy.title().should('eq', `Transaction details ${aCorporateCardSurchargeTransaction.reference} - ${serviceName} Sandbox test - GOV.UK Pay`)
 
       // Ensure page details match up
       // Amount

--- a/test/cypress/integration/transactions/transaction_search_spec.js
+++ b/test/cypress/integration/transactions/transaction_search_spec.js
@@ -160,8 +160,8 @@ describe('Transactions', () => {
       cy.visit(transactionsUrl)
     })
     describe('Transactions List', () => {
-      it(`should have the page title 'Transactions - ${serviceName} sandbox test - GOV.UK Pay'`, () => {
-        cy.title().should('eq', `Transactions - ${serviceName} sandbox test - GOV.UK Pay`)
+      it(`should have the page title 'Transactions - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
+        cy.title().should('eq', `Transactions - ${serviceName} Sandbox test - GOV.UK Pay`)
       })
 
       describe('Filtering', () => {

--- a/test/integration/get_gateway_account_ft_test.js
+++ b/test/integration/get_gateway_account_ft_test.js
@@ -71,7 +71,7 @@ describe('get account', function () {
           type: 'test',
           payment_provider: 'sandbox',
           supports3ds: false,
-          full_type: 'sandbox test'
+          full_type: 'Sandbox test'
         })
       })
       .end(done)
@@ -111,7 +111,7 @@ describe('get account', function () {
         expect(data.body.currentGatewayAccount).to.deep.equal({
           type: 'test',
           payment_provider: 'sandbox',
-          full_type: 'sandbox test',
+          full_type: 'Sandbox test',
           paymentProvider: 'sandbox',
           paymentMethod: 'direct debit'
         })

--- a/test/unit/utils/format-PSP-name.test.js
+++ b/test/unit/utils/format-PSP-name.test.js
@@ -1,0 +1,16 @@
+'use strict'
+
+// NPM dependencies
+const { expect } = require('chai')
+
+// Local dependencies
+const formatPSPname = require('../../../app/utils/format-PSP-name')
+
+describe('When a payment provider name is passed to the function', () => {
+  it('it should convert it from all lowercase to capitalised', () => {
+    expect(formatPSPname('worldpay')).to.equal('Worldpay')
+  })
+  it('unless it’s epdq when it should do something special', () => {
+    expect(formatPSPname('epdq')).to.equal('ePDQ')
+  })
+})


### PR DESCRIPTION
Before we use to just capitalise them which doesn't looks great for ePDQ as it came out like Epdq, which is a shame. Now it comes out how it should do