### PR TITLE
PP-7677 Add account dashboard route

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-01-19T17:38:25Z",
+  "generated_at": "2021-01-22T15:30:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -72,7 +72,7 @@
         "hashed_secret": "ece65afda87c1c6120602c9a3b66890308d7e53c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 138,
+        "line_number": 141,
         "type": "Secret Keyword"
       }
     ],

--- a/app/paths.js
+++ b/app/paths.js
@@ -23,6 +23,9 @@ module.exports = {
       index: '/credentials',
       edit: '/credentials/edit'
     },
+    dashboard: {
+      index: '/dashboard'
+    },
     digitalWallet: {
       applePay: '/digital-wallet/apple-pay',
       googlePay: '/digital-wallet/google-pay'

--- a/app/routes.js
+++ b/app/routes.js
@@ -86,7 +86,7 @@ const stripeSetupDashboardRedirectController = require('./controllers/stripe-set
 
 // Assignments
 const {
-  healthcheck, registerUser, user, dashboard, selfCreateService, transactions,
+  healthcheck, registerUser, user, dashboard: index, selfCreateService, transactions,
   serviceSwitcher, teamMembers, staticPaths, inviteValidation, editServiceName, merchantDetails,
   requestToGoLive, policyPages,
   allServiceTransactions, payouts, redirects
@@ -94,6 +94,7 @@ const {
 const {
   apiKeys,
   credentials,
+  dashboard,
   digitalWallet,
   emailNotifications,
   notificationCredentials,
@@ -150,7 +151,7 @@ module.exports.bind = function (app) {
   // LOGIN
   app.get(user.logIn, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, redirectLoggedInUser, loginController.loginGet)
   app.post(user.logIn, validateAndRefreshCsrf, trimUsername, loginController.loginUser, hasServices, resolveService, getAccount, loginController.postLogin)
-  app.get(dashboard.index, enforceUserAuthenticated, validateAndRefreshCsrf, hasServices, resolveService, getAccount, dashboardController.dashboardActivity)
+  app.get(index.index, enforceUserAuthenticated, validateAndRefreshCsrf, hasServices, resolveService, getAccount, dashboardController.dashboardActivity)
   app.get(user.noAccess, loginController.noAccess)
   app.get(user.logOut, loginController.logout)
   app.get(user.otpSendAgain, enforceUserFirstFactor, validateAndRefreshCsrf, loginController.sendAgainGet)
@@ -265,6 +266,9 @@ module.exports.bind = function (app) {
   // ----------------------------
   // GATEWAY ACCOUNT LEVEL ROUTES
   // ----------------------------
+
+  // Dashboard
+  account.get(dashboard.index, dashboardController.dashboardActivity)
 
   // Transactions
   app.get(transactions.index, permission('transactions:read'), getAccount, paymentMethodIsCard, transactionsListController)


### PR DESCRIPTION
Add new route for the account dashboard. Adding this before merging changes to redirect to this route so that there is no risk of getting 404s on redirects when we deploy changes to redirect to the new route.

