### PR TITLE
PP-6717 Allow editing organisation number for all services

### DIFF
--- a/app/controllers/edit_merchant_details/post-edit-controller.js
+++ b/app/controllers/edit_merchant_details/post-edit-controller.js
@@ -30,6 +30,10 @@ const validationRules = [
     maxLength: 255
   },
   {
+    field: clientFieldNames.telephoneNumber,
+    validator: validatePhoneNumber
+  },
+  {
     field: clientFieldNames.addressLine1,
     validator: validateMandatoryField,
     maxLength: 255
@@ -52,10 +56,6 @@ const validationRules = [
 ]
 
 const directDebitAccountValidationRules = [
-  {
-    field: clientFieldNames.telephoneNumber,
-    validator: validatePhoneNumber
-  },
   {
     field: clientFieldNames.email,
     validator: validateEmail
@@ -108,6 +108,7 @@ const submitForm = async function (form, serviceExternalId, correlationId, hasDi
 
   const serviceUpdateRequest = new ServiceUpdateRequest()
     .replace(validPaths.merchantDetails.name, form[clientFieldNames.name])
+    .replace(validPaths.merchantDetails.telephoneNumber, form[clientFieldNames.telephoneNumber])
     .replace(validPaths.merchantDetails.addressLine1, form[clientFieldNames.addressLine1])
     .replace(validPaths.merchantDetails.addressLine2, form[clientFieldNames.addressLine2])
     .replace(validPaths.merchantDetails.addressCity, form[clientFieldNames.addressCity])
@@ -116,7 +117,6 @@ const submitForm = async function (form, serviceExternalId, correlationId, hasDi
 
   if (hasDirectDebitGatewayAccount) {
     serviceUpdateRequest
-      .replace(validPaths.merchantDetails.telephoneNumber, form[clientFieldNames.telephoneNumber])
       .replace(validPaths.merchantDetails.email, form[clientFieldNames.email])
   }
 

--- a/app/views/merchant_details/edit_merchant_details.njk
+++ b/app/views/merchant_details/edit_merchant_details.njk
@@ -90,28 +90,28 @@
       })
     }}
 
+    {% set phoneError = false %}
+    {% if errors["telephone-number"] %}
+      {% set phoneError = {
+        text: errors["telephone-number"]
+      } %}
+    {% endif %}
+
+    {{
+      govukInput({
+      value: merchant_details.telephone_number,
+        label: {
+          text: "Phone number"
+        },
+        errorMessage: phoneError,
+        id: "telephone-number",
+        name: "telephone-number",
+        classes: "govuk-!-width-two-thirds",
+        type: "tel"
+      })
+    }}
+
     {% if has_direct_debit_gateway_account or has_card_and_dd_gateway_account %}
-
-      {% set phoneError = false %}
-      {% if errors["telephone-number"] %}
-        {% set phoneError = {
-          text: errors["telephone-number"]
-        } %}
-      {% endif %}
-
-      {{
-        govukInput({
-        value: merchant_details.telephone_number,
-          label: {
-            text: "Phone number"
-          },
-          errorMessage: phoneError,
-          id: "telephone-number",
-          name: "telephone-number",
-          classes: "govuk-!-width-two-thirds",
-          type: "tel"
-        })
-      }}
 
       {% set emailError = false %}
       {% if errors["merchant-email"] %}

--- a/test/cypress/integration/settings/merchant_details_spec.js
+++ b/test/cypress/integration/settings/merchant_details_spec.js
@@ -34,6 +34,7 @@ describe('Dashboard', () => {
 
       // Attempt to add an invalid postcode with all other details being legitimate
       cy.get('#merchant-name').type('Tom & Jerry')
+      cy.get('#telephone-number').type('0113 496 0000')
       cy.get('#address-line1').type('Clive House')
       cy.get('#address-line2').type('10 Downing Street')
       cy.get('#address-city').type('London')

--- a/test/unit/controller/edit_merchant_details_controller/post-edit.test.js
+++ b/test/unit/controller/edit_merchant_details_controller/post-edit.test.js
@@ -76,6 +76,7 @@ describe('edit merchant details controller - post', () => {
         service: buildServiceModel(serviceExternalId),
         body: {
           'merchant-name': validName,
+          'telephone-number': validTelephoneNumber,
           'address-line1': validLine1,
           'address-line2': validLine2,
           'address-city': validCity,
@@ -97,6 +98,11 @@ describe('edit merchant details controller - post', () => {
           'op': 'replace',
           'path': 'merchant_details/name',
           'value': validName
+        },
+        {
+          'op': 'replace',
+          'path': 'merchant_details/telephone_number',
+          'value': validTelephoneNumber
         },
         {
           'op': 'replace',
@@ -176,6 +182,11 @@ describe('edit merchant details controller - post', () => {
         },
         {
           'op': 'replace',
+          'path': 'merchant_details/telephone_number',
+          'value': validTelephoneNumber
+        },
+        {
+          'op': 'replace',
           'path': 'merchant_details/address_line1',
           'value': validLine1
         },
@@ -198,11 +209,6 @@ describe('edit merchant details controller - post', () => {
           'op': 'replace',
           'path': 'merchant_details/address_country',
           'value': countryGB
-        },
-        {
-          'op': 'replace',
-          'path': 'merchant_details/telephone_number',
-          'value': validTelephoneNumber
         },
         {
           'op': 'replace',
@@ -257,6 +263,7 @@ describe('edit merchant details controller - post', () => {
       expect(req.session.pageData.editMerchantDetails.success).to.be.false // eslint-disable-line
       expect(req.session.pageData.editMerchantDetails.errors).to.deep.equal({
         'merchant-name': 'This field cannot be blank',
+        'telephone-number': 'This field cannot be blank',
         'address-line1': 'This field cannot be blank',
         'address-city': 'This field cannot be blank',
         'address-postcode': 'This field cannot be blank',
@@ -351,13 +358,12 @@ describe('edit merchant details controller - post', () => {
       })
     })
   })
-  describe('when the update merchant details call has invalid telephone number', () => {
+  describe('when the update merchant details call has invalid telephone number for a direct debit account', () => {
     let mockServiceService
     let req
     let res
     before(async function () {
       const service = buildServiceModel(serviceExternalId)
-      service.hasDirectDebitGatewayAccount = true
 
       res = setupMocks()
       req = {


### PR DESCRIPTION
Previously, it was only possible to edit if the service had a direct debit account.

However, we collect the phone number as part of the go live process as we send it to Stripe.

Make this editable on the organisation details page. Also make it mandatory. As we require it for accounts that are going live anyway, it seems acceptable to always require it.



