### PR TITLE
PP-7491 Add error classes

### DIFF
--- a/app/errors.js
+++ b/app/errors.js
@@ -1,0 +1,33 @@
+'use strict'
+
+class DomainError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = this.constructor.name
+    Error.captureStackTrace(this, this.constructor)
+  }
+}
+
+/**
+ * Thrown when there is no authentication session for the user.
+ */
+class NotAuthenticatedError extends DomainError {
+}
+
+/**
+ * Thrown when the user does not have permission to access a resource.
+ */
+class NotAuthorisedError extends DomainError {
+}
+
+/**
+ * Thrown when the resource that a route is trying to access cannot be found.
+ */
+class NotFoundError extends DomainError {
+}
+
+module.exports = {
+  NotAuthenticatedError,
+  NotAuthorisedError,
+  NotFoundError
+}

--- a/test/unit/errors.test.js
+++ b/test/unit/errors.test.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const { expect } = require('chai')
+const { NotAuthenticatedError, NotAuthorisedError, NotFoundError } = require('../../app/errors')
+
+describe('Error classes', () => {
+  it('should construct NotAuthenticatedError', () => {
+    const error = new NotAuthenticatedError('not authenticated')
+    expect(error.message).to.equal('not authenticated')
+    expect(error.name).to.equal('NotAuthenticatedError')
+    expect(error.stack).to.not.be.null // eslint-disable-line
+  })
+
+  it('should construct NotAuthorisedError', () => {
+    const error = new NotAuthorisedError('not authorised')
+    expect(error.message).to.equal('not authorised')
+    expect(error.name).to.equal('NotAuthorisedError')
+    expect(error.stack).to.not.be.null // eslint-disable-line
+  })
+
+  it('should construct NotFoundError', () => {
+    const error = new NotFoundError('not found')
+    expect(error.message).to.equal('not found')
+    expect(error.name).to.equal('NotFoundError')
+    expect(error.stack).to.not.be.null // eslint-disable-line
+  })
+})


### PR DESCRIPTION
Add custom error classes. These will be handled by a catch-all error handler at the end of the express stack which will render the appropriate error page.