### PR TITLE
 PP-6633 Add account status panel

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -40,4 +40,5 @@ $govuk-page-width: 1200px;
 @import "components/digital-wallet";
 @import "components/padding";
 @import "components/reporting-columns";
+@import "components/account-status-panel";
 

--- a/app/assets/sass/components/account-status-panel.scss
+++ b/app/assets/sass/components/account-status-panel.scss
@@ -1,0 +1,6 @@
+.account-status-panel {
+  border-color: govuk-colour("blue");
+  border-style: solid;
+  padding: 20px;
+  margin-bottom: 10px;
+}

--- a/app/views/dashboard/_stripe_account_setup_banner.njk
+++ b/app/views/dashboard/_stripe_account_setup_banner.njk
@@ -1,0 +1,31 @@
+{% if stripeAccountSetup and (not stripeAccountSetup.bankAccount or not stripeAccountSetup.vatNumberCompanyNumber or not stripeAccountSetup.responsiblePerson) %}
+  <div class="govuk-grid-column-full">
+    <div class="account-status-panel">
+      <h3 class="govuk-heading-m govuk-!-font-weight-bold" style="">You must add more details to continue taking payments</h3>
+      <p class="govuk-body-m">Your service can now take payments from users. You must add more details soon or Stripe will not pay the money into your bank account. Please add:</p>
+
+      <ul class="govuk-list">
+        {% if stripeAccountSetup.responsiblePerson %}
+          <li> - details about your responsible person</li>
+        {% endif %}
+        {% if stripeAccountSetup.bankAccount %}
+          <li> - bank details</li>
+        {% endif %}
+        {% if stripeAccountSetup.vatNumberCompanyNumber %}
+          <li> - your organisation’s VAT number</li>
+        {% endif %}
+      </ul>
+
+      {{
+      govukButton({
+        text: 'Add details',
+        classes: 'govuk-!-margin-right-1',
+        href: routes.stripeSetup.accountSetup,
+        attributes: {
+          id: "add-account-details"
+        }
+      })
+    }}
+    </div>
+  </div>
+{% endif %}

--- a/app/views/dashboard/index.njk
+++ b/app/views/dashboard/index.njk
@@ -18,6 +18,7 @@ Dashboard - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK
       </div>
     {% endif %}
   {% else %}
+    {% include "./_stripe_account_setup_banner.njk" %}
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l first-steps__title">Dashboard</h1>
     </div>


### PR DESCRIPTION
## WHAT

- Added account status panel to Dashboard which is shown when feature flag `ENABLE_ACCOUNT_STATUS_PANEL` is `true`
      and Stripe account is not fully setup
- Add details button in the panel points to `routes.stripeSetup.accountSetup` which is to be added when Stripe onboarding
      design is finalised and implemented
- Message is tentative and to be updated after design is finalised
- Also removed Xray tracing for dashboard controller as we are using it (removed from frontend) and could potentially be removed from other places too.

Panel looks like below (content to be updated after the design is finalised)
<img width="1238" alt="Screenshot 2020-06-08 at 15 03 43" src="https://user-images.githubusercontent.com/40598480/84040660-cb5aba80-a99a-11ea-90d3-63d37246bef8.png">
