### PR TITLE
PP-5236 Api key create requests pass through account type

### DIFF
--- a/app/controllers/api-keys/post-create.controller.js
+++ b/app/controllers/api-keys/post-create.controller.js
@@ -13,7 +13,8 @@ module.exports = async function createAPIKey (req, res, next) {
     description: description,
     account_id: accountId,
     created_by: req.user.email,
-    token_type: isADirectDebitAccount(accountId) ? 'DIRECT_DEBIT' : 'CARD'
+    token_type: isADirectDebitAccount(accountId) ? 'DIRECT_DEBIT' : 'CARD',
+    token_account_type: req.account.type
   }
 
   try {

--- a/app/controllers/payment-links/post-review.controller.js
+++ b/app/controllers/payment-links/post-review.controller.js
@@ -35,7 +35,8 @@ module.exports = async function createPaymentLink (req, res) {
         account_id: gatewayAccountId,
         created_by: req.user.email,
         type: 'PRODUCTS',
-        description: `Token for “${paymentLinkTitle}” payment link`
+        description: `Token for “${paymentLinkTitle}” payment link`,
+        token_account_type: req.account.type
       }
     })
 

--- a/test/unit/controller/api-keys/post-create.controller.ft.test.js
+++ b/test/unit/controller/api-keys/post-create.controller.ft.test.js
@@ -38,14 +38,16 @@ describe('POST to create an API key', () => {
           'account_id': GATEWAY_ACCOUNT_ID,
           'description': '',
           'created_by': user.email,
-          'token_type': 'CARD'
+          'token_type': 'CARD',
+          'token_account_type': 'live'
         }
       )
         .reply(200, TOKEN_RESPONSE)
 
       nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
         .reply(200, {
-          payment_provider: 'sandbox'
+          payment_provider: 'sandbox',
+          type: 'live'
         })
 
       supertest(app)
@@ -86,14 +88,16 @@ describe('POST to create an API key', () => {
           'account_id': GATEWAY_ACCOUNT_ID,
           'description': DESCRIPTION,
           'created_by': user.email,
-          'token_type': 'CARD'
+          'token_type': 'CARD',
+          'token_account_type': 'test'
         }
       )
         .reply(200, TOKEN_RESPONSE)
 
       nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
         .reply(200, {
-          payment_provider: 'sandbox'
+          payment_provider: 'sandbox',
+          type: 'test'
         })
 
       VALID_PAYLOAD.description = DESCRIPTION

--- a/test/unit/controller/payment-links/post-review.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-review.controller.ft.test.js
@@ -28,10 +28,12 @@ const VALID_CREATE_TOKEN_REQUEST = {
   account_id: GATEWAY_ACCOUNT_ID,
   created_by: VALID_USER.email,
   type: 'PRODUCTS',
-  description: `Token for “${PAYMENT_TITLE}” payment link`
+  description: `Token for “${PAYMENT_TITLE}” payment link`,
+  token_account_type: 'test'
 }
 const VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE = {
-  payment_provider: 'sandbox'
+  payment_provider: 'sandbox',
+  type: 'test'
 }
 const VALID_CREATE_TOKEN_RESPONSE = { token: randomUuid() }
 


### PR DESCRIPTION
Include the account type for the gateway account that is requesting a
new API key. This is applied to both account API keys and API keys
associated with payment links for the account.

Entirely internal and ad-hoc features like demo payments to test with
your users are not included -- with this set up API keys generated with
those features will not provide token account type and will not
expect a prefix on the resulting token.

Update mocks to guarantee the account type is being correctly propagated
through to public auth.


## How to test 
- All integration, cypress and end to end tests should continue to pass; that latest version of public auth master will accept this parameter and should respond with success


