### PR TITLE
PP-6662 Dashboard > Stripe Onboarding banner > include status

### DIFF
--- a/app/assets/sass/components/account-status-panel.scss
+++ b/app/assets/sass/components/account-status-panel.scss
@@ -6,4 +6,8 @@
   .govuk-grid-column-two-thirds{
     padding: 0;
   }
+
+  &--restricted{
+    border: 5px solid govuk-colour("red"); 
+  } 
 }

--- a/app/middleware/get_gateway_account.js
+++ b/app/middleware/get_gateway_account.js
@@ -35,9 +35,9 @@ module.exports = function (req, res, next) {
         return connectorClient.getStripeAccountSetup(accountId, req.correlationId)
       }
     })
-    .then((accountSetupDetails = null) => {
-      if (accountSetupDetails) {
-        req.account.accountSetupDetails = accountSetupDetails
+    .then((connectorGatewayAccountStripeProgress = null) => {
+      if (connectorGatewayAccountStripeProgress) {
+        req.account.connectorGatewayAccountStripeProgress = connectorGatewayAccountStripeProgress
       }
       next()
     })

--- a/app/services/clients/stripe/stripe_client.js
+++ b/app/services/clients/stripe/stripe_client.js
@@ -44,5 +44,11 @@ module.exports = {
   updatePerson: function (stripeAccountId, stripePersonId, body) {
     const stripePerson = new StripePerson(body)
     return stripe.accounts.updatePerson(stripeAccountId, stripePersonId, stripePerson.basicObject())
+  },
+
+  retrieveAccountDetails: function (stripeAccountId) {
+    return stripe.accounts.retrieve(stripeAccountId, {
+      timeout: 10000
+    })
   }
 }

--- a/app/views/dashboard/_stripe_account_setup_banner.njk
+++ b/app/views/dashboard/_stripe_account_setup_banner.njk
@@ -1,24 +1,48 @@
 {% if permissions.stripe_account_details_update %}
-  {% set stripeAccountSetup = account.accountSetupDetails %}
-  {% if stripeAccountSetup and (not stripeAccountSetup.bankAccount or not stripeAccountSetup.vatNumber or not stripeAccountSetup.companyNumber or not stripeAccountSetup.responsiblePerson) %}
-    <div class="account-status-panel govuk-grid-row govuk-!-margin-bottom-5">
+  {% set connectorGatewayAccountStripeProgress = gatewayAccount.connectorGatewayAccountStripeProgress %}
+
+  {% set isStripeAccountRestricted = stripeAccount.charges_enabled === false %}
+  {% set stripeAccountHasDeadline = stripeAccount.requirements.current_deadline %}
+  {% set isConnectorStripeJourneyComplete = connectorGatewayAccountStripeProgress.bankAccount and connectorGatewayAccountStripeProgress.vatNumber and connectorGatewayAccountStripeProgress.companyNumber and connectorGatewayAccountStripeProgress.responsiblePerson %}
+
+  {% set panelModifierClass %}
+    {% if isStripeAccountRestricted %}
+      account-status-panel--restricted
+    {% endif %}
+  {% endset %}
+
+  {% if connectorGatewayAccountStripeProgress and (not isConnectorStripeJourneyComplete) %}
+    <div class="account-status-panel {{panelModifierClass}} govuk-grid-row govuk-!-margin-bottom-5">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m">You must add more details to receive money into your bank account</h2>
-        <p class="govuk-body-m">
-          Your service can now take payments from users. You must add more details or Stripe will not pay the money into your bank account. Please add:
-        </p>
+        {% if isStripeAccountRestricted %}
+          <h2 class="govuk-heading-m">Stripe have restricted your account</h2>
+
+          <p class="govuk-body-m">To start taking payments again, please add:</p>
+        {% elif stripeAccountHasDeadline %}
+          {% set dateString = stripeAccount.requirements.current_deadline %}
+
+          <h2 class="govuk-heading-m">You must add more details by {{dateString}} to continue taking payments</h2>
+          <p class="govuk-body-m">
+            Your service can now take payments from users. You must add more details by {{dateString}} or Stripe will not pay the money into your bank account. Please add:
+          </p>
+        {% else %}
+          <h2 class="govuk-heading-m">You must add more details to receive money into your bank account</h2>
+          <p class="govuk-body-m">
+            Your service can now take payments from users. You must add more details or Stripe will not pay the money into your bank account. Please add:
+          </p>
+        {% endif %}
 
         <ul class="govuk-list govuk-list--bullet">
-          {% if not stripeAccountSetup.bankAccount %}
+          {% if not connectorGatewayAccountStripeProgress.bankAccount %}
             <li>bank details</li>
           {% endif %}
-          {% if not stripeAccountSetup.responsiblePerson %}
+          {% if not connectorGatewayAccountStripeProgress.responsiblePerson %}
             <li>details about your responsible person</li>
           {% endif %}
-          {% if not stripeAccountSetup.vatNumber %}
+          {% if not connectorGatewayAccountStripeProgress.vatNumber %}
             <li>your organisation’s VAT number</li>
            {% endif %}
-          {% if not stripeAccountSetup.companyNumber %}
+          {% if not connectorGatewayAccountStripeProgress.companyNumber %}
             <li>your company registration number if you’ve registered your company</li>
           {% endif %}
         </ul>
@@ -33,6 +57,16 @@
           }
         })
       }}
+      </div>
+    </div>
+  {% elif  isStripeAccountRestricted %}
+    <div class="account-status-panel account-status-panel--restricted govuk-grid-row govuk-!-margin-bottom-5">
+      <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-heading-m">Stripe have restricted your account</h2>
+          <p class="govuk-body-m">To start taking payments again, please contact support.</p>
+          <p class="govuk-body">
+            <a class="govuk-link" href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk" target="_top">govuk-pay-support@digital.cabinet-office.gov.uk</a>
+          </p>
       </div>
     </div>
   {% endif %}

--- a/app/views/dashboard/index.njk
+++ b/app/views/dashboard/index.njk
@@ -5,8 +5,8 @@ Dashboard - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK
 {% endblock %}
 
 {% block mainContent %}
-  {% if account.paymentMethod === 'direct debit' and account.paymentProvider === 'gocardless' %}
-    {% if account.isConnected === false %}
+  {% if gatewayAccount.paymentMethod === 'direct debit' and gatewayAccount.paymentProvider === 'gocardless' %}
+    {% if gatewayAccount.isConnected === false %}
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l first-steps__title">Connect to GoCardless</h1>
         {% include "./_link-to-gocardless.njk" %}

--- a/app/views/includes/phase_banner.njk
+++ b/app/views/includes/phase_banner.njk
@@ -6,8 +6,8 @@
       {% if currentGatewayAccount %}
         {% set paymentProvider = currentGatewayAccount.payment_provider and currentGatewayAccount.payment_provider.toLowerCase() %}
         {% set isLive = currentGatewayAccount.type === "live" %}
-        {% set stripeAccountIsSetup = (currentGatewayAccount.accountSetupDetails.bankAccount and currentGatewayAccount.accountSetupDetails.responsiblePerson
-           and currentGatewayAccount.accountSetupDetails.vatNumber and currentGatewayAccount.accountSetupDetails.companyNumber) %}
+        {% set stripeAccountIsSetup = (currentGatewayAccount.connectorGatewayAccountStripeProgress.bankAccount and currentGatewayAccount.connectorGatewayAccountStripeProgress.responsiblePerson
+           and currentGatewayAccount.connectorGatewayAccountStripeProgress.vatNumber and currentGatewayAccount.connectorGatewayAccountStripeProgress.companyNumber) %}
 
         {% set tagModifierClass %}
           {% if not isLive %}


### PR DESCRIPTION
- Update `stripe_client.js` - add new method to get Stripe account details directly from Stripe.
  - This method has 1 second timeout and will allow the Dashboad to continue to display even if the call fails.
- Update Dashboard controller
  - Get stripe account id from Connector
  - Use new method in `stripe_client` to get Stripe account details
- Update integration test
- Update Stripe banner nunjucks file
  - Checks for the current_deadline, if that exists then a date is shown in the banner
  - If payouts_enabled = false then a restricted banner is shown.

# Condition 1:
When Stripe returns a `current_deadline` - display that in the banner:
![image](https://user-images.githubusercontent.com/59831992/87177062-f191b400-c2d2-11ea-93f8-23399a1454d4.png)


# Condition 2:
When Stripe returns `payouts_enabled=false` - display a restricted banner:
![image](https://user-images.githubusercontent.com/59831992/87177092-fb1b1c00-c2d2-11ea-9c28-28999ef243c6.png)


# Condition 3:
When Stripe returns `payouts_enabled=false` and all Stripe details have been filled on - display a restricted banner requesting user to contact support:
![image](https://user-images.githubusercontent.com/59831992/87177114-053d1a80-c2d3-11ea-9caa-f9e12e60d644.png)

