### PR TITLE
PP-7002 Stop passing markup in flash messages

### DIFF
--- a/app/controllers/credentials.controller.js
+++ b/app/controllers/credentials.controller.js
@@ -93,9 +93,9 @@ module.exports = {
     const { username, password } = _.get(req, 'body')
 
     if (!username) {
-      req.flash('genericError', `Enter a username`)
+      req.flash('genericError', 'Enter a username')
     } else if (!password) {
-      req.flash('genericError', `Enter a password`)
+      req.flash('genericError', 'Enter a password')
     } else {
       const failedValidationMessage = isPasswordLessThanTenChars(password)
       if (failedValidationMessage) {

--- a/app/controllers/payment-links/post-amount.controller.js
+++ b/app/controllers/payment-links/post-amount.controller.js
@@ -14,16 +14,16 @@ module.exports = (req, res) => {
   const paymentLinkAmount = req.body['payment-amount']
 
   if (!paymentAmountType) {
-    req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="govuk-list govuk-error-summary__list"><li><a href="#fixed-or-variable">Is the payment for a fixed amount?</a></li></ul>`)
-    req.flash('errorType', `paymentAmountType`)
+    req.flash('error', 'Is the payment for a fixed amount?')
+    req.flash('errorType', 'paymentAmountType')
     return res.redirect(paths.paymentLinks.amount)
   }
 
   let formattedPaymentLinkAmount = safeConvertPoundsStringToPence(paymentLinkAmount)
 
   if (paymentLinkAmount !== '' && formattedPaymentLinkAmount === null) {
-    req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="govuk-list govuk-error-summary__list"><li><a href="#payment-amount">Enter the amount</a></li></ul>`)
-    req.flash('errorType', `paymentAmountFormat`)
+    req.flash('error', 'Enter the amount')
+    req.flash('errorType', 'paymentAmountFormat')
     return res.redirect(paths.paymentLinks.amount)
   }
 

--- a/app/controllers/payment-links/post-edit-amount.controller.js
+++ b/app/controllers/payment-links/post-edit-amount.controller.js
@@ -14,16 +14,16 @@ module.exports = (req, res) => {
   const editData = lodash.get(req, 'session.editPaymentLinkData', {})
 
   if (!paymentAmountType) {
-    req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#fixed-or-variable">Is the payment for a fixed amount?</a></li></ul>`)
-    req.flash('errorType', `paymentAmountType`)
+    req.flash('error', 'Is the payment for a fixed amount?')
+    req.flash('errorType', 'paymentAmountType')
     return res.redirect(formattedPathFor(paths.paymentLinks.editAmount, req.params.productExternalId))
   }
 
   let sanitisedAmount = safeConvertPoundsStringToPence(paymentLinkAmount)
 
   if (paymentLinkAmount !== '' && sanitisedAmount === null) {
-    req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#payment-amount">Enter the amount</a></li></ul>`)
-    req.flash('errorType', `paymentAmountFormat`)
+    req.flash('error', 'Enter the amount')
+    req.flash('errorType', 'paymentAmountFormat')
     return res.redirect(formattedPathFor(paths.paymentLinks.editAmount, req.params.productExternalId))
   }
 

--- a/app/controllers/payment-links/post-edit-information.controller.js
+++ b/app/controllers/payment-links/post-edit-information.controller.js
@@ -15,7 +15,7 @@ module.exports = (req, res) => {
   lodash.set(req, 'session.editPaymentLinkData', editData)
 
   if (editData.name === '') {
-    req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#payment-link-title">Title</a></li></ul>`)
+    req.flash('error', 'Enter a title')
     return res.redirect(formattedPathFor(paths.paymentLinks.editInformation, req.params.productExternalId))
   }
 

--- a/app/controllers/payment-links/post-edit-reference.controller.js
+++ b/app/controllers/payment-links/post-edit-reference.controller.js
@@ -17,7 +17,7 @@ module.exports = (req, res) => {
 
   if (req.body['reference-type-group'] === 'custom') {
     if (req.body['reference-label'] === '') {
-      req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="govuk-list govuk-error-summary__list"><li><a href="#reference-label">Name of your payment reference number</a></li></ul>`)
+      req.flash('error', 'Enter a name for your payment reference')
       req.flash('errorType', `label`)
       return res.redirect(formattedPathFor(paths.paymentLinks.editReference, req.params.productExternalId))
     }

--- a/app/controllers/payment-links/post-information.controller.js
+++ b/app/controllers/payment-links/post-information.controller.js
@@ -23,7 +23,7 @@ module.exports = (req, res) => {
   lodash.set(req, 'session.pageData.createPaymentLink', updatedPageData)
 
   if (updatedPageData.paymentLinkTitle === '') {
-    req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="govuk-list govuk-error-summary__list"><li><a href="#payment-link-title">Title</a></li></ul>`)
+    req.flash('error', 'Enter a title')
     return res.redirect(paths.paymentLinks.information)
   }
 

--- a/app/controllers/payment-links/post-reference.controller.js
+++ b/app/controllers/payment-links/post-reference.controller.js
@@ -14,14 +14,14 @@ module.exports = (req, res) => {
   const paymentReferenceHint = req.body['reference-hint-text'].trim()
 
   if (!paymentReferenceType) {
-    req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="govuk-list govuk-error-summary__list"><li><a href="#standard-or-custom-ref">Would you like us to create a payment reference number for your users?</a></li></ul>`)
+    req.flash('error', 'Would you like us to create a payment reference number for your users?')
     req.flash('errorType', `paymentReferenceType`)
     return res.redirect(paths.paymentLinks.reference)
   }
 
   if (paymentReferenceType === 'custom') {
     if (paymentReferenceLabel === '') {
-      req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="govuk-list govuk-error-summary__list"><li><a href="#reference-label">Name of your payment reference number</a></li></ul>`)
+      req.flash('error', 'Enter a name for your payment reference')
       req.flash('errorType', `label`)
       return res.redirect(paths.paymentLinks.reference)
     }

--- a/app/controllers/payment-links/post-web-address.controller.js
+++ b/app/controllers/payment-links/post-web-address.controller.js
@@ -17,7 +17,7 @@ module.exports = (req, res) => {
   let updatedPageData = lodash.cloneDeep(pageData)
 
   if (updatedPageData.productNamePath === '') {
-    req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="govuk-list govuk-error-summary__list"><li><a href="#payment-name-path">Please change the website address</a></li></ul>`)
+    req.flash('error', 'Please change the website address')
     return res.redirect(paths.paymentLinks.webAddress)
   }
 
@@ -27,7 +27,7 @@ module.exports = (req, res) => {
   productsClient.product.getByProductPath(updatedPageData.serviceNamePath, updatedPageData.productNamePath)
     .then(product => {
     // if product exists we need to alert the user they must use a different URL
-      req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="govuk-list govuk-error-summary__list"><li><a href="#payment-name-path">Website address</a></li></ul>`)
+      req.flash('error', 'Please change the website address')
       return res.redirect(paths.paymentLinks.webAddress)
     })
     .catch((err) => { // eslint-disable-line handle-callback-err

--- a/app/controllers/user/phone-number/post.controller.js
+++ b/app/controllers/user/phone-number/post.controller.js
@@ -8,7 +8,7 @@ const { invalidTelephoneNumber } = require('../../../utils/validation/telephone-
 
 module.exports = async (req, res) => {
   if (invalidTelephoneNumber(req.body.phone)) {
-    req.flash('genericError', '<h2>There was a problem with the details you gave for:</h2><ul class="govuk-list govuk-error-summary__list"><li><a href="#phone">Invalid telephone number.</a></li></ul>')
+    req.flash('error', 'Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
     return res.redirect(paths.user.phoneNumber)
   }
 

--- a/app/views/payment-links/amount.njk
+++ b/app/views/payment-links/amount.njk
@@ -14,6 +14,27 @@
   <form action="{{ nextPage }}" class="form" method="post">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
+    {% if flash.error and flash.errorType[0] === "paymentAmountType" %}
+      {% set errorList = [{
+        text: flash.error | safe,
+        href: "#amount-type-fixed"
+        }]
+      %}
+    {% elif flash.error and flash.errorType[0] === "paymentAmountFormat" %}
+      {% set errorList = [{
+          text: flash.error | safe,
+          href: "#payment-amount"
+          }]
+        %}
+    {% endif %}
+
+    {% if errorList | length %}
+      {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorList
+        }) }}
+    {% endif %}
+
     {% set noSelectionError = false %}
     {% if flash.errorType[0] === "paymentAmountType" %}
     {% set noSelectionError = {

--- a/app/views/payment-links/edit-amount.njk
+++ b/app/views/payment-links/edit-amount.njk
@@ -13,6 +13,27 @@
   <form action="{{ self }}" class="form" method="post">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
+    {% if flash.error and flash.errorType[0] === "paymentAmountType" %}
+      {% set errorList = [{
+        text: flash.error | safe,
+        href: "#amount-type-fixed"
+        }]
+      %}
+    {% elif flash.error and flash.errorType[0] === "paymentAmountFormat" %}
+      {% set errorList = [{
+          text: flash.error | safe,
+          href: "#payment-amount"
+          }]
+        %}
+    {% endif %}
+
+    {% if errorList | length %}
+      {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorList
+        }) }}
+    {% endif %}
+
     {% set noSelectionError = false %}
     {% if flash.errorType[0] === "paymentAmountType" %}
     {% set noSelectionError = {

--- a/app/views/payment-links/edit-information.njk
+++ b/app/views/payment-links/edit-information.njk
@@ -10,6 +10,16 @@
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
+  {% if flash.error %}
+    {{ govukErrorSummary({
+          titleText: 'There is a problem',
+          errorList: [{
+            text: flash.error | safe,
+            href: '#payment-link-title'
+          }]
+        }) }}
+  {% endif %}
+
   <aside class="pay-info-warning-box">
     <p class="govuk-body">Editing the payment link title does not change the web&nbsp;address.</p>
   </aside>
@@ -22,7 +32,7 @@
     {% endif %}
 
     {% set titleError = false %}
-    {% if flash.genericError %}
+    {% if flash.error %}
     {% set titleError = {
       text: "This field cannot be blank"
     } %}

--- a/app/views/payment-links/edit-reference.njk
+++ b/app/views/payment-links/edit-reference.njk
@@ -11,6 +11,27 @@
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
+  {% if flash.error and flash.errorType[0] === "paymentReferenceType" %}
+    {% set errorList = [{
+      text: flash.error | safe,
+      href: "#standard-or-custom-ref"
+      }]
+    %}
+  {% elif flash.error and flash.errorType[0] === "label" %}
+    {% set errorList = [{
+        text: flash.error | safe,
+        href: "#reference-label"
+        }]
+      %}
+  {% endif %}
+
+  {% if errorList | length %}
+    {{ govukErrorSummary({
+        titleText: "There is a problem",
+        errorList: errorList
+      }) }}
+  {% endif %}
+  
   <form action="{{ self }}" class="form" method="post" data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {% if change.length %}

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -11,6 +11,16 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
+  {% if flash.error %}
+    {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: [{
+            text: flash.error | safe,
+            href: "#payment-link-title"
+          }]
+        }) }}
+  {% endif %}
+
   {% if isWelsh %}
     <h1 class="govuk-heading-l">Set Welsh payment link information</h1>
   {% else %}
@@ -25,7 +35,7 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
     {% endif %}
 
     {% set titleError = false %}
-    {% if flash.genericError %}
+    {% if flash.error %}
       {% set titleError = {
         text: 'This field cannot be blank'
       } %}

--- a/app/views/payment-links/reference.njk
+++ b/app/views/payment-links/reference.njk
@@ -11,6 +11,27 @@
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
+  {% if flash.error and flash.errorType[0] === "paymentReferenceType" %}
+    {% set errorList = [{
+      text: flash.error | safe,
+      href: "#reference-type-custom"
+      }]
+    %}
+  {% elif flash.error and flash.errorType[0] === "label" %}
+    {% set errorList = [{
+        text: flash.error | safe,
+        href: "#reference-label"
+        }]
+      %}
+  {% endif %}
+
+  {% if errorList | length %}
+    {{ govukErrorSummary({
+        titleText: "There is a problem",
+        errorList: errorList
+      }) }}
+  {% endif %}
+
   <form action="{{ routes.paymentLinks.reference }}" class="form" method="post" data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {% if change.length %}
@@ -108,7 +129,7 @@
           {
               value: "custom",
               text: "Yes",
-              checked: paymentReferenceType === 'custom',
+              checked: paymentReferenceType === 'custom' or blankReferenceLabelError,
               id: "reference-type-custom",
               conditional: {
                 html: customReferenceHTML
@@ -117,7 +138,7 @@
           {
               value: "standard",
               text: "No",
-              checked: paymentReferenceType === 'standard' or blankReferenceLabelError,
+              checked: paymentReferenceType === 'standard',
               id: "reference-type-standard",
               conditional: {
                 html: standardReferenceHTML

--- a/app/views/payment-links/web-address.njk
+++ b/app/views/payment-links/web-address.njk
@@ -11,6 +11,16 @@
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
+  {% if flash.error %}
+    {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: [{
+            text: flash.error | safe,
+            href: "#payment-name-path"
+          }]
+        }) }}
+  {% endif %}
+
   <h1 class="govuk-heading-l">The website address is already taken</h1>
 
   <form action="{{ routes.paymentLinks.webAddress }}" class="form" method="post" data-validate>
@@ -26,7 +36,7 @@
       <span class="govuk-hint pay-text-black">
         {{friendlyURL}}/{{currentService.name | removeIndefiniteArticles | slugify}}/
       </span>
-      {% if flash.genericError %}
+      {% if flash.error %}
         <span id="payment-name-path-error" class="govuk-error-message">
           The website address is already taken
         </span>

--- a/app/views/team-members/edit-phone-number.njk
+++ b/app/views/team-members/edit-phone-number.njk
@@ -16,11 +16,21 @@
 
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
+  {% if flash.error %}
+    {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: [{
+            text: flash.error | safe,
+            href: "#phone"
+          }]
+        }) }}
+  {% endif %}
+
   <h1 class="govuk-heading-l">Change your phone number</h1>
   <p class="govuk-body">Your phone number is used to send a text message code when you sign in to help verify your identity.</p>
 
   {% set phoneError = false %}
-  {% if flash.genericError %}
+  {% if flash.error %}
   {% set phoneError = {
     text: "Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192"
   } %}

--- a/test/cypress/integration/user/edit-phone-number.cy.test.js
+++ b/test/cypress/integration/user/edit-phone-number.cy.test.js
@@ -39,7 +39,7 @@ describe('Edit phone number flow', () => {
         cy.visit('/my-profile/phone-number')
         cy.get('input[name="phone"]').clear().type('not a number')
         cy.get('#save-phone-number').click()
-        cy.get('.error-summary').should('exist')
+        cy.get('.govuk-error-summary').should('exist')
         cy.get('input[name="phone"]').should('have.class', 'govuk-input--error')
       })
     })

--- a/test/unit/controller/payment-links/post-edit-amount.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-edit-amount.controller.ft.test.js
@@ -132,9 +132,9 @@ describe('POST payment link edit amount controller', () => {
     })
 
     it('should redirect with error message', () => {
-      expect(session.flash).to.have.property('genericError')
-      expect(session.flash.genericError.length).to.equal(1)
-      expect(session.flash.genericError[0]).to.equal('<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#fixed-or-variable">Is the payment for a fixed amount?</a></li></ul>')
+      expect(session.flash).to.have.property('error')
+      expect(session.flash.error.length).to.equal(1)
+      expect(session.flash.error[0]).to.equal('Is the payment for a fixed amount?')
     })
   })
 
@@ -170,9 +170,9 @@ describe('POST payment link edit amount controller', () => {
     })
 
     it('should redirect with error message', () => {
-      expect(session.flash).to.have.property('genericError')
-      expect(session.flash.genericError.length).to.equal(1)
-      expect(session.flash.genericError[0]).to.equal('<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#payment-amount">Enter the amount</a></li></ul>')
+      expect(session.flash).to.have.property('error')
+      expect(session.flash.error.length).to.equal(1)
+      expect(session.flash.error[0]).to.equal('Enter the amount')
     })
   })
 })

--- a/test/unit/controller/payment-links/post-edit-information.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-edit-information.controller.ft.test.js
@@ -96,9 +96,9 @@ describe('POST payment link edit information controller', () => {
     })
 
     it('should redirect with error message', () => {
-      expect(session.flash).to.have.property('genericError')
-      expect(session.flash.genericError.length).to.equal(1)
-      expect(session.flash.genericError[0]).to.equal('<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#payment-link-title">Title</a></li></ul>')
+      expect(session.flash).to.have.property('error')
+      expect(session.flash.error.length).to.equal(1)
+      expect(session.flash.error[0]).to.equal('Enter a title')
     })
   })
 })

--- a/test/unit/controller/payment-links/post-information.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-information.controller.ft.test.js
@@ -197,9 +197,9 @@ describe('Create payment link information controller', () => {
     })
 
     it('should add a relevant error message to the session \'flash\'', () => {
-      expect(session.flash).to.have.property('genericError')
-      expect(session.flash.genericError.length).to.equal(1)
-      expect(session.flash.genericError[0]).to.equal('<h2>There was a problem with the details you gave for:</h2><ul class="govuk-list govuk-error-summary__list"><li><a href="#payment-link-title">Title</a></li></ul>')
+      expect(session.flash).to.have.property('error')
+      expect(session.flash.error.length).to.equal(1)
+      expect(session.flash.error[0]).to.equal('Enter a title')
     })
   })
 })

--- a/test/unit/controller/payment-links/post-web-address.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-web-address.controller.ft.test.js
@@ -118,7 +118,7 @@ describe('Create payment link web address post controller', () => {
     })
 
     it('should expect session to contain error message', () => {
-      expect(session.flash.genericError).to.have.property('length').to.equal(1)
+      expect(session.flash.error).to.have.property('length').to.equal(1)
     })
   })
 })


### PR DESCRIPTION
We're using flash messages to display errors for certain journeys.
These are the payment link journey and editing a user's phone number.

To avoid passing markup in, use "error" as the flash key rather than
"genericError" and construct the error summary in each template that
expects an error. We are already using the flash message to display the
inline error message on the form.

This isn't our favoured pattern but it removes the anti-pattern of
controllers constructing the HTML in the quickest way.


