### PR TITLE
PP-7680 Remove granular permissions checks for transaction search

### DIFF
--- a/app/views/transactions/list.njk
+++ b/app/views/transactions/list.njk
@@ -3,19 +3,13 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col" id="reference-header">Reference number</th>
-      {% if permissions.transactions_email_read %}
       <th class="govuk-table__header" scope="col" id="email-header">Email</th>
-      {% endif %}
-      {% if permissions.transactions_amount_read %}
       <th class="govuk-table__header" scope="col" id="amount-header">Amount</th>
         {% if isStripeAccount %}
         <th class="govuk-table__header" scope="col" id="amount-header">PSP Fee</th>
         <th class="govuk-table__header" scope="col" id="amount-header">Net</th>
         {% endif %}
-      {% endif %}
-      {% if permissions.transactions_card_type_read %}
       <th class="govuk-table__header" scope="col" id="brand-header">Card brand</th>
-      {% endif %}
       <th class="govuk-table__header" scope="col" id="state-header">State</th>
       <th class="govuk-table__header govuk-table__header--numeric" scope="col" id="time-header">Date created</th>
     </tr>
@@ -28,28 +22,22 @@
           {{result.reference}}
         </a>
       </th>
-      {% if permissions.transactions_email_read %}
       <td class="govuk-table__cell transactions-list--item govuk-!-font-size-14 email">{{result.email}}</td>
+      <td class="govuk-table__cell transactions-list--item amount govuk-!-font-size-14" id="amount">
+        {%- if result.total_amount and result.corporate_card_surcharge -%}
+          {{result.total_amount}}
+          <span class="govuk-!-display-block govuk-!-font-size-14">(with card fee)</span>
+        {%- else -%}
+          <span style="white-space: pre">{{result.amount}}</span>
+        {%- endif -%}
+      </td>
+      {% if isStripeAccount %}
+        <td data-cell-type="fee" class="govuk-table__cell transactions-list--item govuk-!-font-size-14 state">{{result.fee}}</td>
+        <td data-cell-type="net" class="govuk-table__cell transactions-list--item govuk-!-font-size-14 state">
+          <span style="white-space: pre">{{result.net_amount or result.total_amount or result.amount}}</span>
+        </td>
       {% endif %}
-      {% if permissions.transactions_amount_read %}
-            <td class="govuk-table__cell transactions-list--item amount govuk-!-font-size-14" id="amount">
-                  {%- if result.total_amount and result.corporate_card_surcharge -%}
-                    {{result.total_amount}}
-                    <span class="govuk-!-display-block govuk-!-font-size-14">(with card fee)</span>
-                  {%- else -%}
-                    <span style="white-space: pre">{{result.amount}}</span>
-                  {%- endif -%}
-            </td>
-            {% if isStripeAccount %}
-              <td data-cell-type="fee" class="govuk-table__cell transactions-list--item govuk-!-font-size-14 state">{{result.fee}}</td>
-              <td data-cell-type="net" class="govuk-table__cell transactions-list--item govuk-!-font-size-14 state">
-                <span style="white-space: pre">{{result.net_amount or result.total_amount or result.amount}}</span>
-              </td>
-            {% endif %}
-      {% endif %}
-      {% if permissions.transactions_card_type_read %}
       <td class="govuk-table__cell transactions-list--item govuk-!-font-size-14 brand">{{result.card_details.card_brand}}</td>
-      {% endif %}
       <td class="govuk-table__cell transactions-list--item govuk-!-font-size-14 state">{{result.state_friendly}}</td>
       <td class="govuk-table__cell transactions-list--item govuk-!-font-size-14 govuk-table__cell--numeric time">{{result.created}}</td>
     </tr>

--- a/test/ui/transaction-list.ui.test.js
+++ b/test/ui/transaction-list.ui.test.js
@@ -89,12 +89,6 @@ describe('The transaction list view', function () {
       'results': [
         buildTransaction(100, '£50.00', 'Declined', 'failed', 'Visa', 'example1@mail.fake')
       ],
-      permissions: {
-        'transactions_email_read': true,
-        'transactions_amount_read': true,
-        'transactions_card_type_read': true,
-        'transactions_download_read': true
-      },
       hasResults: true,
       total: 9999,
       showCsvDownload: true,
@@ -154,60 +148,6 @@ describe('The transaction list view', function () {
         .withTableDataAt(6, templateData.results[ix].created)
     })
     body.should.containSelector('p#csv-download').withExactText('Filter results to download a CSV of transactions')
-  })
-
-  it('should not render amount if no permission', function () {
-    const templateData = {
-      'results': [
-        buildTransaction(100, '£50.00', 'Success', 'success', 'Visa', 'example1@mail.fake'),
-        buildTransaction(101, '£20.00', 'Refund error', 'error', 'Mastercard', 'example2@mail.fake')
-      ],
-      permissions: {
-        'transactions_email_read': true,
-        'transactions_card_type_read': true
-      }
-    }
-
-    const body = renderTemplate('transactions/index', templateData)
-
-    body.should.not.containSelector('#transactions-list .amount')
-    body.should.not.containSelector('#amount-header')
-  })
-
-  it('should not render email if no permission', function () {
-    const templateData = {
-      'results': [
-        buildTransaction(100, '£50.00', 'Timed out', 'failed', 'Visa', 'example1@mail.fake'),
-        buildTransaction(101, '£20.00', 'Success', 'success', 'Mastercard', 'example2@mail.fake')
-      ],
-      permissions: {
-        'transactions_amount_read': true,
-        'transactions_card_type_read': true
-      }
-    }
-
-    const body = renderTemplate('transactions/index', templateData)
-
-    body.should.not.containSelector('#transactions-list .email')
-    body.should.not.containSelector('#email-header')
-  })
-
-  it('should not render card brand if no permission', function () {
-    const templateData = {
-      'results': [
-        buildTransaction(100, '£50.00', 'Success', 'success', 'Visa', 'example1@mail.fake'),
-        buildTransaction(101, '£20.00', 'Success', 'success', 'Mastercard', 'example2@mail.fake')
-      ],
-      permissions: {
-        'transactions_email_read': true,
-        'transactions_amount_read': true
-      }
-    }
-
-    const body = renderTemplate('transactions/index', templateData)
-
-    body.should.not.containSelector('#transactions-list .brand')
-    body.should.not.containSelector('#brand-header')
   })
 
   it('should render all transactions with corporate surcharge', function () {


### PR DESCRIPTION
## WHAT 

Currently we show fields (amount, email, card_brand) based on granular permissions
  (`transactions_email_read, transactions_amount_read, transactions_card_type_read`) for user service role.
  But granular permissions are not applied 
     - for searches
     - when users download CSV 
     -  and currently there is no permission model for pages like all live services transactions (which shows transactions data for multiple live accounts).
     
 Initial use case (PP-1469) when introducing permissions was a `super-admin` may not need to view `email, amount, description, card brand` fields. But super-admin role is currently not used. All other roles are service specific and permissions (transactions_email_read, transactions_amount_read, transactions_card_type_read) are available for all roles. So we can safely remove these permission checks in search UI until we have a use case for such granular restrictions.
