### PR TITLE
PP-5996 Enable get multiple gateway accounts pact test

### DIFF
--- a/test/unit/clients/connector_client/connector_get_multiple_gateway_accounts_test.js
+++ b/test/unit/clients/connector_client/connector_get_multiple_gateway_accounts_test.js
@@ -22,7 +22,7 @@ chai.use(chaiAsPromised)
 
 describe('connector client - get multiple gateway accounts', function () {
   let provider = Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'connector',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
@@ -46,7 +46,7 @@ describe('connector client - get multiple gateway accounts', function () {
       provider.addInteraction(
         new PactInteractionBuilder(ACCOUNTS_RESOURCE)
           .withUponReceiving('a valid get gateway accounts request')
-          .withState(`Gateway accounts with ids 111, 222 exist in the database`)
+          .withState('gateway accounts with ids 111, 222 exist in the database')
           .withMethod('GET')
           .withQuery('accountIds', '111,222')
           .withResponseBody(validGetGatewayAccountsResponse.getPactified())


### PR DESCRIPTION
This pact test was disabled as there was not previously a provider state
in connector. There now is, so enable it.

