### PR TITLE
PP-6864 Replace test for responsible person template logic

### DIFF
--- a/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
@@ -18,14 +18,10 @@ describe('Stripe setup: responsible person page', () => {
   const typedAddressLine2 = 'Putney '
   const city = 'London'
   const typedCity = 'London '
-  const postcode = 'SW15 1LP'
   const typedPostcode = 'sw151lp '
   const typedDobDay = '25 '
   const typedDobMonth = ' 02'
   const typedDobYear = '1971 '
-  const longText = 'This text is 300 ................................................................................' +
-    '...............................................................................................................' +
-    '............................................................................ characters long'
 
   beforeEach(() => {
     cy.setEncryptedCookies(userExternalId, gatewayAccountId)
@@ -129,37 +125,6 @@ describe('Stripe setup: responsible person page', () => {
 
         cy.get('input[name="answers-need-changing"]').should('not.exist')
         cy.get('input[name="answers-checked"]').should('not.exist')
-      })
-    })
-
-    it('should only show address once in error summary if error in both address lines', () => {
-      cy.get('#responsible-person-form').within(() => {
-        cy.get('#first-name').type(typedLastName)
-        cy.get('#last-name').type(typedLastName)
-        cy.get('#home-address-line-1').type(longText)
-        cy.get('#home-address-line-2').type(longText)
-        cy.get('#home-address-city').type(typedCity)
-        cy.get('#home-address-postcode').type(postcode)
-        cy.get('#dob-day').type(typedDobDay)
-        cy.get('#dob-month').type(typedDobMonth)
-        cy.get('#dob-year').type(typedDobYear)
-        cy.get('button').click()
-      })
-
-      cy.get('.govuk-error-summary').should('exist').within(() => {
-        cy.get('a[href="#home-address-line-1"]').should('contain', 'Building and street')
-        cy.get('a[href="#home-address-line-2"]').should('not.exist')
-      })
-
-      cy.get('#responsible-person-form').should('exist').within(() => {
-        cy.get('.govuk-form-group--error > input#home-address-line-1').parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('exist')
-          cy.get('input#home-address-line-1').should('have.attr', 'value', longText)
-        })
-        cy.get('.govuk-form-group--error > input#home-address-line-2').parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('exist')
-          cy.get('input#home-address-line-2').should('have.attr', 'value', longText)
-        })
       })
     })
   })

--- a/test/ui/responsible-persion.ui.test.js
+++ b/test/ui/responsible-persion.ui.test.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const { expect } = require('chai')
+const cheerio = require('cheerio')
+const { render } = require('../test-helpers/html-assertions')
+
+describe('Stripe setup - responsible person view', () => {
+  it('should display an error in summary for address line 1', done => {
+    const templateData = {
+      errors: { 'home-address-line-1': 'Inline error message' }
+    }
+
+    const body = render('stripe-setup/responsible-person/index', templateData)
+
+    const $ = cheerio.load(body)
+    expect($('.govuk-error-summary__list li').length).to.equal(1)
+    expect($('.govuk-error-summary__list li a[href$="#home-address-line-1"]').text()).to.equal('Building and street')
+
+    done()
+  })
+
+  it('should display an error in summary for address line 2', done => {
+    const templateData = {
+      errors: { 'home-address-line-2': 'Inline error message' }
+    }
+
+    const body = render('stripe-setup/responsible-person/index', templateData)
+
+    const $ = cheerio.load(body)
+    expect($('.govuk-error-summary__list li').length).to.equal(1)
+    expect($('.govuk-error-summary__list li a[href$="#home-address-line-2"]').text()).to.equal('Building and street')
+
+    done()
+  })
+
+  it('should only display single error in error summary if there is an error for both address lines', done => {
+    const templateData = {
+      errors: {
+        'home-address-line-1': 'Inline error message',
+        'home-address-line-2': 'Inline error message' }
+    }
+
+    const body = render('stripe-setup/responsible-person/index', templateData)
+
+    const $ = cheerio.load(body)
+    expect($('.govuk-error-summary__list li').length).to.equal(1)
+    expect($('.govuk-error-summary__list li a[href$="#home-address-line-1"]').text()).to.equal('Building and street')
+
+    done()
+  })
+})


### PR DESCRIPTION
We had a cypress test that tested an edge case of template logic that both address line 1 and address line 2 display the same error summary in the summary list, and if there are errors for both fields, it is only displayed once.

To do this test, we had to type a very long string for address line 2 as this is the only error that can be simulated.

As this is template logic, it is suited to a template test. So replace the cypress test with some simple template tests for this.