### PR TITLE
PP-6487 Payout page ends coverage

### DIFF
--- a/app/views/payouts/list.njk
+++ b/app/views/payouts/list.njk
@@ -29,7 +29,7 @@ Payouts - GOV.UK Pay
   {% for key, group in payoutGroups %}
     <h2 class="govuk-heading-m">{{ group.date.format('DD MMMM') }}</h2>
 
-    <table class="govuk-table">
+    <table class="govuk-table" id="payout-list">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Service</th>

--- a/test/cypress/integration/payouts/payouts_list_spec.js
+++ b/test/cypress/integration/payouts/payouts_list_spec.js
@@ -1,0 +1,46 @@
+const SESSION_USER_ID = 'some-user-id'
+const GATEWAY_ACCOUNT_ID = 10
+const NUMBER_OF_HEADER_ROWS = 1
+
+function getStubsForPayoutScenario (payouts = []) {
+  return [{
+    name: 'getUserSuccess',
+    opts: {
+      external_id: SESSION_USER_ID,
+      email: 'some-user@email.com',
+      service_roles: [{
+        service: {
+          name: 'some-service-name',
+          gateway_account_ids: [ GATEWAY_ACCOUNT_ID ]
+        }
+      }]
+    }
+  }, {
+    name: 'getGatewayAccountsSuccess',
+    opts: {
+      gateway_account_id: GATEWAY_ACCOUNT_ID,
+      payment_provider: 'stripe',
+      type: 'live'
+    }
+  }, {
+    name: 'getLedgerPayoutSuccess',
+    opts: {
+      payouts,
+      gateway_account_id: GATEWAY_ACCOUNT_ID
+    }
+  }]
+}
+
+describe('Payout list page', () => {
+  beforeEach(() => cy.setEncryptedCookies(SESSION_USER_ID, GATEWAY_ACCOUNT_ID))
+
+  it('should correctly display payouts given a successful response from Ledger', () => {
+    const payouts = [
+      { gatewayAccountId: GATEWAY_ACCOUNT_ID, paidOutDate: '2019-01-29T08:00:00.000000Z' }
+    ]
+    cy.task('setupStubs', getStubsForPayoutScenario(payouts))
+
+    cy.visit('/payouts')
+    cy.get('#payout-list').find('tr').should('have.length', NUMBER_OF_HEADER_ROWS + payouts.length)
+  })
+})

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -8,6 +8,7 @@ const userFixtures = require('../../fixtures/user_fixtures')
 const gatewayAccountFixtures = require('../../fixtures/gateway_account_fixtures')
 const transactionDetailsFixtures = require('../../fixtures/transaction_fixtures')
 const ledgerTransactionFixtures = require('../../fixtures/ledger_transaction_fixtures')
+const ledgerPayoutFixtures = require('../../fixtures/payout_fixtures')
 const cardFixtures = require('../../fixtures/card_fixtures')
 const serviceFixtures = require('../../fixtures/service_fixtures')
 const goLiveRequestFixtures = require('../../fixtures/go_live_requests_fixture')
@@ -340,6 +341,16 @@ module.exports = {
     const path = `/v1/transaction/${opts.transaction_id}`
     return simpleStubBuilder('GET', path, 200, {
       response: ledgerTransactionFixtures.validTransactionDetailsResponse(opts).getPlain()
+    })
+  },
+  getLedgerPayoutSuccess: (opts = {}) => {
+    const path = '/v1/payout'
+    return simpleStubBuilder('GET', path, 200, {
+      query: {
+        gateway_account_id: opts.gateway_account_id,
+        page: opts.page || 1
+      },
+      response: ledgerPayoutFixtures.validPayoutSearchResponse(opts.payouts || []).getPlain()
     })
   },
   getLedgerEventsSuccess: (opts = {}) => {


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-selfservice/pull/2003

Cypress will use mounteback to stub ledger payout requests, this adds a
helper to the stubs file that can then be called by the cypress test.

Verify end to end that the payout page will respond and format results
correctly.