### PR TITLE
PP-7108 DAC Audit - Copy API key > Add "aria-live" region

### DIFF
--- a/app/browsered/copy-text.js
+++ b/app/browsered/copy-text.js
@@ -14,11 +14,18 @@ module.exports = () => {
     const textToCopy = document.getElementsByClassName(targetElement)[0].innerText
     const originalLabelText = e.target.innerText
 
+    const targetNotificationElement = e.target.dataset['notificationTarget']
+    const notificationElement = document.getElementsByClassName(targetNotificationElement)[0]
+
     temp.value = textToCopy
     temp.select()
     document.execCommand('copy')
     temp.remove()
     e.target.innerText = e.target.dataset.success
+
+    if (notificationElement) {
+      notificationElement.innerText = e.target.dataset.success
+    }
 
     window.setTimeout(() => {
       e.target.innerText = originalLabelText

--- a/app/views/api-keys/create.njk
+++ b/app/views/api-keys/create.njk
@@ -65,10 +65,14 @@ Create an API key - {{currentService.name}} {{currentGatewayAccount.full_type}} 
           id: "generate-button",
           "data-copy-text": true,
           "data-target": "copy-this-api-key",
-          "data-success": "API key has been copied"
+          "data-success": "API key has been copied",
+          "data-notification-target": "copy-this-api-key-notification" 
         }
       })
     }}
+
+    <div class="copy-this-api-key-notification govuk-visually-hidden" aria-live="assertive"></div>
+
     <p class="govuk-body">
       <a class="govuk-link govuk-link--no-visited-state" href="{{routes.apiKeys.index}}" id="finish-link">
         Back to API keys


### PR DESCRIPTION
- In the `create API key` flow, when you press the button `Copy API key to clopboard`, it does the following:
  - Button contains a data attribute with a selector to a hidden div that has `aria-live=assertive`
  - When the button is pressed, it also updates the div with the message `Copy API key to clipboard`
  - This message is read out by screen readers.

Screenshots:
![image](https://user-images.githubusercontent.com/59831992/93891751-a7ba4680-fce3-11ea-9bcd-bb4506615fdf.png)

![image](https://user-images.githubusercontent.com/59831992/93891817-bbfe4380-fce3-11ea-869f-3a23d34943b9.png)


