### PR TITLE
PP-6029 Buildpack manifest

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,9 @@
+memory: 500M
+disk_quota: 500M
+selfservice_session_encryption_key: asdjhbwefbo23r23rbfik2roiwhefwbqw
+selfservice_analytics_tracking_id: testing-123
+selfservice_analytics_tracking_id_xgov: testing-123
+selfservice_gocardless_test_oauth_base_url: http://example.com
+selfservice_gocardless_live_oauth_base_url: http://example.com
+selfservice_gocardless_test_client_id: testing-123
+selfservice_gocardless_live_client_id: testing-123

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,33 @@
+---
+applications:
+- name: selfservice
+  buildpacks:
+  - nodejs_buildpack
+  health-check-type: http
+  health-check-http-endpoint: '/healthcheck'
+  health-check-invocation-timeout: 5
+  memory: ((memory))
+  disk_quota: ((disk_quota))
+  command: npm start
+  env:
+    NODE_ENV: production
+    SESSION_ENCRYPTION_KEY: ((selfservice_session_encryption_key))
+    COOKIE_MAX_AGE: '10800000'
+    ANALYTICS_TRACKING_ID: ((selfservice_analytics_tracking_id))
+    ANALYTICS_TRACKING_ID_XGOV: ((selfservice_analytics_tracking_id_xgov))
+
+    SELFSERVICE_URL: https://((selfservice_url))
+    PUBLIC_AUTH_URL: ((publicauth_url))
+    CONNECTOR_URL: ((card_connector_url))
+    PRODUCTS_URL: ((products_url))
+    DIRECT_DEBIT_CONNECTOR_URL: ((direct_debit_connector_url))
+    LEDGER_URL: ((ledger_url))
+
+    PRODUCTS_FRIENDLY_BASE_URI: ((products_friendly_base_uri))
+    GOCARDLESS_TEST_OAUTH_BASE_URL: ((selfservice_gocardless_test_oauth_base_url))
+    GOCARDLESS_LIVE_OAUTH_BASE_URL: ((selfservice_gocardless_live_oauth_base_url))
+    GOCARDLESS_TEST_CLIENT_ID: ((selfservice_gocardless_test_client_id))
+    GOCARDLESS_LIVE_CLIENT_ID: ((selfservice_gocardless_live_client_id))
+    ZENDESK_URL: "https://govuk.zendesk.com/api/v2"
+  routes:
+  - route: ((selfservice_url))

--- a/package-lock.json
+++ b/package-lock.json
@@ -3447,19 +3447,19 @@
           }
         },
         "chokidar": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-          "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
+          "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
           "dev": true,
           "requires": {
             "anymatch": "~3.1.1",
             "braces": "~3.0.2",
-            "fsevents": "~2.1.1",
+            "fsevents": "~2.1.2",
             "glob-parent": "~5.1.0",
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
-            "readdirp": "~3.2.0"
+            "readdirp": "~3.3.0"
           }
         },
         "cliui": {
@@ -3520,12 +3520,12 @@
           "dev": true
         },
         "readdirp": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-          "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
+          "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
           "dev": true,
           "requires": {
-            "picomatch": "^2.0.4"
+            "picomatch": "^2.0.7"
           }
         },
         "string-width": {
@@ -13170,9 +13170,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
-      "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
       "dev": true
     },
     "pify": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": "12.2.0"
+    "node": "12.11.1"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
Add cf manifest.yaml to run selfservice using node buildpack.
Using node 12.11.1 as that is lowest 12.x version supported by
PaaS.

To push run e.g.
```
cf push \
--var adminusers_url=http://adminusers-dev-dom.apps.internal \
--var card_connector_url=http://card-connector-dev-dom.apps.internal \
--var ledger_url=http://ledger-dev-dom.apps.internal \
--var selfservice_url=pay-selfservice-dev-dom.london.cloudapps.digital \
--var public_auth_url=http://publicauth-dev-dom.apps.internal \
--var products_url=http://products-dev-dom.apps.internal \
--var direct_debit_connector_url=http://directdebit-connector-dev-dom.apps.internal
```