### PR TITLE
PP-7509 Log salient reporting column actions

### DIFF
--- a/app/controllers/payment-links/metadata/metadata-form.js
+++ b/app/controllers/payment-links/metadata/metadata-form.js
@@ -120,7 +120,7 @@ function isValidLengthForCellContent (value) {
 
 function isNotDuplicate (value, existingMetadata) {
   if (existingMetadata) {
-    const found = Object.keys(existingMetadata).find(metadataKey => value === metadataKey)
+    const found = Object.keys(existingMetadata).find(metadataKey => String(value).toLowerCase() === String(metadataKey).toLowerCase())
     return !found
   }
 

--- a/app/controllers/payment-links/post-update-reporting-column.controller.js
+++ b/app/controllers/payment-links/post-update-reporting-column.controller.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const logger = require('../../utils/logger')
+const logger = require('../../utils/logger')(__filename)
 const MetadataForm = require('./metadata/metadata-form')
 const { getPaymentLinksContext, metadata } = require('../../utils/payment-links')
 const { keys } = require('@govuk-pay/pay-js-commons').logging
@@ -32,7 +32,7 @@ function addMetadata (req, res, next) {
     )
 
     const logContext = {
-      is_internal_user: req.user && req.user.internal_user,
+      is_internal_user: req.user && req.user.internalUser,
       reporting_column_key: form.values[form.fields.metadataKey.id],
       product_external_id: req.params && req.params.productExternalId
     }
@@ -80,7 +80,7 @@ function editMetadata (req, res, next) {
     )
 
     const logContext = {
-      is_internal_user: req.user && req.user.internal_user,
+      is_internal_user: req.user && req.user.internalUser,
       original_reporting_column_key: key,
       reporting_column_key: form.values[form.fields.metadataKey.id],
       product_external_id: req.params && req.params.productExternalId
@@ -104,7 +104,7 @@ function deleteMetadata (req, res, next) {
     metadata.removeMetadata(paymentLinksContext.sessionData, key)
 
     const logContext = {
-      is_internal_user: req.user && req.user.internal_user,
+      is_internal_user: req.user && req.user.internalUser,
       reporting_column_key: key,
       product_external_id: req.params && req.params.productExternalId
     }

--- a/app/controllers/payment-links/post-update-reporting-column.controller.js
+++ b/app/controllers/payment-links/post-update-reporting-column.controller.js
@@ -1,77 +1,122 @@
 'use strict'
 
+const logger = require('../../utils/logger')
 const MetadataForm = require('./metadata/metadata-form')
 const { getPaymentLinksContext, metadata } = require('../../utils/payment-links')
+const { keys } = require('@govuk-pay/pay-js-commons').logging
 
 const { response } = require('../../utils/response.js')
 
-function addMetadata (req, res) {
-  const paymentLinksContext = getPaymentLinksContext(req)
-  const pageData = {
-    self: paymentLinksContext.addMetadataPageUrl,
-    cancelRoute: paymentLinksContext.listMetadataPageUrl,
-    createLink: paymentLinksContext.isCreatingPaymentLink
+function addMetadata (req, res, next) {
+  try {
+    const paymentLinksContext = getPaymentLinksContext(req)
+    const pageData = {
+      self: paymentLinksContext.addMetadataPageUrl,
+      cancelRoute: paymentLinksContext.listMetadataPageUrl,
+      createLink: paymentLinksContext.isCreatingPaymentLink
+    }
+    const form = new MetadataForm(req.body, paymentLinksContext.sessionData && paymentLinksContext.sessionData.metadata)
+    const validated = form.validate()
+
+    if (validated.errors.length) {
+      pageData.tested = validated
+      pageData.form = form
+      response(req, res, 'payment-links/reporting-columns/edit-reporting-columns', pageData)
+      return
+    }
+
+    metadata.addMetadata(
+      paymentLinksContext.sessionData,
+      form.values[form.fields.metadataKey.id],
+      form.values[form.fields.metadataValue.id]
+    )
+
+    const logContext = {
+      is_internal_user: req.user && req.user.internal_user,
+      reporting_column_key: form.values[form.fields.metadataKey.id],
+      product_external_id: req.params && req.params.productExternalId
+    }
+    logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
+    logContext[keys.GATEWAY_ACCOUNT_TYPE] = req.account && req.account.type
+    logContext[keys.GATEWAY_ACCOUNT_ID] = req.account && req.account.gateway_account_id
+    logger.info('Reporting column added', logContext)
+
+    res.redirect(paymentLinksContext.listMetadataPageUrl)
+  } catch (error) {
+    next(error)
   }
-  const form = new MetadataForm(req.body, paymentLinksContext.sessionData && paymentLinksContext.sessionData.metadata)
-  const validated = form.validate()
-
-  if (validated.errors.length) {
-    pageData.tested = validated
-    pageData.form = form
-    response(req, res, 'payment-links/reporting-columns/edit-reporting-columns', pageData)
-    return
-  }
-
-  metadata.addMetadata(
-    paymentLinksContext.sessionData,
-    form.values[form.fields.metadataKey.id],
-    form.values[form.fields.metadataValue.id]
-  )
-
-  res.redirect(paymentLinksContext.listMetadataPageUrl)
 }
 
-function editMetadata (req, res) {
-  const paymentLinksContext = getPaymentLinksContext(req)
-  const key = req.params.metadataKey
+function editMetadata (req, res, next) {
+  try {
+    const paymentLinksContext = getPaymentLinksContext(req)
+    const key = req.params.metadataKey
 
-  const existingMetadata = { ...paymentLinksContext.sessionData.metadata }
-  delete existingMetadata[key]
-  const form = new MetadataForm(req.body, existingMetadata)
+    const existingMetadata = { ...paymentLinksContext.sessionData.metadata }
+    delete existingMetadata[key]
+    const form = new MetadataForm(req.body, existingMetadata)
 
-  const pageData = {
-    self: paymentLinksContext.editMetadataPageUrl,
-    cancelRoute: paymentLinksContext.listMetadataPageUrl,
-    isEditing: true,
-    canEditKey: true,
-    createLink: paymentLinksContext.isCreatingPaymentLink
+    const pageData = {
+      self: paymentLinksContext.editMetadataPageUrl,
+      cancelRoute: paymentLinksContext.listMetadataPageUrl,
+      isEditing: true,
+      canEditKey: true,
+      createLink: paymentLinksContext.isCreatingPaymentLink
+    }
+    const validated = form.validate()
+
+    if (validated.errors.length) {
+      pageData.tested = validated
+      pageData.form = form
+      response(req, res, 'payment-links/reporting-columns/edit-reporting-columns', pageData)
+      return
+    }
+
+    metadata.updateMetadata(
+      paymentLinksContext.sessionData,
+      key,
+      form.values[form.fields.metadataKey.id],
+      form.values[form.fields.metadataValue.id]
+    )
+
+    const logContext = {
+      is_internal_user: req.user && req.user.internal_user,
+      original_reporting_column_key: key,
+      reporting_column_key: form.values[form.fields.metadataKey.id],
+      product_external_id: req.params && req.params.productExternalId
+    }
+    logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
+    logContext[keys.GATEWAY_ACCOUNT_TYPE] = req.account && req.account.type
+    logContext[keys.GATEWAY_ACCOUNT_ID] = req.account && req.account.gateway_account_id
+    logger.info('Reporting column updated', logContext)
+
+    res.redirect(paymentLinksContext.listMetadataPageUrl)
+  } catch (error) {
+    next(error)
   }
-  const validated = form.validate()
-
-  if (validated.errors.length) {
-    pageData.tested = validated
-    pageData.form = form
-    response(req, res, 'payment-links/reporting-columns/edit-reporting-columns', pageData)
-    return
-  }
-
-  metadata.updateMetadata(
-    paymentLinksContext.sessionData,
-    key,
-    form.values[form.fields.metadataKey.id],
-    form.values[form.fields.metadataValue.id]
-  )
-
-  res.redirect(paymentLinksContext.listMetadataPageUrl)
 }
 
-function deleteMetadata (req, res) {
-  const paymentLinksContext = getPaymentLinksContext(req)
-  const key = req.params.metadataKey
+function deleteMetadata (req, res, next) {
+  try {
+    const paymentLinksContext = getPaymentLinksContext(req)
+    const key = req.params.metadataKey
 
-  metadata.removeMetadata(paymentLinksContext.sessionData, key)
+    metadata.removeMetadata(paymentLinksContext.sessionData, key)
 
-  res.redirect(paymentLinksContext.listMetadataPageUrl)
+    const logContext = {
+      is_internal_user: req.user && req.user.internal_user,
+      reporting_column_key: key,
+      product_external_id: req.params && req.params.productExternalId
+    }
+    logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
+    logContext[keys.GATEWAY_ACCOUNT_TYPE] = req.account && req.account.type
+    logContext[keys.GATEWAY_ACCOUNT_ID] = req.account && req.account.gateway_account_id
+    logger.info('Reporting column deleted', logContext)
+
+    res.redirect(paymentLinksContext.listMetadataPageUrl)
+  } catch (error) {
+    next(error)
+  }
 }
 
 module.exports = {

--- a/test/unit/controller/payment-links/metadata/paymentlink-metadata-form.test.js
+++ b/test/unit/controller/payment-links/metadata/paymentlink-metadata-form.test.js
@@ -53,6 +53,22 @@ describe('Payment link metadata form model', () => {
     expect(tested.errorMaps['metadata-cell-value']).to.be.undefined // eslint-disable-line
   })
 
+  it('correctly validates case insensitive duplicate keys', () => {
+    const newMetadata = {
+      'metadata-column-header': 'DuPlicAte-Key',
+      'metadata-cell-value': 'a-value'
+    }
+
+    const existingMetadata = {
+      'duplicate-key': 'a-value'
+    }
+
+    const form = new MetadataForm(newMetadata, existingMetadata)
+    const tested = form.validate()
+    expect(tested.errors.length).to.eq(1)
+    expect(tested.errorMaps['metadata-column-header']).to.include('Column header must not already exist') // eslint-disable-line
+  })
+
   it('correctly validates when the number of metadata columns exceeds the max number of allowed metadata columns', () => {
     const body = {
       'metadata-column-header': 'test 11 header',


### PR DESCRIPTION
Updating reporting columns should catch all errors that could happen
during controller execution.

Add logs with salient information requested in the ticket for tracking
volumes of in-session changes.

Fix duplicate check to make it in-line with the products and public api
backend.