### PR TITLE
PP-6008 Don't verify stubs if no stubs setup

### DIFF
--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -73,6 +73,8 @@ module.exports = (on, config) => {
         json: true
       }).then(response => {
         response.stubs.forEach((stub) => {
+          // NOTE: if the "verifyCalledTimes" is specified for a stub, we will attempt to verify
+          // for all `it` blocks the stub is setup for, and the counter is reset for every `it`.
           if (stub.verifyCalledTimes) {
             // the matches array is added to stubs only when Mountebank is run with the --debug flag
             const timesCalled = (stub.matches && stub.matches.length) || 0
@@ -84,6 +86,14 @@ module.exports = (on, config) => {
 
         return null
       })
+        .catch(err => {
+          if (err.statusCode === 404) {
+            // imposter probably hasn't been added in Mountebank as no stubs were setup for the current
+            // test
+            return null
+          }
+          throw err
+        })
     }
   })
 

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -46,6 +46,9 @@ const simpleStubBuilder = function simpleStubBuilder (method, path, responseCode
       is: response
     }]
   }
+
+  // NOTE: if the "verifyCalledTimes" is specified, we will attempt to verify for all `it` blocks
+  // the stub is setup for, and the counter is reset for every `it`.
   if (additionalParams.verifyCalledTimes) {
     stub.verifyCalledTimes = additionalParams.verifyCalledTimes
   }


### PR DESCRIPTION
If we haven't set up any stubs for a test, then a call to
mountebank/imposters/8000 will return a 404 and cause an error to be
thrown when verifying the number of times a stub has been called.

Fix this by swallowing a 404 response from mountebank.

