### PR TITLE
PP-7094 Update links on dashboard to use correct states

### DIFF
--- a/app/controllers/dashboard/dashboard-activity.controller.js
+++ b/app/controllers/dashboard/dashboard-activity.controller.js
@@ -128,7 +128,6 @@ module.exports = async (req, res) => {
       const result = await LedgerClient.transactionSummary(gatewayAccountId, fromDateTime, toDateTime, { correlationId: correlationId })
       response(req, res, 'dashboard/index', Object.assign(model, {
         activity: result,
-        successfulTransactionsState: 'payment-success',
         fromDateTime,
         toDateTime,
         transactionsPeriodString

--- a/app/views/dashboard/_activity.njk
+++ b/app/views/dashboard/_activity.njk
@@ -47,7 +47,7 @@
   <article class="dashboard-total-group govuk-grid-column-one-third">
     <header class="dashboard-total-group__heading">
       <h2 class="dashboard-total-group__title">
-        <a class="govuk-link" href="{{routes.transactions.index}}?state={{successfulTransactionsState}}&amp;{{ transactionsPeriodString }}" title="View successful payment transactions for chosen time period">
+        <a class="govuk-link" href="{{routes.transactions.index}}?state=Success&amp;{{ transactionsPeriodString }}" title="View successful payment transactions for chosen time period">
           Successful payments
         </a>    
       </h2>
@@ -62,7 +62,7 @@
   <article class="dashboard-total-group govuk-grid-column-one-third">
     <header class="dashboard-total-group__heading">
       <h2 class="dashboard-total-group__title">
-        <a class="govuk-link" href="{{routes.transactions.index}}?state=refund-success&amp;{{ transactionsPeriodString }}" title="View refunded transactions for chosen time period">
+        <a class="govuk-link" href="{{routes.transactions.index}}?state=Refund+success&amp;{{ transactionsPeriodString }}" title="View refunded transactions for chosen time period">
           Successful refunds
         </a>
       </h2>
@@ -77,7 +77,7 @@
   <article class="dashboard-total-group govuk-grid-column-one-third">
     <header class="dashboard-total-group__heading">
       <h2 class="dashboard-total-group__title">
-        <a class="govuk-link" href="{{routes.transactions.index}}?state=payment-success&amp;state=refund-success&amp;{{ transactionsPeriodString }}" title="View successful payments and refunded transactions for chosen time period">
+        <a class="govuk-link" href="{{routes.transactions.index}}?state=Success&amp;state=Refund+success&amp;{{ transactionsPeriodString }}" title="View successful payments and refunded transactions for chosen time period">
           Net income
         </a>
       </h2>


### PR DESCRIPTION
The links used state strings that do not map to any of the states expected by the transactions list page. It is possible, these are old representations of the states.

Update the links so that they filter the transactions list correctly.


