### PR TITLE
PP-7422: Add a function to call to connector to check Worldpay 3DS Flex credentials

### DIFF
--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -30,6 +30,7 @@ const ACCEPTED_CARD_TYPES_FRONTEND_PATH = ACCOUNT_FRONTEND_PATH + '/card-types'
 const ACCOUNT_NOTIFICATION_CREDENTIALS_PATH = '/v1/api/accounts' + '/{accountId}' + '/notification-credentials'
 const ACCOUNT_CREDENTIALS_PATH = ACCOUNT_FRONTEND_PATH + '/credentials'
 const EMAIL_NOTIFICATION__PATH = '/v1/api/accounts/{accountId}/email-notification'
+const CHECK_WORLDPAY_3DS_FLEX_CREDENTIALS_PATH = '/v1/api/accounts/{accountId}/worldpay/check-3ds-flex-config'
 const FLEX_CREDENTIALS_PATH = '/v1/api/accounts/{accountId}/3ds-flex-credentials'
 const TOGGLE_3DS_PATH = ACCOUNTS_FRONTEND_PATH + '/{accountId}/3ds-toggle'
 
@@ -301,11 +302,31 @@ ConnectorClient.prototype = {
   },
 
   /**
- *
- * @param {Object} params
- * @param {Function} successCallback
- * @returns {Promise}
- */
+   * Checks Worldpay 3DS Flex credentials
+   *
+   * @param {Object} params
+   * @returns {Promise<Object>}
+   */
+  postCheckWorldpay3dsFlexCredentials: function (params) {
+    return baseClient.post(
+      {
+        baseUrl: this.connectorUrl,
+        url: CHECK_WORLDPAY_3DS_FLEX_CREDENTIALS_PATH.replace('{accountId}', params.gatewayAccountId),
+        json: true,
+        body: params.payload,
+        correlationId: params.correlationId,
+        description: 'Check Worldpay 3DS Flex credentials',
+        service: SERVICE_NAME
+      }
+    )
+  },
+
+  /**
+   *
+   * @param {Object} params
+   * @param {Function} successCallback
+   * @returns {Promise}
+   */
   post3dsFlexAccountCredentials: function (params) {
     return new Promise((resolve, reject) => {
       const url = _get3dsFlexCredentialsUrlFor(params.gatewayAccountId, this.connectorUrl)
@@ -695,7 +716,7 @@ ConnectorClient.prototype = {
     })
   },
 
-    /**
+  /**
    * @param gatewayAccountId
    * @param integrationVersion3ds (number)
    * @param correlationId

--- a/test/fixtures/worldpay-3ds-flex-credentials.fixtures.js
+++ b/test/fixtures/worldpay-3ds-flex-credentials.fixtures.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const path = require('path')
+const _ = require('lodash')
+
+const pactBase = require(path.join(__dirname, '/pact-base'))
+const pactRegister = pactBase()
+
+const checkValidWorldpay3dsFlexCredentialsRequest = function checkValidWorldpay3dsFlexCredentialsRequest (opts = {}) {
+  const data = {
+    correlationId: opts.correlationId || 'a1',
+    gatewayAccountId: opts.gatewayAccountId || 333,
+    payload: {
+      organisational_unit_id: opts.organisationalUnitId || '5bd9b55e4444761ac0af1c80',
+      issuer: opts.issuer || '5bd9e0e4444dce153428c940',
+      jwt_mac_key: opts.jwtMacKey || 'fa2daee2-1fbb-45ff-4444-52805d5cd9e0'
+    }
+  }
+
+  return {
+    getPactified: () => {
+      return pactRegister.pactify(data)
+    },
+    getPlain: () => {
+      return _.clone(data)
+    }
+  }
+}
+
+const checkValidWorldpay3dsFlexCredentialsResponse = function checkValidWorldpay3dsFlexCredentialsResponse (opts = {}) {
+  const data = {
+    result: opts.result || 'valid'
+  }
+
+  return {
+    getPactified: () => {
+      return pactRegister.pactify(data)
+    },
+    getPlain: () => {
+      return _.clone(data)
+    }
+  }
+}
+
+module.exports = {
+  checkValidWorldpay3dsFlexCredentialsRequest,
+  checkValidWorldpay3dsFlexCredentialsResponse
+}

--- a/test/unit/clients/adminusers-client/user/authenticate.pact.test.js
+++ b/test/unit/clients/adminusers-client/user/authenticate.pact.test.js
@@ -8,6 +8,7 @@ var userFixtures = require('../../../../fixtures/user.fixtures')
 var PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 
 chai.use(chaiAsPromised)
+chai.should()
 
 const expect = chai.expect
 const USER_PATH = '/v1/api/users'

--- a/test/unit/clients/connector-client/connector-post-worldpay-check-3ds-flex-config.pact.test.js
+++ b/test/unit/clients/connector-client/connector-post-worldpay-check-3ds-flex-config.pact.test.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const path = require('path')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const { Pact } = require('@pact-foundation/pact')
+const expect = chai.expect
+chai.should()
+chai.use(chaiAsPromised)
+
+const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
+const worldpay3dsFlexCredentialsFixtures = require('../../../fixtures/worldpay-3ds-flex-credentials.fixtures')
+const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient
+const PORT = Math.floor(Math.random() * 48127) + 1024
+const connectorClient = new Connector(`http://localhost:${PORT}`)
+const ACCOUNTS_RESOURCE = '/v1/api/accounts'
+const EXISTING_GATEWAY_ACCOUNT_ID = 333
+const CHECK_WORLDPAY_3DS_FLEX_CREDENTIALS = 'worldpay/check-3ds-flex-config'
+
+describe('connector client - check Worldpay 3DS Flex credentials', () => {
+  const provider = new Pact({
+    consumer: 'selfservice',
+    provider: 'connector',
+    port: PORT,
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(() => provider.setup())
+  afterEach(() => provider.verify())
+  after(() => provider.finalize())
+
+  describe('when a request to check Worldpay 3DS Flex credentials is made', () => {
+    describe('and the credentials are valid and pass the existing format validation', () => {
+      const checkValidWorldpay3dsFlexCredentialsRequest = worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsRequest()
+      const checkValidWorldpay3dsFlexCredentialsResponse = worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsResponse()
+      before(() => {
+        const pactifiedRequest = checkValidWorldpay3dsFlexCredentialsRequest.getPactified()
+        const pactifiedResponse = checkValidWorldpay3dsFlexCredentialsResponse.getPactified()
+
+        provider.addInteraction(
+          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${EXISTING_GATEWAY_ACCOUNT_ID}/${CHECK_WORLDPAY_3DS_FLEX_CREDENTIALS}`)
+            .withState(`a gateway account ${EXISTING_GATEWAY_ACCOUNT_ID} with Worldpay 3DS Flex credentials exists`)
+            .withUponReceiving('a request to check Worldpay 3DS Flex credentials')
+            .withMethod('POST')
+            .withRequestHeaders({ 'Content-Type': 'application/json' })
+            .withRequestBody(pactifiedRequest.payload)
+            .withStatusCode(200)
+            .withResponseHeaders({ 'Content-Type': 'application/json' })
+            .withResponseBody(pactifiedResponse)
+            .build()
+        )
+      })
+
+      it('should return valid', () => {
+        const valid3dsFlexCredentials = checkValidWorldpay3dsFlexCredentialsRequest.getPlain()
+        const validResult = checkValidWorldpay3dsFlexCredentialsResponse.getPlain()
+        return connectorClient.postCheckWorldpay3dsFlexCredentials(valid3dsFlexCredentials)
+          .should.be.fulfilled.then((response) => {
+            expect(response).to.deep.equal(validResult)
+          })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This change

- adds a new function `postCheckWorldpay3dsFlexCredentials` which makes a call to a connector application to check Worldpay 3DS Flex credentials.
- adds a PACT test to test the function to ensure that it can handle a happy scenario correctly.
- fixes authenticate PACT tests failures.