### PR TITLE
BAU Refine all service transactions UX

### DIFF
--- a/app/controllers/transactions/transaction_detail_controller.js
+++ b/app/controllers/transactions/transaction_detail_controller.js
@@ -14,11 +14,16 @@ module.exports = (req, res) => {
   const accountId = auth.getCurrentGatewayAccountId(req)
   const chargeId = req.params.chargeId
   const correlationId = req.headers[CORRELATION_HEADER]
+
   Charge(correlationId)
     .findWithEvents(accountId, chargeId)
     .then(data => {
       data.indexFilters = req.session.filters
-      data.redirectBackLink = req.session.backLink
+      if (req.session.backLink) {
+        data.redirectBackLink = req.session.backLink
+        delete req.session.backLink
+      }
+      data.service = req.service
       response(req, res, 'transaction_detail/index', data)
     })
     .catch(err => {

--- a/app/routes.js
+++ b/app/routes.js
@@ -225,13 +225,13 @@ module.exports.bind = function (app) {
   //  TRANSACTIONS
   app.get(transactions.index, xraySegmentCls, permission('transactions:read'), getAccount, paymentMethodIsCard, transactionsListController)
   app.get(transactions.download, xraySegmentCls, permission('transactions-download:read'), getAccount, paymentMethodIsCard, transactionsDownloadController)
-  app.get(transactions.detail, xraySegmentCls, permission('transactions-details:read'), getAccount, paymentMethodIsCard, transactionDetailController)
+  app.get(transactions.detail, xraySegmentCls, permission('transactions-details:read'), resolveService, getAccount, paymentMethodIsCard, transactionDetailController)
   app.post(transactions.refund, xraySegmentCls, permission('refunds:create'), getAccount, paymentMethodIsCard, transactionRefundController)
-  app.get(transactions.redirectDetail, xraySegmentCls, permission('transactions-details:read'), getAccount, paymentMethodIsCard, transactionDetailRedirectController)
+  app.get(transactions.redirectDetail, xraySegmentCls, permission('transactions-details:read'), getAccount, transactionDetailRedirectController)
 
   // ALL SERVICE TRANSACTIONS
-  app.get(allServiceTransactions.index, xraySegmentCls, permission('transactions:read'), getAccount, paymentMethodIsCard, allTransactionsController.getController)
-  app.get(allServiceTransactions.download, xraySegmentCls, permission('transactions-download:read'), getAccount, paymentMethodIsCard, allTransactionsController.downloadTransactions)
+  app.get(allServiceTransactions.index, xraySegmentCls, permission('transactions:read'), getAccount, allTransactionsController.getController)
+  app.get(allServiceTransactions.download, xraySegmentCls, permission('transactions-download:read'), getAccount, allTransactionsController.downloadTransactions)
 
   // YOUR PSP
   app.get(yourPsp.index, xraySegmentCls, permission('gateway-credentials:read'), getAccount, paymentMethodIsCard, yourPspController.getIndex)

--- a/app/views/all_service_transactions/index.njk
+++ b/app/views/all_service_transactions/index.njk
@@ -20,6 +20,16 @@ Transactions for all live services - GOV.UK Pay
 <script src="/public/js/components/datetime-picker.js"></script>
 {% endblock %}
 
+{% block beforeContent %}
+  {{ super() }}
+  {{
+    govukBackLink({
+      text: "Back to My services",
+      href: routes.serviceSwitcher.index
+    })
+  }}
+{% endblock %}
+
 {% block mainContent %}
 <div class="govuk-grid-column-full">
   <h1 class="govuk-heading-l">Transactions for all live services</h1>

--- a/app/views/services/index.njk
+++ b/app/views/services/index.njk
@@ -13,7 +13,7 @@
     </div>
   {% endif %}
 
-  <h1 class="govuk-heading-l govuk-grid-column-one-third govuk-!-margin-bottom-3 service-count">
+  <h1 class="govuk-heading-l govuk-grid-column-full govuk-!-margin-bottom-3 service-count">
     {% if services_singular %}
       You have {{services.length}} service
     {% else %}
@@ -21,16 +21,20 @@
     {% endif %}
   </h1>
 
-  <p class="govuk-body govuk-grid-column-two-thirds pay-text-align-right-l govuk-!-margin-top-2 govuk-!-margin-bottom-0">
-    {% if env.PROTOTYPE_MULTIACCOUNT_REPORTING === "true" %}
-      <a href="{{routes.allServiceTransactions.index}}" class="govuk-link govuk-!-margin-right-3 govuk-link--no-visited-state create-service">
-        All Service Transactions
+  <div class="govuk-grid-column-full">
+    <p class="govuk-body">
+      <a href="{{routes.serviceSwitcher.create}}" class="govuk-link govuk-link--no-visited-state create-service">
+        Add a new service
       </a>
+    </p>
+    {% if env.PROTOTYPE_MULTIACCOUNT_REPORTING === "true" %}
+    <p class="govuk-body">
+      <a href="{{routes.allServiceTransactions.index}}" class="govuk-link govuk-!-margin-right-3 govuk-link--no-visited-state create-service">
+        View transactions for all live services
+      </a>
+    </p>
     {% endif %}
-    <a href="{{routes.serviceSwitcher.create}}" class="govuk-link govuk-link--no-visited-state create-service">
-      Add a new service
-    </a>
-  </p>
+  </div>
 
   <div class="govuk-grid-column-full">
     {% if services.length > 7 %}

--- a/app/views/transaction_detail/_details.njk
+++ b/app/views/transaction_detail/_details.njk
@@ -1,6 +1,14 @@
 {% set isStripeAccount = currentGatewayAccount.payment_provider === 'stripe' %}
 <table class="transaction-details govuk-table">
   <tbody class="govuk-table__body">
+
+  {% if contextIsAllServiceTransactions and service %}
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">Service name:</th>
+    <td class="govuk-table__cell govuk-!-font-size-16" id="service_name">{{ (service.serviceName and service.serviceName.en) or service.name }}</td>
+  </tr>
+  {% endif %}
+
   <tr class="govuk-table__row">
     <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">Reference number:</th>
     <td class="govuk-table__cell govuk-!-font-size-16" id="reference">{{reference}}</td>

--- a/app/views/transaction_detail/index.njk
+++ b/app/views/transaction_detail/index.njk
@@ -1,5 +1,8 @@
 {% extends "../layout.njk" %}
 
+{% set contextIsAllServiceTransactions = redirectBackLink %}
+{% set hideServiceHeader = contextIsAllServiceTransactions %}
+
 {% block pageTitle %}
   Transaction details {{charge_id}} - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
@@ -7,10 +10,11 @@
 {% block beforeContent %}
   {{ super() }}
   {% set defaultBackLink %}{{routes.transactions.index}}{% if indexFilters %}?{{indexFilters}}{% endif %}{% endset %}
-  {% set backLink = redirectBackLink if redirectBackLink else defaultBackLink %}
+  {% set backLink = redirectBackLink if contextIsAllServiceTransactions else defaultBackLink %}
+  {% set backLinkText = 'Transactions for all live services' if contextIsAllServiceTransactions else 'Transactions list' %}
   {{
     govukBackLink({
-      text: 'Transactions list',
+      text: backLinkText,
       href: backLink | safe,
       attributes: {
         id: 'arrowed'


### PR DESCRIPTION
**My services page:**
* update text on link to read 'View transactions from all live services" (screenshot 1)
* move links on services overview page to be in a full column (screenshot 1)

**Transaction list:**
* add back links to my service page from all service transactions (screenshot 2)

**Transaction details (IFF coming from all service transactions):**
* add back links to all service transactions from transaction detail with updated text (screenshot 3)
* hide service navigation on transaction detail page as we're not currently in a service context (screenshot 3)
* add service name to the transaction detail page (screenshot 3)

**Fixes:**
* delete backLink context URL every time that it's used, this will avoid
the cookie session continuing to believe it's in the all services view
* remove `paymentMethodIsCard` from all 'all service transactions' routes, these don't belong to an individual account and so will not have a single payment method (stops bug denying access if the user is otherwise in a direct debit account)

![Screenshot 2020-04-06 at 14 22 21](https://user-images.githubusercontent.com/2844572/78563637-378e3600-7813-11ea-9521-a28733fd7cda.png)
![Screenshot 2020-04-06 at 14 22 32](https://user-images.githubusercontent.com/2844572/78563640-3957f980-7813-11ea-9452-a04c95a5caff.png)
![Screenshot 2020-04-06 at 14 22 42](https://user-images.githubusercontent.com/2844572/78563645-3a892680-7813-11ea-842a-49202f309e00.png)

