### PR TITLE
PP-6864 Improve organisation address cypress tests

### DIFF
--- a/test/cypress/integration/request-to-go-live/organisation-address.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/organisation-address.cy.test.js
@@ -16,171 +16,136 @@ describe('The organisation address page', () => {
   const invalidPostcode = '123'
   const validTelephoneNumber = '01134960000'
   const invalidTelephoneNumber = 'abd'
-  const longText = 'This text is 256 ...............................................................................' +
-    '...............................................................................................................' +
-    '..................................characters long'
-
-  beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-  })
 
   describe('The go-live stage is ENTERED_ORGANISATION_NAME and there are no existing merchant details', () => {
     beforeEach(() => {
-      const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')
-      utils.setupGetUserAndGatewayAccountStubs(serviceRole)
-
-      cy.visit(pageUrl)
+      // keep the same session for entire describe block
+      Cypress.Cookies.preserveOnce('session')
+      Cypress.Cookies.preserveOnce('gateway_account')
     })
 
-    it('should display form', () => {
-      cy.get('h1').should('contain', `What is your organisation's address?`)
-
-      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
-        .should('exist')
-        .within(() => {
-          cy.get('label[for="address-line1"]').should('exist')
-          cy.get('input#address-line1[name="address-line1"]').should('exist')
-          cy.get('input#address-line2[name="address-line2"]').should('exist')
-
-          cy.get('label[for="address-city"]').should('exist')
-          cy.get('input#address-city[name="address-city"]').should('exist')
-
-          cy.get('label[for="address-country"]').should('exist')
-          cy.get('select#address-country[name="address-country"]').should('exist')
-
-          cy.get('label[for="address-postcode"]').should('exist')
-          cy.get('input#address-postcode[name="address-postcode"]').should('exist')
-
-          cy.get('label[for="telephone-number"]').should('exist')
-          cy.get('span#telephone-number-hint').should('exist')
-          cy.get('input#telephone-number[name="telephone-number"]').should('exist')
-        })
-    })
-
-    it('should display errors when validation fails', () => {
-      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
-        .within(() => {
-          // create errors for all fields except country by leaving them blank or inputting invalid values
-          cy.get('#address-line2').type(longText, { delay: 0 })
-          cy.get('button').click()
-        })
-
-      cy.get('.govuk-error-summary').find('a').should('have.length', 4)
-      cy.get('.govuk-error-summary').should('exist').within(() => {
-        cy.get('a[href="#address-line1"]').should('contain', 'Building and street')
-        cy.get('a[href="#address-city"]').should('contain', 'Town or city')
-        cy.get('a[href="#address-postcode"]').should('contain', 'Postcode')
-        cy.get('a[href="#telephone-number"]').should('contain', 'Telephone number')
+    describe('Form validation', () => {
+      beforeEach(() => {
+        const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')
+        utils.setupGetUserAndGatewayAccountStubs(serviceRole)
       })
 
-      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
-        .within(() => {
-          cy.get('.govuk-form-group--error > input#address-line1').parent().should('exist').within(() => {
-            cy.get('.govuk-error-message').should('contain', 'This field cannot be blank')
-          })
-          cy.get('.govuk-form-group--error > input#address-line2').parent().should('exist').within(() => {
-            cy.get('.govuk-error-message').should('contain', 'The text is too long')
-            cy.get('input#address-line2').should('have.value', longText)
-          })
-          cy.get('.govuk-form-group--error > input#address-city').parent().should('exist').within(() => {
-            cy.get('.govuk-error-message').should('contain', 'This field cannot be blank')
-          })
-          cy.get('.govuk-form-group--error > input#address-postcode').parent().should('exist').within(() => {
-            cy.get('.govuk-error-message').should('contain', 'This field cannot be blank')
-          })
-          cy.get('.govuk-form-group--error > input#telephone-number').parent().should('exist').within(() => {
-            cy.get('.govuk-error-message').should('contain', 'This field cannot be blank')
-          })
-        })
-    })
+      it('should display form', () => {
+        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.visit(pageUrl)
 
-    it('should keep entered responses when validation fails', () => {
-      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
-        .within(() => {
-          cy.get('#address-line1').type(validLine1)
-          cy.get('#address-line2').type(validLine2)
-          cy.get('#address-city').type(validCity)
-          cy.get('#address-country').select(countryIe)
-          cy.get('#address-postcode').type(validPostcodeIe)
-          cy.get('#telephone-number').type(invalidTelephoneNumber)
-          cy.get('button').click()
-        })
+        cy.get('h1').should('contain', `What is your organisation's address?`)
 
-      cy.get('.govuk-error-summary').find('a').should('have.length', 1)
-      cy.get('.govuk-error-summary').should('exist').within(() => {
-        cy.get('a[href="#telephone-number"]').should('contain', 'Telephone number')
+        cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
+          .should('exist')
+          .within(() => {
+            cy.get('label[for="address-line1"]').should('exist')
+            cy.get('input#address-line1[name="address-line1"]').should('exist')
+            cy.get('input#address-line2[name="address-line2"]').should('exist')
+
+            cy.get('label[for="address-city"]').should('exist')
+            cy.get('input#address-city[name="address-city"]').should('exist')
+
+            cy.get('label[for="address-country"]').should('exist')
+            cy.get('select#address-country[name="address-country"]').should('exist')
+
+            cy.get('label[for="address-postcode"]').should('exist')
+            cy.get('input#address-postcode[name="address-postcode"]').should('exist')
+
+            cy.get('label[for="telephone-number"]').should('exist')
+            cy.get('span#telephone-number-hint').should('exist')
+            cy.get('input#telephone-number[name="telephone-number"]').should('exist')
+          })
       })
 
-      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
-        .within(() => {
-          cy.get('.govuk-form-group--error > input#telephone-number').parent().should('exist').within(() => {
-            cy.get('.govuk-error-message').should('contain', 'Invalid telephone number')
+      it('should display errors when validation fails', () => {
+        cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
+          .within(() => {
+            // create errors by leaving fields blank or inputting invalid values
+            cy.get('#address-postcode').type(invalidPostcode)
+            cy.get('#telephone-number').type(invalidTelephoneNumber)
+
+            cy.get('button').click()
           })
 
-          cy.get('#address-line1').should('have.value', validLine1)
-          cy.get('#address-line2').should('have.value', validLine2)
-          cy.get('#address-city').should('have.value', validCity)
-          cy.get('#address-country').should('have.value', countryIe)
-          cy.get('#address-postcode').should('have.value', validPostcodeIe)
-          cy.get('#telephone-number').should('have.value', invalidTelephoneNumber)
-        })
-    })
-
-    it('should show errors for invalid postcode', () => {
-      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
-        .within(() => {
-          cy.get('#address-line1').type(validLine1)
-          cy.get('#address-line2').type(validLine2)
-          cy.get('#address-city').type(validCity)
-          cy.get('#address-country').select(countryGb)
-          cy.get('#address-postcode').type(invalidPostcode)
-          cy.get('#telephone-number').type(validTelephoneNumber)
-          cy.get('button').click()
+        cy.get('.govuk-error-summary').find('a').should('have.length', 4)
+        cy.get('.govuk-error-summary').should('exist').within(() => {
+          cy.get('a[href="#address-line1"]').should('contain', 'Building and street')
+          cy.get('a[href="#address-city"]').should('contain', 'Town or city')
+          cy.get('a[href="#address-postcode"]').should('contain', 'Postcode')
+          cy.get('a[href="#telephone-number"]').should('contain', 'Telephone number')
         })
 
-      cy.get('.govuk-error-summary').find('a').should('have.length', 1)
-      cy.get('.govuk-error-summary').should('exist').within(() => {
-        cy.get('a[href="#address-postcode"]').should('contain', 'Postcode')
+        cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
+          .within(() => {
+            cy.get('.govuk-form-group--error > input#address-line1').parent().should('exist').within(() => {
+              cy.get('.govuk-error-message').should('contain', 'This field cannot be blank')
+            })
+            cy.get('.govuk-form-group--error > input#address-city').parent().should('exist').within(() => {
+              cy.get('.govuk-error-message').should('contain', 'This field cannot be blank')
+            })
+            cy.get('.govuk-form-group--error > input#address-postcode').parent().should('exist').within(() => {
+              cy.get('.govuk-error-message').should('contain', 'Please enter a real postcode')
+            })
+            cy.get('.govuk-form-group--error > input#telephone-number').parent().should('exist').within(() => {
+              cy.get('.govuk-error-message').should('contain', 'Invalid telephone number')
+            })
+          })
       })
 
-      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
-        .within(() => {
-          cy.get('.govuk-form-group--error > input#address-postcode').parent().should('exist').within(() => {
-            cy.get('.govuk-error-message').should('contain', 'Please enter a real postcode')
+      it('should keep entered responses when validation fails', () => {
+        cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
+          .within(() => {
+            // fill in the rest of the form fields
+            cy.get('#address-line1').type(validLine1)
+            cy.get('#address-line2').type(validLine2)
+            cy.get('#address-city').type(validCity)
+            cy.get('#address-country').select(countryGb)
+            cy.get('button').click()
           })
-        })
-    })
-  })
 
-  describe('Valid details submitted', () => {
-    beforeEach(() => {
-      const initialServiceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')
-      const afterUpdateServiceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS')
-
-      const getUserAndGateayAccountStubs = utils.getUserWithModifiedServiceRoleOnNextRequestStub(initialServiceRole, afterUpdateServiceRole)
-
-      cy.task('setupStubs', [
-        utils.patchUpdateServiceSuccessCatchAllStub('ENTERED_ORGANISATION_ADDRESS'),
-        ...getUserAndGateayAccountStubs
-      ])
-
-      cy.visit(pageUrl)
-    })
-
-    it('should submit organisation address when validation succeeds', () => {
-      cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
-        .within(() => {
-          cy.get('#address-line1').type(validLine1)
-          cy.get('#address-line2').type(validLine2)
-          cy.get('#address-city').type(validCity)
-          cy.get('#address-country').select(countryGb)
-          cy.get('#address-postcode').type(validPostcodeGb)
-          cy.get('#telephone-number').type(validTelephoneNumber)
-          cy.get('button').click()
+        cy.get('.govuk-error-summary').find('a').should('have.length', 2)
+        cy.get('.govuk-error-summary').should('exist').within(() => {
+          cy.get('a[href="#address-postcode"]').should('contain', 'Postcode')
+          cy.get('a[href="#telephone-number"]').should('contain', 'Telephone number')
         })
 
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`)
+        cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
+          .within(() => {
+            cy.get('#address-line1').should('have.value', validLine1)
+            cy.get('#address-line2').should('have.value', validLine2)
+            cy.get('#address-city').should('have.value', validCity)
+            cy.get('#address-country').should('have.value', countryGb)
+            cy.get('#address-postcode').should('have.value', invalidPostcode)
+            cy.get('#telephone-number').should('have.value', invalidTelephoneNumber)
+          })
+      })
+    })
+
+    describe('Valid details submitted', () => {
+      beforeEach(() => {
+        const afterUpdateServiceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS')
+
+        cy.task('setupStubs', [
+          utils.patchUpdateServiceSuccessCatchAllStub('ENTERED_ORGANISATION_ADDRESS'),
+          ...utils.getUserAndGatewayAccountStubs(afterUpdateServiceRole)
+        ])
+      })
+
+      it('should submit organisation address when validation succeeds', () => {
+        cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
+          .within(() => {
+            // correct the validation errors
+            cy.get('#address-postcode').clear()
+            cy.get('#telephone-number').clear()
+            cy.get('#address-postcode').type(validPostcodeGb)
+            cy.get('#telephone-number').type(validTelephoneNumber)
+            cy.get('button').click()
+          })
+
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`)
+        })
       })
     })
   })
@@ -198,6 +163,7 @@ describe('The organisation address page', () => {
     serviceRole.service.merchant_details = merchantDetails
 
     it('should display form with existing details pre-filled', () => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
       utils.setupGetUserAndGatewayAccountStubs(serviceRole)
       cy.visit(`/service/${serviceExternalId}/request-to-go-live/organisation-address`)
 
@@ -217,6 +183,7 @@ describe('The organisation address page', () => {
     const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')
     serviceRole.role = { permissions: [] }
     beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
       utils.setupGetUserAndGatewayAccountStubs(serviceRole)
     })
 
@@ -230,6 +197,7 @@ describe('The organisation address page', () => {
   describe('Service has invalid go live stage', () => {
     const serviceRole = utils.buildServiceRoleForGoLiveStage('NOT_STARTED')
     beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
       utils.setupGetUserAndGatewayAccountStubs(serviceRole)
     })
 


### PR DESCRIPTION
- Stop typing in long string to test validation for address line 2 as this isn't worthwhile for the amount of time taken.
- Roll test for validation of postcode into the other test checking validations
- Don't re-fill the form multiple times, instead stay on the same page and edit fields in different test cases to save time. Using cy.Cookies.preserveOnce allows for this.

