### PR TITLE
PP-7583 Move digital wallet routes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-01-13T17:09:45Z",
+  "generated_at": "2021-01-14T14:42:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -72,7 +72,7 @@
         "hashed_secret": "ece65afda87c1c6120602c9a3b66890308d7e53c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 62,
         "type": "Secret Keyword"
       }
     ],

--- a/app/controllers/digital-wallet/post-apple-pay.controller.js
+++ b/app/controllers/digital-wallet/post-apple-pay.controller.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const paths = require('../../paths')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { CORRELATION_HEADER } = require('../../utils/correlation-header')
@@ -10,12 +11,13 @@ module.exports = async (req, res) => {
   const gatewayAccountId = req.account.gateway_account_id
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   const enable = req.body['apple-pay'] === 'on'
+  const formattedPath = formatAccountPathsFor(paths.account.digitalWallet.applePay, req.account && req.account.external_id)
 
   try {
     await connector.toggleApplePay(gatewayAccountId, enable, correlationId)
 
     req.flash('generic', `Apple Pay successfully ${enable ? 'enabled' : 'disabled'}.`)
-    return res.redirect(paths.digitalWallet.applePay)
+    return res.redirect(formattedPath)
   } catch (error) {
     return renderErrorView(req, res, false, error.errorCode)
   }

--- a/app/controllers/digital-wallet/post-google-pay.controller.js
+++ b/app/controllers/digital-wallet/post-google-pay.controller.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const paths = require('../../paths')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const logger = require('../../utils/logger')(__filename)
 const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
@@ -12,10 +13,11 @@ module.exports = async (req, res) => {
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   const enable = req.body['google-pay'] === 'on'
   const gatewayMerchantId = req.body.merchantId
+  const formattedPath = formatAccountPathsFor(paths.account.digitalWallet.googlePay, req.account && req.account.external_id)
 
   if (enable && !gatewayMerchantId) {
     req.flash('genericError', 'Enter a valid Merchant ID')
-    return res.redirect(paths.digitalWallet.googlePay)
+    return res.redirect(formattedPath)
   }
 
   if (enable) {
@@ -26,7 +28,7 @@ module.exports = async (req, res) => {
       logger.info(`${correlationId} error setting google pay merchant ID for ${gatewayAccountId}: `, error)
       if (error.errorCode === 400) {
         req.flash('genericError', 'There was an error enabling google pay. Check that the Merchant ID you entered is correct and that your PSP account credentials have been set.')
-        return res.redirect(paths.digitalWallet.googlePay)
+        return res.redirect(formattedPath)
       } else {
         return renderErrorView(req, res, false, error.errorCode)
       }
@@ -38,7 +40,7 @@ module.exports = async (req, res) => {
     logger.info(`${correlationId} ${enable ? 'enabled' : 'disabled'} google pay boolean for ${gatewayAccountId}`)
 
     req.flash('generic', `Google Pay successfully ${enable ? 'enabled' : 'disabled'}.`)
-    return res.redirect(paths.digitalWallet.googlePay)
+    return res.redirect(formattedPath)
   } catch (error) {
     logger.error(`${correlationId} error enabling google pay for ${gatewayAccountId}: ${error}`)
     return renderErrorView(req, res, false, error.errorCode)

--- a/app/paths.js
+++ b/app/paths.js
@@ -12,6 +12,10 @@ module.exports = {
   keys,
   account: {
     root: `/account/:${keys.GATEWAY_ACCOUNT_EXTERNAL_ID}`,
+    digitalWallet: {
+      applePay: '/digital-wallet/apple-pay',
+      googlePay: '/digital-wallet/google-pay'
+    },
     paymentTypes: {
       index: '/payment-types'
     },
@@ -77,10 +81,6 @@ module.exports = {
     create: '/api-keys/create',
     revoke: '/api-keys/revoke',
     update: '/api-keys/update'
-  },
-  digitalWallet: {
-    applePay: '/digital-wallet/apple-pay',
-    googlePay: '/digital-wallet/google-pay'
   },
   emailNotifications: {
     index: '/email-notifications',

--- a/app/routes.js
+++ b/app/routes.js
@@ -89,10 +89,11 @@ const {
   healthcheck, registerUser, user, dashboard, selfCreateService, transactions, credentials,
   apiKeys, serviceSwitcher, teamMembers, staticPaths, inviteValidation, editServiceName, merchantDetails,
   notificationCredentials, emailNotifications: emailNotifications, toggleMotoMaskCardNumberAndSecurityCode, prototyping, paymentLinks,
-  requestToGoLive, policyPages, stripeSetup, stripe, digitalWallet,
+  requestToGoLive, policyPages, stripeSetup, stripe,
   settings, yourPsp, allServiceTransactions, payouts
 } = paths
 const { 
+  digitalWallet,
   paymentTypes,
   toggle3ds,
   toggleBillingAddress
@@ -176,23 +177,19 @@ module.exports.bind = function (app) {
     ...lodash.values(credentials),
     ...lodash.values(notificationCredentials),
     ...lodash.values(apiKeys),
-    ...lodash.values(paymentTypes),
     ...lodash.values(emailNotifications),
     ...lodash.values(editServiceName),
     ...lodash.values(serviceSwitcher),
     ...lodash.values(teamMembers),
-    ...lodash.values(toggle3ds),
     ...lodash.values(merchantDetails),
     ...lodash.values(prototyping.demoPayment),
     ...lodash.values(prototyping.demoService),
     ...lodash.values(paymentLinks),
     ...lodash.values(user.profile),
-    ...lodash.values(toggleBillingAddress),
     ...lodash.values(requestToGoLive),
     ...lodash.values(policyPages),
     ...lodash.values(stripeSetup),
     ...lodash.values(stripe),
-    ...lodash.values(digitalWallet),
     ...lodash.values(settings),
     ...lodash.values(yourPsp),
     ...lodash.values(payouts),
@@ -250,10 +247,10 @@ module.exports.bind = function (app) {
   account.post(paymentTypes.index, permission('payment-types:update'), paymentTypesController.postIndex)
 
   // DIGITAL WALLET
-  app.get(digitalWallet.applePay, permission('payment-types:update'), getAccount, paymentMethodIsCard, digitalWalletController.getApplePay)
-  app.post(digitalWallet.applePay, permission('payment-types:update'), getAccount, paymentMethodIsCard, digitalWalletController.postApplePay)
-  app.get(digitalWallet.googlePay, permission('payment-types:update'), getAccount, paymentMethodIsCard, digitalWalletController.getGooglePay)
-  app.post(digitalWallet.googlePay, permission('payment-types:update'), getAccount, paymentMethodIsCard, digitalWalletController.postGooglePay)
+  account.get(digitalWallet.applePay, permission('payment-types:update'), paymentMethodIsCard, digitalWalletController.getApplePay)
+  account.post(digitalWallet.applePay, permission('payment-types:update'), paymentMethodIsCard, digitalWalletController.postApplePay)
+  account.get(digitalWallet.googlePay, permission('payment-types:update'), paymentMethodIsCard, digitalWalletController.getGooglePay)
+  account.post(digitalWallet.googlePay, permission('payment-types:update'), paymentMethodIsCard, digitalWalletController.postGooglePay)
 
   // EMAIL
   app.get(emailNotifications.index, permission('email-notification-template:read'), getAccount, getEmailNotification, paymentMethodIsCard, emailNotificationsController.index)

--- a/app/utils/nav-builder.js
+++ b/app/utils/nav-builder.js
@@ -8,7 +8,7 @@ const formatPSPname = require('./format-PSP-name')
 
 const mainSettingsPaths = [
   paths.settings,
-  paths.digitalWallet,
+  paths.account.digitalWallet,
   paths.account.toggle3ds,
   paths.account.toggleBillingAddress,
   paths.emailNotifications,
@@ -100,10 +100,6 @@ const adminNavigationItems = (currentPath, permissions, type, paymentProvider, a
     }
   ]
 }
-
-// const pathMatches(url, paths) {
-
-// }
 
 module.exports = {
   serviceNavigationItems: serviceNavigationItems,

--- a/app/views/billing-address/index.njk
+++ b/app/views/billing-address/index.njk
@@ -39,7 +39,7 @@
       }}
     {% endif %}
 
-    <form class="permission-main" method="post" action="{{ routes.toggleBillingAddress.index }}">
+    <form class="permission-main" method="post">
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
       {{
         govukRadios({

--- a/app/views/digital-wallet/apple-pay.njk
+++ b/app/views/digital-wallet/apple-pay.njk
@@ -22,7 +22,7 @@
         <li>corporate card fees cannot be applied to payments made with Apple Pay.</li>
       </ul>
 
-      <form method="post" action="{{routes.digitalWallet.applePay}}">
+      <form method="post">
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
         {{
           govukRadios({

--- a/app/views/digital-wallet/google-pay.njk
+++ b/app/views/digital-wallet/google-pay.njk
@@ -27,7 +27,7 @@
         You’ll need a Google Pay merchant ID. Refer to the <a class="govuk-link" href="https://docs.payments.service.gov.uk/digital_wallets/#enable-google-pay">GOV.UK Pay documentation on enabling Google Pay</a> to learn where to find your merchant ID.
       </p>
 
-      <form method="post" action="{{routes.digitalWallet.googlePay}}">
+      <form method="post">
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
         {% set merchantID %}

--- a/app/views/settings/index.njk
+++ b/app/views/settings/index.njk
@@ -33,7 +33,7 @@
               classes: 'govuk-!-width-one-quarter',
               items: [
                 {
-                  href: routes.digitalWallet.applePay,
+                  href: formatAccountPathsFor(routes.account.digitalWallet.applePay, currentGatewayAccount.external_id),
                   classes: 'govuk-link--no-visited-state',
                   text: 'Change' if permissions.toggle_billing_address_update else 'View',
                   visuallyHiddenText: 'Apple Pay settings'
@@ -54,7 +54,7 @@
               classes: 'govuk-!-width-one-quarter',
               items: [
                 {
-                  href: routes.digitalWallet.googlePay,
+                  href: formatAccountPathsFor(routes.account.digitalWallet.googlePay, currentGatewayAccount.external_id),
                   classes: 'govuk-link--no-visited-state',
                   text: 'Change' if permissions.toggle_billing_address_update else 'View',
                   visuallyHiddenText: 'Google Pay settings'

--- a/test/cypress/integration/settings/allow-apple-pay.cy.test.js
+++ b/test/cypress/integration/settings/allow-apple-pay.cy.test.js
@@ -1,11 +1,22 @@
 const userStubs = require('../../stubs/user-stubs')
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 
-function setupStubs (userExternalId, gatewayAccountId, serviceName, allowApplePay) {
+const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+const gatewayAccountId = 42
+const gatewayAccountExternalId = 'a-valid-external-id'
+const serviceName = 'My Awesome Service'
+
+function setupStubs (allowApplePay) {
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName }),
     gatewayAccountStubs.getGatewayAccountSuccess({
       gatewayAccountId,
+      paymentProvider: 'worldpay',
+      allowApplePay: allowApplePay
+    }),
+    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+      gatewayAccountId,
+      gatewayAccountExternalId,
       paymentProvider: 'worldpay',
       allowApplePay: allowApplePay
     })
@@ -13,17 +24,13 @@ function setupStubs (userExternalId, gatewayAccountId, serviceName, allowApplePa
 }
 
 describe('Apple Pay', () => {
-  const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
-  const gatewayAccountId = 42
-  const serviceName = 'My Awesome Service'
-
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('session', 'gateway_account')
   })
 
   describe('is disabled when unsupported', () => {
     beforeEach(() => {
-      setupStubs(userExternalId, gatewayAccountId, serviceName, false)
+      setupStubs(false)
     })
 
     it('should show it is disabled', () => {
@@ -41,7 +48,7 @@ describe('Apple Pay', () => {
 
   describe('but allow us to enable when supported', () => {
     beforeEach(() => {
-      setupStubs(userExternalId, gatewayAccountId, serviceName, false)
+      setupStubs(false)
     })
 
     it('Show that is is disabled', () => {
@@ -54,7 +61,7 @@ describe('Apple Pay', () => {
 
   describe('Show enabled after turning on', () => {
     beforeEach(() => {
-      setupStubs(userExternalId, gatewayAccountId, serviceName, true)
+      setupStubs(true)
     })
 
     it('should allow us to enable', () => {

--- a/test/cypress/integration/settings/allow-google-pay.cy.test.js
+++ b/test/cypress/integration/settings/allow-google-pay.cy.test.js
@@ -1,11 +1,22 @@
 const userStubs = require('../../stubs/user-stubs')
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 
-function setupStubs (userExternalId, gatewayAccountId, serviceName, allowGooglePay) {
+const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+const gatewayAccountId = 42
+const gatewayAccountExternalId = 'a-valid-external-id'
+const serviceName = 'My Awesome Service'
+
+function setupStubs (allowGooglePay) {
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName }),
     gatewayAccountStubs.getGatewayAccountSuccess({
       gatewayAccountId,
+      paymentProvider: 'worldpay',
+      allowGooglePay: allowGooglePay
+    }),
+    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+      gatewayAccountId,
+      gatewayAccountExternalId,
       paymentProvider: 'worldpay',
       allowGooglePay: allowGooglePay
     })
@@ -13,17 +24,13 @@ function setupStubs (userExternalId, gatewayAccountId, serviceName, allowGoogleP
 }
 
 describe('Google Pay', () => {
-  const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
-  const gatewayAccountId = 42
-  const serviceName = 'My Awesome Service'
-
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('session', 'gateway_account')
   })
 
   describe('is disabled', () => {
     beforeEach(() => {
-      setupStubs(userExternalId, gatewayAccountId, serviceName, false)
+      setupStubs(false)
     })
 
     it('should show it is disabled', () => {
@@ -41,7 +48,7 @@ describe('Google Pay', () => {
 
   describe('but allow us to enable when supported', () => {
     beforeEach(() => {
-      setupStubs(userExternalId, gatewayAccountId, serviceName, false)
+      setupStubs(false)
     })
 
     it('should allow us to enable', () => {
@@ -54,7 +61,7 @@ describe('Google Pay', () => {
 
   describe('Show enabled after turning on', () => {
     beforeEach(() => {
-      setupStubs(userExternalId, gatewayAccountId, serviceName, true)
+      setupStubs(true)
     })
 
     it('should allow us to enable', () => {


### PR DESCRIPTION
Move apple/google pay settings URLs to use new account URL structure.

Also remove some paths from the authenticatedPaths array in routes.js as all the required middleware is now called for all routes using the account router.


