### PR TITLE
PP-6848 Remove additional call for stripe setup

### DIFF
--- a/app/controllers/stripe-setup/add-psp-account-details/get-controller.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/get-controller.js
@@ -1,29 +1,24 @@
 'use strict'
 
 const paths = require('../../../paths')
-const logger = require('../../../utils/logger')(__filename)
 const { response, renderErrorView } = require('../../../utils/response')
-const { ConnectorClient } = require('../../../services/clients/connector.client')
-const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 
 module.exports = async (req, res) => {
-  try {
-    const stripeAccountSetup = await connectorClient.getStripeAccountSetup(
-      req.account.gateway_account_id, req.correlationId)
+  if (!req.account || !req.account.connectorGatewayAccountStripeProgress) {
+    return renderErrorView(req, res, 'Please try again or contact support team')
+  }
 
-    if (!stripeAccountSetup.bankAccount) {
-      res.redirect(303, paths.stripeSetup.bankDetails)
-    } else if (!stripeAccountSetup.responsiblePerson) {
-      res.redirect(303, paths.stripeSetup.responsiblePerson)
-    } else if (!stripeAccountSetup.vatNumber) {
-      res.redirect(303, paths.stripeSetup.vatNumber)
-    } else if (!stripeAccountSetup.companyNumber) {
-      res.redirect(303, paths.stripeSetup.companyNumber)
-    } else {
-      response(req, res, 'stripe-setup/go-live-complete')
-    }
-  } catch (error) {
-    logger.error(`${req.correlationId} error with Stripe > Add PSP account details : ${error}`)
-    return renderErrorView(req, res, false, error.errorCode)
+  const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
+
+  if (!stripeAccountSetup.bankAccount) {
+    res.redirect(303, paths.stripeSetup.bankDetails)
+  } else if (!stripeAccountSetup.responsiblePerson) {
+    res.redirect(303, paths.stripeSetup.responsiblePerson)
+  } else if (!stripeAccountSetup.vatNumber) {
+    res.redirect(303, paths.stripeSetup.vatNumber)
+  } else if (!stripeAccountSetup.companyNumber) {
+    res.redirect(303, paths.stripeSetup.companyNumber)
+  } else {
+    response(req, res, 'stripe-setup/go-live-complete')
   }
 }

--- a/app/controllers/stripe-setup/add-psp-account-details/get-controller.test.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/get-controller.test.js
@@ -1,30 +1,28 @@
 'use strict'
 
-const sinon = require('sinon')
-const proxyquire = require('proxyquire')
-const paths = require('../../../paths')
+const chai = require('chai')
 
-const getController = function getController (stripeAccountSetupResponse) {
-  return proxyquire('./get-controller', {
-    '../../../services/clients/connector.client': {
-      ConnectorClient: function () {
-        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => Promise.resolve(stripeAccountSetupResponse)
-      }
-    }
-  })
-}
+const chaiAsPromised = require('chai-as-promised')
+const sinon = require('sinon')
+
+const { expect } = chai
+chai.use(chaiAsPromised)
+
+const paths = require('../../../paths')
+const getController = require('./get-controller')
 
 describe('get controller', () => {
-  const req = {
-    account: {
-      gateway_account_id: 'gatewayId'
-    },
-    correlationId: 'requestId'
-  }
-
+  let req
   let res
 
   beforeEach(() => {
+    req = {
+      account: {
+        gateway_account_id: 'gatewayId',
+        connectorGatewayAccountStripeProgress: {}
+      },
+      correlationId: 'requestId'
+    }
     res = {
       setHeader: sinon.stub(),
       status: sinon.spy(),
@@ -34,56 +32,68 @@ describe('get controller', () => {
   })
 
   it('should redirect to bank account setup page', async () => {
-    const controller = getController({
-      bankAccount: false,
-      responsiblePerson: false,
-      vatNumber: false,
-      companyNumber: false
-    })
-    await controller(req, res)
+    req.account.connectorGatewayAccountStripeProgress.bankAccount = false
+    getController(req, res)
     sinon.assert.calledWith(res.redirect, 303, paths.stripeSetup.bankDetails)
   })
 
   it('should redirect to responsible person page', async () => {
-    const controller = getController({
-      bankAccount: true,
-      responsiblePerson: false,
-      vatNumber: false,
-      companyNumber: false
-    })
-    await controller(req, res)
+    req.account.connectorGatewayAccountStripeProgress.bankAccount = true
+    getController(req, res)
     sinon.assert.calledWith(res.redirect, 303, paths.stripeSetup.responsiblePerson)
   })
 
   it('should redirect to VAT number page', async () => {
-    const controller = getController({
+    req.account.connectorGatewayAccountStripeProgress = {
       bankAccount: true,
-      responsiblePerson: true,
-      vatNumber: false
-    })
-    await controller(req, res)
+      responsiblePerson: true
+    }
+    getController(req, res)
     sinon.assert.calledWith(res.redirect, 303, paths.stripeSetup.vatNumber)
   })
 
   it('should redirect to company registration number page', async () => {
-    const controller = getController({
+    req.account.connectorGatewayAccountStripeProgress = {
       bankAccount: true,
       responsiblePerson: true,
-      vatNumber: true,
-      companyNumber: false
-    })
-    await controller(req, res)
+      vatNumber: true
+    }
+    getController(req, res)
     sinon.assert.calledWith(res.redirect, 303, paths.stripeSetup.companyNumber)
   })
 
   it('should render go live complete page when all steps are completed', async () => {
-    const controller = getController({
+    req.account.connectorGatewayAccountStripeProgress = {
       bankAccount: true,
       responsiblePerson: true,
       vatNumber: true,
       companyNumber: true
-    })
-    await controller(req, res)
+    }
+    getController(req, res)
     sinon.assert.calledWith(res.render, 'stripe-setup/go-live-complete')
+  })
+
+  it('should render an error page when req.account is undefined', done => {
+    req.account = undefined
+
+    getController(req, res)
+
+    setTimeout(() => {
+      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+      expect(res.render.calledWith('error', { message: 'Please try again or contact support team' })).to.be.true // eslint-disable-line
+      done()
+    }, 250)
+  })
+
+  it('should render an error page when req.account.connectorGatewayAccountStripeProgress is undefined', done => {
+    req.account.connectorGatewayAccountStripeProgress = undefined
+
+    getController(req, res)
+
+    setTimeout(() => {
+      expect(res.status.calledWith(500)).to.be.true // eslint-disable-line
+      expect(res.render.calledWith('error', { message: 'Please try again or contact support team' })).to.be.true // eslint-disable-line
+      done()
+    }, 250)
   })
 })

--- a/app/middleware/stripe-setup/check-bank-details-not-submitted.js
+++ b/app/middleware/stripe-setup/check-bank-details-not-submitted.js
@@ -1,8 +1,6 @@
 'use strict'
 
 // Local dependencies
-const { ConnectorClient } = require('../../services/clients/connector.client')
-const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 const { renderErrorView } = require('../../utils/response')
 const paths = require('../../paths')
 
@@ -12,14 +10,15 @@ module.exports = function checkBankDetailsNotSubmitted (req, res, next) {
     return
   }
 
-  connector.getStripeAccountSetup(req.account.gateway_account_id, req.correlationId).then(stripeSetupResponse => {
-    if (stripeSetupResponse.bankAccount) {
+  const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
+  if (!stripeAccountSetup) {
+    renderErrorView(req, res, 'Please try again or contact support team')
+  } else {
+    if (stripeAccountSetup.bankAccount) {
       req.flash('genericError', 'You’ve already provided your bank details.<br />Contact GOV.UK Pay support if you need to update them.')
       res.redirect(303, paths.dashboard.index)
     } else {
       next()
     }
-  }).catch(() => {
-    renderErrorView(req, res, 'Please try again or contact support team')
-  })
+  }
 }

--- a/app/middleware/stripe-setup/check-company-number-not-submitted.js
+++ b/app/middleware/stripe-setup/check-company-number-not-submitted.js
@@ -1,8 +1,6 @@
 'use strict'
 
 // Local dependencies
-const { ConnectorClient } = require('../../services/clients/connector.client')
-const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 const { renderErrorView } = require('../../utils/response')
 const paths = require('../../paths')
 
@@ -12,14 +10,15 @@ module.exports = function checkCompanyNumberNotSubmitted (req, res, next) {
     return
   }
 
-  connector.getStripeAccountSetup(req.account.gateway_account_id, req.correlationId).then(stripeSetupResponse => {
-    if (stripeSetupResponse.companyNumber) {
+  const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
+  if (!stripeAccountSetup) {
+    renderErrorView(req, res, 'Please try again or contact support team')
+  } else {
+    if (stripeAccountSetup.companyNumber) {
       req.flash('genericError', 'You’ve already provided your company registration number.<br />Contact GOV.UK Pay support if you need to update it.')
       res.redirect(303, paths.dashboard.index)
     } else {
       next()
     }
-  }).catch(() => {
-    renderErrorView(req, res, 'Please try again or contact support team')
-  })
+  }
 }

--- a/app/middleware/stripe-setup/check-company-number-not-submitted.test.js
+++ b/app/middleware/stripe-setup/check-company-number-not-submitted.test.js
@@ -3,11 +3,11 @@
 // NPM dependencies
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
-const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
 // Local dependencies
 const paths = require('../../paths')
+const checkCompanyNumberNotSubmitted = require('./check-company-number-not-submitted')
 
 // Global setup
 chai.use(chaiAsPromised)
@@ -22,7 +22,8 @@ describe('Check "Company registration number" not submitted middleware', () => {
     req = {
       correlationId: 'correlation-id',
       account: {
-        gateway_account_id: '1'
+        gateway_account_id: '1',
+        connectorGatewayAccountStripeProgress: {}
       },
       flash: sinon.spy()
     }
@@ -36,11 +37,9 @@ describe('Check "Company registration number" not submitted middleware', () => {
   })
 
   it('should call next when "Company number" flag is false', done => {
-    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
-      companyNumber: false
-    })
+    req.account.connectorGatewayAccountStripeProgress.companyNumber = false
 
-    middleware(req, res, next)
+    checkCompanyNumberNotSubmitted(req, res, next)
 
     setTimeout(() => {
       expect(next.calledOnce).to.be.true // eslint-disable-line
@@ -51,11 +50,9 @@ describe('Check "Company registration number" not submitted middleware', () => {
   })
 
   it('should redirect to the dashboard with error message when "Company number" flag is true', done => {
-    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
-      companyNumber: true
-    })
+    req.account.connectorGatewayAccountStripeProgress.companyNumber = true
 
-    middleware(req, res, next)
+    checkCompanyNumberNotSubmitted(req, res, next)
 
     setTimeout(() => {
       expect(next.notCalled).to.be.true // eslint-disable-line
@@ -66,12 +63,9 @@ describe('Check "Company registration number" not submitted middleware', () => {
   })
 
   it('should render an error page when req.account is undefined', done => {
-    const middleware = getMiddlewareWithConnectorClientResolvedPromiseMock({
-      companyNumber: false
-    })
     req.account = undefined
 
-    middleware(req, res, next)
+    checkCompanyNumberNotSubmitted(req, res, next)
 
     setTimeout(() => {
       expect(next.notCalled).to.be.true // eslint-disable-line
@@ -81,12 +75,10 @@ describe('Check "Company registration number" not submitted middleware', () => {
     }, 250)
   })
 
-  it('should render an error page when connector rejects the call', done => {
-    const middleware = getMiddlewareWithConnectorClientRejectedPromiseMock({
-      companyNumber: false
-    })
+  it('should render an error page when req.account.connectorGatewayAccountStripeProgress is undefined', done => {
+    req.account.connectorGatewayAccountStripeProgress = undefined
 
-    middleware(req, res, next)
+    checkCompanyNumberNotSubmitted(req, res, next)
 
     setTimeout(() => {
       expect(next.notCalled).to.be.true // eslint-disable-line
@@ -96,31 +88,3 @@ describe('Check "Company registration number" not submitted middleware', () => {
     }, 250)
   })
 })
-
-function getMiddlewareWithConnectorClientResolvedPromiseMock (getStripeAccountSetupResponse) {
-  return proxyquire('./check-company-number-not-submitted', {
-    '../../services/clients/connector.client': {
-      ConnectorClient: function () {
-        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => {
-          return new Promise(resolve => {
-            resolve(getStripeAccountSetupResponse)
-          })
-        }
-      }
-    }
-  })
-}
-
-function getMiddlewareWithConnectorClientRejectedPromiseMock (getStripeAccountSetupResponse) {
-  return proxyquire('./check-company-number-not-submitted', {
-    '../../services/clients/connector.client': {
-      ConnectorClient: function () {
-        this.getStripeAccountSetup = (gatewayAccountId, correlationId) => {
-          return new Promise((resolve, reject) => {
-            reject(new Error())
-          })
-        }
-      }
-    }
-  })
-}

--- a/app/middleware/stripe-setup/check-responsible-person-not-submitted.js
+++ b/app/middleware/stripe-setup/check-responsible-person-not-submitted.js
@@ -1,8 +1,6 @@
 'use strict'
 
 // Local dependencies
-const { ConnectorClient } = require('../../services/clients/connector.client')
-const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 const { renderErrorView } = require('../../utils/response')
 const paths = require('../../paths')
 
@@ -12,14 +10,15 @@ module.exports = function checkResponsiblePersonNotSubmitted (req, res, next) {
     return
   }
 
-  connector.getStripeAccountSetup(req.account.gateway_account_id, req.correlationId).then(stripeSetupResponse => {
-    if (stripeSetupResponse.responsiblePerson) {
+  const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
+  if (!stripeAccountSetup) {
+    renderErrorView(req, res, 'Please try again or contact support team')
+  } else {
+    if (stripeAccountSetup.responsiblePerson) {
       req.flash('genericError', 'You’ve already nominated your responsible person.<br>Contact GOV.UK Pay support if you need to change them.')
       res.redirect(303, paths.dashboard.index)
     } else {
       next()
     }
-  }).catch(() => {
-    renderErrorView(req, res, 'Please try again or contact support team')
-  })
+  }
 }

--- a/app/middleware/stripe-setup/check-vat-number-not-submitted.js
+++ b/app/middleware/stripe-setup/check-vat-number-not-submitted.js
@@ -1,8 +1,6 @@
 'use strict'
 
 // Local dependencies
-const { ConnectorClient } = require('../../services/clients/connector.client')
-const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 const { renderErrorView } = require('../../utils/response')
 const paths = require('../../paths')
 
@@ -12,14 +10,15 @@ module.exports = function checkVatNumberNotSubmitted (req, res, next) {
     return
   }
 
-  connector.getStripeAccountSetup(req.account.gateway_account_id, req.correlationId).then(stripeSetupResponse => {
-    if (stripeSetupResponse.vatNumber) {
+  const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
+  if (!stripeAccountSetup) {
+    renderErrorView(req, res, 'Please try again or contact support team')
+  } else {
+    if (stripeAccountSetup.vatNumber) {
       req.flash('genericError', 'You’ve already provided your VAT number.<br />Contact GOV.UK Pay support if you need to update it.')
       res.redirect(303, paths.dashboard.index)
     } else {
       next()
     }
-  }).catch(() => {
-    renderErrorView(req, res, 'Please try again or contact support team')
-  })
+  }
 }

--- a/test/cypress/integration/stripe-setup/bank-details.cy.test.js
+++ b/test/cypress/integration/stripe-setup/bank-details.cy.test.js
@@ -152,7 +152,7 @@ describe('Stripe setup: bank details page', () => {
         cy.task('setupStubs', [
           commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
-          stubStripeSetupGetForMultipleCalls(false, false, true, true),
+          stubStripeSetupGetForMultipleCalls(false, true),
           stubStripeAccountGet('acct_123example123'),
           commonStubs.getDashboardStatisticsStub()
         ])

--- a/test/cypress/integration/stripe-setup/company-number.cy.test.js
+++ b/test/cypress/integration/stripe-setup/company-number.cy.test.js
@@ -115,7 +115,7 @@ describe('Stripe setup: company number page', () => {
         cy.task('setupStubs', [
           commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
-          stubStripeSetupGetForMultipleCallsAndCompanyNumberCompleted(gatewayAccountId, false, false, true, true),
+          stubStripeSetupGetForMultipleCallsAndCompanyNumberCompleted(gatewayAccountId, false, true),
           stubStripeAccountGet(gatewayAccountId, 'acct_123example123'),
           stubDashboardStatisticsGet()
         ])

--- a/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
@@ -279,7 +279,7 @@ describe('Stripe setup: responsible person page', () => {
       cy.task('setupStubs', [
         commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
         commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
-        stubStripeSetupGetForMultipleCalls(false, false, false, true),
+        stubStripeSetupGetForMultipleCalls(false, true),
         stubStripeAccountGet('acct_123example123'),
         commonStubs.getDashboardStatisticsStub()
       ])

--- a/test/cypress/integration/stripe-setup/vat-number.cy.test.js
+++ b/test/cypress/integration/stripe-setup/vat-number.cy.test.js
@@ -97,7 +97,7 @@ describe('Stripe setup: VAT number page', () => {
         cy.task('setupStubs', [
           commonStubs.getUserStub(userExternalId, [gatewayAccountId]),
           commonStubs.getGatewayAccountStub(gatewayAccountId, 'live', 'stripe'),
-          stubStripeSetupGetForMultipleCallsAndVatNumberCompleted(gatewayAccountId, false, false, true, true),
+          stubStripeSetupGetForMultipleCallsAndVatNumberCompleted(gatewayAccountId, false, true),
           stubStripeAccountGet(gatewayAccountId, 'acct_123example123'),
           stubDashboardStatisticsGet()
         ])


### PR DESCRIPTION
## WHAT
- We have getAccount (get-gateway-account.js) middleware where we get make a call to connector to get current stripe setup and is added to req.account object.
  We can remove getStripeSetup calls from controllers as it is taken care in middle and information available on req object


