### PR TITLE
BAU Move client instantiation out of requests

### DIFF
--- a/app/controllers/credentials.controller.js
+++ b/app/controllers/credentials.controller.js
@@ -13,7 +13,11 @@ const { CONNECTOR_URL } = process.env
 const { CORRELATION_HEADER } = require('../utils/correlation-header')
 const { isPasswordLessThanTenChars } = require('../browsered/field-validation-checks')
 
-const connectorClient = () => new ConnectorClient(CONNECTOR_URL)
+// this module uses the old base client pub/ sub `on` error propagation, in certain
+// cases this relies on the instance of the client being unique to correctly
+// handle errors. This instantiation should be removed when the newer promise
+// based client is used
+const newConnectorClient = () => new ConnectorClient(CONNECTOR_URL)
 
 function showSuccessView (viewMode, req, res) {
   let responsePayload = {}
@@ -118,7 +122,7 @@ module.exports = {
     var url = connectorUrl.replace('{accountId}', accountId)
     var correlationId = req.headers[CORRELATION_HEADER] || ''
 
-    connectorClient().postAccountNotificationCredentials({
+    newConnectorClient().postAccountNotificationCredentials({
       payload: { username, password },
       correlationId: correlationId,
       gatewayAccountId: accountId
@@ -167,7 +171,7 @@ module.exports = {
     var correlationId = req.headers[CORRELATION_HEADER] || ''
 
     var startTime = new Date()
-    connectorClient().patchAccountCredentials({
+    newConnectorClient().patchAccountCredentials({
       payload: credentialsPatchRequestValueOf(req),
       correlationId: correlationId,
       gatewayAccountId: accountId

--- a/app/controllers/payment-types/get-index.controller.js
+++ b/app/controllers/payment-types/get-index.controller.js
@@ -5,6 +5,8 @@ const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
 const auth = require('../../services/auth.service')
 
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+
 function formatLabel (card) {
   if (card.brand === 'visa' || card.brand === 'master-card') {
     return `${card.label} ${card.type.toLowerCase()}`
@@ -53,7 +55,6 @@ function formatCardsForTemplate (allCards, acceptedCards, threeDSEnabled) {
 }
 
 module.exports = async (req, res) => {
-  const connector = new ConnectorClient(process.env.CONNECTOR_URL)
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = auth.getCurrentGatewayAccountId(req)
 

--- a/app/controllers/payment-types/post-index.controller.js
+++ b/app/controllers/payment-types/post-index.controller.js
@@ -8,8 +8,9 @@ const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
 const auth = require('../../services/auth.service.js')
 
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+
 module.exports = async (req, res) => {
-  const connector = new ConnectorClient(process.env.CONNECTOR_URL)
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = auth.getCurrentGatewayAccountId(req)
 

--- a/app/controllers/toggle-3ds/3ds.get.controller.js
+++ b/app/controllers/toggle-3ds/3ds.get.controller.js
@@ -6,8 +6,9 @@ const { response, renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
 
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+
 module.exports = async (req, res) => {
-  const connector = new ConnectorClient(process.env.CONNECTOR_URL)
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = req.account.gateway_account_id
 

--- a/app/controllers/toggle-3ds/3ds.post.controller.js
+++ b/app/controllers/toggle-3ds/3ds.post.controller.js
@@ -5,8 +5,9 @@ const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
 
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+
 module.exports = async (req, res) => {
-  const connector = new ConnectorClient(process.env.CONNECTOR_URL)
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = req.account.gateway_account_id
 

--- a/app/controllers/transactions/transaction-list.controller.js
+++ b/app/controllers/transactions/transaction-list.controller.js
@@ -12,6 +12,10 @@ const { response } = require('../../utils/response.js')
 const { renderErrorView } = require('../../utils/response.js')
 const { getFilters, describeFilters } = require('../../utils/filters.js')
 const states = require('../../utils/states')
+
+// this module uses the old base client pub/ sub `on` error propagation, in certain
+// cases this relies on the instance of the client being unique to correctly
+// handle errors.
 const client = new ConnectorClient(process.env.CONNECTOR_URL)
 
 const { CORRELATION_HEADER } = require('../../utils/correlation-header.js')

--- a/app/controllers/your-psp/post-flex.controller.js
+++ b/app/controllers/your-psp/post-flex.controller.js
@@ -13,9 +13,9 @@ const ORGANISATIONAL_UNIT_ID_FIELD = 'organisational-unit-id'
 const ISSUER_FIELD = 'issuer'
 const JWT_MAC_KEY_FIELD = 'jwt-mac-key'
 
-module.exports = async (req, res) => {
-  const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
+module.exports = async (req, res) => {
   const correlationId = req.headers[correlationHeader] || ''
 
   const accountId = req.account.gateway_account_id

--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -21,7 +21,6 @@ const responseBodyToServiceTransformer = body => new Service(body)
 
 module.exports = function (clientOptions = {}) {
   const baseUrl = clientOptions.baseUrl || ADMINUSERS_URL
-  const correlationId = clientOptions.correlationId || ''
   const userResource = `/v1/api/users`
   const forgottenPasswordResource = `/v1/api/forgotten-passwords`
   const resetPasswordResource = `/v1/api/reset-password`
@@ -34,7 +33,7 @@ module.exports = function (clientOptions = {}) {
      * @param {string} externalId
      * @return {Promise<User>} A promise of a User
      */
-  const getUserByExternalId = (externalId, subSegment) => {
+  const getUserByExternalId = (externalId, subSegment, correlationId = '') => {
     return baseClient.get(
       {
         baseUrl,
@@ -56,7 +55,7 @@ module.exports = function (clientOptions = {}) {
      * @param {string} externalId
      * @return {Promise<User>} A promise of a User
      */
-  const getUsersByExternalIds = (externalIds = []) => {
+  const getUsersByExternalIds = (externalIds = [], correlationId = '') => {
     return baseClient.get(
       {
         baseUrl,
@@ -79,7 +78,7 @@ module.exports = function (clientOptions = {}) {
      * @param password
      * @returns {Promise<User>}
      */
-  const authenticateUser = (username, password) => {
+  const authenticateUser = (username, password, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -103,7 +102,7 @@ module.exports = function (clientOptions = {}) {
      * @param externalId
      * @returns {Promise}
      */
-  const incrementSessionVersionForUser = (externalId) => {
+  const incrementSessionVersionForUser = (externalId, correlationId = '') => {
     return baseClient.patch(
       {
         baseUrl,
@@ -127,7 +126,7 @@ module.exports = function (clientOptions = {}) {
      * @param username
      * @returns {Promise<ForgottenPassword>}
      */
-  const createForgottenPassword = (username) => {
+  const createForgottenPassword = (username, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -149,7 +148,7 @@ module.exports = function (clientOptions = {}) {
      * @param code
      * @returns {Promise<ForgottenPassword>}
      */
-  const getForgottenPassword = (code) => {
+  const getForgottenPassword = (code, correlationId = '') => {
     return baseClient.get(
       {
         baseUrl,
@@ -169,7 +168,7 @@ module.exports = function (clientOptions = {}) {
      * @param newPassword
      * @returns {Promise}
      */
-  const updatePasswordForUser = (token, newPassword) => {
+  const updatePasswordForUser = (token, newPassword, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -192,7 +191,7 @@ module.exports = function (clientOptions = {}) {
      * @param externalId
      * @returns {Promise}
      */
-  const sendSecondFactor = (externalId, provisional) => {
+  const sendSecondFactor = (externalId, provisional, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -213,7 +212,7 @@ module.exports = function (clientOptions = {}) {
      * @param code
      * @returns {Promise}
      */
-  const authenticateSecondFactor = (externalId, code) => {
+  const authenticateSecondFactor = (externalId, code, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -229,7 +228,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const getServiceUsers = (serviceExternalId) => {
+  const getServiceUsers = (serviceExternalId, correlationId = '') => {
     return baseClient.get(
       {
         baseUrl,
@@ -250,7 +249,7 @@ module.exports = function (clientOptions = {}) {
      * @param serviceExternalId
      * @param roleName
      */
-  const assignServiceRole = (userExternalId, serviceExternalId, roleName) => {
+  const assignServiceRole = (userExternalId, serviceExternalId, roleName, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -276,7 +275,7 @@ module.exports = function (clientOptions = {}) {
      * @param roleName
      * @returns {Promise<User>}
      */
-  const updateServiceRole = (externalId, serviceExternalId, roleName) => {
+  const updateServiceRole = (externalId, serviceExternalId, roleName, correlationId = '') => {
     return baseClient.put(
       {
         baseUrl,
@@ -302,7 +301,7 @@ module.exports = function (clientOptions = {}) {
      * @param roleName
      * @returns {Promise}
      */
-  const inviteUser = (invitee, senderId, serviceExternalId, roleName) => {
+  const inviteUser = (invitee, senderId, serviceExternalId, roleName, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -326,7 +325,7 @@ module.exports = function (clientOptions = {}) {
    * Get a invited users for a given service
    * @param serviceExternalId
    */
-  const getInvitedUsersList = (serviceExternalId) => {
+  const getInvitedUsersList = (serviceExternalId, correlationId = '') => {
     return baseClient.get(
       {
         baseUrl,
@@ -348,7 +347,7 @@ module.exports = function (clientOptions = {}) {
    * Get a valid invite or error if it's expired
    * @param inviteCode
    */
-  const getValidatedInvite = (inviteCode) => {
+  const getValidatedInvite = (inviteCode, correlationId = '') => {
     return baseClient.get(
       {
         baseUrl,
@@ -370,7 +369,7 @@ module.exports = function (clientOptions = {}) {
      * @param password
      * @returns {*|Constructor}
      */
-  const generateInviteOtpCode = (inviteCode, telephoneNumber, password) => {
+  const generateInviteOtpCode = (inviteCode, telephoneNumber, password, correlationId = '') => {
     let postData = {
       baseUrl,
       url: `${inviteResource}/${inviteCode}/otp/generate`,
@@ -400,7 +399,7 @@ module.exports = function (clientOptions = {}) {
      * @param gatewayAccountIds
      * @returns {*|promise|Constructor}
      */
-  const completeInvite = (inviteCode, gatewayAccountIds) => {
+  const completeInvite = (inviteCode, gatewayAccountIds, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -417,7 +416,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const verifyOtpAndCreateUser = (code, verificationCode) => {
+  const verifyOtpAndCreateUser = (code, verificationCode, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -435,7 +434,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const verifyOtpForServiceInvite = (inviteCode, verificationCode) => {
+  const verifyOtpForServiceInvite = (inviteCode, verificationCode, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -453,7 +452,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const resendOtpCode = (code, phoneNumber) => {
+  const resendOtpCode = (code, phoneNumber, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -478,7 +477,7 @@ module.exports = function (clientOptions = {}) {
      * @param phoneNumber
      * @param password
      */
-  const submitServiceRegistration = (email, phoneNumber, password) => {
+  const submitServiceRegistration = (email, phoneNumber, password, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -497,7 +496,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const deleteUser = (serviceExternalId, removerExternalId, userExternalId) => {
+  const deleteUser = (serviceExternalId, removerExternalId, userExternalId, correlationId = '') => {
     let headers = {}
     headers[HEADER_USER_CONTEXT] = removerExternalId
 
@@ -528,7 +527,7 @@ module.exports = function (clientOptions = {}) {
      * @param gatewayAccountIds
      * @returns {*|promise|Constructor}
      */
-  const createService = (serviceName, serviceNameCy, gatewayAccountIds) => {
+  const createService = (serviceName, serviceNameCy, gatewayAccountIds, correlationId = '') => {
     let postBody = {
       baseUrl,
       url: `${serviceResource}`,
@@ -561,7 +560,7 @@ module.exports = function (clientOptions = {}) {
    * @param body
    * @returns {*|Constructor|promise}
    */
-  const updateService = (serviceExternalId, body) => {
+  const updateService = (serviceExternalId, body, correlationId = '') => {
     return baseClient.patch({
       baseUrl,
       url: `${serviceResource}/${serviceExternalId}`,
@@ -582,7 +581,7 @@ module.exports = function (clientOptions = {}) {
      * @param serviceName
      * @returns {*|Constructor|promise}
      */
-  const updateServiceName = (serviceExternalId, serviceName, serviceNameCy) => {
+  const updateServiceName = (serviceExternalId, serviceName, serviceNameCy, correlationId = '') => {
     return baseClient.patch(
       {
         baseUrl,
@@ -615,7 +614,7 @@ module.exports = function (clientOptions = {}) {
    * @param collectBillingAddress
    * @returns {*|Constructor|promise}
    */
-  const updateCollectBillingAddress = (serviceExternalId, collectBillingAddress) => {
+  const updateCollectBillingAddress = (serviceExternalId, collectBillingAddress, correlationId = '') => {
     return baseClient.patch(
       {
         baseUrl,
@@ -642,7 +641,7 @@ module.exports = function (clientOptions = {}) {
      * @param gatewayAccountIds {String[]} a list of (unassigned) gateway account ids to add to the service
      * @returns {Promise<Service|Error>}
      */
-  const addGatewayAccountsToService = (serviceExternalId, gatewayAccountIds) => {
+  const addGatewayAccountsToService = (serviceExternalId, gatewayAccountIds, correlationId = '') => {
     return baseClient.patch(
       {
         baseUrl,
@@ -668,7 +667,7 @@ module.exports = function (clientOptions = {}) {
      * @param code
      * @returns {Promise}
      */
-  const provisionNewOtpKey = (externalId) => {
+  const provisionNewOtpKey = (externalId, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -690,7 +689,7 @@ module.exports = function (clientOptions = {}) {
      * @param secondFactor {String} 'SMS' or 'APP'
      * @returns {Promise}
      */
-  const configureNewOtpKey = (externalId, code, secondFactor) => {
+  const configureNewOtpKey = (externalId, code, secondFactor, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -708,7 +707,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const updateCurrentGoLiveStage = (serviceExternalId, newStage) => {
+  const updateCurrentGoLiveStage = (serviceExternalId, newStage, correlationId = '') => {
     return baseClient.patch(
       {
         baseUrl,
@@ -728,7 +727,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const addStripeAgreementIpAddress = (serviceExternalId, ipAddress) => {
+  const addStripeAgreementIpAddress = (serviceExternalId, ipAddress, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -743,7 +742,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const addGovUkAgreementEmailAddress = (serviceExternalId, userExternalId) => {
+  const addGovUkAgreementEmailAddress = (serviceExternalId, userExternalId, correlationId = '') => {
     return baseClient.post(
       {
         baseUrl,
@@ -764,7 +763,7 @@ module.exports = function (clientOptions = {}) {
      * @param newPhoneNumber
      * @returns {Promise}
      */
-  const updatePhoneNumberForUser = (externalId, newPhoneNumber) => {
+  const updatePhoneNumberForUser = (externalId, newPhoneNumber, correlationId = '') => {
     return baseClient.patch(
       {
         baseUrl,

--- a/app/services/email.service.js
+++ b/app/services/email.service.js
@@ -11,14 +11,18 @@ const notificationUpdateUrl = function (accountID) {
   return process.env.CONNECTOR_URL + EMAIL_NOTIFICATION_UPDATE_API_PATH.replace('{accountId}', accountID)
 }
 
-const connectorClient = function () {
+// this module uses the old base client pub/ sub `on` error propagation, in certain
+// cases this relies on the instance of the client being unique to correctly
+// handle errors. This instantiation should be removed when the newer promise
+// based client is used
+const newConnectorClient = function () {
   return new ConnectorClient(process.env.CONNECTOR_URL)
 }
 
 const getEmailSettings = function (accountID, correlationId) {
   return new Promise(function (resolve, reject) {
     const startTime = new Date()
-    connectorClient().getAccount({
+    newConnectorClient().getAccount({
       gatewayAccountId: accountID,
       correlationId: correlationId
     })
@@ -42,7 +46,7 @@ const updateConfirmationTemplate = function (accountID, emailText, correlationId
   return new Promise(function (resolve, reject) {
     const startTime = new Date()
     const patch = { 'op': 'replace', 'path': '/payment_confirmed/template_body', 'value': emailText }
-    connectorClient().updateConfirmationEmail({
+    newConnectorClient().updateConfirmationEmail({
       payload: patch,
       correlationId: correlationId,
       gatewayAccountId: accountID
@@ -63,7 +67,7 @@ const setEmailCollectionMode = function (accountID, collectionMode, correlationI
   return new Promise(function (resolve, reject) {
     const startTime = new Date()
     const patch = { 'op': 'replace', 'path': 'email_collection_mode', 'value': collectionMode }
-    connectorClient().updateEmailCollectionMode({
+    newConnectorClient().updateEmailCollectionMode({
       payload: patch,
       correlationId: correlationId,
       gatewayAccountId: accountID
@@ -82,7 +86,7 @@ const setConfirmationEnabled = function (accountID, enabled, correlationId) {
   return new Promise(function (resolve, reject) {
     const startTime = new Date()
     const patch = { 'op': 'replace', 'path': '/payment_confirmed/enabled', 'value': enabled }
-    connectorClient().updateConfirmationEmailEnabled({
+    newConnectorClient().updateConfirmationEmailEnabled({
       payload: patch,
       correlationId: correlationId,
       gatewayAccountId: accountID
@@ -101,7 +105,7 @@ const setRefundEmailEnabled = function (accountID, enabled, correlationId) {
   return new Promise(function (resolve, reject) {
     const startTime = new Date()
     const patch = { 'op': 'replace', 'path': '/refund_issued/enabled', 'value': enabled }
-    connectorClient().updateRefundEmailEnabled({
+    newConnectorClient().updateRefundEmailEnabled({
       payload: patch,
       correlationId: correlationId,
       gatewayAccountId: accountID

--- a/app/services/service-registration.service.js
+++ b/app/services/service-registration.service.js
@@ -3,14 +3,14 @@
 const logger = require('../utils/logger')(__filename)
 const getAdminUsersClient = require('./clients/adminusers.client')
 const ConnectorClient = require('./clients/connector.client').ConnectorClient
-const connectorClient = () => new ConnectorClient(process.env.CONNECTOR_URL)
+const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 
 const completeServiceInvite = (inviteCode, gatewayAccountIds, correlationId) => {
   return getAdminUsersClient({ correlationId }).completeInvite(inviteCode, gatewayAccountIds)
 }
 
 const createGatewayAccount = function (correlationId) {
-  return connectorClient().createGatewayAccount('sandbox', 'test', null, null, correlationId)
+  return connectorClient.createGatewayAccount('sandbox', 'test', null, null, correlationId)
 }
 
 module.exports = {

--- a/app/services/service-registration.service.js
+++ b/app/services/service-registration.service.js
@@ -5,8 +5,10 @@ const getAdminUsersClient = require('./clients/adminusers.client')
 const ConnectorClient = require('./clients/connector.client').ConnectorClient
 const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 
+const adminUsersClient = getAdminUsersClient()
+
 const completeServiceInvite = (inviteCode, gatewayAccountIds, correlationId) => {
-  return getAdminUsersClient({ correlationId }).completeInvite(inviteCode, gatewayAccountIds)
+  return adminUsersClient.completeInvite(inviteCode, gatewayAccountIds, correlationId)
 }
 
 const createGatewayAccount = function (correlationId) {
@@ -24,7 +26,7 @@ module.exports = {
    * @param correlationId
    */
   submitRegistration: function (email, phoneNumber, password, correlationId) {
-    return getAdminUsersClient({ correlationId }).submitServiceRegistration(email, phoneNumber, password)
+    return adminUsersClient.submitServiceRegistration(email, phoneNumber, password, correlationId)
   },
 
   /**
@@ -35,7 +37,7 @@ module.exports = {
    * @param correlationId
    */
   submitServiceInviteOtpCode: (code, otpCode, correlationId) => {
-    return getAdminUsersClient({ correlationId }).verifyOtpForServiceInvite(code, otpCode)
+    return adminUsersClient.verifyOtpForServiceInvite(code, otpCode, correlationId)
   },
 
   /**
@@ -67,7 +69,7 @@ module.exports = {
    * @returns {*|Constructor}
    */
   generateServiceInviteOtpCode: function (inviteCode, correlationId) {
-    return getAdminUsersClient({ correlationId }).generateInviteOtpCode(inviteCode)
+    return adminUsersClient.generateInviteOtpCode(inviteCode, correlationId)
   },
 
   /**
@@ -78,6 +80,6 @@ module.exports = {
    * @param correlationId
    */
   resendOtpCode: function (code, phoneNumber, correlationId) {
-    return getAdminUsersClient({ correlationId }).resendOtpCode(code, phoneNumber)
+    return adminUsersClient.resendOtpCode(code, phoneNumber, correlationId)
   }
 }

--- a/app/services/service.service.js
+++ b/app/services/service.service.js
@@ -9,6 +9,7 @@ const { isADirectDebitAccount } = directDebitConnectorClient
 const CardGatewayAccount = require('../models/GatewayAccount.class')
 const Service = require('../models/Service.class')
 const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
+const adminUsersClient = getAdminUsersClient()
 
 /**
  * @method getServicesForUser
@@ -40,7 +41,7 @@ function updateServiceName (serviceExternalId, serviceName, serviceNameCy, corre
   if (!serviceExternalId) {
     return Promise.reject(new Error(`argument: 'serviceExternalId' cannot be undefined`))
   }
-  return getAdminUsersClient({ correlationId }).updateServiceName(serviceExternalId, serviceName, serviceNameCy)
+  return adminUsersClient.updateServiceName(serviceExternalId, serviceName, serviceNameCy, correlationId)
     .then(result => {
       // Update gateway account service names in connector
       const gatewayAccountIds = lodash.get(result, 'gateway_account_ids', [])
@@ -66,7 +67,7 @@ function updateServiceName (serviceExternalId, serviceName, serviceNameCy, corre
  * @returns {Promise<Service>} the updated service
  */
 function updateService (serviceExternalId, serviceUpdateRequest, correlationId) {
-  return getAdminUsersClient({ correlationId }).updateService(serviceExternalId, serviceUpdateRequest)
+  return adminUsersClient.updateService(serviceExternalId, serviceUpdateRequest, correlationId)
 }
 
 /**
@@ -81,7 +82,7 @@ function createService (serviceName, serviceNameCy, correlationId) {
 
   return connectorClient.createGatewayAccount('sandbox', 'test', serviceName, null, correlationId)
     .then(gatewayAccount =>
-      getAdminUsersClient({ correlationId }).createService(serviceName, serviceNameCy, [gatewayAccount.gateway_account_id])
+      adminUsersClient.createService(serviceName, serviceNameCy, [gatewayAccount.gateway_account_id], correlationId)
     )
 }
 
@@ -94,7 +95,7 @@ function createService (serviceName, serviceNameCy, correlationId) {
  * @returns {*|Promise|Promise}
  */
 function toggleCollectBillingAddress (serviceExternalId, collectBillingAddress, correlationId) {
-  return getAdminUsersClient({ correlationId }).updateCollectBillingAddress(serviceExternalId, collectBillingAddress)
+  return adminUsersClient.updateCollectBillingAddress(serviceExternalId, collectBillingAddress, correlationId)
 }
 
 /**
@@ -106,7 +107,7 @@ function toggleCollectBillingAddress (serviceExternalId, collectBillingAddress, 
  * @returns {*|Promise|Promise}
  */
 function updateCurrentGoLiveStage (serviceExternalId, newStage, correlationId) {
-  return getAdminUsersClient({ correlationId }).updateCurrentGoLiveStage(serviceExternalId, newStage)
+  return adminUsersClient.updateCurrentGoLiveStage(serviceExternalId, newStage, correlationId)
 }
 
 /**
@@ -118,7 +119,7 @@ function updateCurrentGoLiveStage (serviceExternalId, newStage, correlationId) {
  * @returns {*|Promise|Promise}
  */
 function addStripeAgreementIpAddress (serviceExternalId, ipAddress, correlationId) {
-  return getAdminUsersClient({ correlationId }).addStripeAgreementIpAddress(serviceExternalId, ipAddress)
+  return adminUsersClient.addStripeAgreementIpAddress(serviceExternalId, ipAddress, correlationId)
 }
 
 /**
@@ -130,7 +131,7 @@ function addStripeAgreementIpAddress (serviceExternalId, ipAddress, correlationI
  * @returns {*|Promise|Promise}
  */
 function addGovUkAgreementEmailAddress (serviceExternalId, userExternalId, correlationId) {
-  return getAdminUsersClient({ correlationId }).addGovUkAgreementEmailAddress(serviceExternalId, userExternalId)
+  return adminUsersClient.addGovUkAgreementEmailAddress(serviceExternalId, userExternalId, correlationId)
 }
 
 module.exports = {

--- a/app/services/user-registration.service.js
+++ b/app/services/user-registration.service.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const getAdminUsersClient = require('./clients/adminusers.client')
+const adminUsersClient = getAdminUsersClient()
 
 module.exports = {
 
@@ -14,7 +15,7 @@ module.exports = {
    * @returns {*|Constructor}
    */
   submitRegistration: function (code, telephoneNumber, password, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).generateInviteOtpCode(code, telephoneNumber, password)
+    return adminUsersClient.generateInviteOtpCode(code, telephoneNumber, password, correlationId)
   },
 
   /**
@@ -25,15 +26,15 @@ module.exports = {
    * @param correlationId
    */
   verifyOtpAndCreateUser: function (code, verifyCode, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).verifyOtpAndCreateUser(code, verifyCode)
+    return adminUsersClient.verifyOtpAndCreateUser(code, verifyCode, correlationId)
   },
 
   resendOtpCode: function (code, phoneNumber, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).resendOtpCode(code, phoneNumber)
+    return adminUsersClient.resendOtpCode(code, phoneNumber, correlationId)
   },
 
   completeInvite: function (code, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).completeInvite(code)
+    return adminUsersClient.completeInvite(code, correlationId)
   }
 
 }

--- a/app/services/user.service.js
+++ b/app/services/user.service.js
@@ -13,9 +13,7 @@ module.exports = {
    */
   authenticate: function (username, submittedPassword, correlationId) {
     if (!username || !submittedPassword) {
-      return new Promise(function (resolve, reject) {
-        reject(new Error('Failed to authenticate'))
-      })
+      return Promise.reject(new Error('Failed to authenticate'))
     }
     return adminUsersClient.authenticateUser(username, submittedPassword, correlationId)
   },
@@ -28,9 +26,7 @@ module.exports = {
    */
   authenticateSecondFactor: function (externalId, code, correlationId) {
     if (!externalId || !code) {
-      return new Promise(function (resolve, reject) {
-        reject(new Error('Failed to authenticate second factor'))
-      })
+      return Promise.reject(new Error('Failed to authenticate second factor'))
     }
 
     return adminUsersClient.authenticateSecondFactor(externalId, code, correlationId)

--- a/app/services/user.service.js
+++ b/app/services/user.service.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const getAdminUsersClient = require('./clients/adminusers.client')
+const adminUsersClient = getAdminUsersClient()
 
 module.exports = {
 
@@ -16,7 +17,7 @@ module.exports = {
         reject(new Error('Failed to authenticate'))
       })
     }
-    return getAdminUsersClient({ correlationId: correlationId }).authenticateUser(username, submittedPassword)
+    return adminUsersClient.authenticateUser(username, submittedPassword, correlationId)
   },
 
   /**
@@ -32,7 +33,7 @@ module.exports = {
       })
     }
 
-    return getAdminUsersClient({ correlationId: correlationId }).authenticateSecondFactor(externalId, code)
+    return adminUsersClient.authenticateSecondFactor(externalId, code, correlationId)
   },
 
   /**
@@ -41,7 +42,7 @@ module.exports = {
    * @returns {Promise<User>}
    */
   findByExternalId: (externalId, correlationId, subSegment) => {
-    return getAdminUsersClient({ correlationId: correlationId }).getUserByExternalId(externalId, subSegment)
+    return adminUsersClient.getUserByExternalId(externalId, subSegment, correlationId)
   },
 
   /**
@@ -50,7 +51,7 @@ module.exports = {
    * @returns {Promise<User>}
    */
   findMultipleByExternalIds: function (externalIds, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).getUsersByExternalIds(externalIds)
+    return adminUsersClient.getUsersByExternalIds(externalIds, correlationId)
   },
 
   /**
@@ -59,7 +60,7 @@ module.exports = {
    * @returns {Promise}
    */
   sendOTP: function (user, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).sendSecondFactor(user.externalId, false)
+    return adminUsersClient.sendSecondFactor(user.externalId, false, correlationId)
   },
 
   /**
@@ -68,9 +69,7 @@ module.exports = {
    * @returns {Promise}
    */
   sendProvisonalOTP: function (user, correlationId) {
-    return getAdminUsersClient({
-      correlationId: correlationId
-    }).sendSecondFactor(user.externalId, true)
+    return adminUsersClient.sendSecondFactor(user.externalId, true, correlationId)
   },
 
   /**
@@ -79,7 +78,7 @@ module.exports = {
    * @returns {Promise}
    */
   sendPasswordResetToken: function (username, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).createForgottenPassword(username)
+    return adminUsersClient.createForgottenPassword(username, correlationId)
   },
 
   /**
@@ -87,7 +86,7 @@ module.exports = {
    * @returns {Promise}
    */
   findByResetToken: function (token) {
-    return getAdminUsersClient().getForgottenPassword(token)
+    return adminUsersClient.getForgottenPassword(token)
   },
 
   /**
@@ -96,7 +95,7 @@ module.exports = {
    * @returns {Promise}
    */
   logOut: function (user, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).incrementSessionVersionForUser(user.externalId)
+    return adminUsersClient.incrementSessionVersionForUser(user.externalId, correlationId)
   },
 
   /**
@@ -105,7 +104,7 @@ module.exports = {
    * @returns {Promise}
    */
   getServiceUsers: function (externalServiceId, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).getServiceUsers(externalServiceId)
+    return adminUsersClient.getServiceUsers(externalServiceId, correlationId)
   },
 
   /**
@@ -114,7 +113,7 @@ module.exports = {
    * @returns {Promise}
    */
   updatePassword: function updatePassword (token, newPassword) {
-    return getAdminUsersClient().updatePasswordForUser(token, newPassword)
+    return adminUsersClient.updatePasswordForUser(token, newPassword)
   },
 
   /**
@@ -125,7 +124,7 @@ module.exports = {
    * @returns {Promise.<User>}
    */
   updateServiceRole: function (externalId, roleName, externalServiceId, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).updateServiceRole(externalId, externalServiceId, roleName)
+    return adminUsersClient.updateServiceRole(externalId, externalServiceId, roleName, correlationId)
   },
 
   /**
@@ -137,7 +136,7 @@ module.exports = {
    * @returns {Promise.<User>}
    */
   assignServiceRole: function (externalId, externalServiceId, roleName, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).assignServiceRole(externalId, externalServiceId, roleName)
+    return adminUsersClient.assignServiceRole(externalId, externalServiceId, roleName, correlationId)
   },
 
   /**
@@ -148,7 +147,7 @@ module.exports = {
    * @param correlationId
    */
   inviteUser: function (invitee, senderId, externalServiceId, roleName, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).inviteUser(invitee, senderId, externalServiceId, roleName)
+    return adminUsersClient.inviteUser(invitee, senderId, externalServiceId, roleName, correlationId)
   },
 
   /**
@@ -156,7 +155,7 @@ module.exports = {
    * @param correlationId
    */
   getInvitedUsersList: function (externalServiceId, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).getInvitedUsersList(externalServiceId)
+    return adminUsersClient.getInvitedUsersList(externalServiceId, correlationId)
   },
 
   /**
@@ -167,7 +166,7 @@ module.exports = {
    * @param correlationId
    */
   delete: function (externalServiceId, removerExternalId, userExternalId, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).deleteUser(externalServiceId, removerExternalId, userExternalId)
+    return adminUsersClient.deleteUser(externalServiceId, removerExternalId, userExternalId, correlationId)
   },
 
   /**
@@ -180,7 +179,7 @@ module.exports = {
       return Promise.reject(new Error('No externalId specified'))
     }
 
-    return getAdminUsersClient({ correlationId: correlationId }).provisionNewOtpKey(externalId)
+    return adminUsersClient.provisionNewOtpKey(externalId, correlationId)
   },
 
   /**
@@ -195,7 +194,7 @@ module.exports = {
       Promise.reject(new Error('No externalId specified'))
     }
 
-    return getAdminUsersClient({ correlationId: correlationId }).configureNewOtpKey(externalId, code, secondFactor)
+    return adminUsersClient.configureNewOtpKey(externalId, code, secondFactor, correlationId)
   },
 
   /**
@@ -203,6 +202,6 @@ module.exports = {
    * @returns {Promise}
    */
   updatePhoneNumber: function (externalId, newPhoneNumber) {
-    return getAdminUsersClient().updatePhoneNumberForUser(externalId, newPhoneNumber)
+    return adminUsersClient.updatePhoneNumberForUser(externalId, newPhoneNumber)
   }
 }

--- a/app/services/validate-invite.service.js
+++ b/app/services/validate-invite.service.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const getAdminUsersClient = require('./clients/adminusers.client')
+const adminUsersClient = getAdminUsersClient()
 
 module.exports = {
 
@@ -10,6 +11,6 @@ module.exports = {
    * @param correlationId
    */
   getValidatedInvite: function (code, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).getValidatedInvite(code)
+    return adminUsersClient.getValidatedInvite(code, correlationId)
   }
 }


### PR DESCRIPTION
Large objects shouldn't be instantiated in code that is called frequently, where it can be helped (for example, during the lifecycle of a request).

Node modules and exports can be considered singletons by default, use this to allow clients to be instantiated once and called as many times as required.

Hopefully this can be raised and followed as general practice.