### PR TITLE
PP-7709 Show telephone payment link on dashboard if appropriate

### DIFF
--- a/app/views/dashboard/_links.njk
+++ b/app/views/dashboard/_links.njk
@@ -8,6 +8,15 @@
 <div class="govuk-grid-column-full flex-grid links-container" data-click-events data-click-category="Dashboard" data-click-action="First steps link clicked">
 
   <div class="flex-grid--row">
+    {% if links.telephonePaymentLink in linksToDisplay %}
+    <article class="{{columnClass}} links__box" id="take-a-telephone-payment-link">
+      <a href="{{ telephonePaymentLink }}">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Take a telephone payment</h2>
+        <p class="govuk-body govuk-!-margin-bottom-0">Take a payment now by having a user give their card details over the phone.</p>
+      </a>
+    </article>
+    {% endif %}
+
     {% if links.demoPayment in linksToDisplay %}
     <article class="{{columnClass}} links__box" id="demo-payment-link">
       <a href="{{formatAccountPathsFor(routes.account.prototyping.demoPayment.index,  currentGatewayAccount.external_id)}}">

--- a/test/fixtures/service.fixtures.js
+++ b/test/fixtures/service.fixtures.js
@@ -111,7 +111,8 @@ module.exports = {
       redirect_to_service_immediately_on_terminal_state: false,
       collect_billing_address: false,
       current_go_live_stage: 'NOT_STARTED',
-      current_psp_test_account_stage: 'NOT_STARTED'
+      current_psp_test_account_stage: 'NOT_STARTED',
+      agent_initiated_moto_enabled: false
     })
 
     const service = {
@@ -124,7 +125,8 @@ module.exports = {
       collect_billing_address: opts.collect_billing_address,
       current_go_live_stage: opts.current_go_live_stage,
       experimental_features_enabled: true,
-      current_psp_test_account_stage: opts.current_psp_test_account_stage
+      current_psp_test_account_stage: opts.current_psp_test_account_stage,
+      agent_initiated_moto_enabled: opts.agent_initiated_moto_enabled
     }
 
     if (opts.merchant_details) {

--- a/test/fixtures/user.fixtures.js
+++ b/test/fixtures/user.fixtures.js
@@ -275,6 +275,7 @@ module.exports = {
     const collectBillingAddress = (opts.collect_billing_address && opts.collect_billing_address === true)
     const currentGoLiveStage = opts.current_go_live_stage || goLiveStage.NOT_STARTED
     const currentPspTestAccountStage = opts.current_psp_test_account_stage || stripeTestAccountStage.NOT_STARTED
+    const agentInitiatedMotoEnabled = opts.agent_initiated_moto_enabled || false
 
     const userOpts = {
       external_id: opts.external_id || newExternalId,
@@ -287,7 +288,8 @@ module.exports = {
           gateway_account_ids: gatewayAccountIds,
           collect_billing_address: collectBillingAddress,
           current_go_live_stage: currentGoLiveStage,
-          current_psp_test_account_stage: currentPspTestAccountStage
+          current_psp_test_account_stage: currentPspTestAccountStage,
+          agent_initiated_moto_enabled: agentInitiatedMotoEnabled
         },
         role: opts.role || {
           name: 'admin',


### PR DESCRIPTION
Show a ‘Take a telephone payment’ link on the dashboard if all of the following are true:

- The service has the `agent_initiated_moto_enabled` flag set to true
- There is at least one `AGENT_INITIATED_MOTO` product for the gateway account
- The user has the `agent-initiated-moto:create` permission

The link links directly to the initial page of the payment journey for the `AGENT_INITIATED_MOTO` product (if there is more than one, only the first one is used — this is fine for now while we control the creation of `AGENT_INITIATED_MOTO` products).

![image](https://user-images.githubusercontent.com/24316348/108712737-20c9fe00-750f-11eb-8571-19c8fa56c4ae.png)