### PR TITLE
PP-8015 Cookie banner - replace "aria-describedby" with "aria-label=cookie banner"

### DIFF
--- a/app/views/includes/cookie-message.njk
+++ b/app/views/includes/cookie-message.njk
@@ -1,4 +1,4 @@
-<div id="pay-cookie-banner" class="pay-cookie-banner govuk-width-container" data-module="pay-cookie-banner" role="region" aria-describedby="pay-cookie-banner__heading">
+<div id="pay-cookie-banner" class="pay-cookie-banner govuk-width-container" data-module="pay-cookie-banner" role="region" aria-label="cookie banner">
   <div class="pay-cookie-banner__wrapper">
     <h2 class="pay-cookie-banner__heading govuk-heading-m" id="pay-cookie-banner__heading">
       Can we store analytics cookies on your device?


### PR DESCRIPTION


- This will make the banner easier to navigate for screen readers.

