### PR TITLE
PP-6958 Mask credit card number and security code for Moto

### DIFF
--- a/app/controllers/settings/get.settings.controller.js
+++ b/app/controllers/settings/get.settings.controller.js
@@ -17,7 +17,10 @@ module.exports = (req, res) => {
     collectBillingAddress: req.service.collectBillingAddress,
     emailCollectionMode: humaniseEmailMode(req.account.emailCollectionMode),
     confirmationEmailEnabled: req.account.emailEnabled,
-    refundEmailEnabled: req.account.refundEmailEnabled
+    refundEmailEnabled: req.account.refundEmailEnabled,
+    allowMoto: req.account.allow_moto,
+    motoMaskCardNumberInputEnabled: req.account.moto_mask_card_number_input,
+    motoMaskSecurityCodeInputEnabled: req.account.moto_mask_card_security_code_input,
   }
 
   return response(req, res, 'settings/index', pageData)

--- a/app/controllers/toggle-moto-mask-card-number/index.js
+++ b/app/controllers/toggle-moto-mask-card-number/index.js
@@ -1,0 +1,4 @@
+'use strict'
+
+exports.get = require('./toggleMotoMaskCardNumber.get.controller')
+exports.post = require('./toggleMotoMaskCardNumber.post.controller')

--- a/app/controllers/toggle-moto-mask-card-number/toggleMotoMaskCardNumber.get.controller.js
+++ b/app/controllers/toggle-moto-mask-card-number/toggleMotoMaskCardNumber.get.controller.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const { response } = require('../../utils/response')
+
+module.exports = function showToggleMaskCardNumberPage(req, res) {
+  const pageData = {
+    allowMoto: req.account.allow_moto,
+    motoMaskCardNumberInputEnabled: req.account.moto_mask_card_number_input
+  }
+
+  response(req, res, 'toggle-moto-mask-card-number/index', pageData)
+}

--- a/app/controllers/toggle-moto-mask-card-number/toggleMotoMaskCardNumber.post.controller.js
+++ b/app/controllers/toggle-moto-mask-card-number/toggleMotoMaskCardNumber.post.controller.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const paths = require('../../paths')
+const { renderErrorView } = require('../../utils/response')
+const { ConnectorClient } = require('../../services/clients/connector.client')
+const { correlationHeader } = require('../../utils/correlation-header')
+
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+
+module.exports = async function toggleMaskCardNumber(req, res) {
+  const correlationId = req.headers[correlationHeader] || ''
+  const accountId = req.account.gateway_account_id
+  const enableMaskCardNumber = req.body['moto-mask-card-number-input-toggle'] === 'on'
+
+  try {
+    await connector.toggleMotoMaskCardNumberInput(accountId, enableMaskCardNumber, correlationId)
+
+    req.flash('generic', 'Your changes have saved')
+    return res.redirect(paths.toggleMotoMaskCardNumberAndSecurityCode.cardNumber)
+  } catch (error) {
+    return renderErrorView(req, res, false, error.errorCode)
+  }
+}

--- a/app/controllers/toggle-moto-mask-security-code/index.js
+++ b/app/controllers/toggle-moto-mask-security-code/index.js
@@ -1,0 +1,4 @@
+'use strict'
+
+exports.get = require('./maskSecurityCode.get.controller')
+exports.post = require('./maskSecurityCode.post.controller')

--- a/app/controllers/toggle-moto-mask-security-code/maskSecurityCode.get.controller.js
+++ b/app/controllers/toggle-moto-mask-security-code/maskSecurityCode.get.controller.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const { response } = require('../../utils/response')
+
+module.exports = function showToggleMaskCardSecurityCodePage(req, res) {
+  const pageData = {
+    allowMoto: req.account.allow_moto,
+    motoMaskCardNumberInputEnabled: req.account.moto_mask_card_number_input,
+    motoMaskCardSecurityCodeInputEnabled: req.account.moto_mask_card_security_code_input
+  }
+
+  response(req, res, 'toggle-moto-mask-security-code/index', pageData)
+}

--- a/app/controllers/toggle-moto-mask-security-code/maskSecurityCode.post.controller.js
+++ b/app/controllers/toggle-moto-mask-security-code/maskSecurityCode.post.controller.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const paths = require('../../paths')
+
+const { renderErrorView } = require('../../utils/response')
+const { ConnectorClient } = require('../../services/clients/connector.client')
+const { correlationHeader } = require('../../utils/correlation-header')
+
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+
+module.exports = async function toggleMaskCardSecurityCode(req, res) {
+  const correlationId = req.headers[correlationHeader] || ''
+  const accountId = req.account.gateway_account_id
+  const enableMaskSecurityCode = req.body['moto-mask-security-code-input-toggle'] === 'on'
+
+  try {
+    await connector.toggleMotoMaskSecurityCodeInput(accountId, enableMaskSecurityCode, correlationId)
+
+    req.flash('generic', 'Your changes have saved')
+    return res.redirect(paths.toggleMotoMaskCardNumberAndSecurityCode.securityCode)
+  } catch (error) {
+    return renderErrorView(req, res, false, error.errorCode)
+  }
+}

--- a/app/paths.js
+++ b/app/paths.js
@@ -117,6 +117,10 @@ module.exports = {
   toggle3ds: {
     index: '/3ds'
   },
+  toggleMotoMaskCardNumberAndSecurityCode: {
+    cardNumber: '/moto-mask-card-number',
+    securityCode: '/moto-mask-security-code'
+  },
   toggleBillingAddress: {
     index: '/billing-address'
   },

--- a/app/routes.js
+++ b/app/routes.js
@@ -57,6 +57,8 @@ const inviteUserController = require('./controllers/invite-user.controller')
 const registerController = require('./controllers/register-user.controller')
 const serviceRolesUpdateController = require('./controllers/service-roles-update.controller')
 const toggle3dsController = require('./controllers/toggle-3ds')
+const toggleMotoMaskCardNumber = require('./controllers/toggle-moto-mask-card-number')
+const toggleMotoMaskSecurityCode = require('./controllers/toggle-moto-mask-security-code')
 const selfCreateServiceController = require('./controllers/register-service.controller')
 const createServiceController = require('./controllers/create-service.controller')
 const inviteValidationController = require('./controllers/invite-validation.controller')
@@ -91,7 +93,7 @@ const stripeSetupDashboardRedirectController = require('./controllers/stripe-set
 const {
   healthcheck, registerUser, user, dashboard, selfCreateService, transactions, credentials,
   apiKeys, serviceSwitcher, teamMembers, staticPaths, inviteValidation, editServiceName, merchantDetails,
-  notificationCredentials: nc, paymentTypes: pt, emailNotifications: en, toggle3ds: t3ds, prototyping, paymentLinks,
+  notificationCredentials: nc, paymentTypes: pt, emailNotifications: en, toggle3ds: t3ds, toggleMotoMaskCardNumberAndSecurityCode: toggleMotoMaskCardNumberAndSecurityCode, prototyping, paymentLinks,
   partnerApp, toggleBillingAddress: billingAddress, requestToGoLive, policyPages, stripeSetup, stripe, digitalWallet,
   settings, yourPsp, allServiceTransactions, payouts
 } = paths
@@ -314,6 +316,12 @@ module.exports.bind = function (app) {
   // 3D SECURE TOGGLE
   app.get(t3ds.index, xraySegmentCls, permission('toggle-3ds:read'), getAccount, paymentMethodIsCard, toggle3dsController.get)
   app.post(t3ds.index, xraySegmentCls, permission('toggle-3ds:update'), getAccount, paymentMethodIsCard, toggle3dsController.post)
+
+  // MOTO MASK CARD NUMBER & SECURITY CODE TOGGLE
+  app.get(toggleMotoMaskCardNumberAndSecurityCode.cardNumber, xraySegmentCls, permission('moto-mask-input:read'), getAccount, paymentMethodIsCard, toggleMotoMaskCardNumber.get)
+  app.post(toggleMotoMaskCardNumberAndSecurityCode.cardNumber, xraySegmentCls, permission('moto-mask-input:update'), getAccount, paymentMethodIsCard, toggleMotoMaskCardNumber.post)
+  app.get(toggleMotoMaskCardNumberAndSecurityCode.securityCode, xraySegmentCls, permission('moto-mask-input:read'), getAccount, paymentMethodIsCard, toggleMotoMaskSecurityCode.get)
+  app.post(toggleMotoMaskCardNumberAndSecurityCode.securityCode, xraySegmentCls, permission('moto-mask-input:update'), getAccount, paymentMethodIsCard, toggleMotoMaskSecurityCode.post)
 
   // BILLING ADDRESS TOGGLE
   app.get(billingAddress.index, xraySegmentCls, permission('toggle-billing-address:read'), getAccount, paymentMethodIsCard, toggleBillingAddressController.getIndex)

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -41,7 +41,7 @@ const responseBodyToStripeAccountTransformer = body => new StripeAccount(body)
  * @private
  * @param  {object} self
  */
-function _createResponseHandler (self) {
+function _createResponseHandler(self) {
   return function (callback) {
     return function (error, response, body) {
       if (error || !isInArray(response.statusCode, [200, 202])) {
@@ -70,47 +70,47 @@ function _createResponseHandler (self) {
  * @param  {Object} value - value to find into the array
  * @param {Object[]} array - array source for finding the given value
  */
-function isInArray (value, array) {
+function isInArray(value, array) {
   return array.indexOf(value) > -1
 }
 
 /** @private */
-function _accountApiUrlFor (gatewayAccountId, url) {
+function _accountApiUrlFor(gatewayAccountId, url) {
   return url + ACCOUNT_API_PATH.replace('{accountId}', gatewayAccountId)
 }
 
 /** @private */
-function _accountUrlFor (gatewayAccountId, url) {
+function _accountUrlFor(gatewayAccountId, url) {
   return url + ACCOUNT_FRONTEND_PATH.replace('{accountId}', gatewayAccountId)
 }
 
 /** @private */
-function _accountsUrlFor (gatewayAccountIds, url) {
+function _accountsUrlFor(gatewayAccountIds, url) {
   return url + ACCOUNTS_FRONTEND_PATH + '?accountIds=' + gatewayAccountIds.join(',')
 }
 
 /** @private */
-function _accountNotificationCredentialsUrlFor (gatewayAccountId, url) {
+function _accountNotificationCredentialsUrlFor(gatewayAccountId, url) {
   return url + ACCOUNT_NOTIFICATION_CREDENTIALS_PATH.replace('{accountId}', gatewayAccountId)
 }
 
 /** @private */
-function _accountCredentialsUrlFor (gatewayAccountId, url) {
+function _accountCredentialsUrlFor(gatewayAccountId, url) {
   return url + ACCOUNT_CREDENTIALS_PATH.replace('{accountId}', gatewayAccountId)
 }
 
 /** @private */
-function _accountAcceptedCardTypesUrlFor (gatewayAccountId, url) {
+function _accountAcceptedCardTypesUrlFor(gatewayAccountId, url) {
   return url + ACCEPTED_CARD_TYPES_FRONTEND_PATH.replace('{accountId}', gatewayAccountId)
 }
 
 /** @private */
-function _cardTypesUrlFor (url) {
+function _cardTypesUrlFor(url) {
   return url + CARD_TYPES_API_PATH
 }
 
 /** @private */
-function _serviceNameUrlFor (gatewayAccountId, url) {
+function _serviceNameUrlFor(gatewayAccountId, url) {
   return url + SERVICE_NAME_FRONTEND_PATH.replace('{accountId}', gatewayAccountId)
 }
 
@@ -133,7 +133,7 @@ var _getToggle3dsUrlFor = function (accountID, url) {
  * Connects to connector
  * @param {string} connectorUrl connector url
  */
-function ConnectorClient (connectorUrl) {
+function ConnectorClient(connectorUrl) {
   this.connectorUrl = connectorUrl
   this.responseHandler = _createResponseHandler(this)
 
@@ -509,6 +509,57 @@ ConnectorClient.prototype = {
       }
     )
   },
+
+  /**
+   * @param gatewayAccountId
+   * @param isMaskCardNumber (boolean)
+   * @param correlationId
+   * @returns {Promise<Object>}
+   */
+
+  toggleMotoMaskCardNumberInput: function (gatewayAccountId, isMaskCardNumber, correlationId) {
+    return baseClient.patch(
+      {
+        baseUrl: this.connectorUrl,
+        url: ACCOUNT_API_PATH.replace('{accountId}', gatewayAccountId),
+        json: true,
+        body: {
+          op: 'replace',
+          path: 'moto_mask_card_number_input',
+          value: isMaskCardNumber
+        },
+        correlationId,
+        description: 'Toggle gateway account card number masking setting',
+        service: SERVICE_NAME
+      }
+    )
+  },
+
+  /**
+   * @param gatewayAccountId
+   * @param isMaskSecurityCode (boolean)
+   * @param correlationId
+   * @returns {Promise<Object>}
+   */
+
+  toggleMotoMaskSecurityCodeInput: function (gatewayAccountId, isMaskSecurityCode, correlationId) {
+    return baseClient.patch(
+      {
+        baseUrl: this.connectorUrl,
+        url: ACCOUNT_API_PATH.replace('{accountId}', gatewayAccountId),
+        json: true,
+        body: {
+          op: 'replace',
+          path: 'moto_mask_card_security_code_input',
+          value: isMaskSecurityCode
+        },
+        correlationId,
+        description: 'Toggle gateway account card security code masking setting',
+        service: SERVICE_NAME
+      }
+    )
+  },
+
   /**
    * @param gatewayAccountId
    * @param gatewayMerchantId (string)

--- a/app/views/includes/settings-read-only.njk
+++ b/app/views/includes/settings-read-only.njk
@@ -1,3 +1,3 @@
 <aside class="pay-info-warning-box">
-  <p class="govuk-body">You don’t have permission to manage settings. Contact your service admin if you would like to manage 3D secure, accepted card types, email notifications, or billing address.</p>
+  <p class="govuk-body">You don’t have permission to manage settings. Contact your service admin if you would like to manage 3D secure, accepted card types, email notifications, billing address or mask card numbers or security codes for MOTO services.</p>
 </aside>

--- a/app/views/settings/index.njk
+++ b/app/views/settings/index.njk
@@ -207,5 +207,60 @@
       })
     }}
     <p class="govuk-body"><a class="govuk-link" href="{{routes.emailNotifications.index}}" id="templates-link">See templates and add a custom paragraph.</a></p>
+    
+    {% if allowMoto %}
+      <h1 id="moto-mask-security-settings-heading" class="govuk-heading-m govuk-!-margin-top-8">Security</h1>
+      <p class="govuk-body">Hide sensitive details being viewed on a call agent's screen.</p>
+
+      {{
+        govukSummaryList({
+          classes: 'pay-!-border-top pay-!-padding-top-2-small',
+          rows: [
+            {
+              key: {
+                text: 'Hide card numbers',
+                classes: 'govuk-!-width-one-half'
+              },
+              value: {
+                text: 'On' if motoMaskCardNumberInputEnabled else 'Off',
+                classes: 'govuk-!-width-one-quarter'
+              },
+              actions: {
+                classes: 'govuk-!-width-one-quarter',
+                items: [
+                  {
+                    href: routes.toggleMotoMaskCardNumberAndSecurityCode.cardNumber,
+                    classes: 'govuk-link--no-visited-state',
+                    text: 'Change' if permissions.moto_mask_input_update else 'View',
+                    visuallyHiddenText: 'Moto Secure settings'
+                  }
+                ]
+              }
+            },
+            {
+              key: {
+                text: 'Hide card security codes',
+                classes: 'govuk-!-width-one-half'
+              },
+              value: {
+                text: 'On' if motoMaskSecurityCodeInputEnabled else 'Off',
+                classes: 'govuk-!-width-one-quarter'
+              },
+              actions: {
+                classes: 'govuk-!-width-one-quarter',
+                items: [
+                  {
+                    href: routes.toggleMotoMaskCardNumberAndSecurityCode.securityCode,
+                    classes: 'govuk-link--no-visited-state',
+                    text: 'Change' if permissions.moto_mask_input_update else 'View',
+                    visuallyHiddenText: 'Moto Secure settings'
+                  }
+                ]
+              }
+            }
+          ]
+        })
+      }}
+    {% endif %} 
   </div>
 {% endblock %}

--- a/app/views/toggle-moto-mask-card-number/index.njk
+++ b/app/views/toggle-moto-mask-card-number/index.njk
@@ -1,0 +1,69 @@
+{% extends "layout.njk" %}
+
+{% block pageTitle %}
+  MOTO  - hide card numbers for {{ currentService.name }} - GOV.UK Pay
+{% endblock %}
+
+{% block side_navigation %}
+  {% include "includes/side-navigation.njk" %}
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-column-two-thirds">
+    {% if not permissions.moto_mask_input_update %}
+      {% set disabled = true %}
+      {% include "../includes/settings-read-only.njk" %}
+    {% endif %}
+
+    {% if allowMoto %}
+      <h1 class="govuk-heading-l">Do you want to stop call agents and people near them from viewing sensitive details on their screen?</h1>
+
+      <p class="govuk-body-l">If you hide the card number, call agents will be unable to read the numbers entered on their screen.</p>
+
+      <form method="post">
+        <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+        {{
+          govukRadios({
+            idPrefix: 'moto-mask-card-number-input-toggle',
+            name: 'moto-mask-card-number-input-toggle',
+            fieldset: {
+              legend: {
+                text: 'Card number:',
+                classes: 'govuk-!-font-weight-bold'
+              }
+            },
+            items: [
+              {
+                text: 'Hidden',
+                value: 'on',
+                checked: true if motoMaskCardNumberInputEnabled else false,
+                disabled: disabled
+              },
+              {
+                text: 'Visible',
+                value: 'off',
+                checked: true if not motoMaskCardNumberInputEnabled else false,
+                disabled: disabled
+              }
+            ]
+          })
+        }}
+
+        {{
+          govukButton({
+            text: 'Save changes',
+            classes: 'govuk-!-margin-bottom-3',
+            disabled: disabled,
+            attributes: {
+              id: "save-moto-mask-changes"
+            }
+          })
+        }}
+      </form>
+      <p class="govuk-body">or <a href="{{routes.settings.index}}" class="govuk-link govuk-link--no-visited-state">cancel</a></p>
+    {% else %}
+      <h1 class="govuk-heading-l govuk-!-margin-top-6">This feature is not available</h1>
+      <p class="govuk-body" id="threeds-not-supported">Masking of card numbers and security codes is not allowed for this account.</p>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/app/views/toggle-moto-mask-security-code/index.njk
+++ b/app/views/toggle-moto-mask-security-code/index.njk
@@ -1,0 +1,69 @@
+{% extends "layout.njk" %}
+
+{% block pageTitle %}
+  MOTO  - hide security codes for {{ currentService.name }} - GOV.UK Pay
+{% endblock %}
+
+{% block side_navigation %}
+  {% include "includes/side-navigation.njk" %}
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-column-two-thirds">
+    {% if not permissions.moto_mask_input_update %}
+      {% set disabled = true %}
+      {% include "../includes/settings-read-only.njk" %}
+    {% endif %}
+
+    {% if allowMoto %}
+      <h1 class="govuk-heading-l">Do you want to stop call agents and people near them from viewing sensitive details on their screen?</h1>
+
+      <p class="govuk-body-l">If you hide security codes, call agents will be unable to read the numbers entered on their screen.</p>
+
+      <form method="post">
+        <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+        {{
+          govukRadios({
+            idPrefix: 'moto-mask-security-code-input-toggle',
+            name: 'moto-mask-security-code-input-toggle',
+            fieldset: {
+              legend: {
+                text: 'Security code:',
+                classes: 'govuk-!-font-weight-bold'
+              }
+            },
+            items: [
+              {
+                text: 'Hidden',
+                value: 'on',
+                checked: true if motoMaskCardSecurityCodeInputEnabled else false,
+                disabled: disabled
+              },
+              {
+                text: 'Visible',
+                value: 'off',
+                checked: true if not motoMaskCardSecurityCodeInputEnabled else false,
+                disabled: disabled
+              }
+            ]
+          })
+        }}
+
+        {{
+          govukButton({
+            text: 'Save changes',
+            classes: 'govuk-!-margin-bottom-3',
+            disabled: disabled,
+            attributes: {
+              id: "save-moto-mask-changes"
+            }
+          })
+        }}
+      </form>
+      <p class="govuk-body">or <a href="{{routes.settings.index}}" class="govuk-link govuk-link--no-visited-state">cancel</a></p>
+    {% else %}
+      <h1 class="govuk-heading-l govuk-!-margin-top-6">This feature is not available</h1>
+      <p class="govuk-body" id="threeds-not-supported">Masking of card numbers and security codes is not allowed for this account.</p>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js
+++ b/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js
@@ -1,0 +1,167 @@
+'use strict'
+
+const userStubs = require('../../stubs/user-stubs')
+const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+
+describe('MOTO mask security section', () => {
+  const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+  const gatewayAccountId = 42
+  const serviceName = 'Purchase a positron projection permit'
+
+  function setupMotoStubs (opts = {}) {
+    let stubs = []
+    let user
+
+    if (opts.readonly) {
+      const role = {
+        permissions: [
+          {
+            name: 'transactions-details:read',
+            description: 'ViewTransactionsOnly'
+          },
+          {
+            name: 'moto-mask-input:read',
+            description: 'ViewMaskMotoOnly'
+          }
+        ]
+      }
+      user = userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName, role })
+    } else {
+      user = userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName })
+    }
+
+    const gatewayAccount = gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId, paymentProvider: opts.gateway, allowMoto: opts.allowMoto, motoMaskCardNumber: opts.motoMaskCardNumber, motoMaskSecurityCode: opts.motoMaskSecurityCode })
+    const card = gatewayAccountStubs.getAcceptedCardTypesSuccess({ gatewayAccountId, updated: false, maestro: opts.maestro })
+    const patchUpdateMotoMaskCardNumber = gatewayAccountStubs.patchUpdateMotoMaskCardNumber({ motoMaskCardNumber: opts.motoMaskCardNumber })
+    const patchUpdateMotoMaskSecurityCode = gatewayAccountStubs.patchUpdateMotoMaskSecurityCode({ motoMaskCardSecurityCode: opts.motoMaskCardSecurityCode })
+
+    stubs.push(user, gatewayAccount, card, patchUpdateMotoMaskCardNumber, patchUpdateMotoMaskSecurityCode)
+
+    cy.task('setupStubs', stubs)
+  }
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('session', 'gateway_account')
+  })
+
+  describe('When accessing MOTO mask settings', () => {
+    describe('when gateway account has allowMoto=false', () => {
+      beforeEach(() => {
+        setupMotoStubs({ allowMoto: false })
+      })
+
+      it('should not show mask security section', () => {
+        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.visit('/settings')
+        cy.get('#moto-mask-security-settings-heading').should('not.exist')
+      })
+    })
+
+    describe('mask card number - when user has read permission and card number mask disabled', () => {
+      beforeEach(() => {
+        setupMotoStubs({ readonly: true, allowMoto: true, motoMaskCardNumber: false })
+      })
+
+      it('should show radios as disabled and card number mask disabled', () => {
+        cy.visit('/settings')
+        cy.get('.govuk-summary-list__key').eq(4).should('contain', 'Hide card number')
+        cy.get('.govuk-summary-list__value').eq(4).should('contain', 'Off')
+        cy.get('.govuk-summary-list__actions a').eq(4).contains('View')
+        cy.get('.govuk-summary-list__actions a').eq(4).click()
+        cy.title().should('eq', `MOTO - hide card numbers for ${serviceName} - GOV.UK Pay`)
+        cy.get('.pay-info-warning-box').should('exist')
+        cy.get('input[value="on"]').should('be.disabled')
+        cy.get('input[value="off"]').should('be.disabled')
+        cy.get('input[value="on"]').should('not.be.checked')
+        cy.get('input[value="off"]').should('be.checked')
+      })
+    })
+
+    describe('mask card number - when user has update permission and card number mask disabled', () => {
+      beforeEach(() => {
+        setupMotoStubs({ readonly: false, allowMoto: true, motoMaskCardNumber: false })
+      })
+
+      it('should show radios as enabled and card number mask disabled', () => {
+        cy.visit('/settings')
+        cy.get('.govuk-summary-list__key').eq(4).should('contain', 'Hide card number')
+        cy.get('.govuk-summary-list__value').eq(4).should('contain', 'Off')
+        cy.get('.govuk-summary-list__actions a').eq(4).contains('Change')
+        cy.get('.govuk-summary-list__actions a').eq(4).click()
+        cy.title().should('eq', `MOTO - hide card numbers for ${serviceName} - GOV.UK Pay`)
+        cy.get('input[value="on"]').should('not.be.disabled')
+        cy.get('input[value="off"]').should('not.be.disabled')
+        cy.get('input[value="on"]').should('not.be.checked')
+        cy.get('input[value="off"]').should('be.checked')
+      })
+    })
+
+    describe('mask card number - when user has update permission and updates card number to enabled', () => {
+      beforeEach(() => {
+        setupMotoStubs({ readonly: false, allowMoto: true, motoMaskCardNumber: true })
+      })
+
+      it(`should show 'save chanegs' notification`, () => {
+        cy.get('input[value="on"]').click()
+        cy.get('#save-moto-mask-changes').click()
+        cy.get('input[value="on"]').should('be.checked')
+        cy.get('input[value="off"]').should('not.be.checked')
+        cy.get('.notification').contains('Your changes have saved')
+      })
+    })
+
+    describe('mask security code - when user has read permission and security code mask disabled', () => {
+      beforeEach(() => {
+        setupMotoStubs({ readonly: true, allowMoto: true, motoMaskSecurityCode: false })
+      })
+
+      it('should show radios as disabled and card number mask disabled', () => {
+        cy.visit('/settings')
+        cy.get('.govuk-summary-list__key').eq(5).should('contain', 'Hide card security codes')
+        cy.get('.govuk-summary-list__value').eq(5).should('contain', 'Off')
+        cy.get('.govuk-summary-list__actions a').eq(5).contains('View')
+        cy.get('.govuk-summary-list__actions a').eq(5).click()
+        cy.title().should('eq', `MOTO - hide security codes for ${serviceName} - GOV.UK Pay`)
+        cy.get('.pay-info-warning-box').should('exist')
+        cy.get('input[value="on"]').should('be.disabled')
+        cy.get('input[value="off"]').should('be.disabled')
+        cy.get('input[value="on"]').should('not.be.checked')
+        cy.get('input[value="off"]').should('be.checked')
+      })
+    })
+
+    describe('mask security code - when user has update permission and security code mask disabled', () => {
+      beforeEach(() => {
+        setupMotoStubs({ readonly: false, allowMoto: true, motoMaskSecurityCode: false })
+      })
+
+      it('should show radios as enabled and no masking', () => {
+        cy.visit('/settings')
+        cy.get('.govuk-summary-list__key').eq(5).should('contain', 'Hide card security codes')
+        cy.get('.govuk-summary-list__value').eq(5).should('contain', 'Off')
+        cy.get('.govuk-summary-list__actions a').eq(5).contains('Change')
+        cy.get('.govuk-summary-list__actions a').eq(5).click()
+        cy.title().should('eq', `MOTO - hide security codes for ${serviceName} - GOV.UK Pay`)
+        cy.get('input[value="on"]').should('not.be.disabled')
+        cy.get('input[value="off"]').should('not.be.disabled')
+        cy.get('input[value="on"]').should('not.be.checked')
+        cy.get('input[value="off"]').should('be.checked')
+      })
+    })
+
+    describe('mask security code - when user has update permission and updates security code to enabled', () => {
+      beforeEach(() => {
+        setupMotoStubs({ readonly: false, allowMoto: true, motoMaskSecurityCode: true })
+      })
+
+      it('should show radios as enabled and hidden as checked', () => {
+        cy.get('input[value="on"]').click()
+        cy.get('#save-moto-mask-changes').click()
+        cy.title().should('eq', `MOTO - hide security codes for ${serviceName} - GOV.UK Pay`)
+        cy.get('input[value="on"]').should('be.checked')
+        cy.get('input[value="off"]').should('not.be.checked')
+        cy.get('.notification').contains('Your changes have saved')
+      })
+    })
+  })
+})

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -436,6 +436,28 @@ module.exports = {
       verifyCalledTimes: opts.verifyCalledTimes
     })
   },
+
+  patchUpdateMotoMaskSecurityCode: (opts = {}) => {
+    const path = `/v1/api/accounts/${opts.gateway_account_id}`
+    return simpleStubBuilder('PATCH', path, 200, {
+      request: {
+        op: 'replace',
+        path: 'moto_mask_security_code_input',
+        value: opts.motoMaskCardSecurityCode
+      }
+    })
+  },
+
+  patchUpdateMotoMaskCardNumber: (opts = {}) => {
+    const path = `/v1/api/accounts/${opts.gateway_account_id}`
+    return simpleStubBuilder('PATCH', path, 200, {
+      request: {
+        op: 'replace',
+        path: 'moto_mask_card_number_input',
+        value: opts.motoMaskCardNumber
+      }
+    })
+  },
   patchUpdate3DS: (opts = {}) => {
     const path = `/v1/api/frontend/accounts/${opts.gateway_account_id}/3ds-toggle`
     // TODO: this should use a fixture to construct the request body

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -15,6 +15,9 @@ const getGatewayAccountSuccess = function (opts) {
   if (opts.requires3ds) {
     stubOptions.requires3ds = opts.requires3ds
   }
+  if (opts.allowMoto) {
+    stubOptions.allow_moto = opts.allowMoto
+  }
   if (opts.type) {
     stubOptions.type = opts.type
   }
@@ -27,6 +30,14 @@ const getGatewayAccountSuccess = function (opts) {
 
   if (opts.allowMoto) {
     stubOptions.allow_moto = opts.allowMoto
+  }
+
+  if (opts.motoMaskCardNumber) {
+    stubOptions.moto_mask_card_number_input = opts.motoMaskCardNumber
+  }
+
+  if (opts.motoMaskSecurityCode) {
+    stubOptions.moto_mask_card_security_code_input = opts.motoMaskSecurityCode
   }
 
   if (opts.notificationCredentials) {
@@ -110,6 +121,24 @@ const patchUpdate3DS = function (opts) {
   }
 }
 
+const patchUpdateMotoMaskSecurityCode = function (opts) {
+  return {
+    name: 'patchUpdateMotoMaskSecurityCode',
+    opts: {
+      moto_mask_card_security_code_input: opts.motoMaskCardSecurityCode
+    }
+  }
+}
+
+const patchUpdateMotoMaskCardNumber = function (opts) {
+  return {
+    name: 'patchUpdateMotoMaskCardNumber',
+    opts: {
+      moto_mask_card_number_input: opts.motoMaskCardNumber
+    }
+  }
+}
+
 const patchConfirmationEmailToggleSuccess = function (opts) {
   return {
     name: 'patchConfirmationEmailToggleSuccess',
@@ -177,5 +206,7 @@ module.exports = {
   patchRefundEmailToggleSuccess,
   patchAccountEmailCollectionModeSuccess,
   patchUpdateCredentials,
-  patchUpdateFlexCredentials
+  patchUpdateFlexCredentials,
+  patchUpdateMotoMaskCardNumber,
+  patchUpdateMotoMaskSecurityCode
 }

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -29,7 +29,9 @@ function validGatewayAccount (opts) {
         enabled: true
       }
     },
-    allow_moto: opts.allow_moto || false
+    allow_moto: opts.allow_moto || false,
+    moto_mask_card_number_input: opts.moto_mask_card_number_input || false,
+    moto_mask_card_security_code_input: opts.moto_mask_card_security_code_input || false
   }
 
   if (opts.description) {

--- a/test/fixtures/user.fixtures.js
+++ b/test/fixtures/user.fixtures.js
@@ -198,7 +198,16 @@ const defaultPermissions = [
   {
     name: 'payouts:read',
     description: 'View payouts'
+  },
+  {
+    name: 'moto-mask-input:update',
+    description: 'Update moto mask for card number and security code'
+  },
+  {
+    name: 'moto-mask-input:read',
+    description: 'View moto mask for card number and security code'
   }
+
 ]
 
 // Setup

--- a/test/ui/toggle-collect-billing-address.ui.test.js
+++ b/test/ui/toggle-collect-billing-address.ui.test.js
@@ -29,7 +29,7 @@ describe('The toggle Billing Address page', function () {
 
     const body = renderTemplate('billing-address/index', templateData)
 
-    body.should.containSelector('.pay-info-warning-box').withExactText('You don’t have permission to manage settings. Contact your service admin if you would like to manage 3D secure, accepted card types, email notifications, or billing address.')
+    body.should.containSelector('.pay-info-warning-box').withExactText('You don’t have permission to manage settings. Contact your service admin if you would like to manage 3D secure, accepted card types, email notifications, billing address or mask card numbers or security codes for MOTO services.')
     body.should.containSelector('#billing-address-toggle-2').withAttribute('checked')
     body.should.containSelector('#billing-address-toggle-2').withAttribute('disabled')
     body.should.containSelector('#billing-address-toggle-button').withAttribute('disabled')

--- a/test/unit/clients/connector-client/connector-patch-moto-mask-card-number.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-moto-mask-card-number.pact.test.js
@@ -1,0 +1,63 @@
+'use strict'
+
+// NPM dependencies
+const { Pact } = require('@pact-foundation/pact')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+
+// Custom dependencies
+const path = require('path')
+const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
+const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient
+const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
+
+const ACCOUNTS_RESOURCE = '/v1/api/accounts'
+const port = Math.floor(Math.random() * 48127) + 1024
+const connectorClient = new Connector(`http://localhost:${port}`)
+const existingGatewayAccountId = 667
+
+// Global setup
+chai.use(chaiAsPromised)
+
+describe('connector client - patch MOTO mask card number toggle (enabled) request', () => {
+  const patchRequestParams = { path: 'moto_mask_card_number_input', value: true }
+  const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams).getPlain()
+
+  let provider = new Pact({
+    consumer: 'selfservice',
+    provider: 'connector',
+    port: port,
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(() => provider.setup())
+  after(() => provider.finalize())
+
+  describe('MOTO mask card number input toggle - supported payment provider request', () => {
+    const motoMaskCardNumberInputProviderState =
+      `a gateway account with MOTO enabled and an external id ${existingGatewayAccountId} exists in the database`
+
+    before(() => {
+      return provider.addInteraction(
+        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
+          .withUponReceiving('a valid patch MOTO mask card number input (enabled) request')
+          .withState(motoMaskCardNumberInputProviderState)
+          .withMethod('PATCH')
+          .withRequestBody(request)
+          .withStatusCode(200)
+          .withResponseHeaders({})
+          .build())
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should toggle successfully', done => {
+      connectorClient.toggleMotoMaskCardNumberInput(existingGatewayAccountId, true, null)
+        .should.be.fulfilled
+        .notify(done)
+    })
+  })
+})

--- a/test/unit/clients/connector-client/connector-patch-moto-mask-security-code.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-moto-mask-security-code.pact.test.js
@@ -1,0 +1,64 @@
+'use strict'
+
+// NPM dependencies
+const { Pact } = require('@pact-foundation/pact')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+
+// Custom dependencies
+const path = require('path')
+const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
+const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient
+const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
+
+// Constants
+const ACCOUNTS_RESOURCE = '/v1/api/accounts'
+const port = Math.floor(Math.random() * 48127) + 1024
+const connectorClient = new Connector(`http://localhost:${port}`)
+const existingGatewayAccountId = 667
+
+// Global setup
+chai.use(chaiAsPromised)
+
+describe('connector client - patch MOTO mask security code toggle (enabled) request', () => {
+  const patchRequestParams = { path: 'moto_mask_card_security_code_input', value: true }
+  const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams).getPlain()
+
+  let provider = new Pact({
+    consumer: 'selfservice',
+    provider: 'connector',
+    port: port,
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(() => provider.setup())
+  after(() => provider.finalize())
+
+  describe('MOTO mask security code input toggle - supported payment provider request', () => {
+    const motoMaskSecurityCodeInputProviderState =
+      `a gateway account with MOTO enabled and an external id ${existingGatewayAccountId} exists in the database`
+
+    before(() => {
+      return provider.addInteraction(
+        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
+          .withUponReceiving('a valid patch MOTO mask security code input (enabled) request')
+          .withState(motoMaskSecurityCodeInputProviderState)
+          .withMethod('PATCH')
+          .withRequestBody(request)
+          .withStatusCode(200)
+          .withResponseHeaders({})
+          .build())
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should toggle successfully', done => {
+      connectorClient.toggleMotoMaskSecurityCodeInput(existingGatewayAccountId, true, null)
+        .should.be.fulfilled
+        .notify(done)
+    })
+  })
+})


### PR DESCRIPTION
Description:
- Add new routes:
  - /moto-mask-card-number
  - /moto-mask-security-code
- Added new controllers
- Updated connector client
  - toggleMotoMaskCardNumberInput
  - toggleMotoMaskSecurityCodeInput
- Updated settings page with new section for updating Moto mask settings
- Updated pact tests
- Updated cypress tests

# New Moto security section on card setting page
<img width="1014" alt="Screenshot 2020-09-01 at 16 26 08" src="https://user-images.githubusercontent.com/16921687/91873248-b2e3fe80-ec70-11ea-886d-ce97bc51ae90.png">

# New page to mask Moto card number
<img width="1022" alt="Screenshot 2020-09-01 at 16 27 05" src="https://user-images.githubusercontent.com/16921687/91873111-8e882200-ec70-11ea-89c8-e5715bc69602.png">

# New page to mask Moto security code
<img width="1022" alt="Screenshot 2020-09-01 at 16 28 45" src="https://user-images.githubusercontent.com/16921687/91873026-7adcbb80-ec70-11ea-8f45-ac6cbf9c7ab9.png">
 

