### PR TITLE
PP-7228 Use error summary for smartpay credentials page

### DIFF
--- a/app/views/credentials/smartpay.njk
+++ b/app/views/credentials/smartpay.njk
@@ -1,11 +1,18 @@
 {% extends "./index.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
 
 {% block provider_content %}
+  {{ errorSummary ({
+    errors: lastNotificationsData.errors,
+    hrefs: {
+      username: '#notification-username', 
+      password: '#notification-password' {# // pragma: allowlist secret #}
+    }
+  }) }}
   {% if editNotificationCredentialsMode %}
     <form id="notification_credentials_form" method="post" action="{{routes.notificationCredentials.update}}" data-validate>
       <input id="notification-csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
-      {% set username %}{{lastNotificationsData.username or currentGatewayAccount.notificationCredentials.userName}}{% endset %}
       {{ govukInput({
           label: {
             text: "Username"
@@ -17,7 +24,8 @@
           attributes: {
             "data-validate": "required"
           },
-          value: username
+          value: lastNotificationsData.username or currentGatewayAccount.notificationCredentials.userName,
+          errorMessage: { text: lastNotificationsData.errors.username } if lastNotificationsData.errors.username else false
         })
       }}
 
@@ -32,7 +40,8 @@
           attributes: {
             "data-validate": "required passwordLessThanTenChars"
           },
-          value: lastNotificationsData.password
+          value: lastNotificationsData.password,
+          errorMessage: { text: lastNotificationsData.errors.password } if lastNotificationsData.errors.password else false
         })
       }}
 


### PR DESCRIPTION
Rather than using the req.flash to display form validation errors, put the validation errors in the session cookie and then display them on the form after redirecting using the `error-summary.njk` nunjucks macro, which wraps the design system component.


