### PR TITLE
PP-6638 Redirect to account details redirect route

### DIFF
--- a/app/controllers/stripe-setup/bank-details/post.controller.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.js
@@ -52,7 +52,11 @@ module.exports = (req, res) => {
         return connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'bank_account', req.correlationId)
       })
       .then(() => {
-        return res.redirect(303, paths.dashboard.index)
+        if (process.env.ENABLE_ACCOUNT_STATUS_PANEL === 'true') {
+          return res.redirect(303, paths.stripe.addPspAccountDetails)
+        } else {
+          return res.redirect(303, paths.dashboard.index)
+        }
       })
       .catch(error => {
         // check if it is Stripe related error

--- a/app/controllers/stripe-setup/bank-details/post.controller.test.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.test.js
@@ -47,63 +47,59 @@ describe('Bank details post controller', () => {
         }
       }
     }
+
+    process.env.ENABLE_ACCOUNT_STATUS_PANEL = true
   })
 
-  it('should call stripe and connector and redirect to the dashboard', done => {
-    updateBankAccountMock = sinon.spy((stripeAccountId, body) => {
-      return new Promise(resolve => {
-        resolve()
-      })
-    })
-    setStripeAccountSetupFlagMock = sinon.spy((gatewayAccountId, stripeAccountSetupFlag, correlationId) => {
-      return new Promise(resolve => {
-        resolve()
-      })
-    })
+  it('should call stripe and connector and redirect to the dashboard when feature flag is disabled', async () => {
+    process.env.ENABLE_ACCOUNT_STATUS_PANEL = false
+    updateBankAccountMock = sinon.spy(() => Promise.resolve())
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
     const controller = getControllerWithMocks()
 
-    controller(req, res)
+    await controller(req, res)
 
-    setTimeout(() => {
-      expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
-        bank_account_sort_code: sanitisedSortCode,
-        bank_account_number: sanitisedAccountNumber
-      })).to.be.true
-      expect(setStripeAccountSetupFlagMock.calledWith(req.account.gateway_account_id, 'bank_account', req.correlationId)).to.be.true // eslint-disable-line
-      expect(res.redirect.calledWith(303, paths.dashboard.index)).to.be.true // eslint-disable-line
-      done()
-    }, 250)
+    expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+      bank_account_sort_code: sanitisedSortCode,
+      bank_account_number: sanitisedAccountNumber
+    })).to.be.true
+    expect(setStripeAccountSetupFlagMock.calledWith(req.account.gateway_account_id, 'bank_account', req.correlationId)).to.be.true // eslint-disable-line
+    expect(res.redirect.calledWith(303, paths.dashboard.index)).to.be.true // eslint-disable-line
   })
 
-  it('should render error page when Stripe returns unknown error', done => {
-    updateBankAccountMock = sinon.spy((stripeAccountId, body) => {
-      return new Promise((resolve, reject) => {
-        reject(new Error())
-      })
-    })
-    setStripeAccountSetupFlagMock = sinon.spy((gatewayAccountId, stripeAccountSetupFlag, correlationId) => {
-      return new Promise(resolve => {
-        resolve()
-      })
-    })
+  it('should call stripe and connector and redirect to add psp account details redirect route', async () => {
+    updateBankAccountMock = sinon.spy(() => Promise.resolve())
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
     const controller = getControllerWithMocks()
 
-    controller(req, res)
+    await controller(req, res)
 
-    setTimeout(() => {
-      expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
-        bank_account_sort_code: sanitisedSortCode,
-        bank_account_number: sanitisedAccountNumber
-      })).to.be.true
-      expect(setStripeAccountSetupFlagMock.notCalled).to.be.true // eslint-disable-line
-      expect(res.redirect.notCalled).to.be.true // eslint-disable-line
-      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
-      expect(res.render.calledWith('error', { message: 'Please try again or contact support team' })).to.be.true // eslint-disable-line
-      done()
-    }, 250)
+    expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+      bank_account_sort_code: sanitisedSortCode,
+      bank_account_number: sanitisedAccountNumber
+    })).to.be.true
+    expect(setStripeAccountSetupFlagMock.calledWith(req.account.gateway_account_id, 'bank_account', req.correlationId)).to.be.true // eslint-disable-line
+    expect(res.redirect.calledWith(303, paths.stripe.addPspAccountDetails)).to.be.true // eslint-disable-line
   })
 
-  it('should re-render the form page when Stripe returns "routing_number_invalid" error', done => {
+  it('should render error page when Stripe returns unknown error', async () => {
+    updateBankAccountMock = sinon.spy(() => Promise.reject(new Error()))
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
+    const controller = getControllerWithMocks()
+
+    await controller(req, res)
+
+    expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+      bank_account_sort_code: sanitisedSortCode,
+      bank_account_number: sanitisedAccountNumber
+    })).to.be.true
+    expect(setStripeAccountSetupFlagMock.notCalled).to.be.true // eslint-disable-line
+    expect(res.redirect.notCalled).to.be.true // eslint-disable-line
+    expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+    expect(res.render.calledWith('error', { message: 'Please try again or contact support team' })).to.be.true // eslint-disable-line
+  })
+
+  it('should re-render the form page when Stripe returns "routing_number_invalid" error', async () => {
     updateBankAccountMock = sinon.spy((stripeAccountId, body) => {
       return new Promise((resolve, reject) => {
         const error = new Error()
@@ -111,28 +107,21 @@ describe('Bank details post controller', () => {
         reject(error)
       })
     })
-    setStripeAccountSetupFlagMock = sinon.spy((gatewayAccountId, stripeAccountSetupFlag, correlationId) => {
-      return new Promise(resolve => {
-        resolve()
-      })
-    })
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
     const controller = getControllerWithMocks()
 
-    controller(req, res)
+    await controller(req, res)
 
-    setTimeout(() => {
-      expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
-        bank_account_sort_code: sanitisedSortCode,
-        bank_account_number: sanitisedAccountNumber
-      })).to.be.true
-      expect(setStripeAccountSetupFlagMock.notCalled).to.be.true // eslint-disable-line
-      expect(res.redirect.notCalled).to.be.true // eslint-disable-line
-      expect(res.render.called).to.be.true // eslint-disable-line
-      done()
-    }, 250)
+    expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+      bank_account_sort_code: sanitisedSortCode,
+      bank_account_number: sanitisedAccountNumber
+    })).to.be.true
+    expect(setStripeAccountSetupFlagMock.notCalled).to.be.true // eslint-disable-line
+    expect(res.redirect.notCalled).to.be.true // eslint-disable-line
+    expect(res.render.called).to.be.true // eslint-disable-line
   })
 
-  it('should re-render the form page when Stripe returns "account_number_invalid" error', done => {
+  it('should re-render the form page when Stripe returns "account_number_invalid" error', async () => {
     updateBankAccountMock = sinon.spy((stripeAccountId, body) => {
       return new Promise((resolve, reject) => {
         const error = new Error()
@@ -140,53 +129,35 @@ describe('Bank details post controller', () => {
         reject(error)
       })
     })
-    setStripeAccountSetupFlagMock = sinon.spy((gatewayAccountId, stripeAccountSetupFlag, correlationId) => {
-      return new Promise(resolve => {
-        resolve()
-      })
-    })
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
     const controller = getControllerWithMocks()
 
-    controller(req, res)
+    await controller(req, res)
 
-    setTimeout(() => {
-      expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
-        bank_account_sort_code: sanitisedSortCode,
-        bank_account_number: sanitisedAccountNumber
-      })).to.be.true
-      expect(setStripeAccountSetupFlagMock.notCalled).to.be.true // eslint-disable-line
-      expect(res.redirect.notCalled).to.be.true // eslint-disable-line
-      expect(res.render.called).to.be.true // eslint-disable-line
-      done()
-    }, 250)
+    expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+      bank_account_sort_code: sanitisedSortCode,
+      bank_account_number: sanitisedAccountNumber
+    })).to.be.true
+    expect(setStripeAccountSetupFlagMock.notCalled).to.be.true // eslint-disable-line
+    expect(res.redirect.notCalled).to.be.true // eslint-disable-line
+    expect(res.render.called).to.be.true // eslint-disable-line
   })
 
-  it('should render error page when connector returns error', done => {
-    updateBankAccountMock = sinon.spy((stripeAccountId, body) => {
-      return new Promise(resolve => {
-        resolve()
-      })
-    })
-    setStripeAccountSetupFlagMock = sinon.spy((gatewayAccountId, stripeAccountSetupFlag, correlationId) => {
-      return new Promise((resolve, reject) => {
-        reject(new Error())
-      })
-    })
+  it('should render error page when connector returns error', async () => {
+    updateBankAccountMock = sinon.spy(() => Promise.resolve())
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.reject(new Error()))
     const controller = getControllerWithMocks()
 
-    controller(req, res)
+    await controller(req, res)
 
-    setTimeout(() => {
-      expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
-        bank_account_sort_code: sanitisedSortCode,
-        bank_account_number: sanitisedAccountNumber
-      })).to.be.true
-      expect(setStripeAccountSetupFlagMock.calledWith(req.account.gateway_account_id, 'bank_account', req.correlationId)).to.be.true // eslint-disable-line
-      expect(res.redirect.notCalled).to.be.true // eslint-disable-line
-      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
-      expect(res.render.calledWith('error', { message: 'Please try again or contact support team' })).to.be.true // eslint-disable-line
-      done()
-    }, 250)
+    expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+      bank_account_sort_code: sanitisedSortCode,
+      bank_account_number: sanitisedAccountNumber
+    })).to.be.true
+    expect(setStripeAccountSetupFlagMock.calledWith(req.account.gateway_account_id, 'bank_account', req.correlationId)).to.be.true // eslint-disable-line
+    expect(res.redirect.notCalled).to.be.true // eslint-disable-line
+    expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+    expect(res.render.calledWith('error', { message: 'Please try again or contact support team' })).to.be.true // eslint-disable-line
   })
 
   function getControllerWithMocks () {

--- a/app/controllers/stripe-setup/bank-details/post.controller.test.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.test.js
@@ -1,17 +1,8 @@
 'use strict'
 
-// NPM dependencies
-const chai = require('chai')
-const chaiAsPromised = require('chai-as-promised')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
-
-// Local dependencies
 const paths = require('../../../paths')
-
-// Global setup
-chai.use(chaiAsPromised)
-const { expect } = chai // must be called after chai.use(chaiAsPromised) to use "should.eventually"
 
 describe('Bank details post controller', () => {
   const rawAccountNumber = '00012345'
@@ -59,12 +50,12 @@ describe('Bank details post controller', () => {
 
     await controller(req, res)
 
-    expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+    sinon.assert.calledWith(updateBankAccountMock, res.locals.stripeAccount.stripeAccountId, {
       bank_account_sort_code: sanitisedSortCode,
       bank_account_number: sanitisedAccountNumber
-    })).to.be.true
-    expect(setStripeAccountSetupFlagMock.calledWith(req.account.gateway_account_id, 'bank_account', req.correlationId)).to.be.true // eslint-disable-line
-    expect(res.redirect.calledWith(303, paths.dashboard.index)).to.be.true // eslint-disable-line
+    })
+    sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'bank_account', req.correlationId)
+    sinon.assert.calledWith(res.redirect, 303, paths.dashboard.index)
   })
 
   it('should call stripe and connector and redirect to add psp account details redirect route', async () => {
@@ -74,12 +65,12 @@ describe('Bank details post controller', () => {
 
     await controller(req, res)
 
-    expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+    sinon.assert.calledWith(updateBankAccountMock, res.locals.stripeAccount.stripeAccountId, {
       bank_account_sort_code: sanitisedSortCode,
       bank_account_number: sanitisedAccountNumber
-    })).to.be.true
-    expect(setStripeAccountSetupFlagMock.calledWith(req.account.gateway_account_id, 'bank_account', req.correlationId)).to.be.true // eslint-disable-line
-    expect(res.redirect.calledWith(303, paths.stripe.addPspAccountDetails)).to.be.true // eslint-disable-line
+    })
+    sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'bank_account', req.correlationId)
+    sinon.assert.calledWith(res.redirect, 303, paths.stripe.addPspAccountDetails)
   })
 
   it('should render error page when Stripe returns unknown error', async () => {
@@ -89,14 +80,14 @@ describe('Bank details post controller', () => {
 
     await controller(req, res)
 
-    expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+    sinon.assert.calledWith(updateBankAccountMock, res.locals.stripeAccount.stripeAccountId, {
       bank_account_sort_code: sanitisedSortCode,
       bank_account_number: sanitisedAccountNumber
-    })).to.be.true
-    expect(setStripeAccountSetupFlagMock.notCalled).to.be.true // eslint-disable-line
-    expect(res.redirect.notCalled).to.be.true // eslint-disable-line
-    expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
-    expect(res.render.calledWith('error', { message: 'Please try again or contact support team' })).to.be.true // eslint-disable-line
+    })
+    sinon.assert.notCalled(setStripeAccountSetupFlagMock)
+    sinon.assert.notCalled(res.redirect)
+    sinon.assert.calledWith(res.status, 500)
+    sinon.assert.calledWith(res.render, 'error', { message: 'Please try again or contact support team' })
   })
 
   it('should re-render the form page when Stripe returns "routing_number_invalid" error', async () => {
@@ -112,13 +103,13 @@ describe('Bank details post controller', () => {
 
     await controller(req, res)
 
-    expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+    sinon.assert.calledWith(updateBankAccountMock, res.locals.stripeAccount.stripeAccountId, {
       bank_account_sort_code: sanitisedSortCode,
       bank_account_number: sanitisedAccountNumber
-    })).to.be.true
-    expect(setStripeAccountSetupFlagMock.notCalled).to.be.true // eslint-disable-line
-    expect(res.redirect.notCalled).to.be.true // eslint-disable-line
-    expect(res.render.called).to.be.true // eslint-disable-line
+    })
+    sinon.assert.notCalled(setStripeAccountSetupFlagMock)
+    sinon.assert.notCalled(res.redirect)
+    sinon.assert.called(res.render)
   })
 
   it('should re-render the form page when Stripe returns "account_number_invalid" error', async () => {
@@ -134,13 +125,13 @@ describe('Bank details post controller', () => {
 
     await controller(req, res)
 
-    expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+    sinon.assert.calledWith(updateBankAccountMock, res.locals.stripeAccount.stripeAccountId, {
       bank_account_sort_code: sanitisedSortCode,
       bank_account_number: sanitisedAccountNumber
-    })).to.be.true
-    expect(setStripeAccountSetupFlagMock.notCalled).to.be.true // eslint-disable-line
-    expect(res.redirect.notCalled).to.be.true // eslint-disable-line
-    expect(res.render.called).to.be.true // eslint-disable-line
+    })
+    sinon.assert.notCalled(setStripeAccountSetupFlagMock)
+    sinon.assert.notCalled(res.redirect)
+    sinon.assert.called(res.render)
   })
 
   it('should render error page when connector returns error', async () => {
@@ -150,14 +141,14 @@ describe('Bank details post controller', () => {
 
     await controller(req, res)
 
-    expect(updateBankAccountMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+    sinon.assert.calledWith(updateBankAccountMock, res.locals.stripeAccount.stripeAccountId, {
       bank_account_sort_code: sanitisedSortCode,
       bank_account_number: sanitisedAccountNumber
-    })).to.be.true
-    expect(setStripeAccountSetupFlagMock.calledWith(req.account.gateway_account_id, 'bank_account', req.correlationId)).to.be.true // eslint-disable-line
-    expect(res.redirect.notCalled).to.be.true // eslint-disable-line
-    expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
-    expect(res.render.calledWith('error', { message: 'Please try again or contact support team' })).to.be.true // eslint-disable-line
+    })
+    sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'bank_account', req.correlationId)
+    sinon.assert.notCalled(res.redirect)
+    sinon.assert.calledWith(res.status, 500)
+    sinon.assert.calledWith(res.render, 'error', { message: 'Please try again or contact support team' })
   })
 
   function getControllerWithMocks () {

--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -112,7 +112,12 @@ module.exports = async function (req, res) {
       const person = personsResponse.data.pop()
       await updatePerson(stripeAccountId, person.id, buildStripePerson(formFields))
       await connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'responsible_person', req.correlationId)
-      await res.redirect(303, paths.dashboard.index)
+
+      if (process.env.ENABLE_ACCOUNT_STATUS_PANEL === 'true') {
+        return res.redirect(303, paths.stripe.addPspAccountDetails)
+      } else {
+        return res.redirect(303, paths.dashboard.index)
+      }
     } catch (error) {
       logger.error(`[requestId=${req.correlationId}] Error creating responsible person with Stripe - ${error.message}`)
       return renderErrorView(req, res, 'Please try again or contact support team')

--- a/app/controllers/stripe-setup/vat-number-company-number/check-your-answers/post.controller.test.js
+++ b/app/controllers/stripe-setup/vat-number-company-number/check-your-answers/post.controller.test.js
@@ -1,17 +1,8 @@
 'use strict'
 
-// NPM dependencies
-const chai = require('chai')
-const chaiAsPromised = require('chai-as-promised')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
-
-// Local dependencies
 const paths = require('../../../../paths')
-
-// Global setup
-chai.use(chaiAsPromised)
-const { expect } = chai // must be called after chai.use(chaiAsPromised) to use "should.eventually"
 
 describe('"VAT number / company number - check your answers" post controller', () => {
   const rawVatNumber = 'GB999 9999 73'
@@ -70,12 +61,12 @@ describe('"VAT number / company number - check your answers" post controller', (
 
     await controller(req, res)
 
-    expect(updateCompanyMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+    sinon.assert.calledWith(updateCompanyMock, res.locals.stripeAccount.stripeAccountId, {
       vat_id: sanitisedVatNumber,
       tax_id: sanitisedCompanyNumber
-    })).to.be.true
-    expect(setStripeAccountSetupFlagMock.calledWith(req.account.gateway_account_id, 'vat_number_company_number', req.correlationId)).to.be.true // eslint-disable-line
-    expect(res.redirect.calledWith(303, paths.dashboard.index)).to.be.true // eslint-disable-line
+    })
+    sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'vat_number_company_number', req.correlationId)
+    sinon.assert.calledWith(res.redirect, 303, paths.dashboard.index)
   })
 
   it('should call stripe and connector with all data and redirect to the add account details redirect route', async () => {
@@ -85,12 +76,12 @@ describe('"VAT number / company number - check your answers" post controller', (
 
     await controller(req, res)
 
-    expect(updateCompanyMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+    sinon.assert.calledWith(updateCompanyMock, res.locals.stripeAccount.stripeAccountId, {
       vat_id: sanitisedVatNumber,
       tax_id: sanitisedCompanyNumber
-    })).to.be.true
-    expect(setStripeAccountSetupFlagMock.calledWith(req.account.gateway_account_id, 'vat_number_company_number', req.correlationId)).to.be.true // eslint-disable-line
-    expect(res.redirect.calledWith(303, paths.stripe.addPspAccountDetails)).to.be.true // eslint-disable-line
+    })
+    sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'vat_number_company_number', req.correlationId)
+    sinon.assert.calledWith(res.redirect, 303, paths.stripe.addPspAccountDetails)
   })
 
   it('should call stripe and connector with VAT number only and redirect to the add account details redirect route', async () => {
@@ -105,11 +96,11 @@ describe('"VAT number / company number - check your answers" post controller', (
 
     await controller(req, res)
 
-    expect(updateCompanyMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+    sinon.assert.calledWith(updateCompanyMock, res.locals.stripeAccount.stripeAccountId, {
       vat_id: sanitisedVatNumber
-    })).to.be.true
-    expect(setStripeAccountSetupFlagMock.calledWith(req.account.gateway_account_id, 'vat_number_company_number', req.correlationId)).to.be.true // eslint-disable-line
-    expect(res.redirect.calledWith(303, paths.stripe.addPspAccountDetails)).to.be.true // eslint-disable-line
+    })
+    sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'vat_number_company_number', req.correlationId)
+    sinon.assert.calledWith(res.redirect, 303, paths.stripe.addPspAccountDetails)
   })
 
   it('should render error page when Stripe returns an error', async () => {
@@ -119,14 +110,14 @@ describe('"VAT number / company number - check your answers" post controller', (
 
     await controller(req, res)
 
-    expect(updateCompanyMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+    sinon.assert.calledWith(updateCompanyMock, res.locals.stripeAccount.stripeAccountId, {
       vat_id: sanitisedVatNumber,
       tax_id: sanitisedCompanyNumber
-    })).to.be.true
-    expect(setStripeAccountSetupFlagMock.notCalled).to.be.true // eslint-disable-line
-    expect(res.redirect.notCalled).to.be.true // eslint-disable-line
-    expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
-    expect(res.render.calledWith('error', { message: 'Please try again or contact support team' })).to.be.true // eslint-disable-line
+    })
+    sinon.assert.notCalled(setStripeAccountSetupFlagMock)
+    sinon.assert.notCalled(res.redirect)
+    sinon.assert.calledWith(res.status, 500)
+    sinon.assert.calledWith(res.render, 'error', { message: 'Please try again or contact support team' })
   })
 
   it('should render error page when connector returns error', async () => {
@@ -136,14 +127,14 @@ describe('"VAT number / company number - check your answers" post controller', (
 
     await controller(req, res)
 
-    expect(updateCompanyMock.calledWith(res.locals.stripeAccount.stripeAccountId, { // eslint-disable-line
+    sinon.assert.calledWith(updateCompanyMock, res.locals.stripeAccount.stripeAccountId, {
       vat_id: sanitisedVatNumber,
       tax_id: sanitisedCompanyNumber
-    })).to.be.true
-    expect(setStripeAccountSetupFlagMock.calledWith(req.account.gateway_account_id, 'vat_number_company_number', req.correlationId)).to.be.true // eslint-disable-line
-    expect(res.redirect.notCalled).to.be.true // eslint-disable-line
-    expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
-    expect(res.render.calledWith('error', { message: 'Please try again or contact support team' })).to.be.true // eslint-disable-line
+    })
+    sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'vat_number_company_number', req.correlationId)
+    sinon.assert.notCalled(res.redirect)
+    sinon.assert.calledWith(res.status, 500)
+    sinon.assert.calledWith(res.render, 'error', { message: 'Please try again or contact support team' })
   })
 
   function getControllerWithMocks () {


### PR DESCRIPTION
If the `ENABLE_ACCOUNT_STATUS_PANEL` environment variable is set to true, redirect to the new `/stripe/add-psp-account-details` route when details are saved on each page . This route determines the next page in the add account details flow to show the user.

If the feature flag is not enabled, redirect to the dashboard as was done previously.

Refactor edited tests to use async/await and reduce the number of lines of test code a bit.
