### PR TITLE
PP-7488 Skip resolve service middleware if service already resolved

### DIFF
--- a/app/browsered/multi-select.js
+++ b/app/browsered/multi-select.js
@@ -85,7 +85,7 @@ const closeMultiSelectOnEscapeKeypress = function () {
       mulitSelectElements.forEach(element => {
         if (element.style.visibility === 'visible') {
           element.style.visibility = 'hidden'
-          element.closest(TOP_LEVEL_SELECTOR).querySelector(OPEN_BUTTON_SELECTOR).focus()     
+          element.closest(TOP_LEVEL_SELECTOR).querySelector(OPEN_BUTTON_SELECTOR).focus()
         }
       })
     }

--- a/app/controllers/my-services/get-index.controller.js
+++ b/app/controllers/my-services/get-index.controller.js
@@ -29,7 +29,7 @@ module.exports = async (req, res) => {
   const aggregatedGatewayAccounts = await serviceService.getGatewayAccounts(aggregatedGatewayAccountIds, req.correlationId)
 
   const servicesData = servicesRoles
-    .sort((a,b) => a.service.id - b.service.id)
+    .sort((a, b) => a.service.id - b.service.id)
     .map(serviceRole => {
       // For Direct Debit currently we initialise req.user.serviceRoles[].service.gatewayAccountIds with external ids,
       // but for Cards we initialise with internal ids.

--- a/app/controllers/your-psp/get.controller.js
+++ b/app/controllers/your-psp/get.controller.js
@@ -8,11 +8,13 @@ module.exports = (req, res) => {
   const isWorldpay3dsFlexCredentialsConfigured = req.account.worldpay_3ds_flex &&
     req.account.worldpay_3ds_flex.organisational_unit_id !== undefined &&
     req.account.worldpay_3ds_flex.organisational_unit_id.length > 0
-  
+
   const is3dsEnabled = req.account.requires3ds === true
 
   const isWorldpay3dsFlexEnabled = is3dsEnabled && req.account.integration_version_3ds === 2
 
-  return response(req, res, 'your-psp/index', { isAccountCredentialsConfigured, is3dsEnabled,
-    isWorldpay3dsFlexEnabled, isWorldpay3dsFlexCredentialsConfigured })
+  return response(req, res, 'your-psp/index', { isAccountCredentialsConfigured,
+    is3dsEnabled,
+    isWorldpay3dsFlexEnabled,
+    isWorldpay3dsFlexCredentialsConfigured })
 }

--- a/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.js
+++ b/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.js
@@ -6,21 +6,21 @@ const { ConnectorClient } = require('../../services/clients/connector.client')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
 module.exports = async function toggleWorldpay3dsFlex (req, res) {
-    const accountId = req.account.gateway_account_id
-    const toggleWorldpay3dsFlex = req.body['toggle-worldpay-3ds-flex']
+  const accountId = req.account.gateway_account_id
+  const toggleWorldpay3dsFlex = req.body['toggle-worldpay-3ds-flex']
 
-    if (req.body['toggle-worldpay-3ds-flex'] === 'on' || req.body['toggle-worldpay-3ds-flex'] === 'off') {
-        const enabling3dsFlex = toggleWorldpay3dsFlex === 'on'
-        const message = enabling3dsFlex ? '3DS Flex has been turned on.' : '3DS Flex has been turned off. Your payments will now use 3DS only.'
-        const integrationVersion3ds = enabling3dsFlex ? 2 : 1
-        try {
-            await connector.updateIntegrationVersion3ds(accountId, integrationVersion3ds, req.correlationId)
-            req.flash('generic', message)
-            return res.redirect(303, paths.yourPsp.index)
-        } catch (error) {
-            return renderErrorView(req, res, false, error.errorCode)
-        }
-    } else {
-        return renderErrorView(req, res, false, 400)
+  if (req.body['toggle-worldpay-3ds-flex'] === 'on' || req.body['toggle-worldpay-3ds-flex'] === 'off') {
+    const enabling3dsFlex = toggleWorldpay3dsFlex === 'on'
+    const message = enabling3dsFlex ? '3DS Flex has been turned on.' : '3DS Flex has been turned off. Your payments will now use 3DS only.'
+    const integrationVersion3ds = enabling3dsFlex ? 2 : 1
+    try {
+      await connector.updateIntegrationVersion3ds(accountId, integrationVersion3ds, req.correlationId)
+      req.flash('generic', message)
+      return res.redirect(303, paths.yourPsp.index)
+    } catch (error) {
+      return renderErrorView(req, res, false, error.errorCode)
     }
+  } else {
+    return renderErrorView(req, res, false, 400)
   }
+}

--- a/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.test.js
+++ b/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.test.js
@@ -23,7 +23,7 @@ describe('Toggle Worldpay 3DS Flex controller', () => {
       setHeader: sinon.stub(),
       status: sinon.spy(),
       redirect: sinon.spy(),
-      render: sinon.spy(),
+      render: sinon.spy()
     }
   })
 
@@ -105,7 +105,7 @@ describe('Toggle Worldpay 3DS Flex controller', () => {
       },
       '../../utils/response': {
         renderErrorView: renderErrorViewMock
-      },
+      }
     })
   }
 })

--- a/app/middleware/resolve-service.js
+++ b/app/middleware/resolve-service.js
@@ -34,7 +34,7 @@ module.exports = (req, res, next) => {
   if (req.service) {
     // Skip running this middleware if the service has already been resolved. This is because
     // the ./permissions.js middleware also returns this middleware. We are changing to a different
-    // middleware to resolve the service as part of 
+    // middleware to resolve the service as part of
     // https://payments-platform.atlassian.net/browse/PP-7520 so this is to enable that switchover
     // while it is in progress. We can remove the resolve-service middleware when this is done.
     return next()

--- a/app/middleware/resolve-service.js
+++ b/app/middleware/resolve-service.js
@@ -31,6 +31,15 @@ const gatewayAccountType = req => {
 
 // This middleware resolves the current service in context
 module.exports = (req, res, next) => {
+  if (req.service) {
+    // Skip running this middleware if the service has already been resolved. This is because
+    // the ./permissions.js middleware also returns this middleware. We are changing to a different
+    // middleware to resolve the service as part of 
+    // https://payments-platform.atlassian.net/browse/PP-7520 so this is to enable that switchover
+    // while it is in progress. We can remove the resolve-service middleware when this is done.
+    return next()
+  }
+
   const { externalServiceId } = req.params
   const gatewayAccountId = _.get(req, 'gateway_account.currentGatewayAccountId')
 

--- a/app/services/service-registration.service.js
+++ b/app/services/service-registration.service.js
@@ -17,7 +17,7 @@ function submitServiceInviteOtpCode (code, otpCode, correlationId) {
 
 async function createPopulatedService (inviteCode, correlationId) {
   const adminusersClient = getAdminUsersClient({ correlationId })
-  
+
   const gatewayAccount = await connectorClient().createGatewayAccount('sandbox', 'test', null, null, correlationId)
   const completeInviteResponse = await adminusersClient.completeInvite(inviteCode, [gatewayAccount.gateway_account_id])
   const user = await adminusersClient.getUserByExternalId(completeInviteResponse.user_external_id)


### PR DESCRIPTION
Skip running this middleware if the service has already been resolved. This is because the `permissions.js` middleware also returns this middleware. We are changing to a different middleware to resolve the service as part of https://payments-platform.atlassian.net/browse/PP-7520 so this is to enable that switchover while it is in progress. We can remove the resolve service middleware when this is done.

Bundled in a commit to run the linter. It's only `resolve-service.js` that has code changes.