### PR TITLE
BAU - Fix broken link to Google Pay documentation

### DIFF
--- a/app/views/digital-wallet/google-pay.njk
+++ b/app/views/digital-wallet/google-pay.njk
@@ -24,7 +24,7 @@
       </ul>
 
       <p class="govuk-body">
-        You’ll need a Google Pay merchant ID. Refer to the <a class="govuk-link" href="https://docs.payments.service.gov.uk/optional_features/digital_wallets/#enable-google-pay">GOV.UK Pay documentation on enabling Google Pay</a> to learn where to find your merchant ID.
+        You’ll need a Google Pay merchant ID. Refer to the <a class="govuk-link" href="https://docs.payments.service.gov.uk/digital_wallets/#enable-google-pay">GOV.UK Pay documentation on enabling Google Pay</a> to learn where to find your merchant ID.
       </p>
 
       <form method="post" action="{{routes.digitalWallet.googlePay}}">


### PR DESCRIPTION
Description:
- On selfservice.payments.service.gov.uk/digital-wallet/google-pay the link to the Google Pay documentation is broken. This PR provides the correct link


