### PR TITLE
PP-7509 Pass session metadata through to products calls

### DIFF
--- a/app/controllers/payment-links/post-review.controller.js
+++ b/app/controllers/payment-links/post-review.controller.js
@@ -20,7 +20,8 @@ module.exports = async function createPaymentLink (req, res) {
     paymentReferenceType,
     paymentReferenceLabel,
     paymentReferenceHint,
-    isWelsh
+    isWelsh,
+    metadata
   } = lodash.get(req, 'session.pageData.createPaymentLink', {})
 
   if (!paymentLinkTitle) {
@@ -47,6 +48,7 @@ module.exports = async function createPaymentLink (req, res) {
       type: productTypes.ADHOC,
       serviceNamePath,
       productNamePath,
+      metadata,
       language: isWelsh ? supportedLanguage.WELSH : supportedLanguage.ENGLISH,
       referenceEnabled: paymentReferenceType === 'custom',
       ...paymentLinkDescription && { description: paymentLinkDescription },

--- a/app/services/clients/products.client.js
+++ b/app/services/clients/products.client.js
@@ -65,7 +65,8 @@ function createProduct (options) {
       reference_enabled: options.referenceEnabled,
       reference_label: options.referenceLabel,
       reference_hint: options.referenceHint,
-      language: options.language || supportedLanguage.ENGLISH
+      language: options.language || supportedLanguage.ENGLISH,
+      ...options.metadata && { metadata: options.metadata }
     },
     description: 'create a product for a service',
     service: SERVICE_NAME
@@ -91,7 +92,8 @@ function updateProduct (gatewayAccountId, productExternalId, options) {
       price: options.price,
       reference_enabled: options.referenceEnabled,
       reference_label: options.referenceLabel,
-      reference_hint: options.referenceHint
+      reference_hint: options.referenceHint,
+      ...options.metadata && { metadata: options.metadata }
     },
     description: 'update an existing product',
     service: SERVICE_NAME

--- a/test/fixtures/product.fixtures.js
+++ b/test/fixtures/product.fixtures.js
@@ -27,6 +27,7 @@ module.exports = {
       data.reference_label = opts.reference_label
       data.reference_hint = opts.reference_hint
     }
+    if (opts.metadata) data.metadata = opts.metadata
     return {
       getPactified: () => {
         return pactProducts.pactify(data)


### PR DESCRIPTION
The create and manage flow both now curate and validate metadata in the
payment link session, allowing the user to safely create, update and
delete metadata.

The backend now supports receiving a complete metadata object, pass this
through to the API calls.


