### PR TITLE
PP-7445 Normalise gateway account urls when upgrading

### DIFF
--- a/app/utils/gateway-account-urls.js
+++ b/app/utils/gateway-account-urls.js
@@ -14,7 +14,12 @@ const templatedAccountPaths = allAccountPaths.filter((path) => path.includes(':'
 
 const removeEmptyValues = (value) => !!value
 
-function isLegacyAccountsUrl (url) {
+function removeTrailingPathForwardSlash (path = '') {
+  return path.replace(/\/+$/, '')
+}
+
+function isLegacyAccountsUrl (targetUrl) {
+  const url = removeTrailingPathForwardSlash(targetUrl)
   if (allAccountPaths.includes(url)) {
     return true
   } else {

--- a/app/utils/gateway-account-urls.js.test.js
+++ b/app/utils/gateway-account-urls.js.test.js
@@ -8,6 +8,12 @@ describe('account URL checker', () => {
     expect(result).to.be.true //eslint-disable-line
   })
 
+  it('correctly identifies URLs with trailing forward slash', () => {
+    const url = '/billing-address/'
+    const result = accountsUrl.isLegacyAccountsUrl(url)
+    expect(result).to.be.true //eslint-disable-line
+  })
+
   it('correctly upgrades a URL to the account structure', () => {
     const url = '/create-payment-link/manage/some-product-external-id/add-reporting-column/some-metadata-key'
     const gatewayAccountExternalId = 'some-account-external-id'


### PR DESCRIPTION
Some browsers force navigating to remembered routes when visiting a particular
resource, the account url parsing should be resilient to trailing `/` to
correctly match when this is the case.

