### PR TITLE
PP-7482 Payment links rename manage payment link index

### DIFF
--- a/app/controllers/payment-links/get-amount.controller.js
+++ b/app/controllers/payment-links/get-amount.controller.js
@@ -22,7 +22,7 @@ module.exports = function showAmountPage (req, res, next) {
     paymentAmountType,
     nextPage: paths.paymentLinks.amount,
     returnToStart: paths.paymentLinks.start,
-    manage: paths.paymentLinks.manage.managePage,
+    manage: paths.paymentLinks.manage.index,
     isWelsh: sessionData.isWelsh,
     errors: recovered.errors
   })

--- a/app/controllers/payment-links/get-delete.controller.js
+++ b/app/controllers/payment-links/get-delete.controller.js
@@ -24,12 +24,12 @@ module.exports = (req, res) => {
       ])
         .then(() => {
           req.flash('generic', 'The payment link was successfully deleted')
-          res.redirect(paths.paymentLinks.manage.managePage)
+          res.redirect(paths.paymentLinks.manage.index)
         })
     })
     .catch((err) => {
       logger.error(`[requestId=${req.correlationId}] Delete product failed - ${err.message}`)
       req.flash('genericError', 'Something went wrong when deleting the payment link. Please try again or contact support.')
-      res.redirect(paths.paymentLinks.manage.managePage)
+      res.redirect(paths.paymentLinks.manage.index)
     })
 }

--- a/app/controllers/payment-links/get-disable.controller.js
+++ b/app/controllers/payment-links/get-disable.controller.js
@@ -10,11 +10,11 @@ module.exports = (req, res) => {
   productsClient.product.disable(gatewayAccountId, req.params.productExternalId)
     .then(() => {
       req.flash('generic', 'The payment link was successfully deleted')
-      res.redirect(paths.paymentLinks.manage.managePage)
+      res.redirect(paths.paymentLinks.manage.index)
     })
     .catch((err) => {
       logger.error(`[requestId=${req.correlationId}] Disable product failed - ${err.message}`)
       req.flash('genericError', 'Something went wrong when deleting the payment link. Please try again or contact support.')
-      res.redirect(paths.paymentLinks.manage.managePage)
+      res.redirect(paths.paymentLinks.manage.index)
     })
 }

--- a/app/controllers/payment-links/get-edit-amount.controller.js
+++ b/app/controllers/payment-links/get-edit-amount.controller.js
@@ -13,7 +13,7 @@ module.exports = function showEditAmountPage (req, res) {
   const sessionData = lodash.get(req, 'session.editPaymentLinkData')
   if (!sessionData || sessionData.externalId !== productExternalId) {
     req.flash('genericError', 'Something went wrong. Please try again.')
-    return res.redirect(paths.paymentLinks.manage.managePage)
+    return res.redirect(paths.paymentLinks.manage.index)
   }
 
   const recovered = sessionData.amountPageRecovered || {}

--- a/app/controllers/payment-links/get-edit-information.controller.js
+++ b/app/controllers/payment-links/get-edit-information.controller.js
@@ -13,7 +13,7 @@ module.exports = function showEditInformationPage (req, res, next) {
   const sessionData = lodash.get(req, 'session.editPaymentLinkData')
   if (!sessionData || sessionData.externalId !== productExternalId) {
     req.flash('genericError', 'Something went wrong. Please try again.')
-    return res.redirect(paths.paymentLinks.manage.managePage)
+    return res.redirect(paths.paymentLinks.manage.index)
   }
 
   const recovered = sessionData.informationPageRecovered || {}

--- a/app/controllers/payment-links/get-edit-reference.controller.js
+++ b/app/controllers/payment-links/get-edit-reference.controller.js
@@ -13,7 +13,7 @@ module.exports = function showEditReferencePage (req, res, next) {
   const sessionData = lodash.get(req, 'session.editPaymentLinkData')
   if (!sessionData || sessionData.externalId !== productExternalId) {
     req.flash('genericError', 'Something went wrong. Please try again.')
-    return res.redirect(paths.paymentLinks.manage.managePage)
+    return res.redirect(paths.paymentLinks.manage.index)
   }
 
   const recovered = sessionData.referencePageRecovered || {}

--- a/app/controllers/payment-links/post-edit-amount.controller.js
+++ b/app/controllers/payment-links/post-edit-amount.controller.js
@@ -12,7 +12,7 @@ module.exports = function postEditAmount (req, res) {
   const sessionData = lodash.get(req, 'session.editPaymentLinkData')
   if (!sessionData || sessionData.externalId !== productExternalId) {
     req.flash('genericError', 'Something went wrong. Please try again.')
-    return res.redirect(paths.paymentLinks.manage.managePage)
+    return res.redirect(paths.paymentLinks.manage.index)
   }
 
   const type = req.body['amount-type-group']

--- a/app/controllers/payment-links/post-edit-information.controller.js
+++ b/app/controllers/payment-links/post-edit-information.controller.js
@@ -11,7 +11,7 @@ module.exports = function postEditInformation (req, res) {
   const sessionData = lodash.get(req, 'session.editPaymentLinkData')
   if (!sessionData || sessionData.externalId !== productExternalId) {
     req.flash('genericError', 'Something went wrong. Please try again.')
-    return res.redirect(paths.paymentLinks.manage.managePage)
+    return res.redirect(paths.paymentLinks.manage.index)
   }
 
   const name = req.body['payment-link-title']

--- a/app/controllers/payment-links/post-edit-reference.controller.js
+++ b/app/controllers/payment-links/post-edit-reference.controller.js
@@ -11,7 +11,7 @@ module.exports = function postEditReference (req, res) {
   const sessionData = lodash.get(req, 'session.editPaymentLinkData')
   if (!sessionData || sessionData.externalId !== productExternalId) {
     req.flash('genericError', 'Something went wrong. Please try again.')
-    return res.redirect(paths.paymentLinks.manage.managePage)
+    return res.redirect(paths.paymentLinks.manage.index)
   }
 
   const referenceEnabled = req.body['reference-type-group'] === 'custom'

--- a/app/controllers/payment-links/post-edit.controller.js
+++ b/app/controllers/payment-links/post-edit.controller.js
@@ -12,14 +12,14 @@ module.exports = async function updatePaymentLink (req, res, next) {
   const editPaymentLinkData = lodash.get(req, 'session.editPaymentLinkData')
   if (!editPaymentLinkData || editPaymentLinkData.externalId !== productExternalId) {
     req.flash('genericError', 'Something went wrong. Please try again.')
-    return res.redirect(paths.paymentLinks.manage.managePage)
+    return res.redirect(paths.paymentLinks.manage.index)
   }
 
   try {
     await productsClient.product.update(gatewayAccountId, productExternalId, editPaymentLinkData)
     lodash.unset(req, 'session.editPaymentLinkData')
     req.flash('generic', `Your payment link has been updated`)
-    res.redirect(paths.paymentLinks.manage.managePage)
+    res.redirect(paths.paymentLinks.manage.index)
   } catch (err) {
     return next(new Error(`Update of payment link failed. Error: ${err.message}`))
   }

--- a/app/controllers/payment-links/post-review.controller.js
+++ b/app/controllers/payment-links/post-review.controller.js
@@ -65,7 +65,7 @@ module.exports = async function createPaymentLink (req, res) {
 
     lodash.unset(req, 'session.pageData.createPaymentLink')
     req.flash('createPaymentLinkSuccess', true)
-    res.redirect(paths.paymentLinks.manage.managePage)
+    res.redirect(paths.paymentLinks.manage.index)
   } catch (error) {
     logger.error(`[requestId=${req.correlationId}] Creating a payment link failed - ${error.message}`)
     req.flash('genericError', 'Something went wrong. Please try again or contact support.')

--- a/app/paths.js
+++ b/app/paths.js
@@ -157,8 +157,8 @@ module.exports = {
     editMetadata: '/create-payment-link/add-reporting-column/:metadataKey',
     deleteMetadata: '/create-payment-link/add-reporting-column/:metadataKey/delete',
     manage: {
+      index: '/create-payment-link/manage',
       edit: '/create-payment-link/manage/edit/:productExternalId',
-      managePage: '/create-payment-link/manage',
       disable: '/create-payment-link/manage/disable/:productExternalId',
       delete: '/create-payment-link/manage/delete/:productExternalId',
       editInformation: '/create-payment-link/manage/edit/information/:productExternalId',

--- a/app/routes.js
+++ b/app/routes.js
@@ -363,7 +363,7 @@ module.exports.bind = function (app) {
   app.post(paymentLinks.manage.editMetadata, permission('tokens:create'), getAccount, paymentLinksController.postUpdateReportingColumn.editMetadata)
   app.post(paymentLinks.manage.deleteMetadata, permission('tokens:create'), getAccount, paymentLinksController.postUpdateReportingColumn.deleteMetadata)
 
-  app.get(paymentLinks.manage.managePage, xraySegmentCls, permission('transactions:read'), getAccount, paymentLinksController.getManage)
+  app.get(paymentLinks.manage.index, xraySegmentCls, permission('transactions:read'), getAccount, paymentLinksController.getManage)
   app.get(paymentLinks.manage.disable, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.getDisable)
   app.get(paymentLinks.manage.delete, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.getDelete)
   app.get(paymentLinks.manage.edit, xraySegmentCls, permission('tokens:create'), getAccount, paymentLinksController.getEdit)

--- a/app/views/dashboard/_links.njk
+++ b/app/views/dashboard/_links.njk
@@ -31,7 +31,7 @@
       <a href="{{routes.paymentLinks.start}}">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Create and manage payment links</h2>
       {% else %}
-      <a href="{{routes.paymentLinks.manage.managePage}}">
+      <a href="{{routes.paymentLinks.manage.index}}">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">View payment links</h2>
       {% endif %}
         <p class="govuk-body govuk-!-margin-bottom-0">A payment link lets you take card payments online, even if you don't have a digital&nbsp;service.</p>

--- a/app/views/payment-links/_nav.njk
+++ b/app/views/payment-links/_nav.njk
@@ -2,7 +2,7 @@
   <nav role="navigation" class="navigation settings-navigation">
     <ul class="govuk-list govuk-!-margin-bottom-9">
        <li class="{% if createLink %}govuk-!-font-weight-bold {% endif %}govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline govuk-!-display-block" href="{{ routes.paymentLinks.start }}">Create a payment link</a></li>
-      <li class="{% if not createLink %}govuk-!-font-weight-bold {% endif %}govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline govuk-!-display-block" href="{{ routes.paymentLinks.manage.managePage }}">Manage payment&nbsp;links</a></li>
+      <li class="{% if not createLink %}govuk-!-font-weight-bold {% endif %}govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline govuk-!-display-block" href="{{ routes.paymentLinks.manage.index }}">Manage payment&nbsp;links</a></li>
     </ul>
   </nav>
 </aside>

--- a/app/views/payment-links/edit-amount.njk
+++ b/app/views/payment-links/edit-amount.njk
@@ -96,7 +96,7 @@
         classes: "button"
       })
     }}
-    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state cancel" href="{{ routes.paymentLinks.manage.managePage }}">Cancel</a></p>
+    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state cancel" href="{{ routes.paymentLinks.manage.index }}">Cancel</a></p>
   </form>
 
   {% if not isWelsh %}

--- a/app/views/payment-links/edit-information.njk
+++ b/app/views/payment-links/edit-information.njk
@@ -112,7 +112,7 @@
       })
     }}
 
-    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state cancel" href="{{ routes.paymentLinks.manage.managePage }}">Cancel</a></p>
+    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state cancel" href="{{ routes.paymentLinks.manage.index }}">Cancel</a></p>
   </form>
 
   {% if not isWelsh %}

--- a/app/views/payment-links/edit-reference.njk
+++ b/app/views/payment-links/edit-reference.njk
@@ -142,7 +142,7 @@
         classes: "button"
       })
     }}
-    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state cancel" href="{{ routes.paymentLinks.manage.managePage }}">Cancel</a></p>
+    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state cancel" href="{{ routes.paymentLinks.manage.index }}">Cancel</a></p>
   </form>
 
   {% if not isWelsh %}

--- a/app/views/payment-links/edit.njk
+++ b/app/views/payment-links/edit.njk
@@ -136,7 +136,7 @@
         }
       })
     }}
-    <p class="govuk-body"><a id="update-payment-link-cancel" class="govuk-link govuk-link--no-visited-state cancel" href="{{ routes.paymentLinks.manage.managePage }}">Cancel</a></p>
+    <p class="govuk-body"><a id="update-payment-link-cancel" class="govuk-link govuk-link--no-visited-state cancel" href="{{ routes.paymentLinks.manage.index }}">Cancel</a></p>
   </form>
 </section>
 {% endblock %}

--- a/test/unit/controller/payment-links/get-delete.controller.ft.test.js
+++ b/test/unit/controller/payment-links/get-delete.controller.ft.test.js
@@ -61,7 +61,7 @@ describe('Manage payment links - delete controller', () => {
     })
 
     it('should redirect to the manage page', () => {
-      expect(response.header).to.have.property('location').to.equal(paths.paymentLinks.manage.managePage)
+      expect(response.header).to.have.property('location').to.equal(paths.paymentLinks.manage.index)
     })
 
     it('should add a relevant generic message to the session \'flash\'', () => {
@@ -105,7 +105,7 @@ describe('Manage payment links - delete controller', () => {
     })
 
     it('should redirect to the manage page', () => {
-      expect(response.header).to.have.property('location').to.equal(paths.paymentLinks.manage.managePage)
+      expect(response.header).to.have.property('location').to.equal(paths.paymentLinks.manage.index)
     })
 
     it('should add a relevant error message to the session \'flash\'', () => {
@@ -146,7 +146,7 @@ describe('Manage payment links - delete controller', () => {
     })
 
     it('should redirect to the manage page', () => {
-      expect(response.header).to.have.property('location').to.equal(paths.paymentLinks.manage.managePage)
+      expect(response.header).to.have.property('location').to.equal(paths.paymentLinks.manage.index)
     })
 
     it('should add a relevant error message to the session \'flash\'', () => {
@@ -189,7 +189,7 @@ describe('Manage payment links - delete controller', () => {
     })
 
     it('should redirect to the manage page', () => {
-      expect(response.header).to.have.property('location').to.equal(paths.paymentLinks.manage.managePage)
+      expect(response.header).to.have.property('location').to.equal(paths.paymentLinks.manage.index)
     })
 
     it('should add a relevant error message to the session \'flash\'', () => {

--- a/test/unit/controller/payment-links/get-disable.controller.ft.test.js
+++ b/test/unit/controller/payment-links/get-disable.controller.ft.test.js
@@ -42,7 +42,7 @@ describe('Manage payment links - disable controller', () => {
     })
 
     it('should redirect to the manage page', () => {
-      expect(response.header).to.have.property('location').to.equal(paths.paymentLinks.manage.managePage)
+      expect(response.header).to.have.property('location').to.equal(paths.paymentLinks.manage.index)
     })
 
     it('should add a relevant generic message to the session \'flash\'', () => {
@@ -82,7 +82,7 @@ describe('Manage payment links - disable controller', () => {
     })
 
     it('should redirect to the manage page', () => {
-      expect(response.header).to.have.property('location').to.equal(paths.paymentLinks.manage.managePage)
+      expect(response.header).to.have.property('location').to.equal(paths.paymentLinks.manage.index)
     })
 
     it('should add a relevant error message to the session \'flash\'', () => {

--- a/test/unit/controller/payment-links/post-edit.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-edit.controller.ft.test.js
@@ -71,7 +71,7 @@ describe('POST edit payment link controller', () => {
   })
 
   it('should redirect to the manage page with a success message', () => {
-    expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.manage.managePage)
+    expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.manage.index)
     expect(session.flash).to.have.property('generic')
     expect(session.flash.generic.length).to.equal(1)
     expect(session.flash.generic[0]).to.equal('Your payment link has been updated')

--- a/test/unit/controller/payment-links/post-review.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-review.controller.ft.test.js
@@ -88,7 +88,7 @@ describe('Create payment link review controller', () => {
 
     it('should redirect to the manage page with a success message', () => {
       expect(session.flash).to.have.property('createPaymentLinkSuccess')
-      expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.manage.managePage)
+      expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.manage.index)
     })
   })
   describe('successful submission for a Welsh payment link', () => {
@@ -126,7 +126,7 @@ describe('Create payment link review controller', () => {
     })
 
     it('should redirect to the manage page', () => {
-      expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.manage.managePage)
+      expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.manage.index)
     })
   })
   describe('the product creation fails', () => {
@@ -250,7 +250,7 @@ describe('Create payment link review controller', () => {
 
     it('should redirect to the manage page with a success message', () => {
       expect(session.flash).to.have.property('createPaymentLinkSuccess')
-      expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.manage.managePage)
+      expect(result.headers).to.have.property('location').to.equal(paths.paymentLinks.manage.index)
     })
   })
   describe('when paymentLinkTitle is missing from the session', () => {


### PR DESCRIPTION
As the root page for managing payment links is now nested in the
`paymentLinks.manage` attribute, rename the key to `index`.


