### PR TITLE
PP-7734 Stop setting `gateway_account` cookie in Cypress tests

### DIFF
--- a/test/cypress/integration/all-service-transactions/all-service-transactions.cy.test.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions.cy.test.js
@@ -75,7 +75,7 @@ describe('All service transactions', () => {
     })
 
     it('should display All Service Transactions list page with live transactions', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccount1.gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.task('setupStubs', [
         userStub,
         gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccount1, gatewayAccount2, gatewayAccount3]),

--- a/test/cypress/integration/dashboard/dashboard-go-live-link.cy.test.js
+++ b/test/cypress/integration/dashboard/dashboard-go-live-link.cy.test.js
@@ -1,13 +1,13 @@
 'use strict'
 
 const utils = require('../../utils/request-to-go-live-utils')
-const { userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceExternalId } = utils.variables
+const { userExternalId, gatewayAccountExternalId, serviceExternalId } = utils.variables
 
 const dashboardUrl = `/account/${gatewayAccountExternalId}/dashboard`
 
 describe('Go live link on dashboard', () => {
   beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    cy.setEncryptedCookies(userExternalId)
   })
 
   describe('Card gateway account', () => {

--- a/test/cypress/integration/dashboard/dashboard-links.cy.test.js
+++ b/test/cypress/integration/dashboard/dashboard-links.cy.test.js
@@ -38,7 +38,7 @@ function getStubsForDashboard (gatewayAccountId, type, paymentProvider, goLiveSt
 describe('the links are displayed correctly on the dashboard', () => {
   describe('card gateway account', () => {
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
     })
 
     it('should display 2 links for a live sandbox account', () => {

--- a/test/cypress/integration/dashboard/dashboard-statistics.cy.test.js
+++ b/test/cypress/integration/dashboard/dashboard-statistics.cy.test.js
@@ -38,7 +38,7 @@ describe('Account dashboard', () => {
   })
 
   it('should display dashboard page', () => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    cy.setEncryptedCookies(userExternalId)
 
     cy.visit(`/account/${gatewayAccountExternalId}/dashboard`)
     cy.title().should('eq', `Dashboard - ${serviceName} Sandbox test - GOV.UK Pay`)

--- a/test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.test.js
+++ b/test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.test.js
@@ -11,7 +11,7 @@ describe('The Stripe psp details banner', () => {
   const gatewayAccountExternalId = 'a-valid-external-id'
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
   beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    cy.setEncryptedCookies(userExternalId)
     cy.task('setupStubs', [
       userStubs.getUserSuccess({ userExternalId, gatewayAccountId, gatewayAccountExternalId }),
       gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId, type: 'live', paymentProvider: 'stripe' }),

--- a/test/cypress/integration/errors/errors.cy.test.js
+++ b/test/cypress/integration/errors/errors.cy.test.js
@@ -16,7 +16,7 @@ describe('Error pages', () => {
 
   describe('User logged in', () => {
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, 1)
+      cy.setEncryptedCookies(userExternalId)
       cy.task('setupStubs', [userStubs.getUserSuccess({ userExternalId })])
     })
 

--- a/test/cypress/integration/feedback/feedback.cy.test.js
+++ b/test/cypress/integration/feedback/feedback.cy.test.js
@@ -17,7 +17,7 @@ describe('Feedback page', () => {
   })
 
   it('should display Feedback page', () => {
-    cy.setEncryptedCookies(authenticatedUserId, 1)
+    cy.setEncryptedCookies(authenticatedUserId)
     cy.visit('/feedback')
 
     cy.title().should('eq', 'Give feedback — GOV.UK Pay')

--- a/test/cypress/integration/index/index.cy.test.js
+++ b/test/cypress/integration/index/index.cy.test.js
@@ -8,7 +8,7 @@ const gatewayAccountId = '42'
 
 describe('The index page', () => {
   beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    cy.setEncryptedCookies(userExternalId)
 
     cy.task('setupStubs', [
       userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),

--- a/test/cypress/integration/manage-team-members/edit-permissions.cy.test.js
+++ b/test/cypress/integration/manage-team-members/edit-permissions.cy.test.js
@@ -42,7 +42,7 @@ describe('Edit service user permissions', () => {
   })
 
   it('should display team members page', () => {
-    cy.setEncryptedCookies(AUTHENTICATED_USER_ID, 1)
+    cy.setEncryptedCookies(AUTHENTICATED_USER_ID)
 
     cy.visit(`/service/${SERVICE_EXTERNAL_ID}/team-members`)
 

--- a/test/cypress/integration/manage-team-members/manage-team-members.cy.test.js
+++ b/test/cypress/integration/manage-team-members/manage-team-members.cy.test.js
@@ -42,7 +42,7 @@ describe('Manage team members page', () => {
   })
 
   it('should display the manage team members page with users in correct categories', () => {
-    cy.setEncryptedCookies(AUTHENTICATED_USER_ID, 1)
+    cy.setEncryptedCookies(AUTHENTICATED_USER_ID)
 
     cy.visit(`/service/${SERVICE_EXTERNAL_ID}/team-members`)
 

--- a/test/cypress/integration/my-services/add-new-service.cy.test.js
+++ b/test/cypress/integration/my-services/add-new-service.cy.test.js
@@ -32,7 +32,7 @@ describe('Add a new service', () => {
 
   describe('Add a new service without a Welsh name', () => {
     it('should display the my services page', () => {
-      cy.setEncryptedCookies(authenticatedUserId, 1)
+      cy.setEncryptedCookies(authenticatedUserId)
       setupStubs()
 
       cy.visit('/my-services')
@@ -62,7 +62,7 @@ describe('Add a new service', () => {
 
   describe('Add a new service with a Welsh name', () => {
     it('should display the my services page', () => {
-      cy.setEncryptedCookies(authenticatedUserId, 1)
+      cy.setEncryptedCookies(authenticatedUserId)
       setupStubs()
 
       cy.visit('/my-services')

--- a/test/cypress/integration/my-services/my-services-links.cy.test.js
+++ b/test/cypress/integration/my-services/my-services-links.cy.test.js
@@ -21,7 +21,7 @@ describe('Service has a live account that supports payouts', () => {
   it('should display link to view payouts', () => {
     cy.task('setupStubs', getUserAndAccountStubs('live', 'stripe'))
 
-    cy.setEncryptedCookies(authenticatedUserId, 1)
+    cy.setEncryptedCookies(authenticatedUserId)
     cy.visit('/my-services')
     cy.title().should('eq', 'Choose service - GOV.UK Pay')
 
@@ -42,7 +42,7 @@ describe('Service does not have a live account that supports payouts', () => {
   it('should display link to view payouts', () => {
     cy.task('setupStubs', getUserAndAccountStubs('test', 'sandbox'))
 
-    cy.setEncryptedCookies(authenticatedUserId, 1)
+    cy.setEncryptedCookies(authenticatedUserId)
     cy.visit('/my-services')
     cy.title().should('eq', 'Choose service - GOV.UK Pay')
 
@@ -54,7 +54,7 @@ describe('User has access to no live services', () => {
   it('should link to all service transactions test', () => {
     cy.task('setupStubs', getUserAndAccountStubs('test', 'sandbox'))
 
-    cy.setEncryptedCookies(authenticatedUserId, 1)
+    cy.setEncryptedCookies(authenticatedUserId)
     cy.visit('/my-services')
     cy.title().should('eq', 'Choose service - GOV.UK Pay')
 
@@ -66,7 +66,7 @@ describe('User has access to one or more live services', () => {
   it('should display link to all service transactions', () => {
     cy.task('setupStubs', getUserAndAccountStubs('live', 'worldpay'))
 
-    cy.setEncryptedCookies(authenticatedUserId, 1)
+    cy.setEncryptedCookies(authenticatedUserId)
     cy.visit('/my-services')
     cy.title().should('eq', 'Choose service - GOV.UK Pay')
 

--- a/test/cypress/integration/my-services/update-service-name.cy.test.js
+++ b/test/cypress/integration/my-services/update-service-name.cy.test.js
@@ -31,7 +31,7 @@ describe('Update service name', () => {
 
   describe('Edit a service name without a Welsh name', () => {
     it('should display the my services page', () => {
-      cy.setEncryptedCookies(authenticatedUserId, 1)
+      cy.setEncryptedCookies(authenticatedUserId)
       setupStubs(serviceName)
 
       cy.visit('/my-services')
@@ -76,7 +76,7 @@ describe('Update service name', () => {
 
   describe('Edit a service name with a Welsh name', () => {
     it('should display the my services page', () => {
-      cy.setEncryptedCookies(authenticatedUserId, 1)
+      cy.setEncryptedCookies(authenticatedUserId)
       setupStubs(welshServiceName)
 
       cy.visit('/my-services')

--- a/test/cypress/integration/payment-links/create-payment-link.cy.test.js
+++ b/test/cypress/integration/payment-links/create-payment-link.cy.test.js
@@ -31,7 +31,7 @@ describe('The create payment link flow', () => {
 
     describe('The create payment link start page', () => {
       it('Should display page content', () => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
         cy.visit(`/account/${gatewayAccountExternalId}/create-payment-link`)
 
         cy.get('h1').should('contain', 'Create a payment link')
@@ -41,7 +41,7 @@ describe('The create payment link flow', () => {
       })
 
       it('Should navigate to create payment link in English information page', () => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
         cy.visit(`/account/${gatewayAccountExternalId}/create-payment-link`)
 
         cy.get('a#create-payment-link').click()
@@ -285,7 +285,7 @@ describe('The create payment link flow', () => {
 
     describe('The create payment link start page', () => {
       it('Should navigate to create payment link in Welsh information page', () => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
         cy.visit(`/account/${gatewayAccountExternalId}/create-payment-link`)
 
         cy.get(`a[href="/account/${gatewayAccountExternalId}/create-payment-link/information?language=cy"]`).click()

--- a/test/cypress/integration/payment-links/delete-payment-links.cy.test.js
+++ b/test/cypress/integration/payment-links/delete-payment-links.cy.test.js
@@ -12,7 +12,7 @@ const product = {
 
 describe('Should delete payment link', () => {
   beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    cy.setEncryptedCookies(userExternalId)
     cy.task('setupStubs', [
       userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),
       gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'test', paymentProvider: 'worldpay' }),

--- a/test/cypress/integration/payment-links/edit-payment-link.cy.test.js
+++ b/test/cypress/integration/payment-links/edit-payment-link.cy.test.js
@@ -49,7 +49,7 @@ describe('Editing a payment link', () => {
     })
 
     it('should navigate to the edit page', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/create-payment-link/manage`)
 
       cy.get('ul.payment-links-list > li > div > a').contains('Edit').click()
@@ -260,7 +260,7 @@ describe('Editing a payment link', () => {
     })
 
     it('should navigate to the edit page', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/create-payment-link/manage`)
 
       cy.get('ul.payment-links-list > li > div > a').contains('Edit').click()

--- a/test/cypress/integration/payment-links/manage-payment-links.cy.test.js
+++ b/test/cypress/integration/payment-links/manage-payment-links.cy.test.js
@@ -47,7 +47,7 @@ function setupStubs (products) {
 
 describe('The manage payment links page', () => {
   beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    cy.setEncryptedCookies(userExternalId)
   })
 
   describe('No payment links', () => {

--- a/test/cypress/integration/payouts/payouts-list.cy.test.js
+++ b/test/cypress/integration/payouts/payouts-list.cy.test.js
@@ -33,7 +33,7 @@ describe('Payout list page', () => {
   })
 
   it('should correctly display payouts given a successful response from Ledger', () => {
-    cy.setEncryptedCookies(userExternalId, liveGatewayAccountId)
+    cy.setEncryptedCookies(userExternalId)
 
     const payouts = [
       { gatewayAccountId: liveGatewayAccountId, paidOutDate: '2019-01-29T08:00:00.000000Z' }

--- a/test/cypress/integration/request-psp-test-account/index.cy.test.js
+++ b/test/cypress/integration/request-psp-test-account/index.cy.test.js
@@ -29,7 +29,7 @@ describe('Request PSP test account: index', () => {
   }
 
   beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    cy.setEncryptedCookies(userExternalId)
   })
 
   describe('PSP test account stage is NOT_STARTED', () => {

--- a/test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.test.js
+++ b/test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.test.js
@@ -26,7 +26,7 @@ describe('Request PSP test account: submit request', () => {
   }
 
   beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    cy.setEncryptedCookies(userExternalId)
   })
 
   describe('PSP test account stage is NOT_STARTED', () => {

--- a/test/cypress/integration/request-to-go-live/agreement.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/agreement.cy.test.js
@@ -28,7 +28,7 @@ describe('Request to go live: agreement', () => {
 
   describe('User does not have permission', () => {
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       const serviceRole = utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_STRIPE')
       serviceRole.role = {
         permissions: []
@@ -45,7 +45,7 @@ describe('Request to go live: agreement', () => {
 
   describe('The service has the wrong go live stage', () => {
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME'))
     })
 
@@ -62,7 +62,7 @@ describe('Request to go live: agreement', () => {
 
   describe('Stripe has been chosen as the PSP', () => {
     it('should display "Read and accept our legal terms" page when in CHOSEN_PSP_STRIPE', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_STRIPE'))
 
       cy.visit(requestToGoLiveAgreementUrl)
@@ -101,7 +101,7 @@ describe('Request to go live: agreement', () => {
 
   describe('Worldpay has been chosen as the PSP', () => {
     it('should display "Read and accept our legal terms" page when in CHOSEN_PSP_WORLDPAY', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_WORLDPAY'))
 
       cy.visit(requestToGoLiveAgreementUrl)
@@ -137,7 +137,7 @@ describe('Request to go live: agreement', () => {
 
   describe('Government bankings PSP has been chosen as the PSP', () => {
     it('should display "Read and accept our legal terms" page when in CHOSEN_PSP_GOV_BANKING_WORLDPAY', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_GOV_BANKING_WORLDPAY'))
 
       cy.visit(requestToGoLiveAgreementUrl)

--- a/test/cypress/integration/request-to-go-live/choose-how-to-process-payments.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/choose-how-to-process-payments.cy.test.js
@@ -28,7 +28,7 @@ describe('Request to go live: choose how to process payments', () => {
 
   describe('Service has correct go live stage and user selects Stripe account', () => {
     it('should display the page with non-stipe payment providers collapsed', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS'))
 
       cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
@@ -59,7 +59,7 @@ describe('Request to go live: choose how to process payments', () => {
 
   describe('Service has correct go live stage and user selects non Stripe account', () => {
     it('should expand other payment provider options', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS'))
 
       cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
@@ -92,7 +92,7 @@ describe('Request to go live: choose how to process payments', () => {
 
   describe('Service has correct go live stage and user selects government banking account', () => {
     it('should visit page', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS'))
 
       cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
@@ -111,7 +111,7 @@ describe('Request to go live: choose how to process payments', () => {
 
   describe('Validation', () => {
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS'))
     })
 
@@ -145,12 +145,12 @@ describe('Request to go live: choose how to process payments', () => {
 
   describe('Service has wrong go live stage', () => {
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('NOT_STARTED'))
     })
 
     it('should redirect to "Request to go live: index" page when in wrong stage', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
 
       cy.get('h1').should('contain', 'Request a live account')
@@ -163,7 +163,7 @@ describe('Request to go live: choose how to process payments', () => {
 
   describe('User does not have the correct permissions', () => {
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS')
       serviceRole.role = {
         permissions: []

--- a/test/cypress/integration/request-to-go-live/index.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/index.cy.test.js
@@ -25,7 +25,7 @@ describe('Request to go live: index', () => {
   }
 
   beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    cy.setEncryptedCookies(userExternalId)
   })
 
   describe('User does not have the correct permissions', () => {

--- a/test/cypress/integration/request-to-go-live/organisation-address.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/organisation-address.cy.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const utils = require('../../utils/request-to-go-live-utils')
-const { userExternalId, gatewayAccountId, serviceExternalId } = utils.variables
+const { userExternalId, serviceExternalId } = utils.variables
 
 const pageUrl = `/service/${serviceExternalId}/request-to-go-live/organisation-address`
 
@@ -30,7 +30,7 @@ describe('The organisation address page', () => {
       })
 
       it('should display form', () => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
         cy.visit(pageUrl)
 
         cy.get('h1').should('contain', `What is your organisation’s address?`)
@@ -162,7 +162,7 @@ describe('The organisation address page', () => {
     serviceRole.service.merchant_details = merchantDetails
 
     it('should display form with existing details pre-filled', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       utils.setupGetUserAndGatewayAccountStubs(serviceRole)
       cy.visit(`/service/${serviceExternalId}/request-to-go-live/organisation-address`)
 
@@ -182,7 +182,7 @@ describe('The organisation address page', () => {
     const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')
     serviceRole.role = { permissions: [] }
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       utils.setupGetUserAndGatewayAccountStubs(serviceRole)
     })
 
@@ -196,7 +196,7 @@ describe('The organisation address page', () => {
   describe('Service has invalid go live stage', () => {
     const serviceRole = utils.buildServiceRoleForGoLiveStage('NOT_STARTED')
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       utils.setupGetUserAndGatewayAccountStubs(serviceRole)
     })
 

--- a/test/cypress/integration/request-to-go-live/organisation-name.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/organisation-name.cy.test.js
@@ -20,7 +20,7 @@ describe('Request to go live: organisation name page', () => {
     const serviceRole = utils.buildServiceRoleForGoLiveStage('NOT_STARTED')
     serviceRole.role = { permissions: [] }
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       utils.setupGetUserAndGatewayAccountStubs(serviceRole)
     })
 
@@ -34,7 +34,7 @@ describe('Request to go live: organisation name page', () => {
   describe('Service has invalid go live stage', () => {
     const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       utils.setupGetUserAndGatewayAccountStubs(serviceRole)
     })
     it('should redirect to "Request to go live: index" page when in wrong stage', () => {
@@ -57,7 +57,7 @@ describe('Request to go live: organisation name page', () => {
     })
 
     it('should display an empty form', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.task('setupStubs', utils.getUserAndGatewayAccountStubs(notStartedServiceRole))
 
       cy.visit(requestToGoLivePageOrganisationNameUrl)
@@ -108,7 +108,7 @@ describe('Request to go live: organisation name page', () => {
 
   describe('Service has NOT_STARTED go live stage and organisation name is pre-filled', () => {
     it('should show form with pre-filled organisation name', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
 
       const serviceRoleWithMerchantDetails = utils.buildServiceRoleWithMerchantDetails({ name: organisationName }, 'NOT_STARTED')
       cy.task('setupStubs', utils.getUserAndGatewayAccountStubs(serviceRoleWithMerchantDetails))

--- a/test/cypress/integration/settings/3ds.cy.test.js
+++ b/test/cypress/integration/settings/3ds.cy.test.js
@@ -50,7 +50,7 @@ describe('3DS settings page', () => {
     })
 
     it('should not show on settings index and should show explainer and no radios', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('.govuk-summary-list__key').first().should('not.contain', '3D Secure')
       cy.visit(`/account/${gatewayAccountExternalId}/3ds`)
@@ -68,7 +68,7 @@ describe('3DS settings page', () => {
       })
 
       it('should show info box and inputs should be disabled ', () => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(2).should('contain', '3D Secure')
         cy.get('.govuk-summary-list__value').eq(2).should('contain', 'Off')
@@ -87,7 +87,7 @@ describe('3DS settings page', () => {
       })
 
       it('should show Worldpay specific merchant code stuff and radios', () => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(2).should('contain', '3D Secure')
         cy.get('.govuk-summary-list__value').eq(2).should('contain', 'Off')
@@ -106,7 +106,7 @@ describe('3DS settings page', () => {
       })
 
       it('should show Worldpay specific merchant code stuff and radios', () => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(2).should('contain', '3D Secure')
         cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
@@ -125,7 +125,7 @@ describe('3DS settings page', () => {
       })
 
       it('should show Worldpay specific merchant code stuff and disabled radios', () => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(2).should('contain', '3D Secure')
         cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
@@ -149,7 +149,7 @@ describe('3DS settings page', () => {
       })
 
       it('should show success message and radios should update', () => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(2).should('contain', '3D Secure')
         cy.get('.govuk-summary-list__value').eq(2).should('contain', 'Off')
@@ -190,7 +190,7 @@ describe('3DS settings page', () => {
     })
 
     it('should show Stripe specific disabled message and radios', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('.govuk-summary-list__key').first().should('contain', '3D Secure')
       cy.get('.govuk-summary-list__value').first().should('contain', 'On')

--- a/test/cypress/integration/settings/allow-apple-pay.cy.test.js
+++ b/test/cypress/integration/settings/allow-apple-pay.cy.test.js
@@ -29,7 +29,7 @@ describe('Apple Pay', () => {
     })
 
     it('should show it is disabled', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
       cy.get('a').contains('Change Apple Pay settings').click()
@@ -47,7 +47,7 @@ describe('Apple Pay', () => {
     })
 
     it('Show that is is disabled', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
       cy.get('a').contains('Change Apple Pay settings').click()

--- a/test/cypress/integration/settings/allow-google-pay.cy.test.js
+++ b/test/cypress/integration/settings/allow-google-pay.cy.test.js
@@ -29,7 +29,7 @@ describe('Google Pay', () => {
     })
 
     it('should show it is disabled', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
       cy.get('a').contains('Change Google Pay settings').click()
@@ -47,7 +47,7 @@ describe('Google Pay', () => {
     })
 
     it('should allow us to enable', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
       cy.get('a').contains('Change Google Pay settings').click()

--- a/test/cypress/integration/settings/email-notifications.cy.test.js
+++ b/test/cypress/integration/settings/email-notifications.cy.test.js
@@ -21,7 +21,7 @@ function setupStubs (role) {
 describe('Settings', () => {
   describe('For an admin user', () => {
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       setupStubs()
 
       cy.visit(settingsUrl)
@@ -122,7 +122,7 @@ describe('Settings', () => {
 
   describe('For a read-only user', () => {
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       const role = {
         permissions: [
           {

--- a/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js
+++ b/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js
@@ -56,7 +56,7 @@ describe('MOTO mask security section', () => {
       })
 
       it('should not show mask security section', () => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('#moto-mask-security-settings-heading').should('not.exist')
       })

--- a/test/cypress/integration/settings/merchant-details.cy.test.js
+++ b/test/cypress/integration/settings/merchant-details.cy.test.js
@@ -6,7 +6,7 @@ describe('Dashboard', () => {
   const gatewayAccountId = 42
 
   beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    cy.setEncryptedCookies(userExternalId)
 
     cy.task('setupStubs', [
       userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName: 'service-name' }),

--- a/test/cypress/integration/settings/payment-types.cy.test.js
+++ b/test/cypress/integration/settings/payment-types.cy.test.js
@@ -26,7 +26,7 @@ describe('Payment types', () => {
     })
 
     it('should show page title', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
       cy.title().should('eq', `Manage payment types - ${serviceName} - GOV.UK Pay`)
     })

--- a/test/cypress/integration/settings/your-psp.cy.test.js
+++ b/test/cypress/integration/settings/your-psp.cy.test.js
@@ -118,7 +118,7 @@ describe('Your PSP settings page', () => {
     })
 
     it('should not show link to Your PSP in the side navigation', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('#navigation-menu-your-psp').should('have.length', 0)
     })
@@ -132,7 +132,7 @@ describe('Your PSP settings page', () => {
     })
 
     it('should show link to "Your PSP - Worldpay" in the side navigation', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Worldpay')
       cy.get('#navigation-menu-your-psp').click()
@@ -244,7 +244,7 @@ describe('Your PSP settings page', () => {
         worldpay3dsFlex: testFlexCredentials
       })
 
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(yourPspPath)
       cy.get('.value-merchant-id').should('contain', testCredentials.merchant_id)
       cy.get('.value-username').should('contain', testCredentials.username)
@@ -267,7 +267,7 @@ describe('Your PSP settings page', () => {
         worldpay3dsFlex: testFlexCredentials
       })
 
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(yourPspPath)
       cy.get('#worldpay-3ds-flex-is-off').should('exist')
       cy.get('#worldpay-3ds-flex-is-on').should('not.exist')
@@ -288,7 +288,7 @@ describe('Your PSP settings page', () => {
         worldpay3dsFlex: testFlexCredentials
       })
 
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(yourPspPath)
       cy.get('#worldpay-3ds-flex-is-on').should('exist')
       cy.get('#worldpay-3ds-flex-is-off').should('not.exist')
@@ -308,7 +308,7 @@ describe('Your PSP settings page', () => {
         credentials: testCredentials
       })
 
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(yourPspPath)
       cy.get('#worldpay-3ds-flex-is-off').should('exist')
       cy.get('#worldpay-3ds-flex-is-on').should('not.exist')
@@ -325,7 +325,7 @@ describe('Your PSP settings page', () => {
         worldpay3dsFlex: testFlexCredentials
       })
 
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(yourPspPath)
       cy.get('#worldpay-3ds-flex-is-off').should('exist')
       cy.get('#worldpay-3ds-flex-is-on').should('not.exist')
@@ -342,7 +342,7 @@ describe('Your PSP settings page', () => {
     })
 
     it('should show link to "Your PSP - Smartpay" in the side navigation', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Smartpay')
       cy.get('#navigation-menu-your-psp').click()
@@ -390,7 +390,7 @@ describe('Your PSP settings page', () => {
     })
 
     it('should show all credentials as configured', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(yourPspPath)
       cy.get('.value-merchant-id').should('contain', testCredentials.merchant_id)
       cy.get('.value-username').should('contain', testCredentials.username)
@@ -408,7 +408,7 @@ describe('Your PSP settings page', () => {
     })
 
     it('should show link to "Your PSP - ePDQ" in the side navigation', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/settings`)
       cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - ePDQ')
       cy.get('#navigation-menu-your-psp').click()
@@ -447,7 +447,7 @@ describe('Your PSP settings page', () => {
     })
 
     it('should show all credentials as configured', () => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       cy.visit(yourPspPath)
       cy.get('.value-merchant-id').should('contain', testCredentials.merchant_id)
       cy.get('.value-username').should('contain', testCredentials.username)

--- a/test/cypress/integration/stripe-setup/bank-details.cy.test.js
+++ b/test/cypress/integration/stripe-setup/bank-details.cy.test.js
@@ -38,7 +38,7 @@ function setupStubs (bankAccount, type = 'live', paymentProvider = 'stripe') {
 describe('Stripe setup: bank details page', () => {
   describe('Card gateway account', () => {
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
     })
 
     describe('Bank details page is shown', () => {

--- a/test/cypress/integration/stripe-setup/company-number.cy.test.js
+++ b/test/cypress/integration/stripe-setup/company-number.cy.test.js
@@ -39,7 +39,7 @@ describe('Stripe setup: company number page', () => {
       beforeEach(() => {
         setupStubs(false)
 
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId, {})
+        cy.setEncryptedCookies(userExternalId, {})
         cy.visit(companyNumberUrl)
       })
 
@@ -106,7 +106,7 @@ describe('Stripe setup: company number page', () => {
 
     describe('when user is admin, account is Stripe and "company number" is already submitted', () => {
       beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
       })
 
       it('should redirect to Dashboard with an error message when displaying the page', () => {
@@ -146,7 +146,7 @@ describe('Stripe setup: company number page', () => {
 
     describe('when it is not a Stripe gateway account', () => {
       beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
       })
 
       it('should show a 404 error when gateway account is not Stripe', () => {
@@ -161,7 +161,7 @@ describe('Stripe setup: company number page', () => {
 
     describe('when it is not a live gateway account', () => {
       beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
       })
 
       it('should show a 404 error when gateway account is not live', () => {
@@ -176,7 +176,7 @@ describe('Stripe setup: company number page', () => {
 
     describe('when the user does not have the correct permissions', () => {
       beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
       })
 
       it('should show a permission error when the user does not have enough permissions', () => {

--- a/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
@@ -48,7 +48,7 @@ function setupStubs (responsiblePerson, type = 'live', paymentProvider = 'stripe
 
 describe('Stripe setup: responsible person page', () => {
   beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    cy.setEncryptedCookies(userExternalId)
   })
 
   describe('when user is admin, account is Stripe and responsible person not already nominated', () => {

--- a/test/cypress/integration/stripe-setup/vat-number.cy.test.js
+++ b/test/cypress/integration/stripe-setup/vat-number.cy.test.js
@@ -39,7 +39,7 @@ describe('Stripe setup: VAT number page', () => {
       beforeEach(() => {
         setupStubs(false)
 
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId, {})
+        cy.setEncryptedCookies(userExternalId, {})
 
         cy.visit(vatNumberUrl)
       })
@@ -86,7 +86,7 @@ describe('Stripe setup: VAT number page', () => {
 
     describe('when user is admin, account is Stripe and "VAT number" is already submitted', () => {
       beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
       })
 
       it('should redirect to Dashboard with an error message when displaying the page', () => {
@@ -122,7 +122,7 @@ describe('Stripe setup: VAT number page', () => {
 
     describe('when it is not a Stripe gateway account', () => {
       beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
       })
 
       it('should show a 404 error when gateway account is not Stripe', () => {
@@ -137,7 +137,7 @@ describe('Stripe setup: VAT number page', () => {
 
     describe('when it is not a live gateway account', () => {
       beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
       })
 
       it('should show a 404 error when gateway account is not live', () => {
@@ -152,7 +152,7 @@ describe('Stripe setup: VAT number page', () => {
 
     describe('when the user does not have the correct permissions', () => {
       beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+        cy.setEncryptedCookies(userExternalId)
       })
 
       it('should show a permission error when the user does not have enough permissions', () => {

--- a/test/cypress/integration/transactions/transaction-details.cy.test.js
+++ b/test/cypress/integration/transactions/transaction-details.cy.test.js
@@ -90,7 +90,7 @@ describe('Transaction details page', () => {
   }
 
   beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    cy.setEncryptedCookies(userExternalId)
   })
 
   describe('page content', () => {

--- a/test/cypress/integration/transactions/transaction-list-pagination.cy.test.js
+++ b/test/cypress/integration/transactions/transaction-list-pagination.cy.test.js
@@ -50,7 +50,7 @@ describe('Transactions list pagination', () => {
 
   describe('Default sandbox gateway transactions', () => {
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
     })
     describe('Pagination', () => {
       it('should display pagination links with previous page disabled for first page', () => {

--- a/test/cypress/integration/transactions/transaction-search.cy.test.js
+++ b/test/cypress/integration/transactions/transaction-search.cy.test.js
@@ -107,7 +107,7 @@ function assertTransactionRow (row, reference, transactionLink, email, amount, c
 
 describe('Transactions List', () => {
   beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+    cy.setEncryptedCookies(userExternalId)
   })
 
   describe('Filtering', () => {

--- a/test/cypress/integration/user/edit-phone-number.cy.test.js
+++ b/test/cypress/integration/user/edit-phone-number.cy.test.js
@@ -17,7 +17,7 @@ describe('Edit phone number flow', () => {
 
   describe('Pre edit', () => {
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       setupStubs(userExternalId, gatewayAccountId, serviceName, testPhoneNumber)
     })
 
@@ -46,7 +46,7 @@ describe('Edit phone number flow', () => {
   })
   describe('Post edit', () => {
     beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId, gatewayAccountId)
+      cy.setEncryptedCookies(userExternalId)
       setupStubs(userExternalId, gatewayAccountId, serviceName, testPhoneNumberNew)
     })
 

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -23,12 +23,7 @@ module.exports = (on, config) => {
         opts.user_external_id,
         opts.pageData
       )
-      const encryptedGatewayAccountCookie = generateEncryptedGatewayAccountCookie(
-        config.env.TEST_SESSION_ENCRYPTION_KEY,
-        opts.gateway_account_id
-      )
-
-      return { encryptedSessionCookie, encryptedGatewayAccountCookie }
+      return { encryptedSessionCookie }
     },
     /**
      * Makes a post request to Mountebank to setup an Imposter with stubs built using the array of
@@ -103,13 +98,4 @@ function generateEncryptedSessionCookie (sessionEncyptionKey, userExternalId, pa
       pageData
     })
   return encryptedSessionCookie
-}
-
-function generateEncryptedGatewayAccountCookie (sessionEncyptionKey, gatewayAccountId) {
-  const encryptedGatewayAccountCookie = cookieMonster.getCookie('gateway_account', sessionEncyptionKey,
-    {
-      currentGatewayAccountId: gatewayAccountId,
-      icamefrom: 'cypress.io'
-    })
-  return encryptedGatewayAccountCookie
 }

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -1,10 +1,8 @@
-Cypress.Commands.add('setEncryptedCookies', (userId, gatewayAccountId, pageData = {}) => {
+Cypress.Commands.add('setEncryptedCookies', (userId, pageData = {}) => {
   cy.task('getCookies', {
     user_external_id: userId,
-    gateway_account_id: gatewayAccountId,
     pageData
   }).then(cookies => {
     cy.setCookie('session', cookies.encryptedSessionCookie)
-    cy.setCookie('gateway_account', cookies.encryptedGatewayAccountCookie)
   })
 })


### PR DESCRIPTION
This cookie is no longer relied on by any code, so can stop setting it in tests.

