### PR TITLE
PP-5760 Remove trailing dashes in log lines

### DIFF
--- a/app/controllers/credentials_controller.js
+++ b/app/controllers/credentials_controller.js
@@ -105,7 +105,7 @@ module.exports = {
       return res.redirect(paths.notificationCredentials.edit)
     }
 
-    logger.info('Calling connector to update provider notification credentials -', {
+    logger.info('Calling connector to update provider notification credentials', {
       service: 'connector',
       method: 'POST',
       url: '/frontend/accounts/{id}/notification-credentials'
@@ -127,14 +127,14 @@ module.exports = {
       var duration = new Date() - startTime
       logger.info(`[${correlationId}] - POST to ${url} ended - elapsed time: ${duration} ms`)
       if (connectorResponse && connectorResponse.statusCode) {
-        logger.error(`[${correlationId}] Calling connector to update provider notification credentials failed -`, {
+        logger.error(`[${correlationId}] Calling connector to update provider notification credentials failed`, {
           service: 'connector',
           method: 'POST',
           url: connectorUrl,
           status: connectorResponse.statusCode
         })
       } else {
-        logger.error(`[${correlationId}] Calling connector to update provider notification credentials threw exception  -`, {
+        logger.error(`[${correlationId}] Calling connector to update provider notification credentials threw exception`, {
           service: 'connector',
           method: 'POST',
           url: connectorUrl,
@@ -147,7 +147,7 @@ module.exports = {
   },
 
   update: function (req, res) {
-    logger.debug('Calling connector to update provider credentials -', {
+    logger.debug('Calling connector to update provider credentials', {
       service: 'connector',
       method: 'PATCH',
       url: '/frontend/accounts/{id}/credentials'
@@ -155,7 +155,7 @@ module.exports = {
     var accountId = auth.getCurrentGatewayAccountId(req)
     var connectorUrl = CONNECTOR_URL + '/v1/frontend/accounts/{accountId}/credentials'
 
-    logger.info('Calling connector to update provider credentials -', {
+    logger.info('Calling connector to update provider credentials', {
       service: 'connector',
       method: 'PATCH',
       url: '/frontend/accounts/{id}/credentials'
@@ -177,14 +177,14 @@ module.exports = {
       logger.info(`[${correlationId}] - PATCH to ${url} ended - elapsed time: ${duration} ms`)
 
       if (connectorResponse && connectorResponse.statusCode) {
-        logger.error(`[${correlationId}] Calling connector to update provider credentials failed. Redirecting back to credentials view -`, {
+        logger.error(`[${correlationId}] Calling connector to update provider credentials failed. Redirecting back to credentials view`, {
           service: 'connector',
           method: 'PATCH',
           url: connectorUrl,
           status: connectorResponse.statusCode
         })
       } else {
-        logger.error(`[${correlationId}] Calling connector to update provider credentials threw exception  -`, {
+        logger.error(`[${correlationId}] Calling connector to update provider credentials threw exception`, {
           service: 'connector',
           method: 'PATCH',
           url: connectorUrl,

--- a/app/controllers/dashboard/dashboard-activity-controller.js
+++ b/app/controllers/dashboard/dashboard-activity-controller.js
@@ -138,7 +138,7 @@ module.exports = (req, res) => {
         .catch((error, ledgerResponse) => {
           subsegment.close(error)
           const status = _.get(ledgerResponse, 'statusCode', 404)
-          logger.error(`[${correlationId}] Calling ledger to get transactions summary failed -`, {
+          logger.error(`[${correlationId}] Calling ledger to get transactions summary failed`, {
             service: 'ledger',
             method: 'GET',
             status,
@@ -151,7 +151,7 @@ module.exports = (req, res) => {
         })
     }, clsSegment)
   } catch (err) {
-    logger.error(`[${correlationId}] ${err.message} -`, {
+    logger.error(`[${correlationId}] ${err.message}`, {
       service: 'frontend',
       method: 'GET',
       error: err,

--- a/app/controllers/transactions/transaction_download_controller.js
+++ b/app/controllers/transactions/transaction_download_controller.js
@@ -54,7 +54,7 @@ module.exports = (req, res) => {
       }
     })
     .then(csv => {
-      logger.debug('Sending csv attachment download -', { 'filename': name })
+      logger.debug('Sending csv attachment download', { 'filename': name })
       res.setHeader('Content-disposition', 'attachment; filename="' + name + '"')
       res.setHeader('Content-Type', 'text/csv')
       res.send(csv)

--- a/app/middleware/error_logger.js
+++ b/app/middleware/error_logger.js
@@ -21,7 +21,7 @@ module.exports = function (err, req, res, next) {
   }
 
   // log the exception
-  logger.error(`[requestId=${req.correlationId}] Internal server error -`, errorPayload)
+  logger.error(`[requestId=${req.correlationId}] Internal server error`, errorPayload)
   // re-throw it
   next(err)
 }

--- a/app/models/email.js
+++ b/app/models/email.js
@@ -121,8 +121,8 @@ module.exports = function (correlationId) {
 
   const clientFailure = function (error, reject, methodType, correlationId, isPatchEndpoint) {
     const errMsg = isPatchEndpoint
-      ? `[${correlationId}] Calling connector to update email notifications for an account threw exception -`
-      : `[${correlationId}] Calling connector to get/patch account data threw exception -`
+      ? `[${correlationId}] Calling connector to update email notifications for an account threw exception`
+      : `[${correlationId}] Calling connector to get/patch account data threw exception`
     logger.error(errMsg, {
       service: 'connector',
       method: methodType,

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -172,7 +172,7 @@ ConnectorClient.prototype = {
     let url = params.url || searchUrl(this.connectorUrl, params)
     let responseHandler = this.responseHandler(successCallback)
 
-    logger.debug('Calling connector to search account transactions -', {
+    logger.debug('Calling connector to search account transactions', {
       service: 'connector',
       method: 'GET',
       url: url
@@ -225,7 +225,7 @@ ConnectorClient.prototype = {
    */
   getCharge: function (params, successCallback) {
     let url = _chargeUrlFor(params.gatewayAccountId, params.chargeId, this.connectorUrl)
-    logger.debug('Calling connector to get charge -', {
+    logger.debug('Calling connector to get charge', {
       service: 'connector',
       method: 'GET',
       url: url,

--- a/app/services/service_registration_service.js
+++ b/app/services/service_registration_service.js
@@ -53,7 +53,7 @@ module.exports = {
           resolve(completeServiceInviteResponse)
         })
         .catch(error => {
-          logger.error(`[requestId=${correlationId}] Create populated service orchestration error -`, error)
+          logger.error(`[requestId=${correlationId}] Create populated service orchestration error`, error)
           reject(error)
         })
     })

--- a/app/services/transaction_service.js
+++ b/app/services/transaction_service.js
@@ -72,7 +72,7 @@ const searchAllConnector = (accountId, filters, correlationId) => {
 }
 
 function clientUnavailable (error, reject, correlationId) {
-  logger.error(`[${correlationId}] Calling connector to search transactions for an account threw exception -`, {
+  logger.error(`[${correlationId}] Calling connector to search transactions for an account threw exception`, {
     service: 'connector',
     method: 'GET',
     error: error

--- a/app/utils/request_logger.js
+++ b/app/utils/request_logger.js
@@ -15,7 +15,7 @@ module.exports = {
   },
 
   logRequestFailure: (context, response) => {
-    logger.info(`[${context.correlationId}] Calling ${context.service} to ${context.description} failed -`, {
+    logger.info(`[${context.correlationId}] Calling ${context.service} to ${context.description} failed`, {
       service: context.service,
       method: context.method,
       url: context.url,
@@ -24,7 +24,7 @@ module.exports = {
   },
 
   logRequestError: (context, error) => {
-    logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} threw exception -`, {
+    logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} threw exception`, {
       service: context.service,
       method: context.method,
       url: context.url,

--- a/test/unit/middleware/error_logger_test.js
+++ b/test/unit/middleware/error_logger_test.js
@@ -44,7 +44,7 @@ describe('error_handler middleware', function () {
         message: err
       }
     }
-    assert(loggerErrorSpy.calledWith(`[requestId=${req.correlationId}] Internal server error -`, errorPayload))
+    assert(loggerErrorSpy.calledWith(`[requestId=${req.correlationId}] Internal server error`, errorPayload))
     assert(next.calledWith(err))
 
     done()
@@ -75,7 +75,7 @@ describe('error_handler middleware', function () {
         stack: err.stack
       }
     }
-    assert(loggerErrorSpy.calledWith(`[requestId=${req.correlationId}] Internal server error -`, errorPayload))
+    assert(loggerErrorSpy.calledWith(`[requestId=${req.correlationId}] Internal server error`, errorPayload))
     assert(next.calledWith(err))
 
     done()


### PR DESCRIPTION
These dashes were there previously because before we logged in JSON the
logger would concatenate the JSON object it was passed as a second
parameter into the line.

Now, however, the keys in this JSON object are merged into the top-level
JSON object for the logline, so there is a hanging dash on the end of
the message which makes it appear that the message is incomplete. Remove
these.


