### PR TITLE
PP-7002 Always display generic flash messages as headers

### DIFF
--- a/app/controllers/payment-links/post-review.controller.js
+++ b/app/controllers/payment-links/post-review.controller.js
@@ -70,7 +70,7 @@ module.exports = (req, res) => {
     })
     .then(product => {
       lodash.unset(req, 'session.pageData.createPaymentLink')
-      req.flash('generic', 'Your payment link is now live. Give this link to your users to collect payments for your service.')
+      req.flash('createPaymentLinkSuccess', true)
       res.redirect(paths.paymentLinks.manage)
     })
     .catch((err) => {

--- a/app/controllers/two-factor-auth-controller/post-configure.controller.js
+++ b/app/controllers/two-factor-auth-controller/post-configure.controller.js
@@ -13,11 +13,7 @@ module.exports = (req, res) => {
   const method = lodash.get(req, 'session.pageData.twoFactorAuthMethod', 'APP')
   userService.configureNewOtpKey(req.user.externalId, code, method, req.correlationId)
     .then(user => {
-      if (method === 'APP') {
-        req.flash('generic', 'Your sign-in method has been updated. Use your authenticator app when you next sign in.')
-      } else {
-        req.flash('generic', 'Your sign-in method has been updated. We’ll send you a text message when you next sign in.')
-      }
+      req.flash('otpMethodUpdated', method)
       return res.redirect(paths.user.profile)
     })
     .catch((err) => {

--- a/app/views/includes/flash.njk
+++ b/app/views/includes/flash.njk
@@ -1,3 +1,5 @@
+{% from "../macro/success-notification.njk" import successNotification %}
+
 {% block flash %}
   <div class="govuk-grid-column-two-thirds">
     {% if flash.genericError %}
@@ -8,11 +10,9 @@
     </div>
     {% endif %}
     {% if flash.generic %}
-    <div class="flash-container flash-container--good">
-      <div class="notification generic-flash">
-        {{ flash.generic | safe }}
-      </div>
-    </div>
+    {{ successNotification({
+      heading: flash.generic | safe
+    }) }}
     {% endif %}
   </div>
 {% endblock %}

--- a/app/views/macro/success-notification.njk
+++ b/app/views/macro/success-notification.njk
@@ -1,0 +1,8 @@
+{% macro successNotification(params) %}
+  <div class="flash-container flash-container--good">
+    <div class="notification">
+      <h2>{{ params.heading | safe }}</h2>
+      <p>{{ params.body | safe }}</p>
+    </div>
+  </div>
+{% endmacro %}

--- a/app/views/payment-links/manage.njk
+++ b/app/views/payment-links/manage.njk
@@ -1,4 +1,5 @@
 {% extends "../layout.njk" %}
+{% from "../macro/success-notification.njk" import successNotification %}
 
 {% block pageTitle %}
   {% if permissions.tokens_create %}Manage{% else %}View{% endif %} a payment link - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
@@ -10,6 +11,13 @@
 
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
+{% if flash.createPaymentLinkSuccess %}
+    {{ successNotification({
+      heading: "Your payment link is now live",
+      body: "Give this link to your users to collect payments for your service."
+    }) }}
+{% endif %}
+
 {% if not permissions.tokens_create %}
   <aside class="pay-info-warning-box">
     <p class="govuk-body">You don’t have permission to create or edit payment links. Contact your service admin if you would like to manage payment links.</p>

--- a/app/views/team-members/team-member-profile.njk
+++ b/app/views/team-members/team-member-profile.njk
@@ -1,10 +1,21 @@
 {% extends "../layout.njk" %}
+{% from "../macro/success-notification.njk" import successNotification %}
 
 {% block pageTitle %}
 My profile - GOV.UK Pay
 {% endblock %}
 
 {% block mainContent %}
+<div class="govuk-grid-column-two-thirds">
+  {% if flash.otpMethodUpdated %}
+    {{ successNotification({
+          heading: "Your sign-in method has been updated",
+          body: "Use your authenticator app when you next sign in." 
+                if flash.otpMethodUpdated[0] === "APP" 
+                else "We’ll send you a text message when you next sign in."
+    }) }}
+  {% endif %}
+</div>
 <div class="govuk-grid-column-full">
   <h1 id="details-for" class="govuk-heading-l page-title">
       My profile

--- a/app/views/transaction-detail/index.njk
+++ b/app/views/transaction-detail/index.njk
@@ -1,4 +1,5 @@
 {% extends "../layout.njk" %}
+{% from "../macro/success-notification.njk" import successNotification %}
 
 {% set contextIsAllServiceTransactions = redirectBackLink %}
 {% set hideServiceHeader = contextIsAllServiceTransactions %}
@@ -26,12 +27,10 @@
 {% block mainContent %}
   <div class="govuk-grid-column-two-thirds">
     {% if flash.refundSuccess %}
-      <div class="flash-container flash-container--good">
-        <div class="notification generic-flash">
-          <h2 class="govuk-heading-m">Refund successful</h2>
-          <p class="govuk-body">It may take up to 6 days to process.</p>
-        </div>
-      </div>
+      {{ successNotification({
+        heading: "Refund successful",
+        body: "It may take up to 6 days to process."
+      }) }}
     {% elif flash.refundError %}
       <div class="govuk-error-summary hidden" aria-labelledby="error-summary-heading-example-1" role="alert" tabindex="-1" data-module="govuk-error-summary">
         <h2 class="govuk-error-summary__title" id="error-summary-heading-example-1">

--- a/test/cypress/integration/settings/your-psp.cy.test.js
+++ b/test/cypress/integration/settings/your-psp.cy.test.js
@@ -189,7 +189,7 @@ describe('Your PSP settings page', () => {
       cy.location().should((location) => {
         expect(location.pathname).to.eq(`/your-psp`)
       })
-      cy.get('.generic-flash').should('contain', 'Credentials deleted. 3DS Flex has been removed from your account. Your payments will now use 3DS only.')
+      cy.get('.notification').should('contain', 'Credentials deleted. 3DS Flex has been removed from your account. Your payments will now use 3DS only.')
       cy.get('.value-organisational-unit-id').should('contain', 'Not configured')
       cy.get('.value-issuer').should('contain', 'Not configured')
       cy.get('.value-jwt-mac-key').should('contain', 'Not configured')

--- a/test/cypress/integration/user/edit-phone-number.cy.test.js
+++ b/test/cypress/integration/user/edit-phone-number.cy.test.js
@@ -54,7 +54,7 @@ describe('Edit phone number flow', () => {
       cy.visit('/my-profile/phone-number')
       cy.get('input[name="phone"]').clear().type(testPhoneNumberNew)
       cy.get('#save-phone-number').click()
-      cy.get('.generic-flash').should('exist').should('contain', 'Phone number updated')
+      cy.get('.notification').should('exist').should('contain', 'Phone number updated')
       cy.get('#telephone-number').should('contain', testPhoneNumberNew)
     })
   })

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -17,6 +17,7 @@ const productFixtures = require('../../fixtures/product.fixtures')
 const goCardlessConnectFixtures = require('../../fixtures/go-cardless-connect.fixtures')
 const ledgerFixture = require('../../fixtures/ledger-transaction.fixtures')
 const inviteFixtures = require('../../fixtures/invite.fixtures')
+const tokenFixtures = require('../../fixtures/token.fixtures')
 
 const simpleStubBuilder = function simpleStubBuilder (method, path, responseCode, additionalParams = {}) {
   const request = {
@@ -515,6 +516,18 @@ module.exports = {
       request: serviceFixtures.validCreateServiceRequest(opts).getPlain(),
       response: serviceFixtures.validServiceResponse(opts).getPlain(),
       verifyCalledTimes: opts.verifyCalledTimes
+    })
+  },
+  postCreateTokenForAccountSuccess: (opts = {}) => {
+    const path = '/v1/frontend/auth'
+    return simpleStubBuilder('POST', path, 200, {
+      response: tokenFixtures.validCreateTokenForGatewayAccountResponse().getPlain()
+    })
+  },
+  postCreateProductSuccess: (opts = {}) => {
+    const path = '/v1/api/products'
+    return simpleStubBuilder('POST', path, 200, {
+      response: productFixtures.validProductResponse(opts).getPlain()
     })
   }
 }

--- a/test/cypress/stubs/products-stubs.js
+++ b/test/cypress/stubs/products-stubs.js
@@ -38,9 +38,16 @@ const getProductsByGatewayAccountIdFailure = function (gatewayAccountId) {
   }
 }
 
+const postCreateProductSuccess = function() {
+  return {
+    name: 'postCreateProductSuccess'
+  }
+}
+
 module.exports = {
   getProductsStub,
   getProductByExternalIdStub,
   deleteProductStub,
-  getProductsByGatewayAccountIdFailure
+  getProductsByGatewayAccountIdFailure,
+  postCreateProductSuccess
 }

--- a/test/cypress/stubs/token-stubs.js
+++ b/test/cypress/stubs/token-stubs.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const postCreateTokenForAccountSuccess = function postCreateTokenForAccountSuccess (opts) {
+  return {
+    name: 'postCreateTokenForAccountSuccess',
+    opts
+  }
+}
+
+module.exports = {
+  postCreateTokenForAccountSuccess
+}

--- a/test/fixtures/token.fixtures.js
+++ b/test/fixtures/token.fixtures.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const path = require('path')
+const _ = require('lodash')
+
+const pactBase = require(path.join(__dirname, '/pact-base'))
+const pactRegister = pactBase()
+
+const validCreateTokenForGatewayAccountRequest = function validCreateTokenForGatewayAccountRequest (opts = {}) {
+  const data = {
+    account_id: opts.account_id,
+    created_by: opts.created_by || 'foo@example.com',
+    type: opts.type || 'PRODUCTS',
+    description: opts.description || 'A token'
+  }
+
+  return {
+    getPactified: () => {
+      return pactRegister.pactify(data)
+    },
+    getPlain: () => {
+      return _.clone(data)
+    }
+  }
+}
+
+const validCreateTokenForGatewayAccountResponse = function validCreateTokenForGatewayAccountResponse (opts = {}) {
+  const data = {
+    token: opts.token || 'a-token'
+  }
+
+  return {
+    getPactified: () => {
+      return pactRegister.pactify(data)
+    },
+    getPlain: () => {
+      return _.clone(data)
+    }
+  }
+}
+
+module.exports = {
+  validCreateTokenForGatewayAccountRequest,
+  validCreateTokenForGatewayAccountResponse
+}

--- a/test/unit/controller/payment-links/post-review.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-review.controller.ft.test.js
@@ -87,9 +87,7 @@ describe('Create payment link review controller', () => {
     })
 
     it('should redirect to the manage page with a success message', () => {
-      expect(session.flash).to.have.property('generic')
-      expect(session.flash.generic.length).to.equal(1)
-      expect(session.flash.generic[0]).to.contain('Your payment link is now live.')
+      expect(session.flash).to.have.property('createPaymentLinkSuccess')
       expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.manage)
     })
   })
@@ -251,9 +249,7 @@ describe('Create payment link review controller', () => {
     })
 
     it('should redirect to the manage page with a success message', () => {
-      expect(session.flash).to.have.property('generic')
-      expect(session.flash.generic.length).to.equal(1)
-      expect(session.flash.generic[0]).to.contain('Your payment link is now live.')
+      expect(session.flash).to.have.property('createPaymentLinkSuccess')
       expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.manage)
     })
   })


### PR DESCRIPTION
When removing markup passed in flash messages, there was a content regression meaning all success messages were displayed with the govuk paragraph formatting, when before usually were either just a header or a header followed by a paragraph.

Make it so that all notifications shown using the 'generic' flash put the content in a h2.

For cases where we want a header and a paragraph, use a different flash key and handle this in the individual templates that show the the notifications.

Create a nunjucks macro for re-use of the notification component.


