### PR TITLE
PP-6156 Add metadata to page for individual payment link

### DIFF
--- a/app/controllers/payment-links/get-edit-controller.js
+++ b/app/controllers/payment-links/get-edit-controller.js
@@ -17,7 +17,10 @@ module.exports = (req, res) => {
     self: formattedPathFor(paths.paymentLinks.edit, req.params.productExternalId),
     editInformation: formattedPathFor(paths.paymentLinks.editInformation, req.params.productExternalId),
     editReference: formattedPathFor(paths.paymentLinks.editReference, req.params.productExternalId),
-    editAmount: formattedPathFor(paths.paymentLinks.editAmount, req.params.productExternalId)
+    editAmount: formattedPathFor(paths.paymentLinks.editAmount, req.params.productExternalId),
+    addMetadata: formattedPathFor(paths.paymentLinks.metadata.add, req.params.productExternalId),
+    formattedPathFor,
+    paths
   }
 
   const gatewayAccountId = auth.getCurrentGatewayAccountId(req)

--- a/app/paths.js
+++ b/app/paths.js
@@ -152,7 +152,8 @@ module.exports = {
     editReference: '/create-payment-link/manage/edit/reference/:productExternalId',
     editAmount: '/create-payment-link/manage/edit/amount/:productExternalId',
     metadata: {
-      add: '/create-payment-link/manage/edit/:productExternalId/metadata'
+      add: '/create-payment-link/manage/edit/:productExternalId/metadata',
+      edit: '/create-payment-link/manage/edit/:productExternalId/metadata/:metadataKey'
     }
   },
   feedback: '/feedback',

--- a/app/utils/replace_params_in_path.js
+++ b/app/utils/replace_params_in_path.js
@@ -4,7 +4,7 @@ module.exports = (path, ...pathParams) => {
   const paramNames = path.split('/').filter(segment => segment.charAt(0) === ':')
   paramNames.forEach((paramName, index) => {
     if (pathParams[index]) {
-      path = path.replace(paramName, pathParams[index])
+      path = path.replace(paramName, encodeURIComponent(pathParams[index]))
     }
   })
   return path

--- a/app/views/payment-links/edit.njk
+++ b/app/views/payment-links/edit.njk
@@ -1,7 +1,7 @@
 {% extends "../layout.njk" %}
 
 {% block pageTitle %}
-  Edit your payment link - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+  Payment link - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
 {% block side_navigation %}
@@ -10,7 +10,7 @@
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
-  <h1 class="govuk-heading-l">Edit your payment link</h1>
+  <h1 class="govuk-heading-l">Payment link</h1>
 
   {% set detailsHTML %}
     {% if product.description %}
@@ -40,6 +40,7 @@
       <span class="pay-text-grey">User can choose</span>
     {% endif %}
   {% endset %}
+
 
   {{
     govukSummaryList({
@@ -119,6 +120,46 @@
       ]
     })
   }}
+
+{% if currentService.experimentalFeaturesEnabled %}
+  <h2 class="govuk-heading-m">Reporting columns</h2>
+  <p class="govuk-body">Add extra columns to your transactions, for example cost centre code or business area.<p>
+  <p class="govuk-body">This can make it easier to match up payments with other systems.</p>
+
+  {% if product.metadata %}
+    <dl class="govuk-summary-list">
+      {% for metadataKey, metadataValue in product.metadata | dictsort %}
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              {{metadataKey}}
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{metadataValue}}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="{{ formattedPathFor(paths.paymentLinks.metadata.edit, product.externalId, metadataKey) }}">
+                Change<span class="govuk-visually-hidden"> ‘{{ metadataKey }}’</span>
+              </a>
+            </dd>
+          </div>
+      {% endfor %}
+    </dl>
+    {% endif %}
+
+    {% set addReportingColumnButtonText %}
+      {% if product.metadata %}
+        Add another reporting column
+      {% else %}
+        Add a reporting column
+      {% endif %}
+    {% endset %}
+
+    {{ govukButton({
+      text: addReportingColumnButtonText,
+      classes: "govuk-button--secondary",
+      href: addMetadata
+    }) }}
+  {% endif %}
 
   <form action="{{ self }}" class="form" method="post">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>

--- a/test/unit/utils/replace_params_in_path_test.js
+++ b/test/unit/utils/replace_params_in_path_test.js
@@ -1,0 +1,22 @@
+'use strict'
+
+// NPM dependencies
+const { expect } = require('chai')
+
+// Local dependencies
+const formattedPathFor = require('../../../app/utils/replace_params_in_path')
+
+describe('When a path is formatted', () => {
+  it('should replace each placeholder with the appropriate value by index', () => {
+    let formattedPath = formattedPathFor('/foo/:placeholder1/bar/:placeholder2', 'value1', 'value2')
+    expect(formattedPath).to.equal('/foo/value1/bar/value2')
+  })
+  it('should URL-encode the replaced value', () => {
+    let formattedPath = formattedPathFor('/foo/:placeholder', 'abc?dëf=ghi j/k😀')
+    expect(formattedPath).to.equal('/foo/abc%3Fd%C3%ABf%3Dghi%20j%2Fk%F0%9F%98%80')
+  })
+  it('should not replace a placeholder if no replacement is supplied', () => {
+    let formattedPath = formattedPathFor('/foo/:placeholder1/bar/:placeholder2', 'value1')
+    expect(formattedPath).to.equal('/foo/value1/bar/:placeholder2')
+  })
+})


### PR DESCRIPTION
On the page for each individual payment link, add a section for reporting columns (metadata associated with the payment link), complete with links to add a new reporting column and edit the
existing ones. Reporting columns are sorted alphabetically (case-insensitively) by metadata key.

The reporting columns section is only shown if the `experimentalFeaturesEnabled` flag is set on the service.

While the reporting columns section uses the [summary list component from the GOV.UK Design System](https://design-system.service.gov.uk/components/summary-list/), it uses HTML rather than the Nunjucks macro. This is because the number of rows in the table is dynamic (it’s produced by iterating over the metadata keys) and there’s no nice way to tell the summary list component Nunjucks macro that we want a variable number of rows (we’d have to pull the construction of the `rows` object out of the template itself, which is complicated).