### PR TITLE
PP-7090 DAC Audit - Api keys page > Replace tabs with links

### DIFF
--- a/app/views/api-keys/_keys.njk
+++ b/app/views/api-keys/_keys.njk
@@ -9,6 +9,19 @@
   There are no {{token_state}} API keys
   {% endif %}
 </h2>
+
+{% if active %}
+  {% set apiKeyLinkRoute = routes.apiKeys.revoked %}
+  {% set apiKeyLinkText = 'revoked' %}
+{% else %}
+  {% set apiKeyLinkRoute = routes.apiKeys.index %}
+  {% set apiKeyLinkText = 'active' %}
+{% endif %}
+
+<div class="govuk-body">
+  <a class="govuk-link" href="{{ apiKeyLinkRoute }}">View {{apiKeyLinkText}} keys</a>
+</div>
+
 {% if permissions.tokens_create %}
   {% if active %}
     {{

--- a/app/views/api-keys/index.njk
+++ b/app/views/api-keys/index.njk
@@ -11,38 +11,7 @@ API Keys - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK 
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l page-title">API Keys</h1>
-
-{% set keysHTML %}
+  
   {% include "./_keys.njk" %}
-{% endset %}
-
-  <div class="govuk-tabs">
-    <ul class="govuk-tabs__list">
-      {% if active %}
-        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-          <a class="govuk-tabs__tab" href="#active-keys" aria-selected="true">
-            Active keys
-          </a>
-        </li>
-        <li class="govuk-tabs__list-item">
-          <a id="revoked-keys-tab" class="govuk-tabs__tab govuk-tabs__tab" href="{{ routes.apiKeys.revoked }}">
-            Revoked keys
-          </a>
-        </li>
-      {% else %}
-        <li class="govuk-tabs__list-item">
-          <a class="govuk-tabs__tab" href="{{ routes.apiKeys.index }}">
-            Active keys
-          </a>
-        </li>
-        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-          <a class="govuk-tabs__tab" href="#revoked-keys" aria-selected="true">
-            Revoked keys
-          </a>
-        </li>
-      {% endif %}
-    </ul>
-    {% include "./_keys.njk" %}
-  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
- Would take too long to update the tabs to work fully with the Design Sytem tabs component.
- Therefore, removed the tabs and replaced with plain links.

## Updated main API Keys page:
![image](https://user-images.githubusercontent.com/59831992/93607496-4df30d00-f9c1-11ea-9382-2ec28dd1b373.png)


## Updated Revoked API Keys page
![image](https://user-images.githubusercontent.com/59831992/93607395-2bf98a80-f9c1-11ea-851e-51794c02d25a.png)


