### PR TITLE
PP-7079 DAC Audit - Stripe Setup > VAT number heading - move the label tag inside the heading tag

### DIFF
--- a/app/views/stripe-setup/vat-number/index.njk
+++ b/app/views/stripe-setup/vat-number/index.njk
@@ -19,7 +19,7 @@
         errorList: errorList
       }) }}
     {% endif %}
-    <label for="vat-number"><h1 class="govuk-heading-l govuk-!-margin-bottom-6">What is your organisation’s VAT number?</h1></label>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-6"><label for="vat-number">What is your organisation’s VAT number?</label></h1>
 
     <form id="vat-number-form" method="post"
           action="/vat-number" novalidate>


### PR DESCRIPTION
- The label tag was outside the H1 tag.
- This has been moved into the H1 tag.