### PR TITLE
PP-7002 Handle edit payment link conflicts better

### DIFF
--- a/app/controllers/payment-links/get-edit-amount.controller.js
+++ b/app/controllers/payment-links/get-edit-amount.controller.js
@@ -7,16 +7,19 @@ const paths = require('../../paths')
 const formattedPathFor = require('../../utils/replace-params-in-path')
 const supportedLanguage = require('../../models/supported-language')
 
-module.exports = function showEditAmountPage (req, res, next) {
+module.exports = function showEditAmountPage (req, res) {
+  const { productExternalId } = req.params
+
   const sessionData = lodash.get(req, 'session.editPaymentLinkData')
-  if (!sessionData) {
-    return next(new Error('Edit payment link data not found in session cookie'))
+  if (!sessionData || sessionData.externalId != productExternalId) {
+    req.flash('genericError', 'Something went wrong. Please try again.')
+    return res.redirect(paths.paymentLinks.manage)
   }
 
   const recovered = sessionData.amountPageRecovered || {}
   delete sessionData.amountPageRecovered
 
-  const self = formattedPathFor(paths.paymentLinks.editAmount, req.params.productExternalId)
+  const self = formattedPathFor(paths.paymentLinks.editAmount, productExternalId)
   const change = lodash.get(req, 'query.field', {})
   const amountType = recovered.type || sessionData.price ? 'fixed' : 'variable'
   const amountInPence = recovered.amount || sessionData.price

--- a/app/controllers/payment-links/get-edit-information.controller.js
+++ b/app/controllers/payment-links/get-edit-information.controller.js
@@ -8,15 +8,18 @@ const formattedPathFor = require('../../utils/replace-params-in-path')
 const supportedLanguage = require('../../models/supported-language')
 
 module.exports = function showEditInformationPage (req, res, next) {
+  const { productExternalId } = req.params
+  
   const sessionData = lodash.get(req, 'session.editPaymentLinkData')
-  if (!sessionData) {
-    return next(new Error('Edit payment link data not found in session cookie'))
+  if (!sessionData || sessionData.externalId != productExternalId) {
+    req.flash('genericError', 'Something went wrong. Please try again.')
+    return res.redirect(paths.paymentLinks.manage)
   }
 
   const recovered = sessionData.informationPageRecovered || {}
   delete sessionData.informationPageRecovered
 
-  const self = formattedPathFor(paths.paymentLinks.editInformation, req.params.productExternalId)
+  const self = formattedPathFor(paths.paymentLinks.editInformation, productExternalId)
   const change = lodash.get(req, 'query.field', {})
   const paymentLinkTitle = recovered.name || sessionData.name
   const paymentLinkDescription = recovered.description || sessionData.description

--- a/app/controllers/payment-links/get-edit-reference.controller.js
+++ b/app/controllers/payment-links/get-edit-reference.controller.js
@@ -10,15 +10,18 @@ const formattedPathFor = require('../../utils/replace-params-in-path')
 const supportedLanguage = require('../../models/supported-language')
 
 module.exports = function showEditReferencePage (req, res, next) {
+  const { productExternalId } = req.params
+
   const sessionData = lodash.get(req, 'session.editPaymentLinkData')
-  if (!sessionData) {
-    return next(new Error('Edit payment link data not found in session cookie'))
+  if (!sessionData || sessionData.externalId != productExternalId) {
+    req.flash('genericError', 'Something went wrong. Please try again.')
+    return res.redirect(paths.paymentLinks.manage)
   }
 
   const recovered = sessionData.referencePageRecovered || {}
   delete sessionData.referencePageRecovered
 
-  const self = formattedPathFor(paths.paymentLinks.editReference, req.params.productExternalId)
+  const self = formattedPathFor(paths.paymentLinks.editReference, productExternalId)
   const change = lodash.get(req, 'query.field', {})
   const referenceLabel = recovered.referenceLabel || sessionData.referenceLabel
   const referenceHint = recovered.referenceHint || sessionData.referenceHint

--- a/app/controllers/payment-links/post-edit-amount.controller.js
+++ b/app/controllers/payment-links/post-edit-amount.controller.js
@@ -8,10 +8,13 @@ const paths = require('../../paths')
 const formattedPathFor = require('../../utils/replace-params-in-path')
 const { safeConvertPoundsStringToPence } = require('../../utils/currency-formatter')
 
-module.exports = function postEditAmount (req, res, next) {
+module.exports = function postEditAmount (req, res) {
+  const { productExternalId } = req.params
+  
   const sessionData = lodash.get(req, 'session.editPaymentLinkData')
-  if (!sessionData) {
-    return next(new Error('Edit payment link data not found in session cookie'))
+  if (!sessionData || sessionData.externalId != productExternalId) {
+    req.flash('genericError', 'Something went wrong. Please try again.')
+    return res.redirect(paths.paymentLinks.manage)
   }
 
   const type = req.body['amount-type-group']
@@ -34,11 +37,11 @@ module.exports = function postEditAmount (req, res, next) {
       type,
       amount: ''
     }
-    return res.redirect(formattedPathFor(paths.paymentLinks.editAmount, req.params.productExternalId))
+    return res.redirect(formattedPathFor(paths.paymentLinks.editAmount, productExternalId))
   }
 
   sessionData.price = amountInPence
   lodash.set(req, 'session.editPaymentLinkData', sessionData)
 
-  return res.redirect(formattedPathFor(paths.paymentLinks.edit, req.params.productExternalId))
+  return res.redirect(formattedPathFor(paths.paymentLinks.edit, productExternalId))
 }

--- a/app/controllers/payment-links/post-edit-information.controller.js
+++ b/app/controllers/payment-links/post-edit-information.controller.js
@@ -7,10 +7,13 @@ const lodash = require('lodash')
 const paths = require('../../paths')
 const formattedPathFor = require('../../utils/replace-params-in-path')
 
-module.exports = function postEditInformation (req, res, next) {
+module.exports = function postEditInformation (req, res) {
+  const { productExternalId } = req.params
+  
   const sessionData = lodash.get(req, 'session.editPaymentLinkData')
-  if (!sessionData) {
-    return next(new Error('Edit payment link data not found in session cookie'))
+  if (!sessionData || sessionData.externalId != productExternalId) {
+    req.flash('genericError', 'Something went wrong. Please try again.')
+    return res.redirect(paths.paymentLinks.manage)
   }
 
   const name = req.body['payment-link-title']
@@ -25,11 +28,11 @@ module.exports = function postEditInformation (req, res, next) {
       name,
       description
     }
-    return res.redirect(formattedPathFor(paths.paymentLinks.editInformation, req.params.productExternalId))
+    return res.redirect(formattedPathFor(paths.paymentLinks.editInformation, productExternalId))
   }
 
   sessionData.name = name
   sessionData.description = description
 
-  return res.redirect(formattedPathFor(paths.paymentLinks.edit, req.params.productExternalId))
+  return res.redirect(formattedPathFor(paths.paymentLinks.edit, productExternalId))
 }

--- a/app/controllers/payment-links/post-edit-reference.controller.js
+++ b/app/controllers/payment-links/post-edit-reference.controller.js
@@ -7,10 +7,13 @@ const lodash = require('lodash')
 const paths = require('../../paths')
 const formattedPathFor = require('../../utils/replace-params-in-path')
 
-module.exports = function postEditReference (req, res, next) {
+module.exports = function postEditReference (req, res) {
+  const { productExternalId } = req.params
+  
   const sessionData = lodash.get(req, 'session.editPaymentLinkData')
-  if (!sessionData) {
-    return next(new Error('Edit payment link data not found in session cookie'))
+  if (!sessionData || sessionData.externalId != productExternalId) {
+    req.flash('genericError', 'Something went wrong. Please try again.')
+    return res.redirect(paths.paymentLinks.manage)
   }
 
   const referenceEnabled = req.body['reference-type-group'] === 'custom'
@@ -27,12 +30,12 @@ module.exports = function postEditReference (req, res, next) {
       referenceLabel,
       referenceHint
     }
-    return res.redirect(formattedPathFor(paths.paymentLinks.editReference, req.params.productExternalId))
+    return res.redirect(formattedPathFor(paths.paymentLinks.editReference, productExternalId))
   }
 
   sessionData.referenceEnabled = referenceEnabled
   sessionData.referenceLabel = referenceLabel
   sessionData.referenceHint = referenceHint
 
-  return res.redirect(formattedPathFor(paths.paymentLinks.edit, req.params.productExternalId))
+  return res.redirect(formattedPathFor(paths.paymentLinks.edit, productExternalId))
 }

--- a/app/controllers/payment-links/post-edit.controller.js
+++ b/app/controllers/payment-links/post-edit.controller.js
@@ -1,28 +1,26 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
-const logger = require('../../utils/logger')(__filename)
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
-const auth = require('../../services/auth.service.js')
-const { renderErrorView } = require('../../utils/response.js')
 
-module.exports = (req, res) => {
-  const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
+module.exports = async function updatePaymentLink (req, res, next) {
+  const { productExternalId } = req.params
+  const gatewayAccountId = req.account.gateway_account_id
 
-  const editPaymentLinkData = lodash.get(req, 'session.editPaymentLinkData', {})
-  productsClient.product.update(gatewayAccountId, req.params.productExternalId, editPaymentLinkData)
-    .then(product => {
-      lodash.unset(req, 'session.editPaymentLinkData')
-      req.flash('generic', `Your payment link has been updated`)
-      res.redirect(paths.paymentLinks.manage)
-    })
-    .catch((err) => {
-      console.log(err)
-      logger.error(`[requestId=${req.correlationId}] update of payment link failed - ${err.message}`)
-      renderErrorView(req, res)
-    })
+  const editPaymentLinkData = lodash.get(req, 'session.editPaymentLinkData')
+  if (!editPaymentLinkData || editPaymentLinkData.externalId != productExternalId) {
+    req.flash('genericError', 'Something went wrong. Please try again.')
+    return res.redirect(paths.paymentLinks.manage)
+  }
+
+  try {
+    await productsClient.product.update(gatewayAccountId, productExternalId, editPaymentLinkData)
+    lodash.unset(req, 'session.editPaymentLinkData')
+    req.flash('generic', `Your payment link has been updated`)
+    res.redirect(paths.paymentLinks.manage)
+  } catch (err) {
+    return next(new Error(`Update of payment link failed. Error: ${err.message}`))
+  }
 }

--- a/app/middleware/express-unhandled-error-handler.js
+++ b/app/middleware/express-unhandled-error-handler.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const logger = require('../utils/logger')(__filename)
+const { keys } = require('@govuk-pay/pay-js-commons').logging
+const { CORRELATION_HEADER } = require('../utils/correlation-header')
 const { renderErrorView } = require('../utils/response')
 
 const UNHANDLED_ERROR_MESSAGE = 'There is a problem with the payments platform. Please contact the support team.'
@@ -11,6 +13,11 @@ module.exports = function errorHandler (err, req, res, next) {
     return next(err)
   }
 
-  logger.error('Unhandled error caught - ' + err.stack)
+  const logContext = {
+    // trim the stack as long log messages are truncated by Splunk
+    stack: err.stack.substring(0, 300),
+  }
+  logContext[keys.CORRELATION_ID] = req.headers[CORRELATION_HEADER]
+  logger.error(`Unhandled error caught: ${err.message}`, logContext)
   renderErrorView(req, res, UNHANDLED_ERROR_MESSAGE, UNHANDLED_ERROR_STATUS)
 }

--- a/test/unit/controller/payment-links/get-edit-amount.controller.test.js
+++ b/test/unit/controller/payment-links/get-edit-amount.controller.test.js
@@ -13,23 +13,34 @@ describe('GET edit amount controller', () => {
     req = {
       params: {
         productExternalId
-      }
+      },
+      flash: sinon.spy()
     }
     res = {
       render: sinon.spy(),
       setHeaders: sinon.spy(),
-      status: sinon.spy()
+      status: sinon.spy(),
+      redirect: sinon.spy()
     }
     next = sinon.spy()
   })
 
-  it('should pass an error to next when session data not found', () => {
+  it('should return to "Manage payment links" with an error if session data not found', () => {
     getEditAmountController(req, res, next)
-    sinon.assert.calledWith(next, sinon.match.instanceOf(Error))
+    sinon.assert.calledWith(res.redirect, '/create-payment-link/manage')
+  })
+
+  it('should return to "Manage payment links" with an error if ID in URL does not match ID in session', () => {
+    lodash.set(req, 'session.editPaymentLinkData', {
+      externalId: 'a-different-id'
+    })
+    getEditAmountController(req, res, next)
+    sinon.assert.calledWith(res.redirect, '/create-payment-link/manage')
   })
 
   it('should send field values from session when rendering page for fixed amount', () => {
     lodash.set(req, 'session.editPaymentLinkData', {
+      externalId: productExternalId,
       price: '1050',
       language: 'cy'
     })
@@ -46,6 +57,7 @@ describe('GET edit amount controller', () => {
 
   it('should send field values from session when rendering page for variable amount', () => {
     lodash.set(req, 'session.editPaymentLinkData', {
+      externalId: productExternalId,
       price: '',
       language: 'en'
     })
@@ -69,6 +81,7 @@ describe('GET edit amount controller', () => {
       }
     }
     const session = {
+      externalId: productExternalId,
       price: '',
       language: 'en',
       amountPageRecovered: recovered

--- a/test/unit/controller/payment-links/get-edit-information.controller.test.js
+++ b/test/unit/controller/payment-links/get-edit-information.controller.test.js
@@ -13,23 +13,34 @@ describe('GET edit information controller', () => {
     req = {
       params: {
         productExternalId
-      }
+      },
+      flash: sinon.spy()
     }
     res = {
       render: sinon.spy(),
       setHeaders: sinon.spy(),
-      status: sinon.spy()
+      status: sinon.spy(),
+      redirect: sinon.spy()
     }
     next = sinon.spy()
   })
 
-  it('should pass an error to next when session data not found', () => {
+  it('should return to "Manage payment links" with an error if session data not found', () => {
     getEditInformationController(req, res, next)
-    sinon.assert.calledWith(next, sinon.match.instanceOf(Error))
+    sinon.assert.calledWith(res.redirect, '/create-payment-link/manage')
+  })
+
+  it('should return to "Manage payment links" with an error if ID in URL does not match ID in session', () => {
+    lodash.set(req, 'session.editPaymentLinkData', {
+      externalId: 'a-different-id'
+    })
+    getEditInformationController(req, res, next)
+    sinon.assert.calledWith(res.redirect, '/create-payment-link/manage')
   })
 
   it('should send field values from session when rendering page', () => {
     const session = {
+      externalId: productExternalId,
       name: 'a payment link',
       description: 'a description',
       language: 'cy'
@@ -55,6 +66,7 @@ describe('GET edit information controller', () => {
       }
     }
     const session = {
+      externalId: productExternalId,
       name: 'a payment link',
       description: 'a description',
       language: 'cy',

--- a/test/unit/controller/payment-links/get-edit-reference.controller.test.js
+++ b/test/unit/controller/payment-links/get-edit-reference.controller.test.js
@@ -13,23 +13,34 @@ describe('GET edit reference controller', () => {
     req = {
       params: {
         productExternalId
-      }
+      },
+      flash: sinon.spy()
     }
     res = {
       render: sinon.spy(),
       setHeaders: sinon.spy(),
-      status: sinon.spy()
+      status: sinon.spy(),
+      redirect: sinon.spy()
     }
     next = sinon.spy()
   })
 
-  it('should pass an error to next when session data not found', () => {
+  it('should return to "Manage payment links" with an error if session data not found', () => {
     getEditReferenceController(req, res, next)
-    sinon.assert.calledWith(next, sinon.match.instanceOf(Error))
+    sinon.assert.calledWith(res.redirect, '/create-payment-link/manage')
+  })
+
+  it('should return to "Manage payment links" with an error if ID in URL does not match ID in session', () => {
+    lodash.set(req, 'session.editPaymentLinkData', {
+      externalId: 'a-different-id'
+    })
+    getEditReferenceController(req, res, next)
+    sinon.assert.calledWith(res.redirect, '/create-payment-link/manage')
   })
 
   it('should send field values from session when rendering page', () => {
     const session = {
+      externalId: productExternalId,
       referenceEnabled: true,
       referenceLabel: 'A label',
       referenceHint: 'A hint',
@@ -58,6 +69,7 @@ describe('GET edit reference controller', () => {
       }
     }
     const session = {
+      externalId: productExternalId,
       referenceEnabled: false,
       referenceLabel: 'A label',
       referenceHint: 'A hint',

--- a/test/unit/controller/payment-links/post-edit-amount.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-edit-amount.controller.ft.test.js
@@ -25,7 +25,7 @@ describe('POST payment link edit amount controller', () => {
     let result, session, app
     before('Arrange', () => {
       session = getMockSession(VALID_USER)
-      session.editPaymentLinkData = {}
+      session.editPaymentLinkData = { externalId: PRODUCT_EXTERNAL_ID }
       app = createAppWithSession(getApp(), session)
     })
     before('Act', done => {
@@ -66,7 +66,7 @@ describe('POST payment link edit amount controller', () => {
     let result, session, app
     before('Arrange', () => {
       session = getMockSession(VALID_USER)
-      session.editPaymentLinkData = {}
+      session.editPaymentLinkData = { externalId: PRODUCT_EXTERNAL_ID }
       app = createAppWithSession(getApp(), session)
     })
     before('Act', done => {
@@ -107,7 +107,7 @@ describe('POST payment link edit amount controller', () => {
     let result, session, app
     before('Arrange', () => {
       session = getMockSession(VALID_USER)
-      session.editPaymentLinkData = {}
+      session.editPaymentLinkData = { externalId: PRODUCT_EXTERNAL_ID }
       app = createAppWithSession(getApp(), session)
     })
     before('Act', done => {
@@ -147,7 +147,7 @@ describe('POST payment link edit amount controller', () => {
     let result, session, app
     before('Arrange', () => {
       session = getMockSession(VALID_USER)
-      session.editPaymentLinkData = {}
+      session.editPaymentLinkData = { externalId: PRODUCT_EXTERNAL_ID }
       app = createAppWithSession(getApp(), session)
     })
     before('Act', done => {

--- a/test/unit/controller/payment-links/post-edit-information.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-edit-information.controller.ft.test.js
@@ -25,7 +25,7 @@ describe('POST payment link edit information controller', () => {
     let result, session, app
     before('Arrange', () => {
       session = getMockSession(VALID_USER)
-      session.editPaymentLinkData = {}
+      session.editPaymentLinkData = { externalId: PRODUCT_EXTERNAL_ID }
       app = createAppWithSession(getApp(), session)
     })
     before('Act', done => {
@@ -69,7 +69,7 @@ describe('POST payment link edit information controller', () => {
     let result, session, app
     before('Arrange', () => {
       session = getMockSession(VALID_USER)
-      session.editPaymentLinkData = {}
+      session.editPaymentLinkData = { externalId: PRODUCT_EXTERNAL_ID }
       app = createAppWithSession(getApp(), session)
     })
     before('Act', done => {


### PR DESCRIPTION
It is currently only possible to edit one payment link at a time due to how we use the session for this journey. So editing 2 payment links in different browser tabs isn't possible and results in unexpected behaviour currently.

Handle this by:

- If on the summary page for editing the payment link and the ID in the URL doesn't match that in the session, clear the session and show the page for the payment link with id from the URL.
- If trying to visit a page to edit individual details of a payment link and the ID in the URL does not match the ID in the session, put the user back on the "Manage payment links" page with an error message.
- If attempting to make a POST request to update a payment link and the ID in the URL does not match the ID in the session, also put the user back on the "Manage payment links" page with an error message.

When they are put on the "Manage payment links" page, this clears any other session they have, so if there are multiple tabs open, editing on none of them will work. Until they start again on a single tab.

