### PR TITLE
PP-6758 Update search consumer to use payment details

### DIFF
--- a/app/services/clients/ledger_client.js
+++ b/app/services/clients/ledger_client.js
@@ -54,7 +54,6 @@ const transactions = function transactions (gatewayAccountIds = [], filters = {}
   const formatOptions = { arrayFormat: 'comma' }
   const path = '/v1/transaction'
   const params = {
-    with_parent_transaction: true,
     account_id: gatewayAccountIds
   }
 

--- a/app/services/clients/utils/ledger_legacy_connector_parity.js
+++ b/app/services/clients/utils/ledger_legacy_connector_parity.js
@@ -25,14 +25,13 @@ const legacyConnectorTransactionParity = (transaction) => {
   transaction.charge_id = transaction.transaction_id
 
   if (transaction.transaction_type && transaction.transaction_type.toLowerCase() === 'refund') {
-    if (transaction.parent_transaction !== undefined && transaction.parent_transaction !== null) {
-      let charge = transaction.parent_transaction
-      transaction.charge_id = charge.transaction_id
-      transaction.gateway_transaction_id = charge.gateway_transaction_id
-      transaction.reference = charge.reference
-      transaction.description = charge.description
-      transaction.email = charge.email
-      transaction.card_details = charge.card_details
+    if (transaction.payment_details !== undefined && transaction.payment_details !== null) {
+      let paymentDetails = transaction.payment_details
+      transaction.charge_id = transaction.parent_transaction_id
+      transaction.reference = paymentDetails.reference
+      transaction.description = paymentDetails.description
+      transaction.email = paymentDetails.email
+      transaction.card_details = paymentDetails.card_details
     }
   }
 

--- a/app/services/transaction_service.js
+++ b/app/services/transaction_service.js
@@ -19,8 +19,7 @@ const searchLedger = async function searchLedger (gatewayAccountIds = [], filter
 const csvSearchUrl = function csvSearchParams (filters, gatewayAccountIds = []) {
   const formatOptions = { arrayFormat: 'comma' }
   const params = {
-    account_id: gatewayAccountIds,
-    with_parent_transaction: true
+    account_id: gatewayAccountIds
   }
 
   const formattedParams = qs.stringify(params, formatOptions)

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -367,7 +367,6 @@ module.exports = {
     return simpleStubBuilder('GET', path, 200, {
       query: lodash.defaults(opts.filters, {
         account_id: opts.gateway_account_id,
-        with_parent_transaction: true,
         page: opts.page || 1,
         display_size: opts.display_size || 100
       }),

--- a/test/fixtures/ledger_transaction_fixtures.js
+++ b/test/fixtures/ledger_transaction_fixtures.js
@@ -166,24 +166,20 @@ const buildRefundDetails = (opts = {}) => {
     parent_transaction_id: opts.parent_transaction_id || 'puuhl0gu7egigin7oh9c75p4m1'
   }
 
-  if (opts.includeParentTransaction) {
-    const parentTransactionOpts = {
-      gateway_account_id: opts.gateway_account_id || '1',
-      transaction_id: opts.parent_transaction_id,
-      includeCardDetails: true,
-      includeAddress: true,
-      includeRefundSummary: true,
-      includeSettlementSummary: true,
-      status: 'success',
-      finished: true,
-      refund_summary_status: 'full',
-      amount_available: 0,
-      amount_submitted: opts.amount,
-      amount_refunded: opts.amount,
-      capture_submit_time: opts.capture_submit_time || null,
-      captured_date: opts.captured_date || null
+  if (opts.includePaymentDetails) {
+    const paymentDetails = {
+      description: opts.description || 'ref1',
+      reference: opts.reference || 'ref188888',
+      email: opts.email || 'test@example.org',
+      card_details: {
+        last_digits_card_number: opts.last_digits_card_number || '0002',
+        cardholder_name: opts.cardholder_name || 'Test User',
+        expiry_date: opts.expiry_date || '08/23',
+        card_brand: opts.card_brand || 'Visa'
+      },
+      transaction_type: 'PAYMENT'
     }
-    result.parent_transaction = buildTransactionDetails(parentTransactionOpts)
+    result.payment_details = paymentDetails
   }
   return result
 }

--- a/test/unit/clients/ledger_client/ledger_search_transaction_test.js
+++ b/test/unit/clients/ledger_client/ledger_search_transaction_test.js
@@ -74,7 +74,6 @@ describe('ledger client', function () {
       return pactTestProvider.addInteraction(
         new PactInteractionBuilder(`${TRANSACTION_RESOURCE}`)
           .withQuery('account_id', params.account_id)
-          .withQuery('with_parent_transaction', 'true')
           .withQuery('page', '1')
           .withQuery('display_size', '100')
           .withUponReceiving('a valid search transaction details request')
@@ -132,7 +131,6 @@ describe('ledger client', function () {
       return pactTestProvider.addInteraction(
         new PactInteractionBuilder(`${TRANSACTION_RESOURCE}`)
           .withQuery('account_id', params.account_id)
-          .withQuery('with_parent_transaction', 'true')
           .withQuery('page', '1')
           .withQuery('display_size', '100')
           .withQuery('email', params.filters.email)
@@ -201,7 +199,6 @@ describe('ledger client', function () {
       return pactTestProvider.addInteraction(
         new PactInteractionBuilder(`${TRANSACTION_RESOURCE}`)
           .withQuery('account_id', params.account_id)
-          .withQuery('with_parent_transaction', 'true')
           .withQuery('reference', params.filters.reference)
           .withQuery('from_date', fromDateTime)
           .withQuery('to_date', toDateTime)
@@ -253,7 +250,7 @@ describe('ledger client', function () {
           type: 'refund',
           capture_submit_time: '2019-09-21T13:14:16.067Z',
           captured_date: '2019-09-21',
-          includeParentTransaction: true
+          includePaymentDetails: true
         },
         {
           amount: 2000,
@@ -280,7 +277,6 @@ describe('ledger client', function () {
       return pactTestProvider.addInteraction(
         new PactInteractionBuilder(`${TRANSACTION_RESOURCE}`)
           .withQuery('account_id', params.account_id)
-          .withQuery('with_parent_transaction', 'true')
           .withQuery('page', '1')
           .withQuery('display_size', '100')
           .withQuery('from_date', fromDateTime)
@@ -343,7 +339,6 @@ describe('ledger client', function () {
       return pactTestProvider.addInteraction(
         new PactInteractionBuilder(`${TRANSACTION_RESOURCE}`)
           .withQuery('account_id', params.account_id)
-          .withQuery('with_parent_transaction', 'true')
           .withQuery('page', '1')
           .withQuery('display_size', '100')
           .withQuery('to_date', toDateTime)

--- a/test/unit/clients/ledger_client/legacy_connector_parity_util_test.js
+++ b/test/unit/clients/ledger_client/legacy_connector_parity_util_test.js
@@ -24,16 +24,16 @@ describe('Ledger service client legacy parity utilities', () => {
     it('Correctly maps ledger values on refund parent transaction to current connector names', () => {
       const ledgerTransactionFixture = {
         transaction_id: 'some-transaction-id',
+        parent_transaction_id: 'payment-transaction-id',
         transaction_type: 'REFUND',
         refunded_by: 'f579410614654249987ad939f5ef53a1',
         refund_summary: {
           amount_refunded: 1000
         },
-        parent_transaction: {
-          transaction_id: 'charge-id',
-          gateway_transaction_id: 'payment-gateway-transaction-id',
+        gateway_transaction_id: 'refund-gateway-transaction-id',
+        payment_details: {
           reference: 'payment-reference',
-          description: 'payment-descriptiom',
+          description: 'payment-description',
           email: 'test-email@example.org',
           card_details: {
             cardholder_name: 'test-name',
@@ -46,11 +46,11 @@ describe('Ledger service client legacy parity utilities', () => {
       }
 
       const result = legacyConnectorTransactionParity(ledgerTransactionFixture)
-      assert.strictEqual(result.charge_id, 'charge-id')
+      assert.strictEqual(result.charge_id, 'payment-transaction-id')
       assert.strictEqual(result.refund_summary.user_external_id, 'f579410614654249987ad939f5ef53a1')
-      assert.strictEqual(result.gateway_transaction_id, 'payment-gateway-transaction-id')
+      assert.strictEqual(result.gateway_transaction_id, 'refund-gateway-transaction-id')
       assert.strictEqual(result.reference, 'payment-reference')
-      assert.strictEqual(result.description, 'payment-descriptiom')
+      assert.strictEqual(result.description, 'payment-description')
       assert.strictEqual(result.email, 'test-email@example.org')
       assert.strictEqual(result.card_details.cardholder_name, 'test-name')
       assert.strictEqual(result.card_details.card_brand, 'visa')
@@ -96,7 +96,7 @@ describe('Ledger service client legacy parity utilities', () => {
       assert.strictEqual(refundResult.submitted_by, 'some-user-id')
     })
 
-    it('Correcly transforms resource type', () => {
+    it('Correctly transforms resource type', () => {
       const { events } = legacyConnectorEventsParity(ledgerTransactionEventsFixture)
       const result = events[0]
       assert.strictEqual(result.type, 'payment')
@@ -111,10 +111,10 @@ describe('Ledger service client legacy parity utilities', () => {
         },
         {
           transaction_id: 'some-transaction-id',
+          parent_transaction_id: 'payment-transaction-id',
           transaction_type: 'REFUND',
           refunded_by: 'f579410614654249987ad939f5ef53a1',
-          parent_transaction: {
-            transaction_id: 'charge-id',
+          payment_details: {
             reference: 'payment-reference'
           }
         }]
@@ -122,7 +122,7 @@ describe('Ledger service client legacy parity utilities', () => {
       const transactions = legacyConnectorTransactionsParity(ledgerTransactionsSearchFixture)
 
       assert.strictEqual(transactions.results[0].charge_id, 'some-charge-id')
-      assert.strictEqual(transactions.results[1].charge_id, 'charge-id')
+      assert.strictEqual(transactions.results[1].charge_id, 'payment-transaction-id')
       assert.strictEqual(transactions.results[1].refund_summary.user_external_id, 'f579410614654249987ad939f5ef53a1')
       assert.strictEqual(transactions.results[1].reference, 'payment-reference')
     })


### PR DESCRIPTION
`payment_details` are now available as a top level attribute on refunds.
These should be used in favour of relying on the nested
`parent_transaction` entity.

Remove `with_parent_transaction` from transaction searches as this
information is now stored flat and the query parameter deprecated.