### PR TITLE
PP-7735 Inline userIsAuthorised middleware

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { Router } = require('express')
-const lodash = require('lodash')
 
 const logger = require('./utils/logger')(__filename)
 const response = require('./utils/response.js').response
@@ -189,17 +188,6 @@ module.exports.bind = function (app) {
   // AUTHENTICATED ROUTES
   // ----------------------
 
-  const authenticatedPaths = [
-    ...lodash.values(allServiceTransactions),
-    ...lodash.values(serviceSwitcher),
-    ...lodash.values(user.profile),
-    ...lodash.values(policyPages),
-    ...lodash.values(payouts),
-    paths.feedback
-  ] // Extract all the authenticated paths as a single array
-
-  app.use(authenticatedPaths, userIsAuthorised) // Enforce authentication on all get requests
-
   // Site index
   app.get(index, userIsAuthorised, rootController.get)
 
@@ -208,40 +196,40 @@ module.exports.bind = function (app) {
   // -------------------------
 
   // Service switcher
-  app.get(serviceSwitcher.index, myServicesController.getIndex)
-  app.post(serviceSwitcher.switch, myServicesController.postIndex)
-  app.get(serviceSwitcher.create, createServiceController.get)
-  app.post(serviceSwitcher.create, createServiceController.post)
+  app.get(serviceSwitcher.index, userIsAuthorised, myServicesController.getIndex)
+  app.post(serviceSwitcher.switch, userIsAuthorised, myServicesController.postIndex)
+  app.get(serviceSwitcher.create, userIsAuthorised, createServiceController.get)
+  app.post(serviceSwitcher.create, userIsAuthorised, createServiceController.post)
 
   // All service transactions
-  app.get(allServiceTransactions.index, allTransactionsController.getController)
-  app.get(allServiceTransactions.indexStatusFilter, allTransactionsController.getController)
-  app.get(allServiceTransactions.download, allTransactionsController.downloadTransactions)
-  app.get(allServiceTransactions.downloadStatusFilter, allTransactionsController.downloadTransactions)
-  app.get(allServiceTransactions.redirectDetail, transactionDetailRedirectController)
+  app.get(allServiceTransactions.index, userIsAuthorised, allTransactionsController.getController)
+  app.get(allServiceTransactions.indexStatusFilter, userIsAuthorised, allTransactionsController.getController)
+  app.get(allServiceTransactions.download, userIsAuthorised, allTransactionsController.downloadTransactions)
+  app.get(allServiceTransactions.downloadStatusFilter, userIsAuthorised, allTransactionsController.downloadTransactions)
+  app.get(allServiceTransactions.redirectDetail, userIsAuthorised, transactionDetailRedirectController)
 
   // Payouts
-  app.get(payouts.list, payoutsController.listAllServicesPayouts)
-  app.get(payouts.listStatusFilter, payoutsController.listAllServicesPayouts)
+  app.get(payouts.list, userIsAuthorised, payoutsController.listAllServicesPayouts)
+  app.get(payouts.listStatusFilter, userIsAuthorised, payoutsController.listAllServicesPayouts)
 
   // Policy document downloads
-  app.get(policyPages.download, policyDocumentsController.download)
+  app.get(policyPages.download, userIsAuthorised, policyDocumentsController.download)
 
   // Feedback
-  app.get(paths.feedback, feedbackController.getIndex)
-  app.post(paths.feedback, feedbackController.postIndex)
+  app.get(paths.feedback, userIsAuthorised, feedbackController.getIndex)
+  app.post(paths.feedback, userIsAuthorised, feedbackController.postIndex)
 
   // User profile
-  app.get(user.profile.index, serviceUsersController.profile)
-  app.get(user.profile.phoneNumber, userPhoneNumberController.get)
-  app.post(user.profile.phoneNumber, userPhoneNumberController.post)
+  app.get(user.profile.index, userIsAuthorised, serviceUsersController.profile)
+  app.get(user.profile.phoneNumber, userIsAuthorised, userPhoneNumberController.get)
+  app.post(user.profile.phoneNumber, userIsAuthorised, userPhoneNumberController.post)
 
   // Configure 2FA
-  app.get(user.profile.twoFactorAuth.index, twoFactorAuthController.getIndex)
-  app.post(user.profile.twoFactorAuth.index, twoFactorAuthController.postIndex)
-  app.get(user.profile.twoFactorAuth.configure, twoFactorAuthController.getConfigure)
-  app.post(user.profile.twoFactorAuth.configure, twoFactorAuthController.postConfigure)
-  app.post(user.profile.twoFactorAuth.resend, twoFactorAuthController.postResend)
+  app.get(user.profile.twoFactorAuth.index, userIsAuthorised, twoFactorAuthController.getIndex)
+  app.post(user.profile.twoFactorAuth.index, userIsAuthorised, twoFactorAuthController.postIndex)
+  app.get(user.profile.twoFactorAuth.configure, userIsAuthorised, twoFactorAuthController.getConfigure)
+  app.post(user.profile.twoFactorAuth.configure, userIsAuthorised, twoFactorAuthController.postConfigure)
+  app.post(user.profile.twoFactorAuth.resend, userIsAuthorised, twoFactorAuthController.postResend)
 
   // --------------------
   // SERVICE LEVEL ROUTES

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -30,17 +30,6 @@ const pathsNotRequiringAuthentication = [
   paths.staticPaths.naxsiError
 ]
 
-function flattenPaths (arrayThatMayContainObjects) {
-  return arrayThatMayContainObjects.reduce((paths, val) => {
-    if (typeof val === 'object' && val != null) {
-      return paths.concat(flattenPaths(Object.values(val)))
-    } else {
-      paths.push(val)
-      return paths
-    }
-  }, [])
-}
-
 describe('The Express router', () => {
   it('should include authorisation middleware in stack for all paths not in exceptions', () => {
     const app = {
@@ -52,17 +41,6 @@ describe('The Express router', () => {
 
     routes.bind(app)
 
-    // We currently call `app.use` to specify a list of paths to use certain middleware for,
-    // including the authorisation middleware. We need to check that paths are either included in
-    // the array for this call, or the middleware is added to the stack individually for the route
-    const authenticatedPathsArg = app.use.getCalls()
-      .find(call => {
-        return Array.isArray(call.args[0]) &&
-          call.args.includes(userIsAuthorised)
-      })
-      .args[0]
-    const authenticatedPaths = flattenPaths(authenticatedPathsArg)
-
     const registerRouteCalls = [
       ...app.get.getCalls(),
       ...app.post.getCalls()
@@ -72,7 +50,6 @@ describe('The Express router', () => {
       .filter(call => {
         const path = call.args[0]
         return !pathsNotRequiringAuthentication.includes(path) &&
-          !authenticatedPaths.includes(path) &&
           !call.args.includes(userIsAuthorised)
       })
       .map(call => call.args[0])


### PR DESCRIPTION
Remove the array of `authenticatedPaths` to apply this middleware to and inline the middleware per route. This should make it clearer what middleware is being called on the routes and should make it harder to make mistakes when adding a new route.

The unit test for `routes.test.js` ensures that all routes using the main Express router call this middleware unless they are specifically excluded which adds protection against coding mistakes.

