### PR TITLE
BAU Remove 3DS flex warning

### DIFF
--- a/app/views/your-psp/_worldpay-flex.njk
+++ b/app/views/your-psp/_worldpay-flex.njk
@@ -11,11 +11,6 @@
 
 <p class="govuk-body">If you have set up 3DS Flex on your Worldpay account, you need to enter the following details to turn 3DS Flex on. You’ll find these details in your <a class="govuk-link" href="https://secure.worldpay.com/sso/public/auth/login.html">Worldpay account</a>.</p>
 
-{{ govukWarningText({
-  text: "If your credentials are wrong, you are not able to take payments.",
-  iconFallbackText: "Warning"
-}) }}
-
 {{  govukSummaryList({
     rows: [
       {


### PR DESCRIPTION
Now that credentials are verified before being saved in the backend
there is no need to warn users about this implication up front.

Also @stevenjmesser told me to.
