### PR TITLE
PP-7734 Redirect to my services for old URLs if no cookie

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -414,26 +414,29 @@ module.exports.bind = function (app) {
 
   app.all('*', (req, res, next) => {
     if (accountUrls.isLegacyAccountsUrl(req.url)) {
-      if (req.user) {
-        const currentSessionAccountExternalId = req.gateway_account && req.gateway_account.currentGatewayAccountExternalId
-        if (currentSessionAccountExternalId) {
-          const upgradedPath = accountUrls.getUpgradedAccountStructureUrl(req.url, currentSessionAccountExternalId)
-          logger.info('Accounts URL utility upgraded a request to a legacy account URL', {
-            url: req.originalUrl,
-            redirected_url: upgradedPath,
-            session_has_user: !!req.user,
-            is_internal_user: req.user && req.user.internalUser
-          })
-          res.redirect(upgradedPath)
-          return
-        }
-      } else {
+      if (!req.user) {
         if (req.session) {
           req.session.last_url = req.url
         }
         res.redirect(user.logIn)
         return
       }
+
+      const currentSessionAccountExternalId = req.gateway_account && req.gateway_account.currentGatewayAccountExternalId
+      if (currentSessionAccountExternalId) {
+        const upgradedPath = accountUrls.getUpgradedAccountStructureUrl(req.url, currentSessionAccountExternalId)
+        logger.info('Accounts URL utility upgraded a request to a legacy account URL', {
+          url: req.originalUrl,
+          redirected_url: upgradedPath,
+          session_has_user: !!req.user,
+          is_internal_user: req.user && req.user.internalUser
+        })
+        res.redirect(upgradedPath)
+        return
+      }
+
+      res.redirect(serviceSwitcher.index)
+      return
     }
     logger.info('Page not found', {
       url: req.originalUrl

--- a/test/integration/routes.it.test.js
+++ b/test/integration/routes.it.test.js
@@ -5,7 +5,7 @@ const session = require('../test-helpers/mock-session.js')
 
 describe('URL upgrade utility', () => {
   it('correctly upgrades URLs in the account specific paths', () => {
-    const app = session.getAppWithLoggedInUser(getApp(), session.getUser())
+    const app = session.getAppWithLoggedInUserWithGatewayAccountCookie(getApp(), session.getUser())
     return request(app)
       .get('/billing-address')
       .expect(302)
@@ -15,7 +15,7 @@ describe('URL upgrade utility', () => {
   })
 
   it('correctly upgrades URLs in the account specific paths with complex templated values', () => {
-    const app = session.getAppWithLoggedInUser(getApp(), session.getUser())
+    const app = session.getAppWithLoggedInUserWithGatewayAccountCookie(getApp(), session.getUser())
     return request(app)
       .get('/create-payment-link/manage/some-product-external-id/add-reporting-column/some-metadata-key')
       .expect(302)
@@ -36,8 +36,18 @@ describe('URL upgrade utility', () => {
       })
   })
 
-  it('correctly 404s as expected for non account specific paths', () => {
+  it('redirects to My services for an old URL if there is no gateway account cookie set', () => {
     const app = session.getAppWithLoggedInUser(getApp(), session.getUser())
+    return request(app)
+      .get('/billing-address')
+      .expect(302)
+      .then((res) => {
+        res.header['location'].should.include('/my-services') // eslint-disable-line
+      })
+  })
+
+  it('correctly 404s as expected for non account specific paths', () => {
+    const app = session.getAppWithLoggedInUserWithGatewayAccountCookie(getApp(), session.getUser())
     return request(app)
       .get('/unknown-address')
       .expect(404)


### PR DESCRIPTION
If a user visits an old account URL not containing the account external ID, if they don't have a `gateway_account` cookie set, redirect them to "My services".

This will allow us to stop setting the `gateway_account` cookie when users first log in and retain sensible behaviour.

