### PR TITLE
PP-7893 Add back id used by endtoend tests

### DIFF
--- a/app/views/api-keys/_keys.njk
+++ b/app/views/api-keys/_keys.njk
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-m govuk-!-margin-top-6">
+<h2 class="govuk-heading-m govuk-!-margin-top-6" id="{{header_id}}">
   {% if tokens.length %}
     {% if tokens_singular %}
       There is 1 {{token_state}} API key

--- a/app/views/api-keys/index.njk
+++ b/app/views/api-keys/index.njk
@@ -32,6 +32,7 @@ API Keys - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK 
   {% endif %}
 
   {% set token_state = "active" %}
+  {% set header_id = "active-tokens" %}
   {% include "./_keys.njk" %}
 
   <div class="govuk-body key-list-item">

--- a/app/views/api-keys/revoked-keys.njk
+++ b/app/views/api-keys/revoked-keys.njk
@@ -19,6 +19,7 @@ Revoked API Keys - {{currentService.name}} {{currentGatewayAccount.full_type}} -
     <h1 class="govuk-heading-l page-title">Revoked API Keys</h1>
 
     {% set token_state = "revoked" %}
+    {% set header_id = "revoked-tokens" %}
     {% include "./_keys.njk" %}
     
   </div>


### PR DESCRIPTION
The id on the header is used by end to end tests to check which page it's on. It's not a nice way of doing it but add it back in to avoid the hassle of editing the end to end tests.


