### PR TITLE
PP-7570 Clean up logging

### DIFF
--- a/app/controllers/all-service-transactions/get.controller.js
+++ b/app/controllers/all-service-transactions/get.controller.js
@@ -13,7 +13,6 @@ const paths = require('../../paths')
 const states = require('../../utils/states')
 const client = new ConnectorClient(process.env.CONNECTOR_URL)
 const logger = require('../../utils/logger')(__filename)
-const { keys } = require('@govuk-pay/pay-js-commons').logging
 const { NoServicesWithPermissionError } = require('../../errors')
 
 const { CORRELATION_HEADER } = require('../../utils/correlation-header.js')
@@ -33,15 +32,11 @@ module.exports = async function getTransactionsForAllServices (req, res, next) {
   try {
     const userPermittedAccountsSummary = await permissions.getGatewayAccountsFor(req.user, filterLiveAccounts, 'transactions:read')
 
-    const logContext = {
+    logger.info('Listing all services transactions', {
       gateway_account_ids: userPermittedAccountsSummary.gatewayAccountIds,
       user_number_of_live_services: req.user.numberOfLiveServices,
-      internal_user: req.user.internalUser,
       is_live: filterLiveAccounts
-    }
-    logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
-    logContext[keys.CORRELATION_ID] = correlationId
-    logger.info('Listing all services transactions', logContext)
+    })
 
     if (!userPermittedAccountsSummary.gatewayAccountIds.length) {
       return next(new NoServicesWithPermissionError('You do not have any associated services with rights to view these transactions.'))

--- a/app/controllers/billing-address/toggle-billing-address.controller.js
+++ b/app/controllers/billing-address/toggle-billing-address.controller.js
@@ -29,7 +29,7 @@ const postIndex = async (req, res) => {
     } else {
       req.flash('generic', 'Billing address is turned off for this service')
     }
-    logger.info(`[${correlationId}] - Updated collect billing address enabled(${req.body['billing-address-toggle']}). user=${req.session.passport.user}`)
+    logger.info(`Updated collect billing address enabled(${req.body['billing-address-toggle']})`)
     res.redirect(formatAccountPathsFor(paths.account.toggleBillingAddress.index, req.account && req.account.external_id))
   } catch (error) {
     renderErrorView(req, res, error.message)

--- a/app/controllers/dashboard/dashboard-activity.controller.js
+++ b/app/controllers/dashboard/dashboard-activity.controller.js
@@ -136,7 +136,7 @@ module.exports = async (req, res) => {
 
     const transactionsPeriodString = `fromDate=${encodeURIComponent(datetime(fromDateTime, 'date'))}&fromTime=${encodeURIComponent(datetime(fromDateTime, 'time'))}&toDate=${encodeURIComponent(datetime(toDateTime, 'date'))}&toTime=${encodeURIComponent(datetime(toDateTime, 'time'))}`
 
-    logger.info(`[${correlationId}] successfully logged in`)
+    logger.info(`Successfully logged in`)
 
     try {
       const result = await LedgerClient.transactionSummary(gatewayAccountId, fromDateTime, toDateTime, { correlationId: correlationId })
@@ -148,7 +148,7 @@ module.exports = async (req, res) => {
       }))
     } catch (error) {
       const status = _.get(error.message, 'statusCode', 404)
-      logger.error(`[${correlationId}] Calling ledger to get transactions summary failed`, {
+      logger.error('Calling ledger to get transactions summary failed', {
         service: 'ledger',
         method: 'GET',
         status,
@@ -160,7 +160,7 @@ module.exports = async (req, res) => {
       }))
     }
   } catch (err) {
-    logger.error(`[${correlationId}] ${err.message}`, {
+    logger.error(`Error getting transaction summary: ${err.message}`, {
       service: 'frontend',
       method: 'GET',
       error: err,
@@ -216,10 +216,10 @@ async function getStripeAccountDetails (gatewayAccountId, correlationId) {
 
       return formattedStripeAccount
     } catch (e) {
-      logger.error(`[${correlationId}] Calling Stripe failed to get Stripe account details for: ${stripeAccountId}`)
+      logger.error(`Calling Stripe failed to get Stripe account details for: ${stripeAccountId}`)
     }
   } catch (e) {
-    logger.error(`[${correlationId}] Calling Connector failed to get Stripe account id for: ${gatewayAccountId}`)
+    logger.error(`Calling Connector failed to get Stripe account id for: ${gatewayAccountId}`)
   }
 
   return null
@@ -239,7 +239,7 @@ async function getTelephonePaymentLinks (gatewayAccountId, correlationId) {
   try {
     return await ProductsClient.product.getByGatewayAccountIdAndType(gatewayAccountId, 'AGENT_INITIATED_MOTO')
   } catch (e) {
-    logger.error(`[${correlationId}] Calling products failed for ${gatewayAccountId}`)
+    logger.error(`Calling products failed for ${gatewayAccountId}`)
   }
   return []
 }

--- a/app/controllers/digital-wallet/post-google-pay.controller.js
+++ b/app/controllers/digital-wallet/post-google-pay.controller.js
@@ -3,12 +3,11 @@
 const paths = require('../../paths')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const logger = require('../../utils/logger')(__filename)
-const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { CORRELATION_HEADER } = require('../../utils/correlation-header')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
-module.exports = async (req, res) => {
+module.exports = async (req, res, next) => {
   const gatewayAccountId = req.account.gateway_account_id
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   const enable = req.body['google-pay'] === 'on'
@@ -23,26 +22,25 @@ module.exports = async (req, res) => {
   if (enable) {
     try {
       await connector.setGatewayMerchantId(gatewayAccountId, gatewayMerchantId, correlationId)
-      logger.info(`${correlationId} set google pay merchant ID for ${gatewayAccountId}`)
+      logger.info('Set google pay merchant ID')
     } catch (error) {
-      logger.info(`${correlationId} error setting google pay merchant ID for ${gatewayAccountId}: `, error)
+      logger.info('Error setting google pay merchant ID', { error })
       if (error.errorCode === 400) {
         req.flash('genericError', 'There was an error enabling google pay. Check that the Merchant ID you entered is correct and that your PSP account credentials have been set.')
         return res.redirect(formattedPath)
       } else {
-        return renderErrorView(req, res, false, error.errorCode)
+        next(error)
       }
     }
   }
 
   try {
     await connector.toggleGooglePay(gatewayAccountId, enable, correlationId)
-    logger.info(`${correlationId} ${enable ? 'enabled' : 'disabled'} google pay boolean for ${gatewayAccountId}`)
+    logger.info(`${enable ? 'enabled' : 'disabled'} google pay boolean}`)
 
     req.flash('generic', `Google Pay successfully ${enable ? 'enabled' : 'disabled'}.`)
     return res.redirect(formattedPath)
   } catch (error) {
-    logger.error(`${correlationId} error enabling google pay for ${gatewayAccountId}: ${error}`)
-    return renderErrorView(req, res, false, error.errorCode)
+    next(error)
   }
 }

--- a/app/controllers/email-notifications/email-notifications.controller.js
+++ b/app/controllers/email-notifications/email-notifications.controller.js
@@ -34,7 +34,7 @@ const toggleConfirmationEmail = function (req, res, enabled) {
   const correlationId = _.get(req, 'headers.' + CORRELATION_HEADER, '')
   emailService.setConfirmationEnabled(accountID, enabled, correlationId)
     .then(() => {
-      logger.info(`[${correlationId}] - Updated confirmation email enabled(${enabled}). user=${req.session.passport.user}, gateway_account=${accountID}`)
+      logger.info(`Updated confirmation email enabled(${enabled})`)
       res.redirect(303, formatAccountPathsFor(paths.account.settings.index, req.account && req.account.external_id))
     })
 }
@@ -56,7 +56,7 @@ module.exports.collectionEmailUpdate = (req, res) => {
   const correlationId = _.get(req, 'headers.' + CORRELATION_HEADER, '')
   emailService.setEmailCollectionMode(accountID, emailCollectionMode, correlationId)
     .then(() => {
-      logger.info(`[${correlationId}] - Updated email collection mode (${emailCollectionMode}). user=${req.session.passport.user}, gateway_account=${accountID}`)
+      logger.info(`Updated email collection mode (${emailCollectionMode})`)
       res.redirect(303, formatAccountPathsFor(paths.account.settings.index, req.account && req.account.external_id))
     })
 }
@@ -98,7 +98,7 @@ module.exports.refundEmailUpdate = (req, res) => {
   const correlationId = _.get(req, 'headers.' + CORRELATION_HEADER, '')
   emailService.setRefundEmailEnabled(accountID, emailRefundEnabled, correlationId)
     .then(() => {
-      logger.info(`[${correlationId}] - Updated refund email enabled(${emailRefundEnabled}). user=${req.session.passport.user}, gateway_account=${accountID}`)
+      logger.info(`Updated refund email enabled(${emailRefundEnabled})`)
       res.redirect(303, formatAccountPathsFor(paths.account.settings.index, req.account && req.account.external_id))
     })
 }
@@ -145,7 +145,7 @@ module.exports.update = (req, res) => {
   const correlationId = _.get(req, 'headers.' + CORRELATION_HEADER, '')
   emailService.updateConfirmationTemplate(accountID, newEmailText, correlationId)
     .then(() => {
-      logger.info(`[${correlationId}] - Updated email notifications custom paragraph. user=${req.session.passport.user}, gateway_account=${accountID}`)
+      logger.info('Updated email notifications custom paragraph')
       res.redirect(303, formatAccountPathsFor(paths.account.settings.index, req.account && req.account.external_id))
     })
 }

--- a/app/controllers/invite-user.controller.js
+++ b/app/controllers/invite-user.controller.js
@@ -75,7 +75,7 @@ module.exports = {
       lodash.set(req, 'session.pageData', { invitee })
       res.redirect(303, formatServicePathsFor(paths.service.teamMembers.invite, externalServiceId))
     } else if (!role) {
-      logger.error(`[requestId=${correlationId}] cannot identify role from user input ${roleId}`)
+      logger.error(`Cannot identify role from user input ${roleId}`)
       renderErrorView(req, res, messages.inviteError, 200)
     } else {
       userService.inviteUser(invitee, senderId, externalServiceId, role.name, correlationId)
@@ -90,7 +90,7 @@ module.exports = {
               response(req, res, 'error-with-link', messages.emailConflict(invitee, externalServiceId))
               break
             default:
-              logger.error(`[requestId=${req.correlationId}]  Unable to send invitation to user - ` + JSON.stringify(err))
+              logger.error(`Unable to send invitation to user - ${JSON.stringify(err)}`)
               renderErrorView(req, res, messages.inviteError, 200)
           }
         })

--- a/app/controllers/invite-validation.controller.js
+++ b/app/controllers/invite-validation.controller.js
@@ -15,7 +15,7 @@ const messages = {
 }
 
 const handleError = (req, res, err) => {
-  logger.warn(`[requestId=${req.correlationId}] Invalid invite code attempted ${req.code}, error = ${err.errorCode}`)
+  logger.warn(`Invalid invite code attempted ${req.code}, error = ${err.errorCode}`)
 
   switch (err.errorCode) {
     case 404:

--- a/app/controllers/login/after-otp-login.controller.js
+++ b/app/controllers/login/after-otp-login.controller.js
@@ -1,17 +1,13 @@
 'use strict'
 
-const _ = require('lodash')
-
 const logger = require('../../utils/logger')(__filename)
 const { setSessionVersion } = require('../../services/auth.service')
-const CORRELATION_HEADER = require('../../utils/correlation-header').CORRELATION_HEADER
 
 module.exports = (req, res) => {
   req.session.secondFactor = 'totp'
   const redirectUrl = req.session.last_url || '/'
   delete req.session.last_url
-  const correlationId = _.get(req, 'headers.' + CORRELATION_HEADER, '')
-  logger.info(`[${correlationId}] successfully entered a valid 2fa token`)
+  logger.info('Successfully entered a valid 2fa token')
   setSessionVersion(req)
   res.redirect(redirectUrl)
 }

--- a/app/controllers/login/logout.controller.js
+++ b/app/controllers/login/logout.controller.js
@@ -1,9 +1,6 @@
 'use strict'
 
-const _ = require('lodash')
-
 const logger = require('../../utils/logger')(__filename)
-const CORRELATION_HEADER = require('../../utils/correlation-header').CORRELATION_HEADER
 const userService = require('../../services/user.service')
 const router = require('../../routes')
 
@@ -13,8 +10,7 @@ module.exports = (req, res) => {
   }
 
   if (req.session) {
-    const correlationId = _.get(req, 'headers.' + CORRELATION_HEADER, '')
-    logger.info(`[${correlationId}] logged out`)
+    logger.info('Logged out')
     req.session.destroy()
   }
 

--- a/app/controllers/login/post-login.controller.js
+++ b/app/controllers/login/post-login.controller.js
@@ -3,7 +3,6 @@
 const _ = require('lodash')
 
 const logger = require('../../utils/logger')(__filename)
-const CORRELATION_HEADER = require('../../utils/correlation-header').CORRELATION_HEADER
 const paths = require('../../paths')
 
 /**
@@ -14,8 +13,7 @@ const paths = require('../../paths')
  * @param res
  */
 module.exports = (req, res) => {
-  const correlationId = _.get(req, 'headers.' + CORRELATION_HEADER, '')
   req.session = _.pick(req.session, ['passport', 'last_url', 'currentGatewayAccountId'])
-  logger.info(`[${correlationId}] successfully attempted username/password combination`)
+  logger.info('Successfully attempted username/password combination')
   res.redirect(paths.user.otpLogIn)
 }

--- a/app/controllers/login/setup-direct-login-after-register.controller.js
+++ b/app/controllers/login/setup-direct-login-after-register.controller.js
@@ -4,8 +4,7 @@ const logger = require('../../utils/logger')(__filename)
 
 module.exports = (req, res, userExternalId) => {
   if (!userExternalId) {
-    const correlationId = req.correlationId
-    logger.error(`[requestId=${correlationId}] unable to log user in directly after registration. missing user external id in req`)
+    logger.error('Unable to log user in directly after registration. Missing user external id in req')
     res.redirect(303, '/login')
     return
   }

--- a/app/controllers/make-a-demo-payment/go-to-payment.controller.js
+++ b/app/controllers/make-a-demo-payment/go-to-payment.controller.js
@@ -39,7 +39,7 @@ module.exports = async function makeDemoPayment (req, res) {
     lodash.unset(req, 'session.pageData.makeADemoPayment')
     res.redirect(createProductResponse.links.pay.href)
   } catch (error) {
-    logger.error(`[requestId=${req.correlationId}] Making a demo payment failed - ${error.message}`)
+    logger.error(`Making a demo payment failed - ${error.message}`)
     req.flash('genericError', 'Something went wrong. Please try again.')
     res.redirect(formatAccountPathsFor(paths.account.prototyping.demoPayment.index, req.account.external_id))
   }

--- a/app/controllers/payment-links/get-delete.controller.js
+++ b/app/controllers/payment-links/get-delete.controller.js
@@ -25,7 +25,7 @@ module.exports = async (req, res) => {
     req.flash('generic', 'The payment link was successfully deleted')
     return res.redirect(formatAccountPathsFor(paths.account.paymentLinks.manage.index, req.account && req.account.external_id))
   } catch (err) {
-    logger.error(`[requestId=${req.correlationId}] Delete product failed - ${err.message}`)
+    logger.error(`Delete product failed - ${err.message}`)
     req.flash('genericError', 'Something went wrong when deleting the payment link. Please try again or contact support.')
     return res.redirect(formatAccountPathsFor(paths.account.paymentLinks.manage.index, req.account && req.account.external_id))
   }

--- a/app/controllers/payment-links/get-disable.controller.js
+++ b/app/controllers/payment-links/get-disable.controller.js
@@ -13,7 +13,7 @@ module.exports = async (req, res) => {
     req.flash('generic', 'The payment link was successfully deleted')
     return res.redirect(formatAccountPathsFor(paths.account.paymentLinks.manage.index, req.account && req.account.external_id))
   } catch (err) {
-    logger.error(`[requestId=${req.correlationId}] Disable product failed - ${err.message}`)
+    logger.error(`Disable product failed - ${err.message}`)
     req.flash('genericError', 'Something went wrong when deleting the payment link. Please try again or contact support.')
     return res.redirect(formatAccountPathsFor(paths.account.paymentLinks.manage.index, req.account && req.account.external_id))
   }

--- a/app/controllers/payment-links/post-edit.controller.js
+++ b/app/controllers/payment-links/post-edit.controller.js
@@ -6,7 +6,6 @@ const paths = require('../../paths')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const productsClient = require('../../services/clients/products.client.js')
 const logger = require('../../utils/logger')(__filename)
-const { keys } = require('@govuk-pay/pay-js-commons').logging
 
 module.exports = async function updatePaymentLink (req, res, next) {
   const { productExternalId } = req.params
@@ -23,17 +22,11 @@ module.exports = async function updatePaymentLink (req, res, next) {
     await productsClient.product.update(gatewayAccountId, productExternalId, editPaymentLinkData)
 
     const numberOfMetadataKeys = (editPaymentLinkData.metadata && Object.keys(editPaymentLinkData.metadata).length) || 0
-    const logContext = {
-      is_internal_user: req.user && req.user.internalUser,
+    logger.info('Updated payment link', {
       product_external_id: req.params && req.params.productExternalId,
       has_metadata: !!numberOfMetadataKeys,
       number_of_metadata_keys: numberOfMetadataKeys
-    }
-    logContext[keys.GATEWAY_ACCOUNT_TYPE] = req.account && req.account.type
-    logContext[keys.GATEWAY_ACCOUNT_ID] = req.account && req.account.gateway_account_id
-    logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
-
-    logger.info('Updated payment link', logContext)
+    })
 
     lodash.unset(req, 'session.editPaymentLinkData')
     req.flash('generic', 'Your payment link has been updated')

--- a/app/controllers/payment-links/post-review.controller.js
+++ b/app/controllers/payment-links/post-review.controller.js
@@ -9,7 +9,6 @@ const productsClient = require('../../services/clients/products.client.js')
 const productTypes = require('../../utils/product-types')
 const publicAuthClient = require('../../services/clients/public-auth.client')
 const supportedLanguage = require('../../models/supported-language')
-const { keys } = require('@govuk-pay/pay-js-commons').logging
 
 module.exports = async function createPaymentLink (req, res) {
   const gatewayAccountId = req.account.gateway_account_id
@@ -68,24 +67,18 @@ module.exports = async function createPaymentLink (req, res) {
     await productsClient.product.create(productPayload)
 
     const numberOfMetadataKeys = (metadata && Object.keys(metadata).length) || 0
-    const logContext = {
-      is_internal_user: req.user && req.user.internalUser,
+    logger.info('Created payment link', {
       product_external_id: req.params && req.params.productExternalId,
       has_metadata: !!numberOfMetadataKeys,
       number_of_metadata_keys: numberOfMetadataKeys
-    }
-    logContext[keys.GATEWAY_ACCOUNT_TYPE] = req.account && req.account.type
-    logContext[keys.GATEWAY_ACCOUNT_ID] = req.account && req.account.gateway_account_id
-    logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
-
-    logger.info('Created payment link', logContext)
+    })
 
     lodash.unset(req, 'session.pageData.createPaymentLink')
     req.flash('createPaymentLinkSuccess', true)
 
     res.redirect(formatAccountPathsFor(paths.account.paymentLinks.manage.index, req.account && req.account.external_id))
   } catch (error) {
-    logger.error(`[requestId=${req.correlationId}] Creating a payment link failed - ${error.message}`)
+    logger.error(`Creating a payment link failed - ${error.message}`)
     req.flash('genericError', 'Something went wrong. Please try again or contact support.')
     res.redirect(formatAccountPathsFor(paths.account.paymentLinks.review, req.account && req.account.external_id))
   }

--- a/app/controllers/payment-links/post-update-reporting-column.controller.js
+++ b/app/controllers/payment-links/post-update-reporting-column.controller.js
@@ -3,7 +3,6 @@
 const logger = require('../../utils/logger')(__filename)
 const MetadataForm = require('./metadata/metadata-form')
 const { getPaymentLinksContext, metadata } = require('../../utils/payment-links')
-const { keys } = require('@govuk-pay/pay-js-commons').logging
 
 const { response } = require('../../utils/response.js')
 
@@ -31,15 +30,10 @@ function addMetadata (req, res, next) {
       form.values[form.fields.metadataValue.id]
     )
 
-    const logContext = {
-      is_internal_user: req.user && req.user.internalUser,
+    logger.info('Reporting column added', {
       reporting_column_key: form.values[form.fields.metadataKey.id],
       product_external_id: req.params && req.params.productExternalId
-    }
-    logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
-    logContext[keys.GATEWAY_ACCOUNT_TYPE] = req.account && req.account.type
-    logContext[keys.GATEWAY_ACCOUNT_ID] = req.account && req.account.gateway_account_id
-    logger.info('Reporting column added', logContext)
+    })
 
     res.redirect(paymentLinksContext.listMetadataPageUrl)
   } catch (error) {
@@ -78,17 +72,11 @@ function editMetadata (req, res, next) {
       form.values[form.fields.metadataKey.id],
       form.values[form.fields.metadataValue.id]
     )
-
-    const logContext = {
-      is_internal_user: req.user && req.user.internalUser,
+    logger.info('Reporting column updated', {
       original_reporting_column_key: key,
       reporting_column_key: form.values[form.fields.metadataKey.id],
       product_external_id: req.params && req.params.productExternalId
-    }
-    logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
-    logContext[keys.GATEWAY_ACCOUNT_TYPE] = req.account && req.account.type
-    logContext[keys.GATEWAY_ACCOUNT_ID] = req.account && req.account.gateway_account_id
-    logger.info('Reporting column updated', logContext)
+    })
 
     res.redirect(paymentLinksContext.listMetadataPageUrl)
   } catch (error) {
@@ -103,15 +91,10 @@ function deleteMetadata (req, res, next) {
 
     metadata.removeMetadata(paymentLinksContext.sessionData, key)
 
-    const logContext = {
-      is_internal_user: req.user && req.user.internalUser,
+    logger.info('Reporting column deleted', {
       reporting_column_key: key,
       product_external_id: req.params && req.params.productExternalId
-    }
-    logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
-    logContext[keys.GATEWAY_ACCOUNT_TYPE] = req.account && req.account.type
-    logContext[keys.GATEWAY_ACCOUNT_ID] = req.account && req.account.gateway_account_id
-    logger.info('Reporting column deleted', logContext)
+    })
 
     res.redirect(paymentLinksContext.listMetadataPageUrl)
   } catch (error) {

--- a/app/controllers/payouts/payout-list.controller.js
+++ b/app/controllers/payouts/payout-list.controller.js
@@ -1,6 +1,5 @@
 const moment = require('moment')
 const logger = require('../../utils/logger')(__filename)
-const { keys } = require('@govuk-pay/pay-js-commons').logging
 const { response } = require('../../utils/response.js')
 const permissions = require('../../utils/permissions')
 const payoutService = require('./payouts.service')
@@ -24,15 +23,12 @@ const listAllServicesPayouts = async function listAllServicesPayouts (req, res, 
       return next(new NoServicesWithPermissionError('You do not have any associated services with rights to view payments to bank accounts.'))
     }
     const payoutSearchResult = await payoutService.payouts(userPermittedAccountsSummary.gatewayAccountIds, req.user, page)
-    const logContext = {
+    logger.info('Fetched page of payouts for all services', {
       current_page: page,
-      internal_user: req.user.internalUser,
       gateway_account_ids: userPermittedAccountsSummary.gatewayAccountIds,
       user_number_of_services: req.user.numberOfLiveServices,
       is_live: filterLiveAccounts
-    }
-    logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
-    logger.info('Fetched page of payouts for all services', logContext)
+    })
 
     if (process.env.PAYOUTS_RELEASE_DATE) {
       payoutsReleaseDate = moment.unix(process.env.PAYOUTS_RELEASE_DATE)

--- a/app/controllers/policy/policy-download.controller.js
+++ b/app/controllers/policy/policy-download.controller.js
@@ -13,10 +13,10 @@ const downloadDocumentsPolicyPage = async function downloadDocumentsPolicyPage (
     const documentConfig = await supportedPolicyDocuments.lookup(key)
     const link = await policyBucket.generatePrivateLink(documentConfig)
 
-    logger.info(`[${req.correlationId}] user ${req.user.externalId} signed private link for ${key}: ${link}`)
+    logger.info(`User ${req.user.externalId} signed private link for ${key}: ${link}`)
     return response(req, res, documentConfig.template, { link })
   } catch (error) {
-    logger.error(`[${req.correlationId}] unable to generate document link ${error.message}`)
+    logger.error(`Unable to generate document link ${error.message}`)
     renderErrorView(req, res, error.message)
   }
 }

--- a/app/controllers/register-service.controller.js
+++ b/app/controllers/register-service.controller.js
@@ -251,7 +251,7 @@ const submitOtpResend = async function submitOtpResend (req, res) {
     sessionData.telephone_number = telephoneNumber
     res.redirect(303, paths.selfCreateService.otpVerify)
   } catch (err) {
-    logger.warn(`[requestId=${req.correlationId}] Invalid invite code attempted ${req.code}, error = ${err.errorCode}`)
+    logger.warn(`Invalid invite code attempted ${req.code}, error = ${err.errorCode}`)
     if (err.errorCode === 404) {
       renderErrorView(req, res, 'Unable to process registration at this time', 404)
     } else {
@@ -301,7 +301,7 @@ const submitYourServiceName = async function submitYourServiceName (req, res) {
       lodash.unset(req, 'session.pageData.submitYourServiceName')
       res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, account.external_id))
     } catch (err) {
-      logger.debug(`[requestId=${correlationId}] invalid user input - service name`)
+      logger.debug('Invalid user input - service name')
       renderErrorView(req, res, err)
     }
   }

--- a/app/controllers/register-user.controller.js
+++ b/app/controllers/register-user.controller.js
@@ -20,7 +20,7 @@ const messages = {
 }
 
 const handleError = (req, res, err) => {
-  logger.warn(`[requestId=${req.correlationId}] Invalid invite code attempted ${req.code}, error = ${err.errorCode}`)
+  logger.warn(`Invalid invite code attempted ${req.code}, error = ${err.errorCode}`)
 
   switch (err.errorCode) {
     case 404:

--- a/app/controllers/request-psp-test-account/post.controller.js
+++ b/app/controllers/request-psp-test-account/post.controller.js
@@ -6,7 +6,6 @@ const getAdminUsersClient = require('../../services/clients/adminusers.client')
 const logger = require('../../utils/logger')(__filename)
 const { CREATED, NOT_STARTED, REQUEST_SUBMITTED } = require('../../models/psp-test-account-stage')
 const adminUsersClient = getAdminUsersClient()
-const { keys } = require('@govuk-pay/pay-js-commons').logging
 
 async function submitRequestAndUpdatePspTestAccountStatus (req) {
   const message = `Service name: ${req.service.name}
@@ -28,14 +27,7 @@ async function submitRequestAndUpdatePspTestAccountStatus (req) {
 
   await zendeskClient.createTicket(zendeskOpts)
   await adminUsersClient.updatePspTestAccountStage(req.service.externalId, REQUEST_SUBMITTED, req.correlationId)
-
-  const logContext = {
-    is_internal_user: req.user && req.user.internalUser
-  }
-  logContext[keys.USER_EXTERNAL_ID] = req.user.externalId
-  logContext[keys.SERVICE_EXTERNAL_ID] = req.service.externalId
-
-  logger.info('Request submitted for Stripe test account', logContext)
+  logger.info('Request submitted for Stripe test account')
 }
 
 module.exports = async function submitRequestForPspTestAccount (req, res, next) {

--- a/app/controllers/request-to-go-live/agreement/post.controller.js
+++ b/app/controllers/request-to-go-live/agreement/post.controller.js
@@ -38,7 +38,7 @@ async function postUserIpAddress (req) {
   if (req.service.currentGoLiveStage === 'CHOSEN_PSP_STRIPE') {
     const ipAddress = getUserIpAddress(req)
     if (!isIPv4(ipAddress) && !isIPv6(ipAddress)) {
-      logger.error(`request ${req.correlationId} has an invalid ip address: ` + ipAddress)
+      logger.error(`Request has an invalid ip address: ${ipAddress}`)
       throw new Error('Please try again or contact support team.')
     }
     await addStripeAgreementIpAddress(req.service.externalId, ipAddress, req.correlationId)

--- a/app/controllers/service-roles-update.controller.js
+++ b/app/controllers/service-roles-update.controller.js
@@ -14,8 +14,8 @@ let hasSameService = (admin, user, externalServiceId) => {
   return admin.hasService(externalServiceId) && user.hasService(externalServiceId)
 }
 
-let serviceIdMismatchView = (req, res, adminUserExternalId, targetServiceExternalId, targetUserExternalId, correlationId) => {
-  logger.error(`[requestId=${correlationId}] service mismatch when admin:${adminUserExternalId} attempting to assign new role on service:${targetServiceExternalId} for user:${targetUserExternalId} without existing role`)
+let serviceIdMismatchView = (req, res, adminUserExternalId, targetServiceExternalId, targetUserExternalId) => {
+  logger.error(`Service mismatch when admin:${adminUserExternalId} attempting to assign new role on service:${targetServiceExternalId} for user:${targetUserExternalId} without existing role`)
   return renderErrorView(req, res, 'Unable to update permissions for this user')
 }
 
@@ -76,12 +76,12 @@ module.exports = {
     try {
       const user = await userService.findByExternalId(externalUserId, correlationId)
       if (!hasSameService(req.user, user, serviceExternalId)) {
-        return serviceIdMismatchView(req, res, req.user.externalId, serviceExternalId, user.externalId, correlationId)
+        return serviceIdMismatchView(req, res, req.user.externalId, serviceExternalId, user.externalId)
       } else {
         return response(req, res, 'team-members/team-member-permissions', viewData(user))
       }
     } catch (err) {
-      logger.error(`[requestId=${correlationId}] error displaying user permission view [${err}]`)
+      logger.error(`Error displaying user permission view [${err}]`)
       return renderErrorView(req, res, 'Unable to locate the user')
     }
   },
@@ -108,7 +108,7 @@ module.exports = {
     }
 
     if (!targetRole) {
-      logger.error(`[requestId=${correlationId}] cannot identify role from user input ${targetRoleExtId}. possible hack`)
+      logger.error(`Cannot identify role from user input ${targetRoleExtId}. possible hack`)
       return renderErrorView(req, res, 'Unable to update user permission')
     }
 
@@ -124,13 +124,13 @@ module.exports = {
             await userService.updateServiceRole(user.externalId, targetRole.name, serviceExternalId, correlationId)
             return onSuccess(user)
           } catch (err) {
-            logger.error(`[requestId=${correlationId}] error updating user service role [${err}]`)
+            logger.error(`Error updating user service role [${err}]`)
             return renderErrorView(req, res, 'Unable to update user permission')
           }
         }
       }
     } catch (err) {
-      logger.error(`[requestId=${correlationId}] error locating user when updating user service role [${err}]`)
+      logger.error(`Error locating user when updating user service role [${err}]`)
       return renderErrorView(req, res, 'Unable to locate the user')
     }
   }

--- a/app/controllers/service-users.controller.js
+++ b/app/controllers/service-users.controller.js
@@ -76,7 +76,7 @@ module.exports = {
     ])
       .then(onSuccess)
       .catch((err) => {
-        logger.error(`[requestId=${req.correlationId}] error retrieving users for service ${externalServiceId}. [${err}]`)
+        logger.error(`error retrieving users for service ${externalServiceId}. [${err}]`)
         renderErrorView(req, res, 'Unable to retrieve the services users')
       })
   },

--- a/app/controllers/stripe-setup/bank-details/post.controller.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.js
@@ -75,7 +75,7 @@ module.exports = async (req, res, next) => {
       }
     }
     // the error is generic
-    logger.error(`[${req.correlationId}] Error submitting bank details, error = `, error)
+    logger.error(`Error submitting bank details, error = `, error)
     return renderErrorView(req, res, 'Please try again or contact support team')
   }
 }

--- a/app/controllers/stripe-setup/company-number/post.controller.js
+++ b/app/controllers/stripe-setup/company-number/post.controller.js
@@ -47,7 +47,7 @@ module.exports = async (req, res, next) => {
 
       return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))
     } catch (error) {
-      logger.error(`[${req.correlationId}] Error submitting "Company registration number" details, error = `, error)
+      logger.error(`Error submitting "Company registration number" details, error = `, error)
       return renderErrorView(req, res, 'Please try again or contact support team')
     }
   }

--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -124,7 +124,7 @@ module.exports = async function (req, res, next) {
 
       return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))
     } catch (error) {
-      logger.error(`[requestId=${req.correlationId}] Error creating responsible person with Stripe - ${error.message}`)
+      logger.error(`Error creating responsible person with Stripe - ${error.message}`)
       return renderErrorView(req, res, 'Please try again or contact support team')
     }
   }

--- a/app/controllers/stripe-setup/stripe-setup-link/stripe-setup-dashboard-redirect.controller.js
+++ b/app/controllers/stripe-setup/stripe-setup-link/stripe-setup-dashboard-redirect.controller.js
@@ -6,7 +6,6 @@ const { ConnectorClient } = require('../../../services/clients/connector.client'
 const { isADirectDebitAccount } = require('../../../services/clients/direct-debit-connector.client')
 const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 const logger = require('../../../utils/logger')(__filename)
-const { keys } = require('@govuk-pay/pay-js-commons').logging
 
 function getTargetServiceForRedirect (user, externalServiceId) {
   return user.serviceRoles.filter((serviceRole) => serviceRole.service.externalId === externalServiceId)[0]
@@ -25,9 +24,6 @@ module.exports = async (req, res) => {
     }
   }
 
-  const logContext = {}
-  logContext[keys.USER_EXTERNAL_ID] = req.user && req.user.externalId
-  logContext[keys.SERVICE_EXTERNAL_ID] = externalServiceId
-  logger.warn('User has no access to this service for dashboard redirect', logContext)
+  logger.warn('User has no access to this service for dashboard redirect')
   res.redirect(302, paths.index)
 }

--- a/app/controllers/stripe-setup/vat-number/post.controller.js
+++ b/app/controllers/stripe-setup/vat-number/post.controller.js
@@ -45,7 +45,7 @@ module.exports = async (req, res, next) => {
 
       return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))
     } catch (error) {
-      logger.error(`[${req.correlationId}] Error submitting "VAT number" details, error = `, error)
+      logger.error(`Error submitting "VAT number" details, error = `, error)
       return renderErrorView(req, res, 'Please try again or contact support team')
     }
   }

--- a/app/controllers/test-with-your-users/disable.controller.js
+++ b/app/controllers/test-with-your-users/disable.controller.js
@@ -13,7 +13,7 @@ module.exports = (req, res) => {
       res.redirect(formatAccountPathsFor(paths.account.prototyping.demoService.links, req.account.external_id))
     })
     .catch((err) => {
-      logger.error(`[requestId=${req.correlationId}] Disable product failed - ${err.message}`)
+      logger.error(`Disable product failed - ${err.message}`)
       req.flash('genericError', 'Something went wrong when deleting the prototype link. Please try again or contact support.')
       res.redirect(formatAccountPathsFor(paths.account.prototyping.demoService.links, req.account.external_id))
     })

--- a/app/controllers/test-with-your-users/links.controller.js
+++ b/app/controllers/test-with-your-users/links.controller.js
@@ -22,7 +22,7 @@ module.exports = (req, res) => {
       return response(req, res, 'dashboard/demo-service/index', params)
     })
     .catch((err) => {
-      logger.error(`[requestId=${req.correlationId}] Get PROTOTYPE product by gateway account id failed - ${err.message}`)
+      logger.error(`Get PROTOTYPE product by gateway account id failed - ${err.message}`)
       renderErrorView(req, res)
     })
 }

--- a/app/controllers/test-with-your-users/submit.controller.js
+++ b/app/controllers/test-with-your-users/submit.controller.js
@@ -58,7 +58,7 @@ module.exports = async (req, res) => {
     lodash.set(req, 'session.pageData.createPrototypeLink', {})
     return response(req, res, 'dashboard/demo-service/confirm', { prototypeLink })
   } catch (err) {
-    logger.error(`[requestId=${req.correlationId}] Create product failed - ${err.message}`)
+    logger.error(`Create product failed - ${err.message}`)
     req.flash('genericError', 'Something went wrong. Please try again or contact support.')
     return res.redirect(formatAccountPathsFor(paths.account.prototyping.demoService.create, req.account.external_id))
   }

--- a/app/controllers/two-factor-auth-controller/get-configure.controller.js
+++ b/app/controllers/two-factor-auth-controller/get-configure.controller.js
@@ -25,7 +25,7 @@ module.exports = async function showConfigureSecondFactorMethod (req, res) {
     }
     return response(req, res, 'two-factor-auth/configure', pageData)
   } catch (err) {
-    logger.error(`[requestId=${req.correlationId}] Failed to generate QR code - ${err.message}`)
+    logger.error(`Failed to generate QR code - ${err.message}`)
     req.flash('genericError', 'Something went wrong. Please try again or contact support.')
     return res.redirect(paths.user.profile.twoFactorAuth.index)
   }

--- a/app/controllers/two-factor-auth-controller/post-configure.controller.js
+++ b/app/controllers/two-factor-auth-controller/post-configure.controller.js
@@ -22,7 +22,7 @@ module.exports = async function postUpdateSecondFactorMethod (req, res) {
       })
     } else {
       req.flash('genericError', 'Something went wrong. Please try again or contact support.')
-      logger.error(`[requestId=${req.correlationId}] Activating new OTP key failed, server error`)
+      logger.error(`Activating new OTP key failed, server error`)
     }
     return res.redirect(paths.user.profile.twoFactorAuth.configure)
   }

--- a/app/controllers/two-factor-auth-controller/post-index.controller.js
+++ b/app/controllers/two-factor-auth-controller/post-index.controller.js
@@ -17,7 +17,7 @@ module.exports = async (req, res) => {
     }
     return res.redirect(paths.user.profile.twoFactorAuth.configure)
   } catch (err) {
-    logger.error(`[requestId=${req.correlationId}] Provisioning new OTP key failed - ${err.message}`)
+    logger.error(`Provisioning new OTP key failed - ${err.message}`)
     req.flash('genericError', 'Something went wrong. Please try again or contact support.')
     return res.redirect(paths.user.profile.twoFactorAuth.index)
   }

--- a/app/controllers/two-factor-auth-controller/post-resend.controller.js
+++ b/app/controllers/two-factor-auth-controller/post-resend.controller.js
@@ -11,7 +11,7 @@ module.exports = (req, res) => {
       return res.redirect(paths.user.profile.twoFactorAuth.configure)
     })
     .catch(err => {
-      logger.error(`[requestId=${req.correlationId}] Reseding OTP key SMS failed - ${err.message}`)
+      logger.error(`Reseding OTP key SMS failed - ${err.message}`)
       req.flash('genericError', 'Something went wrong. Please try again or contact support.')
       return res.redirect(paths.user.profile.twoFactorAuth.configure)
     })

--- a/app/middleware/error-logger.js
+++ b/app/middleware/error-logger.js
@@ -21,7 +21,7 @@ module.exports = function (err, req, res, next) {
   }
 
   // log the exception
-  logger.error(`[requestId=${req.correlationId}] Internal server error`, errorPayload)
+  logger.error(`Internal server error`, errorPayload)
   // re-throw it
   next(err)
 }

--- a/app/middleware/get-service-and-gateway-account.middleware.js
+++ b/app/middleware/get-service-and-gateway-account.middleware.js
@@ -32,10 +32,10 @@ async function getGatewayAccountByExternalId (gatewayAccountExternalId, correlat
 
     return account
   } catch (err) {
-    const logContext = {}
-    logContext['error'] = err.message
-    logContext['error_code'] = err.errorCode
-    logContext['GATEWAY_ACCOUNT_EXTERNAL_ID'] = gatewayAccountExternalId
+    const logContext = {
+      error: err.message,
+      error_code: err.errorCode
+    }
 
     if (err.errorCode === 404) {
       logger.info('Gateway account not found', logContext)

--- a/app/routes.js
+++ b/app/routes.js
@@ -427,8 +427,7 @@ module.exports.bind = function (app) {
         logger.info('Accounts URL utility upgraded a request to a legacy account URL', {
           url: req.originalUrl,
           redirected_url: upgradedPath,
-          session_has_user: !!req.user,
-          is_internal_user: req.user && req.user.internalUser
+          session_has_user: !!req.user
         })
         res.redirect(upgradedPath)
         return

--- a/app/services/auth.service.js
+++ b/app/services/auth.service.js
@@ -38,8 +38,7 @@ module.exports = {
 // Middleware
 function lockOutDisabledUsers (req, res, next) {
   if (req.user && req.user.disabled) {
-    const correlationId = req.headers[CORRELATION_HEADER] || ''
-    logger.info(`[${correlationId}] user: ${lodash.get(req, 'user.externalId')} locked out due to many password attempts`)
+    logger.info('User locked out due to many password attempts')
     return noAccess(req, res, next)
   }
   return next()
@@ -104,20 +103,20 @@ function setSessionVersion (req) {
 
 function redirectToLogin (req, res) {
   req.session.last_url = req.originalUrl
-  logger.info(`[${req.correlationId}] Redirecting attempt to access ${req.originalUrl} to ${paths.user.logIn}`)
+  logger.info(`Redirecting attempt to access ${req.originalUrl} to ${paths.user.logIn}`)
   res.redirect(paths.user.logIn)
 }
 
 function hasValidSession (req) {
   const isValid = sessionValidator.validate(req.user, req.session)
-  if (!isValid) logger.info(`[${req.correlationId}] Invalid session version for user. User session_version: ${lodash.get(req, 'user.sessionVersion', 0)}, session version ${lodash.get(req, 'session.version')}`)
+  if (!isValid) logger.info(`Invalid session version for user. User session_version: ${lodash.get(req, 'user.sessionVersion', 0)}, session version ${lodash.get(req, 'session.version')}`)
   return isValid
 }
 
 function addUserFieldsToLogContext (req, res, next) {
   if (req.user) {
     addLoggingField(USER_EXTERNAL_ID, req.user.externalId)
-    addLoggingField('is_internal_user', req.user.internalUser)
+    addLoggingField('internal_user', req.user.internalUser)
   }
   next()
 }
@@ -139,7 +138,7 @@ function deserializeUser (req, externalId, done) {
       done(null, user)
     })
     .catch(err => {
-      logger.info(`[${req.correlationId}]: Failed to retrieve user, '${externalId}', from adminusers with statuscode: ${err.errorCode}`)
+      logger.info(`Failed to retrieve user, '${externalId}', from adminusers with statuscode: ${err.errorCode}`)
       done(err)
     })
 }

--- a/app/services/service-registration.service.js
+++ b/app/services/service-registration.service.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { keys } = require('@govuk-pay/pay-js-commons').logging
-
 const logger = require('../utils/logger')(__filename)
 const getAdminUsersClient = require('./clients/adminusers.client')
 const ConnectorClient = require('./clients/connector.client').ConnectorClient
@@ -21,14 +19,7 @@ async function createPopulatedService (inviteCode, correlationId) {
   const gatewayAccount = await connectorClient.createGatewayAccount('sandbox', 'test', null, null, correlationId)
   const completeInviteResponse = await adminUsersClient.completeInvite(correlationId, inviteCode, [gatewayAccount.gateway_account_id])
   const user = await adminUsersClient.getUserByExternalId(completeInviteResponse.user_external_id, correlationId)
-
-  const logContext = {
-    internal_user: user.internalUser
-  }
-  logContext[keys.USER_EXTERNAL_ID] = user.externalId
-  logContext[keys.SERVICE_EXTERNAL_ID] = completeInviteResponse.service_external_id
-  logContext[keys.GATEWAY_ACCOUNT_ID] = gatewayAccount.gateway_account_id
-  logger.info('Created new service with test account during user registration', logContext)
+  logger.info('Created new service with test account during user registration')
 
   return user
 }

--- a/app/services/service.service.js
+++ b/app/services/service.service.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const lodash = require('lodash')
-const { keys } = require('@govuk-pay/pay-js-commons').logging
 
 const logger = require('../utils/logger')(__filename)
 const getAdminUsersClient = require('./clients/adminusers.client')
@@ -56,14 +55,7 @@ async function createService (serviceName, serviceNameCy, user, correlationId) {
 
   const gatewayAccount = await connectorClient.createGatewayAccount('sandbox', 'test', serviceName, null, correlationId)
   const service = await adminUsersClient.createService(serviceName, serviceNameCy, [gatewayAccount.gateway_account_id], correlationId)
-
-  const logContext = {
-    internal_user: user.internalUser
-  }
-  logContext[keys.USER_EXTERNAL_ID] = user.externalId
-  logContext[keys.SERVICE_EXTERNAL_ID] = service.externalId
-  logContext[keys.GATEWAY_ACCOUNT_ID] = gatewayAccount.gateway_account_id
-  logger.info('New service added by existing user', logContext)
+  logger.info('New service added by existing user')
 
   return service
 }

--- a/app/services/transaction.service.js
+++ b/app/services/transaction.service.js
@@ -43,7 +43,7 @@ const csvSearchUrl = function csvSearchParams (filters, gatewayAccountIds = []) 
 const logCsvFileStreamComplete = function logCsvFileStreamComplete (timestampStreamStart, filters, gatewayAccountIds, user, correlationId,
   allServiceTransactions, liveAccounts) {
   const timestampStreamEnd = Date.now()
-  const logContext = {
+  logger.info('Completed file stream', {
     time_taken: timestampStreamEnd - timestampStreamStart,
     from_date: filters.fromDate,
     to_date: filters.toDate,
@@ -53,15 +53,11 @@ const logCsvFileStreamComplete = function logCsvFileStreamComplete (timestampStr
     method: 'future',
     gateway_account_ids: gatewayAccountIds,
     multiple_accounts: gatewayAccountIds.length > 1,
-    internal_user: user.internalUser,
     all_service_transactions: allServiceTransactions,
     user_number_of_live_services: user.numberOfLiveServices,
     is_live: liveAccounts,
     filters: Object.keys(filters).sort().join(', ')
-  }
-  logContext[keys.USER_EXTERNAL_ID] = user && user.externalId
-  logContext[keys.CORRELATION_ID] = correlationId
-  logger.info('Completed file stream', logContext)
+  })
 }
 
 const ledgerFindWithEvents = async function ledgerFindWithEvents (accountId, chargeId, correlationId) {
@@ -92,10 +88,7 @@ const refund = async function refundTransaction (gatewayAccountId, chargeId, amo
     refund_amount_available: refundAmountAvailable,
     amount: amount
   }
-  logContext[keys.USER_EXTERNAL_ID] = userExternalId
-  logContext[keys.GATEWAY_ACCOUNT_ID] = gatewayAccountId
   logContext[keys.PAYMENT_EXTERNAL_ID] = chargeId
-  logContext[keys.CORRELATION_ID] = correlationId
   logger.log('info', 'Submitting a refund for a charge', logContext)
 
   const payload = {

--- a/app/utils/request-logger.js
+++ b/app/utils/request-logger.js
@@ -1,22 +1,19 @@
 const logger = require('./logger')(__filename)
-const { keys } = require('@govuk-pay/pay-js-commons').logging
 
 module.exports = {
   logRequestStart: context => {
-    const logContext = {
+    logger.info(`Calling ${context.service} to ${context.description}`, {
       service: context.service,
       method: context.method,
       url: context.url,
       description: context.description,
       ...context.additionalLoggingFields
-    }
-    logContext[keys.CORRELATION_ID] = context.correlationId
-    logger.info(`Calling ${context.service} to ${context.description}`, logContext)
+    })
   },
 
   logRequestEnd: (context, response) => {
     let duration = new Date() - context.startTime
-    const logContext = {
+    logger.info(`${context.method} to ${context.url} ended - elapsed time: ${duration} ms`, {
       service: context.service,
       method: context.method,
       url: context.url,
@@ -24,34 +21,28 @@ module.exports = {
       response_time: duration,
       status: response && response.statusCode,
       ...context.additionalLoggingFields
-    }
-    logContext[keys.CORRELATION_ID] = context.correlationId
-    logger.info(`${context.method} to ${context.url} ended - elapsed time: ${duration} ms`, logContext)
+    })
   },
 
   logRequestFailure: (context, response) => {
-    const logContext = {
+    logger.info(`Calling ${context.service} to ${context.description} failed`, {
       service: context.service,
       method: context.method,
       url: context.url,
       description: context.description,
       status: response.statusCode,
       ...context.additionalLoggingFields
-    }
-    logContext[keys.CORRELATION_ID] = context.correlationId
-    logger.info(`Calling ${context.service} to ${context.description} failed`, logContext)
+    })
   },
 
   logRequestError: (context, error) => {
-    const logContext = {
+    logger.error(`Calling ${context.service} to ${context.description} threw exception`, {
       service: context.service,
       method: context.method,
       url: context.url,
       description: context.description,
       error: error,
       ...context.additionalLoggingFields
-    }
-    logContext[keys.CORRELATION_ID] = context.correlationId
-    logger.error(`Calling ${context.service} to ${context.description} threw exception`, logContext)
+    })
   }
 }

--- a/app/utils/response.js
+++ b/app/utils/response.js
@@ -1,7 +1,6 @@
 const _ = require('lodash')
 const logger = require('./logger')(__filename)
 const displayConverter = require('./display-converter')
-const { CORRELATION_ID } = require('@govuk-pay/pay-js-commons').logging.keys
 
 const ERROR_MESSAGE = 'There is a problem with the payments platform'
 const ERROR_VIEW = 'error'
@@ -12,7 +11,6 @@ function response (req, res, template, data = {}) {
 }
 
 function errorResponse (req, res, msg = ERROR_MESSAGE, status = 500) {
-  let correlationId = req.correlationId
   if (typeof msg !== 'string') {
     msg = 'Please try again or contact support team.'
   }
@@ -22,7 +20,6 @@ function errorResponse (req, res, msg = ERROR_MESSAGE, status = 500) {
     'status': status,
     'error_message': msg
   }
-  errorMeta[CORRELATION_ID] = correlationId
 
   if (status === 500) {
     logger.error('An error has occurred. Rendering error view', errorMeta)

--- a/test/unit/middleware/error-handler.test.js
+++ b/test/unit/middleware/error-handler.test.js
@@ -101,12 +101,6 @@ describe('Error handler middleware', () => {
       service: new Service(serviceFixtures.validServiceResponse({ external_id: serviceExternalId })),
       account: gatewayAccountFixtures.validGatewayAccountResponse({ gateway_account_id: gatewayAccountId })
     }
-    const expectedLogContext = {
-      'x_request_id': correlationId,
-      'user_external_id': userExternalId,
-      'service_external_id': serviceExternalId,
-      'gateway_account_id': gatewayAccountId
-    }
 
     it('should log at info level for NotAuthenticatedError', () => {
       const err = new NotAuthenticatedError('not authenticated')
@@ -117,7 +111,7 @@ describe('Error handler middleware', () => {
       errorHandler(err, notAuthorisedReq, res, null)
 
       const expectedMessage = 'NotAuthenticatedError handled: not authenticated. Redirecting attempt to access /foo/bar to /login'
-      sinon.assert.calledWith(infoLoggerSpy, expectedMessage, expectedLogContext)
+      sinon.assert.calledWith(infoLoggerSpy, expectedMessage)
     })
 
     it('should log at info level for UserAccountDisabledError', () => {
@@ -125,7 +119,7 @@ describe('Error handler middleware', () => {
       errorHandler(err, reqWithSessionData, res, null)
 
       const expectedMessage = 'UserAccountDisabledError handled, rendering no access page'
-      sinon.assert.calledWith(infoLoggerSpy, expectedMessage, expectedLogContext)
+      sinon.assert.calledWith(infoLoggerSpy, expectedMessage)
     })
 
     it('should log at info level for NotAuthorisedError', () => {
@@ -133,7 +127,7 @@ describe('Error handler middleware', () => {
       errorHandler(err, reqWithSessionData, res, null)
 
       const expectedMessage = 'NotAuthorisedError handled: user does not have authorisation. Rendering error page'
-      sinon.assert.calledWith(infoLoggerSpy, expectedMessage, expectedLogContext)
+      sinon.assert.calledWith(infoLoggerSpy, expectedMessage)
     })
 
     it('should log at info level for PermissionDeniedError', () => {
@@ -141,7 +135,7 @@ describe('Error handler middleware', () => {
       errorHandler(err, reqWithSessionData, res, null)
 
       const expectedMessage = 'PermissionDeniedError handled: User does not have permission do-cool-things for service. Rendering error page'
-      sinon.assert.calledWith(infoLoggerSpy, expectedMessage, expectedLogContext)
+      sinon.assert.calledWith(infoLoggerSpy, expectedMessage)
     })
 
     it('should log at info level for NotFoundError', () => {
@@ -149,7 +143,7 @@ describe('Error handler middleware', () => {
       errorHandler(err, reqWithSessionData, res, null)
 
       const expectedMessage = 'NotFoundError handled: Transaction not found. Rendering 404 page'
-      sinon.assert.calledWith(infoLoggerSpy, expectedMessage, expectedLogContext)
+      sinon.assert.calledWith(infoLoggerSpy, expectedMessage)
     })
 
     it('should log at error level for generic Error', () => {
@@ -157,7 +151,7 @@ describe('Error handler middleware', () => {
       errorHandler(err, reqWithSessionData, res, null)
 
       const expectedMessage = 'Unhandled error caught: A generic error'
-      sinon.assert.calledWithMatch(errorLoggerSpy, expectedMessage, expectedLogContext)
+      sinon.assert.calledWithMatch(errorLoggerSpy, expectedMessage)
     })
   })
 })

--- a/test/unit/middleware/error-logger.test.js
+++ b/test/unit/middleware/error-logger.test.js
@@ -42,7 +42,7 @@ describe('error_handler middleware', function () {
         message: err
       }
     }
-    assert(loggerErrorSpy.calledWith(`[requestId=${req.correlationId}] Internal server error`, errorPayload))
+    assert(loggerErrorSpy.calledWith(`Internal server error`, errorPayload))
     assert(next.calledWith(err))
 
     done()
@@ -73,7 +73,7 @@ describe('error_handler middleware', function () {
         stack: err.stack
       }
     }
-    assert(loggerErrorSpy.calledWith(`[requestId=${req.correlationId}] Internal server error`, errorPayload))
+    assert(loggerErrorSpy.calledWith(`Internal server error`, errorPayload))
     assert(next.calledWith(err))
 
     done()


### PR DESCRIPTION
As we now attach the correlation id, user, service, and account info to all log lines when it is available using AsyncLocalStorage, we no need to attach this information to individual log lines.

See b18c7571d774ab3c591d4bf614f24ac38a923de0 for implementation of this.

Remove occurrences where we log this info in individual log lines.

