### PR TITLE
PP-7632 Fix styling of divider on "My services"

### DIFF
--- a/app/assets/sass/components/my-services.scss
+++ b/app/assets/sass/components/my-services.scss
@@ -32,5 +32,5 @@
 }
 
 .overview-divider {
-  border-top: 5px solid govuk-colour("black");
+  border-bottom: 5px solid $govuk-border-colour;
 }


### PR DESCRIPTION
Use border-bottom rather than border-top to avoid a double line.
Use $govuk-border-colour for colour

