### PR TITLE
PP-5965 Send user email for refunds

### DIFF
--- a/app/controllers/transactions/transaction_refund_controller.js
+++ b/app/controllers/transactions/transaction_refund_controller.js
@@ -4,7 +4,7 @@
 const Charge = require('../../models/charge.js')
 const auth = require('../../services/auth_service.js')
 const router = require('../../routes.js')
-const {CORRELATION_HEADER} = require('../../utils/correlation_header.js')
+const { CORRELATION_HEADER } = require('../../utils/correlation_header.js')
 
 const reasonMessages = {
   'refund_complete': '<h2>Refund successful</h2> It may take up to 6 days to process.',
@@ -19,10 +19,11 @@ const reasonMessages = {
 module.exports = (req, res) => {
   const correlationId = req.headers[CORRELATION_HEADER]
   const userExternalId = req.user.externalId
+  const userEmail = req.user.email
   const charge = Charge(correlationId)
   const accountId = auth.getCurrentGatewayAccountId(req)
   const chargeId = req.params.chargeId
-  const show = router.generateRoute(router.paths.transactions.detail, {chargeId})
+  const show = router.generateRoute(router.paths.transactions.detail, { chargeId })
 
   const refundAmount = req.body['refund-type'] === 'full' ? req.body['full-amount'] : req.body['refund-amount']
   const refundAmountAvailableInPence = parseInt(req.body['refund-amount-available-in-pence'])
@@ -36,7 +37,7 @@ module.exports = (req, res) => {
   let refundAmountForConnector = parseInt(refundMatch[1]) * 100
   if (refundMatch[2]) refundAmountForConnector += parseInt(refundMatch[2])
 
-  return charge.refund(accountId, chargeId, refundAmountForConnector, refundAmountAvailableInPence, userExternalId)
+  return charge.refund(accountId, chargeId, refundAmountForConnector, refundAmountAvailableInPence, userExternalId, userEmail)
     .then(
       () => {
         req.flash('generic', reasonMessages['refund_complete'])

--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -34,12 +34,13 @@ module.exports = function (correlationId) {
     }
   }
 
-  function refund (accountId, chargeId, amount, refundAmountAvailable, userExternalId) {
+  function refund (accountId, chargeId, amount, refundAmountAvailable, userExternalId, userEmail) {
     return new Promise(function (resolve, reject) {
       const payload = {
         amount: amount,
         refund_amount_available: refundAmountAvailable,
-        user_external_id: userExternalId
+        user_external_id: userExternalId,
+        user_email: userEmail
       }
 
       logger.log('info', 'Submitting a refund for a charge', {

--- a/test/unit/controller/refunds_controller_test.js
+++ b/test/unit/controller/refunds_controller_test.js
@@ -2,7 +2,7 @@
 
 // NPM dependencies
 const sinon = require('sinon')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const nock = require('nock')
 
 // Custom dependencies
@@ -18,7 +18,8 @@ describe('Refund scenario:', function () {
       'x-request-id': '1234'
     }
     req.user = {
-      externalId: '92734386'
+      externalId: '92734386',
+      email: 'test@example.com'
     }
     req.service = {
       gatewayAccountIds: ['123', '456']
@@ -47,6 +48,7 @@ describe('Refund scenario:', function () {
     }
     nock(process.env.CONNECTOR_URL).post('/v1/api/accounts/' + '123' + '/charges/' + '123456' + '/refunds', {
       'user_external_id': req.user.externalId,
+      'user_email': req.user.email,
       'amount': 500000,
       'refund_amount_available': 5000
     })
@@ -64,6 +66,7 @@ describe('Refund scenario:', function () {
     }
     nock(process.env.CONNECTOR_URL).post('/v1/api/accounts/' + '123' + '/charges/' + '123456' + '/refunds', {
       'user_external_id': req.user.externalId,
+      'user_email': req.user.email,
       'amount': 600000,
       'refund_amount_available': 5000
     })
@@ -81,6 +84,7 @@ describe('Refund scenario:', function () {
     }
     nock(process.env.CONNECTOR_URL).post('/v1/api/accounts/' + '123' + '/charges/' + '123456' + '/refunds', {
       'user_external_id': req.user.externalId,
+      'user_email': req.user.email,
       'amount': 1,
       'refund_amount_available': 5000
     })
@@ -98,6 +102,7 @@ describe('Refund scenario:', function () {
     }
     nock(process.env.CONNECTOR_URL).post('/v1/api/accounts/' + '123' + '/charges/' + '123456' + '/refunds', {
       'user_external_id': req.user.externalId,
+      'user_email': req.user.email,
       'amount': 1,
       'refund_amount_available': 5000
     })
@@ -115,6 +120,7 @@ describe('Refund scenario:', function () {
     }
     nock(process.env.CONNECTOR_URL).post('/v1/api/accounts/' + '123' + '/charges/' + '123456' + '/refunds', {
       'user_external_id': req.user.externalId,
+      'user_email': req.user.email,
       'amount': 1,
       'refund_amount_available': 5000
     })
@@ -132,6 +138,7 @@ describe('Refund scenario:', function () {
     }
     nock(process.env.CONNECTOR_URL).post('/v1/api/accounts/' + '123' + '/charges/' + '123456' + '/refunds', {
       'user_external_id': req.user.externalId,
+      'user_email': req.user.email,
       'amount': 1,
       'refund_amount_available': 5000
     })


### PR DESCRIPTION
## WHAT
- Pass user email for refunds as Connector can receive `user_email` on refunds endpoint https://github.com/alphagov/pay-connector/pull/1996