### PR TITLE
PP-7520 Account URL structure

### DIFF
--- a/app/controllers/billing-address/toggle-billing-address.controller.js
+++ b/app/controllers/billing-address/toggle-billing-address.controller.js
@@ -4,7 +4,8 @@ const lodash = require('lodash')
 
 const logger = require('../../utils/logger')(__filename)
 const { response } = require('../../utils/response')
-const router = require('../../routes')
+const paths = require('../../paths')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const { renderErrorView } = require('../../utils/response')
 const serviceService = require('../../services/service.service')
 const { CORRELATION_HEADER } = require('../../utils/correlation-header')
@@ -29,7 +30,7 @@ const postIndex = async (req, res) => {
       req.flash('generic', 'Billing address is turned off for this service')
     }
     logger.info(`[${correlationId}] - Updated collect billing address enabled(${req.body['billing-address-toggle']}). user=${req.session.passport.user}`)
-    res.redirect(router.paths.toggleBillingAddress.index)
+    res.redirect(formatAccountPathsFor(paths.account.toggleBillingAddress.index, req.account && req.account.external_id))
   } catch (error) {
     renderErrorView(req, res, error.message)
   }

--- a/app/middleware/get-service-and-gateway-account.middleware.js
+++ b/app/middleware/get-service-and-gateway-account.middleware.js
@@ -90,7 +90,7 @@ module.exports = async function getServiceAndGatewayAccount (req, res, next) {
           req.account = gatewayAccount
           // TODO: To be removed once URLs are updated to use the format /service/:serviceExternalId/account/:gatewayAccountExternalId/xxx.
           // Currently authService.getCurrentGatewayAccountId() sets below if account is available on session or derives one from user services.
-          req.gateway_account = { currentGatewayAccountId: gatewayAccount.gateway_account_id }
+          req.gateway_account = { currentGatewayAccountId: gatewayAccount.gateway_account_id, currentGatewayAccountExternalId: gatewayAccount.external_id }
         }
       }
 

--- a/app/paths.js
+++ b/app/paths.js
@@ -3,10 +3,18 @@
 const generateRoute = require('./utils/generate-route')
 const formattedPathFor = require('./utils/replace-params-in-path')
 
+const keys = {
+  SERVICE_EXTERNAL_ID: 'serviceExternalId',
+  GATEWAY_ACCOUNT_EXTERNAL_ID: 'gatewayAccountExternalId'
+}
+
 module.exports = {
-  keys: {
-    SERVICE_EXTERNAL_ID: 'serviceExternalId',
-    GATEWAY_ACCOUNT_EXTERNAL_ID: 'gatewayAccountExternalId'
+  keys,
+  account: {
+    root: `/account/:${keys.GATEWAY_ACCOUNT_EXTERNAL_ID}`,
+    toggleBillingAddress: {
+      index: '/billing-address'
+    }
   },
   transactions: {
     index: '/transactions',
@@ -127,9 +135,6 @@ module.exports = {
   toggleMotoMaskCardNumberAndSecurityCode: {
     cardNumber: '/moto-hide-card-number',
     securityCode: '/moto-hide-security-code'
-  },
-  toggleBillingAddress: {
-    index: '/billing-address'
   },
   healthcheck: {
     path: '/healthcheck'

--- a/app/routes.js
+++ b/app/routes.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Router } = require('express')
 const lodash = require('lodash')
 const AWSXRay = require('aws-xray-sdk')
 const { getNamespace, createNamespace } = require('continuation-local-storage')
@@ -8,6 +9,9 @@ const logger = require('./utils/logger')(__filename)
 const response = require('./utils/response.js').response
 const generateRoute = require('./utils/generate-route')
 const paths = require('./paths.js')
+
+const userIsAuthorised = require('./middleware/user-is-authorised')
+const getServiceAndAccount = require('./middleware/get-service-and-gateway-account.middleware')
 
 // Middleware
 const { lockOutDisabledUsers, enforceUserAuthenticated, enforceUserFirstFactor, redirectLoggedInUser } = require('./services/auth.service')
@@ -90,9 +94,10 @@ const {
   healthcheck, registerUser, user, dashboard, selfCreateService, transactions, credentials,
   apiKeys, serviceSwitcher, teamMembers, staticPaths, inviteValidation, editServiceName, merchantDetails,
   notificationCredentials: nc, paymentTypes: pt, emailNotifications: en, toggle3ds: t3ds, toggleMotoMaskCardNumberAndSecurityCode, prototyping, paymentLinks,
-  partnerApp, toggleBillingAddress: billingAddress, requestToGoLive, policyPages, stripeSetup, stripe, digitalWallet,
+  partnerApp, requestToGoLive, policyPages, stripeSetup, stripe, digitalWallet,
   settings, yourPsp, allServiceTransactions, payouts
 } = paths
+const { toggleBillingAddress: billingAddress } = paths.account
 
 // Exports
 module.exports.generateRoute = generateRoute
@@ -102,6 +107,9 @@ module.exports.paths = paths
 const clsXrayConfig = require('../config/xray-cls')
 
 module.exports.bind = function (app) {
+  const account = new Router({ mergeParams: true })
+  account.use(getServiceAndAccount, userIsAuthorised)
+
   AWSXRay.enableManualMode()
   AWSXRay.setLogger(logger)
   AWSXRay.middleware.setSamplingRules('aws-xray.rules')
@@ -320,9 +328,10 @@ module.exports.bind = function (app) {
   app.get(toggleMotoMaskCardNumberAndSecurityCode.securityCode, xraySegmentCls, permission('moto-mask-input:read'), getAccount, paymentMethodIsCard, toggleMotoMaskSecurityCode.get)
   app.post(toggleMotoMaskCardNumberAndSecurityCode.securityCode, xraySegmentCls, permission('moto-mask-input:update'), getAccount, paymentMethodIsCard, toggleMotoMaskSecurityCode.post)
 
-  // BILLING ADDRESS TOGGLE
-  app.get(billingAddress.index, xraySegmentCls, permission('toggle-billing-address:read'), getAccount, paymentMethodIsCard, toggleBillingAddressController.getIndex)
-  app.post(billingAddress.index, xraySegmentCls, permission('toggle-billing-address:update'), getAccount, paymentMethodIsCard, toggleBillingAddressController.postIndex)
+  // app.get(billingAddress.index, xraySegmentCls, permission('toggle-billing-address:read'), getAccount, paymentMethodIsCard, toggleBillingAddressController.getIndex)
+  // app.post(billingAddress.index, xraySegmentCls, permission('toggle-billing-address:update'), getAccount, paymentMethodIsCard, toggleBillingAddressController.postIndex)
+  account.get(billingAddress.index, permission('toggle-billing-address:read'), toggleBillingAddressController.getIndex)
+  account.post(billingAddress.index, permission('toggle-billing-address:update'), toggleBillingAddressController.postIndex)
 
   // Prototyping
   app.get(prototyping.demoService.index, xraySegmentCls, permission('transactions:read'), resolveService, getAccount, restrictToSandbox, testWithYourUsersController.index)
@@ -521,6 +530,8 @@ module.exports.bind = function (app) {
     xraySegmentCls,
     userPhoneNumberController.post
   )
+
+  app.use(paths.account.root, account)
 
   app.all('*', (req, res) => {
     res.status(404)

--- a/app/routes.js
+++ b/app/routes.js
@@ -328,8 +328,6 @@ module.exports.bind = function (app) {
   app.get(toggleMotoMaskCardNumberAndSecurityCode.securityCode, xraySegmentCls, permission('moto-mask-input:read'), getAccount, paymentMethodIsCard, toggleMotoMaskSecurityCode.get)
   app.post(toggleMotoMaskCardNumberAndSecurityCode.securityCode, xraySegmentCls, permission('moto-mask-input:update'), getAccount, paymentMethodIsCard, toggleMotoMaskSecurityCode.post)
 
-  // app.get(billingAddress.index, xraySegmentCls, permission('toggle-billing-address:read'), getAccount, paymentMethodIsCard, toggleBillingAddressController.getIndex)
-  // app.post(billingAddress.index, xraySegmentCls, permission('toggle-billing-address:update'), getAccount, paymentMethodIsCard, toggleBillingAddressController.postIndex)
   account.get(billingAddress.index, permission('toggle-billing-address:read'), toggleBillingAddressController.getIndex)
   account.post(billingAddress.index, permission('toggle-billing-address:update'), toggleBillingAddressController.postIndex)
 
@@ -534,6 +532,9 @@ module.exports.bind = function (app) {
   app.use(paths.account.root, account)
 
   app.all('*', (req, res) => {
+    logger.info('Page not found', {
+      url: req.originalUrl
+    })
     res.status(404)
     res.render('404')
   })

--- a/app/utils/format-account-paths-for.js
+++ b/app/utils/format-account-paths-for.js
@@ -1,0 +1,12 @@
+'use strict'
+const urlJoin = require('url-join')
+
+const paths = require('./../paths')
+const formattedPathFor = require('./replace-params-in-path')
+
+function formatAccountPathsFor (path, gatewayAccountExternalId, ...params) {
+  const completePath = urlJoin(paths.account.root, path)
+  return formattedPathFor(completePath, gatewayAccountExternalId, ...params)
+}
+
+module.exports = formatAccountPathsFor

--- a/app/utils/format-accounts-paths-for.test.js
+++ b/app/utils/format-accounts-paths-for.test.js
@@ -1,0 +1,10 @@
+const { expect } = require('chai')
+
+const formatAccountPathsFor = require('./format-account-paths-for')
+
+describe('formatting account paths utility', () => {
+  it('outputs a full account path given relative path and id', () => {
+    const path = formatAccountPathsFor('/billing-address', 'a-valid-external-id')
+    expect(path).to.equal('/account/a-valid-external-id/billing-address')
+  })
+})

--- a/app/views/settings/index.njk
+++ b/app/views/settings/index.njk
@@ -121,7 +121,7 @@
               classes: 'govuk-!-width-one-quarter',
               items: [
                 {
-                  href: routes.toggleBillingAddress.index,
+                  href: formatAccountPathsFor(routes.account.toggleBillingAddress.index, currentGatewayAccount.external_id),
                   classes: 'govuk-link--no-visited-state',
                   text: 'Change' if permissions.toggle_billing_address_update else 'View',
                   visuallyHiddenText: 'collect billing address settings'
@@ -207,7 +207,7 @@
       })
     }}
     <p class="govuk-body"><a class="govuk-link" href="{{routes.emailNotifications.index}}" id="templates-link">See templates and add a custom paragraph.</a></p>
-    
+
     {% if allowMoto %}
       <h1 id="moto-mask-security-settings-heading" class="govuk-heading-m govuk-!-margin-top-8">Security</h1>
       <p class="govuk-body">Hide sensitive details being viewed on a call agent’s screen.</p>
@@ -261,6 +261,6 @@
           ]
         })
       }}
-    {% endif %} 
+    {% endif %}
   </div>
 {% endblock %}

--- a/server.js
+++ b/server.js
@@ -24,6 +24,7 @@ const logger = require('./app/utils/logger')(__filename)
 const loggingMiddleware = require('./app/middleware/logging-middleware')
 const Sentry = require('./app/utils/sentry.js').initialiseSentry()
 const formatPSPname = require('./app/utils/format-PSP-name')
+const formatAccountPathsFor = require('./app/utils/format-account-paths-for')
 
 // Global constants
 const port = (process.env.PORT || 3000)
@@ -54,6 +55,7 @@ function initialiseGlobalMiddleware (app) {
   app.use(function (req, res, next) {
     res.locals.asset_path = '/public/'
     res.locals.routes = router.paths
+    res.locals.formatAccountPathsFor = formatAccountPathsFor
     res.locals.analyticsTrackingId = ANALYTICS_TRACKING_ID
     noCache(res)
     next()

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -11,6 +11,7 @@ function validGatewayAccount (opts) {
   const gatewayAccount = {
     payment_provider: opts.payment_provider || 'sandbox',
     gateway_account_id: opts.gateway_account_id || 31,
+    external_id: opts.external_id || 'a-valid-external-id',
     allow_apple_pay: opts.allow_apple_pay || false,
     allow_google_pay: opts.allow_google_pay || false,
     service_name: opts.service_name || '8b9370c1a83c4d71a538a1691236acc2',


### PR DESCRIPTION
Introduces a new sub router architecture for admin tool routes. This
allows account specific pages to sit behind the account router and have
common middleware taken care of. It also uses the new middleware
following the proposed middleware architecture design that adhere to
best error handling practice and don't directly respond to the HTTP
request.

To prove/ test the proposed router architecture, update the toggle
billing address feature page to use the new account URL structure.