### PR TITLE
PP-7299 Remove experimental flag around payment link helper text

### DIFF
--- a/app/views/payment-links/manage.njk
+++ b/app/views/payment-links/manage.njk
@@ -36,11 +36,9 @@
     {% endif %}
   </p>
 
-  {% if currentService.experimentalFeaturesEnabled %}
-    <p class="govuk-body payment-links-list--header">
-      You can download reports about your payments from your account. Edit a payment link to add extra columns to these reports. For example, to include your cost centre code.
-    </p>
-  {% endif %}
+  <p class="govuk-body payment-links-list--header">
+    You can download reports about your payments from your account. Edit a payment link to add extra columns to these reports. For example, to include your cost centre code.
+  </p>
 
   {% if englishPaymentLinks.length %}
   <ul class="govuk-list pay-!-border-top govuk-!-padding-top-3 govuk-!-padding-bottom-3 payment-links-list">


### PR DESCRIPTION
This flag should have been removed when reporting columns for payment
links was released. This will always show the helper text providing
information about reporting columns to the user. This pattern will be
further iterated on by bringing reporting columns in-line with payment
creation.

![Screenshot 2020-11-23 at 09 50 06](https://user-images.githubusercontent.com/2844572/99948412-57a64180-2d71-11eb-961a-58d29b4e7d36.png)
