### PR TITLE
PP-6864 Re-enable skipped cypress tests

### DIFF
--- a/test/cypress/integration/dashboard/dashboard-go-live-link.cy.test.js
+++ b/test/cypress/integration/dashboard/dashboard-go-live-link.cy.test.js
@@ -17,7 +17,7 @@ describe('Go live link on dashboard', () => {
         cy.visit('/')
       })
 
-      it.skip('should show request to go live link when go-live stage is NOT_STARTED', () => {
+      it('should show request to go live link when go-live stage is NOT_STARTED', () => {
         cy.get('#request-to-go-live-link').should('exist')
         cy.get('#request-to-go-live-link h2').should('contain', 'Request a live account')
         cy.get('#request-to-go-live-link a').should('have.attr', 'href', `/service/${serviceExternalId}/request-to-go-live`)
@@ -25,7 +25,7 @@ describe('Go live link on dashboard', () => {
     })
 
     describe('Continue link shown', () => {
-      it.skip('should show continue link when go-live stage is ENTERED_ORGANISATION_NAME', () => {
+      it('should show continue link when go-live stage is ENTERED_ORGANISATION_NAME', () => {
         utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME'))
         cy.visit('/')
 
@@ -34,7 +34,7 @@ describe('Go live link on dashboard', () => {
         cy.get('#request-to-go-live-link a').should('have.attr', 'href', `/service/${serviceExternalId}/request-to-go-live`)
       })
 
-      it.skip('should show continue link when go-live stage is CHOSEN_PSP_STRIPE', () => {
+      it('should show continue link when go-live stage is CHOSEN_PSP_STRIPE', () => {
         utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_STRIPE'))
         cy.visit('/')
 
@@ -43,7 +43,7 @@ describe('Go live link on dashboard', () => {
         cy.get('#request-to-go-live-link a').should('have.attr', 'href', `/service/${serviceExternalId}/request-to-go-live`)
       })
 
-      it.skip('should show continue link when go-live stage is CHOSEN_PSP_WORLDPAY', () => {
+      it('should show continue link when go-live stage is CHOSEN_PSP_WORLDPAY', () => {
         utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_WORLDPAY'))
         cy.visit('/')
 
@@ -52,7 +52,7 @@ describe('Go live link on dashboard', () => {
         cy.get('#request-to-go-live-link a').should('have.attr', 'href', `/service/${serviceExternalId}/request-to-go-live`)
       })
 
-      it.skip('should show continue link when go-live stage is CHOSEN_PSP_SMARTPAY', () => {
+      it('should show continue link when go-live stage is CHOSEN_PSP_SMARTPAY', () => {
         utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_SMARTPAY'))
         cy.visit('/')
 
@@ -61,7 +61,7 @@ describe('Go live link on dashboard', () => {
         cy.get('#request-to-go-live-link a').should('have.attr', 'href', `/service/${serviceExternalId}/request-to-go-live`)
       })
 
-      it.skip('should show continue link when go-live stage is CHOSEN_PSP_EPDQ', () => {
+      it('should show continue link when go-live stage is CHOSEN_PSP_EPDQ', () => {
         utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_EPDQ'))
         cy.visit('/')
 
@@ -72,7 +72,7 @@ describe('Go live link on dashboard', () => {
     })
 
     describe('Waiting to go live text shown', () => {
-      it.skip('should show waiting to go live text when go-live stage is TERMS_AGREED_STRIPE', () => {
+      it('should show waiting to go live text when go-live stage is TERMS_AGREED_STRIPE', () => {
         utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('TERMS_AGREED_STRIPE'))
         cy.visit('/')
 
@@ -80,7 +80,7 @@ describe('Go live link on dashboard', () => {
         cy.get('#request-to-go-live-link h2').should('contain', 'Your live account')
       })
 
-      it.skip('should show waiting to go live text when go-live stage is TERMS_AGREED_WORLDPAY', () => {
+      it('should show waiting to go live text when go-live stage is TERMS_AGREED_WORLDPAY', () => {
         utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('TERMS_AGREED_WORLDPAY'))
         cy.visit('/')
 
@@ -88,7 +88,7 @@ describe('Go live link on dashboard', () => {
         cy.get('#request-to-go-live-link h2').should('contain', 'Your live account')
       })
 
-      it.skip('should show waiting to go live text when go-live stage is TERMS_AGREED_SMARTPAY', () => {
+      it('should show waiting to go live text when go-live stage is TERMS_AGREED_SMARTPAY', () => {
         utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('TERMS_AGREED_SMARTPAY'))
         cy.visit('/')
 
@@ -96,7 +96,7 @@ describe('Go live link on dashboard', () => {
         cy.get('#request-to-go-live-link h2').should('contain', 'Your live account')
       })
 
-      it.skip('should show waiting to go live text when go-live stage is TERMS_AGREED_EPDQ', () => {
+      it('should show waiting to go live text when go-live stage is TERMS_AGREED_EPDQ', () => {
         utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('TERMS_AGREED_EPDQ'))
         cy.visit('/')
 
@@ -106,21 +106,21 @@ describe('Go live link on dashboard', () => {
     })
 
     describe('Go live link not shown', () => {
-      it.skip('should not show request to go live link when go-live stage is LIVE', () => {
+      it('should not show request to go live link when go-live stage is LIVE', () => {
         utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('LIVE'))
         cy.visit('/')
 
         cy.get('#request-to-go-live-link').should('not.exist')
       })
 
-      it.skip('should not show request to go live link when go-live stage is DENIED', () => {
+      it('should not show request to go live link when go-live stage is DENIED', () => {
         utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('DENIED'))
         cy.visit('/')
 
         cy.get('#request-to-go-live-link').should('not.exist')
       })
 
-      it.skip('should not show request to go live link when user is not an admin', () => {
+      it('should not show request to go live link when user is not an admin', () => {
         const serviceRole = utils.buildServiceRoleForGoLiveStage('NOT_STARTED')
         serviceRole.role = {
           permissions: []
@@ -133,7 +133,7 @@ describe('Go live link on dashboard', () => {
   })
 
   describe('Direct debit gateway account', () => {
-    it.skip('should display next steps to go live link', () => {
+    it('should display next steps to go live link', () => {
       const directDebitGatewayAccountId = 'DIRECT_DEBIT:101'
 
       cy.task('setupStubs', [


### PR DESCRIPTION
These were supposedly flakey, re-enable so we can work out why and fix them


