### PR TITLE
PP-6008 Refactor Cypress stubs configuration

### DIFF
--- a/test/cypress/integration/my-services/add_new_service_spec.js
+++ b/test/cypress/integration/my-services/add_new_service_spec.js
@@ -37,7 +37,7 @@ function getCreateServiceStub (englishName, welshName) {
   return {
     name: 'postCreateServiceSuccess',
     opts: {
-      gateway_account_id: 2,
+      gateway_account_ids: [newGatewayAccountId],
       service_name: serviceName,
       external_id: newServiceId
     }

--- a/test/cypress/integration/settings/payment-types-spec.js
+++ b/test/cypress/integration/settings/payment-types-spec.js
@@ -37,7 +37,7 @@ describe('Payment types', () => {
           }
         },
         {
-          name: 'postAcceptedCardsForAccountSuccess',
+          name: 'getAcceptedCardsForAccountSuccess',
           opts: {
             account_id: gatewayAccountId
           }
@@ -101,7 +101,7 @@ describe('Payment types', () => {
           }
         },
         {
-          name: 'postAcceptedCardsForAccountSuccess',
+          name: 'getAcceptedCardsForAccountSuccess',
           opts: {
             account_id: gatewayAccountId
           }

--- a/test/cypress/integration/transactions/transaction_details_spec.js
+++ b/test/cypress/integration/transactions/transaction_details_spec.js
@@ -68,6 +68,7 @@ function defaultTransactionDetails (events, opts = {}) {
 describe('Transaction details page', () => {
   const transactionsUrl = `/transactions`
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+  const userEmail = 'a-user@example.com'
 
   const getStubs = (transactionDetails) => {
     return [
@@ -75,6 +76,7 @@ describe('Transaction details page', () => {
         name: 'getUserSuccess',
         opts: {
           external_id: userExternalId,
+          email: userEmail,
           service_roles: [{
             service: {
               name: serviceName,
@@ -503,7 +505,8 @@ describe('Transaction details page', () => {
             charge_id: transactionDetails.transaction_id,
             amount: refundAmount,
             refund_amount_available: transactionDetails.amount,
-            user_external_id: userExternalId
+            user_external_id: userExternalId,
+            user_email: userEmail
           }
         }
       ])

--- a/test/fixtures/transaction_fixtures.js
+++ b/test/fixtures/transaction_fixtures.js
@@ -209,7 +209,8 @@ module.exports = {
     const data = {
       amount: opts.amount || 101,
       refund_amount_available: opts.refund_amount_available || 100,
-      user_external_id: opts.user_external_id || '3b7b5f33-24ea-4405-88d2-0a1b13efb20c'
+      user_external_id: opts.user_external_id || '3b7b5f33-24ea-4405-88d2-0a1b13efb20c',
+      user_email: opts.user_email || 'foo@example.com'
     }
 
     return {


### PR DESCRIPTION
Refactor the stubs configuration file to reduce code duplication by adding a method to setup stubs which have an uncomplicated configuration.

Make all predicates in the stubs use 'deepEquals' to ensure we are matching entirely on request bodys.