### PR TITLE
BAU select node version compatible with PaaS buildpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": "^12.18.2"
+    "node": "^12.16.3"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
PaaS node buildpack version 1.7.18 supports 12.16.3 as the current
highest version of node 12.X. This change should only effect the version
of Node that is selected when deploying to PaaS.

## WHAT
```
-----> Nodejs Buildpack version 1.7.18
          **WARNING** buildpack version changed from 1.7.13 to 1.7.18
   -----> Installing binaries
          engines.node (package.json): ^12.18.1
          engines.npm (package.json): unspecified (use default)
          **WARNING** Node version in .nvmrc ignored in favor of 'engines' field in package.json
          **ERROR** Unable to install node: no match found for ^12.18.1 in [10.19.0 10.20.1 12.16.2 12.16.3 13.12.0 13.14.0]
```

