### PR TITLE
PP-7583 URL Restructure - API Keys

### DIFF
--- a/app/controllers/api-keys/post-create.controller.js
+++ b/app/controllers/api-keys/post-create.controller.js
@@ -4,7 +4,7 @@ const { response } = require('../../utils/response.js')
 const publicAuthClient = require('../../services/clients/public-auth.client')
 const { isADirectDebitAccount } = require('../../services/clients/direct-debit-connector.client.js')
 
-module.exports = async function createAPIKey (req, res, next) {
+module.exports = async function createApiKey (req, res, next) {
   const accountId = req.account.gateway_account_id
   const correlationId = req.correlationId
   const description = req.body.description

--- a/app/controllers/api-keys/post-revoke.controller.js
+++ b/app/controllers/api-keys/post-revoke.controller.js
@@ -3,8 +3,11 @@
 const paths = require('../../paths')
 const publicAuthClient = require('../../services/clients/public-auth.client')
 const logger = require('../../utils/logger')(__filename)
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 
-module.exports = async (req, res) => {
+module.exports = async function revokeApiKey (req, res) {
+  const apiKeysPath = formatAccountPathsFor(paths.account.apiKeys.index, req.account.external_id)
+
   const accountId = req.account.gateway_account_id
   const payload = {
     token_link: req.body.token_link
@@ -16,10 +19,10 @@ module.exports = async (req, res) => {
     })
 
     req.flash('generic', 'The API key was successfully revoked')
-    return res.redirect(paths.apiKeys.index)
+    return res.redirect(apiKeysPath)
   } catch (error) {
     logger.error('Error revoking API key', { error: error.message })
     req.flash('genericError', 'Something went wrong. Please try again or contact support.')
-    return res.redirect(paths.apiKeys.index)
+    return res.redirect(apiKeysPath)
   }
 }

--- a/app/controllers/api-keys/post-update.controller.js
+++ b/app/controllers/api-keys/post-update.controller.js
@@ -3,8 +3,11 @@
 const paths = require('../../paths')
 const publicAuthClient = require('../../services/clients/public-auth.client')
 const logger = require('../../utils/logger')(__filename)
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 
-module.exports = (req, res) => {
+module.exports = async function updateApiKey (req, res) {
+  const apiKeysPath = formatAccountPathsFor(paths.account.apiKeys.index, req.account.external_id)
+
   // this does not need to be explicitly tied down to account_id
   // right now because the UUID space is big enough that no-one
   // will be able to discover other peoples' tokens to change them
@@ -13,17 +16,17 @@ module.exports = (req, res) => {
     description: req.body.description
   }
 
-  publicAuthClient.updateToken({
-    payload: payload,
-    correlationId: req.correlationId
-  })
-    .then(() => {
-      req.flash('generic', 'The API key description was successfully updated')
-      res.redirect(paths.apiKeys.index)
+  try {
+    await publicAuthClient.updateToken({
+      payload: payload,
+      correlationId: req.correlationId
     })
-    .catch(error => {
-      logger.error('Error updating API key description', { error })
-      req.flash('genericError', 'Something went wrong. Please try again or contact support.')
-      res.redirect(paths.apiKeys.index)
-    })
+
+    req.flash('generic', 'The API key description was successfully updated')
+    res.redirect(apiKeysPath)
+  } catch (error) {
+    logger.error('Error updating API key description', { error })
+    req.flash('genericError', 'Something went wrong. Please try again or contact support.')
+    res.redirect(apiKeysPath)
+  }
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -40,6 +40,13 @@ module.exports = {
     toggleMotoMaskCardNumberAndSecurityCode: {
       cardNumber: '/moto-hide-card-number',
       securityCode: '/moto-hide-security-code'
+    },
+    apiKeys: {
+      index: '/api-keys',
+      revoked: '/api-keys/revoked',
+      create: '/api-keys/create',
+      revoke: '/api-keys/revoke',
+      update: '/api-keys/update'
     }
   },
   transactions: {
@@ -90,13 +97,6 @@ module.exports = {
   },
   dashboard: {
     index: '/'
-  },
-  apiKeys: {
-    index: '/api-keys',
-    revoked: '/api-keys/revoked',
-    create: '/api-keys/create',
-    revoke: '/api-keys/revoke',
-    update: '/api-keys/update'
   },
   serviceSwitcher: {
     index: '/my-services',

--- a/app/routes.js
+++ b/app/routes.js
@@ -86,12 +86,13 @@ const stripeSetupDashboardRedirectController = require('./controllers/stripe-set
 // Assignments
 const {
   healthcheck, registerUser, user, dashboard, selfCreateService, transactions, credentials,
-  apiKeys, serviceSwitcher, teamMembers, staticPaths, inviteValidation, editServiceName, merchantDetails,
+  serviceSwitcher, teamMembers, staticPaths, inviteValidation, editServiceName, merchantDetails,
   notificationCredentials, prototyping, paymentLinks,
   requestToGoLive, policyPages, stripeSetup, stripe,
   settings, yourPsp, allServiceTransactions, payouts
 } = paths
 const {
+  apiKeys,
   digitalWallet,
   emailNotifications,
   paymentTypes,
@@ -235,12 +236,12 @@ module.exports.bind = function (app) {
   app.post(merchantDetails.edit, permission('merchant-details:update'), merchantDetailsController.postEdit)
 
   // API KEYS
-  app.get(apiKeys.index, permission('tokens-active:read'), getAccount, apiKeysController.getIndex)
-  app.get(apiKeys.revoked, permission('tokens-revoked:read'), getAccount, apiKeysController.getRevoked)
-  app.get(apiKeys.create, permission('tokens:create'), getAccount, apiKeysController.getCreate)
-  app.post(apiKeys.create, permission('tokens:create'), getAccount, apiKeysController.postCreate)
-  app.post(apiKeys.revoke, permission('tokens:delete'), getAccount, apiKeysController.postRevoke)
-  app.post(apiKeys.update, permission('tokens:update'), getAccount, apiKeysController.postUpdate)
+  account.get(apiKeys.index, permission('tokens-active:read'), apiKeysController.getIndex)
+  account.get(apiKeys.revoked, permission('tokens-revoked:read'), apiKeysController.getRevoked)
+  account.get(apiKeys.create, permission('tokens:create'), apiKeysController.getCreate)
+  account.post(apiKeys.create, permission('tokens:create'), apiKeysController.postCreate)
+  account.post(apiKeys.revoke, permission('tokens:delete'), apiKeysController.postRevoke)
+  account.post(apiKeys.update, permission('tokens:update'), apiKeysController.postUpdate)
 
   account.get(paymentTypes.index, permission('payment-types:read'), paymentTypesController.getIndex)
   account.post(paymentTypes.index, permission('payment-types:update'), paymentTypesController.postIndex)

--- a/app/utils/nav-builder.js
+++ b/app/utils/nav-builder.js
@@ -49,11 +49,11 @@ const serviceNavigationItems = (currentPath, permissions, type) => {
   navigationItems.push({
     id: 'navigation-menu-settings',
     name: 'Settings',
-    url: type === 'card' ? paths.settings.index : paths.apiKeys.index,
+    url: paths.settings.index,
     current: currentPath !== '/' ? pathLookup(currentPath, [
       ...mainSettingsPaths,
       ...yourPspPaths,
-      paths.apiKeys,
+      paths.account.apiKeys,
       paths.account.paymentTypes
     ]) : false,
     permissions: _.some([
@@ -69,6 +69,8 @@ const serviceNavigationItems = (currentPath, permissions, type) => {
 }
 
 const adminNavigationItems = (currentPath, permissions, type, paymentProvider, account = {}) => {
+  const apiKeysPath = formatAccountPathsFor(paths.account.apiKeys.index, account.external_id)
+
   return [
     {
       id: 'navigation-menu-settings-home',
@@ -80,8 +82,8 @@ const adminNavigationItems = (currentPath, permissions, type, paymentProvider, a
     {
       id: 'navigation-menu-api-keys',
       name: 'API keys',
-      url: paths.apiKeys.index,
-      current: pathLookup(currentPath, paths.apiKeys.index),
+      url: apiKeysPath,
+      current: pathLookup(currentPath, paths.account.apiKeys.index),
       permissions: permissions.tokens_update
     },
     {

--- a/app/views/api-keys/_key.njk
+++ b/app/views/api-keys/_key.njk
@@ -37,7 +37,7 @@
     {% endif %}
 
     {% if permissions.tokens_delete %}
-    <form class="target-to-show" id="delete-{{token.token_link}}" method="POST" action="{{routes.apiKeys.revoke}}">
+    <form class="target-to-show" id="delete-{{token.token_link}}" method="POST" action="{{formatAccountPathsFor(routes.account.apiKeys.revoke, currentGatewayAccount.external_id)}}">
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
       <input type="hidden" name="token_link" value="{{token.token_link}}"/>
       <div class="govuk-error-summary govuk-!-margin-top-6" role="group" aria-labelledby="error-summary" tabindex="-1">
@@ -64,7 +64,7 @@ govuk-link--no-visited-state target-to-show--cancel" href="#main">Cancel</a>
     </form>
     {% endif %}
     {% if permissions.tokens_update %}
-      <form class="target-to-show govuk-!-margin-top-6" id="update-{{token.token_link}}" method="POST" action="{{routes.apiKeys.update}}">
+      <form class="target-to-show govuk-!-margin-top-6" id="update-{{token.token_link}}" method="POST" action="{{formatAccountPathsFor(routes.account.apiKeys.update, currentGatewayAccount.external_id)}}">
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
         <input type="hidden" name="token_link" value="{{token.token_link}}"/>
         {{

--- a/app/views/api-keys/_keys.njk
+++ b/app/views/api-keys/_keys.njk
@@ -11,17 +11,17 @@
 </h2>
 
 {% if active %}
-  {% set apiKeyLinkRoute = routes.apiKeys.revoked %}
+  {% set apiKeyLinkRoute = routes.account.apiKeys.revoked %}
   {% set apiKeyLinkText = 'revoked' %}
   {% set apiKeyLinkId = 'revoked-keys-link' %}
 {% else %}
-  {% set apiKeyLinkRoute = routes.apiKeys.index %}
+  {% set apiKeyLinkRoute = routes.account.apiKeys.index %}
   {% set apiKeyLinkText = 'active' %}
   {% set apiKeyLinkId = 'active-keys-link' %}
 {% endif %}
 
 <div class="govuk-body">
-  <a class="govuk-link" href="{{ apiKeyLinkRoute }}" id="{{apiKeyLinkId}}">View {{apiKeyLinkText}} keys</a>
+  <a class="govuk-link" href="{{ formatAccountPathsFor(apiKeyLinkRoute, currentGatewayAccount.external_id) }}" id="{{apiKeyLinkId}}">View {{apiKeyLinkText}} keys</a>
 </div>
 
 {% if permissions.tokens_create %}
@@ -29,7 +29,7 @@
     {{
       govukButton({
         text: "Create a new API key",
-        href: routes.apiKeys.create,
+        href: formatAccountPathsFor(routes.account.apiKeys.create, currentGatewayAccount.external_id),
         classes: "generate-key",
         attributes: {
           id: "create-api-key"

--- a/app/views/api-keys/create.njk
+++ b/app/views/api-keys/create.njk
@@ -12,7 +12,7 @@ Create an API key - {{currentService.name}} {{currentGatewayAccount.full_type}} 
 <div class="govuk-grid-column-two-thirds">
   {% if not token %}
   <h1 class="govuk-heading-l page-title">Create an API key</h1>
-    <form class="form" method="post" action="{{routes.apiKeys.create}}">
+    <form class="form" method="post" action="{{formatAccountPathsFor(routes.account.apiKeys.create, currentGatewayAccount.external_id)}}">
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
       {{
@@ -44,7 +44,7 @@ Create an API key - {{currentService.name}} {{currentGatewayAccount.full_type}} 
       }}
     </form>
     <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="{{routes.apiKeys.index}}">Cancel</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{formatAccountPathsFor(routes.account.apiKeys.index, currentGatewayAccount.external_id)}}">Cancel</a>
     </p>
   {% else %}
     <h1 class="govuk-heading-l page-title">New API key</h1>
@@ -74,7 +74,7 @@ Create an API key - {{currentService.name}} {{currentGatewayAccount.full_type}} 
     <div class="copy-this-api-key-notification govuk-visually-hidden" aria-live="assertive"></div>
 
     <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="{{routes.apiKeys.index}}" id="finish-link">
+      <a class="govuk-link govuk-link--no-visited-state" href="{{formatAccountPathsFor(routes.account.apiKeys.index, currentGatewayAccount.external_id)}}" id="finish-link">
         Back to API keys
       </a>
     </p>

--- a/app/views/api-keys/update.njk
+++ b/app/views/api-keys/update.njk
@@ -22,7 +22,7 @@ Create an API key - {{currentService.name}} {{currentGatewayAccount.full_type}} 
     <button type="submit" id="save-description-{{token.token_link}}" href="#{{token.token_link}}" class="button">
       Save changes<span class="visuallyhidden"> to {{token.description}}</span>
     </button>
-    <a id="cancel-{{token.token_link}}" href="{{routes.apiKeys.index}}" class="button-link">
+    <a id="cancel-{{token.token_link}}" href="{{formatAccountPathsFor(routes.account.apiKeys.index, currentGatewayAccount.external_id)}}" class="button-link">
       Cancel<span class="visuallyhidden"> edits to {{token.description}}</span>
     </a>
   </div>

--- a/test/ui/navigation.ui.test.js
+++ b/test/ui/navigation.ui.test.js
@@ -1,5 +1,6 @@
 const { render } = require('../test-helpers/html-assertions')
 const { serviceNavigationItems, adminNavigationItems } = require('../../app/utils/nav-builder')
+const formatAccountPathsFor = require('../../app/utils/format-account-paths-for')
 
 describe('navigation menu', function () {
   it('should render only Home link when user does have any of the required permissions to show the navigation links', function () {
@@ -15,7 +16,8 @@ describe('navigation menu', function () {
       hideServiceNav: false,
       serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'card'),
       links: [],
-      linksToDisplay: []
+      linksToDisplay: [],
+      formatAccountPathsFor: formatAccountPathsFor
     }
 
     const body = render('dashboard/index', templateData)
@@ -72,7 +74,8 @@ describe('navigation menu', function () {
     const templateData = {
       permissions: testPermissions,
       showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'sandbox')
+      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'sandbox'),
+      formatAccountPathsFor: formatAccountPathsFor
     }
 
     const body = render('api-keys/index', templateData)
@@ -93,7 +96,8 @@ describe('navigation menu', function () {
     const templateData = {
       permissions: testPermissions,
       showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'worldpay')
+      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'worldpay'),
+      formatAccountPathsFor: formatAccountPathsFor
     }
 
     const body = render('api-keys/index', templateData)
@@ -114,7 +118,8 @@ describe('navigation menu', function () {
     const templateData = {
       permissions: testPermissions,
       showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'stripe')
+      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'stripe'),
+      formatAccountPathsFor: formatAccountPathsFor
     }
 
     const body = render('api-keys/index', templateData)
@@ -135,7 +140,8 @@ describe('navigation menu', function () {
     const templateData = {
       permissions: testPermissions,
       showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'sandbox')
+      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'sandbox'),
+      formatAccountPathsFor: formatAccountPathsFor
     }
 
     const body = render('api-keys/index', templateData)
@@ -155,7 +161,8 @@ describe('navigation menu', function () {
     const templateData = {
       permissions: testPermissions,
       showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'sandbox')
+      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'sandbox'),
+      formatAccountPathsFor: formatAccountPathsFor
     }
 
     const body = render('api-keys/index', templateData)
@@ -178,7 +185,8 @@ describe('navigation menu', function () {
     const templateData = {
       permissions: testPermissions,
       showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'direct debit')
+      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'direct debit'),
+      formatAccountPathsFor: formatAccountPathsFor
     }
 
     const body = render('api-keys/index', templateData)
@@ -206,7 +214,8 @@ describe('navigation menu', function () {
     const templateData = {
       permissions: testPermissions,
       showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'worldpay')
+      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'worldpay'),
+      formatAccountPathsFor: formatAccountPathsFor
     }
 
     const body = render('api-keys/index', templateData)

--- a/test/unit/controller/api-keys/get-index.controller.ft.test.js
+++ b/test/unit/controller/api-keys/get-index.controller.ft.test.js
@@ -9,10 +9,14 @@ const mockSession = require('../../../test-helpers/mock-session')
 const userCreator = require('../../../test-helpers/user-creator')
 const paths = require('../../../../app/paths')
 const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
+const formatAccountPathsFor = require('../../../../app/utils/format-account-paths-for')
 
 const { PUBLIC_AUTH_URL, CONNECTOR_URL } = process.env
 
 const GATEWAY_ACCOUNT_ID = '182364'
+const EXTERNAL_GATEWAY_ACCOUNT_ID = 'an-external-id'
+
+const apiKeysIndexPath = formatAccountPathsFor(paths.account.apiKeys.index, EXTERNAL_GATEWAY_ACCOUNT_ID)
 
 const TOKEN_1 = {
   issued_date: '15 May 2018 - 09:13',
@@ -53,7 +57,7 @@ describe('API keys index', () => {
       mockGetActiveAPIKeys(GATEWAY_ACCOUNT_ID).reply(200, [])
 
       supertest(app)
-        .get(paths.apiKeys.index)
+        .get(apiKeysIndexPath)
         .set('Accept', 'application/json')
         .end((err, res) => {
           response = res
@@ -80,7 +84,7 @@ describe('API keys index', () => {
       mockGetActiveAPIKeys(GATEWAY_ACCOUNT_ID).reply(200, { tokens: [TOKEN_1] })
 
       supertest(app)
-        .get(paths.apiKeys.index)
+        .get(apiKeysIndexPath)
         .set('Accept', 'application/json')
         .end((err, res) => {
           response = res
@@ -112,7 +116,7 @@ describe('API keys index', () => {
       mockGetActiveAPIKeys(GATEWAY_ACCOUNT_ID).reply(200, { tokens: [TOKEN_1, TOKEN_2] })
 
       supertest(app)
-        .get(paths.apiKeys.index)
+        .get(apiKeysIndexPath)
         .set('Accept', 'application/json')
         .end((err, res) => {
           response = res
@@ -139,8 +143,11 @@ describe('API keys index', () => {
 })
 
 function mockConnectorGetAccount () {
-  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-    .reply(200, gatewayAccountFixtures.validGatewayAccountResponse({
-      gateway_account_id: GATEWAY_ACCOUNT_ID
-    }))
+  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+    .reply(200, gatewayAccountFixtures.validGatewayAccountResponse(
+      {
+        external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,
+        gateway_account_id: GATEWAY_ACCOUNT_ID
+      }
+    ))
 }

--- a/test/unit/controller/api-keys/get-revoked.controller.ft.test.js
+++ b/test/unit/controller/api-keys/get-revoked.controller.ft.test.js
@@ -9,10 +9,14 @@ const mockSession = require('../../../test-helpers/mock-session')
 const userCreator = require('../../../test-helpers/user-creator')
 const paths = require('../../../../app/paths')
 const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
+const formatAccountPathsFor = require('../../../../app/utils/format-account-paths-for')
 
 const { PUBLIC_AUTH_URL, CONNECTOR_URL } = process.env
 
 const GATEWAY_ACCOUNT_ID = '182364'
+const EXTERNAL_GATEWAY_ACCOUNT_ID = 'an-external-id'
+
+const apiKeysRevokedIndexPath = formatAccountPathsFor(paths.account.apiKeys.revoked, EXTERNAL_GATEWAY_ACCOUNT_ID)
 
 const TOKEN_1 = {
   issued_date: '14 May 2018 - 15:33',
@@ -39,10 +43,13 @@ const mockGetRevokedAPIKeys = gatewayAccountId => {
 }
 
 function mockConnectorGetAccount () {
-  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-    .reply(200, gatewayAccountFixtures.validGatewayAccountResponse({
-      gateway_account_id: GATEWAY_ACCOUNT_ID
-    }))
+  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+    .reply(200, gatewayAccountFixtures.validGatewayAccountResponse(
+      {
+        external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,
+        gateway_account_id: GATEWAY_ACCOUNT_ID
+      }
+    ))
 }
 
 describe('Revoked API keys index', () => {
@@ -62,7 +69,7 @@ describe('Revoked API keys index', () => {
       mockGetRevokedAPIKeys(GATEWAY_ACCOUNT_ID).reply(200, [])
 
       supertest(app)
-        .get(paths.apiKeys.revoked)
+        .get(apiKeysRevokedIndexPath)
         .set('Accept', 'application/json')
         .end((err, res) => {
           response = res
@@ -89,7 +96,7 @@ describe('Revoked API keys index', () => {
       mockGetRevokedAPIKeys(GATEWAY_ACCOUNT_ID).reply(200, { tokens: [TOKEN_1] })
 
       supertest(app)
-        .get(paths.apiKeys.revoked)
+        .get(apiKeysRevokedIndexPath)
         .set('Accept', 'application/json')
         .end((err, res) => {
           response = res
@@ -121,7 +128,7 @@ describe('Revoked API keys index', () => {
       mockGetRevokedAPIKeys(GATEWAY_ACCOUNT_ID).reply(200, { tokens: [TOKEN_1, TOKEN_2] })
 
       supertest(app)
-        .get(paths.apiKeys.revoked)
+        .get(apiKeysRevokedIndexPath)
         .set('Accept', 'application/json')
         .end((err, res) => {
           response = res

--- a/test/unit/controller/api-keys/post-create.controller.ft.test.js
+++ b/test/unit/controller/api-keys/post-create.controller.ft.test.js
@@ -9,7 +9,8 @@ const { getApp } = require('../../../../server')
 const mockSession = require('../../../test-helpers/mock-session')
 const userCreator = require('../../../test-helpers/user-creator')
 const paths = require('../../../../app/paths')
-const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
+const formatAccountPathsFor = require('../../../../app/utils/format-account-paths-for')
+const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
 
 const { PUBLIC_AUTH_URL, CONNECTOR_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '182364'
@@ -23,12 +24,18 @@ const VALID_PAYLOAD = {
   'description': ''
 }
 
+const EXTERNAL_GATEWAY_ACCOUNT_ID = 'an-external-id'
+const apiKeyCreatePath = formatAccountPathsFor(paths.account.apiKeys.create, EXTERNAL_GATEWAY_ACCOUNT_ID)
+
 function mockConnectorGetAccount (type) {
-  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-    .reply(200, gatewayAccountFixtures.validGatewayAccountResponse({
-      gateway_account_id: GATEWAY_ACCOUNT_ID,
-      type
-    }))
+  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+    .reply(200, validGatewayAccountResponse(
+      {
+        external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,
+        gateway_account_id: GATEWAY_ACCOUNT_ID,
+        type
+      }
+    ))
 }
 
 describe('POST to create an API key', () => {
@@ -56,7 +63,7 @@ describe('POST to create an API key', () => {
         .reply(200, TOKEN_RESPONSE)
 
       supertest(app)
-        .post(paths.apiKeys.create)
+        .post(apiKeyCreatePath)
         .set('Accept', 'application/json')
         .set('x-request-id', REQUEST_ID)
         .send(VALID_PAYLOAD)
@@ -104,7 +111,7 @@ describe('POST to create an API key', () => {
       VALID_PAYLOAD.description = DESCRIPTION
 
       supertest(app)
-        .post(paths.apiKeys.create)
+        .post(apiKeyCreatePath)
         .set('Accept', 'application/json')
         .set('x-request-id', REQUEST_ID)
         .send(VALID_PAYLOAD)


### PR DESCRIPTION
with @sandorarpa

- paths.js
  - Move API paths to `account` section.
- routes.js
  - Add all API Key paths to the `account router`
- Update all API key views and controllers
  - Update all references to API key pages to use the new URL structure
    - i.e. /account/<gateway-account>/api-keys/*
- Update functional tests to use mock calls for the new account middleware
- Updated nav-builder to use new account URLs for the API Keys
- Updated template test for the navigation

