### PR TITLE
PP-6780 Do not run Snyk when running unit tests locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "watch-live-reload": "./node_modules/.bin/grunt watch",
     "lint": "./node_modules/.bin/standard --fix",
     "lint-sass": "./node_modules/.bin/sass-lint -v",
-    "test": "npm run snyk-protect && rm -rf ./pacts && NODE_ENV=test ./node_modules/mocha/bin/mocha --exclude **/*.cy.test.js '!(node_modules)/**/*.test'.js",
+    "test": "rm -rf ./pacts && NODE_ENV=test ./node_modules/mocha/bin/mocha --exclude **/*.cy.test.js '!(node_modules)/**/*.test'.js",
     "cypress:server": "mb --debug | DISABLE_APPMETRICS=true node --inspect -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
     "cypress:test": "cypress run",
     "cypress:test-headed": "cypress open",


### PR DESCRIPTION
- Updated npm `test` script - extracted the mocha command into a new script: `test:clean-pacts-run-mocha`
- Created new npm script: `test:local`
  - Does not run the Snyk command.
  - Uses the new `test:clean-pacts-run-mocha`

