### PR TITLE
PP-5760 Don't log error when error page shown for BAU errors

### DIFF
--- a/app/utils/response.js
+++ b/app/utils/response.js
@@ -1,6 +1,7 @@
 const _ = require('lodash')
 const logger = require('./logger')(__filename)
-let displayConverter = require('./display_converter')
+const displayConverter = require('./display_converter')
+const { CORRELATION_ID } = require('@govuk-pay/pay-js-commons').logging.keys
 
 const ERROR_MESSAGE = 'There is a problem with the payments platform'
 const ERROR_VIEW = 'error'
@@ -10,20 +11,28 @@ function response (req, res, template, data = {}) {
   render(req, res, template, convertedData)
 }
 
-function errorResponse (req, res, msg, status) {
+function errorResponse (req, res, msg, status = 500) {
   if (!msg) msg = ERROR_MESSAGE
   let correlationId = req.correlationId
   if (typeof msg !== 'string') {
     msg = 'Please try again or contact support team.'
   }
   let data = { 'message': msg }
-  logger.error(`[${correlationId}] ${status} An error has occurred. Rendering error view -`, { errorMessage: msg })
-  res.setHeader('Content-Type', 'text/html')
-  if (status) {
-    res.status(status)
-  } else {
-    res.status(500)
+
+  const errorMeta = {
+    'status': status,
+    'error_message': msg
   }
+  errorMeta[CORRELATION_ID] = correlationId
+
+  if (status === 500) {
+    logger.error('An error has occurred. Rendering error view', errorMeta)
+  } else {
+    logger.info('An error has occurred. Rendering error view', errorMeta)
+  }
+  res.setHeader('Content-Type', 'text/html')
+
+  res.status(status)
   render(req, res, ERROR_VIEW, data)
 }
 


### PR DESCRIPTION
We were logging a line at error level whenever an error page was
displayed, but we display the error page for events such as trying to
redeem an expired invite.

Only log an error if the status code is 500, not for other statuses.

Also move information in the log line into structured key/values.

