### PR TITLE
PP-6492 Payouts page pagination component

### DIFF
--- a/app/controllers/payouts/payout_list_controller.js
+++ b/app/controllers/payouts/payout_list_controller.js
@@ -4,8 +4,9 @@ const payoutService = require('./payouts_service')
 
 const listAllServicesPayouts = async function listAllServicesPayouts (req, res) {
   try {
+    const { page } = req.query
     const gatewayAccounts = await liveUserServicesGatewayAccounts(req.user)
-    const payoutSearchResult = await payoutService.payouts(gatewayAccounts.accounts, req.user)
+    const payoutSearchResult = await payoutService.payouts(gatewayAccounts.accounts, req.user, page)
     response(req, res, 'payouts/list', { payoutSearchResult })
   } catch (error) {
     renderErrorView(req, res, 'Failed to fetch payouts')

--- a/app/controllers/payouts/payout_list_controller.js
+++ b/app/controllers/payouts/payout_list_controller.js
@@ -5,8 +5,8 @@ const payoutService = require('./payouts_service')
 const listAllServicesPayouts = async function listAllServicesPayouts (req, res) {
   try {
     const gatewayAccounts = await liveUserServicesGatewayAccounts(req.user)
-    const payoutGroups = await payoutService.payouts(gatewayAccounts.accounts, req.user)
-    response(req, res, 'payouts/list', { payoutGroups })
+    const payoutSearchResult = await payoutService.payouts(gatewayAccounts.accounts, req.user)
+    response(req, res, 'payouts/list', { payoutSearchResult })
   } catch (error) {
     renderErrorView(req, res, 'Failed to fetch payouts')
   }

--- a/app/controllers/payouts/payouts_service.js
+++ b/app/controllers/payouts/payouts_service.js
@@ -6,6 +6,7 @@ const Paginator = require('../../utils/paginator')
 const { indexServiceNamesByGatewayAccountId } = require('./user_services_names')
 
 const PAGE_SIZE = 20
+const MAX_PAGES = 2
 
 const getPayoutDate = function getPayoutDate (payout) {
   return payout.paid_out_date || payout.created_date
@@ -36,12 +37,12 @@ const formatPayoutPages = function formatPayoutPages (payoutSearchResponse) {
   const { total, page } = payoutSearchResponse
   const paginator = new Paginator(total, PAGE_SIZE, page)
   const hasMultiplePages = paginator.getLast() > 1
-  const links = hasMultiplePages && paginator.getNamedCentredRange(2, true, true)
+  const links = hasMultiplePages && paginator.getNamedCentredRange(MAX_PAGES, true, true)
   return { total, page, links }
 }
 
-const payouts = async function payouts (gatewayAccountId, user = {}) {
-  const payoutSearchResponse = await Ledger.payouts(gatewayAccountId)
+const payouts = async function payouts (gatewayAccountId, user = {}, page = 1) {
+  const payoutSearchResponse = await Ledger.payouts(gatewayAccountId, page, PAGE_SIZE)
   return {
     groups: groupPayoutsByDate(payoutSearchResponse.results, user),
     pages: formatPayoutPages(payoutSearchResponse)

--- a/app/services/clients/ledger_client.js
+++ b/app/services/clients/ledger_client.js
@@ -108,11 +108,12 @@ const transactionSummary = function transactionSummary (gatewayAccountId, fromDa
   return baseClient.get(configuration)
 }
 
-const payouts = function payouts (gatewayAccountId, page = 1) {
+const payouts = function payouts (gatewayAccountId, page = 1, displaySize = 20) {
   const configuration = {
     url: '/v1/payout',
     qs: {
       gateway_account_id: gatewayAccountId,
+      display_size: displaySize,
       page
     },
     description: 'List payouts for a given gateway account ID',

--- a/app/services/clients/ledger_client.js
+++ b/app/services/clients/ledger_client.js
@@ -108,12 +108,12 @@ const transactionSummary = function transactionSummary (gatewayAccountId, fromDa
   return baseClient.get(configuration)
 }
 
-const payouts = function payouts (gatewayAccountId, page = 1, displaySize = 20) {
+const payouts = function payouts (gatewayAccountId, page = 1, displaySize) {
   const configuration = {
     url: '/v1/payout',
     qs: {
       gateway_account_id: gatewayAccountId,
-      display_size: displaySize,
+      ...displaySize && { display_size: displaySize },
       page
     },
     description: 'List payouts for a given gateway account ID',

--- a/app/views/payouts/list.njk
+++ b/app/views/payouts/list.njk
@@ -24,9 +24,8 @@ Payouts - GOV.UK Pay
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 </div>
 
-
 <div class="govuk-grid-column-two-thirds">
-  {% for key, group in payoutGroups %}
+  {% for key, group in payoutSearchResult.groups %}
     <h2 class="govuk-heading-m">{{ group.date.format('DD MMMM') }}</h2>
 
     <table class="govuk-table" id="payout-list">
@@ -51,4 +50,9 @@ Payouts - GOV.UK Pay
     <p class="govuk-body">No payouts found.</p>
   {% endfor %}
 </div>
+
+<div class="govuk-grid-column-two-thirds">
+  {% include "payouts/paginator.njk" %}
+</div>
+
 {% endblock %}

--- a/app/views/payouts/paginator.njk
+++ b/app/views/payouts/paginator.njk
@@ -1,0 +1,18 @@
+{% set links = payoutSearchResult.pages.links %}
+{% if links and links.length %}
+<div class="pagination">
+  {% for paginationLink in links %}
+    <form class="paginationForm page-{{paginationLink.pageName}}" method="GET">
+      <input type="hidden" name="page" value="{{paginationLink.pageNumber}}"/>
+
+      <button class="pagination {{paginationLink.pageName}} {% if paginationLink.activePage %}active{% endif %}" type="submit">
+        {% if paginationLink.hasSymbolicName %}
+          {{paginationLink.pageName}}<span class="govuk-visually-hidden"> page of results</span>
+        {% else %}
+          <span class="govuk-visually-hidden">Results page </span>{{paginationLink.pageName}}
+        {% endif %}
+      </button>
+    </form>
+  {% endfor %}
+</div>
+{% endif %}

--- a/app/views/payouts/paginator.njk
+++ b/app/views/payouts/paginator.njk
@@ -1,6 +1,6 @@
 {% set links = payoutSearchResult.pages.links %}
 {% if links and links.length %}
-<div class="pagination">
+<div class="pagination" id="pagination">
   {% for paginationLink in links %}
     <form class="paginationForm page-{{paginationLink.pageName}}" method="GET">
       <input type="hidden" name="page" value="{{paginationLink.pageNumber}}"/>

--- a/test/cypress/integration/payouts/payouts_list_spec.js
+++ b/test/cypress/integration/payouts/payouts_list_spec.js
@@ -1,8 +1,7 @@
 const SESSION_USER_ID = 'some-user-id'
 const GATEWAY_ACCOUNT_ID = 10
-const NUMBER_OF_HEADER_ROWS = 1
 
-function getStubsForPayoutScenario (payouts = []) {
+function getStubsForPayoutScenario (payouts = [], payoutOpts = {}) {
   return [{
     name: 'getUserSuccess',
     opts: {
@@ -26,7 +25,8 @@ function getStubsForPayoutScenario (payouts = []) {
     name: 'getLedgerPayoutSuccess',
     opts: {
       payouts,
-      gateway_account_id: GATEWAY_ACCOUNT_ID
+      gateway_account_id: GATEWAY_ACCOUNT_ID,
+      ...payoutOpts
     }
   }]
 }
@@ -41,6 +41,24 @@ describe('Payout list page', () => {
     cy.task('setupStubs', getStubsForPayoutScenario(payouts))
 
     cy.visit('/payouts')
-    cy.get('#payout-list').find('tr').should('have.length', NUMBER_OF_HEADER_ROWS + payouts.length)
+    cy.get('#payout-list').find('tr').should('have.length', 2)
+    cy.get('#pagination').should('not.exist')
+  })
+
+  it('pagination component should correclty link for a large set', () => {
+    const payouts = [
+      { gatewayAccountId: GATEWAY_ACCOUNT_ID, paidOutDate: '2019-01-28T08:00:00.000000Z' },
+      { gatewayAccountId: GATEWAY_ACCOUNT_ID, paidOutDate: '2019-01-28T08:00:00.000000Z' }
+    ]
+    const page = 2
+    cy.task('setupStubs', getStubsForPayoutScenario(payouts, { total: 80, page }))
+
+    cy.visit(`/payouts?page=${page}`)
+
+    cy.get('#payout-list').find('tr').should('have.length', 3)
+
+    cy.get('#pagination').should('exist')
+    cy.get(`.pagination .${page}`).should('have.class', 'active')
+    cy.get('.pagination').should('have.length', 7)
   })
 })

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -345,12 +345,14 @@ module.exports = {
   },
   getLedgerPayoutSuccess: (opts = {}) => {
     const path = '/v1/payout'
+    const { total, page } = opts
     return simpleStubBuilder('GET', path, 200, {
       query: {
         gateway_account_id: opts.gateway_account_id,
-        page: opts.page || 1
+        page: opts.page || 1,
+        display_size: opts.display_size || 20
       },
-      response: ledgerPayoutFixtures.validPayoutSearchResponse(opts.payouts || []).getPlain()
+      response: ledgerPayoutFixtures.validPayoutSearchResponse(opts.payouts || [], { total, page }).getPlain()
     })
   },
   getLedgerEventsSuccess: (opts = {}) => {

--- a/test/fixtures/payout_fixtures.js
+++ b/test/fixtures/payout_fixtures.js
@@ -24,13 +24,13 @@ function decoratePactOptions (response) {
 }
 
 module.exports = {
-  validPayoutSearchResponse: (payoutOpts = []) => {
+  validPayoutSearchResponse: (payoutOpts = [], opts = {}) => {
     const payouts = payoutOpts.map(buildPayout)
     const response = {
       results: payouts,
-      total: payouts.length,
+      total: opts.total || payouts.length,
       count: payouts.length,
-      page: 1
+      page: opts.page || 1
     }
     return decoratePactOptions(response)
   }

--- a/test/integration/payouts/payouts_service_it_test.js
+++ b/test/integration/payouts/payouts_service_it_test.js
@@ -23,10 +23,12 @@ describe('payouts service list payouts helper', () => {
     ledgerMock.get(LEDGER_PAYOUT_BACKEND_ROUTE)
       .reply(200, fixtures.validPayoutSearchResponse(payouts).getPlain())
 
-    const result = await payoutService.payouts(gatewayAccountId)
+    const { groups, pages } = await payoutService.payouts(gatewayAccountId)
 
-    expect(Object.keys(result).length).to.equal(1)
-    expect(result['2019-01-29'].entries.length).to.equal(2)
+    expect(Object.keys(groups).length).to.equal(1)
+    expect(groups['2019-01-29'].entries.length).to.equal(2)
+    expect(pages.total).to.equal(2)
+    expect(pages.page).to.equal(1)
   })
 
   it('responds with an empty well formed object given no payouts', async () => {
@@ -34,8 +36,10 @@ describe('payouts service list payouts helper', () => {
     ledgerMock.get(LEDGER_PAYOUT_BACKEND_ROUTE)
       .reply(200, fixtures.validPayoutSearchResponse(payouts).getPlain())
 
-    const result = await payoutService.payouts(gatewayAccountId)
+    const { groups, pages } = await payoutService.payouts(gatewayAccountId)
 
-    expect(result).to.deep.equal({})
+    expect(groups).to.deep.equal({})
+    expect(pages.total).to.equal(0)
+    expect(pages.page).to.equal(1)
   })
 })

--- a/test/integration/payouts/payouts_service_it_test.js
+++ b/test/integration/payouts/payouts_service_it_test.js
@@ -8,7 +8,7 @@ const fixtures = require('./../../fixtures/payout_fixtures')
 
 const gatewayAccountId = '100'
 const ledgerMock = nock(process.env.LEDGER_URL)
-const LEDGER_PAYOUT_BACKEND_ROUTE = `/v1/payout?gateway_account_id=${gatewayAccountId}&page=1`
+const LEDGER_PAYOUT_BACKEND_ROUTE = `/v1/payout?gateway_account_id=${gatewayAccountId}&display_size=20&page=1`
 
 describe('payouts service list payouts helper', () => {
   afterEach(() => {


### PR DESCRIPTION
Include pagination object in result from payout search in the payouts
service response. 

This uses the `Paginator` utility also used by
transactions and has a very similar template to ensure the user
experience is the same across both components.

Service integration tests should cover the shape of the payouts search result, the pagination component linking through query string -> controller -> server -> ledger client is covered in Cypress.