### PR TITLE
PP-6958 public facing url should contain 'hide' not 'mask'

### DIFF
--- a/app/paths.js
+++ b/app/paths.js
@@ -117,8 +117,8 @@ module.exports = {
     index: '/3ds'
   },
   toggleMotoMaskCardNumberAndSecurityCode: {
-    cardNumber: '/moto-mask-card-number',
-    securityCode: '/moto-mask-security-code'
+    cardNumber: '/moto-hide-card-number',
+    securityCode: '/moto-hide-security-code'
   },
   toggleBillingAddress: {
     index: '/billing-address'


### PR DESCRIPTION
Description:

 - Currently the public facing urls are moto-mask-card-number & moto-mask-security-code. We are modifying then to be moto-hide-card-number & moto-hide-security-code respectively.


