### PR TITLE
PP-7207 DAC Audit - Transactions > Multi-select for Card Brand & Payment Status

### DIFF
--- a/app/browsered/multi-select.js
+++ b/app/browsered/multi-select.js
@@ -47,10 +47,12 @@ function progressivelyEnhanceSelects () {
       })
     }
     select.outerHTML = multiSelect(configuration)
-    const newMultiSelect = document.getElementById(`${configuration.id}`)
+    const newMultiSelect = document.getElementById(`${configuration.id}__container`)
+
     const openButton = [...newMultiSelect.querySelectorAll(OPEN_BUTTON_SELECTOR)][0]
     const closeButton = [...newMultiSelect.querySelectorAll(CLOSE_BUTTON_SELECTOR)][0]
     const items = [...newMultiSelect.querySelectorAll(ITEM_SELECTOR)]
+
     const dropdown = [...newMultiSelect.querySelectorAll(DROPDOWN_SELECTOR)][0]
     const scrollContainer = [...newMultiSelect.querySelectorAll(SCROLL_CONTAINER_SELECTOR)][0]
     openButton.addEventListener('click', onOpenButtonClick, false)
@@ -83,12 +85,14 @@ const onOpenButtonClick = event => {
   target.blur();
   [...target.closest(TOP_LEVEL_SELECTOR).querySelectorAll(DROPDOWN_SELECTOR)][0].style.visibility = 'visible';
   [...target.closest(TOP_LEVEL_SELECTOR).querySelectorAll(ITEM_SELECTOR)][0].focus()
+  target.setAttribute('aria-expanded', true)
 }
 
 const onCloseAreaClick = event => {
   const { target } = event;
   [...target.closest(TOP_LEVEL_SELECTOR).querySelectorAll(OPEN_BUTTON_SELECTOR)][0].focus();
   [...target.closest(TOP_LEVEL_SELECTOR).querySelectorAll(DROPDOWN_SELECTOR)][0].style.visibility = 'hidden'
+  target.setAttribute('aria-expanded', false)
 }
 
 const onItemChange = event => {

--- a/app/views/includes/multi-select.njk
+++ b/app/views/includes/multi-select.njk
@@ -1,7 +1,7 @@
-<div id="{{id}}" class="multi-select">
+<div id="{{id}}__container" class="multi-select">
   <button type="button"
     class="multi-select-title"
-    id="option-select-title-{{name}}">
+    id="{{id}}" aria-expanded="false">
     <div><span class="govuk-visually-hidden">Currently selected: </span><span class="multi-select-current-selections"></span></div>
   </button>
   <div role="group" aria-labelledby="option-select-title-{{name}}"

--- a/test/cypress/integration/transactions/transaction-list-pagination.cy.test.js
+++ b/test/cypress/integration/transactions/transaction-list-pagination.cy.test.js
@@ -167,8 +167,8 @@ describe('Transactions list pagination', () => {
         cy.get('#email').invoke('val').should('contain', 'gds4')
         cy.get('#lastDigitsCardNumber').invoke('val').should('contain', '4242')
         cy.get('#cardholderName').invoke('val').should('contain', 'doe')
-        cy.get('#option-select-title-state').invoke('text').should('contain', 'Success')
-        cy.get('#option-select-title-brand').invoke('text').should('contain', 'Visa, Mastercard')
+        cy.get('#state').invoke('text').should('contain', 'Success')
+        cy.get('#card-brand').invoke('text').should('contain', 'Visa, Mastercard')
       })
 
       it('should return correct display size options when total over 500', () => {

--- a/test/cypress/integration/transactions/transaction-search.cy.test.js
+++ b/test/cypress/integration/transactions/transaction-search.cy.test.js
@@ -223,9 +223,9 @@ describe('Transactions List', () => {
       ])
 
       cy.get('#state').click()
-      cy.get(`#state .govuk-checkboxes__input[value='Success']`).click()
-      cy.get(`#state .govuk-checkboxes__input[value='In progress']`).click()
-      cy.get(`#state .govuk-checkboxes__input[value='Refund submitted']`).click()
+      cy.get(`#state__container .govuk-checkboxes__input[value='Success']`).click()
+      cy.get(`#state__container .govuk-checkboxes__input[value='In progress']`).click()
+      cy.get(`#state__container .govuk-checkboxes__input[value='Refund submitted']`).click()
 
       cy.get('#reference').type('ref123')
       cy.get('#fromDate').type('03/5/2018')
@@ -233,8 +233,8 @@ describe('Transactions List', () => {
       cy.get('#toDate').type('04/5/2018')
       cy.get('#toTime').type('01:00:00')
       cy.get('#card-brand').click()
-      cy.get(`#card-brand .govuk-checkboxes__input[value=visa]`).click()
-      cy.get(`#card-brand .govuk-checkboxes__input[value=master-card]`).click()
+      cy.get(`#card-brand__container .govuk-checkboxes__input[value=visa]`).click()
+      cy.get(`#card-brand__container .govuk-checkboxes__input[value=master-card]`).click()
       cy.get('#email').type('gds4')
       cy.get('#lastDigitsCardNumber').type('4242')
       cy.get('#cardholderName').type('doe')


### PR DESCRIPTION
- Add JS to toggle 'aria-expanded=true/false' on the button
- Fix ID of the button to match the label
- Update Cypress tests to use the new ID for:
  - Transaction > Card brand filter multi-select
  - Transaction > Status filter multi-select


