### PR TITLE
PP-7588 Demonstrate how pact dependency will be removed from fixtures

### DIFF
--- a/test/fixtures/user.fixtures.js
+++ b/test/fixtures/user.fixtures.js
@@ -322,23 +322,8 @@ module.exports = {
     }
   },
 
-  /**
-   * @param request Params override response
-   * @return {{getPactified: (function()) Pact response, getAsObject: (function()) User, getPlain: (function()) request with overrides applied}}
-   */
   validMultipleUserResponse: (opts = []) => {
-    const data = opts.map(buildUserWithDefaults)
-    return {
-      getPactified: () => {
-        return data.map(pactUsers.pactify)
-      },
-      getAsObject: () => {
-        return data.map(datum => new User(datum))
-      },
-      getPlain: () => {
-        return data
-      }
-    }
+    return opts.map(buildUserWithDefaults)
   },
 
   validAuthenticateRequest: (options) => {

--- a/test/test-helpers/pact/pactifier.js
+++ b/test/test-helpers/pact/pactifier.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const pactBase = require('../../fixtures/pact-base')
+
+const userResponsePactifier = pactBase({
+  array: ['service_roles', '_links'],
+  length: [{ key: 'permissions', length: 1 }]
+})
+
+module.exports = {
+  userResponsePactifier
+}


### PR DESCRIPTION
Want to remove the pact dependency so that fixtures can be used directly by Cypress test code, which cannot use Node dependencies.

The pact dependency is currently used to construct pacts for responses which include the appropriate matchers.

To do this:
- Remove `.getPactified()` methods returned by fixtures. Instead, "pactify" the response in the pact test itself.
- Add utility to return "pactifiers" to pactify certain responses.
- Remove `getPlain()` and `getObject()` methods returned by fixtures and just return the raw response object. We can construct the models returned by `getObject()` wherever we need them easily enough.



