### PR TITLE
PP-7786 Payments to your bank account status filter

### DIFF
--- a/app/controllers/my-services/get-index.controller.js
+++ b/app/controllers/my-services/get-index.controller.js
@@ -8,10 +8,9 @@ const serviceService = require('../../services/service.service')
 const { filterGatewayAccountIds } = require('../../utils/permissions')
 const getHeldPermissions = require('../../utils/get-held-permissions')
 
-function hasLiveStripeAccount (gatewayAccounts) {
+function hasStripeAccount (gatewayAccounts) {
   return gatewayAccounts.some(gatewayAccount =>
-    gatewayAccount.payment_provider === 'stripe' &&
-    gatewayAccount.type === 'live')
+    gatewayAccount.payment_provider === 'stripe')
 }
 
 function sortServicesByLiveThenName (a, b) {
@@ -82,7 +81,7 @@ module.exports = async function getServiceList (req, res) {
     services: servicesData,
     services_singular: servicesData.length === 1,
     env: process.env,
-    has_account_with_payouts: hasLiveStripeAccount(aggregatedGatewayAccounts),
+    has_account_with_payouts: hasStripeAccount(aggregatedGatewayAccounts),
     has_live_account: filterGatewayAccountIds(aggregatedGatewayAccounts, true).length,
     show_whats_new_notification: shouldShowNotification(isMyServicesDefaultView, req.cookies)
   }

--- a/app/controllers/payouts/payout-list.controller.js
+++ b/app/controllers/payouts/payout-list.controller.js
@@ -1,5 +1,4 @@
 const moment = require('moment')
-const paths = require('../../../app/paths')
 const logger = require('../../utils/logger')(__filename)
 const { keys } = require('@govuk-pay/pay-js-commons').logging
 const { response } = require('../../utils/response.js')
@@ -36,7 +35,7 @@ const listAllServicesPayouts = async function listAllServicesPayouts (req, res, 
     if (process.env.PAYOUTS_RELEASE_DATE) {
       payoutsReleaseDate = moment.unix(process.env.PAYOUTS_RELEASE_DATE)
     }
-    response(req, res, 'payouts/list', { payoutSearchResult, paths, payoutsReleaseDate, filterLiveAccounts, hasLiveAccounts: userPermittedAccountsSummary.hasLiveAccounts })
+    response(req, res, 'payouts/list', { payoutSearchResult, payoutsReleaseDate, filterLiveAccounts, hasLiveAccounts: userPermittedAccountsSummary.hasLiveAccounts, enableTestReports: process.env.ENABLE_TEST_REPORTS === 'true' })
   } catch (error) {
     return next(new Error('Failed to fetch payouts'))
   }

--- a/app/controllers/payouts/payout-list.controller.js
+++ b/app/controllers/payouts/payout-list.controller.js
@@ -10,9 +10,14 @@ const { NoServicesWithPermissionError } = require('../../errors')
 const listAllServicesPayouts = async function listAllServicesPayouts (req, res, next) {
   const { page } = req.query
 
+  // a filter param will be set on status specific routes, if they're not set the
+  // default behaviour should be live
+  const { statusFilter } = req.params
+  const filterLiveAccounts = statusFilter !== 'test'
+
   try {
     let payoutsReleaseDate
-    const userPermittedAccountsSummary = await permissions.getGatewayAccountsFor(req.user, true, 'payouts:read')
+    const userPermittedAccountsSummary = await permissions.getGatewayAccountsFor(req.user, filterLiveAccounts, 'payouts:read')
 
     if (!userPermittedAccountsSummary.gatewayAccountIds.length) {
       return next(new NoServicesWithPermissionError('You do not have any associated services with rights to view payments to bank accounts.'))
@@ -22,7 +27,8 @@ const listAllServicesPayouts = async function listAllServicesPayouts (req, res, 
       current_page: page,
       internal_user: req.user.internalUser,
       gateway_account_ids: userPermittedAccountsSummary.gatewayAccountIds,
-      user_number_of_live_services: req.user.numberOfLiveServices
+      user_number_of_services: req.user.numberOfLiveServices,
+      is_live: filterLiveAccounts
     }
     logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
     logger.info('Fetched page of payouts for all services', logContext)
@@ -30,7 +36,7 @@ const listAllServicesPayouts = async function listAllServicesPayouts (req, res, 
     if (process.env.PAYOUTS_RELEASE_DATE) {
       payoutsReleaseDate = moment.unix(process.env.PAYOUTS_RELEASE_DATE)
     }
-    response(req, res, 'payouts/list', { payoutSearchResult, paths, payoutsReleaseDate })
+    response(req, res, 'payouts/list', { payoutSearchResult, paths, payoutsReleaseDate, filterLiveAccounts, hasLiveAccounts: userPermittedAccountsSummary.hasLiveAccounts })
   } catch (error) {
     return next(new Error('Failed to fetch payouts'))
   }

--- a/app/controllers/payouts/payout-list.controller.js
+++ b/app/controllers/payouts/payout-list.controller.js
@@ -35,7 +35,7 @@ const listAllServicesPayouts = async function listAllServicesPayouts (req, res, 
     if (process.env.PAYOUTS_RELEASE_DATE) {
       payoutsReleaseDate = moment.unix(process.env.PAYOUTS_RELEASE_DATE)
     }
-    response(req, res, 'payouts/list', { payoutSearchResult, payoutsReleaseDate, filterLiveAccounts, hasLiveAccounts: userPermittedAccountsSummary.hasLiveAccounts, enableTestReports: process.env.ENABLE_TEST_REPORTS === 'true' })
+    response(req, res, 'payouts/list', { payoutSearchResult, payoutsReleaseDate, filterLiveAccounts, hasLiveAccounts: userPermittedAccountsSummary.hasLiveAccounts, enableTestReports: process.env.ENABLE_TEST_REPORTS === 'true', hasTestStripeAccount: userPermittedAccountsSummary.hasTestStripeAccount })
   } catch (error) {
     return next(new Error('Failed to fetch payouts'))
   }

--- a/app/paths.js
+++ b/app/paths.js
@@ -212,7 +212,8 @@ module.exports = {
     download: '/policy/download/:key'
   },
   payouts: {
-    list: '/payments-to-your-bank-account'
+    list: '/payments-to-your-bank-account',
+    listStatusFilter: '/payments-to-your-bank-account/:statusFilter(test|live)'
   },
   requestPspTestAccount: '/service/:externalServiceId/request-stripe-test-account'
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -215,6 +215,7 @@ module.exports.bind = function (app) {
 
   // Payouts
   app.get(payouts.list, payoutsController.listAllServicesPayouts)
+  app.get(payouts.listStatusFilter, payoutsController.listAllServicesPayouts)
 
   // Policy document downloads
   app.get(policyPages.download, policyDocumentsController.download)

--- a/app/utils/permissions.js
+++ b/app/utils/permissions.js
@@ -15,7 +15,8 @@ const getGatewayAccountsFor = async function getGatewayAccountsFor (user, filter
   return {
     gatewayAccountIds: filterGatewayAccountIds(userGatewayAccounts, filterLiveAccounts),
     headers: getAllAccountDetailHeaders(userGatewayAccounts),
-    hasLiveAccounts: filterGatewayAccountIds(userGatewayAccounts, true).length > 0
+    hasLiveAccounts: filterGatewayAccountIds(userGatewayAccounts, true).length > 0,
+    hasTestStripeAccount: userGatewayAccounts.filter((account) => account.type === 'test' && account.payment_provider === 'stripe').length > 0
   }
 }
 

--- a/app/views/payouts/list.njk
+++ b/app/views/payouts/list.njk
@@ -26,7 +26,9 @@ Payments to your bank account - GOV.UK Pay
   {% if enableTestReports %}
   <p class="govuk-body">
     {% if filterLiveAccounts %}
+      {% if hasTestStripeAccount %}
       <a class="govuk-link govuk-link--no-visited-state" href="{{ routes.formattedPathFor(routes.payouts.listStatusFilter, 'test') }}">Switch to test accounts</a>
+      {% endif %}
     {% else %}
       {% if hasLiveAccounts %}
         <a class="govuk-link govuk-link--no-visited-state" href="{{ routes.payouts.list }}">Switch to live accounts</a>

--- a/app/views/payouts/list.njk
+++ b/app/views/payouts/list.njk
@@ -16,12 +16,25 @@ Payments to your bank account - GOV.UK Pay
 
 {% block mainContent %}
 <div class="govuk-grid-column-full">
-  <h1 class="govuk-heading-l">Payments to your bank account</h1>
+  <h1 class="govuk-heading-l">
+    Payments to your bank account
+    <strong class="govuk-tag govuk-tag--grey">{{ "LIVE" if filterLiveAccounts else "TEST" }}</strong>
+  </h1>
 </div>
-<div class="govuk-grid-column-two-thirds">
-  <p class="govuk-body govuk-!-margin-bottom-8">Payments Stripe has made to your bank account.</p>
+<div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-8">
+  <p class="govuk-body">Payments Stripe has made to your bank account.</p>
+  <p class="govuk-body">
+    {% if filterLiveAccounts %}
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ routes.formattedPathFor(routes.payouts.listStatusFilter, 'test') }}">Switch to test accounts</a>
+    {% else %}
+      {% if hasLiveAccounts %}
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ routes.payouts.list }}">Switch to live accounts</a>
+      {% endif %}
+    {% endif %}
+  </p>
 </div>
 
+{% set transactionsDownloadPath = paths.allServiceTransactions.download if filterLiveAccounts else paths.formattedPathFor(paths.allServiceTransactions.downloadStatusFilter, 'test') %}
 <div class="govuk-grid-column-two-thirds">
   {% for key, group in payoutSearchResult.groups %}
     {% set dateString = group.date.format('DD MMMM') %}
@@ -43,7 +56,7 @@ Payments to your bank account - GOV.UK Pay
             {{ payoutEntry.amount | penceToPoundsWithCurrency }}
           </td>
           <td class="govuk-table__cell">
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ paths.allServiceTransactions.download }}?gatewayPayoutId={{payoutEntry.gateway_payout_id}}">
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ transactionsDownloadPath }}?gatewayPayoutId={{payoutEntry.gateway_payout_id}}">
               Download CSV <span class="govuk-visually-hidden">for {{ payoutEntry.serviceName }} on {{ dateString }}</span>
             </a>
           </td>

--- a/app/views/payouts/list.njk
+++ b/app/views/payouts/list.njk
@@ -23,6 +23,7 @@ Payments to your bank account - GOV.UK Pay
 </div>
 <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-8">
   <p class="govuk-body">Payments Stripe has made to your bank account.</p>
+  {% if enableTestReports %}
   <p class="govuk-body">
     {% if filterLiveAccounts %}
       <a class="govuk-link govuk-link--no-visited-state" href="{{ routes.formattedPathFor(routes.payouts.listStatusFilter, 'test') }}">Switch to test accounts</a>
@@ -32,9 +33,10 @@ Payments to your bank account - GOV.UK Pay
       {% endif %}
     {% endif %}
   </p>
+  {% endif %}
 </div>
 
-{% set transactionsDownloadPath = paths.allServiceTransactions.download if filterLiveAccounts else paths.formattedPathFor(paths.allServiceTransactions.downloadStatusFilter, 'test') %}
+{% set transactionsDownloadPath = routes.allServiceTransactions.download if filterLiveAccounts else routes.formattedPathFor(routes.allServiceTransactions.downloadStatusFilter, 'test') %}
 <div class="govuk-grid-column-two-thirds">
   {% for key, group in payoutSearchResult.groups %}
     {% set dateString = group.date.format('DD MMMM') %}

--- a/app/views/services/index.njk
+++ b/app/views/services/index.njk
@@ -76,9 +76,11 @@
     </p>
     {% endif %}
 
+    {% set payoutsPath = routes.payouts.list if has_live_account else routes.formattedPathFor(routes.payouts.listStatusFilter, 'test') %}
+
     {% if has_account_with_payouts %}
       <p class="govuk-body">
-        <a href="{{routes.payouts.list}}" class="govuk-link govuk-!-margin-right-3 govuk-link--no-visited-state">
+        <a href="{{ payoutsPath }}" class="govuk-link govuk-!-margin-right-3 govuk-link--no-visited-state">
           Show payments to your bank account
         </a>
       </p>

--- a/test/cypress/integration/my-services/my-services-links.cy.test.js
+++ b/test/cypress/integration/my-services/my-services-links.cy.test.js
@@ -40,7 +40,7 @@ describe('Service has a live account that supports payouts', () => {
 
 describe('Service does not have a live account that supports payouts', () => {
   it('should display link to view payouts', () => {
-    cy.task('setupStubs', getUserAndAccountStubs('test', 'stripe'))
+    cy.task('setupStubs', getUserAndAccountStubs('test', 'sandbox'))
 
     cy.setEncryptedCookies(authenticatedUserId, 1)
     cy.visit('/my-services')

--- a/test/unit/utils/permissions.test.js
+++ b/test/unit/utils/permissions.test.js
@@ -65,6 +65,7 @@ describe('gateway account filter utiltiies', () => {
       expect(result.headers.shouldGetStripeHeaders).to.be.true // eslint-disable-line
       expect(result.headers.shouldGetMotoHeaders).to.be.true // eslint-disable-line
       expect(result.hasLiveAccounts).to.equal(false)
+      expect(result.hasTestStripeAccount).to.equal(true)
     })
 
     it('correctly identifies non stripe and moto headers', async () => {
@@ -118,6 +119,7 @@ describe('gateway account filter utiltiies', () => {
       const testResult = await getGatewayAccountsFor(user, false, 'perm-1')
       expect(testResult.gatewayAccountIds).to.deep.equal([ '2' ])
       expect(testResult.hasLiveAccounts).to.equal(true)
+      expect(testResult.hasTestStripeAccount).to.equal(false)
     })
 
     it('correctly filters services by users permission role', async () => {


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-selfservice/pull/2584

Allow the payments to your bank account page to filter live or test
accounts based on the updated cross account permissions utility.

Add a tag to show what environment is being displayed following the
ticket design.

Update the download link for live and test environments.

Add a link to switch between live and test environments with the
following logic:
* viewing test data and has live accounts - show switch to live
* viewing test data with no live accounts - nothing
* viewing live data - show switch to test

<img width="658" alt="Screenshot 2021-02-19 at 15 41 37" src="https://user-images.githubusercontent.com/2844572/108530332-68614780-72cd-11eb-94f9-842a501a0d90.png">

<img width="659" alt="Screenshot 2021-02-19 at 15 41 47" src="https://user-images.githubusercontent.com/2844572/108530355-6bf4ce80-72cd-11eb-966e-70ea60b207ae.png">
