### PR TITLE
BAU Remove reference from transaction details title

### DIFF
--- a/app/views/transaction_detail/index.njk
+++ b/app/views/transaction_detail/index.njk
@@ -1,7 +1,7 @@
 {% extends "../layout.njk" %}
 
 {% block pageTitle %}
-  Transaction details {{reference}} - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+  Transaction details {{charge_id}} - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
 {% block beforeContent %}


### PR DESCRIPTION
* `reference` is being used by services to include personal information
like paying user name
* we send our page titles to google analytics
* patch the page title to use transaction ID (in our control) vs.
reference (out of our control)