### PR TITLE
PP-7489 Add adminusers and connector clients methods

### DIFF
--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -556,6 +556,51 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
+   * Get a service by externalId
+   *
+   * @param externalId
+   * @returns {*|promise|Constructor}
+   */
+  const getServiceByExternalId = (serviceExternalId) => {
+    return baseClient.get(
+      {
+        baseUrl,
+        url: `${serviceResource}/${serviceExternalId}`,
+        json: true,
+        correlationId: correlationId,
+        description: 'find a service',
+        service: SERVICE_NAME,
+        transform: responseBodyToServiceTransformer,
+        baseClientErrorHandler: 'old'
+      }
+    )
+  }
+
+  /**
+   * Get service for a given gateway account ID
+   *
+   * @param gatewayAccountId
+   * @returns {*|promise|Constructor}
+   */
+  const getServiceForGatewayAccount = (gatewayAccountId) => {
+    return baseClient.get(
+      {
+        baseUrl,
+        url: `${serviceResource}`,
+        qs: {
+          gatewayAccountId: gatewayAccountId
+        },
+        json: true,
+        correlationId: correlationId,
+        description: 'find a service for a given gateway account',
+        service: SERVICE_NAME,
+        transform: responseBodyToServiceTransformer,
+        baseClientErrorHandler: 'old'
+      }
+    )
+  }
+
+  /**
    * Update service
    *
    * @param serviceExternalId
@@ -824,6 +869,8 @@ module.exports = function (clientOptions = {}) {
     addGatewayAccountsToService,
     updateCurrentGoLiveStage,
     addStripeAgreementIpAddress,
-    addGovUkAgreementEmailAddress
+    addGovUkAgreementEmailAddress,
+    getServiceByExternalId,
+    getServiceForGatewayAccount
   }
 }

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -15,6 +15,7 @@ const StripeAccount = require('../../models/StripeAccount.class')
 const SERVICE_NAME = 'connector'
 const ACCOUNTS_API_PATH = '/v1/api/accounts'
 const ACCOUNT_API_PATH = ACCOUNTS_API_PATH + '/{accountId}'
+const ACCOUNT_API_BY_EXTERNAL_ID_PATH = ACCOUNTS_API_PATH + '/external-id/{externalId}'
 const CHARGES_API_PATH = ACCOUNT_API_PATH + '/charges'
 const CHARGE_API_PATH = CHARGES_API_PATH + '/{chargeId}'
 const CHARGE_REFUNDS_API_PATH = CHARGE_API_PATH + '/refunds'
@@ -80,6 +81,11 @@ function _accountApiUrlFor (gatewayAccountId, url) {
 /** @private */
 function _accountUrlFor (gatewayAccountId, url) {
   return url + ACCOUNT_FRONTEND_PATH.replace('{accountId}', gatewayAccountId)
+}
+
+/** @private */
+function _accountByExternalIdUrlFor (gatewayAccountExternalId, url) {
+  return url + ACCOUNT_API_BY_EXTERNAL_ID_PATH.replace('{externalId}', gatewayAccountExternalId)
 }
 
 /** @private */
@@ -166,6 +172,25 @@ ConnectorClient.prototype = {
       oldBaseClient.get(url, params, callbackToPromiseConverter, null)
         .on('error', callbackToPromiseConverter)
     })
+  },
+  /**
+   * Retrieves gateway account by external ID
+   * @param params
+   *          An object with the following elements;
+   *            gatewayAccountExternalId (required)
+   *            correlationId (optional)
+   *@return {Promise}
+   */
+  getAccountByExternalId: function (params) {
+    let url = _accountByExternalIdUrlFor(params.gatewayAccountExternalId, this.connectorUrl)
+    let context = {
+      url: url,
+      correlationId: params.correlationId,
+      description: 'get an account',
+      service: SERVICE_NAME
+    }
+
+    return baseClient.get(url, context)
   },
 
   /**


### PR DESCRIPTION
## WHAT
Added client methods to get gateway accounts and service by external ID. These will be used by new getGatewayAccountAndService middleware (https://github.com/alphagov/pay-selfservice/pull/2399)
- Added `getAccountByExternalId` to connector client to retrieve gateway account by external ID
- Added `getServiceByExternalId` & `getServiceForGatewayAccount` to adminusers client to get service by external ID or for gateway account
