### PR TITLE
PP-8032 Standardise error handling

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-03-30T09:42:57Z",
+  "generated_at": "2021-05-06T08:10:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -141,7 +141,7 @@
         "hashed_secret": "48dc804af4a64a0fb46349beef10e94f4fef6a08",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 78,
+        "line_number": 79,
         "type": "Secret Keyword"
       }
     ],

--- a/app/controllers/billing-address/toggle-billing-address.controller.js
+++ b/app/controllers/billing-address/toggle-billing-address.controller.js
@@ -6,24 +6,23 @@ const logger = require('../../utils/logger')(__filename)
 const { response } = require('../../utils/response')
 const paths = require('../../paths')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
-const { renderErrorView } = require('../../utils/response')
 const serviceService = require('../../services/service.service')
 const { CORRELATION_HEADER } = require('../../utils/correlation-header')
 
-const getIndex = (req, res) => {
+function getIndex (req, res) {
   const model = {
     collectBillingAddress: req.service.collectBillingAddress
   }
   response(req, res, 'billing-address/index', model)
 }
 
-const postIndex = async (req, res) => {
+async function postIndex (req, res, next) {
   const correlationId = lodash.get(req, 'headers.' + CORRELATION_HEADER, '')
   const serviceExternalId = lodash.get(req, 'service.externalId')
   const isEnabled = req.body['billing-address-toggle'] === 'on'
-  const result = await serviceService.toggleCollectBillingAddress(serviceExternalId, isEnabled, correlationId)
 
   try {
+    const result = await serviceService.toggleCollectBillingAddress(serviceExternalId, isEnabled, correlationId)
     if (result.collect_billing_address) {
       req.flash('generic', 'Billing address is turned on for this service')
     } else {
@@ -31,8 +30,8 @@ const postIndex = async (req, res) => {
     }
     logger.info(`Updated collect billing address enabled(${req.body['billing-address-toggle']})`)
     res.redirect(formatAccountPathsFor(paths.account.toggleBillingAddress.index, req.account && req.account.external_id))
-  } catch (error) {
-    renderErrorView(req, res, error.message)
+  } catch (err) {
+    next(err)
   }
 }
 

--- a/app/controllers/digital-wallet/post-apple-pay.controller.js
+++ b/app/controllers/digital-wallet/post-apple-pay.controller.js
@@ -2,12 +2,11 @@
 
 const paths = require('../../paths')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
-const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { CORRELATION_HEADER } = require('../../utils/correlation-header')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
-module.exports = async (req, res) => {
+module.exports = async (req, res, next) => {
   const gatewayAccountId = req.account.gateway_account_id
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   const enable = req.body['apple-pay'] === 'on'
@@ -18,7 +17,7 @@ module.exports = async (req, res) => {
 
     req.flash('generic', `Apple Pay successfully ${enable ? 'enabled' : 'disabled'}.`)
     return res.redirect(formattedPath)
-  } catch (error) {
-    return renderErrorView(req, res, false, error.errorCode)
+  } catch (err) {
+    next(err)
   }
 }

--- a/app/controllers/edit-merchant-details/post-edit.controller.js
+++ b/app/controllers/edit-merchant-details/post-edit.controller.js
@@ -2,8 +2,6 @@
 
 const lodash = require('lodash')
 
-const logger = require('../../utils/logger')(__filename)
-const { renderErrorView } = require('../../utils/response')
 const paths = require('../../paths')
 const serviceService = require('../../services/service.service')
 const formatServicePathsFor = require('../../utils/format-service-paths-for')
@@ -126,7 +124,7 @@ const buildErrorsPageData = (errors, form) => {
   }
 }
 
-module.exports = async function (req, res) {
+module.exports = async function updateMerchantDetails (req, res, next) {
   try {
     const correlationId = lodash.get(req, 'correlationId')
     const serviceExternalId = req.service.externalId
@@ -143,8 +141,7 @@ module.exports = async function (req, res) {
       lodash.set(req, 'session.pageData.editMerchantDetails', pageData)
       res.redirect(formatServicePathsFor(paths.service.merchantDetails.edit, serviceExternalId))
     }
-  } catch (error) {
-    logger.error(`Error submitting organisation details - ${error.stack}`)
-    renderErrorView(req, res)
+  } catch (err) {
+    next(err)
   }
 }

--- a/app/controllers/invite-user.controller.js
+++ b/app/controllers/invite-user.controller.js
@@ -1,6 +1,5 @@
 const lodash = require('lodash')
-const logger = require('../utils/logger')(__filename)
-const { renderErrorView, response } = require('../utils/response.js')
+const { response } = require('../utils/response.js')
 const userService = require('../services/user.service.js')
 const paths = require('../paths.js')
 const rolesModule = require('../utils/roles')
@@ -26,75 +25,64 @@ const messages = {
   }
 }
 
-module.exports = {
-
-  /**
-   * Show 'Invite a team member' page
-   * @param req
-   * @param res
-   */
-
-  index: (req, res) => {
-    let roles = rolesModule.roles
-    const externalServiceId = req.service.externalId
-    const teamMemberIndexLink = formatServicePathsFor(paths.service.teamMembers.index, externalServiceId)
-    const teamMemberInviteSubmitLink = formatServicePathsFor(paths.service.teamMembers.invite, externalServiceId)
-    const serviceHasAgentInitiatedMotoEnabled = req.service.agentInitiatedMotoEnabled
-    const invitee = lodash.get(req, 'session.pageData.invitee', '')
-    let data = {
-      teamMemberIndexLink: teamMemberIndexLink,
-      teamMemberInviteSubmitLink: teamMemberInviteSubmitLink,
-      serviceHasAgentInitiatedMotoEnabled: serviceHasAgentInitiatedMotoEnabled,
-      admin: { id: roles['admin'].extId },
-      viewAndRefund: { id: roles['view-and-refund'].extId },
-      view: { id: roles['view-only'].extId },
-      viewAndInitiateMoto: { id: roles['view-and-initiate-moto'].extId },
-      viewRefundAndInitiateMoto: { id: roles['view-refund-and-initiate-moto'].extId },
-      invitee
-    }
-
-    return response(req, res, 'team-members/team-member-invite', data)
-  },
-
-  /**
-   * Save invite
-   * @param req
-   * @param res
-   */
-  invite: (req, res) => {
-    const correlationId = req.correlationId
-    const senderId = req.user.externalId
-    const externalServiceId = req.service.externalId
-    const invitee = req.body['invitee-email'].trim()
-    const roleId = parseInt(req.body['role-input'])
-
-    const role = rolesModule.getRoleByExtId(roleId)
-
-    if (!emailValidator(invitee)) {
-      req.flash('genericError', 'Enter a valid email address')
-      lodash.set(req, 'session.pageData', { invitee })
-      res.redirect(303, formatServicePathsFor(paths.service.teamMembers.invite, externalServiceId))
-    } else if (!role) {
-      logger.error(`Cannot identify role from user input ${roleId}`)
-      renderErrorView(req, res, messages.inviteError, 200)
-    } else {
-      userService.inviteUser(invitee, senderId, externalServiceId, role.name, correlationId)
-        .then(() => {
-          if (lodash.has(req, 'session.pageData.invitee')) delete req.session.pageData.invitee
-          req.flash('generic', `Invite sent to ${invitee}`)
-          res.redirect(303, formatServicePathsFor(paths.service.teamMembers.index, externalServiceId))
-        })
-        .catch(err => {
-          switch (err.errorCode) {
-            case 412:
-              response(req, res, 'error-with-link', messages.emailConflict(invitee, externalServiceId))
-              break
-            default:
-              logger.error(`Unable to send invitation to user - ${JSON.stringify(err)}`)
-              renderErrorView(req, res, messages.inviteError, 200)
-          }
-        })
-    }
+function index (req, res) {
+  let roles = rolesModule.roles
+  const externalServiceId = req.service.externalId
+  const teamMemberIndexLink = formatServicePathsFor(paths.service.teamMembers.index, externalServiceId)
+  const teamMemberInviteSubmitLink = formatServicePathsFor(paths.service.teamMembers.invite, externalServiceId)
+  const serviceHasAgentInitiatedMotoEnabled = req.service.agentInitiatedMotoEnabled
+  const invitee = lodash.get(req, 'session.pageData.invitee', '')
+  let data = {
+    teamMemberIndexLink: teamMemberIndexLink,
+    teamMemberInviteSubmitLink: teamMemberInviteSubmitLink,
+    serviceHasAgentInitiatedMotoEnabled: serviceHasAgentInitiatedMotoEnabled,
+    admin: { id: roles['admin'].extId },
+    viewAndRefund: { id: roles['view-and-refund'].extId },
+    view: { id: roles['view-only'].extId },
+    viewAndInitiateMoto: { id: roles['view-and-initiate-moto'].extId },
+    viewRefundAndInitiateMoto: { id: roles['view-refund-and-initiate-moto'].extId },
+    invitee
   }
 
+  return response(req, res, 'team-members/team-member-invite', data)
+}
+
+async function invite (req, res, next) {
+  const correlationId = req.correlationId
+  const senderId = req.user.externalId
+  const externalServiceId = req.service.externalId
+  const invitee = req.body['invitee-email'].trim()
+  const roleId = parseInt(req.body['role-input'])
+
+  const role = rolesModule.getRoleByExtId(roleId)
+
+  if (!emailValidator(invitee)) {
+    req.flash('genericError', 'Enter a valid email address')
+    lodash.set(req, 'session.pageData', { invitee })
+    res.redirect(303, formatServicePathsFor(paths.service.teamMembers.invite, externalServiceId))
+  } else if (!role) {
+    next(new Error(`Cannot identify role from user input ${roleId}`))
+  } else {
+    try {
+      await userService.inviteUser(invitee, senderId, externalServiceId, role.name, correlationId)
+      if (lodash.has(req, 'session.pageData.invitee')) {
+        delete req.session.pageData.invitee
+      }
+      req.flash('generic', `Invite sent to ${invitee}`)
+      res.redirect(303, formatServicePathsFor(paths.service.teamMembers.index, externalServiceId))
+    } catch (err) {
+      switch (err.errorCode) {
+        case 412:
+          response(req, res, 'error-with-link', messages.emailConflict(invitee, externalServiceId))
+          break
+        default:
+          next(err)
+      }
+    }
+  }
+}
+
+module.exports = {
+  index,
+  invite
 }

--- a/app/controllers/invite-validation.controller.js
+++ b/app/controllers/invite-validation.controller.js
@@ -1,86 +1,67 @@
 'use strict'
 
-const logger = require('../utils/logger')(__filename)
 const { renderErrorView } = require('../utils/response')
 const validateInviteService = require('../services/validate-invite.service')
 const serviceRegistrationService = require('../services/service-registration.service')
 const paths = require('../paths')
 
-// Constants
-const messages = {
-  missingCookie: 'Unable to process registration at this time',
-  internalError: 'Unable to process registration at this time',
-  linkExpired: 'This invitation is no longer valid',
-  invalidOtp: 'Invalid verification code'
-}
+/**
+ * Intermediate endpoint which captures the invite code and validate.
+ * Upon success this forwards the request to proceed with registration.
+ * In case of service invite it also sends the otp verification code.
+ *
+ * @param req
+ * @param res
+ * @returns {Promise.<T>}
+ */
+async function validateInvite (req, res, next) {
+  const code = req.params.code
+  const correlationId = req.correlationId
 
-const handleError = (req, res, err) => {
-  logger.warn(`Invalid invite code attempted ${req.code}, error = ${err.errorCode}`)
+  try {
+    const invite = await validateInviteService.getValidatedInvite(code, correlationId)
+    if (!req.register_invite) {
+      req.register_invite = {}
+    }
 
-  switch (err.errorCode) {
-    case 404:
-      renderErrorView(req, res, messages.missingCookie, 404)
-      break
-    case 410:
-      renderErrorView(req, res, messages.linkExpired, 410)
-      break
-    default:
-      renderErrorView(req, res, messages.internalError, 500)
+    req.register_invite.code = code
+
+    if (invite.telephone_number) {
+      req.register_invite.telephone_number = invite.telephone_number
+    }
+
+    if (invite.email) {
+      req.register_invite.email = invite.email
+    }
+
+    if (invite.type === 'user') {
+      req.register_invite.email = invite.email
+      const redirectTarget = invite.user_exist ? paths.registerUser.subscribeService : paths.registerUser.registration
+      res.redirect(302, redirectTarget)
+    } else if (invite.type === 'service') {
+      if (invite.user_exist) {
+        res.redirect(302, paths.serviceSwitcher.index)
+      } else {
+        await serviceRegistrationService.generateServiceInviteOtpCode(code, correlationId)
+        res.redirect(302, paths.selfCreateService.otpVerify)
+      }
+    } else {
+      next(new Error('Unrecognised invite type'))
+    }
+  } catch (err) {
+    switch (err.errorCode) {
+      case 404:
+        renderErrorView(req, res, 'There has been a problem proceeding with this registration. Please try again.', 404)
+        break
+      case 410:
+        renderErrorView(req, res, 'This invitation is no longer valid', 410)
+        break
+      default:
+        next(err)
+    }
   }
 }
 
 module.exports = {
-
-  /**
-   * Intermediate endpoint which captures the invite code and validate.
-   * Upon success this forwards the request to proceed with registration.
-   * In case of service invite it also sends the otp verification code.
-   *
-   * @param req
-   * @param res
-   * @returns {Promise.<T>}
-   */
-  validateInvite: (req, res) => {
-    const code = req.params.code
-    const correlationId = req.correlationId
-    const processAndRedirect = (invite) => {
-      if (!req.register_invite) {
-        req.register_invite = {}
-      }
-
-      req.register_invite.code = code
-
-      if (invite.telephone_number) {
-        req.register_invite.telephone_number = invite.telephone_number
-      }
-
-      if (invite.email) {
-        req.register_invite.email = invite.email
-      }
-
-      if (invite.type === 'user') {
-        req.register_invite.email = invite.email
-        const redirectTarget = invite.user_exist ? paths.registerUser.subscribeService : paths.registerUser.registration
-        res.redirect(302, redirectTarget)
-      } else if (invite.type === 'service') {
-        if (invite.user_exist) {
-          res.redirect(302, paths.serviceSwitcher.index)
-        } else {
-          serviceRegistrationService.generateServiceInviteOtpCode(code, correlationId)
-            .then(() => {
-              res.redirect(302, paths.selfCreateService.otpVerify)
-            })
-            .catch((err) => {
-              handleError(req, res, err)
-            })
-        }
-      } else {
-        handleError(req, res, 'Unrecognised invite type')
-      }
-    }
-
-    return validateInviteService.getValidatedInvite(code, correlationId)
-      .then(processAndRedirect)
-      .catch((err) => handleError(req, res, err))
-  }
+  validateInvite
 }

--- a/app/controllers/login/otp-login.controller.js
+++ b/app/controllers/login/otp-login.controller.js
@@ -1,24 +1,21 @@
 'use strict'
 
-const logger = require('../../utils/logger')(__filename)
 const userService = require('../../services/user.service')
-const { renderErrorView } = require('../../utils/response')
 const CORRELATION_HEADER = require('../../utils/correlation-header').CORRELATION_HEADER
 
-module.exports = (req, res) => {
+module.exports = async function showOtpLogin (req, res, next) {
   const PAGE_PARAMS = {}
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   PAGE_PARAMS.authenticatorMethod = req.user.secondFactor
 
   if (!req.session.sentCode && req.user.secondFactor === 'SMS') {
-    userService.sendOTP(req.user, correlationId).then(() => {
+    try {
+      await userService.sendOTP(req.user, correlationId)
       req.session.sentCode = true
       res.render('login/otp-login', PAGE_PARAMS)
-    })
-      .catch(err => {
-        renderErrorView(req, res)
-        logger.error(err)
-      })
+    } catch (err) {
+      next(err)
+    }
   } else {
     res.render('login/otp-login', PAGE_PARAMS)
   }

--- a/app/controllers/login/send-again-post.controller.js
+++ b/app/controllers/login/send-again-post.controller.js
@@ -1,21 +1,19 @@
 'use strict'
 
-const logger = require('../../utils/logger')(__filename)
 const userService = require('../../services/user.service')
 const paths = require('../../paths')
 const { renderErrorView } = require('../../utils/response')
 const CORRELATION_HEADER = require('../../utils/correlation-header').CORRELATION_HEADER
 
-module.exports = (req, res) => {
+module.exports = async function resendOtp (req, res, next) {
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   if (req.user.secondFactor === 'SMS') {
-    userService.sendOTP(req.user, correlationId).then(() => {
+    try {
+      await userService.sendOTP(req.user, correlationId)
       res.redirect(paths.user.otpLogIn)
-    })
-      .catch(err => {
-        renderErrorView(req, res)
-        logger.error(err)
-      })
+    } catch (err) {
+      next(err)
+    }
   } else {
     renderErrorView(req, res, 'You do not use text messages to sign in', 400)
   }

--- a/app/controllers/payment-types/get-index.controller.js
+++ b/app/controllers/payment-types/get-index.controller.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { response, renderErrorView } = require('../../utils/response')
+const { response } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
@@ -52,7 +52,7 @@ function formatCardsForTemplate (allCards, acceptedCards, threeDSEnabled) {
   }
 }
 
-module.exports = async (req, res) => {
+module.exports = async function showCardTypes (req, res, next) {
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = req.account.gateway_account_id
 
@@ -61,7 +61,7 @@ module.exports = async (req, res) => {
     const { card_types: acceptedCards } = await connector.getAcceptedCardsForAccountPromise(accountId, correlationId)
 
     response(req, res, 'payment-types/card-types', formatCardsForTemplate(allCards, acceptedCards, req.account.requires3ds))
-  } catch (error) {
-    renderErrorView(req, res, 'Unable to fetch payment types. Please try again or contact support team.', error.errorCode)
+  } catch (err) {
+    next(err)
   }
 }

--- a/app/controllers/payment-types/post-index.controller.js
+++ b/app/controllers/payment-types/post-index.controller.js
@@ -4,12 +4,11 @@ const lodash = require('lodash')
 
 const paths = require('../../paths')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
-const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
-module.exports = async (req, res) => {
+module.exports = async function updateCardTypes (req, res, next) {
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = req.account.gateway_account_id
 
@@ -33,7 +32,7 @@ module.exports = async (req, res) => {
     return res.redirect(
       formatAccountPathsFor(paths.account.paymentTypes.index, req.account && req.account.external_id)
     )
-  } catch (error) {
-    return renderErrorView(req, res, 'Unable to update payment types. Please try again or contact support team.', error.errorCode)
+  } catch (err) {
+    next(err)
   }
 }

--- a/app/controllers/policy/policy-download.controller.js
+++ b/app/controllers/policy/policy-download.controller.js
@@ -1,12 +1,12 @@
 'use strict'
 
 const logger = require('../../utils/logger')(__filename)
-const { response, renderErrorView } = require('../../utils/response')
+const { response } = require('../../utils/response')
 
 const supportedPolicyDocuments = require('./supported-policy-documents')
 const policyBucket = require('./aws-s3-policy-bucket')
 
-const downloadDocumentsPolicyPage = async function downloadDocumentsPolicyPage (req, res, next) {
+async function downloadDocumentsPolicyPage (req, res, next) {
   const key = req.params.key
 
   try {
@@ -15,9 +15,8 @@ const downloadDocumentsPolicyPage = async function downloadDocumentsPolicyPage (
 
     logger.info(`User ${req.user.externalId} signed private link for ${key}: ${link}`)
     return response(req, res, documentConfig.template, { link })
-  } catch (error) {
-    logger.error(`Unable to generate document link ${error.message}`)
-    renderErrorView(req, res, error.message)
+  } catch (err) {
+    next(err)
   }
 }
 

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.js
@@ -2,7 +2,6 @@
 
 const lodash = require('lodash')
 
-const logger = require('../../../utils/logger')(__filename)
 const goLiveStageToNextPagePath = require('../go-live-stage-to-next-page-path')
 const goLiveStage = require('../../../models/go-live-stage')
 const paths = require('../../../paths')
@@ -10,7 +9,6 @@ const {
   validateMandatoryField, validateOptionalField, validatePostcode, validatePhoneNumber
 } = require('../../../utils/validation/server-side-form-validations')
 const { updateService } = require('../../../services/service.service')
-const { renderErrorView } = require('../../../utils/response')
 const { validPaths, ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
 const formatServicePathsFor = require('../../../utils/format-service-paths-for')
 
@@ -113,7 +111,7 @@ const buildErrorsPageData = (form, errors) => {
   }
 }
 
-module.exports = async function (req, res) {
+module.exports = async function submitOrganisationAddress (req, res, next) {
   try {
     const form = normaliseForm(req.body)
     const errors = validateForm(form)
@@ -129,8 +127,7 @@ module.exports = async function (req, res) {
       lodash.set(req, 'session.pageData.requestToGoLive.organisationAddress', pageData)
       res.redirect(303, formatServicePathsFor(paths.service.requestToGoLive.organisationAddress, req.service.externalId))
     }
-  } catch (error) {
-    logger.error(`Error submitting organisation address - ${error.stack}`)
-    renderErrorView(req, res)
+  } catch (err) {
+    next(err)
   }
 }

--- a/app/controllers/service-roles-update.controller.js
+++ b/app/controllers/service-roles-update.controller.js
@@ -21,117 +21,101 @@ let serviceIdMismatchView = (req, res, adminUserExternalId, targetServiceExterna
 
 const formatServicePathsFor = require('../utils/format-service-paths-for')
 
-module.exports = {
-  /**
-   *
-   * @param req
-   * @param res
-   * @path param externalId
-   */
-  index: async (req, res) => {
-    let correlationId = req.correlationId
-    let externalUserId = req.params.externalUserId
-    let serviceExternalId = req.service.externalId
-    let serviceHasAgentInitiatedMotoEnabled = req.service.agentInitiatedMotoEnabled
+async function index (req, res, next) {
+  let correlationId = req.correlationId
+  let externalUserId = req.params.externalUserId
+  let serviceExternalId = req.service.externalId
+  let serviceHasAgentInitiatedMotoEnabled = req.service.agentInitiatedMotoEnabled
 
-    let viewData = user => {
-      const editPermissionsLink = formatServicePathsFor(paths.service.teamMembers.permissions, serviceExternalId, user.externalId)
-      const teamMemberIndexLink = formatServicePathsFor(paths.service.teamMembers.index, serviceExternalId)
-      const teamMemberProfileLink = formatServicePathsFor(paths.service.teamMembers.show, serviceExternalId, user.externalId)
+  let viewData = user => {
+    const editPermissionsLink = formatServicePathsFor(paths.service.teamMembers.permissions, serviceExternalId, user.externalId)
+    const teamMemberIndexLink = formatServicePathsFor(paths.service.teamMembers.index, serviceExternalId)
+    const teamMemberProfileLink = formatServicePathsFor(paths.service.teamMembers.show, serviceExternalId, user.externalId)
 
-      const role = user.getRoleForService(serviceExternalId)
-      return {
-        email: user.email,
-        editPermissionsLink,
-        teamMemberIndexLink,
-        teamMemberProfileLink,
-        serviceHasAgentInitiatedMotoEnabled,
-        admin: {
-          id: roles['admin'].extId,
-          checked: _.get(role, 'name') === 'admin' ? 'checked' : ''
-        },
-        viewAndRefund: {
-          id: roles['view-and-refund'].extId,
-          checked: _.get(role, 'name') === 'view-and-refund' ? 'checked' : ''
-        },
-        view: {
-          id: roles['view-only'].extId,
-          checked: _.get(role, 'name') === 'view-only' ? 'checked' : ''
-        },
-        viewAndInitiateMoto: {
-          id: roles['view-and-initiate-moto'].extId,
-          checked: _.get(role, 'name') === 'view-and-initiate-moto' ? 'checked' : ''
-        },
-        viewRefundAndInitiateMoto: {
-          id: roles['view-refund-and-initiate-moto'].extId,
-          checked: _.get(role, 'name') === 'view-refund-and-initiate-moto' ? 'checked' : ''
-        }
+    const role = user.getRoleForService(serviceExternalId)
+    return {
+      email: user.email,
+      editPermissionsLink,
+      teamMemberIndexLink,
+      teamMemberProfileLink,
+      serviceHasAgentInitiatedMotoEnabled,
+      admin: {
+        id: roles['admin'].extId,
+        checked: _.get(role, 'name') === 'admin' ? 'checked' : ''
+      },
+      viewAndRefund: {
+        id: roles['view-and-refund'].extId,
+        checked: _.get(role, 'name') === 'view-and-refund' ? 'checked' : ''
+      },
+      view: {
+        id: roles['view-only'].extId,
+        checked: _.get(role, 'name') === 'view-only' ? 'checked' : ''
+      },
+      viewAndInitiateMoto: {
+        id: roles['view-and-initiate-moto'].extId,
+        checked: _.get(role, 'name') === 'view-and-initiate-moto' ? 'checked' : ''
+      },
+      viewRefundAndInitiateMoto: {
+        id: roles['view-refund-and-initiate-moto'].extId,
+        checked: _.get(role, 'name') === 'view-refund-and-initiate-moto' ? 'checked' : ''
       }
-    }
-
-    if (req.user.externalId === externalUserId) {
-      return renderErrorView(req, res, 'Not allowed to update self permission', 403)
-    }
-
-    try {
-      const user = await userService.findByExternalId(externalUserId, correlationId)
-      if (!hasSameService(req.user, user, serviceExternalId)) {
-        return serviceIdMismatchView(req, res, req.user.externalId, serviceExternalId, user.externalId)
-      } else {
-        return response(req, res, 'team-members/team-member-permissions', viewData(user))
-      }
-    } catch (err) {
-      logger.error(`Error displaying user permission view [${err}]`)
-      return renderErrorView(req, res, 'Unable to locate the user')
-    }
-  },
-
-  /**
-   *
-   * @param req
-   * @param res
-   * @path param externalId
-   */
-  update: async (req, res) => {
-    let externalUserId = req.params.externalUserId
-    let serviceExternalId = req.service.externalId
-    let targetRoleExtId = parseInt(req.body['role-input'])
-    let targetRole = getRole(targetRoleExtId)
-    let correlationId = req.correlationId
-    let onSuccess = (user) => {
-      req.flash('generic', 'Permissions have been updated')
-      res.redirect(303, formatServicePathsFor(paths.service.teamMembers.show, serviceExternalId, user.externalId))
-    }
-
-    if (req.user.externalId === externalUserId) {
-      return renderErrorView(req, res, 'Not allowed to update self permission', 403)
-    }
-
-    if (!targetRole) {
-      logger.error(`Cannot identify role from user input ${targetRoleExtId}. possible hack`)
-      return renderErrorView(req, res, 'Unable to update user permission')
-    }
-
-    try {
-      const user = await userService.findByExternalId(externalUserId, correlationId)
-      if (!hasSameService(req.user, user, serviceExternalId)) {
-        serviceIdMismatchView(req, res, req.user.externalId, serviceExternalId, user.externalId, correlationId)
-      } else {
-        if (targetRole.name === user.getRoleForService(serviceExternalId)) {
-          return onSuccess(user)
-        } else {
-          try {
-            await userService.updateServiceRole(user.externalId, targetRole.name, serviceExternalId, correlationId)
-            return onSuccess(user)
-          } catch (err) {
-            logger.error(`Error updating user service role [${err}]`)
-            return renderErrorView(req, res, 'Unable to update user permission')
-          }
-        }
-      }
-    } catch (err) {
-      logger.error(`Error locating user when updating user service role [${err}]`)
-      return renderErrorView(req, res, 'Unable to locate the user')
     }
   }
+
+  if (req.user.externalId === externalUserId) {
+    return renderErrorView(req, res, 'Not allowed to update self permission', 403)
+  }
+
+  try {
+    const user = await userService.findByExternalId(externalUserId, correlationId)
+    if (!hasSameService(req.user, user, serviceExternalId)) {
+      return serviceIdMismatchView(req, res, req.user.externalId, serviceExternalId, user.externalId)
+    } else {
+      return response(req, res, 'team-members/team-member-permissions', viewData(user))
+    }
+  } catch (err) {
+    next(err)
+  }
+}
+
+async function update (req, res, next) {
+  let externalUserId = req.params.externalUserId
+  let serviceExternalId = req.service.externalId
+  let targetRoleExtId = parseInt(req.body['role-input'])
+  let targetRole = getRole(targetRoleExtId)
+  let correlationId = req.correlationId
+  let onSuccess = (user) => {
+    req.flash('generic', 'Permissions have been updated')
+    res.redirect(303, formatServicePathsFor(paths.service.teamMembers.show, serviceExternalId, user.externalId))
+  }
+
+  if (req.user.externalId === externalUserId) {
+    return renderErrorView(req, res, 'Not allowed to update self permission', 403)
+  }
+
+  if (!targetRole) {
+    logger.error(`Cannot identify role from user input ${targetRoleExtId}. possible hack`)
+    return renderErrorView(req, res, 'Unable to update user permission')
+  }
+
+  try {
+    const user = await userService.findByExternalId(externalUserId, correlationId)
+    if (!hasSameService(req.user, user, serviceExternalId)) {
+      serviceIdMismatchView(req, res, req.user.externalId, serviceExternalId, user.externalId, correlationId)
+    } else {
+      if (targetRole.name === user.getRoleForService(serviceExternalId)) {
+        return onSuccess(user)
+      } else {
+        await userService.updateServiceRole(user.externalId, targetRole.name, serviceExternalId, correlationId)
+        return onSuccess(user)
+      }
+    }
+  } catch (err) {
+    next(err)
+  }
+}
+
+module.exports = {
+  index,
+  update
 }

--- a/app/controllers/stripe-setup/add-psp-account-details/get.controller.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/get.controller.js
@@ -2,11 +2,11 @@
 
 const paths = require('../../../paths')
 const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
-const { response, renderErrorView } = require('../../../utils/response')
+const { response } = require('../../../utils/response')
 
-module.exports = async (req, res) => {
+module.exports = async function getPspAccountDetails (req, res, next) {
   if (!req.account || !req.account.connectorGatewayAccountStripeProgress) {
-    return renderErrorView(req, res, 'Please try again or contact support team')
+    return next(new Error('Stripe setup progress is not available on request'))
   }
 
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress

--- a/app/controllers/stripe-setup/bank-details/post.controller.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.js
@@ -2,8 +2,7 @@
 
 const lodash = require('lodash')
 
-const logger = require('../../../utils/logger')(__filename)
-const { response, renderErrorView } = require('../../../utils/response')
+const { response } = require('../../../utils/response')
 const bankDetailsValidations = require('./bank-details-validations')
 const { updateBankAccount } = require('../../../services/clients/stripe/stripe.client')
 const { ConnectorClient } = require('../../../services/clients/connector.client')
@@ -74,9 +73,7 @@ module.exports = async (req, res, next) => {
         })
       }
     }
-    // the error is generic
-    logger.error(`Error submitting bank details, error = `, error)
-    return renderErrorView(req, res, 'Please try again or contact support team')
+    next(error)
   }
 }
 

--- a/app/controllers/stripe-setup/bank-details/post.controller.test.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.test.js
@@ -50,7 +50,7 @@ describe('Bank details post controller', () => {
     setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
     const controller = getControllerWithMocks()
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.calledWith(updateBankAccountMock, res.locals.stripeAccount.stripeAccountId, {
       bank_account_sort_code: sanitisedSortCode,
@@ -65,7 +65,7 @@ describe('Bank details post controller', () => {
     setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
     const controller = getControllerWithMocks()
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.calledWith(updateBankAccountMock, res.locals.stripeAccount.stripeAccountId, {
       bank_account_sort_code: sanitisedSortCode,
@@ -73,8 +73,8 @@ describe('Bank details post controller', () => {
     })
     sinon.assert.notCalled(setStripeAccountSetupFlagMock)
     sinon.assert.notCalled(res.redirect)
-    sinon.assert.calledWith(res.status, 500)
-    sinon.assert.calledWith(res.render, 'error', sinon.match({ message: 'Please try again or contact support team' }))
+    const expectedError = sinon.match.instanceOf(Error)
+    sinon.assert.calledWith(next, expectedError)
   })
 
   it('should render error page when stripe setup is not available on request', async () => {
@@ -93,7 +93,7 @@ describe('Bank details post controller', () => {
     const controller = getControllerWithMocks()
     req.account.connectorGatewayAccountStripeProgress = { bankAccount: true }
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.calledWith(req.flash, 'genericError', 'You’ve already provided your bank details. Contact GOV.UK Pay support if you need to update them.')
     sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/dashboard`)
@@ -110,7 +110,7 @@ describe('Bank details post controller', () => {
     setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
     const controller = getControllerWithMocks()
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.calledWith(updateBankAccountMock, res.locals.stripeAccount.stripeAccountId, {
       bank_account_sort_code: sanitisedSortCode,
@@ -132,7 +132,7 @@ describe('Bank details post controller', () => {
     setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
     const controller = getControllerWithMocks()
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.calledWith(updateBankAccountMock, res.locals.stripeAccount.stripeAccountId, {
       bank_account_sort_code: sanitisedSortCode,
@@ -148,7 +148,7 @@ describe('Bank details post controller', () => {
     setStripeAccountSetupFlagMock = sinon.spy(() => Promise.reject(new Error()))
     const controller = getControllerWithMocks()
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.calledWith(updateBankAccountMock, res.locals.stripeAccount.stripeAccountId, {
       bank_account_sort_code: sanitisedSortCode,
@@ -156,8 +156,8 @@ describe('Bank details post controller', () => {
     })
     sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'bank_account', req.correlationId)
     sinon.assert.notCalled(res.redirect)
-    sinon.assert.calledWith(res.status, 500)
-    sinon.assert.calledWith(res.render, 'error', sinon.match({ message: 'Please try again or contact support team' }))
+    const expectedError = sinon.match.instanceOf(Error)
+    sinon.assert.calledWith(next, expectedError)
   })
 
   function getControllerWithMocks () {

--- a/app/controllers/stripe-setup/company-number/post.controller.js
+++ b/app/controllers/stripe-setup/company-number/post.controller.js
@@ -2,8 +2,7 @@
 
 const lodash = require('lodash')
 
-const logger = require('../../../utils/logger')(__filename)
-const { response, renderErrorView } = require('../../../utils/response')
+const { response } = require('../../../utils/response')
 const { updateCompany } = require('../../../services/clients/stripe/stripe.client')
 const companyNumberValidations = require('./company-number-validations')
 const { ConnectorClient } = require('../../../services/clients/connector.client')
@@ -46,9 +45,8 @@ module.exports = async (req, res, next) => {
       await connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'company_number', req.correlationId)
 
       return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))
-    } catch (error) {
-      logger.error(`Error submitting "Company registration number" details, error = `, error)
-      return renderErrorView(req, res, 'Please try again or contact support team')
+    } catch (err) {
+      next(err)
     }
   }
 }

--- a/app/controllers/stripe-setup/company-number/post.controller.test.js
+++ b/app/controllers/stripe-setup/company-number/post.controller.test.js
@@ -63,7 +63,7 @@ describe('Company number POST controller', () => {
 
     req.body = { ...postBody }
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.calledWith(updateCompanyMock, res.locals.stripeAccount.stripeAccountId, {
       'tax_id': '1234567890'
@@ -88,7 +88,7 @@ describe('Company number POST controller', () => {
     const controller = getControllerWithMocks()
     req.account.connectorGatewayAccountStripeProgress = { companyNumber: true }
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.calledWith(req.flash, 'genericError', 'You’ve already provided your company registration number. Contact GOV.UK Pay support if you need to update it.')
     sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/dashboard`)
@@ -101,13 +101,13 @@ describe('Company number POST controller', () => {
 
     req.body = { ...postBody }
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.called(updateCompanyMock)
     sinon.assert.notCalled(setStripeAccountSetupFlagMock)
     sinon.assert.notCalled(res.redirect)
-    sinon.assert.calledWith(res.status, 500)
-    sinon.assert.calledWith(res.render, 'error', sinon.match({ message: 'Please try again or contact support team' }))
+    const expectedError = sinon.match.instanceOf(Error)
+    sinon.assert.calledWith(next, expectedError)
   })
 
   it('should render error when connector returns error', async function () {
@@ -117,12 +117,12 @@ describe('Company number POST controller', () => {
 
     req.body = { ...postBody }
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.called(updateCompanyMock)
     sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'company_number', req.correlationId)
     sinon.assert.notCalled(res.redirect)
-    sinon.assert.calledWith(res.status, 500)
-    sinon.assert.calledWith(res.render, 'error', sinon.match({ message: 'Please try again or contact support team' }))
+    const expectedError = sinon.match.instanceOf(Error)
+    sinon.assert.calledWith(next, expectedError)
   })
 })

--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -5,8 +5,7 @@ const ukPostcode = require('uk-postcode')
 
 const paths = require('../../../paths')
 const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
-const logger = require('../../../utils/logger')(__filename)
-const { response, renderErrorView } = require('../../../utils/response')
+const { response } = require('../../../utils/response')
 const {
   validateMandatoryField, validateOptionalField, validatePostcode, validateDateOfBirth
 } = require('../../../utils/validation/server-side-form-validations')
@@ -123,9 +122,8 @@ module.exports = async function (req, res, next) {
       await connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'responsible_person', req.correlationId)
 
       return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))
-    } catch (error) {
-      logger.error(`Error creating responsible person with Stripe - ${error.message}`)
-      return renderErrorView(req, res, 'Please try again or contact support team')
+    } catch (err) {
+      next(err)
     }
   }
 }

--- a/app/controllers/stripe-setup/responsible-person/post.controller.test.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.test.js
@@ -102,7 +102,7 @@ describe('Responsible person POST controller', () => {
 
     req.body = { ...postBodyWithAddress2 }
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.calledWith(updatePersonMock, res.locals.stripeAccount.stripeAccountId, personId, {
       first_name: firstNameNormalised,
@@ -132,7 +132,7 @@ describe('Responsible person POST controller', () => {
 
     req.body = { ...postBody }
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.calledWith(updatePersonMock, res.locals.stripeAccount.stripeAccountId, personId, {
       first_name: firstNameNormalised,
@@ -164,7 +164,7 @@ describe('Responsible person POST controller', () => {
     const controller = getControllerWithMocks()
     req.account.connectorGatewayAccountStripeProgress = { responsiblePerson: true }
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.calledWith(req.flash, 'genericError', 'You’ve already nominated your responsible person. Contact GOV.UK Pay support if you need to change them.')
     sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/dashboard`)
@@ -183,13 +183,13 @@ describe('Responsible person POST controller', () => {
 
     req.body = { ...postBody }
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.called(updatePersonMock)
     sinon.assert.notCalled(setStripeAccountSetupFlagMock)
     sinon.assert.notCalled(res.redirect)
-    sinon.assert.calledWith(res.status, 500)
-    sinon.assert.calledWith(res.render, 'error', sinon.match({ message: 'Please try again or contact support team' }))
+    const expectedError = sinon.match.instanceOf(Error)
+    sinon.assert.calledWith(next, expectedError)
   })
 
   it('should render error when connector returns error', async function () {
@@ -205,12 +205,12 @@ describe('Responsible person POST controller', () => {
 
     req.body = { ...postBody }
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.called(updatePersonMock)
     sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'responsible_person', req.correlationId)
     sinon.assert.notCalled(res.redirect)
-    sinon.assert.calledWith(res.status, 500)
-    sinon.assert.calledWith(res.render, 'error', sinon.match({ message: 'Please try again or contact support team' }))
+    const expectedError = sinon.match.instanceOf(Error)
+    sinon.assert.calledWith(next, expectedError)
   })
 })

--- a/app/controllers/stripe-setup/vat-number/post.controller.js
+++ b/app/controllers/stripe-setup/vat-number/post.controller.js
@@ -2,8 +2,7 @@
 
 const lodash = require('lodash')
 
-const logger = require('../../../utils/logger')(__filename)
-const { response, renderErrorView } = require('../../../utils/response')
+const { response } = require('../../../utils/response')
 const { updateCompany } = require('../../../services/clients/stripe/stripe.client')
 const vatNumberValidations = require('./vat-number-validations')
 const { ConnectorClient } = require('../../../services/clients/connector.client')
@@ -44,9 +43,8 @@ module.exports = async (req, res, next) => {
       await connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'vat_number', req.correlationId)
 
       return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))
-    } catch (error) {
-      logger.error(`Error submitting "VAT number" details, error = `, error)
-      return renderErrorView(req, res, 'Please try again or contact support team')
+    } catch (err) {
+      next(err)
     }
   }
 }

--- a/app/controllers/stripe-setup/vat-number/post.controller.test.js
+++ b/app/controllers/stripe-setup/vat-number/post.controller.test.js
@@ -62,7 +62,7 @@ describe('VAT number POST controller', () => {
 
     req.body = { ...postBody }
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.calledWith(updateCompanyMock, res.locals.stripeAccount.stripeAccountId, {
       'vat_id': 'GB999999973'
@@ -87,7 +87,7 @@ describe('VAT number POST controller', () => {
     const controller = getControllerWithMocks()
     req.account.connectorGatewayAccountStripeProgress = { vatNumber: true }
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.calledWith(req.flash, 'genericError', 'You’ve already provided your VAT number. Contact GOV.UK Pay support if you need to update it.')
     sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/dashboard`)
@@ -100,13 +100,13 @@ describe('VAT number POST controller', () => {
 
     req.body = { ...postBody }
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.called(updateCompanyMock)
     sinon.assert.notCalled(setStripeAccountSetupFlagMock)
     sinon.assert.notCalled(res.redirect)
-    sinon.assert.calledWith(res.status, 500)
-    sinon.assert.calledWith(res.render, 'error', sinon.match({ message: 'Please try again or contact support team' }))
+    const expectedError = sinon.match.instanceOf(Error)
+    sinon.assert.calledWith(next, expectedError)
   })
 
   it('should render error when connector returns error', async function () {
@@ -116,12 +116,12 @@ describe('VAT number POST controller', () => {
 
     req.body = { ...postBody }
 
-    await controller(req, res)
+    await controller(req, res, next)
 
     sinon.assert.called(updateCompanyMock)
     sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'vat_number', req.correlationId)
     sinon.assert.notCalled(res.redirect)
-    sinon.assert.calledWith(res.status, 500)
-    sinon.assert.calledWith(res.render, 'error', sinon.match({ message: 'Please try again or contact support team' }))
+    const expectedError = sinon.match.instanceOf(Error)
+    sinon.assert.calledWith(next, expectedError)
   })
 })

--- a/app/controllers/test-with-your-users/links.controller.js
+++ b/app/controllers/test-with-your-users/links.controller.js
@@ -1,13 +1,11 @@
 'use strict'
 
-const logger = require('../../utils/logger')(__filename)
 const { response } = require('../../utils/response.js')
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
-const { renderErrorView } = require('../../utils/response.js')
 const formatAccountPathsFor = require('../../../app/utils/format-account-paths-for')
 
-module.exports = (req, res) => {
+module.exports = async function getIndex (req, res, next) {
   const params = {
     productsTab: true,
     createPage: formatAccountPathsFor(paths.account.prototyping.demoService.create, req.account.external_id),
@@ -15,14 +13,12 @@ module.exports = (req, res) => {
     linksPage: formatAccountPathsFor(paths.account.prototyping.demoService.links, req.account.external_id)
   }
 
-  productsClient.product.getByGatewayAccountIdAndType(req.account.gateway_account_id, 'PROTOTYPE')
-    .then(prototypeProducts => {
-      params.productsLength = prototypeProducts.length
-      params.products = prototypeProducts
-      return response(req, res, 'dashboard/demo-service/index', params)
-    })
-    .catch((err) => {
-      logger.error(`Get PROTOTYPE product by gateway account id failed - ${err.message}`)
-      renderErrorView(req, res)
-    })
+  try {
+    const prototypeProducts = await productsClient.product.getByGatewayAccountIdAndType(req.account.gateway_account_id, 'PROTOTYPE')
+    params.productsLength = prototypeProducts.length
+    params.products = prototypeProducts
+    return response(req, res, 'dashboard/demo-service/index', params)
+  } catch (err) {
+    next(err)
+  }
 }

--- a/app/controllers/toggle-3ds/3ds.get.controller.js
+++ b/app/controllers/toggle-3ds/3ds.get.controller.js
@@ -2,11 +2,11 @@
 
 const lodash = require('lodash')
 
-const { response, renderErrorView } = require('../../utils/response')
+const { response } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
 
-module.exports = async (req, res) => {
+module.exports = async function get3dsSettings (req, res, next) {
   const connector = new ConnectorClient(process.env.CONNECTOR_URL)
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = req.account.gateway_account_id
@@ -23,7 +23,7 @@ module.exports = async (req, res) => {
     }
 
     return response(req, res, 'toggle-3ds/index', pageData)
-  } catch (error) {
-    return renderErrorView(req, res, false, error.errorCode)
+  } catch (err) {
+    next(err)
   }
 }

--- a/app/controllers/toggle-3ds/3ds.post.controller.js
+++ b/app/controllers/toggle-3ds/3ds.post.controller.js
@@ -2,12 +2,11 @@
 
 const paths = require('../../paths')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
-const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
-module.exports = async (req, res) => {
+module.exports = async function submit3dsSettings (req, res, next) {
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = req.account.gateway_account_id
 
@@ -25,7 +24,7 @@ module.exports = async (req, res) => {
     await connector.update3dsEnabled(params)
     req.flash('generic', '3D secure settings have been updated')
     return res.redirect(formatAccountPathsFor(paths.account.toggle3ds.index, req.account && req.account.external_id))
-  } catch (error) {
-    return renderErrorView(req, res, false, error.errorCode)
+  } catch (err) {
+    next(err)
   }
 }

--- a/app/controllers/toggle-moto-mask-card-number/toggleMotoMaskCardNumber.post.controller.js
+++ b/app/controllers/toggle-moto-mask-card-number/toggleMotoMaskCardNumber.post.controller.js
@@ -2,13 +2,12 @@
 
 const paths = require('../../paths')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
-const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
 
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
-module.exports = async function toggleMaskCardNumber (req, res) {
+module.exports = async function toggleMaskCardNumber (req, res, next) {
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = req.account.gateway_account_id
   const enableMaskCardNumber = req.body['moto-mask-card-number-input-toggle'] === 'on'
@@ -19,7 +18,7 @@ module.exports = async function toggleMaskCardNumber (req, res) {
 
     req.flash('generic', 'Your changes have saved')
     return res.redirect(formattedPath)
-  } catch (error) {
-    return renderErrorView(req, res, false, error.errorCode)
+  } catch (err) {
+    next(err)
   }
 }

--- a/app/controllers/toggle-moto-mask-security-code/maskSecurityCode.post.controller.js
+++ b/app/controllers/toggle-moto-mask-security-code/maskSecurityCode.post.controller.js
@@ -2,13 +2,12 @@
 
 const paths = require('../../paths')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
-const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { correlationHeader } = require('../../utils/correlation-header')
 
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
-module.exports = async function toggleMaskCardSecurityCode (req, res) {
+module.exports = async function toggleMaskCardSecurityCode (req, res, next) {
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = req.account.gateway_account_id
   const enableMaskSecurityCode = req.body['moto-mask-security-code-input-toggle'] === 'on'
@@ -19,7 +18,7 @@ module.exports = async function toggleMaskCardSecurityCode (req, res) {
 
     req.flash('generic', 'Your changes have saved')
     return res.redirect(formattedPath)
-  } catch (error) {
-    return renderErrorView(req, res, false, error.errorCode)
+  } catch (err) {
+    next(err)
   }
 }

--- a/app/controllers/user/phone-number/get.controller.js
+++ b/app/controllers/user/phone-number/get.controller.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const { renderErrorView, response } = require('../../../utils/response')
+const { response } = require('../../../utils/response')
 const userService = require('../../../services/user.service')
 
-module.exports = async (req, res) => {
+module.exports = async function showUpdatePhoneNumber (req, res, next) {
   try {
     const { telephoneNumber } = await userService.findByExternalId(req.user.externalId)
     return response(req, res, 'team-members/edit-phone-number', { telephoneNumber })
-  } catch (error) {
-    return renderErrorView(req, res, 'Unable to retrieve user')
+  } catch (err) {
+    next(err)
   }
 }

--- a/app/controllers/user/phone-number/post.controller.js
+++ b/app/controllers/user/phone-number/post.controller.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const { renderErrorView, response } = require('../../../utils/response')
+const { response } = require('../../../utils/response')
 const userService = require('../../../services/user.service')
 const paths = require('../../../paths')
 const { invalidTelephoneNumber } = require('../../../utils/validation/telephone-number-validation')
 
-module.exports = async function updatePhoneNumber (req, res) {
+module.exports = async function updatePhoneNumber (req, res, next) {
   const telephoneNumber = req.body.phone
   if (invalidTelephoneNumber(telephoneNumber)) {
     const pageData = {
@@ -22,7 +22,7 @@ module.exports = async function updatePhoneNumber (req, res) {
 
     req.flash('generic', 'Phone number updated')
     return res.redirect(paths.user.profile.index)
-  } catch (error) {
-    return renderErrorView(req, res, 'Unable to update phone number. Please try again or contact support team.')
+  } catch (err) {
+    next(err)
   }
 }

--- a/app/controllers/your-psp/post-flex.controller.js
+++ b/app/controllers/your-psp/post-flex.controller.js
@@ -16,7 +16,7 @@ const ORGANISATIONAL_UNIT_ID_FIELD = 'organisational-unit-id'
 const ISSUER_FIELD = 'issuer'
 const JWT_MAC_KEY_FIELD = 'jwt-mac-key'
 
-module.exports = async (req, res) => {
+module.exports = async function submit3dsFlexCredentials (req, res, next) {
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = req.account.gateway_account_id
   const flexUrl = formatAccountPathsFor(paths.account.yourPsp.flex, req.account && req.account.external_id)
@@ -71,8 +71,8 @@ module.exports = async (req, res) => {
     await connector.post3dsFlexAccountCredentials(flexParams)
     req.flash('generic', 'Your Worldpay 3DS Flex settings have been updated')
     return res.redirect(indexUrl)
-  } catch (error) {
-    return renderErrorView(req, res, false, error.errorCode)
+  } catch (err) {
+    return next(err)
   }
 }
 

--- a/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.js
+++ b/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.js
@@ -6,7 +6,7 @@ const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
-module.exports = async function toggleWorldpay3dsFlex (req, res) {
+module.exports = async function toggleWorldpay3dsFlex (req, res, next) {
   const accountId = req.account.gateway_account_id
   const toggleWorldpay3dsFlex = req.body['toggle-worldpay-3ds-flex']
   const indexUrl = formatAccountPathsFor(paths.account.yourPsp.index, req.account && req.account.external_id)
@@ -19,8 +19,8 @@ module.exports = async function toggleWorldpay3dsFlex (req, res) {
       await connector.updateIntegrationVersion3ds(accountId, integrationVersion3ds, req.correlationId)
       req.flash('generic', message)
       return res.redirect(303, indexUrl)
-    } catch (error) {
-      return renderErrorView(req, res, false, error.errorCode)
+    } catch (err) {
+      next(err)
     }
   } else {
     return renderErrorView(req, res, false, 400)

--- a/app/routes.js
+++ b/app/routes.js
@@ -243,7 +243,7 @@ module.exports.bind = function (app) {
   service.get(teamMembers.show, permission('users-service:read'), serviceUsersController.show)
   service.get(teamMembers.permissions, permission('users-service:create'), serviceRolesUpdateController.index)
   service.post(teamMembers.permissions, permission('users-service:create'), serviceRolesUpdateController.update)
-  service.post(teamMembers.delete, permission('users-service:delete'), serviceUsersController.delete)
+  service.post(teamMembers.delete, permission('users-service:delete'), serviceUsersController.remove)
 
   // Invite team member
   service.get(teamMembers.invite, permission('users-service:create'), inviteUserController.index)

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lint": "./node_modules/.bin/standard --fix",
     "lint-sass": "./node_modules/.bin/sass-lint -v",
     "test": "rm -rf ./pacts && NODE_ENV=test ./node_modules/mocha/bin/mocha --exclude **/*.cy.test.js '!(node_modules)/**/*.test'.js",
+    "test:no-pact": "rm -rf ./pacts && NODE_ENV=test ./node_modules/mocha/bin/mocha --exclude '**/*+(.cy|.pact)'.test.js '!(node_modules)/**/*.test'.js",
     "test:pact": "rm -rf ./pacts && NODE_ENV=test ./node_modules/mocha/bin/mocha **/*.pact.test.js",
     "cypress:server": "mb --debug | DISABLE_APPMETRICS=true node --inspect -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
     "cypress:test": "cypress run",

--- a/test/cypress/integration/settings/your-psp.cy.test.js
+++ b/test/cypress/integration/settings/your-psp.cy.test.js
@@ -214,7 +214,7 @@ describe('Your PSP settings page', () => {
       cy.get('#jwt-mac-key').type(testFailureFlexCredentials.jwt_mac_key)
       cy.get('#submitFlexCredentials').click()
       cy.get('h1').should('contain', 'An error occurred')
-      cy.get('#errorMsg').should('contain', 'Please try again or contact support team.')
+      cy.get('#errorMsg').should('contain', 'There is a problem with the payments platform. Please contact the support team.')
       cy.location().should((location) => {
         expect(location.pathname).to.eq(yourPspPath + '/flex')
       })

--- a/test/integration/invite-users.controller.ft.test.js
+++ b/test/integration/invite-users.controller.ft.test.js
@@ -101,9 +101,9 @@ describe('invite user controller', function () {
           'role-input': unknownRoleId,
           csrfToken: csrf().create('123')
         })
-        .expect(200)
+        .expect(500)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to send invitation at this time')
+          expect(res.body.message).to.equal('There is a problem with the payments platform. Please contact the support team.')
         })
         .end(done)
     })

--- a/test/integration/invite-validation.controller.ft.test.js
+++ b/test/integration/invite-validation.controller.ft.test.js
@@ -161,7 +161,7 @@ describe('Invite validation tests', () => {
         .set('x-request-id', 'bob')
         .expect(404)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time')
+          expect(res.body.message).to.equal('There has been a problem proceeding with this registration. Please try again.')
         })
         .end(done)
     })

--- a/test/integration/payment-types/payment-types.it.test.js
+++ b/test/integration/payment-types/payment-types.it.test.js
@@ -76,7 +76,7 @@ describe('Payment types', function () {
 
       return whenGetPaymentTypes(app)
         .expect(500)
-        .expect(response => expect(response.text).to.contain('Unable to fetch payment types. Please try again or contact support team.'))
+        .expect(response => expect(response.text).to.contain('There is a problem with the payments platform. Please contact the support team.'))
     })
   })
   describe('update payment types', function () {
@@ -99,7 +99,7 @@ describe('Payment types', function () {
 
       return whenPaymentTypesUpdated(app, { debit: 'visa-id-1234' })
         .expect(500)
-        .expect(response => expect(response.text).to.contain('Unable to update payment types. Please try again or contact support team.'))
+        .expect(response => expect(response.text).to.contain('There is a problem with the payments platform. Please contact the support team.'))
     })
   })
 })

--- a/test/integration/service-roles-update.ft.test.js
+++ b/test/integration/service-roles-update.ft.test.js
@@ -96,9 +96,6 @@ describe('user permissions update controller', function () {
         .get(formatServicePathsFor(paths.service.teamMembers.permissions, EXTERNAL_SERVICE_ID, EXTERNAL_ID_TO_VIEW))
         .set('Accept', 'application/json')
         .expect(500)
-        .expect((res) => {
-          expect(res.body.message).to.equal('Unable to locate the user')
-        })
         .end(done)
     })
 
@@ -222,9 +219,6 @@ describe('user permissions update controller', function () {
           csrfToken: csrf().create('123')
         })
         .expect(500)
-        .expect((res) => {
-          expect(res.body.message).to.equal('Unable to locate the user')
-        })
         .end(done)
     })
 
@@ -268,9 +262,6 @@ describe('user permissions update controller', function () {
           csrfToken: csrf().create('123')
         })
         .expect(500)
-        .expect((res) => {
-          expect(res.body.message).to.equal('Unable to update user permission')
-        })
         .end(done)
     })
 
@@ -295,7 +286,7 @@ describe('user permissions update controller', function () {
         })
         .expect(500)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to update user permission')
+          expect(res.body.message).to.equal('There is a problem with the payments platform. Please contact the support team.')
         })
         .end(done)
     })

--- a/test/unit/controller/test-with-your-users-controller/links.controller.ft.test.js
+++ b/test/unit/controller/test-with-your-users-controller/links.controller.ft.test.js
@@ -237,7 +237,7 @@ describe('Show the prototype links', () => {
 
     it('should show an error page', () => {
       expect(response.status).to.equal(500)
-      expect(response.body).to.have.property('message', 'There is a problem with the payments platform')
+      expect(response.body).to.have.property('message', 'There is a problem with the payments platform. Please contact the support team.')
     })
   })
 })


### PR DESCRIPTION
For unexpected errors, pass the error to `next` to be handled by our error handling middleware. This will allow for errors to be handled uniformly, displaying the same page for all unexpected errors as recommended by the design system.

This will also allow us to in future stop logging at error level for all error pages shown, as the error handler will send unexpected errors to Sentry explicitly. When we do this the noise in Sentry caused by business as usual errors will be reduced.

## Note

Hiding whitespace changes will make this PR easier to review.