### PR TITLE
PP-5760 Changes logRequestFailure to log at info level

### DIFF
--- a/app/utils/request_logger.js
+++ b/app/utils/request_logger.js
@@ -15,7 +15,7 @@ module.exports = {
   },
 
   logRequestFailure: (context, response) => {
-    logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} failed -`, {
+    logger.info(`[${context.correlationId}] Calling ${context.service} to ${context.description} failed -`, {
       service: context.service,
       method: context.method,
       url: context.url,


### PR DESCRIPTION
## WHAT
This PR ensures that errors involving user authentication aren't sent to Sentry. This is done by changing the logger in logRequestFailure to log at .info level.

