### PR TITLE
BAU Use autocomplete=current-password for login page password

### DIFF
--- a/app/views/login/login.njk
+++ b/app/views/login/login.njk
@@ -75,7 +75,7 @@ Sign in to GOV.UK Pay
         type: "password",
         attributes: {
           "data-validate": "required",
-          "autocomplete": "off"
+          "autocomplete": "current-password"
         }
       })
     }}


### PR DESCRIPTION
On the admin tool login page, change the password field’s `autocomplete=off` to `autocomplete=current-password`.

WCAG 2.1 AA requires us to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose), which can be achieved by always using the [appropriate `autocomplete` attribute for a form field if there is one](https://www.w3.org/WAI/WCAG21/Techniques/html/H98). For password fields, this is
[`autocomplete=current-password`](https://www.w3.org/TR/WCAG21/#input-purposes).