### PR TITLE
PP-7765 add psp test account stage to pact test

### DIFF
--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -12,6 +12,7 @@ class Service {
     this.currentGoLiveStage = serviceData.current_go_live_stage
     this.experimentalFeaturesEnabled = serviceData.experimental_features_enabled
     this.createdDate = serviceData.created_date
+    this.currentPspTestAccountStage = serviceData.current_psp_test_account_stage
   }
 
   /**
@@ -29,7 +30,8 @@ class Service {
       collect_billing_address: this.collectBillingAddress,
       current_go_live_stage: this.currentGoLiveStage,
       experimental_features_enabled: this.experimentalFeaturesEnabled,
-      created_date: this.createdDate
+      created_date: this.createdDate,
+      current_psp_test_account_stage: this.currentPspTestAccountStage
     }
   }
 }

--- a/app/models/ServiceUpdateRequest.class.js
+++ b/app/models/ServiceUpdateRequest.class.js
@@ -11,7 +11,8 @@ const validPaths = {
     telephoneNumber: 'merchant_details/telephone_number',
     email: 'merchant_details/email'
   },
-  currentGoLiveStage: 'current_go_live_stage'
+  currentGoLiveStage: 'current_go_live_stage',
+  currentPspTestAccountStage: 'current_psp_test_account_stage'
 }
 
 const ops = {

--- a/app/models/psp-test-account-stage.js
+++ b/app/models/psp-test-account-stage.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = {
+  NOT_STARTED: 'NOT_STARTED',
+  REQUEST_SUBMITTED: 'REQUEST_SUBMITTED',
+  CREATED: 'CREATED'
+}

--- a/test/fixtures/service.fixtures.js
+++ b/test/fixtures/service.fixtures.js
@@ -102,7 +102,8 @@ module.exports = {
       },
       redirect_to_service_immediately_on_terminal_state: false,
       collect_billing_address: false,
-      current_go_live_stage: 'NOT_STARTED'
+      current_go_live_stage: 'NOT_STARTED',
+      current_psp_test_account_stage: 'NOT_STARTED'
     })
 
     const service = {
@@ -114,7 +115,8 @@ module.exports = {
       redirect_to_service_immediately_on_terminal_state: opts.redirect_to_service_immediately_on_terminal_state,
       collect_billing_address: opts.collect_billing_address,
       current_go_live_stage: opts.current_go_live_stage,
-      experimental_features_enabled: true
+      experimental_features_enabled: true,
+      current_psp_test_account_stage: opts.current_psp_test_account_stage
     }
 
     if (opts.merchant_details) {

--- a/test/unit/clients/adminusers-client/service/update-service.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/update-service.pact.test.js
@@ -10,6 +10,7 @@ const getAdminUsersClient = require('../../../../../app/services/clients/adminus
 const serviceFixtures = require('../../../../fixtures/service.fixtures')
 const { validPaths, ServiceUpdateRequest } = require('../../../../../app/models/ServiceUpdateRequest.class')
 const goLiveStage = require('../../../../../app/models/go-live-stage')
+const pspTestAccountStage = require('../../../../../app/models/psp-test-account-stage')
 const { pactify } = require('../../../../test-helpers/pact/pactifier').defaultPactifier
 
 // Constants
@@ -85,6 +86,7 @@ describe('adminusers client - patch request to update service', function () {
       email: 'foo@example.com'
     }
     const currentGoLiveStage = goLiveStage.ENTERED_ORGANISATION_NAME
+    const currentPspTestAccountStage = pspTestAccountStage.REQUEST_SUBMITTED
 
     const validUpdateServiceRequest = new ServiceUpdateRequest()
       .replace(validPaths.merchantDetails.name, merchantDetails.name)
@@ -96,12 +98,14 @@ describe('adminusers client - patch request to update service', function () {
       .replace(validPaths.merchantDetails.telephoneNumber, merchantDetails.telephone_number)
       .replace(validPaths.merchantDetails.email, merchantDetails.email)
       .replace(validPaths.currentGoLiveStage, currentGoLiveStage)
+      .replace(validPaths.currentPspTestAccountStage, currentPspTestAccountStage)
       .formatPayload()
 
     const validUpdateServiceResponse = serviceFixtures.validServiceResponse({
       external_id: existingServiceExternalId,
       merchant_details: merchantDetails,
-      current_go_live_stage: currentGoLiveStage
+      current_go_live_stage: currentGoLiveStage,
+      current_psp_test_account_stage: currentPspTestAccountStage
     })
 
     before(() => {
@@ -123,6 +127,7 @@ describe('adminusers client - patch request to update service', function () {
       expect(service.externalId).to.equal(existingServiceExternalId)
       expect(service.merchantDetails).to.deep.equal(merchantDetails)
       expect(service.currentGoLiveStage).to.equal(currentGoLiveStage)
+      expect(service.currentPspTestAccountStage).to.equal(currentPspTestAccountStage)
     })
   })
 


### PR DESCRIPTION
## WHAT
- add new field `current_psp_test_account_stage` to Serivce class
- add new field `current_psp_test_account_stage` to ServiceUpdateRequest class
- create enum type `current_psp_test_account_stage`
- update relevant pact test
