### PR TITLE
Pp 7859 metadata filter controller updates

### DIFF
--- a/app/controllers/all-service-transactions/get.controller.js
+++ b/app/controllers/all-service-transactions/get.controller.js
@@ -73,6 +73,7 @@ module.exports = async function getTransactionsForAllServices (req, res, next) {
     model.allServiceTransactions = true
     model.filterLiveAccounts = filterLiveAccounts
     model.hasLiveAccounts = userPermittedAccountsSummary.hasLiveAccounts
+    model.isExperimentalFeaturesEnabled = req.user.serviceRoles.some(serviceRole => serviceRole.service.experimentalFeaturesEnabled)
 
     return response(req, res, 'transactions/index', model)
   } catch (err) {

--- a/app/utils/transaction-view.js
+++ b/app/utils/transaction-view.js
@@ -83,7 +83,8 @@ module.exports = {
         fromTime: filtersResult.fromTime,
         toTime: filtersResult.toTime,
         cardholderName: filtersResult.cardholderName,
-        lastDigitsCardNumber: filtersResult.lastDigitsCardNumber
+        lastDigitsCardNumber: filtersResult.lastDigitsCardNumber,
+        metadataValue: filtersResult.metadataValue
       })
 
     return connectorData

--- a/app/views/transactions/filter.njk
+++ b/app/views/transactions/filter.njk
@@ -210,9 +210,12 @@
       </fieldset>
     </div>
     {% if isExperimentalFeaturesEnabled %}
+      {% if filters.metadataValue %}
+        {% set detailsElementOpenHtml = 'open="true"' %}
+      {% endif %}
       <div class="govuk-grid-column-full">
         <div class="govuk-grid-column-one-half">
-          <details class="govuk-details" data-module="govuk-details">
+          <details class="govuk-details" data-module="govuk-details" {{ detailsElementOpenHtml }}>
             <summary class="govuk-details__summary">
               <span class="govuk-details__summary-text">
                 Advanced filters

--- a/test/cypress/integration/transactions/transaction-search.cy.test.js
+++ b/test/cypress/integration/transactions/transaction-search.cy.test.js
@@ -223,7 +223,8 @@ describe('Transactions List', () => {
             card_brands: 'visa,master-card',
             last_digits_card_number: '4242',
             cardholder_name: 'doe',
-            refund_states: 'submitted'
+            refund_states: 'submitted',
+            metadata_value: 'test'
           }
         })
       ])
@@ -244,6 +245,9 @@ describe('Transactions List', () => {
       cy.get('#email').type('gds4')
       cy.get('#lastDigitsCardNumber').type('4242')
       cy.get('#cardholderName').type('doe')
+
+      cy.contains('Advanced filters').click()
+      cy.get('#metadataValue').type('test')
 
       cy.get('#filter').click()
 


### PR DESCRIPTION
- Add the 'Advanced filters' to 'All transactions' view.
- Keep the 'Advanced filters' toggle open if a user has already submitted
  a metadata filter search.
- Update the controller, to pass the metadata filter values to the base client.
- Update the `download transactions` link to include query param for metadata filter.
- Update Cypress test for `transaction search` to include testing by metadata.