### PR TITLE
PP-5827 For SmartPay, use “Merchant account code” consistently

### DIFF
--- a/app/views/credentials/smartpay.njk
+++ b/app/views/credentials/smartpay.njk
@@ -52,7 +52,7 @@
 
         {{ govukInput({
             label: {
-              text: "Merchant ID"
+              text: "Merchant account code"
             },
             id: "merchantId",
             name: "merchantId",

--- a/app/views/your-psp/_smartpay.njk
+++ b/app/views/your-psp/_smartpay.njk
@@ -8,7 +8,7 @@
     rows: [
       {
         key: {
-          text: "Merchant code"
+          text: "Merchant account code"
         },
         value: {
           text: currentGatewayAccount.credentials.merchant_id if isAccountCredentialsConfigured else "Not configured",

--- a/test/ui/credentials_ui_tests.js
+++ b/test/ui/credentials_ui_tests.js
@@ -74,7 +74,7 @@ describe('The credentials view in edit mode', function () {
 
     body.should.containInputField('merchantId', 'text')
       .withAttribute('value', 'a-merchant-id')
-      .withLabel('Merchant ID')
+      .withLabel('Merchant account code')
 
     body.should.containInputField('username', 'text')
       .withAttribute('value', 'a-username')


### PR DESCRIPTION
We were using “Merchant code” in some places and “Merchant ID” in others. SmartPay themselves variously use “Merchant account”, “Account code” or “MerchantAccount” and add to the confusion by having a higher-level container for these things called either an “Account” or “Company” depending on where you are.

“Merchant account code” is the name our tech writer thinks will be clearest.