### PR TITLE
PP-6763 - Remove direct debit smoke test from self-service Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,9 +111,8 @@ pipeline {
         deployEcs("selfservice")
       }
     }
-    stage('Direct Debit Smoke Test') {
-      when { branch 'master' }
-      steps { runDirectDebitSmokeTest() }
+    stage('Smoke Test') {
+      
     }
     stage('Pact Tag') {
       when {


### PR DESCRIPTION
Description:
- Before we can turn off the direct debit smoke test we need to ensure that no pipeline calls it. This ensures that the self-service Jenkins pipeline doesn't call the direct debit smoke Jenkins function


