### PR TITLE
PP-6487 Payouts service gets payouts

### DIFF
--- a/app/controllers/payouts/payouts_service.js
+++ b/app/controllers/payouts/payouts_service.js
@@ -1,5 +1,7 @@
 const moment = require('moment')
 
+const Ledger = require('../../../app/services/clients/ledger_client')
+
 const { indexServiceNamesByGatewayAccountId } = require('./user_services_names')
 
 const getPayoutDate = function getPayoutDate (payout) {
@@ -27,6 +29,12 @@ const groupPayoutsByDate = function groupPayoutsByDate (payouts, user) {
   return groups
 }
 
+const payouts = async function payouts (gatewayAccountId, user = {}) {
+  const payoutSearchResponse = await Ledger.payouts(gatewayAccountId)
+  return groupPayoutsByDate(payoutSearchResponse.results, user)
+}
+
 module.exports = {
+  payouts,
   groupPayoutsByDate
 }

--- a/test/integration/payouts/payouts_service_it_test.js
+++ b/test/integration/payouts/payouts_service_it_test.js
@@ -1,0 +1,41 @@
+const chai = require('chai')
+const nock = require('nock')
+
+const { expect } = chai
+
+const payoutService = require('./../../../app/controllers/payouts/payouts_service')
+const fixtures = require('./../../fixtures/payout_fixtures')
+
+const gatewayAccountId = '100'
+const ledgerMock = nock(process.env.LEDGER_URL)
+const LEDGER_PAYOUT_BACKEND_ROUTE = `/v1/payout?gateway_account_id=${gatewayAccountId}&page=1`
+
+describe('payouts service list payouts helper', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('responds with grouped payouts given a well formed request and existing payouts', async () => {
+    const payouts = [
+      { gatewayAccountId, paidOutDate: '2019-01-29T08:00:00.000000Z' },
+      { gatewayAccountId, paidOutDate: '2019-01-29T09:00:00.000000Z' }
+    ]
+    ledgerMock.get(LEDGER_PAYOUT_BACKEND_ROUTE)
+      .reply(200, fixtures.validPayoutSearchResponse(payouts).getPlain())
+
+    const result = await payoutService.payouts(gatewayAccountId)
+
+    expect(Object.keys(result).length).to.equal(1)
+    expect(result['2019-01-29'].entries.length).to.equal(2)
+  })
+
+  it('responds with an empty well formed object given no payouts', async () => {
+    const payouts = []
+    ledgerMock.get(LEDGER_PAYOUT_BACKEND_ROUTE)
+      .reply(200, fixtures.validPayoutSearchResponse(payouts).getPlain())
+
+    const result = await payoutService.payouts(gatewayAccountId)
+
+    expect(result).to.deep.equal({})
+  })
+})


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-selfservice/pull/2001

Service level abstraction to fetch payouts from Ledger and format them
as required in the template.

Cover with integration test that verifies the ledger client wrapper is
calling the correct backend route and the shape of the response is
expected by the service formatter.