### PR TITLE
PP-6771 Use structured arguments when logging outgoing requests

### DIFF
--- a/app/services/clients/base_client/wrapper.js
+++ b/app/services/clients/base_client/wrapper.js
@@ -82,7 +82,7 @@ module.exports = function (method, verb) {
       requestLogger.logRequestError(context, err)
     })
     call.on('response', response => {
-      requestLogger.logRequestEnd(context)
+      requestLogger.logRequestEnd(context, response)
       if (!(response && SUCCESS_CODES.includes(response.statusCode))) {
         requestLogger.logRequestFailure(context, response)
       }

--- a/app/utils/request_logger.js
+++ b/app/utils/request_logger.js
@@ -1,34 +1,53 @@
 const logger = require('./logger')(__filename)
+const { keys } = require('@govuk-pay/pay-js-commons').logging
 
 module.exports = {
   logRequestStart: context => {
-    logger.debug(`Calling ${context.service}  ${context.description}-`, {
+    const logContext = {
       service: context.service,
       method: context.method,
-      url: context.url
-    })
+      url: context.url,
+      description: context.description
+    }
+    logContext[keys.CORRELATION_ID] = context.correlationId
+    logger.info(`Calling ${context.service} to ${context.description}`, logContext)
   },
 
-  logRequestEnd: context => {
+  logRequestEnd: (context, response) => {
     let duration = new Date() - context.startTime
-    logger.info(`[${context.correlationId}] - ${context.method} to ${context.url} ended - elapsed time: ${duration} ms`)
+    const logContext = {
+      service: context.service,
+      method: context.method,
+      url: context.url,
+      description: context.description,
+      response_time: duration,
+      status: response && response.statusCode
+    }
+    logContext[keys.CORRELATION_ID] = context.correlationId
+    logger.info(`${context.method} to ${context.url} ended - elapsed time: ${duration} ms`, logContext)
   },
 
   logRequestFailure: (context, response) => {
-    logger.info(`[${context.correlationId}] Calling ${context.service} to ${context.description} failed`, {
+    const logContext = {
       service: context.service,
       method: context.method,
       url: context.url,
+      description: context.description,
       status: response.statusCode
-    })
+    }
+    logContext[keys.CORRELATION_ID] = context.correlationId
+    logger.info(`Calling ${context.service} to ${context.description} failed`, logContext)
   },
 
   logRequestError: (context, error) => {
-    logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} threw exception`, {
+    const logContext = {
       service: context.service,
       method: context.method,
       url: context.url,
+      description: context.description,
       error: error
-    })
+    }
+    logContext[keys.CORRELATION_ID] = context.correlationId
+    logger.error(`Calling ${context.service} to ${context.description} threw exception`, logContext)
   }
 }


### PR DESCRIPTION
Use structured logging arguments for all log lines produced when making outgoing requests and consistently include the available information for all log lines.