### PR TITLE
PP-6591 Payouts routes passed through auth middleware

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -213,6 +213,7 @@ module.exports.bind = function (app) {
     ...lodash.values(digitalWallet),
     ...lodash.values(settings),
     ...lodash.values(yourPsp),
+    ...lodash.values(payouts),
     user.profile,
     paths.feedback
   ] // Extract all the authenticated paths as a single array


### PR DESCRIPTION
Navigating to payout pages would crash without authentication as the
paths hadn't been registered behind the auth middleware. This wouldn't
reveal any sensitive information but would give some indication to the
internal URL structure.

Fix this by passing all `payouts` path correctly to the authentication
middleware.


