### PR TITLE
PP-5989 Update guidance on payment links so that people don't include PII

### DIFF
--- a/app/views/payment-links/edit-reference.njk
+++ b/app/views/payment-links/edit-reference.njk
@@ -100,6 +100,9 @@
                 classes: "govuk-fieldset__legend--l"
             }
         },
+        hint: {
+          text: "You can use numbers or words in your payment reference. For example, you can include the applicant’s name or an existing reference number."
+        },
         errorMessage: noSelectionError,
         items: [
           {

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -34,12 +34,12 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
 
     {% if isWelsh %}
       {% set titleLabel = 'Welsh title' %}
-      {% set titleHint = 'Briefly describe what the user is paying for. For example, <span lang="cy">“Talu am drwydded barcio”</span>. This will also be your website address.' %}
+      {% set titleHint = 'Briefly describe what the user is paying for. For example, <span lang="cy">“Talu am drwydded barcio”</span>. This will also be your website address. Don’t include names or personal information.' %}
       {% set detailsHint = 'Give your users more information in Welsh. For example, you could tell them how long it takes for their application to be processed.' %}
       {% set lang = "cy" %}
     {% else %}
       {% set titleLabel = 'Title' %}
-      {% set titleHint = 'Briefly describe what the user is paying for. For example, “Pay for a parking permit”. This will also be your website address.' %}
+      {% set titleHint = 'Briefly describe what the user is paying for. For example, “Pay for a parking permit”. This will also be your website address. Don’t include names or personal information.' %}
       {% set detailsHint = 'Give your users more information. For example, you could tell them how long it takes for their application to be processed.' %}
       {% set lang = "en" %}
     {% endif %}

--- a/app/views/payment-links/reference.njk
+++ b/app/views/payment-links/reference.njk
@@ -100,6 +100,9 @@
                 classes: "govuk-fieldset__legend--l"
             }
         },
+        hint: {
+          text: "You can use numbers or words in your payment reference. For example, you can include the applicant’s name or an existing reference number."
+        },
         errorMessage: noSelectionError,
         items: [
           {

--- a/test/cypress/integration/payment-links/create_payment_link_spec.js
+++ b/test/cypress/integration/payment-links/create_payment_link_spec.js
@@ -100,6 +100,7 @@ describe('The create payment link flow', () => {
     describe('Reference page', () => {
       it('should have instructions for an English patment link when "yes" is selected', () => {
         cy.get('h1').should('contain', 'Do your users already have a payment reference?')
+        cy.get('#reference-type-group-hint').should('contain', `You can use numbers or words in your payment reference. For example, you can include the applicant’s name or an existing reference number.`)
 
         cy.get('form[method=post][action="/create-payment-link/reference"]').should('exist')
           .within(() => {
@@ -287,6 +288,7 @@ describe('The create payment link flow', () => {
     describe('Reference page', () => {
       it('should have Welsh-specific instructions when "yes" is selected', () => {
         cy.get('h1').should('contain', 'Do your users already have a payment reference?')
+        cy.get('#reference-type-group-hint').should('contain', `You can use numbers or words in your payment reference. For example, you can include the applicant’s name or an existing reference number.`)
 
         cy.get('form[method=post][action="/create-payment-link/reference"]').should('exist')
           .within(() => {


### PR DESCRIPTION
- When creating a Payment Link, add new guidance which states not to use PII information.
- Add new hint text for Adding / Editing Payment Reference - which states not to add PII information.

IMPORTANT NOTE: Please check Welsh as well.