### PR TITLE
PP-8048 Add step to workflow job to run Cypress tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,9 +32,16 @@ jobs:
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress
-      - name: Install Dependencies
+      - name: Install dependencies
         run: npm ci
       - name: Compile
         run: npm run compile
-      - name: Unit Test
-        run: npm test
+      - name: Run lint
+        run: npm run lint
+      - name: Run unit tests
+        run: npm test -- --forbid-only --forbid-pending
+      - name: Run cypress tests
+        run: |
+          npm run cypress:server > /dev/null 2>&1 &
+          sleep 3
+          npm run cypress:test


### PR DESCRIPTION
We might want this as a separate job we can run in parallel, particularly if we can share the build artefacts so they only need to be built once for the workflow. For now add as another step to the same job.

