### PR TITLE
PP-6638 Add Stripe account details flow controller

### DIFF
--- a/app/controllers/stripe-setup/add-psp-account-details/get-controller.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/get-controller.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const paths = require('../../../paths')
+const { response } = require('../../../utils/response')
+const { ConnectorClient } = require('../../../services/clients/connector_client')
+const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
+
+module.exports = async (req, res) => {
+  const stripeAccountSetup = await connectorClient.getStripeAccountSetup(
+    req.account.gateway_account_id, req.correlationId)
+
+  if (!stripeAccountSetup.bankAccount) {
+    res.redirect(303, paths.stripeSetup.bankDetails)
+  } else if (!stripeAccountSetup.responsiblePerson) {
+    res.redirect(303, paths.stripeSetup.responsiblePerson)
+  } else if (!stripeAccountSetup.vatNumberCompanyNumber) {
+    res.redirect(303, paths.stripeSetup.vatNumberCompanyNumber)
+  } else {
+    response(req, res, 'stripe-setup/go-live-complete')
+  }
+}

--- a/app/controllers/stripe-setup/add-psp-account-details/get-controller.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/get-controller.js
@@ -1,21 +1,27 @@
 'use strict'
 
 const paths = require('../../../paths')
-const { response } = require('../../../utils/response')
+const logger = require('../../../utils/logger')(__filename)
+const { response, renderErrorView } = require('../../../utils/response')
 const { ConnectorClient } = require('../../../services/clients/connector_client')
 const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 
 module.exports = async (req, res) => {
-  const stripeAccountSetup = await connectorClient.getStripeAccountSetup(
-    req.account.gateway_account_id, req.correlationId)
+  try {
+    const stripeAccountSetup = await connectorClient.getStripeAccountSetup(
+      req.account.gateway_account_id, req.correlationId)
 
-  if (!stripeAccountSetup.bankAccount) {
-    res.redirect(303, paths.stripeSetup.bankDetails)
-  } else if (!stripeAccountSetup.responsiblePerson) {
-    res.redirect(303, paths.stripeSetup.responsiblePerson)
-  } else if (!stripeAccountSetup.vatNumberCompanyNumber) {
-    res.redirect(303, paths.stripeSetup.vatNumberCompanyNumber)
-  } else {
-    response(req, res, 'stripe-setup/go-live-complete')
+    if (!stripeAccountSetup.bankAccount) {
+      res.redirect(303, paths.stripeSetup.bankDetails)
+    } else if (!stripeAccountSetup.responsiblePerson) {
+      res.redirect(303, paths.stripeSetup.responsiblePerson)
+    } else if (!stripeAccountSetup.vatNumberCompanyNumber) {
+      res.redirect(303, paths.stripeSetup.vatNumberCompanyNumber)
+    } else {
+      response(req, res, 'stripe-setup/go-live-complete')
+    }
+  } catch (error) {
+    logger.error(`${req.correlationId} error with Stripe > Add PSP account details : ${error}`)
+    return renderErrorView(req, res, false, error.errorCode)
   }
 }

--- a/app/controllers/stripe-setup/add-psp-account-details/get-controller.test.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/get-controller.test.js
@@ -1,0 +1,86 @@
+'use strict'
+
+// NPM dependencies
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+const paths = require('../../../paths')
+
+// Global setup
+chai.use(chaiAsPromised)
+const { expect } = chai
+
+const getController = function getController (stripeAccountSetupResponse) {
+  return proxyquire('./get-controller', {
+    '../../../services/clients/connector_client': {
+      ConnectorClient: function () {
+        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => {
+          return new Promise(resolve => {
+            resolve(stripeAccountSetupResponse)
+          })
+        }
+      }
+    }
+  })
+}
+
+describe('get controller', () => {
+  const req = {
+    account: {
+      gateway_account_id: 'gatewayId'
+    },
+    correlationId: 'requestId'
+  }
+
+  let res
+
+  beforeEach(() => {
+    res = {
+      setHeader: sinon.stub(),
+      status: sinon.spy(),
+      redirect: sinon.spy(),
+      render: sinon.spy()
+    }
+  })
+
+  it('should redirect to bank account setup page', async () => {
+    const controller = getController({
+      bankAccount: false,
+      responsiblePerson: false,
+      vatNumberCompanyNumber: false
+    })
+    await controller(req, res)
+    expect(res.redirect.calledWith(303, paths.stripeSetup.bankDetails)).to.equal(true)
+  })
+
+  it('should redirect to responsible person page', async () => {
+    const controller = getController({
+      bankAccount: true,
+      responsiblePerson: false,
+      vatNumberCompanyNumber: false
+    })
+    await controller(req, res)
+    expect(res.redirect.calledWith(303, paths.stripeSetup.responsiblePerson)).to.equal(true)
+  })
+
+  it('should redirect to VAT number page', async () => {
+    const controller = getController({
+      bankAccount: true,
+      responsiblePerson: true,
+      vatNumberCompanyNumber: false
+    })
+    await controller(req, res)
+    expect(res.redirect.calledWith(303, paths.stripeSetup.vatNumberCompanyNumber)).to.equal(true)
+  })
+
+  it('should render go live complete page when all steps are completed', async () => {
+    const controller = getController({
+      bankAccount: true,
+      responsiblePerson: true,
+      vatNumberCompanyNumber: true
+    })
+    await controller(req, res)
+    expect(res.render.calledWith('stripe-setup/go-live-complete')).to.equal(true)
+  })
+})

--- a/app/controllers/stripe-setup/add-psp-account-details/get-controller.test.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/get-controller.test.js
@@ -1,25 +1,14 @@
 'use strict'
 
-// NPM dependencies
-const chai = require('chai')
-const chaiAsPromised = require('chai-as-promised')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 const paths = require('../../../paths')
-
-// Global setup
-chai.use(chaiAsPromised)
-const { expect } = chai
 
 const getController = function getController (stripeAccountSetupResponse) {
   return proxyquire('./get-controller', {
     '../../../services/clients/connector_client': {
       ConnectorClient: function () {
-        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => {
-          return new Promise(resolve => {
-            resolve(stripeAccountSetupResponse)
-          })
-        }
+        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => Promise.resolve(stripeAccountSetupResponse)
       }
     }
   })
@@ -51,7 +40,7 @@ describe('get controller', () => {
       vatNumberCompanyNumber: false
     })
     await controller(req, res)
-    expect(res.redirect.calledWith(303, paths.stripeSetup.bankDetails)).to.equal(true)
+    sinon.assert.calledWith(res.redirect, 303, paths.stripeSetup.bankDetails)
   })
 
   it('should redirect to responsible person page', async () => {
@@ -61,7 +50,7 @@ describe('get controller', () => {
       vatNumberCompanyNumber: false
     })
     await controller(req, res)
-    expect(res.redirect.calledWith(303, paths.stripeSetup.responsiblePerson)).to.equal(true)
+    sinon.assert.calledWith(res.redirect, 303, paths.stripeSetup.responsiblePerson)
   })
 
   it('should redirect to VAT number page', async () => {
@@ -71,7 +60,7 @@ describe('get controller', () => {
       vatNumberCompanyNumber: false
     })
     await controller(req, res)
-    expect(res.redirect.calledWith(303, paths.stripeSetup.vatNumberCompanyNumber)).to.equal(true)
+    sinon.assert.calledWith(res.redirect, 303, paths.stripeSetup.vatNumberCompanyNumber)
   })
 
   it('should render go live complete page when all steps are completed', async () => {
@@ -81,6 +70,6 @@ describe('get controller', () => {
       vatNumberCompanyNumber: true
     })
     await controller(req, res)
-    expect(res.render.calledWith('stripe-setup/go-live-complete')).to.equal(true)
+    sinon.assert.calledWith(res.render, 'stripe-setup/go-live-complete')
   })
 })

--- a/app/controllers/stripe-setup/add-psp-account-details/index.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = {
+  get: require('./get-controller')
+}

--- a/app/paths.js
+++ b/app/paths.js
@@ -186,6 +186,9 @@ module.exports = {
     companyNumber: '/vat-number-company-number/company-number',
     checkYourAnswers: '/vat-number-company-number/check-your-answers'
   },
+  stripe: {
+    addPspAccountDetails: '/stripe/add-psp-account-details'
+  },
   settings: {
     index: '/settings'
   },

--- a/app/routes.js
+++ b/app/routes.js
@@ -77,6 +77,7 @@ const stripeSetupVatNumberCompanyNumberController = require('./controllers/strip
 const stripeSetupVatNumberController = require('./controllers/stripe-setup/vat-number-company-number/vat-number')
 const stripeSetupCompanyNumberController = require('./controllers/stripe-setup/vat-number-company-number/company-number')
 const stripeSetupCheckYourAnswersController = require('./controllers/stripe-setup/vat-number-company-number/check-your-answers')
+const stripeSetupAddPspAccountDetailsController = require('./controllers/stripe-setup/add-psp-account-details')
 const paymentTypesController = require('./controllers/payment-types')
 const settingsController = require('./controllers/settings')
 const userPhoneNumberController = require('./controllers/user/phone-number')
@@ -91,7 +92,7 @@ const {
   healthcheck, registerUser, user, dashboard, selfCreateService, transactions, credentials,
   apiKeys, serviceSwitcher, teamMembers, staticPaths, inviteValidation, editServiceName, merchantDetails,
   notificationCredentials: nc, paymentTypes: pt, emailNotifications: en, toggle3ds: t3ds, prototyping, paymentLinks,
-  partnerApp, toggleBillingAddress: billingAddress, requestToGoLive, policyPages, stripeSetup, digitalWallet,
+  partnerApp, toggleBillingAddress: billingAddress, requestToGoLive, policyPages, stripeSetup, stripe, digitalWallet,
   settings, yourPsp, allServiceTransactions, payouts
 } = paths
 
@@ -209,6 +210,7 @@ module.exports.bind = function (app) {
     ...lodash.values(requestToGoLive),
     ...lodash.values(policyPages),
     ...lodash.values(stripeSetup),
+    ...lodash.values(stripe),
     ...lodash.values(digitalWallet),
     ...lodash.values(settings),
     ...lodash.values(yourPsp),
@@ -509,6 +511,15 @@ module.exports.bind = function (app) {
     getStripeAccount,
     checkVatNumberCompanyNumberNotSubmitted,
     stripeSetupCheckYourAnswersController.post
+  )
+
+  app.get(stripe.addPspAccountDetails,
+    xraySegmentCls,
+    permission('stripe-account-details:update'),
+    getAccount,
+    paymentMethodIsCard,
+    restrictToLiveStripeAccount,
+    stripeSetupAddPspAccountDetailsController.get
   )
 
   app.get(user.phoneNumber,

--- a/app/views/stripe-setup/go-live-complete.njk
+++ b/app/views/stripe-setup/go-live-complete.njk
@@ -1,0 +1,11 @@
+{% extends "../layout.njk" %}
+
+{% block pageTitle %}
+  Go live complete - {{ currentService.name }} - GOV.UK Pay
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Go live complete</h1>
+  </div>
+{% endblock %}


### PR DESCRIPTION
- Added '/stripe/add-psp-account-details' route and controller which
redirects to the next page of details to fill out depending on what
has already been filled out.
- If all details have been filled out, render the setup complete page.
The copy for this has not been added as part of this commit.


