### PR TITLE
PP-7002 Display errors better for create payment link journey

### DIFF
--- a/app/controllers/payment-links/get-web-address.controller.js
+++ b/app/controllers/payment-links/get-web-address.controller.js
@@ -6,13 +6,22 @@ const lodash = require('lodash')
 // Local dependencies
 const { response } = require('../../utils/response.js')
 
-module.exports = (req, res) => {
+module.exports = function showWebAddressPage (req, res, next) {
   const friendlyURL = process.env.PRODUCTS_FRIENDLY_BASE_URI
-  const pageData = lodash.get(req, 'session.pageData.createPaymentLink', {})
-  const productNamePath = pageData.productNamePath || ''
+
+  const sessionData = lodash.get(req, 'session.pageData.createPaymentLink')
+  if (!sessionData) {
+    next(new Error('Payment link data not found in session cookie'))
+  }
+
+  const recovered = sessionData.webAddressPageRecovered || {}
+  delete sessionData.webAddressPageRecovered
+
+  const productNamePath = recovered.path || sessionData.productNamePath || ''
 
   return response(req, res, 'payment-links/web-address', {
     friendlyURL,
-    productNamePath
+    productNamePath,
+    errors: recovered.errors
   })
 }

--- a/app/controllers/payment-links/post-reference.controller.js
+++ b/app/controllers/payment-links/post-reference.controller.js
@@ -1,36 +1,38 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
-
-// Local dependencies
 const paths = require('../../paths')
 
-module.exports = (req, res) => {
-  const pageData = lodash.get(req, 'session.pageData.createPaymentLink', {})
-  let updatedPageData = lodash.cloneDeep(pageData)
-  const paymentReferenceType = req.body['reference-type-group']
-  const paymentReferenceLabel = req.body['reference-label'].trim()
-  const paymentReferenceHint = req.body['reference-hint-text'].trim()
+module.exports = function postReference (req, res, next) {
+  const sessionData = lodash.get(req, 'session.pageData.createPaymentLink')
+  if (!sessionData) {
+    next(new Error('Payment link data not found in session cookie'))
+  }
 
-  if (!paymentReferenceType) {
-    req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="govuk-list govuk-error-summary__list"><li><a href="#standard-or-custom-ref">Would you like us to create a payment reference number for your users?</a></li></ul>`)
-    req.flash('errorType', `paymentReferenceType`)
+  const type = req.body['reference-type-group']
+  const label = req.body['reference-label'].trim()
+  const hint = req.body['reference-hint-text'].trim()
+
+  const errors = {}
+  if (!type) {
+    errors.type = 'Would you like us to create a payment reference number for your users?'
+  } else if (type === 'custom' && label === '') {
+    errors.label = 'Enter a name for your payment reference'
+  }
+
+  if (!lodash.isEmpty(errors)) {
+    sessionData.referencePageRecovered = {
+      errors,
+      type,
+      label,
+      hint
+    }
     return res.redirect(paths.paymentLinks.reference)
   }
 
-  if (paymentReferenceType === 'custom') {
-    if (paymentReferenceLabel === '') {
-      req.flash('genericError', `<h2>There was a problem with the details you gave for:</h2><ul class="govuk-list govuk-error-summary__list"><li><a href="#reference-label">Name of your payment reference number</a></li></ul>`)
-      req.flash('errorType', `label`)
-      return res.redirect(paths.paymentLinks.reference)
-    }
-  }
-
-  updatedPageData.paymentReferenceType = paymentReferenceType
-  updatedPageData.paymentReferenceLabel = paymentReferenceType === 'custom' ? paymentReferenceLabel : ''
-  updatedPageData.paymentReferenceHint = paymentReferenceType === 'custom' ? paymentReferenceHint : ''
-  lodash.set(req, 'session.pageData.createPaymentLink', updatedPageData)
+  sessionData.paymentReferenceType = type
+  sessionData.paymentReferenceLabel = type === 'custom' ? label : ''
+  sessionData.paymentReferenceHint = type === 'custom' ? hint : ''
 
   if (req.body['change'] === 'true') {
     req.flash('generic', 'The details have been updated')

--- a/app/views/macro/error-summary.njk
+++ b/app/views/macro/error-summary.njk
@@ -1,0 +1,20 @@
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% macro errorSummary(params) %}
+  {% set errorList = [] %}
+  {% for error in params.errors %}
+    {% if error.show %}
+      {% set errorList = (errorList.push({
+          text: error.text | safe,
+          href: error.href
+        }), errorList) %}
+    {% endif %}
+  {% endfor %}
+
+  {% if errorList | length %}
+    {{ govukErrorSummary({
+        titleText: params.titleText or "There is a problem",
+        errorList: errorList
+      }) }}
+  {% endif %}
+{% endmacro %}

--- a/app/views/macro/error-summary.njk
+++ b/app/views/macro/error-summary.njk
@@ -2,18 +2,16 @@
 
 {% macro errorSummary(params) %}
   {% set errorList = [] %}
-  {% for error in params.errors %}
-    {% if error.show %}
-      {% set errorList = (errorList.push({
-          text: error.text | safe,
-          href: error.href
-        }), errorList) %}
-    {% endif %}
+  {% for key, message in params.errors %}
+    {% set errorList = (errorList.push({
+        text: message | safe,
+        href: params.hrefs[key]
+      }), errorList) %}
   {% endfor %}
 
   {% if errorList | length %}
     {{ govukErrorSummary({
-        titleText: params.titleText or "There is a problem",
+        titleText: "There is a problem",
         errorList: errorList
       }) }}
   {% endif %}

--- a/app/views/payment-links/amount.njk
+++ b/app/views/payment-links/amount.njk
@@ -1,4 +1,5 @@
 {% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
 
 {% block pageTitle %}
   Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
@@ -11,22 +12,39 @@
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
+  {% if errors %}
+    {{ errorSummary({
+      errors: [
+        {
+          show: errors.type,
+          text: errors.type,
+          href: "#amount-type-fixed"
+        },
+        {
+          show: errors.amount,
+          text: errors.amount,
+          href: "#payment-amount"
+        }
+      ]
+      }) }}
+  {% endif %}
+
   <form action="{{ nextPage }}" class="form" method="post">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {% set noSelectionError = false %}
-    {% if flash.errorType[0] === "paymentAmountType" %}
+    {% if errors.type %}
     {% set noSelectionError = {
         text: "Please choose an option"
     } %}
     {% endif %}
 
     {% set variableHTML %}
-      <div class="currency-input govuk-form-group{% if flash.errorType[0] === 'paymentAmountFormat' %} govuk-form-group--error{% endif %}">
+      <div class="currency-input govuk-form-group{% if errors.amount %} govuk-form-group--error{% endif %}">
         <label class="govuk-label" for="payment-amount">
           Enter the amount
           <span class="govuk-visually-hidden">in &pound;</span>
-          {% if flash.errorType[0] === "paymentAmountFormat" %}
+          {% if errors.amount %}
           <span class="govuk-error-message">
             Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”
           </span>
@@ -35,7 +53,7 @@
         <div class="currency-input__inner">
           <span class="currency-input__inner__unit">&pound;</span>
           <input
-            class="govuk-input govuk-input--width-10{% if flash.errorType[0] === 'paymentAmountFormat' %} govuk-input--error{% endif %}"
+            class="govuk-input govuk-input--width-10{% if errors.amount %} govuk-input--error{% endif %}"
             aria-label="Enter amount in pounds"
             name="payment-amount"
             autofocus
@@ -67,7 +85,7 @@
               value: "fixed",
               text: "Yes",
               id: "amount-type-fixed",
-              checked: paymentAmountType === "fixed" or flash.errorType[0] === "paymentAmountFormat",
+              checked: paymentAmountType === "fixed",
               conditional: {
                 html: variableHTML
               }

--- a/app/views/payment-links/amount.njk
+++ b/app/views/payment-links/amount.njk
@@ -12,22 +12,13 @@
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
-  {% if errors %}
-    {{ errorSummary({
-      errors: [
-        {
-          show: errors.type,
-          text: errors.type,
-          href: "#amount-type-fixed"
-        },
-        {
-          show: errors.amount,
-          text: errors.amount,
-          href: "#payment-amount"
-        }
-      ]
-      }) }}
-  {% endif %}
+  {{ errorSummary ({
+    errors: errors,
+    hrefs: {
+      type: "#amount-type-fixed",
+      amount: "#payment-amount"
+    }
+  }) }}
 
   <form action="{{ nextPage }}" class="form" method="post">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -12,15 +12,12 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
-  {% if errors %}
-    {{ errorSummary ({
-      errors: [{
-        show: errors.title,
-        text: errors.title,
-        href: "#payment-link-title"
-      }]
-    }) }}
-  {% endif %}
+  {{ errorSummary ({
+    errors: errors,
+    hrefs: {
+      title: "#payment-link-title"
+    }
+  }) }}
 
   {% if isWelsh %}
     <h1 class="govuk-heading-l">Set Welsh payment link information</h1>

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -1,4 +1,5 @@
 {% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
 
 {% block pageTitle %}
 Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
@@ -11,6 +12,16 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
+  {% if errors %}
+    {{ errorSummary ({
+      errors: [{
+        show: errors.title,
+        text: errors.title,
+        href: "#payment-link-title"
+      }]
+    }) }}
+  {% endif %}
+
   {% if isWelsh %}
     <h1 class="govuk-heading-l">Set Welsh payment link information</h1>
   {% else %}
@@ -25,9 +36,9 @@ Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_typ
     {% endif %}
 
     {% set titleError = false %}
-    {% if flash.genericError %}
+    {% if errors.title %}
       {% set titleError = {
-        text: 'This field cannot be blank'
+        text: errors.title | safe
       } %}
     {% endif %}
     {% set confirmationLabel %}{{friendlyURL}}/{{serviceName | removeIndefiniteArticles | slugify}}/{% endset %}

--- a/app/views/payment-links/reference.njk
+++ b/app/views/payment-links/reference.njk
@@ -12,22 +12,13 @@
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
-  {% if errors %}
-    {{ errorSummary({
-      errors: [
-        {
-          show: errors.type,
-          text: errors.type,
-          href: "#reference-type-custom"
-        },
-        {
-          show: errors.label,
-          text: errors.label,
-          href: "#reference-label"
-        }
-      ]
-      }) }}
-  {% endif %}
+  {{ errorSummary ({
+    errors: errors,
+    hrefs: {
+      type: "#reference-type-custom",
+      label: "#reference-label"
+    }
+  }) }}
 
   <form action="{{ routes.paymentLinks.reference }}" class="form" method="post" data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>

--- a/app/views/payment-links/reference.njk
+++ b/app/views/payment-links/reference.njk
@@ -1,4 +1,5 @@
 {% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
 
 {% block pageTitle %}
   Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
@@ -11,6 +12,23 @@
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
+  {% if errors %}
+    {{ errorSummary({
+      errors: [
+        {
+          show: errors.type,
+          text: errors.type,
+          href: "#reference-type-custom"
+        },
+        {
+          show: errors.label,
+          text: errors.label,
+          href: "#reference-label"
+        }
+      ]
+      }) }}
+  {% endif %}
+
   <form action="{{ routes.paymentLinks.reference }}" class="form" method="post" data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {% if change.length %}
@@ -18,14 +36,14 @@
     {% endif %}
 
     {% set noSelectionError = false %}
-    {% if flash.errorType[0] === "paymentReferenceType" %}
+    {% if errors.type %}
     {% set noSelectionError = {
         text: "Please choose an option"
     } %}
     {% endif %}
 
     {% set blankReferenceLabelError = false %}
-    {% if flash.errorType[0] === "label" %}
+    {% if errors.label %}
     {% set blankReferenceLabelError = {
         text: "Reference number cannot be blank"
     } %}
@@ -117,7 +135,7 @@
           {
               value: "standard",
               text: "No",
-              checked: paymentReferenceType === 'standard' or blankReferenceLabelError,
+              checked: paymentReferenceType === 'standard',
               id: "reference-type-standard",
               conditional: {
                 html: standardReferenceHTML

--- a/app/views/payment-links/web-address.njk
+++ b/app/views/payment-links/web-address.njk
@@ -12,15 +12,12 @@
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
-  {% if errors %}
-    {{ errorSummary ({
-      errors: [{
-        show: errors.path,
-        text: errors.path,
-        href: "#payment-name-path"
-      }]
-    }) }}
-  {% endif %}
+  {{ errorSummary ({
+    errors: errors,
+    hrefs: {
+      path: "#payment-name-path"
+    }
+  }) }}
 
   <h1 class="govuk-heading-l">The website address is already taken</h1>
 

--- a/app/views/payment-links/web-address.njk
+++ b/app/views/payment-links/web-address.njk
@@ -1,4 +1,5 @@
 {% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
 
 {% block pageTitle %}
   Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
@@ -11,6 +12,16 @@
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
+  {% if errors %}
+    {{ errorSummary ({
+      errors: [{
+        show: errors.path,
+        text: errors.path,
+        href: "#payment-name-path"
+      }]
+    }) }}
+  {% endif %}
+
   <h1 class="govuk-heading-l">The website address is already taken</h1>
 
   <form action="{{ routes.paymentLinks.webAddress }}" class="form" method="post" data-validate>
@@ -26,7 +37,7 @@
       <span class="govuk-hint pay-text-black">
         {{friendlyURL}}/{{currentService.name | removeIndefiniteArticles | slugify}}/
       </span>
-      {% if flash.genericError %}
+      {% if errors.path %}
         <span id="payment-name-path-error" class="govuk-error-message">
           The website address is already taken
         </span>

--- a/test/unit/controller/payment-links/get-information.controller.ft.test.js
+++ b/test/unit/controller/payment-links/get-information.controller.ft.test.js
@@ -51,21 +51,69 @@ describe('Create payment link information controller', () => {
       expect(result.statusCode).to.equal(200)
     })
 
-    it(`should include a cancel link linking to the Create payment link index`, () => {
+    it('should include a cancel link linking to the Create payment link index', () => {
       expect($('.cancel').attr('href')).to.equal(paths.paymentLinks.start)
     })
 
-    it(`should have itself as the form action`, () => {
+    it('should have itself as the form action', () => {
       expect($('form').attr('action')).to.equal(paths.paymentLinks.information)
     })
 
-    it(`should have blank value in the Title input`, () =>
-      expect($(`input[name='payment-link-title']`).val()).to.be.undefined
+    it('should have blank value in the Title input', () =>
+      expect($('input[name="payment-link-title"]').val()).to.be.undefined
     )
 
-    it(`should have blank value in the Details textarea`, () =>
-      expect($(`textarea[name='payment-link-description']`).val()).to.equal('')
+    it('should have blank value in the Details textarea', () =>
+      expect($('textarea[name="payment-link-description"]').val()).to.equal('')
     )
+  })
+
+  describe('when returning to the page with validation errors', () => {
+    const titleError = 'Something wrong with the title'
+    let $, session
+    before(done => {
+      const user = getUser({
+        gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+        permissions: [{ name: 'tokens:create' }]
+      })
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
+        payment_provider: 'sandbox'
+      })
+      session = getMockSession(user)
+      lodash.set(session, 'pageData.createPaymentLink.informationPageRecovered', {
+        title: 'Title',
+        description: 'Hello world',
+        errors: {
+          title: titleError
+        }
+      })
+      supertest(createAppWithSession(getApp(), session))
+        .get(paths.paymentLinks.information)
+        .end((err, res) => {
+          $ = cheerio.load(res.text)
+          done(err)
+        })
+    })
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should set the value of the Title input to recovered value', () =>
+      expect($('input[name="payment-link-title"]').val()).to.equal('Title')
+    )
+
+    it('should set the value of the Details textarea to recovered value', () =>
+      expect($('textarea[name="payment-link-description"]').val()).to.equal('Hello world')
+    )
+
+    it('should show an error summary', () => {
+      expect($('.govuk-error-summary__list li').length).to.equal(1)
+      expect($('.govuk-error-summary__list li a[href$="#payment-link-title"]').text()).to.equal(titleError)
+    })
+
+    it('should show inline errors', () => {
+      expect($('.govuk-error-message').length).to.equal(1)
+    })
   })
 
   describe('if returning here to change fields', () => {
@@ -94,12 +142,12 @@ describe('Create payment link information controller', () => {
       nock.cleanAll()
     })
 
-    it(`should pre-set the value of the Title input to pre-existing data if present in the session`, () =>
-      expect($(`input[name='payment-link-title']`).val()).to.equal(session.pageData.createPaymentLink.paymentLinkTitle)
+    it('should pre-set the value of the Title input to pre-existing data if present in the session', () =>
+      expect($('input[name="payment-link-title"]').val()).to.equal(session.pageData.createPaymentLink.paymentLinkTitle)
     )
 
-    it(`should pre-set the value of the Details textarea to pre-existing data if present in the session`, () =>
-      expect($(`textarea[name='payment-link-description']`).val()).to.equal(session.pageData.createPaymentLink.paymentLinkDescription)
+    it('should pre-set the value of the Details textarea to pre-existing data if present in the session', () =>
+      expect($('textarea[name="payment-link-description"]').val()).to.equal(session.pageData.createPaymentLink.paymentLinkDescription)
     )
   })
 

--- a/test/unit/controller/payment-links/get-reference.controller.ft.test.js
+++ b/test/unit/controller/payment-links/get-reference.controller.ft.test.js
@@ -45,25 +45,83 @@ describe('Create payment link reference controller', () => {
       expect(result.statusCode).to.equal(200)
     })
 
-    it(`should include a cancel link linking to the Create payment link index`, () => {
+    it('should include a cancel link linking to the Create payment link index', () => {
       expect($('.cancel').attr('href')).to.equal(paths.paymentLinks.start)
     })
 
-    it(`should have itself as the form action`, () => {
+    it('should have itself as the form action', () => {
       expect($('form').attr('action')).to.equal(paths.paymentLinks.reference)
     })
 
-    it(`should have no checked radio buttons`, () =>
-      expect($(`input[type="radio"]:checked`).length).to.equal(0)
+    it('should have no checked radio buttons', () =>
+      expect($('input[type="radio"]:checked').length).to.equal(0)
     )
 
-    it(`should have blank value in the reference input`, () =>
-      expect($(`input[name='reference-label']`).val()).to.be.undefined
+    it('should have blank value in the reference input', () =>
+      expect($('input[name="reference-label"]').val()).to.be.undefined
     )
 
-    it(`should have blank value in the reference hint text input`, () =>
-      expect($(`input[name='reference-hint-text']`).val()).to.be.undefined
+    it('should have blank value in the reference hint text input', () =>
+      expect($('input[name="reference-hint-text"]').val()).to.be.undefined
     )
+  })
+
+  describe('when returning to the page with validation errors', () => {
+    const label = 'Hello world'
+    const hint = 'Some words'
+    const typeError = 'Something wrong with the type'
+    const labelError = 'Something wrong with the label'
+    let $, session
+    before(done => {
+      const user = getUser({
+        gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+        permissions: [{ name: 'tokens:create' }]
+      })
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
+        payment_provider: 'sandbox'
+      })
+      session = getMockSession(user)
+      lodash.set(session, 'pageData.createPaymentLink.referencePageRecovered', {
+        type: 'custom',
+        label,
+        hint,
+        errors: {
+          type: typeError,
+          label: labelError
+        }
+      })
+      supertest(createAppWithSession(getApp(), session))
+        .get(paths.paymentLinks.reference)
+        .end((err, res) => {
+          $ = cheerio.load(res.text)
+          done(err)
+        })
+    })
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should set the custom reference radio to checked', () =>
+      expect($('#reference-type-custom:checked').length).to.equal(1)
+    )
+
+    it('should set the value of the reference to pre-existing data present in the session', () =>
+      expect($('input[name="reference-label"]').val()).to.equal(label)
+    )
+
+    it('should set the value of the reference hint to pre-existing data present in the session', () =>
+      expect($('textarea[name="reference-hint-text"]').val()).to.equal(hint)
+    )
+
+    it('should show an error summary', () => {
+      expect($('.govuk-error-summary__list li').length).to.equal(2)
+      expect($('.govuk-error-summary__list li a[href$="#reference-type-custom"]').text()).to.equal(typeError)
+      expect($('.govuk-error-summary__list li a[href$="#reference-label"]').text()).to.equal(labelError)
+    })
+
+    it('should show inline errors', () => {
+      expect($('.govuk-error-message').length).to.equal(2)
+    })
   })
 
   describe('if returning here to change fields', () => {
@@ -95,16 +153,16 @@ describe('Create payment link reference controller', () => {
         nock.cleanAll()
       })
 
-      it(`should set the custom reference radio to checked`, () =>
-        expect($(`#reference-type-custom:checked`).length).to.equal(1)
+      it('should set the custom reference radio to checked', () =>
+        expect($('#reference-type-custom:checked').length).to.equal(1)
       )
 
-      it(`should set the value of the reference to pre-existing data present in the session`, () =>
-        expect($(`input[name='reference-label']`).val()).to.equal(session.pageData.createPaymentLink.paymentReferenceLabel)
+      it('should set the value of the reference to recovered value', () =>
+        expect($('input[name="reference-label"]').val()).to.equal(session.pageData.createPaymentLink.paymentReferenceLabel)
       )
 
-      it(`should set the value of the reference hint to pre-existing data present in the session`, () =>
-        expect($(`textarea[name='reference-hint-text']`).val()).to.equal(session.pageData.createPaymentLink.paymentReferenceHint)
+      it('should set the value of the reference hint to recovered value', () =>
+        expect($('textarea[name="reference-hint-text"]').val()).to.equal(session.pageData.createPaymentLink.paymentReferenceHint)
       )
     })
 
@@ -136,16 +194,16 @@ describe('Create payment link reference controller', () => {
         nock.cleanAll()
       })
 
-      it(`should set the standard reference radio to checked`, () =>
-        expect($(`#reference-type-standard:checked`).length).to.equal(1)
+      it('should set the standard reference radio to checked', () =>
+        expect($('#reference-type-standard:checked').length).to.equal(1)
       )
 
-      it(`should set the value of the reference to blank`, () =>
-        expect($(`input[name='reference-label']`).val()).to.be.undefined
+      it('should set the value of the reference to blank', () =>
+        expect($('input[name="reference-label"]').val()).to.be.undefined
       )
 
-      it(`should set the value of the reference hint to blank`, () =>
-        expect($(`input[name='reference-hint-text']`).val()).to.be.undefined
+      it('should set the value of the reference hint to blank', () =>
+        expect($('input[name="reference-hint-text"]').val()).to.be.undefined
       )
     })
   })

--- a/test/unit/controller/payment-links/post-amount.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-amount.controller.ft.test.js
@@ -28,6 +28,7 @@ describe('Create payment link amount post controller', () => {
     }
     before('Arrange', () => {
       session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.createPaymentLink', {})
       app = createAppWithSession(getApp(), session)
     })
     before('Act', done => {
@@ -68,6 +69,7 @@ describe('Create payment link amount post controller', () => {
     }
     before('Arrange', () => {
       session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.createPaymentLink', {})
       app = createAppWithSession(getApp(), session)
     })
     before('Act', done => {
@@ -108,6 +110,7 @@ describe('Create payment link amount post controller', () => {
     }
     before('Arrange', () => {
       session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.createPaymentLink', {})
       app = createAppWithSession(getApp(), session)
     })
     before('Act', done => {
@@ -147,6 +150,7 @@ describe('Create payment link amount post controller', () => {
     }
     before('Arrange', () => {
       session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.createPaymentLink', {})
       app = createAppWithSession(getApp(), session)
     })
     before('Act', done => {
@@ -159,8 +163,9 @@ describe('Create payment link amount post controller', () => {
         })
     })
 
-    it('should pass an error with "paymentAmountType"', () => {
-      expect(session.flash.errorType[0]).to.equal('paymentAmountType')
+    it('should have a recovered object stored on the session containing error', () => {
+      const recovered = lodash.get(session, 'pageData.createPaymentLink.amountPageRecovered', {})
+      expect(recovered.errors).to.have.property('type')
     })
 
     it('should redirect with status code 302', () => {

--- a/test/unit/controller/payment-links/post-reference.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-reference.controller.ft.test.js
@@ -28,6 +28,7 @@ describe('Create payment link reference post controller', () => {
     }
     before('Arrange', () => {
       session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.createPaymentLink', {})
       app = createAppWithSession(getApp(), session)
     })
     before('Act', done => {
@@ -74,6 +75,7 @@ describe('Create payment link reference post controller', () => {
     }
     before('Arrange', () => {
       session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.createPaymentLink', {})
       app = createAppWithSession(getApp(), session)
     })
     before('Act', done => {
@@ -120,6 +122,7 @@ describe('Create payment link reference post controller', () => {
     }
     before('Arrange', () => {
       session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.createPaymentLink', {})
       app = createAppWithSession(getApp(), session)
     })
     before('Act', done => {
@@ -132,8 +135,9 @@ describe('Create payment link reference post controller', () => {
         })
     })
 
-    it('should pass an error with "paymentReferenceType"', () => {
-      expect(session.flash.errorType[0]).to.equal('paymentReferenceType')
+    it('should have a recovered object stored on the session containing error', () => {
+      const recovered = lodash.get(session, 'pageData.createPaymentLink.referencePageRecovered', {})
+      expect(recovered.errors).to.have.property('type')
     })
 
     it('should redirect with status code 302', () => {
@@ -151,10 +155,11 @@ describe('Create payment link reference post controller', () => {
       'csrfToken': csrf().create('123'),
       'reference-type-group': 'custom',
       'reference-label': '',
-      'reference-hint-text': ''
+      'reference-hint-text': 'hint text'
     }
     before('Arrange', () => {
       session = getMockSession(VALID_USER)
+      lodash.set(session, 'pageData.createPaymentLink', {})
       app = createAppWithSession(getApp(), session)
     })
     before('Act', done => {
@@ -167,8 +172,12 @@ describe('Create payment link reference post controller', () => {
         })
     })
 
-    it('should pass an error with "label"', () => {
-      expect(session.flash.errorType[0]).to.equal('label')
+    it('should have a recovered object stored on the session containing errors and submitted data', () => {
+      const recovered = lodash.get(session, 'pageData.createPaymentLink.referencePageRecovered', {})
+      expect(recovered).to.have.property('type').to.equal('custom')
+      expect(recovered).to.have.property('label').to.equal('')
+      expect(recovered).to.have.property('hint').to.equal('hint text')
+      expect(recovered.errors).to.have.property('label')
     })
 
     it('should redirect with status code 302', () => {

--- a/test/unit/controller/payment-links/post-web-address.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-web-address.controller.ft.test.js
@@ -117,8 +117,11 @@ describe('Create payment link web address post controller', () => {
       expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.webAddress)
     })
 
-    it('should expect session to contain error message', () => {
-      expect(session.flash.genericError).to.have.property('length').to.equal(1)
+    it('should have a recovered object stored on the session containing errors and submitted data', () => {
+      const recovered = lodash.get(session, 'pageData.createPaymentLink.webAddressPageRecovered', {})
+      expect(recovered).to.have.property('path').to.equal(PAYMENT_TITLE_SLUGIFIED)
+      expect(recovered).to.have.property('errors')
+      expect(recovered.errors).to.have.property('path')
     })
   })
 })


### PR DESCRIPTION
Previously we were passing validation errors from the POST controller when we redirect to the GET controller in flash messages in a confusing way.
These also contained HTML markup constructed by the controller which is not advised.

Make this work in a more sensible way by putting the validation errors as well as the submitted form values into the session cookie in a "recovered" object. Then in the GET controller after redirect, retrieve from here and delete the object from the session.

Create a nunjucks macro "errorSummary" which takes a list of errors and displays them in the design system error summary component when required. This simplifies the repeated template logic. And can be used in other existing places where we show an error summary.

