### PR TITLE
PP-7585 Refactor adminUsers client to remove instance correlationId

### DIFF
--- a/app/controllers/forgotten-password.controller.js
+++ b/app/controllers/forgotten-password.controller.js
@@ -49,7 +49,7 @@ const passwordRequested = function passwordRequested (req, res) {
 const newPasswordGet = async function newPasswordGet (req, res) {
   const { id } = req.params
   try {
-    await userService.findByResetToken(id)
+    await userService.findByResetToken(id, req.correlationId)
     res.render('forgotten-password/new-password', { id: id })
   } catch (err) {
     req.flash('genericError', 'The password reset request has expired or is invalid. Please try again.')
@@ -62,7 +62,7 @@ const newPasswordPost = async function newPasswordPost (req, res) {
     const { id } = req.params
     const password = req.body.password
 
-    const forgottenPassword = await userService.findByResetToken(id)
+    const forgottenPassword = await userService.findByResetToken(id, req.correlationId)
     const user = await userService.findByExternalId(forgottenPassword.user_external_id, req.correlationId)
 
     const validPassword = validatePassword(password)
@@ -75,9 +75,9 @@ const newPasswordPost = async function newPasswordPost (req, res) {
       })
     }
 
-    await userService.updatePassword(id, password)
+    await userService.updatePassword(id, password, req.correlationId)
     try {
-      await userService.logOut(user)
+      await userService.logOut(user, req.correlationId)
     } catch (err) {
       // treat as success even if updating session version fails
     }

--- a/app/controllers/service-users.controller.js
+++ b/app/controllers/service-users.controller.js
@@ -125,7 +125,7 @@ module.exports = {
       }
     }
 
-    return userService.findByExternalId(externalUserId)
+    return userService.findByExternalId(externalUserId, req.correlationId)
       .then(onSuccess)
       .catch(() => renderErrorView(req, res, 'Unable to retrieve user'))
   },
@@ -188,7 +188,7 @@ module.exports = {
       })
     }
 
-    return userService.findByExternalId(req.user.externalId)
+    return userService.findByExternalId(req.user.externalId, req.correlationId)
       .then(onSuccess)
       .catch(() => renderErrorView(req, res, 'Unable to retrieve user'))
   }

--- a/app/controllers/transactions/transaction-detail.controller.js
+++ b/app/controllers/transactions/transaction-detail.controller.js
@@ -12,7 +12,7 @@ module.exports = (req, res) => {
   const accountId = auth.getCurrentGatewayAccountId(req)
   const chargeId = req.params.chargeId
 
-  ledgerFindWithEvents(accountId, chargeId)
+  ledgerFindWithEvents(accountId, chargeId, req.correlationId)
     .then(data => {
       data.indexFilters = req.session.filters
       if (req.session.backLink) {

--- a/app/controllers/two-factor-auth-controller/post-index.controller.js
+++ b/app/controllers/two-factor-auth-controller/post-index.controller.js
@@ -12,7 +12,7 @@ module.exports = (req, res) => {
 
   const sendSMS = (method, user) => {
     if (method === 'SMS') {
-      return userService.sendProvisonalOTP(user, req.correlationId)
+      return userService.sendProvisionalOTP(user, req.correlationId)
     }
     return Promise.resolve()
   }

--- a/app/controllers/two-factor-auth-controller/post-resend.controller.js
+++ b/app/controllers/two-factor-auth-controller/post-resend.controller.js
@@ -5,7 +5,7 @@ const userService = require('../../services/user.service.js')
 const paths = require('../../paths')
 
 module.exports = (req, res) => {
-  userService.sendProvisonalOTP(req.user, req.correlationId)
+  userService.sendProvisionalOTP(req.user, req.correlationId)
     .then(() => {
       req.flash('generic', 'Another verification code has been sent to your phone')
       return res.redirect(paths.user.profile.twoFactorAuth.configure)

--- a/app/controllers/user/phone-number/post.controller.js
+++ b/app/controllers/user/phone-number/post.controller.js
@@ -18,7 +18,7 @@ module.exports = async function updatePhoneNumber (req, res) {
   }
 
   try {
-    await userService.updatePhoneNumber(req.user.externalId, telephoneNumber)
+    await userService.updatePhoneNumber(req.user.externalId, telephoneNumber, req.correlationId)
 
     req.flash('generic', 'Phone number updated')
     return res.redirect(paths.user.profile.index)

--- a/app/services/auth.service.js
+++ b/app/services/auth.service.js
@@ -96,7 +96,7 @@ function localStrategyAuth (req, username, password, done) {
 }
 
 function localStrategy2Fa (req, done) {
-  return userService.authenticateSecondFactor(req.user.externalId, req.body.code)
+  return userService.authenticateSecondFactor(req.user.externalId, req.body.code, req.correlationId)
     .then((user) => done(null, user))
     .catch(() => done(null, false, { message: 'The verification code you’ve used is incorrect or has expired.' }))
 }

--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -21,7 +21,6 @@ const responseBodyToServiceTransformer = body => new Service(body)
 
 module.exports = function (clientOptions = {}) {
   const baseUrl = clientOptions.baseUrl || ADMINUSERS_URL
-  const correlationId = clientOptions.correlationId || ''
   const userResource = `/v1/api/users`
   const forgottenPasswordResource = `/v1/api/forgotten-passwords`
   const resetPasswordResource = `/v1/api/reset-password`
@@ -29,12 +28,13 @@ module.exports = function (clientOptions = {}) {
   const inviteResource = `/v1/api/invites`
 
   /**
-     * Get a User by external id
-     *
-     * @param {string} externalId
-     * @return {Promise<User>} A promise of a User
-     */
-  const getUserByExternalId = (externalId) => {
+   * Get a User by external id
+   *
+   * @param {string} externalId
+   * @param correlationId
+   * @return {Promise<User>} A promise of a User
+   */
+  const getUserByExternalId = (externalId, correlationId) => {
     return baseClient.get(
       {
         baseUrl,
@@ -50,12 +50,13 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     * Get a User by external id
-     *
-     * @param {string} externalId
-     * @return {Promise<User>} A promise of a User
-     */
-  const getUsersByExternalIds = (externalIds = []) => {
+   * Get a User by external id
+   *
+   * @return {Promise<User>} A promise of a User
+   * @param externalIds
+   * @param correlationId
+   */
+  const getUsersByExternalIds = (externalIds = [], correlationId) => {
     return baseClient.get(
       {
         baseUrl,
@@ -74,11 +75,12 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     * @param username
-     * @param password
-     * @returns {Promise<User>}
-     */
-  const authenticateUser = (username, password) => {
+   * @param username
+   * @param password
+   * @param correlationId
+   * @returns {Promise<User>}
+   */
+  const authenticateUser = (username, password, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
@@ -98,11 +100,12 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     *
-     * @param externalId
-     * @returns {Promise}
-     */
-  const incrementSessionVersionForUser = (externalId) => {
+   *
+   * @param externalId
+   * @param correlationId
+   * @returns {Promise}
+   */
+  const incrementSessionVersionForUser = (externalId, correlationId) => {
     return baseClient.patch(
       {
         baseUrl,
@@ -122,11 +125,12 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     *
-     * @param username
-     * @returns {Promise<ForgottenPassword>}
-     */
-  const createForgottenPassword = (username) => {
+   *
+   * @param username
+   * @param correlationId
+   * @returns {Promise<ForgottenPassword>}
+   */
+  const createForgottenPassword = (username, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
@@ -144,11 +148,12 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     *
-     * @param code
-     * @returns {Promise<ForgottenPassword>}
-     */
-  const getForgottenPassword = (code) => {
+   *
+   * @param code
+   * @param correlationId
+   * @returns {Promise<ForgottenPassword>}
+   */
+  const getForgottenPassword = (code, correlationId) => {
     return baseClient.get(
       {
         baseUrl,
@@ -163,12 +168,13 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     *
-     * @param token
-     * @param newPassword
-     * @returns {Promise}
-     */
-  const updatePasswordForUser = (token, newPassword) => {
+   *
+   * @param token
+   * @param newPassword
+   * @param correlationId
+   * @returns {Promise}
+   */
+  const updatePasswordForUser = (token, newPassword, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
@@ -187,11 +193,13 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     *
-     * @param externalId
-     * @returns {Promise}
-     */
-  const sendSecondFactor = (externalId, provisional) => {
+   *
+   * @param externalId
+   * @param provisional
+   * @param correlationId
+   * @returns {Promise}
+   */
+  const sendSecondFactor = (externalId, provisional, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
@@ -207,12 +215,13 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     *
-     * @param externalId
-     * @param code
-     * @returns {Promise}
-     */
-  const authenticateSecondFactor = (externalId, code) => {
+   *
+   * @param externalId
+   * @param code
+   * @param correlationId
+   * @returns {Promise}
+   */
+  const authenticateSecondFactor = (externalId, code, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
@@ -228,7 +237,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const getServiceUsers = (serviceExternalId) => {
+  const getServiceUsers = (serviceExternalId, correlationId) => {
     return baseClient.get(
       {
         baseUrl,
@@ -244,12 +253,13 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     *
-     * @param userExternalId
-     * @param serviceExternalId
-     * @param roleName
-     */
-  const assignServiceRole = (userExternalId, serviceExternalId, roleName) => {
+   *
+   * @param userExternalId
+   * @param serviceExternalId
+   * @param roleName
+   * @param correlationId
+   */
+  const assignServiceRole = (userExternalId, serviceExternalId, roleName, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
@@ -269,13 +279,14 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     *
-     * @param externalId
-     * @param serviceExternalId
-     * @param roleName
-     * @returns {Promise<User>}
-     */
-  const updateServiceRole = (externalId, serviceExternalId, roleName) => {
+   *
+   * @param externalId
+   * @param serviceExternalId
+   * @param roleName
+   * @param correlationId
+   * @returns {Promise<User>}
+   */
+  const updateServiceRole = (externalId, serviceExternalId, roleName, correlationId) => {
     return baseClient.put(
       {
         baseUrl,
@@ -294,14 +305,15 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     *
-     * @param invitee
-     * @param senderId
-     * @param serviceExternalId
-     * @param roleName
-     * @returns {Promise}
-     */
-  const inviteUser = (invitee, senderId, serviceExternalId, roleName) => {
+   *
+   * @param invitee
+   * @param senderId
+   * @param serviceExternalId
+   * @param roleName
+   * @param correlationId
+   * @returns {Promise}
+   */
+  const inviteUser = (invitee, senderId, serviceExternalId, roleName, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
@@ -324,8 +336,9 @@ module.exports = function (clientOptions = {}) {
   /**
    * Get a invited users for a given service
    * @param serviceExternalId
+   * @param correlationId
    */
-  const getInvitedUsersList = (serviceExternalId) => {
+  const getInvitedUsersList = (serviceExternalId, correlationId) => {
     return baseClient.get(
       {
         baseUrl,
@@ -346,8 +359,9 @@ module.exports = function (clientOptions = {}) {
   /**
    * Get a valid invite or error if it's expired
    * @param inviteCode
+   * @param correlationId
    */
-  const getValidatedInvite = (inviteCode) => {
+  const getValidatedInvite = (inviteCode, correlationId) => {
     return baseClient.get(
       {
         baseUrl,
@@ -362,14 +376,15 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     * Generate OTP code for an invite
-     *
-     * @param inviteCode
-     * @param telephoneNumber
-     * @param password
-     * @returns {*|Constructor}
-     */
-  const generateInviteOtpCode = (inviteCode, telephoneNumber, password) => {
+   * Generate OTP code for an invite
+   *
+   * @param inviteCode
+   * @param telephoneNumber
+   * @param password
+   * @param correlationId
+   * @returns {*|Constructor}
+   */
+  const generateInviteOtpCode = (inviteCode, telephoneNumber, password, correlationId) => {
     let postData = {
       baseUrl,
       url: `${inviteResource}/${inviteCode}/otp/generate`,
@@ -393,13 +408,14 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     * Complete a service invite
-     *
-     * @param inviteCode
-     * @param gatewayAccountIds
-     * @returns {*|promise|Constructor}
-     */
-  const completeInvite = (inviteCode, gatewayAccountIds) => {
+   * Complete a service invite
+   *
+   * @param correlationId
+   * @param inviteCode
+   * @param gatewayAccountIds
+   * @returns {*|promise|Constructor}
+   */
+  const completeInvite = (correlationId, inviteCode, gatewayAccountIds) => {
     return baseClient.post(
       {
         baseUrl,
@@ -416,7 +432,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const verifyOtpAndCreateUser = (code, verificationCode) => {
+  const verifyOtpAndCreateUser = (code, verificationCode, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
@@ -434,7 +450,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const verifyOtpForServiceInvite = (inviteCode, verificationCode) => {
+  const verifyOtpForServiceInvite = (inviteCode, verificationCode, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
@@ -452,7 +468,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const resendOtpCode = (code, phoneNumber) => {
+  const resendOtpCode = (code, phoneNumber, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
@@ -471,13 +487,14 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     * Submit service registration details
-     *
-     * @param email
-     * @param phoneNumber
-     * @param password
-     */
-  const submitServiceRegistration = (email, phoneNumber, password) => {
+   * Submit service registration details
+   *
+   * @param email
+   * @param phoneNumber
+   * @param password
+   * @param correlationId
+   */
+  const submitServiceRegistration = (email, phoneNumber, password, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
@@ -496,7 +513,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const deleteUser = (serviceExternalId, removerExternalId, userExternalId) => {
+  const deleteUser = (serviceExternalId, removerExternalId, userExternalId, correlationId) => {
     let headers = {}
     headers[HEADER_USER_CONTEXT] = removerExternalId
 
@@ -521,13 +538,15 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     * Create a service
-     *
-     * @param serviceName
-     * @param gatewayAccountIds
-     * @returns {*|promise|Constructor}
-     */
-  const createService = (serviceName, serviceNameCy, gatewayAccountIds) => {
+   * Create a service
+   *
+   * @param serviceName
+   * @param serviceNameCy
+   * @param gatewayAccountIds
+   * @param correlationId
+   * @returns {*|promise|Constructor}
+   */
+  const createService = (serviceName, serviceNameCy, gatewayAccountIds, correlationId) => {
     let postBody = {
       baseUrl,
       url: `${serviceResource}`,
@@ -559,9 +578,10 @@ module.exports = function (clientOptions = {}) {
    *
    * @param serviceExternalId
    * @param body
+   * @param correlationId
    * @returns {*|Constructor|promise}
    */
-  const updateService = (serviceExternalId, body) => {
+  const updateService = (serviceExternalId, body, correlationId) => {
     return baseClient.patch({
       baseUrl,
       url: `${serviceResource}/${serviceExternalId}`,
@@ -576,13 +596,15 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     * Update service name
-     *
-     * @param serviceExternalId
-     * @param serviceName
-     * @returns {*|Constructor|promise}
-     */
-  const updateServiceName = (serviceExternalId, serviceName, serviceNameCy) => {
+   * Update service name
+   *
+   * @param serviceExternalId
+   * @param serviceName
+   * @param serviceNameCy
+   * @param correlationId
+   * @returns {*|Constructor|promise}
+   */
+  const updateServiceName = (serviceExternalId, serviceName, serviceNameCy, correlationId) => {
     return baseClient.patch(
       {
         baseUrl,
@@ -613,9 +635,10 @@ module.exports = function (clientOptions = {}) {
    *
    * @param serviceExternalId
    * @param collectBillingAddress
+   * @param correlationId
    * @returns {*|Constructor|promise}
    */
-  const updateCollectBillingAddress = (serviceExternalId, collectBillingAddress) => {
+  const updateCollectBillingAddress = (serviceExternalId, collectBillingAddress, correlationId) => {
     return baseClient.patch(
       {
         baseUrl,
@@ -636,13 +659,14 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     * Add gateway accounts to service
-     *
-     * @param serviceExternalId
-     * @param gatewayAccountIds {String[]} a list of (unassigned) gateway account ids to add to the service
-     * @returns {Promise<Service|Error>}
-     */
-  const addGatewayAccountsToService = (serviceExternalId, gatewayAccountIds) => {
+   * Add gateway accounts to service
+   *
+   * @param serviceExternalId
+   * @param gatewayAccountIds {String[]} a list of (unassigned) gateway account ids to add to the service
+   * @param correlationId
+   * @returns {Promise<Service|Error>}
+   */
+  const addGatewayAccountsToService = (serviceExternalId, gatewayAccountIds, correlationId) => {
     return baseClient.patch(
       {
         baseUrl,
@@ -663,12 +687,12 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     *
-     * @param externalId
-     * @param code
-     * @returns {Promise}
-     */
-  const provisionNewOtpKey = (externalId) => {
+   *
+   * @param externalId
+   * @param correlationId
+   * @returns {Promise}
+   */
+  const provisionNewOtpKey = (externalId, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
@@ -684,13 +708,14 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     *
-     * @param externalId
-     * @param code
-     * @param secondFactor {String} 'SMS' or 'APP'
-     * @returns {Promise}
-     */
-  const configureNewOtpKey = (externalId, code, secondFactor) => {
+   *
+   * @param externalId
+   * @param code
+   * @param secondFactor {String} 'SMS' or 'APP'
+   * @param correlationId
+   * @returns {Promise}
+   */
+  const configureNewOtpKey = (externalId, code, secondFactor, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
@@ -708,7 +733,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const updateCurrentGoLiveStage = (serviceExternalId, newStage) => {
+  const updateCurrentGoLiveStage = (serviceExternalId, newStage, correlationId) => {
     return baseClient.patch(
       {
         baseUrl,
@@ -728,7 +753,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const addStripeAgreementIpAddress = (serviceExternalId, ipAddress) => {
+  const addStripeAgreementIpAddress = (serviceExternalId, ipAddress, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
@@ -743,7 +768,7 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const addGovUkAgreementEmailAddress = (serviceExternalId, userExternalId) => {
+  const addGovUkAgreementEmailAddress = (serviceExternalId, userExternalId, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
@@ -759,12 +784,13 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-     *
-     * @param externalId
-     * @param newPhoneNumber
-     * @returns {Promise}
-     */
-  const updatePhoneNumberForUser = (externalId, newPhoneNumber) => {
+   *
+   * @param externalId
+   * @param newPhoneNumber
+   * @param correlationId
+   * @returns {Promise}
+   */
+  const updatePhoneNumberForUser = (externalId, newPhoneNumber, correlationId) => {
     return baseClient.patch(
       {
         baseUrl,

--- a/app/services/service-registration.service.js
+++ b/app/services/service-registration.service.js
@@ -7,20 +7,20 @@ const getAdminUsersClient = require('./clients/adminusers.client')
 const ConnectorClient = require('./clients/connector.client').ConnectorClient
 const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 
+const adminUsersClient = getAdminUsersClient()
+
 function submitRegistration (email, phoneNumber, password, correlationId) {
-  return getAdminUsersClient({ correlationId }).submitServiceRegistration(email, phoneNumber, password)
+  return adminUsersClient.submitServiceRegistration(email, phoneNumber, password, correlationId)
 }
 
 function submitServiceInviteOtpCode (code, otpCode, correlationId) {
-  return getAdminUsersClient({ correlationId }).verifyOtpForServiceInvite(code, otpCode)
+  return adminUsersClient.verifyOtpForServiceInvite(code, otpCode, correlationId)
 }
 
 async function createPopulatedService (inviteCode, correlationId) {
-  const adminusersClient = getAdminUsersClient({ correlationId })
-
   const gatewayAccount = await connectorClient.createGatewayAccount('sandbox', 'test', null, null, correlationId)
-  const completeInviteResponse = await adminusersClient.completeInvite(inviteCode, [gatewayAccount.gateway_account_id])
-  const user = await adminusersClient.getUserByExternalId(completeInviteResponse.user_external_id)
+  const completeInviteResponse = await adminUsersClient.completeInvite(correlationId, inviteCode, [gatewayAccount.gateway_account_id])
+  const user = await adminUsersClient.getUserByExternalId(completeInviteResponse.user_external_id, correlationId)
 
   const logContext = {
     internal_user: user.internalUser
@@ -34,11 +34,11 @@ async function createPopulatedService (inviteCode, correlationId) {
 }
 
 function generateServiceInviteOtpCode (inviteCode, correlationId) {
-  return getAdminUsersClient({ correlationId }).generateInviteOtpCode(inviteCode)
+  return adminUsersClient.generateInviteOtpCode(inviteCode, null, null, correlationId)
 }
 
 function resendOtpCode (code, phoneNumber, correlationId) {
-  return getAdminUsersClient({ correlationId }).resendOtpCode(code, phoneNumber)
+  return adminUsersClient.resendOtpCode(code, phoneNumber, correlationId)
 }
 
 module.exports = {

--- a/app/services/service.service.js
+++ b/app/services/service.service.js
@@ -11,6 +11,7 @@ const { isADirectDebitAccount } = directDebitConnectorClient
 const CardGatewayAccount = require('../models/GatewayAccount.class')
 const Service = require('../models/Service.class')
 const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
+const adminUsersClient = getAdminUsersClient()
 
 async function getGatewayAccounts (gatewayAccountIds, correlationId) {
   const cardGatewayAccountIds = gatewayAccountIds.filter(id => !isADirectDebitAccount(id))
@@ -28,7 +29,7 @@ function updateServiceName (serviceExternalId, serviceName, serviceNameCy, corre
   if (!serviceExternalId) {
     return Promise.reject(new Error(`argument: 'serviceExternalId' cannot be undefined`))
   }
-  return getAdminUsersClient({ correlationId }).updateServiceName(serviceExternalId, serviceName, serviceNameCy)
+  return adminUsersClient.updateServiceName(serviceExternalId, serviceName, serviceNameCy, correlationId)
     .then(result => {
       // Update gateway account service names in connector
       const gatewayAccountIds = lodash.get(result, 'gateway_account_ids', [])
@@ -46,7 +47,7 @@ function updateServiceName (serviceExternalId, serviceName, serviceNameCy, corre
 }
 
 function updateService (serviceExternalId, serviceUpdateRequest, correlationId) {
-  return getAdminUsersClient({ correlationId }).updateService(serviceExternalId, serviceUpdateRequest)
+  return adminUsersClient.updateService(serviceExternalId, serviceUpdateRequest, correlationId)
 }
 
 async function createService (serviceName, serviceNameCy, user, correlationId) {
@@ -54,7 +55,7 @@ async function createService (serviceName, serviceNameCy, user, correlationId) {
   if (!serviceNameCy) serviceNameCy = ''
 
   const gatewayAccount = await connectorClient.createGatewayAccount('sandbox', 'test', serviceName, null, correlationId)
-  const service = await getAdminUsersClient({ correlationId }).createService(serviceName, serviceNameCy, [gatewayAccount.gateway_account_id])
+  const service = await adminUsersClient.createService(serviceName, serviceNameCy, [gatewayAccount.gateway_account_id], correlationId)
 
   const logContext = {
     internal_user: user.internalUser
@@ -68,19 +69,19 @@ async function createService (serviceName, serviceNameCy, user, correlationId) {
 }
 
 function toggleCollectBillingAddress (serviceExternalId, collectBillingAddress, correlationId) {
-  return getAdminUsersClient({ correlationId }).updateCollectBillingAddress(serviceExternalId, collectBillingAddress)
+  return adminUsersClient.updateCollectBillingAddress(serviceExternalId, collectBillingAddress, correlationId)
 }
 
 function updateCurrentGoLiveStage (serviceExternalId, newStage, correlationId) {
-  return getAdminUsersClient({ correlationId }).updateCurrentGoLiveStage(serviceExternalId, newStage)
+  return adminUsersClient.updateCurrentGoLiveStage(serviceExternalId, newStage, correlationId)
 }
 
 function addStripeAgreementIpAddress (serviceExternalId, ipAddress, correlationId) {
-  return getAdminUsersClient({ correlationId }).addStripeAgreementIpAddress(serviceExternalId, ipAddress)
+  return adminUsersClient.addStripeAgreementIpAddress(serviceExternalId, ipAddress, correlationId)
 }
 
 function addGovUkAgreementEmailAddress (serviceExternalId, userExternalId, correlationId) {
-  return getAdminUsersClient({ correlationId }).addGovUkAgreementEmailAddress(serviceExternalId, userExternalId)
+  return adminUsersClient.addGovUkAgreementEmailAddress(serviceExternalId, userExternalId, correlationId)
 }
 
 module.exports = {

--- a/app/services/transaction.service.js
+++ b/app/services/transaction.service.js
@@ -63,7 +63,7 @@ const logCsvFileStreamComplete = function logCsvFileStreamComplete (timestampStr
   logger.info('Completed file stream', logContext)
 }
 
-const ledgerFindWithEvents = async function ledgerFindWithEvents (accountId, chargeId) {
+const ledgerFindWithEvents = async function ledgerFindWithEvents (accountId, chargeId, correlationId) {
   try {
     const charge = await Ledger.transaction(chargeId, accountId)
     const transactionEvents = await Ledger.events(chargeId, accountId)
@@ -75,7 +75,7 @@ const ledgerFindWithEvents = async function ledgerFindWithEvents (accountId, cha
       .uniq()
       .value()
 
-    const users = await userService.findMultipleByExternalIds(userIds)
+    const users = await userService.findMultipleByExternalIds(userIds, correlationId)
 
     return transactionView.buildPaymentView(charge, transactionEvents, users)
   } catch (error) {

--- a/app/services/user-registration.service.js
+++ b/app/services/user-registration.service.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const getAdminUsersClient = require('./clients/adminusers.client')
+const adminUsersClient = getAdminUsersClient()
 
 module.exports = {
 
@@ -14,7 +15,7 @@ module.exports = {
    * @returns {*|Constructor}
    */
   submitRegistration: function (code, telephoneNumber, password, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).generateInviteOtpCode(code, telephoneNumber, password)
+    return adminUsersClient.generateInviteOtpCode(code, telephoneNumber, password, correlationId)
   },
 
   /**
@@ -25,15 +26,15 @@ module.exports = {
    * @param correlationId
    */
   verifyOtpAndCreateUser: function (code, verifyCode, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).verifyOtpAndCreateUser(code, verifyCode)
+    return adminUsersClient.verifyOtpAndCreateUser(code, verifyCode, correlationId)
   },
 
   resendOtpCode: function (code, phoneNumber, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).resendOtpCode(code, phoneNumber)
+    return adminUsersClient.resendOtpCode(code, phoneNumber, correlationId)
   },
 
   completeInvite: function (code, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).completeInvite(code)
+    return adminUsersClient.completeInvite(correlationId, code)
   }
 
 }

--- a/app/services/user.service.js
+++ b/app/services/user.service.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const getAdminUsersClient = require('./clients/adminusers.client')
+const adminUsersClient = getAdminUsersClient()
 
 module.exports = {
 
@@ -16,7 +17,7 @@ module.exports = {
         reject(new Error('Failed to authenticate'))
       })
     }
-    return getAdminUsersClient({ correlationId: correlationId }).authenticateUser(username, submittedPassword)
+    return adminUsersClient.authenticateUser(username, submittedPassword, correlationId)
   },
 
   /**
@@ -32,7 +33,7 @@ module.exports = {
       })
     }
 
-    return getAdminUsersClient({ correlationId: correlationId }).authenticateSecondFactor(externalId, code)
+    return adminUsersClient.authenticateSecondFactor(externalId, code, correlationId)
   },
 
   /**
@@ -41,16 +42,16 @@ module.exports = {
    * @returns {Promise<User>}
    */
   findByExternalId: (externalId, correlationId) => {
-    return getAdminUsersClient({ correlationId: correlationId }).getUserByExternalId(externalId)
+    return adminUsersClient.getUserByExternalId(externalId, correlationId)
   },
 
   /**
-   * @param {Array} externalId
+   * @param {Array} externalIds
    * @param {String} correlationId
    * @returns {Promise<User>}
    */
   findMultipleByExternalIds: function (externalIds, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).getUsersByExternalIds(externalIds)
+    return adminUsersClient.getUsersByExternalIds(externalIds, correlationId)
   },
 
   /**
@@ -59,7 +60,7 @@ module.exports = {
    * @returns {Promise}
    */
   sendOTP: function (user, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).sendSecondFactor(user.externalId, false)
+    return adminUsersClient.sendSecondFactor(user.externalId, false, correlationId)
   },
 
   /**
@@ -67,27 +68,26 @@ module.exports = {
    * @param correlationId
    * @returns {Promise}
    */
-  sendProvisonalOTP: function (user, correlationId) {
-    return getAdminUsersClient({
-      correlationId: correlationId
-    }).sendSecondFactor(user.externalId, true)
+  sendProvisionalOTP: function (user, correlationId) {
+    return adminUsersClient.sendSecondFactor(user.externalId, true, correlationId)
   },
 
   /**
-   * @param user
+   * @param username
    * @param correlationId
    * @returns {Promise}
    */
   sendPasswordResetToken: function (username, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).createForgottenPassword(username)
+    return adminUsersClient.createForgottenPassword(username, correlationId)
   },
 
   /**
    * @param token
+   * @param correlationId
    * @returns {Promise}
    */
-  findByResetToken: function (token) {
-    return getAdminUsersClient().getForgottenPassword(token)
+  findByResetToken: function (token, correlationId) {
+    return adminUsersClient.getForgottenPassword(token, correlationId)
   },
 
   /**
@@ -96,7 +96,7 @@ module.exports = {
    * @returns {Promise}
    */
   logOut: function (user, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).incrementSessionVersionForUser(user.externalId)
+    return adminUsersClient.incrementSessionVersionForUser(user.externalId, correlationId)
   },
 
   /**
@@ -105,16 +105,17 @@ module.exports = {
    * @returns {Promise}
    */
   getServiceUsers: function (externalServiceId, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).getServiceUsers(externalServiceId)
+    return adminUsersClient.getServiceUsers(externalServiceId, correlationId)
   },
 
   /**
    * @param token
    * @param newPassword
+   * @param correlationId
    * @returns {Promise}
    */
-  updatePassword: function updatePassword (token, newPassword) {
-    return getAdminUsersClient().updatePasswordForUser(token, newPassword)
+  updatePassword: function updatePassword (token, newPassword, correlationId) {
+    return adminUsersClient.updatePasswordForUser(token, newPassword, correlationId)
   },
 
   /**
@@ -125,7 +126,7 @@ module.exports = {
    * @returns {Promise.<User>}
    */
   updateServiceRole: function (externalId, roleName, externalServiceId, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).updateServiceRole(externalId, externalServiceId, roleName)
+    return adminUsersClient.updateServiceRole(externalId, externalServiceId, roleName, correlationId)
   },
 
   /**
@@ -137,7 +138,7 @@ module.exports = {
    * @returns {Promise.<User>}
    */
   assignServiceRole: function (externalId, externalServiceId, roleName, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).assignServiceRole(externalId, externalServiceId, roleName)
+    return adminUsersClient.assignServiceRole(externalId, externalServiceId, roleName, correlationId)
   },
 
   /**
@@ -148,7 +149,7 @@ module.exports = {
    * @param correlationId
    */
   inviteUser: function (invitee, senderId, externalServiceId, roleName, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).inviteUser(invitee, senderId, externalServiceId, roleName)
+    return adminUsersClient.inviteUser(invitee, senderId, externalServiceId, roleName, correlationId)
   },
 
   /**
@@ -156,7 +157,7 @@ module.exports = {
    * @param correlationId
    */
   getInvitedUsersList: function (externalServiceId, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).getInvitedUsersList(externalServiceId)
+    return adminUsersClient.getInvitedUsersList(externalServiceId, correlationId)
   },
 
   /**
@@ -167,7 +168,7 @@ module.exports = {
    * @param correlationId
    */
   delete: function (externalServiceId, removerExternalId, userExternalId, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).deleteUser(externalServiceId, removerExternalId, userExternalId)
+    return adminUsersClient.deleteUser(externalServiceId, removerExternalId, userExternalId, correlationId)
   },
 
   /**
@@ -180,7 +181,7 @@ module.exports = {
       return Promise.reject(new Error('No externalId specified'))
     }
 
-    return getAdminUsersClient({ correlationId: correlationId }).provisionNewOtpKey(externalId)
+    return adminUsersClient.provisionNewOtpKey(externalId, correlationId)
   },
 
   /**
@@ -195,14 +196,16 @@ module.exports = {
       Promise.reject(new Error('No externalId specified'))
     }
 
-    return getAdminUsersClient({ correlationId: correlationId }).configureNewOtpKey(externalId, code, secondFactor)
+    return adminUsersClient.configureNewOtpKey(externalId, code, secondFactor, correlationId)
   },
 
   /**
+   * @param externalId
    * @param newPhoneNumber
+   * @param correlationId
    * @returns {Promise}
    */
-  updatePhoneNumber: function (externalId, newPhoneNumber) {
-    return getAdminUsersClient().updatePhoneNumberForUser(externalId, newPhoneNumber)
+  updatePhoneNumber: function (externalId, newPhoneNumber, correlationId) {
+    return adminUsersClient.updatePhoneNumberForUser(externalId, newPhoneNumber, correlationId)
   }
 }

--- a/app/services/validate-invite.service.js
+++ b/app/services/validate-invite.service.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const getAdminUsersClient = require('./clients/adminusers.client')
+const adminUsersClient = getAdminUsersClient()
 
 module.exports = {
 
@@ -10,6 +11,6 @@ module.exports = {
    * @param correlationId
    */
   getValidatedInvite: function (code, correlationId) {
-    return getAdminUsersClient({ correlationId: correlationId }).getValidatedInvite(code)
+    return adminUsersClient.getValidatedInvite(code, correlationId)
   }
 }

--- a/test/unit/clients/adminusers-client/invite/complete-service-invite.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/complete-service-invite.pact.test.js
@@ -69,7 +69,7 @@ describe('adminusers client - complete an invite', function () {
     afterEach(() => provider.verify())
 
     it('should complete a service invite successfully', function (done) {
-      adminusersClient.completeInvite(inviteCode, gatewayAccountIds).should.be.fulfilled.then(response => {
+      adminusersClient.completeInvite('correlation-id', inviteCode, gatewayAccountIds).should.be.fulfilled.then(response => {
         expect(response.invite).to.deep.equal(validInviteCompleteResponse.invite)
         expect(response.user_external_id).to.equal(userExternalId)
         expect(response.service_external_id).to.equal(serviceExternalId)
@@ -100,7 +100,7 @@ describe('adminusers client - complete an invite', function () {
     afterEach(() => provider.verify())
 
     it('should 404 NOT FOUND if invite code not found', function (done) {
-      adminusersClient.completeInvite(nonExistingInviteCode, gatewayAccountIds).should.be.rejected.then(function (response) {
+      adminusersClient.completeInvite('correlation-id', nonExistingInviteCode, gatewayAccountIds).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(404)
       }).should.notify(done)
     })
@@ -129,7 +129,7 @@ describe('adminusers client - complete an invite', function () {
     afterEach(() => provider.verify())
 
     it('should 409 CONFLICT if user with same email exists', function (done) {
-      adminusersClient.completeInvite(inviteCode, gatewayAccountIds).should.be.rejected.then(function (response) {
+      adminusersClient.completeInvite('correlation-id', inviteCode, gatewayAccountIds).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(409)
       }).should.notify(done)
     })
@@ -160,7 +160,7 @@ describe('adminusers client - complete an invite', function () {
     afterEach(() => provider.verify())
 
     it('should 400 BAD REQUEST if gateway accounts are non numeric', function (done) {
-      adminusersClient.completeInvite(inviteCode, invalidGatewayAccountIds).should.be.rejected.then(function (response) {
+      adminusersClient.completeInvite('correlation-id', inviteCode, invalidGatewayAccountIds).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(400)
       }).should.notify(done)
     })

--- a/test/unit/clients/adminusers-client/invite/complete-user-invite.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/complete-user-invite.pact.test.js
@@ -63,7 +63,7 @@ describe('adminusers client - complete a user invite', function () {
     afterEach(() => provider.verify())
 
     it('should complete a service invite successfully', function (done) {
-      adminusersClient.completeInvite(inviteCode).should.be.fulfilled.then(response => {
+      adminusersClient.completeInvite('correlation-id', inviteCode).should.be.fulfilled.then(response => {
         expect(response.invite).to.deep.equal(validInviteCompleteResponse.invite)
         expect(response.user_external_id).to.equal(userExternalId)
         expect(response.service_external_id).to.equal(serviceExternalId)
@@ -89,7 +89,7 @@ describe('adminusers client - complete a user invite', function () {
     afterEach(() => provider.verify())
 
     it('should 404 NOT FOUND if invite code not found', function (done) {
-      adminusersClient.completeInvite(nonExistingInviteCode).should.be.rejected.then(function (response) {
+      adminusersClient.completeInvite('correlation-id', nonExistingInviteCode).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(404)
       }).should.notify(done)
     })
@@ -113,7 +113,7 @@ describe('adminusers client - complete a user invite', function () {
     afterEach(() => provider.verify())
 
     it('should 410 GONE if invite is expired', function (done) {
-      adminusersClient.completeInvite(inviteCode).should.be.rejected.then(function (response) {
+      adminusersClient.completeInvite('correlation-id', inviteCode).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(410)
       }).should.notify(done)
     })


### PR DESCRIPTION
## WHAT
- Refactored adminUsers client methods to move `correlationId` to each individual call rather than being set at the instance level.  This allows code that calls this adminUsers client to instantiate once using singleton pattern.
- Updated code to instantiate adminUsers client once rather than per call
