### PR TITLE
PP-8131 Namespace PSP and credential pages by provider

### DIFF
--- a/app/controllers/credentials.controller.js
+++ b/app/controllers/credentials.controller.js
@@ -15,8 +15,10 @@ const connectorClient = new ConnectorClient(CONNECTOR_URL)
 
 function showSuccessView (viewMode, req, res) {
   let responsePayload = {}
+  const { paymentProvider } = req.params
 
   responsePayload.editNotificationCredentialsMode = (viewMode === EDIT_NOTIFICATION_CREDENTIALS_MODE)
+  responsePayload.paymentProvider = paymentProvider
 
   const invalidCreds = _.get(req, 'session.pageData.editNotificationCredentials')
   if (invalidCreds) {
@@ -25,7 +27,7 @@ function showSuccessView (viewMode, req, res) {
   }
   responsePayload.change = _.get(req, 'query.change', {})
 
-  response(req, res, 'credentials/' + req.account.payment_provider, responsePayload)
+  response(req, res, 'credentials/' + paymentProvider, responsePayload)
 }
 
 function loadIndex (req, res, next, viewMode) {
@@ -79,6 +81,7 @@ module.exports = {
 
   updateNotificationCredentials: async function (req, res, next) {
     const accountId = req.account.gateway_account_id
+    const { paymentProvider } = req.params
     const username = req.body.username && req.body.username.trim()
     const password = req.body.password && req.body.password.trim()
 
@@ -95,7 +98,7 @@ module.exports = {
 
     if (_.get(req, 'session.flash.genericError.length')) {
       _.set(req, 'session.pageData.editNotificationCredentials', { username, password })
-      return res.redirect(formatAccountPathsFor(paths.account.notificationCredentials.edit, req.account && req.account.external_id))
+      return res.redirect(formatAccountPathsFor(paths.account.notificationCredentials.edit, req.account.external_id, paymentProvider))
     }
 
     const correlationId = req.headers[CORRELATION_HEADER] || ''
@@ -107,7 +110,7 @@ module.exports = {
         gatewayAccountId: accountId
       })
 
-      return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account && req.account.external_id))
+      return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, paymentProvider))
     } catch (err) {
       next(err)
     }
@@ -115,6 +118,7 @@ module.exports = {
 
   update: async function (req, res, next) {
     const accountId = req.account.gateway_account_id
+    const { paymentProvider } = req.params
     const correlationId = req.headers[CORRELATION_HEADER] || ''
 
     try {
@@ -122,7 +126,7 @@ module.exports = {
         payload: credentialsPatchRequestValueOf(req), correlationId: correlationId, gatewayAccountId: accountId
       })
 
-      return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account && req.account.external_id))
+      return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, paymentProvider))
     } catch (err) {
       next(err)
     }

--- a/app/controllers/credentials.controller.test.js
+++ b/app/controllers/credentials.controller.test.js
@@ -28,6 +28,7 @@ describe('gateway credentials controller', () => {
         merchantId: ' merchant-id '
       },
       account: {},
+      params: {},
       headers: {}
     }
     await credentialsController.update(req, expressResponseStub)
@@ -42,6 +43,7 @@ describe('gateway credentials controller', () => {
       },
       account: {},
       headers: {},
+      params: {},
       flash: sinon.spy()
     }
     await credentialsController.updateNotificationCredentials(req, expressResponseStub)

--- a/app/controllers/your-psp/get-flex.controller.js
+++ b/app/controllers/your-psp/get-flex.controller.js
@@ -6,6 +6,7 @@ const { response } = require('../../utils/response')
 
 module.exports = (req, res) => {
   const { change } = req.query || {}
+  const { paymentProvider } = req.params
 
   const isFlexConfigured = req.account.worldpay_3ds_flex &&
     req.account.worldpay_3ds_flex.organisational_unit_id !== undefined &&
@@ -32,5 +33,5 @@ module.exports = (req, res) => {
     }
   }
 
-  return response(req, res, 'your-psp/flex', { errors, change, isFlexConfigured, orgUnitId, issuer })
+  return response(req, res, 'your-psp/flex', { errors, change, isFlexConfigured, orgUnitId, issuer, paymentProvider })
 }

--- a/app/controllers/your-psp/get.controller.js
+++ b/app/controllers/your-psp/get.controller.js
@@ -3,6 +3,7 @@
 const { response } = require('../../utils/response')
 
 module.exports = (req, res) => {
+  const { paymentProvider } = req.params
   const isAccountCredentialsConfigured = req.account.credentials && req.account.credentials.merchant_id !== undefined
 
   const isWorldpay3dsFlexCredentialsConfigured = req.account.worldpay_3ds_flex &&
@@ -16,5 +17,6 @@ module.exports = (req, res) => {
   return response(req, res, 'your-psp/index', { isAccountCredentialsConfigured,
     is3dsEnabled,
     isWorldpay3dsFlexEnabled,
-    isWorldpay3dsFlexCredentialsConfigured })
+    isWorldpay3dsFlexCredentialsConfigured,
+    paymentProvider })
 }

--- a/app/controllers/your-psp/post-flex.controller.js
+++ b/app/controllers/your-psp/post-flex.controller.js
@@ -19,8 +19,8 @@ const JWT_MAC_KEY_FIELD = 'jwt-mac-key'
 module.exports = async function submit3dsFlexCredentials (req, res, next) {
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = req.account.gateway_account_id
-  const flexUrl = formatAccountPathsFor(paths.account.yourPsp.flex, req.account && req.account.external_id)
-  const indexUrl = formatAccountPathsFor(paths.account.yourPsp.index, req.account && req.account.external_id)
+  const flexUrl = formatAccountPathsFor(paths.account.yourPsp.flex, req.account.external_id)
+  const indexUrl = formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, 'worldpay')
 
   const orgUnitId = lodash.get(req.body, ORGANISATIONAL_UNIT_ID_FIELD, '').trim()
   const issuer = lodash.get(req.body, ISSUER_FIELD, '').trim()

--- a/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.js
+++ b/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.js
@@ -9,7 +9,7 @@ const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 module.exports = async function toggleWorldpay3dsFlex (req, res, next) {
   const accountId = req.account.gateway_account_id
   const toggleWorldpay3dsFlex = req.body['toggle-worldpay-3ds-flex']
-  const indexUrl = formatAccountPathsFor(paths.account.yourPsp.index, req.account && req.account.external_id)
+  const indexUrl = formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, 'worldpay')
 
   if (req.body['toggle-worldpay-3ds-flex'] === 'on' || req.body['toggle-worldpay-3ds-flex'] === 'off') {
     const enabling3dsFlex = toggleWorldpay3dsFlex === 'on'

--- a/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.test.js
+++ b/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.test.js
@@ -39,7 +39,7 @@ describe('Toggle Worldpay 3DS Flex controller', () => {
 
     sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 2, req.correlationId)
     sinon.assert.calledWith(req.flash, 'generic', '3DS Flex has been turned on.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/${gatewayAccountExternalId}/your-psp`)
+    sinon.assert.calledWith(res.redirect, 303, `/account/${gatewayAccountExternalId}/your-psp/worldpay`)
   })
 
   it('should toggle 3DS Flex off by setting 3DS integration version to 1', async () => {
@@ -51,7 +51,7 @@ describe('Toggle Worldpay 3DS Flex controller', () => {
 
     sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 1, req.correlationId)
     sinon.assert.calledWith(req.flash, 'generic', '3DS Flex has been turned off. Your payments will now use 3DS only.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/${gatewayAccountExternalId}/your-psp`)
+    sinon.assert.calledWith(res.redirect, 303, `/account/${gatewayAccountExternalId}/your-psp/worldpay`)
   })
 
   it('should call next with error if problem calling connector', async () => {

--- a/app/paths.js
+++ b/app/paths.js
@@ -20,8 +20,8 @@ module.exports = {
       update: '/api-keys/update'
     },
     credentials: {
-      index: '/credentials',
-      edit: '/credentials/edit'
+      index: '/credentials/:paymentProvider',
+      edit: '/credentials/:paymentProvider/edit'
     },
     dashboard: {
       index: '/dashboard'
@@ -43,8 +43,8 @@ module.exports = {
       refund: '/email-settings-refund'
     },
     notificationCredentials: {
-      edit: '/notification-credentials/edit',
-      update: '/notification-credentials'
+      edit: '/notification-credentials/:paymentProvider/edit',
+      update: '/notification-credentials/:paymentProvider'
     },
     paymentLinks: {
       start: '/create-payment-link',
@@ -117,8 +117,8 @@ module.exports = {
       refund: '/transactions/:chargeId/refund'
     },
     yourPsp: {
-      index: '/your-psp',
-      flex: '/your-psp/flex',
+      index: '/your-psp/:paymentProvider',
+      flex: '/your-psp/worldpay/flex',
       worldpay3dsFlex: '/your-psp/worldpay-3ds-flex'
     }
   },

--- a/app/utils/nav-builder.js
+++ b/app/utils/nav-builder.js
@@ -15,11 +15,7 @@ const mainSettingsPaths = [
   paths.account.toggleMotoMaskCardNumberAndSecurityCode
 ]
 
-const yourPspPaths = [
-  paths.account.yourPsp,
-  paths.account.credentials,
-  paths.account.notificationCredentials
-]
+const yourPspPaths = [ 'your-psp', 'credentials', 'notification-credentials' ]
 
 const serviceNavigationItems = (currentPath, permissions, type, account = {}) => {
   const navigationItems = []
@@ -50,9 +46,8 @@ const serviceNavigationItems = (currentPath, permissions, type, account = {}) =>
     id: 'navigation-menu-settings',
     name: 'Settings',
     url: formatAccountPathsFor(paths.account.settings.index, account.external_id),
-    current: currentPath !== '/' ? pathLookup(currentPath, [
+    current: currentPath !== '/' ? yourPspPaths.filter(path => currentPath.includes(path)).length || pathLookup(currentPath, [
       ...mainSettingsPaths,
-      ...yourPspPaths,
       paths.account.apiKeys,
       paths.account.paymentTypes
     ]) : false,
@@ -89,8 +84,8 @@ const adminNavigationItems = (currentPath, permissions, type, paymentProvider, a
     {
       id: 'navigation-menu-your-psp',
       name: `Your PSP - ${formatPSPname(paymentProvider)}`,
-      url: formatAccountPathsFor(paths.account.yourPsp.index, account.external_id),
-      current: pathLookup(currentPath, yourPspPaths),
+      url: formatAccountPathsFor(paths.account.yourPsp.index, account.external_id, paymentProvider),
+      current: yourPspPaths.filter(path => currentPath.includes(path)).length || pathLookup(currentPath, yourPspPaths),
       permissions: permissions.gateway_credentials_update && type === 'card' && (paymentProvider !== 'stripe') && (paymentProvider !== 'sandbox')
     },
     {

--- a/app/views/credentials/epdq.njk
+++ b/app/views/credentials/epdq.njk
@@ -3,7 +3,7 @@
 {% block provider_content %}
 
   {% if permissions.gateway_credentials_update %}
-    <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.index, currentGatewayAccount.external_id) }}" data-validate>
+    <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.index, currentGatewayAccount.external_id, paymentProvider) }}" data-validate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
       {{ govukInput({

--- a/app/views/credentials/index.njk
+++ b/app/views/credentials/index.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  Account credentials - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+  Account credentials - {{currentService.name}} {{ paymentProvider | formatPSPname }} - GOV.UK Pay
 {% endblock %}
 
 {% block side_navigation %}
@@ -11,9 +11,9 @@
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
   {% if editNotificationCredentialsMode %}
-    <h1 class="govuk-heading-l page-title" id="view-title">Your {{ currentGatewayAccount.payment_provider | formatPSPname }} notification credentials</h1>
+    <h1 class="govuk-heading-l page-title" id="view-title">Your {{ paymentProvider | formatPSPname }} notification credentials</h1>
   {% else %}
-    <h1 class="govuk-heading-l page-title" id="view-title">Your {{ currentGatewayAccount.payment_provider | formatPSPname }} credentials</h1>
+    <h1 class="govuk-heading-l page-title" id="view-title">Your {{ paymentProvider | formatPSPname }} credentials</h1>
   {% endif %}
 
   {% block provider_content %}

--- a/app/views/credentials/smartpay.njk
+++ b/app/views/credentials/smartpay.njk
@@ -2,7 +2,7 @@
 
 {% block provider_content %}
   {% if editNotificationCredentialsMode %}
-    <form id="notification_credentials_form" method="post" action="{{ formatAccountPathsFor(routes.account.notificationCredentials.update, currentGatewayAccount.external_id) }}" data-validate>
+    <form id="notification_credentials_form" method="post" action="{{ formatAccountPathsFor(routes.account.notificationCredentials.update, currentGatewayAccount.external_id, paymentProvider) }}" data-validate>
       <input id="notification-csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
       {% set username %}{{lastNotificationsData.username or currentGatewayAccount.notificationCredentials.userName}}{% endset %}
@@ -47,7 +47,7 @@
     </form>
   {% else %}
     {% if permissions.gateway_credentials_update %}
-      <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.index, currentGatewayAccount.external_id) }}" data-validate>
+      <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.index, currentGatewayAccount.external_id, paymentProvider) }}" data-validate>
           <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
         {{ govukInput({

--- a/app/views/credentials/worldpay.njk
+++ b/app/views/credentials/worldpay.njk
@@ -2,7 +2,7 @@
 
 {% block provider_content %}
   {% if permissions.gateway_credentials_update %}
-    <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.index, currentGatewayAccount.external_id) }}" data-validate>
+    <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.index, currentGatewayAccount.external_id, paymentProvider) }}" data-validate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
       {% if change === 'merchantId' %}
@@ -113,7 +113,7 @@
     </form>
 
     <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id) }}">Cancel</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, paymentProvider) }}">Cancel</a>
     </p>
   {% endif %}
 {% endblock %}

--- a/app/views/your-psp/_epdq.njk
+++ b/app/views/your-psp/_epdq.njk
@@ -18,7 +18,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id) + "?change=merchantId",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=merchantId",
               text: "Change",
               visuallyHiddenText: "account credentials",
               attributes: {
@@ -39,7 +39,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id) + "?change=username",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=username",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }
@@ -57,7 +57,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id) + "?change=password",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=password",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }
@@ -75,7 +75,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id) + "?change=password",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=password",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }
@@ -93,7 +93,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id) + "?change=password",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=password",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }

--- a/app/views/your-psp/_smartpay.njk
+++ b/app/views/your-psp/_smartpay.njk
@@ -17,7 +17,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id) + "?change=merchantId",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=merchantId",
               text: "Change",
               visuallyHiddenText: "account credentials",
               attributes: {
@@ -38,7 +38,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id) + "?change=username",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=username",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }
@@ -56,7 +56,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id) + "?change=password",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=password",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }
@@ -94,7 +94,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.notificationCredentials.edit, currentGatewayAccount.external_id) + "?change=username",
+              href: formatAccountPathsFor(routes.account.notificationCredentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=username",
               text: "Change",
               visuallyHiddenText: "account credentials",
               attributes: {
@@ -115,7 +115,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.notificationCredentials.edit, currentGatewayAccount.external_id) + "?change=password",
+              href: formatAccountPathsFor(routes.account.notificationCredentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=password",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }

--- a/app/views/your-psp/_worldpay-flex.njk
+++ b/app/views/your-psp/_worldpay-flex.njk
@@ -1,3 +1,4 @@
+{% set paymentProvider = 'worldpay' %}
 <h2 class="govuk-heading-m govuk-!-margin-top-9">3DS Flex</h2>
 
 {{ govukInsetText({
@@ -24,7 +25,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id) + "?change=organisationalUnitId",
+              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, paymentProvider) + "?change=organisationalUnitId",
               text: "Change",
               visuallyHiddenText: "3DS Flex credentials",
               attributes: {
@@ -45,7 +46,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id) + "?change=issuer",
+              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, paymentProvider) + "?change=issuer",
               text: "Change",
               visuallyHiddenText: "3DS Flex credentials"
             }
@@ -63,7 +64,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id) + "?change=password",
+              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, paymentProvider) + "?change=password",
               text: "Change",
               visuallyHiddenText: "3DS Flex credentials"
             }
@@ -75,7 +76,7 @@
 }}
 
 {% if (is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured) or isWorldpay3dsFlexEnabled %}
-  <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.worldpay3dsFlex, currentGatewayAccount.external_id) }}">
+  <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.worldpay3dsFlex, currentGatewayAccount.external_id, paymentProvider) }}">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}">
     {% if is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured and not isWorldpay3dsFlexEnabled %}
         <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="on">

--- a/app/views/your-psp/_worldpay.njk
+++ b/app/views/your-psp/_worldpay.njk
@@ -17,7 +17,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id) + "?change=merchantId",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=merchantId",
               text: "Change",
               visuallyHiddenText: "account credentials",
               attributes: {
@@ -38,7 +38,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id) + "?change=username",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=username",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }
@@ -56,7 +56,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id) + "?change=password",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=password",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }

--- a/app/views/your-psp/flex.njk
+++ b/app/views/your-psp/flex.njk
@@ -1,5 +1,5 @@
 {% extends "layout.njk" %}
-
+{% set paymentProvider = 'worldpay' %}
 {% block pageTitle %}
   {% if errors %}
     Error:
@@ -14,7 +14,7 @@
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Your Worldpay 3DS Flex credentials</h1>
-    <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id) }}">
+    <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, paymentProvider) }}">
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
         {% if errors %}
           {% set errorList = [] %}
@@ -174,7 +174,7 @@
       }}
     </form>
     <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id) }}">Cancel</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, paymentProvider) }}">Cancel</a>
     </p>
 </div>
 {% endblock %}

--- a/app/views/your-psp/index.njk
+++ b/app/views/your-psp/index.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  Your PSP - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+  Your PSP - {{currentService.name}} {{ paymentProvider | formatPSPname }} - GOV.UK Pay
 {% endblock %}
 
 {% block side_navigation %}
@@ -10,16 +10,16 @@
 
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
-  <h1 class="govuk-heading-l page-title">Your payment service provider (PSP) - {{ currentGatewayAccount.payment_provider | formatPSPname }}</h1>
+  <h1 class="govuk-heading-l page-title">Your payment service provider (PSP) - {{ paymentProvider | formatPSPname }}</h1>
 
-  {% if currentGatewayAccount.payment_provider === "worldpay" %}
+  {% if paymentProvider === "worldpay" %}
     {% include "./_worldpay.njk" %}
     {% include "./_worldpay-flex.njk" %}
   {% endif %}
-  {% if currentGatewayAccount.payment_provider === "smartpay" %}
+  {% if paymentProvider === "smartpay" %}
     {% include "./_smartpay.njk" %}
   {% endif %}
-  {% if currentGatewayAccount.payment_provider === "epdq" %}
+  {% if paymentProvider === "epdq" %}
     {% include "./_epdq.njk" %}
   {% endif %}
 </div>

--- a/test/cypress/integration/settings/your-psp.cy.test.js
+++ b/test/cypress/integration/settings/your-psp.cy.test.js
@@ -156,7 +156,7 @@ describe('Your PSP settings page', () => {
       cy.get('#password').type(testCredentials.password)
       cy.get('#submitCredentials').click()
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath)
+        expect(location.pathname).to.eq(`${yourPspPath}/worldpay`)
       })
     })
 
@@ -176,7 +176,7 @@ describe('Your PSP settings page', () => {
       cy.get('#jwt-mac-key').type(' ' + testFlexCredentials.jwt_mac_key + ' ')
       cy.get('#submitFlexCredentials').click()
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath)
+        expect(location.pathname).to.eq(`${yourPspPath}/worldpay`)
       })
     })
 
@@ -204,7 +204,7 @@ describe('Your PSP settings page', () => {
       cy.get('#issuer').should('have.value', testInvalidFlexCredentials.issuer)
       cy.get('#jwt-mac-key').should('have.value', '')
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath + '/flex')
+        expect(location.pathname).to.eq(`${yourPspPath}/worldpay` + '/flex')
       })
     })
 
@@ -216,7 +216,7 @@ describe('Your PSP settings page', () => {
       cy.get('h1').should('contain', 'An error occurred')
       cy.get('#errorMsg').should('contain', 'There is a problem with the payments platform. Please contact the support team.')
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath + '/flex')
+        expect(location.pathname).to.eq(`${yourPspPath}/worldpay` + '/flex')
       })
     })
 
@@ -231,7 +231,7 @@ describe('Your PSP settings page', () => {
       cy.get('h1').should('contain', 'An error occurred')
       cy.get('#errorMsg').should('contain', 'Please try again or contact support team.')
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath + '/flex')
+        expect(location.pathname).to.eq(`${yourPspPath}/worldpay` + '/flex')
       })
     })
   })
@@ -245,7 +245,7 @@ describe('Your PSP settings page', () => {
       })
 
       cy.setEncryptedCookies(userExternalId)
-      cy.visit(yourPspPath)
+      cy.visit(`${yourPspPath}/worldpay`)
       cy.get('.value-merchant-id').should('contain', testCredentials.merchant_id)
       cy.get('.value-username').should('contain', testCredentials.username)
       cy.get('.value-password').should('contain', '●●●●●●●●')
@@ -268,14 +268,14 @@ describe('Your PSP settings page', () => {
       })
 
       cy.setEncryptedCookies(userExternalId)
-      cy.visit(yourPspPath)
+      cy.visit(`${yourPspPath}/worldpay`)
       cy.get('#worldpay-3ds-flex-is-off').should('exist')
       cy.get('#worldpay-3ds-flex-is-on').should('not.exist')
       cy.get('#disable-worldpay-3ds-flex-button').should('not.exist')
 
       cy.get('#enable-worldpay-3ds-flex-button').should('exist').click()
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath)
+        expect(location.pathname).to.eq(`${yourPspPath}/worldpay`)
       })
     })
 
@@ -289,14 +289,14 @@ describe('Your PSP settings page', () => {
       })
 
       cy.setEncryptedCookies(userExternalId)
-      cy.visit(yourPspPath)
+      cy.visit(`${yourPspPath}/worldpay`)
       cy.get('#worldpay-3ds-flex-is-on').should('exist')
       cy.get('#worldpay-3ds-flex-is-off').should('not.exist')
       cy.get('#enable-worldpay-3ds-flex-button').should('not.exist')
 
       cy.get('#disable-worldpay-3ds-flex-button').should('exist').click()
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath)
+        expect(location.pathname).to.eq(`${yourPspPath}/worldpay`)
       })
     })
 
@@ -309,7 +309,7 @@ describe('Your PSP settings page', () => {
       })
 
       cy.setEncryptedCookies(userExternalId)
-      cy.visit(yourPspPath)
+      cy.visit(`${yourPspPath}/worldpay`)
       cy.get('#worldpay-3ds-flex-is-off').should('exist')
       cy.get('#worldpay-3ds-flex-is-on').should('not.exist')
       cy.get('#disable-worldpay-3ds-flex-button').should('not.exist')
@@ -326,7 +326,7 @@ describe('Your PSP settings page', () => {
       })
 
       cy.setEncryptedCookies(userExternalId)
-      cy.visit(yourPspPath)
+      cy.visit(`${yourPspPath}/worldpay`)
       cy.get('#worldpay-3ds-flex-is-off').should('exist')
       cy.get('#worldpay-3ds-flex-is-on').should('not.exist')
       cy.get('#disable-worldpay-3ds-flex-button').should('not.exist')
@@ -363,7 +363,7 @@ describe('Your PSP settings page', () => {
       cy.get('#password').type(testCredentials.password)
       cy.get('#submitCredentials').click()
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath)
+        expect(location.pathname).to.eq(`${yourPspPath}/smartpay`)
       })
     })
 
@@ -375,7 +375,7 @@ describe('Your PSP settings page', () => {
       cy.get('#notification-password').type(testCredentials.password)
       cy.get('#submitNotificationCredentials').click()
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath)
+        expect(location.pathname).to.eq(`${yourPspPath}/smartpay`)
       })
     })
   })
@@ -391,7 +391,7 @@ describe('Your PSP settings page', () => {
 
     it('should show all credentials as configured', () => {
       cy.setEncryptedCookies(userExternalId)
-      cy.visit(yourPspPath)
+      cy.visit(`${yourPspPath}/smartpay`)
       cy.get('.value-merchant-id').should('contain', testCredentials.merchant_id)
       cy.get('.value-username').should('contain', testCredentials.username)
       cy.get('.value-password').should('contain', '●●●●●●●●')
@@ -433,7 +433,7 @@ describe('Your PSP settings page', () => {
       cy.get('#shaOutPassphrase').type(testCredentials.password)
       cy.get('#submitCredentials').click()
       cy.location().should((location) => {
-        expect(location.pathname).to.eq(yourPspPath)
+        expect(location.pathname).to.eq(`${yourPspPath}/epdq`)
       })
     })
   })
@@ -448,7 +448,7 @@ describe('Your PSP settings page', () => {
 
     it('should show all credentials as configured', () => {
       cy.setEncryptedCookies(userExternalId)
-      cy.visit(yourPspPath)
+      cy.visit(`${yourPspPath}/epdq`)
       cy.get('.value-merchant-id').should('contain', testCredentials.merchant_id)
       cy.get('.value-username').should('contain', testCredentials.username)
       cy.get('.value-password').should('contain', '●●●●●●●●')


### PR DESCRIPTION
Link specficially to payment provider versions of PSP and credential
configuration pages.

This willl support individual accounts to link to multiple credential
configurations.

It will also allow supported PSP credential specific pages, Worldpay
with Worldpay credential validation.

### How to test

- The "Your PSP" and "Credentials" pages should work exactly as they do now, no user facing changes