### PR TITLE
PP-7509 Payment link update (create and edit) logging

### DIFF
--- a/app/controllers/payment-links/post-edit.controller.js
+++ b/app/controllers/payment-links/post-edit.controller.js
@@ -4,6 +4,9 @@ const lodash = require('lodash')
 
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
+const logger = require('../../utils/logger')(__filename)
+const { keys } = require('@govuk-pay/pay-js-commons').logging
+const { CORRELATION_HEADER } = require('../../utils/correlation-header.js')
 
 module.exports = async function updatePaymentLink (req, res, next) {
   const { productExternalId } = req.params
@@ -16,6 +19,19 @@ module.exports = async function updatePaymentLink (req, res, next) {
   }
 
   try {
+
+    const correlationId = req.headers[CORRELATION_HEADER] || ''
+
+    const logContext = {
+      internal_user: req.user.internalUser,
+      product_external_id: req.params.productExternalId
+    }
+
+    logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
+    logContext[keys.CORRELATION_ID] = correlationId
+
+    logger.info(`Updating Payment link`, logContext)
+
     await productsClient.product.update(gatewayAccountId, productExternalId, editPaymentLinkData)
     lodash.unset(req, 'session.editPaymentLinkData')
     req.flash('generic', `Your payment link has been updated`)


### PR DESCRIPTION
- Add logging messages when the backend is called to:
  - Add new Payment link
  - Edit existing Payment link

Include `has_metadata` from the ticket and additional information about
the gateway account creating or updating the payment link.

