### PR TITLE
PP-5956 Display whether a payment is MOTO on transaction details page

### DIFF
--- a/app/views/transaction_detail/_details.njk
+++ b/app/views/transaction_detail/_details.njk
@@ -131,5 +131,12 @@
     <td class="govuk-table__cell govuk-!-font-size-16" id="delayed-capture">On</td>
   </tr>
   {% endif %}
+
+  {% if currentGatewayAccount.allow_moto %}
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">MOTO:</th>
+    <td class="govuk-table__cell govuk-!-font-size-16" id="moto">{% if moto %}Yes{% else %}No{% endif %}</td>
+  </tr>
+  {% endif %}
   </tbody>
 </table>


### PR DESCRIPTION
If the `allow_moto` flag is true for the gateway account, show a 'MOTO:' row on the transaction details page with a value of 'Yes' or 'No'.

If the `allow_moto` flag is false for the gateway account, do not show the 'MOTO:' row on the transaction details page.

Add a Cypress test for this behaviour.

