### PR TITLE
PP-5760-Remove logging invitation error for existing user

### DIFF
--- a/app/controllers/invite_user_controller.js
+++ b/app/controllers/invite_user_controller.js
@@ -83,13 +83,12 @@ module.exports = {
           res.redirect(303, formattedPathFor(paths.teamMembers.index, externalServiceId))
         })
         .catch(err => {
-          logger.error(`[requestId=${req.correlationId}]  Unable to send invitation to user - ` + JSON.stringify(err))
-
           switch (err.errorCode) {
             case 412:
               successResponse(req, res, 'error_logged_in', messages.emailConflict(invitee, externalServiceId))
               break
             default:
+              logger.error(`[requestId=${req.correlationId}]  Unable to send invitation to user - ` + JSON.stringify(err))
               errorResponse(req, res, messages.inviteError, 200)
           }
         })


### PR DESCRIPTION
## WHAT

Description:
- We log to Sentry when we don't sending an invitation to a user that already exists
- To fix this I've moved the logger underneath the default statement




