### PR TITLE
PP-6820 Improve hint for org name

### DIFF
--- a/app/views/merchant_details/edit_merchant_details.njk
+++ b/app/views/merchant_details/edit_merchant_details.njk
@@ -50,45 +50,35 @@
   {% endif %}
   <h1 class="govuk-heading-l page-title">Organisation details</h1>
   {% if has_card_and_dd_gateway_account %}
-    <p class="govuk-body" id="merchant-details-info">Payment card schemes and Direct Debit require the details of the organisation taking payment to be shown to the
+    <p class="govuk-hint govuk-!-margin-bottom-7" id="merchant-details-info">Payment card schemes and Direct Debit require the details of the organisation taking payment to be shown to the
       payer. This information is displayed in emails and on payment pages.</p>
   {% elif has_direct_debit_gateway_account %}
-    <p class="govuk-body" id="merchant-details-info">Direct Debit requires the details of the organisation taking payment to be shown to the payer. This information is
+    <p class="govuk-hint govuk-!-margin-bottom-7" id="merchant-details-info">Direct Debit requires the details of the organisation taking payment to be shown to the payer. This information is
       displayed in emails and on payment pages.</p>
   {% elif has_card_gateway_account %}
-    <p class="govuk-body" id="merchant-details-info">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
+    <p class="govuk-hint govuk-!-margin-bottom-7" id="merchant-details-info">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
   {% endif %}
 
   <form id="merchant-details-form" method="post" action="/organisation-details/edit/{{currentService.externalId}}">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
-    {% set nameError = false %}
-    {% if errors["merchant-name"] %}
-      {% set nameError = {
-        text: errors["merchant-name"]
-      } %}
-    {% endif %}
-
-    {{
-      govukInput({
-        value: merchant_details.name,
-        label: {
-          text: "Name"
-        },
-        hint: {
-          text: "Organisation or department that holds the bank account with payment service provider",
-          classes: "govuk-!-width-two-thirds"
-        },
-        errorMessage: nameError,
-        id: "merchant-name",
-        name: "merchant-name",
-        classes: "govuk-!-width-two-thirds",
-        type: "text",
-        attributes: {
-          "data-validate": "required"
-        }
-      })
-    }}
+    <div class="govuk-form-group {% if errors['merchant-name'] %} govuk-form-group--error {% endif %}">
+      <label class="govuk-label" for="merchant-name">
+        Name
+      </label>
+      <span id="merchant-name-hint" class="govuk-hint govuk-!-width-two-thirds">
+        <p>Enter the main name of your organisation, not your local office or individual department.</p>
+        <p>Write the organisation name in full. Only use acronyms that are widely understood (for example, NHS).</p>
+      </span>
+      {% if errors['merchant-name'] %}
+      <span id="merchant-name-error" class="govuk-error-message">
+        <span class="govuk-visually-hidden">Error:</span> {{errors["merchant-name"]}}
+      </span>
+      {% endif %}
+      <input class="govuk-input govuk-!-width-two-thirds {% if errors['merchant-name'] %} govuk-input--error {% endif %}"
+             id="merchant-name" name="merchant-name" type="text" aria-describedby="merchant-name-hint"
+             data-validate="required" value="{{merchant_details.name}}"/>
+    </div>
 
     {% set phoneError = false %}
     {% if errors["telephone-number"] %}

--- a/app/views/request-to-go-live/organisation-name.njk
+++ b/app/views/request-to-go-live/organisation-name.njk
@@ -26,31 +26,31 @@
           action="/service/{{ currentService.externalId }}/request-to-go-live/organisation-name" data-validate="true" >
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
-      {% set organisationNameError = false %}
-      {% if errors['organisation-name'] %}
-        {% set organisationNameError = {
-          text: "Please enter a valid name"
-        } %}
-      {% endif %}
-      {{ govukInput({
-        label: {
-          text: "What is your organisation called?",
-          isPageHeading: true,
-          classes: "govuk-label--l"
-        },
-        hint: {
-          text: "Enter the main name of your organisation, not the name of your local office or individual department."
-        },
-        id: "request-to-go-live-organisation-name-input",
-        name: "organisation-name",
-        value: organisationName,
-        type: "text",
-        errorMessage: organisationNameError,
-        attributes: {
-          "data-validate": "required isFieldGreaterThanMaxLengthChars",
-          "data-validate-max-length": "255"
-        }
-      }) }}
+      <div class="govuk-form-group {% if errors['organisation-name'] %} govuk-form-group--error {% endif %}">
+        <h1 class="govuk-label-wrapper">
+           <label class="govuk-label govuk-label--l" for="request-to-go-live-organisation-name-input">
+            What is your organisation called?
+          </label>
+        </h1>
+
+        <span id="request-to-go-live-organisation-name-input-hint" class="govuk-hint">
+          <p>Payment card schemes require the details of the organisation taking payment to be shown on payment pages. </p>
+          <p>Enter the main name of your organisation, not your local office or individual department.</p>
+          Write the organisation name in full. Only use acronyms that are widely understood (for example, NHS).
+        </span>
+
+        {% if errors['organisation-name'] %}
+          <span id="request-to-go-live-organisation-name-input-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> {{errors['organisation-name']}}
+          </span>
+        {% endif %}
+
+        <input class="govuk-input  {% if errors['organisation-name'] %} govuk-input--error {% endif %}"
+               id="request-to-go-live-organisation-name-input" name="organisation-name"
+               type="text" aria-describedby="request-to-go-live-organisation-name-input-hint"
+               data-validate="required isFieldGreaterThanMaxLengthChars" data-validate-max-length="255"
+               value="{{organisationName}}"/>
+      </div>
 
       {{ govukButton({ text: "Continue" }) }}
     </form>

--- a/test/unit/controller/edit_merchant_details_controller/get-edit.test.js
+++ b/test/unit/controller/edit_merchant_details_controller/get-edit.test.js
@@ -135,7 +135,7 @@ describe('edit merchant details controller - get', () => {
       expect(response.statusCode).to.equal(200)
     })
     it(`should show empty inputs and GB selected as country`, () => {
-      expect($('#merchant-name')).withNoAttribute('value')
+      expect($('#merchant-name').val()).equal('')
       expect($('#address-line1')).withNoAttribute('value')
       expect($('#address-line2')).withNoAttribute('value')
       expect($('#address-city')).withNoAttribute('value')
@@ -174,7 +174,7 @@ describe('edit merchant details controller - get', () => {
       expect(response.statusCode).to.equal(200)
     })
     it(`should show empty inputs and GB selected as country`, () => {
-      expect($('#merchant-name')).withNoAttribute('value')
+      expect($('#merchant-name').val()).equal('')
       expect($('#telephone-number')).withNoAttribute('value')
       expect($('#merchant-email')).withNoAttribute('value')
       expect($('#address-line1')).withNoAttribute('value')
@@ -215,7 +215,7 @@ describe('edit merchant details controller - get', () => {
       expect(response.statusCode).to.equal(200)
     })
     it(`should show empty inputs and GB selected as country`, () => {
-      expect($('#merchant-name')).withNoAttribute('value')
+      expect($('#merchant-name').val()).equal('')
       expect($('#telephone-number')).withNoAttribute('value')
       expect($('#merchant-email')).withNoAttribute('value')
       expect($('#address-line1')).withNoAttribute('value')


### PR DESCRIPTION
## WHAT
- Improved hint text for org name to make it clear for service users entering org name.
- Uses html instead of nunjucks template as html line breaks are escaped if added to nunjucks text

## New pages

# **Onboarding flow**
![Screenshot 2020-07-28 at 09 41 40](https://user-images.githubusercontent.com/40598480/88643834-1ef3a580-d0ba-11ea-8afc-95652136c808.png)

# **Organisation details**
![Screenshot 2020-07-28 at 12 08 27](https://user-images.githubusercontent.com/40598480/88658271-12c41400-d0cb-11ea-9178-121e017c5634.png)


