### PR TITLE
PP-6010 Add mechanism to specify matchers for pacts

### DIFF
--- a/test/fixtures/card_fixtures.js
+++ b/test/fixtures/card_fixtures.js
@@ -1,11 +1,6 @@
 'use strict'
 
-// NPM dependencies
-const path = require('path')
-
-// Global setup
-const pactBase = require(path.join(__dirname, '/pact_base'))
-const pactRegister = pactBase()
+const { pactify } = require('./pact_base')
 
 module.exports = {
   validCardTypesResponse: () => {
@@ -75,7 +70,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -129,7 +124,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -179,7 +174,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data

--- a/test/fixtures/gateway_account_fixtures.js
+++ b/test/fixtures/gateway_account_fixtures.js
@@ -1,12 +1,7 @@
 'use strict'
 
-// NPM dependencies
-const path = require('path')
 const _ = require('lodash')
-
-// Global setup
-const pactBase = require(path.join(__dirname, '/pact_base'))
-const pactRegister = pactBase()
+const { pactify } = require('./pact_base')
 
 function validGatewayAccount (opts) {
   const gatewayAccount = {
@@ -68,7 +63,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -84,7 +79,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -100,7 +95,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -116,7 +111,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -138,7 +133,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -150,7 +145,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -165,7 +160,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -184,7 +179,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -204,7 +199,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)

--- a/test/fixtures/go_live_requests_fixture.js
+++ b/test/fixtures/go_live_requests_fixture.js
@@ -1,14 +1,8 @@
 'use strict'
 
-const path = require('path')
 const _ = require('lodash')
-
-// Custom dependencies
-const pactBase = require(path.join(__dirname, '/pact_base'))
 const utils = require('../cypress/utils/request_to_go_live_utils')
-
-// Global setup
-const pactServices = pactBase({ array: ['service_ids'] })
+const { pactify } = require('./pact_base')
 
 module.exports = {
   validPostGovUkPayAgreementRequest: opts => {
@@ -20,7 +14,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactServices.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -37,7 +31,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactServices.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -54,7 +48,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactServices.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)

--- a/test/fixtures/invite_fixtures.js
+++ b/test/fixtures/invite_fixtures.js
@@ -1,12 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const _ = require('lodash')
-
-const pactBase = require('./pact_base')
-
-// Global setup
-const pactInvites = pactBase()
+const { pactify, withPactified } = require('./pact_base')
 
 function buildInviteWithDefaults (opts) {
   const data = _.defaults(opts, {
@@ -43,7 +38,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactInvites.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -56,7 +51,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactInvites.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -69,7 +64,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactInvites.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -90,7 +85,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactInvites.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -103,7 +98,7 @@ module.exports = {
       errors: ['user [' + userName + '] not authorised to perform operation [invite] in service [' + serviceId + ']']
     }
 
-    return pactInvites.withPactified(response)
+    return withPactified(response)
   },
 
   validRegistrationRequest: (opts = {}) => {
@@ -114,7 +109,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactInvites.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -130,7 +125,7 @@ module.exports = {
       errors: responseData
     }
 
-    return pactInvites.withPactified(response)
+    return withPactified(response)
   },
 
   invalidInviteCreateResponseWhenFieldsMissing: () => {
@@ -139,7 +134,7 @@ module.exports = {
       errors: ['Field [email] is required']
     }
 
-    return pactInvites.withPactified(response)
+    return withPactified(response)
   },
 
   conflictingInviteResponseWhenEmailUserAlreadyCreated: (email) => {
@@ -149,7 +144,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactInvites.withPactified(response)
+        return withPactified(response)
       },
       getPlain: () => {
         return response
@@ -165,7 +160,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactInvites.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -181,7 +176,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactInvites.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -199,7 +194,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactInvites.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -218,7 +213,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactInvites.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -236,7 +231,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactInvites.pactify(response)
+        return pactify(response)
       },
       getPlain: () => {
         return _.clone(response)

--- a/test/fixtures/ledger_transaction_fixtures.js
+++ b/test/fixtures/ledger_transaction_fixtures.js
@@ -1,12 +1,7 @@
 'use strict'
 
-// NPM dependencies
-const path = require('path')
 const lodash = require('lodash')
-
-// Global setup
-const pactBase = require(path.join(__dirname, '/pact_base'))
-const pactRegister = pactBase()
+const { pactify, matchers } = require('./pact_base')
 
 const buildChargeEventWithDefaults = (opts = {}) => {
   const chargeEvent = {
@@ -197,7 +192,7 @@ module.exports = {
     }
 
     return {
-      getPactified: () => pactRegister.pactify(data),
+      getPactified: () => pactify(data),
       getPlain: () => data
     }
   },
@@ -209,7 +204,7 @@ module.exports = {
     const data = buildTransactionDetails(opts)
 
     return {
-      getPactified: () => pactRegister.pactify(data),
+      getPactified: () => pactify(data),
       getPlain: () => data
     }
   },
@@ -219,7 +214,7 @@ module.exports = {
     const data = buildTransactionDetails(opts)
 
     return {
-      getPactified: () => pactRegister.pactify(data),
+      getPactified: () => pactify(data),
       getPlain: () => data
     }
   },
@@ -248,7 +243,9 @@ module.exports = {
     }
 
     return {
-      getPactified: () => pactRegister.pactify(data),
+      getPactified: () => pactify(data, {
+        status: matchers.EXACT_STRING
+      }),
       getPlain: () => data
     }
   },
@@ -260,7 +257,7 @@ module.exports = {
     }
 
     return {
-      getPactified: () => pactRegister.pactify(data),
+      getPactified: () => pactify(data),
       getPlain: () => data
     }
   },
@@ -270,7 +267,7 @@ module.exports = {
     }
 
     return {
-      getPactified: () => pactRegister.pactify(data),
+      getPactified: () => pactify(data),
       getPlain: () => data
     }
   },
@@ -281,7 +278,7 @@ module.exports = {
     }
 
     return {
-      getPactified: () => pactRegister.pactify(data),
+      getPactified: () => pactify(data),
       getPlain: () => data
     }
   },
@@ -307,7 +304,7 @@ module.exports = {
       data._links = opts.links
     }
     return {
-      getPactified: () => pactRegister.pactify(data),
+      getPactified: () => pactify(data),
       getPlain: () => data
     }
   },
@@ -324,7 +321,7 @@ module.exports = {
       net_income: opts.paymentTotal && opts.refundTotal ? (opts.paymentTotal - opts.refundTotal) : (12000 - 2300)
     }
     return {
-      getPactified: () => pactRegister.pactify(data),
+      getPactified: () => pactify(data),
       getPlain: () => data
     }
   }

--- a/test/fixtures/pact_base.js
+++ b/test/fixtures/pact_base.js
@@ -1,64 +1,66 @@
 const _ = require('lodash')
 const { Matchers } = require('@pact-foundation/pact')
-const { somethingLike, eachLike, term } = Matchers
+const { somethingLike, eachLike, term, string } = Matchers
 
-module.exports = function (options = {}) {
-  const pactifySimpleArray = (arr) => {
-    const pactified = []
-    arr.forEach((val) => {
-      if (val.constructor === Object) {
-        pactified.push(pactify(val))
-      } else {
-        pactified.push(somethingLike(val))
-      }
-    })
-    return pactified
-  }
+const matchers = {
+  AN_ARRAY_WITH_LENGTH: 0,
+  EXACT_STRING: 1
+}
 
-  const pactifyNestedArray = (arr) => {
-    return eachLike(pactify(arr[0]), { min: arr.length })
-  }
-
-  const pactify = (object) => {
-    const pactified = {}
-    _.forIn(object, (value, key) => {
-      if (value === null) {
-        pactified[key] = null
-      } else if (options.array && options.array.indexOf(key) !== -1) {
-        let length
-        if (options.length && options.length.find(lengthKey => lengthKey.key === key)) {
-          length = options.length.find(lengthKey => lengthKey.key === key).length
-        } else {
-          length = value.length
-        }
-        pactified[key] = eachLike(somethingLike(value[0]), { min: length })
-      } else if (value.constructor === Array) {
-        pactified[key] = pactifySimpleArray(value)
-      } else if (value.constructor === Object) {
-        pactified[key] = pactify(value)
-      } else {
-        pactified[key] = somethingLike(value)
-      }
-    })
-    return pactified
-  }
-
-  const withPactified = (payload) => {
-    return {
-      getPlain: () => payload,
-      getPactified: () => pactify(payload)
+const pactifySimpleArray = (arr, matchOptions = {}) => {
+  const pactified = []
+  arr.forEach((val) => {
+    if (val.constructor === Object) {
+      pactified.push(pactify(val, matchOptions))
+    } else {
+      pactified.push(somethingLike(val))
     }
-  }
+  })
+  return pactified
+}
 
-  const pactifyMatch = (generate, matcher) => {
-    return term({ generate: generate, matcher: matcher })
-  }
+const pactifyNestedArray = (arr, matchOptions = {}) => {
+  return eachLike(pactify(arr[0], matchOptions), { min: arr.length })
+}
 
+const pactify = (object, matchOptions = {}) => {
+  const pactified = {}
+  _.forIn(object, (value, key) => {
+    if (value === null) {
+      pactified[key] = null
+    } else if (key in matchOptions) {
+      if (matchOptions[key] === matchers.AN_ARRAY_WITH_LENGTH) {
+        pactified[key] = eachLike(somethingLike(value[0]), { min: value.length })
+      } else if (matchOptions[key] === matchers.EXACT_STRING) {
+        pactified[key] = string(value)
+      }
+    } else if (value.constructor === Array) {
+      pactified[key] = pactifySimpleArray(value, matchOptions)
+    } else if (value.constructor === Object) {
+      pactified[key] = pactify(value, matchOptions)
+    } else {
+      pactified[key] = somethingLike(value)
+    }
+  })
+  return pactified
+}
+
+const withPactified = (payload, matchOptions = {}) => {
   return {
-    pactifyMatch: pactifyMatch,
-    pactifySimpleArray: pactifySimpleArray,
-    pactifyNestedArray: pactifyNestedArray,
-    pactify: pactify,
-    withPactified: withPactified
+    getPlain: () => payload,
+    getPactified: () => pactify(payload, matchOptions)
   }
+}
+
+const pactifyMatch = (generate, matcher) => {
+  return term({ generate: generate, matcher: matcher })
+}
+
+module.exports = {
+  pactifyMatch,
+  pactifySimpleArray,
+  pactifyNestedArray,
+  pactify,
+  withPactified,
+  matchers
 }

--- a/test/fixtures/product_fixtures.js
+++ b/test/fixtures/product_fixtures.js
@@ -1,12 +1,10 @@
 'use strict'
-const pactBase = require('./pact_base')
 
-// Global setup
-const pactProducts = pactBase()
+const { pactify } = require('./pact_base')
 
 module.exports = {
   pactifyRandomData: (opts = {}) => {
-    pactProducts.pactify(opts)
+    pactify(opts)
   },
 
   validCreateProductRequest: (opts = {}) => {
@@ -29,7 +27,7 @@ module.exports = {
     }
     return {
       getPactified: () => {
-        return pactProducts.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -60,7 +58,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactProducts.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -107,7 +105,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactProducts.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -122,7 +120,7 @@ module.exports = {
     }
     return {
       getPactified: () => {
-        return pactProducts.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data

--- a/test/fixtures/self_register_fixtures.js
+++ b/test/fixtures/self_register_fixtures.js
@@ -1,14 +1,7 @@
 'use strict'
 
-// NPM dependencies
-const path = require('path')
 const _ = require('lodash')
-
-// Custom dependencies
-const pactBase = require(path.join(__dirname, '/pact_base'))
-
-// Global setup
-const pactRegister = pactBase()
+const { pactify, withPactified } = require('./pact_base')
 
 function validPassword () {
   return 'G0VUkPay2017Rocks'
@@ -27,7 +20,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -44,7 +37,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -59,7 +52,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -74,7 +67,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -90,7 +83,7 @@ module.exports = {
       errors: responseData
     }
 
-    return pactRegister.withPactified(response)
+    return withPactified(response)
   }
 
 }

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -1,14 +1,7 @@
 'use strict'
 
-// NPM dependencies
-const path = require('path')
 const _ = require('lodash')
-
-// Custom dependencies
-const pactBase = require(path.join(__dirname, '/pact_base'))
-
-// Global setup
-const pactServices = pactBase({ array: ['service_ids'] })
+const { pactify, withPactified, pactifyNestedArray, pactifySimpleArray } = require('./pact_base')
 
 const buildServiceNameWithDefaults = (opts = {}) => {
   _.defaults(opts, {
@@ -42,7 +35,7 @@ module.exports = {
     }]
     return {
       getPactified: () => {
-        return pactServices.pactifyNestedArray(data)
+        return pactifyNestedArray(data)
       },
       getPlain: () => {
         return data
@@ -61,7 +54,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactServices.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -90,7 +83,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactServices.pactifyNestedArray(data)
+        return pactifyNestedArray(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -106,7 +99,7 @@ module.exports = {
       errors: responseData
     }
 
-    return pactServices.withPactified(response)
+    return withPactified(response)
   },
 
   addGatewayAccountsRequest: (gatewayAccountIds = ['666']) => {
@@ -118,7 +111,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactServices.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -135,7 +128,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactServices.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -152,7 +145,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactServices.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -171,7 +164,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactServices.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -188,7 +181,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactServices.pactifySimpleArray(data)
+        return pactifySimpleArray(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -236,7 +229,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactServices.pactify(service)
+        return pactify(service)
       },
       getPlain: () => {
         return _.clone(service)

--- a/test/fixtures/stripe_account_fixtures.js
+++ b/test/fixtures/stripe_account_fixtures.js
@@ -1,13 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
-
-// Local dependencies
-const pactBase = require('./pact_base')
-
-// Global setup
-const pactRegister = pactBase()
+const { pactify } = require('./pact_base')
 
 module.exports = {
   buildGetStripeAccountResponse (opts = {}) {
@@ -17,7 +11,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return lodash.clone(data)

--- a/test/fixtures/stripe_account_setup_fixtures.js
+++ b/test/fixtures/stripe_account_setup_fixtures.js
@@ -1,12 +1,7 @@
 'use strict'
 
-// NPM dependencies
-const path = require('path')
 const _ = require('lodash')
-
-// Global setup
-const pactBase = require(path.join(__dirname, '/pact_base'))
-const pactRegister = pactBase()
+const { pactify } = require('./pact_base')
 
 function buildUpdateStripeAccountSetupFlagRequest (path, completed) {
   const data = [
@@ -19,7 +14,7 @@ function buildUpdateStripeAccountSetupFlagRequest (path, completed) {
 
   return {
     getPactified: () => {
-      return pactRegister.pactify(data)
+      return pactify(data)
     },
     getPlain: () => {
       return _.clone(data)
@@ -49,7 +44,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)
@@ -64,7 +59,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return _.clone(data)

--- a/test/fixtures/transaction_fixtures.js
+++ b/test/fixtures/transaction_fixtures.js
@@ -1,12 +1,7 @@
 'use strict'
 
-// NPM dependencies
-const path = require('path')
 const lodash = require('lodash')
-
-// Global setup
-const pactBase = require(path.join(__dirname, '/pact_base'))
-const pactRegister = pactBase()
+const { pactify } = require('./pact_base')
 
 const buildChargeEventWithDefaults = (opts = {}) => {
   const chargeEvent = {
@@ -134,7 +129,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -153,7 +148,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -165,7 +160,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -198,7 +193,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -215,7 +210,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data
@@ -229,7 +224,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactRegister.pactify(data)
+        return pactify(data)
       },
       getPlain: () => {
         return data

--- a/test/fixtures/user_fixtures.js
+++ b/test/fixtures/user_fixtures.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const User = require('../../app/models/User.class')
-const pactBase = require('./pact_base')
 const goLiveStage = require('../../app/models/go-live-stage')
 const serviceFixtures = require('./service_fixtures')
+const { pactify, withPactified, pactifyMatch } = require('./pact_base')
 
 // Constants
 const defaultPermissions = [
@@ -193,12 +191,6 @@ const defaultPermissions = [
   }
 ]
 
-// Setup
-const pactUsers = pactBase({
-  array: ['service_roles', '_links'],
-  length: [{ key: 'permissions', length: 1 }]
-})
-
 const buildServiceRole = (opts = {}) => {
   return {
     service: serviceFixtures.validServiceResponse(opts.service).getPlain(),
@@ -296,7 +288,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactUsers.pactify(data)
+        return pactify(data)
       },
       getAsObject: () => {
         return new User(data)
@@ -315,7 +307,7 @@ module.exports = {
     const data = opts.map(buildUserWithDefaults)
     return {
       getPactified: () => {
-        return data.map(pactUsers.pactify)
+        return data.map(data => pactify(data))
       },
       getAsObject: () => {
         return data.map(datum => new User(datum))
@@ -332,7 +324,7 @@ module.exports = {
       password: options.password || 'password'
     }
 
-    return pactUsers.withPactified(request)
+    return withPactified(request)
   },
 
   unauthorizedUserResponse: () => {
@@ -340,7 +332,7 @@ module.exports = {
       errors: ['invalid username and/or password']
     }
 
-    return pactUsers.withPactified(response)
+    return withPactified(response)
   },
 
   badAuthenticateResponse: () => {
@@ -348,7 +340,7 @@ module.exports = {
       errors: ['Field [username] is required', 'Field [password] is required']
     }
 
-    return pactUsers.withPactified(response)
+    return withPactified(response)
   },
 
   validIncrementSessionVersionRequest: () => {
@@ -358,7 +350,7 @@ module.exports = {
       value: 1
     }
 
-    return pactUsers.withPactified(request)
+    return withPactified(request)
   },
 
   validAuthenticateSecondFactorRequest: (code) => {
@@ -366,7 +358,7 @@ module.exports = {
       code: code || '123456'
     }
 
-    return pactUsers.withPactified(request)
+    return withPactified(request)
   },
 
   validUpdatePasswordRequest: (token, newPassword) => {
@@ -375,7 +367,7 @@ module.exports = {
       new_password: newPassword || 'G0VUkPay2017Rocks'
     }
 
-    return pactUsers.withPactified(request)
+    return withPactified(request)
   },
 
   validUpdateServiceRoleRequest: (role) => {
@@ -383,7 +375,7 @@ module.exports = {
       role_name: role || 'admin'
     }
 
-    return pactUsers.withPactified(request)
+    return withPactified(request)
   },
 
   validAssignServiceRoleRequest: (opts = {}) => {
@@ -392,7 +384,7 @@ module.exports = {
       role_name: opts.role_name || 'admin'
     }
 
-    return pactUsers.withPactified(request)
+    return withPactified(request)
   },
 
   validPasswordAuthenticateRequest: (opts = {}) => {
@@ -403,8 +395,8 @@ module.exports = {
     const passwordMatcher = opts.passwordMatcher || 'validpassword'
 
     return {
-      username: pactUsers.pactifyMatch(usernameGenerate, usernameMatcher),
-      password: pactUsers.pactifyMatch(passwordGenerate, passwordMatcher)
+      username: pactifyMatch(usernameGenerate, usernameMatcher),
+      password: pactifyMatch(passwordGenerate, passwordMatcher)
     }
   },
 
@@ -416,8 +408,8 @@ module.exports = {
     const passwordMatcher = opts.passwordMatcher || 'invalidpassword'
 
     return {
-      username: pactUsers.pactifyMatch(usernameGenerate, usernameMatcher),
-      password: pactUsers.pactifyMatch(passwordGenerate, passwordMatcher)
+      username: pactifyMatch(usernameGenerate, usernameMatcher),
+      password: pactifyMatch(passwordGenerate, passwordMatcher)
     }
   },
 
@@ -426,7 +418,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactUsers.pactify(data)
+        return pactify(data)
       },
       getAsObject: () => {
         return new User(data)
@@ -442,7 +434,7 @@ module.exports = {
 
     return {
       getPactified: () => {
-        return pactUsers.pactify(users)
+        return pactify(users)
       },
       getAsObject: () => {
         const usersObject = []
@@ -460,7 +452,7 @@ module.exports = {
       errors: ['invalid username and/or password']
     }
 
-    return pactUsers.withPactified(response)
+    return withPactified(response)
   },
 
   validForgottenPasswordCreateRequest: (username) => {
@@ -468,7 +460,7 @@ module.exports = {
       username: username || 'username@email.com'
     }
 
-    return pactUsers.withPactified(request)
+    return withPactified(request)
   },
 
   validForgottenPasswordResponse: (payload) => {
@@ -485,7 +477,7 @@ module.exports = {
       }]
     }
 
-    return pactUsers.withPactified(response)
+    return withPactified(response)
   },
 
   badForgottenPasswordResponse: () => {
@@ -493,7 +485,7 @@ module.exports = {
       errors: ['Field [username] is required']
     }
 
-    return pactUsers.withPactified(response)
+    return withPactified(response)
   },
 
   badRequestResponseWhenFieldsMissing: (missingFields) => {
@@ -504,6 +496,6 @@ module.exports = {
       errors: responseData
     }
 
-    return pactUsers.withPactified(response)
+    return withPactified(response)
   }
 }

--- a/test/fixtures/user_service_fixture.js
+++ b/test/fixtures/user_service_fixture.js
@@ -1,15 +1,7 @@
 'use strict'
 
-// NPM dependencies
-const path = require('path')
-const _ = require('lodash')
-
-// Custom dependencies
-const userFixtures = require(path.join(__dirname, '/user_fixtures'))
-const pactBase = require(path.join(__dirname, '/pact_base'))
-
-// Global setup
-const pactServices = pactBase({ array: ['service_ids'] })
+const userFixtures = require('./user_fixtures')
+const { pactifyNestedArray } = require('./pact_base')
 
 module.exports = {
 
@@ -24,7 +16,7 @@ module.exports = {
     }
     return {
       getPactified: () => {
-        return pactServices.pactifyNestedArray(data)
+        return pactifyNestedArray(data)
       },
       getPlain: () => {
         return data


### PR DESCRIPTION
Before, when we "pactified" a fixture, the default behaviour was to match all fields in a response on type. There was the ability to specify some different behaviour for arrays but the way this is used isn't particularly useful.

Add the ability to specify specific matchers for keys in a request/response object when it is "pactified". Current matchers that can be specified are:

`AN_ARRAY_WITH_LENGTH` - will match an array with a minimum of the given length with all elements having the same type as the first element specified.

`EXACT_STRING` - exactly matches on the string specified in the request/response object

_____________________________________

NOTE: The main change is in pact_base to pass in a `matchOptions` parameter to `pactify` and this file hasn't changed as much as git thinks it has
