### PR TITLE
BAU: Fix all service transactions download

### DIFF
--- a/app/views/transactions/index.njk
+++ b/app/views/transactions/index.njk
@@ -59,7 +59,7 @@
     {{ filtersDescription | safe }}
   </h3>
 
-  {% if permissions.transactions_download_read %}
+  {% if allServiceTransactions or permissions.transactions_download_read %}
 
     {% if (hasResults) %}
       {% if (showCsvDownload) %}


### PR DESCRIPTION
## WHAT
- All live service transactions download link doesnot appear for users as we check for transaction.read permission,
  but this route is not tied to specific service and we can show the link directly (other checks about number of transactions before transactions download link appears is still in place).
  All live services transactions controllers (get, download) has checks in place to render error page if user doesn't have access to live services.

