### PR TITLE
PP-6864 Remove gateway account stub with repeat behaviour

### DIFF
--- a/test/cypress/integration/settings/your-psp.cy.test.js
+++ b/test/cypress/integration/settings/your-psp.cy.test.js
@@ -64,8 +64,8 @@ describe('Your PSP settings page', () => {
       gatewayAccount.opts.notificationCredentials = opts.notificationCredentials
     }
 
-    if (opts.worldpay_3ds_flex) {
-      gatewayAccount.opts.worldpay_3ds_flex = opts.worldpay_3ds_flex
+    if (opts.worldpay3dsFlex) {
+      gatewayAccount.opts.worldpay_3ds_flex = opts.worldpay3dsFlex
     }
 
     const card = gatewayAccountStubs.getAcceptedCardTypesSuccess({ gatewayAccountId, updated: false })
@@ -84,20 +84,12 @@ describe('Your PSP settings page', () => {
     let stubs = []
 
     const user = userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName })
-
-    const gatewayAccount = gatewayAccountStubs.getGatewayAccountSuccessRepeat([{
-      gatewayAccountId,
-      worldpay3dsFlex: opts.worldpay_3ds_flex,
-      paymentProvider: opts.gateway,
-      credentials: opts.credentials,
-      repeat: 2
-    },
-    {
+    const gatewayAccount = gatewayAccountStubs.getGatewayAccountSuccess({
       gatewayAccountId,
       paymentProvider: opts.gateway,
       worldpay3dsFlex: opts.worldpay_3ds_flex_remove,
       credentials: opts.credentials
-    }])
+    })
 
     const patchUpdateCredentials = {
       name: 'patchUpdateCredentials',
@@ -188,16 +180,13 @@ describe('Your PSP settings page', () => {
   })
 
   describe('When using a Worldpay account with existing credentials', () => {
-    beforeEach(() => {
-      setupRemoveFlexCredsStubs({
+    it('should show all credentials as configured', () => {
+      setupYourPspStubs({
         gateway: 'worldpay',
         credentials: testCredentials,
-        worldpay_3ds_flex: testFlexCredentials,
-        worldpay_3ds_flex_remove: testRemoveFlexCredentials
+        worldpay3dsFlex: testFlexCredentials
       })
-    })
 
-    it('should show all credentials as configured', () => {
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
       cy.visit('/your-psp')
       cy.get('.value-merchant-id').should('contain', testCredentials.merchant_id)
@@ -206,10 +195,17 @@ describe('Your PSP settings page', () => {
       cy.get('.value-organisational-unit-id').should('contain', testFlexCredentials.organisational_unit_id)
       cy.get('.value-issuer').should('contain', testFlexCredentials.issuer)
       cy.get('.value-jwt-mac-key').should('contain', '●●●●●●●●')
+
+      cy.get('#flex-credentials-change-link').click()
     })
 
     it('should allow removing 3DS Flex credentials', function () {
-      cy.get('#flex-credentials-change-link').click()
+      setupRemoveFlexCredsStubs({
+        gateway: 'worldpay',
+        credentials: testCredentials,
+        worldpay_3ds_flex_remove: testRemoveFlexCredentials
+      })
+
       cy.get('#removeFlexCredentials').should('be.visible')
       cy.get('#removeFlexCredentials').click()
       cy.location().should((location) => {

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -230,46 +230,6 @@ module.exports = {
       response: gatewayAccountFixtures.validGatewayAccountsResponse({ accounts: [opts] }).getPlain()
     })
   },
-  getGatewayAccountSuccessRepeatNTimes: (opts = {}) => {
-    const aValidGetGatewayAccountResponse = gatewayAccountFixtures.validGatewayAccountResponse(opts[0]).getPlain()
-    const aSecondValidGetGatewayAccountResponse = gatewayAccountFixtures.validGatewayAccountResponse(opts[1]).getPlain()
-    return [
-      {
-        predicates: [{
-          equals: {
-            method: 'GET',
-            path: `/v1/frontend/accounts/${opts[0].gateway_account_id}`,
-            headers: {
-              'Accept': 'application/json'
-            }
-          }
-        }],
-        responses: [{
-          is: {
-            statusCode: 200,
-            headers: {
-              'Content-Type': 'application/json'
-            },
-            body: aValidGetGatewayAccountResponse
-          },
-          _behaviors: {
-            repeat: 1
-          }
-        }, {
-          is: {
-            statusCode: 200,
-            headers: {
-              'Content-Type': 'application/json'
-            },
-            body: aSecondValidGetGatewayAccountResponse
-          },
-          _behaviors: {
-            repeat: 1
-          }
-        }]
-      }
-    ]
-  },
   getDirectDebitGatewayAccountSuccess: (opts = {}) => {
     const path = '/v1/api/accounts/' + opts.gateway_account_id
     return simpleStubBuilder('GET', path, 200, {

--- a/test/cypress/utils/gateway-account-stubs.js
+++ b/test/cypress/utils/gateway-account-stubs.js
@@ -18,6 +18,12 @@ const getGatewayAccountSuccess = function (opts) {
   if (opts.type) {
     stubOptions.type = opts.type
   }
+  if (opts.worldpay3dsFlex) {
+    stubOptions.worldpay_3ds_flex = opts.worldpay3dsFlex
+  }
+  if (opts.credentials) {
+    stubOptions.credentials = opts.credentials
+  }
 
   return {
     name: 'getGatewayAccountSuccess',
@@ -78,25 +84,6 @@ const getCardTypesSuccess = function () {
   }
 }
 
-const getGatewayAccountSuccessRepeat = function (opts) {
-  return {
-    name: 'getGatewayAccountSuccessRepeat',
-    opts: [{
-      gateway_account_id: opts[0].gatewayAccountId,
-      worldpay_3ds_flex: opts[0].worldpay3dsFlex,
-      payment_provider: opts[0].paymentProvider,
-      credentials: opts[0].credentials,
-      repeat: 2
-    },
-    {
-      gateway_account_id: opts[1].gatewayAccountId,
-      payment_provider: opts[1].paymentProvider,
-      worldpay_3ds_flex: opts[1].worldpay3dsFlex,
-      credentials: opts[1].credentials
-    }]
-  }
-}
-
 const patchUpdate3DS = function (opts) {
   return {
     name: 'patchUpdate3DS',
@@ -108,7 +95,6 @@ const patchUpdate3DS = function (opts) {
 
 module.exports = {
   getGatewayAccountSuccess,
-  getGatewayAccountSuccessRepeat,
   getGatewayAccountsSuccess,
   getAcceptedCardTypesSuccess,
   getDirectDebitGatewayAccountSuccess,


### PR DESCRIPTION
The repeat behaviour was required because we were setting up all the stubs in the `beforeEach` for a `describe` block in a Cypress test.

By move the stub setup to the individual `it` blocks where the stubs will be called, we can avoid this behaviour and make the stub setup less confusing.


