### PR TITLE
PP-7629 Account URL upgrader redirect to login without session

### DIFF
--- a/test/integration/routes.it.test.js
+++ b/test/integration/routes.it.test.js
@@ -2,10 +2,10 @@ const request = require('supertest')
 
 const { getApp } = require('../../server')
 const session = require('../test-helpers/mock-session.js')
-const app = session.getAppWithLoggedInUser(getApp(), session.getUser())
 
-describe('URL upgrade utility', () => {
+describe.only('URL upgrade utility', () => {
   it('correctly upgrades URLs in the account specific paths', () => {
+    const app = session.getAppWithLoggedInUser(getApp(), session.getUser())
     return request(app)
       .get('/billing-address')
       .expect(302)
@@ -14,7 +14,20 @@ describe('URL upgrade utility', () => {
       })
   })
 
+  it('correctly redirects to login in the account specific paths and without a logged in session', () => {
+    const requestSession = {}
+    const app = session.getAppWithLoggedOutSession(getApp(), requestSession)
+    return request(app)
+      .get('/billing-address')
+      .expect(302)
+      .then((res) => {
+        res.header['location'].should.include('/login') // eslint-disable-line
+        requestSession.last_url.should.equal('/billing-address') //eslint-disable-line
+      })
+  })
+
   it('correctly 404s as expected for non account specific paths', () => {
+    const app = session.getAppWithLoggedInUser(getApp(), session.getUser())
     return request(app)
       .get('/unknown-address')
       .expect(404)

--- a/test/integration/routes.it.test.js
+++ b/test/integration/routes.it.test.js
@@ -3,7 +3,7 @@ const request = require('supertest')
 const { getApp } = require('../../server')
 const session = require('../test-helpers/mock-session.js')
 
-describe.only('URL upgrade utility', () => {
+describe('URL upgrade utility', () => {
   it('correctly upgrades URLs in the account specific paths', () => {
     const app = session.getAppWithLoggedInUser(getApp(), session.getUser())
     return request(app)
@@ -11,6 +11,16 @@ describe.only('URL upgrade utility', () => {
       .expect(302)
       .then((res) => {
         res.header['location'].should.include('/account/external-id-set-by-create-app-with-session/billing-address') // eslint-disable-line
+      })
+  })
+
+  it('correctly upgrades URLs in the account specific paths with complex templated values', () => {
+    const app = session.getAppWithLoggedInUser(getApp(), session.getUser())
+    return request(app)
+      .get('/create-payment-link/manage/some-product-external-id/add-reporting-column/some-metadata-key')
+      .expect(302)
+      .then((res) => {
+        res.header['location'].should.include('/account/external-id-set-by-create-app-with-session/create-payment-link/manage/some-product-external-id/add-reporting-column/some-metadata-key') // eslint-disable-line
       })
   })
 


### PR DESCRIPTION
If the user is not logged in but have directly visited a legacy account
specific URL we may not have all the information we need to direct
them to the correct account.

In this case previously middleware on those URLs would have redirected
the user to login.

Update the URL upgrader to factor in this scenario.

Prove this by removing the API keys route from the legacy middleware
auth stack, this page is currently accessed by ZAP tests before having ever
logged in.