### PR TITLE
BAU — Replace apostrophes with right single quotation marks

### DIFF
--- a/app/views/request-to-go-live/choose-how-to-process-payments.njk
+++ b/app/views/request-to-go-live/choose-how-to-process-payments.njk
@@ -64,7 +64,7 @@
           },
           {
             value: 'gov_banking',
-            text: "Government Banking's provider",
+            text: "Government Banking’s provider",
             label: {
               classes: "govuk-label--s"
             },

--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -63,7 +63,7 @@ Request a live account - {{ currentService.name }} - GOV.UK Pay
 
     {% call govukFieldset({
     legend: {
-    text: "What is your organisation's address?",
+    text: "What is your organisation’s address?",
     classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-4",
     isPageHeading: true
     }

--- a/app/views/settings/index.njk
+++ b/app/views/settings/index.njk
@@ -210,7 +210,7 @@
     
     {% if allowMoto %}
       <h1 id="moto-mask-security-settings-heading" class="govuk-heading-m govuk-!-margin-top-8">Security</h1>
-      <p class="govuk-body">Hide sensitive details being viewed on a call agent's screen.</p>
+      <p class="govuk-body">Hide sensitive details being viewed on a call agent’s screen.</p>
 
       {{
         govukSummaryList({

--- a/test/cypress/integration/request-to-go-live/organisation-address.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/organisation-address.cy.test.js
@@ -33,7 +33,7 @@ describe('The organisation address page', () => {
         cy.setEncryptedCookies(userExternalId, gatewayAccountId)
         cy.visit(pageUrl)
 
-        cy.get('h1').should('contain', `What is your organisation's address?`)
+        cy.get('h1').should('contain', `What is your organisation’s address?`)
 
         cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)
           .should('exist')


### PR DESCRIPTION
Replace ' apostrophes (U+0027) with ’ right single quotation marks (U+2019) in possessive nouns in user-facing text on admin tool pages.

Because it was annoying me.