### PR TITLE
PP-6239 Add page to download PCI attestation of compliance

### DIFF
--- a/app/controllers/policy/supportedPolicyDocuments.js
+++ b/app/controllers/policy/supportedPolicyDocuments.js
@@ -17,6 +17,11 @@ const supportedPolicyDocuments = [
     key: 'stripe-connected-account-agreement',
     title: 'Stripe Connected Account Agreement',
     template: 'policy/document-downloads/stripe_connected_account_agreement'
+  },
+  {
+    key: 'pci-dss-attestation-of-compliance',
+    title: 'Attestation of Compliance for PCI',
+    template: 'policy/document-downloads/pci_dss_attestation_of_compliance'
   }
 ]
 

--- a/app/views/includes/footer-categories.njk
+++ b/app/views/includes/footer-categories.njk
@@ -1,4 +1,4 @@
-<div class="govuk-footer__navigation" data-click-events data-click-category="Footer" data-click-action="Navigation link clicked">
+<div class="govuk-footer__navigation" data-click-events="data-click-events" data-click-category="Footer" data-click-action="Navigation link clicked">
   <div class="govuk-footer__section">
     <h2 class="govuk-footer__heading govuk-heading-m govuk-!-margin-bottom-4 govuk-!-padding-bottom-0 pay-!-border-bottom-0">About</h2>
     <ul class="govuk-footer__list">
@@ -40,19 +40,22 @@
     </ul>
   </div>
   {% if loggedIn %}
-  <div class="govuk-footer__section">
-    <h2 class="govuk-footer__heading govuk-heading-m govuk-!-margin-bottom-4 govuk-!-padding-bottom-0 pay-!-border-bottom-0">Legal Terms</h2>
-    <ul class="govuk-footer__list">
-      <li class="govuk-footer__list-item">
-        <a class="govuk-footer__link" href="/policy/download/memorandum-of-understanding-for-crown-bodies">Memorandum of understanding for Crown bodies</a>
-      </li>
-      <li class="govuk-footer__list-item">
-        <a class="govuk-footer__link" href="/policy/download/contract-for-non-crown-bodies">Contract for non-Crown bodies</a>
-      </li>
-      <li class="govuk-footer__list-item">
-        <a class="govuk-footer__link" href="/policy/download/stripe-connected-account-agreement">Stripe Connected Account Agreement</a>
-      </li>
-    </ul>
-  </div>
+    <div class="govuk-footer__section">
+      <h2 class="govuk-footer__heading govuk-heading-m govuk-!-margin-bottom-4 govuk-!-padding-bottom-0 pay-!-border-bottom-0">Legal Terms</h2>
+      <ul class="govuk-footer__list">
+        <li class="govuk-footer__list-item">
+          <a class="govuk-footer__link" href="/policy/download/memorandum-of-understanding-for-crown-bodies">Memorandum of understanding for Crown bodies</a>
+        </li>
+        <li class="govuk-footer__list-item">
+          <a class="govuk-footer__link" href="/policy/download/contract-for-non-crown-bodies">Contract for non-Crown bodies</a>
+        </li>
+        <li class="govuk-footer__list-item">
+          <a class="govuk-footer__link" href="/policy/download/stripe-connected-account-agreement">Stripe Connected Account Agreement</a>
+        </li>
+        <li class="govuk-footer__list-item">
+          <a class="govuk-footer__link" href="/policy/download/pci-dss-attestation-of-compliance">Attestation of Compliance for PCI</a>
+        </li>
+      </ul>
+    </div>
   {% endif %}
 </div>

--- a/app/views/policy/document-downloads/pci_dss_attestation_of_compliance.njk
+++ b/app/views/policy/document-downloads/pci_dss_attestation_of_compliance.njk
@@ -1,0 +1,30 @@
+{% extends "../../layout.njk" %}
+
+{% block pageTitle %}
+  Policy Document Download - GOV.UK Pay
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      GOV.UK Pay’s Payment Card Industry compliance
+    </h1>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      GOV.UK Pay is certified as a level 1 service provider with the Payment Card Industry Data Security Standard (PCI DSS) version 3.2.1. The PCI DSS provides guidance to help maintain payment security. You can read more on our
+      <a class="govuk-link" href="https://www.payments.service.gov.uk/security/">security and compliance page</a>.
+    </p>
+
+    <p class="govuk-body">
+      You can download
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ link }}" download="download">proof of our compliance</a>
+      (also known as ‘attestation of compliance’) if you need it for your records.
+    </p>
+
+    <p class="govuk-body">
+      This document contains confidential information and you should not share it outside of your organisation.
+    </p>
+  </div>
+{% endblock %}


### PR DESCRIPTION
- Add a link in the footer under "Legal terms" to a new "Attestation of
Compliance for PCI" page. This contains a link to download a document
from S3.

Co-authored-by: Iqbal Ahmed <iqbal.ahmed@digital.cabinet-office.gov.uk>

