### PR TITLE
PP-7588 Remove pact dependency from account and card type fixtures

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2020-12-21T16:39:58Z",
+  "generated_at": "2020-12-21T18:08:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -189,7 +189,7 @@
         "hashed_secret": "cca5ec6518072e9005bd723123ec52b8e978a448",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16,
+        "line_number": 10,
         "type": "Hex High Entropy String"
       }
     ],

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -137,18 +137,18 @@ module.exports = {
   getGatewayAccountSuccess: (opts = {}) => {
     const path = '/v1/frontend/accounts/' + opts.gateway_account_id
     return simpleStubBuilder('GET', path, 200, {
-      response: gatewayAccountFixtures.validGatewayAccountResponse(opts).getPlain()
+      response: gatewayAccountFixtures.validGatewayAccountResponse(opts)
     })
   },
   getGatewayAccountByExternalIdSuccess: (opts = {}) => {
     const path = '/v1/api/accounts/external-id/' + opts.external_id
     return simpleStubBuilder('GET', path, 200, {
-      response: gatewayAccountFixtures.validGatewayAccountResponse(opts).getPlain()
+      response: gatewayAccountFixtures.validGatewayAccountResponse(opts)
     })
   },
   getGatewayAccountSuccessRepeat: (opts = {}) => {
-    const aValidGetGatewayAccountResponse = gatewayAccountFixtures.validGatewayAccountResponse(opts[0]).getPlain()
-    const aDifferentValidGetGatewayAccountResponse = gatewayAccountFixtures.validGatewayAccountResponse(opts[1]).getPlain()
+    const aValidGetGatewayAccountResponse = gatewayAccountFixtures.validGatewayAccountResponse(opts[0])
+    const aDifferentValidGetGatewayAccountResponse = gatewayAccountFixtures.validGatewayAccountResponse(opts[1])
     return [
       {
         predicates: [{
@@ -233,37 +233,37 @@ module.exports = {
       query: {
         accountIds: opts.gateway_account_id.toString()
       },
-      response: gatewayAccountFixtures.validGatewayAccountsResponse({ accounts: [opts] }).getPlain()
+      response: gatewayAccountFixtures.validGatewayAccountsResponse({ accounts: [opts] })
     })
   },
   getDirectDebitGatewayAccountSuccess: (opts = {}) => {
     const path = '/v1/api/accounts/' + opts.gateway_account_id
     return simpleStubBuilder('GET', path, 200, {
-      response: gatewayAccountFixtures.validDirectDebitGatewayAccountResponse(opts).getPlain()
+      response: gatewayAccountFixtures.validDirectDebitGatewayAccountResponse(opts)
     })
   },
   getAccountAuthSuccess: (opts = {}) => {
     const path = '/v1/frontend/auth/' + opts.gateway_account_id
     return simpleStubBuilder('GET', path, 200, {
-      response: gatewayAccountFixtures.validGatewayAccountTokensResponse(opts).getPlain()
+      response: gatewayAccountFixtures.validGatewayAccountTokensResponse(opts)
     })
   },
   patchAccountEmailCollectionModeSuccess: (opts = {}) => {
     const path = '/v1/api/accounts/' + opts.gateway_account_id
     return simpleStubBuilder('PATCH', path, 200, {
-      request: gatewayAccountFixtures.validGatewayAccountEmailCollectionModeRequest(opts.collectionMode).getPlain()
+      request: gatewayAccountFixtures.validGatewayAccountEmailCollectionModeRequest(opts.collectionMode)
     })
   },
   patchConfirmationEmailToggleSuccess: (opts = {}) => {
     const path = `/v1/api/accounts/${opts.gateway_account_id}/email-notification`
     return simpleStubBuilder('PATCH', path, 200, {
-      request: gatewayAccountFixtures.validGatewayAccountEmailConfirmationToggleRequest(opts.enabled).getPlain()
+      request: gatewayAccountFixtures.validGatewayAccountEmailConfirmationToggleRequest(opts.enabled)
     })
   },
   patchRefundEmailToggleSuccess: (opts = {}) => {
     const path = `/v1/api/accounts/${opts.gateway_account_id}/email-notification`
     return simpleStubBuilder('PATCH', path, 200, {
-      request: gatewayAccountFixtures.validGatewayAccountEmailRefundToggleRequest(opts.enabled).getPlain()
+      request: gatewayAccountFixtures.validGatewayAccountEmailRefundToggleRequest(opts.enabled)
     })
   },
   postUserAuthenticateSuccess: (opts = {}) => {
@@ -354,20 +354,20 @@ module.exports = {
   getCardTypesSuccess: () => {
     const path = '/v1/api/card-types'
     return simpleStubBuilder('GET', path, 200, {
-      response: cardFixtures.validCardTypesResponse().getPlain()
+      response: cardFixtures.validCardTypesResponse()
     })
   },
   getAcceptedCardTypesSuccess: opts => {
     const path = `/v1/frontend/accounts/${opts.account_id}/card-types`
     const response = opts.updated
-      ? cardFixtures.validUpdatedAcceptedCardTypesResponse().getPlain()
-      : cardFixtures.validAcceptedCardTypesResponse(opts).getPlain()
+      ? cardFixtures.validUpdatedAcceptedCardTypesResponse()
+      : cardFixtures.validAcceptedCardTypesResponse(opts)
     return simpleStubBuilder('GET', path, 200, { response: response })
   },
   getAcceptedCardsForAccountSuccess: opts => {
     const path = `/v1/frontend/accounts/${opts.account_id}/card-types`
     return simpleStubBuilder('GET', path, 200, {
-      response: cardFixtures.validUpdatedAcceptedCardTypesResponse().getPlain()
+      response: cardFixtures.validUpdatedAcceptedCardTypesResponse()
     })
   },
   patchUpdateServiceGoLiveStageSuccess: (opts = {}) => {
@@ -542,8 +542,8 @@ module.exports = {
   postCreateGatewayAccountSuccess: (opts = {}) => {
     const path = '/v1/api/accounts'
     return simpleStubBuilder('POST', path, 200, {
-      request: gatewayAccountFixtures.validCreateGatewayAccountRequest(opts).getPlain(),
-      response: gatewayAccountFixtures.validGatewayAccountResponse(opts).getPlain(),
+      request: gatewayAccountFixtures.validCreateGatewayAccountRequest(opts),
+      response: gatewayAccountFixtures.validGatewayAccountResponse(opts),
       verifyCalledTimes: opts.verifyCalledTimes
     })
   },

--- a/test/fixtures/card.fixtures.js
+++ b/test/fixtures/card.fixtures.js
@@ -1,14 +1,8 @@
 'use strict'
 
-const path = require('path')
-
-// Global setup
-const pactBase = require(path.join(__dirname, '/pact-base'))
-const pactRegister = pactBase()
-
 module.exports = {
   validCardTypesResponse: () => {
-    let data = {
+    return {
       card_types: [{
         id: 'a1200c73-204d-45f5-8fca-e4ee5ed1b1a7',
         brand: 'visa',
@@ -71,15 +65,6 @@ module.exports = {
         requires3ds: true
       }]
     }
-
-    return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
-    }
   },
   validAcceptedCardTypesResponse: opts => {
     let data = {
@@ -126,17 +111,10 @@ module.exports = {
       })
     }
 
-    return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
-    }
+    return data
   },
   validUpdatedAcceptedCardTypesResponse: () => {
-    let data = {
+    return {
       card_types: [{
         id: 'a1200c73-204d-45f5-8fca-e4ee5ed1b1a7',
         brand: 'visa',
@@ -174,15 +152,6 @@ module.exports = {
         type: 'CREDIT',
         requires3ds: false
       }]
-    }
-
-    return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
     }
   }
 }

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -1,12 +1,5 @@
 'use strict'
 
-const path = require('path')
-const _ = require('lodash')
-
-// Global setup
-const pactBase = require(path.join(__dirname, '/pact-base'))
-const pactRegister = pactBase()
-
 function validGatewayAccount (opts) {
   const gatewayAccount = {
     payment_provider: opts.payment_provider || 'sandbox',
@@ -66,71 +59,35 @@ function validGatewayAccount (opts) {
 
 module.exports = {
   validGatewayAccountPatchRequest: (opts = {}) => {
-    const data = {
+    return {
       op: 'replace',
       path: opts.path,
       value: opts.value
     }
-
-    return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
   },
   validGatewayAccountEmailRefundToggleRequest: (enabled = true) => {
-    const data = {
+    return {
       op: 'replace',
       path: '/refund/enabled',
       value: enabled
     }
-
-    return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
   },
   validGatewayAccountEmailConfirmationToggleRequest: (enabled = true) => {
-    const data = {
+    return {
       op: 'replace',
       path: '/confirmation/enabled',
       value: enabled
     }
-
-    return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
   },
   validGatewayAccountEmailCollectionModeRequest: (collectionMode = 'MANDATORY') => {
-    const data = {
+    return {
       op: 'replace',
       path: 'email_collection_mode',
       value: collectionMode
     }
-
-    return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
   },
   validGatewayAccountTokensResponse: (opts = {}) => {
-    let data = {
+    return {
       tokens:
         [{
           issued_date: opts.issued_date || '03 Sep 2018 - 10:05',
@@ -141,60 +98,24 @@ module.exports = {
           created_by: opts.created_by || 'System generated'
         }]
     }
-
-    return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
-    }
   },
   validGatewayAccountResponse: (opts = {}) => {
-    let data = validGatewayAccount(opts)
-
-    return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
-    }
+    return validGatewayAccount(opts)
   },
   validGatewayAccountsResponse: (opts = {}) => {
     const accounts = opts.accounts.map(validGatewayAccount)
-    let data = {
-      accounts: accounts
-    }
-
     return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
+      accounts: accounts
     }
   },
   validDirectDebitGatewayAccountResponse: (opts = {}) => {
-    const data = {
+    return {
       gateway_account_id: opts.gateway_account_id || 73,
       gateway_account_external_id: opts.gateway_account_external_id || 'DIRECT_DEBIT:' + 'a9c797ab271448bdba21359e15672076',
       payment_provider: opts.payment_provider || 'sandbox',
       type: opts.type || 'test',
       analytics_id: opts.analytics_id || 'd82dae5bcb024828bb686574a932b5a5',
       is_connected: opts.is_connected || false
-    }
-
-    return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
     }
   },
   validCreateGatewayAccountRequest: (opts = {}) => {
@@ -207,14 +128,6 @@ module.exports = {
     if (opts.analytics_id) {
       data.analytics_id = opts.analytics_id
     }
-
-    return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
+    return data
   }
 }

--- a/test/integration/add-psp-details.ft.test.js
+++ b/test/integration/add-psp-details.ft.test.js
@@ -35,7 +35,7 @@ describe('Add stripe psp details route', function () {
           gateway_account_id: GATEWAY_ACCOUNT_ID,
           payment_provider: 'stripe',
           type: 'live'
-        }).getPlain())
+        }))
 
       connectorMock
         .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/stripe-setup`)

--- a/test/integration/self-registration/self-registration-otp-verify.ft.test.js
+++ b/test/integration/self-registration/self-registration-otp-verify.ft.test.js
@@ -76,7 +76,7 @@ describe('create service otp validation', function () {
       const mockConnectorCreateGatewayAccountResponse =
         gatewayAccountFixtures.validGatewayAccountResponse({
           gateway_account_id: gatewayAccountId
-        }).getPlain()
+        })
       const mockAdminUsersInviteCompleteRequest =
         inviteFixtures.validInviteCompleteRequest({
           gateway_account_ids: [gatewayAccountId]

--- a/test/integration/service-registration.service.it.test.js
+++ b/test/integration/service-registration.service.it.test.js
@@ -34,7 +34,7 @@ describe('create populated service', function () {
     const mockConnectorCreateGatewayAccountResponse =
       gatewayAccountFixtures.validGatewayAccountResponse({
         gateway_account_id: gatewayAccountId
-      }).getPlain()
+      })
     const mockAdminUsersInviteCompleteRequest =
       inviteFixtures.validInviteCompleteRequest({
         gateway_account_ids: [gatewayAccountId]
@@ -85,7 +85,7 @@ describe('create populated service', function () {
     const mockConnectorCreateGatewayAccountResponse =
       gatewayAccountFixtures.validGatewayAccountResponse({
         gateway_account_id: gatewayAccountId
-      }).getPlain()
+      })
     const mockAdminUsersInviteCompleteRequest =
       inviteFixtures.validInviteCompleteRequest({
         gateway_account_ids: [gatewayAccountId]
@@ -113,7 +113,7 @@ describe('create populated service', function () {
     const mockConnectorCreateGatewayAccountResponse =
       gatewayAccountFixtures.validGatewayAccountResponse({
         gateway_account_id: gatewayAccountId
-      }).getPlain()
+      })
     const mockAdminUsersInviteCompleteRequest =
       inviteFixtures.validInviteCompleteRequest({
         gateway_account_ids: [gatewayAccountId]

--- a/test/integration/stripe-setup-dashboard-redirect.controller.it.test.js
+++ b/test/integration/stripe-setup-dashboard-redirect.controller.it.test.js
@@ -28,7 +28,7 @@ describe('Service dashboard redirect to live account controller', function () {
       }]
     })
     connectorMock.get('/v1/frontend/accounts?accountIds=540')
-      .reply(200, accountsResponse.getPlain())
+      .reply(200, accountsResponse)
   })
 
   it('correctly redirects to the dashboard page', () => {

--- a/test/unit/clients/adminusers-client/invite/invite-user.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/invite-user.pact.test.js
@@ -1,10 +1,10 @@
 const { Pact } = require('@pact-foundation/pact')
-var path = require('path')
-var chai = require('chai')
-var chaiAsPromised = require('chai-as-promised')
-var getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
-var inviteFixtures = require('../../../../fixtures/invite.fixtures')
-var PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
+const path = require('path')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
+const inviteFixtures = require('../../../../fixtures/invite.fixtures')
+const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 
 chai.use(chaiAsPromised)
 
@@ -14,8 +14,8 @@ const port = Math.floor(Math.random() * 48127) + 1024
 const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 describe('adminusers client - invite user', function () {
-  let externalServiceId = '12345'
-  let provider = new Pact({
+  const externalServiceId = '12345'
+  const provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
     port: port,
@@ -29,10 +29,10 @@ describe('adminusers client - invite user', function () {
   after(() => provider.finalize())
 
   describe('success', function () {
-    let validInvite = inviteFixtures.validInviteRequest({ externalServiceId: externalServiceId })
+    const validInvite = inviteFixtures.validInviteRequest({ externalServiceId: externalServiceId })
 
     before((done) => {
-      let pactified = validInvite.getPactified()
+      const pactified = validInvite.getPactified()
       provider.addInteraction(
         new PactInteractionBuilder(`${INVITES_PATH}`)
           .withUponReceiving('a valid user invite user request')
@@ -48,7 +48,7 @@ describe('adminusers client - invite user', function () {
     afterEach(() => provider.verify())
 
     it('should create a invite successfully', function (done) {
-      let invite = validInvite.getPlain()
+      const invite = validInvite.getPlain()
 
       adminusersClient.inviteUser(invite.email, invite.sender, externalServiceId, invite.role_name).should.be.fulfilled.then(function (inviteResponse) {
         expect(inviteResponse.email).to.be.equal(invite.email)
@@ -57,11 +57,11 @@ describe('adminusers client - invite user', function () {
   })
 
   describe('not found', () => {
-    let nonExistentServiceId = '111111'
-    let validInvite = inviteFixtures.validInviteRequest({ externalServiceId: nonExistentServiceId })
+    const nonExistentServiceId = '111111'
+    const validInvite = inviteFixtures.validInviteRequest({ externalServiceId: nonExistentServiceId })
 
     before((done) => {
-      let pactified = validInvite.getPactified()
+      const pactified = validInvite.getPactified()
       provider.addInteraction(
         new PactInteractionBuilder(`${INVITES_PATH}`)
           .withUponReceiving('a valid user invite user request for a non-existent service')
@@ -76,7 +76,7 @@ describe('adminusers client - invite user', function () {
     afterEach(() => provider.verify())
 
     it('should return not found', function (done) {
-      let invite = validInvite.getPlain()
+      const invite = validInvite.getPlain()
 
       adminusersClient.inviteUser(invite.email, invite.sender, nonExistentServiceId, invite.role_name).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(404)
@@ -85,11 +85,11 @@ describe('adminusers client - invite user', function () {
   })
 
   describe('bad request', () => {
-    let invalidInvite = inviteFixtures.invalidInviteRequest({ externalServiceId: externalServiceId })
-    let errorResponse = inviteFixtures.invalidInviteCreateResponseWhenFieldsMissing()
+    const invalidInvite = inviteFixtures.invalidInviteRequest({ externalServiceId: externalServiceId })
+    const errorResponse = inviteFixtures.invalidInviteCreateResponseWhenFieldsMissing()
 
     before((done) => {
-      let pactified = invalidInvite.getPactified()
+      const pactified = invalidInvite.getPactified()
 
       provider.addInteraction(
         new PactInteractionBuilder(`${INVITES_PATH}`)
@@ -107,7 +107,7 @@ describe('adminusers client - invite user', function () {
     afterEach(() => provider.verify())
 
     it('should return bad request', function (done) {
-      let invite = invalidInvite.getPlain()
+      const invite = invalidInvite.getPlain()
 
       adminusersClient.inviteUser(invite.email, invite.sender, externalServiceId, invite.role_name).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(400)
@@ -118,11 +118,11 @@ describe('adminusers client - invite user', function () {
   })
 
   describe('conflicting request', () => {
-    let validInvite = inviteFixtures.validInviteRequest({ externalServiceId: externalServiceId })
-    let errorResponse = inviteFixtures.conflictingInviteResponseWhenEmailUserAlreadyCreated(validInvite.getPlain().email).getPactified()
+    const validInvite = inviteFixtures.validInviteRequest({ externalServiceId: externalServiceId })
+    const errorResponse = inviteFixtures.conflictingInviteResponseWhenEmailUserAlreadyCreated(validInvite.getPlain().email).getPactified()
 
     before((done) => {
-      let pactified = validInvite.getPactified()
+      const pactified = validInvite.getPactified()
 
       provider.addInteraction(
         new PactInteractionBuilder(`${INVITES_PATH}`)
@@ -139,7 +139,7 @@ describe('adminusers client - invite user', function () {
     afterEach(() => provider.verify())
 
     it('should return conflict', function (done) {
-      let invite = validInvite.getPlain()
+      const invite = validInvite.getPlain()
 
       adminusersClient.inviteUser(invite.email, invite.sender, externalServiceId, invite.role_name).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(409)
@@ -150,11 +150,11 @@ describe('adminusers client - invite user', function () {
   })
 
   describe('not permitted', () => {
-    let validInvite = inviteFixtures.validInviteRequest({ externalServiceId: externalServiceId })
-    let errorResponse = inviteFixtures.notPermittedInviteResponse(validInvite.getPlain().email, externalServiceId)
+    const validInvite = inviteFixtures.validInviteRequest({ externalServiceId: externalServiceId })
+    const errorResponse = inviteFixtures.notPermittedInviteResponse(validInvite.getPlain().email, externalServiceId)
 
     before((done) => {
-      let pactified = validInvite.getPactified()
+      const pactified = validInvite.getPactified()
 
       provider.addInteraction(
         new PactInteractionBuilder(`${INVITES_PATH}`)
@@ -171,7 +171,7 @@ describe('adminusers client - invite user', function () {
     afterEach(() => provider.verify())
 
     it('should return not permitted', function (done) {
-      let invite = validInvite.getPlain()
+      const invite = validInvite.getPlain()
 
       adminusersClient.inviteUser(invite.email, invite.sender, externalServiceId, invite.role_name).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(403)

--- a/test/unit/clients/connector-client/connector-client-create-gateway-account.pact.test.js
+++ b/test/unit/clients/connector-client/connector-client-create-gateway-account.pact.test.js
@@ -36,12 +36,11 @@ describe('connector client - create gateway account', function () {
     const validCreateGatewayAccountRequest = gatewayAccountFixtures.validCreateGatewayAccountRequest()
 
     before((done) => {
-      const pactified = validCreateGatewayAccountRequest.getPactified()
       provider.addInteraction(
         new PactInteractionBuilder(ACCOUNTS_RESOURCE)
           .withUponReceiving('a valid create gateway account request')
           .withMethod('POST')
-          .withRequestBody(pactified)
+          .withRequestBody(validCreateGatewayAccountRequest)
           .withStatusCode(201)
           .build()
       )
@@ -52,12 +51,11 @@ describe('connector client - create gateway account', function () {
     afterEach(() => provider.verify())
 
     it('should submit create gateway account successfully', function (done) {
-      const createGatewayAccount = validCreateGatewayAccountRequest.getPlain()
       connectorClient.createGatewayAccount(
-        createGatewayAccount.payment_provider,
-        createGatewayAccount.type,
-        createGatewayAccount.service_name,
-        createGatewayAccount.analytics_id
+        validCreateGatewayAccountRequest.payment_provider,
+        validCreateGatewayAccountRequest.type,
+        validCreateGatewayAccountRequest.service_name,
+        validCreateGatewayAccountRequest.analytics_id
       ).should.be.fulfilled.should.notify(done)
     })
   })
@@ -71,12 +69,11 @@ describe('connector client - create gateway account', function () {
     }
 
     before((done) => {
-      const pactified = invalidCreateGatewayAccountRequest.getPactified()
       provider.addInteraction(
         new PactInteractionBuilder(ACCOUNTS_RESOURCE)
           .withUponReceiving('an invalid create gateway account request')
           .withMethod('POST')
-          .withRequestBody(pactified)
+          .withRequestBody(invalidCreateGatewayAccountRequest)
           .withStatusCode(400)
           .withResponseBody(errorResponse)
           .build()
@@ -88,12 +85,11 @@ describe('connector client - create gateway account', function () {
     afterEach(() => provider.verify())
 
     it('should return 400 on missing fields', function (done) {
-      const createGatewayAccount = invalidCreateGatewayAccountRequest.getPlain()
       connectorClient.createGatewayAccount(
-        createGatewayAccount.payment_provider,
-        createGatewayAccount.type,
-        createGatewayAccount.service_name,
-        createGatewayAccount.analytics_id
+        invalidCreateGatewayAccountRequest.payment_provider,
+        invalidCreateGatewayAccountRequest.type,
+        invalidCreateGatewayAccountRequest.service_name,
+        invalidCreateGatewayAccountRequest.analytics_id
       ).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(400)
         expect(response.message).to.deep.equal(errorResponse)

--- a/test/unit/clients/connector-client/connector-get-card-types.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-card-types.pact.test.js
@@ -8,6 +8,7 @@ const path = require('path')
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient
 const cardFixtures = require('../../../fixtures/card.fixtures')
+const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPactifier
 
 // Constants
 const CARD_TYPES_RESOURCE = '/v1/api/card-types'
@@ -36,14 +37,13 @@ describe('connector client', function () {
     const validCardTypesResponse = cardFixtures.validCardTypesResponse()
 
     before((done) => {
-      const pactified = validCardTypesResponse.getPactified()
       provider.addInteraction(
         new PactInteractionBuilder(`${CARD_TYPES_RESOURCE}`)
           .withUponReceiving('a valid card types request')
           .withState('Card types exist in the database')
           .withMethod('GET')
           .withStatusCode(200)
-          .withResponseBody(pactified)
+          .withResponseBody(pactify(validCardTypesResponse))
           .build()
       ).then(() => done())
         .catch(done)
@@ -52,7 +52,7 @@ describe('connector client', function () {
     afterEach(() => provider.verify())
 
     it('should get card types successfully', function (done) {
-      const getCardTypes = validCardTypesResponse.getPlain()
+      const getCardTypes = validCardTypesResponse
       connectorClient.getAllCardTypes((connectorData, connectorResponse) => {
         expect(connectorResponse.body).to.deep.equal(getCardTypes)
         done()

--- a/test/unit/clients/connector-client/connector-get-gateway-account.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-gateway-account.pact.test.js
@@ -8,6 +8,7 @@ const path = require('path')
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient
 const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
+const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPactifier
 
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/frontend/accounts'
@@ -45,7 +46,7 @@ describe('connector client - get gateway account', function () {
           .withUponReceiving('a valid get gateway account request')
           .withState(`User ${existingGatewayAccountId} exists in the database`)
           .withMethod('GET')
-          .withResponseBody(validGetGatewayAccountResponse.getPactified())
+          .withResponseBody(pactify(validGetGatewayAccountResponse))
           .withStatusCode(200)
           .build()
       )
@@ -56,14 +57,13 @@ describe('connector client - get gateway account', function () {
     afterEach(() => provider.verify())
 
     it('should get gateway account successfully', function (done) {
-      const getGatewayAccount = validGetGatewayAccountResponse.getPlain()
       const params = {
         gatewayAccountId: existingGatewayAccountId,
         correlationId: null
       }
       connectorClient.getAccount(params)
         .should.be.fulfilled.then((response) => {
-          expect(response).to.deep.equal(getGatewayAccount)
+          expect(response).to.deep.equal(validGetGatewayAccountResponse)
         }).should.notify(done)
     })
   })

--- a/test/unit/clients/connector-client/connector-get-multiple-gateway-accounts.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-multiple-gateway-accounts.pact.test.js
@@ -8,6 +8,7 @@ const path = require('path')
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient
 const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
+const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPactifier
 
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/frontend/accounts'
@@ -47,7 +48,7 @@ describe('connector client - get multiple gateway accounts', function () {
           .withState('gateway accounts with ids 111, 222 exist in the database')
           .withMethod('GET')
           .withQuery('accountIds', '111,222')
-          .withResponseBody(validGetGatewayAccountsResponse.getPactified())
+          .withResponseBody(pactify(validGetGatewayAccountsResponse))
           .withStatusCode(200)
           .build()
       )
@@ -58,10 +59,9 @@ describe('connector client - get multiple gateway accounts', function () {
     afterEach(() => provider.verify())
 
     it('should get multiple gateway accounts successfully', function (done) {
-      const getGatewayAccounts = validGetGatewayAccountsResponse.getPlain()
       connectorClient.getAccounts({ gatewayAccountIds: [111, 222], correlationId: null })
         .should.be.fulfilled.then((response) => {
-          expect(response).to.deep.equal(getGatewayAccounts)
+          expect(response).to.deep.equal(validGetGatewayAccountsResponse)
         }).should.notify(done)
     })
   })

--- a/test/unit/clients/connector-client/connector-patch-apple-pay-toggle.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-apple-pay-toggle.pact.test.js
@@ -21,7 +21,7 @@ chai.use(chaiAsPromised)
 
 describe('connector client - patch apple pay toggle (enabled) request', () => {
   const patchRequestParams = { path: 'allow_apple_pay', value: true }
-  const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams).getPlain()
+  const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams)
 
   let provider = new Pact({
     consumer: 'selfservice',

--- a/test/unit/clients/connector-client/connector-patch-email-collection-mode.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-email-collection-mode.pact.test.js
@@ -45,7 +45,7 @@ describe('connector client - patch email collection mode', function () {
           .withUponReceiving('a valid patch email collection mode (mandatory) request')
           .withState(defaultState)
           .withMethod('PATCH')
-          .withRequestBody(validGatewayAccountEmailCollectionModeRequest.getPactified())
+          .withRequestBody(validGatewayAccountEmailCollectionModeRequest)
           .withStatusCode(200)
           .build()
       )
@@ -58,7 +58,7 @@ describe('connector client - patch email collection mode', function () {
     it('should set email collection mode to mandatory', function (done) {
       const params = {
         gatewayAccountId: existingGatewayAccountId,
-        payload: validGatewayAccountEmailCollectionModeRequest.getPlain()
+        payload: validGatewayAccountEmailCollectionModeRequest
       }
       connectorClient.updateEmailCollectionMode(params, (connectorData, connectorResponse) => {
         expect(connectorResponse.statusCode).to.equal(200)
@@ -77,7 +77,7 @@ describe('connector client - patch email collection mode', function () {
           .withUponReceiving('a valid patch email collection mode (optional) request')
           .withState(defaultState)
           .withMethod('PATCH')
-          .withRequestBody(validGatewayAccountEmailCollectionModeRequest.getPactified())
+          .withRequestBody(validGatewayAccountEmailCollectionModeRequest)
           .withStatusCode(200)
           .build()
       )
@@ -90,7 +90,7 @@ describe('connector client - patch email collection mode', function () {
     it('should set email collection mode to optional', function (done) {
       const params = {
         gatewayAccountId: existingGatewayAccountId,
-        payload: validGatewayAccountEmailCollectionModeRequest.getPlain()
+        payload: validGatewayAccountEmailCollectionModeRequest
       }
       connectorClient.updateEmailCollectionMode(params, (connectorData, connectorResponse) => {
         expect(connectorResponse.statusCode).to.equal(200)
@@ -109,7 +109,7 @@ describe('connector client - patch email collection mode', function () {
           .withUponReceiving('a valid patch email collection mode (off) request')
           .withState(`Gateway account ${existingGatewayAccountId} exists in the database`)
           .withMethod('PATCH')
-          .withRequestBody(validGatewayAccountEmailCollectionModeRequest.getPactified())
+          .withRequestBody(validGatewayAccountEmailCollectionModeRequest)
           .withStatusCode(200)
           .build()
       )
@@ -122,7 +122,7 @@ describe('connector client - patch email collection mode', function () {
     it('should set email collection mode to mandatory', function (done) {
       const params = {
         gatewayAccountId: existingGatewayAccountId,
-        payload: validGatewayAccountEmailCollectionModeRequest.getPlain()
+        payload: validGatewayAccountEmailCollectionModeRequest
       }
       connectorClient.updateEmailCollectionMode(params, (connectorData, connectorResponse) => {
         expect(connectorResponse.statusCode).to.equal(200)

--- a/test/unit/clients/connector-client/connector-patch-email-confirmation-toggle.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-email-confirmation-toggle.pact.test.js
@@ -44,7 +44,7 @@ describe('connector client - patch email confirmation toggle', function () {
           .withUponReceiving('a valid patch email confirmation toggle (enabled) request')
           .withState(defaultState)
           .withMethod('PATCH')
-          .withRequestBody(validGatewayAccountEmailConfirmationToggleRequest.getPactified())
+          .withRequestBody(validGatewayAccountEmailConfirmationToggleRequest)
           .withStatusCode(200)
           .build()
       )
@@ -57,7 +57,7 @@ describe('connector client - patch email confirmation toggle', function () {
     it('should toggle successfully', function (done) {
       const params = {
         gatewayAccountId: existingGatewayAccountId,
-        payload: validGatewayAccountEmailConfirmationToggleRequest.getPlain()
+        payload: validGatewayAccountEmailConfirmationToggleRequest
       }
       connectorClient.updateConfirmationEmailEnabled(params, (connectorData, connectorResponse) => {
         expect(connectorResponse.statusCode).to.equal(200)

--- a/test/unit/clients/connector-client/connector-patch-email-refund-toggle.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-email-refund-toggle.pact.test.js
@@ -44,7 +44,7 @@ describe('connector client - patch email refund toggle', function () {
           .withUponReceiving('a valid patch email refund toggle (enabled) request')
           .withState(defaultState)
           .withMethod('PATCH')
-          .withRequestBody(validGatewayAccountEmailRefundToggleRequest.getPactified())
+          .withRequestBody(validGatewayAccountEmailRefundToggleRequest)
           .withStatusCode(200)
           .build()
       )
@@ -57,7 +57,7 @@ describe('connector client - patch email refund toggle', function () {
     it('should toggle successfully', function (done) {
       const params = {
         gatewayAccountId: existingGatewayAccountId,
-        payload: validGatewayAccountEmailRefundToggleRequest.getPlain()
+        payload: validGatewayAccountEmailRefundToggleRequest
       }
       connectorClient.updateRefundEmailEnabled(params, (connectorData, connectorResponse) => {
         expect(connectorResponse.statusCode).to.equal(200)

--- a/test/unit/clients/connector-client/connector-patch-google-pay-toggle.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-google-pay-toggle.pact.test.js
@@ -21,7 +21,7 @@ chai.use(chaiAsPromised)
 
 describe('connector client - patch google pay toggle (enabled) request', () => {
   const patchRequestParams = { path: 'allow_google_pay', value: true }
-  const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams).getPlain()
+  const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams)
 
   let provider = new Pact({
     consumer: 'selfservice',

--- a/test/unit/clients/connector-client/connector-patch-integration-version-3ds.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-integration-version-3ds.pact.test.js
@@ -37,7 +37,7 @@ describe('Update 3DS integration version', () => {
 
   describe('Update 3DS integration version to 1', () => {
     const patchRequestParams = { path: 'integration_version_3ds', value: 1 }
-    const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams).getPlain()
+    const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams)
 
     before(() => {
       return provider.addInteraction(
@@ -62,7 +62,7 @@ describe('Update 3DS integration version', () => {
 
   describe('Update 3DS integration version to 2', () => {
     const patchRequestParams = { path: 'integration_version_3ds', value: 2 }
-    const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams).getPlain()
+    const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams)
 
     before(() => {
       return provider.addInteraction(

--- a/test/unit/clients/connector-client/connector-patch-moto-mask-card-number.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-moto-mask-card-number.pact.test.js
@@ -21,7 +21,7 @@ chai.use(chaiAsPromised)
 
 describe('connector client - patch MOTO mask card number toggle (enabled) request', () => {
   const patchRequestParams = { path: 'moto_mask_card_number_input', value: true }
-  const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams).getPlain()
+  const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams)
 
   let provider = new Pact({
     consumer: 'selfservice',

--- a/test/unit/clients/connector-client/connector-patch-moto-mask-security-code.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-moto-mask-security-code.pact.test.js
@@ -22,7 +22,7 @@ chai.use(chaiAsPromised)
 
 describe('connector client - patch MOTO mask security code toggle (enabled) request', () => {
   const patchRequestParams = { path: 'moto_mask_card_security_code_input', value: true }
-  const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams).getPlain()
+  const request = gatewayAccountFixtures.validGatewayAccountPatchRequest(patchRequestParams)
 
   let provider = new Pact({
     consumer: 'selfservice',

--- a/test/unit/clients/direct-debit-connector-client/get-direct-debit-gateway-account.pact.test.js
+++ b/test/unit/clients/direct-debit-connector-client/get-direct-debit-gateway-account.pact.test.js
@@ -7,6 +7,7 @@ const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
 const { PactInteractionBuilder } = require('../../../fixtures/pact-interaction-builder')
 const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
+const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPactifier
 const getDirectDebitConnectorClient = require('../../../../app/services/clients/direct-debit-connector.client2')
 const GatewayAccount = require('../../../../app/models/DirectDebitGatewayAccount.class')
 
@@ -45,7 +46,7 @@ describe('connector client - get gateway account', function () {
           .withUponReceiving('a valid get gateway account request')
           .withState(`Direct Debit gateway account with id ${existingDirectDebitGatewayAccountId} exists in the database`)
           .withMethod('GET')
-          .withResponseBody(validGetGatewayAccountResponse.getPactified())
+          .withResponseBody(pactify(validGetGatewayAccountResponse))
           .withStatusCode(200)
           .build()
       )
@@ -56,7 +57,7 @@ describe('connector client - get gateway account', function () {
     afterEach(() => provider.verify())
 
     it('should get gateway account successfully', function (done) {
-      const gatewayAccount = new GatewayAccount(validGetGatewayAccountResponse.getPlain())
+      const gatewayAccount = new GatewayAccount(validGetGatewayAccountResponse)
       const params = {
         gatewayAccountId: existingDirectDebitGatewayAccountId,
         correlationId: null

--- a/test/unit/clients/publicauth-client/get-tokens.pact.test.js
+++ b/test/unit/clients/publicauth-client/get-tokens.pact.test.js
@@ -14,6 +14,7 @@ process.env.PUBLIC_AUTH_URL = `http://localhost:${port}${TOKENS_PATH}`
 const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
 const publicauthClient = require('../../../../app/services/clients/public-auth.client')
 const PactInteractionBuilder = require('../../../fixtures/pact-interaction-builder').PactInteractionBuilder
+const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPactifier
 
 chai.use(chaiAsPromised)
 
@@ -43,7 +44,7 @@ describe('publicauth client - get tokens', function () {
         new PactInteractionBuilder(`${TOKENS_PATH}/${params.accountId}`)
           .withState(`Gateway account ${params.accountId} exists in the database`)
           .withUponReceiving('a valid service auth request')
-          .withResponseBody(getServiceAuthResponse.getPactified())
+          .withResponseBody(pactify(getServiceAuthResponse))
           .build()
       ).then(() => { done() })
     })
@@ -51,10 +52,8 @@ describe('publicauth client - get tokens', function () {
     afterEach(() => provider.verify())
 
     it('should return service tokens information successfully', function (done) {
-      const expectedTokensData = getServiceAuthResponse.getPlain()
-
       publicauthClient.getActiveTokensForAccount(params).then(function (tokens) {
-        expect(tokens).to.deep.equal(expectedTokensData)
+        expect(tokens).to.deep.equal(getServiceAuthResponse)
         done()
       })
     })

--- a/test/unit/controller/billing-address-controller/toggle-billing-address.controller.ft.test.js
+++ b/test/unit/controller/billing-address-controller/toggle-billing-address.controller.ft.test.js
@@ -46,7 +46,7 @@ describe('Toggle billing address collection controller', () => {
     before(done => {
       user = buildUserWithCollectBillingAddress(true)
       connectorMock.get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
-        .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }).getPlain())
+        .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }))
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user)
       const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
@@ -70,7 +70,7 @@ describe('Toggle billing address collection controller', () => {
     before(done => {
       user = buildUserWithCollectBillingAddress(false)
       connectorMock.get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
-        .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }).getPlain())
+        .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }))
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user)
       const app = mockSession.getAppWithLoggedInUser(getApp(), new User(user))
@@ -94,7 +94,7 @@ describe('Toggle billing address collection controller', () => {
     before(done => {
       user = buildUserWithCollectBillingAddress(true)
       connectorMock.get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
-        .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }).getPlain())
+        .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }))
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user)
       adminusersMock.patch(`${SERVICES_RESOURCE}/${EXTERNAL_SERVICE_ID}`)
@@ -128,7 +128,7 @@ describe('Toggle billing address collection controller', () => {
     before(done => {
       user = buildUserWithCollectBillingAddress(false)
       connectorMock.get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
-        .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }).getPlain())
+        .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }))
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user)
       adminusersMock.patch(`${SERVICES_RESOURCE}/${EXTERNAL_SERVICE_ID}`)

--- a/test/unit/controller/dashboard/dashboard-activity.controller.ft.test.js
+++ b/test/unit/controller/dashboard/dashboard-activity.controller.ft.test.js
@@ -34,7 +34,7 @@ const mockConnectorGetGatewayAccount = (paymentProvider, type) => {
       gateway_account_id: GATEWAY_ACCOUNT_ID,
       payment_provider: paymentProvider,
       type: type
-    }).getPlain())
+    }))
 }
 
 const mockConnectorGetStripeSetup = (bankAccount, responsiblePerson, vatNumber, companyNumber) => {

--- a/test/unit/controller/payment-links/post-edit.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-edit.controller.ft.test.js
@@ -43,7 +43,7 @@ describe('POST edit payment link controller', () => {
   let result, session, app
   before('Arrange', () => {
     connectorMock.get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-      .reply(200, validGatewayAccountResponse({ gateway_account_id: GATEWAY_ACCOUNT_ID }).getPlain())
+      .reply(200, validGatewayAccountResponse({ gateway_account_id: GATEWAY_ACCOUNT_ID }))
     productsMock.patch(`/v1/api/gateway-account/${GATEWAY_ACCOUNT_ID}/products/${PRODUCT_EXTERNAL_ID}`).reply(200, PAYMENT_1)
     session = getMockSession(VALID_USER)
     session.editPaymentLinkData = {

--- a/test/unit/controller/service-switch.controller.it.test.js
+++ b/test/unit/controller/service-switch.controller.it.test.js
@@ -31,7 +31,7 @@ describe('service switch controller: list of accounts', function () {
           gateway_account_id: iter,
           service_name: `account ${iter}`,
           type: _.sample(['test', 'live'])
-        }).getPlain())
+        }))
       })
 
     const req = {
@@ -210,7 +210,7 @@ describe('service switch controller: display added to the new service msg', func
           gateway_account_id: iter,
           service_name: `account ${iter}`,
           type: _.sample(['test', 'live'])
-        }).getPlain())
+        }))
       })
 
     const newServiceName = 'My New Service'

--- a/test/unit/controller/stripe-setup/stripe-setup-dashboard-redirect.controller.test.js
+++ b/test/unit/controller/stripe-setup/stripe-setup-dashboard-redirect.controller.test.js
@@ -45,7 +45,7 @@ describe('Dashboard redirect controller', () => {
         payment_provider: 'stripe',
         type: 'live'
       }]
-    }).getPlain()
+    })
     accountSpy = sinon.stub(ConnectorClient.prototype, 'getAccounts').callsFake(() => gatewayAccountResponse)
 
     await dashboardRedirectController(req, res)
@@ -69,7 +69,7 @@ describe('Dashboard redirect controller', () => {
       accounts: [{
         gateway_account_id: '2'
       }]
-    }).getPlain()
+    })
     accountSpy = sinon.stub(ConnectorClient.prototype, 'getAccounts').callsFake(() => gatewayAccountResponse)
 
     await dashboardRedirectController(req, res)
@@ -87,7 +87,7 @@ describe('Dashboard redirect controller', () => {
         gateway_account_id: '5',
         type: 'live'
       }]
-    }).getPlain()
+    })
     accountSpy = sinon.stub(ConnectorClient.prototype, 'getAccounts').callsFake(() => gatewayAccountResponse)
 
     await dashboardRedirectController(req, res)

--- a/test/unit/middleware/error-handler.test.js
+++ b/test/unit/middleware/error-handler.test.js
@@ -99,7 +99,7 @@ describe('Error handler middleware', () => {
       ...req,
       user: new User(userFixtures.validUserResponse({ external_id: userExternalId })),
       service: new Service(serviceFixtures.validServiceResponse({ external_id: serviceExternalId })),
-      account: gatewayAccountFixtures.validGatewayAccountResponse({ gateway_account_id: gatewayAccountId }).getPlain()
+      account: gatewayAccountFixtures.validGatewayAccountResponse({ gateway_account_id: gatewayAccountId })
     }
     const expectedLogContext = {
       'x_request_id': correlationId,

--- a/test/unit/services/service.service.test.js
+++ b/test/unit/services/service.service.test.js
@@ -34,7 +34,7 @@ const getGatewayAccounts = function () {
             gateway_account_id: iter,
             service_name: `account ${iter}`,
             type: _.sample(['test', 'live'])
-          }).getPlain())
+          }))
         })
       })
     }

--- a/test/unit/utils/permissions.test.js
+++ b/test/unit/utils/permissions.test.js
@@ -50,10 +50,10 @@ describe('gateway account filter utiltiies', () => {
                 accounts: [
                   validGatewayAccountResponse({
                     payment_provider: 'stripe'
-                  }).getPlain(),
+                  }),
                   validGatewayAccountResponse({
                     allow_moto: true
-                  }).getPlain()
+                  })
                 ]
               }
             }
@@ -73,7 +73,7 @@ describe('gateway account filter utiltiies', () => {
             async getAccounts () {
               return {
                 accounts: [
-                  validGatewayAccountResponse().getPlain()
+                  validGatewayAccountResponse()
                 ]
               }
             }
@@ -96,15 +96,15 @@ describe('gateway account filter utiltiies', () => {
                   validGatewayAccountResponse({
                     gateway_account_id: '1',
                     type: 'live'
-                  }).getPlain(),
+                  }),
                   validGatewayAccountResponse({
                     gateway_account_id: '2',
                     type: 'test'
-                  }).getPlain(),
+                  }),
                   validGatewayAccountResponse({
                     gateway_account_id: '3',
                     type: 'live'
-                  }).getPlain()
+                  })
                 ]
               }
             }


### PR DESCRIPTION
Remove dependency on pact-base which depends on the npm module @pact-foundation/pact/ from `card.fixtures.js` and `gateway-account.fixtures,js`.

Use the pactifier utility to pactify any responses in pact test constructed using the fixtures.

Calls to getPlain() for the fixtures are removed as the fixtures now return a plain object