### PR TITLE
PP-8032 Don't log at error level every time we show error

### DIFF
--- a/app/utils/response.js
+++ b/app/utils/response.js
@@ -21,11 +21,7 @@ function errorResponse (req, res, msg = ERROR_MESSAGE, status = 500) {
     'error_message': msg
   }
 
-  if (status === 500) {
-    logger.error('An error has occurred. Rendering error view', errorMeta)
-  } else {
-    logger.info('An error has occurred. Rendering error view', errorMeta)
-  }
+  logger.info('An error has occurred. Rendering error view', errorMeta)
   res.setHeader('Content-Type', 'text/html')
 
   res.status(status)


### PR DESCRIPTION
All unexpected errors are now handled by the error handler middleware which sends the error to Sentry before rendering the internal error page.

There are many other times we render the error view, when there are errors for things such as cookies missing or invites having expired which are "business as usual" and do not need to be investigated by a developer. This will stop events being sent to Sentry for these type of errors.