### PR TITLE
PP-6771 Log filters for transaction search and download

### DIFF
--- a/app/controllers/all-service-transactions/download-transactions.js
+++ b/app/controllers/all-service-transactions/download-transactions.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const logger = require('../../utils/logger')(__filename)
-const { keys } = require('@govuk-pay/pay-js-commons').logging
 const date = require('../../utils/dates')
 const transactionService = require('../../services/transaction_service')
 const Stream = require('../../services/clients/stream_client')
@@ -27,20 +25,7 @@ module.exports = (req, res) => {
       const timestampStreamStart = Date.now()
       const data = (chunk) => { res.write(chunk) }
       const complete = () => {
-        const timestampStreamEnd = Date.now()
-        const logContext = {
-          time_taken: timestampStreamEnd - timestampStreamStart,
-          from_date: filters.fromDate,
-          to_date: filters.toDate,
-          gateway_payout_id: filters.gatewayPayoutId,
-          payment_states: filters.payment_states,
-          refund_states: filters.refund_stats,
-          method: 'future'
-        }
-        logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
-        logContext[keys.GATEWAY_ACCOUNT_ID] = userPermittedAccountsSummary.gatewayAccountIds
-        logContext[keys.CORRELATION_ID] = correlationId
-        logger.info('Completed file stream', logContext)
+        transactionService.logCsvFileStreamComplete(timestampStreamStart, filters, userPermittedAccountsSummary.gatewayAccountIds, req.user, correlationId)
         res.end()
       }
       const error = () => renderErrorView(req, res, 'Unable to download list of transactions.')

--- a/app/controllers/transactions/transaction_download_controller.js
+++ b/app/controllers/transactions/transaction_download_controller.js
@@ -1,5 +1,5 @@
 'use strict'
-const logger = require('../../utils/logger')(__filename)
+
 const transactionService = require('../../services/transaction_service')
 const auth = require('../../services/auth_service')
 const date = require('../../utils/dates')
@@ -20,17 +20,7 @@ const fetchTransactionCsvWithHeader = function fetchTransactionCsvWithHeader (re
   const timestampStreamStart = Date.now()
   const data = (chunk) => { res.write(chunk) }
   const complete = () => {
-    const timestampStreamEnd = Date.now()
-    logger.info('Completed file stream', {
-      gateway_account_id: accountId,
-      time_taken: timestampStreamEnd - timestampStreamStart,
-      from_date: filters.fromDate,
-      to_date: filters.toDate,
-      payment_states: filters.payment_states,
-      refund_states: filters.refund_stats,
-      x_request_id: correlationId,
-      method: 'future'
-    })
+    transactionService.logCsvFileStreamComplete(timestampStreamStart, filters, [accountId], req.user, correlationId)
     res.end()
   }
   const error = () => renderErrorView(req, res, 'Unable to download list of transactions.')

--- a/app/services/clients/base_client/wrapper.js
+++ b/app/services/clients/base_client/wrapper.js
@@ -32,7 +32,8 @@ module.exports = function (method, verb) {
       url: joinURL(lodash.get(opts, 'baseUrl', ''), opts.url),
       method: opts.method,
       description: opts.description,
-      service: opts.service
+      service: opts.service,
+      additionalLoggingFields: opts.additionalLoggingFields
     }
 
     // Set headers and optional x-ray trace headers

--- a/app/services/clients/ledger_client.js
+++ b/app/services/clients/ledger_client.js
@@ -63,7 +63,12 @@ const transactions = function transactions (gatewayAccountIds = [], filters = {}
   const configuration = Object.assign({
     url: `${path}?${formattedParams}&${formattedFilterParams}`,
     description: 'List transactions for a given gateway account ID',
-    transform: legacyConnectorTransactionsParity
+    transform: legacyConnectorTransactionsParity,
+    additionalLoggingFields: {
+      gateway_account_ids: gatewayAccountIds,
+      multiple_accounts: gatewayAccountIds.length > 1,
+      filters: Object.keys(filters).sort().join(', ')
+    }
   }, defaultOptions, options)
 
   return baseClient.get(configuration)

--- a/app/services/transaction_service.js
+++ b/app/services/transaction_service.js
@@ -2,6 +2,8 @@
 
 const qs = require('qs')
 
+const logger = require('../utils/logger')(__filename)
+const { keys } = require('@govuk-pay/pay-js-commons').logging
 const Ledger = require('../services/clients/ledger_client')
 const getQueryStringForParams = require('../utils/get_query_string_for_params')
 
@@ -26,5 +28,25 @@ const csvSearchUrl = function csvSearchParams (filters, gatewayAccountIds = []) 
   return `${process.env.LEDGER_URL}/v1/transaction?${formattedParams}&${formattedFilterParams}`
 }
 
+const logCsvFileStreamComplete = function logCsvFileStreamComplete (timestampStreamStart, filters, gatewayAccountIds, user, correlationId) {
+  const timestampStreamEnd = Date.now()
+  const logContext = {
+    time_taken: timestampStreamEnd - timestampStreamStart,
+    from_date: filters.fromDate,
+    to_date: filters.toDate,
+    gateway_payout_id: filters.gatewayPayoutId,
+    payment_states: filters.payment_states,
+    refund_states: filters.refund_stats,
+    method: 'future',
+    gateway_account_ids: gatewayAccountIds,
+    multiple_accounts: gatewayAccountIds.length > 1,
+    filters: Object.keys(filters).sort().join(', ')
+  }
+  logContext[keys.USER_EXTERNAL_ID] = user && user.externalId
+  logContext[keys.CORRELATION_ID] = correlationId
+  logger.info('Completed file stream', logContext)
+}
+
 exports.search = searchLedger
 exports.csvSearchUrl = csvSearchUrl
+exports.logCsvFileStreamComplete = logCsvFileStreamComplete

--- a/app/utils/request_logger.js
+++ b/app/utils/request_logger.js
@@ -7,7 +7,8 @@ module.exports = {
       service: context.service,
       method: context.method,
       url: context.url,
-      description: context.description
+      description: context.description,
+      ...context.additionalLoggingFields
     }
     logContext[keys.CORRELATION_ID] = context.correlationId
     logger.info(`Calling ${context.service} to ${context.description}`, logContext)
@@ -21,7 +22,8 @@ module.exports = {
       url: context.url,
       description: context.description,
       response_time: duration,
-      status: response && response.statusCode
+      status: response && response.statusCode,
+      ...context.additionalLoggingFields
     }
     logContext[keys.CORRELATION_ID] = context.correlationId
     logger.info(`${context.method} to ${context.url} ended - elapsed time: ${duration} ms`, logContext)
@@ -33,7 +35,8 @@ module.exports = {
       method: context.method,
       url: context.url,
       description: context.description,
-      status: response.statusCode
+      status: response.statusCode,
+      ...context.additionalLoggingFields
     }
     logContext[keys.CORRELATION_ID] = context.correlationId
     logger.info(`Calling ${context.service} to ${context.description} failed`, logContext)
@@ -45,7 +48,8 @@ module.exports = {
       method: context.method,
       url: context.url,
       description: context.description,
-      error: error
+      error: error,
+      ...context.additionalLoggingFields
     }
     logContext[keys.CORRELATION_ID] = context.correlationId
     logger.error(`Calling ${context.service} to ${context.description} threw exception`, logContext)


### PR DESCRIPTION
Log the filters that are applied to transaction searches and CSV downloads as well as the gateway account ids.

Additionally log a `multiple_accounts` field, which has a boolean value, to quickly get whether the request was for all gateway accounts for a user.

The intention of this is to be able to easily group requests by their filters in Splunk so we can see which combinations of filters cause the search to take longer.

Extract logging when csv streaming is complete to a function in transaction_service to reduce duplication.