### PR TITLE
PP-7583 Fix inconsistency in setting session gateway account id

### DIFF
--- a/app/middleware/get-service-and-gateway-account.middleware.js
+++ b/app/middleware/get-service-and-gateway-account.middleware.js
@@ -90,7 +90,10 @@ module.exports = async function getServiceAndGatewayAccount (req, res, next) {
           req.account = gatewayAccount
           // TODO: To be removed once URLs are updated to use the format /service/:serviceExternalId/account/:gatewayAccountExternalId/xxx.
           // Currently authService.getCurrentGatewayAccountId() sets below if account is available on session or derives one from user services.
-          req.gateway_account = { currentGatewayAccountId: gatewayAccount.gateway_account_id, currentGatewayAccountExternalId: gatewayAccount.external_id }
+          req.gateway_account = {
+            currentGatewayAccountId: gatewayAccount.gateway_account_id && String(gatewayAccount.gateway_account_id),
+            currentGatewayAccountExternalId: gatewayAccount.external_id
+          }
         }
       }
 


### PR DESCRIPTION
Previously the gateway account id has always been set from the admin
users service role list, this will always be a string as admin users
also stores external ids in the same way.

The proposed structure now uses middleware that fetches the gateway
account directly from Connector, providing a `number` id.

While we are using both methodologies (and moving over to the
proposed) we will need to normalise this value into a String to make
sure the checks by existing middleware continue to succeed.

This fixes an issue with the service being incorrectly reset to the
default service after the existing middleware failed to find the newly
set gateway account id as it was comparing a number to a string.


