### PR TITLE
zd3866092: Redact entire email

### DIFF
--- a/app/views/includes/head.njk
+++ b/app/views/includes/head.njk
@@ -19,7 +19,7 @@
   ga('govuk_shared.linker.set', 'anonymizeIp', true);
   ga('govuk_shared.linker:autoLink', ['www.gov.uk']);
 
-  var filtered_page_path = document.location.pathname + document.location.search.replace(/&email=[\w%.-]*/, '');
+  var filtered_page_path = document.location.pathname + document.location.search.replace(/&email=[\w%.-]*@[\w%.-]*/, '');
   ga('set', 'page', filtered_page_path);
   ga('send', 'pageview');
   ga('govuk_shared.send', 'pageview');


### PR DESCRIPTION
We send analytics to the cross gov google analytics app too. They (GOV.UK) have some
script that flags when personal information isn't redacted. While we have
redacted the front part of the email (i.e. everything before the "@"), it's
possible the GOV.UK script is still flagging the emails even though the front
part is redacted. Removing the entire email might solve the problem.



