### PR TITLE
PP-7488 Remove permission check from new authorisation middleware

### DIFF
--- a/app/errors.js
+++ b/app/errors.js
@@ -26,6 +26,12 @@ class UserAccountDisabledError extends DomainError {
 class NotAuthorisedError extends DomainError {
 }
 
+class PermissionDeniedError extends DomainError {
+  constructor (permission) {
+    super(`User does not have permission ${permission} for service`)
+  }
+}
+
 /**
  * Thrown when the resource that a route is trying to access cannot be found.
  */
@@ -36,5 +42,6 @@ module.exports = {
   NotAuthenticatedError,
   UserAccountDisabledError,
   NotAuthorisedError,
+  PermissionDeniedError,
   NotFoundError
 }

--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -6,6 +6,7 @@ const {
   NotAuthenticatedError,
   UserAccountDisabledError,
   NotAuthorisedError,
+  PermissionDeniedError,
   NotFoundError
 } = require('../errors')
 const paths = require('../paths')
@@ -45,6 +46,11 @@ module.exports = function errorHandler (err, req, res, next) {
 
   if (err instanceof NotAuthorisedError) {
     logger.info(`NotAuthorisedError handled: ${err.message}. Rendering error page`, logContext)
+    return renderErrorView(req, res, 'You do not have the rights to access this service.', 403)
+  }
+
+  if (err instanceof PermissionDeniedError) {
+    logger.info(`PermissionDeniedError handled: ${err.message}. Rendering error page`, logContext)
     return renderErrorView(req, res, 'You do not have the administrator rights to perform this operation.', 403)
   }
 

--- a/app/middleware/permission.js
+++ b/app/middleware/permission.js
@@ -1,20 +1,26 @@
+'use strict'
+
 const resolveService = require('./resolve-service')
+const { PermissionDeniedError } = require('../errors')
+
 /**
  * @param {String} permission User must be associated to a role with the given permission
  * to have authorization for the operation.
  *
  * For the moment if undefined, the check is skipped.
  */
-module.exports = function (permission) {
-  return [resolveService, function (req, res, next) {
-    if (!permission) {
-      return next()
+module.exports = function getUserHasPermissionMiddleware (permission) {
+  // TODO: currently this also returns the resolveService middleware to ensure it is run on the
+  // route first. This won't be necessary when we have switched over to using our new middleware
+  // stack in https://payments-platform.atlassian.net/browse/PP-7520
+  return [resolveService, function userHasPermission (req, res, next) {
+    if (!req.user || !req.service) {
+      return next(new Error('Request data is missing'))
+    }
+    if (permission && !req.user.hasPermission(req.service.externalId, permission)) {
+      return next(new PermissionDeniedError(permission))
     }
 
-    if (req.user.hasPermission(req.service.externalId, permission)) {
-      return next()
-    } else {
-      return res.status(401).render('error', { 'message': 'You do not have the administrator rights to perform this operation.' })
-    }
+    return next()
   }]
 }

--- a/app/middleware/user-is-authorised.js
+++ b/app/middleware/user-is-authorised.js
@@ -3,38 +3,33 @@
 const { NotAuthorisedError, NotAuthenticatedError, UserAccountDisabledError } = require('../errors')
 const { SERVICE_EXTERNAL_ID, GATEWAY_ACCOUNT_EXTERNAL_ID } = require('../paths').keys
 
-module.exports = function getUserIsAuthorisedMiddleware (permission) {
-  return function userIsAuthorised (req, res, next) {
-    const { user, session, params, service } = req
+module.exports = function userIsAuthorised (req, res, next) {
+  const { user, session, params, service } = req
 
-    if (!user) {
-      return next(new NotAuthenticatedError('User not found on request'))
-    }
-    if (!session) {
-      return next(new NotAuthenticatedError('Session not found on request'))
-    }
-    if (user.sessionVersion !== session.version) {
-      return next(new NotAuthenticatedError(`Invalid session version - session version is ${session.version}, user session version is ${user.sessionVersion}`))
-    }
-    if (user.disabled) {
-      return next(new UserAccountDisabledError('User account is disabled'))
-    }
-    if (!(session.secondFactor && session.secondFactor === 'totp')) {
-      return next(new NotAuthenticatedError('Not completed second factor authentication'))
-    }
-
-    if (params[GATEWAY_ACCOUNT_EXTERNAL_ID] || params[SERVICE_EXTERNAL_ID]) {
-      if (!service) {
-        return next(new NotAuthorisedError('Service not found on request'))
-      }
-      if (!user.serviceRoles.find(serviceRole => serviceRole.service.externalId === service.externalId)) {
-        return next(new NotAuthorisedError('User does not have service role for service'))
-      }
-      if (permission && !user.hasPermission(service.externalId, permission)) {
-        return next(new NotAuthorisedError(`User does not have permission ${permission} for service`))
-      }
-    }
-
-    next()
+  if (!user) {
+    return next(new NotAuthenticatedError('User not found on request'))
   }
+  if (!session) {
+    return next(new NotAuthenticatedError('Session not found on request'))
+  }
+  if (user.sessionVersion !== session.version) {
+    return next(new NotAuthenticatedError(`Invalid session version - session version is ${session.version}, user session version is ${user.sessionVersion}`))
+  }
+  if (!(session.secondFactor && session.secondFactor === 'totp')) {
+    return next(new NotAuthenticatedError('Not completed second factor authentication'))
+  }
+  if (user.disabled) {
+    return next(new UserAccountDisabledError('User account is disabled'))
+  }
+
+  if (params[GATEWAY_ACCOUNT_EXTERNAL_ID] || params[SERVICE_EXTERNAL_ID]) {
+    if (!service) {
+      return next(new NotAuthorisedError('Service not found on request'))
+    }
+    if (!user.serviceRoles.find(serviceRole => serviceRole.service.externalId === service.externalId)) {
+      return next(new NotAuthorisedError('User does not have service role for service'))
+    }
+  }
+
+  next()
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -512,12 +512,12 @@ module.exports.bind = function (app) {
     stripeSetupAddPspAccountDetailsController.get
   )
 
-  app.get(user.profile.phoneNumber ,
+  app.get(user.profile.phoneNumber,
     xraySegmentCls,
     userPhoneNumberController.get
   )
 
-  app.post(user.profile.phoneNumber ,
+  app.post(user.profile.phoneNumber,
     xraySegmentCls,
     userPhoneNumberController.post
   )

--- a/test/unit/middleware/permission.test.js
+++ b/test/unit/middleware/permission.test.js
@@ -1,0 +1,105 @@
+'use strict'
+
+const sinon = require('sinon')
+const { expect } = require('chai')
+
+const getPermissionMiddleware = require('../../../app/middleware/permission')
+const { PermissionDeniedError } = require('../../../app/errors')
+const userFixtures = require('../../fixtures/user.fixtures')
+const serviceFixtures = require('../../fixtures/service.fixtures')
+
+const serviceExternalId = 'a-service-external-id'
+const permission = 'do-cool-things'
+
+const service = serviceFixtures.validServiceResponse({
+  external_id: serviceExternalId
+}).getAsObject()
+
+const userWithPermissionForService = userFixtures.validUserResponse({
+  service_roles: [{
+    service: {
+      external_id: serviceExternalId
+    },
+    role: {
+      permissions: [{ name: permission }]
+    }
+  }]
+}).getAsObject()
+
+const userWithPermissionForDifferentService = userFixtures.validUserResponse({
+  service_roles: [
+    {
+      service: {
+        external_id: serviceExternalId
+      },
+      role: {
+        permissions: [{ name: 'a-different-permission' }]
+      }
+    },
+    {
+      service: {
+        external_id: 'a-different-service-id'
+      },
+      role: {
+        permissions: [{ name: permission }]
+      }
+    }
+  ]
+}).getAsObject()
+
+const res = {}
+let next
+
+describe('Permission check middleware', () => {
+  beforeEach(() => {
+    next = sinon.spy()
+  })
+
+  describe('middleware has permission to check', () => {
+    const middleware = getPermissionMiddleware(permission)[1]
+
+    describe('user does not have permission for service', () => {
+      it('should throw an error', () => {
+        const req = {
+          user: userWithPermissionForDifferentService,
+          service
+        }
+
+        middleware(req, res, next)
+
+        const expectedError = sinon.match.instanceOf(PermissionDeniedError)
+          .and(sinon.match.has('message', `User does not have permission ${permission} for service`))
+        sinon.assert.calledWith(next, expectedError)
+      })
+    })
+
+    describe('user has permission for service', () => {
+      it('should call next without arguments', () => {
+        const req = {
+          user: userWithPermissionForService,
+          service
+        }
+
+        middleware(req, res, next)
+
+        sinon.assert.calledOnce(next)
+        expect(next.firstCall.args).to.have.length(0)
+      })
+    })
+  })
+
+  describe('middleware does not have permission to check', () => {
+    const middleware = getPermissionMiddleware()[1]
+    it('should call next without arguments', () => {
+      const req = {
+        user: userWithPermissionForDifferentService,
+        service
+      }
+
+      middleware(req, res, next)
+
+      sinon.assert.calledOnce(next)
+      expect(next.firstCall.args).to.have.length(0)
+    })
+  })
+})

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -30,7 +30,7 @@ const pathsNotRequiringAuthentication = [
   paths.staticPaths.naxsiError
 ]
 
-function flattenPaths(arrayThatMayContainObjects) {
+function flattenPaths (arrayThatMayContainObjects) {
   return arrayThatMayContainObjects.reduce((paths, val) => {
     if (typeof val === 'object' && val != null) {
       return paths.concat(flattenPaths(Object.values(val)))
@@ -52,7 +52,7 @@ describe('The Express router', () => {
 
     routes.bind(app)
 
-    // We currently call `app.use` to specify a list of paths to use certain middleware for, 
+    // We currently call `app.use` to specify a list of paths to use certain middleware for,
     // including the authorisation middleware. We need to check that paths are either included in
     // the array for this call, or the middleware is added to the stack individually for the route
     const authenticatedPathsArg = app.use.getCalls()


### PR DESCRIPTION
We've decided that our new pattern for setting up routes will be to create various routers for the different route paths. Something like the following:
  - Service router - sets up all routes for pages related to a specific service
  - Account router - sets up all routes for pages related to a specific account
  - Some other router(s) for other logged in routes such as user profile settings and all services views

We can then initialise the authorisation middleware (user-is-authorised.js) on the router level rather than on each individual route as this middleware must be run on every logged in route.

The permissions middleware requires initialisation with a specific permission string which will depend on the route, so must be included on individual routes and therefore needs to remain separate.

Remove permissions checks from the new authorisation middleware and update existing permissions middleware to throw a new `PermissionDeniedError` which is handled by the error handler middleware to follow our new pattern. This will not change any external behaviour.

