### PR TITLE
PP-6709 Only show all service transactions link for live service users

### DIFF
--- a/app/controllers/my-services/get-index-controller.js
+++ b/app/controllers/my-services/get-index-controller.js
@@ -7,6 +7,7 @@ const _ = require('lodash')
 const { response } = require('../../utils/response')
 const serviceService = require('../../services/service_service')
 const getHeldPermissions = require('../../utils/get_held_permissions')
+const { getLiveGatewayAccountIds } = require('../../utils/permissions')
 
 const hasAccountWithPayouts = function hasLiveStripeAccount (gatewayAccounts) {
   return gatewayAccounts.some(gatewayAccount =>
@@ -54,7 +55,8 @@ module.exports = async (req, res) => {
     services: servicesData,
     services_singular: servicesData.length === 1,
     env: process.env,
-    has_account_with_payouts: hasAccountWithPayouts(aggregatedGatewayAccounts)
+    has_account_with_payouts: hasAccountWithPayouts(aggregatedGatewayAccounts),
+    has_live_account: getLiveGatewayAccountIds(aggregatedGatewayAccounts).length
   }
   if (newServiceId) {
     servicesData.filter(serviceData => {

--- a/app/utils/permissions.js
+++ b/app/utils/permissions.js
@@ -53,5 +53,6 @@ const getLiveGatewayAccountIds = function getLiveGatewayAccountIds (gatewayAccou
 
 module.exports = {
   userServicesContainsGatewayAccount,
-  getLiveGatewayAccountsFor
+  getLiveGatewayAccountsFor,
+  getLiveGatewayAccountIds
 }

--- a/app/views/services/index.njk
+++ b/app/views/services/index.njk
@@ -27,7 +27,7 @@
         Add a new service
       </a>
     </p>
-    {% if env.PROTOTYPE_MULTIACCOUNT_REPORTING === "true" %}
+    {% if has_live_account %}
     <p class="govuk-body">
       <a href="{{routes.allServiceTransactions.index}}" class="govuk-link govuk-!-margin-right-3 govuk-link--no-visited-state">
         View transactions for all live services

--- a/test/cypress/integration/my-services/my_services_links_spec.js
+++ b/test/cypress/integration/my-services/my_services_links_spec.js
@@ -52,3 +52,33 @@ describe('Service does not have a live account that supports payouts', () => {
     cy.contains('a', 'View payments to your bank account').should('not.exist')
   })
 })
+
+describe('User has access to no live services', () => {
+  it('should not display link to all service transactions', () => {
+    cy.task('setupStubs', [
+      getUserStubWithServiceName(authenticatedUserId, [1]),
+      getGatewayAccountsStub(1, 'test', 'sandbox')
+    ])
+
+    cy.setEncryptedCookies(authenticatedUserId, 1)
+    cy.visit('/my-services')
+    cy.title().should('eq', 'Choose service - GOV.UK Pay')
+
+    cy.contains('a', 'View transactions for all live services').should('not.exist')
+  })
+})
+
+describe('User has access to one or more live services', () => {
+  it('should display link to all service transactions', () => {
+    cy.task('setupStubs', [
+      getUserStubWithServiceName(authenticatedUserId, [1]),
+      getGatewayAccountsStub(1, 'live', 'worldpay')
+    ])
+
+    cy.setEncryptedCookies(authenticatedUserId, 1)
+    cy.visit('/my-services')
+    cy.title().should('eq', 'Choose service - GOV.UK Pay')
+
+    cy.contains('a', 'View transactions for all live services')
+  })
+})


### PR DESCRIPTION
* remove feature flag that has been enabled in all environments.
* only show all service transactions link if a user has access to live
services that they would have permissions to see.