### PR TITLE
PP-6672 Add live account requested banner

### DIFF
--- a/app/views/dashboard/_live_account_requested_banner.njk
+++ b/app/views/dashboard/_live_account_requested_banner.njk
@@ -1,0 +1,12 @@
+{% if permissions.go_live_stage_read and goLiveRequested %}
+  <div class="govuk-grid-column-full govuk-!-margin-bottom-3">
+    <div class="account-status-panel">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-heading-m">GOV.UK Pay are reviewing your request to go live</h2>
+          <p class="govuk-body-m">GOV.UK Pay will review your request within 1 working day. Once approved, we will email you with instructions to add more details.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/app/views/dashboard/index.njk
+++ b/app/views/dashboard/index.njk
@@ -18,6 +18,7 @@ Dashboard - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK
       </div>
     {% endif %}
   {% else %}
+    {% include "./_live_account_requested_banner.njk" %}
     {% include "./_stripe_account_setup_banner.njk" %}
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l first-steps__title">Dashboard</h1>

--- a/test/unit/controller/dashboard/dashboard-activity-controller.test.js
+++ b/test/unit/controller/dashboard/dashboard-activity-controller.test.js
@@ -387,6 +387,55 @@ describe('dashboard-activity-controller', () => {
       })
     })
   })
+  describe('When the dashboard is retrieved for a service that has requested to go live', () => {
+    let session
+
+    before('Arrange', () => {
+      session = getMockSession(getUser({
+        gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+        current_go_live_stage: 'TERMS_AGREED_STRIPE',
+        permissions: [{ name: 'transactions:read' }, { name: 'go-live-stage:read' }]
+      }))
+
+      mockLedgerGetTransactionsSummary()
+      mockConnectorGetGatewayAccount('sandbox', 'test')
+      app = createAppWithSession(getApp(), session)
+    })
+
+    it('it should display the live account requested panel', async () => {
+      let $ = await getDashboard()
+      expect($('.account-status-panel').length).to.equal(1)
+      expect($('.account-status-panel h2').text()).to.equal('GOV.UK Pay are reviewing your request to go live')
+    })
+
+    afterEach(() => {
+      nock.cleanAll()
+    })
+  })
+  describe('When the dashboard is retrieved for a service that has requested to go live and the user is not an admin', () => {
+    let session
+
+    before('Arrange', () => {
+      session = getMockSession(getUser({
+        gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+        current_go_live_stage: 'TERMS_AGREED_STRIPE',
+        permissions: [{ name: 'transactions:read' }]
+      }))
+
+      mockLedgerGetTransactionsSummary()
+      mockConnectorGetGatewayAccount('sandbox', 'test')
+      app = createAppWithSession(getApp(), session)
+    })
+
+    it('it should not display the live account requested panel', async () => {
+      let $ = await getDashboard()
+      expect($('.account-status-panel').length).to.equal(0)
+    })
+
+    afterEach(() => {
+      nock.cleanAll()
+    })
+  })
   describe('When the dashboard is retrieved for Stripe account', () => {
     let session
 


### PR DESCRIPTION
If the user has requested a live account, and a live account has not
yet been created, display a banner on the dashboard.

Only show the banner if the user has the permission 'go-live-stage:read'
which indicates they are an admin with permission to make a request to
go live.

<img width="1239" alt="Screenshot 2020-06-23 at 17 22 26" src="https://user-images.githubusercontent.com/5648592/85429103-2503dd00-b576-11ea-8315-119f5f7ebdd5.png">
