### PR TITLE
PP-7235 Update refund section UI

### DIFF
--- a/app/views/transaction-detail/_refund.njk
+++ b/app/views/transaction-detail/_refund.njk
@@ -1,3 +1,5 @@
+<h2 class="govuk-heading-m govuk-!-margin-top-1">Refund</h2>
+
 <form id="refundForm" action="{{ formatAccountPathsFor(routes.account.transactions.refund, currentGatewayAccount.external_id, charge_id) }}" method="post" class="target-to-show {% if flash.genericError %}active{% endif %}">
   <input id="full-amount" type="hidden" name="full-amount" value="{{ refundable_amount }}" >
   <input id="amount-available" type="hidden" name="refund-amount-available-in-pence" value="{{ refund_summary.amount_available }}" />
@@ -37,12 +39,6 @@
     {{
       govukRadios({
         name: "refund-type",
-        fieldset: {
-          legend: {
-            text: "Refund payment",
-            classes: "govuk-fieldset__legend--m"
-          }
-        },
         items: [
           {
             value: "full",
@@ -71,12 +67,6 @@
     {{
       govukRadios({
         name: "refund-type",
-        fieldset: {
-          legend: {
-            text: "Refund payment",
-            classes: "govuk-fieldset__legend--m"
-          }
-        },
         items: [
           {
             value: "full",
@@ -107,7 +97,7 @@
   <div class="govuk-form-group govuk-!-margin-top-6">
     {{
       govukButton({
-        text: 'Refund payment',
+        text: 'Confirm refund',
         classes: 'govuk-button--warning refund__submit-button',
         preventDoubleClick: true,
         attributes: {

--- a/app/views/transaction-detail/index.njk
+++ b/app/views/transaction-detail/index.njk
@@ -84,11 +84,11 @@
   <div class="govuk-grid-column-one-third">
     {% if refundable %}
       {% if permissions.refunds_create %}
-        <div class="target-to-show--toggle-container {% if not flash.genericError %}active{% endif %}">
-          <a href="#refundForm" class="govuk-button govuk-button--warning refund__toggle target-to-show--toggle delete">Refund payment</a>
-          <p class="govuk-body">You can also give partial&nbsp;refunds</p>
-        </div>
         {% include "./_refund.njk" %}
+        <div class="target-to-show--toggle-container {% if not flash.genericError %}active{% endif %}">
+          <p class="govuk-body">Make a full or partial refund.</p>
+          <a href="#refundForm" class="govuk-button govuk-button--secondary refund__toggle target-to-show--toggle delete">Refund payment</a>
+        </div>
       {% endif %}
     {% endif %}
   </div>

--- a/test/cypress/integration/all-service-transactions/all-service-transactions.cy.test.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions.cy.test.js
@@ -188,7 +188,7 @@ describe('All service transactions', () => {
       ])
 
       cy.get('a.refund__toggle').click()
-      cy.get('button').contains('Refund payment').click()
+      cy.get('button').contains('Confirm refund').click()
     })
 
     it('should still have correct breadcrumb and back link', () => {


### PR DESCRIPTION
 - Update refund button as per design recommentation
   - Add/change heading to 'Refund'
   - Make refund button secondary on the page
   - Change 'Refund button' to 'Confirm refund' when submitting for refund


1. On visiting transaction page
<img width="803" alt="Screenshot 2021-04-01 at 17 15 54" src="https://user-images.githubusercontent.com/40598480/113323676-2389f100-930e-11eb-8acb-58203aa08664.png">


2. On clicking 'Refund payment'
<img width="794" alt="Screenshot 2021-04-01 at 17 16 05" src="https://user-images.githubusercontent.com/40598480/113323699-297fd200-930e-11eb-84f2-43dc3dae7f49.png">


3. On confirming refund

<img width="782" alt="Screenshot 2021-04-01 at 17 16 23" src="https://user-images.githubusercontent.com/40598480/113323809-503e0880-930e-11eb-8691-b78e4b2eee71.png">

