### PR TITLE
PP-7735 Make service URLs uniform

### DIFF
--- a/app/paths.js
+++ b/app/paths.js
@@ -163,11 +163,14 @@ module.exports = {
     update: '/service/:externalServiceId/edit-name'
   },
   merchantDetails: {
-    index: '/organisation-details/:externalServiceId',
-    edit: '/organisation-details/edit/:externalServiceId'
+    index: '/service/:externalServiceId/organisation-details',
+    edit: '/service/:externalServiceId/organisation-details/edit',
+    indexOld: '/organisation-details/:externalServiceId',
+    editOld: '/organisation-details/edit/:externalServiceId'
   },
   teamMembers: {
-    index: '/service/:externalServiceId',
+    index: '/service/:externalServiceId/team-members',
+    indexOld: '/service/:externalServiceId',
     show: '/service/:externalServiceId/team-member/:externalUserId',
     delete: '/service/:externalServiceId/team-member/:externalUserId/delete',
     permissions: '/service/:externalServiceId/team-member/:externalUserId/permissions',

--- a/app/routes.js
+++ b/app/routes.js
@@ -278,6 +278,12 @@ module.exports.bind = function (app) {
   app.get(requestPspTestAccount, permission('psp-test-account-stage:update'), requestPspTestAccountController.get)
   app.post(requestPspTestAccount, permission('psp-test-account-stage:update'), requestPspTestAccountController.post)
 
+  // TODO: these routes are for old URLs and will be removed after the changes with the new URLs have been deployed
+  app.get(merchantDetails.indexOld, permission('merchant-details:read'), merchantDetailsController.getIndex)
+  app.get(merchantDetails.editOld, permission('merchant-details:update'), merchantDetailsController.getEdit)
+  app.post(merchantDetails.editOld, permission('merchant-details:update'), merchantDetailsController.postEdit)
+  app.get(teamMembers.indexOld, resolveService, serviceUsersController.index)
+
   // ----------------------------
   // GATEWAY ACCOUNT LEVEL ROUTES
   // ----------------------------

--- a/app/views/merchant-details/edit-merchant-details.njk
+++ b/app/views/merchant-details/edit-merchant-details.njk
@@ -49,7 +49,7 @@
     <p class="govuk-body" id="merchant-details-info">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
   {% endif %}
 
-  <form id="merchant-details-form" method="post" action="/organisation-details/edit/{{currentService.externalId}}">
+  <form id="merchant-details-form" method="post" action="/service/{{currentService.externalId}}/organisation-details/edit">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
     <div class="govuk-form-group {% if errors['merchant-name'] %} govuk-form-group--error {% endif %}">

--- a/app/views/services/_service-section.njk
+++ b/app/views/services/_service-section.njk
@@ -23,13 +23,13 @@
       <li>
       {% if service.permissions.users_service_create %}
         <p class="govuk-!-margin-top-0 govuk-!-font-size-16">
-          <a class="govuk-link govuk-link--no-visited-state manage-team-members" href="/service/{{ service.external_id }}">
+          <a class="govuk-link govuk-link--no-visited-state manage-team-members" href="/service/{{ service.external_id }}/team-members">
             Manage team members <span class="govuk-visually-hidden">for {{ service.name }}</span>
           </a>
         </p>
       {% else %}
         <p>
-          <a class="govuk-link govuk-link--no-visited-state view-team-members govuk-!-font-size-16" href="/service/{{ service.external_id }}">
+          <a class="govuk-link govuk-link--no-visited-state view-team-members govuk-!-font-size-16" href="/service/{{ service.external_id }}/team-members">
             View team members <span class="govuk-visually-hidden">for {{ service.name }}</span>
           </a>
         </p>
@@ -37,7 +37,7 @@
       </li>
       <li>
       {% if service.permissions.merchant_details_read %}
-        <a class="govuk-link govuk-link--no-visited-state edit-merchant-details govuk-!-font-size-16" href="/organisation-details/{{ service.external_id }}">
+        <a class="govuk-link govuk-link--no-visited-state edit-merchant-details govuk-!-font-size-16" href="/service/{{ service.external_id }}/organisation-details">
           Organisation details <span class="govuk-visually-hidden">for {{ service.name }}</span>
         </a>
       {% endif %}

--- a/test/cypress/integration/manage-team-members/edit-permissions.cy.test.js
+++ b/test/cypress/integration/manage-team-members/edit-permissions.cy.test.js
@@ -44,7 +44,7 @@ describe('Edit service user permissions', () => {
   it('should display team members page', () => {
     cy.setEncryptedCookies(AUTHENTICATED_USER_ID, 1)
 
-    cy.visit(`/service/${SERVICE_EXTERNAL_ID}`)
+    cy.visit(`/service/${SERVICE_EXTERNAL_ID}/team-members`)
 
     cy.get('#team-members-admin-list').find('tr').first().find('td').first().find('a').contains('logged-in-user@example.com (you)')
     cy.get('#team-members-admin-list').find('tr').eq(1).find('td').first().find('a').contains('other-user@example.com')

--- a/test/cypress/integration/manage-team-members/manage-team-members.cy.test.js
+++ b/test/cypress/integration/manage-team-members/manage-team-members.cy.test.js
@@ -44,7 +44,7 @@ describe('Manage team members page', () => {
   it('should display the manage team members page with users in correct categories', () => {
     cy.setEncryptedCookies(AUTHENTICATED_USER_ID, 1)
 
-    cy.visit(`/service/${SERVICE_EXTERNAL_ID}`)
+    cy.visit(`/service/${SERVICE_EXTERNAL_ID}/team-members`)
 
     cy.get('#team-members-admin-list').find('tr').first().find('td').first().find('a').contains('logged-in-user@example.com (you)')
     cy.get('#team-members-admin-list').find('tr').eq(1).find('td').first().find('a').contains('admin-user@example.com')

--- a/test/integration/service-users.ft.test.js
+++ b/test/integration/service-users.ft.test.js
@@ -391,7 +391,7 @@ describe('service users resource', () => {
       .expect(res => {
         expect(res.body.error.title).to.equal('This person has already been removed')
         expect(res.body.error.message).to.equal('This person has already been removed by another administrator.')
-        expect(res.body.link.link).to.equal(`/service/${externalServiceId}`)
+        expect(res.body.link.link).to.equal(`/service/${externalServiceId}/team-members`)
         expect(res.body.link.text).to.equal('View all team members')
         expect(res.body.enable_link).to.equal(true)
       })


### PR DESCRIPTION
Add new URLs for the organisation details page that use the pattern
`/service/:externalServiceId` so that we can use a Router for all
service routes.

Also change the URL for view/edit team members to be
`/service/:externalServiceId/team-members` rather than
`/service/:externalServiceId/` as this isn't really a root URL for a
service.

Keep routes for the old URLs which will be removed after this change
has been deployed. This is to avoid breaking user journeys during
deployment.
