### PR TITLE
BAU Attempt to fix pact port in use errors

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-02-04T12:30:01Z",
+  "generated_at": "2021-02-04T15:25:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -141,7 +141,7 @@
         "hashed_secret": "48dc804af4a64a0fb46349beef10e94f4fef6a08",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 77,
+        "line_number": 78,
         "type": "Secret Keyword"
       }
     ],
@@ -305,7 +305,7 @@
         "hashed_secret": "5f6087367c3abd5ea9bc0d1650277b9f68b9b233",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 71,
+        "line_number": 73,
         "type": "Secret Keyword"
       }
     ],
@@ -314,7 +314,7 @@
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 139,
+        "line_number": 140,
         "type": "Hex High Entropy String"
       }
     ],
@@ -323,7 +323,7 @@
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 99,
+        "line_number": 100,
         "type": "Hex High Entropy String"
       }
     ],
@@ -332,7 +332,7 @@
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 36,
         "type": "Hex High Entropy String"
       }
     ],
@@ -341,7 +341,7 @@
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 61,
+        "line_number": 62,
         "type": "Hex High Entropy String"
       }
     ],
@@ -350,7 +350,7 @@
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 89,
+        "line_number": 90,
         "type": "Hex High Entropy String"
       }
     ],
@@ -361,150 +361,6 @@
         "is_verified": false,
         "line_number": 116,
         "type": "Hex High Entropy String"
-      }
-    ],
-    "test/unit/clients/products-client/payment/create.pact.test.js": [
-      {
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Secret Keyword"
-      }
-    ],
-    "test/unit/clients/products-client/payment/get-by-payment-external-id.pact.test.js": [
-      {
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Secret Keyword"
-      }
-    ],
-    "test/unit/clients/products-client/payment/get-by-product-external-id.pact.test.js": [
-      {
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Secret Keyword"
-      }
-    ],
-    "test/unit/clients/products-client/product/create.pact.test.js": [
-      {
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Secret Keyword"
-      }
-    ],
-    "test/unit/clients/products-client/product/delete.pact.test.js": [
-      {
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 15,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 15,
-        "type": "Secret Keyword"
-      }
-    ],
-    "test/unit/clients/products-client/product/disable.pact.test.js": [
-      {
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 15,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 15,
-        "type": "Secret Keyword"
-      }
-    ],
-    "test/unit/clients/products-client/product/get-by-gateway-account-id-with-metadata.pact.test.js": [
-      {
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Secret Keyword"
-      }
-    ],
-    "test/unit/clients/products-client/product/get-by-gateway-account-id.pact.test.js": [
-      {
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Secret Keyword"
-      }
-    ],
-    "test/unit/clients/products-client/product/get-by-product-external-id.pact.test.js": [
-      {
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Secret Keyword"
       }
     ],
     "test/unit/controller/register-service-controller/register-service.controller.test.js": [

--- a/app/services/clients/public-auth.client.js
+++ b/app/services/clients/public-auth.client.js
@@ -1,13 +1,14 @@
 'use strict'
 
 const baseClient = require('./base-client/base.client')
+const { PUBLIC_AUTH_URL } = require('../../../config')
 // Constants
 const SERVICE_NAME = 'publicauth'
 
 /**
  * @param {string} accountId
  */
-const getUrlForAccountId = accountId => `${process.env.PUBLIC_AUTH_URL}/${accountId}`
+const getUrlForAccountId = accountId => `${PUBLIC_AUTH_URL}/${accountId}`
 
 /**
  * Get active tokens for account

--- a/config/index.js
+++ b/config/index.js
@@ -2,3 +2,4 @@
 
 exports.CORRELATION_HEADER = process.env.CORRELATION_HEADER_NAME || 'x-request-id'
 exports.PRODUCTS_URL = process.env.PRODUCTS_URL
+exports.PUBLIC_AUTH_URL = process.env.PUBLIC_AUTH_URL

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lint": "./node_modules/.bin/standard --fix",
     "lint-sass": "./node_modules/.bin/sass-lint -v",
     "test": "rm -rf ./pacts && NODE_ENV=test ./node_modules/mocha/bin/mocha --exclude **/*.cy.test.js '!(node_modules)/**/*.test'.js",
+    "test:pact": "rm -rf ./pacts && NODE_ENV=test ./node_modules/mocha/bin/mocha **/*.pact.test.js",
     "cypress:server": "mb --debug | DISABLE_APPMETRICS=true node --inspect -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
     "cypress:test": "cypress run",
     "cypress:test-headed": "cypress open",

--- a/test/unit/clients/adminusers-client/invite/generate-invite-otp-code-service.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/generate-invite-otp-code-service.pact.test.js
@@ -10,8 +10,7 @@ const getAdminUsersClient = require('../../../../../app/services/clients/adminus
 
 // Constants
 const INVITE_RESOURCE = '/v1/api/invites'
-let port = Math.floor(Math.random() * 48127) + 1024
-let adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
+let adminUsersClient
 const expect = chai.expect
 
 // Global setup
@@ -21,14 +20,16 @@ describe('adminusers client - generate otp code for service invite', function ()
   let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    adminUsersClient = getAdminUsersClient({ baseUrl: `http://localhost:${opts.port}` })
+  })
   after(() => provider.finalize())
 
   describe('success', () => {
@@ -49,7 +50,7 @@ describe('adminusers client - generate otp code for service invite', function ()
     afterEach(() => provider.verify())
 
     it('should generate service invite otp code successfully', function (done) {
-      adminusersClient.generateInviteOtpCode(inviteCode).should.be.fulfilled.notify(done)
+      adminUsersClient.generateInviteOtpCode(inviteCode).should.be.fulfilled.notify(done)
     })
   })
 
@@ -70,7 +71,7 @@ describe('adminusers client - generate otp code for service invite', function ()
     afterEach(() => provider.verify())
 
     it('should 404 NOT FOUND if service invite code not found', function (done) {
-      adminusersClient.generateInviteOtpCode(nonExistingInviteCode).should.be.rejected.then(function (response) {
+      adminUsersClient.generateInviteOtpCode(nonExistingInviteCode).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(404)
       }).should.notify(done)
     })

--- a/test/unit/clients/adminusers-client/invite/verify-service-otp-code.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/verify-service-otp-code.pact.test.js
@@ -11,21 +11,22 @@ chai.use(chaiAsPromised)
 
 const expect = chai.expect
 const OTP_VALIDATE_RESOURCE = '/v1/api/invites/otp/validate/service'
-const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
+let adminUsersClient
 
 describe('adminusers client - validate otp code for a service', function () {
   const provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'adminusers',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    adminUsersClient = getAdminUsersClient({ baseUrl: `http://localhost:${opts.port}` })
+  })
   after(() => provider.finalize())
 
   describe('success', () => {
@@ -47,7 +48,7 @@ describe('adminusers client - validate otp code for a service', function () {
     afterEach(() => provider.verify())
 
     it('should verify service otp code successfully', function (done) {
-      adminusersClient.verifyOtpForServiceInvite(validRequest.code, validRequest.otp).should.be.fulfilled
+      adminUsersClient.verifyOtpForServiceInvite(validRequest.code, validRequest.otp).should.be.fulfilled
         .should.notify(done)
     })
   })
@@ -73,7 +74,7 @@ describe('adminusers client - validate otp code for a service', function () {
     afterEach(() => provider.verify())
 
     it('should return 400 on missing fields', function (done) {
-      adminusersClient.verifyOtpForServiceInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
+      adminUsersClient.verifyOtpForServiceInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(400)
         expect(response.message.errors.length).to.equal(1)
         expect(response.message.errors[0]).to.equal('Field [code] is required')
@@ -99,7 +100,7 @@ describe('adminusers client - validate otp code for a service', function () {
     afterEach(() => provider.verify())
 
     it('should return 404 if code cannot be found', function (done) {
-      adminusersClient.verifyOtpForServiceInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
+      adminUsersClient.verifyOtpForServiceInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(404)
       }).should.notify(done)
     })
@@ -123,7 +124,7 @@ describe('adminusers client - validate otp code for a service', function () {
     afterEach(() => provider.verify())
 
     it('return 410 if code locked', function (done) {
-      adminusersClient.verifyOtpForServiceInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
+      adminUsersClient.verifyOtpForServiceInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(410)
       }).should.notify(done)
     })

--- a/test/unit/clients/adminusers-client/service/add-gateway-accounts-to-services.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/add-gateway-accounts-to-services.pact.test.js
@@ -12,8 +12,7 @@ const { pactify } = require('../../../../test-helpers/pact/pactifier').defaultPa
 
 // Constants
 const SERVICE_RESOURCE = '/v1/api/services'
-const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
+let adminUsersClient
 const expect = chai.expect
 const serviceExternalId = 'cp5wa'
 let result, request
@@ -27,14 +26,16 @@ describe('admin users client - add gateway accounts to service', () => {
   let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    adminUsersClient = getAdminUsersClient({ baseUrl: `http://localhost:${opts.port}` })
+  })
   after(() => provider.finalize())
 
   describe('a successful add gateway account to service request', () => {
@@ -60,7 +61,7 @@ describe('admin users client - add gateway accounts to service', () => {
     afterEach(() => provider.verify())
 
     it('should update service name', () => {
-      result = adminusersClient.addGatewayAccountsToService(serviceExternalId, gatewayAccountsIdsToAdd)
+      result = adminUsersClient.addGatewayAccountsToService(serviceExternalId, gatewayAccountsIdsToAdd)
 
       return expect(result)
         .to.be.fulfilled
@@ -94,7 +95,7 @@ describe('admin users client - add gateway accounts to service', () => {
     afterEach(() => provider.verify())
 
     it('should reject with an error detailing the conflicting', () => {
-      result = adminusersClient.addGatewayAccountsToService(serviceExternalId, gatewayAccountIds)
+      result = adminUsersClient.addGatewayAccountsToService(serviceExternalId, gatewayAccountIds)
 
       return expect(result)
         .to.be.rejected
@@ -131,7 +132,7 @@ describe('admin users client - add gateway accounts to service', () => {
     afterEach(() => provider.verify())
 
     it('should reject with an error detailing the conflicting', () => {
-      result = adminusersClient.addGatewayAccountsToService(nonExistentServiceId, gatewayAccountIds)
+      result = adminUsersClient.addGatewayAccountsToService(nonExistentServiceId, gatewayAccountIds)
 
       return expect(result)
         .to.be.rejected

--- a/test/unit/clients/adminusers-client/service/create-service.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/create-service.pact.test.js
@@ -12,8 +12,7 @@ const { pactify } = require('../../../../test-helpers/pact/pactifier').defaultPa
 
 // Constants
 const SERVICE_RESOURCE = '/v1/api/services'
-const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
+let adminUsersClient
 const expect = chai.expect
 
 // Global setup
@@ -23,14 +22,16 @@ describe('adminusers client - create a new service', function () {
   let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    adminUsersClient = getAdminUsersClient({ baseUrl: `http://localhost:${opts.port}` })
+  })
   after(() => provider.finalize())
 
   describe('success', () => {
@@ -60,7 +61,7 @@ describe('adminusers client - create a new service', function () {
     afterEach(() => provider.verify())
 
     it('should create a new service', function (done) {
-      adminusersClient.createService().should.be.fulfilled.then(service => {
+      adminUsersClient.createService().should.be.fulfilled.then(service => {
         expect(service.externalId).to.equal(externalId)
         expect(service.name).to.equal(name)
         expect(service.gatewayAccountIds).to.deep.equal(gatewayAccountIds)
@@ -98,7 +99,7 @@ describe('adminusers client - create a new service', function () {
     afterEach(() => provider.verify())
 
     it('should create a new service', function (done) {
-      adminusersClient.createService(null, null, validRequest.gateway_account_ids).should.be.fulfilled.then(service => {
+      adminUsersClient.createService(null, null, validRequest.gateway_account_ids).should.be.fulfilled.then(service => {
         expect(service.externalId).to.equal(externalId)
         expect(service.name).to.equal(name)
         expect(service.gatewayAccountIds).to.deep.equal(validCreateServiceResponse.gateway_account_ids)
@@ -138,7 +139,7 @@ describe('adminusers client - create a new service', function () {
     afterEach(() => provider.verify())
 
     it('should create a new service', function (done) {
-      adminusersClient.createService('Service name', null, null).should.be.fulfilled.then(service => {
+      adminUsersClient.createService('Service name', null, null).should.be.fulfilled.then(service => {
         expect(service.externalId).to.equal(externalId)
         expect(service.name).to.equal(name)
         expect(service.gatewayAccountIds).to.deep.equal(gatewayAccountIds)

--- a/test/unit/clients/adminusers-client/service/govuk-pay-agreement-post-email-address.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/govuk-pay-agreement-post-email-address.pact.test.js
@@ -11,8 +11,7 @@ const validPostGovUkPayAgreementRequest = require('../../../../fixtures/go-live-
 
 // Constants
 const SERVICE_RESOURCE = '/v1/api/services'
-const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
+let adminUsersClient
 
 const userExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
 const serviceExternalId = 'cp5wa'
@@ -23,14 +22,16 @@ describe('adminusers client - post govuk pay agreement - email address', () => {
   let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    adminUsersClient = getAdminUsersClient({ baseUrl: `http://localhost:${opts.port}` })
+  })
   after(() => provider.finalize())
 
   describe('post email address', () => {
@@ -54,7 +55,7 @@ describe('adminusers client - post govuk pay agreement - email address', () => {
     afterEach(() => provider.verify())
 
     it('should post email address successfully', done => {
-      adminusersClient.addGovUkAgreementEmailAddress(serviceExternalId, userExternalId)
+      adminUsersClient.addGovUkAgreementEmailAddress(serviceExternalId, userExternalId)
         .should.be.fulfilled.should.notify(done)
     })
   })

--- a/test/unit/clients/adminusers-client/service/stripe-agreement-post-ip-address.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/stripe-agreement-post-ip-address.pact.test.js
@@ -11,8 +11,7 @@ const validPostStripeAgreementRequest = require('../../../../fixtures/go-live-re
 
 // Constants
 const SERVICE_RESOURCE = '/v1/api/services'
-const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
+let adminUsersClient
 const serviceExternalId = 'rtglNotStarted'
 
 // Global setup
@@ -22,14 +21,16 @@ describe('adminusers client - post stripe agreement - ip address', () => {
   let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    adminUsersClient = getAdminUsersClient({ baseUrl: `http://localhost:${opts.port}` })
+  })
   after(() => provider.finalize())
 
   describe('post ip address', () => {
@@ -54,7 +55,7 @@ describe('adminusers client - post stripe agreement - ip address', () => {
     afterEach(() => provider.verify())
 
     it('should post ip address successfully', done => {
-      adminusersClient.addStripeAgreementIpAddress(serviceExternalId, ipAddress)
+      adminUsersClient.addStripeAgreementIpAddress(serviceExternalId, ipAddress)
         .should.be.fulfilled.should.notify(done)
     })
   })

--- a/test/unit/clients/adminusers-client/service/update-service.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/update-service.pact.test.js
@@ -14,8 +14,7 @@ const { pactify } = require('../../../../test-helpers/pact/pactifier').defaultPa
 
 // Constants
 const SERVICE_RESOURCE = '/v1/api/services'
-const port = Math.floor(Math.random() * 48127) + 1024
-const adminUsersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
+let adminUsersClient
 const expect = chai.expect
 
 // Global setup
@@ -27,14 +26,16 @@ describe('adminusers client - patch request to update service', function () {
   let provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    adminUsersClient = getAdminUsersClient({ baseUrl: `http://localhost:${opts.port}` })
+  })
   after(() => provider.finalize())
 
   describe('a valid update service patch request to update single field', () => {

--- a/test/unit/clients/adminusers-client/user/assign-servicerole.pact.test.js
+++ b/test/unit/clients/adminusers-client/user/assign-servicerole.pact.test.js
@@ -11,8 +11,7 @@ chai.use(chaiAsPromised)
 
 const expect = chai.expect
 const USER_PATH = '/v1/api/users'
-const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
+let adminUsersClient
 
 const existingUserExternalId = '7d19aff33f8948deb97ed16b2912dcd3'
 const existingServiceExternalId = 'cp5wa'
@@ -21,14 +20,16 @@ describe('adminusers client - assign service role to user', function () {
   const provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    adminUsersClient = getAdminUsersClient({ baseUrl: `http://localhost:${opts.port}` })
+  })
   after(() => provider.finalize())
 
   describe('assign user service role API - success', () => {
@@ -69,7 +70,7 @@ describe('adminusers client - assign service role to user', function () {
     afterEach(() => provider.verify())
 
     it('should assign service role to a user successfully', function (done) {
-      adminusersClient.assignServiceRole(existingUserExternalId, existingServiceExternalId, role).should.be.fulfilled.then(function (updatedUser) {
+      adminUsersClient.assignServiceRole(existingUserExternalId, existingServiceExternalId, role).should.be.fulfilled.then(function (updatedUser) {
         const newServiceRole = updatedUser.serviceRoles.find(serviceRole => serviceRole.service.externalId === existingServiceExternalId)
         expect(newServiceRole.role.name).to.be.equal(role)
       }).should.notify(done)
@@ -99,7 +100,7 @@ describe('adminusers client - assign service role to user', function () {
     afterEach(() => provider.verify())
 
     it('should error not found for non existent user when updating service role', function (done) {
-      adminusersClient.assignServiceRole(nonExistentUserExternalId, existingServiceExternalId, role).should.be.rejected.then(function (response) {
+      adminUsersClient.assignServiceRole(nonExistentUserExternalId, existingServiceExternalId, role).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(404)
       }).should.notify(done)
     })
@@ -128,7 +129,7 @@ describe('adminusers client - assign service role to user', function () {
     afterEach(() => provider.verify())
 
     it('should error bad request if service cannot be located', function (done) {
-      adminusersClient.assignServiceRole(existingUserExternalId, serviceExternalId, role).should.be.rejected.then(function (response) {
+      adminUsersClient.assignServiceRole(existingUserExternalId, serviceExternalId, role).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(400)
       }).should.notify(done)
     })

--- a/test/unit/clients/adminusers-client/user/increment-session-version.pact.test.js
+++ b/test/unit/clients/adminusers-client/user/increment-session-version.pact.test.js
@@ -10,21 +10,22 @@ chai.use(chaiAsPromised)
 
 const expect = chai.expect
 const USER_PATH = '/v1/api/users'
-const port = Math.floor(Math.random() * 48127) + 1024
-const adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
+let adminUsersClient
 
 describe('adminusers client - session', function () {
   const provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    adminUsersClient = getAdminUsersClient({ baseUrl: `http://localhost:${opts.port}` })
+  })
   after(() => provider.finalize())
 
   describe('increment session version  API - success', () => {
@@ -45,7 +46,7 @@ describe('adminusers client - session', function () {
     afterEach(() => provider.verify())
 
     it('should increment session version successfully', function (done) {
-      adminusersClient.incrementSessionVersionForUser(existingExternalId).should.be.fulfilled.notify(done)
+      adminUsersClient.incrementSessionVersionForUser(existingExternalId).should.be.fulfilled.notify(done)
     })
   })
 
@@ -69,7 +70,7 @@ describe('adminusers client - session', function () {
     afterEach(() => provider.verify())
 
     it('should return not found if user not exist', function (done) {
-      adminusersClient.incrementSessionVersionForUser(nonExistentExternalId).should.be.rejected.then(function (response) {
+      adminUsersClient.incrementSessionVersionForUser(nonExistentExternalId).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(404)
       }).should.notify(done)
     })

--- a/test/unit/clients/adminusers-client/user/update-password.pact.test.js
+++ b/test/unit/clients/adminusers-client/user/update-password.pact.test.js
@@ -11,20 +11,22 @@ chai.use(chaiAsPromised)
 const expect = chai.expect
 const RESET_PASSWORD_PATH = '/v1/api/reset-password'
 var port = Math.floor(Math.random() * 48127) + 1024
-var adminusersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
+var adminUsersClient = getAdminUsersClient({ baseUrl: `http://localhost:${port}` })
 
 describe('adminusers client - update password', function () {
   const provider = new Pact({
     consumer: 'selfservice',
     provider: 'adminusers',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    adminUsersClient = getAdminUsersClient({ baseUrl: `http://localhost:${opts.port}` })
+  })
   after(() => provider.finalize())
 
   describe('update password for user API - success', () => {
@@ -46,7 +48,7 @@ describe('adminusers client - update password', function () {
     afterEach(() => provider.verify())
 
     it('should update password successfully', function (done) {
-      adminusersClient.updatePasswordForUser(request.forgotten_password_code, request.new_password).should.be.fulfilled.notify(done)
+      adminUsersClient.updatePasswordForUser(request.forgotten_password_code, request.new_password).should.be.fulfilled.notify(done)
     })
   })
 
@@ -68,7 +70,7 @@ describe('adminusers client - update password', function () {
     afterEach(() => provider.verify())
 
     it('should error if forgotten password code is not found/expired', function (done) {
-      adminusersClient.updatePasswordForUser(request.forgotten_password_code, request.new_password).should.be.rejected.then(function (response) {
+      adminUsersClient.updatePasswordForUser(request.forgotten_password_code, request.new_password).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(404)
       }).should.notify(done)
     })

--- a/test/unit/clients/connector-client/connector-client-create-gateway-account.pact.test.js
+++ b/test/unit/clients/connector-client/connector-client-create-gateway-account.pact.test.js
@@ -11,8 +11,7 @@ const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtur
 
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/api/accounts'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 const expect = chai.expect
 
 // Global setup
@@ -22,14 +21,16 @@ describe('connector client - create gateway account', function () {
   const provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('create gateway account - success', () => {

--- a/test/unit/clients/connector-client/connector-get-card-types.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-card-types.pact.test.js
@@ -12,8 +12,7 @@ const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPacti
 
 // Constants
 const CARD_TYPES_RESOURCE = '/v1/api/card-types'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 const expect = chai.expect
 
 // Global setup
@@ -23,14 +22,16 @@ describe('connector client', function () {
   const provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('get card types', () => {

--- a/test/unit/clients/connector-client/connector-get-gateway-account-by-external-id.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-gateway-account-by-external-id.pact.test.js
@@ -10,8 +10,7 @@ const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtur
 const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPactifier
 
 // Constants
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 const expect = chai.expect
 
 const gatewayAccountExternalId = 'abc123'
@@ -20,14 +19,16 @@ describe('connector client - get gateway account by external id', function () {
   const provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('get Smartpay account with credentials - success', () => {

--- a/test/unit/clients/connector-client/connector-get-gateway-account.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-gateway-account.pact.test.js
@@ -12,8 +12,7 @@ const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPacti
 
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/frontend/accounts'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 const expect = chai.expect
 
 // Global setup
@@ -25,14 +24,16 @@ describe('connector client - get gateway account', function () {
   let provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('get single gateway account - success', () => {

--- a/test/unit/clients/connector-client/connector-get-multiple-gateway-accounts.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-multiple-gateway-accounts.pact.test.js
@@ -12,8 +12,7 @@ const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPacti
 
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/frontend/accounts'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 const expect = chai.expect
 
 // Global setup
@@ -23,14 +22,16 @@ describe('connector client - get multiple gateway accounts', function () {
   let provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('get multiple gateway accounts - success', () => {

--- a/test/unit/clients/connector-client/connector-get-stripe-account-setup.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-stripe-account-setup.pact.test.js
@@ -12,8 +12,7 @@ const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPacti
 
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/api/accounts'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 const expect = chai.expect
 
 // Global setup
@@ -26,14 +25,16 @@ describe('connector client - get stripe account setup', () => {
   const provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('get stripe account setup success', () => {

--- a/test/unit/clients/connector-client/connector-get-stripe-account.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-stripe-account.pact.test.js
@@ -12,8 +12,7 @@ const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPacti
 
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/api/accounts'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 const expect = chai.expect
 
 // Global setup
@@ -26,14 +25,16 @@ describe('connector client - get stripe account', () => {
   const provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('get stripe account setup success', () => {

--- a/test/unit/clients/connector-client/connector-patch-apple-pay-toggle.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-apple-pay-toggle.pact.test.js
@@ -11,8 +11,7 @@ const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtur
 
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/api/accounts'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 const expect = chai.expect
 const existingGatewayAccountId = 666
 
@@ -26,14 +25,16 @@ describe('connector client - patch apple pay toggle (enabled) request', () => {
   let provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('apple pay toggle - supported payment provider request', () => {

--- a/test/unit/clients/connector-client/connector-patch-email-collection-mode.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-email-collection-mode.pact.test.js
@@ -11,8 +11,7 @@ const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtur
 
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/api/accounts'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 const expect = chai.expect
 
 // Global setup
@@ -25,14 +24,16 @@ describe('connector client - patch email collection mode', function () {
   let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('patch email collection mode - mandatory', () => {

--- a/test/unit/clients/connector-client/connector-patch-email-confirmation-toggle.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-email-confirmation-toggle.pact.test.js
@@ -11,8 +11,7 @@ const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtur
 
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/api/accounts'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 const expect = chai.expect
 
 // Global setup
@@ -25,14 +24,16 @@ describe('connector client - patch email confirmation toggle', function () {
   let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('patch email confirmation toggle - enabled', () => {

--- a/test/unit/clients/connector-client/connector-patch-email-refund-toggle.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-email-refund-toggle.pact.test.js
@@ -11,8 +11,7 @@ const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtur
 
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/api/accounts'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 const expect = chai.expect
 
 // Global setup
@@ -25,14 +24,16 @@ describe('connector client - patch email refund toggle', function () {
   let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('patch email refund toggle - enabled', () => {

--- a/test/unit/clients/connector-client/connector-patch-google-pay-toggle.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-google-pay-toggle.pact.test.js
@@ -11,8 +11,7 @@ const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtur
 
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/api/accounts'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 const expect = chai.expect
 const existingGatewayAccountId = 666
 
@@ -26,14 +25,16 @@ describe('connector client - patch google pay toggle (enabled) request', () => {
   let provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('google pay toggle - supported payment provider request', () => {

--- a/test/unit/clients/connector-client/connector-patch-integration-version-3ds.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-integration-version-3ds.pact.test.js
@@ -12,8 +12,7 @@ const Connector = require('../../../../app/services/clients/connector.client').C
 const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
 
 const ACCOUNTS_RESOURCE = '/v1/api/accounts'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 
 // Global setup
 chai.use(chaiAsPromised)
@@ -25,14 +24,16 @@ describe('Update 3DS integration version', () => {
   let provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('Update 3DS integration version to 1', () => {

--- a/test/unit/clients/connector-client/connector-patch-moto-mask-card-number.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-moto-mask-card-number.pact.test.js
@@ -12,8 +12,7 @@ const Connector = require('../../../../app/services/clients/connector.client').C
 const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
 
 const ACCOUNTS_RESOURCE = '/v1/api/accounts'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 const existingGatewayAccountId = 667
 
 // Global setup
@@ -26,14 +25,16 @@ describe('connector client - patch MOTO mask card number toggle (enabled) reques
   let provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('MOTO mask card number input toggle - supported payment provider request', () => {

--- a/test/unit/clients/connector-client/connector-patch-moto-mask-security-code.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-moto-mask-security-code.pact.test.js
@@ -13,8 +13,7 @@ const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtur
 
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/api/accounts'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 const existingGatewayAccountId = 667
 
 // Global setup
@@ -27,14 +26,16 @@ describe('connector client - patch MOTO mask security code toggle (enabled) requ
   let provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('MOTO mask security code input toggle - supported payment provider request', () => {

--- a/test/unit/clients/connector-client/connector-post-refund.pact.test.js
+++ b/test/unit/clients/connector-client/connector-post-refund.pact.test.js
@@ -12,8 +12,7 @@ const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPacti
 
 // Constants
 const CHARGES_RESOURCE = '/v1/api/accounts'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 const expect = chai.expect
 
 // Global setup
@@ -27,14 +26,16 @@ describe('connector client', function () {
   const provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('post refund', () => {

--- a/test/unit/clients/connector-client/connector-post-worldpay-check-3ds-flex-config.pact.test.js
+++ b/test/unit/clients/connector-client/connector-post-worldpay-check-3ds-flex-config.pact.test.js
@@ -13,8 +13,7 @@ const worldpay3dsFlexCredentialsFixtures = require('../../../fixtures/worldpay-3
 const Connector = require('../../../../app/services/clients/connector.client').ConnectorClient
 const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPactifier
 
-const PORT = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${PORT}`)
+let connectorClient
 const ACCOUNTS_RESOURCE = '/v1/api/accounts'
 const EXISTING_GATEWAY_ACCOUNT_ID = 333
 const CHECK_WORLDPAY_3DS_FLEX_CREDENTIALS = 'worldpay/check-3ds-flex-config'
@@ -23,14 +22,16 @@ describe('connector client - check Worldpay 3DS Flex credentials', () => {
   const provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
-    port: PORT,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   afterEach(() => provider.verify())
   after(() => provider.finalize())
 

--- a/test/unit/clients/connector-client/connector-set-stripe-account-setup-flag.pact.test.js
+++ b/test/unit/clients/connector-client/connector-set-stripe-account-setup-flag.pact.test.js
@@ -11,8 +11,7 @@ const stripeAccountSetupFixtures = require('../../../fixtures/stripe-account-set
 
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/api/accounts'
-const port = Math.floor(Math.random() * 48127) + 1024
-const connectorClient = new Connector(`http://localhost:${port}`)
+let connectorClient
 
 // Global setup
 chai.use(chaiAsPromised)
@@ -24,14 +23,16 @@ describe('connector client - set stripe account setup flag', () => {
   const provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('set bank account flag', () => {

--- a/test/unit/clients/products-client/product/disable.pact.test.js
+++ b/test/unit/clients/products-client/product/disable.pact.test.js
@@ -9,10 +9,9 @@ const PactInteractionBuilder = require('../../../../test-helpers/pact/pact-inter
 
 // Constants
 const API_RESOURCE = '/v1/api'
-const port = Math.floor(Math.random() * 48127) + 1024
-let result, productExternalId, gatewayAccountId
+let result, productExternalId, gatewayAccountId, productsClient
 
-function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey = 'ABC1234567890DEF') {
+function getProductsClient (baseUrl) {
   return proxyquire('../../../../../app/services/clients/products.client', {
     '../../../config': {
       PRODUCTS_URL: baseUrl
@@ -24,19 +23,20 @@ describe('products client - disable a product', () => {
   let provider = new Pact({
     consumer: 'selfservice-to-be',
     provider: 'products',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    productsClient = getProductsClient(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('when a product is successfully disabled', () => {
     before(done => {
-      const productsClient = getProductsClient()
       gatewayAccountId = '999'
       productExternalId = 'a_valid_external_id'
       provider.addInteraction(
@@ -63,7 +63,6 @@ describe('products client - disable a product', () => {
 
   describe('create a product - bad request', () => {
     before(done => {
-      const productsClient = getProductsClient()
       productExternalId = 'a_non_existant_external_id'
       provider.addInteraction(
         new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}/disable`)

--- a/test/unit/clients/products-client/product/get-by-product-external-id.pact.test.js
+++ b/test/unit/clients/products-client/product/get-by-product-external-id.pact.test.js
@@ -11,10 +11,9 @@ const { pactify } = require('../../../../test-helpers/pact/pactifier').defaultPa
 
 // Constants
 const API_RESOURCE = '/v1/api'
-const port = Math.floor(Math.random() * 48127) + 1024
-let result
+let result, productsClient
 
-function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey = 'ABC1234567890DEF') {
+function getProductsClient (baseUrl) {
   return proxyquire('../../../../../app/services/clients/products.client', {
     '../../../config': {
       PRODUCTS_URL: baseUrl
@@ -26,14 +25,16 @@ describe('products client - find a product by it\'s external id', function () {
   let provider = new Pact({
     consumer: 'selfservice',
     provider: 'products',
-    port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
     pactfileWriteMode: 'merge'
   })
 
-  before(() => provider.setup())
+  before(async () => {
+    const opts = await provider.setup()
+    productsClient = getProductsClient(`http://localhost:${opts.port}`)
+  })
   after(() => provider.finalize())
 
   describe('when a product is successfully found', () => {
@@ -50,7 +51,6 @@ describe('products client - find a product by it\'s external id', function () {
     })
 
     before(done => {
-      const productsClient = getProductsClient()
       provider.addInteraction(
         new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}`)
           .withUponReceiving('a valid get product request by external id')
@@ -90,7 +90,6 @@ describe('products client - find a product by it\'s external id', function () {
 
   describe('when a product is not found', () => {
     before(done => {
-      const productsClient = getProductsClient()
       const gatewayAccountId = 999
       const productExternalId = 'non-existing-id'
       provider.addInteraction(


### PR DESCRIPTION
Selfservice tests fail regularly with the error:
```Error: Port 'XXXXX' is already in use by another process```

The pact-node provider will by default use an available random port if no port is specified
https://www.npmjs.com/package/@pact-foundation/pact-node

Remove our code to get a random port without checking availability and use the assigned port in the URL used by the client in the pact test.


