### PR TITLE
PP-6008 Add ability to verify stubs have been called in Cypress tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint": "./node_modules/.bin/standard --fix",
     "lint-sass": "./node_modules/.bin/sass-lint -v",
     "test": "npm run snyk-protect && rm -rf ./pacts && ./node_modules/mocha/bin/mocha '!(node_modules)/**/*+(.|_)+(test|tests)'.js",
-    "cypress:server": "mb | node --inspect -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
+    "cypress:server": "mb --debug | node --inspect -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
     "cypress:test": "cypress run",
     "cypress:test-headed": "cypress open",
     "snyk-protect": "snyk protect",

--- a/test/cypress/integration/my-services/add_new_service_spec.js
+++ b/test/cypress/integration/my-services/add_new_service_spec.js
@@ -14,7 +14,8 @@ const createGatewayAccountStub = {
     service_name: newServiceName,
     payment_provider: 'sandbox',
     type: 'test',
-    gateway_account_id: newGatewayAccountId
+    gateway_account_id: newGatewayAccountId,
+    verifyCalledTimes: 1
   }
 }
 const assignUserRoleStub = {
@@ -22,7 +23,8 @@ const assignUserRoleStub = {
   opts: {
     external_id: authenticatedUserId,
     service_external_id: newServiceId,
-    role_name: 'admin'
+    role_name: 'admin',
+    verifyCalledTimes: 1
   }
 }
 
@@ -39,9 +41,18 @@ function getCreateServiceStub (englishName, welshName) {
     opts: {
       gateway_account_ids: [newGatewayAccountId],
       service_name: serviceName,
-      external_id: newServiceId
+      external_id: newServiceId,
+      verifyCalledTimes: 1
     }
   }
+}
+
+function setupStubs (stubs = []) {
+  cy.task('setupStubs', [
+    ...stubs,
+    getUserStub(authenticatedUserId, ['1']),
+    getGatewayAccountsStub(1)
+  ])
 }
 
 describe('Add a new service', () => {
@@ -52,24 +63,16 @@ describe('Add a new service', () => {
   })
 
   describe('Add a new service without a Welsh name', () => {
-    beforeEach(() => {
-      cy.task('setupStubs', [
-        getUserStub(authenticatedUserId, ['1']),
-        getGatewayAccountsStub(1),
-        createGatewayAccountStub,
-        assignUserRoleStub,
-        getCreateServiceStub(newServiceName)
-      ])
-    })
-
     it('should display the my services page', () => {
       cy.setEncryptedCookies(authenticatedUserId, 1)
+      setupStubs()
 
       cy.visit('/my-services')
       cy.title().should('eq', 'Choose service - GOV.UK Pay')
     })
 
     it('should navigate to the add new service form', () => {
+      setupStubs()
       cy.get('a').contains('Add a new service').click()
 
       cy.title().should('eq', 'Add a new service - GOV.UK Pay')
@@ -77,6 +80,11 @@ describe('Add a new service', () => {
     })
 
     it('should add a service', () => {
+      setupStubs([
+        createGatewayAccountStub,
+        assignUserRoleStub,
+        getCreateServiceStub(newServiceName)
+      ])
       cy.get('input#service-name').type(newServiceName)
       cy.get('button').contains('Add service').click()
 
@@ -85,24 +93,16 @@ describe('Add a new service', () => {
   })
 
   describe('Add a new service with a Welsh name', () => {
-    beforeEach(() => {
-      cy.task('setupStubs', [
-        getUserStub(authenticatedUserId, ['1']),
-        getGatewayAccountsStub(1),
-        createGatewayAccountStub,
-        assignUserRoleStub,
-        getCreateServiceStub(newServiceName, newServiceWelshName)
-      ])
-    })
-
     it('should display the my services page', () => {
       cy.setEncryptedCookies(authenticatedUserId, 1)
+      setupStubs()
 
       cy.visit('/my-services')
       cy.title().should('eq', 'Choose service - GOV.UK Pay')
     })
 
     it('should navigate to the add new service form', () => {
+      setupStubs()
       cy.get('a').contains('Add a new service').click()
 
       cy.title().should('eq', 'Add a new service - GOV.UK Pay')
@@ -110,12 +110,18 @@ describe('Add a new service', () => {
     })
 
     it('should display Welsh name input', () => {
+      setupStubs()
       cy.get('#checkbox-service-name-cy').click()
       cy.get('#checkbox-service-name-cy').should('have.attr', 'aria-expanded', 'true')
       cy.get('input#service-name-cy').should('exist')
     })
 
     it('should add a service', () => {
+      setupStubs([
+        createGatewayAccountStub,
+        assignUserRoleStub,
+        getCreateServiceStub(newServiceName, newServiceWelshName)
+      ])
       cy.get('input#service-name').type(newServiceName)
       cy.get('input#service-name-cy').type(newServiceWelshName)
       cy.get('button').contains('Add service').click()

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -62,6 +62,28 @@ module.exports = (on, config) => {
      */
     clearStubs () {
       return request.delete(mountebankImpostersUrl)
+    },
+    /**
+     * Makes a request to Mountebank to verify that stubs have been called the expected number of times
+     */
+    verifyStubs () {
+      return request({
+        method: 'GET',
+        url: `${mountebankImpostersUrl}/${config.env.MOUNTEBANK_IMPOSTERS_PORT}`,
+        json: true
+      }).then(response => {
+        response.stubs.forEach((stub) => {
+          if (stub.verifyCalledTimes) {
+            // the matches array is added to stubs only when Mountebank is run with the --debug flag
+            const timesCalled = (stub.matches && stub.matches.length) || 0
+            if (timesCalled !== stub.verifyCalledTimes) {
+              throw new Error(`Expected stub '${stub.name}' to be called ${stub.verifyCalledTimes} times, but was called ${timesCalled} times`)
+            }
+          }
+        })
+
+        return null
+      })
     }
   })
 

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -37,14 +37,20 @@ const simpleStubBuilder = function simpleStubBuilder (method, path, responseCode
     response.body = additionalParams.response
   }
 
-  return [{
+  const stub = {
+    name: `${method} ${path} ${responseCode}`,
     predicates: [{
       deepEquals: request
     }],
     responses: [{
       is: response
     }]
-  }]
+  }
+  if (additionalParams.verifyCalledTimes) {
+    stub.verifyCalledTimes = additionalParams.verifyCalledTimes
+  }
+
+  return [stub]
 }
 
 /**
@@ -489,21 +495,24 @@ module.exports = {
     const path = `/v1/api/users/${opts.external_id}/services`
     return simpleStubBuilder('POST', path, 200, {
       request: userFixtures.validAssignServiceRoleRequest(opts).getPlain(),
-      response: userFixtures.validUserResponse(opts).getPlain()
+      response: userFixtures.validUserResponse(opts).getPlain(),
+      verifyCalledTimes: opts.verifyCalledTimes
     })
   },
   postCreateGatewayAccountSuccess: (opts = {}) => {
     const path = '/v1/api/accounts'
     return simpleStubBuilder('POST', path, 200, {
       request: gatewayAccountFixtures.validCreateGatewayAccountRequest(opts).getPlain(),
-      response: gatewayAccountFixtures.validGatewayAccountResponse(opts).getPlain()
+      response: gatewayAccountFixtures.validGatewayAccountResponse(opts).getPlain(),
+      verifyCalledTimes: opts.verifyCalledTimes
     })
   },
   postCreateServiceSuccess: (opts = {}) => {
     const path = '/v1/api/services'
     return simpleStubBuilder('POST', path, 200, {
       request: serviceFixtures.validCreateServiceRequest(opts).getPlain(),
-      response: serviceFixtures.validServiceResponse(opts).getPlain()
+      response: serviceFixtures.validServiceResponse(opts).getPlain(),
+      verifyCalledTimes: opts.verifyCalledTimes
     })
   }
 }

--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -14,3 +14,7 @@ require('./commands')
 beforeEach(() => {
   cy.task('clearStubs')
 })
+
+afterEach(() => {
+  cy.task('verifyStubs')
+})


### PR DESCRIPTION
In Cypress tests, it is sometimes desired to verify that a HTTP request
to an external service is made to verify the behaviour of a task. The
default behaviour of Mountebank, which is the stub server used by
Cypress tests, is to return a 200 response with an empty body in
response to all requests a matching stub does not exist for. Therefore,
tests will only fail if a stub we expect to be called is not called if
we expect a non-200 response or the application uses the body of the
response in some way.

The example this is implemented for in this commit is adding a new
service. We want to verify that the appropriate calls are made to
adminusers and connector to perform the actions that add the service.
Without verifying these requests are made with the expected request
body, we cannot be confident that a service and gateway account would
have been created in the real world.

The verification that requests are made in the Cypress test in
combination with contract (Pact) tests for the endpoints called serves
as an adequate alternative to end-to-end tests.

Verification of the number of times a stub is called is done by running
mountebank with the `--debug` flag, which records the matches that are
made against each stub. After each test is run, we can then look at the
size of the matches array and compare against the expectation which is
stored in a new `verifyCalledTimes` property on the stubs.


