### PR TITLE
PP-6008-Update-dd-service-name-cypress test

### DIFF
--- a/test/cypress/integration/my-services/update_service_name.js
+++ b/test/cypress/integration/my-services/update_service_name.js
@@ -1,0 +1,116 @@
+'use strict'
+
+const { getUserStubWithServiceName, getGatewayAccountsStub } = require('../../utils/common_stubs')
+const authenticatedUserId = 'authenticated-user-id'
+const serviceExternalId = 'service-external-id'
+const newServiceName = 'Updated Service'
+const serviceName = {
+  en: 'My Service'
+}
+const welshServiceName = {
+  en: 'My Service',
+  cy: 'Cymru'
+}
+
+function setupStubs (serviceName, stubs = []) {
+  cy.task('setupStubs', [
+    ...stubs,
+    getUserStubWithServiceName(authenticatedUserId, ['1'], serviceName, serviceExternalId),
+    getGatewayAccountsStub(1)
+  ])
+}
+
+function getPatchRequestStub (welshServiceName) {
+  return {
+    name: 'patchUpdateServiceNameSuccess',
+    opts: {
+      external_id: serviceExternalId,
+      serviceName: {
+        en: newServiceName,
+        cy: welshServiceName || ''
+      },
+      verifyCalledTimes: 1
+    }
+  }
+}
+
+describe('Update service name', () => {
+  beforeEach(() => {
+    // keep the same session for entire describe block
+    Cypress.Cookies.preserveOnce('session')
+    Cypress.Cookies.preserveOnce('gateway_account')
+  })
+
+  describe('Edit a service name without a Welsh name', () => {
+    it('should display the my services page', () => {
+      cy.setEncryptedCookies(authenticatedUserId, 1)
+      setupStubs(serviceName)
+
+      cy.visit('/my-services')
+      cy.title().should('eq', 'Choose service - GOV.UK Pay')
+    })
+
+    it('should navigate to the edit service name form', () => {
+      setupStubs(serviceName)
+      cy.get('a').contains('Edit name').click()
+
+      cy.title().should('eq', 'Edit service name - GOV.UK Pay')
+      cy.get('#service-name').should('have.attr', 'value', 'My Service')
+      cy.get('#checkbox-service-name-cy').should('have.attr', 'aria-expanded', 'false')
+    })
+
+    it('should show a validation error when service name is empty', () => {
+      setupStubs(serviceName)
+      cy.get('input#service-name').clear()
+      cy.get('button').contains('Save').click()
+
+      cy.title().should('eq', 'Edit service name - GOV.UK Pay')
+
+      cy.get('.govuk-error-summary').find('a').should('have.length', 1)
+      cy.get('.govuk-error-summary').should('exist').within(() => {
+        cy.get('a[href="#service-name"]').should('contain', 'Service name')
+      })
+      cy.get('.govuk-form-group--error > input#service-name').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'This field cannot be blank')
+      })
+    })
+
+    it('should update service name to Updated Service', () => {
+      setupStubs(serviceName, [getPatchRequestStub()])
+      cy.get('input#service-name').clear()
+      cy.get('input#service-name').type(newServiceName)
+      cy.get('button').contains('Save').click()
+
+      cy.title().should('eq', 'Choose service - GOV.UK Pay')
+    })
+  })
+
+  describe('Edit a service name with a Welsh name', () => {
+    it('should display the my services page', () => {
+      cy.setEncryptedCookies(authenticatedUserId, 1)
+      setupStubs(welshServiceName)
+
+      cy.visit('/my-services')
+      cy.title().should('eq', 'Choose service - GOV.UK Pay')
+    })
+
+    it('should navigate to the edit service name form', () => {
+      setupStubs(welshServiceName)
+      cy.get('a').contains('Edit name').click()
+
+      cy.title().should('eq', 'Edit service name - GOV.UK Pay')
+      cy.get('#service-name').should('have.attr', 'value', 'My Service')
+      cy.get('#service-name-cy').should('have.attr', 'value', 'Cymru')
+    })
+
+    it('should update Welsh service name to Cymraeg', () => {
+      setupStubs(welshServiceName, [getPatchRequestStub('Cymraeg')])
+      cy.get('input#service-name').clear()
+      cy.get('input#service-name').type(newServiceName)
+      cy.get('input#service-name-cy').clear()
+      cy.get('input#service-name-cy').type('Cymraeg')
+      cy.get('button').contains('Save').click()
+      cy.title().should('eq', 'Choose service - GOV.UK Pay')
+    })
+  })
+})

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -390,6 +390,14 @@ module.exports = {
       response: serviceFixtures.validServiceResponse(opts).getPlain()
     })
   },
+  patchUpdateServiceNameSuccess: (opts = {}) => {
+    const path = `/v1/api/services/${opts.external_id}`
+    return simpleStubBuilder('PATCH', path, 200, {
+      request: serviceFixtures.validUpdateServiceNameRequest(opts.serviceName).getPlain(),
+      response: serviceFixtures.validServiceResponse(opts).getPlain(),
+      verifyCalledTimes: opts.verifyCalledTimes
+    })
+  },
   patchUpdateServiceSuccessCatchAll: (opts = {}) => {
     const path = `/v1/api/services/${opts.external_id}`
     return simpleStubBuilder('PATCH', path, 200, {

--- a/test/cypress/utils/common_stubs.js
+++ b/test/cypress/utils/common_stubs.js
@@ -15,13 +15,14 @@ module.exports.getUserStub = (userExternalId, gatewayAccountIds, serviceExternal
   }
 }
 
-module.exports.getUserStubWithServiceName = (userExternalId, gatewayAccountIds, serviceName) => {
+module.exports.getUserStubWithServiceName = (userExternalId, gatewayAccountIds, serviceName, serviceExternalId = 'a-service-id') => {
   return {
     name: 'getUserSuccess',
     opts: {
       external_id: userExternalId,
       service_roles: [{
         service: {
+          external_id: serviceExternalId,
           gateway_account_ids: gatewayAccountIds,
           service_name: serviceName
         }


### PR DESCRIPTION
Description:
- Replaces MyServicesIT.editServiceName_shouldSucceed_ForADirectDebitAccount in self-service end-to-end with Cypress test update_service_name.js
- Adds Cypress test for updating Welsh service name

