### PR TITLE
PP-7002 Display error messages properly for edit phone number

### DIFF
--- a/app/controllers/credentials.controller.js
+++ b/app/controllers/credentials.controller.js
@@ -93,9 +93,9 @@ module.exports = {
     const { username, password } = _.get(req, 'body')
 
     if (!username) {
-      req.flash('genericError', `Enter a username`)
+      req.flash('genericError', 'Enter a username')
     } else if (!password) {
-      req.flash('genericError', `Enter a password`)
+      req.flash('genericError', 'Enter a password')
     } else {
       const failedValidationMessage = isPasswordLessThanTenChars(password)
       if (failedValidationMessage) {

--- a/app/controllers/user/phone-number/post.controller.js
+++ b/app/controllers/user/phone-number/post.controller.js
@@ -6,14 +6,20 @@ const userService = require('../../../services/user.service')
 const paths = require('../../../paths')
 const { invalidTelephoneNumber } = require('../../../utils/validation/telephone-number-validation')
 
-module.exports = async (req, res) => {
-  if (invalidTelephoneNumber(req.body.phone)) {
-    req.flash('genericError', '<h2>There was a problem with the details you gave for:</h2><ul class="govuk-list govuk-error-summary__list"><li><a href="#phone">Invalid telephone number.</a></li></ul>')
-    return res.redirect(paths.user.phoneNumber)
+module.exports = async function updatePhoneNumber(req, res) {
+  const telephoneNumber = req.body.phone
+  if (invalidTelephoneNumber(telephoneNumber)) {
+    const pageData = {
+      telephoneNumber,
+      errors: {
+        phone: 'Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192'
+      }
+    }
+    return res.render('team-members/edit-phone-number', pageData)
   }
 
   try {
-    await userService.updatePhoneNumber(req.user.externalId, req.body.phone)
+    await userService.updatePhoneNumber(req.user.externalId, telephoneNumber)
 
     req.flash('generic', 'Phone number updated')
     return res.redirect(paths.user.profile)

--- a/app/views/team-members/edit-phone-number.njk
+++ b/app/views/team-members/edit-phone-number.njk
@@ -1,4 +1,5 @@
 {% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
 
 {% block pageTitle %}
   Edit phone number - My profile - GOV.UK Pay
@@ -16,13 +17,20 @@
 
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
+  {{ errorSummary ({
+    errors: errors,
+    hrefs: {
+      phone: "#phone"
+    }
+  }) }}
+
   <h1 class="govuk-heading-l">Change your phone number</h1>
   <p class="govuk-body">Your phone number is used to send a text message code when you sign in to help verify your identity.</p>
 
   {% set phoneError = false %}
-  {% if flash.genericError %}
+  {% if errors.phone %}
   {% set phoneError = {
-    text: "Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192"
+    text: errors.phone
   } %}
   {% endif %}
 

--- a/test/cypress/integration/user/edit-phone-number.cy.test.js
+++ b/test/cypress/integration/user/edit-phone-number.cy.test.js
@@ -39,7 +39,7 @@ describe('Edit phone number flow', () => {
         cy.visit('/my-profile/phone-number')
         cy.get('input[name="phone"]').clear().type('not a number')
         cy.get('#save-phone-number').click()
-        cy.get('.error-summary').should('exist')
+        cy.get('.govuk-error-summary').should('exist')
         cy.get('input[name="phone"]').should('have.class', 'govuk-input--error')
       })
     })


### PR DESCRIPTION
Avoid passing HTML markup in flash messages to display validation error. Instead re-render the form, passing errors to template.

