### PR TITLE
PP-7585 Fix client method postAcceptedCardsForAccount

### DIFF
--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -293,10 +293,9 @@ ConnectorClient.prototype = {
    */
   postAcceptedCardsForAccount: function (gatewayAccountId, payload, correlationId) {
     const url = _accountAcceptedCardTypesUrlFor(gatewayAccountId, this.connectorUrl)
-    const params = { gatewayAccountId, payload, correlationId }
 
     return baseClient.post(url, {
-      body: params,
+      body: payload,
       correlationId: correlationId,
       description: 'post accepted card types for account',
       service: SERVICE_NAME


### PR DESCRIPTION
## WHAT
- Fixes connector client method `postAcceptedCardsForAccount`: Incorrect data is being sent to connector. It should just be `payload` from controller.
 Caused by https://github.com/alphagov/pay-selfservice/commit/7b793b5d944652fbf7ef17790f25950d5e846794#diff-0a8d6b0be878b39296cfff51f4a3c04eef6f05c5a39740158c1f2a4e86001190L390