### PR TITLE
BAU Trim whitespace from organisation name

### DIFF
--- a/app/controllers/request-to-go-live/organisation-name/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-name/post.controller.js
@@ -15,7 +15,7 @@ const formatServicePathsFor = require('../../../utils/format-service-paths-for')
 const ORGANISATION_NAME_FIELD = 'organisation-name'
 
 module.exports = (req, res) => {
-  const organisationName = lodash.get(req.body, ORGANISATION_NAME_FIELD)
+  const organisationName = req.body[ORGANISATION_NAME_FIELD] && req.body[ORGANISATION_NAME_FIELD].trim()
   const errors = validateOrganisationName(organisationName, ORGANISATION_NAME_FIELD, true)
   if (lodash.isEmpty(errors)) {
     const updateServiceRequest = new ServiceUpdateRequest()


### PR DESCRIPTION
Prevent having duplicate organisations in our reports due to trailing whitespaces by trimming the name when it is entered.

