### PR TITLE
PP-7588 Start simplifying Cypress stub creation

### DIFF
--- a/test/cypress/integration/request-to-go-live/index.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/index.cy.test.js
@@ -1,3 +1,4 @@
+
 const userStubs = require('../../stubs/user-stubs')
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -17,43 +17,10 @@ const ledgerFixture = require('../../fixtures/ledger-transaction.fixtures')
 const inviteFixtures = require('../../fixtures/invite.fixtures')
 const tokenFixtures = require('../../fixtures/token.fixtures')
 const worldpay3dsFlexCredentialsFixtures = require('../../fixtures/worldpay-3ds-flex-credentials.fixtures')
+const { stubBuilder } = require('../stubs/stub-builder')
 
 const simpleStubBuilder = function simpleStubBuilder (method, path, responseCode, additionalParams = {}) {
-  const request = {
-    method,
-    path
-  }
-  if (additionalParams.request) {
-    request.body = additionalParams.request
-  }
-  if (additionalParams.query) {
-    request.query = additionalParams.query
-  }
-
-  const response = {
-    statusCode: responseCode,
-    headers: additionalParams.responseHeaders || { 'Content-Type': 'application/json' }
-  }
-  if (additionalParams.response) {
-    response.body = additionalParams.response
-  }
-
-  const stub = {
-    name: `${method} ${path} ${responseCode}`,
-    predicates: [{
-      deepEquals: request
-    }],
-    responses: [{
-      is: response
-    }]
-  }
-
-  // NOTE: if the "verifyCalledTimes" is specified, we will attempt to verify for all `it` blocks
-  // the stub is setup for, and the counter is reset for every `it`.
-  if (additionalParams.verifyCalledTimes) {
-    stub.verifyCalledTimes = additionalParams.verifyCalledTimes
-  }
-
+  const stub = stubBuilder(method, path, responseCode, additionalParams)
   return [stub]
 }
 

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const gatewayAccountFixtures = require('../../fixtures/gateway-account.fixtures')
+const { stubBuilder } = require('./stub-builder')
+
 function parseGatewayAccountOptions (opts) {
   let stubOptions = { gateway_account_id: opts.gatewayAccountId }
 
@@ -53,13 +56,12 @@ function parseGatewayAccountOptions (opts) {
   return stubOptions
 }
 
-const getGatewayAccountSuccess = function (opts) {
-  const stubOptions = parseGatewayAccountOptions(opts)
-
-  return {
-    name: 'getGatewayAccountSuccess',
-    opts: stubOptions
-  }
+function getGatewayAccountSuccess (opts) {
+  const path = '/v1/frontend/accounts/' + opts.gatewayAccountId
+  const fixtureOpts = parseGatewayAccountOptions(opts)
+  return stubBuilder('GET', path, 200, {
+    response: gatewayAccountFixtures.validGatewayAccountResponse(fixtureOpts)
+  })
 }
 
 const getGatewayAccountByExternalIdSuccess = function (opts) {
@@ -130,7 +132,8 @@ const getAcceptedCardTypesSuccess = function (opts) {
 
 const getCardTypesSuccess = function () {
   return {
-    name: 'getCardTypesSuccess'
+    name: 'getCardTypesSuccess',
+    opts: {}
   }
 }
 

--- a/test/cypress/stubs/go-cardless-connect-stubs.js
+++ b/test/cypress/stubs/go-cardless-connect-stubs.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const exchangeGoCardlessAccessCodeAccountAlreadyConnected = function () {
-  return { name: 'exchangeGoCardlessAccessCodeAccountAlreadyConnected' }
+  return { name: 'exchangeGoCardlessAccessCodeAccountAlreadyConnected', opts: {} }
 }
 
 const redirectToGoCardlessConnectFailure = function () {
-  return { name: 'redirectToGoCardlessConnectFailure' }
+  return { name: 'redirectToGoCardlessConnectFailure', opts: {} }
 }
 
 module.exports = {

--- a/test/cypress/stubs/products-stubs.js
+++ b/test/cypress/stubs/products-stubs.js
@@ -40,7 +40,8 @@ const getProductsByGatewayAccountIdFailure = function (gatewayAccountId) {
 
 const postCreateProductSuccess = function () {
   return {
-    name: 'postCreateProductSuccess'
+    name: 'postCreateProductSuccess',
+    opts: {}
   }
 }
 

--- a/test/cypress/stubs/stub-builder.js
+++ b/test/cypress/stubs/stub-builder.js
@@ -1,0 +1,44 @@
+'use strict'
+
+function stubBuilder (method, path, responseCode, additionalParams = {}) {
+  const request = {
+    method,
+    path
+  }
+  if (additionalParams.request) {
+    request.body = additionalParams.request
+  }
+  if (additionalParams.query) {
+    request.query = additionalParams.query
+  }
+
+  const response = {
+    statusCode: responseCode,
+    headers: additionalParams.responseHeaders || { 'Content-Type': 'application/json' }
+  }
+  if (additionalParams.response) {
+    response.body = additionalParams.response
+  }
+
+  const stub = {
+    name: `${method} ${path} ${responseCode}`,
+    predicates: [{
+      deepEquals: request
+    }],
+    responses: [{
+      is: response
+    }]
+  }
+
+  // NOTE: if the "verifyCalledTimes" is specified, we will attempt to verify for all `it` blocks
+  // the stub is setup for, and the counter is reset for every `it`.
+  if (additionalParams.verifyCalledTimes) {
+    stub.verifyCalledTimes = additionalParams.verifyCalledTimes
+  }
+
+  return stub
+}
+
+module.exports = {
+  stubBuilder
+}

--- a/test/cypress/stubs/user-stubs.js
+++ b/test/cypress/stubs/user-stubs.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const userFixtures = require('../../fixtures/user.fixtures')
+const { stubBuilder } = require('./stub-builder')
+
 const getUserWithServiceRoleStubOpts = function (userExternalId, email, serviceExternalId, roleName, roleDescription) {
   return {
     external_id: userExternalId,
@@ -45,13 +48,13 @@ const getUsersSuccess = function () {
 }
 
 const getUserSuccessWithServiceRole = function (opts) {
-  return {
-    name: 'getUserSuccess',
-    opts: {
+  const path = '/v1/api/users/' + opts.userExternalId
+  return stubBuilder('GET', path, 200, {
+    response: userFixtures.validUserResponse({
       external_id: opts.userExternalId,
       service_roles: [opts.serviceRole]
-    }
-  }
+    })
+  })
 }
 
 const getUserWithNoPermissions = function (userExternalId, gatewayAccountIds) {


### PR DESCRIPTION
Start simplifying the process for generating stubs which are pushed to Mountebank to stub out requests to other services.

This commit demonstrates how this will be done, by moving generating the stub in the format expected by Mountebank and using our fixtures into the stub helper files. Previously this was done in the `stubs.js` file, which made the code quite opaque and confusing.

To allow for this, the `setupStubs` Cypress command will deal with either:
1. An object with name and opts fields to constuct a stub from the `stubs.js` file as it does now
2. An already build Mountebank stub which it will not alter and send directly to Mountebank.