### PR TITLE
PP-6069 Send include fee headers param to ledger

### DIFF
--- a/app/controllers/transactions/transaction_download_controller.js
+++ b/app/controllers/transactions/transaction_download_controller.js
@@ -20,6 +20,7 @@ const fetchTransactionCsvWithHeader = function fetchTransactionCsvWithHeader (re
   const name = `GOVUK_Pay_${date.dateToDefaultFormat(new Date()).replace(' ', '_')}.csv`
   const correlationId = req.headers[CORRELATION_HEADER]
   const url = transactionService.csvSearchUrl(filters, accountId)
+  filters.feeHeaders = req.account && req.account.payment_provider === 'stripe'
 
   const timestampStreamStart = Date.now()
   const data = (chunk) => { res.write(chunk) }

--- a/app/utils/get_query_string_for_params.js
+++ b/app/utils/get_query_string_for_params.js
@@ -12,7 +12,8 @@ function getQueryStringForParams (params = {}, removeEmptyParams = false, flatte
     last_digits_card_number: params.lastDigitsCardNumber,
     card_brand: params.brand,
     from_date: dates.fromDateToApiFormat(params.fromDate, params.fromTime),
-    to_date: dates.toDateToApiFormat(params.toDate, params.toTime)
+    to_date: dates.toDateToApiFormat(params.toDate, params.toTime),
+    ...params.feeHeaders && { fee_headers: params.feeHeaders }
   }
 
   if (!ignorePagination) {


### PR DESCRIPTION
Include `fee_headers` flag if a Stripe gateway account is included in the CSV report.