### PR TITLE
PP-8003 - Release Stripe content changes

### DIFF
--- a/app/assets/csv/sample_reporting_payout.csv
+++ b/app/assets/csv/sample_reporting_payout.csv
@@ -1,0 +1,2 @@
+Reference,Description,Email,Amount,Card Brand,Cardholder Name,Card Expiry Date,Card Number,State,Finished,Error Code,Error Message,Provider ID,GOV.UK Payment ID,Issued By,Date Created,Time Created,Corporate Card Surcharge,Total Amount,Wallet Type,Fee,Net,Card Type,MOTO
+4S8CKS3FN2,test kb,useremail@example.org,10,Visa,test,11/21,4242,Success,true,,,pi_1HG0y2Hj08j2jFuBmM9r9Ybe,9mim88o2gt7atngu9m7i78en6a,,14 Aug 2020,11:20:48,0,10,,0.5,9.5,credit,false

--- a/app/views/dashboard/_links.njk
+++ b/app/views/dashboard/_links.njk
@@ -71,7 +71,7 @@
         <article class="{{columnClass}} links__box" id="request-stripe-test-account">
           <a href="{{formatServicePathsFor(routes.service.requestPspTestAccount, currentService.externalId)}}" class="govuk-link">
             <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Test Stripe’s reporting functionality</h2>
-            <p class="govuk-body govuk-!-margin-bottom-0">Access transaction fee and payout reports to test reconciliation.</p>
+            <p class="govuk-body govuk-!-margin-bottom-0">Access transaction fee and payments to your bank account reports to test reconciliation.</p>
           </a>
         </article>
       {% endif %}

--- a/app/views/payouts/list.njk
+++ b/app/views/payouts/list.njk
@@ -24,9 +24,8 @@ Payments to your bank account - GOV.UK Pay
   </h1>
 </div>
 <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-0">
-  {% if filterLiveAccounts %}
-    <p class="govuk-body">Payments Stripe has made to your bank account.</p>
-  {% else %}
+  <p class="govuk-body">Payments Stripe has made to your bank account.</p>
+  {% if not filterLiveAccounts %}
     <div class="govuk-inset-text">
     <p class="govuk-body">Test reports represent how payments to your bank account appear. They show the total amount received from Stripe in each payment and detail all the transactions.</p>
     <p class="govuk-body">The reports are available the next working day after your test transactions. With test transactions, no payments are made to your bank account.</p>
@@ -83,12 +82,40 @@ Payments to your bank account - GOV.UK Pay
       </tbody>
     </table>
   {% else %}
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    {% if payoutsReleaseDate %}
-    <p class="govuk-body">No payments to your bank account found on or after {{ payoutsReleaseDate.format('D MMMM YYYY') }}.</p>
-    <p class="govuk-body">For historic payments to your bank account please <a class="govuk-link" href="https://www.payments.service.gov.uk/support/">contact support.</a></p>
+    {% if filterLiveAccounts %}
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      {% if payoutsReleaseDate %}
+        <p class="govuk-body">No payments to your bank account found on or after {{ payoutsReleaseDate.format('D MMMM YYYY') }}.</p>
+        <p class="govuk-body">For historic payments to your bank account please <a class="govuk-link" href="https://www.payments.service.gov.uk/support/">contact support.</a></p>
+      {% else %}
+        <p class="govuk-body">No payments to your bank account found.</p>
+      {% endif %}
     {% else %}
-    <p class="govuk-body">No payments to your bank account found.</p>
+      <h2 class="govuk-heading-m">Sample Report</h2>
+      <p class="govuk-body">This is a sample report. If you make test, payments, you'll be able to see a copy of the report using your test payment.</p>
+
+      <table class="govuk-table" id="payout-list">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Service</th>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric">Amount</th>
+            <th scope="col" class="govuk-table__header">View transactions</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td scope="row" class="govuk-table__cell">Test Service</td>
+            <td class="govuk-table__cell govuk-table__cell--numeric">
+              {{ 10000 | penceToPoundsWithCurrency }}
+            </td>
+            <td class="govuk-table__cell">
+              <a class="govuk-link govuk-link--no-visited-state" href="public/csv/sample_reporting_payout.csv">
+                Download CSV
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     {% endif %}
   {% endfor %}
 </div>

--- a/app/views/request-psp-test-account/index.njk
+++ b/app/views/request-psp-test-account/index.njk
@@ -20,18 +20,20 @@
             <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
             <h1 class="govuk-heading-l">Request Stripe test account</h1>
             <p class="govuk-body">
-              If you’ve set up a test service and are planning to use Stripe, GOV.UK Pay’s Payment Service Provider, you can get a test account. You’ll be able to access the same reports and functionality as a live Stripe account, including:
+              If you’re planning to use Stripe, GOV.UK Pay’s Payment Service Provider, get a Stripe test account to test your end-to-end reporting process. The Stripe reports are different to those in a regular 'sandbox' account. You’ll be able to access new reports showing:
             </p>
             <ul class="govuk-list govuk-list--bullet">
-                      <li>transaction fees</li>
-                      <li>gross and net payments</li>
+                      <li>PSP fees, and gross and net payments</li>
                       <li>payments into your bank account</li>
             </ul>
             <p class="govuk-body">
               You can download the data as a CSV file or by integrating with our reporting and reconciliation API.
             </p>
             <p class="govuk-body">
-              We can usually set up a Stripe test account for your service within 2 working days.
+              We can usually set up a Stripe test account for your service within 1 working day. We'll email you when it's ready and include information about making demo payments and accessing reports.
+            </p>
+            <p class="govuk-body">
+              You'll find the Stripe test account in Overview under the service name. You'll have both a Pay test account ("sandbox") and Stripe test account.
             </p>
             <p class="govuk-body">
               If you’re not ready to set up a test account, you can

--- a/test/cypress/integration/payouts/payouts-list.cy.test.js
+++ b/test/cypress/integration/payouts/payouts-list.cy.test.js
@@ -99,6 +99,37 @@ describe('Payout list page', () => {
     })
   })
 
+  it('should show sample report for test account account if the test account has no payouts', () => {
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs,
+      payoutStubs.getLedgerPayoutSuccess({ gatewayAccountId: testGatewayAccountId })
+    ])
+
+    cy.visit('/payments-to-your-bank-account/test')
+    cy.get('h1').find('.govuk-tag').should('have.text', 'TEST')
+    cy.get('#payout-list').find('tr').should('have.length', 2)
+    cy.get('#pagination').should('not.exist')
+
+    cy.get('.govuk-breadcrumbs').within(() => {
+      cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
+      cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Payments to your bank account')
+      cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'TEST')
+    })
+  })
+
+  it('should show no payouts for live account if the live account has no payouts', () => {
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs,
+      payoutStubs.getLedgerPayoutSuccess({ gatewayAccountId: liveGatewayAccountId })
+    ])
+
+    cy.visit('/payments-to-your-bank-account')
+    cy.get('h1').find('.govuk-tag').should('have.text', 'LIVE')
+    cy.get('#pagination').should('not.exist')
+    cy.get('#payout-list').should('not.exist')
+    cy.get('.govuk-section-break.govuk-section-break--l.govuk-section-break--visible').next('p').contains('No payments to your bank account found on or after 22 May 2020')
+  })
+
   it('should show no permissions to access this page if the user has no stripe test accounts', () => {
     cy.task('setupStubs', [
       userStubs.getUserSuccess({


### PR DESCRIPTION
Description:
- Display 'No payments to your bank acount found on or after...' only for live accounts with no payouts
- Display sample report and inset text explaining test reports only for test accounts with no payouts
- Added a cypress test to verify if sample report is displayed on test account if there are no payouts
- Added a cypress test to verify if text is shown indicating no payouts on a live account if there are no payouts