### PR TITLE
Fix capitalisation on add service button

### DIFF
--- a/app/views/services/add_service.njk
+++ b/app/views/services/add_service.njk
@@ -98,7 +98,7 @@
         ]
       }) }}
 
-      {{ govukButton({ text: "Add Service" })}}
+      {{ govukButton({ text: "Add service" })}}
       <p class="govuk-body">
         <a class="govuk-link govuk-link--no-visited-state" id="service-name-cancel-link" href="{{my_services}}">
             Cancel


### PR DESCRIPTION
GOV.UK style is to use _Sentence case_ not _Title Case_ for buttons etc.
