### PR TITLE
PP-7859 Pass metadata_value to Ledger for transaction search

### DIFF
--- a/app/utils/get-query-string-for-params.js
+++ b/app/utils/get-query-string-for-params.js
@@ -15,7 +15,8 @@ function getQueryStringForParams (params = {}, removeEmptyParams = false, flatte
     from_date: dates.fromDateToApiFormat(params.fromDate, params.fromTime),
     to_date: dates.toDateToApiFormat(params.toDate, params.toTime),
     ...params.feeHeaders && { fee_headers: params.feeHeaders },
-    ...params.motoHeader && { moto_header: params.motoHeader }
+    ...params.motoHeader && { moto_header: params.motoHeader },
+    metadata_value: params.metadataValue
   }
 
   if (!ignorePagination) {

--- a/app/views/transactions/filter.njk
+++ b/app/views/transactions/filter.njk
@@ -130,7 +130,7 @@
             items: eventStates
           })
         }}
-        </fieldset> 
+        </fieldset>
     </div>
     <div class="govuk-grid-column-one-half">
       <fieldset class="govuk-fieldset">
@@ -221,9 +221,9 @@
             <div class="govuk-details__text">
               {{
                   govukInput({
-                    id: 'metadata',
-                    name: 'metadata',
-                    value: filters.metadata,
+                    id: 'metadataValue',
+                    name: 'metadataValue',
+                    value: filters.metadataValue,
                     classes: 'govuk-!-font-size-16',
                     label: {
                       text: 'Search by metadata or reporting column',
@@ -234,12 +234,12 @@
                       classes: 'govuk-!-font-size-14'
                     }
                   })
-                }} 
+                }}
             </div>
           </details>
         </div>
       </div>
-    {% endif %} 
+    {% endif %}
     <div class="govuk-grid-column-one-quarter inputs-less-margin">
       {{
         govukButton({


### PR DESCRIPTION
## WHAT
- Pass metadataValue search param & value to Ledger
- Rename query `metadata` to `metadataValue` as per the story and naming is inline with other query params
- Added pact to search transactions by metadata value

