### PR TITLE
PP-6627 Patch and add multi service permissions

### DIFF
--- a/app/controllers/all-service-transactions/download-transactions.js
+++ b/app/controllers/all-service-transactions/download-transactions.js
@@ -7,14 +7,14 @@ const transactionService = require('../../services/transaction_service')
 const Stream = require('../../services/clients/stream_client')
 const { CORRELATION_HEADER } = require('../../utils/correlation_header')
 const { renderErrorView } = require('../../utils/response')
-const { liveUserServicesGatewayAccounts } = require('./../../utils/valid_account_id')
+const { liveUserServicesGatewayAccounts } = require('../../utils/permissions')
 
 module.exports = (req, res) => {
   const filters = req.query
   const correlationId = req.headers[CORRELATION_HEADER]
   const name = `GOVUK_Pay_${date.dateToDefaultFormat(new Date()).replace(' ', '_')}.csv`
 
-  liveUserServicesGatewayAccounts(req.user)
+  liveUserServicesGatewayAccounts(req.user, 'transactions:read')
     .then((gatewayResults) => {
       const accountIdsUsersHasPermissionsFor = gatewayResults.accounts
       filters.feeHeaders = gatewayResults.headers.shouldGetStripeHeaders

--- a/app/controllers/all-service-transactions/get-controller.js
+++ b/app/controllers/all-service-transactions/get-controller.js
@@ -7,7 +7,7 @@ const { response, renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector_client.js')
 const transactionService = require('../../services/transaction_service')
 const { buildPaymentList } = require('../../utils/transaction_view.js')
-const { liveUserServicesGatewayAccounts } = require('./../../utils/valid_account_id')
+const { liveUserServicesGatewayAccounts } = require('../../utils/permissions')
 const { getFilters, describeFilters } = require('../../utils/filters.js')
 const router = require('../../routes.js')
 const states = require('../../utils/states')
@@ -19,7 +19,7 @@ module.exports = async (req, res) => {
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   const filters = getFilters(req)
   try {
-    const gatewayResults = await liveUserServicesGatewayAccounts(req.user)
+    const gatewayResults = await liveUserServicesGatewayAccounts(req.user, 'transactions:read')
     const accountIdsUsersHasPermissionsFor = gatewayResults.accounts
     const searchResultOutput = await transactionService.search(accountIdsUsersHasPermissionsFor, filters.result)
     const cardTypes = await client.getAllCardTypesPromise(correlationId)

--- a/app/controllers/payouts/payout_list_controller.js
+++ b/app/controllers/payouts/payout_list_controller.js
@@ -3,14 +3,14 @@ const paths = require('../../../app/paths')
 const logger = require('../../utils/logger')(__filename)
 const { keys } = require('@govuk-pay/pay-js-commons').logging
 const { response, renderErrorView } = require('../../utils/response.js')
-const { liveUserServicesGatewayAccounts } = require('./../../utils/valid_account_id')
+const { liveUserServicesGatewayAccounts } = require('../../utils/permissions')
 const payoutService = require('./payouts_service')
 
 const listAllServicesPayouts = async function listAllServicesPayouts (req, res) {
   try {
     let payoutsReleaseDate
     const { page } = req.query
-    const gatewayAccounts = await liveUserServicesGatewayAccounts(req.user)
+    const gatewayAccounts = await liveUserServicesGatewayAccounts(req.user, 'payouts:read')
     const payoutSearchResult = await payoutService.payouts(gatewayAccounts.accounts, req.user, page)
     const logContext = {
       gateway_accounts: gatewayAccounts,

--- a/app/controllers/transactions/transaction_detail_redirect_controller.js
+++ b/app/controllers/transactions/transaction_detail_redirect_controller.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const paths = require('../../paths')
-const { userServicesContainsGatewayAccount } = require('../../utils/valid_account_id')
+const { userServicesContainsGatewayAccount } = require('../../utils/permissions')
 const Ledger = require('../../services/clients/ledger_client')
 const { renderErrorView } = require('../../utils/response.js')
 const router = require('../../routes')

--- a/app/utils/permissions.js
+++ b/app/utils/permissions.js
@@ -9,8 +9,8 @@ const userServicesContainsGatewayAccount = function userServicesContainsGatewayA
   return accountId && gatewayAccountIds.indexOf(accountId) !== -1
 }
 
-const liveUserServicesGatewayAccounts = async function liveUserServicesGatewayAccounts (user) {
-  const accounts = await getAccounts(user)
+const liveUserServicesGatewayAccounts = async function liveUserServicesGatewayAccounts (user, permissionName) {
+  const accounts = await getAccounts(user, permissionName)
 
   return {
     headers: accountDetailHeaders(accounts),
@@ -18,8 +18,12 @@ const liveUserServicesGatewayAccounts = async function liveUserServicesGatewayAc
   }
 }
 
-const getAccounts = function getAccounts (user) {
+const getAccounts = function getAccounts (user, permissionName) {
   const gatewayAccountIds = user.serviceRoles
+    .filter((serviceRole) => serviceRole.role.permissions
+      .map((permission) => permission.name)
+      .includes(permissionName)
+    )
     .flatMap(servicesRole => servicesRole.service.gatewayAccountIds)
     .reduce((accumulator, currentValue) => accumulator.concat(currentValue), [])
     .filter(gatewayAccountId => !isADirectDebitAccount(gatewayAccountId))

--- a/app/utils/permissions.js
+++ b/app/utils/permissions.js
@@ -28,8 +28,9 @@ const getAccounts = function getAccounts (user, permissionName) {
     .reduce((accumulator, currentValue) => accumulator.concat(currentValue), [])
     .filter(gatewayAccountId => !isADirectDebitAccount(gatewayAccountId))
 
-  return client.getAccounts({ gatewayAccountIds })
-    .then((result) => result.accounts)
+  return gatewayAccountIds.length
+    ? client.getAccounts({ gatewayAccountIds }).then((result) => result.accounts)
+    : Promise.resolve([])
 }
 
 const accountDetailHeaders = function accountDetailHeaders (accounts) {

--- a/test/fixtures/user_fixtures.js
+++ b/test/fixtures/user_fixtures.js
@@ -190,6 +190,10 @@ const defaultPermissions = [
   {
     name: 'connected-gocardless-account:update',
     description: 'Update connected go cardless account'
+  },
+  {
+    name: 'payouts:read',
+    description: 'View payouts'
   }
 ]
 

--- a/test/unit/utils/permissions_test.js
+++ b/test/unit/utils/permissions_test.js
@@ -1,11 +1,14 @@
+const sinon = require('sinon')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
+
+const { ConnectorClient } = require('../../../app/services/clients/connector_client')
 
 const { validUser } = require('./../../fixtures/user_fixtures')
 const { validGatewayAccountResponse } = require('./../../fixtures/gateway_account_fixtures')
 
 describe('gateway account filter utiltiies', () => {
-  const { userServicesContainsGatewayAccount } = require('./../../../app/utils/valid_account_id')
+  const { userServicesContainsGatewayAccount } = require('../../../app/utils/permissions')
   describe('gateway account exists on users service roles', () => {
     it('returns valid for gateway account belonging to user', () => {
       const opts = {
@@ -31,7 +34,7 @@ describe('gateway account filter utiltiies', () => {
     }
     const user = validUser(opts).getAsObject()
     it('correctly identifies stripe and moto headers for relavent accounts', async () => {
-      const { liveUserServicesGatewayAccounts } = proxyquire('./../../../app/utils/valid_account_id', {
+      const { liveUserServicesGatewayAccounts } = proxyquire('./../../../app/utils/permissions', {
         '../services/clients/connector_client.js': {
           ConnectorClient: class {
             async getAccounts () {
@@ -51,12 +54,12 @@ describe('gateway account filter utiltiies', () => {
       })
       const result = await liveUserServicesGatewayAccounts(user)
 
-      expect(result.headers.shouldGetStripeHeaders).to.be.true // eslint-disable-lin
-      expect(result.headers.shouldGetMotoHeaders).to.be.true // eslint-disable-lin
+      expect(result.headers.shouldGetStripeHeaders).to.be.true // eslint-disable-line
+      expect(result.headers.shouldGetMotoHeaders).to.be.true // eslint-disable-line
     })
 
     it('correctly identifies non stripe and moto headers', async () => {
-      const { liveUserServicesGatewayAccounts } = proxyquire('./../../../app/utils/valid_account_id', {
+      const { liveUserServicesGatewayAccounts } = proxyquire('./../../../app/utils/permissions', {
         '../services/clients/connector_client.js': {
           ConnectorClient: class {
             async getAccounts () {
@@ -71,12 +74,12 @@ describe('gateway account filter utiltiies', () => {
       })
       const result = await liveUserServicesGatewayAccounts(user)
 
-      expect(result.headers.shouldGetStripeHeaders).to.be.false // eslint-disable-lin
-      expect(result.headers.shouldGetMotoHeaders).to.be.false // eslint-disable-lin
+      expect(result.headers.shouldGetStripeHeaders).to.be.false // eslint-disable-line
+      expect(result.headers.shouldGetMotoHeaders).to.be.false // eslint-disable-line
     })
 
     it('correctly filters live accounts', async () => {
-      const { liveUserServicesGatewayAccounts } = proxyquire('./../../../app/utils/valid_account_id', {
+      const { liveUserServicesGatewayAccounts } = proxyquire('./../../../app/utils/permissions', {
         '../services/clients/connector_client.js': {
           ConnectorClient: class {
             async getAccounts () {
@@ -102,6 +105,23 @@ describe('gateway account filter utiltiies', () => {
       })
       const result = await liveUserServicesGatewayAccounts(user)
       expect(result.accounts).to.equal('1,3')
+    })
+
+    it('correctly filters services by users permission role', async () => {
+      const spy = sinon.stub(ConnectorClient.prototype, 'getAccounts').callsFake(() => Promise.resolve({ accounts: [] }))
+
+      const { liveUserServicesGatewayAccounts } = proxyquire(
+        './../../../app/utils/permissions', { '../services/clients/connector_client.js': ConnectorClient }
+      )
+
+      liveUserServicesGatewayAccounts(user)
+      sinon.assert.calledWith(spy, { gatewayAccountIds: [] })
+
+      liveUserServicesGatewayAccounts(user, 'perm-1')
+      sinon.assert.calledWith(spy, { gatewayAccountIds: ['1', '2', '3'] })
+
+      liveUserServicesGatewayAccounts(user, 'permission-user-does-not-have')
+      sinon.assert.calledWith(spy, { gatewayAccountIds: [] })
     })
   })
 })


### PR DESCRIPTION
Re-introducing permissions code following analysis of backend/ consumer
behaviour.

Reference https://github.com/alphagov/pay-selfservice/pull/2034

---

The default behaviour in newer backend routes is require a gateway
account id to be passed in to any resource, passing in nothing `key=[]`
or
in the case of comma separated values `key=` will either filter the data
for no account ids (resulting in nothing returned) OR return `400`
requiring something to be set or non empty values.

In the case of the frontend accounts route being called in this utility,
passing no accounts will treat the route as if there is no filter and
return all accounts.

This behaviour will be patched in the backend as part of this ticket.

Patch this behaviour and avoid an unnecessary call to the backend by
simply returning nothing if no accounts will have valid permissions.

Reference https://github.com/alphagov/pay-selfservice/pull/2037

---

Originally squashed from:
- 08456d2
- 8175d7c
- 1861c62

Reverting a932903.

