### PR TITLE
PP-7786 Payouts list handle no stripe test accounts

### DIFF
--- a/app/controllers/payouts/payout-list.controller.js
+++ b/app/controllers/payouts/payout-list.controller.js
@@ -18,7 +18,9 @@ const listAllServicesPayouts = async function listAllServicesPayouts (req, res, 
     let payoutsReleaseDate
     const userPermittedAccountsSummary = await permissions.getGatewayAccountsFor(req.user, filterLiveAccounts, 'payouts:read')
 
-    if (!userPermittedAccountsSummary.gatewayAccountIds.length) {
+    if (
+      (filterLiveAccounts && !userPermittedAccountsSummary.gatewayAccountIds.length) || (!filterLiveAccounts && !userPermittedAccountsSummary.hasTestStripeAccount)
+    ) {
       return next(new NoServicesWithPermissionError('You do not have any associated services with rights to view payments to bank accounts.'))
     }
     const payoutSearchResult = await payoutService.payouts(userPermittedAccountsSummary.gatewayAccountIds, req.user, page)

--- a/test/cypress/integration/payouts/payouts-list.cy.test.js
+++ b/test/cypress/integration/payouts/payouts-list.cy.test.js
@@ -98,4 +98,25 @@ describe('Payout list page', () => {
       cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'TEST')
     })
   })
+
+  it('should show no permissions to access this page if the user has no stripe test accounts', () => {
+    cy.task('setupStubs', [
+      userStubs.getUserSuccess({
+        userExternalId,
+        gatewayAccountIds: [ testGatewayAccountId ],
+        serviceName: 'some-service-name',
+        email: 'some-user@email.com'
+      }),
+      gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
+        {
+          gatewayAccountId: testGatewayAccountId,
+          paymentProvider: 'sandbox',
+          type: 'test'
+        }
+      ])
+    ])
+
+    cy.visit('/payments-to-your-bank-account/test', { failOnStatusCode: false })
+    cy.get('#errorMsg').should('have.text', 'You do not have any associated services with rights to view payments to bank accounts.')
+  })
 })


### PR DESCRIPTION
Currently the live payouts page is restricted to only users that have
access to live Stripe accounts.

Update the test page to only show to users with test Stripe accounts.

Add Cypress coverage.