### PR TITLE
BAU Fix logged out error shown for phone number page

### DIFF
--- a/app/controllers/user/phone-number/get.controller.js
+++ b/app/controllers/user/phone-number/get.controller.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const { renderErrorView } = require('../../../utils/response')
+const { renderErrorView, response } = require('../../../utils/response')
 const userService = require('../../../services/user.service')
 
 module.exports = async (req, res) => {
   try {
     const { telephoneNumber } = await userService.findByExternalId(req.user.externalId)
-    return res.render('team-members/edit-phone-number', { telephoneNumber })
+    return response(req, res, 'team-members/edit-phone-number', { telephoneNumber })
   } catch (error) {
     return renderErrorView(req, res, 'Unable to retrieve user')
   }

--- a/app/controllers/user/phone-number/post.controller.js
+++ b/app/controllers/user/phone-number/post.controller.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { renderErrorView } = require('../../../utils/response')
+const { renderErrorView, response } = require('../../../utils/response')
 const userService = require('../../../services/user.service')
 const paths = require('../../../paths')
 const { invalidTelephoneNumber } = require('../../../utils/validation/telephone-number-validation')
@@ -14,7 +14,7 @@ module.exports = async function updatePhoneNumber (req, res) {
         phone: 'Invalid telephone number. Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192'
       }
     }
-    return res.render('team-members/edit-phone-number', pageData)
+    return response(req, res, 'team-members/edit-phone-number', pageData)
   }
 
   try {


### PR DESCRIPTION
We now decide whether to show the logged in or logged out header in the display converter, so that we can show the logged in header for errors (PP-7561).

In this case, we were rendering the view directly using `res.render` rather than using the `response` function to render after calling the display converter.

This was the only case for a logged in route where we were rendering in this way.


