### PR TITLE
PP-6010 Improve how we match on arrays in pact files

### DIFF
--- a/test/fixtures/pact_base.js
+++ b/test/fixtures/pact_base.js
@@ -3,20 +3,24 @@ const { Matchers } = require('@pact-foundation/pact')
 const { somethingLike, eachLike, term } = Matchers
 
 module.exports = function (options = {}) {
-  let pactifySimpleArray = (arr) => {
-    let pactified = []
+  const pactifySimpleArray = (arr) => {
+    const pactified = []
     arr.forEach((val) => {
-      pactified.push(somethingLike(val))
+      if (val.constructor === Object) {
+        pactified.push(pactify(val))
+      } else {
+        pactified.push(somethingLike(val))
+      }
     })
     return pactified
   }
 
-  let pactifyNestedArray = (arr) => {
+  const pactifyNestedArray = (arr) => {
     return eachLike(pactify(arr[0]), { min: arr.length })
   }
 
-  let pactify = (object) => {
-    let pactified = {}
+  const pactify = (object) => {
+    const pactified = {}
     _.forIn(object, (value, key) => {
       if (value === null) {
         pactified[key] = null
@@ -39,14 +43,14 @@ module.exports = function (options = {}) {
     return pactified
   }
 
-  let withPactified = (payload) => {
+  const withPactified = (payload) => {
     return {
       getPlain: () => payload,
       getPactified: () => pactify(payload)
     }
   }
 
-  let pactifyMatch = (generate, matcher) => {
+  const pactifyMatch = (generate, matcher) => {
     return term({ generate: generate, matcher: matcher })
   }
 


### PR DESCRIPTION
Previously, if the response body in a pact contained an array, we would
only match on the type for each element in the array. This meant that
for arrays of object, we would only verify that each element was an
object, rather than matching on each field in the object.

Modify logic for generating pact files so that for arrays of objects, we
add matchers for the fields in the object.

This means that, for example the following:

```
"matchingRules": {
  "$.body.events[0]": {
    "match": "type"
  },
  "$.body.events[1]": {
    "match": "type"
  }
}
```

becomes:

```
"matchingRules": {
  "$.body.events[0].amount": {
    "match": "type"
  },
  "$.body.events[0].state.status": {
    "match": "type"
  },
  ...
  "$.body.events[1].amount": {
    "match": "type"
  },
  "$.body.events[1].state.status": {
    "match": "type"
  },
  ...
}
```

