### PR TITLE
BAU Trim filters on the search transaction page

### DIFF
--- a/app/utils/filters.js
+++ b/app/utils/filters.js
@@ -15,8 +15,17 @@ function validateFilters (filters) {
     (pageIsNull || pageIsPositive)
 }
 
+function trimFilterValues (filters) {
+  for (const [key, value] of Object.entries(filters)) {
+    if (typeof value === 'string') {
+      filters[key] = value.trim()
+    }
+  }
+  return filters
+}
+
 function getFilters (req) {
-  let filters = qs.parse(req.query)
+  let filters = trimFilterValues(qs.parse(req.query))
   filters.selectedStates = []
   if (filters.state) {
     filters.selectedStates = typeof filters.state === 'string' ? [filters.state] : filters.state

--- a/test/unit/utils/filters.test.js
+++ b/test/unit/utils/filters.test.js
@@ -40,6 +40,12 @@ describe('filters', () => {
         expect(result).to.have.property('refund_states').to.deep.equal(['success', 'error', 'submitted'])
         expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'capturable', 'success', 'error', 'cancelled', 'timedout', 'declined'])
       })
+
+      it('should trim values from the query object', () => {
+        const { result } = filters.getFilters({ query: { email: ' some-email@email.com ', reference: ' some-ref  ' } })
+        expect(result.email).to.equal('some-email@email.com')
+        expect(result.reference).to.equal('some-ref')
+      })
     })
 
     describe('describeFilter', () => {


### PR DESCRIPTION
Any filter that isn't a predefined choice (states, card brands) should
have leading and trailing whitespace removed. Whitespace can often be
included when copying and pasting. As whitespace at the beginning and
end of values is never stored, searches with these accidental characters
will fail.

Trim the direct input filters before passing them to the backend.


