### PR TITLE
PP-7422: Handle bad result returned by connector

### DIFF
--- a/app/controllers/your-psp/post-flex.controller.js
+++ b/app/controllers/your-psp/post-flex.controller.js
@@ -16,7 +16,6 @@ const ISSUER_FIELD = 'issuer'
 const JWT_MAC_KEY_FIELD = 'jwt-mac-key'
 
 module.exports = async (req, res) => {
-
   const correlationId = req.headers[correlationHeader] || ''
 
   const accountId = req.account.gateway_account_id
@@ -61,6 +60,10 @@ module.exports = async (req, res) => {
         })
         return res.redirect(303, paths.yourPsp.flex)
       }
+    }
+
+    if (response.result !== 'valid') {
+      return renderErrorView(req, res, false)
     }
 
     await connector.post3dsFlexAccountCredentials(flexParams)

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -190,6 +190,16 @@ function postCheckWorldpay3dsFlexCredentialsFailure (opts) {
   })
 }
 
+function postCheckWorldpay3dsFlexCredentialsWithBadResult (opts) {
+  const path = `/v1/api/accounts/${opts.gatewayAccountId}/worldpay/check-3ds-flex-config`
+  return stubBuilder('POST', path, 200, {
+    request: worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsRequest(opts).payload,
+    response: worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsResponse({
+      result: 'bad data'
+    })
+  })
+}
+
 module.exports = {
   getAccountAuthSuccess,
   getGatewayAccountSuccess,
@@ -203,5 +213,6 @@ module.exports = {
   patchRefundEmailToggleSuccess,
   patchAccountEmailCollectionModeSuccess,
   postCheckWorldpay3dsFlexCredentials,
-  postCheckWorldpay3dsFlexCredentialsFailure
+  postCheckWorldpay3dsFlexCredentialsFailure,
+  postCheckWorldpay3dsFlexCredentialsWithBadResult
 }


### PR DESCRIPTION
This change updates post-flex controller to save valid Worldpay 3DS Flex credentials only and only if the result is valid. This change is necessary because the result can contain the value other than "valid" and "invalid". It adds 1 more test to Cypress to test the following scenario.

1. Connector returns result = bad data after checking Worldpay 3DS Flex credentials.

Please note that Self Service application has no way to check that response's body is null or empty before processing it. If the response contains no body or other data,  post-flex controller will attempt to retrieve result from the response's body and this will cause Self Service application to display a generic problem page.