### PR TITLE
PP-6635 refactor permissions' liveUserServicesGatewayAccounts method

### DIFF
--- a/app/controllers/all-service-transactions/download-transactions.js
+++ b/app/controllers/all-service-transactions/download-transactions.js
@@ -7,36 +7,39 @@ const transactionService = require('../../services/transaction_service')
 const Stream = require('../../services/clients/stream_client')
 const { CORRELATION_HEADER } = require('../../utils/correlation_header')
 const { renderErrorView } = require('../../utils/response')
-const { liveUserServicesGatewayAccounts } = require('../../utils/permissions')
+const permissions = require('../../utils/permissions')
 
 module.exports = (req, res) => {
   const filters = req.query
   const correlationId = req.headers[CORRELATION_HEADER]
   const name = `GOVUK_Pay_${date.dateToDefaultFormat(new Date()).replace(' ', '_')}.csv`
 
-  liveUserServicesGatewayAccounts(req.user, 'transactions:read')
-    .then((gatewayResults) => {
-      const accountIdsUsersHasPermissionsFor = gatewayResults.accounts
-      filters.feeHeaders = gatewayResults.headers.shouldGetStripeHeaders
-      filters.motoHeader = gatewayResults.headers.shouldGetMotoHeaders
-      const url = transactionService.csvSearchUrl(filters, accountIdsUsersHasPermissionsFor)
+  permissions.getLiveGatewayAccountsFor(req.user, 'transactions:read')
+    .then((userPermittedAccountsSummary) => {
+      if (!userPermittedAccountsSummary.gatewayAccountIds.length) {
+        res.status(401).render('error', { message: 'You do not have any associated services with rights to view live transactions.' })
+        return
+      }
+      filters.feeHeaders = userPermittedAccountsSummary.headers.shouldGetStripeHeaders
+      filters.motoHeader = userPermittedAccountsSummary.headers.shouldGetMotoHeaders
+      const url = transactionService.csvSearchUrl(filters, userPermittedAccountsSummary.gatewayAccountIds)
 
       const timestampStreamStart = Date.now()
       const data = (chunk) => { res.write(chunk) }
       const complete = () => {
         const timestampStreamEnd = Date.now()
         const logContext = {
-          gateway_account_id: accountIdsUsersHasPermissionsFor,
           time_taken: timestampStreamEnd - timestampStreamStart,
           from_date: filters.fromDate,
           to_date: filters.toDate,
           gateway_payout_id: filters.gatewayPayoutId,
           payment_states: filters.payment_states,
           refund_states: filters.refund_stats,
-          x_request_id: correlationId,
           method: 'future'
         }
         logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
+        logContext[keys.GATEWAY_ACCOUNT_ID] = userPermittedAccountsSummary.gatewayAccountIds
+        logContext[keys.CORRELATION_ID] = correlationId
         logger.info('Completed file stream', logContext)
         res.end()
       }

--- a/app/controllers/payouts/payout_list_controller.js
+++ b/app/controllers/payouts/payout_list_controller.js
@@ -3,21 +3,25 @@ const paths = require('../../../app/paths')
 const logger = require('../../utils/logger')(__filename)
 const { keys } = require('@govuk-pay/pay-js-commons').logging
 const { response, renderErrorView } = require('../../utils/response.js')
-const { liveUserServicesGatewayAccounts } = require('../../utils/permissions')
+const permissions = require('../../utils/permissions')
 const payoutService = require('./payouts_service')
 
 const listAllServicesPayouts = async function listAllServicesPayouts (req, res) {
+  const { page } = req.query
+
   try {
     let payoutsReleaseDate
-    const { page } = req.query
-    const gatewayAccounts = await liveUserServicesGatewayAccounts(req.user, 'payouts:read')
-    const payoutSearchResult = await payoutService.payouts(gatewayAccounts.accounts, req.user, page)
-    const logContext = {
-      gateway_accounts: gatewayAccounts,
-      current_page: page
+    const userPermittedAccountsSummary = await permissions.getLiveGatewayAccountsFor(req.user, 'payouts:read')
+
+    if (!userPermittedAccountsSummary.gatewayAccountIds.length) {
+      res.status(401).render('error', { message: 'You do not have any associated services with rights to view payments to bank accounts.' })
+      return
     }
+    const payoutSearchResult = await payoutService.payouts(userPermittedAccountsSummary.gatewayAccountIds, req.user, page)
+    const logContext = { current_page: page }
     logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
-    logContext[keys.GATEWAY_ACCOUNT_ID] = gatewayAccounts
+    logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
+    logContext[keys.GATEWAY_ACCOUNT_ID] = userPermittedAccountsSummary
     logger.info('Fetched page of payouts for all services', logContext)
 
     if (process.env.PAYOUTS_RELEASE_DATE) {

--- a/app/controllers/payouts/payouts_service.js
+++ b/app/controllers/payouts/payouts_service.js
@@ -41,8 +41,8 @@ const formatPayoutPages = function formatPayoutPages (payoutSearchResponse) {
   return { total, page, links }
 }
 
-const payouts = async function payouts (gatewayAccountId, user = {}, page = 1) {
-  const payoutSearchResponse = await Ledger.payouts(gatewayAccountId, page, PAGE_SIZE)
+const payouts = async function payouts (gatewayAccountIds, user = {}, page = 1) {
+  const payoutSearchResponse = await Ledger.payouts(gatewayAccountIds, page, PAGE_SIZE)
   return {
     groups: groupPayoutsByDate(payoutSearchResponse.results, user),
     pages: formatPayoutPages(payoutSearchResponse)

--- a/app/controllers/transactions/transaction_list_controller.js
+++ b/app/controllers/transactions/transaction_list_controller.js
@@ -27,7 +27,7 @@ module.exports = (req, res) => {
   if (!filters.valid) return error('Invalid search')
 
   transactionService
-    .search(accountId, filters.result, correlationId)
+    .search([ accountId ], filters.result, correlationId)
     .then(transactions => {
       client
         .getAllCardTypes({ correlationId }, allCards => {

--- a/app/services/transaction_service.js
+++ b/app/services/transaction_service.js
@@ -2,20 +2,27 @@
 
 const Ledger = require('../services/clients/ledger_client')
 const getQueryStringForParams = require('../utils/get_query_string_for_params')
+const qs = require('qs')
 
-const searchLedger = async function searchLedger (accountId, filters) {
+const searchLedger = async function searchLedger (gatewayAccountIds = [], filters) {
   try {
-    const transactions = await Ledger.transactions(accountId, filters)
+    const transactions = await Ledger.transactions(gatewayAccountIds, filters)
     return transactions
   } catch (error) {
     throw new Error('GET_FAILED')
   }
 }
 
-const csvSearchUrl = function csvSearchParams (filters, gatewayAccountId) {
-  const queryParams = getQueryStringForParams(filters, true, true, true)
-  const query = queryParams ? `&${queryParams}` : ''
-  return `${process.env.LEDGER_URL}/v1/transaction?with_parent_transaction=true&account_id=${gatewayAccountId}${query}`
+const csvSearchUrl = function csvSearchParams (filters, gatewayAccountIds = []) {
+  const formatOptions = { arrayFormat: 'comma' }
+  const params = {
+    account_id: gatewayAccountIds,
+    with_parent_transaction: true
+  }
+
+  const formattedParams = qs.stringify(params, formatOptions)
+  const formattedFilterParams = getQueryStringForParams(filters, true, true, true)
+  return `${process.env.LEDGER_URL}/v1/transaction?${formattedParams}&${formattedFilterParams}`
 }
 
 exports.search = searchLedger

--- a/app/utils/permissions.js
+++ b/app/utils/permissions.js
@@ -9,16 +9,16 @@ const userServicesContainsGatewayAccount = function userServicesContainsGatewayA
   return accountId && gatewayAccountIds.indexOf(accountId) !== -1
 }
 
-const liveUserServicesGatewayAccounts = async function liveUserServicesGatewayAccounts (user, permissionName) {
-  const accounts = await getAccounts(user, permissionName)
+const getLiveGatewayAccountsFor = async function getLiveGatewayAccountsFor (user, permissionName) {
+  const userGatewayAccounts = await fetchGatewayAccountsFor(user, permissionName)
 
   return {
-    headers: accountDetailHeaders(accounts),
-    accounts: accountsString(accounts)
+    gatewayAccountIds: getLiveGatewayAccountIds(userGatewayAccounts),
+    headers: getAllAccountDetailHeaders(userGatewayAccounts)
   }
 }
 
-const getAccounts = function getAccounts (user, permissionName) {
+const fetchGatewayAccountsFor = function fetchGatewayAccountsFor (user, permissionName) {
   const gatewayAccountIds = user.serviceRoles
     .filter((serviceRole) => serviceRole.role.permissions
       .map((permission) => permission.name)
@@ -33,11 +33,11 @@ const getAccounts = function getAccounts (user, permissionName) {
     : Promise.resolve([])
 }
 
-const accountDetailHeaders = function accountDetailHeaders (accounts) {
-  const shouldGetStripeHeaders = accounts
+const getAllAccountDetailHeaders = function getAllAccountDetailHeaders (gatewayAccounts) {
+  const shouldGetStripeHeaders = gatewayAccounts
     .some((account) => account.payment_provider === 'stripe')
 
-  const shouldGetMotoHeaders = accounts
+  const shouldGetMotoHeaders = gatewayAccounts
     .some((account) => account.allow_moto)
 
   return {
@@ -45,16 +45,13 @@ const accountDetailHeaders = function accountDetailHeaders (accounts) {
   }
 }
 
-const accountsString = function accountsString (accounts) {
-  const emptyAccountsString = '[]'
-  const outputString = accounts
+const getLiveGatewayAccountIds = function getLiveGatewayAccountIds (gatewayAccounts) {
+  return gatewayAccounts
     .filter((account) => account.type === 'live')
     .map((account) => account.gateway_account_id)
-    .join(',')
-  return outputString || emptyAccountsString
 }
 
 module.exports = {
   userServicesContainsGatewayAccount,
-  liveUserServicesGatewayAccounts
+  getLiveGatewayAccountsFor
 }

--- a/app/utils/response.js
+++ b/app/utils/response.js
@@ -11,8 +11,7 @@ function response (req, res, template, data = {}) {
   render(req, res, template, convertedData)
 }
 
-function errorResponse (req, res, msg, status = 500) {
-  if (!msg) msg = ERROR_MESSAGE
+function errorResponse (req, res, msg = ERROR_MESSAGE, status = 500) {
   let correlationId = req.correlationId
   if (typeof msg !== 'string') {
     msg = 'Please try again or contact support team.'

--- a/test/integration/payouts/payouts_service_it_test.js
+++ b/test/integration/payouts/payouts_service_it_test.js
@@ -23,7 +23,7 @@ describe('payouts service list payouts helper', () => {
     ledgerMock.get(LEDGER_PAYOUT_BACKEND_ROUTE)
       .reply(200, fixtures.validPayoutSearchResponse(payouts).getPlain())
 
-    const { groups, pages } = await payoutService.payouts(gatewayAccountId)
+    const { groups, pages } = await payoutService.payouts([ gatewayAccountId ])
 
     expect(Object.keys(groups).length).to.equal(1)
     expect(groups['2019-01-29'].entries.length).to.equal(2)
@@ -36,7 +36,7 @@ describe('payouts service list payouts helper', () => {
     ledgerMock.get(LEDGER_PAYOUT_BACKEND_ROUTE)
       .reply(200, fixtures.validPayoutSearchResponse(payouts).getPlain())
 
-    const { groups, pages } = await payoutService.payouts(gatewayAccountId)
+    const { groups, pages } = await payoutService.payouts([ gatewayAccountId ])
 
     expect(groups).to.deep.equal({})
     expect(pages.total).to.equal(0)

--- a/test/unit/clients/ledger_client/ledger_search_payout_test.js
+++ b/test/unit/clients/ledger_client/ledger_search_payout_test.js
@@ -49,7 +49,7 @@ describe('ledger client', () => {
     afterEach(() => pactTestProvider.verify())
 
     it('should search payouts successfully', async () => {
-      const ledgerResult = await ledgerClient.payouts(GATEWAY_ACCOUNT_ID, 1)
+      const ledgerResult = await ledgerClient.payouts([ GATEWAY_ACCOUNT_ID ], 1)
       expect(ledgerResult).to.deep.equal(response.getPlain())
     })
   })

--- a/test/unit/utils/permissions_test.js
+++ b/test/unit/utils/permissions_test.js
@@ -41,7 +41,7 @@ describe('gateway account filter utiltiies', () => {
     afterEach(() => accountSpy.restore())
 
     it('correctly identifies stripe and moto headers for relavent accounts', async () => {
-      const { liveUserServicesGatewayAccounts } = proxyquire('./../../../app/utils/permissions', {
+      const { getLiveGatewayAccountsFor } = proxyquire('./../../../app/utils/permissions', {
         '../services/clients/connector_client.js': {
           ConnectorClient: class {
             async getAccounts () {
@@ -59,14 +59,14 @@ describe('gateway account filter utiltiies', () => {
           }
         }
       })
-      const result = await liveUserServicesGatewayAccounts(user, 'perm-1')
+      const result = await getLiveGatewayAccountsFor(user, 'perm-1')
 
       expect(result.headers.shouldGetStripeHeaders).to.be.true // eslint-disable-line
       expect(result.headers.shouldGetMotoHeaders).to.be.true // eslint-disable-line
     })
 
     it('correctly identifies non stripe and moto headers', async () => {
-      const { liveUserServicesGatewayAccounts } = proxyquire('./../../../app/utils/permissions', {
+      const { getLiveGatewayAccountsFor } = proxyquire('./../../../app/utils/permissions', {
         '../services/clients/connector_client.js': {
           ConnectorClient: class {
             async getAccounts () {
@@ -79,14 +79,14 @@ describe('gateway account filter utiltiies', () => {
           }
         }
       })
-      const result = await liveUserServicesGatewayAccounts(user, 'perm-1')
+      const result = await getLiveGatewayAccountsFor(user, 'perm-1')
 
       expect(result.headers.shouldGetStripeHeaders).to.be.false // eslint-disable-line
       expect(result.headers.shouldGetMotoHeaders).to.be.false // eslint-disable-line
     })
 
     it('correctly filters live accounts', async () => {
-      const { liveUserServicesGatewayAccounts } = proxyquire('./../../../app/utils/permissions', {
+      const { getLiveGatewayAccountsFor } = proxyquire('./../../../app/utils/permissions', {
         '../services/clients/connector_client.js': {
           ConnectorClient: class {
             async getAccounts () {
@@ -110,25 +110,25 @@ describe('gateway account filter utiltiies', () => {
           }
         }
       })
-      const result = await liveUserServicesGatewayAccounts(user, 'perm-1')
-      expect(result.accounts).to.equal('1,3')
+      const result = await getLiveGatewayAccountsFor(user, 'perm-1')
+      expect(result.gatewayAccountIds).to.deep.equal([ '1', '3' ])
     })
 
     it('correctly filters services by users permission role', async () => {
-      const { liveUserServicesGatewayAccounts } = proxyquire(
+      const { getLiveGatewayAccountsFor } = proxyquire(
         './../../../app/utils/permissions', { '../services/clients/connector_client.js': ConnectorClient }
       )
 
-      liveUserServicesGatewayAccounts(user, 'perm-1')
+      getLiveGatewayAccountsFor(user, 'perm-1')
       sinon.assert.calledWith(accountSpy, { gatewayAccountIds: ['1', '2', '3'] })
     })
 
     it('does not interract with the backend if no services have the required permissions', () => {
-      const { liveUserServicesGatewayAccounts } = proxyquire(
+      const { getLiveGatewayAccountsFor } = proxyquire(
         './../../../app/utils/permissions', { '../services/clients/connector_client.js': ConnectorClient }
       )
 
-      liveUserServicesGatewayAccounts(user, 'permission-user-does-not-have')
+      getLiveGatewayAccountsFor(user, 'permission-user-does-not-have')
       sinon.assert.notCalled(accountSpy)
     })
   })


### PR DESCRIPTION
## WHAT
- refactor permissions to return a list of gateway account ids instead of a string
- refactor methods/variables to a more meaningful name
- update tests accordingly

with @sfount

