### PR TITLE
PP-7592 add onward journey link to email error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,9 @@
 .nyc_output
-.idea
 .sass-cache
 .DS_Store
 .start.pid
 .project
 .settings
-.start.pid
 config/dev-env.json
 .env
 public
@@ -17,6 +15,7 @@ pacts/
 *.txt
 *.log
 *.pid
+.pre-commit-config.yaml
 
 # IntelliJ gubbins
 .idea

--- a/app/views/self-create-service/register.njk
+++ b/app/views/self-create-service/register.njk
@@ -18,23 +18,22 @@
   <h1 class="govuk-heading-l page-title">Create an account</h1>
   <form action="{{routes.selfCreateService.register}}" method="post" id="submit-service-creation" class="form submit-registration">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-    {{
-      govukInput({
-        id: "email",
-        name: "email",
-        type: "email",
-        classes: "govuk-input--width-20",
-        label: {
-            text: "Email",
-            classes: "govuk-label--s"
-        },
-        value: email,
-        hint: {
-          text: "Must be from a government organisation"
-        },
-        errorMessage: { text: errors.email } if errors.email else false
-      })
-    }}
+    <div class="govuk-form-group {% if errors['email'] %} govuk-form-group--error {% endif %}">
+        <label class="govuk-label govuk-label--s" for="email">
+            Email
+        </label>
+        <div id="email-hint" class="govuk-hint">
+            <p class="govuk-hint">Must be from a government organisation</p>
+        </div>
+        {% if errors['email'] %}
+            <span id="email-error" class="govuk-error-message">
+                <span class="govuk-visually-hidden">Error:</span> {{errors["email"]}}. If you cannot create an account using your public sector email address, please <a href="https://www.payments.service.gov.uk/support/" id='support-link'>contact support</a>.
+            </span>
+        {% endif %}
+        <input class="govuk-input govuk-input--width-20 {% if errors['email'] %} govuk-input--error {% endif %}"
+            id="email" name="email" type="email" aria-describedby="email-hint"
+            data-validate="required" value="{{email}}"/>
+    </div>
     {{
       govukInput({
         id: "telephone-number",

--- a/test/ui/self-create-service.ui.test.js
+++ b/test/ui/self-create-service.ui.test.js
@@ -96,4 +96,27 @@ describe('Self-create service view', () => {
 
     done()
   })
+
+  it('should render email error', done => {
+    const telephoneNumber = '01134960000'
+    const email = 'bob@example.com'
+    const templateData = {
+      telephoneNumber: telephoneNumber,
+      email,
+      errors: { email: 'Enter a public sector email address' }
+    }
+
+    const body = renderTemplate('self-create-service/register', templateData)
+
+    body.should.containSelector('h1').withExactText('Create an account')
+
+    body.should.containSelector('form#submit-service-creation').withAttribute('action', paths.selfCreateService.register)
+    body.should.containInputField('email', 'email')
+    body.should.containSelector('#email-error').withText('Error: Enter a public sector email address. If you cannot create an account using your public sector email address, please contact support.')
+    body.should.containSelector('#support-link').withAttribute('href', 'https://www.payments.service.gov.uk/support/')
+    body.should.containInputField('telephone-number', 'tel')
+    body.should.containInputField('password', 'password')
+
+    done()
+  })
 })


### PR DESCRIPTION
## WHAT
- when a user is on the sign up page, and enters a valid email address, but it is not on the approved list, they are shown the link to contact support
- replaced 'govukInput' with custom code. govukInput.errorMessage.text does not render html markups
