### PR TITLE
PP-6152 Add metadata to payment link page

### DIFF
--- a/app/controllers/payment-links/index.js
+++ b/app/controllers/payment-links/index.js
@@ -22,3 +22,7 @@ exports.getEditReference = require('./get-edit-reference-controller')
 exports.postEditReference = require('./post-edit-reference-controller')
 exports.getEditAmount = require('./get-edit-amount-controller')
 exports.postEditAmount = require('./post-edit-amount-controller')
+
+exports.metadata = {
+  add: require('./metadata/resource-controller').addMetadataPage
+}

--- a/app/controllers/payment-links/index.js
+++ b/app/controllers/payment-links/index.js
@@ -24,5 +24,6 @@ exports.getEditAmount = require('./get-edit-amount-controller')
 exports.postEditAmount = require('./post-edit-amount-controller')
 
 exports.metadata = {
-  add: require('./metadata/resource-controller').addMetadataPage
+  add: require('./metadata/resource-controller').addMetadataPage,
+  post: require('./metadata/resource-controller').postMetadataPage
 }

--- a/app/controllers/payment-links/metadata/resource-controller.js
+++ b/app/controllers/payment-links/metadata/resource-controller.js
@@ -1,0 +1,10 @@
+const { response } = require('../../../utils/response.js')
+
+const addMetadataPage = function addMetadataPage (req, res, next) {
+  // @TODO(sfount) rethink how response works, get repsonse context from library and render _in_ the contrller
+  response(req, res, 'payment-links/metadata/edit-metadata')
+}
+
+module.exports = {
+  addMetadataPage
+}

--- a/app/controllers/payment-links/metadata/resource-controller.js
+++ b/app/controllers/payment-links/metadata/resource-controller.js
@@ -1,10 +1,28 @@
 const { response } = require('../../../utils/response.js')
+const formattedPathFor = require('../../../utils/replace_params_in_path')
+const paths = require('../../../paths')
+const lodash = require('lodash')
 
 const addMetadataPage = function addMetadataPage (req, res, next) {
   // @TODO(sfount) rethink how response works, get repsonse context from library and render _in_ the contrller
-  response(req, res, 'payment-links/metadata/edit-metadata')
+  const pageData = {
+    self: formattedPathFor(paths.paymentLinks.metadata.add, req.params.productExternalId)
+  }
+
+  response(req, res, 'payment-links/metadata/edit-metadata', pageData)
+}
+
+const postMetadataPage = (req, res) => {
+  const pageData = lodash.get(req, 'session.pageData.createPaymentLink', {})
+  let updatedPageData = lodash.cloneDeep(pageData)
+
+  updatedPageData.metadataColumnHeader = req.body['metadata-column-header']
+  updatedPageData.PaymentLinkDescription = req.body['payment-link-description']
+
+  return res.redirect(paths.paymentLinks.information)
 }
 
 module.exports = {
-  addMetadataPage
+  addMetadataPage,
+  postMetadataPage
 }

--- a/app/controllers/payment-links/metadata/resource-controller.js
+++ b/app/controllers/payment-links/metadata/resource-controller.js
@@ -1,25 +1,33 @@
-const { response } = require('../../../utils/response.js')
+const { response } = require('../../../utils/response')
 const formattedPathFor = require('../../../utils/replace_params_in_path')
 const paths = require('../../../paths')
-const lodash = require('lodash')
+const { product } = require('../../../services/clients/products_client.js')
 
-const addMetadataPage = function addMetadataPage (req, res, next) {
-  // @TODO(sfount) rethink how response works, get repsonse context from library and render _in_ the contrller
+const addMetadataPage = function addMetadataPage (req, res) {
   const pageData = {
     self: formattedPathFor(paths.paymentLinks.metadata.add, req.params.productExternalId)
   }
-
   response(req, res, 'payment-links/metadata/edit-metadata', pageData)
 }
 
-const postMetadataPage = (req, res) => {
-  const pageData = lodash.get(req, 'session.pageData.createPaymentLink', {})
-  let updatedPageData = lodash.cloneDeep(pageData)
+const postMetadataPage = async function postMetadataPage (req, res) {
+  const key = req.body['metadata-column-header']
+  const value = req.body['metadata-cell-value']
 
-  updatedPageData.metadataColumnHeader = req.body['metadata-column-header']
-  updatedPageData.PaymentLinkDescription = req.body['payment-link-description']
-
-  return res.redirect(paths.paymentLinks.information)
+  try {
+    await product.addMetadataToProduct(req.params.productExternalId, key, value)
+    req.flash('generic', `Reporting column ${key} was added`)
+    res.redirect(formattedPathFor(paths.paymentLinks.edit, req.params.productExternalId))
+  } catch (error) {
+    const pageData = {
+      self: formattedPathFor(paths.paymentLinks.metadata.add, req.params.productExternalId),
+      error: error.message,
+      metadataColumnHeader: key,
+      metadataColumnValue: value
+    }
+    req.flash('genericError', error.message)
+    response(req, res, 'payment-links/metadata/edit-metadata', pageData)
+  }
 }
 
 module.exports = {

--- a/app/middleware/experimental_features.js
+++ b/app/middleware/experimental_features.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const restrictServiceExperimentalFeatures = function restrictServiceExperimentalFeatures (req, res, next) {
+  if (req.service && !req.service.experimentalFeaturesEnabled) {
+    res.status(404).render('404')
+    return
+  }
+  next()
+}
+
+module.exports = restrictServiceExperimentalFeatures

--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -9,6 +9,7 @@ class Service {
     this.merchantDetails = serviceData.merchant_details
     this.collectBillingAddress = serviceData.collect_billing_address
     this.currentGoLiveStage = serviceData.current_go_live_stage
+    this.experimentalFeaturesEnabled = serviceData.experimental_features_enabled
   }
 
   /**
@@ -23,7 +24,8 @@ class Service {
       gateway_account_ids: this.gatewayAccountIds,
       merchant_details: this.merchantDetails,
       collect_billing_address: this.collectBillingAddress,
-      current_go_live_stage: this.currentGoLiveStage
+      current_go_live_stage: this.currentGoLiveStage,
+      experimental_features_enabled: this.experimentalFeaturesEnabled
     }
   }
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -150,7 +150,10 @@ module.exports = {
     edit: '/create-payment-link/manage/edit/:productExternalId',
     editInformation: '/create-payment-link/manage/edit/information/:productExternalId',
     editReference: '/create-payment-link/manage/edit/reference/:productExternalId',
-    editAmount: '/create-payment-link/manage/edit/amount/:productExternalId'
+    editAmount: '/create-payment-link/manage/edit/amount/:productExternalId',
+    metadata: {
+      add: '/create-payment-link/manage/edit/:productExternalId/metadata'
+    }
   },
   feedback: '/feedback',
   partnerApp: {

--- a/app/routes.js
+++ b/app/routes.js
@@ -16,6 +16,7 @@ const { lockOutDisabledUsers, enforceUserAuthenticated, enforceUserFirstFactor, 
 const { validateAndRefreshCsrf, ensureSessionHasCsrfSecret } = require('./middleware/csrf')
 const getEmailNotification = require('./middleware/get_email_notification')
 const getAccount = require('./middleware/get_gateway_account')
+const restrictServiceExperimentalFeatures = require('./middleware/experimental_features')
 const hasServices = require('./middleware/has_services')
 const resolveService = require('./middleware/resolve_service')
 const trimUsername = require('./middleware/trim_username')
@@ -342,8 +343,8 @@ module.exports.bind = function (app) {
   app.post(paymentLinks.editReference, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.postEditReference)
   app.get(paymentLinks.editAmount, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.getEditAmount)
   app.post(paymentLinks.editAmount, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.postEditAmount)
-  app.get(paymentLinks.metadata.add, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.metadata.add)
-  app.post(paymentLinks.metadata.add, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.metadata.post)
+  app.get(paymentLinks.metadata.add, xraySegmentCls, permission('tokens:create'), getAccount, restrictServiceExperimentalFeatures, paymentLinksController.metadata.add)
+  app.post(paymentLinks.metadata.add, xraySegmentCls, permission('tokens:create'), getAccount, restrictServiceExperimentalFeatures, paymentLinksController.metadata.post)
 
   // Configure 2FA
   app.get(user.twoFactorAuth.index, xraySegmentCls, twoFactorAuthController.getIndex)

--- a/app/routes.js
+++ b/app/routes.js
@@ -342,8 +342,8 @@ module.exports.bind = function (app) {
   app.post(paymentLinks.editReference, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.postEditReference)
   app.get(paymentLinks.editAmount, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.getEditAmount)
   app.post(paymentLinks.editAmount, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.postEditAmount)
-
   app.get(paymentLinks.metadata.add, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.metadata.add)
+  app.post(paymentLinks.metadata.add, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.metadata.post)
 
   // Configure 2FA
   app.get(user.twoFactorAuth.index, xraySegmentCls, twoFactorAuthController.getIndex)

--- a/app/routes.js
+++ b/app/routes.js
@@ -343,6 +343,8 @@ module.exports.bind = function (app) {
   app.get(paymentLinks.editAmount, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.getEditAmount)
   app.post(paymentLinks.editAmount, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.postEditAmount)
 
+  app.get(paymentLinks.metadata.add, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.metadata.add)
+
   // Configure 2FA
   app.get(user.twoFactorAuth.index, xraySegmentCls, twoFactorAuthController.getIndex)
   app.post(user.twoFactorAuth.index, xraySegmentCls, twoFactorAuthController.postIndex)

--- a/app/services/clients/products_client.js
+++ b/app/services/clients/products_client.js
@@ -22,7 +22,8 @@ module.exports = {
     delete: deleteProduct,
     getByProductExternalId: getProductByExternalId,
     getByGatewayAccountId: getProductsByGatewayAccountId,
-    getByProductPath: getProductByPath
+    getByProductPath: getProductByPath,
+    addMetadataToProduct: addMetadataToProduct
   },
   payment: {
     create: createPayment,
@@ -94,6 +95,18 @@ function updateProduct (gatewayAccountId, productExternalId, options) {
     description: 'update an existing product',
     service: SERVICE_NAME
   }).then(product => new Product(product))
+}
+
+function addMetadataToProduct (productExternalId, key, value) {
+  const body = {}
+  body[key] = value
+  return baseClient.post({
+    baseUrl,
+    body,
+    url: `/products/${productExternalId}/metadata`,
+    description: 'add metadata to an existing product',
+    service: SERVICE_NAME
+  })
 }
 
 /**

--- a/app/views/payment-links/metadata/edit-metadata.njk
+++ b/app/views/payment-links/metadata/edit-metadata.njk
@@ -1,0 +1,59 @@
+{% extends "../../layout.njk" %}
+
+{% block pageTitle %}
+  Payment link reporting columns - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+{% endblock %}
+
+{% block side_navigation %}
+  {% include "./../_nav.njk" %}
+{% endblock %}
+
+{% block mainContent %}
+<section class="govuk-grid-column-two-thirds">
+  <h1 class="govuk-heading-l">Payment link reporting column</h1>
+  <form action="{{ self }}" class="form" method="post" data-validate>
+    <p class="govuk-body">Reporting columns are not shown to the user making the payment.</p>
+
+    {{
+      govukInput({
+        id: "metadata-column-header",
+        name: "metadata-column-header",
+        label: {
+            text: "Column header"
+        },
+        hint: {
+          html: "Shown in the header row of the report"
+        },
+        attributes: {
+            "autofocus": true
+        }
+      })
+    }}
+
+    {{
+      govukInput({
+        id: "metadata-cell-value",
+        name: "metadata-cell-value",
+        label: {
+            text: "Cell value"
+        },
+        hint: {
+          html: "Added to each row of the report"
+        },
+        attributes: {
+            "autofocus": true
+        }
+      })
+    }}
+
+    {{
+      govukButton({
+        text: "Add reporting column",
+        classes: "button"
+      })
+    }}
+
+    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state cancel" href="{{ routes.paymentLinks.manage }}">Cancel</a></p>
+  </form>
+</section>
+{% endblock %}

--- a/app/views/payment-links/metadata/edit-metadata.njk
+++ b/app/views/payment-links/metadata/edit-metadata.njk
@@ -12,6 +12,7 @@
 <section class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">Payment link reporting column</h1>
   <form action="{{ self }}" class="form" method="post" data-validate>
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <p class="govuk-body">Reporting columns are not shown to the user making the payment.</p>
 
     {{

--- a/app/views/payment-links/metadata/edit-metadata.njk
+++ b/app/views/payment-links/metadata/edit-metadata.njk
@@ -10,6 +10,17 @@
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
+  {% if error %}
+  {{ govukErrorSummary({
+    titleText: "There is a problem",
+    errorList: [{
+      text: error,
+      href: "#metadata-column-header"
+    }]
+    })
+  }}
+  {% endif %}
+
   <h1 class="govuk-heading-l">Payment link reporting column</h1>
   <form action="{{ self }}" class="form" method="post" data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
@@ -22,6 +33,7 @@
         label: {
             text: "Column header"
         },
+        value: metadataColumnHeader,
         hint: {
           html: "Shown in the header row of the report"
         },
@@ -38,11 +50,9 @@
         label: {
             text: "Cell value"
         },
+        value: metadataColumnValue,
         hint: {
           html: "Added to each row of the report"
-        },
-        attributes: {
-            "autofocus": true
         }
       })
     }}

--- a/test/unit/middleware/experimental_features_test.js
+++ b/test/unit/middleware/experimental_features_test.js
@@ -1,0 +1,41 @@
+const path = require('path')
+const sinon = require('sinon')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const experimentalFeatures = require(path.join(__dirname, '/../../../app/middleware/experimental_features.js'))
+
+const { expect } = chai
+let res, next
+
+chai.use(chaiAsPromised)
+
+describe('services experimental features middleware', () => {
+  beforeEach(() => {
+    res = {
+      redirect: sinon.spy(),
+      status: sinon.spy((code) => ({ render: sinon.spy() }))
+    }
+    next = sinon.spy()
+  })
+
+  it('restricts access if experimental features are disabled on the service configuration', () => {
+    const req = {
+      service: {
+        experimentalFfeaturesEnabled: false
+      }
+    }
+    experimentalFeatures(req, res, next)
+    expect(res.status.calledWith(404))
+    expect(next.called).to.be.false // eslint-disable-line
+  })
+
+  it('allows access if experimental features are enabled on the service configuration', () => {
+    const req = {
+      service: {
+        experimentalFeaturesEnabled: true
+      }
+    }
+    experimentalFeatures(req, res, next)
+    expect(next.called).to.be.true // eslint-disable-line
+  })
+})


### PR DESCRIPTION
* resource controllers for GETting add metadata to payment link page
* initial template for column header and cell value form
* restrict access to pages and POST routes by `experimental_features_enabled` flag

