### PR TITLE
PP-6864 Remove additional Cypress.Cookies.preserveOnce calls

### DIFF
--- a/test/cypress/integration/manage-team-members/edit-permissions.cy.test.js
+++ b/test/cypress/integration/manage-team-members/edit-permissions.cy.test.js
@@ -10,8 +10,7 @@ const EDITING_USER_ID = 'user-we-are-editing-id'
 describe('Edit service user permissions', () => {
   beforeEach(() => {
     // keep the same session for entire describe block
-    Cypress.Cookies.preserveOnce('session')
-    Cypress.Cookies.preserveOnce('gateway_account')
+    Cypress.Cookies.preserveOnce('session', 'gateway_account')
 
     const authenticatedUserStubOpts = {
       userExternalId: AUTHENTICATED_USER_ID,

--- a/test/cypress/integration/my-services/add-new-service.cy.test.js
+++ b/test/cypress/integration/my-services/add-new-service.cy.test.js
@@ -27,8 +27,7 @@ function setupStubs (stubs = []) {
 describe('Add a new service', () => {
   beforeEach(() => {
     // keep the same session for entire describe block
-    Cypress.Cookies.preserveOnce('session')
-    Cypress.Cookies.preserveOnce('gateway_account')
+    Cypress.Cookies.preserveOnce('session', 'gateway_account')
   })
 
   describe('Add a new service without a Welsh name', () => {

--- a/test/cypress/integration/my-services/my-services-links.cy.test.js
+++ b/test/cypress/integration/my-services/my-services-links.cy.test.js
@@ -9,8 +9,7 @@ const authenticatedUserId = 'authenticated-user-id'
 describe('Service has a live account that supports payouts', () => {
   beforeEach(() => {
     // keep the same session for entire describe block
-    Cypress.Cookies.preserveOnce('session')
-    Cypress.Cookies.preserveOnce('gateway_account')
+    Cypress.Cookies.preserveOnce('session', 'gateway_account')
   })
 
   it('should display link to view payouts', () => {

--- a/test/cypress/integration/my-services/update-service-name.cy.test.js
+++ b/test/cypress/integration/my-services/update-service-name.cy.test.js
@@ -26,8 +26,7 @@ function setupStubs (serviceName, stubs = []) {
 describe('Update service name', () => {
   beforeEach(() => {
     // keep the same session for entire describe block
-    Cypress.Cookies.preserveOnce('session')
-    Cypress.Cookies.preserveOnce('gateway_account')
+    Cypress.Cookies.preserveOnce('session', 'gateway_account')
   })
 
   describe('Edit a service name without a Welsh name', () => {

--- a/test/cypress/integration/request-to-go-live/organisation-address.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/organisation-address.cy.test.js
@@ -20,8 +20,7 @@ describe('The organisation address page', () => {
   describe('The go-live stage is ENTERED_ORGANISATION_NAME and there are no existing merchant details', () => {
     beforeEach(() => {
       // keep the same session for entire describe block
-      Cypress.Cookies.preserveOnce('session')
-      Cypress.Cookies.preserveOnce('gateway_account')
+      Cypress.Cookies.preserveOnce('session', 'gateway_account')
     })
 
     describe('Form validation', () => {


### PR DESCRIPTION
Can call with multiple cookie names, so just make a single call each time
