### PR TITLE
PP-7583 Remove usages of getCurrentGatewayAccountId from controllers

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-01-12T14:15:13Z",
+  "generated_at": "2021-01-12T17:03:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -232,14 +232,14 @@
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 495,
+        "line_number": 502,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "1695899a3d59e9fe2af1cdf242d8c451b8506173",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 538,
+        "line_number": 546,
         "type": "Secret Keyword"
       }
     ],

--- a/app/controllers/api-keys/get-create.controller.js
+++ b/app/controllers/api-keys/get-create.controller.js
@@ -1,9 +1,8 @@
 'use strict'
 
 const { response } = require('../../utils/response.js')
-const auth = require('../../services/auth.service.js')
 
 module.exports = (req, res) => {
-  const accountId = auth.getCurrentGatewayAccountId(req)
+  const accountId = req.account.gateway_account_id
   response(req, res, 'api-keys/create', { 'account_id': accountId })
 }

--- a/app/controllers/api-keys/get-index.controller.js
+++ b/app/controllers/api-keys/get-index.controller.js
@@ -1,11 +1,10 @@
 'use strict'
 
 const { response, renderErrorView } = require('../../utils/response.js')
-const auth = require('../../services/auth.service.js')
 const publicAuthClient = require('../../services/clients/public-auth.client')
 
 module.exports = (req, res) => {
-  const accountId = auth.getCurrentGatewayAccountId(req)
+  const accountId = req.account.gateway_account_id
   publicAuthClient.getActiveTokensForAccount({
     correlationId: req.correlationId,
     accountId: accountId

--- a/app/controllers/api-keys/get-revoked.controller.js
+++ b/app/controllers/api-keys/get-revoked.controller.js
@@ -1,11 +1,10 @@
 'use strict'
 
 const { response, renderErrorView } = require('../../utils/response.js')
-const auth = require('../../services/auth.service.js')
 const publicAuthClient = require('../../services/clients/public-auth.client')
 
 module.exports = (req, res) => {
-  const accountId = auth.getCurrentGatewayAccountId(req)
+  const accountId = req.account.gateway_account_id
   publicAuthClient.getRevokedTokensForAccount({
     correlationId: req.correlationId,
     accountId: accountId

--- a/app/controllers/api-keys/post-create.controller.js
+++ b/app/controllers/api-keys/post-create.controller.js
@@ -1,12 +1,11 @@
 'use strict'
 
 const { response } = require('../../utils/response.js')
-const auth = require('../../services/auth.service.js')
 const publicAuthClient = require('../../services/clients/public-auth.client')
 const { isADirectDebitAccount } = require('../../services/clients/direct-debit-connector.client.js')
 
 module.exports = async function createAPIKey (req, res, next) {
-  const accountId = auth.getCurrentGatewayAccountId(req)
+  const accountId = req.account.gateway_account_id
   const correlationId = req.correlationId
   const description = req.body.description
   const payload = {

--- a/app/controllers/api-keys/post-revoke.controller.js
+++ b/app/controllers/api-keys/post-revoke.controller.js
@@ -1,12 +1,11 @@
 'use strict'
 
 const paths = require('../../paths')
-const auth = require('../../services/auth.service.js')
 const publicAuthClient = require('../../services/clients/public-auth.client')
 const logger = require('../../utils/logger')(__filename)
 
 module.exports = async (req, res) => {
-  const accountId = auth.getCurrentGatewayAccountId(req)
+  const accountId = req.account.gateway_account_id
   const payload = {
     token_link: req.body.token_link
   }

--- a/app/controllers/credentials.controller.js
+++ b/app/controllers/credentials.controller.js
@@ -6,7 +6,6 @@ const paths = require('../paths')
 const { response } = require('../utils/response')
 const { renderErrorView } = require('../utils/response')
 const { ConnectorClient } = require('../services/clients/connector.client')
-const auth = require('../services/auth.service')
 const router = require('../routes')
 const { CONNECTOR_URL } = process.env
 const { CORRELATION_HEADER } = require('../utils/correlation-header')
@@ -82,7 +81,7 @@ module.exports = {
   },
 
   updateNotificationCredentials: async function (req, res) {
-    const accountId = auth.getCurrentGatewayAccountId((req))
+    const accountId = req.account.gateway_account_id
     const { username, password } = _.get(req, 'body')
 
     if (!username) {
@@ -117,7 +116,7 @@ module.exports = {
   },
 
   update: async function (req, res) {
-    const accountId = auth.getCurrentGatewayAccountId(req)
+    const accountId = req.account.gateway_account_id
     const correlationId = req.headers[CORRELATION_HEADER] || ''
 
     try {

--- a/app/controllers/dashboard/dashboard-activity.controller.js
+++ b/app/controllers/dashboard/dashboard-activity.controller.js
@@ -10,7 +10,6 @@ const LedgerClient = require('../../services/clients/ledger.client')
 const { isADirectDebitAccount } = require('../../services/clients/direct-debit-connector.client.js')
 const { ConnectorClient } = require('../../services/clients/connector.client.js')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
-const auth = require('../../services/auth.service.js')
 const { retrieveAccountDetails } = require('../../services/clients/stripe/stripe.client')
 const { datetime } = require('@govuk-pay/pay-js-commons').nunjucksFilters
 const {
@@ -87,7 +86,7 @@ const displayGoLiveLink = (service, account, user) => {
 }
 
 module.exports = async (req, res) => {
-  const gatewayAccountId = auth.getCurrentGatewayAccountId((req))
+  const gatewayAccountId = req.account.gateway_account_id
 
   const correlationId = _.get(req, 'headers.' + CORRELATION_HEADER, '')
   const period = _.get(req, 'query.period', 'today')

--- a/app/controllers/make-a-demo-payment/go-to-payment.controller.js
+++ b/app/controllers/make-a-demo-payment/go-to-payment.controller.js
@@ -7,10 +7,9 @@ const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
 const productTypes = require('../../utils/product-types')
 const publicAuthClient = require('../../services/clients/public-auth.client')
-const auth = require('../../services/auth.service.js')
 
 module.exports = async function makeDemoPayment (req, res) {
-  const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
+  const gatewayAccountId = req.account.gateway_account_id
   const { paymentAmount, paymentDescription } = lodash.get(req, 'session.pageData.makeADemoPayment', {})
 
   if (!paymentAmount || !paymentDescription) {

--- a/app/controllers/payment-links/get-delete.controller.js
+++ b/app/controllers/payment-links/get-delete.controller.js
@@ -4,10 +4,9 @@ const logger = require('../../utils/logger')(__filename)
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
 const publicAuthClient = require('../../services/clients/public-auth.client.js')
-const auth = require('../../services/auth.service.js')
 
 module.exports = async (req, res) => {
-  const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
+  const gatewayAccountId = req.account.gateway_account_id
 
   try {
     const product = await productsClient.product.getByProductExternalId(gatewayAccountId, req.params.productExternalId)

--- a/app/controllers/payment-links/get-disable.controller.js
+++ b/app/controllers/payment-links/get-disable.controller.js
@@ -3,10 +3,9 @@
 const logger = require('../../utils/logger')(__filename)
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
-const auth = require('../../services/auth.service.js')
 
 module.exports = async (req, res) => {
-  const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
+  const gatewayAccountId = req.account.gateway_account_id
 
   try {
     await productsClient.product.disable(gatewayAccountId, req.params.productExternalId)

--- a/app/controllers/payment-links/get-edit.controller.js
+++ b/app/controllers/payment-links/get-edit.controller.js
@@ -5,7 +5,6 @@ const lodash = require('lodash')
 const { response } = require('../../utils/response.js')
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
-const auth = require('../../services/auth.service.js')
 const formattedPathFor = require('../../utils/replace-params-in-path')
 
 module.exports = async function showEditPaymentLink (req, res, next) {
@@ -39,7 +38,7 @@ module.exports = async function showEditPaymentLink (req, res, next) {
     paths
   }
 
-  const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
+  const gatewayAccountId = req.account.gateway_account_id
   try {
     const product = await productsClient.product.getByProductExternalId(gatewayAccountId, productExternalId)
     const productCheck = lodash.cloneDeep(product)

--- a/app/controllers/payment-links/get-manage.controller.js
+++ b/app/controllers/payment-links/get-manage.controller.js
@@ -4,7 +4,6 @@ const lodash = require('lodash')
 
 const { response } = require('../../utils/response')
 const productsClient = require('../../services/clients/products.client')
-const authService = require('../../services/auth.service')
 const supportedLanguage = require('../../models/supported-language')
 const paths = require('../../paths')
 
@@ -13,7 +12,7 @@ module.exports = async (req, res, next) => {
   lodash.unset(req, 'session.editPaymentLinkData')
 
   try {
-    const products = await productsClient.product.getByGatewayAccountId(authService.getCurrentGatewayAccountId(req))
+    const products = await productsClient.product.getByGatewayAccountId(req.account.gateway_account_id)
     const paymentLinks = products.filter(product => product.type === 'ADHOC')
     const englishPaymentLinks = paymentLinks.filter(link => link.language === supportedLanguage.ENGLISH)
     const welshPaymentLinks = paymentLinks.filter(link => link.language === supportedLanguage.WELSH)

--- a/app/controllers/payment-links/metadata/resource.controller.js
+++ b/app/controllers/payment-links/metadata/resource.controller.js
@@ -3,7 +3,6 @@ const formattedPathFor = require('../../../utils/replace-params-in-path')
 const paths = require('../../../paths')
 const { product } = require('../../../services/clients/products.client.js')
 const MetadataForm = require('./metadata-form')
-const auth = require('../../../services/auth.service.js')
 
 const addMetadataPage = function addMetadataPage (req, res) {
   const pageData = {
@@ -16,7 +15,7 @@ const addMetadataPage = function addMetadataPage (req, res) {
 
 const editMetadataPage = async function editMetadataPage (req, res) {
   const { productExternalId, metadataKey } = req.params
-  const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
+  const gatewayAccountId = req.account.gateway_account_id
 
   try {
     const currentProduct = await product.getByProductExternalId(gatewayAccountId, productExternalId)

--- a/app/controllers/payment-links/post-review.controller.js
+++ b/app/controllers/payment-links/post-review.controller.js
@@ -6,12 +6,11 @@ const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
 const productTypes = require('../../utils/product-types')
 const publicAuthClient = require('../../services/clients/public-auth.client')
-const auth = require('../../services/auth.service.js')
 const supportedLanguage = require('../../models/supported-language')
 const { keys } = require('@govuk-pay/pay-js-commons').logging
 
 module.exports = async function createPaymentLink (req, res) {
-  const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
+  const gatewayAccountId = req.account.gateway_account_id
   const {
     paymentLinkTitle,
     paymentLinkDescription,

--- a/app/controllers/payment-types/get-index.controller.js
+++ b/app/controllers/payment-types/get-index.controller.js
@@ -3,7 +3,6 @@
 const { response, renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
-const auth = require('../../services/auth.service')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
 function formatLabel (card) {
@@ -55,7 +54,7 @@ function formatCardsForTemplate (allCards, acceptedCards, threeDSEnabled) {
 
 module.exports = async (req, res) => {
   const correlationId = req.headers[correlationHeader] || ''
-  const accountId = auth.getCurrentGatewayAccountId(req)
+  const accountId = req.account.gateway_account_id
 
   try {
     const { card_types: allCards } = await connector.getAllCardTypes(correlationId)

--- a/app/controllers/payment-types/post-index.controller.js
+++ b/app/controllers/payment-types/post-index.controller.js
@@ -7,12 +7,11 @@ const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
-const auth = require('../../services/auth.service.js')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
 module.exports = async (req, res) => {
   const correlationId = req.headers[correlationHeader] || ''
-  const accountId = auth.getCurrentGatewayAccountId(req)
+  const accountId = req.account.gateway_account_id
 
   const acceptedDebitCards = typeof req.body.debit === 'string' ? [req.body.debit] : req.body.debit
   const acceptedCreditCards = typeof req.body.credit === 'string' ? [req.body.credit] : req.body.credit

--- a/app/controllers/test-with-your-users/disable.controller.js
+++ b/app/controllers/test-with-your-users/disable.controller.js
@@ -3,10 +3,9 @@
 const logger = require('../../utils/logger')(__filename)
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
-const auth = require('../../services/auth.service.js')
 
 module.exports = (req, res) => {
-  const gatewayAccountId = auth.getCurrentGatewayAccountId(req)
+  const gatewayAccountId = req.account.gateway_account_id
   productsClient.product.disable(gatewayAccountId, req.params.productExternalId)
     .then(() => {
       req.flash('generic', 'Prototype link deleted')

--- a/app/controllers/test-with-your-users/links.controller.js
+++ b/app/controllers/test-with-your-users/links.controller.js
@@ -4,7 +4,6 @@ const logger = require('../../utils/logger')(__filename)
 const { response } = require('../../utils/response.js')
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
-const authService = require('../../services/auth.service.js')
 const { renderErrorView } = require('../../utils/response.js')
 
 module.exports = (req, res) => {
@@ -15,7 +14,7 @@ module.exports = (req, res) => {
     linksPage: paths.prototyping.demoService.links
   }
 
-  productsClient.product.getByGatewayAccountId(authService.getCurrentGatewayAccountId(req))
+  productsClient.product.getByGatewayAccountId(req.account.gateway_account_id)
     .then(products => {
       const prototypeProducts = products.filter(product => product.type === 'PROTOTYPE')
       params.productsLength = prototypeProducts.length

--- a/app/controllers/test-with-your-users/submit.controller.js
+++ b/app/controllers/test-with-your-users/submit.controller.js
@@ -8,12 +8,11 @@ const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
 const productTypes = require('../../utils/product-types')
 const publicAuthClient = require('../../services/clients/public-auth.client')
-const authService = require('../../services/auth.service.js')
 const { isCurrency, isHttps, isAboveMaxAmount } = require('../../browsered/field-validation-checks')
 const { penceToPounds, safeConvertPoundsStringToPence } = require('../../utils/currency-formatter')
 
 module.exports = async (req, res) => {
-  const gatewayAccountId = authService.getCurrentGatewayAccountId(req)
+  const gatewayAccountId = req.account.gateway_account_id
   const confirmationPage = req.body['confirmation-page']
   const paymentDescription = req.body['payment-description']
   const paymentAmountInPence = safeConvertPoundsStringToPence(req.body['payment-amount'], true)

--- a/app/controllers/transactions/transaction-detail.controller.js
+++ b/app/controllers/transactions/transaction-detail.controller.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { ledgerFindWithEvents } = require('../../services/transaction.service')
-const auth = require('../../services/auth.service.js')
 const { response } = require('../../utils/response.js')
 const { renderErrorView } = require('../../utils/response.js')
 
@@ -9,7 +8,7 @@ const defaultMsg = 'Error processing transaction view'
 const notFound = 'Charge not found'
 
 module.exports = (req, res) => {
-  const accountId = auth.getCurrentGatewayAccountId(req)
+  const accountId = req.account.gateway_account_id
   const chargeId = req.params.chargeId
 
   ledgerFindWithEvents(accountId, chargeId, req.correlationId)

--- a/app/controllers/transactions/transaction-download.controller.js
+++ b/app/controllers/transactions/transaction-download.controller.js
@@ -1,14 +1,13 @@
 'use strict'
 
 const transactionService = require('../../services/transaction.service')
-const auth = require('../../services/auth.service')
 const date = require('../../utils/dates')
 const { renderErrorView } = require('../../utils/response')
 const { CORRELATION_HEADER } = require('../../utils/correlation-header')
 const Stream = require('../../services/clients/stream.client')
 
 const fetchTransactionCsvWithHeader = function fetchTransactionCsvWithHeader (req, res) {
-  const accountId = auth.getCurrentGatewayAccountId(req)
+  const accountId = req.account.gateway_account_id
   const filters = req.query
   const name = `GOVUK_Pay_${date.dateToDefaultFormat(new Date()).replace(' ', '_')}.csv`
   const correlationId = req.headers[CORRELATION_HEADER]

--- a/app/controllers/transactions/transaction-list.controller.js
+++ b/app/controllers/transactions/transaction-list.controller.js
@@ -3,7 +3,6 @@
 const url = require('url')
 const _ = require('lodash')
 
-const auth = require('../../services/auth.service.js')
 const router = require('../../routes.js')
 const transactionService = require('../../services/transaction.service')
 const { ConnectorClient } = require('../../services/clients/connector.client.js')
@@ -21,7 +20,7 @@ function error (req, res, msg) {
 }
 
 module.exports = async (req, res, next) => {
-  const accountId = auth.getCurrentGatewayAccountId(req)
+  const accountId = req.account.gateway_account_id
   const filters = getFilters(req)
 
   const correlationId = req.headers[CORRELATION_HEADER] || ''

--- a/test/integration/credentials.ft.test.js
+++ b/test/integration/credentials.ft.test.js
@@ -1,15 +1,17 @@
 'use strict'
 
-const path = require('path')
-require(path.join(__dirname, '/../test-helpers/serialize-mock.js'))
-const userCreator = require(path.join(__dirname, '/../test-helpers/user-creator.js'))
 const request = require('supertest')
-const getApp = require(path.join(__dirname, '/../../server.js')).getApp
 const nock = require('nock')
 const csrf = require('csrf')
-const paths = require(path.join(__dirname, '/../../app/paths.js'))
-const mockSession = require('../test-helpers/mock-session.js')
 const { expect } = require('chai')
+
+const userCreator = require('../test-helpers/user-creator.js')
+require('../test-helpers/serialize-mock.js')
+const getApp = require('../../server.js').getApp
+const paths = require('../../app/paths.js')
+const mockSession = require('../test-helpers/mock-session.js')
+const gatewayAccountFixtures = require('../fixtures/gateway-account.fixtures')
+
 const ACCOUNT_ID = '182364'
 const CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts/' + ACCOUNT_ID
 const CONNECTOR_ACCOUNT_CREDENTIALS_PATH = CONNECTOR_ACCOUNT_PATH + '/credentials'
@@ -393,6 +395,11 @@ describe('Credentials endpoints', () => {
       app = mockSession.getAppWithLoggedInUser(getApp(), user)
 
       userCreator.mockUserResponse(user.toJson(), done)
+      connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+        .reply(200,
+          gatewayAccountFixtures.validGatewayAccountResponse({
+            gateway_account_id: ACCOUNT_ID
+          }))
     })
 
     it('should send new username, password and merchant_id credentials to connector', function (done) {
@@ -516,6 +523,7 @@ describe('Credentials endpoints', () => {
       app = mockSession.createAppWithSession(getApp(), session)
 
       userCreator.mockUserResponse(user.toJson(), done)
+      mockConnectorGetAccount()
     })
 
     it('should send new username and password notification credentials to connector', function (done) {
@@ -573,6 +581,14 @@ describe('Credentials endpoints', () => {
     })
   })
 })
+
+function mockConnectorGetAccount () {
+  connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+    .reply(200,
+      gatewayAccountFixtures.validGatewayAccountResponse({
+        gateway_account_id: ACCOUNT_ID
+      }))
+}
 
 function buildGetRequest (path, app) {
   return request(app)

--- a/test/integration/pagination.ft.test.js
+++ b/test/integration/pagination.ft.test.js
@@ -1,19 +1,22 @@
 'use strict'
 
-const path = require('path')
-require(path.join(__dirname, '/../test-helpers/serialize-mock.js'))
-const userCreator = require(path.join(__dirname, '/../test-helpers/user-creator.js'))
-const request = require('supertest')
 const nock = require('nock')
-const getApp = require(path.join(__dirname, '/../../server.js')).getApp
-const paths = require(path.join(__dirname, '/../../app/paths.js'))
-const session = require(path.join(__dirname, '/../test-helpers/mock-session.js'))
 const querystring = require('querystring')
+const request = require('supertest')
+
+require('../test-helpers/serialize-mock.js')
+const userCreator = require('../test-helpers/user-creator.js')
+const getApp = require('../../server.js').getApp
+const paths = require('../../app/paths.js')
+const session = require('../test-helpers/mock-session.js')
+const gatewayAccountFixtures = require('../fixtures/gateway-account.fixtures')
+
 let app
 
 const gatewayAccountId = '452345'
 
 const CONNECTOR_ALL_CARD_TYPES_API_PATH = '/v1/api/card-types'
+const CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts/' + gatewayAccountId
 const connectorMock = nock(process.env.CONNECTOR_URL)
 
 const ALL_CARD_TYPES = {
@@ -48,6 +51,11 @@ describe('Pagination', function () {
 
     userCreator.mockUserResponse(user.toJson(), done)
 
+    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
+      .reply(200,
+        gatewayAccountFixtures.validGatewayAccountResponse({
+          gateway_account_id: gatewayAccountId
+        }))
     connectorMock.get(CONNECTOR_ALL_CARD_TYPES_API_PATH)
       .reply(200, ALL_CARD_TYPES)
   })

--- a/test/unit/controller/api-keys/get-index.controller.ft.test.js
+++ b/test/unit/controller/api-keys/get-index.controller.ft.test.js
@@ -8,6 +8,7 @@ const { getApp } = require('../../../../server')
 const mockSession = require('../../../test-helpers/mock-session')
 const userCreator = require('../../../test-helpers/user-creator')
 const paths = require('../../../../app/paths')
+const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
 
 const { PUBLIC_AUTH_URL, CONNECTOR_URL } = process.env
 
@@ -48,10 +49,7 @@ describe('API keys index', () => {
   describe('when no API keys exist', () => {
     let response
     before(function (done) {
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-        .reply(200, {
-          payment_provider: 'sandbox'
-        })
+      mockConnectorGetAccount()
       mockGetActiveAPIKeys(GATEWAY_ACCOUNT_ID).reply(200, [])
 
       supertest(app)
@@ -78,10 +76,7 @@ describe('API keys index', () => {
   describe('when one API key exists', () => {
     let response
     before(function (done) {
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-        .reply(200, {
-          payment_provider: 'sandbox'
-        })
+      mockConnectorGetAccount()
       mockGetActiveAPIKeys(GATEWAY_ACCOUNT_ID).reply(200, { tokens: [TOKEN_1] })
 
       supertest(app)
@@ -113,10 +108,7 @@ describe('API keys index', () => {
   describe('when more than one API key exists', () => {
     let response
     before(function (done) {
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-        .reply(200, {
-          payment_provider: 'sandbox'
-        })
+      mockConnectorGetAccount()
       mockGetActiveAPIKeys(GATEWAY_ACCOUNT_ID).reply(200, { tokens: [TOKEN_1, TOKEN_2] })
 
       supertest(app)
@@ -145,3 +137,10 @@ describe('API keys index', () => {
     })
   })
 })
+
+function mockConnectorGetAccount () {
+  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
+    .reply(200, gatewayAccountFixtures.validGatewayAccountResponse({
+      gateway_account_id: GATEWAY_ACCOUNT_ID
+    }))
+}

--- a/test/unit/controller/api-keys/get-revoked.controller.ft.test.js
+++ b/test/unit/controller/api-keys/get-revoked.controller.ft.test.js
@@ -8,6 +8,7 @@ const { getApp } = require('../../../../server')
 const mockSession = require('../../../test-helpers/mock-session')
 const userCreator = require('../../../test-helpers/user-creator')
 const paths = require('../../../../app/paths')
+const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
 
 const { PUBLIC_AUTH_URL, CONNECTOR_URL } = process.env
 
@@ -37,6 +38,13 @@ const mockGetRevokedAPIKeys = gatewayAccountId => {
   return nock(PUBLIC_AUTH_URL).get(`/${gatewayAccountId}?state=revoked`)
 }
 
+function mockConnectorGetAccount () {
+  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
+    .reply(200, gatewayAccountFixtures.validGatewayAccountResponse({
+      gateway_account_id: GATEWAY_ACCOUNT_ID
+    }))
+}
+
 describe('Revoked API keys index', () => {
   let app
   before(function () {
@@ -50,10 +58,7 @@ describe('Revoked API keys index', () => {
   describe('when no API keys exist', () => {
     let response
     before(function (done) {
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-        .reply(200, {
-          payment_provider: 'sandbox'
-        })
+      mockConnectorGetAccount()
       mockGetRevokedAPIKeys(GATEWAY_ACCOUNT_ID).reply(200, [])
 
       supertest(app)
@@ -80,10 +85,7 @@ describe('Revoked API keys index', () => {
   describe('when one API key exists', () => {
     let response
     before(function (done) {
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-        .reply(200, {
-          payment_provider: 'sandbox'
-        })
+      mockConnectorGetAccount()
       mockGetRevokedAPIKeys(GATEWAY_ACCOUNT_ID).reply(200, { tokens: [TOKEN_1] })
 
       supertest(app)
@@ -115,10 +117,7 @@ describe('Revoked API keys index', () => {
   describe('when more than one API key exists', () => {
     let response
     before(function (done) {
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-        .reply(200, {
-          payment_provider: 'sandbox'
-        })
+      mockConnectorGetAccount()
       mockGetRevokedAPIKeys(GATEWAY_ACCOUNT_ID).reply(200, { tokens: [TOKEN_1, TOKEN_2] })
 
       supertest(app)

--- a/test/unit/controller/api-keys/post-revoke.controller.ft.test.js
+++ b/test/unit/controller/api-keys/post-revoke.controller.ft.test.js
@@ -9,6 +9,7 @@ const { getApp } = require('../../../../server')
 const mockSession = require('../../../test-helpers/mock-session')
 const userCreator = require('../../../test-helpers/user-creator')
 const paths = require('../../../../app/paths')
+const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
 
 const { PUBLIC_AUTH_URL, CONNECTOR_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '182364'
@@ -41,9 +42,7 @@ describe('POST to revoke an API key', () => {
       .reply(200, TOKEN_RESPONSE)
 
     nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-      .reply(200, {
-        payment_provider: 'sandbox'
-      })
+      .reply(200, gatewayAccountFixtures.validGatewayAccountResponse({ gateway_account_id: GATEWAY_ACCOUNT_ID }))
 
     supertest(app)
       .post(paths.apiKeys.revoke)

--- a/test/unit/controller/make-a-demo-payment-controller/go-to-payment.controller.ft.test.js
+++ b/test/unit/controller/make-a-demo-payment-controller/go-to-payment.controller.ft.test.js
@@ -11,6 +11,7 @@ const { getMockSession, createAppWithSession, getUser } = require('../../../test
 const paths = require('../../../../app/paths')
 const { randomUuid } = require('../../../../app/utils/random')
 const { validCreateProductRequest, validProductResponse } = require('../../../fixtures/product.fixtures')
+const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
 
 const { PUBLIC_AUTH_URL, PRODUCTS_URL, CONNECTOR_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '929'
@@ -29,9 +30,7 @@ const VALID_CREATE_TOKEN_REQUEST = {
   description: 'Token for Demo Payment',
   type: 'PRODUCTS'
 }
-const VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE = {
-  payment_provider: 'sandbox'
-}
+const VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE = validGatewayAccountResponse({ gateway_account_id: GATEWAY_ACCOUNT_ID })
 const VALID_CREATE_TOKEN_RESPONSE = { token: randomUuid() }
 const VALID_CREATE_PRODUCT_REQUEST = validCreateProductRequest({
   name: PAYMENT_DESCRIPTION,

--- a/test/unit/controller/payment-links/get-delete.controller.ft.test.js
+++ b/test/unit/controller/payment-links/get-delete.controller.ft.test.js
@@ -8,6 +8,7 @@ const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')
 const { randomUuid } = require('../../../../app/utils/random')
+const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
 
 const GATEWAY_ACCOUNT_ID = '929'
 const { PRODUCTS_URL, CONNECTOR_URL, PUBLIC_AUTH_URL } = process.env
@@ -36,9 +37,7 @@ describe('Manage payment links - delete controller', () => {
         gateway_account_ids: [GATEWAY_ACCOUNT_ID],
         permissions: [{ name: 'tokens:create' }]
       })
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
-        payment_provider: 'sandbox'
-      })
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, validGatewayAccountResponse({ gateway_account_id: GATEWAY_ACCOUNT_ID }))
       nock(PUBLIC_AUTH_URL).delete(`/${GATEWAY_ACCOUNT_ID}`).reply(200, {
         revoked: '07/09/2018'
       })

--- a/test/unit/controller/payment-links/get-disable.controller.ft.test.js
+++ b/test/unit/controller/payment-links/get-disable.controller.ft.test.js
@@ -8,6 +8,7 @@ const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')
 const { randomUuid } = require('../../../../app/utils/random')
+const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
 
 const GATEWAY_ACCOUNT_ID = '929'
 const { PRODUCTS_URL, CONNECTOR_URL } = process.env
@@ -21,9 +22,7 @@ describe('Manage payment links - disable controller', () => {
         gateway_account_ids: [GATEWAY_ACCOUNT_ID],
         permissions: [{ name: 'tokens:create' }]
       })
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
-        payment_provider: 'sandbox'
-      })
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, validGatewayAccountResponse({ gateway_account_id: GATEWAY_ACCOUNT_ID }))
       nock(PRODUCTS_URL).patch(`/v1/api/gateway-account/${GATEWAY_ACCOUNT_ID}/products/${productExternalId}/disable`).reply(200)
       session = getMockSession(user)
       supertest(createAppWithSession(getApp(), session))

--- a/test/unit/controller/payment-links/get-edit.controller.ft.test.js
+++ b/test/unit/controller/payment-links/get-edit.controller.ft.test.js
@@ -8,6 +8,7 @@ const paths = require('../../../../app/paths')
 const { expect } = require('chai')
 const formattedPathFor = require('../../../../app/utils/replace-params-in-path')
 const lodash = require('lodash')
+const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
 
 const { PRODUCTS_URL, CONNECTOR_URL } = process.env
 
@@ -46,9 +47,7 @@ describe('Edit a payment link', () => {
     let response
     before(done => {
       nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-        .reply(200, {
-          payment_provider: 'sandbox'
-        })
+        .reply(200, validGatewayAccountResponse({ gateway_account_id: GATEWAY_ACCOUNT_ID }))
       mockGetByProductExternalIdEndpoint(GATEWAY_ACCOUNT_ID, PRODUCT_EXTERNAL_ID).reply(200, PAYMENT_1)
 
       supertest(createAppWithSession(getApp(), session))
@@ -97,9 +96,7 @@ describe('Edit a payment link', () => {
     let response
     before(done => {
       nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-        .reply(200, {
-          payment_provider: 'sandbox'
-        })
+        .reply(200, validGatewayAccountResponse({ gateway_account_id: GATEWAY_ACCOUNT_ID }))
       mockGetByProductExternalIdEndpoint(GATEWAY_ACCOUNT_ID, PRODUCT_EXTERNAL_ID).reply(200, PAYMENT_1)
 
       lodash.set(session, 'editPaymentLinkData', {

--- a/test/unit/controller/payment-links/metadata/paymentlink-metadata-resource.controller.ft.test.js
+++ b/test/unit/controller/payment-links/metadata/paymentlink-metadata-resource.controller.ft.test.js
@@ -10,6 +10,7 @@ const { getApp } = require('../../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../../test-helpers/mock-session')
 const paths = require('../../../../../app/paths')
 const formattedPathFor = require('../../../../../app/utils/replace-params-in-path')
+const { validGatewayAccountResponse } = require('../../../../fixtures/gateway-account.fixtures')
 
 const { PRODUCTS_URL, CONNECTOR_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '929'
@@ -23,9 +24,7 @@ const VALID_USER = getUser({
   gateway_account_ids: [GATEWAY_ACCOUNT_ID],
   permissions: [{ name: 'tokens:create' }]
 })
-const VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE = {
-  payment_provider: 'sandbox'
-}
+const VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE = validGatewayAccountResponse({ gateway_account_id: GATEWAY_ACCOUNT_ID })
 
 describe('Add payment link metadata', () => {
   describe('successfull add metadata submission', () => {

--- a/test/unit/controller/payment-links/post-amount.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-amount.controller.ft.test.js
@@ -4,17 +4,27 @@ const supertest = require('supertest')
 const { expect } = require('chai')
 const lodash = require('lodash')
 const csrf = require('csrf')
+const nock = require('nock')
 
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')
 const { safeConvertPoundsStringToPence } = require('../../../../app/utils/currency-formatter')
+const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
 
+const { CONNECTOR_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '929'
 const VALID_USER = getUser({
   gateway_account_ids: [GATEWAY_ACCOUNT_ID],
   permissions: [{ name: 'tokens:create' }]
 })
+
+function mockConnectorGetAccount () {
+  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
+    .reply(200, validGatewayAccountResponse({
+      gateway_account_id: GATEWAY_ACCOUNT_ID
+    }))
+}
 
 describe('Create payment link amount post controller', () => {
   describe(`when a fixed amount is submitted`, () => {
@@ -28,6 +38,7 @@ describe('Create payment link amount post controller', () => {
       session = getMockSession(VALID_USER)
       lodash.set(session, 'pageData.createPaymentLink', {})
       app = createAppWithSession(getApp(), session)
+      mockConnectorGetAccount()
     })
     before('Act', done => {
       supertest(app)
@@ -69,6 +80,7 @@ describe('Create payment link amount post controller', () => {
       session = getMockSession(VALID_USER)
       lodash.set(session, 'pageData.createPaymentLink', {})
       app = createAppWithSession(getApp(), session)
+      mockConnectorGetAccount()
     })
     before('Act', done => {
       supertest(app)
@@ -110,6 +122,7 @@ describe('Create payment link amount post controller', () => {
       session = getMockSession(VALID_USER)
       lodash.set(session, 'pageData.createPaymentLink', {})
       app = createAppWithSession(getApp(), session)
+      mockConnectorGetAccount()
     })
     before('Act', done => {
       supertest(app)
@@ -150,6 +163,7 @@ describe('Create payment link amount post controller', () => {
       session = getMockSession(VALID_USER)
       lodash.set(session, 'pageData.createPaymentLink', {})
       app = createAppWithSession(getApp(), session)
+      mockConnectorGetAccount()
     })
     before('Act', done => {
       supertest(app)

--- a/test/unit/controller/payment-links/post-review.controller.ft.test.js
+++ b/test/unit/controller/payment-links/post-review.controller.ft.test.js
@@ -11,6 +11,7 @@ const { getMockSession, createAppWithSession, getUser } = require('../../../test
 const paths = require('../../../../app/paths')
 const { randomUuid } = require('../../../../app/utils/random')
 const { validCreateProductRequest, validProductResponse } = require('../../../fixtures/product.fixtures')
+const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
 
 const { PUBLIC_AUTH_URL, PRODUCTS_URL, CONNECTOR_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '929'
@@ -31,10 +32,7 @@ const VALID_CREATE_TOKEN_REQUEST = {
   description: `Token for “${PAYMENT_TITLE}” payment link`,
   token_account_type: 'test'
 }
-const VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE = {
-  payment_provider: 'sandbox',
-  type: 'test'
-}
+const VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE = validGatewayAccountResponse({ gateway_account_id: GATEWAY_ACCOUNT_ID })
 const VALID_CREATE_TOKEN_RESPONSE = { token: randomUuid() }
 
 const buildCreateProductRequest = (language, hasMetadata) => {

--- a/test/unit/controller/test-with-your-users-controller/disable.controller.ft.test.js
+++ b/test/unit/controller/test-with-your-users-controller/disable.controller.ft.test.js
@@ -8,6 +8,7 @@ const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')
 const { randomUuid } = require('../../../../app/utils/random')
+const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
 
 const GATEWAY_ACCOUNT_ID = '929'
 const { PRODUCTS_URL, CONNECTOR_URL } = process.env
@@ -21,9 +22,7 @@ describe('test with your users - disable controller', () => {
         gateway_account_ids: [GATEWAY_ACCOUNT_ID],
         permissions: [{ name: 'transactions:read' }]
       })
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
-        payment_provider: 'sandbox'
-      })
+      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, validGatewayAccountResponse({ gateway_account_id: GATEWAY_ACCOUNT_ID }))
       nock(PRODUCTS_URL).patch(`/v1/api/gateway-account/${GATEWAY_ACCOUNT_ID}/products/${productExternalId}/disable`).reply(200)
       session = getMockSession(user)
       supertest(createAppWithSession(getApp(), session))

--- a/test/unit/controller/test-with-your-users-controller/links.controller.ft.test.js
+++ b/test/unit/controller/test-with-your-users-controller/links.controller.ft.test.js
@@ -2,11 +2,13 @@
 
 const supertest = require('supertest')
 const nock = require('nock')
+const { expect } = require('chai')
+
 const { getApp } = require('../../../../server')
 const mockSession = require('../../../test-helpers/mock-session')
 const userCreator = require('../../../test-helpers/user-creator')
 const paths = require('../../../../app/paths')
-const { expect } = require('chai')
+const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
 
 const { PRODUCTS_URL, CONNECTOR_URL } = process.env
 
@@ -60,6 +62,13 @@ function mockGetProductsByGatewayAccountEndpoint (gatewayAccountId) {
   return nock(PRODUCTS_URL).get(`/v1/api/gateway-account/${gatewayAccountId}/products`)
 }
 
+function mockConnectorGetAccount () {
+  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
+    .reply(200, validGatewayAccountResponse({
+      gateway_account_id: GATEWAY_ACCOUNT_ID
+    }))
+}
+
 describe('Show the prototype links', () => {
   let app
   before(function () {
@@ -73,10 +82,7 @@ describe('Show the prototype links', () => {
   describe('when no links exist', () => {
     let response
     before(function (done) {
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-        .reply(200, {
-          payment_provider: 'sandbox'
-        })
+      mockConnectorGetAccount()
       mockGetProductsByGatewayAccountEndpoint(GATEWAY_ACCOUNT_ID).reply(200, [])
 
       supertest(app)
@@ -110,10 +116,7 @@ describe('Show the prototype links', () => {
   describe('when at least one link exists', () => {
     let response
     before(function (done) {
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-        .reply(200, {
-          payment_provider: 'sandbox'
-        })
+      mockConnectorGetAccount()
       mockGetProductsByGatewayAccountEndpoint(GATEWAY_ACCOUNT_ID).reply(200, [PAYMENT_1])
 
       supertest(app)
@@ -162,10 +165,7 @@ describe('Show the prototype links', () => {
   describe('when more than one link exist', () => {
     let response
     before(function (done) {
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-        .reply(200, {
-          payment_provider: 'sandbox'
-        })
+      mockConnectorGetAccount()
       mockGetProductsByGatewayAccountEndpoint(GATEWAY_ACCOUNT_ID).reply(200, [PAYMENT_1, PAYMENT_2])
 
       supertest(app)
@@ -228,10 +228,7 @@ describe('Show the prototype links', () => {
   describe('when one prototype link and one live link exists', () => {
     let response
     before(function (done) {
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-        .reply(200, {
-          payment_provider: 'sandbox'
-        })
+      mockConnectorGetAccount()
       mockGetProductsByGatewayAccountEndpoint(GATEWAY_ACCOUNT_ID).reply(200, [PAYMENT_1, PAYMENT_3])
 
       supertest(app)
@@ -266,10 +263,7 @@ describe('Show the prototype links', () => {
   describe('when there is a problem retrieving the products', () => {
     let response
     before(function (done) {
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-        .reply(200, {
-          payment_provider: 'sandbox'
-        })
+      mockConnectorGetAccount()
       mockGetProductsByGatewayAccountEndpoint(GATEWAY_ACCOUNT_ID).replyWithError('an error')
 
       supertest(app)


### PR DESCRIPTION
This method contains various logic to look at the cookie and the
available services for the user to determine which gateway account id
should be retrieved.

It is also called by the current middleware that retrieves the gateway
account and puts it on the `req` object as `req.account`. This means
that when it is called in controllers, it will always get the same
gateway account id as `req.account.gateway_account_id`.

Therefore can replace usage in controllers with getting
`req.account.gateway_account_id`.

Fix all the places in function tests where we either weren't nocking the
request to connector to get the gateway account or it wasn't returning
a response with all the expected fields.


