### PR TITLE
PP-7488 Improve logging in error handler

### DIFF
--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -15,6 +15,15 @@ const { renderErrorView } = require('../utils/response')
 module.exports = function errorHandler (err, req, res, next) {
   const logContext = {}
   logContext[keys.CORRELATION_ID] = req.headers[CORRELATION_HEADER]
+  if (req.user) {
+    logContext[keys.USER_EXTERNAL_ID] = req.user.externalId
+  }
+  if (req.service) {
+    logContext[keys.SERVICE_EXTERNAL_ID] = req.service.externalId
+  }
+  if (req.account) {
+    logContext[keys.GATEWAY_ACCOUNT_ID] = req.account.gateway_account_id
+  }
 
   if (res.headersSent) {
     return next(err)
@@ -24,20 +33,23 @@ module.exports = function errorHandler (err, req, res, next) {
     if (req.session) {
       req.session.last_url = req.originalUrl
     }
-    logger.info(`Redirecting attempt to access ${req.originalUrl} to ${paths.user.logIn}`, logContext)
+    logger.info(`NotAuthenticatedError handled: ${err.message}. Redirecting attempt to access ${req.originalUrl} to ${paths.user.logIn}`, logContext)
     return res.redirect(paths.user.logIn)
   }
 
   if (err instanceof UserAccountDisabledError) {
+    logger.info('UserAccountDisabledError handled, rendering no access page', logContext)
     res.status(401)
     return res.render('login/noaccess')
   }
 
   if (err instanceof NotAuthorisedError) {
+    logger.info(`NotAuthorisedError handled: ${err.message}. Rendering error page`, logContext)
     return renderErrorView(req, res, 'You do not have the administrator rights to perform this operation.', 403)
   }
 
   if (err instanceof NotFoundError) {
+    logger.info(`NotFoundError handled: ${err.message}. Rendering 404 page`, logContext)
     res.status(404)
     return res.render('404')
   }


### PR DESCRIPTION
Log when we handle various errors so it's easier to trace what's happened for a request.

Log any useful info we have on the `req` - the user external id, service external id and gateway account id.

