### PR TITLE
BAU Fix displaying errors for forgotten password controller

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2020-09-02T14:26:57Z",
+  "generated_at": "2020-09-07T17:13:42Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -248,7 +248,7 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 160,
+        "line_number": 177,
         "type": "Secret Keyword"
       }
     ],

--- a/app/controllers/forgotten-password.controller.js
+++ b/app/controllers/forgotten-password.controller.js
@@ -1,83 +1,102 @@
 'use strict'
 
-const emailValidator = require('../utils/email-tools.js')
 const paths = require('../paths.js')
-const { renderErrorView } = require('../utils/response.js')
 const userService = require('../services/user.service.js')
+const logger = require('../utils/logger')(__filename)
+const {
+  validateEmail,
+  validatePassword
+} = require('../utils/validation/server-side-form-validations')
+
+const emailGet = function emailGet (req, res) {
+  res.render('forgotten-password/index')
+}
+
+const emailPost = async function emailPost (req, res) {
+  const correlationId = req.correlationId
+  const username = req.body.username
+
+  const validEmail = validateEmail(username)
+  if (!validEmail.valid) {
+    return res.render('forgotten-password/index', {
+      username,
+      errors: {
+        username: validEmail.message
+      }
+    })
+  }
+
+  try {
+    await userService.sendPasswordResetToken(username, correlationId)
+    res.redirect(paths.user.passwordRequested)
+  } catch (err) {
+    if (err.errorCode === 404) {
+      return res.render('forgotten-password/index', {
+        username,
+        errors: {
+          username: "No account was found for this email address"
+        }
+      })
+    } else {
+      logger.error('Sending password reset email failed: ' + err)
+      req.flash('genericError', 'Something went wrong. Please try again.')
+      res.redirect('/reset-password')
+    }
+  }
+}
+
+const passwordRequested = function passwordRequested (req, res) {
+  res.render('forgotten-password/password-requested')
+}
+
+const newPasswordGet = async function newPasswordGet (req, res) {
+  const { id } = req.params
+  try {
+    await userService.findByResetToken(id)
+    res.render('forgotten-password/new-password', { id: id })
+  } catch (err) {
+    req.flash('genericError', 'The password reset request has expired or is invalid. Please try again.')
+    res.redirect('/login')
+  }
+}
+
+const newPasswordPost = async function newPasswordPost (req, res) {
+  try {
+    const { id } = req.params
+    const password = req.body.password
+
+    const forgottenPassword = await userService.findByResetToken(id)
+    const user = await userService.findByExternalId(forgottenPassword.user_external_id, req.correlationId)
+
+    const validPassword = validatePassword(password)
+    if (!validPassword.valid) {
+      return res.render('forgotten-password/new-password', {
+        id: id,
+        errors: {
+          password: validPassword.message
+        }
+      })
+    }
+
+    await userService.updatePassword(id, password)
+    try {
+      await userService.logOut(user)
+    } catch (err) {
+      // treat as success even if updating session version fails
+    }
+    req.session.destroy()
+    req.flash('generic', 'Password has been updated')
+    res.redirect('/login')
+  } catch (error) {
+    req.flash('genericError', 'There has been a problem updating password. Please try again.')
+    res.redirect('/reset-password/' + req.params.id)
+  }
+}
 
 module.exports = {
-
-  emailGet: (req, res) => {
-    res.render('forgotten-password/index')
-  },
-
-  emailPost: (req, res) => {
-    const correlationId = req.correlationId
-    const username = req.body.username
-
-    if (emailValidator(username)) {
-      return userService.sendPasswordResetToken(username, correlationId)
-        .then(() => {
-          res.redirect(paths.user.passwordRequested)
-        }).catch((error) => {
-          req.flash('genericError', error.message)
-          res.redirect('/reset-password/' + req.params.id)
-        })
-    } else if (!username) {
-      req.flash('error', 'You must enter an email address')
-      res.redirect(paths.user.forgottenPassword)
-    } else {
-      req.flash('error', 'You must enter a valid email address')
-      res.redirect(paths.user.forgottenPassword)
-    }
-  },
-
-  passwordRequested: (req, res) => {
-    res.render('forgotten-password/password-requested')
-  },
-
-  newPasswordGet: (req, res) => {
-    const id = req.params.id
-    const render = (user) => {
-      if (!user) return renderErrorView(req, res)
-      res.render('forgotten-password/new-password', { id: id })
-    }
-
-    return userService.findByResetToken(id).then(render, () => {
-      req.flash('genericError', 'Something went wrong. Please request a new password reset email.')
-      res.redirect('/login')
-    })
-  },
-
-  newPasswordPost: (req, res) => {
-    let reqUser
-    return userService
-      .findByResetToken(req.params.id)
-      .then(function (forgottenPassword) {
-        return userService.findByExternalId(forgottenPassword.user_external_id, req.correlationId)
-      })
-      .then(function (user) {
-        if (!user) return renderErrorView(req, res)
-        reqUser = user
-        return userService.updatePassword(req.params.id, req.body.password)
-      })
-      .then(function () {
-        return userService.logOut(reqUser)
-          .then(
-            () => {
-              req.session.destroy()
-              req.flash('generic', 'Password has been updated')
-              res.redirect('/login')
-            }
-          ).catch(() => {
-            req.session.destroy()
-            req.flash('generic', 'Password has been updated')
-            res.redirect('/login')
-          })
-      })
-      .catch(function (error) {
-        req.flash('genericError', error.message)
-        res.redirect('/reset-password/' + req.params.id)
-      })
-  }
+  emailGet,
+  emailPost,
+  passwordRequested,
+  newPasswordGet,
+  newPasswordPost
 }

--- a/app/services/user.service.js
+++ b/app/services/user.service.js
@@ -1,11 +1,6 @@
 'use strict'
 
-const commonPassword = require('common-password')
-
 const getAdminUsersClient = require('./clients/adminusers.client')
-
-// Constants
-const MIN_PASSWORD_LENGTH = 10
 
 module.exports = {
 
@@ -118,20 +113,8 @@ module.exports = {
    * @param newPassword
    * @returns {Promise}
    */
-  updatePassword: function (token, newPassword) {
-    return new Promise(function (resolve, reject) {
-      if (newPassword.length < MIN_PASSWORD_LENGTH) {
-        reject(new Error('Password must be 10 characters or more'))
-      } else if (commonPassword(newPassword)) {
-        reject(new Error('The password you tried to create contains a common phrase or combination of characters. Choose something that’s harder to guess.'))
-      } else {
-        getAdminUsersClient().updatePasswordForUser(token, newPassword)
-          .then(
-            () => resolve(),
-            () => reject(new Error('There has been a problem updating password. Please try again.'))
-          )
-      }
-    })
+  updatePassword: function updatePassword (token, newPassword) {
+    return getAdminUsersClient().updatePasswordForUser(token, newPassword)
   },
 
   /**

--- a/app/utils/validation/server-side-form-validations.js
+++ b/app/utils/validation/server-side-form-validations.js
@@ -2,11 +2,13 @@
 
 const moment = require('moment-timezone')
 const ukPostcode = require('uk-postcode')
+const commonPassword = require('common-password')
 
 const {
   isEmpty,
   isFieldGreaterThanMaxLengthChars,
-  isValidEmail
+  isValidEmail,
+  isPasswordLessThanTenChars
 } = require('../../browsered/field-validation-checks')
 const { invalidTelephoneNumber } = require('./telephone-number-validation')
 
@@ -15,68 +17,57 @@ const validReturnObject = {
   message: null
 }
 
-exports.validateOptionalField = function validateOptionalField (value, maxLength) {
+const notValidReturnObject = message => {
+  return {
+    valid: false,
+    message
+  }
+}
+
+const validateOptionalField = function validateOptionalField (value, maxLength) {
   if (!isEmpty(value)) {
     const textTooLongErrorMessage = isFieldGreaterThanMaxLengthChars(value, maxLength)
 
     if (textTooLongErrorMessage) {
-      return {
-        valid: false,
-        message: textTooLongErrorMessage
-      }
+      return notValidReturnObject(textTooLongErrorMessage)
     }
   }
 
   return validReturnObject
 }
 
-exports.validateMandatoryField = function validateMandatoryField (value, maxLength) {
+const validateMandatoryField = function validateMandatoryField (value, maxLength) {
   const isEmptyErrorMessage = isEmpty(value)
   if (isEmptyErrorMessage) {
-    return {
-      valid: false,
-      message: isEmptyErrorMessage
-    }
+    return notValidReturnObject(isEmptyErrorMessage)
   }
 
   const textTooLongErrorMessage = isFieldGreaterThanMaxLengthChars(value, maxLength)
   if (textTooLongErrorMessage) {
-    return {
-      valid: false,
-      message: textTooLongErrorMessage
-    }
+    return notValidReturnObject(textTooLongErrorMessage)
   }
 
   return validReturnObject
 }
 
-exports.validatePhoneNumber = function validatePhoneNumber (phoneNumber) {
+const validatePhoneNumber = function validatePhoneNumber (phoneNumber) {
   const isEmptyErrorMessage = isEmpty(phoneNumber)
   if (isEmptyErrorMessage) {
-    return {
-      valid: false,
-      message: isEmptyErrorMessage
-    }
+    return notValidReturnObject('Enter a telephone number')
   }
 
   const phoneNumberInvalid = invalidTelephoneNumber(phoneNumber)
   if (phoneNumberInvalid) {
-    return {
-      valid: false,
-      message: 'Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192'
-    }
+    return notValidReturnObject('Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
   }
 
   return validReturnObject
 }
 
-exports.validatePostcode = function validatePostcode (postcode, countryCode) {
+const validatePostcode = function validatePostcode (postcode, countryCode) {
   const isEmptyErrorMessage = isEmpty(postcode)
   if (isEmptyErrorMessage) {
-    return {
-      valid: false,
-      message: isEmptyErrorMessage
-    }
+    return notValidReturnObject('Enter a postcode')
   }
 
   // only do proper validation on UK postcodes
@@ -85,89 +76,56 @@ exports.validatePostcode = function validatePostcode (postcode, countryCode) {
   }
 
   if (!/^[A-z0-9 ]+$/.test(postcode)) {
-    return {
-      valid: false,
-      message: 'Please enter a real postcode'
-    }
+    return notValidReturnObject('Please enter a real postcode')
   }
 
   const postcodeIsInvalid = !ukPostcode.fromString(postcode).isComplete()
   if (postcodeIsInvalid) {
-    return {
-      valid: false,
-      message: 'Please enter a real postcode'
-    }
+    return notValidReturnObject('Please enter a real postcode')
   }
 
   return validReturnObject
 }
 
-exports.validateDateOfBirth = function validateDateOfBirth (day, month, year) {
+const validateDateOfBirth = function validateDateOfBirth (day, month, year) {
   const dayIsEmptyErrorMessage = isEmpty(day)
   const monthIsEmptyErrorMessage = isEmpty(month)
   const yearIsEmptyErrorMessage = isEmpty(year)
 
   if (dayIsEmptyErrorMessage && monthIsEmptyErrorMessage && yearIsEmptyErrorMessage) {
-    return {
-      valid: false,
-      message: 'Enter the date of birth'
-    }
+    return notValidReturnObject('Enter the date of birth')
   }
 
   if (dayIsEmptyErrorMessage && !monthIsEmptyErrorMessage && !yearIsEmptyErrorMessage) {
-    return {
-      valid: false,
-      message: 'Date of birth must include a day'
-    }
+    return notValidReturnObject('Date of birth must include a day')
   }
 
   if (!dayIsEmptyErrorMessage && monthIsEmptyErrorMessage && !yearIsEmptyErrorMessage) {
-    return {
-      valid: false,
-      message: 'Date of birth must include a month'
-    }
+    return notValidReturnObject('Date of birth must include a month')
   }
 
   if (!dayIsEmptyErrorMessage && !monthIsEmptyErrorMessage && yearIsEmptyErrorMessage) {
-    return {
-      valid: false,
-      message: 'Date of birth must include a year'
-    }
+    return notValidReturnObject('Date of birth must include a year')
   }
 
   if (dayIsEmptyErrorMessage && monthIsEmptyErrorMessage && !yearIsEmptyErrorMessage) {
-    return {
-      valid: false,
-      message: 'Date of birth must include a day and month'
-    }
+    return notValidReturnObject('Date of birth must include a day and month')
   }
 
   if (dayIsEmptyErrorMessage && !monthIsEmptyErrorMessage && yearIsEmptyErrorMessage) {
-    return {
-      valid: false,
-      message: 'Date of birth must include a day and year'
-    }
+    return notValidReturnObject('Date of birth must include a day and year')
   }
 
   if (!dayIsEmptyErrorMessage && monthIsEmptyErrorMessage && yearIsEmptyErrorMessage) {
-    return {
-      valid: false,
-      message: 'Date of birth must include a month and year'
-    }
+    return notValidReturnObject('Date of birth must include a month and year')
   }
 
   if (!/^[0-9]{1,2}$/.test(day) || !/^[0-9]{1,2}$/.test(month) || !/^[0-9]+$/.test(year)) {
-    return {
-      valid: false,
-      message: 'Enter a real date of birth'
-    }
+    return notValidReturnObject('Enter a real date of birth')
   }
 
   if (!/^[1-9][0-9]{3}$/.test(year)) {
-    return {
-      valid: false,
-      message: 'Year must have 4 numbers'
-    }
+    return notValidReturnObject('Year must have 4 numbers')
   }
 
   const dateOfBirth = moment({
@@ -177,39 +135,53 @@ exports.validateDateOfBirth = function validateDateOfBirth (day, month, year) {
   })
 
   if (!dateOfBirth.isValid()) {
-    return {
-      valid: false,
-      message: 'Enter a real date of birth'
-    }
+    return notValidReturnObject('Enter a real date of birth')
   }
 
   const now = moment()
   if (dateOfBirth.isAfter(now)) {
-    return {
-      valid: false,
-      message: 'Date of birth must be in the past'
-    }
+    return notValidReturnObject('Date of birth must be in the past')
   }
 
   return validReturnObject
 }
 
-exports.validateEmail = function validateEmail (email) {
-  const isEmptyErrorMessage = isEmpty(email)
-  if (isEmptyErrorMessage) {
-    return {
-      valid: false,
-      message: isEmptyErrorMessage
-    }
+const validateEmail = function validateEmail (email) {
+  if (isEmpty(email)) {
+    return notValidReturnObject('Enter an email address')
   }
 
   const invalidEmailErrorMessage = isValidEmail(email)
   if (invalidEmailErrorMessage) {
-    return {
-      valid: false,
-      message: invalidEmailErrorMessage
-    }
+    return notValidReturnObject(invalidEmailErrorMessage)
   }
 
   return validReturnObject
+}
+
+const validatePassword = function validatePassword (password) {
+  if (isEmpty(password)) {
+    return notValidReturnObject('Enter a password')
+  }
+
+  const invalidPasswordMessage = isPasswordLessThanTenChars(password)
+  if (invalidPasswordMessage) {
+    return notValidReturnObject(invalidPasswordMessage)
+  }
+
+  if (commonPassword(password)) {
+    return notValidReturnObject('The password you tried to create contains a common phrase or combination of characters. Choose something that’s harder to guess.')
+  }
+
+  return validReturnObject
+}
+
+module.exports = {
+  validateOptionalField,
+  validateMandatoryField,
+  validatePhoneNumber,
+  validatePostcode,
+  validateDateOfBirth,
+  validateEmail,
+  validatePassword
 }

--- a/app/utils/validation/server-side-form-validations.test.js
+++ b/app/utils/validation/server-side-form-validations.test.js
@@ -9,7 +9,7 @@ const BLANK_TEXT = ''
 const MAX_LENGTH = 25
 const LOOOONG_TEXT = 'abcdefghijklmnopqrstuvwxyz'
 
-describe('Responsible person page field validations', () => {
+describe('Server side form validations', () => {
   describe('optional text field validations', () => {
     it('should validate that optional text is valid', () => {
       expect(validations.validateOptionalField('some text', MAX_LENGTH).valid).to.be.true // eslint-disable-line
@@ -67,7 +67,7 @@ describe('Responsible person page field validations', () => {
     it('should not be valid when postcode is blank', () => {
       expect(validations.validatePostcode(BLANK_TEXT)).to.deep.equal({
         valid: false,
-        message: 'This field cannot be blank'
+        message: 'Enter a postcode'
       })
     })
 
@@ -220,7 +220,7 @@ describe('Responsible person page field validations', () => {
     it('should not be valid for empty phone number', () => {
       expect(validations.validatePhoneNumber('')).to.deep.equal({
         valid: false,
-        message: 'This field cannot be blank'
+        message: 'Enter a telephone number'
       })
     })
 
@@ -240,7 +240,7 @@ describe('Responsible person page field validations', () => {
     it('should not be valid for empty email address', () => {
       expect(validations.validateEmail('')).to.deep.equal({
         valid: false,
-        message: 'This field cannot be blank'
+        message: 'Enter an email address'
       })
     })
 
@@ -248,6 +248,26 @@ describe('Responsible person page field validations', () => {
       expect(validations.validateEmail('abd')).to.deep.equal({
         valid: false,
         message: 'Please use a valid email address'
+      })
+    })
+  })
+
+  describe('password validation', () => {
+    it('should be valid for a not common password over 10 characters long', () => {
+      expect(validations.validatePassword('over-10-cha').valid).to.be.true // eslint-disable-line
+    })
+
+    it('should not be valid for a password that is too short', () => {
+      expect(validations.validatePassword('ashortstr')).to.deep.equal({
+        valid: false,
+        message:'Password must be 10 characters or more'
+      })
+    })
+
+    it('should not be valid for a common password', () => {
+      expect(validations.validatePassword('1234567890')).to.deep.equal({
+        valid: false,
+        message:'The password you tried to create contains a common phrase or combination of characters. Choose something that’s harder to guess.'
       })
     })
   })

--- a/app/views/forgotten-password/index.njk
+++ b/app/views/forgotten-password/index.njk
@@ -1,4 +1,5 @@
 {% extends "../layout-logged-out.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
 
 {% block pageTitle %}
 Forgot your password - GOV.UK Pay
@@ -6,18 +7,13 @@ Forgot your password - GOV.UK Pay
 
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
-  {% if flash.error %}
-  <div class="govuk-error-summary hidden" aria-labelledby="error-summary-heading-example-1" role="alert" tabindex="-1" data-module="govuk-error-summary">
-    <h2 class="govuk-error-summary__title" id="error-summary-heading-example-1">
-      There was a problem with the details you gave for:
-    </h2>
-    <div class="govuk-error-summary__body">
-      <ul class="govuk-list govuk-error-summary__list">
-        <li><a href="#username">Email</a></li>
-      </ul>
-    </div>
-  </div>
-  {% endif %}
+  {{ errorSummary ({
+    errors: errors,
+    hrefs: {
+      username: '#username'
+    }
+  }) }}
+
   <form action="/reset-password" method="post" class="form submit-forgotten-email">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <h1 class="govuk-heading-l page-title">
@@ -25,20 +21,12 @@ Forgot your password - GOV.UK Pay
     </h1>
     <p class="govuk-body">We'll then send you an email which you can use to set up a new password.</p>
 
-    {% set error = false %}
-
-    {% if flash.error %}
-      {% set error = {
-        text: flash.error
-      } %}
-    {% endif %}
-
     {{ govukInput({
         label: {
           text: "Email address"
         },
         id: "username",
-        errorMessage: error,
+        errorMessage: { text: errors.username } if errors.username else false,
         name: "username",
         classes: "govuk-!-width-two-thirds",
         type: "email"

--- a/app/views/forgotten-password/new-password.njk
+++ b/app/views/forgotten-password/new-password.njk
@@ -1,4 +1,5 @@
 {% extends "../layout-logged-out.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
 
 {% block pageTitle %}
   Create a new password - GOV.UK Pay
@@ -6,6 +7,13 @@
 
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
+  {{ errorSummary ({
+    errors: errors,
+    hrefs: {
+      password: '#password'
+    }
+  }) }}
+
   <form action="/reset-password/{{id}}"method="post" class="form submit-new-password">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
     <h1 class="govuk-heading-l page-title">
@@ -23,7 +31,8 @@
         name: "password",
         classes: "govuk-!-width-two-thirds",
         type: "password",
-        autocomplete: "new-password"
+        autocomplete: "new-password",
+        errorMessage: { text: errors.password } if errors.password else false
       })
     }}
 

--- a/test/unit/controller/edit-merchant-details-controller/post-edit.controller.test.js
+++ b/test/unit/controller/edit-merchant-details-controller/post-edit.controller.test.js
@@ -263,10 +263,10 @@ describe('edit merchant details controller - post', () => {
       expect(req.session.pageData.editMerchantDetails.success).to.be.false // eslint-disable-line
       expect(req.session.pageData.editMerchantDetails.errors).to.deep.equal({
         'merchant-name': 'This field cannot be blank',
-        'telephone-number': 'This field cannot be blank',
+        'telephone-number': 'Enter a telephone number',
         'address-line1': 'This field cannot be blank',
         'address-city': 'This field cannot be blank',
-        'address-postcode': 'This field cannot be blank',
+        'address-postcode': 'Enter a postcode',
         'address-country': 'This field cannot be blank'
       })
     })
@@ -312,10 +312,10 @@ describe('edit merchant details controller - post', () => {
         'merchant-name': 'This field cannot be blank',
         'address-line1': 'This field cannot be blank',
         'address-city': 'This field cannot be blank',
-        'address-postcode': 'This field cannot be blank',
+        'address-postcode': 'Enter a postcode',
         'address-country': 'This field cannot be blank',
-        'telephone-number': 'This field cannot be blank',
-        'merchant-email': 'This field cannot be blank'
+        'telephone-number': 'Enter a telephone number',
+        'merchant-email': 'Enter an email address'
       })
     })
   })


### PR DESCRIPTION
Currently, if an email address is entered that no account is found for, we would attempt to redirect to the URL for resetting the password resulting in a confusing error message being displayed.

Instead, handle a 404 from adminusers by displaying a sensible error message and redirecting to the same page to enter an an email address to request a password reset.

Fix this and also fix the following:
- Display error messages properly using the error summary component and inline error messages.
- Make the controller easier to read by using async/await.
- Don't use anonymous functions for controllers.
- Move password validation out of the service and into the common server-side-form-validations module so we can distinguish between errors from adminusers and errors from selfservice. While doing this, make a few error messages better.


