### PR TITLE
PP-7588 Remove pact dependency from user fixtures

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2020-12-08T11:50:24Z",
+  "generated_at": "2020-12-21T16:39:58Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -248,7 +248,7 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 187,
+        "line_number": 181,
         "type": "Secret Keyword"
       }
     ],
@@ -314,7 +314,7 @@
         "hashed_secret": "5f6087367c3abd5ea9bc0d1650277b9f68b9b233",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 72,
+        "line_number": 71,
         "type": "Secret Keyword"
       }
     ],

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -66,7 +66,7 @@ module.exports = {
   getUserSuccess: (opts = {}) => {
     const path = '/v1/api/users/' + opts.external_id
     return simpleStubBuilder('GET', path, 200, {
-      response: userFixtures.validUserResponse(opts).getPlain()
+      response: userFixtures.validUserResponse(opts)
     })
   },
   getUsersSuccess: (opts = {}) => {
@@ -75,12 +75,12 @@ module.exports = {
       query: {
         ids: opts.userIds ? opts.userIds.join() : ''
       },
-      response: userFixtures.validUsersResponse(opts.users).getPlain()
+      response: userFixtures.validUsersResponse(opts.users)
     })
   },
   getUserSuccessRespondDifferentlySecondTime: (opts = {}) => {
-    const aValidUserResponse = userFixtures.validUserResponse(opts.firstResponseOpts).getPlain()
-    const aSecondValidUserResponse = userFixtures.validUserResponse(opts.secondResponseOpts).getPlain()
+    const aValidUserResponse = userFixtures.validUserResponse(opts.firstResponseOpts)
+    const aSecondValidUserResponse = userFixtures.validUserResponse(opts.secondResponseOpts)
     return [
       {
         predicates: [{
@@ -122,7 +122,7 @@ module.exports = {
   getServiceUsersSuccess: (opts = {}) => {
     const path = `/v1/api/services/${opts.serviceExternalId}/users`
     return simpleStubBuilder('GET', path, 200, {
-      response: userFixtures.validUsersResponse(opts.users).getPlain()
+      response: userFixtures.validUsersResponse(opts.users)
     })
   },
   getInvitedUsersSuccess: (opts = {}) => {
@@ -269,15 +269,15 @@ module.exports = {
   postUserAuthenticateSuccess: (opts = {}) => {
     const path = '/v1/api/users/authenticate'
     return simpleStubBuilder('POST', path, 200, {
-      request: userFixtures.validAuthenticateRequest(opts).getPlain(),
-      response: userFixtures.validUserResponse(opts).getPlain()
+      request: userFixtures.validAuthenticateRequest(opts),
+      response: userFixtures.validUserResponse(opts)
     })
   },
   postUserAuthenticateInvalidPassword: (opts = {}) => {
     const path = '/v1/api/users/authenticate'
     return simpleStubBuilder('POST', path, 401, {
-      request: userFixtures.validAuthenticateRequest(opts).getPlain(),
-      response: userFixtures.invalidPasswordAuthenticateResponse().getPlain()
+      request: userFixtures.validAuthenticateRequest(opts),
+      response: userFixtures.invalidPasswordAuthenticateResponse()
     })
   },
   postSecondFactorSuccess: (opts = {}) => {
@@ -527,15 +527,15 @@ module.exports = {
   putUpdateServiceRoleSuccess: (opts = {}) => {
     const path = `/v1/api/users/${opts.external_id}/services/${opts.serviceExternalId}`
     return simpleStubBuilder('PUT', path, 200, {
-      request: userFixtures.validUpdateServiceRoleRequest(opts.role).getPlain(),
-      response: userFixtures.validUserResponse(opts).getPlain()
+      request: userFixtures.validUpdateServiceRoleRequest(opts.role),
+      response: userFixtures.validUserResponse(opts)
     })
   },
   postAssignServiceRoleSuccess: (opts = {}) => {
     const path = `/v1/api/users/${opts.external_id}/services`
     return simpleStubBuilder('POST', path, 200, {
-      request: userFixtures.validAssignServiceRoleRequest(opts).getPlain(),
-      response: userFixtures.validUserResponse(opts).getPlain(),
+      request: userFixtures.validAssignServiceRoleRequest(opts),
+      response: userFixtures.validUserResponse(opts),
       verifyCalledTimes: opts.verifyCalledTimes
     })
   },

--- a/test/fixtures/user-service.fixture.js
+++ b/test/fixtures/user-service.fixture.js
@@ -17,7 +17,7 @@ module.exports = {
   validServiceUsersResponse: (users) => {
     let data = []
     for (let user of users) {
-      data.push(userFixtures.validUserResponse(user).getPlain())
+      data.push(userFixtures.validUserResponse(user))
     }
     return {
       getPactified: () => {

--- a/test/fixtures/user.fixtures.js
+++ b/test/fixtures/user.fixtures.js
@@ -1,9 +1,6 @@
 'use strict'
 
 const lodash = require('lodash')
-
-const User = require('../../app/models/User.class')
-const pactBase = require('./pact-base')
 const goLiveStage = require('../../app/models/go-live-stage')
 const serviceFixtures = require('./service.fixtures')
 
@@ -208,12 +205,6 @@ const defaultPermissions = [
 
 ]
 
-// Setup
-const pactUsers = pactBase({
-  array: ['service_roles', '_links'],
-  length: [{ key: 'permissions', length: 1 }]
-})
-
 const buildServiceRole = (opts = {}) => {
   return {
     service: serviceFixtures.validServiceResponse(opts.service).getPlain(),
@@ -307,174 +298,93 @@ module.exports = {
     }
 
     // pass this through the known valid structure builder to ensure structure is correct
-    const data = buildUserWithDefaults(userOpts)
-
-    return {
-      getPactified: () => {
-        return pactUsers.pactify(data)
-      },
-      getAsObject: () => {
-        return new User(data)
-      },
-      getPlain: () => {
-        return data
-      }
-    }
-  },
-
-  validMultipleUserResponse: (opts = []) => {
-    return opts.map(buildUserWithDefaults)
+    return buildUserWithDefaults(userOpts)
   },
 
   validAuthenticateRequest: (options) => {
-    const request = {
+    return {
       username: options.username || 'username',
       password: options.password || 'password'
     }
-
-    return pactUsers.withPactified(request)
   },
 
   unauthorizedUserResponse: () => {
-    const response = {
+    return {
       errors: ['invalid username and/or password']
     }
-
-    return pactUsers.withPactified(response)
   },
 
   badAuthenticateResponse: () => {
-    const response = {
+    return {
       errors: ['Field [username] is required', 'Field [password] is required']
     }
-
-    return pactUsers.withPactified(response)
   },
 
   validIncrementSessionVersionRequest: () => {
-    const request = {
+    return {
       op: 'append',
       path: 'sessionVersion',
       value: 1
     }
-
-    return pactUsers.withPactified(request)
   },
 
   validAuthenticateSecondFactorRequest: (code) => {
-    const request = {
+    return {
       code: code || '123456'
     }
-
-    return pactUsers.withPactified(request)
   },
 
   validUpdatePasswordRequest: (token, newPassword) => {
-    const request = {
+    return {
       forgotten_password_code: token || '5ylaem',
       new_password: newPassword || 'G0VUkPay2017Rocks'
     }
-
-    return pactUsers.withPactified(request)
   },
 
   validUpdateServiceRoleRequest: (role) => {
-    const request = {
+    return {
       role_name: role || 'admin'
     }
-
-    return pactUsers.withPactified(request)
   },
 
   validAssignServiceRoleRequest: (opts = {}) => {
-    const request = {
+    return {
       service_external_id: opts.service_external_id || '9en17v',
       role_name: opts.role_name || 'admin'
     }
-
-    return pactUsers.withPactified(request)
   },
 
   validPasswordAuthenticateRequest: (opts = {}) => {
-    const usernameGenerate = opts.username || 'validuser'
-    const usernameMatcher = opts.usernameMatcher || 'validuser'
-
-    const passwordGenerate = opts.password || 'validpassword'
-    const passwordMatcher = opts.passwordMatcher || 'validpassword'
-
     return {
-      username: pactUsers.pactifyMatch(usernameGenerate, usernameMatcher),
-      password: pactUsers.pactifyMatch(passwordGenerate, passwordMatcher)
-    }
-  },
-
-  invalidPasswordAuthenticateRequest: (opts = {}) => {
-    const usernameGenerate = opts.username || 'validuser'
-    const usernameMatcher = opts.usernameMatcher || 'validuser'
-
-    const passwordGenerate = opts.password || 'invalidpassword'
-    const passwordMatcher = opts.passwordMatcher || 'invalidpassword'
-
-    return {
-      username: pactUsers.pactifyMatch(usernameGenerate, usernameMatcher),
-      password: pactUsers.pactifyMatch(passwordGenerate, passwordMatcher)
+      username: opts.username || 'validuser',
+      password: opts.password || 'validpassword'
     }
   },
 
   validUserResponse: (opts = {}) => {
-    const data = buildUserWithDefaults(opts)
-
-    return {
-      getPactified: () => {
-        return pactUsers.pactify(data)
-      },
-      getAsObject: () => {
-        return new User(data)
-      },
-      getPlain: () => {
-        return data
-      }
-    }
+    return buildUserWithDefaults(opts)
   },
 
   validUsersResponse: (opts = []) => {
-    const users = opts.map(buildUserWithDefaults)
-
-    return {
-      getPactified: () => {
-        return pactUsers.pactify(users)
-      },
-      getAsObject: () => {
-        const usersObject = []
-        users.forEach(user => usersObject.push(new User(user)))
-        return new User(usersObject)
-      },
-      getPlain: () => {
-        return users
-      }
-    }
+    return opts.map(buildUserWithDefaults)
   },
 
   invalidPasswordAuthenticateResponse: () => {
-    const response = {
+    return {
       errors: ['invalid username and/or password']
     }
-
-    return pactUsers.withPactified(response)
   },
 
   validForgottenPasswordCreateRequest: (username) => {
-    const request = {
+    return {
       username: username || 'username@email.com'
     }
-
-    return pactUsers.withPactified(request)
   },
 
   validForgottenPasswordResponse: (payload) => {
     const request = payload || {}
     const code = 'h41ne'
-    const response = {
+    return {
       user_external_id: request.userExternalId || 'userExternalId',
       code: request.code || code,
       date: '2010-12-31T22:59:59.132Z',
@@ -484,26 +394,11 @@ module.exports = {
         'method': 'GET'
       }]
     }
-
-    return pactUsers.withPactified(response)
   },
 
   badForgottenPasswordResponse: () => {
-    const response = {
+    return {
       errors: ['Field [username] is required']
     }
-
-    return pactUsers.withPactified(response)
-  },
-
-  badRequestResponseWhenFieldsMissing: (missingFields) => {
-    const responseData = lodash.map(missingFields, (field) => {
-      return `Field [${field}] is required`
-    })
-    const response = {
-      errors: responseData
-    }
-
-    return pactUsers.withPactified(response)
   }
 }

--- a/test/integration/forgotten-password.ft.test.js
+++ b/test/integration/forgotten-password.ft.test.js
@@ -42,8 +42,7 @@ describe('forgotten_password_controller', function () {
     const username = req.body.username
 
     adminusersMock.post(FORGOTTEN_PASSWORD_RESOURCE, userFixtures
-      .validForgottenPasswordCreateRequest(username)
-      .getPlain())
+      .validForgottenPasswordCreateRequest(username))
       .reply(200)
 
     await forgottenPasswordController.emailPost(req, res)
@@ -70,8 +69,7 @@ describe('forgotten_password_controller', function () {
     const username = req.body.username
 
     adminusersMock.post(FORGOTTEN_PASSWORD_RESOURCE, userFixtures
-      .validForgottenPasswordCreateRequest(username)
-      .getPlain())
+      .validForgottenPasswordCreateRequest(username))
       .reply(404)
 
     await forgottenPasswordController.emailPost(req, res)
@@ -84,8 +82,7 @@ describe('forgotten_password_controller', function () {
     const username = req.body.username
 
     adminusersMock.post(FORGOTTEN_PASSWORD_RESOURCE, userFixtures
-      .validForgottenPasswordCreateRequest(username)
-      .getPlain())
+      .validForgottenPasswordCreateRequest(username))
       .reply(500)
 
     await forgottenPasswordController.emailPost(req, res)
@@ -101,7 +98,7 @@ describe('forgotten_password_controller', function () {
     const forgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({ code: token })
 
     adminusersMock.get(`${FORGOTTEN_PASSWORD_RESOURCE}/${token}`)
-      .reply(200, forgottenPasswordResponse.getPlain())
+      .reply(200, forgottenPasswordResponse)
 
     await forgottenPasswordController.newPasswordGet(req, res)
     sinon.assert.calledWith(res.render, 'forgotten-password/new-password', { id: token })
@@ -129,18 +126,17 @@ describe('forgotten_password_controller', function () {
     const userResponse = userFixtures.validUserResponse({ external_id: userExternalId })
 
     adminusersMock.get(`${USER_RESOURCE}/${userExternalId}`)
-      .reply(200, userResponse.getPlain())
+      .reply(200, userResponse)
 
     adminusersMock.get(`${FORGOTTEN_PASSWORD_RESOURCE}/${token}`)
-      .reply(200, forgottenPasswordResponse.getPlain())
+      .reply(200, forgottenPasswordResponse)
 
     adminusersMock.post(RESET_PASSWORD_RESOURCE, userFixtures
-      .validUpdatePasswordRequest(token, req.body.password)
-      .getPlain())
+      .validUpdatePasswordRequest(token, req.body.password))
       .reply(204)
 
     adminusersMock.patch(`${USER_RESOURCE}/${userExternalId}`, userFixtures
-      .validIncrementSessionVersionRequest().getPlain())
+      .validIncrementSessionVersionRequest())
       .reply(200)
 
     await forgottenPasswordController.newPasswordPost(req, res)
@@ -158,19 +154,17 @@ describe('forgotten_password_controller', function () {
     const userResponse = userFixtures.validUserResponse({ external_id: userExternalId })
 
     adminusersMock.get(`${FORGOTTEN_PASSWORD_RESOURCE}/${token}`)
-      .reply(200, forgottenPasswordResponse.getPlain())
+      .reply(200, forgottenPasswordResponse)
 
     adminusersMock.get(`${USER_RESOURCE}/${userExternalId}`)
-      .reply(200, userResponse.getPlain())
+      .reply(200, userResponse)
 
     adminusersMock.post(RESET_PASSWORD_RESOURCE, userFixtures
-      .validUpdatePasswordRequest(token, req.body.password)
-      .getPlain())
+      .validUpdatePasswordRequest(token, req.body.password))
       .reply(204)
 
     adminusersMock.patch(`${USER_RESOURCE}/${userExternalId}`, userFixtures
-      .validIncrementSessionVersionRequest()
-      .getPlain())
+      .validIncrementSessionVersionRequest())
       .reply(500)
 
     await forgottenPasswordController.newPasswordPost(req, res)
@@ -190,10 +184,10 @@ describe('forgotten_password_controller', function () {
     const forgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({ userExternalId: userExternalId, code: token })
 
     adminusersMock.get(`${FORGOTTEN_PASSWORD_RESOURCE}/${token}`)
-      .reply(200, forgottenPasswordResponse.getPlain())
+      .reply(200, forgottenPasswordResponse)
 
     adminusersMock.get(`${USER_RESOURCE}/${userExternalId}`)
-      .reply(200, userResponse.getPlain())
+      .reply(200, userResponse)
 
     await forgottenPasswordController.newPasswordPost(req, res)
     sinon.assert.calledWithMatch(res.render, 'forgotten-password/new-password', {
@@ -214,14 +208,13 @@ describe('forgotten_password_controller', function () {
     const forgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({ userExternalId: userExternalId, code: token })
 
     adminusersMock.get(`${FORGOTTEN_PASSWORD_RESOURCE}/${token}`)
-      .reply(200, forgottenPasswordResponse.getPlain())
+      .reply(200, forgottenPasswordResponse)
 
     adminusersMock.get(`${USER_RESOURCE}/${userExternalId}`)
-      .reply(200, userResponse.getPlain())
+      .reply(200, userResponse)
 
     adminusersMock.post(RESET_PASSWORD_RESOURCE, userFixtures
-      .validUpdatePasswordRequest(token, req.body.password)
-      .getPlain())
+      .validUpdatePasswordRequest(token, req.body.password))
       .reply(500)
 
     await forgottenPasswordController.newPasswordPost(req, res)

--- a/test/integration/login.controller.test.js
+++ b/test/integration/login.controller.test.js
@@ -30,7 +30,7 @@ const ACCOUNT_ID = '182364'
 const USER_RESOURCE = '/v1/api/users'
 const CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts'
 
-let user = mockSession.getUser()
+const user = mockSession.getUser()
 user.serviceRoles[0].service.gatewayAccountIds = [ACCOUNT_ID]
 
 describe('The logged in endpoint', function () {
@@ -318,11 +318,11 @@ describe('otp send again post endpoint', function () {
 
 describe('direct login after user registration', function () {
   it('should redirect user to homepage on a successful registration', function (done) {
-    let userExternalId = 'an-externalid'
-    let email = 'bob@example.com'
-    let gatewayAccountId = '2'
+    const userExternalId = 'an-externalid'
+    const email = 'bob@example.com'
+    const gatewayAccountId = '2'
 
-    let userResponse = userFixtures.validUserResponse({
+    const userResponse = userFixtures.validUserResponse({
       external_id: userExternalId,
       username: email,
       email: email,
@@ -331,12 +331,12 @@ describe('direct login after user registration', function () {
           gateway_account_ids: [gatewayAccountId]
         }
       }]
-    }).getPlain()
+    })
 
     adminusersMock.get(`${USER_RESOURCE}/${userExternalId}`)
       .reply(200, userResponse)
 
-    let connectorMock = nock(process.env.CONNECTOR_URL)
+    const connectorMock = nock(process.env.CONNECTOR_URL)
     const ledgerMock = nock(process.env.LEDGER_URL)
 
     connectorMock.get(`${CONNECTOR_ACCOUNT_PATH}/${gatewayAccountId}`)
@@ -357,13 +357,13 @@ describe('direct login after user registration', function () {
         net_income: 0
       })
 
-    let destroyStub = sinon.stub()
-    let gatewayAccountData = {
+    const destroyStub = sinon.stub()
+    const gatewayAccountData = {
       userExternalId: userExternalId,
       destroy: destroyStub
     }
 
-    let app2 = mockSession.getAppWithRegisterInvitesCookie(getApp(), gatewayAccountData)
+    const app2 = mockSession.getAppWithRegisterInvitesCookie(getApp(), gatewayAccountData)
 
     request(app2)
       .get(paths.registerUser.logUserIn)

--- a/test/integration/register-user.controller.ft.test.js
+++ b/test/integration/register-user.controller.ft.test.js
@@ -217,7 +217,7 @@ describe('register user controller', () => {
       mockRegisterAccountCookie.email = 'invitee@example.com'
       mockRegisterAccountCookie.code = 'nfjkh438rf3901jqf'
       const newUserExtId = 'new-user-ext-id'
-      const validUserResponse = userFixtures.validUserResponse({ external_id: newUserExtId }).getPlain()
+      const validUserResponse = userFixtures.validUserResponse({ external_id: newUserExtId })
 
       adminusersMock.post(`${INVITE_RESOURCE_PATH}/otp/validate`)
         .reply(201, validUserResponse)

--- a/test/integration/self-registration/self-registration-otp-verify.ft.test.js
+++ b/test/integration/self-registration/self-registration-otp-verify.ft.test.js
@@ -91,7 +91,7 @@ describe('create service otp validation', function () {
           user_external_id: userExternalId,
           service_external_id: serviceExternalId
         }).getPlain()
-      const getUserResponse = userFixtures.validUserResponse({ external_id: userExternalId }).getPlain()
+      const getUserResponse = userFixtures.validUserResponse({ external_id: userExternalId })
 
       connectorMock.post(CONNECTOR_ACCOUNTS_URL)
         .reply(201, mockConnectorCreateGatewayAccountResponse)

--- a/test/integration/service-registration.service.it.test.js
+++ b/test/integration/service-registration.service.it.test.js
@@ -49,7 +49,7 @@ describe('create populated service', function () {
         user_external_id: userExternalId,
         service_external_id: serviceExternalId
       }).getPlain()
-    const getUserResponse = userFixtures.validUserResponse({ external_id: userExternalId }).getPlain()
+    const getUserResponse = userFixtures.validUserResponse({ external_id: userExternalId })
 
     const createGatewayAccountMock = connectorMock.post(CONNECTOR_ACCOUNTS_URL)
       .reply(201, mockConnectorCreateGatewayAccountResponse)

--- a/test/integration/service-roles-update.ft.test.js
+++ b/test/integration/service-roles-update.ft.test.js
@@ -14,8 +14,8 @@ let app
 
 chai.use(chaiAsPromised)
 
-let expect = chai.expect
-let adminusersMock = nock(process.env.ADMINUSERS_URL)
+const expect = chai.expect
+const adminusersMock = nock(process.env.ADMINUSERS_URL)
 
 const USER_RESOURCE = '/v1/api/users'
 
@@ -28,7 +28,7 @@ describe('user permissions update controller', function () {
   const EXTERNAL_ID_TO_VIEW = '393266e872594f1593558549caad95ec'
   const USERNAME_TO_VIEW = 'other-user'
 
-  let userInSession = session.getUser({
+  const userInSession = session.getUser({
     external_id: EXTERNAL_ID_IN_SESSION,
     username: USERNAME_IN_SESSION,
     email: USERNAME_IN_SESSION + '@example.com',
@@ -41,7 +41,7 @@ describe('user permissions update controller', function () {
     }]
   })
 
-  let userToView = {
+  const userToView = {
     external_id: EXTERNAL_ID_TO_VIEW,
     username: USERNAME_TO_VIEW,
     email: `${USERNAME_TO_VIEW}@example.com`,
@@ -62,10 +62,10 @@ describe('user permissions update controller', function () {
 
   describe('user permissions update view', function () {
     it('should render the permission update view', function (done) {
-      let getUserResponse = userFixtures.validUserResponse(userToView)
+      const getUserResponse = userFixtures.validUserResponse(userToView)
 
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
-        .reply(200, getUserResponse.getPlain())
+        .reply(200, getUserResponse)
 
       app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
@@ -103,12 +103,12 @@ describe('user permissions update controller', function () {
     })
 
     it('should error if admin does not belong to users service', function (done) {
-      let targetUser = _.cloneDeep(userToView)
+      const targetUser = _.cloneDeep(userToView)
       targetUser.service_roles[0].service.external_id = 'other-service-id'
 
-      let getUserResponse = userFixtures.validUserResponse(targetUser)
+      const getUserResponse = userFixtures.validUserResponse(targetUser)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
-        .reply(200, getUserResponse.getPlain())
+        .reply(200, getUserResponse)
 
       app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
@@ -138,13 +138,13 @@ describe('user permissions update controller', function () {
 
   describe('user permissions update', function () {
     it('should update users permission successfully', function (done) {
-      let getUserResponse = userFixtures.validUserResponse(userToView)
+      const getUserResponse = userFixtures.validUserResponse(userToView)
 
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
-        .reply(200, getUserResponse.getPlain())
+        .reply(200, getUserResponse)
 
       adminusersMock.put(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}/services/${EXTERNAL_SERVICE_ID}`, { 'role_name': 'admin' })
-        .reply(200, getUserResponse.getPlain())
+        .reply(200, getUserResponse)
 
       app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
@@ -163,13 +163,13 @@ describe('user permissions update controller', function () {
     })
 
     it('should update users permission successfully, even if selected role is the same as existing', function (done) {
-      let getUserResponse = userFixtures.validUserResponse(userToView)
+      const getUserResponse = userFixtures.validUserResponse(userToView)
 
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
-        .reply(200, getUserResponse.getPlain())
+        .reply(200, getUserResponse)
 
       adminusersMock.put(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}/services/${EXTERNAL_SERVICE_ID}`, { 'role_name': 'view-only' })
-        .reply(200, getUserResponse.getPlain())
+        .reply(200, getUserResponse)
 
       app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
@@ -229,12 +229,12 @@ describe('user permissions update controller', function () {
     })
 
     it('should error if admin does not belong to users service', function (done) {
-      let targetUser = _.cloneDeep(userToView)
+      const targetUser = _.cloneDeep(userToView)
       targetUser.service_roles[0].service.external_id = 'other-service-id'
 
-      let getUserResponse = userFixtures.validUserResponse(targetUser)
+      const getUserResponse = userFixtures.validUserResponse(targetUser)
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
-        .reply(200, getUserResponse.getPlain())
+        .reply(200, getUserResponse)
 
       app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
@@ -257,7 +257,7 @@ describe('user permissions update controller', function () {
     it('should error if role id cannot be resolved', function (done) {
       app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
-      let nonExistentRoleId = '999'
+      const nonExistentRoleId = '999'
       supertest(app)
         .post(formattedPathFor(paths.teamMembers.permissions, EXTERNAL_SERVICE_ID, EXTERNAL_ID_TO_VIEW))
         .set('Accept', 'application/json')
@@ -275,11 +275,11 @@ describe('user permissions update controller', function () {
     })
 
     it('should error on permission update error in adminusers', function (done) {
-      let getUserResponse = userFixtures.validUserResponse(userToView)
+      const getUserResponse = userFixtures.validUserResponse(userToView)
       app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}`)
-        .reply(200, getUserResponse.getPlain())
+        .reply(200, getUserResponse)
 
       adminusersMock.put(`${USER_RESOURCE}/${EXTERNAL_ID_TO_VIEW}/services/${EXTERNAL_SERVICE_ID}`, { 'role_name': 'admin' })
         .reply(409)

--- a/test/integration/service-users.ft.test.js
+++ b/test/integration/service-users.ft.test.js
@@ -17,6 +17,7 @@ const userFixtures = require('../fixtures/user.fixtures')
 const userServiceFixtures = require('../fixtures/user-service.fixture')
 const paths = require('../../app/paths.js')
 const formattedPathFor = require('../../app/utils/replace-params-in-path')
+const User = require('../../app/models/User.class')
 
 // Local constants
 const adminusersMock = nock(process.env.ADMINUSERS_URL)
@@ -61,7 +62,7 @@ describe('service users resource', () => {
     }
     const serviceUsersRes = userServiceFixtures.validServiceUsersResponse([userOpts])
     const getInvitesRes = serviceFixtures.validListInvitesForServiceResponse()
-    const user = userFixtures.validUserResponse(userOpts).getAsObject()
+    const user = new User(userFixtures.validUserResponse(userOpts))
 
     adminusersMock.get(`${SERVICE_RESOURCE}/${externalServiceId}/users`)
       .reply(200, serviceUsersRes.getPlain())
@@ -200,7 +201,7 @@ describe('service users resource', () => {
     const getUserResponse = userFixtures.validUserResponse(userToView)
 
     adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_OTHER_USER}`)
-      .reply(200, getUserResponse.getPlain())
+      .reply(200, getUserResponse)
 
     app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
@@ -234,7 +235,7 @@ describe('service users resource', () => {
     const getUserResponse = userFixtures.validUserResponse(user)
 
     adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_LOGGED_IN}`)
-      .reply(200, getUserResponse.getPlain())
+      .reply(200, getUserResponse)
 
     app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
@@ -266,7 +267,7 @@ describe('service users resource', () => {
     const getUserResponse = userFixtures.validUserResponse(user)
 
     adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_LOGGED_IN}`)
-      .reply(200, getUserResponse.getPlain())
+      .reply(200, getUserResponse)
 
     app = session.getAppWithSessionWithoutSecondFactor(getApp(), userInSession)
 
@@ -327,7 +328,7 @@ describe('service users resource', () => {
     })
 
     adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_OTHER_USER}`)
-      .reply(200, getUserResponse.getPlain())
+      .reply(200, getUserResponse)
 
     app = session.getAppWithLoggedInUser(getApp(), user)
 
@@ -357,7 +358,7 @@ describe('service users resource', () => {
     const getUserResponse = userFixtures.validUserResponse(userToDelete)
 
     adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_OTHER_USER}`)
-      .reply(200, getUserResponse.getPlain())
+      .reply(200, getUserResponse)
 
     adminusersMock.delete(`${SERVICE_RESOURCE}/${externalServiceId}/users/${EXTERNAL_ID_OTHER_USER}`)
       .reply(200)

--- a/test/test-helpers/mock-session.js
+++ b/test/test-helpers/mock-session.js
@@ -4,10 +4,11 @@ const express = require('express')
 const _ = require('lodash')
 const sinon = require('sinon')
 
+const User = require('../../app/models/User.class')
 const userFixture = require('../fixtures/user.fixtures')
 
 const getUser = (opts) => {
-  return userFixture.validUser(opts).getAsObject()
+  return new User(userFixture.validUser(opts))
 }
 
 const createAppWithSession = function (app, sessionData, gatewayAccountData, registerInviteData) {

--- a/test/test-helpers/pact/pactifier.js
+++ b/test/test-helpers/pact/pactifier.js
@@ -2,11 +2,14 @@
 
 const pactBase = require('../../fixtures/pact-base')
 
+const defaultPactifier = pactBase()
+
 const userResponsePactifier = pactBase({
   array: ['service_roles', '_links'],
   length: [{ key: 'permissions', length: 1 }]
 })
 
 module.exports = {
+  defaultPactifier,
   userResponsePactifier
 }

--- a/test/test-helpers/user-creator.js
+++ b/test/test-helpers/user-creator.js
@@ -7,10 +7,10 @@ const USER_RESOURCE = '/v1/api/users'
 
 function mockUserResponse (userData, cb) {
   adminusersMock.get(`${USER_RESOURCE}/${userData.external_id}`).times(5)
-    .reply(200, userFixtures.validUserResponse(userData).getPlain())
+    .reply(200, userFixtures.validUserResponse(userData))
 
   adminusersMock.get(`${USER_RESOURCE}?username=${userData.username}`).times(5)
-    .reply(200, userFixtures.validUserResponse(userData).getPlain())
+    .reply(200, userFixtures.validUserResponse(userData))
 
   if (cb) cb()
 }

--- a/test/unit/clients/adminusers-client/forgotten-password/create-forgotten-password.pact.test.js
+++ b/test/unit/clients/adminusers-client/forgotten-password/create-forgotten-password.pact.test.js
@@ -1,18 +1,20 @@
 const { Pact } = require('@pact-foundation/pact')
-var path = require('path')
-var chai = require('chai')
-var chaiAsPromised = require('chai-as-promised')
-var getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
-var userFixtures = require('../../../../fixtures/user.fixtures')
-var PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
-let port = Math.floor(Math.random() * 48127) + 1024
-let adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
+const path = require('path')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
+const userFixtures = require('../../../../fixtures/user.fixtures')
+const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
+const { defaultPactifier } = require('../../../../test-helpers/pact/pactifier')
+
+const port = Math.floor(Math.random() * 48127) + 1024
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 chai.use(chaiAsPromised)
 const expect = chai.expect
 const FORGOTTEN_PASSWORD_PATH = '/v1/api/forgotten-passwords'
 
 describe('adminusers client - create forgotten password', function () {
-  let provider = new Pact({
+  const provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
@@ -27,7 +29,7 @@ describe('adminusers client - create forgotten password', function () {
 
   describe('success', () => {
     const username = 'existing-user'
-    let request = userFixtures.validForgottenPasswordCreateRequest(username)
+    const request = userFixtures.validForgottenPasswordCreateRequest(username)
 
     before((done) => {
       provider.addInteraction(
@@ -35,7 +37,7 @@ describe('adminusers client - create forgotten password', function () {
           .withState(`a user exists with username ${username}`)
           .withUponReceiving('a valid forgotten password request')
           .withMethod('POST')
-          .withRequestBody(request.getPlain())
+          .withRequestBody(request)
           .withStatusCode(200)
           .withResponseHeaders({})
           .build()
@@ -45,15 +47,14 @@ describe('adminusers client - create forgotten password', function () {
     afterEach(() => provider.verify())
 
     it('should create a forgotten password entry successfully', function (done) {
-      let requestData = request.getPlain()
-      adminusersClient.createForgottenPassword(requestData.username).should.notify(done)
+      adminusersClient.createForgottenPassword(request.username).should.notify(done)
     })
   })
 
   describe('bad request', () => {
-    let request = { username: '' }
+    const request = { username: '' }
 
-    let badForgottenPasswordResponse = userFixtures.badForgottenPasswordResponse()
+    const badForgottenPasswordResponse = userFixtures.badForgottenPasswordResponse()
 
     before((done) => {
       provider.addInteraction(
@@ -62,7 +63,7 @@ describe('adminusers client - create forgotten password', function () {
           .withMethod('POST')
           .withRequestBody(request)
           .withStatusCode(400)
-          .withResponseBody(badForgottenPasswordResponse.getPactified())
+          .withResponseBody(defaultPactifier.pactify(badForgottenPasswordResponse))
           .build()
       ).then(() => done())
     })
@@ -73,13 +74,13 @@ describe('adminusers client - create forgotten password', function () {
       adminusersClient.createForgottenPassword(request.username).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(400)
         expect(response.message.errors.length).to.equal(1)
-        expect(response.message.errors).to.deep.equal(badForgottenPasswordResponse.getPlain().errors)
+        expect(response.message.errors).to.deep.equal(badForgottenPasswordResponse.errors)
       }).should.notify(done)
     })
   })
 
   describe('not found', () => {
-    let request = userFixtures.validForgottenPasswordCreateRequest('nonexisting')
+    const request = userFixtures.validForgottenPasswordCreateRequest('nonexisting')
 
     before((done) => {
       provider.addInteraction(
@@ -87,7 +88,7 @@ describe('adminusers client - create forgotten password', function () {
           .withState('a user does not exist')
           .withUponReceiving('a forgotten password request for non existent user')
           .withMethod('POST')
-          .withRequestBody(request.getPactified())
+          .withRequestBody(request)
           .withStatusCode(404)
           .withResponseHeaders({})
           .build()
@@ -97,8 +98,7 @@ describe('adminusers client - create forgotten password', function () {
     afterEach(() => provider.verify())
 
     it('should error when forgotten password creation if no user found', function (done) {
-      let requestData = request.getPlain()
-      adminusersClient.createForgottenPassword(requestData.username).should.be.rejected.then(function (response) {
+      adminusersClient.createForgottenPassword(request.username).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(404)
       }).should.notify(done)
     })

--- a/test/unit/clients/adminusers-client/forgotten-password/get-forgotten-password.pact.test.js
+++ b/test/unit/clients/adminusers-client/forgotten-password/get-forgotten-password.pact.test.js
@@ -1,18 +1,20 @@
 const { Pact } = require('@pact-foundation/pact')
-var path = require('path')
-var chai = require('chai')
-var chaiAsPromised = require('chai-as-promised')
-var getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
-var userFixtures = require('../../../../fixtures/user.fixtures')
-var PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
-let port = Math.floor(Math.random() * 48127) + 1024
-let adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
+const path = require('path')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
+const userFixtures = require('../../../../fixtures/user.fixtures')
+const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
+const { defaultPactifier } = require('../../../../test-helpers/pact/pactifier')
+
+const port = Math.floor(Math.random() * 48127) + 1024
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 chai.use(chaiAsPromised)
 const expect = chai.expect
 const FORGOTTEN_PASSWORD_PATH = '/v1/api/forgotten-passwords'
 
 describe('adminusers client - get forgotten password', function () {
-  let provider = new Pact({
+  const provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
@@ -26,16 +28,15 @@ describe('adminusers client - get forgotten password', function () {
   after(() => provider.finalize())
 
   describe('success', () => {
-    let code = 'existing-code'
-    let validForgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({ code: code })
-    let expectedForgottenPassword = validForgottenPasswordResponse.getPlain()
+    const code = 'existing-code'
+    const validForgottenPasswordResponse = userFixtures.validForgottenPasswordResponse({ code: code })
 
     before((done) => {
       provider.addInteraction(
         new PactInteractionBuilder(`${FORGOTTEN_PASSWORD_PATH}/${code}`)
           .withState('a forgotten password entry exist')
           .withUponReceiving('forgotten password get request')
-          .withResponseBody(validForgottenPasswordResponse.getPactified())
+          .withResponseBody(defaultPactifier.pactify(validForgottenPasswordResponse))
           .build()
       ).then(() => done())
     })
@@ -44,16 +45,16 @@ describe('adminusers client - get forgotten password', function () {
 
     it('should GET a forgotten password entry', function (done) {
       adminusersClient.getForgottenPassword(code).should.be.fulfilled.then(function (forgottenPassword) {
-        expect(forgottenPassword.code).to.be.equal(expectedForgottenPassword.code)
-        expect(forgottenPassword.date).to.be.equal(expectedForgottenPassword.date)
-        expect(forgottenPassword.username).to.be.equal(expectedForgottenPassword.username)
-        expect(forgottenPassword._links.length).to.be.equal(expectedForgottenPassword._links.length)
+        expect(forgottenPassword.code).to.be.equal(validForgottenPasswordResponse.code)
+        expect(forgottenPassword.date).to.be.equal(validForgottenPasswordResponse.date)
+        expect(forgottenPassword.username).to.be.equal(validForgottenPasswordResponse.username)
+        expect(forgottenPassword._links.length).to.be.equal(validForgottenPasswordResponse._links.length)
       }).should.notify(done)
     })
   })
 
   describe('not found', () => {
-    let code = 'non-existent-code'
+    const code = 'non-existent-code'
 
     before((done) => {
       provider.addInteraction(

--- a/test/unit/clients/adminusers-client/user/assign-servicerole.pact.test.js
+++ b/test/unit/clients/adminusers-client/user/assign-servicerole.pact.test.js
@@ -1,10 +1,11 @@
 const { Pact } = require('@pact-foundation/pact')
-let path = require('path')
-let chai = require('chai')
-let chaiAsPromised = require('chai-as-promised')
-let getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
-let userFixtures = require('../../../../fixtures/user.fixtures')
-let PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
+const path = require('path')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
+const userFixtures = require('../../../../fixtures/user.fixtures')
+const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
+const { userResponsePactifier } = require('../../../../test-helpers/pact/pactifier')
 
 chai.use(chaiAsPromised)
 
@@ -17,7 +18,7 @@ const existingUserExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
 const existingServiceExternalId = 'cp5wa'
 
 describe('adminusers client - assign service role to user', function () {
-  let provider = new Pact({
+  const provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
@@ -57,9 +58,9 @@ describe('adminusers client - assign service role to user', function () {
           .withUponReceiving('a valid assign service role request')
           .withState(`a user exists external id ${existingUserExternalId} and a service exists with external id ${existingServiceExternalId}`)
           .withMethod('POST')
-          .withRequestBody(request.getPlain())
+          .withRequestBody(request)
           .withStatusCode(200)
-          .withResponseBody(userFixture.getPactified())
+          .withResponseBody(userResponsePactifier.pactify(userFixture))
           .build()
       ).then(() => done())
         .catch(reason => console.log('PACT SETUP FAILED ' + reason))
@@ -88,7 +89,7 @@ describe('adminusers client - assign service role to user', function () {
         new PactInteractionBuilder(`${USER_PATH}/${nonExistentUserExternalId}/services`)
           .withUponReceiving('a service role request for non existent-user')
           .withMethod('POST')
-          .withRequestBody(request.getPlain())
+          .withRequestBody(request)
           .withStatusCode(404)
           .withResponseHeaders({})
           .build()
@@ -105,8 +106,8 @@ describe('adminusers client - assign service role to user', function () {
   })
 
   describe('assign user service role API - 400 response', () => {
-    let role = 'admin'
-    let serviceExternalId = 'XXXXXXXXXXX-invalid-id'
+    const role = 'admin'
+    const serviceExternalId = 'XXXXXXXXXXX-invalid-id'
     const request = userFixtures.validAssignServiceRoleRequest({
       service_external_id: serviceExternalId,
       role_name: role
@@ -118,7 +119,7 @@ describe('adminusers client - assign service role to user', function () {
           .withUponReceiving('an assign service role request for non existent service')
           .withState(`a user exists external id ${existingUserExternalId} and a service exists with external id ${existingServiceExternalId}`)
           .withMethod('POST')
-          .withRequestBody(request.getPlain())
+          .withRequestBody(request)
           .withStatusCode(400)
           .build()
       ).then(() => done())

--- a/test/unit/clients/adminusers-client/user/get-multiple-users.pact.test.js
+++ b/test/unit/clients/adminusers-client/user/get-multiple-users.pact.test.js
@@ -47,7 +47,7 @@ describe('adminusers client - get users', function () {
       }
     })
 
-    const expectedUsers = userFixtures.validMultipleUserResponse(params)
+    const expectedUsers = userFixtures.validUsersResponse(params)
     const usersPactified = userResponsePactifier.pactifySimpleArray(expectedUsers)
 
     before((done) => {

--- a/test/unit/clients/adminusers-client/user/get-user.pact.test.js
+++ b/test/unit/clients/adminusers-client/user/get-user.pact.test.js
@@ -9,6 +9,7 @@ const chaiAsPromised = require('chai-as-promised')
 const userFixtures = require('../../../../fixtures/user.fixtures')
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
+const { userResponsePactifier } = require('../../../../test-helpers/pact/pactifier')
 
 // constants
 const port = Math.floor(Math.random() * 48127) + 1024
@@ -40,7 +41,7 @@ describe('adminusers client - get user', () => {
         new PactInteractionBuilder(`${USER_PATH}/${existingExternalId}`)
           .withState(`a user exists with the given external id ${existingExternalId}`)
           .withUponReceiving('a valid get user request')
-          .withResponseBody(getUserResponse.getPactified())
+          .withResponseBody(userResponsePactifier.pactify(getUserResponse))
           .build()
       ).then(() => { done() })
     })
@@ -48,19 +49,17 @@ describe('adminusers client - get user', () => {
     afterEach(() => provider.verify())
 
     it('should find a user successfully', done => {
-      const expectedUserData = getUserResponse.getPlain()
-
-      adminusersClient.getUserByExternalId(expectedUserData.external_id).should.be.fulfilled.then(user => {
-        expect(user.externalId).to.be.equal(expectedUserData.external_id)
-        expect(user.username).to.be.equal(expectedUserData.username)
-        expect(user.email).to.be.equal(expectedUserData.email)
+      adminusersClient.getUserByExternalId(getUserResponse.external_id).should.be.fulfilled.then(user => {
+        expect(user.externalId).to.be.equal(getUserResponse.external_id)
+        expect(user.username).to.be.equal(getUserResponse.username)
+        expect(user.email).to.be.equal(getUserResponse.email)
         expect(user.serviceRoles.length).to.be.equal(1)
         expect(user.serviceRoles[0].service.gatewayAccountIds.length).to.be.equal(1)
-        expect(user.telephoneNumber).to.be.equal(expectedUserData.telephone_number)
-        expect(user.otpKey).to.be.equal(expectedUserData.otp_key)
-        expect(user.provisionalOtpKey).to.be.equal(expectedUserData.provisional_otp_key)
-        expect(user.secondFactor).to.be.equal(expectedUserData.second_factor)
-        expect(user.serviceRoles[0].role.permissions.length).to.be.equal(expectedUserData.service_roles[0].role.permissions.length)
+        expect(user.telephoneNumber).to.be.equal(getUserResponse.telephone_number)
+        expect(user.otpKey).to.be.equal(getUserResponse.otp_key)
+        expect(user.provisionalOtpKey).to.be.equal(getUserResponse.provisional_otp_key)
+        expect(user.secondFactor).to.be.equal(getUserResponse.second_factor)
+        expect(user.serviceRoles[0].role.permissions.length).to.be.equal(getUserResponse.service_roles[0].role.permissions.length)
       }).should.notify(done)
     })
   })

--- a/test/unit/clients/adminusers-client/user/increment-session-version.pact.test.js
+++ b/test/unit/clients/adminusers-client/user/increment-session-version.pact.test.js
@@ -1,20 +1,20 @@
 const { Pact } = require('@pact-foundation/pact')
-var path = require('path')
-var chai = require('chai')
-var chaiAsPromised = require('chai-as-promised')
-var getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
-var userFixtures = require('../../../../fixtures/user.fixtures')
-var PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
+const path = require('path')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
+const userFixtures = require('../../../../fixtures/user.fixtures')
+const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 
 chai.use(chaiAsPromised)
 
 const expect = chai.expect
 const USER_PATH = '/v1/api/users'
-var port = Math.floor(Math.random() * 48127) + 1024
-var adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
+const port = Math.floor(Math.random() * 48127) + 1024
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 describe('adminusers client - session', function () {
-  let provider = new Pact({
+  const provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
@@ -28,8 +28,8 @@ describe('adminusers client - session', function () {
   after(() => provider.finalize())
 
   describe('increment session version  API - success', () => {
-    let request = userFixtures.validIncrementSessionVersionRequest()
-    let existingExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
+    const request = userFixtures.validIncrementSessionVersionRequest()
+    const existingExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
 
     before((done) => {
       provider.addInteraction(
@@ -37,7 +37,7 @@ describe('adminusers client - session', function () {
           .withState('a user exists')
           .withUponReceiving('a valid increment session version update request')
           .withMethod('PATCH')
-          .withRequestBody(request.getPactified())
+          .withRequestBody(request)
           .build()
       ).then(() => done())
     })
@@ -50,8 +50,8 @@ describe('adminusers client - session', function () {
   })
 
   describe('increment session version API - user not found', () => {
-    let nonExistentExternalId = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
-    let request = userFixtures.validIncrementSessionVersionRequest()
+    const nonExistentExternalId = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+    const request = userFixtures.validIncrementSessionVersionRequest()
 
     before((done) => {
       provider.addInteraction(
@@ -59,7 +59,7 @@ describe('adminusers client - session', function () {
           .withState('a user does not exist')
           .withUponReceiving('a valid increment session version request')
           .withMethod('PATCH')
-          .withRequestBody(request.getPactified())
+          .withRequestBody(request)
           .withResponseHeaders({})
           .withStatusCode(404)
           .build()

--- a/test/unit/clients/adminusers-client/user/update-password.pact.test.js
+++ b/test/unit/clients/adminusers-client/user/update-password.pact.test.js
@@ -14,7 +14,7 @@ var port = Math.floor(Math.random() * 48127) + 1024
 var adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 describe('adminusers client - update password', function () {
-  let provider = new Pact({
+  const provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
@@ -28,7 +28,7 @@ describe('adminusers client - update password', function () {
   after(() => provider.finalize())
 
   describe('update password for user API - success', () => {
-    let request = userFixtures.validUpdatePasswordRequest('avalidforgottenpasswordtoken')
+    const request = userFixtures.validUpdatePasswordRequest('avalidforgottenpasswordtoken')
 
     before((done) => {
       provider.addInteraction(
@@ -36,7 +36,7 @@ describe('adminusers client - update password', function () {
           .withState('a valid forgotten password entry and a related user exists')
           .withUponReceiving('a valid update password request')
           .withMethod('POST')
-          .withRequestBody(request.getPactified())
+          .withRequestBody(request)
           .withStatusCode(204)
           .withResponseHeaders({})
           .build()
@@ -46,13 +46,12 @@ describe('adminusers client - update password', function () {
     afterEach(() => provider.verify())
 
     it('should update password successfully', function (done) {
-      let requestData = request.getPlain()
-      adminusersClient.updatePasswordForUser(requestData.forgotten_password_code, requestData.new_password).should.be.fulfilled.notify(done)
+      adminusersClient.updatePasswordForUser(request.forgotten_password_code, request.new_password).should.be.fulfilled.notify(done)
     })
   })
 
   describe('update password for user API - not found', () => {
-    let request = userFixtures.validUpdatePasswordRequest()
+    const request = userFixtures.validUpdatePasswordRequest()
 
     before((done) => {
       provider.addInteraction(
@@ -60,7 +59,7 @@ describe('adminusers client - update password', function () {
           .withState('a forgotten password does not exists')
           .withUponReceiving('a valid update password request')
           .withMethod('POST')
-          .withRequestBody(request.getPactified())
+          .withRequestBody(request)
           .withStatusCode(404)
           .build()
       ).then(() => done())
@@ -69,8 +68,7 @@ describe('adminusers client - update password', function () {
     afterEach(() => provider.verify())
 
     it('should error if forgotten password code is not found/expired', function (done) {
-      let requestData = request.getPlain()
-      adminusersClient.updatePasswordForUser(requestData.forgotten_password_code, requestData.new_password).should.be.rejected.then(function (response) {
+      adminusersClient.updatePasswordForUser(request.forgotten_password_code, request.new_password).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(404)
       }).should.notify(done)
     })

--- a/test/unit/clients/adminusers-client/user/update-servicerole.pact.test.js
+++ b/test/unit/clients/adminusers-client/user/update-servicerole.pact.test.js
@@ -1,23 +1,24 @@
 const { Pact } = require('@pact-foundation/pact')
-let path = require('path')
-let chai = require('chai')
-let chaiAsPromised = require('chai-as-promised')
-let getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
-let userFixtures = require('../../../../fixtures/user.fixtures')
-let PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
+const path = require('path')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
+const userFixtures = require('../../../../fixtures/user.fixtures')
+const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
+const { userResponsePactifier } = require('../../../../test-helpers/pact/pactifier')
 
 chai.use(chaiAsPromised)
 
 const expect = chai.expect
 const USER_PATH = '/v1/api/users'
-let port = Math.floor(Math.random() * 48127) + 1024
-let adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
+const port = Math.floor(Math.random() * 48127) + 1024
+const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 const existingUserExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
 const existingServiceExternalId = 'cp5wa'
 
 describe('adminusers client - update user service role', function () {
-  let provider = new Pact({
+  const provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
     port: port,
@@ -31,9 +32,9 @@ describe('adminusers client - update user service role', function () {
   after(() => provider.finalize())
 
   describe('update user service role API - success', () => {
-    let role = 'view-and-refund'
-    let request = userFixtures.validUpdateServiceRoleRequest(role)
-    let userFixture = userFixtures.validUserResponse({
+    const role = 'view-and-refund'
+    const request = userFixtures.validUpdateServiceRoleRequest(role)
+    const userFixture = userFixtures.validUserResponse({
       external_id: existingUserExternalId,
       service_roles: [{
         service: { external_id: existingServiceExternalId },
@@ -47,9 +48,9 @@ describe('adminusers client - update user service role', function () {
           .withState(`a service exists with external id ${existingServiceExternalId} with multiple admin users`)
           .withUponReceiving('a valid update service role request')
           .withMethod('PUT')
-          .withRequestBody(request.getPlain())
+          .withRequestBody(request)
           .withStatusCode(200)
-          .withResponseBody(userFixture.getPactified())
+          .withResponseBody(userResponsePactifier.pactify(userFixture))
           .build()
       ).then(() => done())
     })
@@ -57,8 +58,7 @@ describe('adminusers client - update user service role', function () {
     afterEach(() => provider.verify())
 
     it('should update service role of a user successfully', function (done) {
-      let requestData = request.getPlain()
-      adminusersClient.updateServiceRole(existingUserExternalId, existingServiceExternalId, requestData.role_name).should.be.fulfilled.then(function (updatedUser) {
+      adminusersClient.updateServiceRole(existingUserExternalId, existingServiceExternalId, request.role_name).should.be.fulfilled.then(function (updatedUser) {
         const updatedServiceRole = updatedUser.serviceRoles.find(serviceRole => serviceRole.service.externalId === existingServiceExternalId)
         expect(updatedServiceRole.role.name).to.be.equal(role)
       }).should.notify(done)
@@ -66,16 +66,16 @@ describe('adminusers client - update user service role', function () {
   })
 
   describe('update user service role API - user not found', () => {
-    let role = 'view-and-refund'
-    let request = userFixtures.validUpdateServiceRoleRequest(role)
-    let externalId = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' // non existent external id
+    const role = 'view-and-refund'
+    const request = userFixtures.validUpdateServiceRoleRequest(role)
+    const externalId = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' // non existent external id
 
     before((done) => {
       provider.addInteraction(
         new PactInteractionBuilder(`${USER_PATH}/${externalId}/services/${existingServiceExternalId}`)
           .withUponReceiving('an update service role request for non-existent user')
           .withMethod('PUT')
-          .withRequestBody(request.getPlain())
+          .withRequestBody(request)
           .withStatusCode(404)
           .withResponseHeaders({})
           .build()
@@ -85,16 +85,15 @@ describe('adminusers client - update user service role', function () {
     afterEach(() => provider.verify())
 
     it('should error not found for non existent user when updating service role', function (done) {
-      let requestData = request.getPlain()
-      adminusersClient.updateServiceRole(externalId, existingServiceExternalId, requestData.role_name).should.be.rejected.then(function (response) {
+      adminusersClient.updateServiceRole(externalId, existingServiceExternalId, request.role_name).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(404)
       }).should.notify(done)
     })
   })
 
   describe('update user service role API - user does not belong to service', () => {
-    let role = 'admin'
-    let request = userFixtures.validUpdateServiceRoleRequest(role)
+    const role = 'admin'
+    const request = userFixtures.validUpdateServiceRoleRequest(role)
 
     before((done) => {
       provider.addInteraction(
@@ -102,7 +101,7 @@ describe('adminusers client - update user service role', function () {
           .withState(`a user exists external id ${existingUserExternalId} and a service exists with external id ${existingServiceExternalId}`)
           .withUponReceiving('an update service role request for user that does not belong to service')
           .withMethod('PUT')
-          .withRequestBody(request.getPlain())
+          .withRequestBody(request)
           .withStatusCode(409)
           .build()
       ).then(() => done())
@@ -111,16 +110,15 @@ describe('adminusers client - update user service role', function () {
     afterEach(() => provider.verify())
 
     it('should error conflict if user does not have access to the given service id', function (done) {
-      let requestData = request.getPlain()
-      adminusersClient.updateServiceRole(existingUserExternalId, existingServiceExternalId, requestData.role_name).should.be.rejected.then(function (response) {
+      adminusersClient.updateServiceRole(existingUserExternalId, existingServiceExternalId, request.role_name).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(409)
       }).should.notify(done)
     })
   })
 
   describe('update user service role API - minimum no of admin limit reached', () => {
-    let role = 'view-and-refund'
-    let request = userFixtures.validUpdateServiceRoleRequest(role)
+    const role = 'view-and-refund'
+    const request = userFixtures.validUpdateServiceRoleRequest(role)
 
     before((done) => {
       provider.addInteraction(
@@ -128,7 +126,7 @@ describe('adminusers client - update user service role', function () {
           .withState(`a user exists with external id ${existingUserExternalId} with admin role for service with id ${existingServiceExternalId}`)
           .withUponReceiving('an update service role request with minimum number of admins reached')
           .withMethod('PUT')
-          .withRequestBody(request.getPlain())
+          .withRequestBody(request)
           .withStatusCode(412)
           .build()
       ).then(() => done())
@@ -137,8 +135,7 @@ describe('adminusers client - update user service role', function () {
     afterEach(() => provider.verify())
 
     it('should error precondition failed, if number of remaining admins for the service is going to be less than 1', function (done) {
-      let requestData = request.getPlain()
-      adminusersClient.updateServiceRole(existingUserExternalId, existingServiceExternalId, requestData.role_name).should.be.rejected.then(function (response) {
+      adminusersClient.updateServiceRole(existingUserExternalId, existingServiceExternalId, request.role_name).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(412)
       }).should.notify(done)
     })

--- a/test/unit/controller/billing-address-controller/toggle-billing-address.controller.ft.test.js
+++ b/test/unit/controller/billing-address-controller/toggle-billing-address.controller.ft.test.js
@@ -12,6 +12,7 @@ const userFixtures = require('../../../fixtures/user.fixtures')
 const formatAccountPathsFor = require('../../../../app/utils/format-account-paths-for')
 const paths = require('../../../../app/paths.js')
 const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
+const User = require('../../../../app/models/User.class')
 
 // Constants
 const expect = chai.expect
@@ -47,8 +48,8 @@ describe('Toggle billing address collection controller', () => {
       connectorMock.get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
         .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }).getPlain())
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+        .reply(200, user)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .get(toggleBillingAddressPath)
         .end((err, res) => {
@@ -71,8 +72,8 @@ describe('Toggle billing address collection controller', () => {
       connectorMock.get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
         .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }).getPlain())
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+        .reply(200, user)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .get(toggleBillingAddressPath)
         .end((err, res) => {
@@ -95,13 +96,13 @@ describe('Toggle billing address collection controller', () => {
       connectorMock.get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
         .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }).getPlain())
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
+        .reply(200, user)
       adminusersMock.patch(`${SERVICES_RESOURCE}/${EXTERNAL_SERVICE_ID}`)
         .reply(200, {
           collect_billing_address: false
         })
 
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .post(toggleBillingAddressPath)
         .set('Content-Type', 'application/x-www-form-urlencoded')
@@ -129,13 +130,13 @@ describe('Toggle billing address collection controller', () => {
       connectorMock.get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
         .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }).getPlain())
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
+        .reply(200, user)
       adminusersMock.patch(`${SERVICES_RESOURCE}/${EXTERNAL_SERVICE_ID}`)
         .reply(200, {
           collect_billing_address: false
         })
 
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .post(toggleBillingAddressPath)
         .set('Content-Type', 'application/x-www-form-urlencoded')

--- a/test/unit/controller/edit-merchant-details-controller/get-edit.controller.ft.test.js
+++ b/test/unit/controller/edit-merchant-details-controller/get-edit.controller.ft.test.js
@@ -8,6 +8,7 @@ const supertest = require('supertest')
 const userFixtures = require('../../../fixtures/user.fixtures')
 const paths = require('../../../../app/paths.js')
 const formattedPathFor = require('../../../../app/utils/replace-params-in-path')
+const User = require('../../../../app/models/User.class')
 
 const expect = chai.expect
 const adminusersMock = nock(process.env.ADMINUSERS_URL)
@@ -48,8 +49,8 @@ describe('edit merchant details controller - get', () => {
         email: ''
       })
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+        .reply(200, user)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .get(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
@@ -84,8 +85,8 @@ describe('edit merchant details controller - get', () => {
       })
 
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+        .reply(200, user)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .get(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
@@ -121,8 +122,8 @@ describe('edit merchant details controller - get', () => {
         email: ''
       })
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+        .reply(200, user)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .get(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
@@ -160,8 +161,8 @@ describe('edit merchant details controller - get', () => {
       })
 
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+        .reply(200, user)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .get(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
@@ -201,8 +202,8 @@ describe('edit merchant details controller - get', () => {
       })
 
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+        .reply(200, user)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .get(formattedPathFor(paths.merchantDetails.edit, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
@@ -240,12 +241,12 @@ describe('edit merchant details controller - get', () => {
       const user = buildUserResponse(['20'])
 
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
+        .reply(200, user)
       session = {
         csrfSecret: '123',
         12345: { refunded_amount: 5 },
         passport: {
-          user: user.getAsObject()
+          user: new User(user)
         },
         secondFactor: 'totp',
         last_url: 'last_url',
@@ -324,12 +325,12 @@ describe('edit merchant details controller - get', () => {
     before(done => {
       const user = buildUserResponse(['DIRECT_DEBIT:somerandomidhere'])
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
+        .reply(200, user)
       session = {
         csrfSecret: '123',
         12345: { refunded_amount: 5 },
         passport: {
-          user: user.getAsObject()
+          user: new User(user)
         },
         secondFactor: 'totp',
         last_url: 'last_url',

--- a/test/unit/controller/edit-merchant-details-controller/get-index.controller.ft.test.js
+++ b/test/unit/controller/edit-merchant-details-controller/get-index.controller.ft.test.js
@@ -10,10 +10,11 @@ const getApp = require('../../../../server.js').getApp
 const userFixtures = require('../../../fixtures/user.fixtures')
 const paths = require('../../../../app/paths.js')
 const formattedPathFor = require('../../../../app/utils/replace-params-in-path')
+const User = require('../../../../app/models/User.class')
 const adminusersMock = nock(process.env.ADMINUSERS_URL)
 const USER_RESOURCE = '/v1/api/users'
 
-let response, user, $
+let response, $
 
 describe('Organisation details controller - get', () => {
   afterEach(() => {
@@ -29,7 +30,7 @@ describe('Organisation details controller - get', () => {
 
   describe('when the organisation already has details (CREDIT CARD GATEWAY ACCOUNT)', () => {
     before(done => {
-      user = userFixtures.validUserResponse({
+      const user = userFixtures.validUserResponse({
         service_roles: [{
           service: {
             external_id: EXTERNAL_SERVICE_ID,
@@ -49,8 +50,8 @@ describe('Organisation details controller - get', () => {
         }]
       })
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+        .reply(200, user)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
@@ -93,8 +94,8 @@ describe('Organisation details controller - get', () => {
         }]
       })
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+        .reply(200, user)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
@@ -130,8 +131,8 @@ describe('Organisation details controller - get', () => {
         }]
       })
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+        .reply(200, user)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
@@ -162,8 +163,8 @@ describe('Organisation details controller - get', () => {
         }]
       })
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+        .reply(200, user)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
@@ -195,8 +196,8 @@ describe('Organisation details controller - get', () => {
         }]
       })
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+        .reply(200, user)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
@@ -226,8 +227,8 @@ describe('Organisation details controller - get', () => {
         }]
       })
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+        .reply(200, user)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
         .end((err, res) => {
@@ -257,8 +258,8 @@ describe('Organisation details controller - get', () => {
         }]
       })
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
-        .reply(200, user.getPlain())
-      const app = mockSession.getAppWithLoggedInUser(getApp(), user.getAsObject())
+        .reply(200, user)
+      const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
       supertest(app)
         .get(formattedPathFor(paths.merchantDetails.index, EXTERNAL_SERVICE_ID))
         .end((err, res) => {

--- a/test/unit/controller/payouts/payouts.service.test.js
+++ b/test/unit/controller/payouts/payouts.service.test.js
@@ -1,6 +1,7 @@
 const chai = require('chai')
 const { expect } = chai
 const { groupPayoutsByDate } = require('../../../../app/controllers/payouts/payouts.service')
+const User = require('../../../../app/models/User.class')
 const payoutFixtures = require('../../../fixtures/payout.fixtures')
 const userFixtures = require('../../../fixtures/user.fixtures')
 
@@ -35,11 +36,7 @@ describe('payout service data transforms', () => {
         }])
         .getPlain()
 
-      const user = userFixtures
-        .validUser({
-          gateway_account_ids: [ '300' ]
-        })
-        .getAsObject()
+      const user = new User(userFixtures.validUser({ gateway_account_ids: ['300'] }))
 
       const grouped = groupPayoutsByDate(payouts.results, user)
 

--- a/test/unit/controller/payouts/user-services-names.controller.test.js
+++ b/test/unit/controller/payouts/user-services-names.controller.test.js
@@ -1,15 +1,12 @@
 const chai = require('chai')
 const { expect } = chai
 const { indexServiceNamesByGatewayAccountId } = require('../../../../app/controllers/payouts/user-services-names.controller')
+const User = require('../../../../app/models/User.class')
 const fixtures = require('../../../fixtures/user.fixtures')
 
 describe('user services to gateway account id map utility', () => {
   it('indexes gateway accounts to service names given a valid user object', () => {
-    const user = fixtures
-      .validUser({
-        gateway_account_ids: [ '300' ]
-      })
-      .getAsObject()
+    const user = new User(fixtures.validUser({ gateway_account_ids: [ '300' ] }))
     const serviceNameMap = indexServiceNamesByGatewayAccountId(user)
 
     expect(serviceNameMap['300']).to.equal('System Generated')

--- a/test/unit/controller/service-switch.controller.it.test.js
+++ b/test/unit/controller/service-switch.controller.it.test.js
@@ -6,6 +6,7 @@ const _ = require('lodash')
 const connectorMock = nock(process.env.CONNECTOR_URL)
 const ACCOUNTS_FRONTEND_PATH = '/v1/frontend/accounts'
 const serviceSwitchController = require('../../../app/controllers/my-services')
+const User = require('../../../app/models/User.class')
 const userFixtures = require('../../fixtures/user.fixtures')
 const gatewayAccountFixtures = require('../../fixtures/gateway-account.fixtures')
 const chaiAsPromised = require('chai-as-promised')
@@ -35,7 +36,7 @@ describe('service switch controller: list of accounts', function () {
 
     const req = {
       correlationId: 'correlationId',
-      user: userFixtures.validUserResponse({
+      user: new User(userFixtures.validUserResponse({
         username: 'bob',
         service_roles: [
           {
@@ -86,7 +87,7 @@ describe('service switch controller: list of accounts', function () {
               permissions: [{ name: 'blah-blah:blah' }]
             }
           }]
-      }).getAsObject(),
+      })),
       session: {}
     }
 
@@ -115,10 +116,10 @@ describe('service switch controller: list of accounts', function () {
       .reply(200, { accounts: [] })
 
     const req = {
-      user: userFixtures.validUserResponse({
+      user: new User(userFixtures.validUserResponse({
         username: 'bob',
         service_roles: []
-      }).getAsObject(),
+      })),
       session: {}
     }
 
@@ -143,14 +144,14 @@ describe('service switch controller: switching', function () {
 
     const req = {
       originalUrl: 'http://bob.com?accountId=6',
-      user: userFixtures.validUserResponse({
+      user: new User(userFixtures.validUserResponse({
         username: 'bob',
         service_roles: [{
           service: {
             gateway_account_ids: ['6', '5']
           }
         }]
-      }).getAsObject(),
+      })),
       session: session,
       gateway_account: gatewayAccount,
       body: {
@@ -174,10 +175,10 @@ describe('service switch controller: switching', function () {
 
     const req = {
       originalUrl: 'http://bob.com?accountId=6',
-      user: userFixtures.validUserResponse({
+      user: new User(userFixtures.validUserResponse({
         username: 'bob',
         gateway_account_ids: ['8', '666']
-      }).getAsObject(),
+      })),
       session: session
     }
 
@@ -217,7 +218,7 @@ describe('service switch controller: display added to the new service msg', func
 
     const req = {
       correlationId: 'correlationId',
-      user: userFixtures.validUserResponse({
+      user: new User(userFixtures.validUserResponse({
         username: 'bob',
         service_roles: [
           {
@@ -242,7 +243,7 @@ describe('service switch controller: display added to the new service msg', func
               permissions: [{ name: 'blah-blah:blah' }]
             }
           }]
-      }).getAsObject(),
+      })),
       session: {},
       query: {
         s: newServiceExternalId

--- a/test/unit/controller/stripe-setup/stripe-setup-dashboard-redirect.controller.test.js
+++ b/test/unit/controller/stripe-setup/stripe-setup-dashboard-redirect.controller.test.js
@@ -2,6 +2,7 @@ const sinon = require('sinon')
 const { expect } = require('chai')
 
 const { ConnectorClient } = require('../../../../app/services/clients/connector.client')
+const User = require('../../../../app/models/User.class')
 const { validUser } = require('../../../fixtures/user.fixtures')
 const { validGatewayAccountsResponse } = require('../../../fixtures/gateway-account.fixtures')
 const dashboardRedirectController = require('../../../../app/controllers/stripe-setup/stripe-setup-link/stripe-setup-dashboard-redirect.controller')
@@ -12,7 +13,7 @@ describe('Dashboard redirect controller', () => {
   let accountSpy, res, req
 
   beforeEach(() => {
-    const user = validUser({
+    const user = new User(validUser({
       username: 'valid-user',
       service_roles: [{
         service: {
@@ -20,7 +21,7 @@ describe('Dashboard redirect controller', () => {
           gateway_account_ids: serviceGatewayAccountIds
         }
       }]
-    }).getAsObject()
+    }))
 
     req = {
       correlationId: 'correlationId',

--- a/test/unit/middleware/error-handler.test.js
+++ b/test/unit/middleware/error-handler.test.js
@@ -5,6 +5,7 @@ const proxyquire = require('proxyquire')
 const { expect } = require('chai')
 const { NotAuthenticatedError, UserAccountDisabledError, NotAuthorisedError, NotFoundError, PermissionDeniedError } = require('../../../app/errors')
 const paths = require('../../../app/paths')
+const User = require('../../../app/models/User.class')
 const userFixtures = require('../../fixtures/user.fixtures')
 const serviceFixtures = require('../../fixtures/service.fixtures')
 const gatewayAccountFixtures = require('../../fixtures/gateway-account.fixtures')
@@ -95,7 +96,7 @@ describe('Error handler middleware', () => {
     const gatewayAccountId = 'a-gateway-account-id'
     const reqWithSessionData = {
       ...req,
-      user: userFixtures.validUserResponse({ external_id: userExternalId }).getAsObject(),
+      user: new User(userFixtures.validUserResponse({ external_id: userExternalId })),
       service: serviceFixtures.validServiceResponse({ external_id: serviceExternalId }).getAsObject(),
       account: gatewayAccountFixtures.validGatewayAccountResponse({ gateway_account_id: gatewayAccountId }).getPlain()
     }

--- a/test/unit/middleware/get-service-and-gateway-account.middleware.test.js
+++ b/test/unit/middleware/get-service-and-gateway-account.middleware.test.js
@@ -4,6 +4,7 @@ const path = require('path')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const { expect } = require('chai')
+const User = require('../../../app/models/User.class')
 const userFixtures = require('../../fixtures/user.fixtures')
 const stripeAccountSetupFixture = require('../../fixtures/stripe-account-setup.fixtures')
 
@@ -17,14 +18,14 @@ const connectorMock = {
 }
 
 const buildUser = (serviceExternalId, gatewayAccountIds) => {
-  return userFixtures.validUserResponse({
+  return new User(userFixtures.validUserResponse({
     service_roles: [{
       service: {
         external_id: serviceExternalId,
         gateway_account_ids: gatewayAccountIds
       }
     }]
-  }).getAsObject()
+  }))
 }
 
 const setupGetGatewayAccountAndService = function (gatewayAccountID, gatewayAccountExternalId, paymentProvider, serviceExternalId) {

--- a/test/unit/middleware/has-services.test.js
+++ b/test/unit/middleware/has-services.test.js
@@ -6,6 +6,7 @@ const chai = require('chai')
 const { expect } = chai
 const chaiAsPromised = require('chai-as-promised')
 const paths = require('../../../app/paths')
+const User = require('../../../app/models/User.class')
 const hasServices = require(path.join(__dirname, '/../../../app/middleware/has-services.js'))
 const userFixtures = require('../../fixtures/user.fixtures')
 
@@ -23,10 +24,10 @@ describe('user has services middleware', function () {
   })
 
   it('should call next when user has services', function (done) {
-    const user = userFixtures.validUserResponse({
+    const user = new User(userFixtures.validUserResponse({
       services_roles: [{ service: { external_id: '1' } }],
       external_id: 'external-id'
-    }).getAsObject()
+    }))
 
     const req = { user: user, headers: {} }
 

--- a/test/unit/middleware/permission.test.js
+++ b/test/unit/middleware/permission.test.js
@@ -5,6 +5,7 @@ const { expect } = require('chai')
 
 const getPermissionMiddleware = require('../../../app/middleware/permission')
 const { PermissionDeniedError } = require('../../../app/errors')
+const User = require('../../../app/models/User.class')
 const userFixtures = require('../../fixtures/user.fixtures')
 const serviceFixtures = require('../../fixtures/service.fixtures')
 
@@ -15,7 +16,7 @@ const service = serviceFixtures.validServiceResponse({
   external_id: serviceExternalId
 }).getAsObject()
 
-const userWithPermissionForService = userFixtures.validUserResponse({
+const userWithPermissionForService = new User(userFixtures.validUserResponse({
   service_roles: [{
     service: {
       external_id: serviceExternalId
@@ -24,9 +25,9 @@ const userWithPermissionForService = userFixtures.validUserResponse({
       permissions: [{ name: permission }]
     }
   }]
-}).getAsObject()
+}))
 
-const userWithPermissionForDifferentService = userFixtures.validUserResponse({
+const userWithPermissionForDifferentService = new User(userFixtures.validUserResponse({
   service_roles: [
     {
       service: {
@@ -45,7 +46,7 @@ const userWithPermissionForDifferentService = userFixtures.validUserResponse({
       }
     }
   ]
-}).getAsObject()
+}))
 
 const res = {}
 let next

--- a/test/unit/middleware/resolve-service.test.js
+++ b/test/unit/middleware/resolve-service.test.js
@@ -6,16 +6,17 @@ const { expect } = require('chai')
 
 // Local modules
 const resolveService = require('../../../app/middleware/resolve-service')
+const User = require('../../../app/models/User.class')
 const userFixtures = require('../../fixtures/user.fixtures')
 
 const buildUserWithGatewayAccountIds = (gatewayAccountIds) => {
-  return userFixtures.validUserResponse({
+  return new User(userFixtures.validUserResponse({
     service_roles: [{
       service: {
         gateway_account_ids: gatewayAccountIds
       }
     }]
-  }).getAsObject()
+  }))
 }
 
 describe('resolve service middleware', () => {
@@ -24,7 +25,7 @@ describe('resolve service middleware', () => {
   beforeEach(() => {
     res = { setHeader: sinon.spy(), status: sinon.spy(), render: sinon.spy() }
     nextSpy = sinon.spy()
-    user = userFixtures.validUserResponse().getAsObject()
+    user = new User(userFixtures.validUserResponse())
   })
 
   it('from externalServiceId in path param then remove it', () => {

--- a/test/unit/middleware/user-is-authorised.test.js
+++ b/test/unit/middleware/user-is-authorised.test.js
@@ -4,27 +4,28 @@ const sinon = require('sinon')
 const { expect } = require('chai')
 const { NotAuthorisedError, NotAuthenticatedError, UserAccountDisabledError } = require('../../../app/errors')
 const userIsAuthorised = require('../../../app/middleware/user-is-authorised')
+const User = require('../../../app/models/User.class')
 const userFixtures = require('../../fixtures/user.fixtures')
 const serviceFixtures = require('../../fixtures/service.fixtures')
 
 const serviceExternalId = 'a-service-external-id'
 const sessionVersion = 1
 const loggedInSession = { version: sessionVersion, secondFactor: 'totp' }
-const authorisedUser = userFixtures.validUserResponse({
+const authorisedUser = new User(userFixtures.validUserResponse({
   session_version: sessionVersion,
   service_roles: [{
     service: {
       external_id: serviceExternalId
     }
   }]
-}).getAsObject()
+}))
 
-const userWithoutServiceRole = userFixtures.validUserResponse({
+const userWithoutServiceRole = new User(userFixtures.validUserResponse({
   session_version: sessionVersion,
   service_roles: [{
     service: { external_id: 'some-other-service-id' }
   }]
-}).getAsObject()
+}))
 
 const service = serviceFixtures.validServiceResponse({
   external_id: serviceExternalId
@@ -73,7 +74,7 @@ describe('User is authorised middleware', () => {
       it('should call next with error', () => {
         const req = {
           session: { version: 1 },
-          user: userFixtures.validUserResponse({ session_version: 2 }).getAsObject(),
+          user: new User(userFixtures.validUserResponse({ session_version: 2 })),
           params: {}
         }
 
@@ -109,7 +110,7 @@ describe('User is authorised middleware', () => {
         }
         const req = {
           session: loggedInSession,
-          user: userFixtures.validUserResponse(userOpts).getAsObject(),
+          user: new User(userFixtures.validUserResponse(userOpts)),
           params: {}
         }
 

--- a/test/unit/models/User.class.test.js
+++ b/test/unit/models/User.class.test.js
@@ -9,7 +9,7 @@ let user, service, result, permission, role
 
 describe('Class: User', () => {
   before(() => {
-    user = new User(userFixtures.validUserResponse().getPlain())
+    user = new User(userFixtures.validUserResponse())
     service = user.serviceRoles[0].service
     permission = user.serviceRoles[0].role.permissions[0].name
     role = user.serviceRoles[0].role
@@ -66,13 +66,13 @@ describe('Class: User', () => {
   describe('is internal user', () => {
     it('should return false', () => {
       process.env.GDS_INTERNAL_USER_EMAIL_DOMAIN = '@example.org'
-      user = new User(userFixtures.validUserResponse().getPlain())
+      user = new User(userFixtures.validUserResponse())
       result = user.internalUser
       expect(result).to.equal(false)
     })
     it('should return true', function () {
       process.env.GDS_INTERNAL_USER_EMAIL_DOMAIN = '@example.com'
-      user = new User(userFixtures.validUserResponse().getPlain())
+      user = new User(userFixtures.validUserResponse())
       result = user.internalUser
       expect(result).to.equal(true)
     })
@@ -107,7 +107,7 @@ describe('Class: User', () => {
       }]
     }
     it('should return the number of live services', function () {
-      user = new User(userFixtures.validUserResponse(opts).getPlain())
+      user = new User(userFixtures.validUserResponse(opts))
       result = user.numberOfLiveServices
       expect(result).to.equal(2)
     })

--- a/test/unit/utils/permissions.test.js
+++ b/test/unit/utils/permissions.test.js
@@ -3,6 +3,7 @@ const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
 const { ConnectorClient } = require('../../../app/services/clients/connector.client')
+const User = require('../../../app/models/User.class')
 
 const { validUser } = require('../../fixtures/user.fixtures')
 const { validGatewayAccountResponse } = require('../../fixtures/gateway-account.fixtures')
@@ -14,7 +15,7 @@ describe('gateway account filter utiltiies', () => {
       const opts = {
         gateway_account_ids: ['1', '2', '3']
       }
-      const user = validUser(opts).getAsObject()
+      const user = new User(validUser(opts))
       const valid = userServicesContainsGatewayAccount('2', user)
       expect(valid).to.equal(true)
     })
@@ -22,7 +23,7 @@ describe('gateway account filter utiltiies', () => {
       const opts = {
         gateway_account_ids: ['1', '2', '3']
       }
-      const user = validUser(opts).getAsObject()
+      const user = new User(validUser(opts))
       const valid = userServicesContainsGatewayAccount('4', user)
       expect(valid).to.equal(false)
     })
@@ -33,7 +34,7 @@ describe('gateway account filter utiltiies', () => {
     const opts = {
       gateway_account_ids: ['1', '2', '3']
     }
-    const user = validUser(opts).getAsObject()
+    const user = new User(validUser(opts))
 
     beforeEach(() => {
       accountSpy = sinon.stub(ConnectorClient.prototype, 'getAccounts').callsFake(() => Promise.resolve({ accounts: [] }))


### PR DESCRIPTION
Remove dependency on `pact-base` which depends on the npm module `@pact-foundation/pact/`

Use the `pactifier` utility to pactify any responses in pact test constructed using the fixtures.

Any request objects used in pact tests don't need to be pactified, so just use the raw fixture response here.

Replace usages of `getAsObject()` with using the constructor for the `User` model.

Calls to `getPlain()` for the fixtures are removed as the fixtures now return a plain object.

## Notes

I've ran and compared the pacts generated after these change and there were a few differences due to us not pactifying requests, but other than that they're all generated the same.
