### PR TITLE
PP-7489 Extend gateway account object

### DIFF
--- a/app/middleware/has-services.js
+++ b/app/middleware/has-services.js
@@ -5,7 +5,7 @@ const paths = require('../paths')
 module.exports = (req, res, next) => {
   const serviceRoles = _.get(req, 'user.serviceRoles', [])
   if (req.url !== paths.serviceSwitcher.index && serviceRoles.length === 0) {
-    logger.info('User does not belong to any service user_external_id=', _.get(req, 'user.externalId'))
+    logger.info(`User does not belong to any service user_external_id=, ${_.get(req, 'user.externalId')}`)
     res.redirect(paths.serviceSwitcher.index)
   } else {
     next()


### PR DESCRIPTION
## WHAT
- Extends gateway account object (get account and service middleware) with additional attributes similar to get-gateway-account.js middleware

