### PR TITLE
PP-6076 Request CSV with moto header if account has moto enabled

### DIFF
--- a/app/controllers/transactions/transaction_download_controller.js
+++ b/app/controllers/transactions/transaction_download_controller.js
@@ -21,6 +21,7 @@ const fetchTransactionCsvWithHeader = function fetchTransactionCsvWithHeader (re
   const correlationId = req.headers[CORRELATION_HEADER]
 
   filters.feeHeaders = req.account && req.account.payment_provider === 'stripe'
+  filters.motoHeader = req.account && req.account.allow_moto
   const url = transactionService.csvSearchUrl(filters, accountId)
 
   const timestampStreamStart = Date.now()

--- a/app/utils/get_query_string_for_params.js
+++ b/app/utils/get_query_string_for_params.js
@@ -13,7 +13,8 @@ function getQueryStringForParams (params = {}, removeEmptyParams = false, flatte
     card_brand: params.brand,
     from_date: dates.fromDateToApiFormat(params.fromDate, params.fromTime),
     to_date: dates.toDateToApiFormat(params.toDate, params.toTime),
-    ...params.feeHeaders && { fee_headers: params.feeHeaders }
+    ...params.feeHeaders && { fee_headers: params.feeHeaders },
+    ...params.motoHeader && { moto_header: params.motoHeader }
   }
 
   if (!ignorePagination) {


### PR DESCRIPTION
Include the query parameter `moto_header=true` if the account has moto payments enabled when calling ledger to stream the CSV download.

Improve the tests for the backend ledger CSV creation.

