### PR TITLE
PP-7416 Add button to enable or disable Worldpay 3DS Flex

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2020-09-30T11:12:19Z",
+  "generated_at": "2020-11-26T16:54:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -72,7 +72,7 @@
         "hashed_secret": "ece65afda87c1c6120602c9a3b66890308d7e53c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 45,
+        "line_number": 46,
         "type": "Secret Keyword"
       }
     ],

--- a/app/controllers/your-psp/get.controller.js
+++ b/app/controllers/your-psp/get.controller.js
@@ -4,8 +4,15 @@ const { response } = require('../../utils/response')
 
 module.exports = (req, res) => {
   const isAccountCredentialsConfigured = req.account.credentials && req.account.credentials.merchant_id !== undefined
-  const isFlexConfigured = req.account.worldpay_3ds_flex &&
+
+  const isWorldpay3dsFlexCredentialsConfigured = req.account.worldpay_3ds_flex &&
     req.account.worldpay_3ds_flex.organisational_unit_id !== undefined &&
     req.account.worldpay_3ds_flex.organisational_unit_id.length > 0
-  return response(req, res, 'your-psp/index', { isAccountCredentialsConfigured, isFlexConfigured })
+  
+  const is3dsEnabled = req.account.requires3ds === true
+
+  const isWorldpay3dsFlexEnabled = is3dsEnabled && req.account.integration_version_3ds === 2
+
+  return response(req, res, 'your-psp/index', { isAccountCredentialsConfigured, is3dsEnabled,
+    isWorldpay3dsFlexEnabled, isWorldpay3dsFlexCredentialsConfigured })
 }

--- a/app/controllers/your-psp/index.js
+++ b/app/controllers/your-psp/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
 exports.getIndex = require('./get.controller')
+exports.postToggleWorldpay3dsFlex = require('./post-toggle-worldpay-3ds-flex.controller')
 exports.getFlex = require('./get-flex.controller')
 exports.postFlex = require('./post-flex.controller')

--- a/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.js
+++ b/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.js
@@ -11,7 +11,7 @@ module.exports = async function toggleWorldpay3dsFlex (req, res) {
 
     if (req.body['toggle-worldpay-3ds-flex'] === 'on' || req.body['toggle-worldpay-3ds-flex'] === 'off') {
         const enabling3dsFlex = toggleWorldpay3dsFlex === 'on'
-        const message = enabling3dsFlex ? '3DS Flex turned on' : '3DS Flex turned off'
+        const message = enabling3dsFlex ? '3DS Flex has been turned on.' : '3DS Flex has been turned off. Your payments will now use 3DS only.'
         const integrationVersion3ds = enabling3dsFlex ? 2 : 1
         try {
             await connector.updateIntegrationVersion3ds(accountId, integrationVersion3ds, req.correlationId)

--- a/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.test.js
+++ b/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.test.js
@@ -4,7 +4,7 @@ const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const paths = require('../../paths')
 
-describe('Toogle Worldpay 3DS Flex controller', () => {
+describe('Toggle Worldpay 3DS Flex controller', () => {
   let req
   let res
   let updateIntegrationVersion3dsMock
@@ -35,7 +35,7 @@ describe('Toogle Worldpay 3DS Flex controller', () => {
     await controller(req, res)
 
     sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 2, req.correlationId)
-    sinon.assert.calledWith(req.flash, 'generic', '3DS Flex turned on')
+    sinon.assert.calledWith(req.flash, 'generic', '3DS Flex has been turned on.')
     sinon.assert.calledWith(res.redirect, 303, paths.yourPsp.index)
   })
 
@@ -47,7 +47,7 @@ describe('Toogle Worldpay 3DS Flex controller', () => {
     await controller(req, res)
 
     sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 1, req.correlationId)
-    sinon.assert.calledWith(req.flash, 'generic', '3DS Flex turned off')
+    sinon.assert.calledWith(req.flash, 'generic', '3DS Flex has been turned off. Your payments will now use 3DS only.')
     sinon.assert.calledWith(res.redirect, 303, paths.yourPsp.index)
   })
 

--- a/app/paths.js
+++ b/app/paths.js
@@ -16,7 +16,8 @@ module.exports = {
   },
   yourPsp: {
     index: '/your-psp',
-    flex: '/your-psp/flex'
+    flex: '/your-psp/flex',
+    worldpay3dsFlex: '/your-psp/worldpay-3ds-flex'
   },
   credentials: {
     index: '/credentials',

--- a/app/routes.js
+++ b/app/routes.js
@@ -237,6 +237,7 @@ module.exports.bind = function (app) {
 
   // YOUR PSP
   app.get(yourPsp.index, xraySegmentCls, permission('gateway-credentials:read'), getAccount, paymentMethodIsCard, yourPspController.getIndex)
+  app.post(yourPsp.worldpay3dsFlex, xraySegmentCls, permission('toggle-3ds:update'), getAccount, paymentMethodIsCard, yourPspController.postToggleWorldpay3dsFlex)
   app.get(yourPsp.flex, xraySegmentCls, permission('gateway-credentials:update'), getAccount, paymentMethodIsCard, yourPspController.getFlex)
   app.post(yourPsp.flex, xraySegmentCls, permission('gateway-credentials:update'), getAccount, paymentMethodIsCard, yourPspController.postFlex)
 

--- a/app/views/your-psp/_worldpay-flex.njk
+++ b/app/views/your-psp/_worldpay-flex.njk
@@ -1,4 +1,11 @@
-<h2 class="govuk-heading-m govuk-!-margin-top-9">3DS Flex credentials</h2>
+<h2 class="govuk-heading-m govuk-!-margin-top-9">3DS Flex</h2>
+
+{{ govukInsetText({
+  "attributes": {
+    "id": "worldpay-3ds-flex-is-on" if isWorldpay3dsFlexEnabled else "worldpay-3ds-flex-is-off"
+  },
+  text: "3DS Flex is turned on." if isWorldpay3dsFlexEnabled else "3DS Flex is turned off."
+}) }}
 
 <p class="govuk-body">Worldpay’s 3DS Flex improves how 3DS works and will also enable 3DS2 when required. There’s an additional fee to Worldpay to use 3DS Flex. <a class="govuk-link" href="https://www.payments.service.gov.uk/3d-secure-2/">Find out more about 3DS2 and 3DS Flex</a>.</p>
 
@@ -16,7 +23,7 @@
           text: "Organisational unit ID"
         },
         value: {
-          text: currentGatewayAccount.worldpay_3ds_flex.organisational_unit_id if isFlexConfigured else "Not configured",
+          text: currentGatewayAccount.worldpay_3ds_flex.organisational_unit_id if isWorldpay3dsFlexCredentialsConfigured else "Not configured",
           classes: "value-organisational-unit-id"
         },
         actions: {
@@ -37,7 +44,7 @@
           text: "Issuer (API ID)"
         },
         value: {
-          text: currentGatewayAccount.worldpay_3ds_flex.issuer if isFlexConfigured else "Not configured",
+          text: currentGatewayAccount.worldpay_3ds_flex.issuer if isWorldpay3dsFlexCredentialsConfigured else "Not configured",
           classes: "value-issuer"
         },
         actions: {
@@ -55,7 +62,7 @@
           text: "JWT MAC key (API key)"
         },
         value: {
-          text: '●●●●●●●●' if isFlexConfigured else "Not configured",
+          text: '●●●●●●●●' if isWorldpay3dsFlexCredentialsConfigured else "Not configured",
           classes: "value-jwt-mac-key"
         },
         actions: {
@@ -71,3 +78,28 @@
     ]
   })
 }}
+
+{% if (is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured) or isWorldpay3dsFlexEnabled %}
+  <form method="post" action="{{routes.yourPsp.worldpay3dsFlex}}">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}">
+    {% if is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured and not isWorldpay3dsFlexEnabled %}
+        <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="on">
+        {{ govukButton({
+          attributes: {
+            id: "enable-worldpay-3ds-flex-button"
+          },
+          text: "Turn on 3DS Flex",
+          classes: "govuk-button--secondary"
+        }) }}
+    {% elif isWorldpay3dsFlexEnabled %}
+      <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="off">
+      {{ govukButton({
+        attributes: {
+          id: "disable-worldpay-3ds-flex-button"
+        },
+        text: "Turn off 3DS Flex",
+        classes: "govuk-button--secondary"
+      }) }}
+    {% endif %}
+  </form>
+{% endif %}

--- a/app/views/your-psp/flex.njk
+++ b/app/views/your-psp/flex.njk
@@ -170,21 +170,6 @@
         })
       }}
     </form>
-    <form method="post" action="{{routes.yourPsp.flex}}">
-        {% if isFlexConfigured %}
-            <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
-            <input id="remove-credentials" name="remove-credentials" type="hidden" value="true" />
-            {{
-            govukButton({
-                text: "Remove credentials",
-                classes: "govuk-button--warning",
-                attributes: {
-                    id: "removeFlexCredentials"
-                }
-                })
-            }}
-        {% endif %}
-    </form>
     <p class="govuk-body">
       <a class="govuk-link govuk-link--no-visited-state" href="{{ routes.yourPsp.index }}">Cancel</a>
     </p>

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -465,6 +465,16 @@ module.exports = {
       }
     })
   },
+  patchIntegrationVersion3ds: (opts = {}) => {
+    const path = `/v1/api/accounts/${opts.gateway_account_id}`
+    return simpleStubBuilder('PATCH', path, 200, {
+      request: {
+        op: 'replace',
+        path: 'integration_version_3ds',
+        value: opts.patchIntegrationVersion3ds
+      }
+    })
+  },
   redirectToGoCardlessConnectFailure: (opts = {}) => {
     const path = '/oauth/authorize'
     return simpleStubBuilder('GET', path, 500, {

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -15,6 +15,9 @@ const getGatewayAccountSuccess = function (opts) {
   if (opts.requires3ds) {
     stubOptions.requires3ds = opts.requires3ds
   }
+  if (opts.integrationVersion3ds !== undefined) {
+    stubOptions.integrationVersion3ds = opts.integrationVersion3ds
+  }
   if (opts.allowMoto) {
     stubOptions.allow_moto = opts.allowMoto
   }
@@ -121,6 +124,15 @@ const patchUpdate3DS = function (opts) {
   }
 }
 
+const patchIntegrationVersion3ds = function (opts) {
+  return {
+    name: 'patchIntegrationVersion3ds',
+    opts: {
+      integration_version_3ds: opts.integrationVersion3ds
+    }
+  }
+}
+
 const patchUpdateMotoMaskSecurityCode = function (opts) {
   return {
     name: 'patchUpdateMotoMaskSecurityCode',
@@ -202,6 +214,7 @@ module.exports = {
   postCreateGatewayAccountSuccess,
   getCardTypesSuccess,
   patchUpdate3DS,
+  patchIntegrationVersion3ds,
   patchConfirmationEmailToggleSuccess,
   patchRefundEmailToggleSuccess,
   patchAccountEmailCollectionModeSuccess,

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -45,6 +45,9 @@ function validGatewayAccount (opts) {
   if (opts.requires3ds) {
     gatewayAccount.requires3ds = opts.requires3ds
   }
+  if (opts.requires3ds) {
+    gatewayAccount.integration_version_3ds = opts.integrationVersion3ds
+  }
   if (opts.credentials) {
     gatewayAccount.credentials = opts.credentials
   }


### PR DESCRIPTION
Add a button to the ‘Your PSP’ page for Worldpay accounts to enable or disable 3DS Flex.

The enable button is shown only if it’s a Worldpay account, 3DS is enabled, 3DS Flex is disabled and there are 3DS Flex credentials.

![image](https://user-images.githubusercontent.com/24316348/100758586-94b0aa80-33e7-11eb-9cd5-83f639720860.png)

The disable button is shown only if it’s a Worldpay account, 3DS is enabled and 3DS Flex is enabled.

![image](https://user-images.githubusercontent.com/24316348/100758635-a2663000-33e7-11eb-9c83-7791c082999a.png)

No button is shown in other circumstances, meaning, for example, that a service cannot enable 3DS Flex if they have not entered 3DS Flex credentials.

![image](https://user-images.githubusercontent.com/24316348/100758664-ab570180-33e7-11eb-85e6-742df61fc4d5.png)

The page that’s requested when the button is pressed requires the `toggle-3ds:update` permission whereas the page it’s displayed on requires the `gateway-credentials:read` permission. This is a less than ideal but only the `admin` role has either of these so the button won’t be shown to anyone who can’t press it.

Remove the ‘Remove credentials’ button from the 3DS Flex credentials page (which was the only way of turning off 3DS Flex before) because that’s no longer necessary (some code to support this function is still there; it will be removed in a future
commit).