### PR TITLE
PP-6157 Delete payment link metadata

### DIFF
--- a/app/controllers/payment-links/index.js
+++ b/app/controllers/payment-links/index.js
@@ -27,5 +27,6 @@ exports.metadata = {
   add: require('./metadata/resource-controller').addMetadataPage,
   post: require('./metadata/resource-controller').postMetadataPage,
   editPage: require('./metadata/resource-controller').editMetadataPage,
-  editPagePost: require('./metadata/resource-controller').editMetadataPost
+  editPagePost: require('./metadata/resource-controller').editMetadataPost,
+  deletePagePost: require('./metadata/resource-controller').deleteMetadataPost
 }

--- a/app/controllers/payment-links/metadata/resource-controller.js
+++ b/app/controllers/payment-links/metadata/resource-controller.js
@@ -81,9 +81,22 @@ const updateMetadataPage = function updateMetadataPage (updateMethod, path) {
 const postMetadataPage = updateMetadataPage(product.addMetadataToProduct, paths.paymentLinks.metadata.add)
 const editMetadataPost = updateMetadataPage(product.updateProductMetadata, paths.paymentLinks.metadata.edit)
 
+const deleteMetadataPost = async function deleteMetadaPost (req, res, next) {
+  const { productExternalId, metadataKey } = req.params
+
+  try {
+    await product.deleteProductMetadata(productExternalId, metadataKey)
+    req.flash('generic', `Deleted reporting column ${metadataKey}`)
+    res.redirect(formattedPathFor(paths.paymentLinks.edit, productExternalId))
+  } catch (error) {
+    renderErrorView(req, res, 'Failed to delete metadata for product')
+  }
+}
+
 module.exports = {
   addMetadataPage,
   postMetadataPage,
   editMetadataPage,
-  editMetadataPost
+  editMetadataPost,
+  deleteMetadataPost
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -153,7 +153,8 @@ module.exports = {
     editAmount: '/create-payment-link/manage/edit/amount/:productExternalId',
     metadata: {
       add: '/create-payment-link/manage/edit/:productExternalId/metadata',
-      edit: '/create-payment-link/manage/edit/:productExternalId/metadata/:metadataKey'
+      edit: '/create-payment-link/manage/edit/:productExternalId/metadata/:metadataKey',
+      delete: '/create-payment-link/manage/edit/:productExternalId/metadata/:metadataKey/delete'
     }
   },
   feedback: '/feedback',

--- a/app/routes.js
+++ b/app/routes.js
@@ -343,10 +343,12 @@ module.exports.bind = function (app) {
   app.post(paymentLinks.editReference, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.postEditReference)
   app.get(paymentLinks.editAmount, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.getEditAmount)
   app.post(paymentLinks.editAmount, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.postEditAmount)
+
   app.get(paymentLinks.metadata.add, xraySegmentCls, permission('tokens:create'), getAccount, restrictServiceExperimentalFeatures, paymentLinksController.metadata.add)
   app.post(paymentLinks.metadata.add, xraySegmentCls, permission('tokens:create'), getAccount, restrictServiceExperimentalFeatures, paymentLinksController.metadata.post)
   app.get(paymentLinks.metadata.edit, xraySegmentCls, permission('tokens:create'), getAccount, restrictServiceExperimentalFeatures, paymentLinksController.metadata.editPage)
   app.post(paymentLinks.metadata.edit, xraySegmentCls, permission('tokens:create'), getAccount, restrictServiceExperimentalFeatures, paymentLinksController.metadata.editPagePost)
+  app.post(paymentLinks.metadata.delete, xraySegmentCls, permission('tokens:create'), getAccount, restrictServiceExperimentalFeatures, paymentLinksController.metadata.deletePagePost)
 
   // Configure 2FA
   app.get(user.twoFactorAuth.index, xraySegmentCls, twoFactorAuthController.getIndex)

--- a/app/services/clients/products_client.js
+++ b/app/services/clients/products_client.js
@@ -24,7 +24,8 @@ module.exports = {
     getByGatewayAccountId: getProductsByGatewayAccountId,
     getByProductPath: getProductByPath,
     addMetadataToProduct: addMetadataToProduct,
-    updateProductMetadata: updateProductMetadata
+    updateProductMetadata: updateProductMetadata,
+    deleteProductMetadata: deleteProductMetadata
   },
   payment: {
     create: createPayment,
@@ -118,6 +119,15 @@ function updateProductMetadata (productExternalId, key, value) {
     body,
     url: `/products/${productExternalId}/metadata`,
     description: 'update existing metadata on an existing product',
+    service: SERVICE_NAME
+  })
+}
+
+function deleteProductMetadata (productExternalId, key) {
+  return baseClient.delete({
+    baseUrl,
+    url: `/products/${productExternalId}/metadata/${key}`,
+    description: 'delete metadata on an existing product',
     service: SERVICE_NAME
   })
 }

--- a/app/views/payment-links/metadata/edit-metadata.njk
+++ b/app/views/payment-links/metadata/edit-metadata.njk
@@ -20,7 +20,7 @@
 
   {% set pageHeading = ("Edit reporting column" if isEditing else "Payment link reporting column") %}
   <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-  <form action="{{ self }}" class="form" method="post">
+  <form action="{{ self }}" class="form" method="post" style="display: inline">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <p class="govuk-body">Reporting columns are not shown to the user making the payment.</p>
 
@@ -30,7 +30,7 @@
     {% set columnHeaderHint = "Shown in the header row of the report" %}
     {% if isEditing %}
       <p class="govuk-body edit-reporting-column--bottom-spacing">{{columnHeaderHeading}}</p>
-      <p class="govuk-body govuk-hint edit-reporting-column--bottom-spacing">{{columnHeaderHint}}</span> 
+      <p class="govuk-body govuk-hint edit-reporting-column--bottom-spacing">{{columnHeaderHint}}</span>
       <p class="govuk-body govuk-!-font-weight-bold" >{{form.values[metadataKeyField.id]}}</p>
       <input type="hidden" id="{{metadataKeyField.id}}" name="{{metadataKeyField.name}}"
        value="{{form.values[metadataKeyField.id]}}" />
@@ -40,11 +40,11 @@
           id: metadataKeyField.id,
           name: metadataKeyField.name,
           label: {
-              text: columnHeaderHeading 
+              text: columnHeaderHeading
           },
           value: form.values[metadataKeyField.id],
           hint: {
-            html: columnHeaderHint 
+            html: columnHeaderHint
           },
           errorMessage: tested.errorMaps[metadataKeyField.id] and {
             text: tested.errorMaps[metadataKeyField.id]
@@ -52,9 +52,7 @@
           attributes: metadataKeyAttributes
         })
       }}
-    {% endif %} 
-    {# "disabled": "true" if isEditing else "" #}
-
+    {% endif %}
 
     {% set metadataValueField = form.fields.metadataValue %}
     {{
@@ -81,7 +79,20 @@
       })
     }}
 
-    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state cancel" href="{{ cancelRoute }}">Cancel</a></p>
-  </form>
+    </form>
+
+    {% if isEditing %}
+      <form method="post" action="{{ self }}/delete" style="display: inline">
+        <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+        {{
+        govukButton({
+          text: "Delete reporting column",
+          classes: "govuk-button--warning"
+        })
+        }}
+      </form>
+    {% endif %}
+
+  <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state cancel" href="{{ cancelRoute }}">Cancel</a></p>
 </section>
 {% endblock %}


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-selfservice/pull/1888

Basic delete functionality for metadata for payment links, includes all the gubbins, flow can be changed with user testing as needed.

<img width="831" alt="Screenshot 2020-03-09 at 16 08 48" src="https://user-images.githubusercontent.com/2844572/76233671-70d98300-6220-11ea-8fa2-583335268f2f.png">
