### PR TITLE
PP-6494 Trim and validate Worldpay 3DS Flex credentials

### DIFF
--- a/app/browsered/field-validation-checks.js
+++ b/app/browsered/field-validation-checks.js
@@ -22,7 +22,10 @@ const validationErrors = {
   invalidSortCode: 'Enter a valid sort code',
   invalidVatNumber: 'Enter a valid VAT number',
   invalidCompanyNumber: 'Enter a valid company number',
-  sevenDigitCompanyNumber: 'Company numbers in England and Wales have 8 digits and always start with 0'
+  sevenDigitCompanyNumber: 'Company numbers in England and Wales have 8 digits and always start with 0',
+  invalidWorldpay3dsFlexOrgUnitId: 'Enter your organisational unit ID in the format you received it',
+  invalidWorldpay3dsFlexIssuer: 'Enter your issuer in the format you received it',
+  invalidWorldpay3dsFlexJwtMacKey: 'Enter your JWT MAC key in the format you received it'
 }
 
 exports.validationErrors = validationErrors
@@ -132,4 +135,28 @@ exports.isNotCompanyNumber = value => {
   }
 
   return false
+}
+
+exports.isNotWorldpay3dsFlexOrgUnitId = value => {
+  if (/^[0-9a-f]{24}$/.test(value)) {
+    return false
+  } else {
+    return validationErrors.invalidWorldpay3dsFlexOrgUnitId
+  }
+}
+
+exports.isNotWorldpay3dsFlexIssuer = value => {
+  if (/^[0-9a-f]{24}$/.test(value)) {
+    return false
+  } else {
+    return validationErrors.invalidWorldpay3dsFlexIssuer
+  }
+}
+
+exports.isNotWorldpay3dsFlexJwtMacKey = value => {
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(value)) {
+    return false
+  } else {
+    return validationErrors.invalidWorldpay3dsFlexJwtMacKey
+  }
 }

--- a/app/controllers/your-psp/get-flex-controller.js
+++ b/app/controllers/your-psp/get-flex-controller.js
@@ -1,12 +1,38 @@
 'use strict'
 
+// NPM dependencies
+const lodash = require('lodash')
+
 // Local dependencies
 const { response } = require('../../utils/response')
 
 module.exports = (req, res) => {
   const { change } = req.query || {}
+
   const isFlexConfigured = req.account.worldpay_3ds_flex &&
     req.account.worldpay_3ds_flex.organisational_unit_id !== undefined &&
     req.account.worldpay_3ds_flex.organisational_unit_id.length > 0
-  return response(req, res, 'your-psp/flex', { change, isFlexConfigured })
+
+  let errors = false
+  let orgUnitId = lodash.get(req, 'account.worldpay_3ds_flex.organisational_unit_id' || '')
+  let issuer = lodash.get(req, 'account.worldpay_3ds_flex.issuer' || '')
+
+  let worldpay3dsFlexPageData = lodash.get(req, 'session.pageData.worldpay3dsFlex')
+  if (worldpay3dsFlexPageData) {
+    delete req.session.pageData.worldpay3dsFlex
+
+    if (worldpay3dsFlexPageData.errors) {
+      errors = worldpay3dsFlexPageData.errors
+
+      if (worldpay3dsFlexPageData.orgUnitId) {
+        orgUnitId = worldpay3dsFlexPageData.orgUnitId
+      }
+
+      if (worldpay3dsFlexPageData.issuer) {
+        issuer = worldpay3dsFlexPageData.issuer
+      }
+    }
+  }
+
+  return response(req, res, 'your-psp/flex', { errors, change, isFlexConfigured, orgUnitId, issuer })
 }

--- a/app/controllers/your-psp/worldpay-3ds-flex-validations.js
+++ b/app/controllers/your-psp/worldpay-3ds-flex-validations.js
@@ -1,0 +1,50 @@
+'use strict'
+
+// Local dependencies
+const { isNotWorldpay3dsFlexOrgUnitId, isNotWorldpay3dsFlexIssuer, isNotWorldpay3dsFlexJwtMacKey } =
+    require('../../../app/browsered/field-validation-checks')
+
+exports.validateOrgUnitId = (orgUnitId) => {
+  const isNotWorldpay3dsFlexOrgUnitIdErrorMessage = isNotWorldpay3dsFlexOrgUnitId(orgUnitId)
+  if (isNotWorldpay3dsFlexOrgUnitIdErrorMessage) {
+    return {
+      valid: false,
+      message: isNotWorldpay3dsFlexOrgUnitIdErrorMessage
+    }
+  }
+
+  return {
+    valid: true,
+    message: null
+  }
+}
+
+exports.validateIssuer = (issuer) => {
+  const isNotWorldpay3dsFlexIssuerErrorMessage = isNotWorldpay3dsFlexIssuer(issuer)
+  if (isNotWorldpay3dsFlexIssuerErrorMessage) {
+    return {
+      valid: false,
+      message: isNotWorldpay3dsFlexIssuerErrorMessage
+    }
+  }
+
+  return {
+    valid: true,
+    message: null
+  }
+}
+
+exports.validateJwtMacKey = (jwtMacKey) => {
+  const isNotWorldpay3dsFlexJwtMacKeyErrorMessage = isNotWorldpay3dsFlexJwtMacKey(jwtMacKey)
+  if (isNotWorldpay3dsFlexJwtMacKeyErrorMessage) {
+    return {
+      valid: false,
+      message: isNotWorldpay3dsFlexJwtMacKeyErrorMessage
+    }
+  }
+
+  return {
+    valid: true,
+    message: null
+  }
+}

--- a/app/controllers/your-psp/worldpay-3ds-flex-validations.test.js
+++ b/app/controllers/your-psp/worldpay-3ds-flex-validations.test.js
@@ -1,0 +1,54 @@
+'use strict'
+
+// NPM dependencies
+const { expect } = require('chai')
+
+// Local dependencies
+const worldpay3dsFlexValidations = require('./worldpay-3ds-flex-validations')
+
+describe('Worldpay 3DS Flex validations', () => {
+  describe('Organisational unit ID validations', () => {
+    it('should be valid for valid organisational unit ID', () => {
+      const orgUnitId = '5bd9b55e4444761ac0af1c80'
+      expect(worldpay3dsFlexValidations.validateOrgUnitId(orgUnitId).valid).to.be.true // eslint-disable-line
+    })
+
+    it('should not be valid for invalid organisational unit ID', () => {
+      const orgUnitId = 'not valid'
+      expect(worldpay3dsFlexValidations.validateOrgUnitId(orgUnitId)).to.deep.equal({
+        valid: false,
+        message: 'Enter your organisational unit ID in the format you received it'
+      })
+    })
+  })
+
+  describe('Issuer validations', () => {
+    it('should be valid for valid issuer', () => {
+      const issuer = '5bd9e0e4444dce153428c940'
+      expect(worldpay3dsFlexValidations.validateIssuer(issuer).valid).to.be.true // eslint-disable-line
+    })
+
+    it('should not be valid for issuer', () => {
+      const issuer = 'not valid'
+      expect(worldpay3dsFlexValidations.validateIssuer(issuer)).to.deep.equal({
+        valid: false,
+        message: 'Enter your issuer in the format you received it'
+      })
+    })
+  })
+
+  describe('JWT MAC key validations', () => {
+    it('should be valid for valid JWT MAC key', () => {
+      const jwtMacKey = 'fa2daee2-1fbb-45ff-4444-52805d5cd9e0'
+      expect(worldpay3dsFlexValidations.validateJwtMacKey(jwtMacKey).valid).to.be.true // eslint-disable-line
+    })
+
+    it('should not be valid for invalid JWT MAC key', () => {
+      const jwtMacKey = 'not valid'
+      expect(worldpay3dsFlexValidations.validateJwtMacKey(jwtMacKey)).to.deep.equal({
+        valid: false,
+        message: 'Enter your JWT MAC key in the format you received it'
+      })
+    })
+  })
+})

--- a/app/views/your-psp/_worldpay-flex.njk
+++ b/app/views/your-psp/_worldpay-flex.njk
@@ -19,7 +19,7 @@
             {
               href: routes.yourPsp.flex + "?change=organisationalUnitId",
               text: "Change",
-              visuallyHiddenText: "3DS flex credentials",
+              visuallyHiddenText: "3DS Flex credentials",
               attributes: {
                 id: "flex-credentials-change-link"
               }
@@ -29,7 +29,7 @@
       },
       {
         key: {
-          text: "Issuer"
+          text: "Issuer (API ID)"
         },
         value: {
           text: currentGatewayAccount.worldpay_3ds_flex.issuer if isFlexConfigured else "Not configured",
@@ -40,14 +40,14 @@
             {
               href: routes.yourPsp.flex + "?change=issuer",
               text: "Change",
-              visuallyHiddenText: "3DS flex credentials"
+              visuallyHiddenText: "3DS Flex credentials"
             }
           ]
         }
       },
       {
         key: {
-          text: "JWT MAC key"
+          text: "JWT MAC key (API key)"
         },
         value: {
           text: '●●●●●●●●' if isFlexConfigured else "Not configured",
@@ -58,7 +58,7 @@
             {
               href: routes.yourPsp.flex + "?change=password",
               text: "Change",
-              visuallyHiddenText: "3DS flex credentials"
+              visuallyHiddenText: "3DS Flex credentials"
             }
           ]
         }

--- a/app/views/your-psp/flex.njk
+++ b/app/views/your-psp/flex.njk
@@ -11,38 +11,80 @@
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Your Worldpay 3DS Flex credentials</h1>
-    <form method="post" action="{{routes.yourPsp.flex}}" data-validate>
+    <form method="post" action="{{routes.yourPsp.flex}}">
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
+        {% if errors %}
+          {% set errorList = [] %}
+
+          {% if errors['organisational-unit-id'] %}
+            {% set errorList = (errorList.push({
+              text: 'Organisational unit ID',
+              href: '#organisational-unit-id'
+            }), errorList) %}
+            {% set orgUnitIdError = {
+              text: errors["organisational-unit-id"]
+            } %}
+          {% endif %}
+
+          {% if errors['issuer'] %}
+            {% set errorList = (errorList.push({
+              text: 'Issuer',
+              href: '#issuer'
+            }), errorList) %}
+            {% set issuerError = {
+              text: errors["issuer"]
+            } %}
+          {% endif %}
+
+          {% if errors['jwt-mac-key'] %}
+            {% set errorList = (errorList.push({
+              text: 'JWT MAC key',
+              href: '#jwt-mac-key'
+            }), errorList) %}
+            {% set jwtMacKeyError = {
+              text: errors["jwt-mac-key"]
+            } %}
+          {% endif %}
+
+          {{ govukErrorSummary({
+            titleText: 'There was a problem with the details you gave for:',
+            errorList: errorList
+          }) }}
+        {% endif %}
 
       {% if change === 'organisationalUnitId' %}
         {{ govukInput({
             label: {
-              text: "Organisational Unit ID"
+              text: "Organisational unit ID"
             },
+            hint: {
+              text: "Provided to you by Worldpay. For example, ‘5bd9b55e4444761ac0af1c80’."
+            },
+            errorMessage: orgUnitIdError,
             id: "organisational-unit-id",
             name: "organisational-unit-id",
             classes: "govuk-input--width-20",
             type: "text",
             attributes: {
-              "data-validate": "required",
               "autofocus": "autofocus"
             },
-            value: currentGatewayAccount.worldpay_3ds_flex.organisational_unit_id
+            value: orgUnitId
           })
         }}
       {% else %}
         {{ govukInput({
             label: {
-              text: "Organisational Unit ID"
+              text: "Organisational unit ID"
             },
+            hint: {
+              text: "Provided to you by Worldpay. For example, ‘5bd9b55e4444761ac0af1c80’."
+            },
+            errorMessage: orgUnitIdError,
             id: "organisational-unit-id",
             name: "organisational-unit-id",
             classes: "govuk-input--width-20",
             type: "text",
-            attributes: {
-              "data-validate": "required"
-            },
-            value: currentGatewayAccount.worldpay_3ds_flex.organisational_unit_id
+            value: orgUnitId
           })
         }}
       {% endif %}
@@ -50,32 +92,36 @@
       {% if change === 'issuer' %}
         {{ govukInput({
             label: {
-              text: "Issuer"
+              text: "Issuer (API ID)"
             },
+            hint: {
+              text: "Provided to you by Worldpay. For example, ‘5bd9e0e4444dce153428c940’."
+            },
+            errorMessage: issuerError,
             id: "issuer",
             name: "issuer",
             classes: "govuk-input--width-20",
             type: "text",
             attributes: {
-              "data-validate": "required",
               "autofocus": "autofocus"
             },
-            value: currentGatewayAccount.worldpay_3ds_flex.issuer
+            value: issuer
           })
         }}
       {% else %}
         {{ govukInput({
             label: {
-              text: "Issuer"
+              text: "Issuer (API ID)"
             },
+            hint: {
+              text: "Provided to you by Worldpay. For example, ‘5bd9e0e4444dce153428c940’."
+            },
+            errorMessage: issuerError,
             id: "issuer",
             name: "issuer",
             classes: "govuk-input--width-20",
             type: "text",
-            attributes: {
-              "data-validate": "required"
-            },
-            value: currentGatewayAccount.worldpay_3ds_flex.issuer
+            value: issuer
           })
         }}
       {% endif %}
@@ -83,14 +129,17 @@
       {% if change === 'password' %}
         {{ govukInput({
             label: {
-              text: "JWT MAC key"
+              text: "JWT MAC key (API key)"
             },
+            hint: {
+              text: "Provided to you by Worldpay. For example, ‘fa2daee2-1fbb-45ff-4444-52805d5cd9e0’."
+            },
+            errorMessage: jwtMacKeyError,
             id: "jwt-mac-key",
             name: "jwt-mac-key",
             classes: "govuk-input--width-20",
             type: "password",
             attributes: {
-              "data-validate": "required",
               "autofocus": "autofocus"
             }
           })
@@ -98,15 +147,16 @@
         {% else %}
         {{ govukInput({
             label: {
-              text: "JWT MAC key"
+              text: "JWT MAC key (API key)"
             },
+            hint: {
+              text: "Provided to you by Worldpay. For example, ‘fa2daee2-1fbb-45ff-4444-52805d5cd9e0’."
+            },
+            errorMessage: jwtMacKeyError,
             id: "jwt-mac-key",
             name: "jwt-mac-key",
             classes: "govuk-input--width-20",
-            type: "password",
-            attributes: {
-              "data-validate": "required"
-            }
+            type: "password"
           })
         }}
       {% endif %}

--- a/test/cypress/integration/settings/your-psp-spec.js
+++ b/test/cypress/integration/settings/your-psp-spec.js
@@ -15,9 +15,9 @@ describe('Your PSP settings page', () => {
     password: 'email-me'
   }
   const testFlexCredentials = {
-    organisational_unit_id: 'positron-permit-people',
-    issuer: 'jonheslop',
-    jwt_mac_key: 'anti-matter'
+    organisational_unit_id: '5bd9b55e4444761ac0af1c80',
+    issuer: '5bd9e0e4444dce153428c940',
+    jwt_mac_key: 'fa2daee2-1fbb-45ff-4444-52805d5cd9e0'
   }
   const testRemoveFlexCredentials = {
     organisational_unit_id: '',
@@ -205,14 +205,20 @@ describe('Your PSP settings page', () => {
       })
     })
 
-    it('should allow flex credentials to be configured and all values must be set', () => {
+    it('should allow 3DS Flex credentials to be configured (trimming leading and trailing space) and all values must be valid and set', () => {
       cy.get('#flex-credentials-change-link').click()
       cy.get('#removeFlexCredentials').should('not.exist')
-      cy.get('#organisational-unit-id').type(testFlexCredentials.organisational_unit_id)
-      cy.get('#issuer').type(testFlexCredentials.issuer)
+      cy.get('#organisational-unit-id').type('Invalid organisational unit ID')
+      cy.get('#issuer').type('Invalid issuer')
+      cy.get('#jwt-mac-key').type('Invalid JWT MAC key')
       cy.get('#submitFlexCredentials').click()
       cy.get('.govuk-error-summary').should('have.length', 1)
-      cy.get('#jwt-mac-key').type(testFlexCredentials.jwt_mac_key)
+      cy.get('#organisational-unit-id').should('have.value', 'Invalid organisational unit ID')
+      cy.get('#issuer').should('have.value', 'Invalid issuer')
+      cy.get('#jwt-mac-key').should('have.value', '')
+      cy.get('#organisational-unit-id').clear().type(' ' + testFlexCredentials.organisational_unit_id + ' ')
+      cy.get('#issuer').clear().type(' ' + testFlexCredentials.issuer + ' ')
+      cy.get('#jwt-mac-key').type(' ' + testFlexCredentials.jwt_mac_key + ' ')
       cy.get('#submitFlexCredentials').click()
       cy.location().should((location) => {
         expect(location.pathname).to.eq(`/your-psp`)
@@ -241,7 +247,7 @@ describe('Your PSP settings page', () => {
       cy.get('.value-jwt-mac-key').should('contain', '●●●●●●●●')
     })
 
-    it('should allow removing flex credentials', function () {
+    it('should allow removing 3DS Flex credentials', function () {
       cy.get('#flex-credentials-change-link').click()
       cy.get('#removeFlexCredentials').should('be.visible')
       cy.get('#removeFlexCredentials').click()
@@ -359,7 +365,7 @@ describe('Your PSP settings page', () => {
     })
   })
 
-  describe('When using a ePDQ account with existing credentials', () => {
+  describe('When using an ePDQ account with existing credentials', () => {
     beforeEach(() => {
       setupYourPspStubs({
         gateway: 'epdq',

--- a/test/unit/browsered/field-validation-checks-worldpay-3ds-flex.test.js
+++ b/test/unit/browsered/field-validation-checks-worldpay-3ds-flex.test.js
@@ -1,0 +1,72 @@
+'use strict'
+
+// NPM dependencies
+const { expect } = require('chai')
+
+// Local dependencies
+const { isNotWorldpay3dsFlexOrgUnitId, isNotWorldpay3dsFlexIssuer, isNotWorldpay3dsFlexJwtMacKey } =
+    require('../../../app/browsered/field-validation-checks')
+
+const invalidOrgUnitId = 'Enter your organisational unit ID in the format you received it'
+const invalidIssuer = 'Enter your issuer in the format you received it'
+const invalidJwtMacKey = 'Enter your JWT MAC key in the format you received it'
+
+describe('Worldpay 3DS Flex credentials validations', () => {
+  describe('Organisational unit ID validations', () => {
+    it('should be valid when 24 lower-case hexadecimal characters', () => {
+      expect(isNotWorldpay3dsFlexOrgUnitId('1234567890abcdef12345678')).to.be.false // eslint-disable-line
+    })
+
+    it('should not be valid any letter is upper-case', () => {
+      expect(isNotWorldpay3dsFlexOrgUnitId('1234567890abcDef12345678')).to.be.equal(invalidOrgUnitId)
+    })
+
+    it('should not be valid when fewer than 24 characters', () => {
+      expect(isNotWorldpay3dsFlexOrgUnitId('1234567890abcdef1234567')).to.be.equal(invalidOrgUnitId)
+    })
+
+    it('should not be valid when more than 24 characters', () => {
+      expect(isNotWorldpay3dsFlexOrgUnitId('1234567890abcdef123456789')).to.be.equal(invalidOrgUnitId)
+    })
+  })
+
+  describe('Issuer validations', () => {
+    it('should be valid when 24 lower-case hexadecimal characters', () => {
+      expect(isNotWorldpay3dsFlexIssuer('1234567890abcdef12345678')).to.be.false // eslint-disable-line
+    })
+
+    it('should not be valid when letters are upper-case', () => {
+      expect(isNotWorldpay3dsFlexIssuer('1234567890ABCDEF12345678')).to.be.equal(invalidIssuer)
+    })
+
+    it('should not be valid when fewer than 24 characters', () => {
+      expect(isNotWorldpay3dsFlexIssuer('1234567890abcdef1234567')).to.be.equal(invalidIssuer)
+    })
+
+    it('should not be valid when more than 24 characters', () => {
+      expect(isNotWorldpay3dsFlexIssuer('1234567890abcdef123456789')).to.be.equal(invalidIssuer)
+    })
+  })
+
+  describe('JWT MAC key validations', () => {
+    it('should be valid when UUID in canonical 8-4-4-4-12 representation', () => {
+      expect(isNotWorldpay3dsFlexJwtMacKey('abcdef12-3456-7890-abcd-ef1234567890')).to.be.false // eslint-disable-line
+    })
+
+    it('should not be valid when any letter is upper-case', () => {
+      expect(isNotWorldpay3dsFlexJwtMacKey('abcdef12-3456-7890-abCd-ef1234567890')).to.be.equal(invalidJwtMacKey)
+    })
+
+    it('should not be valid when fewer than 36 characters', () => {
+      expect(isNotWorldpay3dsFlexJwtMacKey('abcdef12-3456-7890-abcd-ef123456789')).to.be.equal(invalidJwtMacKey)
+    })
+
+    it('should not be valid when more than 36 characters', () => {
+      expect(isNotWorldpay3dsFlexJwtMacKey('abcdef12-3456-7890-abcd-ef1234567890a')).to.be.equal(invalidJwtMacKey)
+    })
+
+    it('should not be valid when dashes in wrong places', () => {
+      expect(isNotWorldpay3dsFlexJwtMacKey('abcdef-123456-7890-abcd-ef1234567890')).to.be.equal(invalidJwtMacKey)
+    })
+  })
+})


### PR DESCRIPTION
Trim leading and trailing whitespace from entered Worldpay 3DS Flex credentials and validate them according to the following rules:

- Organisational unit ID: 24 lower-case hexadecimal characters e.g. “1234567890abcdef12345678”
- Issuer: 24 lower-case hexadecimal characters e.g. “1234567890abcdef12345678”
- JWT MAC key: a UUID ID in its lowercase canonical textual representation e.g. “abcdef12-3456-7890-abCd-ef1234567890”.

Trimming is because users will almost certainly be copying and pasting these values, so may unintentionally copy leading ortrailing whitespace.

If validation fails, display a standard error summary with error messages saying “Enter your organisational unit ID in the format you received it” or similar, and represent the form with the trimmed organisational unit ID and issuer (but not the JWT MAC key because we treat that like a password) entered by the user prefilled.

Remove the existing client-side validation that checks that a value is entered for each field to avoid mixing client-side and server-side validation (the new server-side validation ensures that no fields are left blank).

Add hint text to each form field saying it’s “Provided to you by Worldpay” with an example of valid input (taken from Worldpay’s test values).

Add parenthical “API ID” and “API key” notes to the issuer and JWT MAC key labels to more closely match how Worldpay describe them. Don’t bother adding Worldpay’s “org unit ID” abbreviation to the organisational unit ID because it’s obvious.

Consistently use regular sentence case when displaying terms like “organisational unit ID” in the admin tool, even though Worldpay use title case, to match our style.

![GOV UK Pay admin tool Worldpay 3DS Flex validation errors](https://user-images.githubusercontent.com/24316348/84763468-25273a00-afc4-11ea-846b-22a841a9eee6.png)
