### PR TITLE
PP-7304 Remove Direct Debit from services page

### DIFF
--- a/app/controllers/my-services/get-index.controller.js
+++ b/app/controllers/my-services/get-index.controller.js
@@ -36,13 +36,11 @@ module.exports = async (req, res) => {
       aggregatedGatewayAccounts.filter(gatewayAccount => serviceRole.service.gatewayAccountIds.includes(gatewayAccount.external_id.toString()) ||
         serviceRole.service.gatewayAccountIds.includes(gatewayAccount.id.toString()))
     const cardAccounts = gatewayAccounts.filter(gatewayAccount => !isDirectDebitAccount(gatewayAccount))
-    const directdebitAccounts = gatewayAccounts.filter(isDirectDebitAccount)
     const payload = {
       name: serviceRole.service.name === 'System Generated' ? 'Temporary Service Name' : serviceRole.service.name,
       external_id: serviceRole.service.externalId,
       gateway_accounts: {
-        cardAccounts: _.sortBy(cardAccounts, 'type', 'asc'),
-        directdebitAccounts
+        cardAccounts: _.sortBy(cardAccounts, 'type', 'asc')
       },
       permissions: getHeldPermissions(serviceRole.role.permissions.map(permission => permission.name))
     }

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -177,24 +177,17 @@ ConnectorClient.prototype = {
    *@return {Promise}
    */
   getAccounts: function (params) {
-    return new Promise((resolve, reject) => {
-      let url = _accountsUrlFor(params.gatewayAccountIds, this.connectorUrl)
-      let startTime = new Date()
-      let context = {
-        url: url,
-        defer: { resolve: resolve, reject: reject },
-        startTime: startTime,
-        correlationId: params.correlationId,
-        method: 'GET',
-        description: 'get an account',
-        service: SERVICE_NAME
-      }
+    let url = _accountsUrlFor(params.gatewayAccountIds, this.connectorUrl)
+    let context = {
+      url: url,
+      correlationId: params.correlationId,
+      description: 'get an account',
+      service: SERVICE_NAME
+    }
 
-      let callbackToPromiseConverter = createCallbackToPromiseConverter(context)
-
-      oldBaseClient.get(url, params, callbackToPromiseConverter)
-        .on('error', callbackToPromiseConverter)
-    })
+    return baseClient.get(
+      url, context
+    )
   },
 
   /**


### PR DESCRIPTION
This is the first PR - the Nunjuks work will be done in another PR:

- Remove the backend Node JS for Direct Debit on the services page.
- Update the connector client
  - getGatewayAccounts - Use the `baseClient` instead of `oldBaseClient`
- Update relevant tests
  - Update Nock requests to work with requests that use the new `baseClient`