### PR TITLE
PP-6596 Payouts transactions download link

### DIFF
--- a/app/controllers/payouts/payout_list_controller.js
+++ b/app/controllers/payouts/payout_list_controller.js
@@ -1,3 +1,4 @@
+const paths = require('../../../app/paths')
 const { response, renderErrorView } = require('../../utils/response.js')
 const { liveUserServicesGatewayAccounts } = require('./../../utils/valid_account_id')
 const payoutService = require('./payouts_service')
@@ -7,7 +8,7 @@ const listAllServicesPayouts = async function listAllServicesPayouts (req, res) 
     const { page } = req.query
     const gatewayAccounts = await liveUserServicesGatewayAccounts(req.user)
     const payoutSearchResult = await payoutService.payouts(gatewayAccounts.accounts, req.user, page)
-    response(req, res, 'payouts/list', { payoutSearchResult })
+    response(req, res, 'payouts/list', { payoutSearchResult, paths })
   } catch (error) {
     renderErrorView(req, res, 'Failed to fetch payouts')
   }

--- a/app/utils/get_query_string_for_params.js
+++ b/app/utils/get_query_string_for_params.js
@@ -11,6 +11,7 @@ function getQueryStringForParams (params = {}, removeEmptyParams = false, flatte
     cardholder_name: params.cardholderName,
     last_digits_card_number: params.lastDigitsCardNumber,
     card_brand: params.brand,
+    gateway_payout_id: params.gatewayPayoutId,
     from_date: dates.fromDateToApiFormat(params.fromDate, params.fromTime),
     to_date: dates.toDateToApiFormat(params.toDate, params.toTime),
     ...params.feeHeaders && { fee_headers: params.feeHeaders },

--- a/app/views/payouts/list.njk
+++ b/app/views/payouts/list.njk
@@ -33,6 +33,7 @@ Payouts - GOV.UK Pay
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Service</th>
           <th scope="col" class="govuk-table__header">Amount</th>
+          <th scope="col" class="govuk-table__header">Payout transactions</th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -41,6 +42,9 @@ Payouts - GOV.UK Pay
           <td scope="row" class="govuk-table__cell">{{ payoutEntry.serviceName }}</td>
           <td class="govuk-table__cell pay-text-align-right">
             {{ payoutEntry.amount | penceToPoundsWithCurrency }}
+          </td>
+          <td class="govuk-table__cell">
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ paths.transactions.download }}?gatewayPayoutId={{payoutEntry.gateway_payout_id}}">Download CSV</a>
           </td>
         </tr>
         {% endfor %}

--- a/app/views/payouts/list.njk
+++ b/app/views/payouts/list.njk
@@ -44,7 +44,7 @@ Payouts - GOV.UK Pay
             {{ payoutEntry.amount | penceToPoundsWithCurrency }}
           </td>
           <td class="govuk-table__cell">
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ paths.transactions.download }}?gatewayPayoutId={{payoutEntry.gateway_payout_id}}">Download CSV</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ paths.allServiceTransactions.download }}?gatewayPayoutId={{payoutEntry.gateway_payout_id}}">Download CSV</a>
           </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
Add 'Payout transactions' column to payout page. This filters the
transaction download by `gateway_payout_id`. 

This uses the permissions/ method already implemented for all live service transactions 
to ensure the user has access to the transactions in the payout they are filtering on.