### PR TITLE
PP-7739 Stripe Test Account > Do not show any Stripe Set-up banners

### DIFF
--- a/test/unit/controller/dashboard/dashboard-activity.controller.ft.test.js
+++ b/test/unit/controller/dashboard/dashboard-activity.controller.ft.test.js
@@ -38,7 +38,7 @@ const mockConnectorGetGatewayAccount = (paymentProvider, type) => {
       gateway_account_id: GATEWAY_ACCOUNT_ID,
       external_id: GATEWAY_ACCOUNT_EXTERNAL_ID,
       payment_provider: paymentProvider,
-      type: type
+      type
     }))
 }
 
@@ -501,7 +501,7 @@ describe('dashboard-activity-controller', () => {
       })
 
       beforeEach('Arrange', () => {
-        mockConnectorGetGatewayAccount('stripe', 'test')
+        mockConnectorGetGatewayAccount('stripe', 'live')
         mockConnectorGetStripeAccount()
       })
 

--- a/test/unit/controller/dashboard/dashboard-activity.controller.test.js
+++ b/test/unit/controller/dashboard/dashboard-activity.controller.test.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const sinon = require('sinon')
+const dashboardController = require('../../../../app/controllers/dashboard/dashboard-activity.controller')
+const User = require('../../../../app/models/User.class')
+const { validUser } = require('../../../fixtures/user.fixtures')
+const { validGatewayAccountResponse } = require('../../../fixtures/gateway-account.fixtures')
+const { ConnectorClient } = require('../../../../app/services/clients/connector.client')
+const StripeClient = require('../../../../app/services/clients/stripe/stripe.client.js')
+
+describe('Controller: Dashboard activity', () => {
+  const externalServiceId = 'service-external-id'
+  const serviceGatewayAccountIds = [ '2', '5' ]
+  let req, res, accountSpy, stripeSpy
+
+  describe('Stripe test account', () => {
+    before(() => {
+      const user = new User(validUser({
+        username: 'valid-user',
+        service_roles: [{
+          service: {
+            external_id: externalServiceId,
+            gateway_account_ids: serviceGatewayAccountIds
+          }
+        }]
+      }))
+
+      const account = validGatewayAccountResponse({
+        payment_provider: 'stripe',
+        type: 'test'
+      })
+
+      req = {
+        account,
+        service: {
+          currentGoLiveStage: null
+        },
+        user
+      }
+
+      res = {
+        status: sinon.spy(),
+        render: sinon.spy()
+      }
+    })
+
+    after(() => {
+      accountSpy.restore()
+      stripeSpy.restore()
+    })
+
+    it(`should not call call the Connector client or the Stripe client`, async () => {
+      accountSpy = sinon.stub(ConnectorClient.prototype, 'getStripeAccount')
+      stripeSpy = sinon.stub(StripeClient, 'retrieveAccountDetails')
+
+      await dashboardController(req, res)
+
+      sinon.assert.notCalled(accountSpy)
+      sinon.assert.notCalled(stripeSpy)
+    })
+  })
+})


### PR DESCRIPTION
with @SandorArpa

- Update the Dashboard activity controller
  - If a Stripe test account > Do not try to retrieve Stripe account details.
  - This prevents showing the Stripe setup banner.
- Add a Unit test for the dashboard activity controller
  - There are existing funcitonal tests but these do not make it easy to test if
    the controller has tried to call Connector function or use the Stripe API.
  - Therefore, add a unit test just to cover this use case.


