### PR TITLE
PP-6000 Change “security code” to “verification code” in content

### DIFF
--- a/app/controllers/two-factor-auth-controller/post-configure-controller.js
+++ b/app/controllers/two-factor-auth-controller/post-configure-controller.js
@@ -23,7 +23,7 @@ module.exports = (req, res) => {
     .catch((err) => {
       let errorMessage
       if (err.errorCode === 401 || err.errorCode === 400) {
-        errorMessage = `<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#code">Please enter a valid security code</a></li></ul>`
+        errorMessage = `<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#code">Please enter a valid verification code</a></li></ul>`
       } else {
         errorMessage = `<h2>Internal server error, please try again</h2>`
         logger.error(`[requestId=${req.correlationId}] Activating new OTP key failed, server error`)

--- a/app/controllers/two-factor-auth-controller/post-resend-controller.js
+++ b/app/controllers/two-factor-auth-controller/post-resend-controller.js
@@ -7,7 +7,7 @@ const paths = require('../../paths')
 module.exports = (req, res) => {
   userService.sendProvisonalOTP(req.user, req.correlationId)
     .then(() => {
-      req.flash('generic', `<h2>Another security code has been sent to your phone</h2>`)
+      req.flash('generic', `<h2>Another verification code has been sent to your phone</h2>`)
       return res.redirect(paths.user.twoFactorAuth.configure)
     })
     .catch(err => {

--- a/app/services/auth_service.js
+++ b/app/services/auth_service.js
@@ -103,7 +103,7 @@ function localStrategyAuth (req, username, password, done) {
 function localStrategy2Fa (req, done) {
   return userService.authenticateSecondFactor(req.user.externalId, req.body.code)
     .then((user) => done(null, user))
-    .catch(() => done(null, false, { message: 'The security code you’ve used is incorrect or has expired.' }))
+    .catch(() => done(null, false, { message: 'The verification code you’ve used is incorrect or has expired.' }))
 }
 
 function localDirectStrategy (req, done) {

--- a/app/views/login/otp-login.njk
+++ b/app/views/login/otp-login.njk
@@ -1,7 +1,7 @@
 {% extends "../layout-logged-out.njk" %}
 
 {% block pageTitle %}
-  Enter security code - GOV.UK Pay
+  Enter verification code - GOV.UK Pay
 {% endblock %}
 
 {% block mainContent %}
@@ -28,10 +28,10 @@
   <form action="{{routes.user.otpLogIn}}" method="post" class="form submit-two-fa" id="otp-login-form" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
     {% if authenticatorMethod === 'SMS' %}
-    <p class="govuk-body">We have sent you a text message with a security code</p>
+    <p class="govuk-body">We have sent you a text message with a verification code</p>
     {% endif %}
     {% if authenticatorMethod === 'APP' %}
-    <p class="govuk-body">Enter the security code shown in your authenticator app</p>
+    <p class="govuk-body">Enter the verification code shown in your authenticator app</p>
     {% endif %}
 
     {% set error = false %}
@@ -43,7 +43,7 @@
 
     {{ govukInput({
         label: {
-          text: "Security code"
+          text: "Verification code"
         },
         errorMessage: error,
         id: "sms_code",

--- a/app/views/login/send_otp_again.njk
+++ b/app/views/login/send_otp_again.njk
@@ -1,7 +1,7 @@
 {% extends "../layout-logged-out.njk" %}
 
 {% block pageTitle %}
-Resend security code - GOV.UK Pay
+Resend verification code - GOV.UK Pay
 {% endblock %}
 
 {% block mainContent %}

--- a/app/views/self_create_service/register.njk
+++ b/app/views/self_create_service/register.njk
@@ -41,7 +41,7 @@
         },
         value: telephoneNumber,
         hint: {
-          text: "We’ll send you a security code by text message"
+          text: "We’ll send you a verification code by text message"
         }
       })
     }}

--- a/app/views/self_create_service/resend_otp.njk
+++ b/app/views/self_create_service/resend_otp.njk
@@ -1,13 +1,13 @@
 {% extends "../layout-logged-out.njk" %}
 
 {% block pageTitle %}
-  Resend security code - GOV.UK Pay
+  Resend verification code - GOV.UK Pay
 {% endblock %}
 
 {% block mainContent %}
 <div id="display_otp_resend" class="govuk-grid-column-two-thirds">
   <h1 class="form-title govuk-heading-l">Check your mobile number</h1>
-  <p class="govuk-body">Check your mobile phone number is correct, then resend the security code.</p>
+  <p class="govuk-body">Check your mobile phone number is correct, then resend the verification code.</p>
   <form action="{{routes.selfCreateService.otpResend}}" class="form" method="post" id="otp-resend-form">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
     {{
@@ -26,7 +26,7 @@
     }}
     {{
       govukButton({
-        text: "Resend security code",
+        text: "Resend verification code",
         classes: "button"
       })
     }}

--- a/app/views/self_create_service/verify_otp.njk
+++ b/app/views/self_create_service/verify_otp.njk
@@ -1,13 +1,13 @@
 {% extends "../layout-logged-out.njk" %}
 
 {% block pageTitle %}
-  Enter security code - GOV.UK Pay
+  Enter verification code - GOV.UK Pay
 {% endblock %}
 
 {% block mainContent %}
 <div id="display_otp_verify" class="govuk-grid-column-two-thirds">
   <h1 class="form-title govuk-heading-l">Check your phone</h1>
-  <p class="govuk-body">We’ve sent you a text message with a security code</p>
+  <p class="govuk-body">We’ve sent you a text message with a verification code</p>
   <form action="{{routes.selfCreateService.otpVerify}}" class="form" method="post" class="submit-two-fa" id="verify-phone-form">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
     {{
@@ -16,7 +16,7 @@
         name: "verify-code",
         classes: "govuk-input--width-10",
         label: {
-            text: "Security code",
+            text: "Verification code",
             classes: "govuk-label--s"
         },
         attributes: {

--- a/app/views/transaction_detail/_details.njk
+++ b/app/views/transaction_detail/_details.njk
@@ -20,7 +20,7 @@
         {% set stateInfo %}
           <p class="govuk-!-font-size-16">The payment was declined. This may happen if:</p>
           <ul class="govuk-!-font-size-16">
-            <li>the payment card failed a fraud check - for example, the cardholder address or the security code did not match the card number, or the card has been blocked</li>
+            <li>the payment card failed a fraud check - for example, the cardholder address or the verification code did not match the card number, or the card has been blocked</li>
             <li>there was a 3D Secure authentication failure - for example, the user entered the incorrect password</li>
             <li>there was not enough money in the account</li>
           </ul>

--- a/app/views/twoFactorAuth/configure.njk
+++ b/app/views/twoFactorAuth/configure.njk
@@ -55,18 +55,18 @@
     {% set codeError = false %}
     {% if flash.genericError %}
       {% set codeError = {
-        text: "Please enter a valid security code"
+        text: "Please enter a valid verification code"
       } %}
     {% endif %}
 
     {% set codeHint = "Enter the code shown in your app to complete the setup" %}
     {% if method === 'SMS' %}
-      {% set codeHint = "We have sent you a text message with a security code" %}
+      {% set codeHint = "We have sent you a text message with a verification code" %}
     {% endif %}
 
     {{ govukInput({
         label: {
-          text: "Security code"
+          text: "Verification code"
         },
         hint: {
           text: codeHint

--- a/app/views/twoFactorAuth/index.njk
+++ b/app/views/twoFactorAuth/index.njk
@@ -60,7 +60,7 @@
   </form>
   {% set detailsHTML %}
     <h2 class="govuk-heading-s">Authenticator apps</h2>
-    <p class="govuk-body">Instead of text message codes, you can use an authenticator app to sign in to GOV.UK Pay. This is an app (usually installed on your phone) that generates a security code whenever you need to sign in. If you choose to use an authenticator app, you will only be able to sign in to GOV.UK Pay using that app and you will no longer receive text message codes.</p>
+    <p class="govuk-body">Instead of text message codes, you can use an authenticator app to sign in to GOV.UK Pay. This is an app (usually installed on your phone) that generates a verification code whenever you need to sign in. If you choose to use an authenticator app, you will only be able to sign in to GOV.UK Pay using that app and you will no longer receive text message codes.</p>
     <p class="govuk-body">GOV.UK Pay works with most authenticator apps. If you do not have one installed already, there are several available. These include:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li><a class="govuk-link" href="https://authy.com/">Authy</a></li>

--- a/app/views/user_registration/re_verify_phone.njk
+++ b/app/views/user_registration/re_verify_phone.njk
@@ -1,7 +1,7 @@
 {% extends "../layout-logged-out.njk" %}
 
 {% block pageTitle %}
-  Resend security code - GOV.UK Pay
+  Resend verification code - GOV.UK Pay
 {% endblock %}
 
 {% block mainContent %}
@@ -25,7 +25,7 @@
           },
           value: telephone_number,
           hint: {
-            text: "We’ll send you a security code by text message"
+            text: "We’ll send you a verification code by text message"
           }
         })
       }}

--- a/app/views/user_registration/register.njk
+++ b/app/views/user_registration/register.njk
@@ -23,7 +23,7 @@
           },
           value: telephone_number,
           hint: {
-            text: "We’ll send you a security code by text message"
+            text: "We’ll send you a verification code by text message"
           }
         })
       }}

--- a/app/views/user_registration/verify_otp.njk
+++ b/app/views/user_registration/verify_otp.njk
@@ -1,13 +1,13 @@
 {% extends "../layout-logged-out.njk" %}
 
 {% block pageTitle %}
-  Enter security code - GOV.UK Pay
+  Enter verification code - GOV.UK Pay
 {% endblock %}
 
 {% block mainContent %}
   <div class="govuk-grid-column-two-thirds">
     <h1 class="form-title govuk-heading-l">Check your phone</h1>
-    <p class="govuk-body">We’ve sent you a text message with a security code</p>
+    <p class="govuk-body">We’ve sent you a text message with a verification code</p>
     <form action="{{routes.registerUser.otpVerify}}" class="form" method="post" class="submit-two-fa" id="verify-phone-form">
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
       {{
@@ -16,7 +16,7 @@
           name: "verify-code",
           classes: "govuk-input--width-10",
           label: {
-              text: "Security code",
+              text: "Verification code",
               classes: "govuk-label--s"
           },
           attributes: {

--- a/test/cypress/integration/user/login_spec.js
+++ b/test/cypress/integration/user/login_spec.js
@@ -70,7 +70,7 @@ describe('Login Page', () => {
         cy.get('#username').type(validUsername)
         cy.get('#password').type(validPassword)
         cy.contains('Continue').click()
-        cy.title().should('eq', 'Enter security code - GOV.UK Pay')
+        cy.title().should('eq', 'Enter verification code - GOV.UK Pay')
         cy.url().should('include', '/otp-login')
       })
     })

--- a/test/ui/login_ui_tests.js
+++ b/test/ui/login_ui_tests.js
@@ -46,7 +46,7 @@ describe('Login view', function () {
       const templateData = {
         authenticatorMethod: 'SMS',
         flash: {
-          error: 'The security code you’ve used is incorrect or has expired.'
+          error: 'The verification code you’ve used is incorrect or has expired.'
         }
       }
 
@@ -54,7 +54,7 @@ describe('Login view', function () {
 
       body.should.containSelector('h1').withExactText('Check your phone')
 
-      body.should.containSelector('.govuk-error-message').withExactText('Error: The security code you’ve used is incorrect or has expired.')
+      body.should.containSelector('.govuk-error-message').withExactText('Error: The verification code you’ve used is incorrect or has expired.')
 
       body.should.containSelector('form#otp-login-form').withAttribute('action', paths.user.otpLogIn)
 
@@ -107,7 +107,7 @@ describe('Login view', function () {
       const templateData = {
         authenticatorMethod: 'APP',
         flash: {
-          error: 'Invalid security code'
+          error: 'Invalid verification code'
         }
       }
 
@@ -115,7 +115,7 @@ describe('Login view', function () {
 
       body.should.containSelector('h1').withExactText('Use your authenticator app')
 
-      body.should.containSelector('.govuk-error-message').withExactText('Error: Invalid security code')
+      body.should.containSelector('.govuk-error-message').withExactText('Error: Invalid verification code')
 
       body.should.containSelector('form#otp-login-form').withAttribute('action', paths.user.otpLogIn)
 

--- a/test/ui/self_create_service_ui_tests.js
+++ b/test/ui/self_create_service_ui_tests.js
@@ -42,7 +42,7 @@ describe('Self-create service view', () => {
 
     body.should.containSelector('h1').withExactText('Check your phone')
 
-    body.should.containSelector('.govuk-body:first-of-type').withExactText(`We’ve sent you a text message with a security code`)
+    body.should.containSelector('.govuk-body:first-of-type').withExactText(`We’ve sent you a text message with a verification code`)
     body.should.containSelector('form#verify-phone-form').withAttribute('action', paths.selfCreateService.otpVerify)
     body.should.containInputField('verify-code', 'text')
 

--- a/test/unit/controller/two-factor-auth-controller/post_configure_controller.test.js
+++ b/test/unit/controller/two-factor-auth-controller/post_configure_controller.test.js
@@ -3,18 +3,18 @@
 // NPM dependencies
 const supertest = require('supertest')
 const csrf = require('csrf')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const nock = require('nock')
 
 // Local dependencies
-const {getApp} = require('../../../../server')
-const {getMockSession, createAppWithSession, getUser} = require('../../../test_helpers/mock_session')
+const { getApp } = require('../../../../server')
+const { getMockSession, createAppWithSession, getUser } = require('../../../test_helpers/mock_session')
 const paths = require('../../../../app/paths')
-const {ADMINUSERS_URL} = process.env
+const { ADMINUSERS_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '929'
 const VALID_USER = getUser({
   gateway_account_ids: [GATEWAY_ACCOUNT_ID],
-  permissions: [{name: 'transactions:read'}]
+  permissions: [{ name: 'transactions:read' }]
 })
 
 describe('Two factor authenticator configure page POST', () => {
@@ -91,7 +91,7 @@ describe('Two factor authenticator configure page POST', () => {
 
     it('should show an error message', () => {
       expect(session.flash.genericError).to.have.property('length').to.equal(1)
-      expect(session.flash.genericError[0]).to.equal('<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#code">Please enter a valid security code</a></li></ul>')
+      expect(session.flash.genericError[0]).to.equal('<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#code">Please enter a valid verification code</a></li></ul>')
     })
   })
 })


### PR DESCRIPTION
We’re inconsistent about whether we use “security code” or “verification code”. Standardise on “verification code” as recommended by @tracy-content.