### PR TITLE
BAU Include policy pages in non-service/account templates

### DIFF
--- a/app/utils/display-converter.js
+++ b/app/utils/display-converter.js
@@ -10,7 +10,11 @@ const hideServiceHeaderTemplates = [
   'feedback/index',
   'error',
   'error-with-link',
-  '404'
+  '404',
+  'policy/document-downloads/contract-for-non-crown-bodies',
+  'policy/document-downloads/memorandum-of-understanding-for-crown-bodies',
+  'policy/document-downloads/pci-dss-attestation-of-compliance',
+  'policy/document-downloads/stripe-connected-account-agreement'
 ]
 
 const hideServiceNavTemplates = [


### PR DESCRIPTION
Policy document pages were being shown as account pages before the
refactored URL based account routing. This behaviour is not desired as
the it would have been the previous account the user had selected, which
will never be directly relevant to the policy document selected.

Include the template path in the non-service/ account pages until the
template inheritance method is reviewed.

**Current behaviour**

![Screenshot 2021-04-19 at 14 30 09](https://user-images.githubusercontent.com/2844572/115262294-4dc01900-a12c-11eb-93e8-a2d4996250a3.png)

<img width="1215" alt="Screenshot 2021-04-19 at 16 28 25" src="https://user-images.githubusercontent.com/2844572/115262297-51ec3680-a12c-11eb-9685-7d1bc19429ed.png">



