### PR TITLE
PP-7520 Payment types page uses new account URL structure

### DIFF
--- a/app/controllers/payment-types/post-index.controller.js
+++ b/app/controllers/payment-types/post-index.controller.js
@@ -3,6 +3,7 @@
 const lodash = require('lodash')
 
 const paths = require('../../paths')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
@@ -18,7 +19,9 @@ module.exports = async (req, res) => {
 
   if (typeof acceptedDebitCards === 'undefined' && typeof acceptedCreditCards === 'undefined') {
     req.flash('genericError', 'You must choose at least one card')
-    return res.redirect(paths.paymentTypes.index)
+    return res.redirect(
+      formatAccountPathsFor(paths.paymentTypes.index, req.account && req.account.external_id)
+    )
   }
 
   const payload = {
@@ -28,7 +31,9 @@ module.exports = async (req, res) => {
   try {
     await connector.postAcceptedCardsForAccount(accountId, payload, correlationId)
     req.flash('generic', 'Accepted card types have been updated')
-    return res.redirect(paths.paymentTypes.index)
+    return res.redirect(
+      formatAccountPathsFor(paths.paymentTypes.index, req.account && req.account.external_id)
+    )
   } catch (error) {
     return renderErrorView(req, res, error.message.message[0], error.errorCode)
   }

--- a/app/routes.js
+++ b/app/routes.js
@@ -271,9 +271,8 @@ module.exports.bind = function (app) {
   app.post(apiKeys.revoke, xraySegmentCls, permission('tokens:delete'), getAccount, apiKeysController.postRevoke)
   app.post(apiKeys.update, xraySegmentCls, permission('tokens:update'), getAccount, apiKeysController.postUpdate)
 
-  // PAYMENT TYPES
-  app.get(pt.index, xraySegmentCls, permission('payment-types:read'), getAccount, paymentMethodIsCard, paymentTypesController.getIndex)
-  app.post(pt.index, xraySegmentCls, permission('payment-types:update'), getAccount, paymentMethodIsCard, paymentTypesController.postIndex)
+  account.get(pt.index, permission('payment-types:read'), paymentTypesController.getIndex)
+  account.post(pt.index, permission('payment-types:update'), paymentTypesController.postIndex)
 
   // DIGITAL WALLET
   app.get(digitalWallet.applePay, xraySegmentCls, permission('payment-types:update'), getAccount, paymentMethodIsCard, digitalWalletController.getApplePay)

--- a/app/utils/display-converter.js
+++ b/app/utils/display-converter.js
@@ -102,7 +102,7 @@ module.exports = function (req, data, template) {
   convertedData.currentService = _.get(req, 'service')
   if (permissions) {
     convertedData.serviceNavigationItems = serviceNavigationItems(url.parse(originalUrl).pathname, permissions, paymentMethod)
-    convertedData.adminNavigationItems = adminNavigationItems(originalUrl, permissions, paymentMethod, paymentProvider)
+    convertedData.adminNavigationItems = adminNavigationItems(originalUrl, permissions, paymentMethod, paymentProvider, account)
   }
   convertedData._features = {}
   if (req.user && req.user.features) {

--- a/app/utils/nav-builder.js
+++ b/app/utils/nav-builder.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash')
 const paths = require('./../paths')
+const formatAccountPathsFor = require('./format-account-paths-for')
 const pathLookup = require('./path-lookup')
 const formatPSPname = require('./format-PSP-name')
 
@@ -55,7 +56,9 @@ const serviceNavigationItems = (originalUrl, permissions, type) => {
   return navigationItems
 }
 
-const adminNavigationItems = (originalUrl, permissions, type, paymentProvider) => {
+const adminNavigationItems = (originalUrl, permissions, type, paymentProvider, account = {}) => {
+  const paymentTypesPath = formatAccountPathsFor(paths.paymentTypes.index, account.external_id)
+
   return [
     {
       id: 'navigation-menu-settings-home',
@@ -81,8 +84,8 @@ const adminNavigationItems = (originalUrl, permissions, type, paymentProvider) =
     {
       id: 'navigation-menu-payment-types',
       name: 'Card types',
-      url: paths.paymentTypes.index,
-      current: pathLookup(originalUrl, paths.paymentTypes.index) || pathLookup(originalUrl, paths.digitalWallet.summary),
+      url: paymentTypesPath,
+      current: pathLookup(originalUrl, paymentTypesPath) || pathLookup(originalUrl, paths.digitalWallet.summary),
       permissions: permissions.payment_types_read && type === 'card'
     }
   ]

--- a/test/cypress/integration/dashboard/dashboard-go-live-link.cy.test.js
+++ b/test/cypress/integration/dashboard/dashboard-go-live-link.cy.test.js
@@ -13,7 +13,7 @@ describe('Go live link on dashboard', () => {
   describe('Card gateway account', () => {
     describe('Go live link shown', () => {
       beforeEach(() => {
-        utils.setupGetUserAndGatewayAccountsStubs(utils.buildServiceRoleForGoLiveStage('NOT_STARTED'))
+        utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('NOT_STARTED'))
         cy.visit('/')
       })
 

--- a/test/cypress/integration/dashboard/dashboard-go-live-link.cy.test.js
+++ b/test/cypress/integration/dashboard/dashboard-go-live-link.cy.test.js
@@ -13,7 +13,7 @@ describe('Go live link on dashboard', () => {
   describe('Card gateway account', () => {
     describe('Go live link shown', () => {
       beforeEach(() => {
-        utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('NOT_STARTED'))
+        utils.setupGetUserAndGatewayAccountsStubs(utils.buildServiceRoleForGoLiveStage('NOT_STARTED'))
         cy.visit('/')
       })
 

--- a/test/cypress/integration/settings/payment-types.cy.test.js
+++ b/test/cypress/integration/settings/payment-types.cy.test.js
@@ -1,10 +1,10 @@
 const userStubs = require('../../stubs/user-stubs')
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 
-function setupStubs (userExternalId, gatewayAccountId, serviceName, updated = false) {
+function setupStubs (userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, updated = false) {
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName }),
-    gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId }),
+    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId }),
     gatewayAccountStubs.getAcceptedCardTypesSuccess({ gatewayAccountId, updated }),
     gatewayAccountStubs.getCardTypesSuccess()
   ])
@@ -12,7 +12,8 @@ function setupStubs (userExternalId, gatewayAccountId, serviceName, updated = fa
 
 describe('Payment types', () => {
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
-  const gatewayAccountId = 42
+  const gatewayAccountId = '42'
+  const gatewayAccountExternalId = 'a-valid-external-id'
   const serviceName = 'Purchase a positron projection permit'
 
   beforeEach(() => {
@@ -21,12 +22,12 @@ describe('Payment types', () => {
 
   describe('Card types', () => {
     beforeEach(() => {
-      setupStubs(userExternalId, gatewayAccountId, serviceName)
+      setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName)
     })
 
     it('should show page title', () => {
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit('/payment-types')
+      cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
       cy.title().should('eq', `Manage payment types - ${serviceName} - GOV.UK Pay`)
     })
     it('should show accepted debit cards', () => {
@@ -52,7 +53,7 @@ describe('Payment types', () => {
 
   describe('Card types', () => {
     beforeEach(() => {
-      setupStubs(userExternalId, gatewayAccountId, serviceName, true)
+      setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, true)
     })
 
     it('should update if we add Diners Club', () => {
@@ -65,7 +66,7 @@ describe('Payment types', () => {
 
   describe('Card types', () => {
     beforeEach(() => {
-      setupStubs(userExternalId, gatewayAccountId, serviceName)
+      setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName)
     })
 
     it('should show error if user tries to disable all card types', () => {

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -140,6 +140,12 @@ module.exports = {
       response: gatewayAccountFixtures.validGatewayAccountResponse(opts).getPlain()
     })
   },
+  getGatewayAccountByExternalIdSuccess: (opts = {}) => {
+    const path = '/v1/api/accounts/external-id/' + opts.external_id
+    return simpleStubBuilder('GET', path, 200, {
+      response: gatewayAccountFixtures.validGatewayAccountResponse(opts).getPlain()
+    })
+  },
   getGatewayAccountSuccessRepeat: (opts = {}) => {
     const aValidGetGatewayAccountResponse = gatewayAccountFixtures.validGatewayAccountResponse(opts[0]).getPlain()
     const aDifferentValidGetGatewayAccountResponse = gatewayAccountFixtures.validGatewayAccountResponse(opts[1]).getPlain()

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const getGatewayAccountSuccess = function (opts) {
+function parseGatewayAccountOptions (opts) {
   let stubOptions = { gateway_account_id: opts.gatewayAccountId }
 
   if (opts.paymentProvider) {
@@ -47,8 +47,26 @@ const getGatewayAccountSuccess = function (opts) {
     stubOptions.notificationCredentials = opts.notificationCredentials
   }
 
+  if (opts.gatewayAccountExternalId) {
+    stubOptions.external_id = opts.gatewayAccountExternalId
+  }
+  return stubOptions
+}
+
+const getGatewayAccountSuccess = function (opts) {
+  const stubOptions = parseGatewayAccountOptions(opts)
+
   return {
     name: 'getGatewayAccountSuccess',
+    opts: stubOptions
+  }
+}
+
+const getGatewayAccountByExternalIdSuccess = function (opts) {
+  const stubOptions = parseGatewayAccountOptions(opts)
+
+  return {
+    name: 'getGatewayAccountByExternalIdSuccess',
     opts: stubOptions
   }
 }
@@ -59,7 +77,8 @@ const getGatewayAccountsSuccess = function (opts) {
     opts: {
       gateway_account_id: opts.gatewayAccountId,
       type: opts.type,
-      payment_provider: opts.paymentProvider
+      payment_provider: opts.paymentProvider,
+      external_id: '42'
     }
   }
 }
@@ -231,6 +250,7 @@ module.exports = {
   getAccountAuthSuccess,
   getGatewayAccountSuccess,
   getGatewayAccountsSuccess,
+  getGatewayAccountByExternalIdSuccess,
   getAcceptedCardTypesSuccess,
   getDirectDebitGatewayAccountSuccess,
   postCreateGatewayAccountSuccess,

--- a/test/cypress/utils/request-to-go-live-utils.js
+++ b/test/cypress/utils/request-to-go-live-utils.js
@@ -38,6 +38,13 @@ const getUserAndGatewayAccountStubs = (serviceRole) => {
   ]
 }
 
+const getUserAndGatewayAccountsStubs = (serviceRole) => {
+  return [
+    userStubs.getUserSuccessWithServiceRole({ userExternalId: variables.userExternalId, serviceRole }),
+    gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId: variables.gatewayAccountId })
+  ]
+}
+
 const patchUpdateGoLiveStageSuccessStub = (currentGoLiveStage) => {
   return serviceStubs.patchUpdateServiceGoLiveStageSuccess({
     serviceExternalId: variables.serviceExternalId,
@@ -65,6 +72,10 @@ const setupGetUserAndGatewayAccountStubs = (serviceRole) => {
   cy.task('setupStubs', getUserAndGatewayAccountStubs(serviceRole))
 }
 
+const setupGetUserAndGatewayAccountsStubs = (serviceRole) => {
+  cy.task('setupStubs', getUserAndGatewayAccountsStubs(serviceRole))
+}
+
 module.exports = {
   variables,
   buildServiceRoleForGoLiveStage,
@@ -73,5 +84,6 @@ module.exports = {
   patchUpdateGoLiveStageSuccessStub,
   patchUpdateGoLiveStageErrorStub,
   patchUpdateServiceSuccessCatchAllStub,
-  setupGetUserAndGatewayAccountStubs
+  setupGetUserAndGatewayAccountStubs,
+  setupGetUserAndGatewayAccountsStubs
 }


### PR DESCRIPTION
- Update routes for the Settings > Payment Types - so that the gateway account
external id is part of the URL
- Added new "get gateway account by external ID" stub for Cypress, this
can now be used for any pages using the new middleware that will fetch
accounts from `/v1/api/accounts/external-id/:id`.
- Updated Cypress tests for payment links page.

With @iqbalgds 
With @SandorArpa 