### PR TITLE
PP-5236 Cleanup token creation controllers

### DIFF
--- a/app/controllers/api-keys/post-create.controller.js
+++ b/app/controllers/api-keys/post-create.controller.js
@@ -1,29 +1,28 @@
 'use strict'
 
-const { response, renderErrorView } = require('../../utils/response.js')
+const { response } = require('../../utils/response.js')
 const auth = require('../../services/auth.service.js')
 const publicAuthClient = require('../../services/clients/public-auth.client')
 const { isADirectDebitAccount } = require('../../services/clients/direct-debit-connector.client.js')
 
-module.exports = (req, res) => {
-  // current account id is either external (DIRECT_DEBIT) or internal (CARD) for now
-  const currentAccountId = auth.getCurrentGatewayAccountId(req)
+module.exports = async function createAPIKey (req, res, next) {
+  const accountId = auth.getCurrentGatewayAccountId(req)
   const correlationId = req.correlationId
   const description = req.body.description
   const payload = {
-    'account_id': currentAccountId,
-    'description': description,
-    'created_by': req.user.email,
-    'token_type': isADirectDebitAccount(currentAccountId) ? 'DIRECT_DEBIT' : 'CARD'
+    description: description,
+    account_id: accountId,
+    created_by: req.user.email,
+    token_type: isADirectDebitAccount(accountId) ? 'DIRECT_DEBIT' : 'CARD'
   }
-  publicAuthClient.createTokenForAccount({
-    payload: payload,
-    accountId: currentAccountId,
-    correlationId: correlationId
-  })
-    .then(publicAuthData => response(req, res, 'api-keys/create', {
-      token: publicAuthData.token,
-      description: description
-    }))
-    .catch((reason) => renderErrorView(req, res))
+
+  try {
+    const createTokenResponse = await publicAuthClient.createTokenForAccount({ payload, accountId, correlationId })
+    response(req, res, 'api-keys/create', {
+      description,
+      token: createTokenResponse.token
+    })
+  } catch (error) {
+    next(error)
+  }
 }


### PR DESCRIPTION
Update controllers that deal with creating potentially external API
keys. Use more up to date Node guidance to make the code clearer.

* Use clearer variable naming
* Use async/ await
* Handle errors using `next` and middleware where appropriate
* Name any large anonymous methods
* Simplify object construction


