### PR TITLE
PP-7583 URL Re-structure > Demo payments

### DIFF
--- a/app/controllers/make-a-demo-payment/edit.controller.js
+++ b/app/controllers/make-a-demo-payment/edit.controller.js
@@ -3,7 +3,7 @@
 const lodash = require('lodash')
 
 const { response } = require('../../utils/response.js')
-const { editDescription } = require('../../paths').prototyping.demoPayment
+const { editDescription } = require('../../paths').account.prototyping.demoPayment
 
 module.exports = (req, res) => {
   const pageData = lodash.get(req, 'session.pageData.makeADemoPayment', {})

--- a/app/controllers/make-a-demo-payment/go-to-payment.controller.js
+++ b/app/controllers/make-a-demo-payment/go-to-payment.controller.js
@@ -7,13 +7,14 @@ const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
 const productTypes = require('../../utils/product-types')
 const publicAuthClient = require('../../services/clients/public-auth.client')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 
 module.exports = async function makeDemoPayment (req, res) {
   const gatewayAccountId = req.account.gateway_account_id
   const { paymentAmount, paymentDescription } = lodash.get(req, 'session.pageData.makeADemoPayment', {})
 
   if (!paymentAmount || !paymentDescription) {
-    return res.redirect(paths.prototyping.demoPayment.index)
+    return res.redirect(formatAccountPathsFor(paths.account.prototyping.demoPayment.index, req.account.external_id))
   }
 
   try {
@@ -40,6 +41,6 @@ module.exports = async function makeDemoPayment (req, res) {
   } catch (error) {
     logger.error(`[requestId=${req.correlationId}] Making a demo payment failed - ${error.message}`)
     req.flash('genericError', 'Something went wrong. Please try again.')
-    res.redirect(paths.prototyping.demoPayment.index)
+    res.redirect(formatAccountPathsFor(paths.account.prototyping.demoPayment.index, req.account.external_id))
   }
 }

--- a/app/controllers/make-a-demo-payment/index.controller.js
+++ b/app/controllers/make-a-demo-payment/index.controller.js
@@ -6,6 +6,7 @@ const { response } = require('../../utils/response.js')
 const paths = require('../../paths')
 const { isCurrency, isAboveMaxAmount } = require('../../browsered/field-validation-checks')
 const { safeConvertPoundsStringToPence } = require('../../utils/currency-formatter')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 
 const DEFAULTS = {
   paymentDescription: 'An example payment description',
@@ -20,13 +21,13 @@ module.exports = (req, res) => {
   if (!paymentAmount || isCurrency(paymentAmount)) {
     lodash.set(req, 'session.pageData.makeADemoPayment.paymentAmount', paymentAmount)
     req.flash('genericError', isCurrency(paymentAmount))
-    return res.redirect(paths.prototyping.demoPayment.editAmount)
+    return res.redirect(formatAccountPathsFor(paths.account.prototyping.demoPayment.editAmount, req.account.external_id))
   }
   const isAboveMaxAmountError = isAboveMaxAmount(paymentAmount)
   if (isAboveMaxAmountError) {
     lodash.set(req, 'session.pageData.makeADemoPayment.paymentAmount', paymentAmount)
     req.flash('genericError', isAboveMaxAmountError)
-    return res.redirect(paths.prototyping.demoPayment.editAmount)
+    return res.redirect(formatAccountPathsFor(paths.account.prototyping.demoPayment.editAmount, req.account.external_id))
   }
 
   if (req.body['payment-amount']) {

--- a/app/controllers/make-a-demo-payment/mock-card-details.controller.js
+++ b/app/controllers/make-a-demo-payment/mock-card-details.controller.js
@@ -4,12 +4,13 @@ const lodash = require('lodash')
 
 const { response } = require('../../utils/response.js')
 const paths = require('../../paths')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 
 module.exports = (req, res) => {
   const { paymentAmount, paymentDescription } = lodash.get(req, 'session.pageData.makeADemoPayment', {})
 
   if (!paymentAmount || !paymentDescription) {
-    return res.redirect(paths.prototyping.demoPayment.index)
+    return res.redirect(formatAccountPathsFor(paths.account.prototyping.demoPayment.index, req.account.external_id))
   }
 
   response(req, res, 'dashboard/demo-payment/mock-card-details', {})

--- a/app/controllers/test-with-your-users/disable.controller.js
+++ b/app/controllers/test-with-your-users/disable.controller.js
@@ -3,17 +3,18 @@
 const logger = require('../../utils/logger')(__filename)
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 
 module.exports = (req, res) => {
   const gatewayAccountId = req.account.gateway_account_id
   productsClient.product.disable(gatewayAccountId, req.params.productExternalId)
     .then(() => {
       req.flash('generic', 'Prototype link deleted')
-      res.redirect(paths.prototyping.demoService.links)
+      res.redirect(formatAccountPathsFor(paths.account.prototyping.demoService.links, req.account.external_id))
     })
     .catch((err) => {
       logger.error(`[requestId=${req.correlationId}] Disable product failed - ${err.message}`)
       req.flash('genericError', 'Something went wrong when deleting the prototype link. Please try again or contact support.')
-      res.redirect(paths.prototyping.demoService.links)
+      res.redirect(formatAccountPathsFor(paths.account.prototyping.demoService.links, req.account.external_id))
     })
 }

--- a/app/controllers/test-with-your-users/links.controller.js
+++ b/app/controllers/test-with-your-users/links.controller.js
@@ -5,13 +5,14 @@ const { response } = require('../../utils/response.js')
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
 const { renderErrorView } = require('../../utils/response.js')
+const formatAccountPathsFor = require('../../../app/utils/format-account-paths-for')
 
 module.exports = (req, res) => {
   const params = {
     productsTab: true,
-    createPage: paths.prototyping.demoService.create,
-    indexPage: paths.prototyping.demoService.index,
-    linksPage: paths.prototyping.demoService.links
+    createPage: formatAccountPathsFor(paths.account.prototyping.demoService.create, req.account.external_id),
+    indexPage: formatAccountPathsFor(paths.account.prototyping.demoService.index, req.account.external_id),
+    linksPage: formatAccountPathsFor(paths.account.prototyping.demoService.links, req.account.external_id)
   }
 
   productsClient.product.getByGatewayAccountId(req.account.gateway_account_id)

--- a/app/controllers/test-with-your-users/submit.controller.js
+++ b/app/controllers/test-with-your-users/submit.controller.js
@@ -10,6 +10,7 @@ const productTypes = require('../../utils/product-types')
 const publicAuthClient = require('../../services/clients/public-auth.client')
 const { isCurrency, isHttps, isAboveMaxAmount } = require('../../browsered/field-validation-checks')
 const { penceToPounds, safeConvertPoundsStringToPence } = require('../../utils/currency-formatter')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 
 module.exports = async (req, res) => {
   const gatewayAccountId = req.account.gateway_account_id
@@ -29,7 +30,7 @@ module.exports = async (req, res) => {
   }
 
   if (lodash.get(req, 'session.flash.genericError.length')) {
-    return res.redirect(paths.prototyping.demoService.create)
+    return res.redirect(formatAccountPathsFor(paths.account.prototyping.demoService.create, req.account.external_id))
   }
 
   try {
@@ -59,6 +60,6 @@ module.exports = async (req, res) => {
   } catch (err) {
     logger.error(`[requestId=${req.correlationId}] Create product failed - ${err.message}`)
     req.flash('genericError', 'Something went wrong. Please try again or contact support.')
-    return res.redirect(paths.prototyping.demoService.create)
+    return res.redirect(formatAccountPathsFor(paths.account.prototyping.demoService.create, req.account.external_id))
   }
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -31,6 +31,22 @@ module.exports = {
     paymentTypes: {
       index: '/payment-types'
     },
+    prototyping: {
+      demoService: {
+        index: '/test-with-your-users',
+        links: '/test-with-your-users/links',
+        create: '/test-with-your-users/create',
+        confirm: '/test-with-your-users/confirm',
+        disable: '/test-with-your-users/links/disable/:productExternalId'
+      },
+      demoPayment: {
+        index: '/make-a-demo-payment',
+        editDescription: '/make-a-demo-payment/edit-description',
+        editAmount: '/make-a-demo-payment/edit-amount',
+        mockCardDetails: '/make-a-demo-payment/mock-card-numbers',
+        goToPaymentScreens: '/make-a-demo-payment/go-to-payment'
+      }
+    },
     settings: {
       index: '/settings'
     },
@@ -144,22 +160,6 @@ module.exports = {
   },
   staticPaths: {
     naxsiError: '/request-denied'
-  },
-  prototyping: {
-    demoService: {
-      index: '/test-with-your-users',
-      links: '/test-with-your-users/links',
-      create: '/test-with-your-users/create',
-      confirm: '/test-with-your-users/confirm',
-      disable: '/test-with-your-users/links/disable/:productExternalId'
-    },
-    demoPayment: {
-      index: '/make-a-demo-payment',
-      editDescription: '/make-a-demo-payment/edit-description',
-      editAmount: '/make-a-demo-payment/edit-amount',
-      mockCardDetails: '/make-a-demo-payment/mock-card-numbers',
-      goToPaymentScreens: '/make-a-demo-payment/go-to-payment'
-    }
   },
   paymentLinks: {
     start: '/create-payment-link',

--- a/app/routes.js
+++ b/app/routes.js
@@ -88,7 +88,7 @@ const stripeSetupDashboardRedirectController = require('./controllers/stripe-set
 const {
   healthcheck, registerUser, user, dashboard, selfCreateService, transactions, credentials,
   serviceSwitcher, teamMembers, staticPaths, inviteValidation, editServiceName, merchantDetails,
-  notificationCredentials, prototyping, paymentLinks,
+  notificationCredentials, paymentLinks,
   requestToGoLive, policyPages, stripeSetup, stripe,
   yourPsp, allServiceTransactions, payouts
 } = paths
@@ -97,6 +97,7 @@ const {
   digitalWallet,
   emailNotifications,
   paymentTypes,
+  prototyping,
   settings,
   toggle3ds,
   toggleBillingAddress,
@@ -185,8 +186,6 @@ module.exports.bind = function (app) {
     ...lodash.values(serviceSwitcher),
     ...lodash.values(teamMembers),
     ...lodash.values(merchantDetails),
-    ...lodash.values(prototyping.demoPayment),
-    ...lodash.values(prototyping.demoService),
     ...lodash.values(paymentLinks),
     ...lodash.values(user.profile),
     ...lodash.values(requestToGoLive),
@@ -357,19 +356,6 @@ module.exports.bind = function (app) {
   account.post(toggleBillingAddress.index, permission('toggle-billing-address:update'), toggleBillingAddressController.postIndex)
 
   // Prototype links
-  app.get(prototyping.demoService.index, permission('transactions:read'), resolveService, getAccount, restrictToSandbox, testWithYourUsersController.index)
-  app.get(prototyping.demoService.links, permission('transactions:read'), resolveService, getAccount, restrictToSandbox, testWithYourUsersController.links)
-  app.get(prototyping.demoService.create, permission('transactions:read'), resolveService, getAccount, restrictToSandbox, testWithYourUsersController.create)
-  app.post(prototyping.demoService.confirm, permission('transactions:read'), resolveService, getAccount, restrictToSandbox, testWithYourUsersController.submit)
-  app.get(prototyping.demoService.disable, permission('transactions:read'), resolveService, getAccount, restrictToSandbox, testWithYourUsersController.disable)
-
-  app.get(prototyping.demoPayment.index, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPaymentController.index)
-  app.post(prototyping.demoPayment.index, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPaymentController.index)
-  app.get(prototyping.demoPayment.editDescription, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPaymentController.edit)
-  app.get(prototyping.demoPayment.editAmount, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPaymentController.edit)
-  app.get(prototyping.demoPayment.mockCardDetails, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPaymentController.mockCardDetails)
-  app.post(prototyping.demoPayment.goToPaymentScreens, permission('transactions:read'), getAccount, restrictToSandbox, makeADemoPaymentController.goToPayment)
-
   account.get(prototyping.demoService.index, permission('transactions:read'), restrictToSandbox, testWithYourUsersController.index)
   account.get(prototyping.demoService.links, permission('transactions:read'), restrictToSandbox, testWithYourUsersController.links)
   account.get(prototyping.demoService.create, permission('transactions:read'), restrictToSandbox, testWithYourUsersController.create)

--- a/app/views/dashboard/_links.njk
+++ b/app/views/dashboard/_links.njk
@@ -9,7 +9,7 @@
   <div class="flex-grid--row">
     {% if links.demoPayment in linksToDisplay %}
     <article class="{{columnClass}} links__box" id="demo-payment-link">
-      <a href="{{routes.prototyping.demoPayment.index}}">
+      <a href="{{formatAccountPathsFor(routes.account.prototyping.demoPayment.index,  currentGatewayAccount.external_id)}}">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Make a demo payment</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Try the payment experience as a user. Then view the completed payment as an administrator on GOV.UK&nbsp;Pay.</p>
       </a>
@@ -18,7 +18,7 @@
 
     {% if links.testPaymentLink in linksToDisplay %}
     <article class="{{columnClass}} links__box" id="test-payment-link-link">
-      <a href="{{routes.prototyping.demoService.index}}">
+      <a href="{{formatAccountPathsFor(routes.account.prototyping.demoService.index,  currentGatewayAccount.external_id)}}">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Test with your users</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Create a reusable link to integrate your service prototype with GOV.UK&nbsp;Pay and test with users.</p>
       </a>

--- a/app/views/dashboard/demo-payment/edit-amount.njk
+++ b/app/views/dashboard/demo-payment/edit-amount.njk
@@ -9,7 +9,7 @@
   {{
     govukBackLink({
       text: "Back to make a demo payment",
-      href: routes.prototyping.demoPayment.index
+      href: formatAccountPathsFor(routes.account.prototyping.demoPayment.index,  currentGatewayAccount.external_id)
     })
   }}
 {% endblock %}
@@ -17,7 +17,7 @@
 {% block mainContent %}
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Edit payment amount</h1>
-    <form method="post" action="{{routes.prototyping.demoPayment.index}}" data-validate="true">
+    <form method="post" action="{{formatAccountPathsFor(routes.account.prototyping.demoPayment.index,  currentGatewayAccount.external_id)}}" data-validate="true">
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
       <div class="currency-input govuk-form-group">

--- a/app/views/dashboard/demo-payment/edit-description.njk
+++ b/app/views/dashboard/demo-payment/edit-description.njk
@@ -9,7 +9,7 @@
   {{
     govukBackLink({
       text: "Back to make a demo payment",
-      href: routes.prototyping.demoPayment.index
+      href: formatAccountPathsFor(routes.account.prototyping.demoPayment.index,  currentGatewayAccount.external_id)
     })
   }}
 {% endblock %}
@@ -17,7 +17,7 @@
 {% block mainContent %}
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Edit payment description</h1>
-    <form method="post" action="{{routes.prototyping.demoPayment.index}}" data-validate="true">
+    <form method="post" action="{{formatAccountPathsFor(routes.account.prototyping.demoPayment.index,  currentGatewayAccount.external_id)}}" data-validate="true">
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
       {{
         govukTextarea({

--- a/app/views/dashboard/demo-payment/index.njk
+++ b/app/views/dashboard/demo-payment/index.njk
@@ -28,7 +28,7 @@ Make a demo payment - {{currentService.name}} {{currentGatewayAccount.full_type}
         <div class="govuk-body govuk-!-margin-0" id="payment-description">
           {{ paymentDescription | striptags(true) | escape | nl2br }}
           <span class="demo-payment-settings__edit-link">
-            <a class="govuk-link govuk-link--no-visited-state" href="{{routes.prototyping.demoPayment.editDescription}}">
+            <a class="govuk-link govuk-link--no-visited-state" href="{{formatAccountPathsFor(routes.account.prototyping.demoPayment.editDescription,  currentGatewayAccount.external_id)}}">
               Edit <span class="govuk-visually-hidden">description</span>
             </a>
           </span>
@@ -44,7 +44,7 @@ Make a demo payment - {{currentService.name}} {{currentGatewayAccount.full_type}
         <div class="govuk-body govuk-!-margin-0" id="payment-amount">
           {{ paymentAmount | penceToPoundsWithCurrency }}
           <span class="demo-payment-settings__edit-link">
-            <a class="govuk-link govuk-link--no-visited-state" href="{{routes.prototyping.demoPayment.editAmount}}">
+            <a class="govuk-link govuk-link--no-visited-state" href="{{formatAccountPathsFor(routes.account.prototyping.demoPayment.editAmount,  currentGatewayAccount.external_id)}}">
               Edit <span class="govuk-visually-hidden">amount</span>
             </a>
           </span>
@@ -57,7 +57,7 @@ Make a demo payment - {{currentService.name}} {{currentGatewayAccount.full_type}
     {{
       govukButton({
         text: "Continue",
-        href: routes.prototyping.demoPayment.mockCardDetails,
+        href: formatAccountPathsFor(routes.account.prototyping.demoPayment.mockCardDetails,  currentGatewayAccount.external_id),
         attributes: {
           id: "prototyping__continue"
         }

--- a/app/views/dashboard/demo-payment/mock-card-details.njk
+++ b/app/views/dashboard/demo-payment/mock-card-details.njk
@@ -9,7 +9,7 @@
   {{
     govukBackLink({
       text: "Back to make a demo payment",
-      href: routes.prototyping.demoPayment.index
+      href: formatAccountPathsFor(routes.account.prototyping.demoPayment.index,  currentGatewayAccount.external_id)
     })
   }}
 {% endblock %}
@@ -28,7 +28,7 @@
   <p class="govuk-body">You can enter any valid value for the other details. For example, it doesn’t matter what expiry date you enter, but it must be in the future.</p>
   <p class="govuk-body">You can also use other card types and see errors. <a class="govuk-link" href="https://docs.payments.service.gov.uk/testing_govuk_pay/#mock-card-numbers-for-testing-purposes">See more card types in our documentation</a>.</p>
 
-  <form method="post" action="{{routes.prototyping.demoPayment.goToPaymentScreens}}" >
+  <form method="post" action="{{formatAccountPathsFor(routes.account.prototyping.demoPayment.goToPaymentScreens,  currentGatewayAccount.external_id)}}" >
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {{
       govukButton({

--- a/app/views/dashboard/demo-service/confirm.njk
+++ b/app/views/dashboard/demo-service/confirm.njk
@@ -9,7 +9,7 @@
   {{
     govukBackLink({
       text: "Back to prototype links",
-      href: routes.prototyping.demoService.links,
+      href: formatAccountPathsFor(routes.account.prototyping.demoService.links,  currentGatewayAccount.external_id),
       attributes: {
         id: "prototyping__links-link-back"
       }
@@ -37,7 +37,7 @@
   {{
     govukButton({
       text: "See prototype links",
-      href: routes.prototyping.demoService.links,
+      href: formatAccountPathsFor(routes.account.prototyping.demoService.links,  currentGatewayAccount.external_id),
       attributes: {
         id: "see-prototype-links"
       }

--- a/app/views/dashboard/demo-service/create.njk
+++ b/app/views/dashboard/demo-service/create.njk
@@ -9,7 +9,7 @@
   {{
     govukBackLink({
       text: "Back to prototype links",
-      href: routes.prototyping.demoService.links
+      href: formatAccountPathsFor(routes.account.prototyping.demoService.links,  currentGatewayAccount.external_id)
     })
   }}
 {% endblock %}
@@ -17,7 +17,7 @@
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">Create a prototype link</h1>
-  <form method="post" action="{{routes.prototyping.demoService.confirm}}" data-validate>
+  <form method="post" action="{{formatAccountPathsFor(routes.account.prototyping.demoService.confirm,  currentGatewayAccount.external_id)}}" data-validate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {{

--- a/app/views/dashboard/demo-service/index.njk
+++ b/app/views/dashboard/demo-service/index.njk
@@ -21,7 +21,7 @@
   {{
     govukButton({
       text: "Create prototype link",
-      href: routes.prototyping.demoService.create,
+      href: formatAccountPathsFor(routes.account.prototyping.demoService.create,  currentGatewayAccount.external_id),
       attributes: {
         id: "prototyping__links-button-create"
       }
@@ -32,13 +32,13 @@
     <ul class="govuk-tabs__list">
       <li class="govuk-tabs__list-item">
         <a class="govuk-tabs__tab {% if not productsTab %}
-govuk-tabs__tab--selected{% endif %}" href="{{routes.prototyping.demoService.index}}">
+govuk-tabs__tab--selected{% endif %}" href="{{formatAccountPathsFor(routes.account.prototyping.demoService.index,  currentGatewayAccount.external_id)}}">
           Mock card numbers
         </a>
       </li>
       <li class="govuk-tabs__list-item">
         <a class="govuk-tabs__tab {% if productsTab %}
-govuk-tabs__tab--selected{% endif %}" href="{{routes.prototyping.demoService.links}}">
+govuk-tabs__tab--selected{% endif %}" href="{{formatAccountPathsFor(routes.account.prototyping.demoService.links,  currentGatewayAccount.external_id)}}">
           Prototype links
         </a>
       </li>

--- a/test/unit/controller/make-a-demo-payment-controller/index.controller.ft.test.js
+++ b/test/unit/controller/make-a-demo-payment-controller/index.controller.ft.test.js
@@ -11,25 +11,35 @@ const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')
 const { penceToPounds } = require('../../../../app/utils/currency-formatter')
+const formatAccountPathsFor = require('../../../../app/utils/format-account-paths-for')
+const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
 
 const GATEWAY_ACCOUNT_ID = '929'
+const EXTERNAL_GATEWAY_ACCOUNT_ID = 'an-external-id'
 const { CONNECTOR_URL } = process.env
 const VALID_USER = getUser({
   gateway_account_ids: [GATEWAY_ACCOUNT_ID],
   permissions: [{ name: 'transactions:read' }]
 })
-const VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE = {
-  payment_provider: 'sandbox'
+
+function mockConnectorGetAccount () {
+  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+    .reply(200, validGatewayAccountResponse(
+      {
+        external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,
+        gateway_account_id: GATEWAY_ACCOUNT_ID
+      }
+    ))
 }
 
 describe('make a demo payment - index controller', () => {
   describe('when no values exist in the body and none are in session', () => {
     let result, $, session
     before(done => {
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+      mockConnectorGetAccount()
       session = getMockSession(VALID_USER)
       supertest(createAppWithSession(getApp(), session))
-        .get(paths.prototyping.demoPayment.index)
+        .get(formatAccountPathsFor(paths.account.prototyping.demoPayment.index, EXTERNAL_GATEWAY_ACCOUNT_ID))
         .end((err, res) => {
           result = res
           $ = cheerio.load(res.text)
@@ -56,14 +66,14 @@ describe('make a demo payment - index controller', () => {
   describe('when values exist in the session but none are in the body', () => {
     let result, $, session, paymentAmount, paymentDescription
     before(done => {
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+      mockConnectorGetAccount()
       paymentAmount = '10000'
       paymentDescription = 'Pay your window tax'
       session = getMockSession(VALID_USER)
       lodash.set(session, 'pageData.makeADemoPayment.paymentAmount', paymentAmount)
       lodash.set(session, 'pageData.makeADemoPayment.paymentDescription', paymentDescription)
       supertest(createAppWithSession(getApp(), session))
-        .get(paths.prototyping.demoPayment.index)
+        .get(formatAccountPathsFor(paths.account.prototyping.demoPayment.index, EXTERNAL_GATEWAY_ACCOUNT_ID))
         .end((err, res) => {
           result = res
           $ = cheerio.load(res.text)
@@ -93,14 +103,14 @@ describe('make a demo payment - index controller', () => {
       describe('and there are also values in the session', () => {
         let result, $, session, paymentAmount, paymentDescription
         before(done => {
-          nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+          mockConnectorGetAccount()
           paymentAmount = '100.00'
           paymentDescription = 'Pay your window tax'
           session = getMockSession(VALID_USER)
           lodash.set(session, 'pageData.makeADemoPayment.paymentAmount', '180.00')
           lodash.set(session, 'pageData.makeADemoPayment.paymentDescription', 'Pay your door tax')
           supertest(createAppWithSession(getApp(), session))
-            .post(paths.prototyping.demoPayment.index)
+            .post(formatAccountPathsFor(paths.account.prototyping.demoPayment.index, EXTERNAL_GATEWAY_ACCOUNT_ID))
             .send({
               'csrfToken': csrf().create('123'),
               'payment-amount': paymentAmount,
@@ -132,12 +142,12 @@ describe('make a demo payment - index controller', () => {
       describe('and there are no values in the session', () => {
         let result, $, session, paymentAmount, paymentDescription
         before(done => {
-          nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+          mockConnectorGetAccount()
           paymentAmount = '100.00'
           paymentDescription = 'Pay your window tax'
           session = getMockSession(VALID_USER)
           supertest(createAppWithSession(getApp(), session))
-            .post(paths.prototyping.demoPayment.index)
+            .post(formatAccountPathsFor(paths.account.prototyping.demoPayment.index, EXTERNAL_GATEWAY_ACCOUNT_ID))
             .send({
               'csrfToken': csrf().create('123'),
               'payment-amount': paymentAmount,
@@ -171,10 +181,10 @@ describe('make a demo payment - index controller', () => {
       describe('because the value includes text', () => {
         let result, session
         before(done => {
-          nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+          mockConnectorGetAccount()
           session = getMockSession(VALID_USER)
           supertest(createAppWithSession(getApp(), session))
-            .post(paths.prototyping.demoPayment.index)
+            .post(formatAccountPathsFor(paths.account.prototyping.demoPayment.index, EXTERNAL_GATEWAY_ACCOUNT_ID))
             .send({
               'csrfToken': csrf().create('123'),
               'payment-amount': 'One Hundred and Eighty Pounds and No Pence',
@@ -194,7 +204,7 @@ describe('make a demo payment - index controller', () => {
           expect(result.statusCode).to.equal(302)
         })
         it(`should redirect to the edit payment amount page`, () => {
-          expect(result.headers).to.have.property('location').to.equal(paths.prototyping.demoPayment.editAmount)
+          expect(result.headers).to.have.property('location').to.equal(formatAccountPathsFor(paths.account.prototyping.demoPayment.editAmount, EXTERNAL_GATEWAY_ACCOUNT_ID))
         })
         it('should add a relevant error message to the session \'flash\'', () => {
           expect(session.flash).to.have.property('genericError')
@@ -205,10 +215,10 @@ describe('make a demo payment - index controller', () => {
       describe('because the value has too many digits to the right of the decimal point', () => {
         let result, session
         before(done => {
-          nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+          mockConnectorGetAccount()
           session = getMockSession(VALID_USER)
           supertest(createAppWithSession(getApp(), session))
-            .post(paths.prototyping.demoPayment.index)
+            .post(formatAccountPathsFor(paths.account.prototyping.demoPayment.index, EXTERNAL_GATEWAY_ACCOUNT_ID))
             .send({
               'csrfToken': csrf().create('123'),
               'payment-amount': '£1234.567',
@@ -228,7 +238,7 @@ describe('make a demo payment - index controller', () => {
           expect(result.statusCode).to.equal(302)
         })
         it(`should redirect to the edit payment amount page`, () => {
-          expect(result.headers).to.have.property('location').to.equal(paths.prototyping.demoPayment.editAmount)
+          expect(result.headers).to.have.property('location').to.equal(formatAccountPathsFor(paths.account.prototyping.demoPayment.editAmount, EXTERNAL_GATEWAY_ACCOUNT_ID))
         })
         it('should add a relevant error message to the session \'flash\'', () => {
           expect(session.flash).to.have.property('genericError')
@@ -239,14 +249,14 @@ describe('make a demo payment - index controller', () => {
       describe('because the value exceeds 100,000', () => {
         let result, session, app
         before('Arrange', () => {
-          nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, VALID_MINIMAL_GATEWAY_ACCOUNT_RESPONSE)
+          mockConnectorGetAccount()
           session = getMockSession(VALID_USER)
           app = createAppWithSession(getApp(), session)
         })
 
         before('Act', done => {
           supertest(app)
-            .post(paths.prototyping.demoPayment.index)
+            .post(formatAccountPathsFor(paths.account.prototyping.demoPayment.index, EXTERNAL_GATEWAY_ACCOUNT_ID))
             .send({
               'csrfToken': csrf().create('123'),
               'payment-amount': '10000000.01',
@@ -266,7 +276,7 @@ describe('make a demo payment - index controller', () => {
           expect(result.statusCode).to.equal(302)
         })
         it(`should redirect to the edit payment amount page`, () => {
-          expect(result.headers).to.have.property('location').to.equal(paths.prototyping.demoPayment.editAmount)
+          expect(result.headers).to.have.property('location').to.equal(formatAccountPathsFor(paths.account.prototyping.demoPayment.editAmount, EXTERNAL_GATEWAY_ACCOUNT_ID))
         })
         it('should add a relevant error message to the session \'flash\'', () => {
           expect(session.flash).to.have.property('genericError')

--- a/test/unit/controller/make-a-demo-payment-controller/mock-card-details.controller.ft.test.js
+++ b/test/unit/controller/make-a-demo-payment-controller/mock-card-details.controller.ft.test.js
@@ -9,8 +9,22 @@ const lodash = require('lodash')
 const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')
+const formatAccountPathsFor = require('../../../../app/utils/format-account-paths-for')
+const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
+
 const { CONNECTOR_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '929'
+const EXTERNAL_GATEWAY_ACCOUNT_ID = 'an-external-id'
+
+function mockConnectorGetAccount () {
+  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+    .reply(200, validGatewayAccountResponse(
+      {
+        external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,
+        gateway_account_id: GATEWAY_ACCOUNT_ID
+      }
+    ))
+}
 
 describe('make a demo payment - mock card details controller', () => {
   describe('when both paymentDescription and paymentAmount exist in the session', () => {
@@ -21,9 +35,7 @@ describe('make a demo payment - mock card details controller', () => {
         gateway_account_ids: [GATEWAY_ACCOUNT_ID],
         permissions: [{ name: 'transactions:read' }]
       }))
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
-        payment_provider: 'sandbox'
-      })
+      mockConnectorGetAccount()
       lodash.set(session, 'pageData.makeADemoPayment', {
         paymentDescription: 'A demo payment',
         paymentAmount: '10.50'
@@ -33,7 +45,7 @@ describe('make a demo payment - mock card details controller', () => {
 
     before('Act', done => {
       supertest(app)
-        .get(paths.prototyping.demoPayment.mockCardDetails)
+        .get(formatAccountPathsFor(paths.account.prototyping.demoPayment.mockCardDetails, EXTERNAL_GATEWAY_ACCOUNT_ID))
         .end((err, res) => {
           result = res
           $ = cheerio.load(res.text)
@@ -50,11 +62,11 @@ describe('make a demo payment - mock card details controller', () => {
     })
 
     it(`should include a back link linking to the demoservice index page`, () => {
-      expect($('.govuk-back-link').attr('href')).to.equal(paths.prototyping.demoPayment.index)
+      expect($('.govuk-back-link').attr('href')).to.equal(formatAccountPathsFor(paths.account.prototyping.demoPayment.index, EXTERNAL_GATEWAY_ACCOUNT_ID))
     })
 
     it(`should include form which has the go to demo payment page as its action`, () => {
-      expect($('form').attr('action')).to.equal(paths.prototyping.demoPayment.goToPaymentScreens)
+      expect($('form').attr('action')).to.equal(formatAccountPathsFor(paths.account.prototyping.demoPayment.goToPaymentScreens, EXTERNAL_GATEWAY_ACCOUNT_ID))
     })
   })
 
@@ -66,9 +78,7 @@ describe('make a demo payment - mock card details controller', () => {
         gateway_account_ids: [GATEWAY_ACCOUNT_ID],
         permissions: [{ name: 'transactions:read' }]
       }))
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
-        payment_provider: 'sandbox'
-      })
+      mockConnectorGetAccount()
       lodash.set(session, 'pageData.makeADemoPayment', {
         paymentDescription: 'A demo payment'
       })
@@ -77,7 +87,7 @@ describe('make a demo payment - mock card details controller', () => {
 
     before('Act', done => {
       supertest(app)
-        .get(paths.prototyping.demoPayment.mockCardDetails)
+        .get(formatAccountPathsFor(paths.account.prototyping.demoPayment.mockCardDetails, EXTERNAL_GATEWAY_ACCOUNT_ID))
         .end((err, res) => {
           result = res
           done(err)
@@ -93,7 +103,7 @@ describe('make a demo payment - mock card details controller', () => {
     })
 
     it('should redirect back to the index page', () => {
-      expect(result.headers).to.have.property('location').to.equal(paths.prototyping.demoPayment.index)
+      expect(result.headers).to.have.property('location').to.equal(formatAccountPathsFor(paths.account.prototyping.demoPayment.index, EXTERNAL_GATEWAY_ACCOUNT_ID))
     })
   })
 
@@ -105,9 +115,7 @@ describe('make a demo payment - mock card details controller', () => {
         gateway_account_ids: [GATEWAY_ACCOUNT_ID],
         permissions: [{ name: 'transactions:read' }]
       }))
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
-        payment_provider: 'sandbox'
-      })
+      mockConnectorGetAccount()
       lodash.set(session, 'pageData.makeADemoPayment', {
         paymentAmount: '10.50'
       })
@@ -116,7 +124,7 @@ describe('make a demo payment - mock card details controller', () => {
 
     before('Act', done => {
       supertest(app)
-        .get(paths.prototyping.demoPayment.mockCardDetails)
+        .get(formatAccountPathsFor(paths.account.prototyping.demoPayment.mockCardDetails, EXTERNAL_GATEWAY_ACCOUNT_ID))
         .end((err, res) => {
           result = res
           done(err)
@@ -132,7 +140,7 @@ describe('make a demo payment - mock card details controller', () => {
     })
 
     it('should redirect back to the index page', () => {
-      expect(result.headers).to.have.property('location').to.equal(paths.prototyping.demoPayment.index)
+      expect(result.headers).to.have.property('location').to.equal(formatAccountPathsFor(paths.account.prototyping.demoPayment.index, EXTERNAL_GATEWAY_ACCOUNT_ID))
     })
   })
 
@@ -144,15 +152,13 @@ describe('make a demo payment - mock card details controller', () => {
         gateway_account_ids: [GATEWAY_ACCOUNT_ID],
         permissions: [{ name: 'transactions:read' }]
       }))
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
-        payment_provider: 'sandbox'
-      })
+      mockConnectorGetAccount()
       app = createAppWithSession(getApp(), session)
     })
 
     before('Act', done => {
       supertest(app)
-        .get(paths.prototyping.demoPayment.mockCardDetails)
+        .get(formatAccountPathsFor(paths.account.prototyping.demoPayment.mockCardDetails, EXTERNAL_GATEWAY_ACCOUNT_ID))
         .end((err, res) => {
           result = res
           done(err)
@@ -168,7 +174,7 @@ describe('make a demo payment - mock card details controller', () => {
     })
 
     it('should redirect back to the index page', () => {
-      expect(result.headers).to.have.property('location').to.equal(paths.prototyping.demoPayment.index)
+      expect(result.headers).to.have.property('location').to.equal(formatAccountPathsFor(paths.account.prototyping.demoPayment.index, EXTERNAL_GATEWAY_ACCOUNT_ID))
     })
   })
 })

--- a/test/unit/controller/test-with-your-users-controller/create.controller.ft.test.js
+++ b/test/unit/controller/test-with-your-users-controller/create.controller.ft.test.js
@@ -10,8 +10,22 @@ const { getApp } = require('../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../test-helpers/mock-session')
 const paths = require('../../../../app/paths')
 const { penceToPounds } = require('../../../../app/utils/currency-formatter')
+const formatAccountPathsFor = require('../../../../app/utils/format-account-paths-for')
+const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
+
 const { CONNECTOR_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '929'
+const EXTERNAL_GATEWAY_ACCOUNT_ID = 'an-external-id'
+
+function mockConnectorGetAccount () {
+  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+    .reply(200, validGatewayAccountResponse(
+      {
+        external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,
+        gateway_account_id: GATEWAY_ACCOUNT_ID
+      }
+    ))
+}
 
 describe('test with your users - create controller', () => {
   let result, $, session
@@ -20,9 +34,7 @@ describe('test with your users - create controller', () => {
       gateway_account_ids: [GATEWAY_ACCOUNT_ID],
       permissions: [{ name: 'transactions:read' }]
     })
-    nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
-      payment_provider: 'sandbox'
-    })
+    mockConnectorGetAccount()
     session = getMockSession(user)
     lodash.set(session, 'pageData.createPrototypeLink', {
       paymentDescription: 'An example prototype payment',
@@ -30,7 +42,7 @@ describe('test with your users - create controller', () => {
       confirmationPage: 'example.gov.uk/payment-complete'
     })
     supertest(createAppWithSession(getApp(), session))
-      .get(paths.prototyping.demoService.create)
+      .get(formatAccountPathsFor(paths.account.prototyping.demoService.create, EXTERNAL_GATEWAY_ACCOUNT_ID))
       .end((err, res) => {
         result = res
         $ = cheerio.load(res.text)
@@ -46,11 +58,11 @@ describe('test with your users - create controller', () => {
   })
 
   it(`should include a back link linking to the demoservice links page`, () => {
-    expect($('.govuk-back-link').attr('href')).to.equal(paths.prototyping.demoService.links)
+    expect($('.govuk-back-link').attr('href')).to.equal(formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))
   })
 
   it(`should have the confirm page as the form action`, () => {
-    expect($('form').attr('action')).to.equal(paths.prototyping.demoService.confirm)
+    expect($('form').attr('action')).to.equal(formatAccountPathsFor(paths.account.prototyping.demoService.confirm, EXTERNAL_GATEWAY_ACCOUNT_ID))
   })
 
   it(`should pre-set the value of the 'payment-description' input to pre-existing data if present in the session`, () =>

--- a/test/unit/controller/test-with-your-users-controller/links.controller.ft.test.js
+++ b/test/unit/controller/test-with-your-users-controller/links.controller.ft.test.js
@@ -9,10 +9,13 @@ const mockSession = require('../../../test-helpers/mock-session')
 const userCreator = require('../../../test-helpers/user-creator')
 const paths = require('../../../../app/paths')
 const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
+const formatAccountPathsFor = require('../../../../app/utils/format-account-paths-for')
 
 const { PRODUCTS_URL, CONNECTOR_URL } = process.env
 
 const GATEWAY_ACCOUNT_ID = '182364'
+const EXTERNAL_GATEWAY_ACCOUNT_ID = 'an-external-id'
+
 const PAYMENT_1 = {
   external_id: 'product-external-id-1',
   gateway_account_id: 'product-gateway-account-id-1',
@@ -63,10 +66,13 @@ function mockGetProductsByGatewayAccountEndpoint (gatewayAccountId) {
 }
 
 function mockConnectorGetAccount () {
-  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-    .reply(200, validGatewayAccountResponse({
-      gateway_account_id: GATEWAY_ACCOUNT_ID
-    }))
+  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+    .reply(200, validGatewayAccountResponse(
+      {
+        external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,
+        gateway_account_id: GATEWAY_ACCOUNT_ID
+      }
+    ))
 }
 
 describe('Show the prototype links', () => {
@@ -86,7 +92,7 @@ describe('Show the prototype links', () => {
       mockGetProductsByGatewayAccountEndpoint(GATEWAY_ACCOUNT_ID).reply(200, [])
 
       supertest(app)
-        .get(paths.prototyping.demoService.links)
+        .get(formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))
         .set('Accept', 'application/json')
         .end((err, res) => {
           response = res
@@ -103,9 +109,9 @@ describe('Show the prototype links', () => {
     })
 
     it('should display the correct page links', () => {
-      expect(response.body).to.have.property('createPage', paths.prototyping.demoService.create)
-      expect(response.body).to.have.property('indexPage', paths.prototyping.demoService.index)
-      expect(response.body).to.have.property('linksPage', paths.prototyping.demoService.links)
+      expect(response.body).to.have.property('createPage', formatAccountPathsFor(paths.account.prototyping.demoService.create, EXTERNAL_GATEWAY_ACCOUNT_ID))
+      expect(response.body).to.have.property('indexPage', formatAccountPathsFor(paths.account.prototyping.demoService.index, EXTERNAL_GATEWAY_ACCOUNT_ID))
+      expect(response.body).to.have.property('linksPage', formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))
     })
 
     it('should not display any link', () => {
@@ -120,7 +126,7 @@ describe('Show the prototype links', () => {
       mockGetProductsByGatewayAccountEndpoint(GATEWAY_ACCOUNT_ID).reply(200, [PAYMENT_1])
 
       supertest(app)
-        .get(paths.prototyping.demoService.links)
+        .get(formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))
         .set('Accept', 'application/json')
         .end((err, res) => {
           response = res
@@ -137,9 +143,9 @@ describe('Show the prototype links', () => {
     })
 
     it('should display the correct page links', () => {
-      expect(response.body).to.have.property('createPage', paths.prototyping.demoService.create)
-      expect(response.body).to.have.property('indexPage', paths.prototyping.demoService.index)
-      expect(response.body).to.have.property('linksPage', paths.prototyping.demoService.links)
+      expect(response.body).to.have.property('createPage', formatAccountPathsFor(paths.account.prototyping.demoService.create, EXTERNAL_GATEWAY_ACCOUNT_ID))
+      expect(response.body).to.have.property('indexPage', formatAccountPathsFor(paths.account.prototyping.demoService.index, EXTERNAL_GATEWAY_ACCOUNT_ID))
+      expect(response.body).to.have.property('linksPage', formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))
     })
 
     it('should display all the links', () => {
@@ -169,7 +175,7 @@ describe('Show the prototype links', () => {
       mockGetProductsByGatewayAccountEndpoint(GATEWAY_ACCOUNT_ID).reply(200, [PAYMENT_1, PAYMENT_2])
 
       supertest(app)
-        .get(paths.prototyping.demoService.links)
+        .get(formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))
         .set('Accept', 'application/json')
         .end((err, res) => {
           response = res
@@ -186,9 +192,9 @@ describe('Show the prototype links', () => {
     })
 
     it('should display the correct page links', () => {
-      expect(response.body).to.have.property('createPage', paths.prototyping.demoService.create)
-      expect(response.body).to.have.property('indexPage', paths.prototyping.demoService.index)
-      expect(response.body).to.have.property('linksPage', paths.prototyping.demoService.links)
+      expect(response.body).to.have.property('createPage', formatAccountPathsFor(paths.account.prototyping.demoService.create, EXTERNAL_GATEWAY_ACCOUNT_ID))
+      expect(response.body).to.have.property('indexPage', formatAccountPathsFor(paths.account.prototyping.demoService.index, EXTERNAL_GATEWAY_ACCOUNT_ID))
+      expect(response.body).to.have.property('linksPage', formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))
     })
 
     it('should display all the links', () => {
@@ -232,7 +238,7 @@ describe('Show the prototype links', () => {
       mockGetProductsByGatewayAccountEndpoint(GATEWAY_ACCOUNT_ID).reply(200, [PAYMENT_1, PAYMENT_3])
 
       supertest(app)
-        .get(paths.prototyping.demoService.links)
+        .get(formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))
         .set('Accept', 'application/json')
         .end((err, res) => {
           response = res
@@ -267,7 +273,7 @@ describe('Show the prototype links', () => {
       mockGetProductsByGatewayAccountEndpoint(GATEWAY_ACCOUNT_ID).replyWithError('an error')
 
       supertest(app)
-        .get(paths.prototyping.demoService.links)
+        .get(formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))
         .set('Accept', 'application/json')
         .end((err, res) => {
           response = res

--- a/test/unit/controller/test-with-your-users-controller/submit.controller.ft.test.js
+++ b/test/unit/controller/test-with-your-users-controller/submit.controller.ft.test.js
@@ -12,8 +12,10 @@ const paths = require('../../../../app/paths')
 const { randomUuid } = require('../../../../app/utils/random')
 const { validCreateProductRequest, validProductResponse } = require('../../../fixtures/product.fixtures')
 const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
+const formatAccountPathsFor = require('../../../../app/utils/format-account-paths-for')
 
 const { PUBLIC_AUTH_URL, PRODUCTS_URL, CONNECTOR_URL } = process.env
+const EXTERNAL_GATEWAY_ACCOUNT_ID = 'an-external-id'
 const GATEWAY_ACCOUNT_ID = '929'
 const API_TOKEN = randomUuid()
 const VALID_USER = getUser({ gateway_account_ids: [GATEWAY_ACCOUNT_ID], permissions: [{ name: 'transactions:read' }] })
@@ -40,9 +42,15 @@ const VALID_CREATE_PRODUCT_REQUEST = validCreateProductRequest({
 })
 const VALID_CREATE_PRODUCT_RESPONSE = validProductResponse(VALID_CREATE_PRODUCT_REQUEST)
 
-function mockConnectorGetGatewayAccount () {
-  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200,
-    validGatewayAccountResponse({ gateway_account_id: GATEWAY_ACCOUNT_ID }))
+function mockConnectorGetAccount (opts = {}) {
+  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+    .reply(200, validGatewayAccountResponse(
+      {
+        external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,
+        gateway_account_id: GATEWAY_ACCOUNT_ID,
+        payment_provider: opts.payment_provider || 'sandbox'
+      }
+    ))
 }
 
 describe('test with your users - submit controller', () => {
@@ -50,11 +58,9 @@ describe('test with your users - submit controller', () => {
     let session, response, $
     before(done => {
       session = getMockSession(VALID_USER)
-      nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`).reply(200, {
-        payment_provider: 'worldpay'
-      })
+      mockConnectorGetAccount({ payment_provider: 'worldpay' })
       supertest(createAppWithSession(getApp(), session))
-        .post(paths.prototyping.demoService.confirm)
+        .post(formatAccountPathsFor(paths.account.prototyping.demoService.confirm, EXTERNAL_GATEWAY_ACCOUNT_ID))
         .send(VALID_PAYLOAD)
         .end((err, res) => {
           response = res
@@ -86,11 +92,11 @@ describe('test with your users - submit controller', () => {
         session = getMockSession(VALID_USER)
         nock(PUBLIC_AUTH_URL).post('', VALID_CREATE_TOKEN_REQUEST)
           .reply(201, { token: API_TOKEN })
-        mockConnectorGetGatewayAccount()
+        mockConnectorGetAccount()
         nock(PRODUCTS_URL).post('/v1/api/products', VALID_CREATE_PRODUCT_REQUEST)
           .reply(201, VALID_CREATE_PRODUCT_RESPONSE)
         supertest(createAppWithSession(getApp(), session))
-          .post(paths.prototyping.demoService.confirm)
+          .post(formatAccountPathsFor(paths.account.prototyping.demoService.confirm, EXTERNAL_GATEWAY_ACCOUNT_ID))
           .send(VALID_PAYLOAD)
           .end((err, res) => {
             response = res
@@ -114,8 +120,8 @@ describe('test with your users - submit controller', () => {
       })
 
       it('should have a back link and a button that link back to the links page', () => {
-        expect($('.govuk-back-link').attr('href')).to.equal(paths.prototyping.demoService.links)
-        expect($('#see-prototype-links').attr('href')).to.equal(paths.prototyping.demoService.links)
+        expect($('.govuk-back-link').attr('href')).to.equal(formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))
+        expect($('#see-prototype-links').attr('href')).to.equal(formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))
       })
     })
     describe('but it is unable to create an API token', () => {
@@ -124,9 +130,9 @@ describe('test with your users - submit controller', () => {
         session = getMockSession(VALID_USER)
         nock(PUBLIC_AUTH_URL).post('', VALID_CREATE_TOKEN_REQUEST)
           .replyWithError('Somet nasty happened')
-        mockConnectorGetGatewayAccount()
+        mockConnectorGetAccount()
         supertest(createAppWithSession(getApp(), session))
-          .post(paths.prototyping.demoService.confirm)
+          .post(formatAccountPathsFor(paths.account.prototyping.demoService.confirm, EXTERNAL_GATEWAY_ACCOUNT_ID))
           .send(VALID_PAYLOAD)
           .end((err, res) => {
             response = res
@@ -142,7 +148,7 @@ describe('test with your users - submit controller', () => {
       })
 
       it('should redirect to the create prototype link page', () => {
-        expect(response.header).to.have.property('location').to.equal(paths.prototyping.demoService.create)
+        expect(response.header).to.have.property('location').to.equal(formatAccountPathsFor(paths.account.prototyping.demoService.create, EXTERNAL_GATEWAY_ACCOUNT_ID))
       })
 
       it('should add a relevant error message to the session \'flash\'', () => {
@@ -157,11 +163,11 @@ describe('test with your users - submit controller', () => {
         session = getMockSession(VALID_USER)
         nock(PUBLIC_AUTH_URL).post('', VALID_CREATE_TOKEN_REQUEST)
           .reply(201, { token: API_TOKEN })
-        mockConnectorGetGatewayAccount()
+        mockConnectorGetAccount()
         nock(PRODUCTS_URL).post('/v1/api/products', VALID_CREATE_PRODUCT_REQUEST)
           .replyWithError('Somet went wrong')
         supertest(createAppWithSession(getApp(), session))
-          .post(paths.prototyping.demoService.confirm)
+          .post(formatAccountPathsFor(paths.account.prototyping.demoService.confirm, EXTERNAL_GATEWAY_ACCOUNT_ID))
           .send(VALID_PAYLOAD)
           .end((err, res) => {
             response = res
@@ -176,7 +182,7 @@ describe('test with your users - submit controller', () => {
       })
 
       it('should redirect to the create prototype link page', () => {
-        expect(response.header).to.have.property('location').to.equal(paths.prototyping.demoService.create)
+        expect(response.header).to.have.property('location').to.equal(formatAccountPathsFor(paths.account.prototyping.demoService.create, EXTERNAL_GATEWAY_ACCOUNT_ID))
       })
 
       it('should add a relevant error message to the session \'flash\'', () => {
@@ -191,14 +197,14 @@ describe('test with your users - submit controller', () => {
       describe('because the value includes text', () => {
         let result, session, app
         before('Arrange', () => {
-          mockConnectorGetGatewayAccount()
+          mockConnectorGetAccount()
           session = getMockSession(VALID_USER)
           app = createAppWithSession(getApp(), session)
         })
 
         before('Act', done => {
           supertest(app)
-            .post(paths.prototyping.demoService.confirm)
+            .post(formatAccountPathsFor(paths.account.prototyping.demoService.confirm, EXTERNAL_GATEWAY_ACCOUNT_ID))
             .send(Object.assign({}, VALID_PAYLOAD, {
               'payment-amount': 'One Hundred and Eighty Pounds and No Pence'
             }))
@@ -216,7 +222,7 @@ describe('test with your users - submit controller', () => {
           expect(result.statusCode).to.equal(302)
         })
         it('should redirect to the create prototype link page', () => {
-          expect(result.header).to.have.property('location').to.equal(paths.prototyping.demoService.create)
+          expect(result.header).to.have.property('location').to.equal(formatAccountPathsFor(paths.account.prototyping.demoService.create, EXTERNAL_GATEWAY_ACCOUNT_ID))
         })
         it('should add a relevant error message to the session \'flash\'', () => {
           expect(session.flash).to.have.property('genericError')
@@ -227,14 +233,14 @@ describe('test with your users - submit controller', () => {
       describe('because the value has too many digits to the right of the decimal point', () => {
         let result, session, app
         before('Arrange', () => {
-          mockConnectorGetGatewayAccount()
+          mockConnectorGetAccount()
           session = getMockSession(VALID_USER)
           app = createAppWithSession(getApp(), session)
         })
 
         before('Act', done => {
           supertest(app)
-            .post(paths.prototyping.demoService.confirm)
+            .post(formatAccountPathsFor(paths.account.prototyping.demoService.confirm, EXTERNAL_GATEWAY_ACCOUNT_ID))
             .send(Object.assign({}, VALID_PAYLOAD, {
               'payment-amount': '£1234.567'
             }))
@@ -252,7 +258,7 @@ describe('test with your users - submit controller', () => {
           expect(result.statusCode).to.equal(302)
         })
         it('should redirect to the create prototype link page', () => {
-          expect(result.header).to.have.property('location').to.equal(paths.prototyping.demoService.create)
+          expect(result.header).to.have.property('location').to.equal(formatAccountPathsFor(paths.account.prototyping.demoService.create, EXTERNAL_GATEWAY_ACCOUNT_ID))
         })
         it('should add a relevant error message to the session \'flash\'', () => {
           expect(session.flash).to.have.property('genericError')
@@ -263,14 +269,14 @@ describe('test with your users - submit controller', () => {
       describe('because the value exceeds 100,000', () => {
         let result, session, app
         before('Arrange', () => {
-          mockConnectorGetGatewayAccount()
+          mockConnectorGetAccount()
           session = getMockSession(VALID_USER)
           app = createAppWithSession(getApp(), session)
         })
 
         before('Act', done => {
           supertest(app)
-            .post(paths.prototyping.demoService.confirm)
+            .post(formatAccountPathsFor(paths.account.prototyping.demoService.confirm, EXTERNAL_GATEWAY_ACCOUNT_ID))
             .send(Object.assign({}, VALID_PAYLOAD, {
               'payment-amount': '10000000.01'
             }))
@@ -288,7 +294,7 @@ describe('test with your users - submit controller', () => {
           expect(result.statusCode).to.equal(302)
         })
         it('should redirect to the create prototype link page', () => {
-          expect(result.header).to.have.property('location').to.equal(paths.prototyping.demoService.create)
+          expect(result.header).to.have.property('location').to.equal(formatAccountPathsFor(paths.account.prototyping.demoService.create, EXTERNAL_GATEWAY_ACCOUNT_ID))
         })
         it('should add a relevant error message to the session \'flash\'', () => {
           expect(session.flash).to.have.property('genericError')
@@ -302,12 +308,9 @@ describe('test with your users - submit controller', () => {
       before(done => {
         session = getMockSession(VALID_USER)
         const app = createAppWithSession(getApp(), session)
-        nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
-          .reply(200, {
-            payment_provider: 'sandbox'
-          })
+        mockConnectorGetAccount()
         supertest(app)
-          .post(paths.prototyping.demoService.confirm)
+          .post(formatAccountPathsFor(paths.account.prototyping.demoService.confirm, EXTERNAL_GATEWAY_ACCOUNT_ID))
           .send(Object.assign({}, VALID_PAYLOAD, { 'confirmation-page': 'http://example.com' }))
           .end((err, res) => {
             response = res
@@ -320,7 +323,7 @@ describe('test with your users - submit controller', () => {
       })
 
       it('should redirect to the create prototype link page', () => {
-        expect(response.header).to.have.property('location').to.equal(paths.prototyping.demoService.create)
+        expect(response.header).to.have.property('location').to.equal(formatAccountPathsFor(paths.account.prototyping.demoService.create, EXTERNAL_GATEWAY_ACCOUNT_ID))
       })
 
       it('should add a relevant error message to the session \'flash\'', () => {
@@ -336,9 +339,9 @@ describe('test with your users - submit controller', () => {
         const app = createAppWithSession(getApp(), session)
         const payload = Object.assign({}, VALID_PAYLOAD)
         delete payload['payment-description']
-        mockConnectorGetGatewayAccount()
+        mockConnectorGetAccount()
         supertest(app)
-          .post(paths.prototyping.demoService.confirm)
+          .post(formatAccountPathsFor(paths.account.prototyping.demoService.confirm, EXTERNAL_GATEWAY_ACCOUNT_ID))
           .send(payload)
           .end((err, res) => {
             response = res
@@ -354,7 +357,7 @@ describe('test with your users - submit controller', () => {
       })
 
       it('should redirect to the create prototype link page', () => {
-        expect(response.header).to.have.property('location').to.equal(paths.prototyping.demoService.create)
+        expect(response.header).to.have.property('location').to.equal(formatAccountPathsFor(paths.account.prototyping.demoService.create, EXTERNAL_GATEWAY_ACCOUNT_ID))
       })
 
       it('should add a relevant error message to the session \'flash\'', () => {


### PR DESCRIPTION
with @SandorArpa 

- Update all 'make a demo payment' and  'prototype' link references to use the new
  URL structure
  - Update the 'paths.js' and 'routes.js' to use the new URL structure and middleware.
  - Use new `/account/<an-external-id>` format.
  - Update all references in template 'njk' files
  - Update all controllers
  - Update functional tests.


