### PR TITLE
PP-6129 Specify token "source" for token creation

### DIFF
--- a/app/controllers/api-keys/post-create.controller.js
+++ b/app/controllers/api-keys/post-create.controller.js
@@ -13,6 +13,7 @@ module.exports = async function createAPIKey (req, res, next) {
     description: description,
     account_id: accountId,
     created_by: req.user.email,
+    type: 'API',
     token_type: isADirectDebitAccount(accountId) ? 'DIRECT_DEBIT' : 'CARD',
     token_account_type: req.account.type
   }

--- a/app/controllers/make-a-demo-payment/go-to-payment.controller.js
+++ b/app/controllers/make-a-demo-payment/go-to-payment.controller.js
@@ -22,7 +22,8 @@ module.exports = (req, res) => {
     payload: {
       account_id: gatewayAccountId,
       created_by: req.user.email,
-      description: `Token for Demo Payment`
+      description: `Token for Demo Payment`,
+      type: 'PRODUCTS'
     }
   })
     .then(publicAuthData => productsClient.product.create({

--- a/app/controllers/test-with-your-users/submit.controller.js
+++ b/app/controllers/test-with-your-users/submit.controller.js
@@ -39,7 +39,8 @@ module.exports = (req, res) => {
     payload: {
       account_id: gatewayAccountId,
       created_by: req.user.email,
-      description: `Token for Prototype: ${req.body['payment-description']}`
+      description: `Token for Prototype: ${req.body['payment-description']}`,
+      type: 'PRODUCTS'
     } })
     .then(publicAuthData => productsClient.product.create({
       payApiToken: publicAuthData.token,

--- a/test/unit/controller/api-keys/post-create.controller.ft.test.js
+++ b/test/unit/controller/api-keys/post-create.controller.ft.test.js
@@ -39,7 +39,8 @@ describe('POST to create an API key', () => {
           'description': '',
           'created_by': user.email,
           'token_type': 'CARD',
-          'token_account_type': 'live'
+          'token_account_type': 'live',
+          'type': 'API'
         }
       )
         .reply(200, TOKEN_RESPONSE)
@@ -89,7 +90,8 @@ describe('POST to create an API key', () => {
           'description': DESCRIPTION,
           'created_by': user.email,
           'token_type': 'CARD',
-          'token_account_type': 'test'
+          'token_account_type': 'test',
+          'type': 'API'
         }
       )
         .reply(200, TOKEN_RESPONSE)

--- a/test/unit/controller/make-a-demo-payment-controller/go-to-payment.controller.ft.test.js
+++ b/test/unit/controller/make-a-demo-payment-controller/go-to-payment.controller.ft.test.js
@@ -26,7 +26,8 @@ const VALID_USER = getUser({
 const VALID_CREATE_TOKEN_REQUEST = {
   account_id: GATEWAY_ACCOUNT_ID,
   created_by: VALID_USER.email,
-  description: 'Token for Demo Payment'
+  description: 'Token for Demo Payment',
+  type: 'PRODUCTS'
 }
 const VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE = {
   payment_provider: 'sandbox'

--- a/test/unit/controller/test-with-your-users-controller/submit.controller.ft.test.js
+++ b/test/unit/controller/test-with-your-users-controller/submit.controller.ft.test.js
@@ -28,7 +28,8 @@ const VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE = {
 const VALID_CREATE_TOKEN_REQUEST = {
   account_id: GATEWAY_ACCOUNT_ID,
   created_by: VALID_USER.email,
-  description: `Token for Prototype: ${VALID_PAYLOAD['payment-description']}`
+  description: `Token for Prototype: ${VALID_PAYLOAD['payment-description']}`,
+  type: 'PRODUCTS'
 }
 const VALID_CREATE_PRODUCT_REQUEST = validCreateProductRequest({
   name: VALID_PAYLOAD['payment-description'],


### PR DESCRIPTION
Self service creates tokens for 4 main reasons:
* generating card API tokens for users
* creating new payment links
* demo payments feature
* test with your users feature

In each of these cases we should be passing a "type" parameter, this
translates to a public auth `TokenSource` which tells public auth if
this api key is intended to be used for an API client or internally as
one of our products.

Payment links and the two testing features we provide all work by
creating products and running test payments through those. As the public
auth token will be used by a "product" this type should be specified.

Update the generate API key route to no longer rely on the default
source (API).

