### PR TITLE
PP-7715 Fix redirect after refund

### DIFF
--- a/app/controllers/all-service-transactions/get.controller.js
+++ b/app/controllers/all-service-transactions/get.controller.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const _ = require('lodash')
+const url = require('url')
 
 const { response } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client.js')
@@ -25,6 +26,9 @@ module.exports = async function getTransactionsForAllServices (req, res, next) {
   // default behaviour should be live
   const { statusFilter } = req.params
   const filterLiveAccounts = statusFilter !== 'test'
+
+  req.session.filters = url.parse(req.url).query
+  req.session.allServicesTransactionsStatusFilter = statusFilter
 
   try {
     const userPermittedAccountsSummary = await permissions.getGatewayAccountsFor(req.user, filterLiveAccounts, 'transactions:read')

--- a/app/controllers/transactions/transaction-detail-redirect.controller.js
+++ b/app/controllers/transactions/transaction-detail-redirect.controller.js
@@ -18,7 +18,7 @@ module.exports = async function redirectToTransactionDetail (req, res) {
     const charge = await Ledger.transactionWithAccountOverride(chargeId)
     if (userServicesContainsGatewayAccount(charge.gateway_account_id, req.user)) {
       req.gateway_account.currentGatewayAccountId = charge.gateway_account_id
-      req.session = { ...req.session, backLink: req.header('Referer') }
+      req.session.contextIsAllServiceTransactions = true
 
       const account = await connector.getAccount({
         gatewayAccountId: charge.gateway_account_id,

--- a/app/controllers/transactions/transaction-detail.controller.js
+++ b/app/controllers/transactions/transaction-detail.controller.js
@@ -10,9 +10,10 @@ module.exports = async function showTransactionDetails (req, res, next) {
   try {
     const data = await ledgerFindWithEvents(accountId, chargeId, req.correlationId)
     data.indexFilters = req.session.filters
-    if (req.session.backLink) {
-      data.redirectBackLink = req.session.backLink
-      delete req.session.backLink
+    if (req.session.contextIsAllServiceTransactions) {
+      data.contextIsAllServiceTransactions = req.session.contextIsAllServiceTransactions
+      data.allServicesTransactionsStatusFilter = req.session.allServicesTransactionsStatusFilter
+      delete req.session.contextIsAllServiceTransactions
     }
     data.service = req.service
 

--- a/app/controllers/transactions/transaction-refund.controller.js
+++ b/app/controllers/transactions/transaction-refund.controller.js
@@ -18,6 +18,7 @@ const refundTransaction = async function refundTransaction (req, res, next) {
     const isFullRefund = req.body['refund-type'] === 'full'
     const refundAmount = isFullRefund ? req.body['full-amount'] : req.body['refund-amount']
     const refundAmountAvailableInPence = parseInt(req.body['refund-amount-available-in-pence'])
+    const contextIsAllServiceTransactions = req.body['context-is-all-services-transactions'] === 'true'
 
     const refundAmountInPence = safeConvertPoundsStringToPence(refundAmount)
     if (!refundAmountInPence) {
@@ -30,6 +31,10 @@ const refundTransaction = async function refundTransaction (req, res, next) {
       req.flash('refundSuccess', 'true')
     } catch (err) {
       req.flash('refundError', err.message)
+    }
+
+    if (contextIsAllServiceTransactions) {
+      req.session.contextIsAllServiceTransactions = true
     }
     res.redirect(transactionDetailPath)
   } catch (err) {

--- a/app/views/transaction-detail/_refund.njk
+++ b/app/views/transaction-detail/_refund.njk
@@ -1,6 +1,7 @@
 <form id="refundForm" action="{{ formatAccountPathsFor(routes.account.transactions.refund, currentGatewayAccount.external_id, charge_id) }}" method="post" class="target-to-show {% if flash.genericError %}active{% endif %}">
   <input id="full-amount" type="hidden" name="full-amount" value="{{ refundable_amount }}" >
   <input id="amount-available" type="hidden" name="refund-amount-available-in-pence" value="{{ refund_summary.amount_available }}" />
+  <input id="context-is-all-services-transactions" type="hidden" name="context-is-all-services-transactions" value="{{contextIsAllServiceTransactions}}" />
   <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}" />
 
   {% set refundRemainingHint %}

--- a/app/views/transaction-detail/index.njk
+++ b/app/views/transaction-detail/index.njk
@@ -2,7 +2,6 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "../macro/breadcrumbs.njk" import breadcrumbs %}
 
-{% set contextIsAllServiceTransactions = redirectBackLink %}
 {% set hideServiceHeader = contextIsAllServiceTransactions %}
 
 {% block pageTitle %}
@@ -20,10 +19,11 @@
       { html: pageTitleBreadcrumbWithTag  }
     ]) }}
 
+    {% set allServicesBackLink %}{{routes.allServiceTransactions.index}}{% if allServicesTransactionsStatusFilter %}/{{allServicesTransactionsStatusFilter}}{% endif %}{% if indexFilters %}?{{indexFilters}}{% endif %}{% endset %}
     {{
       govukBackLink({
         text: 'Back to transactions for all services',
-        href: redirectBackLink | safe
+        href: allServicesBackLink | safe
       })
     }}
   {% else %}
@@ -36,6 +36,7 @@
       })
     }}
   {% endif %}
+
 {% endblock %}
 
 {% block mainContent %}

--- a/test/cypress/integration/all-service-transactions/all-service-transactions.cy.test.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions.cy.test.js
@@ -3,7 +3,6 @@
 const userStubs = require('../../stubs/user-stubs')
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 const transactionStubs = require('../../stubs/transaction-stubs')
-const stripeAccountSetupStubs = require('../../stubs/stripe-account-setup-stub')
 
 describe('All service transactions', () => {
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
@@ -39,23 +38,34 @@ describe('All service transactions', () => {
   const liveTransactions = [
     {
       gateway_account_id: String(gatewayAccount1.gatewayAccountId),
-      reference: 'gateway-account-1-transaction',
+      reference: 'ref1',
       transaction_id: 'transaction-id-1',
       live: true
     },
     {
       gateway_account_id: String(gatewayAccount2.gatewayAccountId),
-      reference: 'gateway-account-2-transaction',
+      reference: 'ref2',
       transaction_id: 'transaction-id-2',
       live: true
     }
   ]
   const testTransactions = [
     {
+      amount: 5000,
       gateway_account_id: String(gatewayAccount3.gatewayAccountId),
-      reference: 'gateway-account-3-transaction',
+      reference: 'ref3',
       transaction_id: 'transaction-id-3',
-      live: false
+      live: false,
+      state: { finished: true, status: 'success' },
+      refund_summary_status: 'available',
+      refund_summary_available: 5000,
+      refund_summary_submitted: 0
+    },
+    {
+      gateway_account_id: String(gatewayAccount3.gatewayAccountId),
+      reference: 'ref4',
+      transaction_id: 'transaction-id-4',
+      live: false,
     }
   ]
 
@@ -91,47 +101,6 @@ describe('All service transactions', () => {
       })
     })
 
-    it('should display Transaction Detail page', () => {
-      cy.task('setupStubs', [
-        userStub,
-        transactionStubs.getLedgerTransactionSuccess({ transactionDetails: liveTransactions[0] }),
-        gatewayAccountStubs.getGatewayAccountSuccess(gatewayAccount1),
-        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess(gatewayAccount1),
-        stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId: gatewayAccount1.gatewayAccountId, bankAccount: true, responsiblePerson: true, vatNumber: true, companyNumber: true }),
-        transactionStubs.getLedgerEventsSuccess({ transactionId: 'transaction-id-1' })
-      ])
-
-      cy.get('#charge-id-transaction-id-1').click()
-
-      cy.get('.transaction-details tbody').find('tr').first().find('td').first().should('contain',
-        'Service 1')
-      cy.get('.transaction-details tbody').find('tr').eq(1).find('td').first().should('contain',
-        'gateway-account-1-transaction')
-    })
-
-    it('should have correct breadcrumb navigation', () => {
-      cy.get('.govuk-breadcrumbs').within(() => {
-        cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
-        cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
-        cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'LIVE')
-      })
-    })
-
-    it('should go back to all services transactions when back button clicked', () => {
-      cy.task('setupStubs', [
-        userStub,
-        gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccount1, gatewayAccount2, gatewayAccount3]),
-        transactionStubs.getLedgerTransactionsSuccess({
-          gatewayAccountIds: [gatewayAccount1.gatewayAccountId, gatewayAccount2.gatewayAccountId],
-          transactions: liveTransactions
-        }),
-        gatewayAccountStubs.getCardTypesSuccess()
-      ])
-      cy.get('.govuk-back-link').should('have.text', 'Back to transactions for all services').click()
-
-      cy.title().should('eq', `Transactions for all services`)
-    })
-
     it('should show test transactions when Swtich to test accounts link clicked', () => {
       cy.task('setupStubs', [
         userStub,
@@ -145,6 +114,27 @@ describe('All service transactions', () => {
 
       cy.get('a').contains('Switch to test accounts').click()
 
+      cy.get('.transactions-list--row').should('have.length', 2)
+      cy.get('#charge-id-transaction-id-3').should('exist')
+      cy.get('#charge-id-transaction-id-4').should('exist')
+    })
+
+    it('should filter payments', () => {
+      cy.task('setupStubs', [
+        userStub,
+        gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccount1, gatewayAccount2, gatewayAccount3]),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
+          transactions: [testTransactions[0]],
+          filters: {
+            reference: 'ref3'
+          }
+        }),
+        gatewayAccountStubs.getCardTypesSuccess()
+      ])
+
+      cy.get('#reference').type('ref3')
+      cy.get('#filter').click()
       cy.get('.transactions-list--row').should('have.length', 1)
       cy.get('#charge-id-transaction-id-3').should('exist')
     })
@@ -155,6 +145,62 @@ describe('All service transactions', () => {
         cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
         cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'TEST')
       })
+    })
+
+    it('should display Transaction Detail page', () => {
+      cy.task('setupStubs', [
+        userStub,
+        transactionStubs.getLedgerTransactionSuccess({ transactionDetails: testTransactions[0] }),
+        gatewayAccountStubs.getGatewayAccountSuccess(gatewayAccount3),
+        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess(gatewayAccount3),
+        transactionStubs.getLedgerEventsSuccess({ transactionId: 'transaction-id-3' })
+      ])
+
+      cy.get('#charge-id-transaction-id-3').click()
+
+      cy.get('.transaction-details tbody').find('tr').first().find('td').first().should('contain',
+        'Service 2')
+      cy.get('.transaction-details tbody').find('tr').eq(1).find('td').first().should('contain',
+        'ref3')
+    })
+
+    it('should have correct breadcrumb navigation', () => {
+      cy.get('.govuk-breadcrumbs').within(() => {
+        cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'TEST')
+      })
+    })
+
+    it('should have correct back link', () => {
+      cy.get('.govuk-back-link')
+        .should('have.text', 'Back to transactions for all services')
+        .should('have.attr', 'href', '/all-service-transactions/test?reference=ref3&email=&cardholderName=&lastDigitsCardNumber=&fromDate=&fromTime=&toDate=&toTime=&metadataValue=')
+    })
+
+    it('should refund a payment', () => {
+      cy.task('setupStubs', [
+        userStub,
+        transactionStubs.getLedgerTransactionSuccess({ transactionDetails: testTransactions[0] }),
+        gatewayAccountStubs.getGatewayAccountSuccess(gatewayAccount3),
+        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess(gatewayAccount3),
+        transactionStubs.getLedgerEventsSuccess({ transactionId: 'transaction-id-3' })
+      ])
+
+      cy.get('a.refund__toggle').click()
+      cy.get('button').contains('Refund payment').click()
+    })
+
+    it('should still have correct breadcrumb and back link', () => {
+      cy.get('.govuk-breadcrumbs').within(() => {
+        cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'TEST')
+      })
+
+      cy.get('.govuk-back-link')
+        .should('have.text', 'Back to transactions for all services')
+        .should('have.attr', 'href', '/all-service-transactions/test?reference=ref3&email=&cardholderName=&lastDigitsCardNumber=&fromDate=&fromTime=&toDate=&toTime=&metadataValue=')
     })
   })
 })


### PR DESCRIPTION
Fix the redirect after making a refund if the user has come from the
"Transactions for all services" page, rather than the transactions list
for a particular account.

Do this by adding a hidden input to the refund form to indicate that we
have come from the all services transactions page which is passed along
with the redirect.

Store the filters for the all services transaction search on the session
as we do for the account transaction search so we can construct the back
link from these, even after redirecting following a refund. Also include
the status filter (live/test) to ensure we get back to the correct
search.


