### PR TITLE
PP-7694 Move request to go live pages to service level

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -252,6 +252,18 @@ module.exports.bind = function (app) {
   app.get(merchantDetails.edit, permission('merchant-details:update'), merchantDetailsController.getEdit)
   app.post(merchantDetails.edit, permission('merchant-details:update'), merchantDetailsController.postEdit)
 
+  // Request to go live
+  app.get(requestToGoLive.index, permission('go-live-stage:read'), requestToGoLiveIndexController.get)
+  app.post(requestToGoLive.index, permission('go-live-stage:update'), requestToGoLiveIndexController.post)
+  app.get(requestToGoLive.organisationName, permission('go-live-stage:update'), requestToGoLiveOrganisationNameController.get)
+  app.post(requestToGoLive.organisationName, permission('go-live-stage:update'), requestToGoLiveOrganisationNameController.post)
+  app.get(requestToGoLive.organisationAddress, permission('go-live-stage:update'), requestToGoLiveOrganisationAddressController.get)
+  app.post(requestToGoLive.organisationAddress, permission('go-live-stage:update'), requestToGoLiveOrganisationAddressController.post)
+  app.get(requestToGoLive.chooseHowToProcessPayments, permission('go-live-stage:update'), requestToGoLiveChooseHowToProcessPaymentsController.get)
+  app.post(requestToGoLive.chooseHowToProcessPayments, permission('go-live-stage:update'), requestToGoLiveChooseHowToProcessPaymentsController.post)
+  app.get(requestToGoLive.agreement, permission('go-live-stage:update'), requestToGoLiveAgreementController.get)
+  app.post(requestToGoLive.agreement, permission('go-live-stage:update'), requestToGoLiveAgreementController.post)
+
   // Service live account dashboard link
   app.get(redirects.stripeSetupLiveDashboardRedirect, stripeSetupDashboardRedirectController.get)
 
@@ -378,29 +390,6 @@ module.exports.bind = function (app) {
   account.get(paymentLinks.manage.editMetadata, permission('tokens:create'), paymentLinksController.getAddReportingColumn.showEditMetadataPage)
   account.post(paymentLinks.manage.editMetadata, permission('tokens:create'), paymentLinksController.postUpdateReportingColumn.editMetadata)
   account.post(paymentLinks.manage.deleteMetadata, permission('tokens:create'), paymentLinksController.postUpdateReportingColumn.deleteMetadata)
-
-  // Request to go live
-  app.get(requestToGoLive.index, permission('go-live-stage:read'), getAccount, requestToGoLiveIndexController.get)
-  app.post(requestToGoLive.index, permission('go-live-stage:update'), getAccount, requestToGoLiveIndexController.post)
-  app.get(requestToGoLive.organisationName, permission('go-live-stage:update'), getAccount, requestToGoLiveOrganisationNameController.get)
-  app.post(requestToGoLive.organisationName, permission('go-live-stage:update'), getAccount, requestToGoLiveOrganisationNameController.post)
-  app.get(requestToGoLive.organisationAddress, permission('go-live-stage:update'), getAccount, requestToGoLiveOrganisationAddressController.get)
-  app.post(requestToGoLive.organisationAddress, permission('go-live-stage:update'), getAccount, requestToGoLiveOrganisationAddressController.post)
-  app.get(requestToGoLive.chooseHowToProcessPayments, permission('go-live-stage:update'), getAccount, requestToGoLiveChooseHowToProcessPaymentsController.get)
-  app.post(requestToGoLive.chooseHowToProcessPayments, permission('go-live-stage:update'), getAccount, requestToGoLiveChooseHowToProcessPaymentsController.post)
-  app.get(requestToGoLive.agreement, permission('go-live-stage:update'), getAccount, requestToGoLiveAgreementController.get)
-  app.post(requestToGoLive.agreement, permission('go-live-stage:update'), getAccount, requestToGoLiveAgreementController.post)
-
-  account.get(requestToGoLive.index, permission('go-live-stage:read'), requestToGoLiveIndexController.get)
-  account.post(requestToGoLive.index, permission('go-live-stage:update'), requestToGoLiveIndexController.post)
-  account.get(requestToGoLive.organisationName, permission('go-live-stage:update'), requestToGoLiveOrganisationNameController.get)
-  account.post(requestToGoLive.organisationName, permission('go-live-stage:update'), requestToGoLiveOrganisationNameController.post)
-  account.get(requestToGoLive.organisationAddress, permission('go-live-stage:update'), requestToGoLiveOrganisationAddressController.get)
-  account.post(requestToGoLive.organisationAddress, permission('go-live-stage:update'), requestToGoLiveOrganisationAddressController.post)
-  account.get(requestToGoLive.chooseHowToProcessPayments, permission('go-live-stage:update'), requestToGoLiveChooseHowToProcessPaymentsController.get)
-  account.post(requestToGoLive.chooseHowToProcessPayments, permission('go-live-stage:update'), requestToGoLiveChooseHowToProcessPaymentsController.post)
-  account.get(requestToGoLive.agreement, permission('go-live-stage:update'), requestToGoLiveAgreementController.get)
-  account.post(requestToGoLive.agreement, permission('go-live-stage:update'), requestToGoLiveAgreementController.post)
 
   // Stripe setup
   account.get(stripeSetup.bankDetails, permission('stripe-bank-details:update'), restrictToLiveStripeAccount, stripeSetupBankDetailsController.get)

--- a/app/utils/display-converter.js
+++ b/app/utils/display-converter.js
@@ -18,7 +18,12 @@ const hideServiceNavTemplates = [
   'team-members/team-member-invite',
   'team-members/team-member-details',
   'team-members/team-member-profile',
-  'team-members/team-member-permissions'
+  'team-members/team-member-permissions',
+  'request-to-go-live/agreement',
+  'request-to-go-live/choose-how-to-process-payments',
+  'request-to-go-live/index',
+  'request-to-go-live/organisation-address',
+  'request-to-go-live/organisation-name'
 ]
 
 /**

--- a/app/views/request-to-go-live/agreement.njk
+++ b/app/views/request-to-go-live/agreement.njk
@@ -1,4 +1,4 @@
-{% extends "../layout.njk" %}
+{% extends "./layout.njk" %}
 
 {% block pageTitle %}
   Read and accept our legal terms - Request a live account - {{ currentService.name }} - GOV.UK Pay

--- a/app/views/request-to-go-live/choose-how-to-process-payments.njk
+++ b/app/views/request-to-go-live/choose-how-to-process-payments.njk
@@ -1,4 +1,4 @@
-{% extends "../layout.njk" %}
+{% extends "./layout.njk" %}
 
 {% block pageTitle %}
   Which payment service provider will you use? - Request a live account - {{ currentService.name }} - GOV.UK Pay

--- a/app/views/request-to-go-live/index.njk
+++ b/app/views/request-to-go-live/index.njk
@@ -1,4 +1,4 @@
-{% extends "../layout.njk" %}
+{% extends "./layout.njk" %}
 
 {% block pageTitle %}
   Request a live account - {{ currentService.name }} - GOV.UK Pay
@@ -38,7 +38,7 @@
           <p class="govuk-body">When we activate your live account, we’ll email you with next steps.</p>
       {% endif %}
 
-      <p class="govuk-body"><a href="{{formatAccountPathsFor(routes.account.dashboard.index, currentGatewayAccount.external_id)}}" class="govuk-link">Return to dashboard</a></p>
+      <p class="govuk-body"><a href="{{routes.serviceSwitcher.index}}" class="govuk-link">Go to My services</a></p>
     </div>
   {% elif denied %}
     <div class="govuk-grid-column-full">
@@ -54,7 +54,7 @@
   {% else %}
     <div class="govuk-grid-column-two-thirds">
       {% if notStarted or startedButStillStepsToComplete %}
-        <h1 class="govuk-heading-l govuk-!-margin-top-6 govuk-!-margin-bottom-2">Request a live account</h1>
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-2">Request a live account</h1>
         <p class="govuk-body-l intro">Complete these steps to request a live account.</p>
       {% endif %}
       <div class="request-to-go-live-list">

--- a/app/views/request-to-go-live/layout.njk
+++ b/app/views/request-to-go-live/layout.njk
@@ -1,0 +1,11 @@
+{% extends "../layout.njk" %}
+
+{% block beforeContent %}
+  {{ super() }}
+  {{
+    govukBackLink({
+      text: "My services",
+      href: routes.serviceSwitcher.index
+    })
+  }}
+{% endblock %}

--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -1,4 +1,4 @@
-{% extends "../layout.njk" %}
+{% extends "./layout.njk" %}
 
 {% block pageTitle %}
   What is your organisation’s address? - Request a live account - {{ currentService.name }} - GOV.UK Pay

--- a/app/views/request-to-go-live/organisation-name.njk
+++ b/app/views/request-to-go-live/organisation-name.njk
@@ -1,4 +1,4 @@
-{% extends "../layout.njk" %}
+{% extends "./layout.njk" %}
 
 {% block pageTitle %}
   What is your organisation called? - Request a live account - {{ currentService.name }} - GOV.UK Pay

--- a/test/cypress/integration/request-to-go-live/agreement.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/agreement.cy.test.js
@@ -67,6 +67,9 @@ describe('Request to go live: agreement', () => {
 
       cy.visit(requestToGoLiveAgreementUrl)
 
+      cy.get('.govuk-back-link').should('have.text', 'My services')
+      cy.get('.service-navigation').should('not.exist')
+
       cy.get('h1').should('contain', 'Read and accept our legal terms')
 
       cy.get('fieldset').should('contain', 'These include the legal terms of Stripe, GOV.UK Pay’s payment service provider.')

--- a/test/cypress/integration/request-to-go-live/choose-how-to-process-payments.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/choose-how-to-process-payments.cy.test.js
@@ -33,6 +33,9 @@ describe('Request to go live: choose how to process payments', () => {
 
       cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
 
+      cy.get('.govuk-back-link').should('have.text', 'My services')
+      cy.get('.service-navigation').should('not.exist')
+
       cy.get('#request-to-go-live-current-step').should('exist')
       cy.get('#request-to-go-live-choose-how-to-process-payments-form').should('exist')
       cy.get('#choose-how-to-process-payments-mode').should('exist')

--- a/test/cypress/integration/request-to-go-live/index.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/index.cy.test.js
@@ -54,6 +54,9 @@ describe('Request to go live: index', () => {
       const requestToGoLivePageUrl = `/service/${serviceExternalId}/request-to-go-live`
       cy.visit(requestToGoLivePageUrl)
 
+      cy.get('.govuk-back-link').should('have.text', 'My services')
+      cy.get('.service-navigation').should('not.exist')
+
       cy.get('h1').should('contain', 'Request a live account')
       cy.get('h1 + p').should('contain', 'Complete these steps to request a live account')
 

--- a/test/cypress/integration/request-to-go-live/organisation-address.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/organisation-address.cy.test.js
@@ -33,6 +33,9 @@ describe('The organisation address page', () => {
         cy.setEncryptedCookies(userExternalId, gatewayAccountId)
         cy.visit(pageUrl)
 
+        cy.get('.govuk-back-link').should('have.text', 'My services')
+        cy.get('.service-navigation').should('not.exist')
+
         cy.get('h1').should('contain', `What is your organisation’s address?`)
 
         cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)

--- a/test/cypress/integration/request-to-go-live/organisation-name.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/organisation-name.cy.test.js
@@ -62,6 +62,9 @@ describe('Request to go live: organisation name page', () => {
 
       cy.visit(requestToGoLivePageOrganisationNameUrl)
 
+      cy.get('.govuk-back-link').should('have.text', 'My services')
+      cy.get('.service-navigation').should('not.exist')
+
       cy.get('h1').should('contain', 'What is your organisation called?')
 
       cy.get('#request-to-go-live-current-step').should('exist')


### PR DESCRIPTION
The URLs for these pages were at the service level, but they were displayed with the account navigation.

As we are going to remove the cookie for determining the current gateway account, these pages will no longer know which account the user has come from.

Remove the `getAccount` middleware from these routes and stop showing the account navigation. Continue displaying the service name header and include a "My services" back link in the top left corner.  Remove some top padding on the index page as this space is now filled by the back link.

<img width="1259" alt="Screenshot 2021-02-02 at 16 05 33" src="https://user-images.githubusercontent.com/5648592/106627695-f5d43600-6570-11eb-807d-6709c49eb5d8.png">

Replace the link on the confirmation page with a "Go to My services" link.

<img width="1259" alt="Screenshot 2021-02-02 at 16 12 14" src="https://user-images.githubusercontent.com/5648592/106628174-6ed38d80-6571-11eb-980c-baefdce61adb.png">

