### PR TITLE
PP-5777 Add environment field to logs

### DIFF
--- a/app/utils/logger.js
+++ b/app/utils/logger.js
@@ -7,7 +7,7 @@ const logger = createLogger({
   format: format.combine(
     splat(),
     prettyPrint(),
-    govUkPayLoggingFormat({ container: 'selfservice' }),
+    govUkPayLoggingFormat({ container: 'selfservice', environment: process.env.ENVIRONMENT }),
     json()
   ),
   transports: [

--- a/test/test_helpers/supress_logs.js
+++ b/test/test_helpers/supress_logs.js
@@ -1,4 +1,4 @@
 'use strict'
 
-const winston = require('winston')
-winston.remove(winston.transports.Console)
+const logger = require('../../app/utils/logger')(__filename)
+logger.transports.forEach(t => (t.silent = true))


### PR DESCRIPTION
Add an 'environment' field to the logs, so that it is possible to filter
by environment using a Splunk text search. Splunk does currently extract
the environment from the source if it is explicitly searched on using
e.g. the term 'environment="production-2"', but some of our reports use
a text search so will not pick up on all log lines.

The text search continues to work for many logs where the environment is
included in some way in the log message, but not for others where it
isn't so it makes sense to get rid of this ambiguity.

In the apps producing the logs, we get the environment from an
environment variable which is already configured for use by Sentry.


