### PR TITLE
PP-7295 Fix created date not included in zendesk ticket

### DIFF
--- a/app/controllers/request-to-go-live/agreement/post.controller.js
+++ b/app/controllers/request-to-go-live/agreement/post.controller.js
@@ -74,7 +74,7 @@ module.exports = (req, res) => {
           ipAddress: ipAddress || '',
           email: agreement.email,
           timestamp: agreement.agreement_time,
-          serviceCreated: req.service.created_date || '(service was created before we captured this date)'
+          serviceCreated: req.service.createdDate || '(service was created before we captured this date)'
         }
         const zendeskOpts = {
           correlationId: req.correlationId,

--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -11,6 +11,7 @@ class Service {
     this.collectBillingAddress = serviceData.collect_billing_address
     this.currentGoLiveStage = serviceData.current_go_live_stage
     this.experimentalFeaturesEnabled = serviceData.experimental_features_enabled
+    this.createdDate = serviceData.created_date
   }
 
   /**
@@ -27,7 +28,8 @@ class Service {
       merchant_details: this.merchantDetails,
       collect_billing_address: this.collectBillingAddress,
       current_go_live_stage: this.currentGoLiveStage,
-      experimental_features_enabled: this.experimentalFeaturesEnabled
+      experimental_features_enabled: this.experimentalFeaturesEnabled,
+      created_date: this.createdDate
     }
   }
 }


### PR DESCRIPTION
We convert the service response from adminusers using a model class.
Update the model to contain a `createdDate` property and user this when building the Zendesk ticket


