### PR TITLE
PP-7489 Add account and service middleware

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2020-11-26T16:54:14Z",
+  "generated_at": "2020-12-08T11:50:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -72,7 +72,7 @@
         "hashed_secret": "ece65afda87c1c6120602c9a3b66890308d7e53c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 46,
+        "line_number": 50,
         "type": "Secret Keyword"
       }
     ],

--- a/app/middleware/get-service-and-gateway-account.middleware.js
+++ b/app/middleware/get-service-and-gateway-account.middleware.js
@@ -1,0 +1,106 @@
+'use strict'
+
+const _ = require('lodash')
+
+const logger = require('../utils/logger')(__filename)
+const paths = require('../../app/paths')
+const { NotFoundError } = require('../../app/errors')
+const Connector = require('../services/clients/connector.client.js').ConnectorClient
+
+const { keys } = require('@govuk-pay/pay-js-commons').logging
+const connectorClient = new Connector(process.env.CONNECTOR_URL)
+
+async function getGatewayAccountByExternalId (gatewayAccountExternalId, correlationId) {
+  try {
+    const params = {
+      gatewayAccountExternalId: gatewayAccountExternalId,
+      correlationId: correlationId
+    }
+    // TODO: PP-7489 - add additional attributes derived by getAccount middleware
+    return await connectorClient.getAccountByExternalId(params)
+  } catch (err) {
+    const logContext = {}
+    logContext['error'] = err.message
+    logContext['GATEWAY_ACCOUNT_EXTERNAL_ID'] = gatewayAccountExternalId
+    logContext[keys.CORRELATION_ID] = correlationId
+
+    if (err.errorCode === 404) {
+      logger.info('Gateway account not found', logContext)
+      throw new NotFoundError('Gateway account not found')
+    } else {
+      logger.error('Error when attempting to retrieve gateway account', logContext)
+      throw new Error('Error retrieving Gateway account')
+    }
+  }
+}
+
+function getService (user, serviceExternalId, gatewayAccount, correlationId) {
+  let service
+  const serviceRoles = _.get(user, 'serviceRoles', [])
+
+  if (serviceRoles.length > 0) {
+    if (serviceExternalId) {
+      service = _.get(serviceRoles.find(serviceRole => {
+        return (serviceRole.service.externalId === serviceExternalId &&
+          (!gatewayAccount || serviceRole.service.gatewayAccountIds.includes(gatewayAccount.gateway_account_id)))
+      }), 'service')
+    } else {
+      if (gatewayAccount) {
+        service = _.get(serviceRoles.find(serviceRole => {
+          return serviceRole.service.gatewayAccountIds.includes(gatewayAccount.gateway_account_id)
+        }), 'service')
+      }
+    }
+  }
+
+  if (service) {
+    // hasCardGatewayAccount is needed to show relevant message (card or directdebit or both) on merchant details page.
+    // Since it is only card currently supported, value is always 'true'
+    service.hasCardGatewayAccount = true
+    return service
+  } else {
+    const logContext = {}
+    logContext[keys.USER_EXTERNAL_ID] = user.externalId
+    logContext[keys.SERVICE_EXTERNAL_ID] = serviceExternalId
+    if (gatewayAccount) {
+      logContext[keys.GATEWAY_ACCOUNT_ID] = gatewayAccount.gateway_account_id
+    }
+    logContext[keys.CORRELATION_ID] = correlationId
+    logger.info('Service not found for user', logContext)
+    throw new NotFoundError('Service not found for user')
+  }
+}
+
+module.exports = async function (req, res, next) {
+  try {
+    const correlationId = req.correlationId
+    const serviceExternalId = req.params[paths.keys.SERVICE_EXTERNAL_ID]
+    const gatewayAccountExternalId = req.params[paths.keys.GATEWAY_ACCOUNT_EXTERNAL_ID]
+
+    if (!serviceExternalId && !gatewayAccountExternalId) {
+      const logContext = {}
+      logContext[keys.CORRELATION_ID] = correlationId
+      logger.info('Could not resolve gateway account external ID or service external ID from request params')
+      throw new Error('Could not resolve gateway account external ID or service external ID from request params')
+    }
+
+    let gatewayAccount
+    if (gatewayAccountExternalId) {
+      gatewayAccount = await getGatewayAccountByExternalId(gatewayAccountExternalId, correlationId)
+      if (gatewayAccount) {
+        req.account = gatewayAccount
+        // TODO: To be removed once URLs are updated to use the format /service/:serviceExternalId/account/:gatewayAccountExternalId/xxx.
+        // Currently authService.getCurrentGatewayAccountId() sets below if account is available on session or derives one from user services.
+        req.gateway_account = { currentGatewayAccountId: gatewayAccount.gateway_account_id }
+      }
+    }
+
+    // uses req.user object which is set by passport (auth.service.js) and has all user services information to find service by serviceExternalId or gatewayAccountId.
+    // A separate API call to adminusers to find service makes it independent of user object but most of tests setup currently relies on req.user
+    req.service = getService(req.user, serviceExternalId, gatewayAccount, correlationId)
+
+    next()
+  } catch (err) {
+    next(err)
+  }
+}

--- a/app/paths.js
+++ b/app/paths.js
@@ -3,6 +3,10 @@
 const path = require('path')
 
 module.exports = {
+  keys: {
+    SERVICE_EXTERNAL_ID: 'serviceExternalId',
+    GATEWAY_ACCOUNT_EXTERNAL_ID: 'gatewayAccountExternalId'
+  },
   transactions: {
     index: '/transactions',
     download: '/transactions/download',

--- a/test/unit/middleware/get-service-and-gateway-account.middleware.test.js
+++ b/test/unit/middleware/get-service-and-gateway-account.middleware.test.js
@@ -1,0 +1,161 @@
+'use strict'
+
+const { NotFoundError } = require('../../../app/errors')
+const path = require('path')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const { expect } = require('chai')
+const userFixtures = require('../../fixtures/user.fixtures')
+
+let req, res, next, connectorGetAccountMock
+
+const connectorMock = {
+  ConnectorClient: function () {
+    this.getAccountByExternalId = connectorGetAccountMock
+  }
+}
+
+const buildUser = (serviceExternalId, gatewayAccountIds) => {
+  return userFixtures.validUserResponse({
+    service_roles: [{
+      service: {
+        external_id: serviceExternalId,
+        gateway_account_ids: gatewayAccountIds
+      }
+    }]
+  }).getAsObject()
+}
+
+const setupGetGatewayAccountAndService = function (gatewayAccountID, gatewayAccountExternalId, paymentProvider, serviceExternalId) {
+  req = {
+    params: { gatewayAccountExternalId: gatewayAccountExternalId, serviceExternalId: serviceExternalId },
+    correlationId: 'some-correlation-id'
+  }
+  req.user = buildUser(serviceExternalId, [gatewayAccountID])
+  next = sinon.spy()
+  connectorGetAccountMock = sinon.spy((params) => {
+    return Promise.resolve({
+      gateway_account_id: gatewayAccountID,
+      external_id: gatewayAccountExternalId,
+      payment_provider: paymentProvider
+    })
+  })
+
+  return proxyquire(path.join(__dirname, '../../../app/middleware/get-service-and-gateway-account.middleware'), {
+    '../services/clients/connector.client.js': connectorMock
+  })
+}
+const setupGetGatewayAccountClientError = function (gatewayAccountExternalId, errorCode) {
+  req = {
+    params: { gatewayAccountExternalId: gatewayAccountExternalId },
+    correlationId: 'some-correlation-id'
+  }
+  next = sinon.spy()
+  connectorGetAccountMock = sinon.spy((params) => {
+    const errorFromConnector = { errorCode: errorCode }
+    return Promise.reject(errorFromConnector)
+  })
+
+  return proxyquire(path.join(__dirname, '../../../app/middleware/get-service-and-gateway-account.middleware'), {
+    '../services/clients/connector.client.js': connectorMock
+  })
+}
+
+describe('middleware: getGatewayAccountAndService', () => {
+  it('should set gateway account and service on request object ', () => {
+    const getGatewayAccountAndService = setupGetGatewayAccountAndService('1', 'some-gateway-external-id', 'worldpay', 'some-service-external-id')
+    next = function () {
+      expect(connectorGetAccountMock.called).to.equal(true)
+      expect(connectorGetAccountMock.calledWith({
+        gatewayAccountExternalId: 'some-gateway-external-id',
+        correlationId: 'some-correlation-id'
+      })).to.equal(true)
+
+      expect(req.account.external_id).to.equal('some-gateway-external-id')
+      expect(req.service.externalId).to.equal('some-service-external-id')
+      expect(req.service.hasCardGatewayAccount).to.equal(true)
+
+      expect(req.gateway_account.currentGatewayAccountId).to.equal('1')
+    }
+    return getGatewayAccountAndService(req, res, next)
+  })
+  it('should not set gateway account, if gateway account external ID is not resolved', () => {
+    const getGatewayAccountAndService = setupGetGatewayAccountAndService('1', 'some-gateway-external-id', 'worldpay', 'some-service-external-id')
+    req.params['gatewayAccountExternalId'] = undefined
+
+    next = function () {
+      expect(req).to.not.have.property('account')
+      expect(req).to.not.have.property('gateway_account')
+
+      expect(req.service.externalId).to.equal('some-service-external-id')
+    }
+    return getGatewayAccountAndService(req, res, next)
+  })
+  it('should error, if both gateway account external ID and service external ID cannot be resolved', () => {
+    const getGatewayAccountAndService = setupGetGatewayAccountAndService('1', 'some-gateway-external-id', 'worldpay', 'some-service-external-id')
+    req.params['gatewayAccountExternalId'] = undefined
+    req.params['serviceExternalId'] = undefined
+
+    next = function (err) {
+      expect(err.message).to.equal('Could not resolve gateway account external ID or service external ID from request params')
+      expect(err).to.be.instanceOf(Error)
+    }
+    return getGatewayAccountAndService(req, res, next)
+  })
+  it('should error, if gateway account not found for gatewayExternalId', () => {
+    const getGatewayAccountAndService = setupGetGatewayAccountClientError('some-gateway-account-external-id', 404)
+
+    next = function (err) {
+      expect(err.message).to.equal('Gateway account not found')
+      expect(err).to.be.instanceOf(NotFoundError)
+    }
+    return getGatewayAccountAndService(req, res, next)
+  })
+  it('should error, if connector returns error (other than 404)', () => {
+    const getGatewayAccountAndService = setupGetGatewayAccountClientError('some-gateway-account-external-id', 500)
+
+    next = function (err) {
+      expect(err.message).to.equal('Error retrieving Gateway account')
+      expect(err).to.be.instanceOf(Error)
+    }
+    return getGatewayAccountAndService(req, res, next)
+  })
+  it('should set service based on gateway account, when serviceExternalId cannot be resolved', () => {
+    const getGatewayAccountAndService = setupGetGatewayAccountAndService('1', 'some-gateway-external-id', 'worldpay', 'some-service-external-id')
+    req.params['serviceExternalId'] = undefined
+    next = function () {
+      expect(req.service.externalId).to.equal('some-service-external-id')
+    }
+    return getGatewayAccountAndService(req, res, next)
+  })
+  it('should error, when service cannot be resolved for serviceExternalId and gateway account (if available)', () => {
+    const getGatewayAccountAndService = setupGetGatewayAccountAndService('1', 'some-gateway-external-id', 'worldpay', 'some-service-external-id')
+    req.params['serviceExternalId'] = 'non-existent-service'
+
+    next = function (err) {
+      expect(err.message).to.equal('Service not found for user')
+      expect(err).to.be.instanceOf(NotFoundError)
+    }
+    return getGatewayAccountAndService(req, res, next)
+  })
+  it('should error, when the gateway account from connector does not belong to service for serviceExternalId', () => {
+    const getGatewayAccountAndService = setupGetGatewayAccountAndService('1', 'some-gateway-external-id', 'worldpay', 'some-service-external-id')
+    req.user.serviceRoles[0].service.gatewayAccountIds = ['some-other-gateway-account']
+
+    next = function (err) {
+      expect(err.message).to.equal('Service not found for user')
+      expect(err).to.be.instanceOf(NotFoundError)
+    }
+    return getGatewayAccountAndService(req, res, next)
+  })
+  it('should error, when serviceExternalId is not available and service cannot be resolved for gateway account', () => {
+    const getGatewayAccountAndService = setupGetGatewayAccountAndService('1', 'some-gateway-external-id', 'worldpay', 'some-service-external-id')
+    req.params['serviceExternalId'] = undefined
+    req.user.serviceRoles[0].service.gatewayAccountIds = ['some-other-gateway-accounts']
+    next = function (err) {
+      expect(err.message).to.equal('Service not found for user')
+      expect(err).to.be.instanceOf(NotFoundError)
+    }
+    return getGatewayAccountAndService(req, res, next)
+  })
+})


### PR DESCRIPTION
## WHAT
- Added new middleware to get account and service based on URL path params

Middleware expects atleast one parameter (gatewayAccountExternalId or serviceExternalId) to be available on request to get gateway account/service. If both are available, additionally checks for gatewayAccount to be part of the service.