### PR TITLE
PP-6492 Payout page order entries descending

### DIFF
--- a/app/controllers/payouts/payouts_service.js
+++ b/app/controllers/payouts/payouts_service.js
@@ -9,7 +9,7 @@ const getPayoutDate = function getPayoutDate (payout) {
 }
 
 const sortPayoutByDateString = function sortPayoutByDateString (a, b) {
-  return new Date(getPayoutDate(a)) - new Date(getPayoutDate(b))
+  return new Date(getPayoutDate(b)) - new Date(getPayoutDate(a))
 }
 
 const groupPayoutsByDate = function groupPayoutsByDate (payouts, user) {

--- a/test/unit/controller/payouts/payouts_service_test.js
+++ b/test/unit/controller/payouts/payouts_service_test.js
@@ -51,5 +51,25 @@ describe('payout service data transforms', () => {
       const grouped = groupPayoutsByDate([], null)
       expect(grouped).to.deep.equal({})
     })
+
+    it('will order formatted payout groups by date descending given entries in any order', () => {
+      const opts = [
+        { paidOutDate: '2019-01-01T08:00:00.000000Z' },
+        { paidOutDate: '2019-01-05T08:00:00.000000Z' },
+        { paidOutDate: '2019-04-03T08:00:00.000000Z' },
+        { paidOutDate: '2019-01-12T08:00:00.000000Z' },
+        { paidOutDate: '2019-01-02T08:00:00.000000Z' }
+      ]
+      const payouts = payoutFixtures.validPayoutSearchResponse(opts).getPlain()
+
+      const grouped = groupPayoutsByDate(payouts.results)
+      const keys = Object.keys(grouped)
+
+      expect(keys[0]).to.equal('2019-04-03')
+      expect(keys[1]).to.equal('2019-01-12')
+      expect(keys[2]).to.equal('2019-01-05')
+      expect(keys[3]).to.equal('2019-01-02')
+      expect(keys[4]).to.equal('2019-01-01')
+    })
   })
 })


### PR DESCRIPTION
Swap the direction of the payout service grouping utility to order the
groups by descending date. Verify that entries in any given order will
be collected into ordered groups.


