### PR TITLE
PP-6487 Add payouts page

### DIFF
--- a/app/controllers/payouts/payout_list_controller.js
+++ b/app/controllers/payouts/payout_list_controller.js
@@ -1,0 +1,17 @@
+const { response, renderErrorView } = require('../../utils/response.js')
+const { liveUserServicesGatewayAccounts } = require('./../../utils/valid_account_id')
+const payoutService = require('./payouts_service')
+
+const listAllServicesPayouts = async function listAllServicesPayouts (req, res) {
+  try {
+    const gatewayAccounts = await liveUserServicesGatewayAccounts(req.user)
+    const payoutGroups = await payoutService.payouts(gatewayAccounts.accounts, req.user)
+    response(req, res, 'payouts/list', { payoutGroups })
+  } catch (error) {
+    renderErrorView(req, res, 'Failed to fetch payouts')
+  }
+}
+
+module.exports = {
+  listAllServicesPayouts
+}

--- a/app/paths.js
+++ b/app/paths.js
@@ -188,5 +188,8 @@ module.exports = {
   },
   settings: {
     index: '/settings'
+  },
+  payouts: {
+    list: '/payouts'
   }
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -85,6 +85,7 @@ const goCardlessRedirect = require('./controllers/partnerapp/handle_redirect_to_
 const goCardlessOAuthGet = require('./controllers/partnerapp/handle_gocardless_connect_get')
 const yourPspController = require('./controllers/your-psp')
 const allTransactionsController = require('./controllers/all-service-transactions/index')
+const payoutsController = require('./controllers/payouts/payout_list_controller')
 
 // Assignments
 const {
@@ -92,7 +93,7 @@ const {
   apiKeys, serviceSwitcher, teamMembers, staticPaths, inviteValidation, editServiceName, merchantDetails,
   notificationCredentials: nc, paymentTypes: pt, emailNotifications: en, toggle3ds: t3ds, prototyping, paymentLinks,
   partnerApp, toggleBillingAddress: billingAddress, requestToGoLive, policyPages, stripeSetup, digitalWallet,
-  settings, yourPsp, allServiceTransactions
+  settings, yourPsp, allServiceTransactions, payouts
 } = paths
 
 // Exports
@@ -231,6 +232,8 @@ module.exports.bind = function (app) {
   // ALL SERVICE TRANSACTIONS
   app.get(allServiceTransactions.index, xraySegmentCls, permission('transactions:read'), getAccount, allTransactionsController.getController)
   app.get(allServiceTransactions.download, xraySegmentCls, permission('transactions-download:read'), getAccount, allTransactionsController.downloadTransactions)
+
+  app.get(payouts.list, permission('transactions:read'), payoutsController.listAllServicesPayouts)
 
   // YOUR PSP
   app.get(yourPsp.index, xraySegmentCls, permission('gateway-credentials:read'), getAccount, paymentMethodIsCard, yourPspController.getIndex)

--- a/app/utils/display_converter.js
+++ b/app/utils/display_converter.js
@@ -8,7 +8,8 @@ const hideServiceHeaderTemplates = [
   'all_service_transactions/index',
   'services/index',
   'services/edit_service_name',
-  'services/add_service'
+  'services/add_service',
+  'payouts/list'
 ]
 
 const hideServiceNavTemplates = [

--- a/app/views/payouts/list.njk
+++ b/app/views/payouts/list.njk
@@ -1,0 +1,54 @@
+{% extends "../layout.njk" %}
+
+{% block pageTitle %}
+Payouts - GOV.UK Pay
+{% endblock %}
+
+{% block beforeContent %}
+  {{ super() }}
+  {{
+    govukBackLink({
+      text: "Back to My services",
+      href: routes.serviceSwitcher.index
+    })
+  }}
+{% endblock %}
+
+{% block mainContent %}
+<div class="govuk-grid-column-full">
+  <h1 class="govuk-heading-l">Payouts</h1>
+</div>
+<div class="govuk-grid-column-two-thirds">
+  <p class="govuk-body">Payments your Payment Service Provider has made to your bank account.</h1>
+
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+</div>
+
+
+<div class="govuk-grid-column-two-thirds">
+  {% for key, group in payoutGroups %}
+    <h2 class="govuk-heading-m">{{ group.date.format('DD MMMM') }}</h2>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Service</th>
+          <th scope="col" class="govuk-table__header">Amount</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        {% for payoutEntry in group.entries %}
+        <tr class="govuk-table__row">
+          <td scope="row" class="govuk-table__cell">{{ payoutEntry.serviceName }}</td>
+          <td class="govuk-table__cell pay-text-align-right">
+            {{ payoutEntry.amount | penceToPoundsWithCurrency }}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p class="govuk-body">No payouts found.</p>
+  {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-selfservice/pull/2002

Adds payout controller and basic view based on the payout services
already implemented.

This will list all payouts showing their amount and associated service,
according to the story it will not:
* allow pagination through payouts
* provide a download link for the transactions

Includes the controller in the main server router with new `/payouts`
path.
