### PR TITLE
PP-4339 Trim gateway credentials before sending to Connector

### DIFF
--- a/app/controllers/credentials.controller.js
+++ b/app/controllers/credentials.controller.js
@@ -44,24 +44,24 @@ function loadIndex (req, res, viewMode) {
 function credentialsPatchRequestValueOf (req) {
   let requestPayload = {
     credentials: {
-      username: req.body.username,
-      password: req.body.password
+      username: req.body.username && req.body.username.trim(),
+      password: req.body.password && req.body.password.trim()
     }
   }
 
   const merchantId = _.get(req, 'body.merchantId')
   if (merchantId) {
-    requestPayload.credentials.merchant_id = req.body.merchantId
+    requestPayload.credentials.merchant_id = req.body.merchantId.trim()
   }
 
   const shaInPassphrase = _.get(req, 'body.shaInPassphrase')
   if (shaInPassphrase) {
-    requestPayload.credentials.sha_in_passphrase = req.body.shaInPassphrase
+    requestPayload.credentials.sha_in_passphrase = req.body.shaInPassphrase.trim()
   }
 
   const shaOutPassphrase = _.get(req, 'body.shaOutPassphrase')
   if (shaOutPassphrase) {
-    requestPayload.credentials.sha_out_passphrase = req.body.shaOutPassphrase
+    requestPayload.credentials.sha_out_passphrase = req.body.shaOutPassphrase.trim()
   }
 
   return requestPayload

--- a/app/controllers/credentials.controller.test.js
+++ b/app/controllers/credentials.controller.test.js
@@ -1,0 +1,34 @@
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+const spy = sinon.spy(() => Promise.resolve())
+const connectorClientMock = {
+  ConnectorClient: function () {
+    this.patchAccountCredentials = spy
+  }
+}
+const credentialsController = proxyquire('./credentials.controller', { '../services/clients/connector.client': connectorClientMock })
+
+// @TODO(sfount) there should be a common pattern of helpers for quickly unit
+//               testing controllers with values that work out of the box
+const expressResponseStub = {
+  setHeader: sinon.stub(),
+  status: sinon.spy(),
+  redirect: sinon.spy(),
+  render: sinon.spy()
+}
+describe('gateway credentials controller', () => {
+  it('should remove leading and trailing whitespace from credentials when submitting them to the backend', async () => {
+    const req = {
+      body: {
+        username: ' username       ',
+        password: ' password ',
+        merchantId: ' merchant-id '
+      },
+      account: {},
+      headers: {}
+    }
+    await credentialsController.update(req, expressResponseStub)
+    sinon.assert.calledWithMatch(spy, { payload: { credentials: { username: 'username', password: 'password', merchant_id: 'merchant-id' } } })
+  })
+})


### PR DESCRIPTION
When users have copied and pasted credentials from their payment service
providers they will sometimes come with hidden whitespace. This should
be removed before sending it to the backend as it can lead to invalid
credentials.

