### PR TITLE
PP-5972 Selfservice uses Ledger accept text/csv

### DIFF
--- a/app/services/clients/ledger_client.js
+++ b/app/services/clients/ledger_client.js
@@ -50,6 +50,22 @@ const transactions = function transactions (gatewayAccountId, filters = {}, urlO
   return baseClient.get(configuration)
 }
 
+const allTransactionsAsCsv = function allTransactionsAsCsv (gatewayAccountId, filters = {}) {
+  const queryParams = getQueryStringForParams(filters, true, true, true)
+  const path = `/v1/transaction?with_parent_transaction=true&account_id=${gatewayAccountId}${queryParams === '' ? '' : '&' + queryParams}`
+  const configuration = {
+    baseUrl: process.env.LEDGER_URL,
+    service: 'ledger',
+    url: path,
+    description: 'List transactions as CSV for a given gateway account ID',
+    json: false,
+    headers: {
+      accept: 'text/csv'
+    }
+  }
+  return baseClient.get(configuration)
+}
+
 const allTransactionPages = async function allTransactionPages (gatewayAccountId, filters = {}, options = {}) {
   let results = []
   const pageOptions = { hasMorePages: true }
@@ -85,6 +101,7 @@ module.exports = {
   transaction,
   transactions,
   allTransactionPages,
+  allTransactionsAsCsv,
   events,
   transactionSummary
 }

--- a/app/services/transaction_service.js
+++ b/app/services/transaction_service.js
@@ -20,5 +20,15 @@ const searchAllLedger = async function searchAllLedger (accountId, filters) {
   }
 }
 
+const searchAllLedgerWithCsv = async function searchAllLedgerWithCsv (accountId, filters) {
+  try {
+    const transactions = await Ledger.allTransactionsAsCsv(accountId, filters)
+    return transactions
+  } catch (error) {
+    throw new Error('GET_FAILED')
+  }
+}
+
 exports.search = searchLedger
 exports.searchAll = searchAllLedger
+exports.searchAllWithCsv = searchAllLedgerWithCsv

--- a/app/utils/get_query_string_for_params.js
+++ b/app/utils/get_query_string_for_params.js
@@ -4,7 +4,7 @@ const querystring = require('querystring')
 const _ = require('lodash')
 const dates = require('./dates.js')
 
-function getQueryStringForParams (params = {}, removeEmptyParams = false, flattenCardBrandsParam = false) {
+function getQueryStringForParams (params = {}, removeEmptyParams = false, flattenCardBrandsParam = false, ignorePagination = false) {
   let queryStrings = {
     reference: params.reference,
     email: params.email,
@@ -12,9 +12,12 @@ function getQueryStringForParams (params = {}, removeEmptyParams = false, flatte
     last_digits_card_number: params.lastDigitsCardNumber,
     card_brand: params.brand,
     from_date: dates.fromDateToApiFormat(params.fromDate, params.fromTime),
-    to_date: dates.toDateToApiFormat(params.toDate, params.toTime),
-    page: params.page || 1,
-    display_size: params.pageSize || 100
+    to_date: dates.toDateToApiFormat(params.toDate, params.toTime)
+  }
+
+  if (!ignorePagination) {
+    queryStrings.page = params.page || 1
+    queryStrings.display_size = params.pageSize || 100
   }
 
   if (params.payment_states) {

--- a/test/integration/json/transaction_download.json
+++ b/test/integration/json/transaction_download.json
@@ -33,6 +33,7 @@
     "gateway_transaction_id": "transaction-1",
     "transaction_type": "PAYMENT",
     "transaction_id": "charge1",
+    "charge_id": "charge1",
     "metadata": {
       "key1": "some string",
       "key2": true,
@@ -73,6 +74,7 @@
     },
     "delayed_capture": false,
     "transaction_type": "PAYMENT",
-    "transaction_id": "charge2"
+    "transaction_id": "charge2",
+    "charge_id": "charge2"
   }
 ]

--- a/test/integration/transaction_download_ft_tests.js
+++ b/test/integration/transaction_download_ft_tests.js
@@ -7,6 +7,7 @@ const _ = require('lodash')
 const querystring = require('querystring')
 const assert = require('chai').assert
 const expect = require('chai').expect
+const jsonToCsv = require('../../app/utils/json_to_csv')
 
 // Local dependencies
 require('../test_helpers/serialize_mock')
@@ -42,6 +43,12 @@ function downloadTransactionList (query) {
   return request(app)
     .get(paths.transactions.download + '?' + querystring.stringify(query))
     .set('Accept', 'application/json')
+}
+
+function downloadTransactionListCSV (query) {
+  return request(app)
+    .get(paths.transactions.download + '?' + querystring.stringify(query))
+    .set('Accept', 'text/csv')
 }
 
 describe('Transaction download endpoints', function () {
@@ -295,6 +302,33 @@ describe('Transaction download endpoints', function () {
       downloadTransactionList()
         .expect(500, { 'message': 'Internal server error' })
         .end(done)
+    })
+
+    it('should request with the correct headers', async () => {
+      const results = require('./json/transaction_download.json')
+      let resultsAsCsv = await jsonToCsv(results)
+      process.env.USE_LEDGER_BACKEND_CSV = true
+
+      ledgerMock
+        .defaultReplyHeaders({
+          'Content-Type': 'text/csv'
+        })
+        .matchHeader('accept', 'text/csv')
+        .matchHeader('content-type', 'application/json')
+        .get(LEDGER_TRANSACTION_PATH)
+        .reply(200, resultsAsCsv)
+
+      return downloadTransactionListCSV()
+        .expect(200)
+        .expect('Content-Type', 'text/csv; charset=utf-8')
+        .expect('Content-disposition', /attachment; filename="GOVUK_Pay_\d\d\d\d-\d\d-\d\d_\d\d:\d\d:\d\d.csv"/)
+        .then(function (res) {
+          const csvContent = res.text
+          const arrayOfLines = csvContent.split('\n')
+          expect(arrayOfLines[0]).to.equal(CSV_COLUMN_NAMES + ',"key1 (metadata)","key2 (metadata)","key3 (metadata)","Card Type"')
+          expect(arrayOfLines[1]).to.equal('"red","desc-red","alice.111@mail.fake","123.45","Visa","TEST01","12/19","4242","Success",true,"","","transaction-1","charge1","","12 May 2016","17:37:29","0.00","123.45","","some string",true,123,"credit"')
+          expect(arrayOfLines[2]).to.equal('"blue","desc-blue","alice.222@mail.fake","9.99","Mastercard","TEST02","12/19","4241","Cancelled",true,"P01234","Something happened","transaction-2","charge2","","12 Apr 2015","19:55:29","0.00","9.99","","","","",""')
+        })
     })
   })
 })


### PR DESCRIPTION
- Selfservice now contains a feature flag, USE_LEDGER_BACKEND_CSV, which when set to true, will ensure that when downloading CSVs it will do so using the accept: text/csv header

- Adds a test to ensure that the information it receives is correct and that the feature flag modifies the headers of the outgoing requests for the CSV