### PR TITLE
PP-7488 Add authorisation middleware

### DIFF
--- a/app/middleware/user-is-authorised.js
+++ b/app/middleware/user-is-authorised.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const { NotAuthorisedError, NotAuthenticatedError, UserAccountDisabledError } = require('../errors')
+const { SERVICE_EXTERNAL_ID, GATEWAY_ACCOUNT_EXTERNAL_ID } = require('../paths').keys
+
+module.exports = function getUserIsAuthorisedMiddleware (permission) {
+  return function userIsAuthorised (req, res, next) {
+    const { user, session, params, service } = req
+
+    if (!user) {
+      return next(new NotAuthenticatedError('User not found on request'))
+    }
+    if (!session) {
+      return next(new NotAuthenticatedError('Session not found on request'))
+    }
+    if (user.sessionVersion !== session.version) {
+      return next(new NotAuthenticatedError(`Invalid session version - session version is ${session.version}, user session version is ${user.sessionVersion}`))
+    }
+    if (user.disabled) {
+      return next(new UserAccountDisabledError('User account is disabled'))
+    }
+    if (!(session.secondFactor && session.secondFactor === 'totp')) {
+      return next(new NotAuthenticatedError('Not completed second factor authentication'))
+    }
+
+    if (params[GATEWAY_ACCOUNT_EXTERNAL_ID] || params[SERVICE_EXTERNAL_ID]) {
+      if (!service) {
+        return next(new NotAuthorisedError('Service not found on request'))
+      }
+      if (!user.serviceRoles.find(serviceRole => serviceRole.service.externalId === service.externalId)) {
+        return next(new NotAuthorisedError('User does not have service role for service'))
+      }
+      if (permission && !user.hasPermission(service.externalId, permission)) {
+        return next(new NotAuthorisedError(`User does not have permission ${permission} for service`))
+      }
+    }
+
+    next()
+  }
+}

--- a/test/fixtures/service.fixtures.js
+++ b/test/fixtures/service.fixtures.js
@@ -4,6 +4,7 @@ const path = require('path')
 const _ = require('lodash')
 
 const pactBase = require(path.join(__dirname, '/pact-base'))
+const Service = require('../../app/models/Service.class')
 
 // Global setup
 const pactServices = pactBase({ array: ['service_ids'] })
@@ -236,6 +237,9 @@ module.exports = {
     return {
       getPactified: () => {
         return pactServices.pactify(service)
+      },
+      getAsObject: () => {
+        return new Service(service)
       },
       getPlain: () => {
         return _.clone(service)

--- a/test/unit/middleware/user-is-authorised.test.js
+++ b/test/unit/middleware/user-is-authorised.test.js
@@ -1,0 +1,265 @@
+'use strict'
+
+const sinon = require('sinon')
+const { expect } = require('chai')
+const { NotAuthorisedError, NotAuthenticatedError, UserAccountDisabledError } = require('../../../app/errors')
+const userIsAuthorised = require('../../../app/middleware/user-is-authorised')
+const userFixtures = require('../../fixtures/user.fixtures')
+const serviceFixtures = require('../../fixtures/service.fixtures')
+
+const serviceExternalId = 'a-service-external-id'
+const permission = 'do-cool-things'
+const sessionVersion = 1
+const loggedInSession = { version: sessionVersion, secondFactor: 'totp' }
+const authorisedUser = userFixtures.validUserResponse({
+  session_version: sessionVersion,
+  service_roles: [{
+    service: {
+      external_id: serviceExternalId
+    },
+    role: {
+      permissions: [{ name: permission }]
+    }
+  }]
+}).getAsObject()
+
+const userWithPermissionForDifferentService = userFixtures.validUserResponse({
+  session_version: sessionVersion,
+  service_roles: [
+    {
+      service: {
+        external_id: serviceExternalId
+      },
+      role: {
+        permissions: [{ name: 'a-different-permission' }]
+      }
+    },
+    {
+      service: {
+        external_id: 'a-different-service-id'
+      },
+      role: {
+        permissions: [{ name: permission }]
+      }
+    }
+  ]
+}).getAsObject()
+
+const userWithoutServiceRole = userFixtures.validUserResponse({
+  session_version: sessionVersion,
+  service_roles: [{
+    service: { external_id: 'some-other-service-id' }
+  }]
+}).getAsObject()
+
+const service = serviceFixtures.validServiceResponse({
+  external_id: serviceExternalId
+}).getAsObject()
+
+const middleware = userIsAuthorised()
+const res = {}
+let next
+
+describe('User is authorised middleware', () => {
+  beforeEach(() => {
+    next = sinon.spy()
+  })
+
+  describe('User is not authenticated', () => {
+    describe('there is no user object on the request', () => {
+      it('should call next with error', () => {
+        const req = {
+          session: {},
+          params: {}
+        }
+
+        middleware(req, res, next)
+
+        const expectedError = sinon.match.instanceOf(NotAuthenticatedError)
+          .and(sinon.match.has('message', 'User not found on request'))
+        sinon.assert.calledWith(next, expectedError)
+      })
+    })
+
+    describe('there is no session object on the request', () => {
+      it('should call next with error', () => {
+        const req = {
+          user: {},
+          params: {}
+        }
+
+        middleware(req, res, next)
+
+        const expectedError = sinon.match.instanceOf(NotAuthenticatedError)
+          .and(sinon.match.has('message', 'Session not found on request'))
+        sinon.assert.calledWith(next, expectedError)
+      })
+    })
+
+    describe('session version does not match user session version', () => {
+      it('should call next with error', () => {
+        const req = {
+          session: { version: 1 },
+          user: userFixtures.validUserResponse({ session_version: 2 }).getAsObject(),
+          params: {}
+        }
+
+        middleware(req, res, next)
+
+        const expectedError = sinon.match.instanceOf(NotAuthenticatedError)
+          .and(sinon.match.has('message', 'Invalid session version - session version is 1, user session version is 2'))
+        sinon.assert.calledWith(next, expectedError)
+      })
+    })
+
+    describe('user account is disabled', () => {
+      it('should call next with error', () => {
+        const userOpts = {
+          session_version: sessionVersion,
+          disabled: true
+        }
+        const req = {
+          session: { version: sessionVersion },
+          user: userFixtures.validUserResponse(userOpts).getAsObject(),
+          params: {}
+        }
+
+        middleware(req, res, next)
+
+        const expectedError = sinon.match.instanceOf(UserAccountDisabledError)
+        sinon.assert.calledWith(next, expectedError)
+      })
+    })
+
+    describe('user has not completed second factor authentication', () => {
+      it('should call next with error', () => {
+        const req = {
+          session: { version: sessionVersion },
+          user: userFixtures.validUserResponse({ session_version: sessionVersion }).getAsObject(),
+          params: {}
+        }
+
+        middleware(req, res, next)
+
+        const expectedError = sinon.match.instanceOf(NotAuthenticatedError)
+          .and(sinon.match.has('message', 'Not completed second factor authentication'))
+        sinon.assert.calledWith(next, expectedError)
+      })
+    })
+  })
+
+  describe('there is no service id or gateway account id path param', () => {
+    it('should call next without arguments', () => {
+      const req = {
+        session: loggedInSession,
+        user: authorisedUser,
+        params: {}
+      }
+
+      middleware(req, res, next)
+
+      sinon.assert.calledOnce(next)
+      expect(next.firstCall.args).to.have.length(0)
+    })
+  })
+
+  describe('there is a gateway account id path param but no service object on request', () => {
+    it('should throw an error', () => {
+      const req = {
+        session: loggedInSession,
+        user: authorisedUser,
+        params: { gatewayAccountExternalId: 'a-gateway-account-id' }
+      }
+
+      middleware(req, res, next)
+
+      const expectedError = sinon.match.instanceOf(NotAuthorisedError)
+        .and(sinon.match.has('message', 'Service not found on request'))
+      sinon.assert.calledWith(next, expectedError)
+    })
+  })
+
+  describe('there is a service id path param but no service object on request', () => {
+    it('should throw an error', () => {
+      const req = {
+        session: loggedInSession,
+        user: authorisedUser,
+        params: { serviceExternalId }
+      }
+
+      middleware(req, res, next)
+
+      const expectedError = sinon.match.instanceOf(NotAuthorisedError)
+        .and(sinon.match.has('message', 'Service not found on request'))
+      sinon.assert.calledWith(next, expectedError)
+    })
+  })
+
+  describe('there is a service id path param and user does not have service role for service', () => {
+    it('should throw an error', () => {
+      const req = {
+        session: loggedInSession,
+        user: userWithoutServiceRole,
+        params: { serviceExternalId },
+        service
+      }
+
+      middleware(req, res, next)
+
+      const expectedError = sinon.match.instanceOf(NotAuthorisedError)
+        .and(sinon.match.has('message', 'User does not have service role for service'))
+      sinon.assert.calledWith(next, expectedError)
+    })
+  })
+
+  describe('there is a service id path param and user has service role for service', () => {
+    it('should call next without arguments', () => {
+      const req = {
+        session: loggedInSession,
+        user: authorisedUser,
+        params: { serviceExternalId },
+        service
+      }
+
+      middleware(req, res, next)
+
+      sinon.assert.calledOnce(next)
+      expect(next.firstCall.args).to.have.length(0)
+    })
+  })
+
+  describe('with permission check', () => {
+    describe('user does not have permission for service', () => {
+      it('should throw an error', () => {
+        const req = {
+          session: loggedInSession,
+          user: userWithPermissionForDifferentService,
+          params: { serviceExternalId },
+          service
+        }
+
+        userIsAuthorised(permission)(req, res, next)
+
+        const expectedError = sinon.match.instanceOf(NotAuthorisedError)
+          .and(sinon.match.has('message', `User does not have permission ${permission} for service`))
+        sinon.assert.calledWith(next, expectedError)
+      })
+    })
+
+    describe('user has permission for service', () => {
+      it('should call next without arguments', () => {
+        const req = {
+          session: loggedInSession,
+          user: authorisedUser,
+          params: { serviceExternalId },
+          service
+        }
+
+        userIsAuthorised(permission)(req, res, next)
+
+        sinon.assert.calledOnce(next)
+        expect(next.firstCall.args).to.have.length(0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Add middleware that will replace existing authorisation middleware and be used alongside the new middleware to resolve the service and gateway account from the URL path params.

This middleware optionally takes a permission string and checks:
- That the user is logged in and has a valid session
- The the middleware to resolve the service from the URL path param has successfully resolved a service if there is a service/gateway account id path param
- That the user has a service role for the resolved service
- If a permission has been specified, that the user has the permission for the resolved service

## Questions

- Existing auth middleware calls `csrf.ensureSessionHasCsrfSecret(req, res, next)`. I haven't added anything to do this on the assumption that we'll change how CSRF is implemented as part of our change, is that correct?
- If there is a User on the session, but they have not completed second factor authentication, currently we redirect them to the OTP entry page. This PR instead directed them to the login page by passing a NotAuthenticatedError to `next`. Should we maintain existing behaviour and add another error type to allow for this, or does this seem ok?


