### PR TITLE
PP-7667 Remove redirect from dashboard activity tool

### DIFF
--- a/app/views/dashboard/_activity.njk
+++ b/app/views/dashboard/_activity.njk
@@ -1,5 +1,4 @@
-
-<form class="govuk-grid-column-full" action="/" method="get">
+<form class="govuk-grid-column-full" action="{{formatAccountPathsFor(routes.account.dashboard.index, currentGatewayAccount.external_id)}}" method="get">
 
   {{ govukSelect({
     formGroup: {
@@ -49,7 +48,7 @@
       <h2 class="dashboard-total-group__title">
         <a class="govuk-link" href="{{routes.transactions.index}}?state=Success&amp;{{ transactionsPeriodString }}" title="View successful payment transactions for chosen time period">
           Successful payments
-        </a>    
+        </a>
       </h2>
     </header>
     <dl class="dashboard-total-group__values dashboard-total-group__values--blue">


### PR DESCRIPTION
Fix a minor regression in the dashboard activity page. The test coverage
for this feature ([at the time of this PR](https://github.com/alphagov/pay-selfservice/blob/master/test/unit/controller/dashboard/dashboard-activity.controller.ft.test.js)) navigates directly to the page however the template
currently relies on the page being redirected from the root index `/`.

Directly submit form requests to the dashboard page for now to line up
with the test coverage. How this should be covered should be considered
following up.


