### PR TITLE
PP-5760 Specify status code when rendering error page

### DIFF
--- a/app/controllers/create_service_controller.js
+++ b/app/controllers/create_service_controller.js
@@ -4,11 +4,11 @@
 const lodash = require('lodash')
 
 // Local Dependencies
-const responses = require('../utils/response')
+const { renderErrorView, response } = require('../utils/response')
 const paths = require('../paths')
 const serviceService = require('../services/service_service')
 const userService = require('../services/user_service')
-const {validateServiceName} = require('../utils/service_name_validation')
+const { validateServiceName } = require('../utils/service_name_validation')
 
 exports.get = (req, res) => {
   let pageData = lodash.get(req, 'session.pageData.createServiceName')
@@ -24,7 +24,7 @@ exports.get = (req, res) => {
   pageData.submit_link = paths.serviceSwitcher.create
   pageData.my_services = paths.serviceSwitcher.index
 
-  return responses.response(req, res, 'services/add_service', pageData)
+  return response(req, res, 'services/add_service', pageData)
 }
 
 exports.post = (req, res) => {
@@ -36,7 +36,7 @@ exports.post = (req, res) => {
   const validationErrorsCy = validateServiceName(serviceNameCy, 'service_name_cy', false)
   if (Object.keys(validationErrors).length || Object.keys(validationErrorsCy).length) {
     lodash.set(req, 'session.pageData.createServiceName', {
-      errors: {...validationErrors, ...validationErrorsCy},
+      errors: { ...validationErrors, ...validationErrorsCy },
       current_name: serviceName,
       current_name_cy: serviceNameCy
     })
@@ -48,7 +48,7 @@ exports.post = (req, res) => {
         res.redirect(paths.serviceSwitcher.index)
       })
       .catch(err => {
-        responses.renderErrorView(req, res, err)
+        renderErrorView(req, res, err)
       })
   }
 }

--- a/app/controllers/forgotten_password_controller.js
+++ b/app/controllers/forgotten_password_controller.js
@@ -3,7 +3,7 @@
 // Local dependencies
 const emailValidator = require('../utils/email_tools.js')
 const paths = require('../paths.js')
-const errorView = require('../utils/response.js').renderErrorView
+const { renderErrorView } = require('../utils/response.js')
 const userService = require('../services/user_service.js')
 
 module.exports = {
@@ -40,8 +40,8 @@ module.exports = {
   newPasswordGet: (req, res) => {
     const id = req.params.id
     const render = (user) => {
-      if (!user) return errorView(req, res)
-      res.render('forgotten_password/new_password', {id: id})
+      if (!user) return renderErrorView(req, res)
+      res.render('forgotten_password/new_password', { id: id })
     }
 
     return userService.findByResetToken(id).then(render, () => {
@@ -58,7 +58,7 @@ module.exports = {
         return userService.findByExternalId(forgottenPassword.user_external_id, req.correlationId)
       })
       .then(function (user) {
-        if (!user) return errorView(req, res)
+        if (!user) return renderErrorView(req, res)
         reqUser = user
         return userService.updatePassword(req.params.id, req.body.password)
       })

--- a/app/controllers/invite_user_controller.js
+++ b/app/controllers/invite_user_controller.js
@@ -1,10 +1,8 @@
 const lodash = require('lodash')
 const logger = require('../utils/logger')(__filename)
-const response = require('../utils/response.js')
+const { renderErrorView, response } = require('../utils/response.js')
 const userService = require('../services/user_service.js')
 const paths = require('../paths.js')
-const successResponse = response.response
-const errorResponse = response.renderErrorView
 const rolesModule = require('../utils/roles')
 const emailValidator = require('../utils/email_tools.js')
 
@@ -51,7 +49,7 @@ module.exports = {
       invitee
     }
 
-    return successResponse(req, res, 'team-members/team_member_invite', data)
+    return response(req, res, 'team-members/team_member_invite', data)
   },
 
   /**
@@ -74,7 +72,7 @@ module.exports = {
       res.redirect(303, formattedPathFor(paths.teamMembers.invite, externalServiceId))
     } else if (!role) {
       logger.error(`[requestId=${correlationId}] cannot identify role from user input ${roleId}`)
-      errorResponse(req, res, messages.inviteError, 200)
+      renderErrorView(req, res, messages.inviteError, 200)
     } else {
       userService.inviteUser(invitee, senderId, externalServiceId, role.name, correlationId)
         .then(() => {
@@ -85,11 +83,11 @@ module.exports = {
         .catch(err => {
           switch (err.errorCode) {
             case 412:
-              successResponse(req, res, 'error_logged_in', messages.emailConflict(invitee, externalServiceId))
+              response(req, res, 'error_logged_in', messages.emailConflict(invitee, externalServiceId))
               break
             default:
               logger.error(`[requestId=${req.correlationId}]  Unable to send invitation to user - ` + JSON.stringify(err))
-              errorResponse(req, res, messages.inviteError, 200)
+              renderErrorView(req, res, messages.inviteError, 200)
           }
         })
     }

--- a/app/controllers/invite_validation_controller.js
+++ b/app/controllers/invite_validation_controller.js
@@ -2,8 +2,7 @@
 
 // Custom dependencies
 const logger = require('../utils/logger')(__filename)
-const response = require('../utils/response')
-const errorResponse = response.renderErrorView
+const { renderErrorView } = require('../utils/response')
 const validateInviteService = require('../services/validate_invite_service')
 const serviceRegistrationService = require('../services/service_registration_service')
 const paths = require('../paths')
@@ -21,13 +20,13 @@ const handleError = (req, res, err) => {
 
   switch (err.errorCode) {
     case 404:
-      errorResponse(req, res, messages.missingCookie, 404)
+      renderErrorView(req, res, messages.missingCookie, 404)
       break
     case 410:
-      errorResponse(req, res, messages.linkExpired, 410)
+      renderErrorView(req, res, messages.linkExpired, 410)
       break
     default:
-      errorResponse(req, res, messages.internalError, 500)
+      renderErrorView(req, res, messages.internalError, 500)
   }
 }
 

--- a/app/controllers/login/otp-login-controller.js
+++ b/app/controllers/login/otp-login-controller.js
@@ -3,7 +3,7 @@
 // Custom dependencies
 const logger = require('../../utils/logger')(__filename)
 const userService = require('../../services/user_service')
-const errorView = require('../../utils/response').renderErrorView
+const { renderErrorView } = require('../../utils/response')
 const CORRELATION_HEADER = require('../../utils/correlation_header').CORRELATION_HEADER
 
 module.exports = (req, res) => {
@@ -17,7 +17,7 @@ module.exports = (req, res) => {
       res.render('login/otp-login', PAGE_PARAMS)
     })
       .catch(err => {
-        errorView(req, res)
+        renderErrorView(req, res)
         logger.error(err)
       })
   } else {

--- a/app/controllers/login/send-again-post-controller.js
+++ b/app/controllers/login/send-again-post-controller.js
@@ -4,7 +4,7 @@
 const logger = require('../../utils/logger')(__filename)
 const userService = require('../../services/user_service')
 const paths = require('../../paths')
-const errorView = require('../../utils/response').renderErrorView
+const { renderErrorView } = require('../../utils/response')
 const CORRELATION_HEADER = require('../../utils/correlation_header').CORRELATION_HEADER
 
 module.exports = (req, res) => {
@@ -14,10 +14,10 @@ module.exports = (req, res) => {
       res.redirect(paths.user.otpLogIn)
     })
       .catch(err => {
-        errorView(req, res)
+        renderErrorView(req, res)
         logger.error(err)
       })
   } else {
-    errorView(req, res, 'You do not use text messages to sign in')
+    renderErrorView(req, res, 'You do not use text messages to sign in')
   }
 }

--- a/app/controllers/login/send-again-post-controller.js
+++ b/app/controllers/login/send-again-post-controller.js
@@ -18,6 +18,6 @@ module.exports = (req, res) => {
         logger.error(err)
       })
   } else {
-    renderErrorView(req, res, 'You do not use text messages to sign in')
+    renderErrorView(req, res, 'You do not use text messages to sign in', 400)
   }
 }

--- a/app/controllers/partnerapp/handle_gocardless_connect_get.js
+++ b/app/controllers/partnerapp/handle_gocardless_connect_get.js
@@ -43,7 +43,7 @@ function processPayload (req, res, getPayload) {
     .catch(err => {
       console.log(err)
       if (err.errorIdentifier === GO_CARDLESS_ACCOUNT_ALREADY_LINKED_TO_ANOTHER_ACCOUNT) {
-        renderErrorView(req, res, 'This GoCardless account is already connected to a GOV.UK Pay account. You’ll need to use a different account.')
+        renderErrorView(req, res, 'This GoCardless account is already connected to a GOV.UK Pay account. You’ll need to use a different account.', 400)
       } else {
         handleBadRequest(req, res, 'Failed to get the token from Direct Debit Connector', err)
       }

--- a/app/controllers/payment-links/get-edit-amount-controller.js
+++ b/app/controllers/payment-links/get-edit-amount-controller.js
@@ -9,7 +9,7 @@ const { response } = require('../../utils/response.js')
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products_client.js')
 const auth = require('../../services/auth_service.js')
-const errorView = require('../../utils/response.js').renderErrorView
+const { renderErrorView } = require('../../utils/response.js')
 const formattedPathFor = require('../../utils/replace_params_in_path')
 const supportedLanguage = require('../../models/supported-language')
 
@@ -32,6 +32,6 @@ module.exports = (req, res) => {
     })
     .catch((err) => {
       logger.error(`[requestId=${req.correlationId}] Get ADHOC product by gateway account id failed - ${err.message}`)
-      errorView(req, res, 'Internal server error')
+      renderErrorView(req, res, 'Internal server error')
     })
 }

--- a/app/controllers/payment-links/get-edit-information-controller.js
+++ b/app/controllers/payment-links/get-edit-information-controller.js
@@ -9,7 +9,7 @@ const { response } = require('../../utils/response.js')
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products_client.js')
 const auth = require('../../services/auth_service.js')
-const errorView = require('../../utils/response.js').renderErrorView
+const { renderErrorView } = require('../../utils/response.js')
 const formattedPathFor = require('../../utils/replace_params_in_path')
 const supportedLanguage = require('../../models/supported-language')
 
@@ -29,6 +29,6 @@ module.exports = (req, res) => {
     })
     .catch((err) => {
       logger.error(`[requestId=${req.correlationId}] Get ADHOC product by gateway account id failed - ${err.message}`)
-      errorView(req, res, 'Internal server error')
+      renderErrorView(req, res, 'Internal server error')
     })
 }

--- a/app/controllers/payment-links/post-edit-controller.js
+++ b/app/controllers/payment-links/post-edit-controller.js
@@ -8,7 +8,7 @@ const logger = require('../../utils/logger')(__filename)
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products_client.js')
 const auth = require('../../services/auth_service.js')
-const errorView = require('../../utils/response.js').renderErrorView
+const { renderErrorView } = require('../../utils/response.js')
 
 module.exports = (req, res) => {
   const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
@@ -23,6 +23,6 @@ module.exports = (req, res) => {
     .catch((err) => {
       console.log(err)
       logger.error(`[requestId=${req.correlationId}] update of payment link failed - ${err.message}`)
-      errorView(req, res, 'Internal server error')
+      renderErrorView(req, res, 'Internal server error')
     })
 }

--- a/app/controllers/register_service_controller.js
+++ b/app/controllers/register_service_controller.js
@@ -6,8 +6,7 @@ const _ = require('lodash')
 // Custom dependencies
 const logger = require('../utils/logger')(__filename)
 const paths = require('../paths')
-const response = require('../utils/response')
-const errorResponse = response.renderErrorView
+const { renderErrorView } = require('../utils/response')
 const serviceService = require('../services/service_service')
 const registrationService = require('../services/service_registration_service')
 const loginController = require('../controllers/login')
@@ -56,7 +55,7 @@ module.exports = {
         })
         res.redirect(303, paths.selfCreateService.confirm)
       } else {
-        errorResponse(req, res, 'Unable to process registration at this time', err.errorCode)
+        renderErrorView(req, res, 'Unable to process registration at this time', err.errorCode)
       }
     }
 
@@ -136,9 +135,9 @@ module.exports = {
       .catch(err => {
         if (err.errorCode === 409) {
           const error = (err.message && err.message.errors) ? err.message.errors : 'Unable to process registration at this time'
-          errorResponse(req, res, error, err.errorCode)
+          renderErrorView(req, res, error, err.errorCode)
         } else {
-          errorResponse(req, res, 'Unable to process registration at this time', err.errorCode || 500)
+          renderErrorView(req, res, 'Unable to process registration at this time', err.errorCode || 500)
         }
       })
   },
@@ -185,9 +184,9 @@ module.exports = {
         .catch(err => {
           logger.warn(`[requestId=${req.correlationId}] Invalid invite code attempted ${req.code}, error = ${err.errorCode}`)
           if (err.errorCode === 404) {
-            errorResponse(req, res, 'Unable to process registration at this time', 404)
+            renderErrorView(req, res, 'Unable to process registration at this time', 404)
           } else {
-            errorResponse(req, res, 'Unable to process registration at this time', 500)
+            renderErrorView(req, res, 'Unable to process registration at this time', 500)
           }
         })
     }
@@ -243,7 +242,7 @@ module.exports = {
         })
         .catch(err => {
           logger.debug(`[requestId=${correlationId}] invalid user input - service name`)
-          response.renderErrorView(req, res, err)
+          renderErrorView(req, res, err)
         })
     }
   }

--- a/app/controllers/register_user_controller.js
+++ b/app/controllers/register_user_controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
 const logger = require('../utils/logger')(__filename)
-const response = require('../utils/response')
-const errorResponse = response.renderErrorView
-const successResponse = response.response
+const { renderErrorView, response } = require('../utils/response')
 const registrationService = require('../services/user_registration_service')
 const paths = require('../paths')
 const loginController = require('./login')
@@ -27,7 +25,7 @@ const withValidatedRegistrationCookie = (req, res, next) => {
     .then(next)
     .catch(err => {
       logger.warn(`[requestId=${correlationId}] unable to validate required cookie for registration - ${err.message}`)
-      errorResponse(req, res, messages.missingCookie, 404)
+      renderErrorView(req, res, messages.missingCookie, 404)
     })
 }
 
@@ -36,13 +34,13 @@ const handleError = (req, res, err) => {
 
   switch (err.errorCode) {
     case 404:
-      errorResponse(req, res, messages.missingCookie, 404)
+      renderErrorView(req, res, messages.missingCookie, 404)
       break
     case 410:
-      errorResponse(req, res, messages.linkExpired, 410)
+      renderErrorView(req, res, messages.linkExpired, 410)
       break
     default:
-      errorResponse(req, res, messages.missingCookie, 500)
+      renderErrorView(req, res, messages.missingCookie, 500)
   }
 }
 
@@ -61,7 +59,7 @@ module.exports = {
       if (req.register_invite.telephone_number) {
         data.telephone_number = req.register_invite.telephone_number
       }
-      successResponse(req, res, 'user_registration/register', data)
+      response(req, res, 'user_registration/register', data)
     }
 
     return withValidatedRegistrationCookie(req, res, renderRegistrationPage)
@@ -130,7 +128,7 @@ module.exports = {
     }
 
     const displayVerifyCodePage = () => {
-      successResponse(req, res, 'user_registration/verify_otp', data)
+      response(req, res, 'user_registration/verify_otp', data)
     }
 
     return withValidatedRegistrationCookie(req, res, displayVerifyCodePage)
@@ -190,7 +188,7 @@ module.exports = {
       const data = {
         telephone_number: telephoneNumber
       }
-      successResponse(req, res, 'user_registration/re_verify_phone', data)
+      response(req, res, 'user_registration/re_verify_phone', data)
     }
 
     return withValidatedRegistrationCookie(req, res, displayReVerifyCodePage)

--- a/app/controllers/service_roles_update_controller.js
+++ b/app/controllers/service_roles_update_controller.js
@@ -60,7 +60,7 @@ module.exports = {
     }
 
     if (req.user.externalId === externalUserId) {
-      renderErrorView(req, res, 'Not allowed to update self permission')
+      renderErrorView(req, res, 'Not allowed to update self permission', 403)
       return
     }
 
@@ -96,7 +96,7 @@ module.exports = {
     }
 
     if (req.user.externalId === externalUserId) {
-      renderErrorView(req, res, 'Not allowed to update self permission')
+      renderErrorView(req, res, 'Not allowed to update self permission', 403)
       return
     }
 

--- a/app/controllers/service_users_controller.js
+++ b/app/controllers/service_users_controller.js
@@ -121,7 +121,7 @@ module.exports = {
           removeTeamMemberLink: removeTeamMemberLink
         })
       } else {
-        renderErrorView(req, res, 'You do not have the rights to access this service.')
+        renderErrorView(req, res, 'You do not have the rights to access this service.', 403)
       }
     }
 
@@ -142,7 +142,7 @@ module.exports = {
     const correlationId = req.correlationId
 
     if (userToRemoveExternalId === removerExternalId) {
-      renderErrorView(req, res, 'Not allowed to delete a user itself')
+      renderErrorView(req, res, 'Not allowed to delete a user itself', 403)
       return
     }
 

--- a/app/controllers/service_users_controller.js
+++ b/app/controllers/service_users_controller.js
@@ -1,11 +1,9 @@
 const _ = require('lodash')
 
 const logger = require('../utils/logger')(__filename)
-const response = require('../utils/response.js')
+const { renderErrorView, response } = require('../utils/response.js')
 const userService = require('../services/user_service.js')
 const paths = require('../paths.js')
-const successResponse = response.response
-const errorResponse = response.renderErrorView
 const roles = require('../utils/roles').roles
 
 const formattedPathFor = require('../utils/replace_params_in_path')
@@ -69,7 +67,7 @@ module.exports = {
       const invitedTeamMembers = mapInvitesByRoles(invitedMembers)
       const inviteTeamMemberLink = formattedPathFor(paths.teamMembers.invite, externalServiceId)
 
-      successResponse(req, res, 'team-members/team_members', {
+      response(req, res, 'team-members/team_members', {
         team_members: teamMembers,
         number_active_members: numberActiveMembers,
         inviteTeamMemberLink: inviteTeamMemberLink,
@@ -90,7 +88,7 @@ module.exports = {
       .then(onSuccess)
       .catch((err) => {
         logger.error(`[requestId=${req.correlationId}] error retrieving users for service ${externalServiceId}. [${err}]`)
-        errorResponse(req, res, 'Unable to retrieve the services users')
+        renderErrorView(req, res, 'Unable to retrieve the services users')
       })
   },
 
@@ -114,7 +112,7 @@ module.exports = {
       const teamMemberIndexLink = formattedPathFor(paths.teamMembers.index, externalServiceId)
 
       if (roleInList && hasSameService) {
-        successResponse(req, res, 'team-members/team_member_details', {
+        response(req, res, 'team-members/team_member_details', {
           username: user.username,
           email: user.email,
           role: roleInList.description,
@@ -123,13 +121,13 @@ module.exports = {
           removeTeamMemberLink: removeTeamMemberLink
         })
       } else {
-        errorResponse(req, res, 'You do not have the rights to access this service.')
+        renderErrorView(req, res, 'You do not have the rights to access this service.')
       }
     }
 
     return userService.findByExternalId(externalUserId)
       .then(onSuccess)
-      .catch(() => errorResponse(req, res, 'Unable to retrieve user'))
+      .catch(() => renderErrorView(req, res, 'Unable to retrieve user'))
   },
 
   /**
@@ -144,7 +142,7 @@ module.exports = {
     const correlationId = req.correlationId
 
     if (userToRemoveExternalId === removerExternalId) {
-      errorResponse(req, res, 'Not allowed to delete a user itself')
+      renderErrorView(req, res, 'Not allowed to delete a user itself')
       return
     }
 
@@ -165,7 +163,7 @@ module.exports = {
         },
         enable_link: true
       }
-      successResponse(req, res, 'error_logged_in', messageUserHasBeenDeleted)
+      response(req, res, 'error_logged_in', messageUserHasBeenDeleted)
     }
 
     return userService.findByExternalId(userToRemoveExternalId, correlationId)
@@ -181,7 +179,7 @@ module.exports = {
    */
   profile: (req, res) => {
     const onSuccess = (user) => {
-      successResponse(req, res, 'team-members/team_member_profile', {
+      response(req, res, 'team-members/team_member_profile', {
         username: user.username,
         email: user.email,
         telephone_number: user.telephoneNumber,
@@ -192,6 +190,6 @@ module.exports = {
 
     return userService.findByExternalId(req.user.externalId)
       .then(onSuccess)
-      .catch(() => errorResponse(req, res, 'Unable to retrieve user'))
+      .catch(() => renderErrorView(req, res, 'Unable to retrieve user'))
   }
 }

--- a/app/controllers/test_with_your_users/links_controller.js
+++ b/app/controllers/test_with_your_users/links_controller.js
@@ -5,7 +5,7 @@ const { response } = require('../../utils/response.js')
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products_client.js')
 const authService = require('../../services/auth_service.js')
-const errorView = require('../../utils/response.js').renderErrorView
+const { renderErrorView } = require('../../utils/response.js')
 
 module.exports = (req, res) => {
   const params = {
@@ -24,6 +24,6 @@ module.exports = (req, res) => {
     })
     .catch((err) => {
       logger.error(`[requestId=${req.correlationId}] Get PROTOTYPE product by gateway account id failed - ${err.message}`)
-      errorView(req, res, 'Internal server error')
+      renderErrorView(req, res, 'Internal server error')
     })
 }

--- a/app/controllers/transactions/transaction_detail_controller.js
+++ b/app/controllers/transactions/transaction_detail_controller.js
@@ -3,9 +3,9 @@
 // Local Dependencies
 const Charge = require('../../models/charge.js')
 const auth = require('../../services/auth_service.js')
-const {response} = require('../../utils/response.js')
-const {renderErrorView} = require('../../utils/response.js')
-const {CORRELATION_HEADER} = require('../../utils/correlation_header.js')
+const { response } = require('../../utils/response.js')
+const { renderErrorView } = require('../../utils/response.js')
+const { CORRELATION_HEADER } = require('../../utils/correlation_header.js')
 
 const defaultMsg = 'Error processing transaction view'
 const notFound = 'Charge not found'
@@ -22,6 +22,10 @@ module.exports = (req, res) => {
       response(req, res, 'transaction_detail/index', data)
     })
     .catch(err => {
-      renderErrorView(req, res, err === 'NOT_FOUND' ? notFound : defaultMsg)
+      if (err === 'NOT_FOUND') {
+        renderErrorView(req, res, notFound, 404)
+      } else {
+        renderErrorView(req, res, defaultMsg, 500)
+      }
     })
 }

--- a/app/middleware/csrf.js
+++ b/app/middleware/csrf.js
@@ -5,7 +5,7 @@ const csrf = require('csrf')
 
 // Local Dependencies
 const logger = require('../utils/logger')(__filename)
-const errorView = require('../utils/response.js').renderErrorView
+const { renderErrorView } = require('../utils/response.js')
 const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
 
 // Assignments and Variables
@@ -22,17 +22,17 @@ function validateAndRefreshCsrf (req, res, next) {
   let session = req.session
   if (!session) {
     logger.warn('Session is not defined')
-    return errorView(req, res, errorMsg, 400)
+    return renderErrorView(req, res, errorMsg, 400)
   }
 
   if (!session.csrfSecret) {
     logger.warn('CSRF secret is not defined for session')
-    return errorView(req, res, errorMsg, 400)
+    return renderErrorView(req, res, errorMsg, 400)
   }
 
   if (req.method !== 'GET' && !isValidCsrf(req)) {
     logger.warn('CSRF secret provided is invalid')
-    return errorView(req, res, errorMsg, 400)
+    return renderErrorView(req, res, errorMsg, 400)
   }
 
   res.locals.csrf = csrf().create(session.csrfSecret)

--- a/app/middleware/get_email_notification.js
+++ b/app/middleware/get_email_notification.js
@@ -1,5 +1,5 @@
 'use strict'
-const errorView = require('../utils/response.js').renderErrorView
+const { renderErrorView } = require('../utils/response.js')
 const Email = require('../models/email.js')
 const _ = require('lodash')
 const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
@@ -10,5 +10,5 @@ module.exports = function (req, res, next) {
       req.account = _.merge(req.account, emailData)
       next()
     })
-    .catch(() => errorView(req, res))
+    .catch(() => renderErrorView(req, res))
 }

--- a/test/integration/service_roles_update_ft_test.js
+++ b/test/integration/service_roles_update_ft_test.js
@@ -37,7 +37,7 @@ describe('user permissions update controller', function () {
         name: 'System Generated',
         external_id: EXTERNAL_SERVICE_ID
       },
-      role: {name: 'admin', description: 'Administrator', permissions: [{name: 'users-service:create'}]}
+      role: { name: 'admin', description: 'Administrator', permissions: [{ name: 'users-service:create' }] }
     }]
   })
 
@@ -50,7 +50,7 @@ describe('user permissions update controller', function () {
         name: 'System Generated',
         external_id: EXTERNAL_SERVICE_ID
       },
-      role: {name: 'view-only', description: 'View only', permissions: []}
+      role: { name: 'view-only', description: 'View only', permissions: [] }
     }]
   }
 
@@ -128,7 +128,7 @@ describe('user permissions update controller', function () {
       supertest(app)
         .get(formattedPathFor(paths.teamMembers.permissions, EXTERNAL_SERVICE_ID, userInSession.externalId))
         .set('Accept', 'application/json')
-        .expect(500)
+        .expect(403)
         .expect((res) => {
           expect(res.body.message).to.equal('Not allowed to update self permission')
         })
@@ -143,7 +143,7 @@ describe('user permissions update controller', function () {
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
         .reply(200, getUserResponse.getPlain())
 
-      adminusersMock.put(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}/services/${EXTERNAL_SERVICE_ID}`, {'role_name': 'admin'})
+      adminusersMock.put(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}/services/${EXTERNAL_SERVICE_ID}`, { 'role_name': 'admin' })
         .reply(200, getUserResponse.getPlain())
 
       app = session.getAppWithLoggedInUser(getApp(), userInSession)
@@ -168,7 +168,7 @@ describe('user permissions update controller', function () {
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
         .reply(200, getUserResponse.getPlain())
 
-      adminusersMock.put(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}/services/${EXTERNAL_SERVICE_ID}`, {'role_name': 'view-only'})
+      adminusersMock.put(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}/services/${EXTERNAL_SERVICE_ID}`, { 'role_name': 'view-only' })
         .reply(200, getUserResponse.getPlain())
 
       app = session.getAppWithLoggedInUser(getApp(), userInSession)
@@ -199,7 +199,7 @@ describe('user permissions update controller', function () {
           'role-input': roles['admin'].extId,
           csrfToken: csrf().create('123')
         })
-        .expect(500)
+        .expect(403)
         .expect((res) => {
           expect(res.body.message).to.equal('Not allowed to update self permission')
         })
@@ -281,7 +281,7 @@ describe('user permissions update controller', function () {
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
         .reply(200, getUserResponse.getPlain())
 
-      adminusersMock.put(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}/services/${EXTERNAL_SERVICE_ID}`, {'role_name': 'admin'})
+      adminusersMock.put(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}/services/${EXTERNAL_SERVICE_ID}`, { 'role_name': 'admin' })
         .reply(409)
 
       supertest(app)

--- a/test/integration/transaction_details_ft_tests.js
+++ b/test/integration/transaction_details_ft_tests.js
@@ -58,7 +58,7 @@ describe('The transaction view scenarios', function () {
         .reply(404, ledgerError)
 
       whenGetTransactionHistory(nonExistentTransactionId, app)
-        .expect(500, { 'message': 'Charge not found' })
+        .expect(404, { 'message': 'Charge not found' })
         .end(done)
     })
 

--- a/test/unit/controller/create_service_controller/get_test.js
+++ b/test/unit/controller/create_service_controller/get_test.js
@@ -2,17 +2,21 @@
 
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const mockResponses = {}
-const createServiceCtrl = proxyquire('../../../../app/controllers/create_service_controller', {
-  '../utils/response': mockResponses
-})
 let req, res
+
+const getController = function (mockResponses) {
+  return proxyquire('../../../../app/controllers/create_service_controller', {
+    '../utils/response': mockResponses
+  })
+}
 
 describe('Controller: createService, Method: get', () => {
   describe('when there is no pre-existing pageData', () => {
     before(() => {
       mockResponses.response = sinon.spy()
+      const createServiceCtrl = getController(mockResponses)
       res = {}
       req = {}
       createServiceCtrl.get(req, res)
@@ -49,6 +53,7 @@ describe('Controller: createService, Method: get', () => {
   describe('when there is pre-existing pageData', () => {
     before(() => {
       mockResponses.response = sinon.spy()
+      const createServiceCtrl = getController(mockResponses)
       res = {}
       req = {
         session: {

--- a/test/unit/controller/create_service_controller/post_test.js
+++ b/test/unit/controller/create_service_controller/post_test.js
@@ -2,26 +2,30 @@
 
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const random = require('../../../../app/utils/random')
 const mockResponses = {}
 const mockServiceService = {}
 const mockUserService = {}
-const addServiceCtrl = proxyquire('../../../../app/controllers/create_service_controller', {
-  '../utils/response': mockResponses,
-  '../services/service_service': mockServiceService,
-  '../services/user_service': mockUserService
-})
 let req, res
+
+const getController = function (mockResponses, mockServiceService, mockUserService) {
+  return proxyquire('../../../../app/controllers/create_service_controller', {
+    '../utils/response': mockResponses,
+    '../services/service_service': mockServiceService,
+    '../services/user_service': mockUserService
+  })
+}
 
 describe('Controller: createService, Method: post', () => {
   describe('when the service name is not empty', () => {
     before(done => {
-      mockServiceService.createService = sinon.stub().resolves({external_id: 'r378y387y8weriyi'})
+      mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
       mockUserService.assignServiceRole = sinon.stub().resolves()
       mockResponses.response = sinon.spy()
+      const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)
       req = {
-        user: {externalId: '38475y38q4758ow4'},
+        user: { externalId: '38475y38q4758ow4' },
         correlationId: random.randomUuid(),
         body: {
           'service-name': 'A brand spanking new service name',
@@ -49,6 +53,7 @@ describe('Controller: createService, Method: post', () => {
     before(done => {
       mockServiceService.createService = sinon.stub().rejects(new Error('something went wrong'))
       mockResponses.renderErrorView = sinon.spy()
+      const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)
       req = {
         correlationId: random.randomUuid(),
         body: {
@@ -76,11 +81,12 @@ describe('Controller: createService, Method: post', () => {
 
   describe('when the service name is not empty, and the create service succeeds, but the assign service role call fails', () => {
     before(done => {
-      mockServiceService.createService = sinon.stub().resolves({external_id: 'r378y387y8weriyi'})
+      mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
       mockUserService.assignServiceRole = sinon.stub().rejects(new Error('something went wrong'))
       mockResponses.renderErrorView = sinon.spy()
+      const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)
       req = {
-        user: {externalId: '38475y38q4758ow4'},
+        user: { externalId: '38475y38q4758ow4' },
         correlationId: random.randomUuid(),
         body: {
           'service-name': 'A brand spanking new service name',
@@ -107,12 +113,13 @@ describe('Controller: createService, Method: post', () => {
 
   describe('when the service name is empty', () => {
     before(done => {
-      mockServiceService.createService = sinon.stub().resolves({external_id: 'r378y387y8weriyi'})
+      mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
       mockUserService.assignServiceRole = sinon.stub().resolves()
       mockResponses.response = sinon.spy()
+      const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)
       req = {
         correlationId: random.randomUuid(),
-        user: {externalId: '38475y38q4758ow4'},
+        user: { externalId: '38475y38q4758ow4' },
         body: {
           'service-name': ''
         }
@@ -135,7 +142,7 @@ describe('Controller: createService, Method: post', () => {
 
     it(`should set prexisting pageData that includes the 'current_name' and errors`, () => {
       expect(req.session.pageData.createServiceName).to.have.property('current_name').to.equal(req.body['service-name'])
-      expect(req.session.pageData.createServiceName).to.have.property('errors').to.deep.equal({service_name: 'This field cannot be blank'})
+      expect(req.session.pageData.createServiceName).to.have.property('errors').to.deep.equal({ service_name: 'This field cannot be blank' })
     })
   })
 
@@ -144,6 +151,7 @@ describe('Controller: createService, Method: post', () => {
       mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
       mockUserService.assignServiceRole = sinon.stub().resolves()
       mockResponses.response = sinon.spy()
+      const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)
       req = {
         user: { externalId: '38475y38q4758ow4' },
         correlationId: random.randomUuid(),
@@ -174,6 +182,7 @@ describe('Controller: createService, Method: post', () => {
       mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
       mockUserService.assignServiceRole = sinon.stub().resolves()
       mockResponses.response = sinon.spy()
+      const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)
       req = {
         user: { externalId: '38475y38q4758ow4' },
         correlationId: random.randomUuid(),


### PR DESCRIPTION
When we display an error page for a BAU error rather than an internal error, specify a non-500 status code so that it doesn't send a 500 status by default. This also prevents an error from being logged for these cases.

The first commit in the PR has some refactoring to improve the way we require the response methods.

I'd recommend looking at the 2 commits separately, as it will be easier to see the changes.

