### PR TITLE
PP-6863 Fix flash message on dashboard

### DIFF
--- a/app/assets/sass/components/flash.scss
+++ b/app/assets/sass/components/flash.scss
@@ -1,4 +1,5 @@
 .flash-container {
+  margin: 0 15px;
   @extend .govuk-error-summary;
     &--good {
     border-color:  govuk-colour("green");

--- a/app/views/dashboard/_stripe-account-setup-banner.njk
+++ b/app/views/dashboard/_stripe-account-setup-banner.njk
@@ -12,7 +12,7 @@
   {% endset %}
 
   {% if connectorGatewayAccountStripeProgress and (not isConnectorStripeJourneyComplete) %}
-    <div class="account-status-panel {{panelModifierClass}} govuk-grid-row govuk-!-margin-bottom-5">
+    <div class="account-status-panel govuk-grid-row {{panelModifierClass}} govuk-!-margin-bottom-5">
       <div class="govuk-grid-column-two-thirds">
         {% if isStripeAccountRestricted %}
           <h2 class="govuk-heading-m">Stripe have restricted your account</h2>
@@ -60,7 +60,7 @@
       </div>
     </div>
   {% elif  isStripeAccountRestricted %}
-    <div class="account-status-panel account-status-panel--restricted govuk-grid-row govuk-!-margin-bottom-5">
+    <div class="account-status-panel govuk-grid-row account-status-panel--restricted govuk-!-margin-bottom-5">
       <div class="govuk-grid-column-two-thirds">
           <h2 class="govuk-heading-m">Stripe have restricted your account</h2>
           <p class="govuk-body-m">To start taking payments again, please contact support.</p>

--- a/app/views/includes/flash.njk
+++ b/app/views/includes/flash.njk
@@ -1,18 +1,16 @@
 {% block flash %}
-  <div class="govuk-grid-column-two-thirds">
-    {% if flash.genericError %}
-    <div class="flash-container">
-      <div class="notification generic-error error-summary">
+  {% if flash.genericError %}
+    <div class="govuk-grid-row govuk-!-margin-bottom-5 flash-container">
+      <div class="govuk-grid-column-two-thirds notification generic-error error-summary">
         {{ flash.genericError | safe }}
       </div>
     </div>
-    {% endif %}
-    {% if flash.generic %}
-    <div class="flash-container flash-container--good">
-      <div class="notification generic-flash">
+  {% endif %}
+  {% if flash.generic %}
+    <div class="govuk-grid-row govuk-!-margin-bottom-5 flash-container flash-container--good">
+      <div class="govuk-grid-column-two-thirds notification generic-flash">
         {{ flash.generic | safe }}
       </div>
     </div>
-    {% endif %}
-  </div>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Was appearing inside the go-live-banner.

We possibly shouldn't use a flash message for these errors, but it now looks like this:
<img width="1254" alt="Screenshot 2020-07-30 at 16 54 34" src="https://user-images.githubusercontent.com/5648592/88945077-6f6b2e80-d285-11ea-9456-bf7a35899a2e.png">

