### PR TITLE
BAU Fix double line below My services breadcrumb

### DIFF
--- a/app/utils/display-converter.js
+++ b/app/utils/display-converter.js
@@ -22,12 +22,15 @@ const hideServiceNavTemplates = [
   'team-members/team-member-details',
   'team-members/team-member-profile',
   'team-members/team-member-permissions',
+  'team-members/edit-phone-number',
   'request-to-go-live/agreement',
   'request-to-go-live/choose-how-to-process-payments',
   'request-to-go-live/index',
   'request-to-go-live/organisation-address',
   'request-to-go-live/organisation-name',
-  'request-psp-test-account/index'
+  'request-psp-test-account/index',
+  'two-factor-auth/index',
+  'two-factor-auth/configure'
 ]
 
 /**


### PR DESCRIPTION
There was an additional `govuk-phase-banner` element below the banner
containing the "My services" link on the edit phone number and change
second factor method pages under "My profile".

Add these views to the list of views that don't display the account
navigation so this doesn't happen.

This is what we were seeing:

<img width="769" alt="Screenshot 2021-03-16 at 17 17 56" src="https://user-images.githubusercontent.com/5648592/111352597-3fd62e80-867c-11eb-884b-e488bdb8ef6a.png">



