### PR TITLE
PP-6591 Update markup to match design doc parity

### DIFF
--- a/app/controllers/payouts/payouts_service.js
+++ b/app/controllers/payouts/payouts_service.js
@@ -5,7 +5,7 @@ const Paginator = require('../../utils/paginator')
 
 const { indexServiceNamesByGatewayAccountId } = require('./user_services_names')
 
-const PAGE_SIZE = 20
+const PAGE_SIZE = 15
 const MAX_PAGES = 2
 
 const getPayoutDate = function getPayoutDate (payout) {

--- a/app/views/payouts/list.njk
+++ b/app/views/payouts/list.njk
@@ -1,7 +1,7 @@
 {% extends "../layout.njk" %}
 
 {% block pageTitle %}
-Payouts - GOV.UK Pay
+Payments to your bank account - GOV.UK Pay
 {% endblock %}
 
 {% block beforeContent %}
@@ -16,12 +16,10 @@ Payouts - GOV.UK Pay
 
 {% block mainContent %}
 <div class="govuk-grid-column-full">
-  <h1 class="govuk-heading-l">Payouts</h1>
+  <h1 class="govuk-heading-l">Payments to your bank account</h1>
 </div>
 <div class="govuk-grid-column-two-thirds">
-  <p class="govuk-body">Payments your Payment Service Provider has made to your bank account.</h1>
-
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  <p class="govuk-body govuk-!-margin-bottom-8">Payments your Payment Service Provider has made to your bank account.</p>
 </div>
 
 <div class="govuk-grid-column-two-thirds">
@@ -32,8 +30,8 @@ Payouts - GOV.UK Pay
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Service</th>
-          <th scope="col" class="govuk-table__header">Amount</th>
-          <th scope="col" class="govuk-table__header">Payout transactions</th>
+          <th scope="col" class="govuk-table__header pay-text-align-right">Amount</th>
+          <th scope="col" class="govuk-table__header">View transactions</th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -51,7 +49,8 @@ Payouts - GOV.UK Pay
       </tbody>
     </table>
   {% else %}
-    <p class="govuk-body">No payouts found.</p>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    <p class="govuk-body">No payments to your bank account found.</p>
   {% endfor %}
 </div>
 

--- a/app/views/payouts/list.njk
+++ b/app/views/payouts/list.njk
@@ -19,18 +19,19 @@ Payments to your bank account - GOV.UK Pay
   <h1 class="govuk-heading-l">Payments to your bank account</h1>
 </div>
 <div class="govuk-grid-column-two-thirds">
-  <p class="govuk-body govuk-!-margin-bottom-8">Payments your Payment Service Provider has made to your bank account.</p>
+  <p class="govuk-body govuk-!-margin-bottom-8">Payments Stripe has made to your bank account.</p>
 </div>
 
 <div class="govuk-grid-column-two-thirds">
   {% for key, group in payoutSearchResult.groups %}
-    <h2 class="govuk-heading-m">{{ group.date.format('DD MMMM') }}</h2>
+    {% set dateString = group.date.format('DD MMMM') %}
+    <h2 class="govuk-heading-m">{{ dateString }}</h2>
 
     <table class="govuk-table" id="payout-list">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Service</th>
-          <th scope="col" class="govuk-table__header pay-text-align-right">Amount</th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">Amount</th>
           <th scope="col" class="govuk-table__header">View transactions</th>
         </tr>
       </thead>
@@ -38,11 +39,13 @@ Payments to your bank account - GOV.UK Pay
         {% for payoutEntry in group.entries %}
         <tr class="govuk-table__row">
           <td scope="row" class="govuk-table__cell">{{ payoutEntry.serviceName }}</td>
-          <td class="govuk-table__cell pay-text-align-right">
+          <td class="govuk-table__cell govuk-table__cell--numeric">
             {{ payoutEntry.amount | penceToPoundsWithCurrency }}
           </td>
           <td class="govuk-table__cell">
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ paths.allServiceTransactions.download }}?gatewayPayoutId={{payoutEntry.gateway_payout_id}}">Download CSV</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ paths.allServiceTransactions.download }}?gatewayPayoutId={{payoutEntry.gateway_payout_id}}">
+              Download CSV <span class="govuk-visually-hidden">for {{ payoutEntry.serviceName }} on {{ dateString }}</span>
+            </a>
           </td>
         </tr>
         {% endfor %}
@@ -54,7 +57,7 @@ Payments to your bank account - GOV.UK Pay
   {% endfor %}
 </div>
 
-<div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-column-two-thirds govuk-!-margin-top-4">
   {% include "payouts/paginator.njk" %}
 </div>
 

--- a/test/cypress/integration/payouts/payouts_list_spec.js
+++ b/test/cypress/integration/payouts/payouts_list_spec.js
@@ -59,6 +59,6 @@ describe('Payout list page', () => {
 
     cy.get('#pagination').should('exist')
     cy.get(`.pagination .${page}`).should('have.class', 'active')
-    cy.get('.pagination').should('have.length', 7)
+    cy.get('.pagination').should('have.length', 8)
   })
 })

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -350,7 +350,7 @@ module.exports = {
       query: {
         gateway_account_id: opts.gateway_account_id,
         page: opts.page || 1,
-        display_size: opts.display_size || 20
+        display_size: opts.display_size || 15
       },
       response: ledgerPayoutFixtures.validPayoutSearchResponse(opts.payouts || [], { total, page }).getPlain()
     })

--- a/test/integration/payouts/payouts_service_it_test.js
+++ b/test/integration/payouts/payouts_service_it_test.js
@@ -8,7 +8,7 @@ const fixtures = require('./../../fixtures/payout_fixtures')
 
 const gatewayAccountId = '100'
 const ledgerMock = nock(process.env.LEDGER_URL)
-const LEDGER_PAYOUT_BACKEND_ROUTE = `/v1/payout?gateway_account_id=${gatewayAccountId}&display_size=20&page=1`
+const LEDGER_PAYOUT_BACKEND_ROUTE = `/v1/payout?gateway_account_id=${gatewayAccountId}&display_size=15&page=1`
 
 describe('payouts service list payouts helper', () => {
   afterEach(() => {


### PR DESCRIPTION
Cleans up payout page markup to match the current design proposal for
the first feature iteration.

* Update title copy to read 'Payments to your bank account'
* Right align amount title
* Remove horizontal line unless there are no payouts
* Add margin following top level description

![Screenshot 2020-06-03 at 10 54 22](https://user-images.githubusercontent.com/2844572/83622962-9dcfd480-a588-11ea-96b8-93ffcbaa30be.png)


