### PR TITLE
PP-6763 - Remove direct debit smoke and end test from publicapi Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,7 @@ pipeline {
                 }
             }
             steps {
-                runAppE2E("selfservice", "card,products,directdebit")
+                runAppE2E("selfservice", "card,products")
             }
         }
       }
@@ -110,10 +110,6 @@ pipeline {
         checkPactCompatibility("selfservice", gitCommit(), "test")
         deployEcs("selfservice")
       }
-    }
-    stage('Direct Debit Smoke Test') {
-      when { branch 'master' }
-      steps { runDirectDebitSmokeTest() }
     }
     stage('Pact Tag') {
       when {


### PR DESCRIPTION
Description:
- Before we can turn off the direct debit smoke test we need to ensure that no pipeline calls it. This ensures that the self-service Jenkins pipeline doesn't call the direct debit smoke Jenkins function
- This also ensures that the direct debit portion of the end to end test suit won't be run