### PR TITLE
PP-7656 Use /v1/frontend/accounts/external-id endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-01-18T10:18:13Z",
+  "generated_at": "2021-01-18T18:52:02Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -182,15 +182,6 @@
         "is_verified": false,
         "line_number": 9,
         "type": "Secret Keyword"
-      }
-    ],
-    "test/fixtures/gateway-account.fixtures.js": [
-      {
-        "hashed_secret": "cca5ec6518072e9005bd723123ec52b8e978a448",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 10,
-        "type": "Hex High Entropy String"
       }
     ],
     "test/fixtures/invite.fixtures.js": [

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -9,7 +9,6 @@ const StripeAccount = require('../../models/StripeAccount.class')
 const SERVICE_NAME = 'connector'
 const ACCOUNTS_API_PATH = '/v1/api/accounts'
 const ACCOUNT_API_PATH = ACCOUNTS_API_PATH + '/{accountId}'
-const ACCOUNT_API_BY_EXTERNAL_ID_PATH = ACCOUNTS_API_PATH + '/external-id/{externalId}'
 const CHARGES_API_PATH = ACCOUNT_API_PATH + '/charges'
 const CHARGE_API_PATH = CHARGES_API_PATH + '/{chargeId}'
 const CHARGE_REFUNDS_API_PATH = CHARGE_API_PATH + '/refunds'
@@ -19,6 +18,7 @@ const STRIPE_ACCOUNT_PATH = ACCOUNT_API_PATH + '/stripe-account'
 
 const ACCOUNTS_FRONTEND_PATH = '/v1/frontend/accounts'
 const ACCOUNT_FRONTEND_PATH = ACCOUNTS_FRONTEND_PATH + '/{accountId}'
+const ACCOUNT_BY_EXTERNAL_ID_PATH = ACCOUNTS_FRONTEND_PATH + '/external-id/{externalId}'
 const SERVICE_NAME_FRONTEND_PATH = ACCOUNT_FRONTEND_PATH + '/servicename'
 const ACCEPTED_CARD_TYPES_FRONTEND_PATH = ACCOUNT_FRONTEND_PATH + '/card-types'
 const ACCOUNT_NOTIFICATION_CREDENTIALS_PATH = '/v1/api/accounts' + '/{accountId}' + '/notification-credentials'
@@ -43,7 +43,7 @@ function _accountUrlFor (gatewayAccountId, url) {
 
 /** @private */
 function _accountByExternalIdUrlFor (gatewayAccountExternalId, url) {
-  return url + ACCOUNT_API_BY_EXTERNAL_ID_PATH.replace('{externalId}', gatewayAccountExternalId)
+  return url + ACCOUNT_BY_EXTERNAL_ID_PATH.replace('{externalId}', gatewayAccountExternalId)
 }
 
 /** @private */

--- a/test/cypress/integration/settings/your-psp.cy.test.js
+++ b/test/cypress/integration/settings/your-psp.cy.test.js
@@ -15,7 +15,7 @@ describe('Your PSP settings page', () => {
   }
   const testNotificationCredentials = {
     version: 1,
-    userName: 'someone',
+    username: 'someone',
     password: 'email-me'
   }
   const testFlexCredentials = {
@@ -393,7 +393,7 @@ describe('Your PSP settings page', () => {
       cy.get('.value-merchant-id').should('contain', testCredentials.merchant_id)
       cy.get('.value-username').should('contain', testCredentials.username)
       cy.get('.value-password').should('contain', '●●●●●●●●')
-      cy.get('.value-notification-username').should('contain', testNotificationCredentials.userName)
+      cy.get('.value-notification-username').should('contain', testNotificationCredentials.username)
       cy.get('.value-notification-password').should('contain', '●●●●●●●●')
     })
   })

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -68,7 +68,7 @@ function getGatewayAccountSuccess (opts) {
 
 function getGatewayAccountByExternalIdSuccess (opts) {
   const fixtureOpts = parseGatewayAccountOptions(opts)
-  const path = `/v1/api/accounts/external-id/${opts.gatewayAccountExternalId}`
+  const path = `/v1/frontend/accounts/external-id/${opts.gatewayAccountExternalId}`
   return stubBuilder('GET', path, 200, {
     response: gatewayAccountFixtures.validGatewayAccountResponse(fixtureOpts)
   })

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -1,5 +1,34 @@
 'use strict'
 
+function validCredentials (opts = {}) {
+  const credentials = {
+    merchant_id: opts.merchant_id || 'merchant-id',
+    username: opts.username || 'username'
+  }
+
+  if (opts.sha_in_passphrase) {
+    credentials.sha_in_passphrase = opts.sha_in_passphrase
+  }
+  if (opts.sha_out_passphrase) {
+    credentials.sha_out_passphrase = opts.sha_out_passphrase
+  }
+  return credentials
+}
+
+function validNotificationCredentials (opts = {}) {
+  return {
+    userName: opts.username || 'username',
+  }
+}
+
+function validWorldpay3dsFlexCredentials (opts = {}) {
+  return {
+    organisational_unit_id: opts.organisational_unit_id || '5bd9b55e4444761ac0af1c80',
+    issuer: opts.issuer || '5bd9e0e4444dce153428c940', // pragma: allowlist secret
+    exemption_engine_enabled: opts.exemption_engine_enabled || false
+  }
+}
+
 function validGatewayAccount (opts) {
   const gatewayAccount = {
     payment_provider: opts.payment_provider || 'sandbox',
@@ -7,9 +36,8 @@ function validGatewayAccount (opts) {
     external_id: opts.external_id || 'a-valid-external-id',
     allow_apple_pay: opts.allow_apple_pay || false,
     allow_google_pay: opts.allow_google_pay || false,
-    service_name: opts.service_name || '8b9370c1a83c4d71a538a1691236acc2',
+    service_name: opts.service_name || 'A fabulous service',
     type: opts.type || 'test',
-    analytics_id: opts.analytics_id || '8b02c7e542e74423aa9e6d0f0628fd58',
     email_collection_mode: opts.email_collection_mode || 'MANDATORY',
     email_notifications: opts.email_notifications || {
       PAYMENT_CONFIRMED: {
@@ -24,7 +52,9 @@ function validGatewayAccount (opts) {
     },
     allow_moto: opts.allow_moto || false,
     moto_mask_card_number_input: opts.moto_mask_card_number_input || false,
-    moto_mask_card_security_code_input: opts.moto_mask_card_security_code_input || false
+    moto_mask_card_security_code_input: opts.moto_mask_card_security_code_input || false,
+    requires3ds: opts.requires3ds || false,
+    integration_version_3ds: opts.integrationVersion3ds || 1
   }
 
   if (opts.description) {
@@ -33,101 +63,109 @@ function validGatewayAccount (opts) {
   if (opts.analytics_id) {
     gatewayAccount.analytics_id = opts.analytics_id
   }
-  if (opts.toggle_3ds) {
-    gatewayAccount.toggle_3ds = opts.toggle_3ds
-  }
-  if (opts.requires3ds) {
-    gatewayAccount.requires3ds = opts.requires3ds
-  }
-  if (opts.requires3ds) {
-    gatewayAccount.integration_version_3ds = opts.integrationVersion3ds
-  }
   if (opts.credentials) {
-    gatewayAccount.credentials = opts.credentials
+    gatewayAccount.credentials = validCredentials(opts.credentials)
   }
-
   if (opts.notificationCredentials) {
-    gatewayAccount.notificationCredentials = opts.notificationCredentials
+    gatewayAccount.notificationCredentials = validNotificationCredentials(opts.notificationCredentials)
   }
-
   if (opts.worldpay_3ds_flex) {
-    gatewayAccount.worldpay_3ds_flex = opts.worldpay_3ds_flex
+    gatewayAccount.worldpay_3ds_flex = validWorldpay3dsFlexCredentials(opts.worldpay_3ds_flex)
   }
 
   return gatewayAccount
 }
 
-module.exports = {
-  validGatewayAccountPatchRequest: (opts = {}) => {
-    return {
-      op: 'replace',
-      path: opts.path,
-      value: opts.value
-    }
-  },
-  validGatewayAccountEmailRefundToggleRequest: (enabled = true) => {
-    return {
-      op: 'replace',
-      path: '/refund/enabled',
-      value: enabled
-    }
-  },
-  validGatewayAccountEmailConfirmationToggleRequest: (enabled = true) => {
-    return {
-      op: 'replace',
-      path: '/confirmation/enabled',
-      value: enabled
-    }
-  },
-  validGatewayAccountEmailCollectionModeRequest: (collectionMode = 'MANDATORY') => {
-    return {
-      op: 'replace',
-      path: 'email_collection_mode',
-      value: collectionMode
-    }
-  },
-  validGatewayAccountTokensResponse: (opts = {}) => {
-    return {
-      tokens:
-        [{
-          issued_date: opts.issued_date || '03 Sep 2018 - 10:05',
-          last_used: opts.last_used || null,
-          token_link: opts.token_link || '32fa3cdd-23c8-4602-a415-b48ede66b5e4',
-          description: opts.description || 'Created from command line',
-          token_type: opts.token_type || 'CARD',
-          created_by: opts.created_by || 'System generated'
-        }]
-    }
-  },
-  validGatewayAccountResponse: (opts = {}) => {
-    return validGatewayAccount(opts)
-  },
-  validGatewayAccountsResponse: (opts = {}) => {
-    const accounts = opts.accounts.map(validGatewayAccount)
-    return {
-      accounts: accounts
-    }
-  },
-  validDirectDebitGatewayAccountResponse: (opts = {}) => {
-    return {
-      gateway_account_id: opts.gateway_account_id || 73,
-      gateway_account_external_id: opts.gateway_account_external_id || 'DIRECT_DEBIT:' + 'a9c797ab271448bdba21359e15672076',
-      payment_provider: opts.payment_provider || 'sandbox',
-      type: opts.type || 'test',
-      analytics_id: opts.analytics_id || 'd82dae5bcb024828bb686574a932b5a5',
-      is_connected: opts.is_connected || false
-    }
-  },
-  validCreateGatewayAccountRequest: (opts = {}) => {
-    const data = {
-      payment_provider: opts.payment_provider || 'sandbox',
-      service_name: opts.service_name || 'This is an account for the GOV.UK Pay team',
-      type: opts.type || 'test'
-    }
-
-    if (opts.analytics_id) {
-      data.analytics_id = opts.analytics_id
-    }
-    return data
+function validGatewayAccountPatchRequest (opts = {}) {
+  return {
+    op: 'replace',
+    path: opts.path,
+    value: opts.value
   }
+}
+
+function validGatewayAccountEmailRefundToggleRequest (enabled = true) {
+  return {
+    op: 'replace',
+    path: '/refund/enabled',
+    value: enabled
+  }
+}
+
+function validGatewayAccountEmailConfirmationToggleRequest (enabled = true) {
+  return {
+    op: 'replace',
+    path: '/confirmation/enabled',
+    value: enabled
+  }
+}
+
+function validGatewayAccountEmailCollectionModeRequest (collectionMode = 'MANDATORY') {
+  return {
+    op: 'replace',
+    path: 'email_collection_mode',
+    value: collectionMode
+  }
+}
+
+function validGatewayAccountTokensResponse (opts = {}) {
+  return {
+    tokens:
+      [{
+        issued_date: opts.issued_date || '03 Sep 2018 - 10:05',
+        last_used: opts.last_used || null,
+        token_link: opts.token_link || '32fa3cdd-23c8-4602-a415-b48ede66b5e4',
+        description: opts.description || 'Created from command line',
+        token_type: opts.token_type || 'CARD',
+        created_by: opts.created_by || 'System generated'
+      }]
+  }
+}
+
+function validGatewayAccountResponse (opts = {}) {
+  return validGatewayAccount(opts)
+}
+
+function validGatewayAccountsResponse (opts = {}) {
+  const accounts = opts.accounts.map(validGatewayAccount)
+  return {
+    accounts: accounts
+  }
+}
+
+function validDirectDebitGatewayAccountResponse (opts = {}) {
+  return {
+    gateway_account_id: opts.gateway_account_id || 73,
+    gateway_account_external_id: opts.gateway_account_external_id || 'DIRECT_DEBIT:' + 'a9c797ab271448bdba21359e15672076',
+    payment_provider: opts.payment_provider || 'sandbox',
+    type: opts.type || 'test',
+    analytics_id: opts.analytics_id || 'd82dae5bcb024828bb686574a932b5a5',
+    is_connected: opts.is_connected || false
+  }
+}
+
+function validCreateGatewayAccountRequest (opts = {}) {
+  const data = {
+    payment_provider: opts.payment_provider || 'sandbox',
+    service_name: opts.service_name || 'This is an account for the GOV.UK Pay team',
+    type: opts.type || 'test'
+  }
+
+  if (opts.analytics_id) {
+    data.analytics_id = opts.analytics_id
+  }
+  return data
+}
+
+
+module.exports = {
+  validGatewayAccountPatchRequest,
+  validGatewayAccountEmailRefundToggleRequest,
+  validGatewayAccountEmailConfirmationToggleRequest,
+  validGatewayAccountEmailCollectionModeRequest,
+  validGatewayAccountTokensResponse,
+  validGatewayAccountResponse,
+  validGatewayAccountsResponse,
+  validDirectDebitGatewayAccountResponse,
+  validCreateGatewayAccountRequest
 }

--- a/test/integration/credentials.ft.test.js
+++ b/test/integration/credentials.ft.test.js
@@ -369,13 +369,13 @@ describe('Credentials endpoints', () => {
             'username': 'a-username',
             'merchant_id': 'a-merchant-id'
           },
-          'notification_credentials': { username: 'a-notification-username' }
+          'notificationCredentials': { username: 'a-notification-username' }
         })
 
       buildGetRequest(paths.notificationCredentials.index, app)
         .expect(200)
         .expect(response => {
-          expect(response.body.currentGatewayAccount.notification_credentials).to.deep.equal({ username: 'a-notification-username' })
+          expect(response.body.currentGatewayAccount.notificationCredentials).to.deep.equal({ username: 'a-notification-username' })
         })
         .end(done)
     })

--- a/test/integration/payment-types/payment-types.it.test.js
+++ b/test/integration/payment-types/payment-types.it.test.js
@@ -19,7 +19,7 @@ const gatewayAccountId = '15486734'
 const gatewayAccountExternalId = 'account-external-id'
 const connectorMock = nock(process.env.CONNECTOR_URL)
 const CONNECTOR_ACCOUNT_CARD_TYPES_PATH = `/v1/frontend/accounts/${gatewayAccountId}/card-types`
-const CONNECTOR_ACCOUNT_BY_EXTERNAL_ID = `/v1/api/accounts/external-id/${gatewayAccountExternalId}`
+const CONNECTOR_ACCOUNT_BY_EXTERNAL_ID = `/v1/frontend/accounts/external-id/${gatewayAccountExternalId}`
 
 let app
 

--- a/test/unit/clients/connector-client/connector-get-gateway-account-by-external-id.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-gateway-account-by-external-id.pact.test.js
@@ -1,0 +1,149 @@
+'use strict'
+
+const { Pact } = require('@pact-foundation/pact')
+const chai = require('chai')
+
+const path = require('path')
+const PactInteractionBuilder = require('../../../test-helpers/pact/pact-interaction-builder').PactInteractionBuilder
+const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient
+const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
+const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPactifier
+
+// Constants
+const port = Math.floor(Math.random() * 48127) + 1024
+const connectorClient = new Connector(`http://localhost:${port}`)
+const expect = chai.expect
+
+const gatewayAccountExternalId = 'abc123'
+
+describe('connector client - get gateway account by external id', function () {
+  const provider = new Pact({
+    consumer: 'selfservice',
+    provider: 'connector',
+    port: port,
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(() => provider.setup())
+  after(() => provider.finalize())
+
+  describe('get Smartpay account with credentials - success', () => {
+    const validGetGatewayAccountResponse = gatewayAccountFixtures.validGatewayAccountResponse({
+      external_id: gatewayAccountExternalId,
+      payment_provider: 'smartpay',
+      description: 'A description',
+      analytics_id: 'an-analytics-id',
+      credentials: {
+        merchant_id: 'merchant-id',
+        username: 'username'
+      },
+      notificationCredentials: {
+        username: 'username'
+      }
+    })
+
+    before(() => {
+      return provider.addInteraction(
+        new PactInteractionBuilder(`/v1/frontend/accounts/external-id/${gatewayAccountExternalId}`)
+          .withUponReceiving('a valid get Smartpay gateway account by external id request')
+          .withState('a Smartpay gateway account with id 333 and external abc123 with credentials exists')
+          .withMethod('GET')
+          .withResponseBody(pactify(validGetGatewayAccountResponse))
+          .withStatusCode(200)
+          .build()
+      )
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should get gateway account successfully', async () => {
+      const params = {
+        gatewayAccountExternalId: gatewayAccountExternalId,
+        correlationId: null
+      }
+      const response = await connectorClient.getAccountByExternalId(params)
+      expect(response).to.deep.equal(validGetGatewayAccountResponse)
+    })
+  })
+
+  describe('get Worldpay account with credentials - success', () => {
+    const validGetGatewayAccountResponse = gatewayAccountFixtures.validGatewayAccountResponse({
+      external_id: gatewayAccountExternalId,
+      payment_provider: 'worldpay',
+      description: 'A description',
+      analytics_id: 'an-analytics-id',
+      credentials: {
+        merchant_id: 'merchant-id',
+        username: 'username'
+      },
+      worldpay_3ds_flex: {
+        organisational_unit_id: 'an-org-id',
+        issuer: 'an-issues'
+      }
+    })
+
+    before(() => {
+      return provider.addInteraction(
+        new PactInteractionBuilder(`/v1/frontend/accounts/external-id/${gatewayAccountExternalId}`)
+          .withUponReceiving('a valid get Worldpay gateway account by external id request')
+          .withState('a gateway account 333 with Worldpay 3DS Flex credentials exists')
+          .withMethod('GET')
+          .withResponseBody(pactify(validGetGatewayAccountResponse))
+          .withStatusCode(200)
+          .build()
+      )
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should get gateway account successfully', async () => {
+      const params = {
+        gatewayAccountExternalId: gatewayAccountExternalId,
+        correlationId: null
+      }
+      const response = await connectorClient.getAccountByExternalId(params)
+      expect(response).to.deep.equal(validGetGatewayAccountResponse)
+    })
+  })
+
+  describe('get ePDQ account with credentials - success', () => {
+    const validGetGatewayAccountResponse = gatewayAccountFixtures.validGatewayAccountResponse({
+      external_id: gatewayAccountExternalId,
+      payment_provider: 'worldpay',
+      description: 'A description',
+      analytics_id: 'an-analytics-id',
+      credentials: {
+        merchant_id: 'merchant-id',
+        username: 'username',
+        sha_in_passphrase: 'sha-in',
+        sha_out_passphrase: 'sha-out'
+      }
+    })
+
+    before(() => {
+      return provider.addInteraction(
+        new PactInteractionBuilder(`/v1/frontend/accounts/external-id/${gatewayAccountExternalId}`)
+          .withUponReceiving('a valid get ePDQ gateway account by external id request')
+          .withState('an ePDQ gateway account with id 333 and external abc123 with credentials exists')
+          .withMethod('GET')
+          .withResponseBody(pactify(validGetGatewayAccountResponse))
+          .withStatusCode(200)
+          .build()
+      )
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should get gateway account successfully', async () => {
+      const params = {
+        gatewayAccountExternalId: gatewayAccountExternalId,
+        correlationId: null
+      }
+      const response = await connectorClient.getAccountByExternalId(params)
+      expect(response).to.deep.equal(validGetGatewayAccountResponse)
+    })
+  })
+})

--- a/test/unit/controller/api-keys/get-index.controller.ft.test.js
+++ b/test/unit/controller/api-keys/get-index.controller.ft.test.js
@@ -143,7 +143,7 @@ describe('API keys index', () => {
 })
 
 function mockConnectorGetAccount () {
-  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
     .reply(200, gatewayAccountFixtures.validGatewayAccountResponse(
       {
         external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,

--- a/test/unit/controller/api-keys/get-revoked.controller.ft.test.js
+++ b/test/unit/controller/api-keys/get-revoked.controller.ft.test.js
@@ -43,7 +43,7 @@ const mockGetRevokedAPIKeys = gatewayAccountId => {
 }
 
 function mockConnectorGetAccount () {
-  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
     .reply(200, gatewayAccountFixtures.validGatewayAccountResponse(
       {
         external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,

--- a/test/unit/controller/api-keys/post-create.controller.ft.test.js
+++ b/test/unit/controller/api-keys/post-create.controller.ft.test.js
@@ -28,7 +28,7 @@ const EXTERNAL_GATEWAY_ACCOUNT_ID = 'an-external-id'
 const apiKeyCreatePath = formatAccountPathsFor(paths.account.apiKeys.create, EXTERNAL_GATEWAY_ACCOUNT_ID)
 
 function mockConnectorGetAccount (type) {
-  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
     .reply(200, validGatewayAccountResponse(
       {
         external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,

--- a/test/unit/controller/api-keys/post-revoke.controller.ft.test.js
+++ b/test/unit/controller/api-keys/post-revoke.controller.ft.test.js
@@ -45,7 +45,7 @@ describe('POST to revoke an API key', () => {
     )
       .reply(200, TOKEN_RESPONSE)
 
-    nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+    nock(CONNECTOR_URL).get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
       .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: GATEWAY_ACCOUNT_ID }))
 
     supertest(app)

--- a/test/unit/controller/api-keys/post-update.controller.ft.test.js
+++ b/test/unit/controller/api-keys/post-update.controller.ft.test.js
@@ -48,7 +48,7 @@ describe('POST to update an API key description', () => {
     )
       .reply(200, TOKEN_RESPONSE)
 
-    nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+    nock(CONNECTOR_URL).get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
       .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: GATEWAY_ACCOUNT_ID }))
 
     supertest(app)

--- a/test/unit/controller/billing-address-controller/toggle-billing-address.controller.ft.test.js
+++ b/test/unit/controller/billing-address-controller/toggle-billing-address.controller.ft.test.js
@@ -45,7 +45,7 @@ describe('Toggle billing address collection controller', () => {
   describe('should get index with billing address on', () => {
     before(done => {
       user = buildUserWithCollectBillingAddress(true)
-      connectorMock.get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+      connectorMock.get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
         .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }))
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user)
@@ -69,7 +69,7 @@ describe('Toggle billing address collection controller', () => {
   describe('should get index with billing address off', () => {
     before(done => {
       user = buildUserWithCollectBillingAddress(false)
-      connectorMock.get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+      connectorMock.get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
         .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }))
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user)
@@ -93,7 +93,7 @@ describe('Toggle billing address collection controller', () => {
   describe('should redirect to index on enable billing address', () => {
     before(done => {
       user = buildUserWithCollectBillingAddress(true)
-      connectorMock.get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+      connectorMock.get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
         .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }))
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user)
@@ -127,7 +127,7 @@ describe('Toggle billing address collection controller', () => {
   describe('should redirect to index on disable billing address', () => {
     before(done => {
       user = buildUserWithCollectBillingAddress(false)
-      connectorMock.get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+      connectorMock.get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
         .reply(200, validGatewayAccountResponse({ external_id: EXTERNAL_GATEWAY_ACCOUNT_ID, gateway_account_id: '666' }))
       adminusersMock.get(`${USER_RESOURCE}/${EXTERNAL_ID_IN_SESSION}`)
         .reply(200, user)

--- a/test/unit/controller/make-a-demo-payment-controller/edit.controller.ft.test.js
+++ b/test/unit/controller/make-a-demo-payment-controller/edit.controller.ft.test.js
@@ -22,7 +22,7 @@ const VALID_USER = getUser({
 })
 
 function mockConnectorGetAccount () {
-  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
     .reply(200, validGatewayAccountResponse(
       {
         external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,

--- a/test/unit/controller/make-a-demo-payment-controller/go-to-payment.controller.ft.test.js
+++ b/test/unit/controller/make-a-demo-payment-controller/go-to-payment.controller.ft.test.js
@@ -45,7 +45,7 @@ const VALID_CREATE_PRODUCT_REQUEST = validCreateProductRequest({
 const VALID_CREATE_PRODUCT_RESPONSE = validProductResponse(VALID_CREATE_PRODUCT_REQUEST)
 
 function mockConnectorGetAccount () {
-  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
     .reply(200, validGatewayAccountResponse(
       {
         external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,

--- a/test/unit/controller/make-a-demo-payment-controller/index.controller.ft.test.js
+++ b/test/unit/controller/make-a-demo-payment-controller/index.controller.ft.test.js
@@ -23,7 +23,7 @@ const VALID_USER = getUser({
 })
 
 function mockConnectorGetAccount () {
-  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
     .reply(200, validGatewayAccountResponse(
       {
         external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,

--- a/test/unit/controller/make-a-demo-payment-controller/mock-card-details.controller.ft.test.js
+++ b/test/unit/controller/make-a-demo-payment-controller/mock-card-details.controller.ft.test.js
@@ -17,7 +17,7 @@ const GATEWAY_ACCOUNT_ID = '929'
 const EXTERNAL_GATEWAY_ACCOUNT_ID = 'an-external-id'
 
 function mockConnectorGetAccount () {
-  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
     .reply(200, validGatewayAccountResponse(
       {
         external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,

--- a/test/unit/controller/test-with-your-users-controller/create.controller.ft.test.js
+++ b/test/unit/controller/test-with-your-users-controller/create.controller.ft.test.js
@@ -18,7 +18,7 @@ const GATEWAY_ACCOUNT_ID = '929'
 const EXTERNAL_GATEWAY_ACCOUNT_ID = 'an-external-id'
 
 function mockConnectorGetAccount () {
-  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
     .reply(200, validGatewayAccountResponse(
       {
         external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,

--- a/test/unit/controller/test-with-your-users-controller/disable.controller.ft.test.js
+++ b/test/unit/controller/test-with-your-users-controller/disable.controller.ft.test.js
@@ -17,7 +17,7 @@ const { PRODUCTS_URL, CONNECTOR_URL } = process.env
 const formatAccountPathsFor = require('../../../../app/utils/format-account-paths-for')
 
 function mockConnectorGetAccount () {
-  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
     .reply(200, validGatewayAccountResponse(
       {
         external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,

--- a/test/unit/controller/test-with-your-users-controller/links.controller.ft.test.js
+++ b/test/unit/controller/test-with-your-users-controller/links.controller.ft.test.js
@@ -66,7 +66,7 @@ function mockGetProductsByGatewayAccountEndpoint (gatewayAccountId) {
 }
 
 function mockConnectorGetAccount () {
-  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
     .reply(200, validGatewayAccountResponse(
       {
         external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,

--- a/test/unit/controller/test-with-your-users-controller/submit.controller.ft.test.js
+++ b/test/unit/controller/test-with-your-users-controller/submit.controller.ft.test.js
@@ -43,7 +43,7 @@ const VALID_CREATE_PRODUCT_REQUEST = validCreateProductRequest({
 const VALID_CREATE_PRODUCT_RESPONSE = validProductResponse(VALID_CREATE_PRODUCT_REQUEST)
 
 function mockConnectorGetAccount (opts = {}) {
-  nock(CONNECTOR_URL).get(`/v1/api/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
+  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
     .reply(200, validGatewayAccountResponse(
       {
         external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,


### PR DESCRIPTION
Use the `v1/frontend` version of the get gateway account by external id endpoint, which returns the gateway credentials. The `v1/api` version of the endpoint will be removed.

Add pact tests to get gateway accounts for each of the payment providers that have credentials set by the user: Worldpay, Smartpay and ePDQ to ensure connector is returning these in the format we're expecting.


## Note

Reviewing with whitespace diffs hidden is recommended as there is some indentation changes.

