### PR TITLE
PP-7458 Order services by ID

### DIFF
--- a/app/controllers/my-services/get-index.controller.js
+++ b/app/controllers/my-services/get-index.controller.js
@@ -28,24 +28,26 @@ module.exports = async (req, res) => {
 
   const aggregatedGatewayAccounts = await serviceService.getGatewayAccounts(aggregatedGatewayAccountIds, req.correlationId)
 
-  const servicesData = servicesRoles.map(serviceRole => {
-    // For Direct Debit currently we initialise req.user.serviceRoles[].service.gatewayAccountIds with external ids,
-    // but for Cards we initialise with internal ids.
-    // We check the gateway accounts' external id first as not to overlap/skip between card payment and direct debit gateway accounts.
-    const gatewayAccounts =
-      aggregatedGatewayAccounts.filter(gatewayAccount => serviceRole.service.gatewayAccountIds.includes(gatewayAccount.external_id.toString()) ||
-        serviceRole.service.gatewayAccountIds.includes(gatewayAccount.id.toString()))
-    const cardAccounts = gatewayAccounts.filter(gatewayAccount => !isDirectDebitAccount(gatewayAccount))
-    const payload = {
-      name: serviceRole.service.name === 'System Generated' ? 'Temporary Service Name' : serviceRole.service.name,
-      external_id: serviceRole.service.externalId,
-      gateway_accounts: {
-        cardAccounts: _.sortBy(cardAccounts, 'type', 'asc')
-      },
-      permissions: getHeldPermissions(serviceRole.role.permissions.map(permission => permission.name))
-    }
-    return payload
-  })
+  const servicesData = servicesRoles
+    .sort((a,b) => a.service.id - b.service.id)
+    .map(serviceRole => {
+      // For Direct Debit currently we initialise req.user.serviceRoles[].service.gatewayAccountIds with external ids,
+      // but for Cards we initialise with internal ids.
+      // We check the gateway accounts' external id first as not to overlap/skip between card payment and direct debit gateway accounts.
+      const gatewayAccounts =
+        aggregatedGatewayAccounts.filter(gatewayAccount => serviceRole.service.gatewayAccountIds.includes(gatewayAccount.external_id.toString()) ||
+          serviceRole.service.gatewayAccountIds.includes(gatewayAccount.id.toString()))
+      const cardAccounts = gatewayAccounts.filter(gatewayAccount => !isDirectDebitAccount(gatewayAccount))
+      const payload = {
+        name: serviceRole.service.name === 'System Generated' ? 'Temporary Service Name' : serviceRole.service.name,
+        external_id: serviceRole.service.externalId,
+        gateway_accounts: {
+          cardAccounts: _.sortBy(cardAccounts, 'type', 'asc')
+        },
+        permissions: getHeldPermissions(serviceRole.role.permissions.map(permission => permission.name))
+      }
+      return payload
+    })
 
   const data = {
     services: servicesData,

--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -2,6 +2,7 @@
 
 class Service {
   constructor (serviceData) {
+    this.id = serviceData.id
     this.externalId = serviceData.external_id
     this.name = serviceData.name
     this.serviceName = serviceData.service_name
@@ -18,6 +19,7 @@ class Service {
    */
   toJson () {
     return {
+      id: this.id,
       external_id: this.externalId,
       name: this.name,
       serviceName: this.serviceName,

--- a/test/unit/controller/service-switch.controller.it.test.js
+++ b/test/unit/controller/service-switch.controller.it.test.js
@@ -25,11 +25,13 @@ describe('service switch controller: list of accounts', function () {
     const directDebitGatewayAccountIds = ['DIRECT_DEBIT:6bugfqvub0isp3rqfknck5vq24', 'DIRECT_DEBIT:ksdfhjhfd;sfksd34']
 
     connectorMock.get(ACCOUNTS_FRONTEND_PATH + `?accountIds=${allServiceGatewayAccountIds.join(',')}`)
-      .reply(200, { accounts: allServiceGatewayAccountIds.map(iter => gatewayAccountFixtures.validGatewayAccountResponse({
-        gateway_account_id: iter,
-        service_name: `account ${iter}`,
-        type: _.sample(['test', 'live'])
-      }).getPlain()) })
+      .reply(200, {
+        accounts: allServiceGatewayAccountIds.map(iter => gatewayAccountFixtures.validGatewayAccountResponse({
+          gateway_account_id: iter,
+          service_name: `account ${iter}`,
+          type: _.sample(['test', 'live'])
+        }).getPlain())
+      })
 
     const req = {
       correlationId: 'correlationId',
@@ -38,6 +40,7 @@ describe('service switch controller: list of accounts', function () {
         service_roles: [
           {
             service: {
+              id: 201,
               name: 'My Service 1',
               external_id: 'service-external-id-1',
               gateway_account_ids: service1gatewayAccountIds
@@ -49,6 +52,7 @@ describe('service switch controller: list of accounts', function () {
           },
           {
             service: {
+              id: 120,
               name: 'My Service 2',
               external_id: 'service-external-id-2',
               gateway_account_ids: service2gatewayAccountIds
@@ -60,6 +64,7 @@ describe('service switch controller: list of accounts', function () {
           },
           {
             service: {
+              id: 12,
               name: 'System Generated',
               external_id: 'service-external-id-3',
               gateway_account_ids: service3gatewayAccountIds
@@ -71,6 +76,7 @@ describe('service switch controller: list of accounts', function () {
           },
           {
             service: {
+              id: 3,
               name: 'Direct Debit service',
               external_id: 'service-external-id-4',
               gateway_account_ids: directDebitGatewayAccountIds
@@ -90,7 +96,8 @@ describe('service switch controller: list of accounts', function () {
         const renderData = arguments[1]
 
         expect(path).to.equal('services/index')
-        expect(renderData.services.map(service => service.name)).to.have.lengthOf(4).and.to.include('My Service 1', 'My Service 2', '', 'Direct Debit service')
+        const renderedServiceNames = renderData.services.map(service => service.name)
+        expect(renderedServiceNames).to.have.lengthOf(4).and.to.have.ordered.members(['Direct Debit service', 'Temporary Service Name', 'My Service 2', 'My Service 1'])
         expect(cardGatewayAccountNamesOf(renderData, 'service-external-id-1')).to.have.lengthOf(2).and.to.include('account 2', 'account 5')
         expect(cardGatewayAccountNamesOf(renderData, 'service-external-id-2')).to.have.lengthOf(3).and.to.include('account 3', 'account 6', 'account 7')
         expect(cardGatewayAccountNamesOf(renderData, 'service-external-id-3')).to.have.lengthOf(2).and.to.include('account 4', 'account 9')


### PR DESCRIPTION
At some point the ordering of services on the “My services page” changed. We weren’t doing any explicit ordering of services so were just relying on the order returned by the database.

This could have been when we bulk updated the “created_date” recently, but it's unclear.

Explicitly order on the id as we think that’s how services were previously ordered.

## Review notes
Hiding whitespace changes in GitHub will make this easier to review as some indentation was changed.