### PR TITLE
PP-6037: Run mountebank stub server in debug mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint": "./node_modules/.bin/standard --fix",
     "lint-sass": "./node_modules/.bin/sass-lint -v",
     "test": "npm run snyk-protect && rm -rf ./pacts && ./node_modules/mocha/bin/mocha '!(node_modules)/**/*+(.|_)+(test|tests)'.js",
-    "cypress:server": "mb | DISABLE_APPMETRICS=true node --inspect -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
+    "cypress:server": "mb --debug | DISABLE_APPMETRICS=true node --inspect -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
     "cypress:test": "cypress run",
     "cypress:test-headed": "cypress open",
     "snyk-protect": "snyk protect",


### PR DESCRIPTION
## WHAT
Some tests rely on the "matches" array being present in the stub server response to assert the stub is called an expected number of times. This feature requires mountebank to be started in debug mode.

The `verifyStubs` test callback relies on the `matches` property being present: https://github.com/alphagov/pay-selfservice/blob/e9482de88ff1eb19f6e1d881ad65bd301b7f31e6/test/cypress/plugins/index.js#L80

This is only present when the `--debug` flag is passed when mountebank is started: http://www.mbtest.org/docs/api/overview#get-imposter

