### PR TITLE
PP-7409 Add test vs. live content for payment link created message

### DIFF
--- a/app/controllers/payment-links/get-manage.controller.js
+++ b/app/controllers/payment-links/get-manage.controller.js
@@ -8,8 +8,10 @@ const productsClient = require('../../services/clients/products.client')
 const authService = require('../../services/auth.service')
 const { renderErrorView } = require('../../utils/response')
 const supportedLanguage = require('../../models/supported-language')
+const paths = require('../../paths')
 
 module.exports = (req, res) => {
+  const externalServiceId = req.service && req.service.externalId
   lodash.unset(req, 'session.editPaymentLinkData')
 
   productsClient.product.getByGatewayAccountId(authService.getCurrentGatewayAccountId(req))
@@ -20,7 +22,9 @@ module.exports = (req, res) => {
       const pageData = {
         productsLength: paymentLinks.length,
         englishPaymentLinks,
-        welshPaymentLinks
+        welshPaymentLinks,
+        paths,
+        externalServiceId
       }
       return response(req, res, 'payment-links/manage', pageData)
     })

--- a/app/views/payment-links/manage.njk
+++ b/app/views/payment-links/manage.njk
@@ -12,10 +12,26 @@
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
 {% if flash.createPaymentLinkSuccess %}
-    {{ successNotification({
-      heading: "Your payment link is now live",
-      body: "Give this link to your users to collect payments for your service."
-    }) }}
+  {% if isTestGateway %}
+    {% set heading = "Your test payment link is ready to use" %}
+    {% set body %}
+      <span>
+        To collect payments from your users with this link you will need to
+        <a class="govuk-link" href="{{ paths.generateRoute(paths.requestToGoLive.index, { externalServiceId: externalServiceId }) }}">request to go live</a>
+        and create the payment link again.
+      </span>
+    {% endset %}
+  {% else %}
+    {% set heading = "Your payment link is now live" %}
+    {% set body %}
+      <span>Give this link to your users to collect payments for your service</span>
+    {% endset %}
+  {% endif %}
+
+  {{ successNotification({
+    heading: heading,
+    body: body
+  }) }}
 {% endif %}
 
 {% if not permissions.tokens_create %}

--- a/app/views/payment-links/manage.njk
+++ b/app/views/payment-links/manage.njk
@@ -13,18 +13,20 @@
 <section class="govuk-grid-column-two-thirds">
 {% if flash.createPaymentLinkSuccess %}
   {% if isTestGateway %}
-    {% set heading = "Your test payment link is ready to use" %}
+    {% set heading = "Your Payment link is ready to test" %}
     {% set body %}
       <span>
-        To collect payments from your users with this link you will need to
-        <a class="govuk-link" href="{{ paths.generateRoute(paths.requestToGoLive.index, { externalServiceId: externalServiceId }) }}">request to go live</a>
-        and create the payment link again.
+        To start collecting payments, you need to
+        <a class="govuk-link" href="{{ paths.generateRoute(paths.requestToGoLive.index, { externalServiceId: externalServiceId }) }}">
+          Request a live account
+        </a>.
+        Once live, you’ll need to recreate your Payment link before you can give it to users.
       </span>
     {% endset %}
   {% else %}
     {% set heading = "Your payment link is now live" %}
     {% set body %}
-      <span>Give this link to your users to collect payments for your service</span>
+      <span>Give this link to your users to collect payments for your service.</span>
     {% endset %}
   {% endif %}
 

--- a/test/cypress/integration/payment-links/create-payment-link.cy.test.js
+++ b/test/cypress/integration/payment-links/create-payment-link.cy.test.js
@@ -241,7 +241,7 @@ describe('The create payment link flow', () => {
           expect(location.pathname).to.eq(`/create-payment-link/manage`)
         })
 
-        cy.get('.notification').find('h2').should('contain', 'Your test payment link is ready to use')
+        cy.get('.notification').find('h2').should('contain', 'Your Payment link is ready to test')
       })
     })
   })

--- a/test/cypress/integration/payment-links/create-payment-link.cy.test.js
+++ b/test/cypress/integration/payment-links/create-payment-link.cy.test.js
@@ -241,7 +241,7 @@ describe('The create payment link flow', () => {
           expect(location.pathname).to.eq(`/create-payment-link/manage`)
         })
 
-        cy.get('.notification').find('h2').should('contain', 'Your payment link is now live')
+        cy.get('.notification').find('h2').should('contain', 'Your test payment link is ready to use')
       })
     })
   })


### PR DESCRIPTION
Payment links created in test and live environments have very different
use cases; the wording for the payment link creation references the
payment link being "live" which conflicts with our use of this status
for accounts.

Add a separate path for test and live accounts to provide users
additional information if they are just testing.

**Payment link created in a test account**

![Screenshot 2020-11-19 at 12 06 30](https://user-images.githubusercontent.com/2844572/99664885-c5e0c080-2a60-11eb-8bc8-aa3d5f7e603d.png)

**Payment link created in a live account**

![Screenshot 2020-11-19 at 12 08 33](https://user-images.githubusercontent.com/2844572/99664892-c8dbb100-2a60-11eb-9af0-430cc31ffcde.png)