### PR TITLE
PP-6864 Improve organisation name cypress test

### DIFF
--- a/test/cypress/utils/request-to-go-live-utils.js
+++ b/test/cypress/utils/request-to-go-live-utils.js
@@ -51,15 +51,6 @@ const getUserAndGatewayAccountStubs = (serviceRole) => {
   ]
 }
 
-const getUserWithModifiedServiceRoleOnNextRequestStub = (serviceRoleBefore, serviceRoleAfter) =>
-  [
-    userStubs.getUserSuccessRepeatFirstResponseNTimes([
-      { userExternalId: variables.userExternalId, serviceRoles: serviceRoleBefore },
-      { userExternalId: variables.userExternalId, serviceRoles: serviceRoleAfter }
-    ]),
-    gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId: variables.gatewayAccountId })
-  ]
-
 const patchUpdateGoLiveStageSuccessStub = (currentGoLiveStage) => {
   return serviceStubs.patchUpdateServiceGoLiveStageSuccess({
     serviceExternalId: variables.serviceExternalId,
@@ -101,7 +92,6 @@ module.exports = {
   buildServiceRoleForGoLiveStageWithMerchantName,
   buildServiceRoleWithMerchantDetails,
   getUserAndGatewayAccountStubs,
-  getUserWithModifiedServiceRoleOnNextRequestStub,
   patchUpdateGoLiveStageSuccessStub,
   patchUpdateGoLiveStageErrorStub,
   patchUpdateServiceSuccessCatchAllStub,


### PR DESCRIPTION
Re-organise stubbing to set up the stubs in the individual `it` blocks to avoid overly complicated stubs with repeat behaviour.

Remove some of the duplication that exists in the test.


