### PR TITLE
PP-6634 Add back in text on responsible person page

### DIFF
--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -251,5 +251,11 @@
 
       {{ govukButton({ text: "Continue" }) }}
     </form>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    <h1 class="govuk-heading-m">What will happen to this information</h1>
+    <p class="govuk-body">We’ll send this information to our payment service provider, Stripe. Stripe will use these
+      details to confirm the responsible person’s identity.</p>
+    <p class="govuk-body">Their details will be processed and stored by Stripe. GOV.UK Pay will not store these
+      details.</p>
   </div>
 {% endblock %}


### PR DESCRIPTION
Was removed by 154a11b9730102d28d01377d61ddc096e1a3fcd0 but we want to add it back in until we have some updated content that has words to the same effect.

