### PR TITLE
PP-7002 Don't pass markup in flash message for 2fa controller

### DIFF
--- a/app/controllers/two-factor-auth-controller/get-configure.controller.js
+++ b/app/controllers/two-factor-auth-controller/get-configure.controller.js
@@ -9,22 +9,26 @@ const logger = require('../../utils/logger')(__filename)
 const { response } = require('../../utils/response.js')
 const paths = require('../../paths')
 
-module.exports = (req, res) => {
-  const PAGE_PARAMS = {
-    method: lodash.get(req, 'session.pageData.twoFactorAuthMethod', 'APP')
-  }
+module.exports = async function showConfigureSeconfFactorMethod (req, res) {
+  const method = lodash.get(req, 'session.pageData.twoFactorAuthMethod', 'APP')
+  const recovered = lodash.get(req, 'session.pageData.configureTwoFactorAuthMethodRecovered', {})
+  lodash.unset(req, 'session.pageData.configureTwoFactorAuthMethodRecovered')
 
-  PAGE_PARAMS.prettyPrintedSecret = req.user.provisionalOtpKey.match(/.{4}/g).join(' ')
+  const prettyPrintedSecret = req.user.provisionalOtpKey.match(/.{4}/g).join(' ')
   const otpUrl = `otpauth://totp/GOV.UK%20Pay:${encodeURIComponent(req.user.username)}?secret=${encodeURIComponent(req.user.provisionalOtpKey)}&issuer=GOV.UK%20Pay&algorithm=SHA1&digits=6&period=30`
 
-  qrcode.toDataURL(otpUrl)
-    .then(url => {
-      PAGE_PARAMS.qrCodeDataUrl = url
-      return response(req, res, 'two-factor-auth/configure', PAGE_PARAMS)
-    })
-    .catch(err => {
-      logger.error(`[requestId=${req.correlationId}] Failed to generate QR code - ${err.message}`)
-      req.flash('genericError', 'Something went wrong. Please try again or contact support.')
-      return res.redirect(paths.user.twoFactorAuth.index)
-    })
+  try {
+    const qrCodeDataUrl = await qrcode.toDataURL(otpUrl)
+    const pageData = {
+      method,
+      prettyPrintedSecret,
+      qrCodeDataUrl,
+      errors: recovered.errors
+    }
+    return response(req, res, 'two-factor-auth/configure', pageData)
+  } catch (err) {
+    logger.error(`[requestId=${req.correlationId}] Failed to generate QR code - ${err.message}`)
+    req.flash('genericError', 'Something went wrong. Please try again or contact support.')
+    return res.redirect(paths.user.twoFactorAuth.index)
+  }
 }

--- a/app/controllers/two-factor-auth-controller/post-configure.controller.js
+++ b/app/controllers/two-factor-auth-controller/post-configure.controller.js
@@ -8,23 +8,24 @@ const logger = require('../../utils/logger')(__filename)
 const paths = require('../../paths')
 const userService = require('../../services/user.service.js')
 
-module.exports = (req, res) => {
+module.exports = async function postUpdateSecondFactorMethod (req, res) {
   const code = req.body['code'] || ''
   const method = lodash.get(req, 'session.pageData.twoFactorAuthMethod', 'APP')
-  userService.configureNewOtpKey(req.user.externalId, code, method, req.correlationId)
-    .then(user => {
-      req.flash('otpMethodUpdated', method)
-      return res.redirect(paths.user.profile)
-    })
-    .catch((err) => {
-      let errorMessage
-      if (err.errorCode === 401 || err.errorCode === 400) {
-        errorMessage = `<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#code">Please enter a valid verification code</a></li></ul>`
-      } else {
-        errorMessage = 'Something went wrong. Please try again or contact support.'
-        logger.error(`[requestId=${req.correlationId}] Activating new OTP key failed, server error`)
-      }
-      req.flash('genericError', errorMessage)
-      return res.redirect(paths.user.twoFactorAuth.configure)
-    })
+  try {
+    await userService.configureNewOtpKey(req.user.externalId, code, method, req.correlationId)
+    req.flash('otpMethodUpdated', method)
+    return res.redirect(paths.user.profile)
+  } catch (err) {
+    if (err.errorCode === 401 || err.errorCode === 400) {
+      lodash.set(req, 'session.pageData.configureTwoFactorAuthMethodRecovered', {
+        errors: {
+          verificationCode: 'The verification code you’ve used is incorrect or has expired'
+        }
+      })
+    } else {
+      req.flash('genericError', 'Something went wrong. Please try again or contact support.')
+      logger.error(`[requestId=${req.correlationId}] Activating new OTP key failed, server error`)
+    }
+    return res.redirect(paths.user.twoFactorAuth.configure)
+  }
 }

--- a/app/views/two-factor-auth/configure.njk
+++ b/app/views/two-factor-auth/configure.njk
@@ -1,4 +1,5 @@
 {% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
 
 {% if method === 'APP' %}
   {% set title = 'Set up an authenticator app' %}
@@ -21,6 +22,14 @@
 {% endblock %}
 
 {% block mainContent %}
+<div class="govuk-grid-column-two-thirds">
+  {{ errorSummary ({
+    errors: errors,
+    hrefs: {
+      verificationCode: "#code"
+    }
+  }) }}
+</div>
 <div class="govuk-grid-column-full">
   <h1 class="govuk-heading-l page-title">
     {{ title }}
@@ -52,13 +61,6 @@
   <form method="post" action="{{routes.user.twoFactorAuth.configure}}" novalidate data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
-    {% set codeError = false %}
-    {% if flash.genericError %}
-      {% set codeError = {
-        text: "Please enter a valid verification code"
-      } %}
-    {% endif %}
-
     {% set codeHint = "Enter the code shown in your app to complete the setup" %}
     {% if method === 'SMS' %}
       {% set codeHint = "We have sent you a text message with a verification code" %}
@@ -71,7 +73,7 @@
         hint: {
           text: codeHint
         },
-        errorMessage: codeError,
+        errorMessage: { text: errors.verificationCode } if  errors.verificationCode else false,
         id: "code",
         name: "code",
         classes: "govuk-input--width-10",

--- a/test/unit/controller/two-factor-auth-controller/get-configure.controller.ft.test.js
+++ b/test/unit/controller/two-factor-auth-controller/get-configure.controller.ft.test.js
@@ -103,4 +103,51 @@ describe('Two factor authenticator configure page GET', () => {
       expect($('.qr-code').length).to.equal(0)
     })
   })
+  describe('if returning to page with validation errors', () => {
+    const verificationCodeError = 'Problem with verification code'
+    let result, $, session
+    before(done => {
+      const user = getUser({
+        gateway_account_ids: [GATEWAY_ACCOUNT_ID],
+        permissions: [{ name: 'transactions:read' }],
+        second_factor: 'APP'
+      })
+      nock(CONNECTOR_URL)
+        .get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
+        .reply(200, {
+          payment_provider: 'sandbox'
+        })
+
+      session = getMockSession(user)
+      lodash.set(session, 'pageData.twoFactorAuthMethod', 'SMS')
+      lodash.set(session, 'pageData.configureTwoFactorAuthMethodRecovered', {
+        errors: {
+          verificationCode: verificationCodeError
+        }
+      })
+      supertest(createAppWithSession(getApp(), session))
+        .get(paths.user.twoFactorAuth.configure)
+        .end((err, res) => {
+          result = res
+          $ = cheerio.load(res.text)
+          done(err)
+        })
+    })
+    after(() => {
+      nock.cleanAll()
+    })
+
+    it('should return a statusCode of 200', () => {
+      expect(result.statusCode).to.equal(200)
+    })
+
+    it('should show an error summary', () => {
+      expect($('.govuk-error-summary__list li').length).to.equal(1)
+      expect($('.govuk-error-summary__list li a[href$="#code"]').text()).to.equal(verificationCodeError)
+    })
+
+    it('should show inline errors', () => {
+      expect($('.govuk-error-message').length).to.equal(1)
+    })
+  })
 })

--- a/test/unit/controller/two-factor-auth-controller/post-configure.controller.ft.test.js
+++ b/test/unit/controller/two-factor-auth-controller/post-configure.controller.ft.test.js
@@ -89,9 +89,10 @@ describe('Two factor authenticator configure page POST', () => {
       expect(result.headers).to.have.property('location').to.equal(paths.user.twoFactorAuth.configure)
     })
 
-    it('should show an error message', () => {
-      expect(session.flash.genericError).to.have.property('length').to.equal(1)
-      expect(session.flash.genericError[0]).to.equal('<h2>There was a problem with the details you gave for:</h2><ul class="error-summary-list"><li><a href="#code">Please enter a valid verification code</a></li></ul>')
+    it('should have a recovered object stored on the session containing errors', () => {
+      const recovered = session.pageData.configureTwoFactorAuthMethodRecovered
+      expect(recovered).to.have.property('errors')
+      expect(recovered.errors).to.have.property('verificationCode')
     })
   })
 })


### PR DESCRIPTION
Put errors in a 'recovered' object on the session and get them in the GET controller after redirect. Then pass errors into the template and use them to to display the error summary component.

Improve the validation message to indicate that the code may have expired. This new error message is taken from another place we validate 2fa auth messages.

Minor code improvements including using async/await.


