### PR TITLE
PP-7585 Instantiate connector client as singleton and cleanup logging

### DIFF
--- a/app/controllers/credentials.controller.js
+++ b/app/controllers/credentials.controller.js
@@ -13,18 +13,13 @@ const { CONNECTOR_URL } = process.env
 const { CORRELATION_HEADER } = require('../utils/correlation-header')
 const { isPasswordLessThanTenChars } = require('../browsered/field-validation-checks')
 
-const connectorClient = () => new ConnectorClient(CONNECTOR_URL)
+const connectorClient = new ConnectorClient(CONNECTOR_URL)
 
 function showSuccessView (viewMode, req, res) {
   let responsePayload = {}
 
-  switch (viewMode) {
-    case EDIT_NOTIFICATION_CREDENTIALS_MODE:
-      responsePayload.editNotificationCredentialsMode = true
-      break
-    default:
-      responsePayload.editNotificationCredentialsMode = false
-  }
+  responsePayload.editNotificationCredentialsMode = (viewMode === EDIT_NOTIFICATION_CREDENTIALS_MODE)
+
   const invalidCreds = _.get(req, 'session.pageData.editNotificationCredentials')
   if (invalidCreds) {
     responsePayload.lastNotificationsData = invalidCreds
@@ -119,7 +114,7 @@ module.exports = {
     var correlationId = req.headers[CORRELATION_HEADER] || ''
 
     try {
-      await connectorClient().postAccountNotificationCredentials({
+      await connectorClient.postAccountNotificationCredentials({
         payload: { username, password },
         correlationId: correlationId,
         gatewayAccountId: accountId
@@ -171,7 +166,7 @@ module.exports = {
     var startTime = new Date()
 
     try {
-      await connectorClient().patchAccountCredentials({
+      await connectorClient.patchAccountCredentials({
         payload: credentialsPatchRequestValueOf(req), correlationId: correlationId, gatewayAccountId: accountId
       })
 

--- a/app/controllers/credentials.controller.js
+++ b/app/controllers/credentials.controller.js
@@ -2,7 +2,6 @@ const EDIT_CREDENTIALS_MODE = 'editCredentials'
 const EDIT_NOTIFICATION_CREDENTIALS_MODE = 'editNotificationCredentials'
 
 const _ = require('lodash')
-const logger = require('../utils/logger')(__filename)
 const paths = require('../paths')
 const { response } = require('../utils/response')
 const { renderErrorView } = require('../utils/response')
@@ -84,7 +83,6 @@ module.exports = {
 
   updateNotificationCredentials: async function (req, res) {
     const accountId = auth.getCurrentGatewayAccountId((req))
-    const connectorUrl = CONNECTOR_URL + '/v1/api/accounts/{accountId}/notification-credentials'
     const { username, password } = _.get(req, 'body')
 
     if (!username) {
@@ -103,15 +101,7 @@ module.exports = {
       return res.redirect(paths.notificationCredentials.edit)
     }
 
-    logger.info('Calling connector to update provider notification credentials', {
-      service: 'connector',
-      method: 'POST',
-      url: '/frontend/accounts/{id}/notification-credentials'
-    })
-
-    var startTime = new Date()
-    var url = connectorUrl.replace('{accountId}', accountId)
-    var correlationId = req.headers[CORRELATION_HEADER] || ''
+    const correlationId = req.headers[CORRELATION_HEADER] || ''
 
     try {
       await connectorClient.postAccountNotificationCredentials({
@@ -120,78 +110,23 @@ module.exports = {
         gatewayAccountId: accountId
       })
 
-      const duration = new Date() - startTime
-      logger.info(`[${correlationId}] - POST to ${url} ended - elapsed time: ${duration} ms`)
       return res.redirect(303, router.paths.yourPsp.index)
     } catch (err) {
-      const duration = new Date() - startTime
-      logger.info(`[${correlationId}] - POST to ${url} ended - elapsed time: ${duration} ms`)
-      if (err && err.errorCode) {
-        logger.error(`[${correlationId}] Calling connector to update provider notification credentials failed`, {
-          service: 'connector',
-          method: 'POST',
-          url: connectorUrl,
-          status: err.errorCode
-        })
-      } else {
-        logger.error(`[${correlationId}] Calling connector to update provider notification credentials threw exception`, {
-          service: 'connector',
-          method: 'POST',
-          url: connectorUrl,
-          error: err
-        })
-      }
-
       return renderErrorView(req, res)
     }
   },
 
   update: async function (req, res) {
-    logger.debug('Calling connector to update provider credentials', {
-      service: 'connector',
-      method: 'PATCH',
-      url: '/frontend/accounts/{id}/credentials'
-    })
-    var accountId = auth.getCurrentGatewayAccountId(req)
-    var connectorUrl = CONNECTOR_URL + '/v1/frontend/accounts/{accountId}/credentials'
-
-    logger.info('Calling connector to update provider credentials', {
-      service: 'connector',
-      method: 'PATCH',
-      url: '/frontend/accounts/{id}/credentials'
-    })
-    var url = connectorUrl.replace('{accountId}', accountId)
-    var correlationId = req.headers[CORRELATION_HEADER] || ''
-
-    var startTime = new Date()
+    const accountId = auth.getCurrentGatewayAccountId(req)
+    const correlationId = req.headers[CORRELATION_HEADER] || ''
 
     try {
       await connectorClient.patchAccountCredentials({
         payload: credentialsPatchRequestValueOf(req), correlationId: correlationId, gatewayAccountId: accountId
       })
 
-      let duration = new Date() - startTime
-      logger.info(`[${correlationId}] - PATCH to ${url} ended - elapsed time: ${duration} ms`)
       return res.redirect(303, router.paths.yourPsp.index)
     } catch (err) {
-      let duration = new Date() - startTime
-      logger.info(`[${correlationId}] - PATCH to ${url} ended - elapsed time: ${duration} ms`)
-
-      if (err && err.errorCode) {
-        logger.error(`[${correlationId}] Calling connector to update provider credentials failed. Redirecting back to credentials view`, {
-          service: 'connector',
-          method: 'PATCH',
-          url: connectorUrl,
-          status: err.errorCode
-        })
-      } else {
-        logger.error(`[${correlationId}] Calling connector to update provider credentials threw exception`, {
-          service: 'connector',
-          method: 'PATCH',
-          url: connectorUrl,
-          error: err
-        })
-      }
       return renderErrorView(req, res)
     }
   }

--- a/app/controllers/payment-types/get-index.controller.js
+++ b/app/controllers/payment-types/get-index.controller.js
@@ -4,6 +4,7 @@ const { response, renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
 const auth = require('../../services/auth.service')
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
 function formatLabel (card) {
   if (card.brand === 'visa' || card.brand === 'master-card') {
@@ -53,7 +54,6 @@ function formatCardsForTemplate (allCards, acceptedCards, threeDSEnabled) {
 }
 
 module.exports = async (req, res) => {
-  const connector = new ConnectorClient(process.env.CONNECTOR_URL)
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = auth.getCurrentGatewayAccountId(req)
 

--- a/app/controllers/payment-types/post-index.controller.js
+++ b/app/controllers/payment-types/post-index.controller.js
@@ -8,9 +8,9 @@ const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
 const auth = require('../../services/auth.service.js')
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
 module.exports = async (req, res) => {
-  const connector = new ConnectorClient(process.env.CONNECTOR_URL)
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = auth.getCurrentGatewayAccountId(req)
 

--- a/app/controllers/toggle-3ds/3ds.post.controller.js
+++ b/app/controllers/toggle-3ds/3ds.post.controller.js
@@ -4,9 +4,9 @@ const paths = require('../../paths')
 const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
 module.exports = async (req, res) => {
-  const connector = new ConnectorClient(process.env.CONNECTOR_URL)
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = req.account.gateway_account_id
 

--- a/app/controllers/your-psp/post-flex.controller.js
+++ b/app/controllers/your-psp/post-flex.controller.js
@@ -9,13 +9,13 @@ const { correlationHeader } = require('../../utils/correlation-header')
 const { validationErrors } = require('../../browsered/field-validation-checks')
 const worldpay3dsFlexValidations = require('./worldpay-3ds-flex-validations')
 
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 // Constants
 const ORGANISATIONAL_UNIT_ID_FIELD = 'organisational-unit-id'
 const ISSUER_FIELD = 'issuer'
 const JWT_MAC_KEY_FIELD = 'jwt-mac-key'
 
 module.exports = async (req, res) => {
-  const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
   const correlationId = req.headers[correlationHeader] || ''
 

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const util = require('util')
-const EventEmitter = require('events').EventEmitter
-
 const logger = require('../../utils/logger')(__filename)
 const baseClient = require('./base-client/base.client')
 const StripeAccountSetup = require('../../models/StripeAccountSetup.class')
@@ -100,8 +97,6 @@ function _getToggle3dsUrlFor (accountID, url) {
  */
 function ConnectorClient (connectorUrl) {
   this.connectorUrl = connectorUrl
-
-  EventEmitter.call(this)
 }
 
 ConnectorClient.prototype = {
@@ -206,12 +201,6 @@ ConnectorClient.prototype = {
    */
   patchAccountCredentials: function (params) {
     const url = _accountCredentialsUrlFor(params.gatewayAccountId, this.connectorUrl)
-
-    logger.debug('Calling connector to patch account credentials', {
-      service: 'connector',
-      method: 'PATCH',
-      url: url
-    })
 
     return baseClient.patch(url, {
       body: params.payload,
@@ -647,7 +636,5 @@ ConnectorClient.prototype = {
     )
   }
 }
-
-util.inherits(ConnectorClient, EventEmitter)
 
 module.exports.ConnectorClient = ConnectorClient

--- a/app/services/email.service.js
+++ b/app/services/email.service.js
@@ -3,24 +3,14 @@
 const logger = require('../utils/logger')(__filename)
 const ConnectorClient = require('./clients/connector.client.js').ConnectorClient
 
-// Constants
-const ACCOUNT_API_PATH = '/v1/api/accounts/{accountId}'
-const EMAIL_NOTIFICATION_UPDATE_API_PATH = ACCOUNT_API_PATH + '/email-notification'
-
-const notificationUpdateUrl = function (accountID) {
-  return process.env.CONNECTOR_URL + EMAIL_NOTIFICATION_UPDATE_API_PATH.replace('{accountId}', accountID)
-}
-
 const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 
 const getEmailSettings = async function (accountID, correlationId) {
-  const startTime = new Date()
   try {
     const data = await connectorClient.getAccount({
       gatewayAccountId: accountID,
       correlationId: correlationId
     })
-    logger.info(`[${correlationId}] - GET account %s ended - elapsed time: %s ms`, accountID, new Date() - startTime)
     return {
       customEmailText: data.email_notifications.PAYMENT_CONFIRMED.template_body,
       emailEnabled: data.email_notifications.PAYMENT_CONFIRMED.enabled,
@@ -28,13 +18,11 @@ const getEmailSettings = async function (accountID, correlationId) {
       refundEmailEnabled: data.email_notifications.REFUND_ISSUED && data.email_notifications.REFUND_ISSUED.enabled
     }
   } catch (err) {
-    logger.info(`[${correlationId}] - GET account %s ended - elapsed time: %s ms`, accountID, new Date() - startTime)
     clientFailure(err, 'GET', false)
   }
 }
 
 const updateConfirmationTemplate = async function (accountID, emailText, correlationId) {
-  const startTime = new Date()
   try {
     const patch = { 'op': 'replace', 'path': '/payment_confirmed/template_body', 'value': emailText }
 
@@ -43,16 +31,12 @@ const updateConfirmationTemplate = async function (accountID, emailText, correla
       correlationId: correlationId,
       gatewayAccountId: accountID
     })
-
-    logger.info(`[${correlationId}] - PATCH to %s ended - elapsed time: %s ms`, notificationUpdateUrl(accountID), new Date() - startTime)
   } catch (err) {
-    logger.info(`[${correlationId}] - PATCH to %s ended - elapsed time: %s ms`, notificationUpdateUrl(accountID), new Date() - startTime)
     clientFailure(err, 'PATCH', true)
   }
 }
 
 const setEmailCollectionMode = async function (accountID, collectionMode, correlationId) {
-  const startTime = new Date()
   try {
     const patch = { 'op': 'replace', 'path': 'email_collection_mode', 'value': collectionMode }
     await connectorClient.updateEmailCollectionMode({
@@ -60,15 +44,12 @@ const setEmailCollectionMode = async function (accountID, collectionMode, correl
       correlationId: correlationId,
       gatewayAccountId: accountID
     })
-    logger.info(`[${correlationId}] - PATCH to account %s ended - elapsed time: %s ms`, accountID, new Date() - startTime)
   } catch (err) {
-    logger.info(`[${correlationId}] - PATCH to account %s ended - elapsed time: %s ms`, accountID, new Date() - startTime)
     clientFailure(err, 'PATCH', false)
   }
 }
 
 const setConfirmationEnabled = async function (accountID, enabled, correlationId) {
-  const startTime = new Date()
   const patch = { 'op': 'replace', 'path': '/payment_confirmed/enabled', 'value': enabled }
 
   try {
@@ -77,15 +58,12 @@ const setConfirmationEnabled = async function (accountID, enabled, correlationId
       correlationId: correlationId,
       gatewayAccountId: accountID
     })
-    logger.info(`[${correlationId}] - PATCH to %s ended - elapsed time: %s ms`, notificationUpdateUrl(accountID), new Date() - startTime)
   } catch (err) {
-    logger.info(`[${correlationId}] - PATCH to %s ended - elapsed time: %s ms`, notificationUpdateUrl(accountID), new Date() - startTime)
     clientFailure(err, 'PATCH', true)
   }
 }
 
 const setRefundEmailEnabled = async function (accountID, enabled, correlationId) {
-  const startTime = new Date()
   try {
     const patch = { 'op': 'replace', 'path': '/refund_issued/enabled', 'value': enabled }
     await connectorClient.updateRefundEmailEnabled({
@@ -93,9 +71,7 @@ const setRefundEmailEnabled = async function (accountID, enabled, correlationId)
       correlationId: correlationId,
       gatewayAccountId: accountID
     })
-    logger.info(`[${correlationId}] - PATCH to %s ended - elapsed time: %s ms`, notificationUpdateUrl(accountID), new Date() - startTime)
   } catch (err) {
-    logger.info(`[${correlationId}] - PATCH to %s ended - elapsed time: %s ms`, notificationUpdateUrl(accountID), new Date() - startTime)
     clientFailure(err, 'PATCH', true)
   }
 }

--- a/app/services/email.service.js
+++ b/app/services/email.service.js
@@ -11,14 +11,12 @@ const notificationUpdateUrl = function (accountID) {
   return process.env.CONNECTOR_URL + EMAIL_NOTIFICATION_UPDATE_API_PATH.replace('{accountId}', accountID)
 }
 
-const connectorClient = function () {
-  return new ConnectorClient(process.env.CONNECTOR_URL)
-}
+const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 
 const getEmailSettings = async function (accountID, correlationId) {
   const startTime = new Date()
   try {
-    const data = await connectorClient().getAccount({
+    const data = await connectorClient.getAccount({
       gatewayAccountId: accountID,
       correlationId: correlationId
     })
@@ -40,7 +38,7 @@ const updateConfirmationTemplate = async function (accountID, emailText, correla
   try {
     const patch = { 'op': 'replace', 'path': '/payment_confirmed/template_body', 'value': emailText }
 
-    await connectorClient().updateConfirmationEmail({
+    await connectorClient.updateConfirmationEmail({
       payload: patch,
       correlationId: correlationId,
       gatewayAccountId: accountID
@@ -57,7 +55,7 @@ const setEmailCollectionMode = async function (accountID, collectionMode, correl
   const startTime = new Date()
   try {
     const patch = { 'op': 'replace', 'path': 'email_collection_mode', 'value': collectionMode }
-    await connectorClient().updateEmailCollectionMode({
+    await connectorClient.updateEmailCollectionMode({
       payload: patch,
       correlationId: correlationId,
       gatewayAccountId: accountID
@@ -74,7 +72,7 @@ const setConfirmationEnabled = async function (accountID, enabled, correlationId
   const patch = { 'op': 'replace', 'path': '/payment_confirmed/enabled', 'value': enabled }
 
   try {
-    await connectorClient().updateConfirmationEmailEnabled({
+    await connectorClient.updateConfirmationEmailEnabled({
       payload: patch,
       correlationId: correlationId,
       gatewayAccountId: accountID
@@ -90,7 +88,7 @@ const setRefundEmailEnabled = async function (accountID, enabled, correlationId)
   const startTime = new Date()
   try {
     const patch = { 'op': 'replace', 'path': '/refund_issued/enabled', 'value': enabled }
-    await connectorClient().updateRefundEmailEnabled({
+    await connectorClient.updateRefundEmailEnabled({
       payload: patch,
       correlationId: correlationId,
       gatewayAccountId: accountID

--- a/app/services/service-registration.service.js
+++ b/app/services/service-registration.service.js
@@ -5,7 +5,7 @@ const { keys } = require('@govuk-pay/pay-js-commons').logging
 const logger = require('../utils/logger')(__filename)
 const getAdminUsersClient = require('./clients/adminusers.client')
 const ConnectorClient = require('./clients/connector.client').ConnectorClient
-const connectorClient = () => new ConnectorClient(process.env.CONNECTOR_URL)
+const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 
 function submitRegistration (email, phoneNumber, password, correlationId) {
   return getAdminUsersClient({ correlationId }).submitServiceRegistration(email, phoneNumber, password)
@@ -18,7 +18,7 @@ function submitServiceInviteOtpCode (code, otpCode, correlationId) {
 async function createPopulatedService (inviteCode, correlationId) {
   const adminusersClient = getAdminUsersClient({ correlationId })
 
-  const gatewayAccount = await connectorClient().createGatewayAccount('sandbox', 'test', null, null, correlationId)
+  const gatewayAccount = await connectorClient.createGatewayAccount('sandbox', 'test', null, null, correlationId)
   const completeInviteResponse = await adminusersClient.completeInvite(inviteCode, [gatewayAccount.gateway_account_id])
   const user = await adminusersClient.getUserByExternalId(completeInviteResponse.user_external_id)
 


### PR DESCRIPTION
## WHAT
- Moves connector client instantiation out of request methods so connector client object is instantiated once and not per request
- Removed request logging from email.service & credentials.controller as both of these now uses new baseclient which logs the same
