### PR TITLE
PP-7110 DAC Audit - Prototype links > Fix reflow issue.

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -44,3 +44,4 @@ $govuk-page-width: 1200px;
 @import "components/psp-go-live-panel";
 @import "components/demo-payment";
 @import "components/my-profile";
+@import "components/prototype-links";

--- a/app/assets/sass/components/prototype-links.scss
+++ b/app/assets/sass/components/prototype-links.scss
@@ -1,0 +1,3 @@
+.pay-protototype-link {
+  word-break: break-all;
+}

--- a/app/views/dashboard/demo-service/confirm.njk
+++ b/app/views/dashboard/demo-service/confirm.njk
@@ -23,7 +23,7 @@
   <p class="govuk-body">This link will send the user to our payment pages. Use it in a “pay now” button, for example, to integrate it with your prototype.</p>
 
   {% set prototypeLink %}
-    <p class="govuk-body govuk-!-font-weight-bold"><a class="govuk-link" id="prototyping__links-link-create-payment" href="{{prototypeLink}}">{{prototypeLink}}</a></p>
+    <p class="govuk-body govuk-!-font-weight-bold"><a class="pay-protototype-link govuk-link" id="prototyping__links-link-create-payment" href="{{prototypeLink}}">{{prototypeLink}}</a></p>
   {% endset %}
 
   {{


### PR DESCRIPTION
- Add the CSS `word-break: break-all` - so that long urls are wrapped across multiple lines.
- Add new SCSS file for prototype links.

Screenshot: Long Prototype urls now wrap onto multiple lines when you zoom in 400%.

![image](https://user-images.githubusercontent.com/59831992/93872199-b7c42d00-fcc7-11ea-9535-54c26ad737e6.png)



