### PR TITLE
PP-7583 Stripe setup account url structure

### DIFF
--- a/app/controllers/stripe-setup/add-psp-account-details/get.controller.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/get.controller.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const paths = require('../../../paths')
+const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
 const { response, renderErrorView } = require('../../../utils/response')
 
 module.exports = async (req, res) => {
@@ -9,15 +10,16 @@ module.exports = async (req, res) => {
   }
 
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
+  const accountExternalId = req.account.external_id
 
   if (!stripeAccountSetup.bankAccount) {
-    res.redirect(303, paths.stripeSetup.bankDetails)
+    res.redirect(303, formatAccountPathsFor(paths.account.stripeSetup.bankDetails, accountExternalId))
   } else if (!stripeAccountSetup.responsiblePerson) {
-    res.redirect(303, paths.stripeSetup.responsiblePerson)
+    res.redirect(303, formatAccountPathsFor(paths.account.stripeSetup.responsiblePerson, accountExternalId))
   } else if (!stripeAccountSetup.vatNumber) {
-    res.redirect(303, paths.stripeSetup.vatNumber)
+    res.redirect(303, formatAccountPathsFor(paths.account.stripeSetup.vatNumber, accountExternalId))
   } else if (!stripeAccountSetup.companyNumber) {
-    res.redirect(303, paths.stripeSetup.companyNumber)
+    res.redirect(303, formatAccountPathsFor(paths.account.stripeSetup.companyNumber, accountExternalId))
   } else {
     response(req, res, 'stripe-setup/go-live-complete')
   }

--- a/app/controllers/stripe-setup/add-psp-account-details/get.controller.test.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/get.controller.test.js
@@ -19,6 +19,7 @@ describe('get controller', () => {
     req = {
       account: {
         gateway_account_id: 'gatewayId',
+        external_id: 'a-valid-external-id',
         connectorGatewayAccountStripeProgress: {}
       },
       correlationId: 'requestId'
@@ -34,13 +35,13 @@ describe('get controller', () => {
   it('should redirect to bank account setup page', async () => {
     req.account.connectorGatewayAccountStripeProgress.bankAccount = false
     getController(req, res)
-    sinon.assert.calledWith(res.redirect, 303, paths.stripeSetup.bankDetails)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/${paths.account.stripeSetup.bankDetails}`)
   })
 
   it('should redirect to responsible person page', async () => {
     req.account.connectorGatewayAccountStripeProgress.bankAccount = true
     getController(req, res)
-    sinon.assert.calledWith(res.redirect, 303, paths.stripeSetup.responsiblePerson)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/${paths.account.stripeSetup.responsiblePerson}`)
   })
 
   it('should redirect to VAT number page', async () => {
@@ -49,7 +50,7 @@ describe('get controller', () => {
       responsiblePerson: true
     }
     getController(req, res)
-    sinon.assert.calledWith(res.redirect, 303, paths.stripeSetup.vatNumber)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/${paths.account.stripeSetup.vatNumber}`)
   })
 
   it('should redirect to company registration number page', async () => {
@@ -59,7 +60,7 @@ describe('get controller', () => {
       vatNumber: true
     }
     getController(req, res)
-    sinon.assert.calledWith(res.redirect, 303, paths.stripeSetup.companyNumber)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/${paths.account.stripeSetup.companyNumber}`)
   })
 
   it('should render go live complete page when all steps are completed', async () => {

--- a/app/controllers/stripe-setup/add-psp-account-details/get.controller.test.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/get.controller.test.js
@@ -35,13 +35,13 @@ describe('get controller', () => {
   it('should redirect to bank account setup page', async () => {
     req.account.connectorGatewayAccountStripeProgress.bankAccount = false
     getController(req, res)
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/${paths.account.stripeSetup.bankDetails}`)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripeSetup.bankDetails}`)
   })
 
   it('should redirect to responsible person page', async () => {
     req.account.connectorGatewayAccountStripeProgress.bankAccount = true
     getController(req, res)
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/${paths.account.stripeSetup.responsiblePerson}`)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripeSetup.responsiblePerson}`)
   })
 
   it('should redirect to VAT number page', async () => {
@@ -50,7 +50,7 @@ describe('get controller', () => {
       responsiblePerson: true
     }
     getController(req, res)
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/${paths.account.stripeSetup.vatNumber}`)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripeSetup.vatNumber}`)
   })
 
   it('should redirect to company registration number page', async () => {
@@ -60,7 +60,7 @@ describe('get controller', () => {
       vatNumber: true
     }
     getController(req, res)
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/${paths.account.stripeSetup.companyNumber}`)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripeSetup.companyNumber}`)
   })
 
   it('should render go live complete page when all steps are completed', async () => {

--- a/app/controllers/stripe-setup/bank-details/post.controller.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.js
@@ -9,6 +9,7 @@ const { updateBankAccount } = require('../../../services/clients/stripe/stripe.c
 const { ConnectorClient } = require('../../../services/clients/connector.client')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 const paths = require('../../../paths')
+const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
 const fieldValidationChecks = require('../../../browsered/field-validation-checks')
 
 // Constants
@@ -38,7 +39,7 @@ module.exports = (req, res) => {
       return connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'bank_account', req.correlationId)
     })
     .then(() => {
-      return res.redirect(303, paths.stripe.addPspAccountDetails)
+      return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))
     })
     .catch(error => {
       // check if it is Stripe related error

--- a/app/controllers/stripe-setup/bank-details/post.controller.test.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.test.js
@@ -19,7 +19,8 @@ describe('Bank details post controller', () => {
     req = {
       correlationId: 'correlation-id',
       account: {
-        gateway_account_id: '1'
+        gateway_account_id: '1',
+        external_id: 'a-valid-external-id'
       },
       body: {
         'account-number': rawAccountNumber,
@@ -52,7 +53,7 @@ describe('Bank details post controller', () => {
       bank_account_number: sanitisedAccountNumber
     })
     sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'bank_account', req.correlationId)
-    sinon.assert.calledWith(res.redirect, 303, paths.stripe.addPspAccountDetails)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/${paths.account.stripe.addPspAccountDetails}`)
   })
 
   it('should render error page when Stripe returns unknown error', async () => {

--- a/app/controllers/stripe-setup/bank-details/post.controller.test.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.test.js
@@ -53,7 +53,7 @@ describe('Bank details post controller', () => {
       bank_account_number: sanitisedAccountNumber
     })
     sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'bank_account', req.correlationId)
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/${paths.account.stripe.addPspAccountDetails}`)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripe.addPspAccountDetails}`)
   })
 
   it('should render error page when Stripe returns unknown error', async () => {

--- a/app/controllers/stripe-setup/company-number/post.controller.js
+++ b/app/controllers/stripe-setup/company-number/post.controller.js
@@ -9,6 +9,7 @@ const companyNumberValidations = require('./company-number-validations')
 const { ConnectorClient } = require('../../../services/clients/connector.client')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 const paths = require('../../../paths')
+const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
 
 // Constants
 const COMPANY_NUMBER_DECLARATION_FIELD = 'company-number-declaration'
@@ -34,7 +35,7 @@ module.exports = async (req, res) => {
       await updateCompany(res.locals.stripeAccount.stripeAccountId, stripeCompanyBody)
       await connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'company_number', req.correlationId)
 
-      return res.redirect(303, paths.stripe.addPspAccountDetails)
+      return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))
     } catch (error) {
       logger.error(`[${req.correlationId}] Error submitting "Company registration number" details, error = `, error)
       return renderErrorView(req, res, 'Please try again or contact support team')

--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -4,6 +4,7 @@ const lodash = require('lodash')
 const ukPostcode = require('uk-postcode')
 
 const paths = require('../../../paths')
+const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
 const logger = require('../../../utils/logger')(__filename)
 const { response, renderErrorView } = require('../../../utils/response')
 const {
@@ -110,7 +111,7 @@ module.exports = async function (req, res) {
       await updatePerson(stripeAccountId, person.id, buildStripePerson(formFields))
       await connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'responsible_person', req.correlationId)
 
-      return res.redirect(303, paths.stripe.addPspAccountDetails)
+      return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))
     } catch (error) {
       logger.error(`[requestId=${req.correlationId}] Error creating responsible person with Stripe - ${error.message}`)
       return renderErrorView(req, res, 'Please try again or contact support team')

--- a/app/controllers/stripe-setup/responsible-person/post.controller.test.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.test.js
@@ -64,7 +64,8 @@ describe('Responsible person POST controller', () => {
     req = {
       correlationId: 'correlation-id',
       account: {
-        gateway_account_id: '1'
+        gateway_account_id: '1',
+        external_id: 'a-valid-external-id'
       }
     }
     res = {
@@ -108,7 +109,7 @@ describe('Responsible person POST controller', () => {
       dob_year: dobYearNormalised
     })
     sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'responsible_person', req.correlationId)
-    sinon.assert.calledWith(res.redirect, 303, paths.stripe.addPspAccountDetails)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/${paths.account.stripe.addPspAccountDetails}`)
   })
 
   it('should call Stripe with normalised details (no second address line), then connector, then redirect to add details redirect route', async function () {
@@ -137,7 +138,7 @@ describe('Responsible person POST controller', () => {
       dob_year: dobYearNormalised
     })
     sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'responsible_person', req.correlationId)
-    sinon.assert.calledWith(res.redirect, 303, paths.stripe.addPspAccountDetails)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/${paths.account.stripe.addPspAccountDetails}`)
   })
 
   it('should render error when Stripe returns error, not call connector, and not redirect', async function () {

--- a/app/controllers/stripe-setup/responsible-person/post.controller.test.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.test.js
@@ -109,7 +109,7 @@ describe('Responsible person POST controller', () => {
       dob_year: dobYearNormalised
     })
     sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'responsible_person', req.correlationId)
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/${paths.account.stripe.addPspAccountDetails}`)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripe.addPspAccountDetails}`)
   })
 
   it('should call Stripe with normalised details (no second address line), then connector, then redirect to add details redirect route', async function () {
@@ -138,7 +138,7 @@ describe('Responsible person POST controller', () => {
       dob_year: dobYearNormalised
     })
     sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'responsible_person', req.correlationId)
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/${paths.account.stripe.addPspAccountDetails}`)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripe.addPspAccountDetails}`)
   })
 
   it('should render error when Stripe returns error, not call connector, and not redirect', async function () {

--- a/app/controllers/stripe-setup/vat-number/post.controller.js
+++ b/app/controllers/stripe-setup/vat-number/post.controller.js
@@ -9,6 +9,7 @@ const vatNumberValidations = require('./vat-number-validations')
 const { ConnectorClient } = require('../../../services/clients/connector.client')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 const paths = require('../../../paths')
+const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
 
 // Constants
 const VAT_NUMBER_FIELD = 'vat-number'
@@ -31,7 +32,7 @@ module.exports = async (req, res) => {
       await updateCompany(res.locals.stripeAccount.stripeAccountId, stripeCompanyBody)
       await connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'vat_number', req.correlationId)
 
-      return res.redirect(303, paths.stripe.addPspAccountDetails)
+      return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))
     } catch (error) {
       logger.error(`[${req.correlationId}] Error submitting "VAT number" details, error = `, error)
       return renderErrorView(req, res, 'Please try again or contact support team')

--- a/app/paths.js
+++ b/app/paths.js
@@ -94,7 +94,49 @@ module.exports = {
       index: '/your-psp',
       flex: '/your-psp/flex',
       worldpay3dsFlex: '/your-psp/worldpay-3ds-flex'
+    },
+    apiKeys: {
+      index: '/api-keys',
+      revoked: '/api-keys/revoked',
+      create: '/api-keys/create',
+      revoke: '/api-keys/revoke',
+      update: '/api-keys/update'
+    },
+    paymentLinks: {
+      start: '/create-payment-link',
+      information: '/create-payment-link/information',
+      webAddress: '/create-payment-link/web-address',
+      reference: '/create-payment-link/reference',
+      amount: '/create-payment-link/amount',
+      review: '/create-payment-link/review',
+      addMetadata: '/create-payment-link/add-reporting-column',
+      editMetadata: '/create-payment-link/add-reporting-column/:metadataKey',
+      deleteMetadata: '/create-payment-link/add-reporting-column/:metadataKey/delete',
+      manage: {
+        index: '/create-payment-link/manage',
+        edit: '/create-payment-link/manage/edit/:productExternalId',
+        disable: '/create-payment-link/manage/disable/:productExternalId',
+        delete: '/create-payment-link/manage/delete/:productExternalId',
+        editInformation: '/create-payment-link/manage/edit/information/:productExternalId',
+        editReference: '/create-payment-link/manage/edit/reference/:productExternalId',
+        editAmount: '/create-payment-link/manage/edit/amount/:productExternalId',
+        addMetadata: '/create-payment-link/manage/:productExternalId/add-reporting-column',
+        editMetadata: '/create-payment-link/manage/:productExternalId/add-reporting-column/:metadataKey',
+        deleteMetadata: '/create-payment-link/manage/:productExternalId/add-reporting-column/:metadataKey/delete'
+      }
+    },
+    stripeSetup: {
+      bankDetails: '/bank-details',
+      responsiblePerson: '/responsible-person',
+      vatNumber: '/vat-number',
+      companyNumber: '/company-number'
+    },
+    stripe: {
+      addPspAccountDetails: '/stripe/add-psp-account-details'
     }
+  },
+  redirects: {
+    stripeSetupLiveDashboardRedirect: '/service/:externalServiceId/dashboard/live'
   },
   transactions: {
     index: '/transactions',
@@ -196,16 +238,6 @@ module.exports = {
   },
   policyPages: {
     download: '/policy/download/:key'
-  },
-  stripeSetup: {
-    bankDetails: '/bank-details',
-    responsiblePerson: '/responsible-person',
-    vatNumber: '/vat-number',
-    companyNumber: '/company-number',
-    stripeSetupLink: '/service/:externalServiceId/dashboard/live'
-  },
-  stripe: {
-    addPspAccountDetails: '/stripe/add-psp-account-details'
   },
   payouts: {
     list: '/payments-to-your-bank-account'

--- a/app/paths.js
+++ b/app/paths.js
@@ -95,36 +95,6 @@ module.exports = {
       flex: '/your-psp/flex',
       worldpay3dsFlex: '/your-psp/worldpay-3ds-flex'
     },
-    apiKeys: {
-      index: '/api-keys',
-      revoked: '/api-keys/revoked',
-      create: '/api-keys/create',
-      revoke: '/api-keys/revoke',
-      update: '/api-keys/update'
-    },
-    paymentLinks: {
-      start: '/create-payment-link',
-      information: '/create-payment-link/information',
-      webAddress: '/create-payment-link/web-address',
-      reference: '/create-payment-link/reference',
-      amount: '/create-payment-link/amount',
-      review: '/create-payment-link/review',
-      addMetadata: '/create-payment-link/add-reporting-column',
-      editMetadata: '/create-payment-link/add-reporting-column/:metadataKey',
-      deleteMetadata: '/create-payment-link/add-reporting-column/:metadataKey/delete',
-      manage: {
-        index: '/create-payment-link/manage',
-        edit: '/create-payment-link/manage/edit/:productExternalId',
-        disable: '/create-payment-link/manage/disable/:productExternalId',
-        delete: '/create-payment-link/manage/delete/:productExternalId',
-        editInformation: '/create-payment-link/manage/edit/information/:productExternalId',
-        editReference: '/create-payment-link/manage/edit/reference/:productExternalId',
-        editAmount: '/create-payment-link/manage/edit/amount/:productExternalId',
-        addMetadata: '/create-payment-link/manage/:productExternalId/add-reporting-column',
-        editMetadata: '/create-payment-link/manage/:productExternalId/add-reporting-column/:metadataKey',
-        deleteMetadata: '/create-payment-link/manage/:productExternalId/add-reporting-column/:metadataKey/delete'
-      }
-    },
     stripeSetup: {
       bankDetails: '/bank-details',
       responsiblePerson: '/responsible-person',

--- a/app/routes.js
+++ b/app/routes.js
@@ -89,8 +89,8 @@ const {
   healthcheck, registerUser, user, dashboard, selfCreateService, transactions, credentials,
   serviceSwitcher, teamMembers, staticPaths, inviteValidation, editServiceName, merchantDetails,
   notificationCredentials,
-  requestToGoLive, policyPages, stripeSetup, stripe,
-  allServiceTransactions, payouts
+  requestToGoLive, policyPages,
+  allServiceTransactions, payouts, redirects
 } = paths
 const {
   apiKeys,
@@ -103,7 +103,9 @@ const {
   toggle3ds,
   toggleBillingAddress,
   toggleMotoMaskCardNumberAndSecurityCode,
-  yourPsp
+  yourPsp,
+  stripeSetup,
+  stripe
 } = paths.account
 
 // Exports
@@ -261,7 +263,7 @@ module.exports.bind = function (app) {
   app.post(merchantDetails.edit, permission('merchant-details:update'), merchantDetailsController.postEdit)
 
   // Service live account dashboard link
-  app.get(stripeSetup.stripeSetupLink, stripeSetupDashboardRedirectController.get)
+  app.get(redirects.stripeSetupLiveDashboardRedirect, stripeSetupDashboardRedirectController.get)
 
   // ----------------------------
   // GATEWAY ACCOUNT LEVEL ROUTES
@@ -423,16 +425,6 @@ module.exports.bind = function (app) {
   account.post(requestToGoLive.agreement, permission('go-live-stage:update'), requestToGoLiveAgreementController.post)
 
   // Stripe setup
-  app.get(stripeSetup.bankDetails, permission('stripe-bank-details:update'), getAccount, paymentMethodIsCard, restrictToLiveStripeAccount, checkBankDetailsNotSubmitted, getStripeAccount, stripeSetupBankDetailsController.get)
-  app.post(stripeSetup.bankDetails, permission('stripe-bank-details:update'), getAccount, paymentMethodIsCard, restrictToLiveStripeAccount, checkBankDetailsNotSubmitted, getStripeAccount, stripeSetupBankDetailsController.post)
-  app.get(stripeSetup.responsiblePerson, permission('stripe-responsible-person:update'), getAccount, paymentMethodIsCard, restrictToLiveStripeAccount, getStripeAccount, checkResponsiblePersonNotSubmitted, stripeSetupResponsiblePersonController.get)
-  app.post(stripeSetup.responsiblePerson, permission('stripe-responsible-person:update'), getAccount, paymentMethodIsCard, restrictToLiveStripeAccount, getStripeAccount, checkResponsiblePersonNotSubmitted, stripeSetupResponsiblePersonController.post)
-  app.get(stripeSetup.vatNumber, permission('stripe-vat-number-company-number:update'), getAccount, paymentMethodIsCard, restrictToLiveStripeAccount, checkVatNumberNotSubmitted, stripeSetupVatNumberController.get)
-  app.post(stripeSetup.vatNumber, permission('stripe-vat-number-company-number:update'), getAccount, paymentMethodIsCard, restrictToLiveStripeAccount, getStripeAccount, checkVatNumberNotSubmitted, stripeSetupVatNumberController.post)
-  app.get(stripeSetup.companyNumber, permission('stripe-vat-number-company-number:update'), getAccount, paymentMethodIsCard, restrictToLiveStripeAccount, checkCompanyNumberNotSubmitted, stripeSetupCompanyNumberController.get)
-  app.post(stripeSetup.companyNumber, permission('stripe-vat-number-company-number:update'), getAccount, paymentMethodIsCard, restrictToLiveStripeAccount, getStripeAccount, checkCompanyNumberNotSubmitted, stripeSetupCompanyNumberController.post)
-  app.get(stripe.addPspAccountDetails, permission('stripe-account-details:update'), getAccount, paymentMethodIsCard, restrictToLiveStripeAccount, stripeSetupAddPspAccountDetailsController.get)
-
   account.get(stripeSetup.bankDetails, permission('stripe-bank-details:update'), paymentMethodIsCard, restrictToLiveStripeAccount, checkBankDetailsNotSubmitted, getStripeAccount, stripeSetupBankDetailsController.get)
   account.post(stripeSetup.bankDetails, permission('stripe-bank-details:update'), paymentMethodIsCard, restrictToLiveStripeAccount, checkBankDetailsNotSubmitted, getStripeAccount, stripeSetupBankDetailsController.post)
   account.get(stripeSetup.responsiblePerson, permission('stripe-responsible-person:update'), paymentMethodIsCard, restrictToLiveStripeAccount, getStripeAccount, checkResponsiblePersonNotSubmitted, stripeSetupResponsiblePersonController.get)

--- a/app/routes.js
+++ b/app/routes.js
@@ -193,9 +193,8 @@ module.exports.bind = function (app) {
     ...lodash.values(user.profile),
     ...lodash.values(requestToGoLive),
     ...lodash.values(policyPages),
-    ...lodash.values(stripeSetup),
-    ...lodash.values(stripe),
     ...lodash.values(payouts),
+    ...lodash.values(redirects),
     paths.feedback
   ] // Extract all the authenticated paths as a single array
 

--- a/app/views/dashboard/_stripe-account-setup-banner.njk
+++ b/app/views/dashboard/_stripe-account-setup-banner.njk
@@ -51,7 +51,7 @@
         govukButton({
           text: 'Add details',
           classes: 'govuk-!-margin-bottom-0',
-          href: routes.stripe.addPspAccountDetails,
+          href: formatAccountPathsFor(routes.account.stripe.addPspAccountDetails, currentGatewayAccount.external_id),
           attributes: {
             id: "add-account-details"
           }

--- a/app/views/stripe-setup/bank-details/index.njk
+++ b/app/views/stripe-setup/bank-details/index.njk
@@ -29,7 +29,7 @@
     <p class="govuk-body govuk-!-margin-bottom-6">This is the bank account payments will go into.</p>
 
     <form id="bank-details-form" method="post"
-          action="/bank-details" data-validate="true">
+          data-validate="true">
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {% set sortCodeError = false %}

--- a/app/views/stripe-setup/company-number/index.njk
+++ b/app/views/stripe-setup/company-number/index.njk
@@ -27,7 +27,7 @@
     {% endif %}
 
     <form id="company-number-form" method="post"
-          action="/company-number">
+          >
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {% set companyNumberError = false %}

--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -73,7 +73,7 @@
 
     <p class="govuk-body">Stripe will store the responsible person’s details, not GOV.UK Pay.</p>
 
-    <form id="responsible-person-form" method="post" action="/responsible-person" class="govuk-!-margin-top-4" novalidate>
+    <form id="responsible-person-form" method="post" class="govuk-!-margin-top-4" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {% call govukFieldset({

--- a/app/views/stripe-setup/vat-number/index.njk
+++ b/app/views/stripe-setup/vat-number/index.njk
@@ -22,7 +22,7 @@
     <h1 class="govuk-heading-l govuk-!-margin-bottom-6"><label for="vat-number">What is your organisation’s VAT number?</label></h1>
 
     <form id="vat-number-form" method="post"
-          action="/vat-number" novalidate>
+          novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {% set vatNumberError = false %}

--- a/test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.test.js
+++ b/test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.test.js
@@ -7,13 +7,15 @@ const stripeAccountSetupStubs = require('../../stubs/stripe-account-setup-stub')
 const stripeAccountStubs = require('../../stubs/stripe-account-stubs')
 
 describe('The Stripe psp details banner', () => {
-  const gatewayAccountId = 22
+  const gatewayAccountId = '22'
+  const gatewayAccountExternalId = 'a-valid-external-id'
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
   beforeEach(() => {
     cy.setEncryptedCookies(userExternalId, gatewayAccountId)
     cy.task('setupStubs', [
-      userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),
+      userStubs.getUserSuccess({ userExternalId, gatewayAccountId, gatewayAccountExternalId }),
       gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId, type: 'live', paymentProvider: 'stripe' }),
+      gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'live', paymentProvider: 'stripe' }),
       transactionsSummaryStubs.getDashboardStatistics(),
       stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
         gatewayAccountId,

--- a/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
@@ -6,6 +6,8 @@ const transactionSummaryStubs = require('../../stubs/transaction-summary-stubs')
 const stripeAccountSetupStubs = require('../../stubs/stripe-account-setup-stub')
 const stripeAccountStubs = require('../../stubs/stripe-account-stubs')
 
+const GATEWAY_ACCOUNT_EXTERNAL_ID = 'a-valid-external-id'
+
 function setupStubs (userExternalId, gatewayAccountId, responsiblePerson, type = 'live', paymentProvider = 'stripe') {
   let stripeSetupStub
 
@@ -20,7 +22,7 @@ function setupStubs (userExternalId, gatewayAccountId, responsiblePerson, type =
 
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),
-    gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId, type, paymentProvider }),
+    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId: GATEWAY_ACCOUNT_EXTERNAL_ID, type, paymentProvider }),
     stripeSetupStub,
     stripeAccountStubs.getStripeAccountSuccess(gatewayAccountId, 'acct_123example123'),
     transactionSummaryStubs.getDashboardStatistics()
@@ -52,7 +54,7 @@ describe('Stripe setup: responsible person page', () => {
     beforeEach(() => {
       setupStubs(userExternalId, gatewayAccountId, false)
 
-      cy.visit('/responsible-person')
+      cy.visit('/account/a-valid-external-id/responsible-person')
     })
 
     it('should display form', () => {
@@ -149,7 +151,7 @@ describe('Stripe setup: responsible person page', () => {
     beforeEach(() => {
       setupStubs(userExternalId, gatewayAccountId, true)
 
-      cy.visit('/responsible-person')
+      cy.visit('/account/a-valid-external-id/responsible-person')
     })
 
     it('should redirect to dashboard with error message instead of showing form', () => {
@@ -165,7 +167,7 @@ describe('Stripe setup: responsible person page', () => {
     beforeEach(() => {
       setupStubs(userExternalId, gatewayAccountId, [false, true])
 
-      cy.visit('/responsible-person')
+      cy.visit('/account/a-valid-external-id/responsible-person')
     })
 
     it('should redirect to dashboard with error message instead of saving details', () => {
@@ -194,7 +196,7 @@ describe('Stripe setup: responsible person page', () => {
     beforeEach(() => {
       setupStubs(userExternalId, gatewayAccountId, false, 'live', 'worldpay')
 
-      cy.visit('/responsible-person', { failOnStatusCode: false })
+      cy.visit('/account/a-valid-external-id/responsible-person', { failOnStatusCode: false })
     })
 
     it('should return a 404', () => {
@@ -206,10 +208,11 @@ describe('Stripe setup: responsible person page', () => {
     beforeEach(() => {
       cy.task('setupStubs', [
         userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
-        gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId, type: 'live', paymentProvider: 'stripe' })
+        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId: GATEWAY_ACCOUNT_EXTERNAL_ID, type: 'live', paymentProvider: 'stripe' }),
+        stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, responsiblePerson: true })
       ])
 
-      cy.visit('/responsible-person', { failOnStatusCode: false })
+      cy.visit('/account/a-valid-external-id/responsible-person', { failOnStatusCode: false })
     })
 
     it('should show a permission denied error', () => {

--- a/test/cypress/stubs/user-stubs.js
+++ b/test/cypress/stubs/user-stubs.js
@@ -44,8 +44,8 @@ function getUserSuccessWithServiceRole (opts) {
   return builGetUserSuccessStub(opts.userExternalId, fixtureOpts)
 }
 
-function getUserWithNoPermissions (userExternalId, gatewayAccountIds) {
-  return getUserSuccess({ userExternalId, gatewayAccountIds, goLiveStage: 'NOT_STARTED', role: { permissions: [] } })
+function getUserWithNoPermissions (userExternalId, gatewayAccountId) {
+  return getUserSuccess({ userExternalId, gatewayAccountId, goLiveStage: 'NOT_STARTED', role: { permissions: [] } })
 }
 
 function postUserAuthenticateSuccess (userExternalId, username, password) {

--- a/test/integration/add-psp-details.ft.test.js
+++ b/test/integration/add-psp-details.ft.test.js
@@ -10,8 +10,8 @@ const { validGatewayAccountResponse } = require('../fixtures/gateway-account.fix
 const { buildGetStripeAccountSetupResponse } = require('../fixtures/stripe-account-setup.fixtures')
 
 const connectorMock = nock(process.env.CONNECTOR_URL)
-const GATEWAY_ACCOUNT_ID = 111
-
+const GATEWAY_ACCOUNT_ID = '111'
+const GATEWAY_ACCOUNT_EXTERNAL_ID = 'a-valid-external-id'
 const { getApp } = require('../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../test-helpers/mock-session')
 
@@ -30,10 +30,10 @@ describe('Add stripe psp details route', function () {
       app = createAppWithSession(getApp(), session)
 
       connectorMock
-        .get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
+        .get(`/v1/frontend/accounts/external-id/${GATEWAY_ACCOUNT_EXTERNAL_ID}`)
         .reply(200, validGatewayAccountResponse({
           gateway_account_id: GATEWAY_ACCOUNT_ID,
-          external_id: 'a-valid-external-id',
+          external_id: GATEWAY_ACCOUNT_EXTERNAL_ID,
           payment_provider: 'stripe',
           type: 'live'
         }))
@@ -50,8 +50,10 @@ describe('Add stripe psp details route', function () {
     })
 
     it('should load the "Go live complete" page', async () => {
+      const url = `/account/a-valid-external-id${paths.account.stripe.addPspAccountDetails}`
+      console.log('going to url', url)
       const res = await supertest(app)
-        .get(`/account/a-valid-external-id/${paths.account.stripe.addPspAccountDetails}`)
+        .get(url)
       const $ = cheerio.load(res.text)
       expect(res.statusCode).to.equal(200)
       expect($('h1').text()).to.contain('Go live complete')

--- a/test/integration/add-psp-details.ft.test.js
+++ b/test/integration/add-psp-details.ft.test.js
@@ -33,6 +33,7 @@ describe('Add stripe psp details route', function () {
         .get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
         .reply(200, validGatewayAccountResponse({
           gateway_account_id: GATEWAY_ACCOUNT_ID,
+          external_id: 'a-valid-external-id',
           payment_provider: 'stripe',
           type: 'live'
         }))
@@ -50,7 +51,7 @@ describe('Add stripe psp details route', function () {
 
     it('should load the "Go live complete" page', async () => {
       const res = await supertest(app)
-        .get(paths.stripe.addPspAccountDetails)
+        .get(`/account/a-valid-external-id/${paths.account.stripe.addPspAccountDetails}`)
       const $ = cheerio.load(res.text)
       expect(res.statusCode).to.equal(200)
       expect($('h1').text()).to.contain('Go live complete')


### PR DESCRIPTION
Update both the controllers for the pages and the redirect utility that
pieces all of the stripe setup steps together.

Move the live dashboard redirect that is given to services when they've
gone live (by support) out of the nested account paths as it belongs to
the service. Once the account URL structure is in place, this can likely
be removed and replaced with a simple link to the new live account that's
been created.