### PR TITLE
PP 6466 Fix Google pay settings page

### DIFF
--- a/app/controllers/digital-wallet/post-google-pay-controller.js
+++ b/app/controllers/digital-wallet/post-google-pay-controller.js
@@ -2,6 +2,7 @@
 
 // Local dependencies
 const paths = require('../../paths')
+const logger = require('../../utils/logger')(__filename)
 const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector_client')
 const { CORRELATION_HEADER } = require('../../utils/correlation_header')
@@ -11,14 +12,36 @@ module.exports = async (req, res) => {
   const gatewayAccountId = req.account.gateway_account_id
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   const enable = req.body['google-pay'] === 'on'
+  const gatewayMerchantId = req.body.merchantId
+
+  if (enable && !gatewayMerchantId) {
+    req.flash('genericError', '<h2>Please enter a valid Merchant ID</h2>')
+    return res.redirect(paths.digitalWallet.googlePay)
+  }
+
+  if (enable) {
+    try {
+      await connector.setGatewayMerchantId(gatewayAccountId, gatewayMerchantId, correlationId)
+      logger.info(`${correlationId} set google pay merchant ID for ${gatewayAccountId}`)
+    } catch (error) {
+      logger.info(`${correlationId} error setting google pay merchant ID for ${gatewayAccountId}: `, error)
+      if (error.errorCode === 400) {
+        req.flash('genericError', `<h2>There was an error enabling google pay. Check that the Merchant ID you entered is correct and that your PSP account credentials have been set.</h2>`)
+        return res.redirect(paths.digitalWallet.googlePay)
+      } else {
+        return renderErrorView(req, res, false, error.errorCode)
+      }
+    }
+  }
 
   try {
     await connector.toggleGooglePay(gatewayAccountId, enable, correlationId)
+    logger.info(`${correlationId} ${enable ? 'enabled' : 'disabled'} google pay boolean for ${gatewayAccountId}`)
 
     req.flash('generic', `<h2>Google Pay successfully ${enable ? 'enabled' : 'disabled'}.</h2>`)
     return res.redirect(paths.digitalWallet.googlePay)
   } catch (error) {
-    req.flash('genericError', `<h2>Something went wrong</h2>`)
+    logger.error(`${correlationId} error enabling google pay for ${gatewayAccountId}: ${error}`)
     return renderErrorView(req, res, false, error.errorCode)
   }
 }

--- a/app/views/digital-wallet/apple-pay.njk
+++ b/app/views/digital-wallet/apple-pay.njk
@@ -22,7 +22,7 @@
         <li>corporate card fees cannot be applied to payments made with Apple Pay.</li>
       </ul>
 
-      <form method="post" action="{{routes.digitalWallet.enableApplePay}}">
+      <form method="post" action="{{routes.digitalWallet.applePay}}">
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
         {{
           govukRadios({

--- a/app/views/digital-wallet/google-pay.njk
+++ b/app/views/digital-wallet/google-pay.njk
@@ -27,7 +27,7 @@
         You’ll need a Google Pay merchant ID. Refer to the <a class="govuk-link" href="https://docs.payments.service.gov.uk/optional_features/digital_wallets/#enable-google-pay">GOV.UK Pay documentation on enabling Google Pay</a> to learn where to find your merchant ID.
       </p>
 
-      <form method="post" action="{{routes.digitalWallet.enableGooglePay}}">
+      <form method="post" action="{{routes.digitalWallet.googlePay}}">
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
         {% set merchantID %}
@@ -37,9 +37,6 @@
               name: "merchantId",
               label: {
                 text: "Merchant ID"
-              },
-              attributes: {
-                required: true
               },
               classes: "govuk-!-width-two-thirds"
             })

--- a/app/views/includes/side_navigation.njk
+++ b/app/views/includes/side_navigation.njk
@@ -1,4 +1,4 @@
-<div class="govuk-grid-column-one-third">
+<div class="govuk-grid-column-one-third navigation--pad-bottom">
     <nav role="navigation" class="settings-navigation">
         <ul class="govuk-list govuk-!-margin-bottom-9">
           {% for item in adminNavigationItems %}


### PR DESCRIPTION
At some point, we stopped sending the merchant ID to connector. This means that although we were changing the `allow_google_pay` setting on the gateway account, it never appeared as enabled because when connector returns the setting, it checks that the merchant ID is there.

Fix the routes that the form on the apple/google pay settings page post to.

Also fix an issue where it was not possible to turn off google pay due to the `required: "true"` attribute on the merchant ID field. Instead do server side validation for this.

The tests need to be improved for this, but as it was already broken, this PR just aims to get it working again.

### Also

Stop alignment being messed up when a flash message shown. This was happening when errors were shown for the google pay settings page.

Added some padding to the settings navigation as a quick fix for this. Although we need to tinker with the layout to fix this properly.

