### PR TITLE
PP-6254 Add cabon-relay

### DIFF
--- a/env-map.yml
+++ b/env-map.yml
@@ -7,6 +7,8 @@ env_vars:
   LEDGER_URL:                  '.[][] | select(.name == "app-catalog") | .credentials.ledger_url'
   ADMINUSERS_URL:              '.[][] | select(.name == "app-catalog") | .credentials.adminusers_url'
   PRODUCTS_FRIENDLY_BASE_URI:  '.[][] | select(.name == "app-catalog") | .credentials.products_ui_redirect_url'
+  METRICS_HOST:                '.[][] | select(.name == "app-catalog") | .credentials.carbon_relay_route'
+  METRICS_PORT:                '.[][] | select(.name == "app-catalog") | .credentials.carbon_relay_port'
   SESSION_ENCRYPTION_KEY:      '.[][] | select(.name == "selfservice-secret-service") | .credentials.card_frontend_session_encryption_key'
   ANALYTICS_TRACKING_ID:       '.[][] | select(.name == "selfservice-secret-service") | .credentials.analytics_tracking_id'
   ZENDESK_USER:                '.[][] | select(.name == "selfservice-secret-service") | .credentials.zendesk_user'

--- a/manifest.yml
+++ b/manifest.yml
@@ -28,6 +28,8 @@ applications:
     DIRECT_DEBIT_CONNECTOR_URL: ""
     LEDGER_URL: ""
     PRODUCTS_FRIENDLY_BASE_URI: ""
+    METRICS_HOST: ""
+    METRICS_PORT: ""
 
     # The below are provisioned by the selfservice-secret-service user-provided service
     SESSION_ENCRYPTION_KEY: ""


### PR DESCRIPTION
Set the `METRICS_HOST` and `METRICS_PORT` from the app-cataloge to send
metrics to the carbon-relay app.


