### PR TITLE
BAU Use design system notification banner component

### DIFF
--- a/app/views/includes/flash.njk
+++ b/app/views/includes/flash.njk
@@ -1,4 +1,4 @@
-{% from "../macro/success-notification.njk" import successNotification %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% block flash %}
   {% if flash.genericError %}
@@ -13,9 +13,16 @@
 
   {% if flash.generic %}
     <div class="govuk-grid-column-two-thirds">
-      {{ successNotification
-        ({heading: flash.generic | safe}) 
-      }}
+      {% set html %}
+        <p class="govuk-notification-banner__heading">
+          {{ flash.generic | safe }}
+        </p>
+      {% endset %}
+
+      {{ govukNotificationBanner({
+        html: html,
+        type: 'success'
+      }) }}
     </div>
   {% endif %}
 {% endblock %}

--- a/app/views/macro/success-notification.njk
+++ b/app/views/macro/success-notification.njk
@@ -1,8 +1,0 @@
-{% macro successNotification(params) %}
-  <div class="flash-container flash-container--good">
-    <div class="notification">
-      <h2>{{ params.heading | safe }}</h2>
-      <p>{{ params.body | safe }}</p>
-    </div>
-  </div>
-{% endmacro %}

--- a/app/views/payment-links/manage.njk
+++ b/app/views/payment-links/manage.njk
@@ -1,5 +1,5 @@
 {% extends "../layout.njk" %}
-{% from "../macro/success-notification.njk" import successNotification %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% block pageTitle %}
   {% if permissions.tokens_create %}Manage{% else %}View{% endif %} a payment link - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
@@ -13,26 +13,28 @@
 <section class="govuk-grid-column-two-thirds">
 {% if flash.createPaymentLinkSuccess %}
   {% if isTestGateway %}
-    {% set heading = "Your Payment link is ready to test" %}
-    {% set body %}
-      <span>
-        To start collecting payments, you need to
-        <a class="govuk-link" href="{{ paths.generateRoute(paths.requestToGoLive.index, { externalServiceId: externalServiceId }) }}">
-          Request a live account
-        </a>.
-        Once live, you’ll need to recreate your Payment link before you can give it to users.
-      </span>
+        {% set html %}
+        <p class="govuk-notification-banner__heading">
+          Your Payment link is ready to test
+        </p>
+        <p class="govuk-body">
+          To start collecting payments, you need to <a class="govuk-link" href="{{ paths.generateRoute(paths.requestToGoLive.index, { externalServiceId: externalServiceId }) }}">Request a live account</a>. Once live, you’ll need to recreate your Payment link before you can give it to users.
+        </p>
     {% endset %}
   {% else %}
-    {% set heading = "Your payment link is now live" %}
-    {% set body %}
-      <span>Give this link to your users to collect payments for your service.</span>
+        {% set html %}
+        <p class="govuk-notification-banner__heading">
+          Your payment link is now live
+        </p>
+        <p class="govuk-body">
+          Give this link to your users to collect payments for your service.
+        </p>
     {% endset %}
   {% endif %}
 
-  {{ successNotification({
-    heading: heading,
-    body: body
+      {{ govukNotificationBanner({
+        html: html,
+        type: 'success'
   }) }}
 {% endif %}
 

--- a/app/views/team-members/team-member-profile.njk
+++ b/app/views/team-members/team-member-profile.njk
@@ -1,5 +1,5 @@
 {% extends "../layout.njk" %}
-{% from "../macro/success-notification.njk" import successNotification %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% block pageTitle %}
 My profile - GOV.UK Pay
@@ -8,11 +8,19 @@ My profile - GOV.UK Pay
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
   {% if flash.otpMethodUpdated %}
-    {{ successNotification({
-          heading: "Your sign-in method has been updated",
-          body: "Use your authenticator app when you next sign in." 
-                if flash.otpMethodUpdated[0] === "APP" 
-                else "We’ll send you a text message when you next sign in."
+    {% set html %}
+      <p class="govuk-notification-banner__heading">Your sign-in method has been updated</p>
+
+      {% if flash.otpMethodUpdated[0] === "APP" %}
+        <p class="govuk-body">Use your authenticator app when you next sign in.</p>
+      {% else %}
+        <p class="govuk-body">We’ll send you a text message when you next sign in.</p>
+      {% endif %}
+    {% endset %}
+
+    {{ govukNotificationBanner({
+      html: html,
+      type: 'success'
     }) }}
   {% endif %}
 </div>

--- a/app/views/transaction-detail/index.njk
+++ b/app/views/transaction-detail/index.njk
@@ -1,5 +1,5 @@
 {% extends "../layout.njk" %}
-{% from "../macro/success-notification.njk" import successNotification %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% set contextIsAllServiceTransactions = redirectBackLink %}
 {% set hideServiceHeader = contextIsAllServiceTransactions %}
@@ -27,9 +27,14 @@
 {% block mainContent %}
   <div class="govuk-grid-column-two-thirds">
     {% if flash.refundSuccess %}
-      {{ successNotification({
-        heading: "Refund successful",
-        body: "It may take up to 6 days to process."
+      {% set html %}
+        <p class="govuk-notification-banner__heading">Refund successful</p>
+        <p class="govuk-body">It may take up to 6 days to process.</p>
+      {% endset %}
+
+      {{ govukNotificationBanner({
+        html: html,
+        type: 'success'
       }) }}
     {% elif flash.refundError %}
       <div class="govuk-error-summary hidden" aria-labelledby="error-summary-heading-example-1" role="alert" tabindex="-1" data-module="govuk-error-summary">

--- a/test/cypress/integration/manage-team-members/edit-permissions.cy.test.js
+++ b/test/cypress/integration/manage-team-members/edit-permissions.cy.test.js
@@ -67,6 +67,6 @@ describe('Edit service user permissions', () => {
   it('should update permission', () => {
     cy.get('#role-view-and-refund-input').click()
     cy.get('button').contains('Save changes').click()
-    cy.get('.flash-container--good').contains('Permissions have been updated')
+    cy.get('.govuk-notification-banner--success').contains('Permissions have been updated')
   })
 })

--- a/test/cypress/integration/payment-links/create-payment-link.cy.test.js
+++ b/test/cypress/integration/payment-links/create-payment-link.cy.test.js
@@ -261,7 +261,7 @@ describe('The create payment link flow', () => {
           expect(location.pathname).to.eq(`/create-payment-link/review`)
         })
 
-        cy.get('.notification').find('h2').should('contain', 'The details have been updated')
+        cy.get('.govuk-notification-banner--success').should('contain', 'The details have been updated')
       })
 
       it('should redirect to the manage payment link page with a success message', () => {
@@ -270,7 +270,7 @@ describe('The create payment link flow', () => {
           expect(location.pathname).to.eq(`/create-payment-link/manage`)
         })
 
-        cy.get('.notification').find('h2').should('contain', 'Your Payment link is ready to test')
+        cy.get('.govuk-notification-banner--success').should('contain', 'Your Payment link is ready to test')
       })
     })
   })

--- a/test/cypress/integration/payment-links/delete-payment-links.cy.test.js
+++ b/test/cypress/integration/payment-links/delete-payment-links.cy.test.js
@@ -34,6 +34,6 @@ describe('Should delete payment link', () => {
     cy.get('a').contains('Yes, delete this link').click()
 
     cy.get('h1').should('contain', 'Manage payment links')
-    cy.get('div.flash-container > div').contains('The payment link was successfully deleted')
+    cy.get('.govuk-notification-banner--success').contains('The payment link was successfully deleted')
   })
 })

--- a/test/cypress/integration/settings/3ds.cy.test.js
+++ b/test/cypress/integration/settings/3ds.cy.test.js
@@ -170,7 +170,7 @@ describe('3DS settings page', () => {
       cy.get('#save-3ds-changes').click()
       cy.get('input[value="on"]').should('be.checked')
       cy.get('input[value="off"]').should('not.be.checked')
-      cy.get('.flash-container').should('contain', '3D secure settings have been updated')
+      cy.get('.govuk-notification-banner--success').should('contain', '3D secure settings have been updated')
       cy.get('#navigation-menu-settings').click()
       cy.get('.govuk-summary-list__key').eq(2).should('contain', '3D Secure')
       cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')

--- a/test/cypress/integration/settings/allow-apple-pay.cy.test.js
+++ b/test/cypress/integration/settings/allow-apple-pay.cy.test.js
@@ -61,7 +61,7 @@ describe('Apple Pay', () => {
       cy.get('input[value="on"]').click()
       cy.get('input[value="on"]').should('be.checked')
       cy.get('.govuk-button').contains('Save changes').click()
-      cy.get('.notification').should('contain', 'Apple Pay successfully enabled.')
+      cy.get('.govuk-notification-banner--success').should('contain', 'Apple Pay successfully enabled.')
       cy.get('input[value="on"]').should('be.checked')
       cy.get('#navigation-menu-settings').click()
       cy.get('.govuk-summary-list__value').first().should('contain', 'On')

--- a/test/cypress/integration/settings/allow-google-pay.cy.test.js
+++ b/test/cypress/integration/settings/allow-google-pay.cy.test.js
@@ -62,7 +62,7 @@ describe('Google Pay', () => {
       cy.get('input[value="on"]').should('be.checked')
       cy.get('#merchantId').type('111111111111111')
       cy.get('.govuk-button').contains('Save changes').click()
-      cy.get('.notification').should('contain', 'Google Pay successfully enabled.')
+      cy.get('.govuk-notification-banner--success').should('contain', 'Google Pay successfully enabled.')
       cy.get('input[value="on"]').should('be.checked')
       cy.get('#navigation-menu-settings').click()
       cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On')

--- a/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js
+++ b/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js
@@ -104,7 +104,7 @@ describe('MOTO mask security section', () => {
         cy.get('#save-moto-mask-changes').click()
         cy.get('input[value="on"]').should('be.checked')
         cy.get('input[value="off"]').should('not.be.checked')
-        cy.get('.notification').contains('Your changes have saved')
+        cy.get('.govuk-notification-banner--success').contains('Your changes have saved')
       })
     })
 
@@ -158,7 +158,7 @@ describe('MOTO mask security section', () => {
         cy.title().should('eq', `MOTO - hide security codes for ${serviceName} - GOV.UK Pay`)
         cy.get('input[value="on"]').should('be.checked')
         cy.get('input[value="off"]').should('not.be.checked')
-        cy.get('.notification').contains('Your changes have saved')
+        cy.get('.govuk-notification-banner--success').contains('Your changes have saved')
       })
     })
   })

--- a/test/cypress/integration/transactions/transaction-details.cy.test.js
+++ b/test/cypress/integration/transactions/transaction-details.cy.test.js
@@ -304,9 +304,9 @@ describe('Transaction details page', () => {
       cy.get('#refund-button').click()
 
       // Ensure the flash container is showing
-      cy.get('.flash-container.flash-container--good').should('be.visible')
+      cy.get('.govuk-notification-banner--success').should('be.visible')
 
-      cy.get('.flash-container').find('h2').should('contain', 'Refund successful')
+      cy.get('.govuk-notification-banner__heading').should('contain', 'Refund successful')
     })
 
     it('should fail when an invalid refund amount is specified', () => {

--- a/test/cypress/integration/user/edit-phone-number.cy.test.js
+++ b/test/cypress/integration/user/edit-phone-number.cy.test.js
@@ -54,7 +54,7 @@ describe('Edit phone number flow', () => {
       cy.visit('/my-profile/phone-number')
       cy.get('input[name="phone"]').clear().type(testPhoneNumberNew)
       cy.get('#save-phone-number').click()
-      cy.get('.notification').should('exist').should('contain', 'Phone number updated')
+      cy.get('.govuk-notification-banner--success').should('exist').should('contain', 'Phone number updated')
       cy.get('#telephone-number').should('contain', testPhoneNumberNew)
     })
   })


### PR DESCRIPTION
Use the new design system notification banner component https://design-system.service.gov.uk/components/notification-banner/ when we display success messages back to the user.

Previously, looked like this:

<img width="821" alt="Screenshot 2021-01-07 at 18 26 45" src="https://user-images.githubusercontent.com/5648592/104040656-d8a98300-51cf-11eb-971a-c7bce84b7feb.png">

Now looks like this:

<img width="821" alt="Screenshot 2021-01-07 at 18 26 36" src="https://user-images.githubusercontent.com/5648592/104040670-dd6e3700-51cf-11eb-83e1-82d577bb2082.png">
