### PR TITLE
PP-6010 Use "@pact-foundation/pact" dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -910,6 +910,230 @@
         "winston": "3.2.1"
       }
     },
+    "@pact-foundation/pact": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact/-/pact-9.6.0.tgz",
+      "integrity": "sha512-jmo5KvXMiJn3BlQoNnN8JtCZfLuGQiF76yJShPTlmjl+NT3PezhQ46BpYoeL9IJF8cVxpbJ79Zs4P3qaT9tEqw==",
+      "requires": {
+        "@pact-foundation/pact-node": "^10.2.3",
+        "@types/bluebird": "^3.5.20",
+        "@types/bunyan": "^1.8.3",
+        "@types/express": "^4.11.1",
+        "bluebird": "~3.5.1",
+        "body-parser": "^1.18.2",
+        "bunyan": "^1.8.12",
+        "cli-color": "^1.1.0",
+        "es6-object-assign": "^1.1.0",
+        "es6-promise": "^4.1.1",
+        "express": "^4.16.3",
+        "graphql": "^14.0.0",
+        "graphql-tag": "^2.9.1",
+        "http-proxy": "^1.17.0",
+        "http-proxy-middleware": "^0.19.0",
+        "lodash": "^4.17.14",
+        "lodash.isfunction": "3.0.8",
+        "lodash.isnil": "4.0.0",
+        "lodash.isundefined": "3.0.1",
+        "lodash.omit": "^4.5.0",
+        "lodash.omitby": "4.6.0",
+        "pkginfo": "^0.4.1",
+        "popsicle": "^9.2.0"
+      },
+      "dependencies": {
+        "@pact-foundation/pact-node": {
+          "version": "10.2.4",
+          "resolved": "https://registry.npmjs.org/@pact-foundation/pact-node/-/pact-node-10.2.4.tgz",
+          "integrity": "sha512-GUYnJoHAcgA/ZNn+/Z4AF1/RyhjGdfUYU20+uAC8kdcXbi/tEQDZT2BX2AtgJYKXtODodQWhtWXlzuRWlKNmEA==",
+          "requires": {
+            "@types/q": "1.0.7",
+            "@types/request": "2.48.2",
+            "bunyan": "1.8.12",
+            "bunyan-prettystream": "0.1.3",
+            "chalk": "2.3.1",
+            "check-types": "7.3.0",
+            "cross-spawn": "^7.0.1",
+            "decompress": "4.2.0",
+            "mkdirp": "0.5.1",
+            "q": "1.5.1",
+            "request": "2.87.0",
+            "rimraf": "2.6.2",
+            "sumchecker": "^2.0.2",
+            "tar": "4.4.2",
+            "underscore": "1.8.3",
+            "unixify": "1.0.0",
+            "url-join": "^4.0.0"
+          }
+        },
+        "@types/bluebird": {
+          "version": "3.5.29",
+          "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.29.tgz",
+          "integrity": "sha512-kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw=="
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.5",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
+        },
+        "chalk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.2.0"
+          }
+        },
+        "check-types": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.3.0.tgz",
+          "integrity": "sha1-Ro9XGkQ1wkJI9f0MsOjYfDw0Hn0="
+        },
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "request": {
+          "version": "2.87.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "tar": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.2.tgz",
+          "integrity": "sha512-BfkE9CciGGgDsATqkikUHrQrraBCO+ke/1f6SFAEMnxyyfN9lxC+nW1NFWMpqH865DhHIy9vQi682gk1X7friw==",
+          "requires": {
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "requires": {
+            "punycode": "^1.4.1"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "@pact-foundation/pact-node": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@pact-foundation/pact-node/-/pact-node-8.4.1.tgz",
@@ -1326,6 +1550,11 @@
         "@types/node": "*"
       }
     },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
+    },
     "@types/chai": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
@@ -1457,13 +1686,35 @@
     "@types/q": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.0.7.tgz",
-      "integrity": "sha512-0WS7XU7sXzQ7J1nbnMKKYdjrrFoO3YtZYgUzeV8JFXffPnHfvSJQleR70I8BOAsOm14i4dyaAZ3YzqIl1YhkXQ==",
-      "dev": true
+      "integrity": "sha512-0WS7XU7sXzQ7J1nbnMKKYdjrrFoO3YtZYgUzeV8JFXffPnHfvSJQleR70I8BOAsOm14i4dyaAZ3YzqIl1YhkXQ=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+    },
+    "@types/request": {
+      "version": "2.48.2",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.2.tgz",
+      "integrity": "sha512-gP+PSFXAXMrd5PcD7SqHeUjdGshAI8vKQ3+AvpQr3ht9iQea+59LOKvKITcQI+Lg+1EIkDP6AFSBUJPWG8GDyA==",
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "@types/restify": {
       "version": "4.3.6",
@@ -1503,6 +1754,11 @@
         "@types/chai": "*",
         "@types/sinon": "*"
       }
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.6.tgz",
+      "integrity": "sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ=="
     },
     "@types/xml2js": {
       "version": "0.4.3",
@@ -3078,7 +3334,6 @@
       "version": "1.8.12",
       "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
       "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
-      "dev": true,
       "requires": {
         "dtrace-provider": "~0.8",
         "moment": "^2.10.6",
@@ -3089,8 +3344,7 @@
     "bunyan-prettystream": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/bunyan-prettystream/-/bunyan-prettystream-0.1.3.tgz",
-      "integrity": "sha1-bDtxMmb2rTIAfHtqsemYokU0nZg=",
-      "dev": true
+      "integrity": "sha1-bDtxMmb2rTIAfHtqsemYokU0nZg="
     },
     "bytes": {
       "version": "3.1.0",
@@ -3662,7 +3916,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
       "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.1.1",
         "d": "1",
@@ -3940,7 +4193,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -3952,7 +4204,6 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -3966,14 +4217,12 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -4749,7 +4998,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
-      "dev": true,
       "requires": {
         "decompress-tar": "^4.0.0",
         "decompress-tarbz2": "^4.0.0",
@@ -4764,8 +5012,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
@@ -4773,7 +5020,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
-      "dev": true,
       "requires": {
         "file-type": "^5.2.0",
         "is-stream": "^1.1.0",
@@ -4784,7 +5030,6 @@
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-          "dev": true,
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
@@ -4794,7 +5039,6 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -4808,8 +5052,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-              "dev": true
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             }
           }
         },
@@ -4817,7 +5060,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           },
@@ -4825,8 +5067,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-              "dev": true
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             }
           }
         },
@@ -4834,7 +5075,6 @@
           "version": "1.6.2",
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-          "dev": true,
           "requires": {
             "bl": "^1.0.0",
             "buffer-alloc": "^1.2.0",
@@ -4851,7 +5091,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
-      "dev": true,
       "requires": {
         "decompress-tar": "^4.1.0",
         "file-type": "^6.1.0",
@@ -4863,8 +5102,7 @@
         "file-type": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
-          "dev": true
+          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
         }
       }
     },
@@ -4872,7 +5110,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
-      "dev": true,
       "requires": {
         "decompress-tar": "^4.1.1",
         "file-type": "^5.2.0",
@@ -4883,7 +5120,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
-      "dev": true,
       "requires": {
         "file-type": "^3.8.0",
         "get-stream": "^2.2.0",
@@ -4894,14 +5130,12 @@
         "file-type": {
           "version": "3.9.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-          "dev": true
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
         },
         "get-stream": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-          "dev": true,
           "requires": {
             "object-assign": "^4.0.1",
             "pinkie-promise": "^2.0.0"
@@ -4910,8 +5144,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
@@ -5306,7 +5539,6 @@
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
       "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
-      "dev": true,
       "optional": true,
       "requires": {
         "nan": "^2.14.0"
@@ -5625,6 +5857,11 @@
         "es6-symbol": "~3.1.1",
         "event-emitter": "~0.3.5"
       }
+    },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
     },
     "es6-promise": {
       "version": "4.2.8",
@@ -6786,7 +7023,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "dev": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -6823,8 +7059,7 @@
     "file-type": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-      "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-      "dev": true
+      "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -8059,8 +8294,7 @@
     "graceful-readlink": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "graphlib": {
       "version": "2.1.8",
@@ -8069,6 +8303,19 @@
       "requires": {
         "lodash": "^4.17.15"
       }
+    },
+    "graphql": {
+      "version": "14.5.8",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.8.tgz",
+      "integrity": "sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==",
+      "requires": {
+        "iterall": "^1.2.2"
+      }
+    },
+    "graphql-tag": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
+      "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg=="
     },
     "growl": {
       "version": "1.10.5",
@@ -8588,6 +8835,17 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+      "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+      "requires": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.11",
+        "micromatch": "^3.1.10"
       }
     },
     "http-signature": {
@@ -9138,8 +9396,7 @@
     "is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-      "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
-      "dev": true
+      "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
     },
     "is-npm": {
       "version": "1.0.0",
@@ -9468,6 +9725,11 @@
       "requires": {
         "handlebars": "^4.1.2"
       }
+    },
+    "iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "jmespath": {
       "version": "0.15.0",
@@ -10334,20 +10596,17 @@
     "lodash.isfunction": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz",
-      "integrity": "sha1-TbcJ/IG8So/XEnpFilNGxc3OLGs=",
-      "dev": true
+      "integrity": "sha1-TbcJ/IG8So/XEnpFilNGxc3OLGs="
     },
     "lodash.isnil": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
-      "integrity": "sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw=",
-      "dev": true
+      "integrity": "sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw="
     },
     "lodash.isundefined": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
-      "integrity": "sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g=",
-      "dev": true
+      "integrity": "sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g="
     },
     "lodash.kebabcase": {
       "version": "4.1.1",
@@ -10366,11 +10625,15 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
     "lodash.omitby": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
-      "integrity": "sha1-XBX/R1StVVAWtTwEExHo8HkgR5E=",
-      "dev": true
+      "integrity": "sha1-XBX/R1StVVAWtTwEExHo8HkgR5E="
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -10619,6 +10882,19 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
         "pify": "^3.0.0"
+      }
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
+    },
+    "make-error-cause": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
+      "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
+      "requires": {
+        "make-error": "^1.2.0"
       }
     },
     "map-age-cleaner": {
@@ -11587,7 +11863,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
       "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
-      "dev": true,
       "optional": true,
       "requires": {
         "mkdirp": "~0.5.1",
@@ -11599,7 +11874,6 @@
           "version": "6.0.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true,
           "optional": true,
           "requires": {
             "inflight": "^1.0.4",
@@ -11613,7 +11887,6 @@
           "version": "2.4.5",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
           "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
-          "dev": true,
           "optional": true,
           "requires": {
             "glob": "^6.0.1"
@@ -11678,7 +11951,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
-      "dev": true,
       "optional": true
     },
     "needle": {
@@ -12312,8 +12584,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -12712,233 +12983,6 @@
         "semver": "^5.1.0"
       }
     },
-    "pact": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/pact/-/pact-4.3.2.tgz",
-      "integrity": "sha1-xtM/2qYDZpO+6No7h8o/AHKCNtI=",
-      "dev": true,
-      "requires": {
-        "@pact-foundation/pact-node": "^6.4.1",
-        "cli-color": "^1.1.0",
-        "es6-promise": "4.1.1",
-        "lodash.isfunction": "3.0.8",
-        "lodash.isnil": "4.0.0",
-        "lodash.isundefined": "3.0.1",
-        "lodash.omitby": "4.6.0"
-      },
-      "dependencies": {
-        "@pact-foundation/pact-node": {
-          "version": "6.21.5",
-          "resolved": "https://registry.npmjs.org/@pact-foundation/pact-node/-/pact-node-6.21.5.tgz",
-          "integrity": "sha512-PkciKaPjwnMoNwe7MSOlD6/ZoSOiUJqzu559JTi5c/XrA5BKw7cPL7lRpsiUrbMW7jsrlYxwmmwj6KlE2kRQpw==",
-          "dev": true,
-          "requires": {
-            "@types/q": "1.0.7",
-            "bunyan": "1.8.12",
-            "bunyan-prettystream": "0.1.3",
-            "caporal": "1.1.0",
-            "chalk": "2.3.1",
-            "check-types": "7.3.0",
-            "decompress": "4.2.0",
-            "mkdirp": "0.5.1",
-            "q": "1.5.1",
-            "request": "2.87.0",
-            "rimraf": "2.6.2",
-            "sumchecker": "^2.0.2",
-            "tar": "4.4.0",
-            "underscore": "1.8.3",
-            "unixify": "1.0.0",
-            "url-join": "^4.0.0"
-          }
-        },
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
-        "async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
-          "dev": true
-        },
-        "caporal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/caporal/-/caporal-1.1.0.tgz",
-          "integrity": "sha512-R5qo2QGoqBM6RvzHonGhUuEJSeqEa4lD1r+cPUEY2+YsXhpQVTS2TvScfIbi6ydFdhzFCNeNUB1v0YrRBvsbdg==",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.4.7",
-            "cli-table3": "^0.5.0",
-            "colorette": "1.0.1",
-            "fast-levenshtein": "^2.0.6",
-            "lodash.camelcase": "^4.3.0",
-            "lodash.kebabcase": "^4.1.1",
-            "lodash.merge": "^4.6.0",
-            "micromist": "1.1.0",
-            "prettyjson": "^1.2.1",
-            "tabtab": "^2.2.2",
-            "winston": "^2.3.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
-          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.2.0"
-          }
-        },
-        "check-types": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.3.0.tgz",
-          "integrity": "sha1-Ro9XGkQ1wkJI9f0MsOjYfDw0Hn0=",
-          "dev": true
-        },
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-          "dev": true
-        },
-        "es6-promise": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-          "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
-          "dev": true
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-          "dev": true,
-          "requires": {
-            "ajv": "^5.1.0",
-            "har-schema": "^2.0.0"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-          "dev": true
-        },
-        "request": {
-          "version": "2.87.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "tar": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.0.tgz",
-          "integrity": "sha512-gJlTiiErwo96K904FnoYWl+5+FBgS+FimU6GMh66XLdLa55al8+d4jeDfPoGwSNHdtWI5FJP6xurmVqhBuGJpQ==",
-          "dev": true,
-          "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.3",
-            "minipass": "^2.2.1",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "yallist": "^3.0.2"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-          "dev": true,
-          "requires": {
-            "punycode": "^1.4.1"
-          }
-        },
-        "uuid": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-          "dev": true
-        },
-        "winston": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
-          "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
-          "dev": true,
-          "requires": {
-            "async": "~1.0.0",
-            "colors": "1.0.x",
-            "cycle": "1.0.x",
-            "eyes": "0.1.x",
-            "isstream": "0.1.x",
-            "stack-trace": "0.0.x"
-          }
-        }
-      }
-    },
     "pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -13173,8 +13217,7 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -13195,14 +13238,12 @@
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -13370,6 +13411,17 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
       "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
+    },
+    "popsicle": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-9.2.0.tgz",
+      "integrity": "sha512-petRj39w05GvH1WKuGFmzxR9+k+R9E7zX5XWTFee7P/qf88hMuLT7aAO/RsmldpQMtJsWQISkTQlfMRECKlxhw==",
+      "requires": {
+        "concat-stream": "^1.4.7",
+        "form-data": "^2.0.0",
+        "make-error-cause": "^1.2.1",
+        "tough-cookie": "^2.0.0"
+      }
     },
     "portfinder": {
       "version": "1.0.20",
@@ -13641,8 +13693,7 @@
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "dev": true
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qrcode": {
       "version": "1.4.4",
@@ -14392,7 +14443,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
       "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
-      "dev": true,
       "optional": true
     },
     "safe-regex": {
@@ -14557,7 +14607,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
-      "dev": true,
       "requires": {
         "commander": "~2.8.1"
       },
@@ -14566,7 +14615,6 @@
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "dev": true,
           "requires": {
             "graceful-readlink": ">= 1.0.0"
           }
@@ -16440,7 +16488,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
-      "dev": true,
       "requires": {
         "is-natural-number": "^4.0.1"
       }
@@ -16493,7 +16540,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz",
       "integrity": "sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=",
-      "dev": true,
       "requires": {
         "debug": "^2.2.0"
       },
@@ -16502,7 +16548,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -16510,8 +16555,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -17222,8 +17266,7 @@
     "to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-      "dev": true
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -17419,8 +17462,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uc.micro": {
       "version": "1.0.6",
@@ -17469,7 +17511,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
       "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
-      "dev": true,
       "requires": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -17479,7 +17520,6 @@
           "version": "5.4.3",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
           "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
-          "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -17529,8 +17569,7 @@
     "underscore": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-      "dev": true
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "underscore.string": {
       "version": "3.3.5",
@@ -17604,7 +17643,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
       "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=",
-      "dev": true,
       "requires": {
         "normalize-path": "^2.1.1"
       },
@@ -17613,7 +17651,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
@@ -18172,8 +18209,7 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "3.2.1",
@@ -18345,7 +18381,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-      "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "dependencies": {
     "@govuk-pay/pay-js-commons": "2.20.1",
+    "@pact-foundation/pact": "9.6.0",
     "@sentry/node": "5.11.1",
     "accessible-autocomplete": "2.0.1",
     "appmetrics": "5.1.1",
@@ -151,7 +152,6 @@
     "notp": "2.0.3",
     "nunjucksify": "2.2.0",
     "nyc": "14.1.1",
-    "pact": "4.3.2",
     "portfinder": "1.0.20",
     "proxyquire": "~2.1.0",
     "sass-lint": "1.12.1",

--- a/test/fixtures/pact_base.js
+++ b/test/fixtures/pact_base.js
@@ -1,18 +1,18 @@
 const _ = require('lodash')
-let Pact = require('pact')
-let matchers = Pact.Matchers
+const { Matchers } = require('@pact-foundation/pact')
+const { somethingLike, eachLike, term } = Matchers
 
 module.exports = function (options = {}) {
   let pactifySimpleArray = (arr) => {
     let pactified = []
     arr.forEach((val) => {
-      pactified.push(matchers.somethingLike(val))
+      pactified.push(somethingLike(val))
     })
     return pactified
   }
 
   let pactifyNestedArray = (arr) => {
-    return matchers.eachLike(pactify(arr[0]), {min: arr.length})
+    return eachLike(pactify(arr[0]), { min: arr.length })
   }
 
   let pactify = (object) => {
@@ -27,13 +27,13 @@ module.exports = function (options = {}) {
         } else {
           length = value.length
         }
-        pactified[key] = matchers.eachLike(matchers.somethingLike(value[0]), {min: length})
+        pactified[key] = eachLike(somethingLike(value[0]), { min: length })
       } else if (value.constructor === Array) {
         pactified[key] = pactifySimpleArray(value)
       } else if (value.constructor === Object) {
         pactified[key] = pactify(value)
       } else {
-        pactified[key] = matchers.somethingLike(value)
+        pactified[key] = somethingLike(value)
       }
     })
     return pactified
@@ -47,7 +47,7 @@ module.exports = function (options = {}) {
   }
 
   let pactifyMatch = (generate, matcher) => {
-    return matchers.term({generate: generate, matcher: matcher})
+    return term({ generate: generate, matcher: matcher })
   }
 
   return {

--- a/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
+++ b/test/unit/clients/adminusers_client/authenticate/authenticate_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
@@ -21,7 +21,7 @@ chai.use(chaiAsPromised)
 const expect = chai.expect
 
 describe('adminusers client - authenticate', () => {
-  const provider = Pact({
+  const provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/forgotten_password/create_forgotten_password_test.js
+++ b/test/unit/clients/adminusers_client/forgotten_password/create_forgotten_password_test.js
@@ -1,4 +1,4 @@
-var Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 var path = require('path')
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
@@ -6,13 +6,13 @@ var getAdminUsersClient = require('../../../../../app/services/clients/adminuser
 var userFixtures = require('../../../../fixtures/user_fixtures')
 var PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
 let port = Math.floor(Math.random() * 48127) + 1024
-let adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+let adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 chai.use(chaiAsPromised)
 const expect = chai.expect
 const FORGOTTEN_PASSWORD_PATH = '/v1/api/forgotten-passwords'
 
 describe('adminusers client - create forgotten password', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
@@ -51,7 +51,7 @@ describe('adminusers client - create forgotten password', function () {
   })
 
   describe('bad request', () => {
-    let request = {username: ''}
+    let request = { username: '' }
 
     let badForgottenPasswordResponse = userFixtures.badForgottenPasswordResponse()
 

--- a/test/unit/clients/adminusers_client/forgotten_password/get_forgotten_password_test.js
+++ b/test/unit/clients/adminusers_client/forgotten_password/get_forgotten_password_test.js
@@ -1,4 +1,4 @@
-var Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 var path = require('path')
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
@@ -6,13 +6,13 @@ var getAdminUsersClient = require('../../../../../app/services/clients/adminuser
 var userFixtures = require('../../../../fixtures/user_fixtures')
 var PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
 let port = Math.floor(Math.random() * 48127) + 1024
-let adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+let adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 chai.use(chaiAsPromised)
 const expect = chai.expect
 const FORGOTTEN_PASSWORD_PATH = '/v1/api/forgotten-passwords'
 
 describe('adminusers client - get forgotten password', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
@@ -27,7 +27,7 @@ describe('adminusers client - get forgotten password', function () {
 
   describe('success', () => {
     let code = 'existing-code'
-    let validForgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({code: code})
+    let validForgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({ code: code })
     let expectedForgottenPassword = validForgottenPasswordResponse.getPlain()
 
     before((done) => {

--- a/test/unit/clients/adminusers_client/invite/complete_service_invite_test.js
+++ b/test/unit/clients/adminusers_client/invite/complete_service_invite_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -14,14 +14,14 @@ const inviteFixtures = require('../../../../fixtures/invite_fixtures')
 // Constants
 const INVITE_RESOURCE = '/v1/api/invites'
 const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 const expect = chai.expect
 
 // Global setup
 chai.use(chaiAsPromised)
 
 describe('adminusers client - complete an invite', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/invite/complete_user_invite_test.js
+++ b/test/unit/clients/adminusers_client/invite/complete_user_invite_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -14,14 +14,14 @@ const inviteFixtures = require('../../../../fixtures/invite_fixtures')
 // Constants
 const INVITE_RESOURCE = '/v1/api/invites'
 let port = Math.floor(Math.random() * 48127) + 1024
-let adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+let adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 const expect = chai.expect
 
 // Global setup
 chai.use(chaiAsPromised)
 
 describe('adminusers client - complete a user invite', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/invite/generate_invite_otp_code_service_test.js
+++ b/test/unit/clients/adminusers_client/invite/generate_invite_otp_code_service_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -13,14 +13,14 @@ const getAdminUsersClient = require('../../../../../app/services/clients/adminus
 // Constants
 const INVITE_RESOURCE = '/v1/api/invites'
 let port = Math.floor(Math.random() * 48127) + 1024
-let adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+let adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 const expect = chai.expect
 
 // Global setup
 chai.use(chaiAsPromised)
 
 describe('adminusers client - generate otp code for service invite', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/invite/generate_invite_otp_code_user_test.js
+++ b/test/unit/clients/adminusers_client/invite/generate_invite_otp_code_user_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -14,14 +14,14 @@ const inviteFixtures = require('../../../../fixtures/invite_fixtures')
 // Constants
 const INVITE_RESOURCE = '/v1/api/invites'
 let port = Math.floor(Math.random() * 48127) + 1024
-let adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+let adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 const expect = chai.expect
 
 // Global setup
 chai.use(chaiAsPromised)
 
 describe('adminusers client - generate otp code for user invite', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/invite/get_invite_test.js
+++ b/test/unit/clients/adminusers_client/invite/get_invite_test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
@@ -14,10 +14,10 @@ const expect = chai.expect
 
 const INVITES_PATH = '/v1/api/invites'
 let port = Math.floor(Math.random() * 48127) + 1024
-let adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+let adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 describe('adminusers client - get a validated invite', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/invite/invite_user_test.js
+++ b/test/unit/clients/adminusers_client/invite/invite_user_test.js
@@ -1,4 +1,4 @@
-var Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 var path = require('path')
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
@@ -11,11 +11,11 @@ chai.use(chaiAsPromised)
 const expect = chai.expect
 const INVITES_PATH = '/v1/api/invites/user'
 const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 describe('adminusers client - invite user', function () {
   let externalServiceId = '12345'
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
     port: port,
@@ -29,7 +29,7 @@ describe('adminusers client - invite user', function () {
   after(() => provider.finalize())
 
   describe('success', function () {
-    let validInvite = inviteFixtures.validInviteRequest({externalServiceId: externalServiceId})
+    let validInvite = inviteFixtures.validInviteRequest({ externalServiceId: externalServiceId })
 
     before((done) => {
       let pactified = validInvite.getPactified()
@@ -58,7 +58,7 @@ describe('adminusers client - invite user', function () {
 
   describe('not found', () => {
     let nonExistentServiceId = '111111'
-    let validInvite = inviteFixtures.validInviteRequest({externalServiceId: nonExistentServiceId})
+    let validInvite = inviteFixtures.validInviteRequest({ externalServiceId: nonExistentServiceId })
 
     before((done) => {
       let pactified = validInvite.getPactified()
@@ -85,7 +85,7 @@ describe('adminusers client - invite user', function () {
   })
 
   describe('bad request', () => {
-    let invalidInvite = inviteFixtures.invalidInviteRequest({externalServiceId: externalServiceId})
+    let invalidInvite = inviteFixtures.invalidInviteRequest({ externalServiceId: externalServiceId })
     let errorResponse = inviteFixtures.invalidInviteCreateResponseWhenFieldsMissing()
 
     before((done) => {
@@ -118,7 +118,7 @@ describe('adminusers client - invite user', function () {
   })
 
   describe('conflicting request', () => {
-    let validInvite = inviteFixtures.validInviteRequest({externalServiceId: externalServiceId})
+    let validInvite = inviteFixtures.validInviteRequest({ externalServiceId: externalServiceId })
     let errorResponse = inviteFixtures.conflictingInviteResponseWhenEmailUserAlreadyCreated(validInvite.getPlain().email).getPactified()
 
     before((done) => {
@@ -150,7 +150,7 @@ describe('adminusers client - invite user', function () {
   })
 
   describe('not permitted', () => {
-    let validInvite = inviteFixtures.validInviteRequest({externalServiceId: externalServiceId})
+    let validInvite = inviteFixtures.validInviteRequest({ externalServiceId: externalServiceId })
     let errorResponse = inviteFixtures.notPermittedInviteResponse(validInvite.getPlain().email, externalServiceId)
 
     before((done) => {

--- a/test/unit/clients/adminusers_client/invite/resend_otp_code_test.js
+++ b/test/unit/clients/adminusers_client/invite/resend_otp_code_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -14,14 +14,14 @@ const inviteFixtures = require('../../../../fixtures/invite_fixtures')
 // Constants
 const INVITE_RESOURCE = '/v1/api/invites'
 const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 const expect = chai.expect
 
 // Global setup
 chai.use(chaiAsPromised)
 
 describe('submit resend otp code API', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/invite/submit_service_registration_test.js
+++ b/test/unit/clients/adminusers_client/invite/submit_service_registration_test.js
@@ -2,7 +2,7 @@
 
 // NPM dependencies
 
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -19,12 +19,12 @@ chai.use(chaiAsPromised)
 
 const expect = chai.expect
 const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 const INVITE_PATH = '/v1/api/invites'
 
 describe('adminusers client - self register service', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/invite/verify_otp_code_test.js
+++ b/test/unit/clients/adminusers_client/invite/verify_otp_code_test.js
@@ -1,4 +1,4 @@
-var Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 var path = require('path')
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
@@ -11,10 +11,10 @@ chai.use(chaiAsPromised)
 const expect = chai.expect
 const INVITE_RESOURCE = '/v1/api/invites'
 var port = Math.floor(Math.random() * 48127) + 1024
-var adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+var adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 describe('adminusers client - submit verification details', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/invite/verify_service_otp_code_test.js
+++ b/test/unit/clients/adminusers_client/invite/verify_service_otp_code_test.js
@@ -1,4 +1,4 @@
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
@@ -14,7 +14,7 @@ const port = Math.floor(Math.random() * 48127) + 1024
 const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 describe('adminusers client - validate otp code for a service', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/service/add_gateway_accounts_to_services_test.js
+++ b/test/unit/clients/adminusers_client/service/add_gateway_accounts_to_services_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -14,7 +14,7 @@ const serviceFixtures = require('../../../../fixtures/service_fixtures')
 // Constants
 const SERVICE_RESOURCE = '/v1/api/services'
 const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 const expect = chai.expect
 const serviceExternalId = 'cp5wa'
 let result, request
@@ -25,7 +25,7 @@ chai.use(chaiAsPromised)
 describe('admin users client - add gateway accounts to service', () => {
   this.timeout = 5000
 
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
@@ -65,7 +65,7 @@ describe('admin users client - add gateway accounts to service', () => {
 
       return expect(result)
         .to.be.fulfilled
-        .and.to.eventually.include({externalId: serviceExternalId})
+        .and.to.eventually.include({ externalId: serviceExternalId })
         .and.to.have.property('gatewayAccountIds').to.include(...gatewayAccountIdsAfter)
     })
   })

--- a/test/unit/clients/adminusers_client/service/create_service_test.js
+++ b/test/unit/clients/adminusers_client/service/create_service_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -21,7 +21,7 @@ const expect = chai.expect
 chai.use(chaiAsPromised)
 
 describe('adminusers client - create a new service', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/service/get_service_users_test.js
+++ b/test/unit/clients/adminusers_client/service/get_service_users_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
@@ -18,12 +18,12 @@ chai.use(chaiAsPromised)
 const expect = chai.expect
 const SERVICES_PATH = '/v1/api/services'
 const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 const existingServiceExternalId = 'cp5wa'
 
 describe('adminusers client - service users', () => {
-  const provider = Pact({
+  const provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/service/govuk_pay_agreement_post_email_address_test.js
+++ b/test/unit/clients/adminusers_client/service/govuk_pay_agreement_post_email_address_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -22,7 +22,7 @@ const serviceExternalId = 'cp5wa'
 chai.use(chaiAsPromised)
 
 describe('adminusers client - post govuk pay agreement - email address', () => {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/service/stripe_agreement_post_ip_address_test.js
+++ b/test/unit/clients/adminusers_client/service/stripe_agreement_post_ip_address_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -21,7 +21,7 @@ const serviceExternalId = 'rtglNotStarted'
 chai.use(chaiAsPromised)
 
 describe('adminusers client - post stripe agreement - ip address', () => {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/service/update_collect_billing_address_test.js
+++ b/test/unit/clients/adminusers_client/service/update_collect_billing_address_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -14,7 +14,7 @@ const serviceFixtures = require('../../../../fixtures/service_fixtures')
 // Constants
 const SERVICE_RESOURCE = '/v1/api/services'
 const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 const expect = chai.expect
 const serviceExternalId = 'cp5wa'
 
@@ -22,7 +22,7 @@ const serviceExternalId = 'cp5wa'
 chai.use(chaiAsPromised)
 
 describe('adminusers client - patch collect billing address toggle', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
@@ -36,7 +36,7 @@ describe('adminusers client - patch collect billing address toggle', function ()
   after(() => provider.finalize())
 
   describe('patch collect billing address toggle - disabled', () => {
-    const validUpdateCollectBillingAddressRequest = serviceFixtures.validCollectBillingAddressToggleRequest({enabled: false})
+    const validUpdateCollectBillingAddressRequest = serviceFixtures.validCollectBillingAddressToggleRequest({ enabled: false })
     const validUpdateCollectBillingAddressResponse = serviceFixtures.validServiceResponse({
       external_id: serviceExternalId,
       collect_billing_address: false

--- a/test/unit/clients/adminusers_client/service/update_request_to_go_live_stage_test.js
+++ b/test/unit/clients/adminusers_client/service/update_request_to_go_live_stage_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -22,7 +22,7 @@ const serviceExternalId = 'cp5wa'
 chai.use(chaiAsPromised)
 
 describe('adminusers client - patch request to go live stage', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/service/update_service_name_test.js
+++ b/test/unit/clients/adminusers_client/service/update_service_name_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -17,13 +17,13 @@ chai.use(chaiAsPromised)
 // Constants
 const SERVICE_RESOURCE = '/v1/api/services'
 const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 const expect = chai.expect
 
 const existingServiceExternalId = 'cp5wa'
 
 describe('adminusers client - update service name', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/service/update_service_test.js
+++ b/test/unit/clients/adminusers_client/service/update_service_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -25,7 +25,7 @@ chai.use(chaiAsPromised)
 const existingServiceExternalId = 'cp5wa'
 
 describe('adminusers client - patch request to update service', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/user/assign_servicerole_test.js
+++ b/test/unit/clients/adminusers_client/user/assign_servicerole_test.js
@@ -1,4 +1,4 @@
-let Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 let path = require('path')
 let chai = require('chai')
 let chaiAsPromised = require('chai-as-promised')
@@ -17,7 +17,7 @@ const existingUserExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
 const existingServiceExternalId = 'cp5wa'
 
 describe('adminusers client - assign service role to user', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/user/authenticate_test.js
+++ b/test/unit/clients/adminusers_client/user/authenticate_test.js
@@ -1,4 +1,4 @@
-var Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 var path = require('path')
 var chai = require('chai')
 var _ = require('lodash')
@@ -12,10 +12,10 @@ chai.use(chaiAsPromised)
 const expect = chai.expect
 const USER_PATH = '/v1/api/users'
 const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 describe('adminusers client - authenticate', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
@@ -29,7 +29,7 @@ describe('adminusers client - authenticate', function () {
   after(() => provider.finalize())
 
   describe('authenticate user API - success', () => {
-    let request = userFixtures.validAuthenticateRequest({username: 'existing-user'})
+    let request = userFixtures.validAuthenticateRequest({ username: 'existing-user' })
     let validUserResponse = userFixtures.validUserResponse()
 
     before((done) => {
@@ -64,7 +64,7 @@ describe('adminusers client - authenticate', function () {
   })
 
   describe('authenticate user API - unauthorized', () => {
-    let request = userFixtures.validAuthenticateRequest({username: 'nonexisting'})
+    let request = userFixtures.validAuthenticateRequest({ username: 'nonexisting' })
 
     let unauthorizedResponse = userFixtures.unauthorizedUserResponse()
 
@@ -94,7 +94,7 @@ describe('adminusers client - authenticate', function () {
   })
 
   describe('authenticate user API - bad request', () => {
-    let request = {username: '', password: ''}
+    let request = { username: '', password: '' }
 
     let badAuthenticateResponse = userFixtures.badAuthenticateResponse()
 

--- a/test/unit/clients/adminusers_client/user/delete_user_test.js
+++ b/test/unit/clients/adminusers_client/user/delete_user_test.js
@@ -1,4 +1,4 @@
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
@@ -6,13 +6,13 @@ const getAdminUsersClient = require('../../../../../app/services/clients/adminus
 const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
 const SERVICES_PATH = '/v1/api/services'
 const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 const expect = chai.expect
 
 chai.use(chaiAsPromised)
 
 describe('adminusers client - delete user', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/user/get_multiple_users_test.js
+++ b/test/unit/clients/adminusers_client/user/get_multiple_users_test.js
@@ -1,5 +1,5 @@
 'use strict'
-let Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 let path = require('path')
 let chai = require('chai')
 let chaiAsPromised = require('chai-as-promised')
@@ -8,13 +8,13 @@ let random = require('../../../../../app/utils/random')
 let getAdminUsersClient = require('../../../../../app/services/clients/adminusers_client')
 let PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
 let port = Math.floor(Math.random() * 48127) + 1024
-let adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+let adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 chai.use(chaiAsPromised)
-const {expect} = chai
+const { expect } = chai
 const USER_PATH = '/v1/api/users'
 
 describe('adminusers client - get users', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/user/get_user_test.js
+++ b/test/unit/clients/adminusers_client/user/get_user_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // npm dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const { expect } = chai
@@ -20,7 +20,7 @@ const USER_PATH = '/v1/api/users'
 chai.use(chaiAsPromised)
 
 describe('adminusers client - get user', () => {
-  const provider = Pact({
+  const provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/user/increment_session_version_test.js
+++ b/test/unit/clients/adminusers_client/user/increment_session_version_test.js
@@ -1,4 +1,4 @@
-var Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 var path = require('path')
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
@@ -11,10 +11,10 @@ chai.use(chaiAsPromised)
 const expect = chai.expect
 const USER_PATH = '/v1/api/users'
 var port = Math.floor(Math.random() * 48127) + 1024
-var adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+var adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 describe('adminusers client - session', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/user/second_factor_test.js
+++ b/test/unit/clients/adminusers_client/user/second_factor_test.js
@@ -1,4 +1,4 @@
-let Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 let path = require('path')
 let chai = require('chai')
 let chaiAsPromised = require('chai-as-promised')
@@ -11,12 +11,12 @@ chai.use(chaiAsPromised)
 const expect = chai.expect
 const USER_PATH = '/v1/api/users'
 let port = Math.floor(Math.random() * 48127) + 1024
-let adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+let adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 const existingExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
 
 describe('adminusers client', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/user/update_password_test.js
+++ b/test/unit/clients/adminusers_client/user/update_password_test.js
@@ -1,4 +1,4 @@
-var Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 var path = require('path')
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
@@ -11,10 +11,10 @@ chai.use(chaiAsPromised)
 const expect = chai.expect
 const RESET_PASSWORD_PATH = '/v1/api/reset-password'
 var port = Math.floor(Math.random() * 48127) + 1024
-var adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+var adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 describe('adminusers client - update password', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/adminusers_client/user/update_servicerole_test.js
+++ b/test/unit/clients/adminusers_client/user/update_servicerole_test.js
@@ -1,4 +1,4 @@
-let Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 let path = require('path')
 let chai = require('chai')
 let chaiAsPromised = require('chai-as-promised')
@@ -11,13 +11,13 @@ chai.use(chaiAsPromised)
 const expect = chai.expect
 const USER_PATH = '/v1/api/users'
 let port = Math.floor(Math.random() * 48127) + 1024
-let adminusersClient = getAdminUsersClient({baseUrl: `http://localhost:${port}`})
+let adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 const existingUserExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
 const existingServiceExternalId = 'cp5wa'
 
 describe('adminusers client - update user service role', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,

--- a/test/unit/clients/connector_client/connector_client_create_gateway_account_test.js
+++ b/test/unit/clients/connector_client/connector_client_create_gateway_account_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -21,7 +21,7 @@ const expect = chai.expect
 chai.use(chaiAsPromised)
 
 describe('connector client - create gateway account', function () {
-  const provider = Pact({
+  const provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'connector',
     port: port,

--- a/test/unit/clients/connector_client/connector_get_card_types_test.js
+++ b/test/unit/clients/connector_client/connector_get_card_types_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -21,7 +21,7 @@ const expect = chai.expect
 chai.use(chaiAsPromised)
 
 describe('connector client', function () {
-  const provider = Pact({
+  const provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'connector',
     port: port,

--- a/test/unit/clients/connector_client/connector_get_gateway_account_test.js
+++ b/test/unit/clients/connector_client/connector_get_gateway_account_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -23,7 +23,7 @@ chai.use(chaiAsPromised)
 const existingGatewayAccountId = 666
 
 describe('connector client - get gateway account', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
     port: port,

--- a/test/unit/clients/connector_client/connector_get_multiple_gateway_accounts_test.js
+++ b/test/unit/clients/connector_client/connector_get_multiple_gateway_accounts_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -21,7 +21,7 @@ const expect = chai.expect
 chai.use(chaiAsPromised)
 
 describe('connector client - get multiple gateway accounts', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
     port: port,

--- a/test/unit/clients/connector_client/connector_get_stripe_account_setup_test.js
+++ b/test/unit/clients/connector_client/connector_get_stripe_account_setup_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
@@ -24,7 +24,7 @@ const existingGatewayAccountId = 42
 const defaultState = `a stripe gateway account with external id ${existingGatewayAccountId} exists in the database`
 
 describe('connector client - get stripe account setup', () => {
-  const provider = Pact({
+  const provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
     port: port,

--- a/test/unit/clients/connector_client/connector_get_stripe_account_test.js
+++ b/test/unit/clients/connector_client/connector_get_stripe_account_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
@@ -24,7 +24,7 @@ const existingGatewayAccountId = 42
 const defaultState = `a stripe gateway account with external id ${existingGatewayAccountId} exists in the database`
 
 describe('connector client - get stripe account', () => {
-  const provider = Pact({
+  const provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
     port: port,

--- a/test/unit/clients/connector_client/connector_patch_apple_pay_toggle_test.js
+++ b/test/unit/clients/connector_client/connector_patch_apple_pay_toggle_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -25,7 +25,7 @@ describe('connector client - patch apple pay toggle (enabled) request', () => {
   const patchRequestParams = { path: 'allow_apple_pay', value: true }
   const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams).getPlain()
 
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
     port: port,

--- a/test/unit/clients/connector_client/connector_patch_email_collection_mode_test.js
+++ b/test/unit/clients/connector_client/connector_patch_email_collection_mode_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -24,7 +24,7 @@ const existingGatewayAccountId = 42
 const defaultState = `Gateway account ${existingGatewayAccountId} exists in the database`
 
 describe('connector client - patch email collection mode', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'connector',
     port: port,

--- a/test/unit/clients/connector_client/connector_patch_email_confirmation_toggle_test.js
+++ b/test/unit/clients/connector_client/connector_patch_email_confirmation_toggle_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -24,7 +24,7 @@ const existingGatewayAccountId = 42
 const defaultState = `Gateway account ${existingGatewayAccountId} exists in the database`
 
 describe('connector client - patch email confirmation toggle', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'connector',
     port: port,

--- a/test/unit/clients/connector_client/connector_patch_email_refund_toggle_test.js
+++ b/test/unit/clients/connector_client/connector_patch_email_refund_toggle_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -24,7 +24,7 @@ const existingGatewayAccountId = 42
 const defaultState = `Gateway account ${existingGatewayAccountId} exists in the database`
 
 describe('connector client - patch email refund toggle', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'connector',
     port: port,

--- a/test/unit/clients/connector_client/connector_patch_google_pay_toggle_test.js
+++ b/test/unit/clients/connector_client/connector_patch_google_pay_toggle_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -25,7 +25,7 @@ describe('connector client - patch google pay toggle (enabled) request', () => {
   const patchRequestParams = { path: 'allow_google_pay', value: true }
   const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams).getPlain()
 
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
     port: port,

--- a/test/unit/clients/connector_client/connector_post_refund_test.js
+++ b/test/unit/clients/connector_client/connector_post_refund_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -25,7 +25,7 @@ const defaultChargeId = 'abc123'
 const defaultChargeState = `Gateway account ${existingGatewayAccountId} exists and has a charge for £1 with id ${defaultChargeId}`
 
 describe('connector client', function () {
-  const provider = Pact({
+  const provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
     port: port,

--- a/test/unit/clients/connector_client/connector_set_stripe_account_setup_flag_test.js
+++ b/test/unit/clients/connector_client/connector_set_stripe_account_setup_flag_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
@@ -23,7 +23,7 @@ const existingGatewayAccountId = 42
 const defaultState = `a stripe gateway account with external id ${existingGatewayAccountId} exists in the database`
 
 describe('connector client - set stripe account setup flag', () => {
-  const provider = Pact({
+  const provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
     port: port,

--- a/test/unit/clients/direct_debit_connector_client/get_direct_debit_gateway_account_test.js
+++ b/test/unit/clients/direct_debit_connector_client/get_direct_debit_gateway_account_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -23,7 +23,7 @@ chai.use(chaiAsPromised)
 const existingDirectDebitGatewayAccountId = 667
 
 describe('connector client - get gateway account', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'direct-debit-connector',
     port: port,

--- a/test/unit/clients/ledger_client/ledger_pact_test_provider.js
+++ b/test/unit/clients/ledger_client/ledger_pact_test_provider.js
@@ -1,13 +1,13 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 
 // Custom dependencies
 const path = require('path')
 const port = parseInt(process.env.LEDGER_URL.match(/\d+(\.\d+)?$/g)[0], 10)
 
-const pactProvider = Pact({
+const pactProvider = new Pact({
   consumer: 'selfservice',
   provider: 'ledger',
   port: port,

--- a/test/unit/clients/product_client/payment/create_test.js
+++ b/test/unit/clients/product_client/payment/create_test.js
@@ -1,8 +1,8 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
-const {expect} = require('chai')
+const { Pact } = require('@pact-foundation/pact')
+const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
 // Custom dependencies
@@ -24,7 +24,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 }
 
 describe('products client - creating a new payment', () => {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,
@@ -41,7 +41,7 @@ describe('products client - creating a new payment', () => {
     before((done) => {
       const productsClient = getProductsClient()
       productExternalId = 'a-valid-product-id'
-      response = productFixtures.validCreatePaymentResponse({product_external_id: productExternalId})
+      response = productFixtures.validCreatePaymentResponse({ product_external_id: productExternalId })
       provider.addInteraction(
         new PactInteractionBuilder(`${PRODUCTS_RESOURCE}/${productExternalId}/payments`)
           .withUponReceiving('a valid create charge create request')

--- a/test/unit/clients/product_client/payment/get_by_payment_external_id_test.js
+++ b/test/unit/clients/product_client/payment/get_by_payment_external_id_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -24,7 +24,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 }
 
 describe('products client - find a payment by it\'s own external id', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,

--- a/test/unit/clients/product_client/payment/get_by_product_external_id_test.js
+++ b/test/unit/clients/product_client/payment/get_by_product_external_id_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -25,7 +25,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 }
 
 describe('products client - find a payment by it\'s associated product external id', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,

--- a/test/unit/clients/product_client/product/create_test.js
+++ b/test/unit/clients/product_client/product/create_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -26,7 +26,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 }
 
 describe('products client - create a new product', () => {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,

--- a/test/unit/clients/product_client/product/delete_test.js
+++ b/test/unit/clients/product_client/product/delete_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -23,7 +23,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 }
 
 describe('products client - delete a product', () => {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,

--- a/test/unit/clients/product_client/product/disable_test.js
+++ b/test/unit/clients/product_client/product/disable_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -23,7 +23,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 }
 
 describe('products client - disable a product', () => {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'products',
     port: port,

--- a/test/unit/clients/product_client/product/get_by_gateway_account_id_test.js
+++ b/test/unit/clients/product_client/product/get_by_gateway_account_id_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -24,7 +24,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 }
 
 describe('products client - find products associated with a particular gateway account id', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'products',
     port: port,

--- a/test/unit/clients/product_client/product/get_by_product_external_id_test.js
+++ b/test/unit/clients/product_client/product/get_by_product_external_id_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -24,7 +24,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 }
 
 describe('products client - find a product by it\'s external id', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'products',
     port: port,

--- a/test/unit/clients/product_client/product/get_by_product_path_test.js
+++ b/test/unit/clients/product_client/product/get_by_product_path_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -24,7 +24,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`) {
 }
 
 describe('products client - find a product by it\'s product path', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice',
     provider: 'products',
     port: port,

--- a/test/unit/clients/publicauth_client/get_tokens_test.js
+++ b/test/unit/clients/publicauth_client/get_tokens_test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // npm dependencies
-const Pact = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const { expect } = chai
@@ -19,7 +19,7 @@ const PactInteractionBuilder = require('../../../fixtures/pact_interaction_build
 chai.use(chaiAsPromised)
 
 describe('publicauth client - get tokens', function () {
-  let provider = Pact({
+  let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'publicauth',
     port: port,


### PR DESCRIPTION
The "pact" npm depency is deprecated, so switch to using "@pact-foundation/pact".

This was previously attempted, but there were issues around promises not being resolved. We have since done some work to make sure promises are resolved properly in tests so it should hopefully work now.

Was previously tried in https://github.com/alphagov/pay-selfservice/pull/1266 then reverted by https://github.com/alphagov/pay-selfservice/pull/1271


