### PR TITLE
PP-5918 Remove reference from transaction detail title (PII)

### DIFF
--- a/app/views/transaction_detail/index.njk
+++ b/app/views/transaction_detail/index.njk
@@ -1,7 +1,7 @@
 {% extends "../layout.njk" %}
 
 {% block pageTitle %}
-  Transaction details {{reference}} - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+  Transaction details {{charge_id}} - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
 {% block beforeContent %}

--- a/test/cypress/integration/transactions/transaction_details_spec.js
+++ b/test/cypress/integration/transactions/transaction_details_spec.js
@@ -120,9 +120,6 @@ describe('Transaction details page', () => {
 
       cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
 
-      // Ensure page title is correct
-      cy.title().should('eq', `Transaction details ${transactionDetails.reference} - ${serviceName} Sandbox test - GOV.UK Pay`)
-
       // Ensure page details match up
       // Reference number
       cy.get('.transaction-details tbody').find('tr').first().find('td').first().should('have.text',
@@ -172,9 +169,6 @@ describe('Transaction details page', () => {
       cy.task('setupStubs', getStubs(aDelayedCaptureTransaction))
 
       cy.visit(`${transactionsUrl}/${aDelayedCaptureTransaction.transaction_id}`)
-
-      // Ensure page title is correct
-      cy.title().should('eq', `Transaction details ${aDelayedCaptureTransaction.reference} - ${serviceName} Sandbox test - GOV.UK Pay`)
 
       // Ensure page details match up
       // Reference number
@@ -229,9 +223,6 @@ describe('Transaction details page', () => {
 
       cy.visit(`${transactionsUrl}/${aCorporateCardSurchargeTransaction.transaction_id}`)
 
-      // Ensure page title is correct
-      cy.title().should('eq', `Transaction details ${aCorporateCardSurchargeTransaction.reference} - ${serviceName} Sandbox test - GOV.UK Pay`)
-
       // Ensure page details match up
       // Amount
       cy.get('#amount').should('have.text',
@@ -254,9 +245,6 @@ describe('Transaction details page', () => {
       cy.task('setupStubs', getStubs(transactionDetails))
 
       cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
-
-      // Ensure page title is correct
-      cy.title().should('eq', `Transaction details ${transactionDetails.reference} - ${serviceName} Sandbox test - GOV.UK Pay`)
 
       // Ensure page details match up
       // Reference number
@@ -334,9 +322,6 @@ describe('Transaction details page', () => {
 
       cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
 
-      // Ensure page title is correct
-      cy.title().should('eq', `Transaction details ${transactionDetails.reference} - ${serviceName} Sandbox test - GOV.UK Pay`)
-
       cy.get('.transaction-events tbody').find('tr').eq(0).find('td').eq(0).should('contain',
         capitalise(events[3].status))
       cy.get('.transaction-events tbody').find('tr').eq(0).find('td').eq(1).should('contain',
@@ -390,9 +375,6 @@ describe('Transaction details page', () => {
 
       cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
 
-      // Ensure page title is correct
-      cy.title().should('eq', `Transaction details ${transactionDetails.reference} - ${serviceName} Sandbox test - GOV.UK Pay`)
-
       cy.get('.transaction-events tbody').find('tr').eq(0).find('td').eq(0).should('contain',
         capitalise(events[2].status))
       cy.get('.transaction-events tbody').find('tr').eq(0).find('td').eq(1).should('contain',
@@ -436,9 +418,6 @@ describe('Transaction details page', () => {
       cy.task('setupStubs', getStubs(transactionDetails))
 
       cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
-
-      // Ensure page title is correct
-      cy.title().should('eq', `Transaction details ${transactionDetails.reference} - ${serviceName} Sandbox test - GOV.UK Pay`)
 
       cy.get('.transaction-events tbody').find('tr').eq(0).find('td').eq(0).should('contain',
         capitalise(events[2].status))
@@ -496,9 +475,6 @@ describe('Transaction details page', () => {
       cy.task('setupStubs', getStubs(transactionDetails))
 
       cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
-
-      // Ensure page title is correct
-      cy.title().should('eq', `Transaction details ${transactionDetails.reference} - ${serviceName} Sandbox test - GOV.UK Pay`)
 
       cy.get('.transaction-events tbody').find('tr').eq(0).find('td').eq(0).should('contain',
         capitalise(events[5].resource_type.toLowerCase()) + ' ' + events[5].status)


### PR DESCRIPTION
* `reference` is being used by services to include personal information
like paying user name
* we send our page titles to google analytics - this is an issue with PII
* patch the page title to use transaction ID (in our control) vs.
reference (out of our control)

Supersedes https://github.com/alphagov/pay-selfservice/pull/1770