### PR TITLE
Pp 7360 payment link reporting columns

### DIFF
--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-pay tunnel $1 adminusers connector directdebit-connector publicauth ledger
+pay tunnel $1 adminusers connector directdebit-connector publicauth ledger products

--- a/test/unit/controller/payment-links/metadata/paymentlink-metadata-form.test.js
+++ b/test/unit/controller/payment-links/metadata/paymentlink-metadata-form.test.js
@@ -21,6 +21,64 @@ describe('Payment link metadata form model', () => {
     expect(tested.errorMaps['metadata-cell-value']).to.be.undefined // eslint-disable-line
   })
 
+  it('correctly validates given input that is too long', () => {
+    const body = { 
+      'metadata-column-header': 'aaaaaaaaaabbbbbbbbbbcccccccccc1',
+      'metadata-cell-value': 'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee2'
+    }
+
+    const form = new MetadataForm(body)
+    const tested = form.validate()
+
+    expect(tested.errors.length).to.eq(2)
+    expect(tested.errorMaps['metadata-column-header']).to.not.be.null // eslint-disable-line
+    expect(tested.errorMaps['metadata-cell-value']).to.not.be.null // eslint-disable-line
+  })
+
+  it('correctly validates a duplicate metadata column', () => {
+    const body = {
+      'metadata-column-header': 'test 2 header',
+      'metadata-cell-value': 'test 2 value'
+    }
+
+    const existingMetadata = {
+      'test 1 header': 'test 1 value',
+      'test 2 header': 'test 2 value'
+    }
+
+    const form = new MetadataForm(body, existingMetadata)
+    const tested = form.validate()
+    expect(tested.errors.length).to.eq(1)
+    expect(tested.errorMaps['metadata-column-header']).to.not.be.null // eslint-disable-line
+    expect(tested.errorMaps['metadata-cell-value']).to.be.undefined // eslint-disable-line
+  })
+
+  it('correctly validates when the number of metadata columns exceeds the max number of allowed metadata columns', () => {
+    const body = {
+      'metadata-column-header': 'test 11 header',
+      'metadata-cell-value': 'test 11 value'
+    }
+
+    const existingMetadata = {
+      'test 1 header': 'test 1 value',
+      'test 2 header': 'test 2 value',
+      'test 3 header': 'test 3 value',
+      'test 4 header': 'test 4 value',
+      'test 5 header': 'test 5 value',
+      'test 6 header': 'test 6 value',
+      'test 7 header': 'test 7 value',
+      'test 8 header': 'test 8 value',
+      'test 9 header': 'test 9 value',
+      'test 10 header': 'test 10 value'
+    }
+
+    const form = new MetadataForm(body, existingMetadata)
+    const tested = form.validate()
+    expect(tested.errors.length).to.eq(1)
+    expect(tested.errorMaps['metadata-column-header']).to.not.be.null // eslint-disable-line
+    expect(tested.errorMaps['metadata-cell-value']).to.be.undefined // eslint-disable-line
+  })
+
   it('correctly passes with all valid inputs', () => {
     const body = { 'metadata-column-header': 'key', 'metadata-cell-value': 'value' }
     const form = new MetadataForm(body)


### PR DESCRIPTION
    PP-7360 Add Payment Links flow > Add Reporting Columns
    
    - Add new validation to `metadata-form.js`
      - Make sure metadata headers and values < 50
      - Make sure metadata headers are unique

    PP-7360 Update tunnel script - add products
    
    - Update script so that when you tunnel into test is also tunnels to 'products'
    - So that you can setup Payment Links in a local instance of Self service that tunnels to test.


