### PR TITLE
PP-7835 Add Cypress assertions for payouts page

### DIFF
--- a/test/cypress/stubs/user-stubs.js
+++ b/test/cypress/stubs/user-stubs.js
@@ -185,7 +185,7 @@ function buildServiceRoleOpts (opts) {
   if (opts.gatewayAccountId) {
     service.gateway_account_ids = [String(opts.gatewayAccountId)]
   } else if (opts.gatewayAccountIds) {
-    service.gateway_account_ids = opts.gatewayAccountIds.join(',')
+    service.gateway_account_ids = opts.gatewayAccountIds.map(String)
   }
 
   if (opts.pspTestAccountStage) {


### PR DESCRIPTION
Add some simple Cypress assertions to check:
- the breadcrumb is correct for the payouts page
- the link to show test payouts works and content is displayed correctly
for test payouts.


