### PR TITLE
PP-6490 Payout search client wrapper

### DIFF
--- a/app/services/clients/ledger_client.js
+++ b/app/services/clients/ledger_client.js
@@ -108,9 +108,24 @@ const transactionSummary = function transactionSummary (gatewayAccountId, fromDa
   return baseClient.get(configuration)
 }
 
+const payouts = function payouts (gatewayAccountId, page) {
+  const configuration = {
+    url: '/v1/payout',
+    qs: {
+      gateway_account_id: gatewayAccountId,
+      page
+    },
+    description: 'List payouts for a given gateway account ID',
+    ...defaultOptions
+  }
+
+  return baseClient.get(configuration)
+}
+
 module.exports = {
   transaction,
   transactions,
+  payouts,
   transactionWithAccountOverride,
   allTransactionPages,
   allTransactionsAsCsv,

--- a/test/fixtures/payout_fixtures.js
+++ b/test/fixtures/payout_fixtures.js
@@ -1,0 +1,39 @@
+'use strict'
+const pactBase = require('./pact_base')
+const pact = pactBase()
+
+function buildPayout (gatewayAccountId) {
+  return {
+    gateway_payout_id: 'some-gateway-payout-id',
+    gateway_account_id: gatewayAccountId || 1,
+    amount: 10000,
+    created_date: '2019-01-29T08:00:00.000000Z',
+    paid_out_date: '2019-01-29T11:00:00.000000Z',
+    state: {
+      status: 'paidout',
+      finshed: true
+    }
+  }
+}
+
+function decoratePactOptions (response) {
+  return {
+    getPactified: () => pact.pactify(response),
+    getPlain: () => response
+  }
+}
+
+module.exports = {
+  validPayoutSearchResponse: (gatewayAccountId) => {
+    const payouts = [
+      buildPayout(gatewayAccountId)
+    ]
+    const response = {
+      results: payouts,
+      total: payouts.length,
+      count: payouts.length,
+      page: 1
+    }
+    return decoratePactOptions(response)
+  }
+}

--- a/test/unit/clients/ledger_client/ledger_search_payout_test.js
+++ b/test/unit/clients/ledger_client/ledger_search_payout_test.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const chai = require('chai')
+
+const PactInteractionBuilder = require('../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const ledgerClient = require('../../../../app/services/clients/ledger_client')
+const payoutFixture = require('../../../fixtures/payout_fixtures')
+const pactTestProvider = require('./ledger_pact_test_provider')
+
+const { expect } = chai
+
+const GATEWAY_ACCOUNT_ID = 1
+
+describe('ledger client', () => {
+  before(() => pactTestProvider.setup())
+  after(() => pactTestProvider.finalize())
+
+  describe('search payouts utility wrapper', () => {
+    const response = payoutFixture.validPayoutSearchResponse({
+      gateway_account_id: GATEWAY_ACCOUNT_ID
+    })
+
+    before(() => {
+      return pactTestProvider.addInteraction(
+        new PactInteractionBuilder('/v1/payout')
+          .withQuery('gateway_account_id', GATEWAY_ACCOUNT_ID)
+          .withQuery('page', '1')
+          .withQuery('display_size', '100')
+          .withUponReceiving('a valid search payout details request')
+          .withState('two payouts exist for selfservice search')
+          .withMethod('GET')
+          .withStatusCode(200)
+          .withResponseBody(response.getPactified())
+          .build()
+      )
+    })
+    afterEach(() => pactTestProvider.verify())
+
+    it('should search payouts successfully', async () => {
+      const ledgerResult = await ledgerClient.payouts(GATEWAY_ACCOUNT_ID, 1)
+      expect(ledgerResult).to.deep.equal(response.getPlain())
+    })
+  })
+})


### PR DESCRIPTION
API resource wrapper utility for ledger payout search. Client call will
be verified when the provider has added this interaction.

Depends on https://github.com/alphagov/pay-selfservice/pull/1991