### PR TITLE
PP-7445 Set account external ID on login

### DIFF
--- a/app/controllers/login/post-login.controller.js
+++ b/app/controllers/login/post-login.controller.js
@@ -16,6 +16,11 @@ const paths = require('../../paths')
 module.exports = (req, res) => {
   const correlationId = _.get(req, 'headers.' + CORRELATION_HEADER, '')
   req.session = _.pick(req.session, ['passport', 'last_url', 'currentGatewayAccountId'])
+  if (req.gateway_account) {
+    // make sure the accounts external ID is set correctly when the user logs in
+    // following this only controlled code (service switcher, redirect controllers) should be able to update the ID
+    req.gateway_account.currentGatewayAccountExternalId = req.account && req.account.external_id
+  }
   logger.info(`[${correlationId}] successfully attempted username/password combination`)
   res.redirect(paths.user.otpLogIn)
 }

--- a/app/controllers/stripe-setup/stripe-setup-link/stripe-setup-dashboard-redirect.controller.js
+++ b/app/controllers/stripe-setup/stripe-setup-link/stripe-setup-dashboard-redirect.controller.js
@@ -20,6 +20,7 @@ module.exports = async (req, res) => {
     const liveGatewayAccounts = result.accounts.filter((gatewayAccount) => gatewayAccount.type === 'live')
     if (liveGatewayAccounts && liveGatewayAccounts.length === 1) {
       req.gateway_account.currentGatewayAccountId = `${liveGatewayAccounts[0].gateway_account_id}`
+      req.gateway_account.currentGatewayAccountExternalId = liveGatewayAccounts[0].external_id
     }
   } else {
     const logContext = {}


### PR DESCRIPTION
As we transition URL structure for accounts only new middleware routes
and the service switcher will be setting the external id required to
redirect to the correct URLs.

Ensure the external ID is set when the user logs in, this should then be
correct until the ID is changed by a known redirect controller.
