### PR TITLE
Revert "zd3866092: Redact entire email"

### DIFF
--- a/app/views/includes/head.njk
+++ b/app/views/includes/head.njk
@@ -19,7 +19,7 @@
   ga('govuk_shared.linker.set', 'anonymizeIp', true);
   ga('govuk_shared.linker:autoLink', ['www.gov.uk']);
 
-  var filtered_page_path = document.location.pathname + document.location.search.replace(/&email=[\w%.-]*@[\w%.-]*/, '');
+  var filtered_page_path = document.location.pathname + document.location.search.replace(/&email=[\w%.-]*/, '');
   ga('set', 'page', filtered_page_path);
   ga('send', 'pageview');
   ga('govuk_shared.send', 'pageview');


### PR DESCRIPTION
Reverts alphagov/pay-selfservice#1785

For some reason this doesn't appear to work. Some emails are redacted, some aren't.