### PR TITLE
PP-6487 Payouts service for grouping payouts

### DIFF
--- a/app/controllers/payouts/payouts_service.js
+++ b/app/controllers/payouts/payouts_service.js
@@ -1,0 +1,32 @@
+const moment = require('moment')
+
+const { indexServiceNamesByGatewayAccountId } = require('./user_services_names')
+
+const getPayoutDate = function getPayoutDate (payout) {
+  return payout.paid_out_date || payout.created_date
+}
+
+const sortPayoutByDateString = function sortPayoutByDateString (a, b) {
+  return new Date(getPayoutDate(a)) - new Date(getPayoutDate(b))
+}
+
+const groupPayoutsByDate = function groupPayoutsByDate (payouts, user) {
+  const serviceNameMap = indexServiceNamesByGatewayAccountId(user)
+  const groups = {}
+
+  payouts.sort(sortPayoutByDateString)
+  payouts.forEach((payout) => {
+    const date = moment(getPayoutDate(payout))
+    const key = date.format('YYYY-MM-DD')
+    payout.serviceName = serviceNameMap[payout.gateway_account_id] || '(No service name)'
+
+    groups[key] = groups[key] || { date, entries: [] }
+    groups[key].entries.push(payout)
+  })
+
+  return groups
+}
+
+module.exports = {
+  groupPayoutsByDate
+}

--- a/app/controllers/payouts/user_services_names.js
+++ b/app/controllers/payouts/user_services_names.js
@@ -1,0 +1,13 @@
+const indexServiceNamesByGatewayAccountId = function indexServiceNamesByGatewayAccountId (user) {
+  const services = (user && user.serviceRoles) || []
+  return services.reduce((aggregate, serviceRole) => {
+    serviceRole.service.gatewayAccountIds.forEach((gatewayAccountId) => {
+      aggregate[gatewayAccountId] = serviceRole.service.serviceName.en
+    })
+    return aggregate
+  }, {})
+}
+
+module.exports = {
+  indexServiceNamesByGatewayAccountId
+}

--- a/test/fixtures/payout_fixtures.js
+++ b/test/fixtures/payout_fixtures.js
@@ -2,13 +2,13 @@
 const pactBase = require('./pact_base')
 const pact = pactBase()
 
-function buildPayout (gatewayAccountId) {
+function buildPayout (opts) {
   return {
     gateway_payout_id: 'some-gateway-payout-id',
-    gateway_account_id: gatewayAccountId || 1,
+    gateway_account_id: opts.gatewayAccountId || 1,
     amount: 10000,
     created_date: '2019-01-29T08:00:00.000000Z',
-    paid_out_date: '2019-01-29T11:00:00.000000Z',
+    paid_out_date: opts.paidOutDate || '2019-01-29T11:00:00.000000Z',
     state: {
       status: 'paidout',
       finshed: true
@@ -24,10 +24,8 @@ function decoratePactOptions (response) {
 }
 
 module.exports = {
-  validPayoutSearchResponse: (gatewayAccountId) => {
-    const payouts = [
-      buildPayout(gatewayAccountId)
-    ]
+  validPayoutSearchResponse: (payoutOpts = []) => {
+    const payouts = payoutOpts.map(buildPayout)
     const response = {
       results: payouts,
       total: payouts.length,

--- a/test/unit/controller/payouts/payouts_service_test.js
+++ b/test/unit/controller/payouts/payouts_service_test.js
@@ -1,0 +1,55 @@
+const chai = require('chai')
+const { expect } = chai
+const { groupPayoutsByDate } = require('./../../../../app/controllers/payouts/payouts_service')
+const payoutFixtures = require('./../../../fixtures/payout_fixtures')
+const userFixtures = require('./../../../fixtures/user_fixtures')
+
+describe('payout service data transforms', () => {
+  describe('grouping payouts by date', () => {
+    it('groups payouts by date given valid payout response', () => {
+      const opts = [
+        { paidOutDate: '2019-01-29T08:00:00.000000Z' },
+        { paidOutDate: '2019-01-26T08:00:00.000000Z' },
+        { paidOutDate: '2019-01-28T08:00:00.000000Z' },
+        { paidOutDate: '2019-01-28T08:00:00.000000Z' },
+        { paidOutDate: '2019-01-21T08:00:00.000000Z' }
+      ]
+      const payouts = payoutFixtures.validPayoutSearchResponse(opts).getPlain()
+
+      const grouped = groupPayoutsByDate(payouts.results)
+
+      expect(Object.keys(grouped).length).to.equal(4)
+      expect(grouped).to.have.keys('2019-01-29', '2019-01-28', '2019-01-26', '2019-01-21')
+      expect(grouped['2019-01-29'].entries).to.have.length(1)
+      expect(grouped['2019-01-29'].date.format('YYYY-MM-DD')).to.equal('2019-01-29')
+      expect(grouped['2019-01-28'].entries).to.have.length(2)
+      expect(grouped['2019-01-26'].entries).to.have.length(1)
+      expect(grouped['2019-01-21'].entries).to.have.length(1)
+    })
+
+    it('will correctly assign service names if a user is provided', () => {
+      const payouts = payoutFixtures
+        .validPayoutSearchResponse([{
+          paidOutDate: '2019-01-21T08:00:00.000000Z',
+          gatewayAccountId: '300'
+        }])
+        .getPlain()
+
+      const user = userFixtures
+        .validUser({
+          gateway_account_ids: [ '300' ]
+        })
+        .getAsObject()
+
+      const grouped = groupPayoutsByDate(payouts.results, user)
+
+      expect(grouped['2019-01-21'].entries).to.have.length(1)
+      expect(grouped['2019-01-21'].entries[0].serviceName).to.equal('System Generated')
+    })
+
+    it('will return a valid empty set if no payouts or user are provided', () => {
+      const grouped = groupPayoutsByDate([], null)
+      expect(grouped).to.deep.equal({})
+    })
+  })
+})

--- a/test/unit/controller/payouts/user_services_names_test.js
+++ b/test/unit/controller/payouts/user_services_names_test.js
@@ -1,0 +1,22 @@
+const chai = require('chai')
+const { expect } = chai
+const { indexServiceNamesByGatewayAccountId } = require('./../../../../app/controllers/payouts/user_services_names')
+const fixtures = require('./../../../fixtures/user_fixtures')
+
+describe('user services to gateway account id map utility', () => {
+  it('indexes gateway accounts to service names given a valid user object', () => {
+    const user = fixtures
+      .validUser({
+        gateway_account_ids: [ '300' ]
+      })
+      .getAsObject()
+    const serviceNameMap = indexServiceNamesByGatewayAccountId(user)
+
+    expect(serviceNameMap['300']).to.equal('System Generated')
+  })
+
+  it('invalid user object will return an empty map', () => {
+    const serviceNameMap = indexServiceNamesByGatewayAccountId(null)
+    expect(serviceNameMap).to.deep.equal({})
+  })
+})


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-selfservice/pull/2000

According to the discovery design document for the payout MVP, we will
be displaying payouts for all services grouped by date.

It is also necessary to provide the services name for each payout entry,
as this information isn't available to the payout (from Ledger) there
will also be a requirement to compliment payouts with the service name.

This adds a service helper method to accept a flat list of payouts and return a
grouped object indexed by date.

If a user object is provided (see User model), this will also add the
service name to each payout object according to the gateway account
assigned to that payout.

Example usage:
```
groupPayoutsByDate([{
  id: '...'
  paid_out_date: '2019-09-01T01...'
})

/*
{
  '2019-09-01': {
    date: Moment(),
    entries: [{
      id: '...'
    }]
  }
}
*/
```