### PR TITLE
PP-6345 All service transactions support optional headers (stripe, moto)

### DIFF
--- a/app/controllers/all-service-transactions/download-transactions.js
+++ b/app/controllers/all-service-transactions/download-transactions.js
@@ -14,7 +14,10 @@ module.exports = (req, res) => {
   const name = `GOVUK_Pay_${date.dateToDefaultFormat(new Date()).replace(' ', '_')}.csv`
 
   liveUserServicesGatewayAccounts(req.user)
-    .then((accountIdsUsersHasPermissionsFor) => {
+    .then((gatewayResults) => {
+      const accountIdsUsersHasPermissionsFor = gatewayResults.accounts
+      filters.feeHeaders = gatewayResults.headers.shouldGetStripeHeaders
+      filters.motoHeader = gatewayResults.headers.shouldGetMotoHeaders
       const url = transactionService.csvSearchUrl(filters, accountIdsUsersHasPermissionsFor)
 
       const timestampStreamStart = Date.now()

--- a/app/controllers/all-service-transactions/get-controller.js
+++ b/app/controllers/all-service-transactions/get-controller.js
@@ -19,7 +19,8 @@ module.exports = async (req, res) => {
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   const filters = getFilters(req)
   try {
-    const accountIdsUsersHasPermissionsFor = await liveUserServicesGatewayAccounts(req.user)
+    const gatewayResults = await liveUserServicesGatewayAccounts(req.user)
+    const accountIdsUsersHasPermissionsFor = gatewayResults.accounts
     const searchResultOutput = await transactionService.search(accountIdsUsersHasPermissionsFor, filters.result)
     const cardTypes = await client.getAllCardTypesPromise(correlationId)
     const model = buildPaymentList(searchResultOutput, cardTypes, null, filters.result, router.paths.allServiceTransactions.download, req.session.backPath)
@@ -47,6 +48,8 @@ module.exports = async (req, res) => {
     }
     model.filterRedirect = router.paths.allServiceTransactions.index
     model.clearRedirect = router.paths.allServiceTransactions.index
+    model.isStripeAccount = gatewayResults.headers.shouldGetStripeHeaders
+
     return response(req, res, 'all_service_transactions/index', model)
   } catch (err) {
     renderErrorView(req, res, 'Unable to fetch transaction information')

--- a/app/controllers/transactions/transaction_list_controller.js
+++ b/app/controllers/transactions/transaction_list_controller.js
@@ -54,6 +54,7 @@ module.exports = (req, res) => {
             })
           }
           model.clearRedirect = router.paths.transactions.index
+          model.isStripeAccount = req.account.payment_provider === 'stripe'
           response(req, res, 'transactions/index', model)
         })
         .on('connectorError', () => error('Unable to retrieve card types.'))

--- a/app/views/transactions/list.njk
+++ b/app/views/transactions/list.njk
@@ -1,5 +1,4 @@
 {% if results.length %}
-{% set isStripeAccount = currentGatewayAccount.payment_provider === 'stripe' %}
 <table id="transactions-list" class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/test/unit/utils/valid_account_ids_test.js
+++ b/test/unit/utils/valid_account_ids_test.js
@@ -1,9 +1,11 @@
 const { expect } = require('chai')
+const proxyquire = require('proxyquire')
 
-const { userServicesContainsGatewayAccount } = require('./../../../app/utils/valid_account_id')
 const { validUser } = require('./../../fixtures/user_fixtures')
+const { validGatewayAccountResponse } = require('./../../fixtures/gateway_account_fixtures')
 
 describe('gateway account filter utiltiies', () => {
+  const { userServicesContainsGatewayAccount } = require('./../../../app/utils/valid_account_id')
   describe('gateway account exists on users service roles', () => {
     it('returns valid for gateway account belonging to user', () => {
       const opts = {
@@ -20,6 +22,86 @@ describe('gateway account filter utiltiies', () => {
       const user = validUser(opts).getAsObject()
       const valid = userServicesContainsGatewayAccount('4', user)
       expect(valid).to.equal(false)
+    })
+  })
+
+  describe('live accounts for a given user', () => {
+    const opts = {
+      gateway_account_ids: ['1', '2', '3']
+    }
+    const user = validUser(opts).getAsObject()
+    it('correctly identifies stripe and moto headers for relavent accounts', async () => {
+      const { liveUserServicesGatewayAccounts } = proxyquire('./../../../app/utils/valid_account_id', {
+        '../services/clients/connector_client.js': {
+          ConnectorClient: class {
+            async getAccounts () {
+              return {
+                accounts: [
+                  validGatewayAccountResponse({
+                    payment_provider: 'stripe'
+                  }).getPlain(),
+                  validGatewayAccountResponse({
+                    allow_moto: true
+                  }).getPlain()
+                ]
+              }
+            }
+          }
+        }
+      })
+      const result = await liveUserServicesGatewayAccounts(user)
+
+      expect(result.headers.shouldGetStripeHeaders).to.be.true // eslint-disable-lin
+      expect(result.headers.shouldGetMotoHeaders).to.be.true // eslint-disable-lin
+    })
+
+    it('correctly identifies non stripe and moto headers', async () => {
+      const { liveUserServicesGatewayAccounts } = proxyquire('./../../../app/utils/valid_account_id', {
+        '../services/clients/connector_client.js': {
+          ConnectorClient: class {
+            async getAccounts () {
+              return {
+                accounts: [
+                  validGatewayAccountResponse().getPlain()
+                ]
+              }
+            }
+          }
+        }
+      })
+      const result = await liveUserServicesGatewayAccounts(user)
+
+      expect(result.headers.shouldGetStripeHeaders).to.be.false // eslint-disable-lin
+      expect(result.headers.shouldGetMotoHeaders).to.be.false // eslint-disable-lin
+    })
+
+    it('correctly filters live accounts', async () => {
+      const { liveUserServicesGatewayAccounts } = proxyquire('./../../../app/utils/valid_account_id', {
+        '../services/clients/connector_client.js': {
+          ConnectorClient: class {
+            async getAccounts () {
+              return {
+                accounts: [
+                  validGatewayAccountResponse({
+                    gateway_account_id: '1',
+                    type: 'live'
+                  }).getPlain(),
+                  validGatewayAccountResponse({
+                    gateway_account_id: '2',
+                    type: 'test'
+                  }).getPlain(),
+                  validGatewayAccountResponse({
+                    gateway_account_id: '3',
+                    type: 'live'
+                  }).getPlain()
+                ]
+              }
+            }
+          }
+        }
+      })
+      const result = await liveUserServicesGatewayAccounts(user)
+      expect(result.accounts).to.equal('1,3')
     })
   })
 })


### PR DESCRIPTION
* for all service transactions an individual gateway account
configuration cannot be used to determine if optional headers should be
shown on the transaction list or transaction download
* instead reduce all gateway accounts available to the session so that
if any of them meet the criteria the headers will be shown

