### PR TITLE
PP-6864 Improvements to request to go live tests

### DIFF
--- a/test/cypress/integration/request-to-go-live/agreement.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/agreement.cy.test.js
@@ -1,19 +1,34 @@
 'use strict'
 
-const lodash = require('lodash')
 const utils = require('../../utils/request-to-go-live-utils')
 const { userExternalId, gatewayAccountId, serviceExternalId } = utils.variables
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 const userStubs = require('../../stubs/user-stubs')
 const goLiveRequestStubs = require('../../stubs/go-live-request-stubs')
+const serviceStubs = require('../../stubs/service-stubs')
+
+const requestToGoLiveAgreementUrl = `/service/${serviceExternalId}/request-to-go-live/agreement`
+
+function getStubsForPageSubmission (chosenPspGoLiveStage, termsAgreedGoLiveStage) {
+  return [
+    userStubs.getUserSuccessRespondDifferentlySecondTime(userExternalId,
+      { gatewayAccountId, serviceExternalId, goLiveStage: chosenPspGoLiveStage, merchantName: 'GDS' },
+      { gatewayAccountId, serviceExternalId, goLiveStage: termsAgreedGoLiveStage, merchantName: 'GDS' }
+    ),
+    gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId }),
+    serviceStubs.patchUpdateServiceGoLiveStageSuccess({ serviceExternalId, gatewayAccountId, currentGoLiveStage: termsAgreedGoLiveStage }),
+    goLiveRequestStubs.postGovUkPayAgreement({ userExternalId, serviceExternalId })
+  ]
+}
 
 describe('Request to go live: agreement', () => {
   beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    Cypress.Cookies.preserveOnce('session', 'gateway_account')
   })
 
-  describe('NO PERMISSIONS', () => {
+  describe('User does not have permission', () => {
     beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
       const serviceRole = utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_STRIPE')
       serviceRole.role = {
         permissions: []
@@ -22,20 +37,19 @@ describe('Request to go live: agreement', () => {
     })
 
     it('should show an error when the user does not have enough permissions', () => {
-      const requestToGoLivePageOrganisationNameUrl = `/service/${serviceExternalId}/request-to-go-live/agreement`
-      cy.visit(requestToGoLivePageOrganisationNameUrl, { failOnStatusCode: false })
+      cy.visit(requestToGoLiveAgreementUrl, { failOnStatusCode: false })
       cy.get('h1').should('contain', 'An error occurred:')
       cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
     })
   })
 
-  describe('REQUEST_TO_GO_LIVE_STAGE_WRONG_STAGE', () => {
+  describe('The service has the wrong go live stage', () => {
     beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
       utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME'))
     })
 
     it('should redirect to "Request to go live: index" page when in wrong stage', () => {
-      const requestToGoLiveAgreementUrl = `/service/${serviceExternalId}/request-to-go-live/agreement`
       cy.visit(requestToGoLiveAgreementUrl)
 
       cy.get('h1').should('contain', 'Request a live account')
@@ -46,42 +60,11 @@ describe('Request to go live: agreement', () => {
     })
   })
 
-  describe('REQUEST_TO_GO_LIVE_STAGE_NOT_STARTED_STAGE', () => {
-    beforeEach(() => {
-      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('NOT_STARTED'))
-    })
-
-    it('should redirect to "Request to go live: index" page when in not started stage', () => {
-      const requestToGoLiveAgreementUrl = `/service/${serviceExternalId}/request-to-go-live/agreement`
-      cy.visit(requestToGoLiveAgreementUrl)
-
-      cy.get('h1').should('contain', 'Request a live account')
-
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live`)
-      })
-    })
-  })
-
-  describe('REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_STRIPE', () => {
-    const repeatGetUserSuccessStub = [
-      userStubs.getUserSuccessRepeatFirstResponseNTimes([
-        { userExternalId, serviceRoles: utils.buildServiceRoleForGoLiveStageWithMerchantName('CHOSEN_PSP_STRIPE') },
-        { userExternalId, serviceRoles: utils.buildServiceRoleForGoLiveStageWithMerchantName('TERMS_AGREED_STRIPE') }
-      ]),
-      gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId })
-    ]
-
-    const stubPayload = lodash.concat(repeatGetUserSuccessStub,
-      utils.patchUpdateGoLiveStageSuccessStub('TERMS_AGREED_STRIPE'),
-      goLiveRequestStubs.postGovUkPayAgreement({ userExternalId, serviceExternalId }),
-      goLiveRequestStubs.postStripeAgreementIpAddress({ serviceExternalId }))
-    beforeEach(() => {
-      cy.task('setupStubs', stubPayload)
-    })
-
+  describe('Stripe has been chosen as the PSP', () => {
     it('should display "Read and accept our legal terms" page when in CHOSEN_PSP_STRIPE', () => {
-      const requestToGoLiveAgreementUrl = `/service/${serviceExternalId}/request-to-go-live/agreement`
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_STRIPE'))
+
       cy.visit(requestToGoLiveAgreementUrl)
 
       cy.get('h1').should('contain', 'Read and accept our legal terms')
@@ -99,6 +82,13 @@ describe('Request to go live: agreement', () => {
 
       cy.get('#request-to-go-live-agreement-form > button').should('exist')
       cy.get('#request-to-go-live-agreement-form > button').should('contain', 'Continue')
+    })
+
+    it('should continue to the index page when terms are agreed to', () => {
+      cy.task('setupStubs', [
+        ...getStubsForPageSubmission('CHOSEN_PSP_STRIPE', 'TERMS_AGREED_STRIPE'),
+        goLiveRequestStubs.postStripeAgreementIpAddress({ serviceExternalId })
+      ])
 
       cy.get('#agreement').check()
       cy.get('#request-to-go-live-agreement-form > button').click()
@@ -109,25 +99,11 @@ describe('Request to go live: agreement', () => {
     })
   })
 
-  describe('REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_WORLDPAY', () => {
-    const repeatGetUserSuccessStub = [
-      userStubs.getUserSuccessRepeatFirstResponseNTimes([
-        { userExternalId, serviceRoles: utils.buildServiceRoleForGoLiveStageWithMerchantName('CHOSEN_PSP_WORLDPAY') },
-        { userExternalId, serviceRoles: utils.buildServiceRoleForGoLiveStageWithMerchantName('TERMS_AGREED_WORLDPAY') }
-      ]),
-      gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId })
-    ]
-
-    const stubPayload = lodash.concat(repeatGetUserSuccessStub,
-      utils.patchUpdateGoLiveStageSuccessStub('TERMS_AGREED_WORLDPAY'),
-      goLiveRequestStubs.postGovUkPayAgreement({ userExternalId, serviceExternalId }))
-
-    beforeEach(() => {
-      cy.task('setupStubs', stubPayload)
-    })
-
+  describe('Worldpay has been chosen as the PSP', () => {
     it('should display "Read and accept our legal terms" page when in CHOSEN_PSP_WORLDPAY', () => {
-      const requestToGoLiveAgreementUrl = `/service/${serviceExternalId}/request-to-go-live/agreement`
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_WORLDPAY'))
+
       cy.visit(requestToGoLiveAgreementUrl)
 
       cy.get('h1').should('contain', 'Read and accept our legal terms')
@@ -145,6 +121,10 @@ describe('Request to go live: agreement', () => {
 
       cy.get('#request-to-go-live-agreement-form > button').should('exist')
       cy.get('#request-to-go-live-agreement-form > button').should('contain', 'Continue')
+    })
+
+    it('should continue to the index page when terms are agreed to', () => {
+      cy.task('setupStubs', getStubsForPageSubmission('CHOSEN_PSP_WORLDPAY', 'TERMS_AGREED_WORLDPAY'))
 
       cy.get('#agreement').check()
       cy.get('#request-to-go-live-agreement-form > button').click()
@@ -155,28 +135,19 @@ describe('Request to go live: agreement', () => {
     })
   })
 
-  describe('REQUEST_TO_GO_LIVE_STAGE_CHOSEN_PSP_GOV_BANKING_WORLDPAY', () => {
-    const repeatGetUserSuccessStub = [
-      userStubs.getUserSuccessRepeatFirstResponseNTimes([
-        { userExternalId, serviceRoles: utils.buildServiceRoleForGoLiveStageWithMerchantName('CHOSEN_PSP_GOV_BANKING_WORLDPAY') },
-        { userExternalId, serviceRoles: utils.buildServiceRoleForGoLiveStageWithMerchantName('TERMS_AGREED_GOV_BANKING_WORLDPAY') }
-      ]),
-      gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId })
-    ]
-
-    const stubPayload = lodash.concat(repeatGetUserSuccessStub,
-      utils.patchUpdateGoLiveStageSuccessStub('TERMS_AGREED_GOV_BANKING_WORLDPAY'),
-      goLiveRequestStubs.postGovUkPayAgreement({ userExternalId, serviceExternalId }))
-
-    beforeEach(() => {
-      cy.task('setupStubs', stubPayload)
-    })
-
+  describe('Government bankings PSP has been chosen as the PSP', () => {
     it('should display "Read and accept our legal terms" page when in CHOSEN_PSP_GOV_BANKING_WORLDPAY', () => {
-      const requestToGoLiveAgreementUrl = `/service/${serviceExternalId}/request-to-go-live/agreement`
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_GOV_BANKING_WORLDPAY'))
+
       cy.visit(requestToGoLiveAgreementUrl)
       cy.get('fieldset').should('not.contain', 'These include the legal terms of Stripe, GOV.UK Pay’s payment service provider.')
       cy.get('ul.govuk-list>li').eq(0).should('contain', 'Crown body the memorandum of understanding applies')
+    })
+
+    it('should continue to the index page when terms are agreed to', () => {
+      cy.task('setupStubs', getStubsForPageSubmission('CHOSEN_PSP_GOV_BANKING_WORLDPAY', 'TERMS_AGREED_GOV_BANKING_WORLDPAY'))
+
       cy.get('#agreement').check()
       cy.get('#request-to-go-live-agreement-form > button').click()
       cy.location().should((location) => {
@@ -185,16 +156,18 @@ describe('Request to go live: agreement', () => {
     })
   })
 
-  describe('adminusers error handlings', () => {
-    const stubPayload = lodash.concat(utils.getUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStageWithMerchantName('CHOSEN_PSP_STRIPE')),
-      goLiveRequestStubs.postGovUkPayAgreement({ userExternalId, serviceExternalId }),
-      utils.patchUpdateGoLiveStageErrorStub('TERMS_AGREED_STRIPE'))
+  describe('Adminusers returns an error', () => {
     beforeEach(() => {
-      cy.task('setupStubs', stubPayload)
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceExternalId, goLiveStage: 'CHOSEN_PSP_STRIPE', merchantName: 'GDS' }),
+        gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId }),
+        goLiveRequestStubs.postGovUkPayAgreement({ userExternalId, serviceExternalId }),
+        utils.patchUpdateGoLiveStageErrorStub('TERMS_AGREED_STRIPE')
+      ])
     })
+
     it('should show "An error occurred: There is a problem with the payments platform"', () => {
-      const requestToGoLiveChooseHowToProcessPaymentUrl = `/service/${serviceExternalId}/request-to-go-live/agreement`
-      cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
+      cy.visit(requestToGoLiveAgreementUrl)
 
       cy.get('#agreement').click()
       cy.get('#request-to-go-live-agreement-form > button').click()

--- a/test/cypress/integration/request-to-go-live/choose-how-to-process-payments.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/choose-how-to-process-payments.cy.test.js
@@ -1,54 +1,36 @@
 'use strict'
 
-const lodash = require('lodash')
 const utils = require('../../utils/request-to-go-live-utils')
 const variables = utils.variables
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 const userStubs = require('../../stubs/user-stubs')
 
+const userExternalId = variables.userExternalId
+const gatewayAccountId = variables.gatewayAccountId
+const serviceExternalId = variables.serviceExternalId
+const requestToGoLiveChooseHowToProcessPaymentUrl = `/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`
+
+function setupStubsForSubmittingChoice (nextGoLiveStage) {
+  cy.task('setupStubs', [
+    userStubs.getUserSuccessRespondDifferentlySecondTime(userExternalId,
+      { gatewayAccountId, serviceExternalId, goLiveStage: 'ENTERED_ORGANISATION_ADDRESS' },
+      { gatewayAccountId, serviceExternalId, goLiveStage: nextGoLiveStage }
+    ),
+    gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId }),
+    utils.patchUpdateGoLiveStageSuccessStub(nextGoLiveStage)
+  ])
+}
+
 describe('Request to go live: choose how to process payments', () => {
-  const userExternalId = variables.userExternalId
-  const gatewayAccountId = variables.gatewayAccountId
-  const serviceExternalId = variables.serviceExternalId
-
   beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-  })
-
-  describe('Service has wrong go live stage', () => {
-    beforeEach(() => {
-      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('NOT_STARTED'))
-    })
-
-    it('should redirect to "Request to go live: index" page when in wrong stage', () => {
-      const requestToGoLiveChooseHowToProcessPaymentUrl = `/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`
-      cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
-
-      cy.get('h1').should('contain', 'Request a live account')
-
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live`)
-      })
-    })
+    Cypress.Cookies.preserveOnce('session', 'gateway_account')
   })
 
   describe('Service has correct go live stage and user selects Stripe account', () => {
-    const repeatGetUserSuccessStub = [
-      userStubs.getUserSuccessRepeatFirstResponseNTimes([
-        { userExternalId, serviceRoles: utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS') },
-        { userExternalId, serviceRoles: utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_STRIPE') }
-      ]),
-      gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId })
-    ]
+    it('should display the page with non-stipe payment providers collapsed', () => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS'))
 
-    const stubPayload = lodash.concat(repeatGetUserSuccessStub,
-      utils.patchUpdateGoLiveStageSuccessStub('CHOSEN_PSP_STRIPE'))
-    beforeEach(() => {
-      cy.task('setupStubs', stubPayload)
-    })
-
-    it('should patch adminusers then redirect to agreement when chosen Stripe', () => {
-      const requestToGoLiveChooseHowToProcessPaymentUrl = `/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`
       cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
 
       cy.get('#request-to-go-live-current-step').should('exist')
@@ -58,12 +40,17 @@ describe('Request to go live: choose how to process payments', () => {
 
       cy.get('#conditional-choose-how-to-process-payments-mode-3').should('exist')
       cy.get('#conditional-choose-how-to-process-payments-mode-3').should('not.be.visible')
+    })
+
+    it('should patch adminusers then redirect to agreement when chosen Stripe', () => {
+      setupStubsForSubmittingChoice('CHOSEN_PSP_STRIPE')
 
       cy.get('#choose-how-to-process-payments-mode').click()
 
       cy.get('#request-to-go-live-choose-how-to-process-payments-form > button').should('exist')
       cy.get('#request-to-go-live-choose-how-to-process-payments-form > button').should('contain', 'Continue')
       cy.get('#request-to-go-live-choose-how-to-process-payments-form > button').click()
+
       cy.location().should((location) => {
         expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live/agreement`)
       })
@@ -71,30 +58,11 @@ describe('Request to go live: choose how to process payments', () => {
   })
 
   describe('Service has correct go live stage and user selects non Stripe account', () => {
-    const repeatGetUserSuccessStub = [
-      userStubs.getUserSuccessRepeatFirstResponseNTimes([
-        { userExternalId, serviceRoles: utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS') },
-        { userExternalId, serviceRoles: utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_EPDQ') }
-      ]),
-      gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId })]
+    it('should expand other payment provider options', () => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS'))
 
-    const stubPayload = lodash.concat(repeatGetUserSuccessStub,
-      utils.patchUpdateGoLiveStageSuccessStub('CHOSEN_PSP_EPDQ'))
-    beforeEach(() => {
-      cy.task('setupStubs', stubPayload)
-    })
-
-    it('should patch choice and then redirect to agreement when chosen ePDQ', () => {
-      const requestToGoLiveChooseHowToProcessPaymentUrl = `/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`
       cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
-
-      cy.get('#request-to-go-live-current-step').should('exist')
-      cy.get('#request-to-go-live-choose-how-to-process-payments-form').should('exist')
-      cy.get('#choose-how-to-process-payments-mode').should('exist')
-      cy.get('#choose-how-to-process-payments-mode-2').should('exist')
-
-      cy.get('#conditional-choose-how-to-process-payments-mode-3').should('exist')
-      cy.get('#conditional-choose-how-to-process-payments-mode-3').should('not.be.visible')
 
       cy.get('#choose-how-to-process-payments-mode-3').click()
       cy.get('#conditional-choose-how-to-process-payments-mode-3').should('be.visible')
@@ -107,6 +75,10 @@ describe('Request to go live: choose how to process payments', () => {
 
       cy.get('#choose-how-to-process-payments-mode-other-3').should('exist')
       cy.get('#conditional-choose-how-to-process-payments-mode-3 label[for=choose-how-to-process-payments-mode-other-3]').should('contain', 'ePDQ')
+    })
+
+    it('should patch choice and then redirect to agreement when chosen ePDQ', () => {
+      setupStubsForSubmittingChoice('CHOSEN_PSP_EPDQ')
 
       cy.get('#choose-how-to-process-payments-mode-other-3').click()
       cy.get('#request-to-go-live-choose-how-to-process-payments-form > button').should('exist')
@@ -119,22 +91,16 @@ describe('Request to go live: choose how to process payments', () => {
   })
 
   describe('Service has correct go live stage and user selects government banking account', () => {
-    const repeatGetUserSuccessStub = [
-      userStubs.getUserSuccessRepeatFirstResponseNTimes([
-        { userExternalId, serviceRoles: utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS') },
-        { userExternalId, serviceRoles: utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_GOV_BANKING_WORLDPAY') }
-      ]),
-      gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId })]
+    it('should visit page', () => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS'))
 
-    const stubPayload = lodash.concat(repeatGetUserSuccessStub,
-      utils.patchUpdateGoLiveStageSuccessStub('CHOSEN_PSP_GOV_BANKING_WORLDPAY'))
-    beforeEach(() => {
-      cy.task('setupStubs', stubPayload)
+      cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
     })
 
     it('should patch choice and then redirect to agreement when chosen government banking', () => {
-      const requestToGoLiveChooseHowToProcessPaymentUrl = `/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`
-      cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
+      setupStubsForSubmittingChoice('CHOSEN_PSP_GOV_BANKING_WORLDPAY')
+
       cy.get('#choose-how-to-process-payments-mode-2').click()
       cy.get('#request-to-go-live-choose-how-to-process-payments-form > button').click()
       cy.location().should((location) => {
@@ -143,30 +109,14 @@ describe('Request to go live: choose how to process payments', () => {
     })
   })
 
-  describe('User does not have the correct permissions', () => {
+  describe('Validation', () => {
     beforeEach(() => {
-      const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS')
-      serviceRole.role = {
-        permissions: []
-      }
-      utils.setupGetUserAndGatewayAccountStubs(serviceRole)
-    })
-
-    it('should show an error when the user does not have enough permissions', () => {
-      const requestToGoLivePageOrganisationNameUrl = `/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`
-      cy.visit(requestToGoLivePageOrganisationNameUrl, { failOnStatusCode: false })
-      cy.get('h1').should('contain', 'An error occurred:')
-      cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
-    })
-  })
-
-  describe('other tests', () => {
-    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
       utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS'))
     })
-    describe('should show an error when no option selected', () => {
+
+    describe('No option selected', () => {
       it('should show "You need to select an option" error msg', () => {
-        const requestToGoLiveChooseHowToProcessPaymentUrl = `/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`
         cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
 
         cy.get('#request-to-go-live-choose-how-to-process-payments-form > button').click()
@@ -178,9 +128,8 @@ describe('Request to go live: choose how to process payments', () => {
       })
     })
 
-    describe('should show an error when no other psp option selected', () => {
+    describe('Other provider radio button selected and no PSP selected', () => {
       it('should show "You need to select one of Worldpay, Smartpay or ePDQ" error msg', () => {
-        const requestToGoLiveChooseHowToProcessPaymentUrl = `/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`
         cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
 
         cy.get('#choose-how-to-process-payments-mode-3').click()
@@ -194,14 +143,50 @@ describe('Request to go live: choose how to process payments', () => {
     })
   })
 
-  describe('adminusers error handlings', () => {
-    const stubPayload = lodash.concat(utils.getUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS')),
-      utils.patchUpdateGoLiveStageErrorStub('CHOSEN_PSP_STRIPE'))
+  describe('Service has wrong go live stage', () => {
     beforeEach(() => {
-      cy.task('setupStubs', stubPayload)
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('NOT_STARTED'))
     })
+
+    it('should redirect to "Request to go live: index" page when in wrong stage', () => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
+
+      cy.get('h1').should('contain', 'Request a live account')
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live`)
+      })
+    })
+  })
+
+  describe('User does not have the correct permissions', () => {
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS')
+      serviceRole.role = {
+        permissions: []
+      }
+      utils.setupGetUserAndGatewayAccountStubs(serviceRole)
+    })
+
+    it('should show an error when the user does not have enough permissions', () => {
+      cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl, { failOnStatusCode: false })
+      cy.get('h1').should('contain', 'An error occurred:')
+      cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+    })
+  })
+
+  describe('Adminusers returns an error', () => {
+    beforeEach(() => {
+      cy.task('setupStubs', [
+        ...utils.getUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS'),
+          utils.patchUpdateGoLiveStageErrorStub('CHOSEN_PSP_STRIPE'))
+      ])
+    })
+
     it('should show "An error occurred: There is a problem with the payments platform"', () => {
-      const requestToGoLiveChooseHowToProcessPaymentUrl = `/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`
       cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
 
       cy.get('#choose-how-to-process-payments-mode').click()

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -78,9 +78,9 @@ module.exports = {
       response: userFixtures.validUsersResponse(opts.users).getPlain()
     })
   },
-  getUserSuccessRepeatFirstResponseNTimes: (opts = {}) => {
-    const aValidUserResponse = userFixtures.validUserResponse(opts[0]).getPlain()
-    const aSecondValidUserResponse = userFixtures.validUserResponse(opts[1]).getPlain()
+  getUserSuccessRespondDifferentlySecondTime: (opts = {}) => {
+    const aValidUserResponse = userFixtures.validUserResponse(opts.firstResponseOpts).getPlain()
+    const aSecondValidUserResponse = userFixtures.validUserResponse(opts.secondResponseOpts).getPlain()
     return [
       {
         predicates: [{
@@ -101,7 +101,7 @@ module.exports = {
             body: aValidUserResponse
           },
           _behaviors: {
-            repeat: opts[0].repeat
+            repeat: opts.firstResponseOpts.repeat
           }
         }, {
           is: {
@@ -112,7 +112,7 @@ module.exports = {
             body: aSecondValidUserResponse
           },
           _behaviors: {
-            repeat: opts[1].repeat
+            repeat: opts.secondResponseOpts.repeat
           }
         }
         ]

--- a/test/cypress/utils/request-to-go-live-utils.js
+++ b/test/cypress/utils/request-to-go-live-utils.js
@@ -20,19 +20,6 @@ const buildServiceRoleForGoLiveStage = (goLiveStage) => {
   }
 }
 
-const buildServiceRoleForGoLiveStageWithMerchantName = (goLiveStage) => {
-  return {
-    service: {
-      external_id: variables.serviceExternalId,
-      current_go_live_stage: goLiveStage,
-      gateway_account_ids: [variables.gatewayAccountId],
-      merchant_details: {
-        name: 'Merchant name'
-      }
-    }
-  }
-}
-
 const buildServiceRoleWithMerchantDetails = (merchantDetails, goLiveStage) => {
   return {
     service: {
@@ -81,7 +68,6 @@ const setupGetUserAndGatewayAccountStubs = (serviceRole) => {
 module.exports = {
   variables,
   buildServiceRoleForGoLiveStage,
-  buildServiceRoleForGoLiveStageWithMerchantName,
   buildServiceRoleWithMerchantDetails,
   getUserAndGatewayAccountStubs,
   patchUpdateGoLiveStageSuccessStub,


### PR DESCRIPTION
- Make it more obvious what the stub that returns different responses to a get user request does and why we use it
- Fix some stylistic points like test naming
- Remove some duplication in the tests
