### PR TITLE
PP-7583 Cleanup mock session test helper

### DIFF
--- a/test/integration/auth.ft.test.js
+++ b/test/integration/auth.ft.test.js
@@ -1,6 +1,6 @@
 require('../test-helpers/serialize-mock.js')
 const request = require('supertest')
-const { getAppWithLoggedInUser, getAppWithSessionAndGatewayAccountCookies, getUser, getAppWithSessionWithoutSecondFactor } = require('../test-helpers/mock-session.js')
+const { getAppWithLoggedInUser, getUser, getAppWithSessionWithoutSecondFactor, getAppWithLoggedOutSession } = require('../test-helpers/mock-session.js')
 const paths = require('../../app/paths.js')
 const server = require('../../server.js')
 
@@ -12,7 +12,7 @@ describe('An endpoint not protected', () => {
   })
 
   it('allows access if not authenticated', done => {
-    app = getAppWithSessionAndGatewayAccountCookies(server.getApp(), {})
+    app = getAppWithLoggedOutSession(server.getApp(), {})
     request(app)
       .get(paths.user.logIn)
       .expect(200)
@@ -47,7 +47,7 @@ describe('An endpoint protected by auth.enforceUserBothFactors', function () {
   })
 
   it('redirects to /login if not authenticated', done => {
-    app = getAppWithSessionAndGatewayAccountCookies(server.getApp(), {})
+    app = getAppWithLoggedOutSession(server.getApp(), {})
     request(app)
       .get(paths.dashboard.index)
       .expect(302)

--- a/test/integration/get-gateway-account.ft.test.js
+++ b/test/integration/get-gateway-account.ft.test.js
@@ -34,9 +34,7 @@ describe('get account', function () {
       ]
 
     })
-    const mockSession = session.getMockSession(user)
-    session.currentGatewayAccountId = '2'
-    app = session.getAppWithSessionAndGatewayAccountCookies(getApp(), mockSession)
+    app = session.getAppWithLoggedInUser(getApp(), user)
     const connectorMock = nock(process.env.CONNECTOR_URL)
     const ledgerMock = nock(process.env.LEDGER_URL)
     connectorMock.get('/v1/frontend/accounts/1').times(2).reply(200, {

--- a/test/integration/login.controller.test.js
+++ b/test/integration/login.controller.test.js
@@ -73,7 +73,7 @@ describe('The logged in endpoint', function () {
   })
 
   it('should redirect to login if not logged in', function (done) {
-    const app = mockSession.getAppWithSessionAndGatewayAccountCookies(getApp(), {})
+    const app = mockSession.getAppWithLoggedOutSession(getApp(), {})
     request(app)
       .get('/')
       .expect(302)
@@ -93,7 +93,7 @@ describe('The logged in endpoint', function () {
 
 describe('The logout endpoint', function () {
   it('should redirect to login', function (done) {
-    const app = mockSession.getAppWithSessionAndGatewayAccountCookies(getApp(), {})
+    const app = mockSession.getAppWithLoggedOutSession(getApp(), {})
     request(app)
       .get('/logout')
       .expect(302)
@@ -152,7 +152,7 @@ describe('The otplogin endpoint', function () {
     adminusersMock.post(`${USER_RESOURCE}/${user.externalId}/second-factor`)
       .reply(200)
 
-    const app = mockSession.getAppWithSessionAndGatewayAccountCookies(getApp(), sessionData)
+    const app = mockSession.getAppWithSessionData(getApp(), sessionData)
     request(app)
       .get('/otp-login')
       .expect(200)
@@ -173,7 +173,7 @@ describe('The otplogin endpoint', function () {
       sentCode: true
     }
 
-    const app = mockSession.getAppWithSessionAndGatewayAccountCookies(getApp(), sessionData)
+    const app = mockSession.getAppWithSessionData(getApp(), sessionData)
 
     request(app)
       .get('/otp-login')
@@ -286,7 +286,7 @@ describe('otp login post endpoint', function () {
     const session = mockSession.getMockSession(user)
     delete session.csrfSecret
 
-    const app2 = mockSession.getAppWithSessionAndGatewayAccountCookies(getApp(), session)
+    const app2 = mockSession.getAppWithSessionData(getApp(), session)
 
     request(app2)
       .post(paths.user.otpLogIn)
@@ -304,7 +304,7 @@ describe('otp send again post endpoint', function () {
     const session = mockSession.getMockSession(user)
     delete session.csrfSecret
 
-    const app2 = mockSession.getAppWithSessionAndGatewayAccountCookies(getApp(), session)
+    const app2 = mockSession.getAppWithSessionData(getApp(), session)
 
     request(app2)
       .post(paths.user.otpSendAgain)

--- a/test/integration/login.ft.test.js
+++ b/test/integration/login.ft.test.js
@@ -13,7 +13,7 @@ const USER_RESOURCE = '/v1/api/users'
 const user = mockSession.getUser()
 const session = mockSession.getMockSession(user)
 
-const app = mockSession.getAppWithSessionAndGatewayAccountCookies(getApp(), session)
+const app = mockSession.getAppWithSessionData(getApp(), session)
 
 function buildGetRequest (path) {
   return request(app)


### PR DESCRIPTION
Functional tests use helper functions in `mock-session.js` to create
the express app with the desired session.

Clean this up by making it more clear how and when the current
gateway account cookie is set by the helper methods.


