### PR TITLE
PP-5770 add pact tests for filtering by from_date

### DIFF
--- a/test/fixtures/ledger_transaction_fixtures.js
+++ b/test/fixtures/ledger_transaction_fixtures.js
@@ -151,7 +151,7 @@ const buildTransactionDetails = (opts = {}) => {
 }
 
 const buildRefundDetails = (opts = {}) => {
-  return {
+  const result = {
     gateway_account_id: opts.gateway_account_id || '1',
     amount: opts.amount || 10,
     state: buildChargeEventStateWithDefaults(opts),
@@ -161,6 +161,27 @@ const buildRefundDetails = (opts = {}) => {
     transaction_id: opts.transaction_id || '1b5kia0u28ll2ic4obv26r5e4h',
     parent_transaction_id: opts.parent_transaction_id || 'puuhl0gu7egigin7oh9c75p4m1'
   }
+
+  if (opts.includeParentTransaction) {
+    const parentTransactionOpts = {
+      gateway_account_id: opts.gateway_account_id || '1',
+      transaction_id: opts.parent_transaction_id,
+      includeCardDetails: true,
+      includeAddress: true,
+      includeRefundSummary: true,
+      includeSettlementSummary: true,
+      status: 'success',
+      finished: true,
+      refund_summary_status: 'full',
+      amount_available: 0,
+      amount_submitted: opts.amount,
+      amount_refunded: opts.amount,
+      capture_submit_time: opts.capture_submit_time || null,
+      captured_date: opts.captured_date || null
+    }
+    result.parent_transaction = buildTransactionDetails(parentTransactionOpts)
+  }
+  return result
 }
 
 module.exports = {

--- a/test/unit/clients/ledger_client/ledger_search_transaction_test.js
+++ b/test/unit/clients/ledger_client/ledger_search_transaction_test.js
@@ -227,4 +227,80 @@ describe('ledger client', function () {
         })
     })
   })
+
+  describe('search transactions with \'from_date\'', () => {
+    const params = {
+      account_id: existingGatewayAccountId,
+      filters: {
+        fromDate: '21/9/2019',
+        fromTime: '01:00:00'
+      }
+    }
+
+    const fromDateTime = '2019-09-21T00:00:00.000Z'
+
+    const validTransactionSearchResponse = transactionDetailsFixtures.validTransactionSearchResponse({
+      gateway_account_id: existingGatewayAccountId,
+      transactions: [
+        {
+          amount: 1850,
+          state: {
+            status: 'success',
+            finished: true
+          },
+          created_date: '2019-09-22T10:14:16.067Z',
+          parent_transaction_id: '222222',
+          type: 'refund',
+          capture_submit_time: '2019-09-21T13:14:16.067Z',
+          captured_date: '2019-09-21',
+          includeParentTransaction: true
+        },
+        {
+          amount: 2000,
+          state: {
+            status: 'success',
+            finished: true
+          },
+          transaction_id: '222222',
+          created_date: '2019-09-21T13:14:16.067Z',
+          refund_summary_status: 'available',
+          refund_summary_available: 2000,
+          amount_submitted: 0,
+          amount_refunded: 0,
+          type: 'payment',
+          card_brand: 'visa',
+          email: 'j.doe@example.org',
+          capture_submit_time: '2019-09-21T13:14:16.067Z',
+          captured_date: '2019-09-21'
+        }
+      ]
+    })
+    before(() => {
+      const pactified = validTransactionSearchResponse.getPactified()
+      return pactTestProvider.addInteraction(
+        new PactInteractionBuilder(`${TRANSACTION_RESOURCE}`)
+          .withQuery('account_id', params.account_id)
+          .withQuery('with_parent_transaction', 'true')
+          .withQuery('page', '1')
+          .withQuery('display_size', '100')
+          .withQuery('from_date', fromDateTime)
+          .withUponReceiving('a valid transaction with from date filter request')
+          .withState('a payment with all fields and a corresponding refund exists')
+          .withMethod('GET')
+          .withStatusCode(200)
+          .withResponseBody(pactified)
+          .build()
+      )
+    })
+
+    afterEach(() => pactTestProvider.verify())
+
+    it('should filter transaction successfully', function () {
+      const searchTransactionDetails = legacyConnectorParityTransformer.legacyConnectorTransactionsParity(validTransactionSearchResponse.getPlain())
+      return ledgerClient.transactions(params.account_id, params.filters)
+        .then((ledgerResponse) => {
+          expect(ledgerResponse).to.deep.equal(searchTransactionDetails)
+        })
+    })
+  })
 })


### PR DESCRIPTION
## WHAT
- add a pact tests that filters transaction by from date
- take the opportunity to fully pact test refund with parent transaction


