### PR TITLE
PP-7561 Render errors using response function

### DIFF
--- a/app/controllers/all-service-transactions/download-transactions.controller.js
+++ b/app/controllers/all-service-transactions/download-transactions.controller.js
@@ -4,39 +4,37 @@ const date = require('../../utils/dates')
 const transactionService = require('../../services/transaction.service')
 const Stream = require('../../services/clients/stream.client')
 const { CORRELATION_HEADER } = require('../../utils/correlation-header')
-const { renderErrorView } = require('../../utils/response')
 const permissions = require('../../utils/permissions')
+const { NoServicesWithPermissionError } = require('../../errors')
 
-module.exports = (req, res) => {
+module.exports = async function dowmloadTransactions (req, res, next) {
   const filters = req.query
   const correlationId = req.headers[CORRELATION_HEADER]
   const name = `GOVUK_Pay_${date.dateToDefaultFormat(new Date()).replace(' ', '_')}.csv`
 
-  permissions.getLiveGatewayAccountsFor(req.user, 'transactions:read')
-    .then((userPermittedAccountsSummary) => {
-      if (!userPermittedAccountsSummary.gatewayAccountIds.length) {
-        res.status(401).render('error', { message: 'You do not have any associated services with rights to view live transactions.' })
-        return
-      }
-      filters.feeHeaders = userPermittedAccountsSummary.headers.shouldGetStripeHeaders
-      filters.motoHeader = userPermittedAccountsSummary.headers.shouldGetMotoHeaders
-      const url = transactionService.csvSearchUrl(filters, userPermittedAccountsSummary.gatewayAccountIds)
+  try {
+    const userPermittedAccountsSummary = await permissions.getLiveGatewayAccountsFor(req.user, 'transactions:read')
+    if (!userPermittedAccountsSummary.gatewayAccountIds.length) {
+      return next(new NoServicesWithPermissionError('You do not have any associated services with rights to view live transactions.'))
+    }
+    filters.feeHeaders = userPermittedAccountsSummary.headers.shouldGetStripeHeaders
+    filters.motoHeader = userPermittedAccountsSummary.headers.shouldGetMotoHeaders
+    const url = transactionService.csvSearchUrl(filters, userPermittedAccountsSummary.gatewayAccountIds)
 
-      const timestampStreamStart = Date.now()
-      const data = (chunk) => { res.write(chunk) }
-      const complete = () => {
-        transactionService.logCsvFileStreamComplete(timestampStreamStart, filters, userPermittedAccountsSummary.gatewayAccountIds, req.user, correlationId, true)
-        res.end()
-      }
-      const error = () => renderErrorView(req, res, 'Unable to download list of transactions.')
-      const client = new Stream(data, complete, error)
+    const timestampStreamStart = Date.now()
+    const data = (chunk) => { res.write(chunk) }
+    const complete = () => {
+      transactionService.logCsvFileStreamComplete(timestampStreamStart, filters, userPermittedAccountsSummary.gatewayAccountIds, req.user, correlationId, true)
+      res.end()
+    }
+    const error = () => next(new Error('Unable to download list of transactions.'))
+    const client = new Stream(data, complete, error)
 
-      res.setHeader('Content-disposition', `attachment; filename="${name}"`)
-      res.setHeader('Content-Type', 'text/csv')
+    res.setHeader('Content-disposition', `attachment; filename="${name}"`)
+    res.setHeader('Content-Type', 'text/csv')
 
-      client.request(url, correlationId)
-    })
-    .catch(() => {
-      renderErrorView(req, res, 'Unable to download list of transactions.')
-    })
+    client.request(url, correlationId)
+  } catch (err) {
+    next(new Error('Unable to download list of transactions.'))
+  }
 }

--- a/app/controllers/stripe-setup/bank-details/post.controller.test.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.test.js
@@ -74,7 +74,7 @@ describe('Bank details post controller', () => {
     sinon.assert.notCalled(setStripeAccountSetupFlagMock)
     sinon.assert.notCalled(res.redirect)
     sinon.assert.calledWith(res.status, 500)
-    sinon.assert.calledWith(res.render, 'error', { message: 'Please try again or contact support team' })
+    sinon.assert.calledWith(res.render, 'error', sinon.match({ message: 'Please try again or contact support team' }))
   })
 
   it('should render error page when stripe setup is not available on request', async () => {
@@ -157,7 +157,7 @@ describe('Bank details post controller', () => {
     sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'bank_account', req.correlationId)
     sinon.assert.notCalled(res.redirect)
     sinon.assert.calledWith(res.status, 500)
-    sinon.assert.calledWith(res.render, 'error', { message: 'Please try again or contact support team' })
+    sinon.assert.calledWith(res.render, 'error', sinon.match({ message: 'Please try again or contact support team' }))
   })
 
   function getControllerWithMocks () {

--- a/app/errors.js
+++ b/app/errors.js
@@ -21,15 +21,25 @@ class UserAccountDisabledError extends DomainError {
 }
 
 /**
- * Thrown when the user does not have permission to access a resource.
+ * Thrown when the user does not have access to a resource.
  */
 class NotAuthorisedError extends DomainError {
 }
 
+/**
+ * Thrown when the user does not have the permission for the given service to access a resource.
+ */
 class PermissionDeniedError extends DomainError {
   constructor (permission) {
     super(`User does not have permission ${permission} for service`)
   }
+}
+
+/**
+ * Thrown when access is denied because the user does not have access to any services with the
+ * required permission.
+ */
+class NoServicesWithPermissionError extends DomainError {
 }
 
 /**
@@ -43,5 +53,6 @@ module.exports = {
   UserAccountDisabledError,
   NotAuthorisedError,
   PermissionDeniedError,
+  NoServicesWithPermissionError,
   NotFoundError
 }

--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -7,11 +7,12 @@ const {
   UserAccountDisabledError,
   NotAuthorisedError,
   PermissionDeniedError,
+  NoServicesWithPermissionError,
   NotFoundError
 } = require('../errors')
 const paths = require('../paths')
 const { CORRELATION_HEADER } = require('../utils/correlation-header')
-const { renderErrorView } = require('../utils/response')
+const { renderErrorView, response } = require('../utils/response')
 
 module.exports = function errorHandler (err, req, res, next) {
   const logContext = {}
@@ -54,10 +55,15 @@ module.exports = function errorHandler (err, req, res, next) {
     return renderErrorView(req, res, 'You do not have the administrator rights to perform this operation.', 403)
   }
 
+  if (err instanceof NoServicesWithPermissionError) {
+    logger.info(`NoServicesWithPermissionError handled: ${err.message}. Rendering error page`, logContext)
+    return renderErrorView(req, res, err.message, 403)
+  }
+
   if (err instanceof NotFoundError) {
     logger.info(`NotFoundError handled: ${err.message}. Rendering 404 page`, logContext)
     res.status(404)
-    return res.render('404')
+    return response(req, res, '404')
   }
 
   if (err && err.code === 'EBADCSRFTOKEN') {


### PR DESCRIPTION
Don't call res.render directly for error pages, as we want to run them through the display converter so we can display the logged in header if the user is logged in.

For places where we did this, call `next` with an error and let the `error-handler` render an appropriate error page using the function in `response.js`.

## Note

Recommended to view with whitespace changes hidden due to indentation changes.


