### PR TITLE
BAU Invalid Permissions Return 401

### DIFF
--- a/app/middleware/permission.js
+++ b/app/middleware/permission.js
@@ -14,7 +14,7 @@ module.exports = function (permission) {
     if (req.user.hasPermission(req.service.externalId, permission)) {
       return next()
     } else {
-      return res.render('error', {'message': 'You do not have the administrator rights to perform this operation.'})
+      return res.status(401).render('error', { 'message': 'You do not have the administrator rights to perform this operation.' })
     }
   }]
 }

--- a/test/cypress/integration/request-to-go-live/agreement_spec.js
+++ b/test/cypress/integration/request-to-go-live/agreement_spec.js
@@ -38,7 +38,7 @@ describe('Request to go live: agreement', () => {
 
     it('should show an error when the user does not have enough permissions', () => {
       const requestToGoLivePageOrganisationNameUrl = `/service/${serviceExternalId}/request-to-go-live/agreement`
-      cy.visit(requestToGoLivePageOrganisationNameUrl)
+      cy.visit(requestToGoLivePageOrganisationNameUrl, { failOnStatusCode: false })
       cy.get('h1').should('contain', 'An error occurred:')
       cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
     })

--- a/test/cypress/integration/request-to-go-live/choose_how_to_process_payments_spec.js
+++ b/test/cypress/integration/request-to-go-live/choose_how_to_process_payments_spec.js
@@ -146,7 +146,7 @@ describe('Request to go live: choose how to process payments', () => {
 
     it('should show an error when the user does not have enough permissions', () => {
       const requestToGoLivePageOrganisationNameUrl = `/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`
-      cy.visit(requestToGoLivePageOrganisationNameUrl)
+      cy.visit(requestToGoLivePageOrganisationNameUrl, { failOnStatusCode: false })
       cy.get('h1').should('contain', 'An error occurred:')
       cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
     })

--- a/test/cypress/integration/request-to-go-live/index_spec.js
+++ b/test/cypress/integration/request-to-go-live/index_spec.js
@@ -44,7 +44,7 @@ describe('Request to go live: index', () => {
 
     it('should show an error when the user does not have enough permissions', () => {
       const requestToGoLivePageUrl = `/service/${serviceExternalId}/request-to-go-live`
-      cy.visit(requestToGoLivePageUrl)
+      cy.visit(requestToGoLivePageUrl, { failOnStatusCode: false })
       cy.get('h1').should('contain', 'An error occurred:')
       cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
     })

--- a/test/cypress/integration/request-to-go-live/organisation_address_spec.js
+++ b/test/cypress/integration/request-to-go-live/organisation_address_spec.js
@@ -221,7 +221,7 @@ describe('The organisation address page', () => {
     })
 
     it('should show an error when the user does not have enough permissions', () => {
-      cy.visit(pageUrl)
+      cy.visit(pageUrl, { failOnStatusCode: false })
       cy.get('h1').should('contain', 'An error occurred:')
       cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
     })

--- a/test/cypress/integration/request-to-go-live/organisation_name_spec.js
+++ b/test/cypress/integration/request-to-go-live/organisation_name_spec.js
@@ -44,7 +44,7 @@ describe('Request to go live: organisation name page', () => {
 
     it('should show an error when the user does not have enough permissions', () => {
       const requestToGoLivePageOrganisationNameUrl = `/service/${serviceExternalId}/request-to-go-live/organisation-name`
-      cy.visit(requestToGoLivePageOrganisationNameUrl)
+      cy.visit(requestToGoLivePageOrganisationNameUrl, { failOnStatusCode: false })
       cy.get('h1').should('contain', 'An error occurred:')
       cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
     })

--- a/test/cypress/integration/stripe-setup/bank_details_spec.js
+++ b/test/cypress/integration/stripe-setup/bank_details_spec.js
@@ -252,7 +252,9 @@ describe('Stripe setup: bank details page', () => {
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe')
         ])
 
-        cy.visit('/bank-details')
+        cy.visit('/bank-details', {
+          failOnStatusCode: false
+        })
         cy.get('h1').should('contain', 'An error occurred:')
         cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
       })

--- a/test/cypress/integration/stripe-setup/responsible_person_spec.js
+++ b/test/cypress/integration/stripe-setup/responsible_person_spec.js
@@ -500,7 +500,7 @@ describe('Stripe setup: responsible person page', () => {
         stubStripeAccountGet('acct_123example123')
       ])
 
-      cy.visit('/responsible-person')
+      cy.visit('/responsible-person', { failOnStatusCode: false })
     })
 
     it('should show a permission denied error', () => {

--- a/test/cypress/integration/stripe-setup/vat-number-company-number/check_your_answers_spec.js
+++ b/test/cypress/integration/stripe-setup/vat-number-company-number/check_your_answers_spec.js
@@ -300,7 +300,7 @@ describe('Stripe setup: "VAT number / company number - check your answers" page'
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe')
         ])
 
-        cy.visit('/vat-number-company-number/check-your-answers')
+        cy.visit('/vat-number-company-number/check-your-answers', { failOnStatusCode: false })
         cy.get('h1').should('contain', 'An error occurred:')
         cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
       })

--- a/test/cypress/integration/stripe-setup/vat-number-company-number/company_number_spec.js
+++ b/test/cypress/integration/stripe-setup/vat-number-company-number/company_number_spec.js
@@ -240,7 +240,7 @@ describe('Stripe setup: company number page', () => {
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe')
         ])
 
-        cy.visit('/vat-number-company-number/company-number')
+        cy.visit('/vat-number-company-number/company-number', { failOnStatusCode: false })
         cy.get('h1').should('contain', 'An error occurred:')
         cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
       })

--- a/test/cypress/integration/stripe-setup/vat-number-company-number/index_spec.js
+++ b/test/cypress/integration/stripe-setup/vat-number-company-number/index_spec.js
@@ -161,7 +161,7 @@ describe('Stripe setup: "VAT number / company number" index page', () => {
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe')
         ])
 
-        cy.visit('/vat-number-company-number')
+        cy.visit('/vat-number-company-number', { failOnStatusCode: false })
         cy.get('h1').should('contain', 'An error occurred:')
         cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
       })

--- a/test/cypress/integration/stripe-setup/vat-number-company-number/vat_number_spec.js
+++ b/test/cypress/integration/stripe-setup/vat-number-company-number/vat_number_spec.js
@@ -173,7 +173,7 @@ describe('Stripe setup: VAT number page', () => {
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe')
         ])
 
-        cy.visit('/vat-number-company-number/vat-number')
+        cy.visit('/vat-number-company-number/vat-number', { failOnStatusCode: false })
         cy.get('h1').should('contain', 'An error occurred:')
         cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
       })


### PR DESCRIPTION
- When we call `res.render()` when a user has invalid permissions, we
should throw a 401 response instead of the current 200.
