### PR TITLE
PP-7588 Remove pact dependency from some more fixtures

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -198,14 +198,14 @@
         "hashed_secret": "c2326bf719e924050321d3adb8d8d3a99723ee95",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 161,
+        "line_number": 80,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "e5a7431b27dbc70d00c5ed873bd4d837bd65720c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 177,
+        "line_number": 87,
         "type": "Hex High Entropy String"
       }
     ],
@@ -359,7 +359,7 @@
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 90,
+        "line_number": 89,
         "type": "Hex High Entropy String"
       }
     ],

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -131,7 +131,7 @@ module.exports = {
       query: {
         serviceId: opts.serviceExternalId
       },
-      response: inviteFixtures.validListInvitesResponse(opts.invites).getPlain()
+      response: inviteFixtures.validListInvitesResponse(opts.invites)
     })
   },
   getGatewayAccountSuccess: (opts = {}) => {
@@ -395,14 +395,14 @@ module.exports = {
   postGovUkPayAgreement: (opts) => {
     const path = `/v1/api/services/${opts.external_id}/govuk-pay-agreement`
     return simpleStubBuilder('POST', path, 201, {
-      request: goLiveRequestFixtures.validPostGovUkPayAgreementRequest(opts).getPlain(),
-      response: goLiveRequestFixtures.validPostGovUkPayAgreementResponse(opts).getPlain()
+      request: goLiveRequestFixtures.validPostGovUkPayAgreementRequest(opts),
+      response: goLiveRequestFixtures.validPostGovUkPayAgreementResponse(opts)
     })
   },
   postStripeAgreementIpAddress: (opts) => {
     const path = `/v1/api/services/${opts.external_id}/stripe-agreement`
     return simpleStubBuilder('POST', path, 201, {
-      request: goLiveRequestFixtures.validPostStripeAgreementRequest(opts).getPlain(),
+      request: goLiveRequestFixtures.validPostStripeAgreementRequest(opts),
       responseHeaders: {}
     })
   },

--- a/test/fixtures/go-live-requests.fixture.js
+++ b/test/fixtures/go-live-requests.fixture.js
@@ -1,63 +1,24 @@
 'use strict'
 
-const path = require('path')
-const _ = require('lodash')
-
-const pactBase = require(path.join(__dirname, '/pact-base'))
 const utils = require('../cypress/utils/request-to-go-live-utils')
 
-// Global setup
-const pactServices = pactBase({ array: ['service_ids'] })
-
 module.exports = {
-  validPostGovUkPayAgreementRequest: opts => {
-    opts = opts || {}
-
-    const data = {
-      user_external_id: opts.user_external_id || utils.variables.userExternalId
-    }
-
+  validPostGovUkPayAgreementRequest: (opts = {}) => {
     return {
-      getPactified: () => {
-        return pactServices.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
+      user_external_id: opts.user_external_id || utils.variables.userExternalId
     }
   },
 
-  validPostGovUkPayAgreementResponse: opts => {
-    opts = opts || {}
-    const data = {
+  validPostGovUkPayAgreementResponse: (opts = {}) => {
+    return {
       email: opts.email || 'someone@example.org',
       agreement_time: opts.agreementTime || '2019-02-13T11:11:16.878Z'
     }
-
-    return {
-      getPactified: () => {
-        return pactServices.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
   },
 
-  validPostStripeAgreementRequest: opts => {
-    opts = opts || {}
-
-    const data = {
-      ip_address: opts.ip_address || '93.184.216.34'
-    }
-
+  validPostStripeAgreementRequest: (opts = {}) => {
     return {
-      getPactified: () => {
-        return pactServices.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
+      ip_address: opts.ip_address || '93.184.216.34'
     }
   }
 }

--- a/test/fixtures/invite.fixtures.js
+++ b/test/fixtures/invite.fixtures.js
@@ -2,11 +2,6 @@
 
 const _ = require('lodash')
 
-const pactBase = require('./pact-base')
-
-// Global setup
-const pactInvites = pactBase()
-
 function buildInviteWithDefaults (opts) {
   const data = _.defaults(opts, {
     type: 'user',
@@ -29,95 +24,32 @@ function buildInviteWithDefaults (opts) {
 module.exports = {
 
   validInviteRequest: (opts = {}) => {
-    const invitee = 'random@example.com'
-    const senderId = '94b3d61ebb624a6aa6598b96b307ec8c'
-    const role = { name: 'admin' }
-
-    const data = {
-      service_external_id: opts.externalServiceId || '2f1920ea261946bface3c89ddb0a9033',
-      email: opts.email || invitee,
-      sender: opts.sender || senderId,
-      role_name: opts.role_name || role
-    }
-
     return {
-      getPactified: () => {
-        return pactInvites.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
+      service_external_id: opts.externalServiceId || '2f1920ea261946bface3c89ddb0a9033',
+      email: opts.email || 'random@example.com',
+      sender: opts.sender || '94b3d61ebb624a6aa6598b96b307ec8c', // pragma: allowlist secret
+      role_name: opts.role_name || 'admin'
     }
   },
 
   validInviteResponse: (opts = {}) => {
-    const data = buildInviteWithDefaults(opts)
-
-    return {
-      getPactified: () => {
-        return pactInvites.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
+    return buildInviteWithDefaults(opts)
   },
 
   validListInvitesResponse: (opts = []) => {
-    const data = opts.map(buildInviteWithDefaults)
-
-    return {
-      getPactified: () => {
-        return pactInvites.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
-  },
-
-  invalidInviteRequest: (opts = {}) => {
-    const senderId = 'e6bbf9a1633044d7aa7700b51d6de373'
-    const role = { name: 'admin' }
-
-    const data = {
-      service_external_id: opts.externalServiceId,
-      email: opts.email || '',
-      sender: opts.sender || senderId,
-      role_name: opts.role_name || role
-    }
-
-    return {
-      getPactified: () => {
-        return pactInvites.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
-    }
+    return opts.map(buildInviteWithDefaults)
   },
 
   notPermittedInviteResponse: (userName, serviceId) => {
-    const response = {
+    return {
       errors: ['user [' + userName + '] not authorised to perform operation [invite] in service [' + serviceId + ']']
     }
-
-    return pactInvites.withPactified(response)
   },
 
   validRegistrationRequest: (opts = {}) => {
-    const data = {
+    return {
       telephone_number: opts.telephone_number || '12345678901',
       password: opts.password || 'password1234'
-    }
-
-    return {
-      getPactified: () => {
-        return pactInvites.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
     }
   },
 
@@ -125,66 +57,35 @@ module.exports = {
     const responseData = _.map(missingFields, (field) => {
       return `Field [${field}] is required`
     })
-    const response = {
+    return {
       errors: responseData
     }
-
-    return pactInvites.withPactified(response)
   },
 
   invalidInviteCreateResponseWhenFieldsMissing: () => {
-    const response = {
+    return {
       // At the moment to discuss Failfast approach to the API rather than error collection
       errors: ['Field [email] is required']
     }
-
-    return pactInvites.withPactified(response)
   },
 
   conflictingInviteResponseWhenEmailUserAlreadyCreated: (email) => {
-    const response = {
-      errors: ['invite with email [' + email + '] already exists']
-    }
-
     return {
-      getPactified: () => {
-        return pactInvites.withPactified(response)
-      },
-      getPlain: () => {
-        return response
-      }
+      errors: ['invite with email [' + email + '] already exists']
     }
   },
 
   validVerifyOtpCodeRequest: (opts = {}) => {
-    const data = {
+    return {
       code: opts.code || 'a0fd0284f5a64a248fd148fb26b3d93c',
       otp: opts.otp || '123456'
-    }
-
-    return {
-      getPactified: () => {
-        return pactInvites.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
     }
   },
 
   validResendOtpCodeRequest: (opts = {}) => {
-    const data = {
+    return {
       code: opts.code || '1e1579ebf2b74981b1261913e4b69e06',
       telephone_number: opts.telephone_number || '01234567891'
-    }
-
-    return {
-      getPactified: () => {
-        return pactInvites.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
     }
   },
 
@@ -192,36 +93,18 @@ module.exports = {
     opts = opts || {}
 
     const gatewayAccountIds = opts.gateway_account_ids || []
-    const data = {
-      gateway_account_ids: gatewayAccountIds
-    }
-
     return {
-      getPactified: () => {
-        return pactInvites.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
+      gateway_account_ids: gatewayAccountIds
     }
   },
 
   validInviteCompleteResponse: (opts = {}) => {
     const invite = buildInviteWithDefaults(opts.invite)
 
-    const data = {
+    return {
       invite,
       user_external_id: opts.user_external_id || '0e167175cd194333844fc415131aa5da',
       service_external_id: opts.service_external_id || '6a149c10cf86493e977fdf6765382f65'
-    }
-
-    return {
-      getPactified: () => {
-        return pactInvites.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
     }
   },
 
@@ -229,17 +112,8 @@ module.exports = {
     const responseData = _.map(nonNumericGatewayAccountIds, (field) => {
       return `Field [${field}] must contain numeric values`
     })
-    const response = {
-      errors: responseData
-    }
-
     return {
-      getPactified: () => {
-        return pactInvites.pactify(response)
-      },
-      getPlain: () => {
-        return _.clone(response)
-      }
+      errors: responseData
     }
   }
 

--- a/test/fixtures/self-register.fixtures.js
+++ b/test/fixtures/self-register.fixtures.js
@@ -1,82 +1,22 @@
 'use strict'
 
-const path = require('path')
 const _ = require('lodash')
-
-const pactBase = require(path.join(__dirname, '/pact-base'))
-
-// Global setup
-const pactRegister = pactBase()
-
-function validPassword () {
-  return 'G0VUkPay2017Rocks'
-}
 
 module.exports = {
 
   validRegisterRequest: (opts = {}) => {
-    const register = 'random@example.com'
-
-    const data = {
-      email: opts.email || register,
-      telephone_number: opts.telephone_number || '07912345678',
-      password: opts.password || validPassword()
-    }
-
     return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
+      email: opts.email || 'random@example.com',
+      telephone_number: opts.telephone_number || '07912345678',
+      password: opts.password || 'G0VUkPay2017Rocks'
     }
   },
 
   invalidEmailRegisterRequest: (opts = {}) => {
-    const data = {
+    return {
       email: opts.email || '',
       telephone_number: opts.telephone_number || '07912345678',
       password: opts.password || 'ndjcnwjk8789e3'
-    }
-
-    return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
-  },
-
-  validServiceNameRequest: (opts = {}) => {
-    const data = {
-      service_name: opts.service_name || 'My Service name'
-    }
-
-    return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
-    }
-  },
-
-  invalidServiceNameRequest: (opts = {}) => {
-    const data = {
-      service_name: opts.service_name || ''
-    }
-
-    return {
-      getPactified: () => {
-        return pactRegister.pactify(data)
-      },
-      getPlain: () => {
-        return _.clone(data)
-      }
     }
   },
 
@@ -84,11 +24,9 @@ module.exports = {
     const responseData = _.map(missingFields, (field) => {
       return `Field [${field}] is required`
     })
-    const response = {
+    return {
       errors: responseData
     }
-
-    return pactRegister.withPactified(response)
   }
 
 }

--- a/test/integration/invite-users.controller.ft.test.js
+++ b/test/integration/invite-users.controller.ft.test.js
@@ -43,7 +43,7 @@ describe('invite user controller', function () {
     it('should invite a new team member successfully', function (done) {
       const validInvite = inviteFixtures.validInviteRequest()
       adminusersMock.post(INVITE_RESOURCE)
-        .reply(201, inviteFixtures.validInviteResponse(validInvite.getPlain()))
+        .reply(201, inviteFixtures.validInviteResponse(validInvite))
       const app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       supertest(app)
@@ -64,7 +64,7 @@ describe('invite user controller', function () {
     it('should error if the user is already invited/exists', function (done) {
       const existingUser = 'existing-user@example.com'
       adminusersMock.post(INVITE_RESOURCE)
-        .reply(412, inviteFixtures.conflictingInviteResponseWhenEmailUserAlreadyCreated(existingUser).getPlain())
+        .reply(412, inviteFixtures.conflictingInviteResponseWhenEmailUserAlreadyCreated(existingUser))
       const app = session.getAppWithLoggedInUser(getApp(), userInSession)
 
       supertest(app)

--- a/test/integration/invite-validation.controller.ft.test.js
+++ b/test/integration/invite-validation.controller.ft.test.js
@@ -40,7 +40,7 @@ describe('Invite validation tests', () => {
         type,
         user_exist: false
       }
-      const validInviteResponse = inviteFixtures.validInviteResponse(opts).getPlain()
+      const validInviteResponse = inviteFixtures.validInviteResponse(opts)
 
       adminusersMock.get(`${INVITE_RESOURCE_PATH}/${code}`)
         .reply(200, validInviteResponse)
@@ -64,7 +64,7 @@ describe('Invite validation tests', () => {
         type,
         user_exist: true
       }
-      const validInviteResponse = inviteFixtures.validInviteResponse(opts).getPlain()
+      const validInviteResponse = inviteFixtures.validInviteResponse(opts)
 
       adminusersMock.get(`${INVITE_RESOURCE_PATH}/${code}`)
         .reply(200, validInviteResponse)
@@ -90,7 +90,7 @@ describe('Invite validation tests', () => {
         telephone_number: telephoneNumber,
         user_exist: false
       }
-      const validInviteResponse = inviteFixtures.validInviteResponse(opts).getPlain()
+      const validInviteResponse = inviteFixtures.validInviteResponse(opts)
 
       adminusersMock.get(`${INVITE_RESOURCE_PATH}/${code}`)
         .reply(200, validInviteResponse)
@@ -116,7 +116,7 @@ describe('Invite validation tests', () => {
         type,
         user_exist: true
       }
-      const validInviteResponse = inviteFixtures.validInviteResponse(opts).getPlain()
+      const validInviteResponse = inviteFixtures.validInviteResponse(opts)
 
       adminusersMock.get(`${INVITE_RESOURCE_PATH}/${code}`)
         .reply(200, validInviteResponse)
@@ -132,7 +132,7 @@ describe('Invite validation tests', () => {
     it('should redirect to register with telephone number, if user did not complete previous attempt after entering registration details', done => {
       const code = '7s8ftgw76rwgu'
       const telephoneNumber = '+441134960000'
-      const validInviteResponse = inviteFixtures.validInviteResponse({ telephone_number: telephoneNumber }).getPlain()
+      const validInviteResponse = inviteFixtures.validInviteResponse({ telephone_number: telephoneNumber })
 
       adminusersMock.get(`${INVITE_RESOURCE_PATH}/${code}`)
         .reply(200, validInviteResponse)

--- a/test/integration/self-registration/self-registration-create-user-account.ft.test.js
+++ b/test/integration/self-registration/self-registration-create-user-account.ft.test.js
@@ -54,9 +54,7 @@ describe('create service otp validation', function () {
   })
 
   it('should redirect to confirmation page on successful registration', function (done) {
-    const validServiceRegistrationRequest = selfRegisterFixtures.validRegisterRequest()
-
-    const request = validServiceRegistrationRequest.getPlain()
+    const request = selfRegisterFixtures.validRegisterRequest()
     adminusersMock.post(`${SERVICE_INVITE_RESOURCE}`, request)
       .reply(201)
 
@@ -75,9 +73,8 @@ describe('create service otp validation', function () {
   })
 
   it('should redirect to register page if user input invalid', function (done) {
-    const invalidServiceRegistrationRequest = selfRegisterFixtures.invalidEmailRegisterRequest()
+    const request = selfRegisterFixtures.invalidEmailRegisterRequest()
 
-    const request = invalidServiceRegistrationRequest.getPlain()
     let session = {}
     app = mockSession.getAppWithLoggedOutSession(getApp(), session)
     supertest(app)

--- a/test/integration/self-registration/self-registration-otp-resend.ft.test.js
+++ b/test/integration/self-registration/self-registration-otp-resend.ft.test.js
@@ -40,7 +40,7 @@ describe('create service otp resend validation', function () {
 
   describe('post to otp resend page', function () {
     it('should redirect to otp verify page on valid telephone number submission', function (done) {
-      const validServiceInviteOtpResendRequestPlain = inviteFixtures.validResendOtpCodeRequest().getPlain()
+      const validServiceInviteOtpResendRequestPlain = inviteFixtures.validResendOtpCodeRequest()
       const registerInviteData = {
         code: validServiceInviteOtpResendRequestPlain.code,
         telephone_number: validServiceInviteOtpResendRequestPlain.telephone_number,
@@ -64,7 +64,7 @@ describe('create service otp resend validation', function () {
 
     it('should ignore cookie telephone number', function (done) {
       const submittedTelephoneNumber = '07451234567'
-      const validServiceInviteOtpResendRequestPlain = inviteFixtures.validResendOtpCodeRequest().getPlain()
+      const validServiceInviteOtpResendRequestPlain = inviteFixtures.validResendOtpCodeRequest()
       const registerInviteData = {
         code: validServiceInviteOtpResendRequestPlain.code,
         telephone_number: validServiceInviteOtpResendRequestPlain.telephone_number,
@@ -92,7 +92,7 @@ describe('create service otp resend validation', function () {
     })
 
     it('should return error when register_invite cookie not present', function (done) {
-      const validServiceInviteOtpResendRequestPlain = inviteFixtures.validResendOtpCodeRequest().getPlain()
+      const validServiceInviteOtpResendRequestPlain = inviteFixtures.validResendOtpCodeRequest()
 
       app = mockSession.getAppWithLoggedOutSession(getApp())
       supertest(app)

--- a/test/integration/self-registration/self-registration-otp-verify.ft.test.js
+++ b/test/integration/self-registration/self-registration-otp-verify.ft.test.js
@@ -80,7 +80,7 @@ describe('create service otp validation', function () {
       const mockAdminUsersInviteCompleteRequest =
         inviteFixtures.validInviteCompleteRequest({
           gateway_account_ids: [gatewayAccountId]
-        }).getPlain()
+        })
       const mockAdminUsersInviteCompleteResponse =
         inviteFixtures.validInviteCompleteResponse({
           invite: {
@@ -90,7 +90,7 @@ describe('create service otp validation', function () {
           },
           user_external_id: userExternalId,
           service_external_id: serviceExternalId
-        }).getPlain()
+        })
       const getUserResponse = userFixtures.validUserResponse({ external_id: userExternalId })
 
       connectorMock.post(CONNECTOR_ACCOUNTS_URL)
@@ -103,7 +103,7 @@ describe('create service otp validation', function () {
       const validServiceInviteOtpRequest = inviteFixtures.validVerifyOtpCodeRequest({
         code: inviteCode
       })
-      adminusersMock.post(`${SERVICE_INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest.getPlain())
+      adminusersMock.post(`${SERVICE_INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest)
         .reply(200)
 
       app = session.getAppWithRegisterInvitesCookie(getApp(), {
@@ -114,7 +114,7 @@ describe('create service otp validation', function () {
       supertest(app)
         .post(paths.selfCreateService.otpVerify)
         .send({
-          'verify-code': validServiceInviteOtpRequest.getPlain().otp,
+          'verify-code': validServiceInviteOtpRequest.otp,
           csrfToken: csrf().create('123')
         })
         .expect(303)
@@ -129,8 +129,8 @@ describe('create service otp validation', function () {
       supertest(app)
         .post(paths.selfCreateService.otpVerify)
         .send({
-          code: validServiceInviteOtpRequest.getPlain().code,
-          'verify-code': validServiceInviteOtpRequest.getPlain().otp,
+          code: validServiceInviteOtpRequest.code,
+          'verify-code': validServiceInviteOtpRequest.otp,
           csrfToken: csrf().create('123')
         })
         .expect(404)
@@ -140,14 +140,14 @@ describe('create service otp validation', function () {
     it('should redirect to verify otp page on verification code with incorrect format', function (done) {
       const validServiceInviteOtpRequest = inviteFixtures.validVerifyOtpCodeRequest()
       const registerInviteData = {
-        code: validServiceInviteOtpRequest.getPlain().code,
+        code: validServiceInviteOtpRequest.code,
         email: 'bob@bob.com'
       }
       app = session.getAppWithRegisterInvitesCookie(getApp(), registerInviteData)
       supertest(app)
         .post(paths.selfCreateService.otpVerify)
         .send({
-          code: validServiceInviteOtpRequest.getPlain().code,
+          code: validServiceInviteOtpRequest.code,
           'verify-code': 'abc',
           csrfToken: csrf().create('123')
         })
@@ -166,17 +166,17 @@ describe('create service otp validation', function () {
     it('should redirect to verify otp page on invalid otp code', function (done) {
       const validServiceInviteOtpRequest = inviteFixtures.validVerifyOtpCodeRequest()
       const registerInviteData = {
-        code: validServiceInviteOtpRequest.getPlain().code,
+        code: validServiceInviteOtpRequest.code,
         email: 'bob@bob.com'
       }
-      adminusersMock.post(`${SERVICE_INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest.getPlain())
+      adminusersMock.post(`${SERVICE_INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest)
         .reply(401)
       app = session.getAppWithRegisterInvitesCookie(getApp(), registerInviteData)
       supertest(app)
         .post(paths.selfCreateService.otpVerify)
         .send({
-          code: validServiceInviteOtpRequest.getPlain().code,
-          'verify-code': validServiceInviteOtpRequest.getPlain().otp,
+          code: validServiceInviteOtpRequest.code,
+          'verify-code': validServiceInviteOtpRequest.otp,
           csrfToken: csrf().create('123')
         })
         .expect(303)
@@ -194,11 +194,11 @@ describe('create service otp validation', function () {
     it('should error if invite code is not found', function (done) {
       const validServiceInviteOtpRequest = inviteFixtures.validVerifyOtpCodeRequest()
       const registerInviteData = {
-        code: validServiceInviteOtpRequest.getPlain().code,
+        code: validServiceInviteOtpRequest.code,
         email: 'bob@bob.com'
       }
 
-      adminusersMock.post(`${SERVICE_INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest.getPlain())
+      adminusersMock.post(`${SERVICE_INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest)
         .reply(404)
 
       app = session.getAppWithRegisterInvitesCookie(getApp(), registerInviteData)
@@ -208,8 +208,8 @@ describe('create service otp validation', function () {
         .set('Accept', 'application/json')
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({
-          code: validServiceInviteOtpRequest.getPlain().code,
-          'verify-code': validServiceInviteOtpRequest.getPlain().otp,
+          code: validServiceInviteOtpRequest.code,
+          'verify-code': validServiceInviteOtpRequest.otp,
           csrfToken: csrf().create('123')
         })
         .expect(404)
@@ -222,11 +222,11 @@ describe('create service otp validation', function () {
     it('should error if invite code is no longer valid (expired)', function (done) {
       const validServiceInviteOtpRequest = inviteFixtures.validVerifyOtpCodeRequest()
       const registerInviteData = {
-        code: validServiceInviteOtpRequest.getPlain().code,
+        code: validServiceInviteOtpRequest.code,
         email: 'bob@bob.com'
       }
 
-      adminusersMock.post(`${SERVICE_INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest.getPlain())
+      adminusersMock.post(`${SERVICE_INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest)
         .reply(410)
 
       app = session.getAppWithRegisterInvitesCookie(getApp(), registerInviteData)
@@ -236,8 +236,8 @@ describe('create service otp validation', function () {
         .set('Accept', 'application/json')
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({
-          code: validServiceInviteOtpRequest.getPlain().code,
-          'verify-code': validServiceInviteOtpRequest.getPlain().otp,
+          code: validServiceInviteOtpRequest.code,
+          'verify-code': validServiceInviteOtpRequest.otp,
           csrfToken: csrf().create('123')
         })
         .expect(410)

--- a/test/integration/self-registration/self-registration-service-naming.ft.test.js
+++ b/test/integration/self-registration/self-registration-service-naming.ft.test.js
@@ -8,7 +8,6 @@ const chaiAsPromised = require('chai-as-promised')
 
 const mockSession = require('../../test-helpers/mock-session')
 const getApp = require('../../../server').getApp
-const selfRegisterFixtures = require('../../fixtures/self-register.fixtures')
 const paths = require('../../../app/paths')
 
 // Constants
@@ -31,8 +30,7 @@ describe('create service - service naming', function () {
 
   it('should redirect to home page on successful submission', function (done) {
     const serviceExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
-    const validServiceNameRequest = selfRegisterFixtures.validServiceNameRequest()
-    const request = validServiceNameRequest.getPlain()
+    const request = { service_name: 'My Service name' }
     const session = mockSession.getUser({ default_service_id: serviceExternalId })
     const service = session.serviceRoles[0].service
     const gatewayAccountId = service.gatewayAccountIds[0]
@@ -59,9 +57,7 @@ describe('create service - service naming', function () {
       .end(done)
   })
   it('should redirect to name your service page if user input invalid', function (done) {
-    const invalidServiceNameRequest = selfRegisterFixtures.invalidServiceNameRequest()
-
-    const request = invalidServiceNameRequest.getPlain()
+    const request = { service_name: '' }
     let session = mockSession.getUser()
     app = mockSession.getAppWithLoggedInUser(getApp(), session)
     supertest(app)

--- a/test/integration/service-registration.service.it.test.js
+++ b/test/integration/service-registration.service.it.test.js
@@ -38,7 +38,7 @@ describe('create populated service', function () {
     const mockAdminUsersInviteCompleteRequest =
       inviteFixtures.validInviteCompleteRequest({
         gateway_account_ids: [gatewayAccountId]
-      }).getPlain()
+      })
     const mockAdminUsersInviteCompleteResponse =
       inviteFixtures.validInviteCompleteResponse({
         invite: {
@@ -48,7 +48,7 @@ describe('create populated service', function () {
         },
         user_external_id: userExternalId,
         service_external_id: serviceExternalId
-      }).getPlain()
+      })
     const getUserResponse = userFixtures.validUserResponse({ external_id: userExternalId })
 
     const createGatewayAccountMock = connectorMock.post(CONNECTOR_ACCOUNTS_URL)
@@ -89,7 +89,7 @@ describe('create populated service', function () {
     const mockAdminUsersInviteCompleteRequest =
       inviteFixtures.validInviteCompleteRequest({
         gateway_account_ids: [gatewayAccountId]
-      }).getPlain()
+      })
 
     const createGatewayAccountMock = connectorMock.post(CONNECTOR_ACCOUNTS_URL)
       .reply(201, mockConnectorCreateGatewayAccountResponse)
@@ -117,7 +117,7 @@ describe('create populated service', function () {
     const mockAdminUsersInviteCompleteRequest =
       inviteFixtures.validInviteCompleteRequest({
         gateway_account_ids: [gatewayAccountId]
-      }).getPlain()
+      })
 
     const createGatewayAccountMock = connectorMock.post(CONNECTOR_ACCOUNTS_URL)
       .reply(201, mockConnectorCreateGatewayAccountResponse)

--- a/test/integration/service-users.ft.test.js
+++ b/test/integration/service-users.ft.test.js
@@ -66,7 +66,7 @@ describe('service users resource', () => {
     adminusersMock.get(`${SERVICE_RESOURCE}/${externalServiceId}/users`)
       .reply(200, serviceUsersRes)
     adminusersMock.get(`${INVITE_RESOURCE}?serviceId=${externalServiceId}`)
-      .reply(200, getInvitesRes.getPlain())
+      .reply(200, getInvitesRes)
     app = session.getAppWithLoggedInUser(getApp(), user)
 
     supertest(app)
@@ -116,7 +116,7 @@ describe('service users resource', () => {
     adminusersMock.get(`${SERVICE_RESOURCE}/${externalServiceId}/users`)
       .reply(200, serviceUsersRes)
     adminusersMock.get(`${INVITE_RESOURCE}?serviceId=${externalServiceId}`)
-      .reply(200, getInvitesRes.getPlain())
+      .reply(200, getInvitesRes)
     app = session.getAppWithLoggedInUser(getApp(), user)
 
     supertest(app)
@@ -159,7 +159,7 @@ describe('service users resource', () => {
     adminusersMock.get(`${SERVICE_RESOURCE}/${noAccessServiceId}/users`)
       .reply(200, serviceUsersRes)
     adminusersMock.get(`${INVITE_RESOURCE}?serviceId=${noAccessServiceId}`)
-      .reply(200, getInvitesRes.getPlain())
+      .reply(200, getInvitesRes)
 
     app = session.getAppWithLoggedInUser(getApp(), user)
 
@@ -440,7 +440,7 @@ describe('service users resource', () => {
     adminusersMock.get(`${SERVICE_RESOURCE}/${externalServiceId}/users`)
       .reply(200, serviceUsersRes)
     adminusersMock.get(`${INVITE_RESOURCE}?serviceId=${externalServiceId}`)
-      .reply(200, getInvitesRes.getPlain())
+      .reply(200, getInvitesRes)
     app = session.getAppWithLoggedInUser(getApp(), user)
 
     supertest(app)

--- a/test/unit/clients/adminusers-client/invite/complete-service-invite.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/complete-service-invite.pact.test.js
@@ -8,6 +8,7 @@ const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
 const inviteFixtures = require('../../../../fixtures/invite.fixtures')
+const { pactify } = require('../../../../test-helpers/pact/pactifier').defaultPactifier
 
 // Constants
 const INVITE_RESOURCE = '/v1/api/invites'
@@ -57,9 +58,9 @@ describe('adminusers client - complete an invite', function () {
           .withState('a valid service invite exists with the given invite code')
           .withUponReceiving('a valid complete service invite request')
           .withMethod('POST')
-          .withRequestBody(validInviteCompleteRequest.getPactified())
+          .withRequestBody(validInviteCompleteRequest)
           .withStatusCode(200)
-          .withResponseBody(validInviteCompleteResponse.getPactified())
+          .withResponseBody(pactify(validInviteCompleteResponse))
           .build()
       ).then(() => done())
         .catch(done)
@@ -68,9 +69,8 @@ describe('adminusers client - complete an invite', function () {
     afterEach(() => provider.verify())
 
     it('should complete a service invite successfully', function (done) {
-      const expectedData = validInviteCompleteResponse.getPlain()
       adminusersClient.completeInvite(inviteCode, gatewayAccountIds).should.be.fulfilled.then(response => {
-        expect(response.invite).to.deep.equal(expectedData.invite)
+        expect(response.invite).to.deep.equal(validInviteCompleteResponse.invite)
         expect(response.user_external_id).to.equal(userExternalId)
         expect(response.service_external_id).to.equal(serviceExternalId)
       }).should.notify(done)
@@ -91,7 +91,7 @@ describe('adminusers client - complete an invite', function () {
           .withState('invite not exists for the given invite code')
           .withUponReceiving('a valid complete service invite request of a non existing invite')
           .withMethod('POST')
-          .withRequestBody(validInviteCompleteRequest.getPactified())
+          .withRequestBody(validInviteCompleteRequest)
           .withStatusCode(404)
           .build()
       ).then(() => done())
@@ -120,7 +120,7 @@ describe('adminusers client - complete an invite', function () {
           .withState('invite conflict for the given invite code')
           .withUponReceiving('a valid complete service invite request with the user with same email exists')
           .withMethod('POST')
-          .withRequestBody(validInviteCompleteRequest.getPactified())
+          .withRequestBody(validInviteCompleteRequest)
           .withStatusCode(409)
           .build()
       ).then(() => done())
@@ -150,9 +150,9 @@ describe('adminusers client - complete an invite', function () {
           .withState('invite expired for the given invite code')
           .withUponReceiving('a valid complete service invite request of an expired invite')
           .withMethod('POST')
-          .withRequestBody(invalidInviteCompleteRequest.getPactified())
+          .withRequestBody(invalidInviteCompleteRequest)
           .withStatusCode(400)
-          .withResponseBody(errorResponse.getPactified())
+          .withResponseBody(pactify(errorResponse))
           .build()
       ).then(() => done())
     })

--- a/test/unit/clients/adminusers-client/invite/complete-user-invite.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/complete-user-invite.pact.test.js
@@ -8,6 +8,7 @@ const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
 const inviteFixtures = require('../../../../fixtures/invite.fixtures')
+const { pactify } = require('../../../../test-helpers/pact/pactifier').defaultPactifier
 
 // Constants
 const INVITE_RESOURCE = '/v1/api/invites'
@@ -53,7 +54,7 @@ describe('adminusers client - complete a user invite', function () {
           .withUponReceiving('a valid complete user invite request')
           .withMethod('POST')
           .withStatusCode(200)
-          .withResponseBody(validInviteCompleteResponse.getPactified())
+          .withResponseBody(pactify(validInviteCompleteResponse))
           .build()
       ).then(() => done())
         .catch(done)
@@ -62,9 +63,8 @@ describe('adminusers client - complete a user invite', function () {
     afterEach(() => provider.verify())
 
     it('should complete a service invite successfully', function (done) {
-      const expectedData = validInviteCompleteResponse.getPlain()
       adminusersClient.completeInvite(inviteCode).should.be.fulfilled.then(response => {
-        expect(response.invite).to.deep.equal(expectedData.invite)
+        expect(response.invite).to.deep.equal(validInviteCompleteResponse.invite)
         expect(response.user_external_id).to.equal(userExternalId)
         expect(response.service_external_id).to.equal(serviceExternalId)
       }).should.notify(done)

--- a/test/unit/clients/adminusers-client/invite/generate-invite-otp-code-user.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/generate-invite-otp-code-user.pact.test.js
@@ -8,6 +8,7 @@ const path = require('path')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
 const inviteFixtures = require('../../../../fixtures/invite.fixtures')
+const { pactify } = require('../../../../test-helpers/pact/pactifier').defaultPactifier
 
 // Constants
 const INVITE_RESOURCE = '/v1/api/invites'
@@ -42,7 +43,7 @@ describe('adminusers client - generate otp code for user invite', function () {
           .withState('a valid invite exists with the given invite code')
           .withUponReceiving('a valid generate user invite otp code request')
           .withMethod('POST')
-          .withRequestBody(validRegistrationRequest.getPactified())
+          .withRequestBody(pactify(validRegistrationRequest))
           .withStatusCode(200)
           .build()
       ).then(() => done())
@@ -52,8 +53,7 @@ describe('adminusers client - generate otp code for user invite', function () {
     afterEach(() => provider.verify())
 
     it('should generate user invite otp code successfully', function (done) {
-      const registration = validRegistrationRequest.getPlain()
-      adminusersClient.generateInviteOtpCode(inviteCode, registration.telephone_number, registration.password).should.be.fulfilled.notify(done)
+      adminusersClient.generateInviteOtpCode(inviteCode, validRegistrationRequest.telephone_number, validRegistrationRequest.password).should.be.fulfilled.notify(done)
     })
   })
 
@@ -69,9 +69,9 @@ describe('adminusers client - generate otp code for user invite', function () {
           .withState('a valid invite exists with the given invite code')
           .withUponReceiving('invalid generate user invite otp code request')
           .withMethod('POST')
-          .withRequestBody(validRegistrationRequest.getPactified())
+          .withRequestBody(validRegistrationRequest)
           .withStatusCode(400)
-          .withResponseBody(errorResponse.getPactified())
+          .withResponseBody(pactify(errorResponse))
           .build()
       ).then(() => done())
         .catch(done)
@@ -80,8 +80,7 @@ describe('adminusers client - generate otp code for user invite', function () {
     afterEach(() => provider.verify())
 
     it('should 400 BAD REQUEST telephone number is not valid', function (done) {
-      const registration = validRegistrationRequest.getPlain()
-      adminusersClient.generateInviteOtpCode(inviteCode, registration.telephone_number, registration.password).should.be.rejected.then(function (response) {
+      adminusersClient.generateInviteOtpCode(inviteCode, validRegistrationRequest.telephone_number, validRegistrationRequest.password).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(400)
         expect(response.message.errors.length).to.equal(1)
         expect(response.message.errors[0]).to.equal('Field [telephone_number] is required')
@@ -99,7 +98,7 @@ describe('adminusers client - generate otp code for user invite', function () {
           .withState('invite not exists for the given invite code')
           .withUponReceiving('a valid generate user invite otp code of a non existing invite')
           .withMethod('POST')
-          .withRequestBody(validRegistrationRequest.getPactified())
+          .withRequestBody(pactify(validRegistrationRequest))
           .withStatusCode(404)
           .build()
       ).then(() => done())
@@ -108,8 +107,7 @@ describe('adminusers client - generate otp code for user invite', function () {
     afterEach(() => provider.verify())
 
     it('should 404 NOT FOUND if user invite code not found', function (done) {
-      const registration = validRegistrationRequest.getPlain()
-      adminusersClient.generateInviteOtpCode(nonExistingInviteCode, registration.telephone_number, registration.password).should.be.rejected.then(function (response) {
+      adminusersClient.generateInviteOtpCode(nonExistingInviteCode, validRegistrationRequest.telephone_number, validRegistrationRequest.password).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(404)
       }).should.notify(done)
     })

--- a/test/unit/clients/adminusers-client/invite/get-invite.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/get-invite.pact.test.js
@@ -7,6 +7,7 @@ const chaiAsPromised = require('chai-as-promised')
 const inviteFixtures = require('../../../../fixtures/invite.fixtures')
 const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
 const PactInteractionBuilder = require('../../../../fixtures/pact-interaction-builder').PactInteractionBuilder
+const { pactify } = require('../../../../test-helpers/pact/pactifier').defaultPactifier
 
 chai.use(chaiAsPromised)
 
@@ -45,7 +46,7 @@ describe('adminusers client - get a validated invite', function () {
         new PactInteractionBuilder(`${INVITES_PATH}/${inviteCode}`)
           .withState('a valid invite exists with the given invite code')
           .withUponReceiving('a valid get invite request')
-          .withResponseBody(getInviteResponse.getPactified())
+          .withResponseBody(pactify(getInviteResponse))
           .build()
       ).then(() => done())
     })
@@ -53,12 +54,10 @@ describe('adminusers client - get a validated invite', function () {
     afterEach(() => provider.verify())
 
     it('should find an invite successfully', function (done) {
-      const expectedInviteData = getInviteResponse.getPlain()
-
       adminusersClient.getValidatedInvite(params.invite_code).should.be.fulfilled.then(function (invite) {
-        expect(invite.email).to.be.equal(expectedInviteData.email)
-        expect(invite.telephone_number).to.be.equal(expectedInviteData.telephone_number)
-        expect(invite.type).to.be.equal(expectedInviteData.type)
+        expect(invite.email).to.be.equal(getInviteResponse.email)
+        expect(invite.telephone_number).to.be.equal(getInviteResponse.telephone_number)
+        expect(invite.type).to.be.equal(getInviteResponse.type)
       }).should.notify(done)
     })
   })

--- a/test/unit/clients/adminusers-client/service/govuk-pay-agreement-post-email-address.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/govuk-pay-agreement-post-email-address.pact.test.js
@@ -35,7 +35,7 @@ describe('adminusers client - post govuk pay agreement - email address', () => {
 
   describe('post email address', () => {
     const payload = { user_external_id: userExternalId }
-    const validGovUkAgreementUserEmailRequest = validPostGovUkPayAgreementRequest(payload).getPlain()
+    const validGovUkAgreementUserEmailRequest = validPostGovUkPayAgreementRequest(payload)
 
     before(done => {
       provider.addInteraction(

--- a/test/unit/clients/adminusers-client/service/stripe-agreement-post-ip-address.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/stripe-agreement-post-ip-address.pact.test.js
@@ -35,7 +35,7 @@ describe('adminusers client - post stripe agreement - ip address', () => {
   describe('post ip address', () => {
     const ipAddress = '93.184.216.34' // example.org
     const opts = { ip_address: ipAddress }
-    const validStripeAgreementRequest = validPostStripeAgreementRequest(opts).getPlain()
+    const validStripeAgreementRequest = validPostStripeAgreementRequest(opts)
 
     before(done => {
       provider.addInteraction(


### PR DESCRIPTION
Remove pact dependency from `go-live-requests.fixture.js`, `invite.fixtures.js` and `self-register.fixtures.js`

Remove some fixtures from `self-register.fixtures.js` that were constructing requests to selfservice endpoints for functional tests as it makes more sense to just declare these in the tests themselves.


