### PR TITLE
PP-7228 Clear recovered session after redirect

### DIFF
--- a/app/controllers/register-service.controller.js
+++ b/app/controllers/register-service.controller.js
@@ -30,7 +30,7 @@ const registrationSessionPresent = function registrationSessionPresent (sessionD
  */
 const showRegistration = function showRegistration (req, res) {
   const recovered = lodash.get(req, 'session.pageData.submitRegistration.recovered', {})
-  lodash.unset('session.pageData.submitRegistration.recovered')
+  lodash.unset(req, 'session.pageData.submitRegistration.recovered')
   res.render('self-create-service/register', {
     email: recovered.email,
     telephoneNumber: recovered.telephoneNumber,


### PR DESCRIPTION
Weren't clearing the recovered session after redirecting, so refreshing the page would cause errors to be re-displayed when we would expect the form and the errors to be cleared.
