### PR TITLE
PP-7630 Fix reporting columns URL encoded key

### DIFF
--- a/app/controllers/payment-links/get-edit.controller.js
+++ b/app/controllers/payment-links/get-edit.controller.js
@@ -24,6 +24,9 @@ module.exports = async function showEditPaymentLink (req, res, next) {
   const addMetadataUrl = shouldUseInlineReportingColumns
     ? formattedPathFor(paths.paymentLinks.manage.addMetadata, productExternalId)
     : formattedPathFor(paths.paymentLinks.metadata.add, productExternalId)
+  const editMetadataPath = shouldUseInlineReportingColumns
+    ? paths.paymentLinks.manage.editMetadata
+    : paths.paymentLinks.metadata.edit
 
   const pageData = {
     self: formattedPathFor(paths.paymentLinks.manage.edit, productExternalId),
@@ -31,6 +34,7 @@ module.exports = async function showEditPaymentLink (req, res, next) {
     editReference: formattedPathFor(paths.paymentLinks.manage.editReference, productExternalId),
     editAmount: formattedPathFor(paths.paymentLinks.manage.editAmount, productExternalId),
     addMetadata: addMetadataUrl,
+    editMetadata: editMetadataPath,
     formattedPathFor,
     paths
   }

--- a/app/controllers/payment-links/get-review.controller.js
+++ b/app/controllers/payment-links/get-review.controller.js
@@ -12,6 +12,7 @@ module.exports = (req, res) => {
   return response(req, res, 'payment-links/review', {
     pageData,
     addMetadata: paths.paymentLinks.addMetadata,
+    editMetadata: paths.paymentLinks.editMetadata,
     metadata: pageData.metadata
   })
 }

--- a/app/controllers/payment-links/get-update-reporting-column.controller.js
+++ b/app/controllers/payment-links/get-update-reporting-column.controller.js
@@ -27,7 +27,7 @@ function showEditMetadataPage (req, res) {
   const form = new MetadataForm(prefilledPage)
   const pageData = {
     form: form,
-    self: `${paymentLinksContext.addMetadataPageUrl}/${key}`,
+    self: paymentLinksContext.editMetadataPageUrl,
     cancelRoute: paymentLinksContext.listMetadataPageUrl,
     isEditing: true,
     canEditKey: true,

--- a/app/controllers/payment-links/metadata/metadata-form.js
+++ b/app/controllers/payment-links/metadata/metadata-form.js
@@ -2,6 +2,7 @@ const METADATA_MAX_HEADER_LENGTH = 30
 const METADATA_MAX_VALUE_LENGTH = 100
 const MAX_NO_OF_METADATA_COLUMNS = 10
 
+const SPECIAL_CHARACTERS = [ '/', '\\', '?', '&' ]
 const fields = {
   metadataKey: {
     id: 'metadata-column-header',
@@ -22,6 +23,10 @@ const fields = {
       {
         validator: isNotExceedingMaxNoOfReportingColumns,
         message: `Number of reporting columns must be ${MAX_NO_OF_METADATA_COLUMNS} or fewer`
+      },
+      {
+        validator: doesNotContainSpecialCharacters,
+        message: `Column header must not include ${SPECIAL_CHARACTERS.join(' ')}`
       }
     ]
   },
@@ -36,6 +41,10 @@ const fields = {
       {
         validator: isValidLengthForCellContent,
         message: `Cell content must be ${METADATA_MAX_VALUE_LENGTH} characters or fewer`
+      },
+      {
+        validator: doesNotContainSpecialCharacters,
+        message: `Cell content must not include ${SPECIAL_CHARACTERS.join(' ')}`
       }
     ]
   }
@@ -128,6 +137,10 @@ function isNotExceedingMaxNoOfReportingColumns (value, existingMetadata) {
   }
 
   return true
+}
+
+function doesNotContainSpecialCharacters (value) {
+  return !SPECIAL_CHARACTERS.some((character) => value.includes(character))
 }
 
 module.exports = MetadataForm

--- a/app/controllers/payment-links/metadata/metadata-form.js
+++ b/app/controllers/payment-links/metadata/metadata-form.js
@@ -2,7 +2,7 @@ const METADATA_MAX_HEADER_LENGTH = 30
 const METADATA_MAX_VALUE_LENGTH = 100
 const MAX_NO_OF_METADATA_COLUMNS = 10
 
-const SPECIAL_CHARACTERS = [ '/', '\\', '?', '&' ]
+const SPECIAL_CHARACTERS = [ '\\' ]
 const fields = {
   metadataKey: {
     id: 'metadata-column-header',
@@ -41,10 +41,6 @@ const fields = {
       {
         validator: isValidLengthForCellContent,
         message: `Cell content must be ${METADATA_MAX_VALUE_LENGTH} characters or fewer`
-      },
-      {
-        validator: doesNotContainSpecialCharacters,
-        message: `Cell content must not include ${SPECIAL_CHARACTERS.join(' ')}`
       }
     ]
   }

--- a/app/controllers/payment-links/post-update-reporting-column.controller.js
+++ b/app/controllers/payment-links/post-update-reporting-column.controller.js
@@ -40,7 +40,7 @@ function editMetadata (req, res) {
   const form = new MetadataForm(req.body, existingMetadata)
 
   const pageData = {
-    self: `${paymentLinksContext.addMetadataPageUrl}/${key}`,
+    self: paymentLinksContext.editMetadataPageUrl,
     cancelRoute: paymentLinksContext.listMetadataPageUrl,
     isEditing: true,
     canEditKey: true,

--- a/app/paths.js
+++ b/app/paths.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const path = require('path')
+const generateRoute = require('./utils/generate-route')
+const formattedPathFor = require('./utils/replace-params-in-path')
 
 module.exports = {
   keys: {
@@ -50,8 +51,8 @@ module.exports = {
         index: '/my-profile/two-factor-auth',
         configure: '/my-profile/two-factor-auth/configure',
         resend: '/my-profile/two-factor-auth/resend'
-      },
-    },
+      }
+    }
   },
   dashboard: {
     index: '/'
@@ -185,7 +186,8 @@ module.exports = {
     linkAccount: '/link-account',
     oauthComplete: '/oauth/complete'
   },
-  generateRoute: require(path.join(__dirname, '/utils/generate-route.js')),
+  generateRoute: generateRoute,
+  formattedPathFor: formattedPathFor,
   requestToGoLive: {
     index: '/service/:externalServiceId/request-to-go-live',
     organisationName: '/service/:externalServiceId/request-to-go-live/organisation-name',

--- a/app/utils/payment-links.js
+++ b/app/utils/payment-links.js
@@ -10,20 +10,25 @@ const paths = require('../paths')
 // based on the request
 function getPaymentLinksContext (req) {
   const isCreatingPaymentLink = !Object.values(paths.paymentLinks.manage).includes(req.route && req.route.path)
+  const params = req.params || {}
 
   if (isCreatingPaymentLink) {
+    const { metadataKey } = params
+
     return {
       sessionData: lodash.get(req, 'session.pageData.createPaymentLink'),
       addMetadataPageUrl: paths.paymentLinks.addMetadata,
+      editMetadataPageUrl: paths.formattedPathFor(paths.paymentLinks.editMetadata, metadataKey),
       listMetadataPageUrl: paths.paymentLinks.review,
       isCreatingPaymentLink
     }
   } else {
-    const { productExternalId } = req.params
+    const { productExternalId, metadataKey } = params
 
     return {
       sessionData: lodash.get(req, 'session.editPaymentLinkData'),
       addMetadataPageUrl: paths.generateRoute(paths.paymentLinks.manage.addMetadata, { productExternalId }),
+      editMetadataPageUrl: paths.formattedPathFor(paths.paymentLinks.manage.editMetadata, productExternalId, metadataKey),
       listMetadataPageUrl: paths.generateRoute(paths.paymentLinks.manage.edit, { productExternalId }),
       isCreatingPaymentLink
     }

--- a/app/views/payment-links/reporting-columns/_manage-reporting-columns.njk
+++ b/app/views/payment-links/reporting-columns/_manage-reporting-columns.njk
@@ -13,7 +13,8 @@
             {{metadataValue}}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="{{ addMetadata }}/{{ metadataKey }}">
+            {% set editMetadataLink = routes.formattedPathFor(editMetadata, product.externalId, metadataKey) if product else routes.formattedPathFor(editMetadata, metadataKey) %}
+            <a class="govuk-link" href="{{ editMetadataLink }}">
               Change<span class="govuk-visually-hidden"> ‘{{ metadataKey }}’</span>
             </a>
           </dd>

--- a/test/cypress/integration/payment-links/edit-payment-link.cy.test.js
+++ b/test/cypress/integration/payment-links/edit-payment-link.cy.test.js
@@ -96,7 +96,7 @@ describe('Editing a payment link', () => {
       cy.get('#reporting-columns-summary').find('.govuk-summary-list__row').eq(1).should('exist').within(() => {
         cy.get('.govuk-summary-list__key').should('contain', 'Finance team')
         cy.get('.govuk-summary-list__value').should('contain', 'Licensing')
-        cy.get('.govuk-summary-list__actions a').should('have.attr', 'href', `/create-payment-link/manage/edit/${productId}/metadata/Finance team`)
+        cy.get('.govuk-summary-list__actions a').should('have.attr', 'href', `/create-payment-link/manage/edit/${productId}/metadata/Finance%20team`)
       })
       cy.get('#reporting-columns-summary').find('.govuk-summary-list__row').eq(2).should('exist').within(() => {
         cy.get('.govuk-summary-list__key').should('contain', 'group')

--- a/test/unit/controller/payment-links/metadata/paymentlink-metadata-form.test.js
+++ b/test/unit/controller/payment-links/metadata/paymentlink-metadata-form.test.js
@@ -22,7 +22,7 @@ describe('Payment link metadata form model', () => {
   })
 
   it('correctly validates given input that is too long', () => {
-    const body = { 
+    const body = {
       'metadata-column-header': 'aaaaaaaaaabbbbbbbbbbcccccccccc1',
       'metadata-cell-value': 'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee2'
     }
@@ -77,6 +77,24 @@ describe('Payment link metadata form model', () => {
     expect(tested.errors.length).to.eq(1)
     expect(tested.errorMaps['metadata-column-header']).to.not.be.null // eslint-disable-line
     expect(tested.errorMaps['metadata-cell-value']).to.be.undefined // eslint-disable-line
+  })
+
+  it('correctly validates when special characters are used for the header', () => {
+    const body = { 'metadata-column-header': 'key1/', 'metadata-cell-value': 'value' }
+    const form = new MetadataForm(body)
+    const tested = form.validate()
+
+    expect(tested.errors.length).to.eq(1)
+    expect(tested.errorMaps['metadata-column-header']).to.contain('Column header must not include')
+  })
+
+  it('correctly validates when special characters are used for the cell content', () => {
+    const body = { 'metadata-column-header': 'key1', 'metadata-cell-value': 'value\&' } // eslint-disable-line
+    const form = new MetadataForm(body)
+    const tested = form.validate()
+
+    expect(tested.errors.length).to.eq(1)
+    expect(tested.errorMaps['metadata-cell-value']).to.contain('Cell content must not include')
   })
 
   it('correctly passes with all valid inputs', () => {

--- a/test/unit/controller/payment-links/metadata/paymentlink-metadata-form.test.js
+++ b/test/unit/controller/payment-links/metadata/paymentlink-metadata-form.test.js
@@ -80,21 +80,12 @@ describe('Payment link metadata form model', () => {
   })
 
   it('correctly validates when special characters are used for the header', () => {
-    const body = { 'metadata-column-header': 'key1/', 'metadata-cell-value': 'value' }
+    const body = { 'metadata-column-header': 'key1\\', 'metadata-cell-value': 'value' }
     const form = new MetadataForm(body)
     const tested = form.validate()
 
     expect(tested.errors.length).to.eq(1)
     expect(tested.errorMaps['metadata-column-header']).to.contain('Column header must not include')
-  })
-
-  it('correctly validates when special characters are used for the cell content', () => {
-    const body = { 'metadata-column-header': 'key1', 'metadata-cell-value': 'value\&' } // eslint-disable-line
-    const form = new MetadataForm(body)
-    const tested = form.validate()
-
-    expect(tested.errors.length).to.eq(1)
-    expect(tested.errorMaps['metadata-cell-value']).to.contain('Cell content must not include')
   })
 
   it('correctly passes with all valid inputs', () => {


### PR DESCRIPTION
Fixes a bug with representing reporting column keys in the URL. These keys should 
be URL encoded, this was removed in order to try and support the current and proposed 
implementations of reporting columns, it is not optional however.

Additionally avoid allowing the backspace character from being included in the key/ value. 

Reporting columns are stored as JSON metadata, they are validated across
multiple services and stored as JSONB in Postgres. In order to reduce
the number of places edge cases could arise, don't allow characters that
could either interfere with the URL structure or JSON keys.

![Screenshot 2020-12-15 at 09 34 42](https://user-images.githubusercontent.com/2844572/102197262-cd0cba00-3eb8-11eb-9dbd-b0d9fc717b6b.png)
