### PR TITLE
PP-5760 Don't log error for invalid OTP code

### DIFF
--- a/app/controllers/two-factor-auth-controller/post-configure-controller.js
+++ b/app/controllers/two-factor-auth-controller/post-configure-controller.js
@@ -21,16 +21,14 @@ module.exports = (req, res) => {
       return res.redirect(paths.user.profile)
     })
     .catch((err) => {
-      let errorMessageLog, errorMessageUser
-      if (err.errorCode === 401) {
-        errorMessageLog = `Activating new OTP key failed, bad code`
-        errorMessageUser = `<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#code">Please enter a valid security code</a></li></ul>`
+      let errorMessage
+      if (err.errorCode === 401 || err.errorCode === 400) {
+        errorMessage = `<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#code">Please enter a valid security code</a></li></ul>`
       } else {
-        errorMessageLog = `Activating new OTP key failed, server error`
-        errorMessageUser = `<h2>Internal server error, please try again</h2>`
+        errorMessage = `<h2>Internal server error, please try again</h2>`
+        logger.error(`[requestId=${req.correlationId}] Activating new OTP key failed, server error`)
       }
-      logger.error(`[requestId=${req.correlationId}] ${errorMessageLog}`)
-      req.flash('genericError', errorMessageUser)
+      req.flash('genericError', errorMessage)
       return res.redirect(paths.user.twoFactorAuth.configure)
     })
 }


### PR DESCRIPTION
Adminusers does some validation on the OTP code that selfservice doesn't
perform, meaning it can return a 400 if the code is not numeric or is
blank.

In selfservice we were treating this as an internal server error, when
it is actually a user input error. Change this to treat a 400 response
as a user input error.

Also don't log user input errors, only log if there was an unexpected
error.


