### PR TITLE
PP-7835 Add Cypress assertions for transactions page

### DIFF
--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -92,24 +92,14 @@ function getGatewayAccountsSuccess (opts) {
   })
 }
 
-function getGatewayAccountsSuccessForMultipleAccounts (opts) {
+function getGatewayAccountsSuccessForMultipleAccounts (accountsOpts) {
   const path = '/v1/frontend/accounts'
   return stubBuilder('GET', path, 200, {
     query: {
-      accountIds: opts.gatewayAccountIds.join(',')
+      accountIds: accountsOpts.map(account => account.gatewayAccountId).join(',')
     },
     response: gatewayAccountFixtures.validGatewayAccountsResponse({
-      accounts: [{
-        gateway_account_id: opts.gatewayAccountId1,
-        type: opts.type,
-        payment_provider: opts.paymentProvider,
-        external_id: opts.externalId1
-      }, {
-        gateway_account_id: opts.gatewayAccountId2,
-        type: opts.type,
-        payment_provider: opts.paymentProvider,
-        external_id: opts.externalId2
-      }]
+      accounts: accountsOpts.map(parseGatewayAccountOptions)
     })
   })
 }

--- a/test/cypress/stubs/transaction-stubs.js
+++ b/test/cypress/stubs/transaction-stubs.js
@@ -28,9 +28,9 @@ function getLedgerTransactionsSuccess (opts) {
   return stubBuilder('GET', path, 200, {
     query: lodash.defaults({ ...opts.filters }, {
       account_id: opts.gatewayAccountIds ? opts.gatewayAccountIds.join(',') : opts.gatewayAccountId,
-      page: opts.page || 1,
-      display_size: opts.displaySize || 100,
-      limit_total: true,
+      page: opts.page || 1,	
+      display_size: opts.displaySize || 100,	
+      limit_total: true,	
       limit_total_size: 5001
     }),
     response: ledgerTransactionFixtures.validTransactionSearchResponse({

--- a/test/cypress/stubs/user-stubs.js
+++ b/test/cypress/stubs/user-stubs.js
@@ -26,31 +26,13 @@ function getUserSuccess (opts) {
   return buildGetUserSuccessStub(opts.userExternalId, fixtureOpts)
 }
 
-function getUserSuccessWithMultipleServices (opts) {
-  const serviceRoles = [
-    {
-      service: {
-        external_id: opts.gatewayAccountExternalId1,
-        gateway_account_ids: [String(opts.gatewayAccountId1)]
-      }
-    },
-    {
-      service: {
-        external_id: opts.gatewayAccountExternalId2,
-        gateway_account_ids: [opts.gatewayAccountId2]
-      }
-    }
-  ]
-
+function getUserSuccessWithMultipleServices (externalId, serviceRoles) {
+  const serviceRoleFixtureOpts = serviceRoles.map(buildServiceRoleOpts)
   const fixtureOpts = {
-    external_id: opts.userExternalId,
-    service_roles: serviceRoles,
-    username: opts.email,
-    email: opts.email,
-    telephone_number: opts.telephoneNumber
+    external_id: externalId,
+    service_roles: serviceRoleFixtureOpts
   }
-
-  return buildGetUserSuccessStub(opts.userExternalId, fixtureOpts)
+  return buildGetUserSuccessStub(externalId, fixtureOpts)
 }
 
 function getUsersSuccess () {
@@ -198,31 +180,38 @@ function getUserSuccessRespondDifferentlySecondTime (userExternalId, firstRespon
 }
 
 function buildServiceRoleOpts (opts) {
-  const serviceRole = {
-    service: {
-      gateway_account_ids: [String(opts.gatewayAccountId)]
-    }
+  const service = {}
+
+  if (opts.gatewayAccountId) {
+    service.gateway_account_ids = [String(opts.gatewayAccountId)]
+  } else if (opts.gatewayAccountIds) {
+    service.gateway_account_ids = opts.gatewayAccountIds.join(',')
   }
 
   if (opts.pspTestAccountStage) {
-    serviceRole.service.current_psp_test_account_stage = opts.pspTestAccountStage
+    service.current_psp_test_account_stage = opts.pspTestAccountStage
   }
 
   if (opts.serviceExternalId) {
-    serviceRole.service.external_id = opts.serviceExternalId
+    service.external_id = opts.serviceExternalId
   }
   if (opts.serviceName) {
-    serviceRole.service.name = opts.serviceName.en || opts.serviceName
-    serviceRole.service.service_name = opts.serviceName
+    service.name = opts.serviceName.en || opts.serviceName
+    service.service_name = opts.serviceName
   }
   if (opts.goLiveStage) {
-    serviceRole.service.current_go_live_stage = opts.goLiveStage
+    service.current_go_live_stage = opts.goLiveStage
   }
   if (opts.merchantName) {
-    serviceRole.service.merchant_details = {
+    service.merchant_details = {
       name: opts.merchantName
     }
   }
+
+  const serviceRole = {
+    service
+  }
+
   if (opts.role) {
     serviceRole.role = opts.role
   }

--- a/test/fixtures/ledger-transaction.fixtures.js
+++ b/test/fixtures/ledger-transaction.fixtures.js
@@ -71,7 +71,8 @@ const buildTransactionDetails = (opts = {}) => {
     created_date: opts.created_date || '2018-05-01T13:27:00.057Z',
     delayed_capture: opts.delayed_capture || false,
     transaction_type: opts.transaction_type || 'PAYMENT',
-    moto: opts.moto || false
+    moto: opts.moto || false,
+    live: opts.live || false,
   }
 
   if (opts.gateway_transaction_id) {
@@ -231,7 +232,7 @@ module.exports = {
   validTransactionSearchResponse: (opts = {}) => {
     let results = []
     opts.transactions.forEach(transaction => {
-      if (transaction.type === 'payment') {
+      if (!transaction.type || transaction.type === 'payment') {
         transaction.includeRefundSummary = true
         transaction.includeSettlementSummary = true
         results.push(buildTransactionDetails(transaction))


### PR DESCRIPTION
Add Cypress assertions for the all services transactions page to check:
- the correct breadcrumb navigation is shown
- clicking "Switch to test accounts" shows accounts for test transactions



