### PR TITLE
PP-6627 Patch calling open Connector route with no accounts

### DIFF
--- a/app/utils/permissions.js
+++ b/app/utils/permissions.js
@@ -28,8 +28,9 @@ const getAccounts = function getAccounts (user, permissionName) {
     .reduce((accumulator, currentValue) => accumulator.concat(currentValue), [])
     .filter(gatewayAccountId => !isADirectDebitAccount(gatewayAccountId))
 
-  return client.getAccounts({ gatewayAccountIds })
-    .then((result) => result.accounts)
+  return gatewayAccountIds.length
+    ? client.getAccounts({ gatewayAccountIds }).then((result) => result.accounts)
+    : Promise.resolve([])
 }
 
 const accountDetailHeaders = function accountDetailHeaders (accounts) {


### PR DESCRIPTION
Patch this behaviour and avoid an unnecessary call to the backend by
returning nothing if no accounts will have valid permissions.

The default behaviour in newer backend routes is to require a gateway
account id to be passed in to any resource, passing in nothing `key=[]`
or
in the case of comma separated values `key=` will either filter the data
for no account ids (resulting in nothing returned `[]`) OR return `400`
requiring non empty values.

In the case of the frontend accounts route being called in this utility,
passing no accounts will treat the route as if there is no filter and
return accounts.

This behaviour will be patched in the backend as part of this ticket.
