### PR TITLE
PP-6633 Show account status panel for relevant users

### DIFF
--- a/app/views/dashboard/_stripe_account_setup_banner.njk
+++ b/app/views/dashboard/_stripe_account_setup_banner.njk
@@ -1,31 +1,33 @@
-{% if stripeAccountSetup and (not stripeAccountSetup.bankAccount or not stripeAccountSetup.vatNumberCompanyNumber or not stripeAccountSetup.responsiblePerson) %}
-  <div class="govuk-grid-column-full">
-    <div class="account-status-panel">
-      <h3 class="govuk-heading-m govuk-!-font-weight-bold" style="">You must add more details to continue taking payments</h3>
-      <p class="govuk-body-m">Your service can now take payments from users. You must add more details soon or Stripe will not pay the money into your bank account. Please add:</p>
+{% if permissions.stripe_account_details_update %}
+  {% if stripeAccountSetup and (not stripeAccountSetup.bankAccount or not stripeAccountSetup.vatNumberCompanyNumber or not stripeAccountSetup.responsiblePerson) %}
+    <div class="govuk-grid-column-full">
+      <div class="account-status-panel">
+        <h3 class="govuk-heading-m govuk-!-font-weight-bold" style="">You must add more details to continue taking payments</h3>
+        <p class="govuk-body-m">Your service can now take payments from users. You must add more details soon or Stripe will not pay the money into your bank account. Please add:</p>
 
-      <ul class="govuk-list">
-        {% if stripeAccountSetup.responsiblePerson %}
-          <li> - details about your responsible person</li>
-        {% endif %}
-        {% if stripeAccountSetup.bankAccount %}
-          <li> - bank details</li>
-        {% endif %}
-        {% if stripeAccountSetup.vatNumberCompanyNumber %}
-          <li> - your organisation’s VAT number</li>
-        {% endif %}
-      </ul>
+        <ul class="govuk-list">
+          {% if stripeAccountSetup.responsiblePerson %}
+            <li> - details about your responsible person</li>
+          {% endif %}
+          {% if stripeAccountSetup.bankAccount %}
+            <li> - bank details</li>
+          {% endif %}
+          {% if stripeAccountSetup.vatNumberCompanyNumber %}
+            <li> - your organisation’s VAT number</li>
+          {% endif %}
+        </ul>
 
-      {{
-      govukButton({
-        text: 'Add details',
-        classes: 'govuk-!-margin-right-1',
-        href: routes.stripeSetup.accountSetup,
-        attributes: {
-          id: "add-account-details"
-        }
-      })
-    }}
+        {{
+        govukButton({
+          text: 'Add details',
+          classes: 'govuk-!-margin-right-1',
+          href: routes.stripeSetup.accountSetup,
+          attributes: {
+            id: "add-account-details"
+          }
+        })
+      }}
+      </div>
     </div>
-  </div>
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
## WHAT

- Displays Stripe account status panel only for users with permission `stripe-account-details:update`
- Refactor `LedgerClient.transactionSummary` promise chain to async/await format to be consistent with await usage within dashboard activity controller
- Added/updated relevant tests

with @iqbalgds 