### PR TITLE
PP-6951 Use custom flash to show refund message

### DIFF
--- a/app/controllers/transactions/transaction-refund.controller.js
+++ b/app/controllers/transactions/transaction-refund.controller.js
@@ -21,15 +21,15 @@ const refundTransaction = async function refundTransaction (req, res, next) {
 
     const refundAmountInPence = safeConvertPoundsStringToPence(refundAmount)
     if (!refundAmountInPence) {
-      req.flash('genericError', 'Choose an amount to refund in pounds and pence using digits and a decimal point. For example “10.50”')
+      req.flash('refundError', 'Enter an amount to refund in pounds and pence using digits and a decimal point. For example “10.50”')
       return res.redirect(transactionDetailPath)
     }
 
     try {
       await refund(accountId, chargeId, refundAmountInPence, refundAmountAvailableInPence, userExternalId, userEmail, correlationId)
-      req.flash('generic', 'Refund successful. It may take up to 6 days to process.')
+      req.flash('refundSuccess', 'true')
     } catch (err) {
-      req.flash('genericError', err.message)
+      req.flash('refundError', err.message)
     }
     res.redirect(transactionDetailPath)
   } catch (err) {

--- a/app/services/transaction.service.js
+++ b/app/services/transaction.service.js
@@ -118,7 +118,7 @@ const refund = async function refundTransaction (gatewayAccountId, chargeId, amo
         }
       }
     }
-    throw new Error('We couldn’t process this refund. Try again later.')
+    throw new Error('We couldn’t process this refund. Please try again or contact support.')
   }
 }
 

--- a/app/views/transaction-detail/index.njk
+++ b/app/views/transaction-detail/index.njk
@@ -25,6 +25,26 @@
 
 {% block mainContent %}
   <div class="govuk-grid-column-two-thirds">
+    {% if flash.refundSuccess %}
+      <div class="flash-container flash-container--good">
+        <div class="notification generic-flash">
+          <h2 class="govuk-heading-m">Refund successful</h2>
+          <p class="govuk-body">It may take up to 6 days to process.</p>
+        </div>
+      </div>
+    {% elif flash.refundError %}
+      <div class="govuk-error-summary hidden" aria-labelledby="error-summary-heading-example-1" role="alert" tabindex="-1" data-module="govuk-error-summary">
+        <h2 class="govuk-error-summary__title" id="error-summary-heading-example-1">
+          Refund failed
+        </h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            <li>{{flash.refundError | safe}}</li>
+          </ul>
+        </div>
+      </div>
+    {% endif %}
+
     <h1 class="govuk-heading-l">Transaction detail</h1>
     {% include "./_details.njk" %}
 
@@ -32,8 +52,8 @@
     {% include "./_payment.njk" %}
 
     {% if metadata %}
-    <h2 class="govuk-heading-m govuk-!-margin-top-9">Metadata</h2>
-        {% include "./_metadata.njk" %}
+      <h2 class="govuk-heading-m govuk-!-margin-top-9">Metadata</h2>
+      {% include "./_metadata.njk" %}
     {% endif %}
 
     {% if permissions.transactions_events_read %}
@@ -50,7 +70,7 @@
           <p class="govuk-body">You can also give partial&nbsp;refunds</p>
         </div>
         {% include "./_refund.njk" %}
-     {% endif %}
+      {% endif %}
     {% endif %}
   </div>
 {% endblock %}

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -290,6 +290,13 @@ module.exports = {
       response: transactionDetailsFixtures.validChargeEventsResponse(opts).getPlain()
     })
   },
+  postRefundSuccess: (opts = {}) => {
+    const path = `/v1/api/accounts/${opts.gateway_account_id}/charges/${opts.charge_id}/refunds`
+    return simpleStubBuilder('POST', path, 200, {
+      request: transactionDetailsFixtures.validTransactionRefundRequest(opts).getPlain(),
+      verifyCalledTimes: opts.verifyCalledTimes
+    })
+  },
   postRefundAmountNotAvailable: (opts = {}) => {
     const path = `/v1/api/accounts/${opts.gateway_account_id}/charges/${opts.charge_id}/refunds`
     return simpleStubBuilder('POST', path, 400, {

--- a/test/cypress/stubs/transaction-stubs.js
+++ b/test/cypress/stubs/transaction-stubs.js
@@ -33,6 +33,21 @@ const getLedgerTransactionsSuccess = function (opts) {
   }
 }
 
+const postRefundSuccess = function (opts) {
+  return {
+    name: 'postRefundSuccess',
+    opts: {
+      gateway_account_id: opts.gatewayAccountId,
+      charge_id: opts.transactionId,
+      amount: opts.refundAmount,
+      refund_amount_available: opts.refundAmountAvailable,
+      user_external_id: opts.userExternalId,
+      user_email: opts.userEmail,
+      verifyTimesCalled: 1
+    }
+  }
+}
+
 const postRefundAmountNotAvailable = function (opts) {
   return {
     name: 'postRefundAmountNotAvailable',
@@ -51,5 +66,6 @@ module.exports = {
   getLedgerEventsSuccess,
   getLedgerTransactionSuccess,
   getLedgerTransactionsSuccess,
+  postRefundSuccess,
   postRefundAmountNotAvailable
 }

--- a/test/unit/controller/transaction-refund.controller.it.test.js
+++ b/test/unit/controller/transaction-refund.controller.it.test.js
@@ -58,7 +58,7 @@ describe('Refund scenario:', function () {
 
     await refundController(req, res)
     sinon.assert.calledWith(res.redirect, '/transactions/123456')
-    sinon.assert.calledWith(req.flash, 'generic', 'Refund successful. It may take up to 6 days to process.')
+    sinon.assert.calledWith(req.flash, 'refundSuccess', 'true')
   })
 
   it('should show refund sucess message for a partial refund', async () => {
@@ -80,7 +80,7 @@ describe('Refund scenario:', function () {
 
     await refundController(req, res)
     sinon.assert.calledWith(res.redirect, '/transactions/123456')
-    sinon.assert.calledWith(req.flash, 'generic', 'Refund successful. It may take up to 6 days to process.')
+    sinon.assert.calledWith(req.flash, 'refundSuccess', 'true')
   })
 
   it('should show error message if partial refund amount is invalid', async () => {
@@ -93,7 +93,7 @@ describe('Refund scenario:', function () {
 
     await refundController(req, res)
     sinon.assert.calledWith(res.redirect, '/transactions/123456')
-    sinon.assert.calledWith(req.flash, 'genericError', 'Choose an amount to refund in pounds and pence using digits and a decimal point. For example “10.50”')
+    sinon.assert.calledWith(req.flash, 'refundError', 'Enter an amount to refund in pounds and pence using digits and a decimal point. For example “10.50”')
   })
 
   it('should show error message if partial refund amount is greater than initial charge', async () => {
@@ -120,7 +120,7 @@ describe('Refund scenario:', function () {
 
     await refundController(req, res)
     sinon.assert.calledWith(res.redirect, '/transactions/123456')
-    sinon.assert.calledWith(req.flash, 'genericError', 'The amount you tried to refund is greater than the amount available to be refunded. Please try again.')
+    sinon.assert.calledWith(req.flash, 'refundError', 'The amount you tried to refund is greater than the amount available to be refunded. Please try again.')
   })
 
   it('should show error message if the partial refund amount is smaller than minimum accepted', async () => {
@@ -147,7 +147,7 @@ describe('Refund scenario:', function () {
 
     await refundController(req, res)
     sinon.assert.calledWith(res.redirect, '/transactions/123456')
-    sinon.assert.calledWith(req.flash, 'genericError', 'The amount you tried to refund is too low. Please try again.')
+    sinon.assert.calledWith(req.flash, 'refundError', 'The amount you tried to refund is too low. Please try again.')
   })
 
   it('should show error message if the partial refund request has already been submitted', async () => {
@@ -173,7 +173,7 @@ describe('Refund scenario:', function () {
 
     await refundController(req, res)
     sinon.assert.calledWith(res.redirect, '/transactions/123456')
-    sinon.assert.calledWith(req.flash, 'genericError', 'This refund request has already been submitted.')
+    sinon.assert.calledWith(req.flash, 'refundError', 'This refund request has already been submitted.')
   })
 
   it('should show error message if refund request has already been fully refunded', async () => {
@@ -199,7 +199,7 @@ describe('Refund scenario:', function () {
 
     await refundController(req, res)
     sinon.assert.calledWith(res.redirect, '/transactions/123456')
-    sinon.assert.calledWith(req.flash, 'genericError', 'This refund request has already been submitted.')
+    sinon.assert.calledWith(req.flash, 'refundError', 'This refund request has already been submitted.')
   })
 
   it('should show error message if unexpected error has occured', async () => {
@@ -224,6 +224,6 @@ describe('Refund scenario:', function () {
 
     await refundController(req, res)
     sinon.assert.calledWith(res.redirect, '/transactions/123456')
-    sinon.assert.calledWith(req.flash, 'genericError', 'We couldn’t process this refund. Try again later.')
+    sinon.assert.calledWith(req.flash, 'refundError', 'We couldn’t process this refund. Please try again or contact support.')
   })
 })


### PR DESCRIPTION
Use a custom flash rather than 'generic' and 'genericError' to pass success/failure message with the redirect after a refund request has been processed.

Then in the template for the transaction details page, handle these custom flash messages to display them how we want. This allows for having a title in the message that we were before creating by passing HTML markup in the flash message string.

Add an additional Cypress test for the refund success case.
