### PR TITLE
PP-6303 Clear Filter Redirect Fix

### DIFF
--- a/app/controllers/all-service-transactions/get-controller.js
+++ b/app/controllers/all-service-transactions/get-controller.js
@@ -51,6 +51,7 @@ module.exports = async (req, res) => {
       })
     }
     model.filterRedirect = router.paths.allServiceTransactions.index
+    model.clearRedirect = router.paths.allServiceTransactions.index
     return response(req, res, 'all_service_transactions/index', model)
   } catch (err) {
     renderErrorView(req, res, 'Unable to fetch transaction information')

--- a/app/controllers/transactions/transaction_list_controller.js
+++ b/app/controllers/transactions/transaction_list_controller.js
@@ -53,6 +53,7 @@ module.exports = (req, res) => {
               brand.selected = filters.result.brand.includes(brand.value)
             })
           }
+          model.clearRedirect = router.paths.transactions.index
           response(req, res, 'transactions/index', model)
         })
         .on('connectorError', () => error('Unable to retrieve card types.'))

--- a/app/views/transactions/filter.njk
+++ b/app/views/transactions/filter.njk
@@ -210,7 +210,7 @@
     </div>
     <div class="govuk-grid-column-one-quarter inputs-less-margin">
       {% if hasFilters %}
-      <a href="{{routes.transactions.index}}" class="govuk-link govuk-link--no-visited-state clear-filter">Clear Filter</a>
+      <a href="{{clearRedirect}}" class="govuk-link govuk-link--no-visited-state clear-filter">Clear Filter</a>
       {% endif %}
     </div>
   </form>


### PR DESCRIPTION
- Currently on the 'all services transactions' page the clear filter
button redirects users to the transactions page for the service they are
logged in on.

- This fixes this by providing a context specific clear route that will
redirect users back to the page they are viewing, without filters.


