### PR TITLE
PP-7708 Allow inviting new users to telephone payments roles

### DIFF
--- a/app/controllers/invite-user.controller.js
+++ b/app/controllers/invite-user.controller.js
@@ -39,13 +39,17 @@ module.exports = {
     const externalServiceId = req.service.externalId
     const teamMemberIndexLink = formattedPathFor(paths.teamMembers.index, externalServiceId)
     const teamMemberInviteSubmitLink = formattedPathFor(paths.teamMembers.invite, externalServiceId)
+    const serviceHasAgentInitiatedMotoEnabled = req.service.agentInitiatedMotoEnabled
     const invitee = lodash.get(req, 'session.pageData.invitee', '')
     let data = {
       teamMemberIndexLink: teamMemberIndexLink,
       teamMemberInviteSubmitLink: teamMemberInviteSubmitLink,
+      serviceHasAgentInitiatedMotoEnabled: serviceHasAgentInitiatedMotoEnabled,
       admin: { id: roles['admin'].extId },
       viewAndRefund: { id: roles['view-and-refund'].extId },
       view: { id: roles['view-only'].extId },
+      viewAndInitiateMoto: { id: roles['view-and-initiate-moto'].extId },
+      viewRefundAndInitiateMoto: { id: roles['view-refund-and-initiate-moto'].extId },
       invitee
     }
 

--- a/app/views/team-members/team-member-invite.njk
+++ b/app/views/team-members/team-member-invite.njk
@@ -25,60 +25,144 @@ Invite a new team member - GOV.UK Pay
   <form id="invite-member-form" method="post" action="{{teamMemberInviteSubmitLink}}" class="govuk-grid-column-two-thirds">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {{ govukInput({
-        label: {
-          text: "Email address"
-        },
-        id: "invitee-email",
-        name: "invitee-email",
-        classes: "govuk-!-width-two-thirds",
-        type: "email"
-      })
-    }}
-
-    {{ govukRadios({
-      idPrefix: "role-input",
-      name: "role-input",
-      fieldset: {
-        legend: {
-          text: "Permission level",
-          classes: "govuk-label--s"
-        }
+      label: {
+        text: "Email address"
       },
-      items: [
-        {
-          value: admin.id,
-          text: "Administrator",
-          label: {
-            classes: "govuk-label--s"
-          },
-          hint: {
-            html: "View transactions<br/>Refund payments</br/>Manage settings"
-          }
-        },
-        {
-          value: viewAndRefund.id,
-          text: "View and refund",
-          label: {
-            classes: "govuk-label--s"
-          },
-          hint: {
-            html: "View transactions<br/>Refund payments</br/>Cannot manage settings"
-          }
-        },
-        {
-          value: view.id,
-          text: "View only",
-          label: {
-            classes: "govuk-label--s"
-          },
-          checked: true,
-          hint: {
-            html: "View transactions<br/>Cannot
-            refund payments</br/>Cannot manage settings"
-          }
-        }
-      ]
+      id: "invitee-email",
+      name: "invitee-email",
+      classes: "govuk-!-width-two-thirds",
+      type: "email"
     }) }}
+    {% if serviceHasAgentInitiatedMotoEnabled %}
+      {{ govukRadios({
+        idPrefix: "role-input",
+        name: "role-input",
+        fieldset: {
+          legend: {
+            text: "Permission level",
+            classes: "govuk-label--s"
+          }
+        },
+        items: [
+          {
+            value: admin.id,
+            text: "Administrator",
+            label: {
+              classes: "govuk-label--s"
+            },
+            hint: {
+              html: "View transactions<br>
+              Refund payments<br>
+              Take telephone payments<br>
+              Manage settings"
+            }
+          },
+          {
+            value: viewAndRefund.id,
+            text: "View and refund",
+            label: {
+              classes: "govuk-label--s"
+            },
+            hint: {
+              html: "View transactions<br>
+              Refund payments<br>
+              Cannot take telephone payments<br>
+              Cannot manage settings"
+            }
+          },
+          {
+            value: view.id,
+            text: "View only",
+            label: {
+              classes: "govuk-label--s"
+            },
+            checked: true,
+            hint: {
+              html: "View transactions<br>
+              Cannot refund payments<br>
+              Cannot take telephone payments<br>
+              Cannot manage settings"
+            }
+          },
+          {
+            value: viewAndInitiateMoto.id,
+            text: "View and take telephone payments",
+            label: {
+              classes: "govuk-label--s"
+            },
+            hint: {
+              html: "View transactions<br>
+              Cannot refund payments<br>
+              Take telephone payments<br>
+              Cannot manage settings"
+            }
+          },
+          {
+            value: viewRefundAndInitiateMoto.id,
+            text: "View, refund and take telephone payments",
+            label: {
+              classes: "govuk-label--s"
+            },
+            hint: {
+              html: "View transactions<br>
+              Refund payments<br>
+              Take telephone payments<br>
+              Cannot manage settings"
+            }
+          }
+        ]
+      }) }}
+    {% else %}
+      {{ govukRadios({
+        idPrefix: "role-input",
+        name: "role-input",
+        fieldset: {
+          legend: {
+            text: "Permission level",
+            classes: "govuk-label--s"
+          }
+        },
+        items: [
+          {
+            value: admin.id,
+            text: "Administrator",
+            label: {
+              classes: "govuk-label--s"
+            },
+            hint: {
+              html: "View transactions<br>
+              Refund payments<br>
+              Manage settings"
+            }
+          },
+          {
+            value: viewAndRefund.id,
+            text: "View and refund",
+            label: {
+              classes: "govuk-label--s"
+            },
+            hint: {
+              html: "View transactions<br>
+              Refund payments<br>
+              Cannot manage settings"
+            }
+          },
+          {
+            value: view.id,
+            text: "View only",
+            label: {
+              classes: "govuk-label--s"
+            },
+            checked: true,
+            hint: {
+              html: "View transactions<br>
+              Cannot refund payments<br>
+              Cannot manage settings"
+            }
+          }
+        ]
+      }) }}
+    {% endif %}
 
     {{ govukButton({ text: "Send invitation email" }) }}
     <p class="govuk-body">

--- a/test/integration/invite-users.controller.ft.test.js
+++ b/test/integration/invite-users.controller.ft.test.js
@@ -34,6 +34,8 @@ describe('invite user controller', function () {
           expect(res.body.admin.id).to.equal(roles['admin'].extId)
           expect(res.body.viewAndRefund.id).to.equal(roles['view-and-refund'].extId)
           expect(res.body.view.id).to.equal(roles['view-only'].extId)
+          expect(res.body.viewAndInitiateMoto.id).to.equal(roles['view-and-initiate-moto'].extId)
+          expect(res.body.viewRefundAndInitiateMoto.id).to.equal(roles['view-refund-and-initiate-moto'].extId)
         })
         .end(done)
     })

--- a/test/ui/invite-user.ui.test.js
+++ b/test/ui/invite-user.ui.test.js
@@ -5,7 +5,7 @@ let paths = require('../../app/paths.js')
 const formattedPathFor = require('../../app/utils/replace-params-in-path')
 
 describe('Invite a team member view', function () {
-  it('should render invite team member view', function () {
+  it('should render the standard invite team member view', function () {
     const externalServiceId = 'some-external-id'
     const teamMemberIndexLink = formattedPathFor(paths.teamMembers.index, externalServiceId)
     const teamMemberInviteSubmitLink = formattedPathFor(paths.teamMembers.invite, externalServiceId)
@@ -15,7 +15,10 @@ describe('Invite a team member view', function () {
       teamMemberInviteSubmitLink: teamMemberInviteSubmitLink,
       admin: { id: 2 },
       viewAndRefund: { id: 3 },
-      view: { id: 4 }
+      view: { id: 4 },
+      viewAndInitiateMoto: { id: 5 },
+      viewRefundAndInitiateMoto: { id: 6 },
+      serviceHasAgentInitiatedMotoEnabled: false
     }
 
     let body = renderTemplate('team-members/team-member-invite', templateData)
@@ -34,5 +37,49 @@ describe('Invite a team member view', function () {
       .withAttribute('type', 'radio')
       .withAttribute('value', '4')
       .withAttribute('checked')
+    body.should.not.containSelector('#role-input-4')
+    body.should.not.containSelector('#role-input-5')
+  })
+
+  it('should render the agent-initiated-MOTO-enhanced invite team member view', function () {
+    const externalServiceId = 'some-external-id'
+    const teamMemberIndexLink = formattedPathFor(paths.teamMembers.index, externalServiceId)
+    const teamMemberInviteSubmitLink = formattedPathFor(paths.teamMembers.invite, externalServiceId)
+
+    let templateData = {
+      teamMemberIndexLink: teamMemberIndexLink,
+      teamMemberInviteSubmitLink: teamMemberInviteSubmitLink,
+      admin: { id: 2 },
+      viewAndRefund: { id: 3 },
+      view: { id: 4 },
+      viewAndInitiateMoto: { id: 5 },
+      viewRefundAndInitiateMoto: { id: 6 },
+      serviceHasAgentInitiatedMotoEnabled: true
+    }
+
+    let body = renderTemplate('team-members/team-member-invite', templateData)
+
+    body.should.containSelector('.govuk-back-link').withAttribute('href', teamMemberIndexLink)
+    body.should.containSelector('form#invite-member-form').withAttribute('action', teamMemberInviteSubmitLink)
+    body.should.containSelector('#role-input')
+      .withAttribute('type', 'radio')
+      .withAttribute('value', '2')
+      .withNoAttribute('checked')
+    body.should.containSelector('#role-input-2')
+      .withAttribute('type', 'radio')
+      .withAttribute('value', '3')
+      .withNoAttribute('checked')
+    body.should.containSelector('#role-input-3')
+      .withAttribute('type', 'radio')
+      .withAttribute('value', '4')
+      .withAttribute('checked')
+    body.should.containSelector('#role-input-4')
+      .withAttribute('type', 'radio')
+      .withAttribute('value', '5')
+      .withNoAttribute('checked')
+      body.should.containSelector('#role-input-5')
+      .withAttribute('type', 'radio')
+      .withAttribute('value', '6')
+      .withNoAttribute('checked')
   })
 })

--- a/test/ui/service-role-update.ui.test.js
+++ b/test/ui/service-role-update.ui.test.js
@@ -34,7 +34,7 @@ describe('The service role update view', function () {
     body.should.not.containSelector('#role-view-refund-and-intiate-moto-input')
   })
 
-  it('should render the agent-initiated-MOTO-enahnced service role update view', function () {
+  it('should render the agent-initiated-MOTO-enhanced service role update view', function () {
     let templateData = {
       email: 'oscar.smith@example.com',
       admin: { id: 2, checked: '' },


### PR DESCRIPTION
Allow admin users of a service to invite a user granting them the `view-and-initiate-moto` or `view-refund-and-initiate-moto` role.

For now, these two new roles are only shown if the service has the `agent_initiated_moto_enabled` flag set, which we’re using to limit which services have the agent-initiated MOTO payments feature.

If the flag is false, a determined admin could still invite a user and grant them one of the new roles. However, on its own that will not allow the user to to do anything more, so it’s not really worth trying to prevent this.