### PR TITLE
PP-7789 Breadcrumbs navigation header

### DIFF
--- a/app/assets/sass/components/navigation.scss
+++ b/app/assets/sass/components/navigation.scss
@@ -26,7 +26,12 @@
 
   @include govuk-media-query(tablet) {
     margin: 0;
-    float: right;
+  }
+
+  &--old {
+    @include govuk-media-query(tablet) {
+      float: right;
+    }
   }
 
   &--list {
@@ -41,9 +46,15 @@
 
     @include govuk-media-query(tablet) {
       display: inline-block;
-      margin: 0 0 0 govuk-spacing(6);
+      margin: 0 govuk-spacing(6) 0 0;
       border-bottom: 5px solid transparent;
       border-left: 0;
+    }
+
+    &--old {
+      @include govuk-media-query(tablet) {
+        margin: 0 0 0 govuk-spacing(6);
+      }
     }
 
     a:link,

--- a/app/utils/display-converter.js
+++ b/app/utils/display-converter.js
@@ -5,8 +5,6 @@ const { serviceNavigationItems, adminNavigationItems } = require('./nav-builder'
 const formatPSPname = require('./format-PSP-name')
 
 const hideServiceHeaderTemplates = [
-  'services/index',
-  'services/edit-service-name',
   'services/add-service',
   'payouts/list',
   'feedback/index',
@@ -16,7 +14,9 @@ const hideServiceHeaderTemplates = [
 ]
 
 const hideServiceNavTemplates = [
-  'merchant_details/edit-merchant_details',
+  'services/edit-service-name',
+  'merchant-details/merchant-details',
+  'merchant-details/edit-merchant-details',
   'team-members/team-members',
   'team-members/team-member-invite',
   'team-members/team-member-details',
@@ -107,6 +107,7 @@ module.exports = function (req, data, template) {
   convertedData.isTestGateway = _.get(convertedData, 'currentGatewayAccount.type') === 'test'
   convertedData.isSandbox = _.get(convertedData, 'currentGatewayAccount.payment_provider') === 'sandbox'
   convertedData.isDigitalWalletSupported = _.get(convertedData, 'currentGatewayAccount.payment_provider') === 'worldpay'
+  convertedData.enabledMyServicesAsDefaultView = process.env.ENABLE_MY_SERVICES_AS_DEFAULT_VIEW === 'true'
   const paymentProvider = _.get(convertedData, 'currentGatewayAccount.payment_provider')
   convertedData.currentService = service
   const currentPath = (relativeUrl && url.parse(relativeUrl).pathname.replace(/([a-z])\/$/g, '$1')) || '' // remove query params and trailing slash

--- a/app/views/feedback/index.njk
+++ b/app/views/feedback/index.njk
@@ -6,12 +6,14 @@ Give feedback — GOV.UK Pay
 
 {% block beforeContent %}
   {{ super() }}
+  {% if not enabledMyServicesAsDefaultView %}
   {{
     govukBackLink({
       text: "My services",
       href: routes.serviceSwitcher.index
     })
   }}
+  {% endif %}
 {% endblock %}
 
 {% block mainContent %}

--- a/app/views/includes/header.njk
+++ b/app/views/includes/header.njk
@@ -3,35 +3,59 @@ govuk-width-container govuk-header__container--{{accountType}}
 {%- endset -%}
 
 {% if loggedIn %}
-{% set payHeaderNavigation = [
-  {
-    text: "My services",
-    href: routes.serviceSwitcher.index,
-    active: services.length > 0,
-    attributes: {
-      id: "my-services"
-    }
-  },
-  {
-    text: "My profile",
-    href: routes.user.profile.index,
-    active: username.length > 0,
-    attributes: {
-      id: "my-profile"
-    }
-  },
-  {
-    text: "Documentation",
-    href: "https://docs.payments.service.gov.uk"
-  },
-  {
-    text: "Sign out",
-    href: routes.user.logOut,
-    attributes: {
-      id: "logout"
-    }
-  }
-] %}
+  {% if enabledMyServicesAsDefaultView %}
+    {% set payHeaderNavigation = [
+      {
+        text: "My profile",
+        href: routes.user.profile.index,
+        active: username.length > 0,
+        attributes: {
+          id: "my-profile"
+        }
+      },
+      {
+        text: "Documentation",
+        href: "https://docs.payments.service.gov.uk"
+      },
+      {
+        text: "Sign out",
+        href: routes.user.logOut,
+        attributes: {
+          id: "logout"
+        }
+      }
+    ] %}
+    {% else %}
+    {% set payHeaderNavigation = [
+      {
+        text: "My services",
+        href: routes.serviceSwitcher.index,
+        active: services.length > 0,
+        attributes: {
+          id: "my-services"
+        }
+      },
+      {
+        text: "My profile",
+        href: routes.user.profile.index,
+        active: username.length > 0,
+        attributes: {
+          id: "my-profile"
+        }
+      },
+      {
+        text: "Documentation",
+        href: "https://docs.payments.service.gov.uk"
+      },
+      {
+        text: "Sign out",
+        href: routes.user.logOut,
+        attributes: {
+          id: "logout"
+        }
+      }
+    ] %}
+    {% endif %}
 {% else %}
 {% set payHeaderNavigation = [
   {

--- a/app/views/includes/phase-banner-old.njk
+++ b/app/views/includes/phase-banner-old.njk
@@ -1,0 +1,53 @@
+{% if currentService.name %}
+<div class="govuk-phase-banner govuk-clearfix pay-top-navigation">
+  <div class="service-info">
+    <h4 class="service-info--name govuk-heading-s">
+      {{currentService.name}}
+      {% if currentGatewayAccount %}
+        {% set paymentProvider = currentGatewayAccount.payment_provider and currentGatewayAccount.payment_provider.toLowerCase() %}
+        {% set isLive = currentGatewayAccount.type === "live" %}
+        {% set stripeAccountIsSetup = (currentGatewayAccount.connectorGatewayAccountStripeProgress.bankAccount and currentGatewayAccount.connectorGatewayAccountStripeProgress.responsiblePerson
+           and currentGatewayAccount.connectorGatewayAccountStripeProgress.vatNumber and currentGatewayAccount.connectorGatewayAccountStripeProgress.companyNumber) %}
+
+        {% set tagModifierClass %}
+          {% if not isLive %}
+            govuk-tag--grey
+          {% elseif paymentProvider === 'stripe' and not stripeAccountIsSetup %}
+            govuk-tag--blue
+          {% endif %}
+        {% endset %}
+
+        {% set tagText %}
+          {% if not isLive %}
+            {% if paymentProvider === 'sandbox' %}
+              Test
+            {% else %}
+              {{ paymentProvider }} Test
+            {% endif %}
+          {% elseif paymentProvider === 'stripe' and not stripeAccountIsSetup %}
+            Live - information needed
+          {% else %}
+            Live
+          {% endif %}
+        {% endset %}
+        <strong class="service-info--tag govuk-tag {{ tagModifierClass }}">{{ tagText }}</strong>
+      {% endif %}
+    </h4>
+  </div>
+  {% if not hideServiceNav %}
+  <nav role="navigation" class="service-navigation service-navigation--old">
+    <ul class="service-navigation--list">
+      {% for item in serviceNavigationItems %}
+        {% if item.permissions %}
+          {% if item.current %}
+            <li class="service-navigation--list-item service-navigation--list-item--old service-navigation--list-item-active"><a id="{{item.id}}" href="{{item.url}}">{{item.name}}</a></li>
+          {% else %}
+            <li class="service-navigation--list-item service-navigation--list-item--old"><a id="{{item.id}}" href="{{item.url}}">{{item.name}}</a></li>
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+    </ul>
+  </nav>
+  {% endif %}
+</div>
+{% endif %}

--- a/app/views/includes/phase-banner.njk
+++ b/app/views/includes/phase-banner.njk
@@ -1,40 +1,51 @@
-{% if currentService.name %}
-<div class="govuk-phase-banner govuk-clearfix pay-top-navigation">
-  <div class="service-info">
-    <h4 class="service-info--name govuk-heading-s">
-      {{currentService.name}}
-      {% if currentGatewayAccount %}
-        {% set paymentProvider = currentGatewayAccount.payment_provider and currentGatewayAccount.payment_provider.toLowerCase() %}
-        {% set isLive = currentGatewayAccount.type === "live" %}
-        {% set stripeAccountIsSetup = (currentGatewayAccount.connectorGatewayAccountStripeProgress.bankAccount and currentGatewayAccount.connectorGatewayAccountStripeProgress.responsiblePerson
-           and currentGatewayAccount.connectorGatewayAccountStripeProgress.vatNumber and currentGatewayAccount.connectorGatewayAccountStripeProgress.companyNumber) %}
+{% from "../macro/breadcrumbs.njk" import breadcrumbs %}
+{% set accountLabelWithTag %}
+  <strong>{{currentService.name}}</strong>
+  {% if currentGatewayAccount %}
+    {% set paymentProvider = currentGatewayAccount.payment_provider and currentGatewayAccount.payment_provider.toLowerCase() %}
+    {% set isLive = currentGatewayAccount.type === "live" %}
+    {% set stripeAccountIsSetup = (currentGatewayAccount.connectorGatewayAccountStripeProgress.bankAccount and currentGatewayAccount.connectorGatewayAccountStripeProgress.responsiblePerson
+      and currentGatewayAccount.connectorGatewayAccountStripeProgress.vatNumber and currentGatewayAccount.connectorGatewayAccountStripeProgress.companyNumber) %}
 
-        {% set tagModifierClass %}
-          {% if not isLive %}
-            govuk-tag--grey
-          {% elseif paymentProvider === 'stripe' and not stripeAccountIsSetup %}
-            govuk-tag--blue
-          {% endif %}
-        {% endset %}
-
-        {% set tagText %}
-          {% if not isLive %}
-            {% if paymentProvider === 'sandbox' %}
-              Test
-            {% else %}
-              {{ paymentProvider }} Test
-            {% endif %}
-          {% elseif paymentProvider === 'stripe' and not stripeAccountIsSetup %}
-            Live - information needed
-          {% else %}
-            Live
-          {% endif %}
-        {% endset %}
-        <strong class="service-info--tag govuk-tag {{ tagModifierClass }}">{{ tagText }}</strong>
+    {% set tagModifierClass %}
+      {% if not isLive %}
+        govuk-tag--grey
+      {% elseif paymentProvider === 'stripe' and not stripeAccountIsSetup %}
+        govuk-tag--blue
       {% endif %}
-    </h4>
-  </div>
-  {% if not hideServiceNav %}
+    {% endset %}
+
+    {% set tagText %}
+      {% if not isLive %}
+        {% if paymentProvider === 'sandbox' %}
+          Test
+        {% else %}
+          {{ paymentProvider }} Test
+        {% endif %}
+      {% elseif paymentProvider === 'stripe' and not stripeAccountIsSetup %}
+        Live - information needed
+      {% else %}
+        Live
+      {% endif %}
+    {% endset %}
+    <strong class="service-info--tag govuk-tag {{ tagModifierClass }}">{{ tagText }}</strong>
+  {% endif %}
+{% endset %}
+
+{% set breadcrumbItems = [
+  { text: "My services", href: routes.serviceSwitcher.index }
+] %}
+
+{% if not hideServiceHeader and currentService.name %}
+{% set breadcrumbItems = (breadcrumbItems.push({
+  html: accountLabelWithTag
+}), breadcrumbItems) %}
+{% endif %}
+
+{{ breadcrumbs(breadcrumbItems) }}
+
+{% if not hideServiceNav and not hideServiceHeader %}
+<div class="govuk-phase-banner govuk-clearfix pay-top-navigation">
   <nav role="navigation" class="service-navigation">
     <ul class="service-navigation--list">
       {% for item in serviceNavigationItems %}
@@ -48,6 +59,5 @@
       {% endfor %}
     </ul>
   </nav>
-  {% endif %}
 </div>
 {% endif %}

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -38,15 +38,14 @@
   {% include "includes/header.njk" %}
 {% endblock %}
 
-{# {% if not hideServiceHeader %} #}
 {% block beforeContent %}
-  {# {% if loggedIn %} #}
-    {% if enabledMyServicesAsDefaultView %}
-      {% include "includes/phase-banner.njk" %}
-    {% else %}
+  {% if enabledMyServicesAsDefaultView and loggedIn %}
+    {% include "includes/phase-banner.njk" %}
+  {% else %}
+    {% if not hideServiceHeader %}
       {% include "includes/phase-banner-old.njk" %}
     {% endif %}
-  {# {% endif %} #}
+  {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -18,6 +18,7 @@
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
 {% set accountType = currentGatewayAccount.type %}
 
@@ -37,10 +38,15 @@
   {% include "includes/header.njk" %}
 {% endblock %}
 
+{# {% if not hideServiceHeader %} #}
 {% block beforeContent %}
-  {% if not hideServiceHeader %}
-    {% include "includes/phase-banner.njk" %}
-  {% endif %}
+  {# {% if loggedIn %} #}
+    {% if enabledMyServicesAsDefaultView %}
+      {% include "includes/phase-banner.njk" %}
+    {% else %}
+      {% include "includes/phase-banner-old.njk" %}
+    {% endif %}
+  {# {% endif %} #}
 {% endblock %}
 
 {% block content %}

--- a/app/views/macro/breadcrumbs.njk
+++ b/app/views/macro/breadcrumbs.njk
@@ -1,0 +1,21 @@
+{% macro breadcrumbs(items) %}
+<div class="govuk-phase-banner govuk-clearfix pay-top-navigation">
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+    {% for item in items %}
+      <li class="govuk-breadcrumbs__list-item govuk-!-font-size-19">
+      {% if item.html %}
+        {{ item.html | safe}}
+      {% elif item.text %}
+        {% if item.href %}
+          <a class="govuk-breadcrumbs__link" href="{{ item.href }}">{{ item.text }}</a>
+        {% else %}
+          {{ item.text }}
+        {% endif %}
+      {% endif %}
+      </li>
+    {% endfor %}
+    </ol>
+  </div>
+</div>
+{% endmacro %}

--- a/app/views/merchant-details/edit-merchant-details.njk
+++ b/app/views/merchant-details/edit-merchant-details.njk
@@ -6,12 +6,14 @@
 
 {% block beforeContent %}
   {{ super() }}
+  {% if not enabledMyServicesAsDefaultView %}
   {{
     govukBackLink({
       text: "My services",
       href: routes.serviceSwitcher.index
     })
   }}
+  {% endif %}
 {% endblock %}
 
 {% block mainContent %}

--- a/app/views/merchant-details/merchant-details.njk
+++ b/app/views/merchant-details/merchant-details.njk
@@ -6,12 +6,14 @@
 
 {% block beforeContent %}
   {{ super() }}
+  {% if not enabledMyServicesAsDefaultView %}
   {{
     govukBackLink({
       text: "My services",
       href: routes.serviceSwitcher.index
     })
   }}
+  {% endif %}
 {% endblock %}
 
 {% block mainContent %}

--- a/app/views/payouts/list.njk
+++ b/app/views/payouts/list.njk
@@ -1,3 +1,4 @@
+{% from '../macro/breadcrumbs.njk' import breadcrumbs %}
 {% extends "../layout.njk" %}
 
 {% block pageTitle %}
@@ -5,13 +6,20 @@ Payments to your bank account - GOV.UK Pay
 {% endblock %}
 
 {% block beforeContent %}
-  {{ super() }}
+  {% if enabledMyServicesAsDefaultView %}
+
+  {{ breadcrumbs([
+    { text: "My services", href: routes.serviceSwitcher.index },
+    { text: "Payments to your bank account" }
+  ]) }}
+  {% else %}
   {{
     govukBackLink({
       text: "Back to My services",
       href: routes.serviceSwitcher.index
     })
   }}
+  {% endif %}
 {% endblock %}
 
 {% block mainContent %}

--- a/app/views/request-psp-test-account/index.njk
+++ b/app/views/request-psp-test-account/index.njk
@@ -6,12 +6,14 @@
 
 {% block beforeContent %}
   {{ super() }}
+  {% if not enabledMyServicesAsDefaultView %}
   {{
     govukBackLink({
       text: "My services",
       href: routes.serviceSwitcher.index
     })
   }}
+  {% endif %}
 {% endblock %}
 
 {% block mainContent %}

--- a/app/views/request-to-go-live/layout.njk
+++ b/app/views/request-to-go-live/layout.njk
@@ -2,10 +2,12 @@
 
 {% block beforeContent %}
   {{ super() }}
+  {% if not enabledMyServicesAsDefaultView %}
   {{
     govukBackLink({
       text: "My services",
       href: routes.serviceSwitcher.index
     })
   }}
+  {% endif %}
 {% endblock %}

--- a/app/views/services/index.njk
+++ b/app/views/services/index.njk
@@ -9,6 +9,10 @@
   <script src="/public/js/components/notification-banner.js"></script>
 {% endblock %}
 
+{% block beforeContent %}
+
+{% endblock %}
+
 {% block mainContent %}
   <div class="govuk-grid-column-two-thirds">
     {% if show_whats_new_notification %}

--- a/app/views/team-members/team-members.njk
+++ b/app/views/team-members/team-members.njk
@@ -6,12 +6,14 @@ Team members - GOV.UK Pay
 
 {% block beforeContent %}
   {{ super() }}
+  {% if not enabledMyServicesAsDefaultView %}
   {{
     govukBackLink({
       text: "Back to My services",
       href: routes.serviceSwitcher.index
     })
   }}
+  {% endif %}
 {% endblock %}
 
 {% block mainContent %}

--- a/app/views/transactions/index.njk
+++ b/app/views/transactions/index.njk
@@ -1,3 +1,4 @@
+{% from "../macro/breadcrumbs.njk" import breadcrumbs %}
 {% extends "../layout.njk" %}
 
 {% block pageTitle %}
@@ -26,14 +27,25 @@
 
 {% block beforeContent %}
   {% if allServiceTransactions %}
-    {{
-      govukBackLink({
-        text: "Back to My services",
-        href: routes.serviceSwitcher.index
-      })
-    }}
+    {% if enabledMyServicesAsDefaultView %}
+      {% set pageTitleBreadcrumbWithTag %}
+        <span>Transactions for all services</span>
+        <strong class="service-info--tag govuk-tag govuk-tag--grey">{{ "LIVE" if filterLiveAccounts else "TEST" }}</strong>
+      {% endset %}
+      {{ breadcrumbs([
+        { text: "My services", href: routes.serviceSwitcher.index },
+        { html: pageTitleBreadcrumbWithTag  }
+      ]) }}
+    {% else %}
+      {{
+        govukBackLink({
+          text: "Back to My services",
+          href: routes.serviceSwitcher.index
+        })
+      }}
+    {% endif %}
   {% else %}
-    {% include "includes/phase-banner.njk" %}
+    {{ super() }}
   {% endif %}
 {% endblock %}
 

--- a/test/cypress/integration/feedback/feedback.cy.test.js
+++ b/test/cypress/integration/feedback/feedback.cy.test.js
@@ -21,7 +21,6 @@ describe('Feedback page', () => {
     cy.visit('/feedback')
 
     cy.title().should('eq', 'Give feedback — GOV.UK Pay')
-    cy.get('.govuk-back-link').contains('My services')
   })
 
   it('should submit Feedback form and display Success notification', () => {

--- a/test/cypress/integration/request-to-go-live/agreement.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/agreement.cy.test.js
@@ -67,9 +67,6 @@ describe('Request to go live: agreement', () => {
 
       cy.visit(requestToGoLiveAgreementUrl)
 
-      cy.get('.govuk-back-link').should('have.text', 'My services')
-      cy.get('.service-navigation').should('not.exist')
-
       cy.get('h1').should('contain', 'Read and accept our legal terms')
 
       cy.get('fieldset').should('contain', 'These include the legal terms of Stripe, GOV.UK Pay’s payment service provider.')

--- a/test/cypress/integration/request-to-go-live/choose-how-to-process-payments.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/choose-how-to-process-payments.cy.test.js
@@ -33,9 +33,6 @@ describe('Request to go live: choose how to process payments', () => {
 
       cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
 
-      cy.get('.govuk-back-link').should('have.text', 'My services')
-      cy.get('.service-navigation').should('not.exist')
-
       cy.get('#request-to-go-live-current-step').should('exist')
       cy.get('#request-to-go-live-choose-how-to-process-payments-form').should('exist')
       cy.get('#choose-how-to-process-payments-mode').should('exist')

--- a/test/cypress/integration/request-to-go-live/index.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/index.cy.test.js
@@ -54,9 +54,6 @@ describe('Request to go live: index', () => {
       const requestToGoLivePageUrl = `/service/${serviceExternalId}/request-to-go-live`
       cy.visit(requestToGoLivePageUrl)
 
-      cy.get('.govuk-back-link').should('have.text', 'My services')
-      cy.get('.service-navigation').should('not.exist')
-
       cy.get('h1').should('contain', 'Request a live account')
       cy.get('h1 + p').should('contain', 'Complete these steps to request a live account')
 

--- a/test/cypress/integration/request-to-go-live/organisation-address.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/organisation-address.cy.test.js
@@ -33,9 +33,6 @@ describe('The organisation address page', () => {
         cy.setEncryptedCookies(userExternalId, gatewayAccountId)
         cy.visit(pageUrl)
 
-        cy.get('.govuk-back-link').should('have.text', 'My services')
-        cy.get('.service-navigation').should('not.exist')
-
         cy.get('h1').should('contain', `What is your organisation’s address?`)
 
         cy.get(`form[method=post][action="/service/${serviceExternalId}/request-to-go-live/organisation-address"]`)

--- a/test/cypress/integration/request-to-go-live/organisation-name.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/organisation-name.cy.test.js
@@ -62,9 +62,6 @@ describe('Request to go live: organisation name page', () => {
 
       cy.visit(requestToGoLivePageOrganisationNameUrl)
 
-      cy.get('.govuk-back-link').should('have.text', 'My services')
-      cy.get('.service-navigation').should('not.exist')
-
       cy.get('h1').should('contain', 'What is your organisation called?')
 
       cy.get('#request-to-go-live-current-step').should('exist')


### PR DESCRIPTION
Update the service/ account navigation "phase_banner" using the new
breadcrumb according to the ticket specification.

Move the account specific navigation down to the line below.

Update pages that currently have a manual link back to the my services
page as they can now rely on the breadcrumb for that functionality.

All changes are behind the future method feature flag.

Beginning to formalising page types
* All services page
* Service page
* Account page 
* Top level

Removes the "My services" link from the navigation header in favour of the breadcrumbs, behind the future feature flag.

**All services page header**

![Screenshot 2021-02-23 at 12 46 46](https://user-images.githubusercontent.com/2844572/108845873-dcedfc00-75d5-11eb-9bc3-c869d88a5df0.png)

**Account page header**

![Screenshot 2021-02-23 at 12 47 04](https://user-images.githubusercontent.com/2844572/108845919-ea0aeb00-75d5-11eb-92d6-a168dd528193.png)

**Service page header**

![Screenshot 2021-02-23 at 12 47 24](https://user-images.githubusercontent.com/2844572/108845945-f1ca8f80-75d5-11eb-8505-a753a8132bd9.png)

**Top level**
![Screenshot 2021-02-23 at 12 47 57](https://user-images.githubusercontent.com/2844572/108845966-f727da00-75d5-11eb-87f9-025b832f5071.png)

with @stephencdaly 