### PR TITLE
PP-6635 Redirect to live account dashboard route

### DIFF
--- a/app/controllers/stripe-setup/stripe-setup-link/index.js
+++ b/app/controllers/stripe-setup/stripe-setup-link/index.js
@@ -1,5 +1,5 @@
 'use strict'
 
 module.exports = {
-  get: require('./get.controller')
+  get: require('./stripe_setup_dashboard_redirect_controller')
 }

--- a/app/controllers/stripe-setup/stripe-setup-link/index.js
+++ b/app/controllers/stripe-setup/stripe-setup-link/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = {
+  get: require('./get.controller')
+}

--- a/app/controllers/stripe-setup/stripe-setup-link/stripe_setup_dashboard_redirect_controller.js
+++ b/app/controllers/stripe-setup/stripe-setup-link/stripe_setup_dashboard_redirect_controller.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const paths = require('../../../../app/paths')
+const { ConnectorClient } = require('../../../services/clients/connector_client')
+const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
+const logger = require('../../../utils/logger')(__filename)
+const { keys } = require('@govuk-pay/pay-js-commons').logging
+
+function getTargetServiceForRedirect (user, externalServiceId) {
+  return user.serviceRoles.filter((service) => service.externalId === externalServiceId)[0]
+}
+
+module.exports = async (req, res) => {
+  const externalServiceId = req.params.externalServiceId
+
+  const targetServiceForRedirect = getTargetServiceForRedirect(req.user, externalServiceId)
+
+  if (targetServiceForRedirect) {
+    const result = await connectorClient.getAccounts(targetServiceForRedirect.gatewayAccountIds)
+    const liveGatewayAccounts = result.accounts.filter((gatewayAccount) => gatewayAccount.type === 'live')
+    if (liveGatewayAccounts && liveGatewayAccounts.length === 1) {
+      req.gateway_account.currentGatewayAccountId = liveGatewayAccounts[0].id
+    }
+  } else {
+    const logContext = {}
+    logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
+    logContext[keys.SERVICE_EXTERNAL_ID] = externalServiceId
+    logger.warn('User has no access to this service for dashboard redirect', logContext)
+  }
+  res.redirect(302, paths.dashboard.index)
+}

--- a/app/controllers/stripe-setup/stripe-setup-link/stripe_setup_dashboard_redirect_controller.js
+++ b/app/controllers/stripe-setup/stripe-setup-link/stripe_setup_dashboard_redirect_controller.js
@@ -14,7 +14,9 @@ module.exports = async (req, res) => {
   const externalServiceId = req.params.externalServiceId
   const targetServiceRoleForRedirect = getTargetServiceForRedirect(req.user, externalServiceId)
   if (targetServiceRoleForRedirect) {
-    const result = await connectorClient.getAccounts(targetServiceRoleForRedirect.service.gatewayAccountIds)
+    const result = await connectorClient.getAccounts({
+      gatewayAccountIds: targetServiceRoleForRedirect.service.gatewayAccountIds
+    })
     const liveGatewayAccounts = result.accounts.filter((gatewayAccount) => gatewayAccount.type === 'live')
     if (liveGatewayAccounts && liveGatewayAccounts.length === 1) {
       req.gateway_account.currentGatewayAccountId = liveGatewayAccounts[0].gateway_account_id

--- a/app/controllers/stripe-setup/stripe-setup-link/stripe_setup_dashboard_redirect_controller.js
+++ b/app/controllers/stripe-setup/stripe-setup-link/stripe_setup_dashboard_redirect_controller.js
@@ -7,19 +7,17 @@ const logger = require('../../../utils/logger')(__filename)
 const { keys } = require('@govuk-pay/pay-js-commons').logging
 
 function getTargetServiceForRedirect (user, externalServiceId) {
-  return user.serviceRoles.filter((service) => service.externalId === externalServiceId)[0]
+  return user.serviceRoles.filter((serviceRole) => serviceRole.service.externalId === externalServiceId)[0]
 }
 
 module.exports = async (req, res) => {
   const externalServiceId = req.params.externalServiceId
-
-  const targetServiceForRedirect = getTargetServiceForRedirect(req.user, externalServiceId)
-
-  if (targetServiceForRedirect) {
-    const result = await connectorClient.getAccounts(targetServiceForRedirect.gatewayAccountIds)
+  const targetServiceRoleForRedirect = getTargetServiceForRedirect(req.user, externalServiceId)
+  if (targetServiceRoleForRedirect) {
+    const result = await connectorClient.getAccounts(targetServiceRoleForRedirect.service.gatewayAccountIds)
     const liveGatewayAccounts = result.accounts.filter((gatewayAccount) => gatewayAccount.type === 'live')
     if (liveGatewayAccounts && liveGatewayAccounts.length === 1) {
-      req.gateway_account.currentGatewayAccountId = liveGatewayAccounts[0].id
+      req.gateway_account.currentGatewayAccountId = liveGatewayAccounts[0].gateway_account_id
     }
   } else {
     const logContext = {}

--- a/app/paths.js
+++ b/app/paths.js
@@ -184,7 +184,8 @@ module.exports = {
     vatNumberCompanyNumber: '/vat-number-company-number',
     vatNumber: '/vat-number-company-number/vat-number',
     companyNumber: '/vat-number-company-number/company-number',
-    checkYourAnswers: '/vat-number-company-number/check-your-answers'
+    checkYourAnswers: '/vat-number-company-number/check-your-answers',
+    stripeSetupLink: '/service/:externalServiceId/dashboard/live'
   },
   settings: {
     index: '/settings'

--- a/app/routes.js
+++ b/app/routes.js
@@ -85,7 +85,7 @@ const goCardlessOAuthGet = require('./controllers/partnerapp/handle_gocardless_c
 const yourPspController = require('./controllers/your-psp')
 const allTransactionsController = require('./controllers/all-service-transactions/index')
 const payoutsController = require('./controllers/payouts/payout_list_controller')
-const stripeSetupinkController = require('./controllers/stripe-setup/stripe-setup-link/stripe_setup_link')
+const stripeSetupDashboardRedirectController = require('./controllers/stripe-setup/stripe-setup-link')
 
 // Assignments
 const {
@@ -511,7 +511,7 @@ module.exports.bind = function (app) {
     checkVatNumberCompanyNumberNotSubmitted,
     stripeSetupCheckYourAnswersController.post
   )
-  app.get(stripeSetup.stripeSetupLink, stripeSetupinkController.get)
+  app.get(stripeSetup.stripeSetupLink, stripeSetupDashboardRedirectController.get)
 
   app.get(user.phoneNumber,
     xraySegmentCls,

--- a/app/routes.js
+++ b/app/routes.js
@@ -85,6 +85,7 @@ const goCardlessOAuthGet = require('./controllers/partnerapp/handle_gocardless_c
 const yourPspController = require('./controllers/your-psp')
 const allTransactionsController = require('./controllers/all-service-transactions/index')
 const payoutsController = require('./controllers/payouts/payout_list_controller')
+const stripeSetupinkController = require('./controllers/stripe-setup/stripe-setup-link/stripe_setup_link')
 
 // Assignments
 const {
@@ -510,6 +511,7 @@ module.exports.bind = function (app) {
     checkVatNumberCompanyNumberNotSubmitted,
     stripeSetupCheckYourAnswersController.post
   )
+  app.get(stripeSetup.stripeSetupLink, stripeSetupinkController.get)
 
   app.get(user.phoneNumber,
     xraySegmentCls,

--- a/test/integration/stripe_setup_dashboard_redirect_controller_it_test.js
+++ b/test/integration/stripe_setup_dashboard_redirect_controller_it_test.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const request = require('supertest')
+const nock = require('nock')
+
+require('../test_helpers/serialize_mock.js')
+const userCreator = require('../test_helpers/user_creator.js')
+const getApp = require('../../server.js').getApp
+const session = require('../test_helpers/mock_session.js')
+
+const connectorMock = nock(process.env.CONNECTOR_URL)
+
+const { validGatewayAccountsResponse } = require('../fixtures/gateway_account_fixtures')
+
+const user = session.getUser()
+const app = session.getAppWithLoggedInUser(getApp(), session.getUser())
+
+describe('Service dashboard redirect to live account controller', function () {
+  afterEach(() => nock.cleanAll())
+
+  beforeEach(function () {
+    userCreator.mockUserResponse(user.toJson())
+
+    const accountsResponse = validGatewayAccountsResponse({
+      accounts: [{
+        payment_provider: 'stripe'
+      }]
+    })
+    connectorMock.get('/v1/frontend/accounts')
+      .reply(200, accountsResponse.getPlain())
+  })
+
+  it('correctly redirects to the dashboard page', () => {
+    const externalServiceId = 'some-external-service-id'
+    return request(app).get(`/service/${externalServiceId}/dashboard/live`)
+      .set('Accept', 'application/json')
+      .expect(302)
+  })
+})

--- a/test/integration/stripe_setup_dashboard_redirect_controller_it_test.js
+++ b/test/integration/stripe_setup_dashboard_redirect_controller_it_test.js
@@ -23,17 +23,17 @@ describe('Service dashboard redirect to live account controller', function () {
 
     const accountsResponse = validGatewayAccountsResponse({
       accounts: [{
-        payment_provider: 'stripe'
+        payment_provider: 'stripe',
+        type: 'live'
       }]
     })
-    connectorMock.get('/v1/frontend/accounts')
+    connectorMock.get('/v1/frontend/accounts?accountIds=540')
       .reply(200, accountsResponse.getPlain())
   })
 
   it('correctly redirects to the dashboard page', () => {
-    const externalServiceId = 'some-external-service-id'
+    const externalServiceId = '193'
     return request(app).get(`/service/${externalServiceId}/dashboard/live`)
-      .set('Accept', 'application/json')
       .expect(302)
   })
 })

--- a/test/unit/controller/stripe-setup/stripe_setup_dashboard_redirect_controller_test.js
+++ b/test/unit/controller/stripe-setup/stripe_setup_dashboard_redirect_controller_test.js
@@ -1,0 +1,151 @@
+const sinon = require('sinon')
+const { expect } = require('chai')
+const proxyquire = require('proxyquire')
+
+const { ConnectorClient } = require('../../../../app/services/clients/connector_client')
+
+const dashboardRedirectController = require('../../../../app/controllers/stripe-setup/stripe-setup-link/stripe_setup_dashboard_redirect_controller')
+
+const { validUser } = require('../../../fixtures/user_fixtures')
+const { validGatewayAccountsResponse } = require('../../../fixtures/gateway_account_fixtures')
+
+describe('Dashboard redirect controller', () => {
+  const externalServiceId = 'service-external-id'
+  const serviceGatewayAccountIds = ['2', '5']
+  let accountSpy, res, req
+
+  beforeEach(() => {
+    req = {}
+    req.correlationId = 'correlationId'
+    req.params = {
+      externalServiceId
+    }
+    req.gateway_account = {
+      currentGatewayAccountId: '1'
+    }
+    req.user = validUser({
+      username: 'bob',
+      service_roles: [
+        {
+          service: {
+            name: 'My Service 1',
+            external_id: externalServiceId,
+            gateway_account_ids: serviceGatewayAccountIds
+          },
+          role: {
+            name: 'admin',
+            permissions: [{ name: 'blah-blah:blah' }]
+          }
+        }]
+    }).getAsObject()
+
+    res = {
+      redirect: sinon.spy()
+    }
+  })
+  afterEach(() => accountSpy.restore())
+
+  it('should assign a new current gateway account the user has access to the service and there is only one live account', async () => {
+    const gatewayAccountResponse = validGatewayAccountsResponse({
+      accounts: [
+        {
+          gateway_account_id: '2'
+        },
+        {
+          gateway_account_id: '5',
+          payment_provider: 'stripe',
+          type: 'live'
+        }
+      ]
+    }).getPlain()
+    proxyquire('../../../../app/controllers/stripe-setup/stripe-setup-link/stripe_setup_dashboard_redirect_controller', {
+      '../../../services/clients/connector_client': {
+        ConnectorClient: class {
+          async getAccounts () {
+            return gatewayAccountResponse
+          }
+        }
+      } })
+
+    accountSpy = sinon.stub(ConnectorClient.prototype, 'getAccounts').callsFake(async () => {
+      return gatewayAccountResponse
+    })
+    await dashboardRedirectController(req, res)
+    expect(req.gateway_account.currentGatewayAccountId).to.be.equal('5')
+    sinon.assert.calledWith(accountSpy, ['2', '5'])
+    sinon.assert.calledWith(res.redirect, 302, '/')
+  })
+
+  it('should not request gateway accounts if the user has no access to the service', async () => {
+    req.user.serviceRoles[0].service.externalId = 'another-service-id'
+    accountSpy = sinon.stub(ConnectorClient.prototype, 'getAccounts')
+
+    await dashboardRedirectController(req, res)
+    expect(req.gateway_account.currentGatewayAccountId).to.be.equal('1')
+    sinon.assert.neverCalledWith(accountSpy, ['6', '10'])
+    sinon.assert.calledWith(res.redirect, 302, '/')
+  })
+
+  it('should not set the session gateway account if the service has no live accounts', async () => {
+    const gatewayAccountResponse = validGatewayAccountsResponse({
+      accounts: [
+        {
+          gateway_account_id: '2'
+        },
+        {
+          gateway_account_id: '5',
+          payment_provider: 'stripe'
+        }
+      ]
+    }).getPlain()
+    proxyquire('../../../../app/controllers/stripe-setup/stripe-setup-link/stripe_setup_dashboard_redirect_controller', {
+      '../../../services/clients/connector_client': {
+        ConnectorClient: class {
+          async getAccounts () {
+            return { gatewayAccountResponse }
+          }
+        }
+      } })
+
+    accountSpy = sinon.stub(ConnectorClient.prototype, 'getAccounts').callsFake(async () => {
+      return gatewayAccountResponse
+    })
+    await dashboardRedirectController(req, res)
+    expect(req.gateway_account.currentGatewayAccountId).to.be.equal('1')
+    sinon.assert.calledWith(accountSpy, ['2', '5'])
+    sinon.assert.calledWith(res.redirect, 302, '/')
+  })
+
+  it('should not set the session gateway account if the service has multiple live accounts', async () => {
+    const gatewayAccountResponse = validGatewayAccountsResponse({
+      accounts: [
+        {
+          gateway_account_id: '2',
+          payment_provider: 'stripe',
+          type: 'live'
+        },
+        {
+          gateway_account_id: '5',
+          payment_provider: 'stripe',
+          type: 'live'
+        }
+      ]
+    }).getPlain()
+    proxyquire('../../../../app/controllers/stripe-setup/stripe-setup-link/stripe_setup_dashboard_redirect_controller', {
+      '../../../services/clients/connector_client': {
+        ConnectorClient: class {
+          async getAccounts () {
+            return gatewayAccountResponse
+          }
+        }
+      } })
+
+    accountSpy = sinon.stub(ConnectorClient.prototype, 'getAccounts').callsFake(async () => {
+      return gatewayAccountResponse
+    })
+    await dashboardRedirectController(req, res)
+    expect(req.gateway_account.currentGatewayAccountId).to.be.equal('1')
+    sinon.assert.calledWith(accountSpy, ['2', '5'])
+    sinon.assert.calledWith(res.redirect, 302, '/')
+  })
+})

--- a/test/unit/controller/stripe-setup/stripe_setup_dashboard_redirect_controller_test.js
+++ b/test/unit/controller/stripe-setup/stripe_setup_dashboard_redirect_controller_test.js
@@ -1,43 +1,33 @@
 const sinon = require('sinon')
 const { expect } = require('chai')
-const proxyquire = require('proxyquire')
 
 const { ConnectorClient } = require('../../../../app/services/clients/connector_client')
-
-const dashboardRedirectController = require('../../../../app/controllers/stripe-setup/stripe-setup-link/stripe_setup_dashboard_redirect_controller')
-
 const { validUser } = require('../../../fixtures/user_fixtures')
 const { validGatewayAccountsResponse } = require('../../../fixtures/gateway_account_fixtures')
+const dashboardRedirectController = require('../../../../app/controllers/stripe-setup/stripe-setup-link/stripe_setup_dashboard_redirect_controller')
 
 describe('Dashboard redirect controller', () => {
   const externalServiceId = 'service-external-id'
-  const serviceGatewayAccountIds = ['2', '5']
+  const serviceGatewayAccountIds = [ '2', '5' ]
   let accountSpy, res, req
 
   beforeEach(() => {
-    req = {}
-    req.correlationId = 'correlationId'
-    req.params = {
-      externalServiceId
-    }
-    req.gateway_account = {
-      currentGatewayAccountId: '1'
-    }
-    req.user = validUser({
-      username: 'bob',
-      service_roles: [
-        {
-          service: {
-            name: 'My Service 1',
-            external_id: externalServiceId,
-            gateway_account_ids: serviceGatewayAccountIds
-          },
-          role: {
-            name: 'admin',
-            permissions: [{ name: 'blah-blah:blah' }]
-          }
-        }]
+    const user = validUser({
+      username: 'valid-user',
+      service_roles: [{
+        service: {
+          external_id: externalServiceId,
+          gateway_account_ids: serviceGatewayAccountIds
+        }
+      }]
     }).getAsObject()
+
+    req = {
+      correlationId: 'correlationId',
+      params: { externalServiceId },
+      gateway_account: { currentGatewayAccountId: '1' },
+      user: user
+    }
 
     res = {
       redirect: sinon.spy()
@@ -47,32 +37,19 @@ describe('Dashboard redirect controller', () => {
 
   it('should assign a new current gateway account the user has access to the service and there is only one live account', async () => {
     const gatewayAccountResponse = validGatewayAccountsResponse({
-      accounts: [
-        {
-          gateway_account_id: '2'
-        },
-        {
-          gateway_account_id: '5',
-          payment_provider: 'stripe',
-          type: 'live'
-        }
-      ]
+      accounts: [{
+        gateway_account_id: '2'
+      }, {
+        gateway_account_id: '5',
+        payment_provider: 'stripe',
+        type: 'live'
+      }]
     }).getPlain()
-    proxyquire('../../../../app/controllers/stripe-setup/stripe-setup-link/stripe_setup_dashboard_redirect_controller', {
-      '../../../services/clients/connector_client': {
-        ConnectorClient: class {
-          async getAccounts () {
-            return gatewayAccountResponse
-          }
-        }
-      } })
+    accountSpy = sinon.stub(ConnectorClient.prototype, 'getAccounts').callsFake(() => gatewayAccountResponse)
 
-    accountSpy = sinon.stub(ConnectorClient.prototype, 'getAccounts').callsFake(async () => {
-      return gatewayAccountResponse
-    })
     await dashboardRedirectController(req, res)
     expect(req.gateway_account.currentGatewayAccountId).to.be.equal('5')
-    sinon.assert.calledWith(accountSpy, ['2', '5'])
+    sinon.assert.calledWith(accountSpy, { gatewayAccountIds: ['2', '5'] })
     sinon.assert.calledWith(res.redirect, 302, '/')
   })
 
@@ -82,70 +59,39 @@ describe('Dashboard redirect controller', () => {
 
     await dashboardRedirectController(req, res)
     expect(req.gateway_account.currentGatewayAccountId).to.be.equal('1')
-    sinon.assert.neverCalledWith(accountSpy, ['6', '10'])
+    sinon.assert.neverCalledWith(accountSpy, { gatewayAccountIds: ['6', '10'] })
     sinon.assert.calledWith(res.redirect, 302, '/')
   })
 
   it('should not set the session gateway account if the service has no live accounts', async () => {
     const gatewayAccountResponse = validGatewayAccountsResponse({
-      accounts: [
-        {
-          gateway_account_id: '2'
-        },
-        {
-          gateway_account_id: '5',
-          payment_provider: 'stripe'
-        }
-      ]
+      accounts: [{
+        gateway_account_id: '2'
+      }]
     }).getPlain()
-    proxyquire('../../../../app/controllers/stripe-setup/stripe-setup-link/stripe_setup_dashboard_redirect_controller', {
-      '../../../services/clients/connector_client': {
-        ConnectorClient: class {
-          async getAccounts () {
-            return { gatewayAccountResponse }
-          }
-        }
-      } })
+    accountSpy = sinon.stub(ConnectorClient.prototype, 'getAccounts').callsFake(() => gatewayAccountResponse)
 
-    accountSpy = sinon.stub(ConnectorClient.prototype, 'getAccounts').callsFake(async () => {
-      return gatewayAccountResponse
-    })
     await dashboardRedirectController(req, res)
     expect(req.gateway_account.currentGatewayAccountId).to.be.equal('1')
-    sinon.assert.calledWith(accountSpy, ['2', '5'])
+    sinon.assert.calledWith(accountSpy, { gatewayAccountIds: ['2', '5'] })
     sinon.assert.calledWith(res.redirect, 302, '/')
   })
 
   it('should not set the session gateway account if the service has multiple live accounts', async () => {
     const gatewayAccountResponse = validGatewayAccountsResponse({
-      accounts: [
-        {
-          gateway_account_id: '2',
-          payment_provider: 'stripe',
-          type: 'live'
-        },
-        {
-          gateway_account_id: '5',
-          payment_provider: 'stripe',
-          type: 'live'
-        }
-      ]
+      accounts: [{
+        gateway_account_id: '2',
+        type: 'live'
+      }, {
+        gateway_account_id: '5',
+        type: 'live'
+      }]
     }).getPlain()
-    proxyquire('../../../../app/controllers/stripe-setup/stripe-setup-link/stripe_setup_dashboard_redirect_controller', {
-      '../../../services/clients/connector_client': {
-        ConnectorClient: class {
-          async getAccounts () {
-            return gatewayAccountResponse
-          }
-        }
-      } })
+    accountSpy = sinon.stub(ConnectorClient.prototype, 'getAccounts').callsFake(() => gatewayAccountResponse)
 
-    accountSpy = sinon.stub(ConnectorClient.prototype, 'getAccounts').callsFake(async () => {
-      return gatewayAccountResponse
-    })
     await dashboardRedirectController(req, res)
     expect(req.gateway_account.currentGatewayAccountId).to.be.equal('1')
-    sinon.assert.calledWith(accountSpy, ['2', '5'])
+    sinon.assert.calledWith(accountSpy, { gatewayAccountIds: ['2', '5'] })
     sinon.assert.calledWith(res.redirect, 302, '/')
   })
 })


### PR DESCRIPTION
e9d3ecf96d694719efd42f6fc08edcf15168ca5f
> - add new controller that sets the live gateway account id to that of
  the  given service then redirects to the dashboard
> - if the user has no access to the given service the it redirects to
  the dashboard without setting the gateway account
