### PR TITLE
BAU Fix pact tests failing locally

### DIFF
--- a/app/services/clients/ledger.client.js
+++ b/app/services/clients/ledger.client.js
@@ -93,8 +93,8 @@ const transactionSummary = function transactionSummary (gatewayAccountId, fromDa
   return baseClient.get(configuration)
 }
 
-const payouts = function payouts (gatewayAccountIds = [], page = 1, displaySize) {
-  const configuration = {
+const payouts = function payouts (gatewayAccountIds = [], page = 1, displaySize, options = {}) {
+  const configuration = Object.assign({
     url: '/v1/payout',
     qs: {
       // qsStringifyOptions doesn't seem to be accepted here and the request library is deprecated for upstream changes
@@ -103,9 +103,8 @@ const payouts = function payouts (gatewayAccountIds = [], page = 1, displaySize)
       ...displaySize && { display_size: displaySize },
       page
     },
-    description: 'List payouts for a given gateway account ID',
-    ...defaultOptions
-  }
+    description: 'List payouts for a given gateway account ID'
+  }, defaultOptions, options)
 
   return baseClient.get(configuration)
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,5 @@
 --reporter spec
 --require ./test/test-helpers/test-env.js
 --require ./test/test-helpers/supress-logs.js
---timeout 5000
+--timeout 10000
 --exit

--- a/test/unit/clients/ledger-client/ledger-get-transaction-details.pact.test.js
+++ b/test/unit/clients/ledger-client/ledger-get-transaction-details.pact.test.js
@@ -21,7 +21,12 @@ const existingGatewayAccountId = '123456'
 const defaultTransactionId = 'ch_123abc456xyz'
 
 describe('ledger client', function () {
-  before(() => pactTestProvider.setup())
+  let ledgerUrl
+
+  before(async () => {
+    const opts = await pactTestProvider.setup()
+    ledgerUrl = `http://localhost:${opts.port}`
+  })
   after(() => pactTestProvider.finalize())
 
   describe('get transaction details', () => {
@@ -55,7 +60,10 @@ describe('ledger client', function () {
 
     it('should get transaction details successfully', function () {
       const getCreatedTransactionDetails = legacyConnectorParityTransformer.legacyConnectorTransactionParity(validCreatedTransactionDetailsResponse)
-      return ledgerClient.transaction(params.transaction_id, params.account_id, { transaction_type: 'PAYMENT' })
+      return ledgerClient.transaction(params.transaction_id, params.account_id, {
+        baseUrl: ledgerUrl,
+        transaction_type: 'PAYMENT'
+      })
         .then((ledgerResponse) => {
           expect(ledgerResponse).to.deep.equal(getCreatedTransactionDetails)
         })
@@ -96,7 +104,10 @@ describe('ledger client', function () {
 
     it('should get transaction with corporate card surcharge details successfully', function () {
       const getTransactionDetails = legacyConnectorParityTransformer.legacyConnectorTransactionParity(validTransactionDetailsResponse)
-      return ledgerClient.transaction(params.transaction_id, params.account_id, { transaction_type: 'PAYMENT' })
+      return ledgerClient.transaction(params.transaction_id, params.account_id, {
+        baseUrl: ledgerUrl,
+        transaction_type: 'PAYMENT'
+      })
         .then((ledgerResponse) => {
           expect(ledgerResponse).to.deep.equal(getTransactionDetails)
         })
@@ -136,7 +147,10 @@ describe('ledger client', function () {
 
     it('should get transaction with metadata details successfully', function () {
       const getTransactionDetails = legacyConnectorParityTransformer.legacyConnectorTransactionParity(validTransactionDetailsResponse)
-      return ledgerClient.transaction(params.transaction_id, params.account_id, { transaction_type: 'PAYMENT' })
+      return ledgerClient.transaction(params.transaction_id, params.account_id, { 
+        baseUrl: ledgerUrl,
+        transaction_type: 'PAYMENT'
+      })
         .then((ledgerResponse) => {
           expect(ledgerResponse).to.deep.equal(getTransactionDetails)
         })

--- a/test/unit/clients/ledger-client/ledger-get-transaction-events.pact.test.js
+++ b/test/unit/clients/ledger-client/ledger-get-transaction-events.pact.test.js
@@ -22,7 +22,12 @@ const defaultTransactionId = 'ch_123abc456xyz'
 const defaultTransactionState = 'a transaction has CREATED and AUTHORISATION_REJECTED payment events'
 
 describe('ledger client', function () {
-  before(() => pactTestProvider.setup())
+  let ledgerUrl
+
+  before(async () => {
+    const opts = await pactTestProvider.setup()
+    ledgerUrl = `http://localhost:${opts.port}`
+  })
   after(() => pactTestProvider.finalize())
 
   describe('get transaction events details', () => {
@@ -64,7 +69,7 @@ describe('ledger client', function () {
 
     it('should get transaction events successfully', function () {
       const getTransactionEventsDetails = legacyConnectorParityTransformer.legacyConnectorEventsParity(validTransactionEventsResponse)
-      return ledgerClient.events(params.transaction_id, params.account_id)
+      return ledgerClient.events(params.transaction_id, params.account_id, { baseUrl: ledgerUrl })
         .then((ledgerResponse) => {
           expect(ledgerResponse).to.deep.equal(getTransactionEventsDetails)
         })

--- a/test/unit/clients/ledger-client/ledger-get-transaction-summary.pact.test.js
+++ b/test/unit/clients/ledger-client/ledger-get-transaction-summary.pact.test.js
@@ -22,7 +22,12 @@ const existingGatewayAccountId = '123456'
 const defaultTransactionState = 'three payments and a refund all in success state exists'
 
 describe('ledger client transaction summary', function () {
-  before(() => pactTestProvider.setup())
+  let ledgerUrl
+
+  before(async () => {
+    const opts = await pactTestProvider.setup()
+    ledgerUrl = `http://localhost:${opts.port}`
+  })
   after(() => pactTestProvider.finalize())
 
   describe('get transaction summary', () => {
@@ -56,7 +61,7 @@ describe('ledger client transaction summary', function () {
 
     it('should get transaction summary successfully', function () {
       const getTransactionSummaryDetails = legacyConnectorParityTransformer.legacyConnectorTransactionSummaryParity(validTransactionSummaryResponse)
-      return ledgerClient.transactionSummary(params.account_id, params.from_date, params.to_date)
+      return ledgerClient.transactionSummary(params.account_id, params.from_date, params.to_date, { baseUrl: ledgerUrl })
         .then((ledgerResponse) => {
           expect(ledgerResponse).to.deep.equal(getTransactionSummaryDetails)
         })

--- a/test/unit/clients/ledger-client/ledger-pact-test-provider.js
+++ b/test/unit/clients/ledger-client/ledger-pact-test-provider.js
@@ -3,21 +3,16 @@
 const { Pact } = require('@pact-foundation/pact')
 
 const path = require('path')
-const port = parseInt(process.env.LEDGER_URL.match(/\d+(\.\d+)?$/g)[0], 10)
 
 const pactProvider = new Pact({
   consumer: 'selfservice',
   provider: 'ledger',
-  port: port,
   log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
   dir: path.resolve(process.cwd(), 'pacts'),
   spec: 2,
   pactfileWriteMode: 'merge'
 })
 module.exports = {
-  getPort: function () {
-    return port
-  },
   addInteraction: function (pact) {
     return pactProvider.addInteraction(pact)
   },

--- a/test/unit/clients/ledger-client/ledger-search-payout.pact.test.js
+++ b/test/unit/clients/ledger-client/ledger-search-payout.pact.test.js
@@ -14,7 +14,12 @@ const { expect } = chai
 const GATEWAY_ACCOUNT_ID = '654321'
 
 describe('ledger client', () => {
-  before(() => pactTestProvider.setup())
+  let ledgerUrl
+
+  before(async () => {
+    const opts = await pactTestProvider.setup()
+    ledgerUrl = `http://localhost:${opts.port}`
+  })
   after(() => pactTestProvider.finalize())
 
   describe('search payouts', () => {
@@ -50,7 +55,7 @@ describe('ledger client', () => {
     afterEach(() => pactTestProvider.verify())
 
     it('should search payouts successfully', async () => {
-      const ledgerResult = await ledgerClient.payouts([ GATEWAY_ACCOUNT_ID ], 1)
+      const ledgerResult = await ledgerClient.payouts([ GATEWAY_ACCOUNT_ID ], 1, null, { baseUrl: ledgerUrl })
       expect(ledgerResult).to.deep.equal(response)
     })
   })

--- a/test/unit/clients/ledger-client/ledger-search-transaction.pact.test.js
+++ b/test/unit/clients/ledger-client/ledger-search-transaction.pact.test.js
@@ -20,7 +20,12 @@ chai.use(chaiAsPromised)
 const existingGatewayAccountId = '123456'
 
 describe('ledger client', function () {
-  before(() => pactTestProvider.setup())
+  let ledgerUrl
+
+  before(async () => {
+    const opts = await pactTestProvider.setup()
+    ledgerUrl = `http://localhost:${opts.port}`
+  })
   after(() => pactTestProvider.finalize())
 
   describe('search transactions with no filters', () => {
@@ -89,7 +94,7 @@ describe('ledger client', function () {
 
     it('should search transaction successfully', function () {
       const searchTransactionDetails = legacyConnectorParityTransformer.legacyConnectorTransactionsParity(validTransactionSearchResponse)
-      return ledgerClient.transactions(params.account_id)
+      return ledgerClient.transactions(params.account_id, {}, { baseUrl: ledgerUrl })
         .then((ledgerResponse) => {
           expect(ledgerResponse).to.deep.equal(searchTransactionDetails)
         })
@@ -149,7 +154,7 @@ describe('ledger client', function () {
 
     it('should search transaction successfully', function () {
       const searchTransactionDetails = legacyConnectorParityTransformer.legacyConnectorTransactionsParity(validFilterTransactionResponse)
-      return ledgerClient.transactions(params.account_id, params.filters)
+      return ledgerClient.transactions(params.account_id, params.filters, { baseUrl: ledgerUrl })
         .then((ledgerResponse) => {
           expect(ledgerResponse).to.deep.equal(searchTransactionDetails)
         })
@@ -220,7 +225,7 @@ describe('ledger client', function () {
 
     it('should search transaction successfully', function () {
       const searchTransactionDetails = legacyConnectorParityTransformer.legacyConnectorTransactionsParity(validFilterTransactionResponse)
-      return ledgerClient.transactions(params.account_id, params.filters)
+      return ledgerClient.transactions(params.account_id, params.filters, { baseUrl: ledgerUrl })
         .then((ledgerResponse) => {
           expect(ledgerResponse).to.deep.equal(searchTransactionDetails)
         })
@@ -296,7 +301,7 @@ describe('ledger client', function () {
 
     it('should filter transaction successfully', function () {
       const searchTransactionDetails = legacyConnectorParityTransformer.legacyConnectorTransactionsParity(validTransactionSearchResponse)
-      return ledgerClient.transactions(params.account_id, params.filters)
+      return ledgerClient.transactions(params.account_id, params.filters, { baseUrl: ledgerUrl })
         .then((ledgerResponse) => {
           expect(ledgerResponse).to.deep.equal(searchTransactionDetails)
         })
@@ -359,7 +364,7 @@ describe('ledger client', function () {
 
     it('should filter transaction successfully', function () {
       const searchTransactionDetails = legacyConnectorParityTransformer.legacyConnectorTransactionsParity(validTransactionSearchResponse)
-      return ledgerClient.transactions(params.account_id, params.filters)
+      return ledgerClient.transactions(params.account_id, params.filters, { baseUrl: ledgerUrl })
         .then((ledgerResponse) => {
           expect(ledgerResponse).to.deep.equal(searchTransactionDetails)
         })
@@ -411,7 +416,7 @@ describe('ledger client', function () {
 
     it('should filter transaction successfully', function () {
       const searchTransactionDetails = legacyConnectorParityTransformer.legacyConnectorTransactionsParity(validTransactionSearchResponse)
-      return ledgerClient.transactions(params.account_id, params.filters)
+      return ledgerClient.transactions(params.account_id, params.filters, { baseUrl: ledgerUrl })
         .then((ledgerResponse) => {
           expect(ledgerResponse).to.deep.equal(searchTransactionDetails)
         })


### PR DESCRIPTION
Pact tests have begun failing locally as they are taking longer than the 5 second timeout. It's unclear why, but increasing the timeout allows for them to pass.

Also, we were using a hardcoded port defined in the test.env file when running ledger pact tests. Instead default to using a free port assigned by the pact provider and pass this to the client when making request to ledger, as we do for all other pact tests.

This means that there isn't possible conflict with another process using the same port.