### PR TITLE
PP-7489 Remove logging from gatewayAccountAndService middleware

### DIFF
--- a/test/unit/middleware/get-service-and-gateway-account.middleware.test.js
+++ b/test/unit/middleware/get-service-and-gateway-account.middleware.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { NotFoundError } = require('../../../app/errors')
 const path = require('path')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
@@ -33,7 +32,7 @@ const setupGetGatewayAccountAndService = function (gatewayAccountID, gatewayAcco
     params: { gatewayAccountExternalId: gatewayAccountExternalId, serviceExternalId: serviceExternalId },
     correlationId: 'some-correlation-id'
   }
-  req.user = buildUser(serviceExternalId, [ `${gatewayAccountID}` ])
+  req.user = buildUser(serviceExternalId, [`${gatewayAccountID}`])
   next = sinon.spy()
   connectorGetAccountMock = sinon.spy((params) => {
     return Promise.resolve({
@@ -70,160 +69,132 @@ const setupGetGatewayAccountClientError = function (gatewayAccountExternalId, er
 }
 
 describe('middleware: getGatewayAccountAndService', () => {
-  it('should set gateway account and service on request object ', () => {
+  it('should set gateway account and service on request object ', async () => {
     const getGatewayAccountAndService = setupGetGatewayAccountAndService(1, 'some-gateway-external-id', 'worldpay', 'some-service-external-id')
-    next = function () {
-      expect(connectorGetAccountMock.called).to.equal(true)
-      expect(connectorGetAccountMock.calledWith({
-        gatewayAccountExternalId: 'some-gateway-external-id',
-        correlationId: 'some-correlation-id'
-      })).to.equal(true)
 
-      expect(req.account.external_id).to.equal('some-gateway-external-id')
-      expect(req.service.externalId).to.equal('some-service-external-id')
-      expect(req.service.hasCardGatewayAccount).to.equal(true)
+    await getGatewayAccountAndService(req, res, next)
 
-      expect(req.gateway_account.currentGatewayAccountId).to.equal(1)
-    }
-    return getGatewayAccountAndService(req, res, next)
+    sinon.assert.calledOnce(next)
+    expect(connectorGetAccountMock.called).to.equal(true)
+    expect(connectorGetAccountMock.calledWith({
+      gatewayAccountExternalId: 'some-gateway-external-id',
+      correlationId: 'some-correlation-id'
+    })).to.equal(true)
+
+    expect(req.account.external_id).to.equal('some-gateway-external-id')
+    expect(req.service.externalId).to.equal('some-service-external-id')
+    expect(req.service.hasCardGatewayAccount).to.equal(true)
+
+    expect(req.gateway_account.currentGatewayAccountId).to.equal(1)
   })
-  it('should not set gateway account, if gateway account external ID is not resolved', () => {
-    const getGatewayAccountAndService = setupGetGatewayAccountAndService(1, 'some-gateway-external-id', 'worldpay', 'some-service-external-id')
-    req.params['gatewayAccountExternalId'] = undefined
-
-    next = function () {
-      expect(req).to.not.have.property('account')
-      expect(req).to.not.have.property('gateway_account')
-
-      expect(req.service.externalId).to.equal('some-service-external-id')
-    }
-    return getGatewayAccountAndService(req, res, next)
-  })
-  it('should error, if both gateway account external ID and service external ID cannot be resolved', () => {
+  it('should error, if both gateway account external ID and service external ID cannot be resolved', async () => {
     const getGatewayAccountAndService = setupGetGatewayAccountAndService(1, 'some-gateway-external-id', 'worldpay', 'some-service-external-id')
     req.params['gatewayAccountExternalId'] = undefined
     req.params['serviceExternalId'] = undefined
 
-    next = function (err) {
-      expect(err.message).to.equal('Could not resolve gateway account external ID or service external ID from request params')
-      expect(err).to.be.instanceOf(Error)
-    }
-    return getGatewayAccountAndService(req, res, next)
-  })
-  it('should error, if gateway account not found for gatewayExternalId', () => {
-    const getGatewayAccountAndService = setupGetGatewayAccountClientError('some-gateway-account-external-id', 404)
+    await getGatewayAccountAndService(req, res, next)
 
-    next = function (err) {
-      expect(err.message).to.equal('Gateway account not found')
-      expect(err).to.be.instanceOf(NotFoundError)
-    }
-    return getGatewayAccountAndService(req, res, next)
+    const expectedError = sinon.match.instanceOf(Error)
+      .and(sinon.match.has('message', 'Could not resolve gateway account external ID or service external ID from request params'))
+    sinon.assert.calledWith(next, expectedError)
   })
-  it('should error, if connector returns error (other than 404)', () => {
+  it('should continue without setting gateway account, if gateway account external ID is not resolved', async () => {
+    const getGatewayAccountAndService = setupGetGatewayAccountAndService(1, 'some-gateway-external-id', 'worldpay', 'some-service-external-id')
+    req.params['gatewayAccountExternalId'] = undefined
+
+    await getGatewayAccountAndService(req, res, next)
+
+    sinon.assert.calledOnce(next)
+
+    expect(req).to.not.have.property('account')
+    expect(req).to.not.have.property('gateway_account')
+
+    expect(req.service.externalId).to.equal('some-service-external-id')
+  })
+  it('should continue without setting gateway account, if connector returns error', async () => {
     const getGatewayAccountAndService = setupGetGatewayAccountClientError('some-gateway-account-external-id', 500)
 
-    next = function (err) {
-      expect(err.message).to.equal('Error retrieving Gateway account')
-      expect(err).to.be.instanceOf(Error)
-    }
-    return getGatewayAccountAndService(req, res, next)
+    await getGatewayAccountAndService(req, res, next)
+    sinon.assert.calledOnce(next)
+    expect(req.account).to.be.undefined // eslint-disable-line
   })
-  it('should set service based on gateway account, when serviceExternalId cannot be resolved', () => {
+  it('should set service based on gateway account, when serviceExternalId cannot be resolved', async () => {
     const getGatewayAccountAndService = setupGetGatewayAccountAndService(1, 'some-gateway-external-id', 'worldpay', 'some-service-external-id')
     req.params['serviceExternalId'] = undefined
-    next = function () {
-      expect(req.service.externalId).to.equal('some-service-external-id')
-    }
-    return getGatewayAccountAndService(req, res, next)
+
+    await getGatewayAccountAndService(req, res, next)
+    sinon.assert.calledOnce(next)
+    expect(req.service.externalId).to.equal('some-service-external-id')
   })
-  it('should error, when service cannot be resolved for serviceExternalId and gateway account (if available)', () => {
+  it('should continue without setting service on request, when service cannot be resolved for serviceExternalId or gateway account (if available)', async () => {
     const getGatewayAccountAndService = setupGetGatewayAccountAndService(1, 'some-gateway-external-id', 'worldpay', 'some-service-external-id')
     req.params['serviceExternalId'] = 'non-existent-service'
 
-    next = function (err) {
-      expect(err.message).to.equal('Service not found for user')
-      expect(err).to.be.instanceOf(NotFoundError)
-    }
-    return getGatewayAccountAndService(req, res, next)
+    await getGatewayAccountAndService(req, res, next)
+    sinon.assert.calledOnce(next)
+    expect(req.service).to.be.undefined // eslint-disable-line
   })
-  it('should error, when the gateway account from connector does not belong to service for serviceExternalId', () => {
+  it('should continue without setting service or gateway account, if user is not available on req object', async () => {
     const getGatewayAccountAndService = setupGetGatewayAccountAndService(1, 'some-gateway-external-id', 'worldpay', 'some-service-external-id')
-    req.user.serviceRoles[0].service.gatewayAccountIds = ['some-other-gateway-account']
+    req.user = undefined
 
-    next = function (err) {
-      expect(err.message).to.equal('Service not found for user')
-      expect(err).to.be.instanceOf(NotFoundError)
-    }
-    return getGatewayAccountAndService(req, res, next)
-  })
-  it('should error, when serviceExternalId is not available and service cannot be resolved for gateway account', () => {
-    const getGatewayAccountAndService = setupGetGatewayAccountAndService(1, 'some-gateway-external-id', 'worldpay', 'some-service-external-id')
-    req.params['serviceExternalId'] = undefined
-    req.user.serviceRoles[0].service.gatewayAccountIds = ['some-other-gateway-accounts']
-    next = function (err) {
-      expect(err.message).to.equal('Service not found for user')
-      expect(err).to.be.instanceOf(NotFoundError)
-    }
-    return getGatewayAccountAndService(req, res, next)
+    await getGatewayAccountAndService(req, res, next)
+    sinon.assert.calledOnce(next)
+    expect(req.service).to.be.undefined // eslint-disable-line
+    expect(req.account).to.be.undefined // eslint-disable-line
   })
   describe('extend gateway account data with disableToggle3ds field', () => {
     ['worldpay', 'smartpay', 'epdq'].forEach(function (value) {
-      it('should extend the account data with disableToggle3ds set to false if account type is ' + value, () => {
+      it('should extend the account data with disableToggle3ds set to false if account type is ' + value, async () => {
         const getGatewayAccountAndService = setupGetGatewayAccountAndService(1, 'some-gateway-external-id', value, 'some-service-external-id')
-        next = function () {
-          expect(req.account.disableToggle3ds).to.equal(false)
-          expect(req.account.external_id).to.equal('some-gateway-external-id')
-        }
-        return getGatewayAccountAndService(req, res, next)
+
+        await getGatewayAccountAndService(req, res, next)
+        expect(req.account.disableToggle3ds).to.equal(false)
+        expect(req.account.external_id).to.equal('some-gateway-external-id')
       })
     })
-    it('should extend the account data with disableToggle3ds set to true if account type is stripe', () => {
+    it('should extend the account data with disableToggle3ds set to true if account type is stripe', async () => {
       const getGatewayAccountAndService = setupGetGatewayAccountAndService(1, 'some-gateway-external-id', 'stripe', 'some-service-external-id')
-      next = function () {
-        expect(req.account.disableToggle3ds).to.equal(true)
-        expect(req.account.external_id).to.equal('some-gateway-external-id')
-      }
-      return getGatewayAccountAndService(req, res, next)
+
+      await getGatewayAccountAndService(req, res, next)
+      expect(req.account.disableToggle3ds).to.equal(true)
+      expect(req.account.external_id).to.equal('some-gateway-external-id')
     })
   })
   describe('extend gateway account data with supports3ds field', () => {
     ['worldpay', 'smartpay', 'epdq', 'stripe'].forEach(function (value) {
-      it('should extend the account data with supports3ds set to true if account type is ' + value, () => {
+      it('should extend the account data with supports3ds set to true if account type is ' + value, async () => {
         const getGatewayAccountAndService = setupGetGatewayAccountAndService(1, 'some-gateway-external-id', value, 'some-service-external-id')
-        next = function () {
-          expect(req.account.supports3ds).to.equal(true)
-          expect(req.account.external_id).to.equal('some-gateway-external-id')
-        }
-        return getGatewayAccountAndService(req, res, next)
+
+        await getGatewayAccountAndService(req, res, next)
+        expect(req.account.supports3ds).to.equal(true)
+        expect(req.account.external_id).to.equal('some-gateway-external-id')
       })
     })
-    it('should extend the account data with supports3ds set to false if account type is sandbox', () => {
+    it('should extend the account data with supports3ds set to false if account type is sandbox', async () => {
       const getGatewayAccountAndService = setupGetGatewayAccountAndService(1, 'some-gateway-external-id', 'sandbox', 'some-service-external-id')
-      next = function () {
-        expect(req.account.supports3ds).to.equal(false)
-        expect(req.account.external_id).to.equal('some-gateway-external-id')
-      }
-      return getGatewayAccountAndService(req, res, next)
+
+      await getGatewayAccountAndService(req, res, next)
+      expect(req.account.supports3ds).to.equal(false)
+      expect(req.account.external_id).to.equal('some-gateway-external-id')
     })
   })
   describe('extend gateway account data stripe setup', () => {
     ['worldpay', 'smartpay', 'epdq', 'sandbox'].forEach(function (value) {
-      it('should not extend the account data with stripe setup if account type is ' + value, () => {
+      it('should not extend the account data with stripe setup if account type is ' + value, async () => {
         const getGatewayAccountAndService = setupGetGatewayAccountAndService(1, 'some-gateway-external-id', value, 'some-service-external-id')
-        next = function () {
-          expect(req.account.external_id).to.equal('some-gateway-external-id')
-          expect(req.account).to.not.have.property('connectorGatewayAccountStripeProgress')
-        }
-        return getGatewayAccountAndService(req, res, next)
+
+        await getGatewayAccountAndService(req, res, next)
+        expect(req.account.external_id).to.equal('some-gateway-external-id')
+        expect(req.account).to.not.have.property('connectorGatewayAccountStripeProgress')
       })
     })
-    it('should extend the account data with supports3ds set to false if account type is stripe', () => {
+    it('should extend the account data with supports3ds set to false if account type is stripe', async () => {
       const getGatewayAccountAndService = setupGetGatewayAccountAndService(1, 'some-gateway-external-id', 'stripe', 'some-service-external-id')
-      next = function () {
-        expect(req.account.external_id).to.equal('some-gateway-external-id')
-        expect(req.account).to.have.property('connectorGatewayAccountStripeProgress')
-      }
-      return getGatewayAccountAndService(req, res, next)
+
+      await getGatewayAccountAndService(req, res, next)
+      expect(req.account.external_id).to.equal('some-gateway-external-id')
+      expect(req.account).to.have.property('connectorGatewayAccountStripeProgress')
     })
   })
 })


### PR DESCRIPTION
## WHAT
- Removed most of the logging as error handler middleware is logging the details now for errors thrown and adds additional context.
- getGatewayaccountAndService middleware doesn't throw exceptions anymore if service or gateway account are not found. Authorisation middleware will check for service/gateway account and user access and throws relevant error
- Refactored tests following story review comments to make sure assertions are always reached
