### PR TITLE
Use GOV.UK Frontend not GOV.UK Elements heading

### DIFF
--- a/app/views/payment-links/edit-amount.njk
+++ b/app/views/payment-links/edit-amount.njk
@@ -92,7 +92,7 @@
 
   {% if not isWelsh %}
   <div class="govuk-!-margin-top-9" id="payment-link-example">
-    <h3 class="heading-small">Example of what the user will see</h3>
+    <h3 class="govuk-heading-s">Example of what the user will see</h3>
     <img class="create-payment-link-screenshot" src="/public/images/adhoc-2-amount.svg" alt="Screenshot of both possible payment link amount pages">
   </div>
   {% endif %}


### PR DESCRIPTION
_Originally authored by @quis as https://github.com/alphagov/pay-selfservice/pull/1749_

---

`heading-small` is the class used by GOV.UK Elements. This app doesn’t include the GOV.UK Elements CSS. It does include the GOV.UK Frontend CSS, where `govuk-heading-s` can be found.

# Before 

![image](https://user-images.githubusercontent.com/355079/69330680-48b31d80-0c4b-11ea-9746-193f19d012e6.png)

# After 

![image](https://user-images.githubusercontent.com/355079/69330657-3df88880-0c4b-11ea-87b0-4d7d22247fa2.png)
