### PR TITLE
PP-7583 Move settings route

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-01-14T16:22:27Z",
+  "generated_at": "2021-01-18T10:18:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -72,7 +72,7 @@
         "hashed_secret": "ece65afda87c1c6120602c9a3b66890308d7e53c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 78,
+        "line_number": 88,
         "type": "Secret Keyword"
       }
     ],
@@ -150,21 +150,21 @@
         "hashed_secret": "d0be4e729498f4cfe8a72a28d4fceae35bd8bb27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 13,
+        "line_number": 14,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "2c877f34a0f47f32a5f3c77e398938b3cdc32221",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 19,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "379f1968f09d8a343338667844e01a2f433f0a3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 23,
         "type": "Hex High Entropy String"
       }
     ],

--- a/app/controllers/email-notifications/email-notifications.controller.js
+++ b/app/controllers/email-notifications/email-notifications.controller.js
@@ -6,10 +6,8 @@ const logger = require('../../utils/logger')(__filename)
 const response = require('../../utils/response.js').response
 const emailService = require('../../services/email.service.js')
 const paths = require('../../paths.js')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const CORRELATION_HEADER = require('../../utils/correlation-header.js').CORRELATION_HEADER
-
-// Constants
-const indexPath = paths.settings.index
 
 const showEmail = function (req, res, resource, locals) {
   const template = 'email-notifications/' + resource
@@ -37,7 +35,7 @@ const toggleConfirmationEmail = function (req, res, enabled) {
   emailService.setConfirmationEnabled(accountID, enabled, correlationId)
     .then(() => {
       logger.info(`[${correlationId}] - Updated confirmation email enabled(${enabled}). user=${req.session.passport.user}, gateway_account=${accountID}`)
-      res.redirect(303, indexPath)
+      res.redirect(303, formatAccountPathsFor(paths.account.settings.index, req.account && req.account.external_id))
     })
 }
 
@@ -59,7 +57,7 @@ module.exports.collectionEmailUpdate = (req, res) => {
   emailService.setEmailCollectionMode(accountID, emailCollectionMode, correlationId)
     .then(() => {
       logger.info(`[${correlationId}] - Updated email collection mode (${emailCollectionMode}). user=${req.session.passport.user}, gateway_account=${accountID}`)
-      res.redirect(303, indexPath)
+      res.redirect(303, formatAccountPathsFor(paths.account.settings.index, req.account && req.account.external_id))
     })
 }
 
@@ -101,7 +99,7 @@ module.exports.refundEmailUpdate = (req, res) => {
   emailService.setRefundEmailEnabled(accountID, emailRefundEnabled, correlationId)
     .then(() => {
       logger.info(`[${correlationId}] - Updated refund email enabled(${emailRefundEnabled}). user=${req.session.passport.user}, gateway_account=${accountID}`)
-      res.redirect(303, indexPath)
+      res.redirect(303, formatAccountPathsFor(paths.account.settings.index, req.account && req.account.external_id))
     })
 }
 
@@ -148,6 +146,6 @@ module.exports.update = (req, res) => {
   emailService.updateConfirmationTemplate(accountID, newEmailText, correlationId)
     .then(() => {
       logger.info(`[${correlationId}] - Updated email notifications custom paragraph. user=${req.session.passport.user}, gateway_account=${accountID}`)
-      res.redirect(303, indexPath)
+      res.redirect(303, formatAccountPathsFor(paths.account.settings.index, req.account && req.account.external_id))
     })
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -31,6 +31,9 @@ module.exports = {
     paymentTypes: {
       index: '/payment-types'
     },
+    settings: {
+      index: '/settings'
+    },
     toggle3ds: {
       index: '/3ds'
     },
@@ -208,9 +211,6 @@ module.exports = {
   },
   stripe: {
     addPspAccountDetails: '/stripe/add-psp-account-details'
-  },
-  settings: {
-    index: '/settings'
   },
   payouts: {
     list: '/payments-to-your-bank-account'

--- a/app/routes.js
+++ b/app/routes.js
@@ -90,13 +90,14 @@ const {
   serviceSwitcher, teamMembers, staticPaths, inviteValidation, editServiceName, merchantDetails,
   notificationCredentials, prototyping, paymentLinks,
   requestToGoLive, policyPages, stripeSetup, stripe,
-  settings, yourPsp, allServiceTransactions, payouts
+  yourPsp, allServiceTransactions, payouts
 } = paths
 const {
   apiKeys,
   digitalWallet,
   emailNotifications,
   paymentTypes,
+  settings,
   toggle3ds,
   toggleBillingAddress,
   toggleMotoMaskCardNumberAndSecurityCode
@@ -192,7 +193,6 @@ module.exports.bind = function (app) {
     ...lodash.values(policyPages),
     ...lodash.values(stripeSetup),
     ...lodash.values(stripe),
-    ...lodash.values(settings),
     ...lodash.values(yourPsp),
     ...lodash.values(payouts),
     paths.feedback
@@ -282,8 +282,6 @@ module.exports.bind = function (app) {
   account.get(transactions.redirectDetail, permission('transactions-details:read'), transactionDetailRedirectController)
 
   // Settings
-  app.get(settings.index, permission('transactions-details:read'), getAccount, settingsController.index)
-
   account.get(settings.index, permission('transactions-details:read'), settingsController.index)
 
   // Your PSP

--- a/app/utils/display-converter.js
+++ b/app/utils/display-converter.js
@@ -100,7 +100,7 @@ module.exports = function (req, data, template) {
   convertedData.currentService = service
   const currentPath = (relativeUrl && url.parse(relativeUrl).pathname.replace(/([a-z])\/$/g, '$1')) || '' // remove query params and trailing slash
   if (permissions) {
-    convertedData.serviceNavigationItems = serviceNavigationItems(currentPath, permissions, paymentMethod)
+    convertedData.serviceNavigationItems = serviceNavigationItems(currentPath, permissions, paymentMethod, account)
     convertedData.adminNavigationItems = adminNavigationItems(currentPath, permissions, paymentMethod, paymentProvider, account)
   }
   convertedData._features = {}

--- a/app/utils/nav-builder.js
+++ b/app/utils/nav-builder.js
@@ -7,7 +7,7 @@ const pathLookup = require('./path-lookup')
 const formatPSPname = require('./format-PSP-name')
 
 const mainSettingsPaths = [
-  paths.settings,
+  paths.account.settings,
   paths.account.digitalWallet,
   paths.account.toggle3ds,
   paths.account.toggleBillingAddress,
@@ -21,7 +21,7 @@ const yourPspPaths = [
   paths.notificationCredentials
 ]
 
-const serviceNavigationItems = (currentPath, permissions, type) => {
+const serviceNavigationItems = (currentPath, permissions, type, account = {}) => {
   const navigationItems = []
   navigationItems.push({
     id: 'navigation-menu-home',
@@ -49,7 +49,7 @@ const serviceNavigationItems = (currentPath, permissions, type) => {
   navigationItems.push({
     id: 'navigation-menu-settings',
     name: 'Settings',
-    url: paths.settings.index,
+    url: formatAccountPathsFor(paths.account.settings.index, account.external_id),
     current: currentPath !== '/' ? pathLookup(currentPath, [
       ...mainSettingsPaths,
       ...yourPspPaths,
@@ -75,7 +75,7 @@ const adminNavigationItems = (currentPath, permissions, type, paymentProvider, a
     {
       id: 'navigation-menu-settings-home',
       name: 'Settings',
-      url: paths.settings.index,
+      url: formatAccountPathsFor(paths.account.settings.index, account.external_id),
       current: pathLookup(currentPath, mainSettingsPaths),
       permissions: type === 'card'
     },

--- a/app/views/billing-address/index.njk
+++ b/app/views/billing-address/index.njk
@@ -78,7 +78,7 @@
         })
       }}
       <p class="govuk-body">
-        <a href="{{routes.settings.index}}" class="govuk-link govuk-link--no-visited-state">
+        <a href="{{ formatAccountPathsFor(routes.account.settings.index, currentGatewayAccount.external_id) }}" class="govuk-link govuk-link--no-visited-state">
           Cancel
         </a>
       </p>

--- a/app/views/digital-wallet/apple-pay.njk
+++ b/app/views/digital-wallet/apple-pay.njk
@@ -55,7 +55,7 @@
         }}
       </form>
       <p class="govuk-body">
-        <a href="{{routes.settings.index}}" class="govuk-link govuk-link--no-visited-state">
+        <a href="{{ formatAccountPathsFor(routes.account.settings.index, currentGatewayAccount.external_id) }}" class="govuk-link govuk-link--no-visited-state">
           No, cancel
         </a>
       </p>

--- a/app/views/digital-wallet/google-pay.njk
+++ b/app/views/digital-wallet/google-pay.njk
@@ -77,7 +77,7 @@
         }}
       </form>
       <p class="govuk-body">
-        <a href="{{routes.settings.index}}" class="govuk-link govuk-link--no-visited-state">
+        <a href="{{ formatAccountPathsFor(routes.account.settings.index, currentGatewayAccount.external_id) }}" class="govuk-link govuk-link--no-visited-state">
           No, cancel
         </a>
       </p>

--- a/app/views/email-notifications/collection-email-mode.njk
+++ b/app/views/email-notifications/collection-email-mode.njk
@@ -73,7 +73,7 @@
       }}
     {% endif %}
     <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="{{routes.settings.index}}">
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ formatAccountPathsFor(routes.account.settings.index, currentGatewayAccount.external_id) }}">
         {{ 'Go back' if isReadyOnly else 'Cancel' }}
       </a>
     </p>

--- a/app/views/email-notifications/confirmation-email-toggle.njk
+++ b/app/views/email-notifications/confirmation-email-toggle.njk
@@ -78,7 +78,7 @@
       }}
     {% endif %}
     <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="{{routes.settings.index}}">
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ formatAccountPathsFor(routes.account.settings.index, currentGatewayAccount.external_id) }}">
         {{ 'Go back' if isReadyOnly else 'Cancel' }}
       </a>
     </p>

--- a/app/views/email-notifications/refund-email-toggle.njk
+++ b/app/views/email-notifications/refund-email-toggle.njk
@@ -76,7 +76,7 @@
       }}
     {% endif %}
     <p class="govuk-body">
-        <a class="govuk-link govuk-link--no-visited-state"href="{{routes.settings.index}}">
+        <a class="govuk-link govuk-link--no-visited-state"href="{{ formatAccountPathsFor(routes.account.settings.index, currentGatewayAccount.external_id) }}">
         {{ 'Go back' if isReadyOnly else 'Cancel' }}
       </a>
     </p>

--- a/app/views/toggle-3ds/index.njk
+++ b/app/views/toggle-3ds/index.njk
@@ -92,7 +92,7 @@
           })
         }}
       </form>
-      <p class="govuk-body">or <a href="{{routes.settings.index}}" class="govuk-link govuk-link--no-visited-state">cancel</a></p>
+      <p class="govuk-body">or <a href="{{ formatAccountPathsFor(routes.account.settings.index, currentGatewayAccount.external_id) }}" class="govuk-link govuk-link--no-visited-state">cancel</a></p>
     {% else %}
       <h1 class="govuk-heading-l govuk-!-margin-top-6">3D Secure</h1>
       <p class="govuk-body" id="threeds-not-supported">3D Secure is not currently supported for this payment service provider (PSP).</p>

--- a/app/views/toggle-moto-mask-card-number/index.njk
+++ b/app/views/toggle-moto-mask-card-number/index.njk
@@ -60,7 +60,7 @@
           })
         }}
       </form>
-      <p class="govuk-body">or <a href="{{routes.settings.index}}" class="govuk-link govuk-link--no-visited-state">cancel</a></p>
+      <p class="govuk-body">or <a href="{{ formatAccountPathsFor(routes.account.settings.index, currentGatewayAccount.external_id) }}" class="govuk-link govuk-link--no-visited-state">cancel</a></p>
     {% else %}
       <h1 class="govuk-heading-l govuk-!-margin-top-6">This feature is not available</h1>
       <p class="govuk-body" id="threeds-not-supported">Masking of card numbers and security codes is not allowed for this account.</p>

--- a/app/views/toggle-moto-mask-security-code/index.njk
+++ b/app/views/toggle-moto-mask-security-code/index.njk
@@ -60,7 +60,7 @@
           })
         }}
       </form>
-      <p class="govuk-body">or <a href="{{routes.settings.index}}" class="govuk-link govuk-link--no-visited-state">cancel</a></p>
+      <p class="govuk-body">or <a href="{{ formatAccountPathsFor(routes.account.settings.index, currentGatewayAccount.external_id) }}" class="govuk-link govuk-link--no-visited-state">cancel</a></p>
     {% else %}
       <h1 class="govuk-heading-l govuk-!-margin-top-6">This feature is not available</h1>
       <p class="govuk-body" id="threeds-not-supported">Masking of card numbers and security codes is not allowed for this account.</p>

--- a/test/cypress/integration/settings/3ds.cy.test.js
+++ b/test/cypress/integration/settings/3ds.cy.test.js
@@ -31,12 +31,11 @@ describe('3DS settings page', () => {
     } else {
       user = userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName })
     }
-    const gatewayAccount = gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId, paymentProvider: opts.gateway, requires3ds: opts.requires3ds })
     const gatewayAccountByExternalId = gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, paymentProvider: opts.gateway, requires3ds: opts.requires3ds })
 
     const card = gatewayAccountStubs.getAcceptedCardTypesSuccess({ gatewayAccountId, updated: false, maestro: opts.maestro })
 
-    stubs.push(user, gatewayAccount, gatewayAccountByExternalId, card)
+    stubs.push(user, gatewayAccountByExternalId, card)
 
     cy.task('setupStubs', stubs)
   }
@@ -52,7 +51,7 @@ describe('3DS settings page', () => {
 
     it('should not show on settings index and should show explainer and no radios', () => {
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit('/settings')
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('.govuk-summary-list__key').first().should('not.contain', '3D Secure')
       cy.visit(`/account/${gatewayAccountExternalId}/3ds`)
       cy.title().should('eq', `3D Secure - ${serviceName} - GOV.UK Pay`)
@@ -70,7 +69,7 @@ describe('3DS settings page', () => {
 
       it('should show info box and inputs should be disabled ', () => {
         cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-        cy.visit('/settings')
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(2).should('contain', '3D Secure')
         cy.get('.govuk-summary-list__value').eq(2).should('contain', 'Off')
         cy.get('a').contains('View 3D Secure settings').click()
@@ -89,7 +88,7 @@ describe('3DS settings page', () => {
 
       it('should show Worldpay specific merchant code stuff and radios', () => {
         cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-        cy.visit('/settings')
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(2).should('contain', '3D Secure')
         cy.get('.govuk-summary-list__value').eq(2).should('contain', 'Off')
         cy.get('a').contains('Change 3D Secure settings').click()
@@ -108,7 +107,7 @@ describe('3DS settings page', () => {
 
       it('should show Worldpay specific merchant code stuff and radios', () => {
         cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-        cy.visit('/settings')
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(2).should('contain', '3D Secure')
         cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
         cy.get('a').contains('Change 3D Secure settings').click()
@@ -127,7 +126,7 @@ describe('3DS settings page', () => {
 
       it('should show Worldpay specific merchant code stuff and disabled radios', () => {
         cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-        cy.visit('/settings')
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(2).should('contain', '3D Secure')
         cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
         cy.get('a').contains('Change 3D Secure settings').click()
@@ -151,7 +150,7 @@ describe('3DS settings page', () => {
 
       it('should show success message and radios should update', () => {
         cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-        cy.visit('/settings')
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(2).should('contain', '3D Secure')
         cy.get('.govuk-summary-list__value').eq(2).should('contain', 'Off')
         cy.get('a').contains('Change 3D Secure settings').click()
@@ -192,7 +191,7 @@ describe('3DS settings page', () => {
 
     it('should show Stripe specific disabled message and radios', () => {
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit('/settings')
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('.govuk-summary-list__key').first().should('contain', '3D Secure')
       cy.get('.govuk-summary-list__value').first().should('contain', 'On')
       cy.get('a').contains('Change 3D Secure settings').click()

--- a/test/cypress/integration/settings/allow-apple-pay.cy.test.js
+++ b/test/cypress/integration/settings/allow-apple-pay.cy.test.js
@@ -9,11 +9,6 @@ const serviceName = 'My Awesome Service'
 function setupStubs (allowApplePay) {
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName }),
-    gatewayAccountStubs.getGatewayAccountSuccess({
-      gatewayAccountId,
-      paymentProvider: 'worldpay',
-      allowApplePay: allowApplePay
-    }),
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
       gatewayAccountId,
       gatewayAccountExternalId,
@@ -35,7 +30,7 @@ describe('Apple Pay', () => {
 
     it('should show it is disabled', () => {
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit('/settings')
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
       cy.get('a').contains('Change Apple Pay settings').click()
       cy.get('input[type="radio"]').should('have.length', 2)
@@ -53,7 +48,7 @@ describe('Apple Pay', () => {
 
     it('Show that is is disabled', () => {
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit('/settings')
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
       cy.get('a').contains('Change Apple Pay settings').click()
     })

--- a/test/cypress/integration/settings/allow-google-pay.cy.test.js
+++ b/test/cypress/integration/settings/allow-google-pay.cy.test.js
@@ -9,11 +9,6 @@ const serviceName = 'My Awesome Service'
 function setupStubs (allowGooglePay) {
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName }),
-    gatewayAccountStubs.getGatewayAccountSuccess({
-      gatewayAccountId,
-      paymentProvider: 'worldpay',
-      allowGooglePay: allowGooglePay
-    }),
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
       gatewayAccountId,
       gatewayAccountExternalId,
@@ -35,7 +30,7 @@ describe('Google Pay', () => {
 
     it('should show it is disabled', () => {
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit('/settings')
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
       cy.get('a').contains('Change Google Pay settings').click()
       cy.get('input[type="radio"]').should('have.length', 2)
@@ -53,7 +48,7 @@ describe('Google Pay', () => {
 
     it('should allow us to enable', () => {
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit('/settings')
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
       cy.get('a').contains('Change Google Pay settings').click()
     })

--- a/test/cypress/integration/settings/email-notifications.cy.test.js
+++ b/test/cypress/integration/settings/email-notifications.cy.test.js
@@ -1,16 +1,15 @@
 const userStubs = require('../../stubs/user-stubs')
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 
-const settingsUrl = `/settings`
 const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
 const gatewayAccountId = 42
 const gatewayAccountExternalId = 'a-valid-external-id'
 const serviceName = 'Test Service'
+const settingsUrl = `/account/${gatewayAccountExternalId}/settings`
 
 function setupStubs (role) {
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName, role }),
-    gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId }),
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId }),
     gatewayAccountStubs.getAccountAuthSuccess({ gatewayAccountId }),
     gatewayAccountStubs.patchConfirmationEmailToggleSuccess({ gatewayAccountId }),

--- a/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js
+++ b/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js
@@ -30,14 +30,6 @@ describe('MOTO mask security section', () => {
     } else {
       user = userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName })
     }
-
-    const gatewayAccount = gatewayAccountStubs.getGatewayAccountSuccess({
-      gatewayAccountId,
-      paymentProvider: opts.gateway,
-      allowMoto: opts.allowMoto,
-      motoMaskCardNumber: opts.motoMaskCardNumber,
-      motoMaskSecurityCode: opts.motoMaskSecurityCode
-    })
     const gatewayAccountByExternalId = gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
       gatewayAccountId,
       gatewayAccountExternalId,
@@ -48,7 +40,7 @@ describe('MOTO mask security section', () => {
     })
     const card = gatewayAccountStubs.getAcceptedCardTypesSuccess({ gatewayAccountId, updated: false, maestro: opts.maestro })
 
-    stubs.push(user, gatewayAccount, gatewayAccountByExternalId, card)
+    stubs.push(user, gatewayAccountByExternalId, card)
 
     cy.task('setupStubs', stubs)
   }
@@ -65,7 +57,7 @@ describe('MOTO mask security section', () => {
 
       it('should not show mask security section', () => {
         cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-        cy.visit('/settings')
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('#moto-mask-security-settings-heading').should('not.exist')
       })
     })
@@ -76,7 +68,7 @@ describe('MOTO mask security section', () => {
       })
 
       it('should show radios as disabled and card number mask disabled', () => {
-        cy.visit('/settings')
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(4).should('contain', 'Hide card numbers')
         cy.get('.govuk-summary-list__value').eq(4).should('contain', 'Off')
         cy.get('.govuk-summary-list__actions a').eq(4).contains('View')
@@ -96,7 +88,7 @@ describe('MOTO mask security section', () => {
       })
 
       it('should show radios as enabled and card number mask disabled', () => {
-        cy.visit('/settings')
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(4).should('contain', 'Hide card numbers')
         cy.get('.govuk-summary-list__value').eq(4).should('contain', 'Off')
         cy.get('.govuk-summary-list__actions a').eq(4).contains('Change')
@@ -129,7 +121,7 @@ describe('MOTO mask security section', () => {
       })
 
       it('should show radios as disabled and card number mask disabled', () => {
-        cy.visit('/settings')
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(5).should('contain', 'Hide card security codes')
         cy.get('.govuk-summary-list__value').eq(5).should('contain', 'Off')
         cy.get('.govuk-summary-list__actions a').eq(5).contains('View')
@@ -149,7 +141,7 @@ describe('MOTO mask security section', () => {
       })
 
       it('should show radios as enabled and no masking', () => {
-        cy.visit('/settings')
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(5).should('contain', 'Hide card security codes')
         cy.get('.govuk-summary-list__value').eq(5).should('contain', 'Off')
         cy.get('.govuk-summary-list__actions a').eq(5).contains('Change')

--- a/test/cypress/integration/settings/your-psp.cy.test.js
+++ b/test/cypress/integration/settings/your-psp.cy.test.js
@@ -6,6 +6,7 @@ const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 describe('Your PSP settings page', () => {
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
   const gatewayAccountId = 42
+  const gatewayAccountExternalId = 'a-valid-external-id'
   const serviceName = 'Purchase a positron projection permit'
   const testCredentials = {
     merchant_id: 'positron-permit-people',
@@ -68,6 +69,16 @@ describe('Your PSP settings page', () => {
       paymentProvider: opts.gateway,
       notificationCredentials: opts.notificationCredentials
     })
+    const gatewayAccountByExternalId = gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+      gatewayAccountId,
+      gatewayAccountExternalId,
+      requires3ds: opts.requires3ds,
+      integrationVersion3ds: opts.integrationVersion3ds,
+      worldpay3dsFlex: opts.worldpay3dsFlex,
+      credentials: opts.credentials,
+      paymentProvider: opts.gateway,
+      notificationCredentials: opts.notificationCredentials
+    })
     const card = gatewayAccountStubs.getAcceptedCardTypesSuccess({ gatewayAccountId, updated: false })
     const postCheckWorldpay3dsFlexCredentialsReturnsValid = gatewayAccountStubs.postCheckWorldpay3dsFlexCredentials({
       gatewayAccountId: gatewayAccountId,
@@ -84,6 +95,7 @@ describe('Your PSP settings page', () => {
     const stubs = [
       user,
       gatewayAccount,
+      gatewayAccountByExternalId,
       card,
       postCheckWorldpay3dsFlexCredentialsReturnsValid,
       postCheckWorldpay3dsFlexCredentialsReturnsInvalid,
@@ -105,7 +117,7 @@ describe('Your PSP settings page', () => {
 
     it('should not show link to Your PSP in the side navigation', () => {
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit('/settings')
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('#navigation-menu-your-psp').should('have.length', 0)
     })
   })
@@ -119,7 +131,7 @@ describe('Your PSP settings page', () => {
 
     it('should show link to "Your PSP - Worldpay" in the side navigation', () => {
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit('/settings')
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Worldpay')
       cy.get('#navigation-menu-your-psp').click()
     })
@@ -207,7 +219,7 @@ describe('Your PSP settings page', () => {
     })
 
     it('should display generic problem page when getting a bad result from connector', () => {
-      cy.visit('/settings')
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('#navigation-menu-your-psp').click()
       cy.get('#flex-credentials-change-link').click()
       cy.get('#organisational-unit-id').type(testBadResultFlexCredentials.organisational_unit_id)
@@ -329,7 +341,7 @@ describe('Your PSP settings page', () => {
 
     it('should show link to "Your PSP - Smartpay" in the side navigation', () => {
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit('/settings')
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Smartpay')
       cy.get('#navigation-menu-your-psp').click()
     })
@@ -395,7 +407,7 @@ describe('Your PSP settings page', () => {
 
     it('should show link to "Your PSP - ePDQ" in the side navigation', () => {
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit('/settings')
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - ePDQ')
       cy.get('#navigation-menu-your-psp').click()
     })

--- a/test/test-helpers/html-assertions.js
+++ b/test/test-helpers/html-assertions.js
@@ -7,6 +7,7 @@ const nunjucks = require('nunjucks')
 const router = require('../../app/routes.js')
 const { nunjucksFilters } = require('@govuk-pay/pay-js-commons')
 const formatPSPname = require('../../app/utils/format-PSP-name')
+const formatAccountPathsFor = require('../../app/utils/format-account-paths-for')
 
 const environment = nunjucks.configure([
   './node_modules/govuk-frontend/',
@@ -26,6 +27,7 @@ environment.addFilter('formatPSPname', formatPSPname)
 
 const render = (templateName, templateData) => {
   templateData.routes = router.paths
+  templateData.formatAccountPathsFor = formatAccountPathsFor
   return environment.render(`${templateName}.njk`, templateData)
 }
 

--- a/test/ui/toggle-collect-billing-address.ui.test.js
+++ b/test/ui/toggle-collect-billing-address.ui.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const path = require('path')
-const renderTemplate = require(path.join(__dirname, '/../test-helpers/html-assertions.js')).render
+const renderTemplate = require('../test-helpers/html-assertions.js').render
 
 describe('The toggle Billing Address page', function () {
   it('should show collections are turned off', () => {


### PR DESCRIPTION
Un-reverts a previously reverted commit to update the settings route to use the new account URL structure.

It was previously reverted due to the potential for the user to see 404s while we were deploying because the new route would not exist on the old instances during deploy, but new instances would redirect to the new route. The new route now already exists so that won't be an issue.
