### PR TITLE
PP-7458 Log when new service is created

### DIFF
--- a/app/controllers/create-service.controller.js
+++ b/app/controllers/create-service.controller.js
@@ -2,7 +2,7 @@
 
 const lodash = require('lodash')
 
-const { renderErrorView, response } = require('../utils/response')
+const { response } = require('../utils/response')
 const paths = require('../paths')
 const serviceService = require('../services/service.service')
 const userService = require('../services/user.service')
@@ -25,7 +25,7 @@ function get (req, res) {
   return response(req, res, 'services/add-service', pageData)
 }
 
-async function post (req, res) {
+async function post (req, res, next) {
   const correlationId = lodash.get(req, 'correlationId')
   const serviceName = lodash.get(req, 'body.service-name')
   const serviceHasNameCy = lodash.get(req, 'body.welsh-service-name-bool')
@@ -46,7 +46,7 @@ async function post (req, res) {
     await userService.assignServiceRole(req.user.externalId, service.externalId, 'admin', correlationId)
     res.redirect(paths.serviceSwitcher.index)
   } catch (err) {
-    renderErrorView(req, res, err)
+    next(err)
   }
 }
 

--- a/app/controllers/create-service.controller.js
+++ b/app/controllers/create-service.controller.js
@@ -8,7 +8,7 @@ const serviceService = require('../services/service.service')
 const userService = require('../services/user.service')
 const { validateServiceName } = require('../utils/service-name-validation')
 
-exports.get = (req, res) => {
+function get (req, res) {
   let pageData = lodash.get(req, 'session.pageData.createServiceName')
 
   if (pageData) {
@@ -25,7 +25,7 @@ exports.get = (req, res) => {
   return response(req, res, 'services/add-service', pageData)
 }
 
-exports.post = (req, res) => {
+async function post (req, res) {
   const correlationId = lodash.get(req, 'correlationId')
   const serviceName = lodash.get(req, 'body.service-name')
   const serviceHasNameCy = lodash.get(req, 'body.welsh-service-name-bool')
@@ -38,15 +38,19 @@ exports.post = (req, res) => {
       current_name: serviceName,
       current_name_cy: serviceNameCy
     })
-    res.redirect(paths.serviceSwitcher.create)
-  } else {
-    return serviceService.createService(serviceName, serviceNameCy, correlationId)
-      .then((service) => userService.assignServiceRole(req.user.externalId, service.external_id, 'admin', correlationId))
-      .then(() => {
-        res.redirect(paths.serviceSwitcher.index)
-      })
-      .catch(err => {
-        renderErrorView(req, res, err)
-      })
+    return res.redirect(paths.serviceSwitcher.create)
   }
+
+  try {
+    const service = await serviceService.createService(serviceName, serviceNameCy, req.user, correlationId)
+    await userService.assignServiceRole(req.user.externalId, service.externalId, 'admin', correlationId)
+    res.redirect(paths.serviceSwitcher.index)
+  } catch (err) {
+    renderErrorView(req, res, err)
+  }
+}
+
+module.exports = {
+  get,
+  post
 }

--- a/app/controllers/register-service.controller.js
+++ b/app/controllers/register-service.controller.js
@@ -179,8 +179,8 @@ const createPopulatedService = async function createPopulatedService (req, res, 
   }
 
   try {
-    const completeInviteResponse = await registrationService.createPopulatedService(req.register_invite.code, correlationId)
-    loginController.setupDirectLoginAfterRegister(req, res, completeInviteResponse.user_external_id)
+    const user = await registrationService.createPopulatedService(req.register_invite.code, correlationId)
+    loginController.setupDirectLoginAfterRegister(req, res, user.externalId)
     return res.redirect(303, paths.selfCreateService.logUserIn)
   } catch (err) {
     if (err.errorCode === 409) {

--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -536,6 +536,7 @@ module.exports = function (clientOptions = {}) {
       body: {},
       correlationId: correlationId,
       description: 'create service',
+      transform: responseBodyToServiceTransformer,
       service: SERVICE_NAME,
       baseClientErrorHandler: 'old'
     }

--- a/test/integration/self-registration/self-registration-otp-verify.ft.test.js
+++ b/test/integration/self-registration/self-registration-otp-verify.ft.test.js
@@ -11,6 +11,7 @@ const session = require('../../test-helpers/mock-session')
 const getApp = require('../../../server').getApp
 const inviteFixtures = require('../../fixtures/invite.fixtures')
 const gatewayAccountFixtures = require('../../fixtures/gateway-account.fixtures')
+const userFixtures = require('../../fixtures/user.fixtures')
 const paths = require('../../../app/paths')
 
 // Constants
@@ -90,11 +91,14 @@ describe('create service otp validation', function () {
           user_external_id: userExternalId,
           service_external_id: serviceExternalId
         }).getPlain()
+      const getUserResponse = userFixtures.validUserResponse({ external_id: userExternalId }).getPlain()
 
       connectorMock.post(CONNECTOR_ACCOUNTS_URL)
         .reply(201, mockConnectorCreateGatewayAccountResponse)
       adminusersMock.post(`${ADMINUSERS_INVITES_URL}/${inviteCode}/complete`, mockAdminUsersInviteCompleteRequest)
         .reply(200, mockAdminUsersInviteCompleteResponse)
+      adminusersMock.get(`/v1/api/users/${userExternalId}`)
+        .reply(200, getUserResponse)
 
       const validServiceInviteOtpRequest = inviteFixtures.validVerifyOtpCodeRequest({
         code: inviteCode

--- a/test/unit/clients/adminusers-client/service/create-service.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/create-service.pact.test.js
@@ -60,9 +60,9 @@ describe('adminusers client - create a new service', function () {
 
     it('should create a new service', function (done) {
       adminusersClient.createService().should.be.fulfilled.then(service => {
-        expect(service.external_id).to.equal(externalId)
+        expect(service.externalId).to.equal(externalId)
         expect(service.name).to.equal(name)
-        expect(service.gateway_account_ids).to.deep.equal(gatewayAccountIds)
+        expect(service.gatewayAccountIds).to.deep.equal(gatewayAccountIds)
       }).should.notify(done)
     })
   })
@@ -98,9 +98,9 @@ describe('adminusers client - create a new service', function () {
 
     it('should create a new service', function (done) {
       adminusersClient.createService(null, null, validRequest.getPlain().gateway_account_ids).should.be.fulfilled.then(service => {
-        expect(service.external_id).to.equal(externalId)
+        expect(service.externalId).to.equal(externalId)
         expect(service.name).to.equal(name)
-        expect(service.gateway_account_ids).to.deep.equal(validCreateServiceResponse.getPlain().gateway_account_ids)
+        expect(service.gatewayAccountIds).to.deep.equal(validCreateServiceResponse.getPlain().gateway_account_ids)
       }).should.notify(done)
     })
   })
@@ -138,9 +138,9 @@ describe('adminusers client - create a new service', function () {
 
     it('should create a new service', function (done) {
       adminusersClient.createService('Service name', null, null).should.be.fulfilled.then(service => {
-        expect(service.external_id).to.equal(externalId)
+        expect(service.externalId).to.equal(externalId)
         expect(service.name).to.equal(name)
-        expect(service.gateway_account_ids).to.deep.equal(gatewayAccountIds)
+        expect(service.gatewayAccountIds).to.deep.equal(gatewayAccountIds)
       }).should.notify(done)
     })
   })

--- a/test/unit/controller/create-service-controller/post.controller.test.js
+++ b/test/unit/controller/create-service-controller/post.controller.test.js
@@ -19,7 +19,7 @@ const getController = function (mockResponses, mockServiceService, mockUserServi
 
 describe('Controller: createService, Method: post', () => {
   describe('when the service name is not empty', () => {
-    before(done => {
+    before(async () => {
       mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
       mockUserService.assignServiceRole = sinon.stub().resolves()
       mockResponses.response = sinon.spy()
@@ -35,12 +35,7 @@ describe('Controller: createService, Method: post', () => {
       res = {
         redirect: sinon.spy()
       }
-      const result = addServiceCtrl.post(req, res)
-      if (result) {
-        result.then(() => done()).catch(done)
-      } else {
-        done(new Error('Didn\'t return a promise'))
-      }
+      await addServiceCtrl.post(req, res)
     })
 
     it(`should call 'res.redirect' with '/my-service'`, () => {
@@ -50,7 +45,7 @@ describe('Controller: createService, Method: post', () => {
   })
 
   describe('when the service name is not empty, but the update call fails', () => {
-    before(done => {
+    before(async () => {
       mockServiceService.createService = sinon.stub().rejects(new Error('something went wrong'))
       mockResponses.renderErrorView = sinon.spy()
       const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)
@@ -62,12 +57,7 @@ describe('Controller: createService, Method: post', () => {
         }
       }
       res = {}
-      const result = addServiceCtrl.post(req, res)
-      if (result) {
-        result.then(() => done()).catch(done)
-      } else {
-        done(new Error('Didn\'t return a promise'))
-      }
+      await addServiceCtrl.post(req, res)
     })
 
     it(`should call 'responses.renderErrorView' with req, res and the error received from the client`, () => {
@@ -80,7 +70,7 @@ describe('Controller: createService, Method: post', () => {
   })
 
   describe('when the service name is not empty, and the create service succeeds, but the assign service role call fails', () => {
-    before(done => {
+    before(async () => {
       mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
       mockUserService.assignServiceRole = sinon.stub().rejects(new Error('something went wrong'))
       mockResponses.renderErrorView = sinon.spy()
@@ -94,12 +84,7 @@ describe('Controller: createService, Method: post', () => {
         }
       }
       res = {}
-      const result = addServiceCtrl.post(req, res)
-      if (result) {
-        result.then(() => done()).catch(done)
-      } else {
-        done(new Error('Didn\'t return a promise'))
-      }
+      await addServiceCtrl.post(req, res)
     })
 
     it(`should call 'responses.renderErrorView' with req, res and the error received from the client`, () => {
@@ -112,7 +97,7 @@ describe('Controller: createService, Method: post', () => {
   })
 
   describe('when the service name is empty', () => {
-    before(done => {
+    before(async () => {
       mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
       mockUserService.assignServiceRole = sinon.stub().resolves()
       mockResponses.response = sinon.spy()
@@ -127,12 +112,7 @@ describe('Controller: createService, Method: post', () => {
       res = {
         redirect: sinon.spy()
       }
-      const result = addServiceCtrl.post(req, res)
-      if (result) {
-        done(new Error('Returned a promise'))
-      } else {
-        done()
-      }
+      await addServiceCtrl.post(req, res)
     })
 
     it(`should call 'res.redirect' with a to create service`, () => {
@@ -147,7 +127,7 @@ describe('Controller: createService, Method: post', () => {
   })
 
   describe('when the Welsh service name is empty', () => {
-    before(done => {
+    before(async () => {
       mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
       mockUserService.assignServiceRole = sinon.stub().resolves()
       mockResponses.response = sinon.spy()
@@ -163,12 +143,7 @@ describe('Controller: createService, Method: post', () => {
       res = {
         redirect: sinon.spy()
       }
-      const result = addServiceCtrl.post(req, res)
-      if (result) {
-        result.then(() => done()).catch(done)
-      } else {
-        done(new Error('Didn\'t return a promise'))
-      }
+      await addServiceCtrl.post(req, res)
     })
 
     it(`should call 'res.redirect' with '/my-service'`, () => {


### PR DESCRIPTION
Log when new service is created:
- as part of user registration
- when an existing user adds a new service

Refactor surrounding code to conform to best practices.

For the create service response from adminusers, transform the response using the `Service` model, like we do for other responses.


