### PR TITLE
PP-6285 Add id to login/otp button

### DIFF
--- a/app/views/login/login.njk
+++ b/app/views/login/login.njk
@@ -80,7 +80,13 @@ Sign in to GOV.UK Pay
       })
     }}
 
-    {{ govukButton({ text: "Continue" }) }}
+    {{ govukButton({
+        text: "Continue",
+        attributes: {
+          id: "continue"
+        }
+      })
+    }}
   </form>
   <p class="govuk-body">
     <a href="/reset-password" class="reset-password govuk-link clear">Forgot your password?</a>

--- a/app/views/login/otp-login.njk
+++ b/app/views/login/otp-login.njk
@@ -59,7 +59,13 @@
       })
     }}
 
-    {{ govukButton({ text: "Continue" }) }}
+    {{ govukButton({
+        text: "Continue",
+        attributes: {
+          id: "continue"
+        }
+      })
+    }}
   </form>
   {% if authenticatorMethod === 'SMS' %}
   <p class="govuk-body"><a class="govuk-link text-messsage-link" href="{{routes.user.otpSendAgain}}">Not received a text message?</a></p>


### PR DESCRIPTION
## WHAT
- Added ID attributes to button on login/otp page, so that the elements can be selected  by ID instead of using `class=govuk-button`. Since we are adding cookie pages, it will have additional buttons with class `govuk-button` which will confuse integration tests as well as e2e tests when logging in for the tests

