### PR TITLE
BAU: Fix err http headers sent on register user and service users controllers

### DIFF
--- a/app/controllers/register-user.controller.js
+++ b/app/controllers/register-user.controller.js
@@ -24,13 +24,11 @@ const handleError = (req, res, err) => {
 
   switch (err.errorCode) {
     case 404:
-      renderErrorView(req, res, messages.missingCookie, 404)
-      break
+      return renderErrorView(req, res, messages.missingCookie, 404)
     case 410:
-      renderErrorView(req, res, messages.linkExpired, 410)
-      break
+      return renderErrorView(req, res, messages.linkExpired, 410)
     default:
-      renderErrorView(req, res, messages.missingCookie, 500)
+      return renderErrorView(req, res, messages.missingCookie, 500)
   }
 }
 
@@ -71,7 +69,7 @@ const subscribeService = async function subscribeService (req, res) {
     const completeResponse = await registrationService.completeInvite(inviteCode, correlationId)
     return res.redirect(303, `${paths.serviceSwitcher.index}?s=${completeResponse.service_external_id}`)
   } catch (err) {
-    handleError(req, res, err)
+    return handleError(req, res, err)
   }
 }
 
@@ -111,9 +109,9 @@ const submitRegistration = async function submitRegistration (req, res) {
   try {
     await registrationService.submitRegistration(sessionData.code, telephoneNumber, password, correlationId)
     sessionData.telephone_number = telephoneNumber
-    res.redirect(303, paths.registerUser.otpVerify)
+    return res.redirect(303, paths.registerUser.otpVerify)
   } catch (err) {
-    handleError(req, res, err)
+    return handleError(req, res, err)
   }
 }
 
@@ -157,13 +155,13 @@ const submitOtpVerify = async function submitOtpVerify (req, res) {
         verificationCode: validOtp.message
       }
     }
-    res.redirect(303, paths.registerUser.otpVerify)
+    return res.redirect(303, paths.registerUser.otpVerify)
   }
 
   try {
     const user = await registrationService.verifyOtpAndCreateUser(sessionData.code, verificationCode, correlationId)
     loginController.setupDirectLoginAfterRegister(req, res, user.external_id)
-    res.redirect(303, paths.registerUser.logUserIn)
+    return res.redirect(303, paths.registerUser.logUserIn)
   } catch (err) {
     if (err.errorCode && err.errorCode === 401) {
       sessionData.recovered = {
@@ -171,9 +169,9 @@ const submitOtpVerify = async function submitOtpVerify (req, res) {
           verificationCode: 'The verification code you’ve used is incorrect or has expired'
         }
       }
-      res.redirect(303, paths.registerUser.otpVerify)
+      return res.redirect(303, paths.registerUser.otpVerify)
     } else {
-      handleError(req, res, err)
+      return handleError(req, res, err)
     }
   }
 }
@@ -226,9 +224,9 @@ const submitReVerifyPhone = async function submitReVerifyPhone (req, res) {
   try {
     await registrationService.resendOtpCode(sessionData.code, telephoneNumber, correlationId)
     sessionData.telephone_number = telephoneNumber
-    res.redirect(303, paths.registerUser.otpVerify)
+    return res.redirect(303, paths.registerUser.otpVerify)
   } catch (err) {
-    handleError(req, res, err)
+    return handleError(req, res, err)
   }
 }
 

--- a/app/controllers/service-users.controller.js
+++ b/app/controllers/service-users.controller.js
@@ -90,7 +90,7 @@ module.exports = {
     const externalServiceId = req.service.externalId
     const externalUserId = req.params.externalUserId
     if (externalUserId === req.user.externalId) {
-      res.redirect(paths.user.profile.index)
+      return res.redirect(paths.user.profile.index)
     }
 
     const onSuccess = (user) => {
@@ -101,7 +101,7 @@ module.exports = {
       const teamMemberIndexLink = formattedPathFor(paths.teamMembers.index, externalServiceId)
 
       if (roleInList && hasSameService) {
-        response(req, res, 'team-members/team-member-details', {
+        return response(req, res, 'team-members/team-member-details', {
           username: user.username,
           email: user.email,
           role: roleInList.description,
@@ -110,7 +110,7 @@ module.exports = {
           removeTeamMemberLink: removeTeamMemberLink
         })
       } else {
-        renderErrorView(req, res, 'You do not have the rights to access this service.', 403)
+        return renderErrorView(req, res, 'You do not have the rights to access this service.', 403)
       }
     }
 


### PR DESCRIPTION
There is the following error on register user and service users controller testing.

```
UnhandledPromiseRejectionWarning: Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
```

This change adds missing `return` to resolve the error in both controllers.
