### PR TITLE
PP-7101 DAC Audit - Transactions Page > Add `fieldset` and `legend` tag

### DIFF
--- a/app/views/transactions/filter.njk
+++ b/app/views/transactions/filter.njk
@@ -79,46 +79,56 @@
       }}
     </div>
     <div class="govuk-grid-column-one-quarter">
-      {{
-        govukSelect({
-          id: "card-brand",
-          name: "brand",
-          classes: 'govuk-!-font-size-16',
-          label: {
-            text: "Card brand",
-            classes: 'govuk-label--s govuk-!-font-size-16 govuk-!-margin-bottom-0'
-          },
-          hint: {
-            text: "Select a brand",
-            classes: 'govuk-!-font-size-14'
-          },
-          attributes: {
-            'data-enhance-multiple': true
-          },
-          items: cardBrands
-        })
-      }}
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-visually-hidden">
+            Card brand
+        </legend>
+        {{
+          govukSelect({
+            id: "card-brand",
+            name: "brand",
+            classes: 'govuk-!-font-size-16',
+            label: {
+              text: "Card brand",
+              classes: 'govuk-label--s govuk-!-font-size-16 govuk-!-margin-bottom-0'
+            },
+            hint: {
+              text: "Select a brand",
+              classes: 'govuk-!-font-size-14'
+            },
+            attributes: {
+              'data-enhance-multiple': true
+            },
+            items: cardBrands
+          })
+        }}
+      </fieldset>
     </div>
     <div class="govuk-grid-column-one-quarter">
-      {{
-        govukSelect({
-          id: "state",
-          name: "state",
-          classes: 'govuk-!-font-size-16',
-          label: {
-            text: "Payment status",
-            classes: 'govuk-label--s govuk-!-font-size-16 govuk-!-margin-bottom-0'
-          },
-          hint: {
-            text: "Select an option",
-            classes: 'govuk-!-font-size-14'
-          },
-          attributes: {
-            'data-enhance-multiple': true
-          },
-          items: eventStates
-        })
-      }}
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-visually-hidden">
+            Payment status
+        </legend>
+        {{
+          govukSelect({
+            id: "state",
+            name: "state",
+            classes: 'govuk-!-font-size-16',
+            label: {
+              text: "Payment status",
+              classes: 'govuk-label--s govuk-!-font-size-16 govuk-!-margin-bottom-0'
+            },
+            hint: {
+              text: "Select an option",
+              classes: 'govuk-!-font-size-14'
+            },
+            attributes: {
+              'data-enhance-multiple': true
+            },
+            items: eventStates
+          })
+        }}
+        </fieldset> 
     </div>
     <div class="govuk-grid-column-one-half">
       <fieldset class="govuk-fieldset">


### PR DESCRIPTION
- On the transactions page, wrap the `Card brand` and `Payment status` with `fieldset` and `legend` tags
- The page will still look the same.

![image](https://user-images.githubusercontent.com/59831992/93864619-13d58400-fcbd-11ea-8fe1-efb2490dd3e6.png)

![image](https://user-images.githubusercontent.com/59831992/93864664-218b0980-fcbd-11ea-9bd4-3d266b3ff510.png)




