### PR TITLE
PP-7570 Fix logging context for POST requests

### DIFF
--- a/server.js
+++ b/server.js
@@ -58,6 +58,9 @@ function addCsrfMiddleware (app) {
 }
 
 function initialiseGlobalMiddleware (app) {
+  app.use(bodyParser.json())
+  app.use(bodyParser.urlencoded({ extended: true }))
+
   app.use(cookieParser())
   app.use(logContextMiddleware)
   logger.stream = {
@@ -87,9 +90,6 @@ function initialiseGlobalMiddleware (app) {
     res.locals.flash = req.flash()
     next()
   }))
-
-  app.use(bodyParser.json())
-  app.use(bodyParser.urlencoded({ extended: true }))
 
   addCsrfMiddleware(app)
 }


### PR DESCRIPTION
There is an issue when body-parser middleware is added after an AsyncLocalStorage store is opened, where the async context is lost.

This is identified here https://stackoverflow.com/questions/64330910/nodejs-asynclocalstorage-getstore-return-undefined, although no cause is identified.

This ordering was also required in Toolbox when using a different library using async_hooks.

Change middleware ordering to fix this.

