### PR TITLE
PP-8032 Handle errors uniformly for registration

### DIFF
--- a/app/errors.js
+++ b/app/errors.js
@@ -48,11 +48,19 @@ class NoServicesWithPermissionError extends DomainError {
 class NotFoundError extends DomainError {
 }
 
+/**
+ * Thrown when data that is expected in the user's session cookie for registration is missing
+ * and it is not possible for us to recover from this, and so want to show an error page.
+ */
+class RegistrationSessionMissingError extends DomainError {
+}
+
 module.exports = {
   NotAuthenticatedError,
   UserAccountDisabledError,
   NotAuthorisedError,
   PermissionDeniedError,
   NoServicesWithPermissionError,
-  NotFoundError
+  NotFoundError,
+  RegistrationSessionMissingError
 }

--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -9,7 +9,8 @@ const {
   NotAuthorisedError,
   PermissionDeniedError,
   NoServicesWithPermissionError,
-  NotFoundError
+  NotFoundError,
+  RegistrationSessionMissingError
 } = require('../errors')
 const paths = require('../paths')
 const { renderErrorView, response } = require('../utils/response')
@@ -52,6 +53,11 @@ module.exports = function errorHandler (err, req, res, next) {
     logger.info(`NotFoundError handled: ${err.message}. Rendering 404 page`)
     res.status(404)
     return response(req, res, '404')
+  }
+
+  if (err instanceof RegistrationSessionMissingError) {
+    logger.info(`RegistrationSessionMissingError handled. Rendering error page`)
+    return renderErrorView(req, res, 'There has been a problem proceeding with this registration. Please try again.', 400)
   }
 
   if (err && err.code === 'EBADCSRFTOKEN') {

--- a/test/integration/register-user.controller.ft.test.js
+++ b/test/integration/register-user.controller.ft.test.js
@@ -74,9 +74,9 @@ describe('register user controller', () => {
         .get(paths.registerUser.registration)
         .set('Accept', 'application/json')
         .set('x-request-id', 'bob')
-        .expect(404)
+        .expect(400)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time')
+          expect(res.body.message).to.equal('There has been a problem proceeding with this registration. Please try again.')
         })
         .end(done)
     })
@@ -96,9 +96,9 @@ describe('register user controller', () => {
         .send({
           csrfToken: csrf().create('123')
         })
-        .expect(404)
+        .expect(400)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time')
+          expect(res.body.message).to.equal('There has been a problem proceeding with this registration. Please try again.')
         })
         .end(done)
     })
@@ -172,10 +172,7 @@ describe('register user controller', () => {
           'password': 'password1234',
           csrfToken: csrf().create('123')
         })
-        .expect(404)
-        .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time')
-        })
+        .expect(500)
         .end(done)
     })
   })
@@ -189,9 +186,9 @@ describe('register user controller', () => {
         .get(paths.registerUser.otpVerify)
         .set('Accept', 'application/json')
         .set('x-request-id', 'bob')
-        .expect(404)
+        .expect(400)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time')
+          expect(res.body.message).to.equal('There has been a problem proceeding with this registration. Please try again.')
         })
         .end(done)
     })
@@ -249,9 +246,9 @@ describe('register user controller', () => {
           'verify-code': '123456',
           csrfToken: csrf().create('123')
         })
-        .expect(404)
+        .expect(400)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time')
+          expect(res.body.message).to.equal('There has been a problem proceeding with this registration. Please try again.')
         })
         .end(done)
     })
@@ -290,10 +287,7 @@ describe('register user controller', () => {
           'verify-code': '123456',
           csrfToken: csrf().create('123')
         })
-        .expect(404)
-        .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time')
-        })
+        .expect(500)
         .end(done)
     })
   })
@@ -325,9 +319,9 @@ describe('register user controller', () => {
         .get(paths.registerUser.reVerifyPhone)
         .set('Accept', 'application/json')
         .set('x-request-id', 'bob')
-        .expect(404)
+        .expect(400)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time')
+          expect(res.body.message).to.equal('There has been a problem proceeding with this registration. Please try again.')
         })
         .end(done)
     })
@@ -378,10 +372,7 @@ describe('register user controller', () => {
           'telephone-number': telephoneNumber,
           csrfToken: csrf().create('123')
         })
-        .expect(404)
-        .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time')
-        })
+        .expect(500)
         .end(done)
     })
 
@@ -426,9 +417,9 @@ describe('register user controller', () => {
           'telephone-number': telephoneNumber,
           csrfToken: csrf().create('123')
         })
-        .expect(404)
+        .expect(400)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time')
+          expect(res.body.message).to.equal('There has been a problem proceeding with this registration. Please try again.')
         })
         .end(done)
     })
@@ -460,9 +451,9 @@ describe('register user controller', () => {
         .get(paths.registerUser.subscribeService)
         .set('Accept', 'application/json')
         .set('x-request-id', 'bob')
-        .expect(404)
+        .expect(400)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time')
+          expect(res.body.message).to.equal('There has been a problem proceeding with this registration. Please try again.')
         })
         .end(done)
     })

--- a/test/integration/self-registration/self-registration-otp-resend.ft.test.js
+++ b/test/integration/self-registration/self-registration-otp-resend.ft.test.js
@@ -34,7 +34,7 @@ describe('create service otp resend validation', function () {
       app = mockSession.getAppWithLoggedOutSession(getApp())
       supertest(app)
         .get('/create-service/resend-otp')
-        .expect(404)
+        .expect(400)
         .end(done)
     })
   })
@@ -102,7 +102,7 @@ describe('create service otp resend validation', function () {
           'telephone-number': validServiceInviteOtpResendRequestPlain.telephone_number,
           csrfToken: csrf().create('123')
         })
-        .expect(404)
+        .expect(400)
         .end(done)
     })
   })

--- a/test/integration/self-registration/self-registration-otp-verify.ft.test.js
+++ b/test/integration/self-registration/self-registration-otp-verify.ft.test.js
@@ -43,7 +43,7 @@ describe('create service otp validation', function () {
       app = session.getAppWithLoggedOutSession(getApp())
       supertest(app)
         .get(paths.selfCreateService.otpVerify)
-        .expect(404)
+        .expect(400)
         .end(done)
     })
 
@@ -133,7 +133,7 @@ describe('create service otp validation', function () {
           'verify-code': validServiceInviteOtpRequest.otp,
           csrfToken: csrf().create('123')
         })
-        .expect(404)
+        .expect(400)
         .end(done)
     })
 
@@ -199,7 +199,7 @@ describe('create service otp validation', function () {
       }
 
       adminusersMock.post(`${SERVICE_INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest)
-        .reply(404)
+        .reply(400)
 
       app = session.getAppWithRegisterInvitesCookie(getApp(), registerInviteData)
 
@@ -212,9 +212,9 @@ describe('create service otp validation', function () {
           'verify-code': validServiceInviteOtpRequest.otp,
           csrfToken: csrf().create('123')
         })
-        .expect(404)
+        .expect(500)
         .expect((res) => {
-          expect(res.body.message).to.equal('Unable to process registration at this time')
+          expect(res.body.message).to.equal('There is a problem with the payments platform. Please contact the support team.')
         })
         .end(done)
     })


### PR DESCRIPTION
Add a new error type to handle in the error handler which is thrown when the registration data isn't found in the session cookie. This allows us to handle these errors uniformly. Use a 400 error code for this as it makes more sense than 404.

Handle unexpected errors by passing an error to next to show the standard 500 error page.