### PR TITLE
PP-7570 Use AsyncLocalStorage to provide shared logging context

### DIFF
--- a/app/services/auth.service.js
+++ b/app/services/auth.service.js
@@ -4,6 +4,8 @@ const lodash = require('lodash')
 const passport = require('passport')
 const LocalStrategy = require('passport-local').Strategy
 const CustomStrategy = require('passport-custom').Strategy
+const { addLoggingField } = require('../utils/log-context')
+const { USER_EXTERNAL_ID } = require('@govuk-pay/pay-js-commons').logging.keys
 
 // TODO: Remove when issue solved
 /*
@@ -112,6 +114,14 @@ function hasValidSession (req) {
   return isValid
 }
 
+function addUserFieldsToLogContext (req, res, next) {
+  if (req.user) {
+    addLoggingField(USER_EXTERNAL_ID, req.user.externalId)
+    addLoggingField('is_internal_user', req.user.internalUser)
+  }
+  next()
+}
+
 function initialise (app) {
   app.use(passport.initialize())
   app.use(passport.session())
@@ -120,6 +130,7 @@ function initialise (app) {
   passport.use('localDirect', new CustomStrategy(localDirectStrategy))
   passport.serializeUser(serializeUser)
   passport.deserializeUser(deserializeUser)
+  app.use(addUserFieldsToLogContext)
 }
 
 function deserializeUser (req, externalId, done) {

--- a/app/utils/log-context.js
+++ b/app/utils/log-context.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const { CORRELATION_ID } = require('@govuk-pay/pay-js-commons').logging.keys
+
+const { AsyncLocalStorage } = require('async_hooks')
+const { CORRELATION_HEADER } = require('../../config')
+
+const asyncLocalStorage = new AsyncLocalStorage()
+
+function logContextMiddleware (req, res, next) {
+  asyncLocalStorage.run({}, () => {
+    asyncLocalStorage.getStore()[CORRELATION_ID] = req.headers[CORRELATION_HEADER]
+    next()
+  })
+}
+
+function addLoggingField (key, value) {
+  if (asyncLocalStorage.getStore()) {
+    asyncLocalStorage.getStore()[key] = value
+  }
+}
+
+function getLoggingFields () {
+  return asyncLocalStorage.getStore()
+}
+
+module.exports = {
+  logContextMiddleware,
+  addLoggingField,
+  getLoggingFields
+}

--- a/app/utils/logger.js
+++ b/app/utils/logger.js
@@ -2,9 +2,18 @@ const { createLogger, format, transports } = require('winston')
 const { json, splat, prettyPrint } = format
 const { govUkPayLoggingFormat } = require('@govuk-pay/pay-js-commons').logging
 const { addSentryToErrorLevel } = require('./sentry.js')
+const { getLoggingFields } = require('./log-context')
+
+const supplementSharedLoggingFields = format((info) => {
+  if (getLoggingFields()) {
+    return Object.assign(info, getLoggingFields())
+  }
+  return info
+})
 
 const logger = createLogger({
   format: format.combine(
+    supplementSharedLoggingFields(),
     splat(),
     prettyPrint(),
     govUkPayLoggingFormat({ container: 'selfservice', environment: process.env.ENVIRONMENT }),

--- a/server.js
+++ b/server.js
@@ -23,6 +23,7 @@ const errorHandler = require('./app/middleware/error-handler')
 const { nunjucksFilters } = require('@govuk-pay/pay-js-commons')
 const logger = require('./app/utils/logger')(__filename)
 const loggingMiddleware = require('./app/middleware/logging-middleware')
+const { logContextMiddleware } = require('./app/utils/log-context')
 const Sentry = require('./app/utils/sentry.js').initialiseSentry()
 const formatPSPname = require('./app/utils/format-PSP-name')
 const formatAccountPathsFor = require('./app/utils/format-account-paths-for')
@@ -58,6 +59,7 @@ function addCsrfMiddleware (app) {
 
 function initialiseGlobalMiddleware (app) {
   app.use(cookieParser())
+  app.use(logContextMiddleware)
   logger.stream = {
     write: function (message) {
       logger.info(message)
@@ -174,8 +176,8 @@ function initialise () {
   app.use(Sentry.Handlers.requestHandler())
   initialisePublic(app)
   initialiseCookies(app)
-  initialiseAuth(app)
   initialiseGlobalMiddleware(app)
+  initialiseAuth(app)
   initialiseTemplateEngine(app)
   initialiseErrorLogging(app)
   initialiseRoutes(app) // This contains the 404 overrider and so should be last

--- a/test/integration/log-context.it.test.js
+++ b/test/integration/log-context.it.test.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const express = require('express')
+const request = require('supertest')
+const { expect } = require('chai')
+
+const logContext = require('../../app/utils/log-context')
+
+describe('Log context async storage', () => {
+  const path = '/test-log-context'
+  let app
+  let assignedLoggingFields
+
+  before(() => {
+    app = express()
+    app.use(logContext.logContextMiddleware)
+    app.use((req, res, next) => {
+      logContext.addLoggingField('a_key', 'foo')
+      next()
+    })
+    app.get(path, (req, res) => {
+      assignedLoggingFields = logContext.getLoggingFields()
+      res.status(200)
+      res.end()
+    })
+  })
+
+  it('should retrieve logging fields from log context', done => {
+    request(app)
+      .get(path)
+      .set('x-request-id', 'bar')
+      .expect(200)
+      .end(() => {
+        expect(assignedLoggingFields).to.deep.equal({
+          'x_request_id': 'bar',
+          'a_key': 'foo'
+        })
+        done()
+      })
+  })
+})


### PR DESCRIPTION
Add middleware to open an AsyncLocalStorage store on a request. Add the correlation ID when the store is initialised.

Add a format function to the logger that pulls fields that have been added to the store and adds them to the log line.

Add middleware to add user info to the log context when it is available. Add account and service info to the log context in the middleware that resolves them.

Re-order the server middleware so that the auth middleware is run after the global middleware that initialises logging amongst other things.

