### PR TITLE
PP-6487 Ledger payout API endpoint client wrapper

### DIFF
--- a/app/services/clients/ledger_client.js
+++ b/app/services/clients/ledger_client.js
@@ -108,9 +108,24 @@ const transactionSummary = function transactionSummary (gatewayAccountId, fromDa
   return baseClient.get(configuration)
 }
 
+const payouts = function payouts (gatewayAccountId, page = 1) {
+  const configuration = {
+    url: '/v1/payout',
+    qs: {
+      gateway_account_id: gatewayAccountId,
+      page
+    },
+    description: 'List payouts for a given gateway account ID',
+    ...defaultOptions
+  }
+
+  return baseClient.get(configuration)
+}
+
 module.exports = {
   transaction,
   transactions,
+  payouts,
   transactionWithAccountOverride,
   allTransactionPages,
   allTransactionsAsCsv,


### PR DESCRIPTION
This wrapper allows Ledger to fetch payouts for a given gateway account
string and page number.

This wrapper will be covered by the following tests when used:
* Consumer pact tests will validate the shape of the data as well as
verifying the correct params are provided to the right endpoint. This
will also make sure the data is returned as expected.
* Integration tests for any controllers that use the wrapper (see https://github.com/alphagov/pay-selfservice/pull/2002)
