### PR TITLE
BAU Remove unneccessary import comments

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2020-08-26T15:22:56Z",
+  "generated_at": "2020-09-02T14:26:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -63,7 +63,7 @@
         "hashed_secret": "379f1968f09d8a343338667844e01a2f433f0a3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 27,
+        "line_number": 25,
         "type": "Hex High Entropy String"
       }
     ],
@@ -72,7 +72,7 @@
         "hashed_secret": "ece65afda87c1c6120602c9a3b66890308d7e53c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 46,
+        "line_number": 45,
         "type": "Secret Keyword"
       }
     ],
@@ -189,7 +189,7 @@
         "hashed_secret": "cca5ec6518072e9005bd723123ec52b8e978a448",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 16,
         "type": "Hex High Entropy String"
       }
     ],
@@ -198,14 +198,14 @@
         "hashed_secret": "c2326bf719e924050321d3adb8d8d3a99723ee95",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 162,
+        "line_number": 161,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "e5a7431b27dbc70d00c5ed873bd4d837bd65720c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 178,
+        "line_number": 177,
         "type": "Hex High Entropy String"
       }
     ],
@@ -214,7 +214,7 @@
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 111,
+        "line_number": 109,
         "type": "Hex High Entropy String"
       }
     ],
@@ -223,7 +223,7 @@
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 49,
+        "line_number": 47,
         "type": "Hex High Entropy String"
       }
     ],
@@ -257,7 +257,7 @@
         "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 167,
+        "line_number": 165,
         "type": "Secret Keyword"
       }
     ],
@@ -266,7 +266,7 @@
         "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 305,
+        "line_number": 303,
         "type": "Secret Keyword"
       }
     ],
@@ -275,28 +275,28 @@
         "hashed_secret": "15b2c9b424ee41a90212461ec7231d9230200920",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 33,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "6b5a612c10a8d0809d4fb09c638e1a6495823bb2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 39,
+        "line_number": 37,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "fe51df43f7b477a219f12f2eaea89e2baa4b5a21",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 41,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "345d3214d7921c9fd9db82a8f5f8d29d681a4a45",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 47,
+        "line_number": 45,
         "type": "Hex High Entropy String"
       }
     ],
@@ -305,7 +305,7 @@
         "hashed_secret": "0780c2a5237c0cdb830303326fb6c33c8297b876",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 47,
+        "line_number": 45,
         "type": "Hex High Entropy String"
       }
     ],
@@ -314,7 +314,7 @@
         "hashed_secret": "5f6087367c3abd5ea9bc0d1650277b9f68b9b233",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 74,
+        "line_number": 72,
         "type": "Secret Keyword"
       }
     ],
@@ -323,7 +323,7 @@
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 141,
+        "line_number": 139,
         "type": "Hex High Entropy String"
       }
     ],
@@ -332,7 +332,7 @@
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 101,
+        "line_number": 99,
         "type": "Hex High Entropy String"
       }
     ],
@@ -341,7 +341,7 @@
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 35,
         "type": "Hex High Entropy String"
       }
     ],
@@ -350,7 +350,7 @@
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 63,
+        "line_number": 61,
         "type": "Hex High Entropy String"
       }
     ],
@@ -377,14 +377,14 @@
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 16,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 16,
         "type": "Secret Keyword"
       }
     ],
@@ -393,14 +393,14 @@
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 16,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 16,
         "type": "Secret Keyword"
       }
     ],
@@ -409,14 +409,14 @@
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 17,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 17,
         "type": "Secret Keyword"
       }
     ],
@@ -425,14 +425,14 @@
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 18,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 18,
         "type": "Secret Keyword"
       }
     ],
@@ -441,14 +441,14 @@
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 15,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 15,
         "type": "Secret Keyword"
       }
     ],
@@ -457,14 +457,14 @@
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 15,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 15,
         "type": "Secret Keyword"
       }
     ],
@@ -473,14 +473,14 @@
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 16,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 16,
         "type": "Secret Keyword"
       }
     ],
@@ -489,14 +489,14 @@
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 16,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 16,
         "type": "Secret Keyword"
       }
     ],
@@ -505,33 +505,15 @@
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 16,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 16,
         "type": "Secret Keyword"
-      }
-    ],
-    "test/unit/controller/api-keys/post-create.controller.ft.test.js": [
-      {
-        "hashed_secret": "cf52a7584f7cc933c74934ade621bfaacf714cc7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Base64 High Entropy String"
-      }
-    ],
-    "test/unit/controller/api-keys/post-update.controller.ft.test.js": [
-      {
-        "hashed_secret": "cf52a7584f7cc933c74934ade621bfaacf714cc7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Base64 High Entropy String"
       }
     ],
     "test/unit/controller/register-service-controller/register-service.controller.test.js": [
@@ -548,7 +530,7 @@
         "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 39,
+        "line_number": 37,
         "type": "Secret Keyword"
       }
     ],
@@ -557,14 +539,14 @@
         "hashed_secret": "ffb6b0df52406a12074ca094831141bccab2f455",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 174,
+        "line_number": 172,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "25d58403fb473d9251b41161c6151b737969889e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 204,
+        "line_number": 202,
         "type": "Secret Keyword"
       }
     ],
@@ -573,7 +555,7 @@
         "hashed_secret": "cca5ec6518072e9005bd723123ec52b8e978a448",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 46,
+        "line_number": 45,
         "type": "Hex High Entropy String"
       }
     ],
@@ -582,21 +564,21 @@
         "hashed_secret": "00af3d8f6e1935cb948dcf0c64ce3ff127035240",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
+        "line_number": 28,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "f37339c5d3ac735a8bf0e6036b10b79ccb5bde1d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 51,
+        "line_number": 49,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 237,
+        "line_number": 235,
         "type": "Secret Keyword"
       }
     ]

--- a/app/browsered.js
+++ b/app/browsered.js
@@ -2,7 +2,6 @@
 
 require('@babel/polyfill')
 
-// Local dependencies
 const multiSelects = require('./browsered/multi-select')
 const fieldValidation = require('./browsered/field-validation')
 const dashboardActivity = require('./browsered/dashboard-activity')

--- a/app/browsered/autocomplete.js
+++ b/app/browsered/autocomplete.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const accessibleAutocomplete = require('accessible-autocomplete')
 
 module.exports = () => {

--- a/app/browsered/field-validation-checks.js
+++ b/app/browsered/field-validation-checks.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const emailValidator = require('../utils/email-tools.js')
 
 // Constants

--- a/app/browsered/field-validation.js
+++ b/app/browsered/field-validation.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM Dependencies
 const every = require('lodash/every')
 
 // Polyfills introduced as a temporary fix to make Smoketests pass. See PP-3489
 require('./polyfills')
 
-// Local Dependencies
 const checks = require('./field-validation-checks')
 
 // Global constants

--- a/app/browsered/multi-select.js
+++ b/app/browsered/multi-select.js
@@ -1,7 +1,6 @@
 'use strict'
 // TODO: we should probably do some browser testing in this project to prove this all works as intended
 
-// Local Dependencies
 const multiSelect = require('../views/includes/multi-select.njk')
 
 // Polyfills introduced as a temporary fix to make Smoketests pass. See PP-3489

--- a/app/controllers/all-service-transactions/get.controller.js
+++ b/app/controllers/all-service-transactions/get.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const _ = require('lodash')
 
 const { response, renderErrorView } = require('../../utils/response')

--- a/app/controllers/api-keys/get-create.controller.js
+++ b/app/controllers/api-keys/get-create.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { response } = require('../../utils/response.js')
 const auth = require('../../services/auth.service.js')
 

--- a/app/controllers/api-keys/get-index.controller.js
+++ b/app/controllers/api-keys/get-index.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { response, renderErrorView } = require('../../utils/response.js')
 const auth = require('../../services/auth.service.js')
 const publicAuthClient = require('../../services/clients/public-auth.client')

--- a/app/controllers/api-keys/get-revoked.controller.js
+++ b/app/controllers/api-keys/get-revoked.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { response, renderErrorView } = require('../../utils/response.js')
 const auth = require('../../services/auth.service.js')
 const publicAuthClient = require('../../services/clients/public-auth.client')

--- a/app/controllers/api-keys/post-create.controller.js
+++ b/app/controllers/api-keys/post-create.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { response, renderErrorView } = require('../../utils/response.js')
 const auth = require('../../services/auth.service.js')
 const publicAuthClient = require('../../services/clients/public-auth.client')

--- a/app/controllers/api-keys/post-revoke.controller.js
+++ b/app/controllers/api-keys/post-revoke.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const paths = require('../../paths')
 const auth = require('../../services/auth.service.js')
 const publicAuthClient = require('../../services/clients/public-auth.client')

--- a/app/controllers/api-keys/post-update.controller.js
+++ b/app/controllers/api-keys/post-update.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const paths = require('../../paths')
 const publicAuthClient = require('../../services/clients/public-auth.client')
 const logger = require('../../utils/logger')(__filename)

--- a/app/controllers/billing-address/toggle-billing-address.controller.js
+++ b/app/controllers/billing-address/toggle-billing-address.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const logger = require('../../utils/logger')(__filename)
 const { response } = require('../../utils/response')
 const router = require('../../routes')

--- a/app/controllers/create-service.controller.js
+++ b/app/controllers/create-service.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM Dependencies
 const lodash = require('lodash')
 
-// Local Dependencies
 const { renderErrorView, response } = require('../utils/response')
 const paths = require('../paths')
 const serviceService = require('../services/service.service')

--- a/app/controllers/digital-wallet/get-apple-pay.controller.js
+++ b/app/controllers/digital-wallet/get-apple-pay.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { response } = require('../../utils/response')
 
 module.exports = (req, res) => {

--- a/app/controllers/digital-wallet/get-google-pay.controller.js
+++ b/app/controllers/digital-wallet/get-google-pay.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { response } = require('../../utils/response')
 
 module.exports = (req, res) => {

--- a/app/controllers/digital-wallet/post-apple-pay.controller.js
+++ b/app/controllers/digital-wallet/post-apple-pay.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const paths = require('../../paths')
 const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')

--- a/app/controllers/digital-wallet/post-google-pay.controller.js
+++ b/app/controllers/digital-wallet/post-google-pay.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const paths = require('../../paths')
 const logger = require('../../utils/logger')(__filename)
 const { renderErrorView } = require('../../utils/response')

--- a/app/controllers/edit-merchant-details/get-index.controller.js
+++ b/app/controllers/edit-merchant-details/get-index.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const paths = require('../../paths')
 const formatPath = require('../../utils/replace-params-in-path')
 const { response } = require('../../utils/response')

--- a/app/controllers/edit-service-name.controller.js
+++ b/app/controllers/edit-service-name.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM Dependencies
 const lodash = require('lodash')
 
-// Local Dependencies
 const responses = require('../utils/response')
 const paths = require('../paths')
 const formatPath = require('../utils/replace-params-in-path')

--- a/app/controllers/email-notifications/email-notifications.controller.js
+++ b/app/controllers/email-notifications/email-notifications.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const _ = require('lodash')
 
-// Local dependencies
 const logger = require('../../utils/logger')(__filename)
 const response = require('../../utils/response.js').response
 const emailService = require('../../services/email.service.js')

--- a/app/controllers/feedback/get-index.controller.js
+++ b/app/controllers/feedback/get-index.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { response } = require('../../utils/response.js')
 
 module.exports = (req, res) => {

--- a/app/controllers/feedback/post-index.controller.js
+++ b/app/controllers/feedback/post-index.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const logger = require('../../utils/logger')(__filename)
 const paths = require('../../paths')
 const zendeskClient = require('../../services/clients/zendesk.client')

--- a/app/controllers/forgotten-password.controller.js
+++ b/app/controllers/forgotten-password.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const emailValidator = require('../utils/email-tools.js')
 const paths = require('../paths.js')
 const { renderErrorView } = require('../utils/response.js')

--- a/app/controllers/invite-validation.controller.js
+++ b/app/controllers/invite-validation.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Custom dependencies
 const logger = require('../utils/logger')(__filename)
 const { renderErrorView } = require('../utils/response')
 const validateInviteService = require('../services/validate-invite.service')

--- a/app/controllers/login/after-otp-login.controller.js
+++ b/app/controllers/login/after-otp-login.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const _ = require('lodash')
 
-// Custom dependencies
 const logger = require('../../utils/logger')(__filename)
 const { setSessionVersion } = require('../../services/auth.service')
 const CORRELATION_HEADER = require('../../utils/correlation-header').CORRELATION_HEADER

--- a/app/controllers/login/login-after-register.controller.js
+++ b/app/controllers/login/login-after-register.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const passport = require('passport')
 
 module.exports = (req, res, next) => {

--- a/app/controllers/login/login-user-otp.controller.js
+++ b/app/controllers/login/login-user-otp.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const passport = require('passport')
 
 module.exports = (req, res, next) => {

--- a/app/controllers/login/login-user.controller.js
+++ b/app/controllers/login/login-user.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const passport = require('passport')
 
 module.exports = (req, res, next) => {

--- a/app/controllers/login/logout.controller.js
+++ b/app/controllers/login/logout.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const _ = require('lodash')
 
-// Custom dependencies
 const logger = require('../../utils/logger')(__filename)
 const CORRELATION_HEADER = require('../../utils/correlation-header').CORRELATION_HEADER
 const userService = require('../../services/user.service')

--- a/app/controllers/login/otp-login.controller.js
+++ b/app/controllers/login/otp-login.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Custom dependencies
 const logger = require('../../utils/logger')(__filename)
 const userService = require('../../services/user.service')
 const { renderErrorView } = require('../../utils/response')

--- a/app/controllers/login/post-login.controller.js
+++ b/app/controllers/login/post-login.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const _ = require('lodash')
 
-// Custom dependencies
 const logger = require('../../utils/logger')(__filename)
 const CORRELATION_HEADER = require('../../utils/correlation-header').CORRELATION_HEADER
 const paths = require('../../paths')

--- a/app/controllers/login/send-again-post.controller.js
+++ b/app/controllers/login/send-again-post.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Custom dependencies
 const logger = require('../../utils/logger')(__filename)
 const userService = require('../../services/user.service')
 const paths = require('../../paths')

--- a/app/controllers/make-a-demo-payment/edit.controller.js
+++ b/app/controllers/make-a-demo-payment/edit.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { response } = require('../../utils/response.js')
 const { editDescription } = require('../../paths').prototyping.demoPayment
 

--- a/app/controllers/make-a-demo-payment/go-to-payment.controller.js
+++ b/app/controllers/make-a-demo-payment/go-to-payment.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const logger = require('../../utils/logger')(__filename)
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')

--- a/app/controllers/make-a-demo-payment/index.controller.js
+++ b/app/controllers/make-a-demo-payment/index.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { response } = require('../../utils/response.js')
 const paths = require('../../paths')
 const { isCurrency, isAboveMaxAmount } = require('../../browsered/field-validation-checks')

--- a/app/controllers/make-a-demo-payment/mock-card-details.controller.js
+++ b/app/controllers/make-a-demo-payment/mock-card-details.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { response } = require('../../utils/response.js')
 const paths = require('../../paths')
 

--- a/app/controllers/my-services/get-index.controller.js
+++ b/app/controllers/my-services/get-index.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const _ = require('lodash')
 
-// local dependencies
 const { response } = require('../../utils/response')
 const serviceService = require('../../services/service.service')
 const getHeldPermissions = require('../../utils/get-held-permissions')

--- a/app/controllers/partnerapp/handle-gocardless-connect-get.controller.js
+++ b/app/controllers/partnerapp/handle-gocardless-connect-get.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Custom dependencies
 const logger = require('../../utils/logger')(__filename)
 const { response, renderErrorView } = require('../../utils/response')
 const directDebitConnectorClient = require('../../services/clients/direct-debit-connector.client')

--- a/app/controllers/payment-links/get-amount.controller.js
+++ b/app/controllers/payment-links/get-amount.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { response } = require('../../utils/response.js')
 const paths = require('../../paths')
 

--- a/app/controllers/payment-links/get-delete.controller.js
+++ b/app/controllers/payment-links/get-delete.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const logger = require('../../utils/logger')(__filename)
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')

--- a/app/controllers/payment-links/get-disable.controller.js
+++ b/app/controllers/payment-links/get-disable.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const logger = require('../../utils/logger')(__filename)
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')

--- a/app/controllers/payment-links/get-edit-reference.controller.js
+++ b/app/controllers/payment-links/get-edit-reference.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { response } = require('../../utils/response.js')
 const paths = require('../../paths')
 const formattedPathFor = require('../../utils/replace-params-in-path')

--- a/app/controllers/payment-links/get-information.controller.js
+++ b/app/controllers/payment-links/get-information.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { response } = require('../../utils/response')
 const supportedLanguage = require('../../models/supported-language')
 

--- a/app/controllers/payment-links/get-manage.controller.js
+++ b/app/controllers/payment-links/get-manage.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const logger = require('../../utils/logger')(__filename)
 const { response } = require('../../utils/response')
 const productsClient = require('../../services/clients/products.client')

--- a/app/controllers/payment-links/get-reference.controller.js
+++ b/app/controllers/payment-links/get-reference.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { response } = require('../../utils/response.js')
 
 module.exports = function showReferencePage (req, res, next) {

--- a/app/controllers/payment-links/get-review.controller.js
+++ b/app/controllers/payment-links/get-review.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { response } = require('../../utils/response.js')
 
 module.exports = (req, res) => {

--- a/app/controllers/payment-links/get-start.controller.js
+++ b/app/controllers/payment-links/get-start.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { response } = require('../../utils/response.js')
 
 module.exports = (req, res) => {

--- a/app/controllers/payment-links/get-web-address.controller.js
+++ b/app/controllers/payment-links/get-web-address.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { response } = require('../../utils/response.js')
 
 module.exports = function showWebAddressPage (req, res, next) {

--- a/app/controllers/payment-links/post-amount.controller.js
+++ b/app/controllers/payment-links/post-amount.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const paths = require('../../paths')
 const { safeConvertPoundsStringToPence } = require('../../utils/currency-formatter')
 

--- a/app/controllers/payment-links/post-edit-amount.controller.js
+++ b/app/controllers/payment-links/post-edit-amount.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const paths = require('../../paths')
 const formattedPathFor = require('../../utils/replace-params-in-path')
 const { safeConvertPoundsStringToPence } = require('../../utils/currency-formatter')

--- a/app/controllers/payment-links/post-edit-information.controller.js
+++ b/app/controllers/payment-links/post-edit-information.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const paths = require('../../paths')
 const formattedPathFor = require('../../utils/replace-params-in-path')
 

--- a/app/controllers/payment-links/post-edit-reference.controller.js
+++ b/app/controllers/payment-links/post-edit-reference.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const paths = require('../../paths')
 const formattedPathFor = require('../../utils/replace-params-in-path')
 

--- a/app/controllers/payment-links/post-information.controller.js
+++ b/app/controllers/payment-links/post-information.controller.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 const { slugify, removeIndefiniteArticles } = require('@govuk-pay/pay-js-commons').nunjucksFilters
 
-// Local dependencies
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
 

--- a/app/controllers/payment-links/post-review.controller.js
+++ b/app/controllers/payment-links/post-review.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const logger = require('../../utils/logger')(__filename)
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')

--- a/app/controllers/payment-links/post-web-address.controller.js
+++ b/app/controllers/payment-links/post-web-address.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
 const { slugify, removeIndefiniteArticles } = require('@govuk-pay/pay-js-commons').nunjucksFilters

--- a/app/controllers/payment-types/get-index.controller.js
+++ b/app/controllers/payment-types/get-index.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { response, renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')

--- a/app/controllers/payment-types/index.js
+++ b/app/controllers/payment-types/index.js
@@ -1,5 +1,4 @@
 'use strict'
 
-// Local Dependencies
 exports.getIndex = require('./get-index.controller')
 exports.postIndex = require('./post-index.controller')

--- a/app/controllers/payment-types/post-index.controller.js
+++ b/app/controllers/payment-types/post-index.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const paths = require('../../paths')
 const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')

--- a/app/controllers/register-service.controller.js
+++ b/app/controllers/register-service.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const _ = require('lodash')
 
-// Custom dependencies
 const logger = require('../utils/logger')(__filename)
 const paths = require('../paths')
 const { renderErrorView } = require('../utils/response')

--- a/app/controllers/request-to-go-live/agreement/get.controller.js
+++ b/app/controllers/request-to-go-live/agreement/get.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const goLiveStage = require('../../../models/go-live-stage')
 const { requestToGoLive } = require('../../../paths')
 const response = require('../../../utils/response')

--- a/app/controllers/request-to-go-live/agreement/post.controller.js
+++ b/app/controllers/request-to-go-live/agreement/post.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const logger = require('../../../utils/logger')(__filename)
 const { requestToGoLive } = require('../../../paths')
 const goLiveStage = require('../../../models/go-live-stage')

--- a/app/controllers/request-to-go-live/choose-how-to-process-payments/get.controller.js
+++ b/app/controllers/request-to-go-live/choose-how-to-process-payments/get.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const goLiveStage = require('../../../models/go-live-stage')
 const { requestToGoLive } = require('../../../paths')
 const response = require('../../../utils/response')

--- a/app/controllers/request-to-go-live/choose-how-to-process-payments/post.controller.js
+++ b/app/controllers/request-to-go-live/choose-how-to-process-payments/post.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const goLiveStageToNextPagePath = require('../go-live-stage-to-next-page-path')
 const { validateProcessPaymentOptions } = require('../../../utils/choose-how-to-process-payments-validation')
 const { requestToGoLive } = require('../../../paths')

--- a/app/controllers/request-to-go-live/go-live-stage-to-next-page-path.js
+++ b/app/controllers/request-to-go-live/go-live-stage-to-next-page-path.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const goLiveStage = require('../../models/go-live-stage')
 const { requestToGoLive } = require('../../paths')
 

--- a/app/controllers/request-to-go-live/index/get.controller.js
+++ b/app/controllers/request-to-go-live/index/get.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const goLiveStage = require('../../../models/go-live-stage')
 const response = require('../../../utils/response')
 

--- a/app/controllers/request-to-go-live/index/post.controller.js
+++ b/app/controllers/request-to-go-live/index/post.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const goLiveStageToNextPagePath = require('../go-live-stage-to-next-page-path')
 
 module.exports = (req, res) => {

--- a/app/controllers/request-to-go-live/organisation-address/get.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/get.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const goLiveStage = require('../../../models/go-live-stage')
 const { requestToGoLive } = require('../../../paths')
 const response = require('../../../utils/response')

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const logger = require('../../../utils/logger')(__filename)
 const goLiveStageToNextPagePath = require('../go-live-stage-to-next-page-path')
 const goLiveStage = require('../../../models/go-live-stage')

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.test.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
-// Local dependencies
 const goLiveStage = require('../../../models/go-live-stage')
 const Service = require('../../../models/Service.class')
 const serviceFixtures = require('../../../../test/fixtures/service.fixtures')

--- a/app/controllers/request-to-go-live/organisation-name/get.controller.js
+++ b/app/controllers/request-to-go-live/organisation-name/get.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const goLiveStage = require('../../../models/go-live-stage')
 const { requestToGoLive } = require('../../../paths')
 const response = require('../../../utils/response')

--- a/app/controllers/request-to-go-live/organisation-name/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-name/post.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const goLiveStageToNextPagePath = require('../go-live-stage-to-next-page-path')
 const goLiveStage = require('../../../models/go-live-stage')
 const { requestToGoLive } = require('../../../paths')

--- a/app/controllers/settings/get.settings.controller.js
+++ b/app/controllers/settings/get.settings.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { response } = require('../../utils/response')
 
 const humaniseEmailMode = mode => {

--- a/app/controllers/stripe-setup/bank-details/bank-details-validations.js
+++ b/app/controllers/stripe-setup/bank-details/bank-details-validations.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { isEmpty, isNotAccountNumber, isNotSortCode } = require('../../../browsered/field-validation-checks')
 
 exports.validateAccountNumber = (accountNumber) => {

--- a/app/controllers/stripe-setup/bank-details/bank-details-validations.test.js
+++ b/app/controllers/stripe-setup/bank-details/bank-details-validations.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const bankDetailsValidations = require('./bank-details-validations')
 
 describe('Bank details validations', () => {

--- a/app/controllers/stripe-setup/bank-details/get.controller.js
+++ b/app/controllers/stripe-setup/bank-details/get.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { response } = require('../../../utils/response')
 
 module.exports = (req, res) => {

--- a/app/controllers/stripe-setup/bank-details/post.controller.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const logger = require('../../../utils/logger')(__filename)
 const { response, renderErrorView } = require('../../../utils/response')
 const bankDetailsValidations = require('./bank-details-validations')

--- a/app/controllers/stripe-setup/company-number/company-number-validations.js
+++ b/app/controllers/stripe-setup/company-number/company-number-validations.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const {
   validationErrors,
   isEmpty,

--- a/app/controllers/stripe-setup/company-number/company-number-validations.test.js
+++ b/app/controllers/stripe-setup/company-number/company-number-validations.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const companyNumberValidations = require('./company-number-validations')
 
 // Constants

--- a/app/controllers/stripe-setup/company-number/get.controller.js
+++ b/app/controllers/stripe-setup/company-number/get.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { response } = require('../../../utils/response')
 
 module.exports = (req, res) => {

--- a/app/controllers/stripe-setup/company-number/post.controller.js
+++ b/app/controllers/stripe-setup/company-number/post.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const logger = require('../../../utils/logger')(__filename)
 const { response, renderErrorView } = require('../../../utils/response')
 const { updateCompany } = require('../../../services/clients/stripe/stripe.client')

--- a/app/controllers/stripe-setup/responsible-person/get.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/get.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { response } = require('../../../utils/response')
 
 module.exports = (req, res) => {

--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 const ukPostcode = require('uk-postcode')
 
-// Local dependencies
 const paths = require('../../../paths')
 const logger = require('../../../utils/logger')(__filename)
 const { response, renderErrorView } = require('../../../utils/response')

--- a/app/controllers/stripe-setup/vat-number/get.controller.js
+++ b/app/controllers/stripe-setup/vat-number/get.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { response } = require('../../../utils/response')
 
 module.exports = (req, res) => {

--- a/app/controllers/stripe-setup/vat-number/post.controller.js
+++ b/app/controllers/stripe-setup/vat-number/post.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const logger = require('../../../utils/logger')(__filename)
 const { response, renderErrorView } = require('../../../utils/response')
 const { updateCompany } = require('../../../services/clients/stripe/stripe.client')

--- a/app/controllers/stripe-setup/vat-number/vat-number-validations.js
+++ b/app/controllers/stripe-setup/vat-number/vat-number-validations.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { isEmpty, isNotVatNumber } = require('../../../browsered/field-validation-checks')
 
 exports.validateVatNumber = function validateVatNumber (value) {

--- a/app/controllers/stripe-setup/vat-number/vat-number-validations.test.js
+++ b/app/controllers/stripe-setup/vat-number/vat-number-validations.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const vatNumberValidations = require('./vat-number-validations')
 
 // Constants

--- a/app/controllers/test-with-your-users/create.controller.js
+++ b/app/controllers/test-with-your-users/create.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { response } = require('../../utils/response.js')
 
 module.exports = (req, res) => {

--- a/app/controllers/test-with-your-users/index.controller.js
+++ b/app/controllers/test-with-your-users/index.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { response } = require('../../utils/response.js')
 
 const PAGE_PARAMS = {

--- a/app/controllers/test-with-your-users/index.js
+++ b/app/controllers/test-with-your-users/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local Dependencies
 exports.index = require('./index.controller')
 exports.links = require('./links.controller')
 exports.disable = require('./disable.controller')

--- a/app/controllers/test-with-your-users/submit.controller.js
+++ b/app/controllers/test-with-your-users/submit.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const logger = require('../../utils/logger')(__filename)
 const { response } = require('../../utils/response.js')
 const paths = require('../../paths')

--- a/app/controllers/toggle-3ds/3ds.get.controller.js
+++ b/app/controllers/toggle-3ds/3ds.get.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { response, renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')

--- a/app/controllers/toggle-3ds/3ds.post.controller.js
+++ b/app/controllers/toggle-3ds/3ds.post.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const paths = require('../../paths')
 const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')

--- a/app/controllers/transactions/transaction-detail.controller.js
+++ b/app/controllers/transactions/transaction-detail.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local Dependencies
 const { ledgerFindWithEvents } = require('../../services/transaction.service')
 const auth = require('../../services/auth.service.js')
 const { response } = require('../../utils/response.js')

--- a/app/controllers/transactions/transaction-list.controller.js
+++ b/app/controllers/transactions/transaction-list.controller.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// Core Dependencies
 const url = require('url')
 const _ = require('lodash')
 
-// Local Dependencies
 const auth = require('../../services/auth.service.js')
 const router = require('../../routes.js')
 const transactionService = require('../../services/transaction.service')

--- a/app/controllers/transactions/transaction-refund.controller.js
+++ b/app/controllers/transactions/transaction-refund.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local Dependencies
 const { refund } = require('../../services/transaction.service')
 const router = require('../../routes.js')
 const { CORRELATION_HEADER } = require('../../utils/correlation-header.js')

--- a/app/controllers/two-factor-auth-controller/get-configure.controller.js
+++ b/app/controllers/two-factor-auth-controller/get-configure.controller.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 const qrcode = require('qrcode')
 
-// Local dependencies
 const logger = require('../../utils/logger')(__filename)
 const { response } = require('../../utils/response.js')
 const paths = require('../../paths')

--- a/app/controllers/two-factor-auth-controller/get-index.controller.js
+++ b/app/controllers/two-factor-auth-controller/get-index.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { response } = require('../../utils/response.js')
 
 module.exports = (req, res) => {

--- a/app/controllers/two-factor-auth-controller/post-configure.controller.js
+++ b/app/controllers/two-factor-auth-controller/post-configure.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const logger = require('../../utils/logger')(__filename)
 const paths = require('../../paths')
 const userService = require('../../services/user.service.js')

--- a/app/controllers/two-factor-auth-controller/post-index.controller.js
+++ b/app/controllers/two-factor-auth-controller/post-index.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const logger = require('../../utils/logger')(__filename)
 const userService = require('../../services/user.service.js')
 const paths = require('../../paths')

--- a/app/controllers/user/phone-number/get.controller.js
+++ b/app/controllers/user/phone-number/get.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { renderErrorView } = require('../../../utils/response')
 const userService = require('../../../services/user.service')
 

--- a/app/controllers/user/phone-number/post.controller.js
+++ b/app/controllers/user/phone-number/post.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { renderErrorView } = require('../../../utils/response')
 const userService = require('../../../services/user.service')
 const paths = require('../../../paths')

--- a/app/controllers/your-psp/get-flex.controller.js
+++ b/app/controllers/your-psp/get-flex.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { response } = require('../../utils/response')
 
 module.exports = (req, res) => {

--- a/app/controllers/your-psp/get.controller.js
+++ b/app/controllers/your-psp/get.controller.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { response } = require('../../utils/response')
 
 module.exports = (req, res) => {

--- a/app/controllers/your-psp/post-flex.controller.js
+++ b/app/controllers/your-psp/post-flex.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const paths = require('../../paths')
 const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')

--- a/app/controllers/your-psp/worldpay-3ds-flex-validations.js
+++ b/app/controllers/your-psp/worldpay-3ds-flex-validations.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { isNotWorldpay3dsFlexOrgUnitId, isNotWorldpay3dsFlexIssuer, isNotWorldpay3dsFlexJwtMacKey } =
     require('../../../app/browsered/field-validation-checks')
 

--- a/app/controllers/your-psp/worldpay-3ds-flex-validations.test.js
+++ b/app/controllers/your-psp/worldpay-3ds-flex-validations.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const worldpay3dsFlexValidations = require('./worldpay-3ds-flex-validations')
 
 describe('Worldpay 3DS Flex validations', () => {

--- a/app/middleware/correlation-id.js
+++ b/app/middleware/correlation-id.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM Dependencies
 const correlator = require('correlation-id')
 
-// Local Dependencies
 const CORRELATION_HEADER = require('../utils/correlation-header').CORRELATION_HEADER
 
 module.exports = correlationMiddleware

--- a/app/middleware/csrf.js
+++ b/app/middleware/csrf.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM Dependencies
 const csrf = require('csrf')
 
-// Local Dependencies
 const logger = require('../utils/logger')(__filename)
 const { renderErrorView } = require('../utils/response.js')
 const CORRELATION_HEADER = require('../utils/correlation-header.js').CORRELATION_HEADER

--- a/app/middleware/payment-method-card.js
+++ b/app/middleware/payment-method-card.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { renderErrorView } = require('../utils/response')
 
 module.exports = (req, res, next) => {

--- a/app/middleware/restrict-to-sandbox.js
+++ b/app/middleware/restrict-to-sandbox.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const { renderErrorView } = require('../utils/response')
 
 module.exports = (req, res, next) => {

--- a/app/middleware/stripe-setup/check-bank-details-not-submitted.js
+++ b/app/middleware/stripe-setup/check-bank-details-not-submitted.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { renderErrorView } = require('../../utils/response')
 const paths = require('../../paths')
 

--- a/app/middleware/stripe-setup/check-company-number-not-submitted.js
+++ b/app/middleware/stripe-setup/check-company-number-not-submitted.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { renderErrorView } = require('../../utils/response')
 const paths = require('../../paths')
 

--- a/app/middleware/stripe-setup/check-responsible-person-not-submitted.js
+++ b/app/middleware/stripe-setup/check-responsible-person-not-submitted.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { renderErrorView } = require('../../utils/response')
 const paths = require('../../paths')
 

--- a/app/middleware/stripe-setup/check-vat-number-not-submitted.js
+++ b/app/middleware/stripe-setup/check-vat-number-not-submitted.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { renderErrorView } = require('../../utils/response')
 const paths = require('../../paths')
 

--- a/app/middleware/stripe-setup/get-stripe-account.js
+++ b/app/middleware/stripe-setup/get-stripe-account.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 const { renderErrorView } = require('../../utils/response')

--- a/app/middleware/stripe-setup/restrict-to-live-stripe-account.test.js
+++ b/app/middleware/stripe-setup/restrict-to-live-stripe-account.test.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const sinon = require('sinon')
 const { expect } = require('chai')
 
-// Local dependencies
 const restrictToLiveStripeAccount = require('./restrict-to-live-stripe-account')
 
 describe('Restrict to live stripe account middleware', () => {

--- a/app/middleware/x-ray.js
+++ b/app/middleware/x-ray.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const getNamespace = require('continuation-local-storage').getNamespace
 
-// Local dependencies
 const clsXrayConfig = require('../../config/xray-cls')
 
 module.exports = (req, res, next) => {

--- a/app/models/Payment.class.js
+++ b/app/models/Payment.class.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM Dependencies
 const lodash = require('lodash')
 
 /**

--- a/app/models/Product.class.js
+++ b/app/models/Product.class.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM Dependencies
 const lodash = require('lodash')
 
 /**

--- a/app/models/TransactionEvent.class.js
+++ b/app/models/TransactionEvent.class.js
@@ -1,9 +1,7 @@
 'use strict'
-// NPM Dependencies
 const lodash = require('lodash')
 const { penceToPoundsWithCurrency } = require('../utils/currency-formatter')
 
-// Local Dependencies
 const states = require('../utils/states')
 const dates = require('../utils/dates')
 

--- a/app/paths.js
+++ b/app/paths.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Node.js core dependencies
 const path = require('path')
 
 module.exports = {

--- a/app/routes.js
+++ b/app/routes.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM Dependencies
 const lodash = require('lodash')
 const AWSXRay = require('aws-xray-sdk')
 const { getNamespace, createNamespace } = require('continuation-local-storage')
 
-// Local Dependencies
 const logger = require('./utils/logger')(__filename)
 const response = require('./utils/response.js').response
 const generateRoute = require('./utils/generate-route')

--- a/app/services/auth.service.js
+++ b/app/services/auth.service.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM Dependencies
 const lodash = require('lodash')
 const passport = require('passport')
 const LocalStrategy = require('passport-local').Strategy
@@ -16,7 +15,6 @@ const getNamespace = require('continuation-local-storage').getNamespace
  */
 require('correlation-id')
 
-// Local Dependencies
 const logger = require('../utils/logger')(__filename)
 const sessionValidator = require('./session-validator.js')
 const paths = require('../paths.js')

--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const baseClient = require('./base-client/base.client')
 const User = require('../../models/User.class')
 const Service = require('../../models/Service.class')

--- a/app/services/clients/base-client/base.client.js
+++ b/app/services/clients/base-client/base.client.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM Dependencies
 const request = require('request')
 const wrapper = require('./wrapper')
 

--- a/app/services/clients/base-client/wrapper.js
+++ b/app/services/clients/base-client/wrapper.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 const joinURL = require('url-join')
 const correlator = require('correlation-id')
 const { getNamespace } = require('continuation-local-storage')
 const AWSXRay = require('aws-xray-sdk')
 
-// Local dependencies
 const requestLogger = require('../../../utils/request-logger')
 const { CORRELATION_HEADER } = require('../../../utils/correlation-header')
 

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const util = require('util')
 const EventEmitter = require('events').EventEmitter
 
-// Local dependencies
 const logger = require('../../utils/logger')(__filename)
 const oldBaseClient = require('./old-base.client')
 const baseClient = require('./base-client/base.client')

--- a/app/services/clients/direct-debit-connector.client.js
+++ b/app/services/clients/direct-debit-connector.client.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local Dependencies
 const GatewayAccount = require('../../models/DirectDebitGatewayAccount.class')
 const baseClient = require('./base-client/base.client')
 

--- a/app/services/clients/direct-debit-connector.client2.js
+++ b/app/services/clients/direct-debit-connector.client2.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const baseClient = require('./base-client/base.client')
 const GatewayAccount = require('../../models/DirectDebitGatewayAccount.class')
 

--- a/app/services/clients/old-base.client.js
+++ b/app/services/clients/old-base.client.js
@@ -10,7 +10,6 @@ const request = require('requestretry')
 const getNamespace = require('continuation-local-storage').getNamespace
 const AWSXRay = require('aws-xray-sdk')
 
-// Local dependencies
 const getRequestContext = require('../../middleware/get-request-context').getRequestContext
 const CORRELATION_HEADER_NAME = require(path.join(__dirname, '/../../utils/correlation-header')).CORRELATION_HEADER
 

--- a/app/services/clients/products.client.js
+++ b/app/services/clients/products.client.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local Dependencies
 const Product = require('../../models/Product.class')
 const Payment = require('../../models/Payment.class')
 const baseClient = require('./base-client/base.client')

--- a/app/services/clients/public-auth.client.js
+++ b/app/services/clients/public-auth.client.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const requestLogger = require('../../utils/request-logger')
 const createCallbackToPromiseConverter = require('../../utils/response-converter').createCallbackToPromiseConverter
 const baseClient = require('./old-base.client')

--- a/app/services/clients/stripe/stripe.client.js
+++ b/app/services/clients/stripe/stripe.client.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const stripe = require('stripe')(process.env.STRIPE_ACCOUNT_API_KEY)
 const ProxyAgent = require('https-proxy-agent')
 
-// Local dependencies
 const StripeBankAccount = require('./stripeBankAccount.model')
 const StripeCompany = require('./stripeCompany.model')
 const StripePerson = require('./stripePerson.model')

--- a/app/services/clients/stripe/stripeBankAccount.model.js
+++ b/app/services/clients/stripe/stripeBankAccount.model.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const Joi = require('joi')
 
 const schema = {

--- a/app/services/clients/stripe/stripeBankAccount.model.test.js
+++ b/app/services/clients/stripe/stripeBankAccount.model.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const StripeBankAccount = require('./stripeBankAccount.model')
 
 describe('StripeBankAccount', () => {

--- a/app/services/clients/stripe/stripeCompany.model.js
+++ b/app/services/clients/stripe/stripeCompany.model.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const Joi = require('joi')
 
 const schema = {

--- a/app/services/clients/stripe/stripeCompany.model.test.js
+++ b/app/services/clients/stripe/stripeCompany.model.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const StripeCompany = require('./stripeCompany.model')
 
 describe('StripeCompany', () => {

--- a/app/services/clients/stripe/stripePerson.model.js
+++ b/app/services/clients/stripe/stripePerson.model.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const Joi = require('joi')
 
 const schema = {

--- a/app/services/clients/stripe/stripePerson.model.test.js
+++ b/app/services/clients/stripe/stripePerson.model.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const StripePerson = require('./stripePerson.model')
 
 const firstName = 'Carol'

--- a/app/services/service.service.js
+++ b/app/services/service.service.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const getAdminUsersClient = require('./clients/adminusers.client')
 const { ConnectorClient } = require('./clients/connector.client')
 const directDebitConnectorClient = require('./clients/direct-debit-connector.client')

--- a/app/services/user.service.js
+++ b/app/services/user.service.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const commonPassword = require('common-password')
 
-// Custom dependencies
 const getAdminUsersClient = require('./clients/adminusers.client')
 
 // Constants

--- a/app/utils/choose-how-to-process-payments-validation.js
+++ b/app/utils/choose-how-to-process-payments-validation.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
 const PSP = 'choose-how-to-process-payments-mode'

--- a/app/utils/email-tools.js
+++ b/app/utils/email-tools.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const rfc822Validator = require('rfc822-validate')
 
 module.exports = (email) => {

--- a/app/utils/registration-validations.js
+++ b/app/utils/registration-validations.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const _ = require('lodash')
 const commonPassword = require('common-password')
 
-// Local dependencies
 const emailValidator = require('./email-tools.js')
 const { invalidTelephoneNumber } = require('../utils/validation/telephone-number-validation')
 

--- a/app/utils/validation/server-side-form-validations.js
+++ b/app/utils/validation/server-side-form-validations.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const moment = require('moment-timezone')
 const ukPostcode = require('uk-postcode')
 
-// Local dependencies
 const {
   isEmpty,
   isFieldGreaterThanMaxLengthChars,

--- a/app/utils/validation/server-side-form-validations.test.js
+++ b/app/utils/validation/server-side-form-validations.test.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 const moment = require('moment-timezone')
 
-// Local dependencies
 const validations = require('./server-side-form-validations')
 
 const BLANK_TEXT = ''

--- a/app/utils/validation/telephone-number-validation.test.js
+++ b/app/utils/validation/telephone-number-validation.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const { invalidTelephoneNumber } = require('./telephone-number-validation')
 
 describe('telephone number validation', () => {

--- a/server.js
+++ b/server.js
@@ -3,7 +3,6 @@ if (process.env.DISABLE_APPMETRICS !== 'true') {
   require('./app/utils/metrics').metrics()
 }
 
-// NPM dependencies
 const express = require('express')
 const nunjucks = require('nunjucks')
 const favicon = require('serve-favicon')
@@ -13,7 +12,6 @@ const argv = require('minimist')(process.argv.slice(2))
 const flash = require('connect-flash')
 const staticify = require('staticify')('./public')
 
-// Custom dependencies
 const router = require('./app/routes')
 const cookieUtil = require('./app/utils/cookie')
 const noCache = require('./app/utils/no-cache')

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -7,11 +7,9 @@
 
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 const request = require('request-promise-native')
 
-// Local dependencies
 const cookieMonster = require('./cookie-monster')
 const stubs = require('./stubs')
 

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const userFixtures = require('../../fixtures/user.fixtures')
 const gatewayAccountFixtures = require('../../fixtures/gateway-account.fixtures')
 const transactionDetailsFixtures = require('../../fixtures/transaction.fixtures')

--- a/test/fixtures/card.fixtures.js
+++ b/test/fixtures/card.fixtures.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const path = require('path')
 
 // Global setup

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const path = require('path')
 const _ = require('lodash')
 

--- a/test/fixtures/go-live-requests.fixture.js
+++ b/test/fixtures/go-live-requests.fixture.js
@@ -3,7 +3,6 @@
 const path = require('path')
 const _ = require('lodash')
 
-// Custom dependencies
 const pactBase = require(path.join(__dirname, '/pact-base'))
 const utils = require('../cypress/utils/request-to-go-live-utils')
 

--- a/test/fixtures/invite.fixtures.js
+++ b/test/fixtures/invite.fixtures.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const _ = require('lodash')
 
 const pactBase = require('./pact-base')

--- a/test/fixtures/ledger-transaction.fixtures.js
+++ b/test/fixtures/ledger-transaction.fixtures.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const path = require('path')
 const lodash = require('lodash')
 

--- a/test/fixtures/self-register.fixtures.js
+++ b/test/fixtures/self-register.fixtures.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const path = require('path')
 const _ = require('lodash')
 
-// Custom dependencies
 const pactBase = require(path.join(__dirname, '/pact-base'))
 
 // Global setup

--- a/test/fixtures/service.fixtures.js
+++ b/test/fixtures/service.fixtures.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const path = require('path')
 const _ = require('lodash')
 
-// Custom dependencies
 const pactBase = require(path.join(__dirname, '/pact-base'))
 
 // Global setup

--- a/test/fixtures/stripe-account-setup.fixtures.js
+++ b/test/fixtures/stripe-account-setup.fixtures.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const path = require('path')
 const _ = require('lodash')
 

--- a/test/fixtures/stripe-account.fixtures.js
+++ b/test/fixtures/stripe-account.fixtures.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const pactBase = require('./pact-base')
 
 // Global setup

--- a/test/fixtures/user-service.fixture.js
+++ b/test/fixtures/user-service.fixture.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const path = require('path')
 
-// Custom dependencies
 const userFixtures = require(path.join(__dirname, '/user.fixtures'))
 const pactBase = require(path.join(__dirname, '/pact-base'))
 

--- a/test/fixtures/user.fixtures.js
+++ b/test/fixtures/user.fixtures.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 
-// Local dependencies
 const User = require('../../app/models/User.class')
 const pactBase = require('./pact-base')
 const goLiveStage = require('../../app/models/go-live-stage')

--- a/test/integration/create-service-controller/create-service-controller-create-populated-service.ft.test.js
+++ b/test/integration/create-service-controller/create-service-controller-create-populated-service.ft.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const nock = require('nock')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const gatewayAccountFixtures = require('../../fixtures/gateway-account.fixtures')
 const inviteFixtures = require('../../fixtures/invite.fixtures')
 const serviceRegistrationService = require('../../../app/services/service-registration.service')

--- a/test/integration/create-service-controller/create-service-controller-otp-resend.ft.test.js
+++ b/test/integration/create-service-controller/create-service-controller-otp-resend.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const nock = require('nock')
 const csrf = require('csrf')
 const supertest = require('supertest')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const mockSession = require('../../test-helpers/mock-session')
 const getApp = require('../../../server').getApp
 const inviteFixtures = require('../../fixtures/invite.fixtures')

--- a/test/integration/create-service-controller/create-service-controller-otp-verify.ft.test.js
+++ b/test/integration/create-service-controller/create-service-controller-otp-verify.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const nock = require('nock')
 const csrf = require('csrf')
 const supertest = require('supertest')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const session = require('../../test-helpers/mock-session')
 const getApp = require('../../../server').getApp
 const inviteFixtures = require('../../fixtures/invite.fixtures')

--- a/test/integration/create-service-controller/create-service-controller-register.ft.test.js
+++ b/test/integration/create-service-controller/create-service-controller-register.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const nock = require('nock')
 const csrf = require('csrf')
 const supertest = require('supertest')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const mockSession = require('../../test-helpers/mock-session')
 const getApp = require('../../../server').getApp
 const selfRegisterFixtures = require('../../fixtures/self-register.fixtures')

--- a/test/integration/create-service-controller/create-service-controller-service-naming.ft.test.js
+++ b/test/integration/create-service-controller/create-service-controller-service-naming.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const nock = require('nock')
 const csrf = require('csrf')
 const supertest = require('supertest')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const mockSession = require('../../test-helpers/mock-session')
 const getApp = require('../../../server').getApp
 const selfRegisterFixtures = require('../../fixtures/self-register.fixtures')

--- a/test/integration/register-user.controller.ft.test.js
+++ b/test/integration/register-user.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const nock = require('nock')
 const supertest = require('supertest')
 const csrf = require('csrf')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Local dependencies
 const paths = require('../../app/paths')
 const getApp = require('../../server').getApp
 const session = require('../test-helpers/mock-session')

--- a/test/integration/validate-invite.controller.ft.test.js
+++ b/test/integration/validate-invite.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const nock = require('nock')
 const supertest = require('supertest')
 const csrf = require('csrf')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Local dependencies
 const paths = require('../../app/paths')
 const getApp = require('../../server').getApp
 const session = require('../test-helpers/mock-session')

--- a/test/test-helpers/html-assertions.js
+++ b/test/test-helpers/html-assertions.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const cheerio = require('cheerio')
 const chai = require('chai')
 const nunjucks = require('nunjucks')
 
-// Local dependencies
 const router = require('../../app/routes.js')
 const { nunjucksFilters } = require('@govuk-pay/pay-js-commons')
 const formatPSPname = require('../../app/utils/format-PSP-name')

--- a/test/test-helpers/mock-session.js
+++ b/test/test-helpers/mock-session.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const express = require('express')
 const _ = require('lodash')
 const sinon = require('sinon')
 
-// Custom dependencies
 const userFixture = require('../fixtures/user.fixtures')
 
 const getUser = (opts) => {

--- a/test/ui/credentials.ui.test.js
+++ b/test/ui/credentials.ui.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const path = require('path')
 
-// Local dependencies
 const renderTemplate = require(path.join(__dirname, '/../test-helpers/html-assertions.js')).render
 const paths = require(path.join(__dirname, '/../../app/paths.js'))
 

--- a/test/ui/digital-wallet.ui.test.js
+++ b/test/ui/digital-wallet.ui.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const path = require('path')
 
-// Local dependencies
 const { render } = require(path.join(__dirname, '/../test-helpers/html-assertions'))
 
 describe('The digital wallet views', () => {

--- a/test/ui/email-notifications.ui.test.js
+++ b/test/ui/email-notifications.ui.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const path = require('path')
 
-// local dependencies
 const renderTemplate = require(path.join(__dirname, '/../test-helpers/html-assertions.js')).render
 
 describe('The email body view', function () {

--- a/test/ui/pagination.ui.test.js
+++ b/test/ui/pagination.ui.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Local dependencies
 const { render } = require('../test-helpers/html-assertions.js')
 
 describe('The pagination links', function () {

--- a/test/ui/register-user.ui.test.js
+++ b/test/ui/register-user.ui.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const path = require('path')
 
-// Custom dependencies
 const renderTemplate = require(path.join(__dirname, '/../test-helpers/html-assertions.js')).render
 const paths = require('../../app/paths.js')
 

--- a/test/ui/self-create-service.ui.test.js
+++ b/test/ui/self-create-service.ui.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Custom dependencies
 const renderTemplate = require('../test-helpers/html-assertions').render
 const paths = require('../../app/paths')
 

--- a/test/ui/service-switcher.ui.test.js
+++ b/test/ui/service-switcher.ui.test.js
@@ -2,7 +2,6 @@
 
 const _ = require('lodash')
 
-// Local Dependencies
 const { render } = require('../test-helpers/html-assertions.js')
 
 // Assignments e.t.c.

--- a/test/ui/transaction-details.ui.test.js
+++ b/test/ui/transaction-details.ui.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
@@ -8,7 +7,6 @@ const cheerio = require('cheerio')
 chai.should()
 chai.use(chaiAsPromised)
 
-// Local dependencies
 const renderTemplate = require(path.join(__dirname, '/../test-helpers/html-assertions.js')).render
 
 describe('The transaction details view', () => {

--- a/test/unit/browsered/field-validation-checks-worldpay-3ds-flex.test.js
+++ b/test/unit/browsered/field-validation-checks-worldpay-3ds-flex.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const { isNotWorldpay3dsFlexOrgUnitId, isNotWorldpay3dsFlexIssuer, isNotWorldpay3dsFlexJwtMacKey } =
     require('../../../app/browsered/field-validation-checks')
 

--- a/test/unit/browsered/field-validation-checks.bank-account-number.test.js
+++ b/test/unit/browsered/field-validation-checks.bank-account-number.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const { isNotAccountNumber } = require('../../../app/browsered/field-validation-checks')
 
 describe('isNotValidAccountNumber', () => {

--- a/test/unit/browsered/field-validation-checks.company-number.test.js
+++ b/test/unit/browsered/field-validation-checks.company-number.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const { isNotCompanyNumber } = require('../../../app/browsered/field-validation-checks')
 
 describe('isNotCompanyNumber', () => {

--- a/test/unit/browsered/field-validation-checks.sort-code.test.js
+++ b/test/unit/browsered/field-validation-checks.sort-code.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const { isNotSortCode } = require('../../../app/browsered/field-validation-checks')
 
 describe('isNotValidSortCode', () => {

--- a/test/unit/browsered/field-validation-checks.test.js
+++ b/test/unit/browsered/field-validation-checks.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const {
   isAboveMaxAmount,
   isPasswordLessThanTenChars,

--- a/test/unit/browsered/field-validation-checks.vat-number.test.js
+++ b/test/unit/browsered/field-validation-checks.vat-number.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const { isNotVatNumber } = require('../../../app/browsered/field-validation-checks')
 
 describe('UK VAT number validations', () => {

--- a/test/unit/clients/adminusers-client/authenticate/authenticate.pact.test.js
+++ b/test/unit/clients/adminusers-client/authenticate/authenticate.pact.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Local dependencies
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
 const userFixtures = require('../../../../fixtures/user.fixtures')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder

--- a/test/unit/clients/adminusers-client/invite/complete-service-invite.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/complete-service-invite.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')

--- a/test/unit/clients/adminusers-client/invite/complete-user-invite.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/complete-user-invite.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')

--- a/test/unit/clients/adminusers-client/invite/generate-invite-otp-code-service.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/generate-invite-otp-code-service.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')

--- a/test/unit/clients/adminusers-client/invite/generate-invite-otp-code-user.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/generate-invite-otp-code-user.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')

--- a/test/unit/clients/adminusers-client/invite/resend-otp-code.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/resend-otp-code.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')

--- a/test/unit/clients/adminusers-client/invite/submit-service-registration.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/submit-service-registration.pact.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 
 const path = require('path')
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')

--- a/test/unit/clients/adminusers-client/service/add-gateway-accounts-to-services.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/add-gateway-accounts-to-services.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')

--- a/test/unit/clients/adminusers-client/service/create-service.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/create-service.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')

--- a/test/unit/clients/adminusers-client/service/get-service-users.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/get-service-users.pact.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Local dependencies
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
 const userServiceFixtures = require('../../../../fixtures/user-service.fixture')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder

--- a/test/unit/clients/adminusers-client/service/govuk-pay-agreement-post-email-address.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/govuk-pay-agreement-post-email-address.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Local dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')

--- a/test/unit/clients/adminusers-client/service/stripe-agreement-post-ip-address.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/stripe-agreement-post-ip-address.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Local dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')

--- a/test/unit/clients/adminusers-client/service/update-collect-billing-address.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/update-collect-billing-address.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Local dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')

--- a/test/unit/clients/adminusers-client/service/update-request-to-go-live-stage.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/update-request-to-go-live-stage.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Local dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')

--- a/test/unit/clients/adminusers-client/service/update-service-name.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/update-service-name.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')

--- a/test/unit/clients/adminusers-client/service/update-service.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/update-service.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')

--- a/test/unit/clients/adminusers-client/user/get-user.pact.test.js
+++ b/test/unit/clients/adminusers-client/user/get-user.pact.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// npm dependencies
 const { Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const { expect } = chai
 const chaiAsPromised = require('chai-as-promised')
 
-// user dependencies
 const userFixtures = require('../../../../fixtures/user.fixtures')
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder

--- a/test/unit/clients/base-client/base.client.test.js
+++ b/test/unit/clients/base-client/base.client.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM Dependencies
 const correlator = require('correlation-id')
 const http = require('http')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
-// Local Dependencies
 const config = require('../../../../app/utils/correlation-header')
 
 describe('baseClient', () => {

--- a/test/unit/clients/base-client/wrapper-arguments.test.js
+++ b/test/unit/clients/base-client/wrapper-arguments.test.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM Dependencies
 const { expect } = require('chai')
 const sinon = require('sinon')
 
-// Local Dependencies
 const wrapper = require('../../../../app/services/clients/base-client/wrapper')
 
 describe('wrapper: arguments handling', () => {

--- a/test/unit/clients/base-client/wrapper-request-callback.test.js
+++ b/test/unit/clients/base-client/wrapper-request-callback.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM Dependencies
 // const request = require('request')
 const { expect } = require('chai')
 const sinon = require('sinon')
@@ -9,7 +8,6 @@ const requestLogger = {}
 const events = require('events')
 const util = require('util')
 
-// Local Dependencies
 const wrapper = proxyquire('../../../../app/services/clients/base-client/wrapper', {
   '../../../utils/request-logger': requestLogger
 })

--- a/test/unit/clients/connector-client/connector-client-create-gateway-account.pact.test.js
+++ b/test/unit/clients/connector-client/connector-client-create-gateway-account.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient

--- a/test/unit/clients/connector-client/connector-get-card-types.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-card-types.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient

--- a/test/unit/clients/connector-client/connector-get-gateway-account.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-gateway-account.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient

--- a/test/unit/clients/connector-client/connector-get-multiple-gateway-accounts.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-multiple-gateway-accounts.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient

--- a/test/unit/clients/connector-client/connector-get-stripe-account-setup.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-stripe-account-setup.pact.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
 
-// Local dependencies
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient
 const stripeAccountSetupFixtures = require('../../../fixtures/stripe-account-setup.fixtures')

--- a/test/unit/clients/connector-client/connector-get-stripe-account.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-stripe-account.pact.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
 
-// Local dependencies
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient
 const stripeAccountFixtures = require('../../../fixtures/stripe-account.fixtures')

--- a/test/unit/clients/connector-client/connector-patch-apple-pay-toggle.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-apple-pay-toggle.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient

--- a/test/unit/clients/connector-client/connector-patch-email-collection-mode.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-email-collection-mode.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient

--- a/test/unit/clients/connector-client/connector-patch-email-confirmation-toggle.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-email-confirmation-toggle.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient

--- a/test/unit/clients/connector-client/connector-patch-email-refund-toggle.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-email-refund-toggle.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient

--- a/test/unit/clients/connector-client/connector-patch-google-pay-toggle.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-google-pay-toggle.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient

--- a/test/unit/clients/connector-client/connector-post-refund.pact.test.js
+++ b/test/unit/clients/connector-client/connector-post-refund.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient

--- a/test/unit/clients/connector-client/connector-set-stripe-account-setup-flag.pact.test.js
+++ b/test/unit/clients/connector-client/connector-set-stripe-account-setup-flag.pact.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
 
-// Local dependencies
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient
 const stripeAccountSetupFixtures = require('../../../fixtures/stripe-account-setup.fixtures')

--- a/test/unit/clients/direct-debit-connector-client/get-direct-debit-gateway-account.pact.test.js
+++ b/test/unit/clients/direct-debit-connector-client/get-direct-debit-gateway-account.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const path = require('path')
 const { PactInteractionBuilder } = require('../../../fixtures/pact-interaction-builder')
 const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')

--- a/test/unit/clients/ledger-client/ledger-get-transaction-details.pact.test.js
+++ b/test/unit/clients/ledger-client/ledger-get-transaction-details.pact.test.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const ledgerClient = require('../../../../app/services/clients/ledger.client')
 const transactionDetailsFixtures = require('../../../fixtures/ledger-transaction.fixtures')

--- a/test/unit/clients/ledger-client/ledger-get-transaction-events.pact.test.js
+++ b/test/unit/clients/ledger-client/ledger-get-transaction-events.pact.test.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const ledgerClient = require('../../../../app/services/clients/ledger.client')
 const transactionDetailsFixtures = require('../../../fixtures/ledger-transaction.fixtures')

--- a/test/unit/clients/ledger-client/ledger-get-transaction-summary.pact.test.js
+++ b/test/unit/clients/ledger-client/ledger-get-transaction-summary.pact.test.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const ledgerClient = require('../../../../app/services/clients/ledger.client')
 

--- a/test/unit/clients/ledger-client/ledger-pact-test-provider.js
+++ b/test/unit/clients/ledger-client/ledger-pact-test-provider.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 
-// Custom dependencies
 const path = require('path')
 const port = parseInt(process.env.LEDGER_URL.match(/\d+(\.\d+)?$/g)[0], 10)
 

--- a/test/unit/clients/ledger-client/ledger-search-transaction.pact.test.js
+++ b/test/unit/clients/ledger-client/ledger-search-transaction.pact.test.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const ledgerClient = require('../../../../app/services/clients/ledger.client')
 const transactionDetailsFixtures = require('../../../fixtures/ledger-transaction.fixtures')

--- a/test/unit/clients/products-client/payment/create.pact.test.js
+++ b/test/unit/clients/products-client/payment/create.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const productFixtures = require('../../../../fixtures/product.fixtures')

--- a/test/unit/clients/products-client/payment/get-by-payment-external-id.pact.test.js
+++ b/test/unit/clients/products-client/payment/get-by-payment-external-id.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const productFixtures = require('../../../../fixtures/product.fixtures')

--- a/test/unit/clients/products-client/payment/get-by-product-external-id.pact.test.js
+++ b/test/unit/clients/products-client/payment/get-by-product-external-id.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
-// Custom dependencies
 const Payment = require('../../../../../app/models/Payment.class')
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder

--- a/test/unit/clients/products-client/product/create.pact.test.js
+++ b/test/unit/clients/products-client/product/create.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const productFixtures = require('../../../../fixtures/product.fixtures')

--- a/test/unit/clients/products-client/product/delete.pact.test.js
+++ b/test/unit/clients/products-client/product/delete.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 

--- a/test/unit/clients/products-client/product/disable.pact.test.js
+++ b/test/unit/clients/products-client/product/disable.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 

--- a/test/unit/clients/products-client/product/get-by-gateway-account-id-with-metadata.pact.test.js
+++ b/test/unit/clients/products-client/product/get-by-gateway-account-id-with-metadata.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const productFixtures = require('../../../../fixtures/product.fixtures')

--- a/test/unit/clients/products-client/product/get-by-gateway-account-id.pact.test.js
+++ b/test/unit/clients/products-client/product/get-by-gateway-account-id.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const productFixtures = require('../../../../fixtures/product.fixtures')

--- a/test/unit/clients/products-client/product/get-by-product-external-id.pact.test.js
+++ b/test/unit/clients/products-client/product/get-by-product-external-id.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const productFixtures = require('../../../../fixtures/product.fixtures')

--- a/test/unit/clients/products-client/product/get-by-product-path.pact.test.js
+++ b/test/unit/clients/products-client/product/get-by-product-path.pact.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
-// Custom dependencies
 const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const productFixtures = require('../../../../fixtures/product.fixtures')

--- a/test/unit/clients/publicauth-client/get-tokens.pact.test.js
+++ b/test/unit/clients/publicauth-client/get-tokens.pact.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// npm dependencies
 const { Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')

--- a/test/unit/controller/api-keys/get-index.controller.ft.test.js
+++ b/test/unit/controller/api-keys/get-index.controller.ft.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 const nock = require('nock')
 const supertest = require('supertest')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const mockSession = require('../../../test-helpers/mock-session')
 const userCreator = require('../../../test-helpers/user-creator')

--- a/test/unit/controller/api-keys/get-revoked.controller.ft.test.js
+++ b/test/unit/controller/api-keys/get-revoked.controller.ft.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 const nock = require('nock')
 const supertest = require('supertest')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const mockSession = require('../../../test-helpers/mock-session')
 const userCreator = require('../../../test-helpers/user-creator')

--- a/test/unit/controller/api-keys/post-create.controller.ft.test.js
+++ b/test/unit/controller/api-keys/post-create.controller.ft.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 const csrf = require('csrf')
 const nock = require('nock')
 const supertest = require('supertest')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const mockSession = require('../../../test-helpers/mock-session')
 const userCreator = require('../../../test-helpers/user-creator')
@@ -16,7 +14,7 @@ const { PUBLIC_AUTH_URL, CONNECTOR_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '182364'
 const REQUEST_ID = 'unique-request-id'
 const TOKEN_RESPONSE = {
-  token: 'g4jcsi2rnsep02397jsh89eqklvmg6gqtc8c0h75ql2is1vl3pldf7c4g7'
+  token: 'an-api-key'
 }
 const DESCRIPTION = 'Some words'
 const VALID_PAYLOAD = {

--- a/test/unit/controller/api-keys/post-revoke.controller.ft.test.js
+++ b/test/unit/controller/api-keys/post-revoke.controller.ft.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 const csrf = require('csrf')
 const nock = require('nock')
 const supertest = require('supertest')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const mockSession = require('../../../test-helpers/mock-session')
 const userCreator = require('../../../test-helpers/user-creator')

--- a/test/unit/controller/api-keys/post-update.controller.ft.test.js
+++ b/test/unit/controller/api-keys/post-update.controller.ft.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 const csrf = require('csrf')
 const nock = require('nock')
 const supertest = require('supertest')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const mockSession = require('../../../test-helpers/mock-session')
 const userCreator = require('../../../test-helpers/user-creator')
@@ -16,7 +14,7 @@ const { PUBLIC_AUTH_URL, CONNECTOR_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '182364'
 const REQUEST_ID = 'unique-request-id'
 const TOKEN_RESPONSE = {
-  token: 'g4jcsi2rnsep02397jsh89eqklvmg6gqtc8c0h75ql2is1vl3pldf7c4g7'
+  token: 'an-api-key'
 }
 const DESCRIPTION = 'Some words'
 const VALID_PAYLOAD = {

--- a/test/unit/controller/billing-address-controller/toggle-billing-address.controller.ft.test.js
+++ b/test/unit/controller/billing-address-controller/toggle-billing-address.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const chai = require('chai')
 const cheerio = require('cheerio')
 const nock = require('nock')
 const supertest = require('supertest')
 const csrf = require('csrf')
 
-// Local dependencies
 const mockSession = require('../../../test-helpers/mock-session.js')
 const getApp = require('../../../../server.js').getApp
 const userFixtures = require('../../../fixtures/user.fixtures')

--- a/test/unit/controller/dashboard/dashboard-activity.controller.ft.test.js
+++ b/test/unit/controller/dashboard/dashboard-activity.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const cheerio = require('cheerio')
 const nock = require('nock')
 const moment = require('moment-timezone')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/edit-merchant-details-controller/get-index.controller.ft.test.js
+++ b/test/unit/controller/edit-merchant-details-controller/get-index.controller.ft.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 const cheerio = require('cheerio')
 const nock = require('nock')
 const supertest = require('supertest')
 
-// Local dependencies
 const mockSession = require('../../../test-helpers/mock-session.js')
 const getApp = require('../../../../server.js').getApp
 const userFixtures = require('../../../fixtures/user.fixtures')

--- a/test/unit/controller/feedback/get-index.controller.test.js
+++ b/test/unit/controller/feedback/get-index.controller.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const cheerio = require('cheerio')
 const nock = require('nock')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/feedback/post-index.controller.test.js
+++ b/test/unit/controller/feedback/post-index.controller.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const csrf = require('csrf')
 const { expect } = require('chai')
 const nock = require('nock')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/login.controller.test.js
+++ b/test/unit/controller/login.controller.test.js
@@ -1,12 +1,9 @@
 'use strict'
 
-// Node.js core dependencies
 const assert = require('assert')
 
-// NPM dependencies
 const sinon = require('sinon')
 
-// Custom dependencies
 const loginController = require('../../../app/controllers/login')
 
 // Global setup

--- a/test/unit/controller/make-a-demo-payment-controller/edit.controller.ft.test.js
+++ b/test/unit/controller/make-a-demo-payment-controller/edit.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const cheerio = require('cheerio')
 const lodash = require('lodash')
 const nock = require('nock')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/make-a-demo-payment-controller/go-to-payment.controller.ft.test.js
+++ b/test/unit/controller/make-a-demo-payment-controller/go-to-payment.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const lodash = require('lodash')
 const nock = require('nock')
 const csrf = require('csrf')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/make-a-demo-payment-controller/index.controller.ft.test.js
+++ b/test/unit/controller/make-a-demo-payment-controller/index.controller.ft.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const cheerio = require('cheerio')
@@ -8,7 +7,6 @@ const lodash = require('lodash')
 const csrf = require('csrf')
 const nock = require('nock')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/make-a-demo-payment-controller/mock-card-details.controller.ft.test.js
+++ b/test/unit/controller/make-a-demo-payment-controller/mock-card-details.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const cheerio = require('cheerio')
 const nock = require('nock')
 const lodash = require('lodash')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/payment-links/get-amount.controller.ft.test.js
+++ b/test/unit/controller/payment-links/get-amount.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const cheerio = require('cheerio')
 const nock = require('nock')
 const lodash = require('lodash')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/payment-links/get-delete.controller.ft.test.js
+++ b/test/unit/controller/payment-links/get-delete.controller.ft.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const nock = require('nock')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/payment-links/get-disable.controller.ft.test.js
+++ b/test/unit/controller/payment-links/get-disable.controller.ft.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const nock = require('nock')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/payment-links/get-information.controller.ft.test.js
+++ b/test/unit/controller/payment-links/get-information.controller.ft.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const cheerio = require('cheerio')
@@ -9,7 +8,6 @@ const lodash = require('lodash')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/payment-links/get-reference.controller.ft.test.js
+++ b/test/unit/controller/payment-links/get-reference.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const cheerio = require('cheerio')
 const nock = require('nock')
 const lodash = require('lodash')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/payment-links/get-review.controller.ft.test.js
+++ b/test/unit/controller/payment-links/get-review.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const cheerio = require('cheerio')
 const nock = require('nock')
 const lodash = require('lodash')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/payment-links/get-web-address.controller.ft.test.js
+++ b/test/unit/controller/payment-links/get-web-address.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const cheerio = require('cheerio')
 const nock = require('nock')
 const lodash = require('lodash')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/payment-links/metadata/paymentlink-metadata-resource.controller.ft.test.js
+++ b/test/unit/controller/payment-links/metadata/paymentlink-metadata-resource.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const cheerio = require('cheerio')
 const nock = require('nock')
 const csrf = require('csrf')
 
-// Local dependencies
 const { getApp } = require('../../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../../test-helpers/mock-session')
 const paths = require('../../../../../app/paths')

--- a/test/unit/controller/payment-links/post-amount.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-amount.controller.ft.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const lodash = require('lodash')
 const csrf = require('csrf')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/payment-links/post-edit-amount.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-edit-amount.controller.ft.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const nock = require('nock')
 const csrf = require('csrf')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/payment-links/post-edit-information.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-edit-information.controller.ft.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const nock = require('nock')
 const csrf = require('csrf')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/payment-links/post-edit.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-edit.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const lodash = require('lodash')
 const nock = require('nock')
 const csrf = require('csrf')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/payment-links/post-information.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-information.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const lodash = require('lodash')
 const nock = require('nock')
 const csrf = require('csrf')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/payment-links/post-reference.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-reference.controller.ft.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const lodash = require('lodash')
 const csrf = require('csrf')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/payment-links/post-review.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-review.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const lodash = require('lodash')
 const nock = require('nock')
 const csrf = require('csrf')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/payment-links/post-web-address.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-web-address.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const lodash = require('lodash')
 const nock = require('nock')
 const csrf = require('csrf')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/request-to-go-live/go-live-stage-to-next-page-path.test.js
+++ b/test/unit/controller/request-to-go-live/go-live-stage-to-next-page-path.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const chai = require('chai')
 
-// Local dependencies
 const goLiveStageToNextPagePath = require('../../../../app/controllers/request-to-go-live/go-live-stage-to-next-page-path')
 const goLiveStage = require('../../../../app/models/go-live-stage')
 

--- a/test/unit/controller/test-with-your-users-controller/create.controller.ft.test.js
+++ b/test/unit/controller/test-with-your-users-controller/create.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const cheerio = require('cheerio')
 const nock = require('nock')
 const lodash = require('lodash')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/test-with-your-users-controller/disable.controller.ft.test.js
+++ b/test/unit/controller/test-with-your-users-controller/disable.controller.ft.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const nock = require('nock')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/test-with-your-users-controller/submit.controller.ft.test.js
+++ b/test/unit/controller/test-with-your-users-controller/submit.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const nock = require('nock')
 const csrf = require('csrf')
 const cheerio = require('cheerio')
 const { expect } = require('chai')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, getUser, createAppWithSession } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/two-factor-auth-controller/get-configure.controller.ft.test.js
+++ b/test/unit/controller/two-factor-auth-controller/get-configure.controller.ft.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const cheerio = require('cheerio')
 const nock = require('nock')
 const lodash = require('lodash')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/two-factor-auth-controller/get-index.controller.ft.test.js
+++ b/test/unit/controller/two-factor-auth-controller/get-index.controller.ft.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const { expect } = require('chai')
 const cheerio = require('cheerio')
 const nock = require('nock')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/two-factor-auth-controller/post-configure.controller.ft.test.js
+++ b/test/unit/controller/two-factor-auth-controller/post-configure.controller.ft.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const csrf = require('csrf')
 const { expect } = require('chai')
 const nock = require('nock')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/two-factor-auth-controller/post-index.controller.ft.test.js
+++ b/test/unit/controller/two-factor-auth-controller/post-index.controller.ft.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies
 const supertest = require('supertest')
 const csrf = require('csrf')
 const { expect } = require('chai')
 const nock = require('nock')
 
-// Local dependencies
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')

--- a/test/unit/controller/validate-invite.controller.test.js
+++ b/test/unit/controller/validate-invite.controller.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const path = require('path')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')

--- a/test/unit/middleware/correlation-id.test.js
+++ b/test/unit/middleware/correlation-id.test.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM Dependencies
 const correlator = require('correlation-id')
 const { expect } = require('chai')
 
-// Local Dependencies
 const { CORRELATION_HEADER } = require('../../../app/utils/correlation-header')
 const correlationMiddleware = require('../../../app/middleware/correlation-id')
 let req

--- a/test/unit/middleware/error-logger.test.js
+++ b/test/unit/middleware/error-logger.test.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// Node.js core dependencies
 const path = require('path')
 const assert = require('assert')
 
-// NPM dependencies
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 

--- a/test/unit/middleware/get-email-notification.test.js
+++ b/test/unit/middleware/get-email-notification.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// Node.js core dependencies
 const path = require('path')
 const assert = require('assert')
 const sinon = require('sinon')

--- a/test/unit/middleware/get-gateway-account.test.js
+++ b/test/unit/middleware/get-gateway-account.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const path = require('path')
 const proxyquire = require('proxyquire')
 const lodash = require('lodash')

--- a/test/unit/middleware/otp-verify.test.js
+++ b/test/unit/middleware/otp-verify.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-// NPM dependencies)
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
-// Custom dependencies
 const paths = require('../../../app/paths')
 
 // Constants

--- a/test/unit/middleware/restrict-to-sandbox.test.js
+++ b/test/unit/middleware/restrict-to-sandbox.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const lodash = require('lodash')
 const sinon = require('sinon')
 const { expect } = require('chai')
 
-// Local dependencies
 const restrictToSandbox = require('../../../app/middleware/restrict-to-sandbox')
 
 describe('restrict-to-sandbox middleware', () => {

--- a/test/unit/middleware/validate-registration-invite-cookie.test.js
+++ b/test/unit/middleware/validate-registration-invite-cookie.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const proxyquire = require('proxyquire')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')

--- a/test/unit/models/User.class.test.js
+++ b/test/unit/models/User.class.test.js
@@ -1,8 +1,6 @@
 'use strict'
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const User = require('../../../app/models/User.class')
 const userFixtures = require('../../fixtures/user.fixtures')
 

--- a/test/unit/services/auth.service.test.js
+++ b/test/unit/services/auth.service.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM Dependencies
 const path = require('path')
 const assert = require('assert')
 const AWSXRay = require('aws-xray-sdk')
@@ -9,7 +8,6 @@ const proxyquire = require('proxyquire')
 const _ = require('lodash')
 const { expect } = require('chai')
 
-// Local Dependencies
 const auth = require('../../../app/services/auth.service.js')
 const paths = require('../../../app/paths.js')
 const mockSession = require('../../test-helpers/mock-session.js')

--- a/test/unit/services/email.service.test.js
+++ b/test/unit/services/email.service.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM Dependencies
 const path = require('path')
 const expect = require('chai').expect
 const _ = require('lodash')

--- a/test/unit/services/service.service.test.js
+++ b/test/unit/services/service.service.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const _ = require('lodash')
 const proxyquire = require('proxyquire')
 const chai = require('chai')
@@ -8,7 +7,6 @@ const chaiAsPromised = require('chai-as-promised')
 chai.use(chaiAsPromised)
 const sinon = require('sinon')
 
-// Local Dependencies
 const gatewayAccountFixtures = require('../../fixtures/gateway-account.fixtures')
 
 const expect = chai.expect

--- a/test/unit/utils/currency-formatter.test.js
+++ b/test/unit/utils/currency-formatter.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 const {
   penceToPounds,

--- a/test/unit/utils/format-PSP-name.test.js
+++ b/test/unit/utils/format-PSP-name.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const formatPSPname = require('../../../app/utils/format-PSP-name')
 
 describe('When a payment provider name is passed to the function', () => {

--- a/test/unit/utils/registration-validations.test.js
+++ b/test/unit/utils/registration-validations.test.js
@@ -1,10 +1,8 @@
 'use strict'
 
-// NPM dependencies
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
-// Custom dependencies
 const validation = require('../../../app/utils/registration-validations')
 
 // Constants

--- a/test/unit/utils/replace-params-in-path.test.js
+++ b/test/unit/utils/replace-params-in-path.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
-// NPM dependencies
 const { expect } = require('chai')
 
-// Local dependencies
 const formattedPathFor = require('../../../app/utils/replace-params-in-path')
 
 describe('When a path is formatted', () => {

--- a/test/unit/utils/response-converter.test.js
+++ b/test/unit/utils/response-converter.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-// NPM dependencies
 const path = require('path')
 const chai = require('chai')
 const sinon = require('sinon')
 
-// Local dependencies
 const responseConverter = require(path.join(__dirname, '/../../../app/utils/response-converter'))
 
 chai.should()


### PR DESCRIPTION
Global replace:
"// NPM dependencies\n" => ""
"// Local dependencies\n" => ""
"// Custom dependencies\n" => ""
"// Node.js core dependencies\n" => ""

Replaced some example API keys in some tests flagged up by the
gds-pre-commit hook with other strings that don't look like secrets.


