### PR TITLE
PP-7708 Allow assigning existing users to telephone payments roles

### DIFF
--- a/app/controllers/service-roles-update.controller.js
+++ b/app/controllers/service-roles-update.controller.js
@@ -32,6 +32,7 @@ module.exports = {
     let correlationId = req.correlationId
     let externalUserId = req.params.externalUserId
     let serviceExternalId = req.service.externalId
+    let serviceHasAgentInitiatedMotoEnabled = req.service.agentInitiatedMotoEnabled
 
     let viewData = user => {
       const editPermissionsLink = formattedPathFor(paths.teamMembers.permissions, serviceExternalId, user.externalId)
@@ -44,6 +45,7 @@ module.exports = {
         editPermissionsLink,
         teamMemberIndexLink,
         teamMemberProfileLink,
+        serviceHasAgentInitiatedMotoEnabled,
         admin: {
           id: roles['admin'].extId,
           checked: _.get(role, 'name') === 'admin' ? 'checked' : ''
@@ -55,6 +57,14 @@ module.exports = {
         view: {
           id: roles['view-only'].extId,
           checked: _.get(role, 'name') === 'view-only' ? 'checked' : ''
+        },
+        viewAndInitiateMoto: {
+          id: roles['view-and-initiate-moto'].extId,
+          checked: _.get(role, 'name') === 'view-and-initiate-moto' ? 'checked' : ''
+        },
+        viewRefundAndInitiateMoto: {
+          id: roles['view-refund-and-initiate-moto'].extId,
+          checked: _.get(role, 'name') === 'view-refund-and-initiate-moto' ? 'checked' : ''
         }
       }
     }

--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -13,6 +13,7 @@ class Service {
     this.experimentalFeaturesEnabled = serviceData.experimental_features_enabled
     this.createdDate = serviceData.created_date
     this.currentPspTestAccountStage = serviceData.current_psp_test_account_stage
+    this.agentInitiatedMotoEnabled = serviceData.agent_initiated_moto_enabled
   }
 
   /**
@@ -31,7 +32,8 @@ class Service {
       current_go_live_stage: this.currentGoLiveStage,
       experimental_features_enabled: this.experimentalFeaturesEnabled,
       created_date: this.createdDate,
-      current_psp_test_account_stage: this.currentPspTestAccountStage
+      current_psp_test_account_stage: this.currentPspTestAccountStage,
+      agent_initiated_moto_enabled: this.agentInitiatedMotoEnabled
     }
   }
 }

--- a/app/utils/roles.js
+++ b/app/utils/roles.js
@@ -15,7 +15,7 @@ module.exports = {
   getRoleByExtId: roleExtId => {
     let found
     _.toArray(roles).forEach(role => {
-      if (role.extId === roleExtId && role.extId !== 500 && role.extId !== 600) {
+      if (role.extId === roleExtId) {
         found = role
       }
     })

--- a/app/views/team-members/team-member-permissions.njk
+++ b/app/views/team-members/team-member-permissions.njk
@@ -30,62 +30,154 @@ Edit team member permissions - GOV.UK Pay
   </dl>
   <form id="role-update-form" method="post" action="{{editPermissionsLink}}">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-    {{
-      govukRadios({
-        idPrefix: 'role-input',
-        name: 'role-input',
-        fieldset: {
-          legend: {
-            text: 'Permission level',
-            classes: 'govuk-fieldset__legend--s'
-          }
-        },
-        items: [
-          {
-              value: admin.id,
-              id: "role-admin-input",
-              text: 'Administrator',
-              classes: 'govuk-label--s',
-              checked: admin.checked,
-              hint: {
-                html: '<ul class="govuk-list pay-text-grey">
-                        <li>View transactions</li>
-                        <li>Refund payments</li>
-                        <li>Manage settings</li>
-                      </ul>'
-              }
+    {% if serviceHasAgentInitiatedMotoEnabled %}
+      {{
+        govukRadios({
+          idPrefix: 'role-input',
+          name: 'role-input',
+          fieldset: {
+            legend: {
+              text: 'Permission level',
+              classes: 'govuk-fieldset__legend--s'
+            }
           },
-          {
-              value: viewAndRefund.id,
-              id: "role-view-and-refund-input",
-              text: 'View and refund',
-              classes: 'govuk-label--s',
-              checked: viewAndRefund.checked,
-              hint: {
-                html: '<ul class="govuk-list pay-text-grey">
-                        <li>View transactions</li>
-                        <li>Refund payments</li>
-                        <li>Cannot manage settings</li>
-                      </ul>'
-              }
+          items: [
+            {
+                value: admin.id,
+                id: "role-admin-input",
+                text: 'Administrator',
+                classes: 'govuk-label--s',
+                checked: admin.checked,
+                hint: {
+                  html: '<ul class="govuk-list pay-text-grey">
+                          <li>View transactions</li>
+                          <li>Refund payments</li>
+                          <li>Take telephone payments</li>
+                          <li>Manage settings</li>
+                        </ul>'
+                }
+            },
+            {
+                value: viewAndRefund.id,
+                id: "role-view-and-refund-input",
+                text: 'View and refund',
+                classes: 'govuk-label--s',
+                checked: viewAndRefund.checked,
+                hint: {
+                  html: '<ul class="govuk-list pay-text-grey">
+                          <li>View transactions</li>
+                          <li>Refund payments</li>
+                          <li>Cannot take telephone payments</li>
+                          <li>Cannot manage settings</li>
+                        </ul>'
+                }
+            },
+            {
+                value: view.id,
+                id: "role-view-input",
+                text: 'View only',
+                classes: 'govuk-label--s',
+                checked: view.checked,
+                hint: {
+                  html: '<ul class="govuk-list pay-text-grey">
+                          <li>View transactions</li>
+                          <li>Cannot refund payments</li>
+                          <li>Cannot take telephone payments</li>
+                          <li>Cannot manage settings</li>
+                        </ul>'
+                }
+            },
+            {
+                value: viewAndInitiateMoto.id,
+                id: "role-view-and-initiate-moto-input",
+                text: 'View and take telephone payments',
+                classes: 'govuk-label--s',
+                checked: viewAndInitiateMoto.checked,
+                hint: {
+                  html: '<ul class="govuk-list pay-text-grey">
+                          <li>View transactions</li>
+                          <li>Cannot refund payments</li>
+                          <li>Take telephone payments</li>
+                          <li>Cannot manage settings</li>
+                        </ul>'
+                }
+            },
+            {
+                value: viewRefundAndInitiateMoto.id,
+                id: "role-view-refund-and-initiate-moto-input",
+                text: 'View, refund and take telephone payments',
+                classes: 'govuk-label--s',
+                checked: viewRefundAndInitiateMoto.checked,
+                hint: {
+                  html: '<ul class="govuk-list pay-text-grey">
+                          <li>View transactions</li>
+                          <li>Refund payments</li>
+                          <li>Take telephone payments</li>
+                          <li>Cannot manage settings</li>
+                        </ul>'
+                }
+            }
+          ]
+        })
+      }}
+    {% else %}
+      {{
+        govukRadios({
+          idPrefix: 'role-input',
+          name: 'role-input',
+          fieldset: {
+            legend: {
+              text: 'Permission level',
+              classes: 'govuk-fieldset__legend--s'
+            }
           },
-          {
-              value: view.id,
-              id: "role-view-input",
-              text: 'View only',
-              classes: 'govuk-label--s',
-              checked: view.checked,
-              hint: {
-                html: '<ul class="govuk-list pay-text-grey">
-                        <li>View transactions</li>
-                        <li>Cannot refund payments</li>
-                        <li>Cannot manage settings</li>
-                      </ul>'
-              }
-          }
-        ]
-      })
-    }}
+          items: [
+            {
+                value: admin.id,
+                id: "role-admin-input",
+                text: 'Administrator',
+                classes: 'govuk-label--s',
+                checked: admin.checked,
+                hint: {
+                  html: '<ul class="govuk-list pay-text-grey">
+                          <li>View transactions</li>
+                          <li>Refund payments</li>
+                          <li>Manage settings</li>
+                        </ul>'
+                }
+            },
+            {
+                value: viewAndRefund.id,
+                id: "role-view-and-refund-input",
+                text: 'View and refund',
+                classes: 'govuk-label--s',
+                checked: viewAndRefund.checked,
+                hint: {
+                  html: '<ul class="govuk-list pay-text-grey">
+                          <li>View transactions</li>
+                          <li>Refund payments</li>
+                          <li>Cannot manage settings</li>
+                        </ul>'
+                }
+            },
+            {
+                value: view.id,
+                id: "role-view-input",
+                text: 'View only',
+                classes: 'govuk-label--s',
+                checked: view.checked,
+                hint: {
+                  html: '<ul class="govuk-list pay-text-grey">
+                          <li>View transactions</li>
+                          <li>Cannot refund payments</li>
+                          <li>Cannot manage settings</li>
+                        </ul>'
+                }
+            }
+          ]
+        })
+      }}
+    {% endif %}
 
     {{
       govukWarningText({

--- a/test/ui/service-role-update.ui.test.js
+++ b/test/ui/service-role-update.ui.test.js
@@ -2,13 +2,16 @@ let path = require('path')
 let renderTemplate = require(path.join(__dirname, '/../test-helpers/html-assertions.js')).render
 
 describe('The service role update view', function () {
-  it('should render service role update view', function () {
+  it('should render the standard service role update view', function () {
     let templateData = {
       email: 'oscar.smith@example.com',
       admin: { id: 2, checked: '' },
       viewAndRefund: { id: 3, checked: '' },
       view: { id: 4, checked: 'checked' },
-      editPermissionsLink: 'some-link'
+      viewAndInitiateMoto: { id: 5, checked: '' },
+      viewRefundAndInitiateMoto: { id: 6, checked: '' },
+      editPermissionsLink: 'some-link',
+      serviceHasAgentInitiatedMotoEnabled: false
     }
 
     let body = renderTemplate('team-members/team-member-permissions', templateData)
@@ -27,5 +30,45 @@ describe('The service role update view', function () {
       .withAttribute('type', 'radio')
       .withAttribute('value', '4')
       .withAttribute('checked')
+    body.should.not.containSelector('#role-view-and-intiate-moto-input')
+    body.should.not.containSelector('#role-view-refund-and-intiate-moto-input')
+  })
+
+  it('should render the agent-initiated-MOTO-enahnced service role update view', function () {
+    let templateData = {
+      email: 'oscar.smith@example.com',
+      admin: { id: 2, checked: '' },
+      viewAndRefund: { id: 3, checked: '' },
+      view: { id: 4, checked: 'checked' },
+      viewAndInitiateMoto: { id: 5, checked: '' },
+      viewRefundAndInitiateMoto: { id: 6, checked: '' },
+      editPermissionsLink: 'some-link',
+      serviceHasAgentInitiatedMotoEnabled: true
+    }
+
+    let body = renderTemplate('team-members/team-member-permissions', templateData)
+
+    body.should.containSelector('#email').withExactText('oscar.smith@example.com')
+    body.should.containSelector('#role-update-form').withAttribute('action', 'some-link')
+    body.should.containSelector('#role-admin-input')
+      .withAttribute('type', 'radio')
+      .withAttribute('value', '2')
+      .withNoAttribute('checked')
+    body.should.containSelector('#role-view-and-refund-input')
+      .withAttribute('type', 'radio')
+      .withAttribute('value', '3')
+      .withNoAttribute('checked')
+    body.should.containSelector('#role-view-input')
+      .withAttribute('type', 'radio')
+      .withAttribute('value', '4')
+      .withAttribute('checked')
+    body.should.containSelector('#role-view-and-initiate-moto-input')
+      .withAttribute('type', 'radio')
+      .withAttribute('value', '5')
+      .withNoAttribute('checked')
+      body.should.containSelector('#role-view-refund-and-initiate-moto-input')
+      .withAttribute('type', 'radio')
+      .withAttribute('value', '6')
+      .withNoAttribute('checked')
   })
 })


### PR DESCRIPTION
Allow admin users of a service to change an existing user’s role to `view-and-initiate-moto` or `view-refund-and-initiate-moto`.

For now, these two new roles are only shown if the service has the `agent_initiated_moto_enabled` flag set, which we’re using to limit which services have the agent-initiated MOTO payments feature.

If the flag is false, a determined admin could still assign one of the new roles to a user. However, on its own that will not allow
the user to to do anything more, so it’s not really worth trying to prevent this.