### PR TITLE
PP-7733 Remove unnecessary middleware

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-03-24T11:54:45Z",
+  "generated_at": "2021-03-25T14:21:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -386,14 +386,14 @@
         "hashed_secret": "ffb6b0df52406a12074ca094831141bccab2f455",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 166,
+        "line_number": 149,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "25d58403fb473d9251b41161c6151b737969889e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 196,
+        "line_number": 179,
         "type": "Secret Keyword"
       }
     ],

--- a/app/services/auth.service.js
+++ b/app/services/auth.service.js
@@ -22,7 +22,6 @@ const CORRELATION_HEADER = require('../utils/correlation-header.js').CORRELATION
 // Exports
 module.exports = {
   enforceUserFirstFactor,
-  enforceUserAuthenticated,
   lockOutDisabledUsers,
   initialise,
   deserializeUser,
@@ -61,24 +60,6 @@ function noAccess (req, res, next) {
   } else {
     next() // don't redirect again if we're already there
   }
-}
-
-function enforceUserBothFactors (req, res, next) {
-  enforceUserFirstFactor(req, res, () => {
-    let hasLoggedInOtp = lodash.get(req, 'session.secondFactor') === 'totp'
-    if (!hasLoggedInOtp) {
-      return res.redirect(paths.user.otpLogIn)
-    }
-
-    next()
-  })
-}
-
-function enforceUserAuthenticated (req, res, next) {
-  if (!hasValidSession(req)) {
-    return redirectToLogin(req, res)
-  }
-  enforceUserBothFactors(req, res, next)
 }
 
 function redirectLoggedInUser (req, res, next) {

--- a/test/integration/auth.ft.test.js
+++ b/test/integration/auth.ft.test.js
@@ -29,19 +29,18 @@ describe('An endpoint not protected', () => {
       .end(done)
   })
 
-  it('redirects to noaccess if user disabled', done => {
+  it('shows noaccess error page if user disabled', done => {
     const user = getUser()
     user.disabled = true
     app = getAppWithLoggedInUser(server.getApp(), user)
     request(app)
       .get(paths.index)
-      .expect(302)
-      .expect('Location', paths.user.noAccess)
+      .expect(401)
       .end(done)
   })
 })
 
-describe('An endpoint protected by auth.enforceUserBothFactors', function () {
+describe('An endpoint protected by is-user-authorised middleware', function () {
   afterEach(function () {
     app = null
   })
@@ -72,7 +71,7 @@ describe('An endpoint protected by auth.enforceUserBothFactors', function () {
     request(app)
       .get(paths.index)
       .expect(302)
-      .expect('Location', paths.user.otpLogIn)
+      .expect('Location', paths.user.logIn)
       .end(done)
   })
 })

--- a/test/integration/login.controller.test.js
+++ b/test/integration/login.controller.test.js
@@ -83,12 +83,12 @@ describe('The logged in endpoint', function () {
       .end(done)
   })
 
-  it('should redirect to otp login if no otp', function (done) {
+  it('should redirect to login if no otp', function (done) {
     const app = mockSession.getAppWithSessionWithoutSecondFactor(getApp(), mockSession.getUser({ gateway_account_ids: [ACCOUNT_ID] }))
     request(app)
       .get('/')
       .expect(302)
-      .expect('Location', '/otp-login')
+      .expect('Location', '/login')
       .end(done)
   })
 })

--- a/test/integration/service-users.ft.test.js
+++ b/test/integration/service-users.ft.test.js
@@ -272,7 +272,7 @@ describe('service users resource', () => {
       .get('/my-profile')
       .set('Accept', 'application/json')
       .expect(302)
-      .expect('Location', '/otp-login')
+      .expect('Location', '/login')
       .end(done)
   })
 

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -4,7 +4,7 @@ const sinon = require('sinon')
 
 const paths = require('../../app/paths')
 const routes = require('../../app/routes')
-const oldAuthorisationMiddleware = require('../../app/services/auth.service').enforceUserAuthenticated
+const userIsAuthorised = require('../../app/middleware/user-is-authorised')
 
 const pathsNotRequiringAuthentication = [
   '/style-guide',
@@ -58,7 +58,7 @@ describe('The Express router', () => {
     const authenticatedPathsArg = app.use.getCalls()
       .find(call => {
         return Array.isArray(call.args[0]) &&
-          call.args.includes(oldAuthorisationMiddleware)
+          call.args.includes(userIsAuthorised)
       })
       .args[0]
     const authenticatedPaths = flattenPaths(authenticatedPathsArg)
@@ -73,7 +73,7 @@ describe('The Express router', () => {
         const path = call.args[0]
         return !pathsNotRequiringAuthentication.includes(path) &&
           !authenticatedPaths.includes(path) &&
-          !call.args.includes(oldAuthorisationMiddleware)
+          !call.args.includes(userIsAuthorised)
       })
       .map(call => call.args[0])
 

--- a/test/unit/services/auth.service.test.js
+++ b/test/unit/services/auth.service.test.js
@@ -98,23 +98,6 @@ describe('auth service', function () {
     })
   })
 
-  describe('enforceUserAndSecondFactor', function () {
-    it('should call next if has valid user', function (done) {
-      auth.enforceUserAuthenticated(validRequest(), response, next)
-      expect(next.calledOnce).to.be.true // eslint-disable-line
-      done()
-    })
-
-    it('should not call next if has a disabled user', function (done) {
-      const invalid = _.cloneDeep(validRequest())
-      invalid.user.disabled = true
-      auth.enforceUserAuthenticated(invalid, response, next)
-      expect(next.called).to.be.false // eslint-disable-line
-      assert(redirect.calledWith(paths.user.noAccess))
-      done()
-    })
-  })
-
   describe('ensureNotDisabled', function () {
     it('should call lockout user when user has a truthy disabled property', function (done) {
       const user = mockSession.getUser({ disabled: true })


### PR DESCRIPTION
Remove the getAccount, hasServices and resolveService middleware on all
routes that no longer require it.

Replace usages of the `enforceUserAuthenticated` middleware with the new
`is-user-authorised` middleware which does all the same checks.

Change tests that expect a redirect to `/otp-login` if the user has not
completed second factor authentication. This was never actually the
behaviour, as there was always a check on the session version first
which is updated after second factor authentication was completed, and
if the session version didn't match we redirected to `/login`. The
new `is-user-authorised` middleware now just always directs to `/login`
so this ambiguity is removed without changing actual behaviour.

