### PR TITLE
PP-7092 DAC Audit - Delete Payment Link > Focus heading & change to H1

### DIFF
--- a/app/browsered/target-to-show.js
+++ b/app/browsered/target-to-show.js
@@ -26,6 +26,10 @@ module.exports.init = () => {
           target.style.display = 'none'
         })
         toggleTarget.style.display = 'block'
+
+        const targetHeading = toggleTarget.querySelector('.target-to-show__heading')
+        if (targetHeading) targetHeading.focus()
+
         if (toggleContainer) toggleContainer.style.display = 'none'
       }, false)
 

--- a/app/views/payment-links/_product.njk
+++ b/app/views/payment-links/_product.njk
@@ -28,9 +28,9 @@
                     {{product.name}}</span></a>
             <div class="target-to-show govuk-!-margin-top-6" id="delete-{{ product.externalId }}">
                 <div class="govuk-error-summary" role="group" aria-labelledby="error-summary" tabindex="-1">
-                    <h1 class="govuk-error-summary__title" id="error-summary">
+                    <h2 tabindex="0" class="target-to-show__heading govuk-error-summary__title" id="error-summary">
                         Are you sure you want to delete this link?
-                    </h1>
+                    </h2>
                     <div class="button-group">
                       {{
                         govukButton({


### PR DESCRIPTION
- When someone clicks `Payment Link > Delete` - then the `heading` of the delete box is put into focus.
- This means a blue outline is displayed around the `Are you sure you want to delete this link?` heading
- Change the heading to the H2
- Also need to add a `tabindex=0` to the heading - to allow it to be focused -see: https://developers.google.com/web/fundamentals/accessibility/focus/using-tabindex

Screen shot:
![image](https://user-images.githubusercontent.com/59831992/93583841-5d139400-f99c-11ea-972e-3f3b9fa28d66.png)


