### PR TITLE
PP-7709 Filter products by type in products not selfservice

### DIFF
--- a/app/controllers/payment-links/get-manage.controller.js
+++ b/app/controllers/payment-links/get-manage.controller.js
@@ -12,8 +12,7 @@ module.exports = async (req, res, next) => {
   lodash.unset(req, 'session.editPaymentLinkData')
 
   try {
-    const products = await productsClient.product.getByGatewayAccountId(req.account.gateway_account_id)
-    const paymentLinks = products.filter(product => product.type === 'ADHOC')
+    const paymentLinks = await productsClient.product.getByGatewayAccountIdAndType(req.account.gateway_account_id, 'ADHOC')
     const englishPaymentLinks = paymentLinks.filter(link => link.language === supportedLanguage.ENGLISH)
     const welshPaymentLinks = paymentLinks.filter(link => link.language === supportedLanguage.WELSH)
     const pageData = {

--- a/app/controllers/test-with-your-users/links.controller.js
+++ b/app/controllers/test-with-your-users/links.controller.js
@@ -15,9 +15,8 @@ module.exports = (req, res) => {
     linksPage: formatAccountPathsFor(paths.account.prototyping.demoService.links, req.account.external_id)
   }
 
-  productsClient.product.getByGatewayAccountId(req.account.gateway_account_id)
-    .then(products => {
-      const prototypeProducts = products.filter(product => product.type === 'PROTOTYPE')
+  productsClient.product.getByGatewayAccountIdAndType(req.account.gateway_account_id, 'PROTOTYPE')
+    .then(prototypeProducts => {
       params.productsLength = prototypeProducts.length
       params.products = prototypeProducts
       return response(req, res, 'dashboard/demo-service/index', params)

--- a/app/services/clients/products.client.js
+++ b/app/services/clients/products.client.js
@@ -20,7 +20,7 @@ module.exports = {
     disable: disableProduct,
     delete: deleteProduct,
     getByProductExternalId: getProductByExternalId,
-    getByGatewayAccountId: getProductsByGatewayAccountId,
+    getByGatewayAccountIdAndType: getProductsByGatewayAccountIdAndType,
     getByProductPath: getProductByPath,
     addMetadataToProduct: addMetadataToProduct,
     updateProductMetadata: updateProductMetadata,
@@ -150,11 +150,11 @@ function getProductByExternalId (gatewayAccountId, productExternalId) {
  * @param {String} gatewayAccountId - The id of the gateway account to retrieve products associated with
  * @returns {Promise<Array<Product>>}
  */
-function getProductsByGatewayAccountId (gatewayAccountId) {
+function getProductsByGatewayAccountIdAndType (gatewayAccountId, productType) {
   return baseClient.get({
     baseUrl,
-    url: `/gateway-account/${gatewayAccountId}/products`,
-    description: 'find a list products associated with a gateway account',
+    url: `/gateway-account/${gatewayAccountId}/products?type=${productType}`,
+    description: 'find a list products associated with a gateway account and a specific type',
     service: SERVICE_NAME
   }).then(products => products.map(product => new Product(product)))
 }

--- a/test/cypress/integration/payment-links/create-payment-link.cy.test.js
+++ b/test/cypress/integration/payment-links/create-payment-link.cy.test.js
@@ -17,7 +17,7 @@ describe('The create payment link flow', () => {
       gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'test', paymentProvider: 'worldpay' }),
       tokenStubs.postCreateTokenForAccountSuccess({ gatewayAccountId }),
       productStubs.postCreateProductSuccess(),
-      productStubs.getProductsStub([{ name: 'A payment link' }], gatewayAccountId)
+      productStubs.getProductsByGatewayAccountIdAndTypeStub([{ name: 'A payment link'}], gatewayAccountId, 'ADHOC')
     ])
     Cypress.Cookies.preserveOnce('session', 'gateway_account')
   })

--- a/test/cypress/integration/payment-links/delete-payment-links.cy.test.js
+++ b/test/cypress/integration/payment-links/delete-payment-links.cy.test.js
@@ -1,6 +1,6 @@
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 const userStubs = require('../../stubs/user-stubs')
-const { getProductsStub, getProductByExternalIdStub, deleteProductStub } = require('../../stubs/products-stubs')
+const { getProductsByGatewayAccountIdAndTypeStub, getProductByExternalIdStub, deleteProductStub } = require('../../stubs/products-stubs')
 const userExternalId = 'a-user-id'
 const gatewayAccountExternalId = 'a-valid-account-id'
 const gatewayAccountId = 42
@@ -16,7 +16,7 @@ describe('Should delete payment link', () => {
     cy.task('setupStubs', [
       userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),
       gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'test', paymentProvider: 'worldpay' }),
-      getProductsStub([product], gatewayAccountId),
+      getProductsByGatewayAccountIdAndTypeStub([product], gatewayAccountId, 'ADHOC'),
       getProductByExternalIdStub(product, gatewayAccountId),
       deleteProductStub(product, gatewayAccountId, 1)
     ])

--- a/test/cypress/integration/payment-links/edit-payment-link.cy.test.js
+++ b/test/cypress/integration/payment-links/edit-payment-link.cy.test.js
@@ -1,6 +1,6 @@
 const userStubs = require('../../stubs/user-stubs')
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
-const { getProductsStub, getProductByExternalIdStub } = require('../../stubs/products-stubs')
+const { getProductsByGatewayAccountIdAndTypeStub, getProductByExternalIdStub } = require('../../stubs/products-stubs')
 const userExternalId = 'a-user-id'
 const gatewayAccountId = 42
 const gatewayAccountExternalId = 'a-valid-account-id'
@@ -24,7 +24,7 @@ function setupStubs (product) {
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'test', paymentProvider: 'worldpay' }),
-    getProductsStub([product], gatewayAccountId),
+    getProductsByGatewayAccountIdAndTypeStub([product], gatewayAccountId, 'ADHOC'),
     getProductByExternalIdStub(product, gatewayAccountId)
   ])
 }

--- a/test/cypress/integration/payment-links/manage-payment-links.cy.test.js
+++ b/test/cypress/integration/payment-links/manage-payment-links.cy.test.js
@@ -41,7 +41,7 @@ function setupStubs (products) {
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'test', paymentProvider: 'worldpay' }),
-    productStubs.getProductsStub(products, gatewayAccountId)
+    productStubs.getProductsByGatewayAccountIdAndTypeStub(products, gatewayAccountId, 'ADHOC')
   ])
 }
 
@@ -188,7 +188,7 @@ describe('The manage payment links page', () => {
       cy.task('setupStubs', [
         userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),
         gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'test', paymentProvider: 'worldpay' }),
-        productStubs.getProductsByGatewayAccountIdFailure()
+        productStubs.getProductsByGatewayAccountIdAndTypeFailure()
       ])
     })
 

--- a/test/cypress/stubs/products-stubs.js
+++ b/test/cypress/stubs/products-stubs.js
@@ -3,9 +3,12 @@
 const productFixtures = require('../../fixtures/product.fixtures')
 const { stubBuilder } = require('./stub-builder')
 
-function getProductsStub (products, gatewayAccountId) {
+function getProductsByGatewayAccountIdAndTypeStub (products, gatewayAccountId, productType) {
   const path = `/v1/api/gateway-account/${gatewayAccountId}/products`
   return stubBuilder('GET', path, 200, {
+    query: {
+      type: productType
+    },
     response: products.map(product =>
       productFixtures.validProductResponse(product))
   })
@@ -25,9 +28,13 @@ function deleteProductStub (product, gatewayAccountId, verifyCalledTimes) {
   })
 }
 
-function getProductsByGatewayAccountIdFailure (gatewayAccountId) {
+function getProductsByGatewayAccountIdAndTypeFailure (gatewayAccountId, productType) {
   const path = `/v1/api/gateway-account/${gatewayAccountId}/products`
-  return stubBuilder('GET', path, 500)
+  return stubBuilder('GET', path, 500, {
+    query: {
+      type: productType
+    },
+  })
 }
 
 function postCreateProductSuccess () {
@@ -38,9 +45,9 @@ function postCreateProductSuccess () {
 }
 
 module.exports = {
-  getProductsStub,
+  getProductsByGatewayAccountIdAndTypeStub,
   getProductByExternalIdStub,
   deleteProductStub,
-  getProductsByGatewayAccountIdFailure,
+  getProductsByGatewayAccountIdAndTypeFailure,
   postCreateProductSuccess
 }

--- a/test/unit/clients/products-client/product/get-by-gateway-account-id-and-type-with-metadata.pact.test.js
+++ b/test/unit/clients/products-client/product/get-by-gateway-account-id-and-type-with-metadata.pact.test.js
@@ -21,7 +21,7 @@ function getProductsClient (baseUrl) {
   })
 }
 
-describe('products client - find a product with metadata associated with a particular gateway account id', function () {
+describe('products client - find a product with metadata associated with a particular gateway account id and type' , function () {
   let provider = new Pact({
     consumer: 'selfservice',
     provider: 'products',
@@ -39,19 +39,21 @@ describe('products client - find a product with metadata associated with a parti
 
   describe('when the product is successfully found', () => {
     const gatewayAccountId = 42
+    const productType = 'ADHOC'
     const response = [
-      productFixtures.validProductResponse({ gateway_account_id: gatewayAccountId, price: 1000, metadata: { key: 'value' } })
+      productFixtures.validProductResponse({ gateway_account_id: gatewayAccountId, price: 1000, type: productType, metadata: { key: 'value' } })
     ]
     before(done => {
       const interaction = new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products`)
-        .withUponReceiving('a valid get product with metadata by gateway account id request')
+        .withQuery('type', productType)
+        .withUponReceiving('a valid get product with metadata by gateway account id and type request')
         .withMethod('GET')
-        .withState('a product with gateway account id 42 and metadata exist')
+        .withState('a product with gateway account id 42 and type ADHOC and metadata exist')
         .withStatusCode(200)
         .withResponseBody(pactifySimpleArray(response))
         .build()
       provider.addInteraction(interaction)
-        .then(() => productsClient.product.getByGatewayAccountId(gatewayAccountId))
+        .then(() => productsClient.product.getByGatewayAccountIdAndType(gatewayAccountId, productType))
         .then(res => {
           result = res
           done()
@@ -67,6 +69,7 @@ describe('products client - find a product with metadata associated with a parti
         expect(product.externalId).to.exist.and.equal(response[index].external_id)
         expect(product.name).to.exist.and.equal(response[index].name)
         expect(product.price).to.exist.and.equal(response[index].price)
+        expect(product.type).to.exist.and.equal(response[index].type)
         expect(product.language).to.exist.and.equal(response[index].language)
         expect(product).to.have.property('links')
         expect(Object.keys(product.links).length).to.equal(2)

--- a/test/unit/clients/products-client/product/get-by-gateway-account-id-and-type.pact.test.js
+++ b/test/unit/clients/products-client/product/get-by-gateway-account-id-and-type.pact.test.js
@@ -21,7 +21,7 @@ function getProductsClient (baseUrl) {
   })
 }
 
-describe('products client - find products associated with a particular gateway account id', function () {
+describe('products client - find products associated with a particular gateway account id and type', function () {
   let provider = new Pact({
     consumer: 'selfservice',
     provider: 'products',
@@ -39,22 +39,24 @@ describe('products client - find products associated with a particular gateway a
 
   describe('when products are successfully found', () => {
     const gatewayAccountId = 42
+    const productType = 'ADHOC'
     const response = [
-      productFixtures.validProductResponse({ gateway_account_id: gatewayAccountId, price: 1000 }),
-      productFixtures.validProductResponse({ gateway_account_id: gatewayAccountId, price: 2000 }),
-      productFixtures.validProductResponse({ gateway_account_id: gatewayAccountId, price: 3000 })
+      productFixtures.validProductResponse({ gateway_account_id: gatewayAccountId, price: 1000, type: productType }),
+      productFixtures.validProductResponse({ gateway_account_id: gatewayAccountId, price: 2000, type: productType }),
+      productFixtures.validProductResponse({ gateway_account_id: gatewayAccountId, price: 3000, type: productType })
     ]
 
     before(done => {
       const interaction = new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products`)
+        .withQuery('type', productType)
         .withUponReceiving('a valid get product by gateway account id request')
         .withMethod('GET')
-        .withState('three products with gateway account id 42 exist')
+        .withState('three products with gateway account id 42 and type ADHOC exist')
         .withStatusCode(200)
         .withResponseBody(pactifySimpleArray(response))
         .build()
       provider.addInteraction(interaction)
-        .then(() => productsClient.product.getByGatewayAccountId(gatewayAccountId))
+        .then(() => productsClient.product.getByGatewayAccountIdAndType(gatewayAccountId, productType))
         .then(res => {
           result = res
           done()
@@ -70,6 +72,7 @@ describe('products client - find products associated with a particular gateway a
         expect(product.externalId).to.exist.and.equal(response[index].external_id)
         expect(product.name).to.exist.and.equal(response[index].name)
         expect(product.price).to.exist.and.equal(response[index].price)
+        expect(product.type).to.exist.and.equal(response[index].type)
         expect(product.language).to.exist.and.equal(response[index].language)
         expect(product).to.have.property('links')
         expect(Object.keys(product.links).length).to.equal(2)
@@ -86,14 +89,16 @@ describe('products client - find products associated with a particular gateway a
   describe('when no products are found', () => {
     before(done => {
       const gatewayAccountId = 98765
+      const productType = 'PROTOTYPE'
       const interaction = new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products`)
+        .withQuery('type', productType)
         .withUponReceiving('a valid get product by gateway account id where the gateway account has no products')
         .withMethod('GET')
         .withStatusCode(200)
         .withResponseBody([])
         .build()
       provider.addInteraction(interaction)
-        .then(() => productsClient.product.getByGatewayAccountId(gatewayAccountId), done)
+        .then(() => productsClient.product.getByGatewayAccountIdAndType(gatewayAccountId, productType), done)
         .then(res => {
           result = res
           done()

--- a/test/unit/controller/test-with-your-users-controller/links.controller.ft.test.js
+++ b/test/unit/controller/test-with-your-users-controller/links.controller.ft.test.js
@@ -46,23 +46,8 @@ const PAYMENT_2 = {
   }]
 }
 
-const PAYMENT_3 = {
-  external_id: 'product-external-id-3',
-  gateway_account_id: 'product-gateway-account-id-3',
-  description: 'product-description-3',
-  name: 'payment-name-3',
-  price: '150',
-  type: 'LIVE',
-  return_url: 'http://return.url',
-  _links: [{
-    rel: 'pay',
-    href: 'http://pay.url',
-    method: 'GET'
-  }]
-}
-
-function mockGetProductsByGatewayAccountEndpoint (gatewayAccountId) {
-  return nock(PRODUCTS_URL).get(`/v1/api/gateway-account/${gatewayAccountId}/products`)
+function mockGetProductsByGatewayAccountAndTypeEndpoint (gatewayAccountId, productType) {
+  return nock(PRODUCTS_URL).get(`/v1/api/gateway-account/${gatewayAccountId}/products?type=${productType}`)
 }
 
 function mockConnectorGetAccount () {
@@ -89,7 +74,7 @@ describe('Show the prototype links', () => {
     let response
     before(function (done) {
       mockConnectorGetAccount()
-      mockGetProductsByGatewayAccountEndpoint(GATEWAY_ACCOUNT_ID).reply(200, [])
+      mockGetProductsByGatewayAccountAndTypeEndpoint(GATEWAY_ACCOUNT_ID, 'PROTOTYPE').reply(200, [])
 
       supertest(app)
         .get(formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))
@@ -123,7 +108,7 @@ describe('Show the prototype links', () => {
     let response
     before(function (done) {
       mockConnectorGetAccount()
-      mockGetProductsByGatewayAccountEndpoint(GATEWAY_ACCOUNT_ID).reply(200, [PAYMENT_1])
+      mockGetProductsByGatewayAccountAndTypeEndpoint(GATEWAY_ACCOUNT_ID, 'PROTOTYPE').reply(200, [PAYMENT_1])
 
       supertest(app)
         .get(formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))
@@ -172,7 +157,7 @@ describe('Show the prototype links', () => {
     let response
     before(function (done) {
       mockConnectorGetAccount()
-      mockGetProductsByGatewayAccountEndpoint(GATEWAY_ACCOUNT_ID).reply(200, [PAYMENT_1, PAYMENT_2])
+      mockGetProductsByGatewayAccountAndTypeEndpoint(GATEWAY_ACCOUNT_ID, 'PROTOTYPE').reply(200, [PAYMENT_1, PAYMENT_2])
 
       supertest(app)
         .get(formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))
@@ -231,46 +216,11 @@ describe('Show the prototype links', () => {
     })
   })
 
-  describe('when one prototype link and one live link exists', () => {
-    let response
-    before(function (done) {
-      mockConnectorGetAccount()
-      mockGetProductsByGatewayAccountEndpoint(GATEWAY_ACCOUNT_ID).reply(200, [PAYMENT_1, PAYMENT_3])
-
-      supertest(app)
-        .get(formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))
-        .set('Accept', 'application/json')
-        .end((err, res) => {
-          response = res
-          done(err)
-        })
-    })
-
-    it('should display only prototype links', () => {
-      expect(response.body).to.have.property('productsLength', 1)
-      expect(response.body).to.have.deep.property('products', [{
-        description: 'product-description-1',
-        externalId: 'product-external-id-1',
-        gatewayAccountId: 'product-gateway-account-id-1',
-        name: 'payment-name-1',
-        price: '150',
-        returnUrl: 'http://return.url',
-        links: {
-          pay: {
-            href: 'http://pay.url',
-            method: 'GET'
-          }
-        },
-        type: 'PROTOTYPE'
-      }])
-    })
-  })
-
   describe('when there is a problem retrieving the products', () => {
     let response
     before(function (done) {
       mockConnectorGetAccount()
-      mockGetProductsByGatewayAccountEndpoint(GATEWAY_ACCOUNT_ID).replyWithError('an error')
+      mockGetProductsByGatewayAccountAndTypeEndpoint(GATEWAY_ACCOUNT_ID, 'PROTOTYPE').replyWithError('an error')
 
       supertest(app)
         .get(formatAccountPathsFor(paths.account.prototyping.demoService.links, EXTERNAL_GATEWAY_ACCOUNT_ID))


### PR DESCRIPTION
When we need all the payment links for a gateway account or all the prototype links for a gateway account, use the new endpoint on the products microservice that filters by type.

This is more efficient than retrieving every live product for a gateway account from the database, dragging them all across the network and then filtering out the ones we do not want.