### PR TITLE
PP-7422: Add tests on checking Worldpay 3DS Flex credentials

### DIFF
--- a/app/views/your-psp/flex.njk
+++ b/app/views/your-psp/flex.njk
@@ -1,6 +1,9 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
+  {% if errors %}
+    Error:
+  {% endif %}
   Your PSP - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
 
@@ -18,7 +21,7 @@
 
           {% if errors['organisational-unit-id'] %}
             {% set errorList = (errorList.push({
-              text: 'Organisational unit ID',
+              text: 'Organisational unit ID may not be correct',
               href: '#organisational-unit-id'
             }), errorList) %}
             {% set orgUnitIdError = {
@@ -28,7 +31,7 @@
 
           {% if errors['issuer'] %}
             {% set errorList = (errorList.push({
-              text: 'Issuer',
+              text: 'Issuer may not be correct',
               href: '#issuer'
             }), errorList) %}
             {% set issuerError = {
@@ -38,7 +41,7 @@
 
           {% if errors['jwt-mac-key'] %}
             {% set errorList = (errorList.push({
-              text: 'JWT MAC key',
+              text: 'JWT MAC key may not be correct',
               href: '#jwt-mac-key'
             }), errorList) %}
             {% set jwtMacKeyError = {
@@ -47,7 +50,7 @@
           {% endif %}
 
           {{ govukErrorSummary({
-            titleText: 'There was a problem with the details you gave for:',
+            titleText: 'There is a problem',
             errorList: errorList
           }) }}
         {% endif %}

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -16,6 +16,7 @@ const goCardlessConnectFixtures = require('../../fixtures/go-cardless-connect.fi
 const ledgerFixture = require('../../fixtures/ledger-transaction.fixtures')
 const inviteFixtures = require('../../fixtures/invite.fixtures')
 const tokenFixtures = require('../../fixtures/token.fixtures')
+const worldpay3dsFlexCredentialsFixtures = require('../../fixtures/worldpay-3ds-flex-credentials.fixtures')
 
 const simpleStubBuilder = function simpleStubBuilder (method, path, responseCode, additionalParams = {}) {
   const request = {
@@ -558,6 +559,26 @@ module.exports = {
     const path = '/v1/api/products'
     return simpleStubBuilder('POST', path, 200, {
       response: productFixtures.validProductResponse(opts).getPlain()
+    })
+  },
+  postCheckWorldpay3dsFlexCredentials: (opts = {}) => {
+    const path = `/v1/api/accounts/${opts.gateway_account_id}/worldpay/check-3ds-flex-config`
+    if (opts.shouldReturnValid) {
+      return simpleStubBuilder('POST', path, 200, {
+        request: worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsRequest().getPlain().payload,
+        response: worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsResponse().getPlain()
+      })
+    } else {
+      return simpleStubBuilder('POST', path, 200, {
+        request: worldpay3dsFlexCredentialsFixtures.checkInvalidWorldpay3dsFlexCredentialsRequest().getPlain().payload,
+        response: worldpay3dsFlexCredentialsFixtures.checkInvalidWorldpay3dsFlexCredentialsResponse().getPlain()
+      })
+    }
+  },
+  postCheckWorldpay3dsFlexCredentialsFailure: (opts = {}) => {
+    const path = `/v1/api/accounts/${opts.gateway_account_id}/worldpay/check-3ds-flex-config`
+    return simpleStubBuilder('POST', path, 500, {
+      request: worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsRequest(opts).getPlain().payload
     })
   }
 }

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -205,6 +205,28 @@ const patchUpdateFlexCredentials = function (opts) {
   }
 }
 
+const postCheckWorldpay3dsFlexCredentials = function (opts) {
+  return {
+    name: 'postCheckWorldpay3dsFlexCredentials',
+    opts: {
+      gateway_account_id: opts.gatewayAccountId,
+      shouldReturnValid: opts.shouldReturnValid
+    }
+  }
+}
+
+const postCheckWorldpay3dsFlexCredentialsFailure = function (opts) {
+  return {
+    name: 'postCheckWorldpay3dsFlexCredentialsFailure',
+    opts: {
+      gateway_account_id: opts.gatewayAccountId,
+      organisational_unit_id: opts.organisational_unit_id,
+      issuer: opts.issuer,
+      jwt_mac_key: opts.jwt_mac_key
+    }
+  }
+}
+
 module.exports = {
   getAccountAuthSuccess,
   getGatewayAccountSuccess,
@@ -221,5 +243,7 @@ module.exports = {
   patchUpdateCredentials,
   patchUpdateFlexCredentials,
   patchUpdateMotoMaskCardNumber,
-  patchUpdateMotoMaskSecurityCode
+  patchUpdateMotoMaskSecurityCode,
+  postCheckWorldpay3dsFlexCredentials,
+  postCheckWorldpay3dsFlexCredentialsFailure
 }

--- a/test/fixtures/worldpay-3ds-flex-credentials.fixtures.js
+++ b/test/fixtures/worldpay-3ds-flex-credentials.fixtures.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const path = require('path')
 const _ = require('lodash')
 
-const pactBase = require(path.join(__dirname, '/pact-base'))
+const pactBase = require('./pact-base')
 const pactRegister = pactBase()
 
 const checkValidWorldpay3dsFlexCredentialsRequest = function checkValidWorldpay3dsFlexCredentialsRequest (opts = {}) {
@@ -11,9 +10,9 @@ const checkValidWorldpay3dsFlexCredentialsRequest = function checkValidWorldpay3
     correlationId: opts.correlationId || 'a1',
     gatewayAccountId: opts.gatewayAccountId || 333,
     payload: {
-      organisational_unit_id: opts.organisationalUnitId || '5bd9b55e4444761ac0af1c80',
+      organisational_unit_id: opts.organisational_unit_id || '5bd9b55e4444761ac0af1c80',
       issuer: opts.issuer || '5bd9e0e4444dce153428c940',
-      jwt_mac_key: opts.jwtMacKey || 'fa2daee2-1fbb-45ff-4444-52805d5cd9e0'
+      jwt_mac_key: opts.jwt_mac_key || 'fa2daee2-1fbb-45ff-4444-52805d5cd9e0'
     }
   }
 
@@ -42,7 +41,45 @@ const checkValidWorldpay3dsFlexCredentialsResponse = function checkValidWorldpay
   }
 }
 
+const checkInvalidWorldpay3dsFlexCredentialsRequest = function checkInvalidWorldpay3dsFlexCredentialsRequest (opts = {}) {
+  const data = {
+    correlationId: opts.correlationId || 'a1',
+    gatewayAccountId: opts.gatewayAccountId || 333,
+    payload: {
+      organisational_unit_id: opts.organisational_unit_id || '5bd9b55e4444761ac0af1c81',
+      issuer: opts.issuer || '5bd9e0e4444dce153428c941',
+      jwt_mac_key: opts.jwt_mac_key || 'ffffffff-aaaa-1111-1111-52805d5cd9e1'
+    }
+  }
+
+  return {
+    getPactified: () => {
+      return pactRegister.pactify(data)
+    },
+    getPlain: () => {
+      return _.clone(data)
+    }
+  }
+}
+
+const checkInvalidWorldpay3dsFlexCredentialsResponse = function checkInvalidWorldpay3dsFlexCredentialsResponse (opts = {}) {
+  const data = {
+    result: opts.result || 'invalid'
+  }
+
+  return {
+    getPactified: () => {
+      return pactRegister.pactify(data)
+    },
+    getPlain: () => {
+      return _.clone(data)
+    }
+  }
+}
+
 module.exports = {
   checkValidWorldpay3dsFlexCredentialsRequest,
-  checkValidWorldpay3dsFlexCredentialsResponse
+  checkValidWorldpay3dsFlexCredentialsResponse,
+  checkInvalidWorldpay3dsFlexCredentialsRequest,
+  checkInvalidWorldpay3dsFlexCredentialsResponse
 }


### PR DESCRIPTION
## WHAT

This change adds two tests to Cypress to test the following scenarios.

1. Connector returns result = invalid after checking Worldpay 3DS Flex credentials.
2. Connector fails while checking Worldpay 3DS Flex credentials.

## HOW 

I ran both mocha tests and cypress tests. They passed. I verified responses from stubs and they were valid.
