### PR TITLE
Revert "PP-7583 Move your psp routes"

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-01-18T11:24:19Z",
+  "generated_at": "2021-01-18T10:18:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -150,21 +150,21 @@
         "hashed_secret": "d0be4e729498f4cfe8a72a28d4fceae35bd8bb27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16,
+        "line_number": 14,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "2c877f34a0f47f32a5f3c77e398938b3cdc32221",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 21,
+        "line_number": 19,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "379f1968f09d8a343338667844e01a2f433f0a3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 23,
         "type": "Hex High Entropy String"
       }
     ],
@@ -232,14 +232,14 @@
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 513,
+        "line_number": 502,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "1695899a3d59e9fe2af1cdf242d8c451b8506173",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 556,
+        "line_number": 546,
         "type": "Secret Keyword"
       }
     ],

--- a/app/controllers/credentials.controller.js
+++ b/app/controllers/credentials.controller.js
@@ -3,10 +3,10 @@ const EDIT_NOTIFICATION_CREDENTIALS_MODE = 'editNotificationCredentials'
 
 const _ = require('lodash')
 const paths = require('../paths')
-const formatAccountPathsFor = require('../utils/format-account-paths-for')
 const { response } = require('../utils/response')
 const { renderErrorView } = require('../utils/response')
 const { ConnectorClient } = require('../services/clients/connector.client')
+const router = require('../routes')
 const { CONNECTOR_URL } = process.env
 const { CORRELATION_HEADER } = require('../utils/correlation-header')
 const { isPasswordLessThanTenChars } = require('../browsered/field-validation-checks')
@@ -109,7 +109,7 @@ module.exports = {
         gatewayAccountId: accountId
       })
 
-      return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account && req.account.external_id))
+      return res.redirect(303, router.paths.yourPsp.index)
     } catch (err) {
       return renderErrorView(req, res)
     }
@@ -124,7 +124,7 @@ module.exports = {
         payload: credentialsPatchRequestValueOf(req), correlationId: correlationId, gatewayAccountId: accountId
       })
 
-      return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account && req.account.external_id))
+      return res.redirect(303, router.paths.yourPsp.index)
     } catch (err) {
       return renderErrorView(req, res)
     }

--- a/app/controllers/your-psp/post-flex.controller.js
+++ b/app/controllers/your-psp/post-flex.controller.js
@@ -3,7 +3,6 @@
 const lodash = require('lodash')
 
 const paths = require('../../paths')
-const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
@@ -18,9 +17,8 @@ const JWT_MAC_KEY_FIELD = 'jwt-mac-key'
 
 module.exports = async (req, res) => {
   const correlationId = req.headers[correlationHeader] || ''
+
   const accountId = req.account.gateway_account_id
-  const flexUrl = formatAccountPathsFor(paths.account.yourPsp.flex, req.account && req.account.external_id)
-  const indexUrl = formatAccountPathsFor(paths.account.yourPsp.index, req.account && req.account.external_id)
 
   const orgUnitId = lodash.get(req.body, ORGANISATIONAL_UNIT_ID_FIELD, '').trim()
   const issuer = lodash.get(req.body, ISSUER_FIELD, '').trim()
@@ -34,7 +32,7 @@ module.exports = async (req, res) => {
       orgUnitId: orgUnitId,
       issuer: issuer
     })
-    return res.redirect(303, flexUrl)
+    return res.redirect(303, paths.yourPsp.flex)
   }
 
   try {
@@ -60,7 +58,7 @@ module.exports = async (req, res) => {
           orgUnitId: orgUnitId,
           issuer: issuer
         })
-        return res.redirect(303, flexUrl)
+        return res.redirect(303, paths.yourPsp.flex)
       }
     }
 
@@ -70,7 +68,7 @@ module.exports = async (req, res) => {
 
     await connector.post3dsFlexAccountCredentials(flexParams)
     req.flash('generic', 'Your Worldpay 3DS Flex settings have been updated')
-    return res.redirect(indexUrl)
+    return res.redirect(paths.yourPsp.index)
   } catch (error) {
     return renderErrorView(req, res, false, error.errorCode)
   }

--- a/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.js
+++ b/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const paths = require('../../paths')
-const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
@@ -9,7 +8,6 @@ const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 module.exports = async function toggleWorldpay3dsFlex (req, res) {
   const accountId = req.account.gateway_account_id
   const toggleWorldpay3dsFlex = req.body['toggle-worldpay-3ds-flex']
-  const indexUrl = formatAccountPathsFor(paths.account.yourPsp.index, req.account && req.account.external_id)
 
   if (req.body['toggle-worldpay-3ds-flex'] === 'on' || req.body['toggle-worldpay-3ds-flex'] === 'off') {
     const enabling3dsFlex = toggleWorldpay3dsFlex === 'on'
@@ -18,7 +16,7 @@ module.exports = async function toggleWorldpay3dsFlex (req, res) {
     try {
       await connector.updateIntegrationVersion3ds(accountId, integrationVersion3ds, req.correlationId)
       req.flash('generic', message)
-      return res.redirect(303, indexUrl)
+      return res.redirect(303, paths.yourPsp.index)
     } catch (error) {
       return renderErrorView(req, res, false, error.errorCode)
     }

--- a/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.test.js
+++ b/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.test.js
@@ -2,9 +2,9 @@
 
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
+const paths = require('../../paths')
 
 describe('Toggle Worldpay 3DS Flex controller', () => {
-  const gatewayAccountExternalId = 'a-gateway-account-external-id'
   let req
   let res
   let updateIntegrationVersion3dsMock
@@ -14,8 +14,7 @@ describe('Toggle Worldpay 3DS Flex controller', () => {
     req = {
       correlationId: 'correlation-id',
       account: {
-        gateway_account_id: '1',
-        external_id: gatewayAccountExternalId
+        gateway_account_id: '1'
       },
       flash: sinon.spy(),
       body: {}
@@ -37,7 +36,7 @@ describe('Toggle Worldpay 3DS Flex controller', () => {
 
     sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 2, req.correlationId)
     sinon.assert.calledWith(req.flash, 'generic', '3DS Flex has been turned on.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/${gatewayAccountExternalId}/your-psp`)
+    sinon.assert.calledWith(res.redirect, 303, paths.yourPsp.index)
   })
 
   it('should toggle 3DS Flex off by setting 3DS integration version to 1', async () => {
@@ -49,7 +48,7 @@ describe('Toggle Worldpay 3DS Flex controller', () => {
 
     sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 1, req.correlationId)
     sinon.assert.calledWith(req.flash, 'generic', '3DS Flex has been turned off. Your payments will now use 3DS only.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/${gatewayAccountExternalId}/your-psp`)
+    sinon.assert.calledWith(res.redirect, 303, paths.yourPsp.index)
   })
 
   it('should render an error if problem calling connector', async () => {

--- a/app/paths.js
+++ b/app/paths.js
@@ -12,13 +12,6 @@ module.exports = {
   keys,
   account: {
     root: `/account/:${keys.GATEWAY_ACCOUNT_EXTERNAL_ID}`,
-    apiKeys: {
-      index: '/api-keys',
-      revoked: '/api-keys/revoked',
-      create: '/api-keys/create',
-      revoke: '/api-keys/revoke',
-      update: '/api-keys/update'
-    },
     digitalWallet: {
       applePay: '/digital-wallet/apple-pay',
       googlePay: '/digital-wallet/google-pay'
@@ -51,10 +44,12 @@ module.exports = {
       cardNumber: '/moto-hide-card-number',
       securityCode: '/moto-hide-security-code'
     },
-    yourPsp: {
-      index: '/your-psp',
-      flex: '/your-psp/flex',
-      worldpay3dsFlex: '/your-psp/worldpay-3ds-flex'
+    apiKeys: {
+      index: '/api-keys',
+      revoked: '/api-keys/revoked',
+      create: '/api-keys/create',
+      revoke: '/api-keys/revoke',
+      update: '/api-keys/update'
     }
   },
   transactions: {
@@ -67,6 +62,11 @@ module.exports = {
   allServiceTransactions: {
     index: '/all-service-transactions',
     download: '/all-service-transactions/download'
+  },
+  yourPsp: {
+    index: '/your-psp',
+    flex: '/your-psp/flex',
+    worldpay3dsFlex: '/your-psp/worldpay-3ds-flex'
   },
   credentials: {
     index: '/credentials',

--- a/app/routes.js
+++ b/app/routes.js
@@ -90,7 +90,7 @@ const {
   serviceSwitcher, teamMembers, staticPaths, inviteValidation, editServiceName, merchantDetails,
   notificationCredentials, prototyping, paymentLinks,
   requestToGoLive, policyPages, stripeSetup, stripe,
-  allServiceTransactions, payouts
+  yourPsp, allServiceTransactions, payouts
 } = paths
 const {
   apiKeys,
@@ -100,8 +100,7 @@ const {
   settings,
   toggle3ds,
   toggleBillingAddress,
-  toggleMotoMaskCardNumberAndSecurityCode,
-  yourPsp
+  toggleMotoMaskCardNumberAndSecurityCode
 } = paths.account
 
 // Exports
@@ -181,6 +180,7 @@ module.exports.bind = function (app) {
     ...lodash.values(allServiceTransactions),
     ...lodash.values(credentials),
     ...lodash.values(notificationCredentials),
+    ...lodash.values(apiKeys),
     ...lodash.values(editServiceName),
     ...lodash.values(serviceSwitcher),
     ...lodash.values(teamMembers),
@@ -193,6 +193,7 @@ module.exports.bind = function (app) {
     ...lodash.values(policyPages),
     ...lodash.values(stripeSetup),
     ...lodash.values(stripe),
+    ...lodash.values(yourPsp),
     ...lodash.values(payouts),
     paths.feedback
   ] // Extract all the authenticated paths as a single array
@@ -284,6 +285,11 @@ module.exports.bind = function (app) {
   account.get(settings.index, permission('transactions-details:read'), settingsController.index)
 
   // Your PSP
+  app.get(yourPsp.index, permission('gateway-credentials:read'), getAccount, paymentMethodIsCard, yourPspController.getIndex)
+  app.post(yourPsp.worldpay3dsFlex, permission('toggle-3ds:update'), getAccount, paymentMethodIsCard, yourPspController.postToggleWorldpay3dsFlex)
+  app.get(yourPsp.flex, permission('gateway-credentials:update'), getAccount, paymentMethodIsCard, yourPspController.getFlex)
+  app.post(yourPsp.flex, permission('gateway-credentials:update'), getAccount, paymentMethodIsCard, yourPspController.postFlex)
+
   account.get(yourPsp.index, permission('gateway-credentials:read'), paymentMethodIsCard, yourPspController.getIndex)
   account.post(yourPsp.worldpay3dsFlex, permission('toggle-3ds:update'), paymentMethodIsCard, yourPspController.postToggleWorldpay3dsFlex)
   account.get(yourPsp.flex, permission('gateway-credentials:update'), paymentMethodIsCard, yourPspController.getFlex)

--- a/app/utils/nav-builder.js
+++ b/app/utils/nav-builder.js
@@ -16,7 +16,7 @@ const mainSettingsPaths = [
 ]
 
 const yourPspPaths = [
-  paths.account.yourPsp,
+  paths.yourPsp,
   paths.credentials,
   paths.notificationCredentials
 ]
@@ -89,7 +89,7 @@ const adminNavigationItems = (currentPath, permissions, type, paymentProvider, a
     {
       id: 'navigation-menu-your-psp',
       name: `Your PSP - ${formatPSPname(paymentProvider)}`,
-      url: formatAccountPathsFor(paths.account.yourPsp.index, account.external_id),
+      url: paths.yourPsp.index,
       current: pathLookup(currentPath, yourPspPaths),
       permissions: permissions.gateway_credentials_update && type === 'card' && (paymentProvider !== 'stripe') && (paymentProvider !== 'sandbox')
     },

--- a/app/views/credentials/worldpay.njk
+++ b/app/views/credentials/worldpay.njk
@@ -113,7 +113,7 @@
     </form>
 
     <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id) }}">Cancel</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ routes.yourPsp.index }}">Cancel</a>
     </p>
   {% endif %}
 {% endblock %}

--- a/app/views/your-psp/_worldpay-flex.njk
+++ b/app/views/your-psp/_worldpay-flex.njk
@@ -29,7 +29,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id) + "?change=organisationalUnitId",
+              href: routes.yourPsp.flex + "?change=organisationalUnitId",
               text: "Change",
               visuallyHiddenText: "3DS Flex credentials",
               attributes: {
@@ -50,7 +50,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id) + "?change=issuer",
+              href: routes.yourPsp.flex + "?change=issuer",
               text: "Change",
               visuallyHiddenText: "3DS Flex credentials"
             }
@@ -68,7 +68,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id) + "?change=password",
+              href: routes.yourPsp.flex + "?change=password",
               text: "Change",
               visuallyHiddenText: "3DS Flex credentials"
             }
@@ -80,7 +80,7 @@
 }}
 
 {% if (is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured) or isWorldpay3dsFlexEnabled %}
-  <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.worldpay3dsFlex, currentGatewayAccount.external_id) }}">
+  <form method="post" action="{{routes.yourPsp.worldpay3dsFlex}}">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}">
     {% if is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured and not isWorldpay3dsFlexEnabled %}
         <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="on">

--- a/app/views/your-psp/flex.njk
+++ b/app/views/your-psp/flex.njk
@@ -14,7 +14,7 @@
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Your Worldpay 3DS Flex credentials</h1>
-    <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id) }}">
+    <form method="post" action="{{routes.yourPsp.flex}}">
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
         {% if errors %}
           {% set errorList = [] %}
@@ -174,7 +174,7 @@
       }}
     </form>
     <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id) }}">Cancel</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ routes.yourPsp.index }}">Cancel</a>
     </p>
 </div>
 {% endblock %}

--- a/test/cypress/integration/settings/your-psp.cy.test.js
+++ b/test/cypress/integration/settings/your-psp.cy.test.js
@@ -8,8 +8,6 @@ describe('Your PSP settings page', () => {
   const gatewayAccountId = 42
   const gatewayAccountExternalId = 'a-valid-external-id'
   const serviceName = 'Purchase a positron projection permit'
-  const yourPspPath = `/account/${gatewayAccountExternalId}/your-psp`
-  
   const testCredentials = {
     merchant_id: 'positron-permit-people',
     username: 'jonheslop',
@@ -156,7 +154,7 @@ describe('Your PSP settings page', () => {
       cy.get('#password').type(testCredentials.password)
       cy.get('#submitCredentials').click()
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath)
+        expect(location.pathname).to.eq(`/your-psp`)
       })
     })
 
@@ -176,7 +174,7 @@ describe('Your PSP settings page', () => {
       cy.get('#jwt-mac-key').type(' ' + testFlexCredentials.jwt_mac_key + ' ')
       cy.get('#submitFlexCredentials').click()
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath)
+        expect(location.pathname).to.eq(`/your-psp`)
       })
     })
 
@@ -204,7 +202,7 @@ describe('Your PSP settings page', () => {
       cy.get('#issuer').should('have.value', testInvalidFlexCredentials.issuer)
       cy.get('#jwt-mac-key').should('have.value', '')
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath + '/flex')
+        expect(location.pathname).to.eq(`/your-psp/flex`)
       })
     })
 
@@ -216,7 +214,7 @@ describe('Your PSP settings page', () => {
       cy.get('h1').should('contain', 'An error occurred:')
       cy.get('#errorMsg').should('contain', 'Please try again or contact support team.')
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath + '/flex')
+        expect(location.pathname).to.eq(`/your-psp/flex`)
       })
     })
 
@@ -231,7 +229,7 @@ describe('Your PSP settings page', () => {
       cy.get('h1').should('contain', 'An error occurred:')
       cy.get('#errorMsg').should('contain', 'Please try again or contact support team.')
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath + '/flex')
+        expect(location.pathname).to.eq(`/your-psp/flex`)
       })
     })
   })
@@ -245,7 +243,7 @@ describe('Your PSP settings page', () => {
       })
 
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit(yourPspPath)
+      cy.visit('/your-psp')
       cy.get('.value-merchant-id').should('contain', testCredentials.merchant_id)
       cy.get('.value-username').should('contain', testCredentials.username)
       cy.get('.value-password').should('contain', '●●●●●●●●')
@@ -268,14 +266,14 @@ describe('Your PSP settings page', () => {
       })
 
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit(yourPspPath)
+      cy.visit('/your-psp')
       cy.get('#worldpay-3ds-flex-is-off').should('exist')
       cy.get('#worldpay-3ds-flex-is-on').should('not.exist')
       cy.get('#disable-worldpay-3ds-flex-button').should('not.exist')
 
       cy.get('#enable-worldpay-3ds-flex-button').should('exist').click()
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath)
+        expect(location.pathname).to.eq(`/your-psp`)
       })
     })
 
@@ -289,14 +287,14 @@ describe('Your PSP settings page', () => {
       })
 
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit(yourPspPath)
+      cy.visit('/your-psp')
       cy.get('#worldpay-3ds-flex-is-on').should('exist')
       cy.get('#worldpay-3ds-flex-is-off').should('not.exist')
       cy.get('#enable-worldpay-3ds-flex-button').should('not.exist')
 
       cy.get('#disable-worldpay-3ds-flex-button').should('exist').click()
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath)
+        expect(location.pathname).to.eq(`/your-psp`)
       })
     })
 
@@ -309,7 +307,7 @@ describe('Your PSP settings page', () => {
       })
 
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit(yourPspPath)
+      cy.visit('/your-psp')
       cy.get('#worldpay-3ds-flex-is-off').should('exist')
       cy.get('#worldpay-3ds-flex-is-on').should('not.exist')
       cy.get('#disable-worldpay-3ds-flex-button').should('not.exist')
@@ -326,7 +324,7 @@ describe('Your PSP settings page', () => {
       })
 
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit(yourPspPath)
+      cy.visit('/your-psp')
       cy.get('#worldpay-3ds-flex-is-off').should('exist')
       cy.get('#worldpay-3ds-flex-is-on').should('not.exist')
       cy.get('#disable-worldpay-3ds-flex-button').should('not.exist')
@@ -363,7 +361,7 @@ describe('Your PSP settings page', () => {
       cy.get('#password').type(testCredentials.password)
       cy.get('#submitCredentials').click()
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath)
+        expect(location.pathname).to.eq(`/your-psp`)
       })
     })
 
@@ -375,7 +373,7 @@ describe('Your PSP settings page', () => {
       cy.get('#notification-password').type(testCredentials.password)
       cy.get('#submitNotificationCredentials').click()
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath)
+        expect(location.pathname).to.eq(`/your-psp`)
       })
     })
   })
@@ -391,7 +389,7 @@ describe('Your PSP settings page', () => {
 
     it('should show all credentials as configured', () => {
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit(yourPspPath)
+      cy.visit('/your-psp')
       cy.get('.value-merchant-id').should('contain', testCredentials.merchant_id)
       cy.get('.value-username').should('contain', testCredentials.username)
       cy.get('.value-password').should('contain', '●●●●●●●●')
@@ -433,7 +431,7 @@ describe('Your PSP settings page', () => {
       cy.get('#shaOutPassphrase').type(testCredentials.password)
       cy.get('#submitCredentials').click()
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath)
+        expect(location.pathname).to.eq(`/your-psp`)
       })
     })
   })
@@ -448,7 +446,7 @@ describe('Your PSP settings page', () => {
 
     it('should show all credentials as configured', () => {
       cy.setEncryptedCookies(userExternalId, gatewayAccountId)
-      cy.visit(yourPspPath)
+      cy.visit('/your-psp')
       cy.get('.value-merchant-id').should('contain', testCredentials.merchant_id)
       cy.get('.value-username').should('contain', testCredentials.username)
       cy.get('.value-password').should('contain', '●●●●●●●●')

--- a/test/integration/credentials.ft.test.js
+++ b/test/integration/credentials.ft.test.js
@@ -13,9 +13,7 @@ const mockSession = require('../test-helpers/mock-session.js')
 const gatewayAccountFixtures = require('../fixtures/gateway-account.fixtures')
 
 const ACCOUNT_ID = '182364'
-const ACCOUNT_EXTERNAL_ID = 'an-account-external-id'
 const CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts/' + ACCOUNT_ID
-// const CONNECTOR_ACCOUNT_BY_EXTERNAL_ID_PATH = '/v1/api/accounts/external-id/' + ACCOUNT_ID
 const CONNECTOR_ACCOUNT_CREDENTIALS_PATH = CONNECTOR_ACCOUNT_PATH + '/credentials'
 const CONNECTOR_ACCOUNT_NOTIFICATION_CREDENTIALS_PATH = '/v1/api/accounts/' + ACCOUNT_ID + '/notification-credentials'
 
@@ -23,7 +21,6 @@ const requestId = 'some-unique-id'
 const defaultCorrelationHeader = {
   reqheaders: { 'x-request-id': requestId }
 }
-const yourPspPath = `/account/${ACCOUNT_EXTERNAL_ID}/your-psp`
 
 const connectorMock = nock(process.env.CONNECTOR_URL, defaultCorrelationHeader)
 
@@ -49,9 +46,9 @@ describe('Credentials endpoints', () => {
     it('should display empty credential values when no gateway credentials are set', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          payment_provider: 'sandbox',
-          gateway_account_id: '1',
-          credentials: {}
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {}
         })
 
       buildGetRequest(paths.credentials.index, app)
@@ -65,16 +62,15 @@ describe('Credentials endpoints', () => {
     it('should display received credentials from connector', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          payment_provider: 'sandbox',
-          gateway_account_id: '1',
-          external_id: ACCOUNT_EXTERNAL_ID,
-          credentials: { username: 'a-username' }
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': { 'username': 'a-username' }
         })
 
       buildGetRequest(paths.credentials.index, app)
         .expect(200)
         .expect(response => {
-          expect(response.body.currentGatewayAccount.credentials).to.deep.equal({ username: 'a-username' })
+          expect(response.body.currentGatewayAccount.credentials).to.deep.equal({ 'username': 'a-username' })
         })
         .end(done)
     })
@@ -82,10 +78,9 @@ describe('Credentials endpoints', () => {
     it('should return the account', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          payment_provider: 'sandbox',
-          gateway_account_id: '1',
-          external_id: ACCOUNT_EXTERNAL_ID,
-          credentials: { username: 'a-username', merchant_id: 'a-merchant-id' }
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': { username: 'a-username', merchant_id: 'a-merchant-id' }
         })
 
       buildGetRequest(paths.credentials.index, app)
@@ -99,22 +94,22 @@ describe('Credentials endpoints', () => {
     it('should display an error if the account does not exist', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(404, {
-          message: "The gateway account id '" + ACCOUNT_ID + "' does not exist"
+          'message': "The gateway account id '" + ACCOUNT_ID + "' does not exist"
         })
 
       buildGetRequest(paths.credentials.index, app)
-        .expect(500, { message: 'There is a problem with the payments platform' })
+        .expect(500, { 'message': 'There is a problem with the payments platform' })
         .end(done)
     })
 
     it('should display an error if connector returns any other error', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(999, {
-          message: 'Some error in Connector'
+          'message': 'Some error in Connector'
         })
 
       buildGetRequest(paths.credentials.index, app)
-        .expect(500, { message: 'There is a problem with the payments platform' })
+        .expect(500, { 'message': 'There is a problem with the payments platform' })
         .end(done)
     })
 
@@ -122,7 +117,7 @@ describe('Credentials endpoints', () => {
       // No connectorMock defined on purpose to mock a network failure
 
       buildGetRequest(paths.credentials.index, app)
-        .expect(500, { message: 'There is a problem with the payments platform' })
+        .expect(500, { 'message': 'There is a problem with the payments platform' })
         .end(done)
     })
   })
@@ -146,10 +141,9 @@ describe('Credentials endpoints', () => {
     it('should display payment provider name', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          payment_provider: 'sandbox',
-          gateway_account_id: '1',
-          external_id: ACCOUNT_EXTERNAL_ID,
-          credentials: {}
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {}
         })
 
       buildGetRequest(paths.credentials.edit, app)
@@ -163,10 +157,9 @@ describe('Credentials endpoints', () => {
     it('should display empty credential values when no gateway credentials are set', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          payment_provider: 'sandbox',
-          gateway_account_id: '1',
-          external_id: ACCOUNT_EXTERNAL_ID,
-          credentials: {}
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {}
         })
 
       buildGetRequest(paths.credentials.edit, app)
@@ -180,16 +173,15 @@ describe('Credentials endpoints', () => {
     it('should display received credentials from connector', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          payment_provider: 'sandbox',
-          gateway_account_id: '1',
-          external_id: ACCOUNT_EXTERNAL_ID,
-          credentials: { username: 'a-username' }
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': { 'username': 'a-username' }
         })
 
       buildGetRequest(paths.credentials.edit, app)
         .expect(200)
         .expect(response => {
-          expect(response.body.currentGatewayAccount.credentials).to.deep.equal({ username: 'a-username' })
+          expect(response.body.currentGatewayAccount.credentials).to.deep.equal({ 'username': 'a-username' })
         })
         .end(done)
     })
@@ -197,10 +189,9 @@ describe('Credentials endpoints', () => {
     it('should return the account', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          payment_provider: 'sandbox',
-          gateway_account_id: '1',
-          external_id: ACCOUNT_EXTERNAL_ID,
-          credentials: { username: 'a-username' }
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': { username: 'a-username' }
         })
 
       buildGetRequest(paths.credentials.edit, app)
@@ -214,22 +205,22 @@ describe('Credentials endpoints', () => {
     it('should display an error if the account does not exist', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(404, {
-          message: "The gateway account id '" + ACCOUNT_ID + "' does not exist"
+          'message': "The gateway account id '" + ACCOUNT_ID + "' does not exist"
         })
 
       buildGetRequest(paths.credentials.edit, app)
-        .expect(500, { message: 'There is a problem with the payments platform' })
+        .expect(500, { 'message': 'There is a problem with the payments platform' })
         .end(done)
     })
 
     it('should display an error if connector returns any other error', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(999, {
-          message: 'Some error in Connector'
+          'message': 'Some error in Connector'
         })
 
       buildGetRequest(paths.credentials.edit, app)
-        .expect(500, { message: 'There is a problem with the payments platform' })
+        .expect(500, { 'message': 'There is a problem with the payments platform' })
         .end(done)
     })
 
@@ -237,7 +228,7 @@ describe('Credentials endpoints', () => {
       // No connectorMock defined on purpose to mock a network failure
 
       buildGetRequest(paths.credentials.edit, app)
-        .expect(500, { message: 'There is a problem with the payments platform' })
+        .expect(500, { 'message': 'There is a problem with the payments platform' })
         .end(done)
     })
   })
@@ -261,10 +252,9 @@ describe('Credentials endpoints', () => {
     it('should display payment provider name', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          payment_provider: 'sandbox',
-          gateway_account_id: '1',
-          external_id: ACCOUNT_EXTERNAL_ID,
-          credentials: {}
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {}
         })
 
       buildGetRequest(paths.notificationCredentials.edit, app)
@@ -278,10 +268,9 @@ describe('Credentials endpoints', () => {
     it('should display empty credential values when no gateway credentials are set', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          payment_provider: 'sandbox',
-          gateway_account_id: '1',
-          external_id: ACCOUNT_EXTERNAL_ID,
-          credentials: {}
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': {}
         })
 
       buildGetRequest(paths.notificationCredentials.edit, app)
@@ -295,16 +284,15 @@ describe('Credentials endpoints', () => {
     it('should display received credentials from connector', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          payment_provider: 'sandbox',
-          gateway_account_id: '1',
-          external_id: ACCOUNT_EXTERNAL_ID,
-          credentials: { username: 'a-username' }
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': { 'username': 'a-username' }
         })
 
       buildGetRequest(paths.notificationCredentials.edit, app)
         .expect(200)
         .expect(response => {
-          expect(response.body.currentGatewayAccount.credentials).to.be.deep.equal({ username: 'a-username' })
+          expect(response.body.currentGatewayAccount.credentials).to.be.deep.equal({ 'username': 'a-username' })
         })
         .end(done)
     })
@@ -312,9 +300,9 @@ describe('Credentials endpoints', () => {
     it('should return the account', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          payment_provider: 'sandbox',
-          gateway_account_id: '1',
-          credentials: { username: 'a-username', merchant_id: 'a-merchant-id' }
+          'payment_provider': 'sandbox',
+          'gateway_account_id': '1',
+          'credentials': { username: 'a-username', merchant_id: 'a-merchant-id' }
         })
 
       buildGetRequest(paths.notificationCredentials.edit, app)
@@ -328,22 +316,22 @@ describe('Credentials endpoints', () => {
     it('should display an error if the account does not exist', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(404, {
-          message: "The gateway account id '" + ACCOUNT_ID + "' does not exist"
+          'message': "The gateway account id '" + ACCOUNT_ID + "' does not exist"
         })
 
       buildGetRequest(paths.notificationCredentials.edit, app)
-        .expect(500, { message: 'There is a problem with the payments platform' })
+        .expect(500, { 'message': 'There is a problem with the payments platform' })
         .end(done)
     })
 
     it('should display an error if connector returns any other error', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(999, {
-          message: 'Some error in Connector'
+          'message': 'Some error in Connector'
         })
 
       buildGetRequest(paths.notificationCredentials.edit, app)
-        .expect(500, { message: 'There is a problem with the payments platform' })
+        .expect(500, { 'message': 'There is a problem with the payments platform' })
         .end(done)
     })
 
@@ -351,7 +339,7 @@ describe('Credentials endpoints', () => {
       // No connectorMock defined on purpose to mock a network failure
 
       buildGetRequest(paths.notificationCredentials.edit, app)
-        .expect(500, { message: 'There is a problem with the payments platform' })
+        .expect(500, { 'message': 'There is a problem with the payments platform' })
         .end(done)
     })
   })
@@ -375,14 +363,13 @@ describe('Credentials endpoints', () => {
     it('should pass through the notification credentials', function (done) {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200, {
-          payment_provider: 'smartpay',
-          gateway_account_id: '1',
-          external_id: ACCOUNT_EXTERNAL_ID,
-          credentials: {
-            username: 'a-username',
-            merchant_id: 'a-merchant-id'
+          'payment_provider': 'smartpay',
+          'gateway_account_id': '1',
+          'credentials': {
+            'username': 'a-username',
+            'merchant_id': 'a-merchant-id'
           },
-          notification_credentials: { username: 'a-notification-username' }
+          'notification_credentials': { username: 'a-notification-username' }
         })
 
       buildGetRequest(paths.notificationCredentials.index, app)
@@ -411,82 +398,84 @@ describe('Credentials endpoints', () => {
       connectorMock.get(CONNECTOR_ACCOUNT_PATH)
         .reply(200,
           gatewayAccountFixtures.validGatewayAccountResponse({
-            gateway_account_id: ACCOUNT_ID,
-            external_id: ACCOUNT_EXTERNAL_ID
+            gateway_account_id: ACCOUNT_ID
           }))
     })
 
     it('should send new username, password and merchant_id credentials to connector', function (done) {
       connectorMock.patch(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
-        credentials: {
-          username: 'a-username',
-          password: 'a-password',
-          merchant_id: 'a-merchant-id'
+        'credentials': {
+          'username': 'a-username',
+          'password': 'a-password',
+          'merchant_id': 'a-merchant-id'
         }
       }).reply(200, {})
 
-      const sendData = { username: 'a-username', password: 'a-password', merchantId: 'a-merchant-id' }
+      const sendData = { 'username': 'a-username', 'password': 'a-password', 'merchantId': 'a-merchant-id' }
+      const expectedLocation = paths.yourPsp.index
       const path = paths.credentials.index
       buildFormPostRequest(path, sendData, true, app)
         .expect(303, {})
-        .expect('Location', yourPspPath)
+        .expect('Location', expectedLocation)
         .end(done)
     })
 
     it('should send new username, password, merchant_id, sha_in_passphrase and sha_out_passphrase credentials to connector', function (done) {
       connectorMock.patch(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
-        credentials: {
-          username: 'a-username',
-          password: 'a-password',
-          merchant_id: 'a-psp-id',
-          sha_in_passphrase: 'a-sha-in-passphrase',
-          sha_out_passphrase: 'a-sha-out-passphrase'
+        'credentials': {
+          'username': 'a-username',
+          'password': 'a-password',
+          'merchant_id': 'a-psp-id',
+          'sha_in_passphrase': 'a-sha-in-passphrase',
+          'sha_out_passphrase': 'a-sha-out-passphrase'
 
         }
       }).reply(200, {})
 
       const sendData = {
-        username: 'a-username',
-        password: 'a-password',
-        merchantId: 'a-psp-id',
-        shaInPassphrase: 'a-sha-in-passphrase',
-        shaOutPassphrase: 'a-sha-out-passphrase'
+        'username': 'a-username',
+        'password': 'a-password',
+        'merchantId': 'a-psp-id',
+        'shaInPassphrase': 'a-sha-in-passphrase',
+        'shaOutPassphrase': 'a-sha-out-passphrase'
       }
+      const expectedLocation = paths.yourPsp.index
       const path = paths.credentials.index
       buildFormPostRequest(path, sendData, true, app)
         .expect(303, {})
-        .expect('Location', yourPspPath)
+        .expect('Location', expectedLocation)
         .end(done)
     })
 
     it('should send any arbitrary credentials together with username and password to connector', function (done) {
       connectorMock.patch(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
-        credentials: {
-          username: 'a-username',
-          password: 'a-password'
+        'credentials': {
+          'username': 'a-username',
+          'password': 'a-password'
         }
       })
         .reply(200, {})
 
-      const sendData = { username: 'a-username', password: 'a-password' }
+      const sendData = { 'username': 'a-username', 'password': 'a-password' }
+      const expectedLocation = paths.yourPsp.index
       const path = paths.credentials.index
       buildFormPostRequest(path, sendData, true, app)
         .expect(303, {})
-        .expect('Location', yourPspPath)
+        .expect('Location', expectedLocation)
         .end(done)
     })
 
     it('should display an error if connector returns failure', function (done) {
       connectorMock.patch(CONNECTOR_ACCOUNT_PATH, {
-        username: 'a-username',
-        password: 'a-password'
+        'username': 'a-username',
+        'password': 'a-password'
       })
         .reply(999, {
-          message: 'Error message'
+          'message': 'Error message'
         })
 
-      const sendData = { username: 'a-username', password: 'a-password' }
-      const expectedData = { message: 'There is a problem with the payments platform' }
+      const sendData = { 'username': 'a-username', 'password': 'a-password' }
+      const expectedData = { 'message': 'There is a problem with the payments platform' }
       const path = paths.credentials.index
       buildFormPostRequest(path, sendData, true, app)
         .expect(500, expectedData)
@@ -496,8 +485,8 @@ describe('Credentials endpoints', () => {
     it('should display an error if the connection to connector fails', function (done) {
       // No connectorMock defined on purpose to mock a network failure
 
-      const sendData = { username: 'a-username', password: 'a-password' }
-      const expectedData = { message: 'There is a problem with the payments platform' }
+      const sendData = { 'username': 'a-username', 'password': 'a-password' }
+      const expectedData = { 'message': 'There is a problem with the payments platform' }
       const path = paths.credentials.index
       buildFormPostRequest(path, sendData, true, app)
         .expect(500, expectedData)
@@ -506,11 +495,11 @@ describe('Credentials endpoints', () => {
 
     it('should fail if there is no csrf', done => {
       connectorMock.patch(CONNECTOR_ACCOUNT_CREDENTIALS_PATH, {
-        username: 'a-username',
-        password: 'a-password'
+        'username': 'a-username',
+        'password': 'a-password'
       }).reply(200, {})
 
-      const sendData = { username: 'a-username', password: 'a-password' }
+      const sendData = { 'username': 'a-username', 'password': 'a-password' }
       const path = paths.credentials.index
       buildFormPostRequest(path, sendData, false, app)
         .expect(400, { message: 'There is a problem with the payments platform' })
@@ -539,21 +528,22 @@ describe('Credentials endpoints', () => {
 
     it('should send new username and password notification credentials to connector', function (done) {
       connectorMock.post(CONNECTOR_ACCOUNT_NOTIFICATION_CREDENTIALS_PATH, {
-        username: 'a-notification-username',
-        password: 'a-notification-password'
+        'username': 'a-notification-username',
+        'password': 'a-notification-password'
       })
         .reply(200, {})
 
-      const sendData = { username: 'a-notification-username', password: 'a-notification-password' }
+      const sendData = { 'username': 'a-notification-username', 'password': 'a-notification-password' }
+      const expectedLocation = paths.yourPsp.index
       const path = paths.notificationCredentials.update
       buildFormPostRequest(path, sendData, true, app)
         .expect(303, {})
-        .expect('Location', yourPspPath)
+        .expect('Location', expectedLocation)
         .end(done)
     })
 
     it('should should flash a relevant error if no password is sent', function (done) {
-      const sendData = { password: 'a-notification-password' }
+      const sendData = { 'password': 'a-notification-password' }
       const path = paths.notificationCredentials.update
       buildFormPostRequest(path, sendData, true, app)
         .expect(res => {
@@ -565,7 +555,7 @@ describe('Credentials endpoints', () => {
         .end(done)
     })
     it('should should flash a relevant error if no password is sent', function (done) {
-      const sendData = { username: 'a-notification-username' }
+      const sendData = { 'username': 'a-notification-username' }
       const path = paths.notificationCredentials.update
       buildFormPostRequest(path, sendData, true, app)
         .expect(res => {
@@ -578,7 +568,7 @@ describe('Credentials endpoints', () => {
     })
 
     it('should should flash a relevant error if too short a password is sent', function (done) {
-      const sendData = { username: 'a-notification-username', password: '123456789' }
+      const sendData = { 'username': 'a-notification-username', 'password': '123456789' }
       const path = paths.notificationCredentials.update
       buildFormPostRequest(path, sendData, true, app)
         .expect(res => {
@@ -596,8 +586,7 @@ function mockConnectorGetAccount () {
   connectorMock.get(CONNECTOR_ACCOUNT_PATH)
     .reply(200,
       gatewayAccountFixtures.validGatewayAccountResponse({
-        gateway_account_id: ACCOUNT_ID,
-        external_id: ACCOUNT_EXTERNAL_ID
+        gateway_account_id: ACCOUNT_ID
       }))
 }
 


### PR DESCRIPTION
This reverts commit f86dee8341b20553280abea18df1c99beac6fbc9.

Reverting as it breaks end to end tests due to the credentials not being available on the new get account by external ID connector endpoint.
