### PR TITLE
PP-6688 Remove var_number_company_number reference

### DIFF
--- a/test/cypress/integration/dashboard/dashboard_stripe_add_details.js
+++ b/test/cypress/integration/dashboard/dashboard_stripe_add_details.js
@@ -11,7 +11,7 @@ describe('The Stripe psp details banner', () => {
       commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
       commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
       commonStubs.getDashboardStatisticsStub(),
-      commonStubs.getGatewayAccountStripeSetupSuccess(gatewayAccountId, false, false, false),
+      commonStubs.getGatewayAccountStripeSetupSuccess(gatewayAccountId, false, false, false, false),
       commonStubs.getStripeAccount(gatewayAccountId, 'stripe-account-id')
     ])
   })

--- a/test/cypress/integration/settings/3ds-spec.js
+++ b/test/cypress/integration/settings/3ds-spec.js
@@ -255,7 +255,7 @@ describe('3DS settings page', () => {
             updated: false
           }
         },
-        commonStubs.getGatewayAccountStripeSetupSuccess(gatewayAccountId, true, true, true)
+        commonStubs.getGatewayAccountStripeSetupSuccess(gatewayAccountId, true, true, true, true)
       ])
     })
 

--- a/test/cypress/integration/stripe-setup/vat_number_spec.js
+++ b/test/cypress/integration/stripe-setup/vat_number_spec.js
@@ -20,7 +20,7 @@ describe('Stripe setup: VAT number page', () => {
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
           stubGetGatewayAccountStripeSetupSuccess(gatewayAccountId, { 'vatNumberCompleted': false }),
           stubStripeAccountGet(gatewayAccountId, 'acct_123example123'),
-          commonStubs.getGatewayAccountStripeSetupSuccess(gatewayAccountId, true, true, true)
+          commonStubs.getGatewayAccountStripeSetupSuccess(gatewayAccountId, true, true, true, true)
         ])
 
         cy.setEncryptedCookies(userExternalId, gatewayAccountId, {})
@@ -80,7 +80,7 @@ describe('Stripe setup: VAT number page', () => {
           stubGetGatewayAccountStripeSetupSuccess(gatewayAccountId, { 'vatNumberCompleted': true }),
           stubStripeAccountGet(gatewayAccountId, 'acct_123example123'),
           stubDashboardStatisticsGet(),
-          commonStubs.getGatewayAccountStripeSetupSuccess(gatewayAccountId, true, true, true)
+          commonStubs.getGatewayAccountStripeSetupSuccess(gatewayAccountId, true, true, true, true)
         ])
 
         cy.visit('/vat-number')
@@ -166,7 +166,7 @@ describe('Stripe setup: VAT number page', () => {
         cy.task('setupStubs', [
           commonStubs.getUserWithNoPermissionsStub(userExternalId, [gatewayAccountId]),
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
-          commonStubs.getGatewayAccountStripeSetupSuccess(gatewayAccountId, true, true, true)
+          commonStubs.getGatewayAccountStripeSetupSuccess(gatewayAccountId, true, true, true, true)
         ])
 
         cy.visit('/vat-number', { failOnStatusCode: false })

--- a/test/cypress/integration/transactions/transaction_details_spec.js
+++ b/test/cypress/integration/transactions/transaction_details_spec.js
@@ -118,7 +118,8 @@ describe('Transaction details page', () => {
           gateway_account_id: gatewayAccountId,
           bank_account: true,
           responsible_person: true,
-          vat_number_company_number: true
+          vat_number: true,
+          company_number: true
         }
       }
     ]

--- a/test/cypress/integration/transactions/transaction_search_spec.js
+++ b/test/cypress/integration/transactions/transaction_search_spec.js
@@ -96,7 +96,8 @@ const sharedStubs = (paymentProvider = 'sandbox') => {
         gateway_account_id: gatewayAccountId,
         bank_account: true,
         responsible_person: true,
-        vat_number_company_number: true
+        vat_number: true,
+        company_number: true
       }
     }
   ]

--- a/test/cypress/utils/common_stubs.js
+++ b/test/cypress/utils/common_stubs.js
@@ -90,14 +90,15 @@ module.exports.getDashboardStatisticsStub = () => {
   }
 }
 
-module.exports.getGatewayAccountStripeSetupSuccess = (gatewayAccountId, bankAccount, responsiblePerson, vatNumber) => {
+module.exports.getGatewayAccountStripeSetupSuccess = (gatewayAccountId, bankAccount, responsiblePerson, vatNumber, companyNumber) => {
   const stripeSetupStub = {
     name: 'getGatewayAccountStripeSetupSuccess',
     opts: {
       gateway_account_id: gatewayAccountId,
       bank_account: bankAccount,
       responsible_person: responsiblePerson,
-      vat_number_company_number: vatNumber
+      vat_number: vatNumber,
+      company_number: companyNumber
     }
   }
   return stripeSetupStub


### PR DESCRIPTION
## WHAT
- Removes usage of `vat_number_company_number` reference from stubs as we no longer have this task.
- Replaces with `vat_number` and `company_number`
