### PR TITLE
PP-5340 Add hint on accepting unionpay

### DIFF
--- a/app/controllers/payment-types/get.index.controller.js
+++ b/app/controllers/payment-types/get.index.controller.js
@@ -39,7 +39,7 @@ function formatCardsForTemplate (allCards, acceptedCards, threeDSEnabled) {
   const creditCards = allCards.filter(card => card.type === 'CREDIT')
     .map(card => {
       const formatted = formatCardInfoForNunjucks(card)
-      if (card.brand === 'american-express') {
+      if (['american-express', 'unionpay'].includes(card.brand)) {
         formatted.hint = {
           html: `You must have already enabled this with your PSP`
         }


### PR DESCRIPTION
Accepting Unionpay has to be enabled with PSPs in same
way Amex does, so add helpful hint for Unionpay. Refraining
from any serious refactoring of this controller/path.