### PR TITLE
PP-7583 Fix zap tests

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -193,6 +193,7 @@ module.exports.bind = function (app) {
     ...lodash.values(policyPages),
     ...lodash.values(payouts),
     ...lodash.values(redirects),
+    ...lodash.values(apiKeys),
     paths.feedback
   ] // Extract all the authenticated paths as a single array
 


### PR DESCRIPTION
Add back in the api-keys path to the authenticated routes array so that
we redirect to the login page when someone tries to access the old
`/api-keys` URL directly without having a gateway account cookie set.

This is to temporarily fix ZAP tests, we will find a better solution to
this.

