### PR TITLE
PP-6688 Middleware for vat_number and company_number checks

### DIFF
--- a/app/middleware/stripe-setup/check-company-number-not-submitted.js
+++ b/app/middleware/stripe-setup/check-company-number-not-submitted.js
@@ -1,0 +1,25 @@
+'use strict'
+
+// Local dependencies
+const { ConnectorClient } = require('../../services/clients/connector_client')
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+const { renderErrorView } = require('../../utils/response')
+const paths = require('../../paths')
+
+module.exports = function checkCompanyNumberNotSubmitted (req, res, next) {
+  if (!req.account) {
+    renderErrorView(req, res, 'Internal server error')
+    return
+  }
+
+  connector.getStripeAccountSetup(req.account.gateway_account_id, req.correlationId).then(stripeSetupResponse => {
+    if (stripeSetupResponse.companyNumber) {
+      req.flash('genericError', 'You’ve already provided your company registration number.<br />Contact GOV.UK Pay support if you need to update it.')
+      res.redirect(303, paths.dashboard.index)
+    } else {
+      next()
+    }
+  }).catch(() => {
+    renderErrorView(req, res, 'Please try again or contact support team')
+  })
+}

--- a/app/middleware/stripe-setup/check-company-number-not-submitted.test.js
+++ b/app/middleware/stripe-setup/check-company-number-not-submitted.test.js
@@ -1,0 +1,126 @@
+'use strict'
+
+// NPM dependencies
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+// Local dependencies
+const paths = require('../../paths')
+
+// Global setup
+chai.use(chaiAsPromised)
+const { expect } = chai // must be called after chai.use(chaiAsPromised) to use "should.eventually"
+
+describe('Check "Company registration number" not submitted middleware', () => {
+  let req
+  let res
+  let next
+
+  beforeEach(() => {
+    req = {
+      correlationId: 'correlation-id',
+      account: {
+        gateway_account_id: '1'
+      },
+      flash: sinon.spy()
+    }
+    res = {
+      setHeader: sinon.stub(),
+      status: sinon.spy(),
+      render: sinon.spy(),
+      redirect: sinon.spy()
+    }
+    next = sinon.spy()
+  })
+
+  it('should call next when "Company number" flag is false', done => {
+    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
+      companyNumber: false
+    })
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.calledOnce).to.be.true // eslint-disable-line
+      expect(req.flash.notCalled).to.be.true // eslint-disable-line
+      expect(res.redirect.notCalled).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should redirect to the dashboard with error message when "Company number" flag is true', done => {
+    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
+      companyNumber: true
+    })
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.notCalled).to.be.true // eslint-disable-line
+      expect(req.flash.calledWith('genericError', 'You’ve already provided your company registration number.<br />Contact GOV.UK Pay support if you need to update it.')).to.be.true // eslint-disable-line
+      expect(res.redirect.calledWith(303, paths.dashboard.index)).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should render an error page when req.account is undefined', done => {
+    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
+      companyNumber: false
+    })
+    req.account = undefined
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.notCalled).to.be.true // eslint-disable-line
+      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+      expect(res.render.calledWith('error', { message: 'Internal server error' })).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should render an error page when connector rejects the call', done => {
+    const middleware = getMiddlewareWithConnectorClientRejectedPromiseMock({
+      companyNumber: false
+    })
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.notCalled).to.be.true // eslint-disable-line
+      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+      expect(res.render.calledWith('error', { message: 'Please try again or contact support team' })).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+})
+
+function getMiddlewareWithConnectorClientResolvedPromiseMock (getStripeAccountSetupResponse) {
+  return proxyquire('./check-company-number-not-submitted', {
+    '../../services/clients/connector_client': {
+      ConnectorClient: function () {
+        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => {
+          return new Promise(resolve => {
+            resolve(getStripeAccountSetupResponse)
+          })
+        }
+      }
+    }
+  })
+}
+
+function getMiddlewareWithConnectorClientRejectedPromiseMock (getStripeAccountSetupResponse) {
+  return proxyquire('./check-company-number-not-submitted', {
+    '../../services/clients/connector_client': {
+      ConnectorClient: function () {
+        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => {
+          return new Promise((resolve, reject) => {
+            reject(new Error())
+          })
+        }
+      }
+    }
+  })
+}

--- a/app/middleware/stripe-setup/check-vat-number-not-submitted.js
+++ b/app/middleware/stripe-setup/check-vat-number-not-submitted.js
@@ -1,0 +1,25 @@
+'use strict'
+
+// Local dependencies
+const { ConnectorClient } = require('../../services/clients/connector_client')
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+const { renderErrorView } = require('../../utils/response')
+const paths = require('../../paths')
+
+module.exports = function checkVatNumberNotSubmitted (req, res, next) {
+  if (!req.account) {
+    renderErrorView(req, res, 'Internal server error')
+    return
+  }
+
+  connector.getStripeAccountSetup(req.account.gateway_account_id, req.correlationId).then(stripeSetupResponse => {
+    if (stripeSetupResponse.vatNumber) {
+      req.flash('genericError', 'You’ve already provided your VAT number.<br />Contact GOV.UK Pay support if you need to update it.')
+      res.redirect(303, paths.dashboard.index)
+    } else {
+      next()
+    }
+  }).catch(() => {
+    renderErrorView(req, res, 'Please try again or contact support team')
+  })
+}

--- a/app/middleware/stripe-setup/check-vat-number-not-submitted.test.js
+++ b/app/middleware/stripe-setup/check-vat-number-not-submitted.test.js
@@ -1,0 +1,126 @@
+'use strict'
+
+// NPM dependencies
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+// Local dependencies
+const paths = require('../../paths')
+
+// Global setup
+chai.use(chaiAsPromised)
+const { expect } = chai // must be called after chai.use(chaiAsPromised) to use "should.eventually"
+
+describe('Check "VAT number" not submitted middleware', () => {
+  let req
+  let res
+  let next
+
+  beforeEach(() => {
+    req = {
+      correlationId: 'correlation-id',
+      account: {
+        gateway_account_id: '1'
+      },
+      flash: sinon.spy()
+    }
+    res = {
+      setHeader: sinon.stub(),
+      status: sinon.spy(),
+      render: sinon.spy(),
+      redirect: sinon.spy()
+    }
+    next = sinon.spy()
+  })
+
+  it('should call next when "VAT number" flag is false', done => {
+    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
+      vatNumber: false
+    })
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.calledOnce).to.be.true // eslint-disable-line
+      expect(req.flash.notCalled).to.be.true // eslint-disable-line
+      expect(res.redirect.notCalled).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should redirect to the dashboard with error message when "VAT number" flag is true', done => {
+    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
+      vatNumber: true
+    })
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.notCalled).to.be.true // eslint-disable-line
+      expect(req.flash.calledWith('genericError', 'You’ve already provided your VAT number.<br />Contact GOV.UK Pay support if you need to update it.')).to.be.true // eslint-disable-line
+      expect(res.redirect.calledWith(303, paths.dashboard.index)).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should render an error page when req.account is undefined', done => {
+    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
+      vatNumber: false
+    })
+    req.account = undefined
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.notCalled).to.be.true // eslint-disable-line
+      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+      expect(res.render.calledWith('error', { message: 'Internal server error' })).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should render an error page when connector rejects the call', done => {
+    const middleware = getMiddlewareWithConnectorClientRejectedPromiseMock({
+      vatNumber: false
+    })
+
+    middleware(req, res, next)
+
+    setTimeout(() => {
+      expect(next.notCalled).to.be.true // eslint-disable-line
+      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+      expect(res.render.calledWith('error', { message: 'Please try again or contact support team' })).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+})
+
+function getMiddlewareWithConnectorClientResolvedPromiseMock (getStripeAccountSetupResponse) {
+  return proxyquire('./check-vat-number-not-submitted', {
+    '../../services/clients/connector_client': {
+      ConnectorClient: function () {
+        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => {
+          return new Promise(resolve => {
+            resolve(getStripeAccountSetupResponse)
+          })
+        }
+      }
+    }
+  })
+}
+
+function getMiddlewareWithConnectorClientRejectedPromiseMock (getStripeAccountSetupResponse) {
+  return proxyquire('./check-vat-number-not-submitted', {
+    '../../services/clients/connector_client': {
+      ConnectorClient: function () {
+        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => {
+          return new Promise((resolve, reject) => {
+            reject(new Error())
+          })
+        }
+      }
+    }
+  })
+}

--- a/app/services/clients/stripe/stripeCompany.model.js
+++ b/app/services/clients/stripe/stripeCompany.model.js
@@ -4,7 +4,7 @@
 const Joi = require('joi')
 
 const schema = {
-  vat_id: Joi.string().required(),
+  vat_id: Joi.string().optional(),
   tax_id: Joi.string().optional()
 }
 
@@ -27,9 +27,11 @@ class StripeCompany {
 
 function build (params) {
   const stripeCompany = {
-    company: {
-      vat_id: params.vat_id
-    }
+    company: {}
+  }
+
+  if (params.vat_id) {
+    stripeCompany.company.vat_id = params.vat_id
   }
 
   if (params.tax_id) {

--- a/app/services/clients/stripe/stripeCompany.model.test.js
+++ b/app/services/clients/stripe/stripeCompany.model.test.js
@@ -44,14 +44,23 @@ describe('StripeCompany', () => {
     })).to.throw('StripeCompany "tax_id" must be a string')
   })
 
-  it('should fail when vat_id is undefined', () => {
+  it('should not fail when vat_id is undefined', () => {
     const vatId = undefined
     const taxId = '000000000'
 
     expect(() => new StripeCompany({
       vat_id: vatId,
       tax_id: taxId
-    })).to.throw('StripeCompany "vat_id" is required')
+    })).not.to.throw('StripeCompany "vat_id" is required')
+
+    expect(new StripeCompany({
+      vat_id: vatId,
+      tax_id: taxId
+    }).basicObject()).to.deep.equal({
+      company: {
+        tax_id: taxId
+      }
+    })
   })
 
   it('should not fail when tax_id is undefined', () => {


### PR DESCRIPTION
## WHAT
We currently have single task (`vat_number_company_number`) for which  we record both `vat number` and `company registration number`, show respones in check your answers page and submit to Stripe at once.

This task is to be split into `vat_number` and `company_number` tasks as check your answers page will be removed and data is to be submitted to Stripe as soon as relevant form (vat number/ company registrationnumber) is submitted.

- Added new middleware to use for new vat_number and company_number tasks (to be introduced) to show error if task is already completed.

- vatId is now optional on StripeCompany model as this information will not we available for company_number task.
