### PR TITLE
PP-7214 "Debounce" refund button submission

### DIFF
--- a/app/views/transaction-detail/_refund.njk
+++ b/app/views/transaction-detail/_refund.njk
@@ -109,6 +109,7 @@
       govukButton({
         text: 'Refund payment',
         classes: 'govuk-button--warning refund__submit-button',
+        preventDoubleClick: true,
         attributes: {
           id: 'refund-button'
         }


### PR DESCRIPTION
Add the `preventDoubleClick` attribute to the refund payment button.
This "debounces" event propagation for clicks for 1 second after the
button is pressed.

This can only prevent subsequent clicks for 1 second.

This is a temporary fix which will help solve double clicking however as
this is a terminal POST request a further script should be added to
fully disable the button until the action is completed.