### PR TITLE
PP-7455 URL Restructure - Transactions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: d6d3bd94604578adbd918c5a00d531d98350d86f # v2.3.0
+    hooks:
+    -   id: detect-private-key
+-   repo: https://github.com/Yelp/detect-secrets
+    rev: a3e7998bfa4924b13df3f9cb49070abdbdff8802 # v0.13.1
+    hooks:
+    -   id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+        exclude: .*/tests/.*

--- a/app/controllers/transactions/transaction-detail-redirect.controller.js
+++ b/app/controllers/transactions/transaction-detail-redirect.controller.js
@@ -1,23 +1,31 @@
 'use strict'
 
-const paths = require('../../paths')
 const { userServicesContainsGatewayAccount } = require('../../utils/permissions')
 const Ledger = require('../../services/clients/ledger.client')
 const { renderErrorView } = require('../../utils/response.js')
 const router = require('../../routes')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
+const { ConnectorClient } = require('../../services/clients/connector.client')
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
 const defaultMsg = 'Error processing transaction view'
 const notFound = 'Charge not found'
 
-module.exports = async (req, res) => {
+module.exports = async function redirectToTransactionDetail (req, res) {
   const chargeId = req.params.chargeId
+  
   try {
-    let charge = await Ledger.transactionWithAccountOverride(chargeId)
+    const charge = await Ledger.transactionWithAccountOverride(chargeId)
     if (userServicesContainsGatewayAccount(charge.gateway_account_id, req.user)) {
       req.gateway_account.currentGatewayAccountId = charge.gateway_account_id
       req.session = { ...req.session, backLink: req.header('Referer') }
-      charge = null
-      res.redirect(302, router.generateRoute(paths.transactions.detail, { chargeId }))
+
+      const account = await connector.getAccount({
+        gatewayAccountId: charge.gateway_account_id,
+        correlationId: req.correlationId
+      })
+
+      res.redirect(302, formatAccountPathsFor(router.paths.account.transactions.detail, account.external_id, chargeId))
     } else {
       renderErrorView(req, res, notFound, 404)
     }

--- a/app/controllers/transactions/transaction-detail.controller.js
+++ b/app/controllers/transactions/transaction-detail.controller.js
@@ -3,6 +3,8 @@
 const { ledgerFindWithEvents } = require('../../services/transaction.service')
 const { response } = require('../../utils/response.js')
 const { renderErrorView } = require('../../utils/response.js')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
+const router = require('../../routes')
 
 const defaultMsg = 'Error processing transaction view'
 const notFound = 'Charge not found'
@@ -10,7 +12,6 @@ const notFound = 'Charge not found'
 module.exports = (req, res) => {
   const accountId = req.account.gateway_account_id
   const chargeId = req.params.chargeId
-
   ledgerFindWithEvents(accountId, chargeId, req.correlationId)
     .then(data => {
       data.indexFilters = req.session.filters
@@ -19,6 +20,10 @@ module.exports = (req, res) => {
         delete req.session.backLink
       }
       data.service = req.service
+
+      const refundUrl = router.generateRoute(formatAccountPathsFor(router.paths.account.transactions.refund, req.account.external_id), { chargeId })
+
+      data.refundUrl = refundUrl
       response(req, res, 'transaction-detail/index', data)
     })
     .catch(err => {

--- a/app/controllers/transactions/transaction-list.controller.js
+++ b/app/controllers/transactions/transaction-list.controller.js
@@ -12,6 +12,7 @@ const { renderErrorView } = require('../../utils/response.js')
 const { getFilters, describeFilters } = require('../../utils/filters.js')
 const states = require('../../utils/states')
 const client = new ConnectorClient(process.env.CONNECTOR_URL)
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 
 const { CORRELATION_HEADER } = require('../../utils/correlation-header.js')
 
@@ -21,6 +22,8 @@ function error (req, res, msg) {
 
 module.exports = async (req, res, next) => {
   const accountId = req.account.gateway_account_id
+  const gatewayAccountExternalId = req.account.external_id
+  
   const filters = getFilters(req)
 
   const correlationId = req.headers[CORRELATION_HEADER] || ''
@@ -40,8 +43,9 @@ module.exports = async (req, res, next) => {
     return next(new Error('Unable to retrieve list of transactions or card types'))
   }
 
-  const model = buildPaymentList(result[0], result[1], accountId, filters.result, router.paths.transactions.download)
-  model.search_path = router.paths.transactions.index
+  const transactionsDownloadLink = formatAccountPathsFor(router.paths.account.transactions.download, req.account.external_id)
+  const model = buildPaymentList(result[0], result[1], gatewayAccountExternalId, filters.result, transactionsDownloadLink)
+  model.search_path = formatAccountPathsFor(router.paths.account.transactions.index, req.account.external_id)
   model.filtersDescription = describeFilters(filters.result)
   model.eventStates = states.allDisplayStateSelectorObjects()
     .map(state => {
@@ -63,7 +67,7 @@ module.exports = async (req, res, next) => {
       brand.selected = filters.result.brand.includes(brand.value)
     })
   }
-  model.clearRedirect = router.paths.transactions.index
+  model.clearRedirect = formatAccountPathsFor(router.paths.account.transactions.index, req.account.external_id)
   model.isStripeAccount = req.account.payment_provider === 'stripe'
 
   return response(req, res, 'transactions/index', model)

--- a/app/controllers/transactions/transaction-refund.controller.js
+++ b/app/controllers/transactions/transaction-refund.controller.js
@@ -4,6 +4,7 @@ const { refund } = require('../../services/transaction.service')
 const router = require('../../routes.js')
 const { CORRELATION_HEADER } = require('../../utils/correlation-header.js')
 const { safeConvertPoundsStringToPence } = require('../../utils/currency-formatter')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 
 const refundTransaction = async function refundTransaction (req, res, next) {
   try {
@@ -12,7 +13,7 @@ const refundTransaction = async function refundTransaction (req, res, next) {
     const userEmail = req.user.email
     const accountId = req.account.gateway_account_id
     const { chargeId } = req.params
-    const transactionDetailPath = router.generateRoute(router.paths.transactions.detail, { chargeId })
+    const transactionDetailPath = formatAccountPathsFor(router.paths.account.transactions.detail, req.account.external_id, chargeId)
 
     const isFullRefund = req.body['refund-type'] === 'full'
     const refundAmount = isFullRefund ? req.body['full-amount'] : req.body['refund-amount']

--- a/app/middleware/get-service-and-gateway-account.middleware.js
+++ b/app/middleware/get-service-and-gateway-account.middleware.js
@@ -101,6 +101,7 @@ module.exports = async function getServiceAndGatewayAccount (req, res, next) {
       // A separate API call to adminusers to find service makes it independent of user object but most of tests setup currently relies on req.user
       req.service = getService(req.user, serviceExternalId, gatewayAccount, correlationId)
     }
+
     next()
   } catch (err) {
     next(err)

--- a/app/paths.js
+++ b/app/paths.js
@@ -110,6 +110,12 @@ module.exports = {
       cardNumber: '/moto-hide-card-number',
       securityCode: '/moto-hide-security-code'
     },
+    transactions: {
+      index: '/transactions',
+      download: '/transactions/download',
+      detail: '/transactions/:chargeId',
+      refund: '/transactions/:chargeId/refund',
+    },
     yourPsp: {
       index: '/your-psp',
       flex: '/your-psp/flex',
@@ -120,16 +126,10 @@ module.exports = {
   redirects: {
     stripeSetupLiveDashboardRedirect: '/service/:externalServiceId/dashboard/live'
   },
-  transactions: {
-    index: '/transactions',
-    download: '/transactions/download',
-    detail: '/transactions/:chargeId',
-    refund: '/transactions/:chargeId/refund',
-    redirectDetail: '/redirect/transactions/:chargeId'
-  },
   allServiceTransactions: {
     index: '/all-service-transactions',
-    download: '/all-service-transactions/download'
+    download: '/all-service-transactions/download',
+    redirectDetail: '/redirect/transactions/:chargeId'
   },
   user: {
     logIn: '/login',

--- a/app/routes.js
+++ b/app/routes.js
@@ -84,7 +84,7 @@ const stripeSetupDashboardRedirectController = require('./controllers/stripe-set
 
 // Assignments
 const {
-  registerUser, user, selfCreateService, transactions,
+  registerUser, user, selfCreateService,
   serviceSwitcher, teamMembers, staticPaths, inviteValidation, editServiceName, merchantDetails,
   requestToGoLive, policyPages,
   allServiceTransactions, payouts, redirects, index
@@ -105,6 +105,7 @@ const {
   toggle3ds,
   toggleBillingAddress,
   toggleMotoMaskCardNumberAndSecurityCode,
+  transactions,
   yourPsp
 } = paths.account
 
@@ -177,7 +178,6 @@ module.exports.bind = function (app) {
   // ----------------------
 
   const authenticatedPaths = [
-    ...lodash.values(transactions),
     ...lodash.values(allServiceTransactions),
     ...lodash.values(editServiceName),
     ...lodash.values(serviceSwitcher),
@@ -210,6 +210,7 @@ module.exports.bind = function (app) {
   // All service transactions
   app.get(allServiceTransactions.index, allTransactionsController.getController)
   app.get(allServiceTransactions.download, allTransactionsController.downloadTransactions)
+  app.get(allServiceTransactions.redirectDetail, transactionDetailRedirectController)
 
   // Payouts
   app.get(payouts.list, payoutsController.listAllServicesPayouts)
@@ -268,17 +269,10 @@ module.exports.bind = function (app) {
   account.get(dashboard.index, dashboardController.dashboardActivity)
 
   // Transactions
-  app.get(transactions.index, permission('transactions:read'), getAccount, paymentMethodIsCard, transactionsListController)
-  app.get(transactions.download, permission('transactions-download:read'), getAccount, paymentMethodIsCard, transactionsDownloadController)
-  app.get(transactions.detail, permission('transactions-details:read'), resolveService, getAccount, paymentMethodIsCard, transactionDetailController)
-  app.post(transactions.refund, permission('refunds:create'), getAccount, paymentMethodIsCard, transactionRefundController)
-  app.get(transactions.redirectDetail, permission('transactions-details:read'), getAccount, transactionDetailRedirectController)
-
   account.get(transactions.index, permission('transactions:read'), paymentMethodIsCard, transactionsListController)
   account.get(transactions.download, permission('transactions-download:read'), paymentMethodIsCard, transactionsDownloadController)
   account.get(transactions.detail, permission('transactions-details:read'), paymentMethodIsCard, transactionDetailController)
   account.post(transactions.refund, permission('refunds:create'), paymentMethodIsCard, transactionRefundController)
-  account.get(transactions.redirectDetail, permission('transactions-details:read'), transactionDetailRedirectController)
 
   // Settings
   account.get(settings.index, permission('transactions-details:read'), settingsController.index)

--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -16,7 +16,9 @@ const ADMINUSERS_URL = process.env.ADMINUSERS_URL
  * @param body
  */
 const responseBodyToUserTransformer = body => new User(body)
-const responseBodyToUserListTransformer = body => body.map(userData => new User(userData))
+const responseBodyToUserListTransformer = body => {
+  return body.map(userData => new User(userData))
+}
 const responseBodyToServiceTransformer = body => new Service(body)
 
 module.exports = function (clientOptions = {}) {

--- a/app/services/transaction.service.js
+++ b/app/services/transaction.service.js
@@ -75,9 +75,12 @@ const ledgerFindWithEvents = async function ledgerFindWithEvents (accountId, cha
       .uniq()
       .value()
 
-    const users = await userService.findMultipleByExternalIds(userIds, correlationId)
-
-    return transactionView.buildPaymentView(charge, transactionEvents, users)
+    if (userIds.length !== 0) {
+      const users = await userService.findMultipleByExternalIds(userIds, correlationId)
+      return transactionView.buildPaymentView(charge, transactionEvents, users)
+    } else {
+      return transactionView.buildPaymentView(charge, transactionEvents)
+    }
   } catch (error) {
     throw getStatusCodeForError(error)
   }

--- a/app/utils/nav-builder.js
+++ b/app/utils/nav-builder.js
@@ -34,8 +34,8 @@ const serviceNavigationItems = (currentPath, permissions, type, account = {}) =>
     navigationItems.push({
       id: 'navigation-menu-transactions',
       name: 'Transactions',
-      url: paths.transactions.index,
-      current: pathLookup(currentPath, paths.transactions.index),
+      url: formatAccountPathsFor(paths.account.transactions.index, account.external_id),
+      current: pathLookup(currentPath, paths.account.transactions.index),
       permissions: permissions.transactions_read
     })
     navigationItems.push({

--- a/app/utils/transaction-view.js
+++ b/app/utils/transaction-view.js
@@ -11,13 +11,14 @@ const states = require('./states')
 const check = require('check-types')
 const url = require('url')
 const TransactionEvent = require('../models/TransactionEvent.class')
+const formatAccountPathsFor = require('../utils/format-account-paths-for')
 
 const DATA_UNAVAILABLE = 'Data unavailable'
 const LEDGER_TRANSACTION_COUNT_LIMIT = 5000
 
 module.exports = {
   /** prepares the transaction list view */
-  buildPaymentList: function (connectorData, allCards, gatewayAccountId, filtersResult, route, backPath) {
+  buildPaymentList: function (connectorData, allCards, gatewayAccountExternalId, filtersResult, route, backPath) {
     connectorData.filters = filtersResult
     connectorData.hasFilters = Object.keys(filtersResult).length !== 0
     connectorData.hasResults = connectorData.results.length !== 0
@@ -57,12 +58,13 @@ module.exports = {
       element.email = (element.email && element.email.length > 20) ? element.email.substring(0, 20) + '…' : element.email
       element.updated = dates.utcToDisplay(element.updated)
       element.created = dates.utcToDisplay(element.created_date)
-      if (!gatewayAccountId) {
-        element.link = router.generateRoute(router.paths.transactions.redirectDetail, {
+      if (!gatewayAccountExternalId) {
+        element.link = router.generateRoute(router.paths.allServiceTransactions.redirectDetail, {
           chargeId: element.charge_id
         })
       } else {
-        element.link = router.generateRoute(router.paths.transactions.detail, {
+        const transactionDetailUrl = formatAccountPathsFor(router.paths.account.transactions.detail, gatewayAccountExternalId)
+        element.link = router.generateRoute(transactionDetailUrl, {
           chargeId: element.charge_id
         })
       }

--- a/app/views/dashboard/_activity.njk
+++ b/app/views/dashboard/_activity.njk
@@ -46,7 +46,7 @@
   <article class="dashboard-total-group govuk-grid-column-one-third">
     <header class="dashboard-total-group__heading">
       <h2 class="dashboard-total-group__title">
-        <a class="govuk-link" href="{{routes.transactions.index}}?state=Success&amp;{{ transactionsPeriodString }}" title="View successful payment transactions for chosen time period">
+        <a class="govuk-link" href="{{formatAccountPathsFor(routes.account.transactions.index, currentGatewayAccount.external_id)}}?state=Success&amp;{{ transactionsPeriodString }}" title="View successful payment transactions for chosen time period">
           Successful payments
         </a>
       </h2>
@@ -61,7 +61,7 @@
   <article class="dashboard-total-group govuk-grid-column-one-third">
     <header class="dashboard-total-group__heading">
       <h2 class="dashboard-total-group__title">
-        <a class="govuk-link" href="{{routes.transactions.index}}?state=Refund+success&amp;{{ transactionsPeriodString }}" title="View refunded transactions for chosen time period">
+        <a class="govuk-link" href="{{formatAccountPathsFor(routes.account.transactions.index, currentGatewayAccount.external_id)}}?state=Refund+success&amp;{{ transactionsPeriodString }}" title="View refunded transactions for chosen time period">
           Successful refunds
         </a>
       </h2>
@@ -76,7 +76,7 @@
   <article class="dashboard-total-group govuk-grid-column-one-third">
     <header class="dashboard-total-group__heading">
       <h2 class="dashboard-total-group__title">
-        <a class="govuk-link" href="{{routes.transactions.index}}?state=Success&amp;state=Refund+success&amp;{{ transactionsPeriodString }}" title="View successful payments and refunded transactions for chosen time period">
+        <a class="govuk-link" href="{{formatAccountPathsFor(routes.account.transactions.index, currentGatewayAccount.external_id)}}?state=Success&amp;state=Refund+success&amp;{{ transactionsPeriodString }}" title="View successful payments and refunded transactions for chosen time period">
           Net income
         </a>
       </h2>

--- a/app/views/transaction-detail/_refund.njk
+++ b/app/views/transaction-detail/_refund.njk
@@ -1,5 +1,4 @@
-
-<form id="refundForm" action="/transactions/{{charge_id}}/refund" method="post" class="target-to-show {% if flash.genericError %}active{% endif %}">
+<form id="refundForm" action="{{ formatAccountPathsFor(routes.account.transactions.refund, currentGatewayAccount.external_id, charge_id) }}" method="post" class="target-to-show {% if flash.genericError %}active{% endif %}">
   <input id="full-amount" type="hidden" name="full-amount" value="{{ refundable_amount }}" >
   <input id="amount-available" type="hidden" name="refund-amount-available-in-pence" value="{{ refund_summary.amount_available }}" />
   <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}" />

--- a/app/views/transaction-detail/index.njk
+++ b/app/views/transaction-detail/index.njk
@@ -10,7 +10,7 @@
 
 {% block beforeContent %}
   {{ super() }}
-  {% set defaultBackLink %}{{routes.transactions.index}}{% if indexFilters %}?{{indexFilters}}{% endif %}{% endset %}
+  {% set defaultBackLink %}{{formatAccountPathsFor(routes.account.transactions.index, currentGatewayAccount.external_id)}}{% if indexFilters %}?{{indexFilters}}{% endif %}{% endset %}
   {% set backLink = redirectBackLink if contextIsAllServiceTransactions else defaultBackLink %}
   {% set backLinkText = 'Transactions for all live services' if contextIsAllServiceTransactions else 'Transactions list' %}
   {{

--- a/test/cypress/integration/all-service-transactions/all-service-transactions.cy.test.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions.cy.test.js
@@ -1,0 +1,115 @@
+'use strict'
+
+const userStubs = require('../../stubs/user-stubs')
+const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+const transactionStubs = require('../../stubs/transaction-stubs')
+const stripeAccountSetupStubs = require('../../stubs/stripe-account-setup-stub')
+
+describe('Transactions list pagination', () => {
+  const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+  const gatewayAccountId1 = 42
+  const gatewayAccountId2 = 43
+  const gatewayAccountExternalId1 = 'a-valid-external-id-1'
+  const gatewayAccountExternalId2 = 'a-valid-external-id-2'
+  const transactionsUrl = `/all-service-transactions`
+  const defaultAmount = 1000
+
+  const defaultTransactionEvents = [{
+    amount: defaultAmount,
+    state: {
+      finished: false,
+      status: 'created'
+    },
+    resource_type: 'PAYMENT',
+    event_type: 'PAYMENT_CREATED',
+    timestamp: '2019-09-18T10:06:17.152Z',
+    data: {}
+  }]
+
+  function generateTransactions (length) {
+    const transactions = []
+    for (let i = 0; i < length; i++) {
+      transactions.push({
+        reference: 'transaction' + i,
+        amount: defaultAmount,
+        type: 'payment',
+        transaction_id: 'transaction-id-' + i,
+        gateway_account_id: String(gatewayAccountId1),
+        events: defaultTransactionEvents
+      })
+    }
+    return transactions
+  }
+
+  function transactionSearchResultOpts (transactionLength, displaySize, page, filters, links) {
+    return {
+      gatewayAccountIds: [ gatewayAccountId1, gatewayAccountId2 ],
+      transactionLength: transactionLength || 50,
+      displaySize: displaySize || 5,
+      page: page || 1,
+      transactionCount: 3,
+      transactions: generateTransactions(2),
+      filters: filters,
+      links: links || {}
+    }
+  }
+
+  describe('All Service Transactions', () => {
+    beforeEach(() => {
+      Cypress.Cookies.preserveOnce('session', 'gateway_account')
+    })
+
+    it('should display All Service Transactions > list page', () => {
+      cy.setEncryptedCookies(userExternalId, gatewayAccountId1)
+      const opts = transactionSearchResultOpts(30, 5, 1, {},
+        {
+          self: { href: '/v1/transactions?&page=&display_size=5&state=' },
+          next_page: { href: '/v1/transactions?&page=3&display_size=5&state=' }
+        })
+
+      cy.task('setupStubs', [
+        userStubs.getUserSuccessWithMultipleServices({ userExternalId, gatewayAccountId1, gatewayAccountId2, gatewayAccountExternalId1, gatewayAccountExternalId2 }),
+        gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts({ gatewayAccountIds: [gatewayAccountId1, gatewayAccountId2], gatewayAccountId1, gatewayAccountId2, gatewayAccountExternalId1, gatewayAccountExternalId2, type: 'live', paymentProvider: 'stripe' }),
+        transactionStubs.getLedgerTransactionsSuccess(opts),
+        gatewayAccountStubs.getCardTypesSuccess()
+      ])
+
+      cy.visit(transactionsUrl + '?pageSize=5&page=')
+      cy.title().should('eq', `Transactions for all live services`)
+
+      cy.get('form.paginationForm.page-Previous').should('exist').within(() => {
+        cy.get('input[name="page"]').should('have.value', '')
+      })
+      cy.get('button.pagination.Previous').should('exist')
+      cy.get('button.pagination.Previous').should('be.disabled')
+
+      cy.get('form.paginationForm.page-Next').should('exist').within(() => {
+        cy.get('input[name="page"]').should('have.value', '2')
+      })
+    })
+
+    it('should display Transaction Detail page', () => {
+      const transactions = generateTransactions(1)
+
+      cy.task('setupStubs', [
+        userStubs.getUserSuccessWithMultipleServices({ userExternalId, gatewayAccountId1, gatewayAccountId2, gatewayAccountExternalId1, gatewayAccountExternalId2 }),
+        transactionStubs.getLedgerTransactionSuccess({ transactionDetails: transactions[0] }),
+        gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId: gatewayAccountId1, gatewayAccountExternalId: gatewayAccountExternalId1 }),
+        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+          gatewayAccountId: gatewayAccountId1,
+          gatewayAccountExternalId: gatewayAccountExternalId1,
+          paymentProvider: 'stripe',
+          allowMoto: false }),
+        stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId: gatewayAccountId1, bankAccount: true, responsiblePerson: true, vatNumber: true, companyNumber: true }),
+        transactionStubs.getLedgerEventsSuccess({ transactionId: 'transaction-id-0', events: defaultTransactionEvents })
+      ])
+
+      cy.get('#charge-id-transaction-id-0').click()
+
+      cy.get('.transaction-details tbody').find('tr').first().find('td').first().should('contain',
+        'System Generated')
+      cy.get('.transaction-details tbody').find('tr').eq(1).find('td').first().should('contain',
+        'transaction0')
+    })
+  })
+})

--- a/test/cypress/integration/transactions/transaction-details.cy.test.js
+++ b/test/cypress/integration/transactions/transaction-details.cy.test.js
@@ -8,6 +8,7 @@ const transactionStubs = require('../../stubs/transaction-stubs')
 const capitalise = string => string[0].toUpperCase() + string.slice(1)
 const convertPenceToPoundsFormatted = pence => `£${(pence / 100).toFixed(2)}`
 const defaultAmount = 1000
+const gatewayAccountExternalId = 'a-valid-external-id'
 const transactionId = 'adb123def456'
 const gatewayAccountId = 42
 const serviceName = 'Test Service'
@@ -69,16 +70,16 @@ function defaultTransactionDetails (events, opts = {}) {
 }
 
 describe('Transaction details page', () => {
-  const transactionsUrl = `/transactions`
+  const transactionsUrl = `/account/${gatewayAccountExternalId}/transactions`
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
   const userEmail = 'a-user@example.com'
 
   const getStubs = (transactionDetails, additionalGatewayAccountOpts = {}) => {
     return [
       userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName, email: userEmail }),
-      userStubs.getUsersSuccess(),
-      gatewayAccountStubs.getGatewayAccountSuccess({
+      gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
         gatewayAccountId,
+        gatewayAccountExternalId,
         paymentProvider: transactionDetails.payment_provider,
         allowMoto: additionalGatewayAccountOpts.allow_moto
       }),

--- a/test/cypress/integration/transactions/transaction-list-pagination.cy.test.js
+++ b/test/cypress/integration/transactions/transaction-list-pagination.cy.test.js
@@ -7,7 +7,8 @@ const transactionStubs = require('../../stubs/transaction-stubs')
 describe('Transactions list pagination', () => {
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
   const gatewayAccountId = 42
-  const transactionsUrl = '/transactions'
+  const gatewayAccountExternalId = 'a-valid-external-id'
+  const transactionsUrl = `/account/${gatewayAccountExternalId}/transactions`
   const serviceName = 'Test Service'
   const defaultAmount = 1000
 
@@ -17,7 +18,8 @@ describe('Transactions list pagination', () => {
       transactions.push({
         reference: 'transaction' + i,
         amount: defaultAmount,
-        type: 'payment'
+        type: 'payment',
+        charge_id: 'charge_id'
       })
     }
     return transactions
@@ -40,7 +42,7 @@ describe('Transactions list pagination', () => {
     return [
       userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName }),
       userStubs.getUsersSuccess(),
-      gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId }),
+      gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId }),
       gatewayAccountStubs.getCardTypesSuccess(),
       transactionStubs.getLedgerTransactionsSuccess(transactionDetails)
     ]
@@ -74,7 +76,7 @@ describe('Transactions list pagination', () => {
         cy.get('button.pagination.Next').should('exist')
       })
 
-      it('should have both next and previous pagination links enabled, when ledger return both links ', () => {
+      it.only('should have both next and previous pagination links enabled, when ledger return both links ', () => {
         const opts = transactionSearchResultOpts(30, 5, 3, {},
           {
             self: { href: '/v1/transactions?&page=2&display_size=5&state=' },

--- a/test/cypress/integration/transactions/transaction-search.cy.test.js
+++ b/test/cypress/integration/transactions/transaction-search.cy.test.js
@@ -3,10 +3,11 @@ const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 const stripeAccountSetupStubs = require('../../stubs/stripe-account-setup-stub')
 const transactionsStubs = require('../../stubs/transaction-stubs')
 
-const transactionsUrl = `/transactions`
 const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
 const gatewayAccountId = 42
+const gatewayAccountExternalId = 'a-valid-external-id'
 const serviceName = 'Test Service'
+const transactionsUrl = `/account/${gatewayAccountExternalId}/transactions`
 
 const convertPenceToPoundsFormatted = pence => `£${(pence / 100).toFixed(2)}`
 
@@ -84,6 +85,11 @@ const sharedStubs = (paymentProvider = 'sandbox') => {
   return [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName }),
     gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId, paymentProvider }),
+    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ 
+      gatewayAccountId,
+      gatewayAccountExternalId,
+      paymentProvider
+    }),
     gatewayAccountStubs.getCardTypesSuccess(),
     stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId })
   ]
@@ -244,9 +250,9 @@ describe('Transactions List', () => {
       // Ensure the right number of transactions is displayed
       cy.get('#transactions-list tbody').find('tr').should('have.length', filteredByMultipleFieldsTransactions.length)
       // Ensure the expected transactions are shown
-      assertTransactionRow(0, filteredByMultipleFieldsTransactions[0].reference, '/transactions/payment-transaction-id',
+      assertTransactionRow(0, filteredByMultipleFieldsTransactions[0].reference, `/account/${gatewayAccountExternalId}/transactions/payment-transaction-id`,
         'test2@example.org', '£15.00', 'Mastercard', 'In progress')
-      assertTransactionRow(1, filteredByMultipleFieldsTransactions[1].reference, '/transactions/payment-transaction-id2',
+      assertTransactionRow(1, filteredByMultipleFieldsTransactions[1].reference, `/account/${gatewayAccountExternalId}/transactions/payment-transaction-id2`,
         'test@example.org', '–£15.00', 'Visa', 'Refund submitted')
     })
   })
@@ -267,7 +273,7 @@ describe('Transactions List', () => {
 
       // Ensure the card fee is displayed correctly
       cy.get('#transactions-list tbody').find('tr').eq(2).find('td').eq(1).should('contain', convertPenceToPoundsFormatted(unfilteredTransactions[2].total_amount)).and('contain', '(with card fee)')
-      cy.get('#download-transactions-link').should('have.attr', 'href', '/transactions/download')
+      cy.get('#download-transactions-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/transactions/download`)
     })
 
     it('should display the fee and total columns for a stripe gateway with fees', () => {

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -55,6 +55,7 @@ function parseGatewayAccountOptions (opts) {
   if (opts.gatewayAccountExternalId) {
     stubOptions.external_id = opts.gatewayAccountExternalId
   }
+
   return stubOptions
 }
 
@@ -86,6 +87,28 @@ function getGatewayAccountsSuccess (opts) {
         type: opts.type,
         payment_provider: opts.paymentProvider,
         external_id: '42'
+      }]
+    })
+  })
+}
+
+function getGatewayAccountsSuccessForMultipleAccounts (opts) {
+  const path = '/v1/frontend/accounts'
+  return stubBuilder('GET', path, 200, {
+    query: {
+      accountIds: opts.gatewayAccountIds.join(',')
+    },
+    response: gatewayAccountFixtures.validGatewayAccountsResponse({
+      accounts: [{
+        gateway_account_id: opts.gatewayAccountId1,
+        type: opts.type,
+        payment_provider: opts.paymentProvider,
+        external_id: opts.externalId1
+      }, {
+        gateway_account_id: opts.gatewayAccountId2,
+        type: opts.type,
+        payment_provider: opts.paymentProvider,
+        external_id: opts.externalId2
       }]
     })
   })
@@ -205,6 +228,7 @@ module.exports = {
   getGatewayAccountSuccess,
   getGatewayAccountsSuccess,
   getGatewayAccountByExternalIdSuccess,
+  getGatewayAccountsSuccessForMultipleAccounts,
   getAcceptedCardTypesSuccess,
   getDirectDebitGatewayAccountSuccess,
   postCreateGatewayAccountSuccess,

--- a/test/cypress/stubs/transaction-stubs.js
+++ b/test/cypress/stubs/transaction-stubs.js
@@ -24,10 +24,11 @@ function getLedgerEventsSuccess (opts) {
 }
 
 function getLedgerTransactionsSuccess (opts) {
+
   const path = '/v1/transaction'
   return stubBuilder('GET', path, 200, {
     query: lodash.defaults({ ...opts.filters }, {
-      account_id: opts.gatewayAccountId,
+      account_id: opts.gatewayAccountIds ? opts.gatewayAccountIds.join(',') : opts.gatewayAccountId,
       page: opts.page || 1,
       display_size: opts.displaySize || 100,
       limit_total: true,

--- a/test/cypress/stubs/user-stubs.js
+++ b/test/cypress/stubs/user-stubs.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { array } = require('joi')
 const userFixtures = require('../../fixtures/user.fixtures')
 const { stubBuilder } = require('./stub-builder')
 
@@ -23,6 +24,33 @@ function buildGetUserSuccessStub (userExternalId, fixtureOpts) {
 
 function getUserSuccess (opts) {
   const fixtureOpts = buildUserWithServiceRoleOpts(opts)
+  return buildGetUserSuccessStub(opts.userExternalId, fixtureOpts)
+}
+
+function getUserSuccessWithMultipleServices (opts) {
+  const serviceRoles = [
+    {
+      service: {
+        external_id: opts.gatewayAccountExternalId1,
+        gateway_account_ids: [String(opts.gatewayAccountId1)]
+      }
+    },
+    {
+      service: {
+        external_id: opts.gatewayAccountExternalId2,
+        gateway_account_ids: [opts.gatewayAccountId2]
+      }
+    }
+  ]
+
+  const fixtureOpts = {
+    external_id: opts.userExternalId,
+    service_roles: serviceRoles,
+    username: opts.email,
+    email: opts.email,
+    telephone_number: opts.telephoneNumber
+  }
+
   return buildGetUserSuccessStub(opts.userExternalId, fixtureOpts)
 }
 
@@ -171,6 +199,7 @@ function getUserSuccessRespondDifferentlySecondTime (userExternalId, firstRespon
 }
 
 function buildServiceRoleOpts (opts) {
+
   const serviceRole = {
     service: {
       gateway_account_ids: [String(opts.gatewayAccountId)]
@@ -223,5 +252,6 @@ module.exports = {
   postUserAuthenticateSuccess,
   postUserAuthenticateInvalidPassword,
   postSecondFactorSuccess,
-  putUpdateServiceRoleSuccess
+  putUpdateServiceRoleSuccess,
+  getUserSuccessWithMultipleServices
 }

--- a/test/fixtures/ledger-transaction.fixtures.js
+++ b/test/fixtures/ledger-transaction.fixtures.js
@@ -78,6 +78,8 @@ const buildTransactionDetails = (opts = {}) => {
     data.gateway_transaction_id = opts.gateway_transaction_id
   }
 
+  
+
   if (opts.gateway_account_id) {
     data.gateway_account_id = opts.gateway_account_id
   }
@@ -146,6 +148,7 @@ const buildTransactionDetails = (opts = {}) => {
   if (opts.net_amount) data.net_amount = opts.net_amount
   if (opts.wallet_type) data.wallet_type = opts.wallet_type
   if (opts.metadata) data.metadata = opts.metadata
+
   return data
 }
 
@@ -231,7 +234,7 @@ module.exports = {
   validTransactionSearchResponse: (opts = {}) => {
     let results = []
     opts.transactions.forEach(transaction => {
-      transaction.gateway_account_id = opts.gateway_account_id
+      // transaction.gateway_account_id = opts.gateway_account_id
       if (transaction.type === 'payment') {
         transaction.includeRefundSummary = true
         transaction.includeSettlementSummary = true

--- a/test/integration/add-psp-details.ft.test.js
+++ b/test/integration/add-psp-details.ft.test.js
@@ -51,7 +51,6 @@ describe('Add stripe psp details route', function () {
 
     it('should load the "Go live complete" page', async () => {
       const url = `/account/a-valid-external-id${paths.account.stripe.addPspAccountDetails}`
-      console.log('going to url', url)
       const res = await supertest(app)
         .get(url)
       const $ = cheerio.load(res.text)

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -1,24 +1,24 @@
-var path = require('path')
+const path = require('path')
 require(path.join(__dirname, '/../test-helpers/html-assertions.js'))
-var assert = require('assert')
-var router = require(path.join(__dirname, '/../../app/routes.js'))
+const assert = require('assert')
+const router = require(path.join(__dirname, '/../../app/routes.js'))
 
 describe('date format', function () {
   it('should return the correct generated url with no query string', function () {
-    var dynamicRoute = router.paths.transactions.detail
-    var route = router.generateRoute(dynamicRoute, { chargeId: 'foo' })
+    const dynamicRoute = router.paths.account.transactions.detail
+    const route = router.generateRoute(dynamicRoute, { chargeId: 'foo' })
     assert.strictEqual('/transactions/foo', route)
   })
 
   it('should return the correct url with paramters appended as query if they are not named', function () {
-    var dynamicRoute = router.paths.transactions.detail
-    var route = router.generateRoute(dynamicRoute, { chargeId: 'foo', foo: 'bar' })
+    const dynamicRoute = router.paths.account.transactions.detail
+    const route = router.generateRoute(dynamicRoute, { chargeId: 'foo', foo: 'bar' })
     assert.strictEqual('/transactions/foo?foo=bar', route)
   })
 
   it('should remove empty params', function () {
-    var dynamicRoute = router.paths.transactions.detail
-    var route = router.generateRoute(dynamicRoute, { chargeId: 'foo', foo: 'bar', choc: 'bar', empty: '' })
+    const dynamicRoute = router.paths.account.transactions.detail
+    const route = router.generateRoute(dynamicRoute, { chargeId: 'foo', foo: 'bar', choc: 'bar', empty: '' })
     assert.strictEqual('/transactions/foo?foo=bar&choc=bar', route)
   })
 })

--- a/test/integration/transaction-redirect-details.ft.test.js
+++ b/test/integration/transaction-redirect-details.ft.test.js
@@ -10,16 +10,18 @@ const paths = require('../../app/paths.js')
 const session = require('../test-helpers/mock-session.js')
 const gatewayAccountId = '15486734'
 const { validTransactionDetailsResponse } = require('../fixtures/ledger-transaction.fixtures')
+const { validGatewayAccountResponse } = require('../fixtures/gateway-account.fixtures')
+
 let app
 
 const connectorMock = nock(process.env.CONNECTOR_URL)
-const CONNECTOR_ACCOUNT_PATH = '/v1/frontend/accounts/' + gatewayAccountId
 const LEDGER_TRANSACTION_PATH = '/v1/transaction/{transactionId}'
 const ledgerMock = nock(process.env.LEDGER_URL)
+const EXTERNAL_GATEWAY_ACCOUNT_ID = 'an-external-id'
 
 function whenGetRedirectTransactionRoute (transactionId, baseApp) {
   return request(baseApp)
-    .get(paths.generateRoute(paths.transactions.redirectDetail, { chargeId: transactionId }))
+    .get(paths.generateRoute(paths.allServiceTransactions.redirectDetail, { chargeId: transactionId }))
     .set('Accept', 'application/json')
 }
 
@@ -42,12 +44,14 @@ describe('The transaction view scenarios', function () {
     app = session.getAppWithLoggedInUser(getApp(), user)
 
     userCreator.mockUserResponse(user.toJson(), done)
-    connectorMock.get(CONNECTOR_ACCOUNT_PATH)
-      .reply(200, {
-        'payment_provider': 'sandbox',
-        'gateway_account_id': gatewayAccountId,
-        'credentials': { 'username': 'a-username' }
-      })
+
+    connectorMock.get(`/v1/frontend/accounts/${gatewayAccountId}`)
+      .reply(200, validGatewayAccountResponse(
+        {
+          external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,
+          gateway_account_id: gatewayAccountId
+        }
+      ))
   })
 
   describe('The transaction redirect endpoint', function () {

--- a/test/ui/transaction-details.ui.test.js
+++ b/test/ui/transaction-details.ui.test.js
@@ -4,6 +4,7 @@ const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
 const cheerio = require('cheerio')
+
 chai.should()
 chai.use(chaiAsPromised)
 
@@ -66,13 +67,16 @@ describe('The transaction details view', () => {
         'transactions_card_type_read': true,
         'transactions_description_read': true,
         'transactions_events_read': true
+      },
+      currentGatewayAccount: {
+        external_id: 'an-external-id'
       }
     }
 
     const body = renderTemplate('transaction-detail/index', templateData)
     const $ = cheerio.load(body)
     body.should.not.containSelector('.refund__toggle-container')
-    $('.govuk-back-link').attr('href').should.equal('/transactions?reference=&email=&state=&fromDate=&fromTime=&toDate=&toTime=')
+    $('.govuk-back-link').attr('href').should.equal('/account/an-external-id/transactions?reference=&email=&state=&fromDate=&fromTime=&toDate=&toTime=')
     $('#reference').html().should.equal('&lt;123412341234&gt; &amp;')
     $('#description').html().should.equal('First ever')
     $('#email').html().should.equal('alice.111@mail.fake')
@@ -173,13 +177,16 @@ describe('The transaction details view', () => {
         'transactions_card_type_read': true,
         'transactions_description_read': true,
         'transactions_events_read': true
+      },
+      currentGatewayAccount: {
+        external_id: 'an-external-id'
       }
     }
 
     const body = renderTemplate('transaction-detail/index', templateData)
     const $ = cheerio.load(body)
     body.should.not.containSelector('.refund__toggle-container')
-    $('.govuk-back-link').attr('href').should.equal('/transactions?reference=&email=&state=&fromDate=&fromTime=&toDate=&toTime=')
+    $('.govuk-back-link').attr('href').should.equal('/account/an-external-id/transactions?reference=&email=&state=&fromDate=&fromTime=&toDate=&toTime=')
     $('#reference').html().should.equal('&lt;123412341234&gt; &amp;')
     $('#description').html().should.equal('First ever')
     $('#email').html().should.equal('alice.111@mail.fake')

--- a/test/unit/controller/transaction-refund.controller.it.test.js
+++ b/test/unit/controller/transaction-refund.controller.it.test.js
@@ -28,7 +28,8 @@ describe('Refund scenario:', function () {
         email: 'test@example.com'
       },
       account: {
-        gateway_account_id: ACCOUNT_ID
+        gateway_account_id: ACCOUNT_ID,
+        external_id: 'an-external-id'
       },
       params: {
         chargeId: CHARGE_ID
@@ -57,7 +58,7 @@ describe('Refund scenario:', function () {
       .reply(202)
 
     await refundController(req, res)
-    sinon.assert.calledWith(res.redirect, '/transactions/123456')
+    sinon.assert.calledWith(res.redirect, '/account/an-external-id/transactions/123456')
     sinon.assert.calledWith(req.flash, 'refundSuccess', 'true')
   })
 
@@ -79,7 +80,7 @@ describe('Refund scenario:', function () {
       .reply(202)
 
     await refundController(req, res)
-    sinon.assert.calledWith(res.redirect, '/transactions/123456')
+    sinon.assert.calledWith(res.redirect, '/account/an-external-id/transactions/123456')
     sinon.assert.calledWith(req.flash, 'refundSuccess', 'true')
   })
 
@@ -92,7 +93,7 @@ describe('Refund scenario:', function () {
     }
 
     await refundController(req, res)
-    sinon.assert.calledWith(res.redirect, '/transactions/123456')
+    sinon.assert.calledWith(res.redirect, '/account/an-external-id/transactions/123456')
     sinon.assert.calledWith(req.flash, 'refundError', 'Enter an amount to refund in pounds and pence using digits and a decimal point. For example “10.50”')
   })
 
@@ -119,7 +120,7 @@ describe('Refund scenario:', function () {
       .reply(400, response)
 
     await refundController(req, res)
-    sinon.assert.calledWith(res.redirect, '/transactions/123456')
+    sinon.assert.calledWith(res.redirect, '/account/an-external-id/transactions/123456')
     sinon.assert.calledWith(req.flash, 'refundError', 'The amount you tried to refund is greater than the amount available to be refunded. Please try again.')
   })
 
@@ -146,7 +147,7 @@ describe('Refund scenario:', function () {
       .reply(400, response)
 
     await refundController(req, res)
-    sinon.assert.calledWith(res.redirect, '/transactions/123456')
+    sinon.assert.calledWith(res.redirect, '/account/an-external-id/transactions/123456')
     sinon.assert.calledWith(req.flash, 'refundError', 'The amount you tried to refund is too low. Please try again.')
   })
 
@@ -172,7 +173,7 @@ describe('Refund scenario:', function () {
       .reply(400, response)
 
     await refundController(req, res)
-    sinon.assert.calledWith(res.redirect, '/transactions/123456')
+    sinon.assert.calledWith(res.redirect, '/account/an-external-id/transactions/123456')
     sinon.assert.calledWith(req.flash, 'refundError', 'This refund request has already been submitted.')
   })
 
@@ -198,7 +199,7 @@ describe('Refund scenario:', function () {
       .reply(400, response)
 
     await refundController(req, res)
-    sinon.assert.calledWith(res.redirect, '/transactions/123456')
+    sinon.assert.calledWith(res.redirect, '/account/an-external-id/transactions/123456')
     sinon.assert.calledWith(req.flash, 'refundError', 'This refund request has already been submitted.')
   })
 
@@ -223,7 +224,7 @@ describe('Refund scenario:', function () {
       .reply(400, response)
 
     await refundController(req, res)
-    sinon.assert.calledWith(res.redirect, '/transactions/123456')
+    sinon.assert.calledWith(res.redirect, '/account/an-external-id/transactions/123456')
     sinon.assert.calledWith(req.flash, 'refundError', 'We couldn’t process this refund. Please try again or contact support.')
   })
 })


### PR DESCRIPTION
With @SandorArpa

- Update to use the new '/account/<external-id>' format for transaction pages.
  - Update controllers.
  - Update templates.
  - Update functional tests.
  - Update UI template tests
- Update Refund redirect controller
  - Add connector call to get `gateway > external_id`
  - Update transaction detail redirect
    - Now redircet to the new URL format: `/account/an-external-id/transactions/<charge-id>`
- Update transaction.service.js
  - Do not make a call to get user external ids for refunds - if there are no refunds.
- Add new Cypress test for `All Service Transactions`
  - Should load Transaction list
  - Show Transaction detail
- Update Cypress test for `transaction detail`
  - Remove stub to get user details for refund events when - not needed when there have been no refunds.




