### PR TITLE
PP-6716 Add integrity checks for CDN scripts

### DIFF
--- a/app/views/all-service-transactions/index.njk
+++ b/app/views/all-service-transactions/index.njk
@@ -13,10 +13,10 @@ Transactions for all live services - GOV.UK Pay
 
 {% block pageSpecificJS %}
 <script src="/public/js/components/link-follower.js"></script>
-<script src="https://unpkg.com/jquery@3.3.1/dist/jquery.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.7.1/js/bootstrap-datepicker.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.10.0/jquery.timepicker.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/datepair.js/0.4.15/jquery.datepair.min.js"></script>
+<script src="https://unpkg.com/jquery@3.3.1/dist/jquery.min.js" integrity="sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.7.1/js/bootstrap-datepicker.min.js" integrity="sha384-w48xMCwgWQu0zb3PvQI/rK5lfN6G+lSWu+qI4ukKZg3I5Xx3/VWA8IiaQ8O7tZur"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.10.0/jquery.timepicker.min.js" integrity="sha384-VCGGyImXZFrgsDyta1kgBiWdDqK5tFDLLQqkVmrAlMD75liEcrwWyHrlsOgWLpI+"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/datepair.js/0.4.15/jquery.datepair.min.js" integrity="sha384-n9nOljWGNI/Dtu7uK9ZIbiRrZZT3MhFq452zDmvmNZm1GPu5gGFXTPyHC09dDXis"></script>
 <script src="/public/js/components/datetime-picker.js"></script>
 {% endblock %}
 

--- a/app/views/all-service-transactions/index.njk
+++ b/app/views/all-service-transactions/index.njk
@@ -13,10 +13,10 @@ Transactions for all live services - GOV.UK Pay
 
 {% block pageSpecificJS %}
 <script src="/public/js/components/link-follower.js"></script>
-<script src="https://unpkg.com/jquery@3.3.1/dist/jquery.min.js" integrity="sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.7.1/js/bootstrap-datepicker.min.js" integrity="sha384-w48xMCwgWQu0zb3PvQI/rK5lfN6G+lSWu+qI4ukKZg3I5Xx3/VWA8IiaQ8O7tZur"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.10.0/jquery.timepicker.min.js" integrity="sha384-VCGGyImXZFrgsDyta1kgBiWdDqK5tFDLLQqkVmrAlMD75liEcrwWyHrlsOgWLpI+"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/datepair.js/0.4.15/jquery.datepair.min.js" integrity="sha384-n9nOljWGNI/Dtu7uK9ZIbiRrZZT3MhFq452zDmvmNZm1GPu5gGFXTPyHC09dDXis"></script>
+<script src="https://unpkg.com/jquery@3.3.1/dist/jquery.min.js" integrity="sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.7.1/js/bootstrap-datepicker.min.js" integrity="sha384-w48xMCwgWQu0zb3PvQI/rK5lfN6G+lSWu+qI4ukKZg3I5Xx3/VWA8IiaQ8O7tZur" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.10.0/jquery.timepicker.min.js" integrity="sha384-VCGGyImXZFrgsDyta1kgBiWdDqK5tFDLLQqkVmrAlMD75liEcrwWyHrlsOgWLpI+" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/datepair.js/0.4.15/jquery.datepair.min.js" integrity="sha384-n9nOljWGNI/Dtu7uK9ZIbiRrZZT3MhFq452zDmvmNZm1GPu5gGFXTPyHC09dDXis" crossorigin="anonymous"></script>
 <script src="/public/js/components/datetime-picker.js"></script>
 {% endblock %}
 

--- a/app/views/transactions/index.njk
+++ b/app/views/transactions/index.njk
@@ -13,10 +13,10 @@ Transactions - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV
 
 {% block pageSpecificJS %}
 <script src="/public/js/components/link-follower.js"></script>
-<script src="https://unpkg.com/jquery@3.3.1/dist/jquery.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.7.1/js/bootstrap-datepicker.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.10.0/jquery.timepicker.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/datepair.js/0.4.15/jquery.datepair.min.js"></script>
+<script src="https://unpkg.com/jquery@3.3.1/dist/jquery.min.js" integrity="sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.7.1/js/bootstrap-datepicker.min.js" integrity="sha384-w48xMCwgWQu0zb3PvQI/rK5lfN6G+lSWu+qI4ukKZg3I5Xx3/VWA8IiaQ8O7tZur"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.10.0/jquery.timepicker.min.js" integrity="sha384-VCGGyImXZFrgsDyta1kgBiWdDqK5tFDLLQqkVmrAlMD75liEcrwWyHrlsOgWLpI+"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/datepair.js/0.4.15/jquery.datepair.min.js" integrity="sha384-n9nOljWGNI/Dtu7uK9ZIbiRrZZT3MhFq452zDmvmNZm1GPu5gGFXTPyHC09dDXis"></script>
 <script src="/public/js/components/datetime-picker.js"></script>
 {% endblock %}
 

--- a/app/views/transactions/index.njk
+++ b/app/views/transactions/index.njk
@@ -13,10 +13,10 @@ Transactions - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV
 
 {% block pageSpecificJS %}
 <script src="/public/js/components/link-follower.js"></script>
-<script src="https://unpkg.com/jquery@3.3.1/dist/jquery.min.js" integrity="sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.7.1/js/bootstrap-datepicker.min.js" integrity="sha384-w48xMCwgWQu0zb3PvQI/rK5lfN6G+lSWu+qI4ukKZg3I5Xx3/VWA8IiaQ8O7tZur"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.10.0/jquery.timepicker.min.js" integrity="sha384-VCGGyImXZFrgsDyta1kgBiWdDqK5tFDLLQqkVmrAlMD75liEcrwWyHrlsOgWLpI+"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/datepair.js/0.4.15/jquery.datepair.min.js" integrity="sha384-n9nOljWGNI/Dtu7uK9ZIbiRrZZT3MhFq452zDmvmNZm1GPu5gGFXTPyHC09dDXis"></script>
+<script src="https://unpkg.com/jquery@3.3.1/dist/jquery.min.js" integrity="sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.7.1/js/bootstrap-datepicker.min.js" integrity="sha384-w48xMCwgWQu0zb3PvQI/rK5lfN6G+lSWu+qI4ukKZg3I5Xx3/VWA8IiaQ8O7tZur" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.10.0/jquery.timepicker.min.js" integrity="sha384-VCGGyImXZFrgsDyta1kgBiWdDqK5tFDLLQqkVmrAlMD75liEcrwWyHrlsOgWLpI+" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/datepair.js/0.4.15/jquery.datepair.min.js" integrity="sha384-n9nOljWGNI/Dtu7uK9ZIbiRrZZT3MhFq452zDmvmNZm1GPu5gGFXTPyHC09dDXis" crossorigin="anonymous"></script>
 <script src="/public/js/components/datetime-picker.js"></script>
 {% endblock %}
 


### PR DESCRIPTION
Add an integrity check to ensurethe file we receive from the CDN is the 
one expected.

Future work may see these files removed entirely (in favour of HTML
standards) or bundled and served by the application.

## To test this change
- [x] Verify that the SHA-384 signatures for the file line up with what
is being served by the CDN
- [ ] Ensure the transaction search date selection still works on common
browsers and no console errors or warnings are shown