### PR TITLE
PP-7295 Send service created date in go-live zendesk ticket

### DIFF
--- a/app/controllers/request-to-go-live/agreement/post.controller.js
+++ b/app/controllers/request-to-go-live/agreement/post.controller.js
@@ -54,6 +54,7 @@ const createZendeskMessage = opts => ` Service name: ${opts.serviceName}
  IP address: ${opts.ipAddress}
  Email address: ${opts.email}
  Time: ${opts.timestamp}
+ Service created at: ${opts.serviceCreated}
 `
 
 module.exports = (req, res) => {
@@ -72,7 +73,8 @@ module.exports = (req, res) => {
           psp: req.service.currentGoLiveStage,
           ipAddress: ipAddress || '',
           email: agreement.email,
-          timestamp: agreement.agreement_time
+          timestamp: agreement.agreement_time,
+          serviceCreated: req.service.created_date || '(service was created before we captured this date)'
         }
         const zendeskOpts = {
           correlationId: req.correlationId,


### PR DESCRIPTION
We now store the date a service was greated on. Include it in the request to go live Zendesk ticket so we have more information about the time taken between creating the test service and requesting a live account when we look at these tickets.

