### PR TITLE
PP-6145 Bump stripe api version to 2020-03-02

### DIFF
--- a/app/services/clients/stripe/stripe_client.js
+++ b/app/services/clients/stripe/stripe_client.js
@@ -17,7 +17,7 @@ const STRIPE_PORT = process.env.STRIPE_PORT
 if (process.env.http_proxy) {
   stripe.setHttpAgent(new ProxyAgent(process.env.http_proxy))
 }
-stripe.setApiVersion('2019-02-19')
+stripe.setApiVersion('2020-03-02')
 // only expect host and port environment variables to be set when running tests
 if (STRIPE_HOST) {
   stripe.setHost(STRIPE_HOST)


### PR DESCRIPTION
No major changes should have happened between our latest stripe api version and
the latest version. Bump for parity with out other services.


