### PR TITLE
PP-7509 Always delete backend product metadata when using in-flow reporting columns

### DIFF
--- a/app/controllers/payment-links/get-edit.controller.js
+++ b/app/controllers/payment-links/get-edit.controller.js
@@ -48,8 +48,8 @@ module.exports = async function showEditPaymentLink (req, res, next) {
       // if this is the first time we're loading the product, update the session editing copy
       if (!editPaymentLinkData.metadata) {
         editPaymentLinkData.metadata = product.metadata
-        delete product.metadata
       }
+      delete product.metadata
     } else {
       // this is an existing workaround because the existing code should always directly reflect the backend
       // this should be removed when we remove the feature flag and are fully in-flow editing


### PR DESCRIPTION
When the flag is enabled for reporting columns that are managed in the
session flow, consistently remove the backend product metadata as it
won't include the changes that have been made since the edit session has
started.

The other values that are managed in the flow are "merged" with the
backend product every time the payment link "edit" page is loaded, this
works because these values will always be replaced. As reporting columns
can be edited and even entirely removed, the session version should be
considered the true copy until submission.

