### PR TITLE
BAU Don't tell user account doesn't exist for password reset

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2020-09-07T17:13:42Z",
+  "generated_at": "2020-09-09T11:43:00Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -248,7 +248,7 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 177,
+        "line_number": 187,
         "type": "Secret Keyword"
       }
     ],

--- a/app/controllers/forgotten-password.controller.js
+++ b/app/controllers/forgotten-password.controller.js
@@ -31,12 +31,9 @@ const emailPost = async function emailPost (req, res) {
     res.redirect(paths.user.passwordRequested)
   } catch (err) {
     if (err.errorCode === 404) {
-      return res.render('forgotten-password/index', {
-        username,
-        errors: {
-          username: "No account was found for this email address"
-        }
-      })
+      // Tell the user an email has been sent if the account doesn't exist
+      // This is to prevent username enumeration
+      res.redirect(paths.user.passwordRequested)
     } else {
       logger.error('Sending password reset email failed: ' + err)
       req.flash('genericError', 'Something went wrong. Please try again.')


### PR DESCRIPTION
Prevent email enumeration attempts by not telling users that an account
doesn't exist when an email address is entered for a non-existent
account.

Instead, show that page that says we have sent an email.

