### PR TITLE
PP-7489 Remove unused client methods

### DIFF
--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -556,51 +556,6 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-   * Get a service by externalId
-   *
-   * @param externalId
-   * @returns {*|promise|Constructor}
-   */
-  const getServiceByExternalId = (serviceExternalId) => {
-    return baseClient.get(
-      {
-        baseUrl,
-        url: `${serviceResource}/${serviceExternalId}`,
-        json: true,
-        correlationId: correlationId,
-        description: 'find a service',
-        service: SERVICE_NAME,
-        transform: responseBodyToServiceTransformer,
-        baseClientErrorHandler: 'old'
-      }
-    )
-  }
-
-  /**
-   * Get service for a given gateway account ID
-   *
-   * @param gatewayAccountId
-   * @returns {*|promise|Constructor}
-   */
-  const getServiceForGatewayAccount = (gatewayAccountId) => {
-    return baseClient.get(
-      {
-        baseUrl,
-        url: `${serviceResource}`,
-        qs: {
-          gatewayAccountId: gatewayAccountId
-        },
-        json: true,
-        correlationId: correlationId,
-        description: 'find a service for a given gateway account',
-        service: SERVICE_NAME,
-        transform: responseBodyToServiceTransformer,
-        baseClientErrorHandler: 'old'
-      }
-    )
-  }
-
-  /**
    * Update service
    *
    * @param serviceExternalId
@@ -869,8 +824,6 @@ module.exports = function (clientOptions = {}) {
     addGatewayAccountsToService,
     updateCurrentGoLiveStage,
     addStripeAgreementIpAddress,
-    addGovUkAgreementEmailAddress,
-    getServiceByExternalId,
-    getServiceForGatewayAccount
+    addGovUkAgreementEmailAddress
   }
 }


### PR DESCRIPTION
## WHAT
- Removed clients methods as these are not currently used. We are using service details available on user object to set on request and using it further in the code base.

