### PR TITLE
PP-6156 Check for reporting columns on edit payment link page

### DIFF
--- a/app/views/payment-links/edit.njk
+++ b/app/views/payment-links/edit.njk
@@ -44,6 +44,9 @@
 
   {{
     govukSummaryList({
+      attributes: {
+        id: "payment-link-summary"
+      },
       rows: [
         {
           key: {
@@ -127,7 +130,7 @@
   <p class="govuk-body">This can make it easier to match up payments with other systems.</p>
 
   {% if product.metadata %}
-    <dl class="govuk-summary-list">
+    <dl id="reporting-columns-summary" class="govuk-summary-list">
       {% for metadataKey, metadataValue in product.metadata | dictsort %}
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">


### PR DESCRIPTION
On the edit payment link page, check for the existence of the reporting columns and the button to add new ones. This test is carefully designed to check the columns are presented in
alphabetical order case-insensitively and that the URLs to change each piece of metadata correctly URL-encode the key name.