### PR TITLE
PP-6085 Remove route from manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -33,5 +33,3 @@ applications:
     GOCARDLESS_TEST_CLIENT_ID: ((selfservice_gocardless_test_client_id))
     GOCARDLESS_LIVE_CLIENT_ID: ((selfservice_gocardless_live_client_id))
     ZENDESK_URL: "https://govuk.zendesk.com/api/v2"
-  routes:
-  - route: ((selfservice_url))


### PR DESCRIPTION
The routes are set when the space is setup by the terraform in
pay-omnibus. Remove the route attribute from the manifest.