### PR TITLE
PP-5977 Disable google analytics

### DIFF
--- a/app/views/includes/head.njk
+++ b/app/views/includes/head.njk
@@ -4,7 +4,15 @@
 {% if analyticsTrackingId %}
 <!-- Google Analytics -->
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+
+  {# The below code is commented out so we don't store Google Analytic cookies for ICO compliance.
+    We create a empty ga() function so not to throw a ReferenceError
+    Uncomment when we enable opt-in for cookies and remove the ga() function. #}
+
+  function ga() {
+  }
+
+  {# (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
@@ -22,7 +30,7 @@
   var filtered_page_path = document.location.pathname + document.location.search.replace(/&email=[\w%.-]*/, '');
   ga('set', 'page', filtered_page_path);
   ga('send', 'pageview');
-  ga('govuk_shared.send', 'pageview');
+  ga('govuk_shared.send', 'pageview'); #}
 
 </script>
 <!-- End Google Analytics -->


### PR DESCRIPTION
Complying with ICO guidance around cookie consent we can't set non-essential cookies without consent being granted. In the short term then we have to disable Google Analytics as it stores cookies.

