### PR TITLE
PP-7488 Ensure authentication middleware is included on all routes that require authorisation

### DIFF
--- a/app/controllers/service-users.controller.js
+++ b/app/controllers/service-users.controller.js
@@ -22,7 +22,7 @@ const mapByRoles = function (users, externalServiceId, currentUser) {
       }
       if (currentUser.externalId === user.externalId) {
         mappedUser.is_current = true
-        mappedUser.link = paths.user.profile
+        mappedUser.link = paths.user.profile.index
       } else {
         mappedUser.link = formattedPathFor(paths.teamMembers.show, externalServiceId, user.externalId)
       }
@@ -101,7 +101,7 @@ module.exports = {
     const externalServiceId = req.service.externalId
     const externalUserId = req.params.externalUserId
     if (externalUserId === req.user.externalId) {
-      res.redirect(paths.user.profile)
+      res.redirect(paths.user.profile.index)
     }
 
     const onSuccess = (user) => {
@@ -184,7 +184,7 @@ module.exports = {
         email: user.email,
         telephone_number: user.telephoneNumber,
         two_factor_auth: user.secondFactor,
-        two_factor_auth_link: paths.user.twoFactorAuth.index
+        two_factor_auth_link: paths.user.profile.twoFactorAuth.index
       })
     }
 

--- a/app/controllers/two-factor-auth-controller/get-configure.controller.js
+++ b/app/controllers/two-factor-auth-controller/get-configure.controller.js
@@ -27,6 +27,6 @@ module.exports = async function showConfigureSecondFactorMethod (req, res) {
   } catch (err) {
     logger.error(`[requestId=${req.correlationId}] Failed to generate QR code - ${err.message}`)
     req.flash('genericError', 'Something went wrong. Please try again or contact support.')
-    return res.redirect(paths.user.twoFactorAuth.index)
+    return res.redirect(paths.user.profile.twoFactorAuth.index)
   }
 }

--- a/app/controllers/two-factor-auth-controller/post-configure.controller.js
+++ b/app/controllers/two-factor-auth-controller/post-configure.controller.js
@@ -12,7 +12,7 @@ module.exports = async function postUpdateSecondFactorMethod (req, res) {
   try {
     await userService.configureNewOtpKey(req.user.externalId, code, method, req.correlationId)
     req.flash('otpMethodUpdated', method)
-    return res.redirect(paths.user.profile)
+    return res.redirect(paths.user.profile.index)
   } catch (err) {
     if (err.errorCode === 401 || err.errorCode === 400) {
       lodash.set(req, 'session.pageData.configureTwoFactorAuthMethodRecovered', {
@@ -24,6 +24,6 @@ module.exports = async function postUpdateSecondFactorMethod (req, res) {
       req.flash('genericError', 'Something went wrong. Please try again or contact support.')
       logger.error(`[requestId=${req.correlationId}] Activating new OTP key failed, server error`)
     }
-    return res.redirect(paths.user.twoFactorAuth.configure)
+    return res.redirect(paths.user.profile.twoFactorAuth.configure)
   }
 }

--- a/app/controllers/two-factor-auth-controller/post-index.controller.js
+++ b/app/controllers/two-factor-auth-controller/post-index.controller.js
@@ -20,11 +20,11 @@ module.exports = (req, res) => {
   userService.provisionNewOtpKey(req.user.externalId, req.correlationId)
     .then(user => sendSMS(method, user))
     .then(() => {
-      return res.redirect(paths.user.twoFactorAuth.configure)
+      return res.redirect(paths.user.profile.twoFactorAuth.configure)
     })
     .catch(err => {
       logger.error(`[requestId=${req.correlationId}] Provisioning new OTP key failed - ${err.message}`)
       req.flash('genericError', 'Something went wrong. Please try again or contact support.')
-      return res.redirect(paths.user.twoFactorAuth.index)
+      return res.redirect(paths.user.profile.twoFactorAuth.index)
     })
 }

--- a/app/controllers/two-factor-auth-controller/post-resend.controller.js
+++ b/app/controllers/two-factor-auth-controller/post-resend.controller.js
@@ -8,11 +8,11 @@ module.exports = (req, res) => {
   userService.sendProvisonalOTP(req.user, req.correlationId)
     .then(() => {
       req.flash('generic', 'Another verification code has been sent to your phone')
-      return res.redirect(paths.user.twoFactorAuth.configure)
+      return res.redirect(paths.user.profile.twoFactorAuth.configure)
     })
     .catch(err => {
       logger.error(`[requestId=${req.correlationId}] Reseding OTP key SMS failed - ${err.message}`)
       req.flash('genericError', 'Something went wrong. Please try again or contact support.')
-      return res.redirect(paths.user.twoFactorAuth.configure)
+      return res.redirect(paths.user.profile.twoFactorAuth.configure)
     })
 }

--- a/app/controllers/user/phone-number/post.controller.js
+++ b/app/controllers/user/phone-number/post.controller.js
@@ -21,7 +21,7 @@ module.exports = async function updatePhoneNumber (req, res) {
     await userService.updatePhoneNumber(req.user.externalId, telephoneNumber)
 
     req.flash('generic', 'Phone number updated')
-    return res.redirect(paths.user.profile)
+    return res.redirect(paths.user.profile.index)
   } catch (error) {
     return renderErrorView(req, res, 'Unable to update phone number. Please try again or contact support team.')
   }

--- a/app/paths.js
+++ b/app/paths.js
@@ -35,13 +35,6 @@ module.exports = {
   },
   user: {
     logIn: '/login',
-    profile: '/my-profile',
-    twoFactorAuth: {
-      index: '/my-profile/two-factor-auth',
-      configure: '/my-profile/two-factor-auth/configure',
-      resend: '/my-profile/two-factor-auth/resend'
-    },
-    phoneNumber: '/my-profile/phone-number',
     otpLogIn: '/otp-login',
     otpSendAgain: '/otp-send-again',
     logOut: '/logout',
@@ -49,7 +42,16 @@ module.exports = {
     noAccess: '/noaccess',
     forgottenPassword: '/reset-password',
     passwordRequested: '/reset-password-requested',
-    forgottenPasswordReset: '/reset-password/:id'
+    forgottenPasswordReset: '/reset-password/:id',
+    profile: {
+      index: '/my-profile',
+      phoneNumber: '/my-profile/phone-number',
+      twoFactorAuth: {
+        index: '/my-profile/two-factor-auth',
+        configure: '/my-profile/two-factor-auth/configure',
+        resend: '/my-profile/two-factor-auth/resend'
+      },
+    },
   },
   dashboard: {
     index: '/'

--- a/app/routes.js
+++ b/app/routes.js
@@ -213,6 +213,7 @@ module.exports.bind = function (app) {
     ...lodash.values(settings),
     ...lodash.values(yourPsp),
     ...lodash.values(payouts),
+    ...lodash.values(toggleMotoMaskCardNumberAndSecurityCode),
     paths.feedback
   ] // Extract all the authenticated paths as a single array
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -202,7 +202,7 @@ module.exports.bind = function (app) {
     ...lodash.values(prototyping.demoPayment),
     ...lodash.values(prototyping.demoService),
     ...lodash.values(paymentLinks),
-    ...lodash.values(user.twoFactorAuth),
+    ...lodash.values(user.profile),
     ...lodash.values(partnerApp),
     ...lodash.values(billingAddress),
     ...lodash.values(requestToGoLive),
@@ -213,7 +213,6 @@ module.exports.bind = function (app) {
     ...lodash.values(settings),
     ...lodash.values(yourPsp),
     ...lodash.values(payouts),
-    user.profile,
     paths.feedback
   ] // Extract all the authenticated paths as a single array
 
@@ -304,7 +303,7 @@ module.exports.bind = function (app) {
   app.get(teamMembers.permissions, xraySegmentCls, permission('users-service:create'), serviceRolesUpdateController.index)
   app.post(teamMembers.permissions, xraySegmentCls, permission('users-service:create'), serviceRolesUpdateController.update)
   app.post(teamMembers.delete, xraySegmentCls, permission('users-service:delete'), serviceUsersController.delete)
-  app.get(user.profile, xraySegmentCls, enforceUserAuthenticated, serviceUsersController.profile)
+  app.get(user.profile.index, xraySegmentCls, enforceUserAuthenticated, serviceUsersController.profile)
 
   // TEAM MEMBERS - INVITE
   app.get(teamMembers.invite, xraySegmentCls, permission('users-service:create'), inviteUserController.index)
@@ -376,11 +375,11 @@ module.exports.bind = function (app) {
   app.post(paymentLinks.metadata.delete, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.metadata.deletePagePost)
 
   // Configure 2FA
-  app.get(user.twoFactorAuth.index, xraySegmentCls, twoFactorAuthController.getIndex)
-  app.post(user.twoFactorAuth.index, xraySegmentCls, twoFactorAuthController.postIndex)
-  app.get(user.twoFactorAuth.configure, xraySegmentCls, twoFactorAuthController.getConfigure)
-  app.post(user.twoFactorAuth.configure, xraySegmentCls, twoFactorAuthController.postConfigure)
-  app.post(user.twoFactorAuth.resend, xraySegmentCls, twoFactorAuthController.postResend)
+  app.get(user.profile.twoFactorAuth.index, xraySegmentCls, twoFactorAuthController.getIndex)
+  app.post(user.profile.twoFactorAuth.index, xraySegmentCls, twoFactorAuthController.postIndex)
+  app.get(user.profile.twoFactorAuth.configure, xraySegmentCls, twoFactorAuthController.getConfigure)
+  app.post(user.profile.twoFactorAuth.configure, xraySegmentCls, twoFactorAuthController.postConfigure)
+  app.post(user.profile.twoFactorAuth.resend, xraySegmentCls, twoFactorAuthController.postResend)
 
   // Feedback
   app.get(paths.feedback, xraySegmentCls, hasServices, resolveService, getAccount, feedbackController.getIndex)
@@ -506,12 +505,12 @@ module.exports.bind = function (app) {
     stripeSetupAddPspAccountDetailsController.get
   )
 
-  app.get(user.phoneNumber,
+  app.get(user.profile.phoneNumber ,
     xraySegmentCls,
     userPhoneNumberController.get
   )
 
-  app.post(user.phoneNumber,
+  app.post(user.profile.phoneNumber ,
     xraySegmentCls,
     userPhoneNumberController.post
   )

--- a/app/views/includes/header.njk
+++ b/app/views/includes/header.njk
@@ -14,7 +14,7 @@ govuk-width-container govuk-header__container--{{accountType}}
   },
   {
     text: "My profile",
-    href: routes.user.profile,
+    href: routes.user.profile.index,
     active: username.length > 0,
     attributes: {
       id: "my-profile"

--- a/app/views/includes/propositional-navigation.njk
+++ b/app/views/includes/propositional-navigation.njk
@@ -4,7 +4,7 @@
     <nav id="proposition-menu" aria-label="Top Level Navigation" aria-hidden="true" data-click-events data-click-category="Header" data-click-action="Navigation link clicked">
       <ul id="proposition-links">
         <li><a {% if services %}class="active"{% endif %} href="{{ routes.serviceSwitcher.index }}" title="My services" id="my-services">My services</a></li>
-        <li><a href="{{ routes.user.profile }}" title="My profile" id="my-profile">My profile</a></li>
+        <li><a href="{{ routes.user.profile.index }}" title="My profile" id="my-profile">My profile</a></li>
         <li><a href="https://docs.payments.service.gov.uk" title="Read the GOV.UK Pay Documentation">Documentation</a></li>
         <li><a href="/logout" title="Log me out" id="logout" class="content logout">Sign out</a></li>
       </ul>

--- a/app/views/team-members/edit-phone-number.njk
+++ b/app/views/team-members/edit-phone-number.njk
@@ -10,7 +10,7 @@
   {{
     govukBackLink({
       text: "My profile",
-      href: routes.user.profile
+      href: routes.user.profile.index
     })
   }}
 {% endblock %}

--- a/app/views/team-members/team-member-profile.njk
+++ b/app/views/team-members/team-member-profile.njk
@@ -38,7 +38,7 @@ My profile - GOV.UK Pay
       <dd class="profile-settings__value govuk-table__cell" id="telephone-number">
         {{telephone_number}} 
         <span class="profile-settings__change-link">
-          <a class="govuk-link" href="{{routes.user.phoneNumber}}" id="change-phone-link">Change <span class="govuk-visually-hidden">mobile number</span></a>
+          <a class="govuk-link" href="{{routes.user.profile.phoneNumber }}" id="change-phone-link">Change <span class="govuk-visually-hidden">mobile number</span></a>
         </span> 
       </dd>
     </div>

--- a/app/views/two-factor-auth/configure.njk
+++ b/app/views/two-factor-auth/configure.njk
@@ -16,7 +16,7 @@
   {{
     govukBackLink({
       text: "My profile",
-      href: routes.user.profile
+      href: routes.user.profile.index
     })
   }}
 {% endblock %}
@@ -58,7 +58,7 @@
     })
   }}
 {% endif %}
-  <form method="post" action="{{routes.user.twoFactorAuth.configure}}" novalidate data-validate>
+  <form method="post" action="{{routes.user.profile.twoFactorAuth.configure}}" novalidate data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {% set codeHint = "Enter the code shown in your app to complete the setup" %}
@@ -92,7 +92,7 @@
   </form>
 
   {% if method === 'SMS' %}
-  <form method="post" action="{{routes.user.twoFactorAuth.resend}}">
+  <form method="post" action="{{routes.user.profile.twoFactorAuth.resend}}">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <div class="govuk-form-group">
       <button class="pay-button--as-link govuk-!-font-size-19" type="submit">
@@ -103,7 +103,7 @@
   {% endif %}
 
   <p class="govuk-body">
-    <a class="govuk-link govuk-link--no-visited-state" id="service-name-cancel-link" href="{{routes.user.twoFactorAuth.index}}">
+    <a class="govuk-link govuk-link--no-visited-state" id="service-name-cancel-link" href="{{routes.user.profile.twoFactorAuth.index}}">
       Cancel
     </a>
   </p>

--- a/app/views/two-factor-auth/index.njk
+++ b/app/views/two-factor-auth/index.njk
@@ -9,7 +9,7 @@
   {{
     govukBackLink({
       text: "My profile",
-      href: routes.user.profile
+      href: routes.user.profile.index
     })
   }}
 {% endblock %}
@@ -21,7 +21,7 @@
   </h1>
 </div>
 <div class="govuk-grid-column-two-thirds">
-  <form method="post" action="{{routes.user.twoFactorAuth.index}}">
+  <form method="post" action="{{routes.user.profile.twoFactorAuth.index}}">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {% if authenticatorMethod === 'SMS' %}
       <p class="govuk-body">You currently use text message codes to sign in to GOV.UK Pay.</p>

--- a/test/unit/controller/two-factor-auth-controller/get-configure.controller.ft.test.js
+++ b/test/unit/controller/two-factor-auth-controller/get-configure.controller.ft.test.js
@@ -30,7 +30,7 @@ describe('Two factor authenticator configure page GET', () => {
       session = getMockSession(user)
       lodash.set(session, 'pageData.twoFactorAuthMethod', 'APP')
       supertest(createAppWithSession(getApp(), session))
-        .get(paths.user.twoFactorAuth.configure)
+        .get(paths.user.profile.twoFactorAuth.configure)
         .end((err, res) => {
           result = res
           $ = cheerio.load(res.text)
@@ -46,11 +46,11 @@ describe('Two factor authenticator configure page GET', () => {
     })
 
     it(`should include a link to My Profile`, () => {
-      expect($('.govuk-back-link').attr('href')).to.equal(paths.user.profile)
+      expect($('.govuk-back-link').attr('href')).to.equal(paths.user.profile.index)
     })
 
     it(`should have itself as the form action`, () => {
-      expect($('form').attr('action')).to.equal(paths.user.twoFactorAuth.configure)
+      expect($('form').attr('action')).to.equal(paths.user.profile.twoFactorAuth.configure)
     })
 
     it(`should have a base64 encoded image in the image src for the QR code`, () => {
@@ -74,7 +74,7 @@ describe('Two factor authenticator configure page GET', () => {
       session = getMockSession(user)
       lodash.set(session, 'pageData.twoFactorAuthMethod', 'SMS')
       supertest(createAppWithSession(getApp(), session))
-        .get(paths.user.twoFactorAuth.configure)
+        .get(paths.user.profile.twoFactorAuth.configure)
         .end((err, res) => {
           result = res
           $ = cheerio.load(res.text)
@@ -90,11 +90,11 @@ describe('Two factor authenticator configure page GET', () => {
     })
 
     it(`should include a link to My Profile`, () => {
-      expect($('.govuk-back-link').attr('href')).to.equal(paths.user.profile)
+      expect($('.govuk-back-link').attr('href')).to.equal(paths.user.profile.index)
     })
 
     it(`should have itself as the form action`, () => {
-      expect($('form').attr('action')).to.equal(paths.user.twoFactorAuth.configure)
+      expect($('form').attr('action')).to.equal(paths.user.profile.twoFactorAuth.configure)
     })
 
     it(`should not show a QR code`, () => {
@@ -124,7 +124,7 @@ describe('Two factor authenticator configure page GET', () => {
         }
       })
       supertest(createAppWithSession(getApp(), session))
-        .get(paths.user.twoFactorAuth.configure)
+        .get(paths.user.profile.twoFactorAuth.configure)
         .end((err, res) => {
           result = res
           $ = cheerio.load(res.text)

--- a/test/unit/controller/two-factor-auth-controller/get-index.controller.ft.test.js
+++ b/test/unit/controller/two-factor-auth-controller/get-index.controller.ft.test.js
@@ -27,7 +27,7 @@ describe('Two factor authenticator configure index GET', () => {
 
       session = getMockSession(user)
       supertest(createAppWithSession(getApp(), session))
-        .get(paths.user.twoFactorAuth.index)
+        .get(paths.user.profile.twoFactorAuth.index)
         .end((err, res) => {
           result = res
           $ = cheerio.load(res.text)
@@ -43,11 +43,11 @@ describe('Two factor authenticator configure index GET', () => {
     })
 
     it(`should include a link to My Profile`, () => {
-      expect($('.govuk-back-link').attr('href')).to.equal(paths.user.profile)
+      expect($('.govuk-back-link').attr('href')).to.equal(paths.user.profile.index)
     })
 
     it(`should have itself as the form action`, () => {
-      expect($('form').attr('action')).to.equal(paths.user.twoFactorAuth.index)
+      expect($('form').attr('action')).to.equal(paths.user.profile.twoFactorAuth.index)
     })
 
     it(`should a button with “Use an authenticator app instead”`, () => {
@@ -71,7 +71,7 @@ describe('Two factor authenticator configure index GET', () => {
 
       session = getMockSession(user)
       supertest(createAppWithSession(getApp(), session))
-        .get(paths.user.twoFactorAuth.index)
+        .get(paths.user.profile.twoFactorAuth.index)
         .end((err, res) => {
           result = res
           $ = cheerio.load(res.text)
@@ -87,11 +87,11 @@ describe('Two factor authenticator configure index GET', () => {
     })
 
     it(`should include a link to My Profile`, () => {
-      expect($('.govuk-back-link').attr('href')).to.equal(paths.user.profile)
+      expect($('.govuk-back-link').attr('href')).to.equal(paths.user.profile.index)
     })
 
     it(`should have itself as the form action`, () => {
-      expect($('form').attr('action')).to.equal(paths.user.twoFactorAuth.index)
+      expect($('form').attr('action')).to.equal(paths.user.profile.twoFactorAuth.index)
     })
 
     it(`should a radio with “A different authenticator app”`, () => {

--- a/test/unit/controller/two-factor-auth-controller/post-configure.controller.ft.test.js
+++ b/test/unit/controller/two-factor-auth-controller/post-configure.controller.ft.test.js
@@ -29,7 +29,7 @@ describe('Two factor authenticator configure page POST', () => {
 
     before('Act', done => {
       supertest(app)
-        .post(paths.user.twoFactorAuth.configure)
+        .post(paths.user.profile.twoFactorAuth.configure)
         .send({
           csrfToken: csrf().create('123'),
           code: '398262'
@@ -48,7 +48,7 @@ describe('Two factor authenticator configure page POST', () => {
     })
 
     it('should redirect to the profile page', () => {
-      expect(result.headers).to.have.property('location').to.equal(paths.user.profile)
+      expect(result.headers).to.have.property('location').to.equal(paths.user.profile.index)
     })
   })
 
@@ -65,7 +65,7 @@ describe('Two factor authenticator configure page POST', () => {
 
     before('Act', done => {
       supertest(app)
-        .post(paths.user.twoFactorAuth.configure)
+        .post(paths.user.profile.twoFactorAuth.configure)
         .send({
           csrfToken: csrf().create('123'),
           code: ''
@@ -84,7 +84,7 @@ describe('Two factor authenticator configure page POST', () => {
     })
 
     it('should redirect to the configure page', () => {
-      expect(result.headers).to.have.property('location').to.equal(paths.user.twoFactorAuth.configure)
+      expect(result.headers).to.have.property('location').to.equal(paths.user.profile.twoFactorAuth.configure)
     })
 
     it('should have a recovered object stored on the session containing errors', () => {

--- a/test/unit/controller/two-factor-auth-controller/post-index.controller.ft.test.js
+++ b/test/unit/controller/two-factor-auth-controller/post-index.controller.ft.test.js
@@ -42,7 +42,7 @@ describe('Two factor authenticator configure index POST', () => {
 
     before('Act', done => {
       supertest(app)
-        .post(paths.user.twoFactorAuth.index)
+        .post(paths.user.profile.twoFactorAuth.index)
         .send({
           csrfToken: csrf().create('123'),
           'two-fa-method': 'APP'
@@ -61,7 +61,7 @@ describe('Two factor authenticator configure index POST', () => {
     })
 
     it('should redirect to the configure page', () => {
-      expect(result.headers).to.have.property('location').to.equal(paths.user.twoFactorAuth.configure)
+      expect(result.headers).to.have.property('location').to.equal(paths.user.profile.twoFactorAuth.configure)
     })
   })
 
@@ -80,7 +80,7 @@ describe('Two factor authenticator configure index POST', () => {
 
     before('Act', done => {
       supertest(app)
-        .post(paths.user.twoFactorAuth.index)
+        .post(paths.user.profile.twoFactorAuth.index)
         .send({
           csrfToken: csrf().create('123'),
           'two-fa-method': 'SMS'
@@ -99,7 +99,7 @@ describe('Two factor authenticator configure index POST', () => {
     })
 
     it('should redirect to the configure page', () => {
-      expect(result.headers).to.have.property('location').to.equal(paths.user.twoFactorAuth.configure)
+      expect(result.headers).to.have.property('location').to.equal(paths.user.profile.twoFactorAuth.configure)
     })
   })
 })


### PR DESCRIPTION
  ## PP-7488 Include MOTO masking settings page in authenticated paths

Not all authentication middleware was run on these routes. This means we weren't checking that the user has a valid session and we weren't applying CSRF checks to the POST route.

##     PP-7488 Ensure all "My profile" routes run authorisation middleware

Group "/my-profile/" paths in object within paths object.

Previously, "/my-profile/phone-number" wasn't added to the authenticated paths array, so not all authorisation middleware was included on this route. This means we weren't checking that the user has a valid session and we weren't applying CSRF checks to the POST route.

Add `paths.profile` to the authenticated routes array so all paths under it have the authorisation middleware and CSRF middleware applied.

