### PR TITLE
PP-8131 Worldpay credentials specific creds page

### DIFF
--- a/app/controllers/credentials/credentials-form.js
+++ b/app/controllers/credentials/credentials-form.js
@@ -40,18 +40,10 @@ class CredentialsForm {
       errorSummaryList: formatErrorsForSummaryList(errors)
     }
   }
-
-  // render(formData = {}) {
-  //   return this.fields.reduce((aggregate, field) => {
-  //     const key = field.key || field.id
-  //     aggregate[key] = typeof formData[field.id] === 'string' ? formData[field.id].trim() : formData[field.id]
-  //     return aggregate
-  //   }, {})
-  // }
 }
 
 function isNotEmpty (value) {
   return value && value.length !== 0
 }
 
-module.exports = { CredentialsForm, isNotEmpty }
+module.exports = { CredentialsForm, isNotEmpty, formatErrorsForSummaryList }

--- a/app/controllers/credentials/credentials-form.js
+++ b/app/controllers/credentials/credentials-form.js
@@ -1,0 +1,57 @@
+function formatErrorsForSummaryList (errors = {}) {
+  return Object.entries(errors).map(([id, message]) => ({
+    href: `#${id}`,
+    text: message
+  }))
+}
+class CredentialsForm {
+  constructor (fields = []) {
+    this.fields = fields
+    this.values = {}
+  }
+
+  from (entity = {}) {
+    const values = this.fields.reduce((aggregate, field) => {
+      const key = field.key || field.id
+      aggregate[field.id] = entity[key]
+      return aggregate
+    }, {})
+    return { values }
+  }
+
+  validate (formData = {}) {
+    const errors = {}
+    const values = {}
+
+    this.fields.forEach((field) => {
+      const valid = field.valid || []
+      values[field.id] = typeof formData[field.id] === 'string' ? formData[field.id].trim() : formData[field.id]
+      valid.some((validator) => {
+        const valid = validator.method(formData[field.id])
+        if (!valid) {
+          errors[field.id] = validator.message
+          return true
+        }
+      })
+    })
+    return {
+      values,
+      errors,
+      errorSummaryList: formatErrorsForSummaryList(errors)
+    }
+  }
+
+  // render(formData = {}) {
+  //   return this.fields.reduce((aggregate, field) => {
+  //     const key = field.key || field.id
+  //     aggregate[key] = typeof formData[field.id] === 'string' ? formData[field.id].trim() : formData[field.id]
+  //     return aggregate
+  //   }, {})
+  // }
+}
+
+function isNotEmpty (value) {
+  return value && value.length !== 0
+}
+
+module.exports = { CredentialsForm, isNotEmpty }

--- a/app/controllers/credentials/credentials-form.test.js
+++ b/app/controllers/credentials/credentials-form.test.js
@@ -1,0 +1,50 @@
+const { expect } = require('chai')
+const { CredentialsForm, isNotEmpty } = require('./credentials-form')
+
+describe('Credentials forms', () => {
+  it('constructs a form with no fields', () => {
+    const form = new CredentialsForm()
+    expect(form).to.not.be.null // eslint-disable-line
+    expect(form.validate().errors).to.deep.equal({})
+  })
+
+  it('correctly validates for empty values', () => {
+    const form = new CredentialsForm([{
+      id: 'some-id', valid: [{ method: isNotEmpty, message: 'Enter some ID' }]
+    }])
+    const results = form.validate({
+      'some-id': ''
+    })
+    expect(results.errors['some-id']).to.equal('Enter some ID')
+    expect(results.errorSummaryList[0]).to.have.keys('href', 'text')
+    expect(results.errorSummaryList[0].href).to.equal('#some-id')
+  })
+
+  it('correctly validates for populated values', () => {
+    const form = new CredentialsForm([{
+      id: 'some-id', key: 'someId', valid: [{ method: isNotEmpty, message: 'Enter some ID' }]
+    }])
+    const results = form.validate({
+      'some-id': 'some-value'
+    })
+    expect(results.values['some-id']).to.equal('some-value')
+    expect(results.errors).to.deep.equal({})
+    expect(results.errorSummaryList).to.have.length(0)
+  })
+
+  it('populates form values from an entity', () => {
+    const form = new CredentialsForm([{
+      id: 'some-id', key: 'someId'
+    }])
+    const results = form.from({ someId: 'an-initial-id' })
+    expect(results.values['some-id']).to.equal('an-initial-id')
+  })
+
+  // it('renders object output based on field keys', () => {
+  //   const form = new CredentialsForm([{
+  //     id: 'some-id', key: 'someId'
+  //   }])
+  //   const results = form.render({ 'some-id': 'an-initial-id' })
+  //   expect(results).to.deep.equal({ someId: 'an-initial-id' })
+  // })
+})

--- a/app/controllers/credentials/credentials-form.test.js
+++ b/app/controllers/credentials/credentials-form.test.js
@@ -39,12 +39,4 @@ describe('Credentials forms', () => {
     const results = form.from({ someId: 'an-initial-id' })
     expect(results.values['some-id']).to.equal('an-initial-id')
   })
-
-  // it('renders object output based on field keys', () => {
-  //   const form = new CredentialsForm([{
-  //     id: 'some-id', key: 'someId'
-  //   }])
-  //   const results = form.render({ 'some-id': 'an-initial-id' })
-  //   expect(results).to.deep.equal({ someId: 'an-initial-id' })
-  // })
 })

--- a/app/controllers/credentials/worldpay.controller.js
+++ b/app/controllers/credentials/worldpay.controller.js
@@ -4,7 +4,7 @@ const { CORRELATION_HEADER } = require('../../utils/correlation-header')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
-const { CredentialsForm, isNotEmpty } = require('./credentials-form')
+const { CredentialsForm, isNotEmpty, formatErrorsForSummaryList } = require('./credentials-form')
 
 const credentialsForm = new CredentialsForm([
   { id: 'merchant_id', valid: [{ method: isNotEmpty, message: 'Enter a merchant code' }] },
@@ -28,6 +28,11 @@ async function updateWorldpayCredentials (req, res, next) {
   }
 
   try {
+    const checkCredentialsWithWorldpay = await connectorClient.postCheckWorldpayCredentials({ correlationId, gatewayAccountId, payload: results.values })
+    if (checkCredentialsWithWorldpay.result !== 'valid') {
+      results.errorSummaryList = formatErrorsForSummaryList({ 'merchant_id': 'Unable to use credentials with Worldpay, check entered credentials' })
+      return response(req, res, 'credentials/worldpay', { form: results })
+    }
     await connectorClient.patchAccountCredentials({
       correlationId,
       gatewayAccountId,

--- a/app/controllers/credentials/worldpay.controller.js
+++ b/app/controllers/credentials/worldpay.controller.js
@@ -1,0 +1,43 @@
+const paths = require('../../paths')
+const { response } = require('../../utils/response')
+const { CORRELATION_HEADER } = require('../../utils/correlation-header')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
+const { ConnectorClient } = require('../../services/clients/connector.client')
+const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
+const { CredentialsForm, isNotEmpty } = require('./credentials-form')
+
+const credentialsForm = new CredentialsForm([
+  { id: 'merchant_id', valid: [{ method: isNotEmpty, message: 'Enter a merchant code' }] },
+  { id: 'username', valid: [{ method: isNotEmpty, message: 'Enter a username' }] },
+  { id: 'password', valid: [{ method: isNotEmpty, message: 'Enter a password' }] }
+])
+
+function showWorldpayCredentialsPage (req, res, next) {
+  const form = credentialsForm.from(req.account.credentials)
+  response(req, res, 'credentials/worldpay', { form })
+}
+
+async function updateWorldpayCredentials (req, res, next) {
+  const gatewayAccountId = req.account.gateway_account_id
+  const correlationId = req.headers[CORRELATION_HEADER] || ''
+
+  const results = credentialsForm.validate(req.body)
+
+  if (results.errorSummaryList.length) {
+    return response(req, res, 'credentials/worldpay', { form: results })
+  }
+
+  try {
+    await connectorClient.patchAccountCredentials({
+      correlationId,
+      gatewayAccountId,
+      payload: { credentials: results.values }
+    })
+
+    return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, 'worldpay'))
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = { showWorldpayCredentialsPage, updateWorldpayCredentials }

--- a/app/paths.js
+++ b/app/paths.js
@@ -20,6 +20,7 @@ module.exports = {
       update: '/api-keys/update'
     },
     credentials: {
+      worldpay: '/credentials/worldpay',
       index: '/credentials/:paymentProvider',
       edit: '/credentials/:paymentProvider/edit'
     },

--- a/app/routes.js
+++ b/app/routes.js
@@ -30,6 +30,7 @@ const transactionDetailController = require('./controllers/transactions/transact
 const transactionRefundController = require('./controllers/transactions/transaction-refund.controller')
 const transactionDetailRedirectController = require('./controllers/transactions/transaction-detail-redirect.controller')
 const credentialsController = require('./controllers/credentials.controller')
+const worldpayCredentialsController = require('./controllers/credentials/worldpay.controller')
 const loginController = require('./controllers/login')
 const dashboardController = require('./controllers/dashboard')
 const apiKeysController = require('./controllers/api-keys')
@@ -296,6 +297,9 @@ module.exports.bind = function (app) {
   account.post(yourPsp.flex, permission('gateway-credentials:update'), yourPspController.postFlex)
 
   // Credentials
+  account.get(credentials.worldpay, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)
+  account.post(credentials.worldpay, permission('gateway-credentials:read'), worldpayCredentialsController.updateWorldpayCredentials)
+
   account.get(credentials.index, permission('gateway-credentials:read'), credentialsController.index)
   account.get(credentials.edit, permission('gateway-credentials:update'), credentialsController.editCredentials)
   account.post(credentials.index, permission('gateway-credentials:update'), credentialsController.update)

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -25,6 +25,7 @@ const ACCOUNT_NOTIFICATION_CREDENTIALS_PATH = '/v1/api/accounts' + '/{accountId}
 const ACCOUNT_CREDENTIALS_PATH = ACCOUNT_FRONTEND_PATH + '/credentials'
 const EMAIL_NOTIFICATION__PATH = '/v1/api/accounts/{accountId}/email-notification'
 const CHECK_WORLDPAY_3DS_FLEX_CREDENTIALS_PATH = '/v1/api/accounts/{accountId}/worldpay/check-3ds-flex-config'
+const CHECK_WORLDPAY_CREDENTIALS_PATH = '/v1/api/accounts/{accountId}/worldpay/check-credentials'
 const FLEX_CREDENTIALS_PATH = '/v1/api/accounts/{accountId}/3ds-flex-credentials'
 const TOGGLE_3DS_PATH = ACCOUNTS_FRONTEND_PATH + '/{accountId}/3ds-toggle'
 
@@ -247,6 +248,20 @@ ConnectorClient.prototype = {
         body: params.payload,
         correlationId: params.correlationId,
         description: 'Check Worldpay 3DS Flex credentials',
+        service: SERVICE_NAME
+      }
+    )
+  },
+
+  postCheckWorldpayCredentials: function (params) {
+    return baseClient.post(
+      {
+        baseUrl: this.connectorUrl,
+        url: CHECK_WORLDPAY_CREDENTIALS_PATH.replace('{accountId}', params.gatewayAccountId),
+        json: true,
+        body: params.payload,
+        correlationId: params.correlationId,
+        description: 'Check Worldpay credentials',
         service: SERVICE_NAME
       }
     )

--- a/app/views/credentials/worldpay.njk
+++ b/app/views/credentials/worldpay.njk
@@ -60,6 +60,7 @@
             name: "password",
             classes: "govuk-input--width-20",
             type: "password",
+            value: form.values.password,
             errorMessage: form.errors.password and {
               text: form.errors.password
             }

--- a/app/views/credentials/worldpay.njk
+++ b/app/views/credentials/worldpay.njk
@@ -1,44 +1,42 @@
-{% extends "./index.njk" %}
+{% extends "layout.njk" %}
 
-{% block provider_content %}
+{% block pageTitle %}
+  Account credentials - {{currentService.name}} Worldpay - GOV.UK Pay
+{% endblock %}
+
+{% block side_navigation %}
+  {% include "includes/side-navigation.njk" %}
+{% endblock %}
+
+{% block mainContent %}
+<div class="govuk-grid-column-two-thirds">
+    {% if form.errorSummaryList and form.errorSummaryList.length %}
+      {{ govukErrorSummary({
+        titleText: 'There is a problem',
+        errorList: form.errorSummaryList
+      }) }}
+    {% endif %}
+    <h1 class="govuk-heading-l page-title" id="view-title">Your Worldpay credentials</h1>
+
   {% if permissions.gateway_credentials_update %}
-    <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.index, currentGatewayAccount.external_id, paymentProvider) }}" data-validate>
+    <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.worldpay, currentGatewayAccount.external_id) }}" data-validate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
-      {% if change === 'merchantId' %}
         {{ govukInput({
             label: {
               text: "Merchant code"
             },
-            id: "merchantId",
-            name: "merchantId",
+            id: "merchant_id",
+            name: "merchant_id",
             classes: "govuk-input--width-20",
             type: "text",
-            attributes: {
-              "data-validate": "required",
-              "autofocus": "autofocus"
-            },
-            value: currentGatewayAccount.credentials.merchant_id
+            value: form.values.merchant_id,
+            errorMessage: form.errors.merchant_id and {
+              text: form.errors.merchant_id
+            }
           })
         }}
-      {% else %}
-        {{ govukInput({
-            label: {
-              text: "Merchant code"
-            },
-            id: "merchantId",
-            name: "merchantId",
-            classes: "govuk-input--width-20",
-            type: "text",
-            attributes: {
-              "data-validate": "required"
-            },
-            value: currentGatewayAccount.credentials.merchant_id
-          })
-        }}
-      {% endif %}
 
-      {% if change === 'username' %}
         {{ govukInput({
             label: {
               text: "Username"
@@ -47,31 +45,13 @@
             name: "username",
             classes: "govuk-input--width-20",
             type: "text",
-            attributes: {
-              "data-validate": "required",
-              "autofocus": "autofocus"
-            },
-            value: currentGatewayAccount.credentials.username
+            value: form.values.username,
+            errorMessage: form.errors.username and {
+              text: form.errors.username
+            }
           })
         }}
-      {% else %}
-        {{ govukInput({
-            label: {
-              text: "Username"
-            },
-            id: "username",
-            name: "username",
-            classes: "govuk-input--width-20",
-            type: "text",
-            attributes: {
-              "data-validate": "required"
-            },
-            value: currentGatewayAccount.credentials.username
-          })
-        }}
-      {% endif %}
 
-      {% if change === 'password' %}
         {{ govukInput({
             label: {
               text: "Password"
@@ -80,27 +60,11 @@
             name: "password",
             classes: "govuk-input--width-20",
             type: "password",
-            attributes: {
-              "data-validate": "required",
-              "autofocus": "autofocus"
+            errorMessage: form.errors.password and {
+              text: form.errors.password
             }
           })
         }}
-        {% else %}
-        {{ govukInput({
-            label: {
-              text: "Password"
-            },
-            id: "password",
-            name: "password",
-            classes: "govuk-input--width-20",
-            type: "password",
-            attributes: {
-              "data-validate": "required"
-            }
-          })
-        }}
-      {% endif %}
 
       {{
         govukButton({
@@ -113,7 +77,8 @@
     </form>
 
     <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, paymentProvider) }}">Cancel</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, 'worldpay') }}">Cancel</a>
     </p>
   {% endif %}
+</div>
 {% endblock %}

--- a/app/views/your-psp/_worldpay.njk
+++ b/app/views/your-psp/_worldpay.njk
@@ -17,7 +17,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=merchantId",
+              href: formatAccountPathsFor(routes.account.credentials.worldpay, currentGatewayAccount.external_id) + "?change=merchantId",
               text: "Change",
               visuallyHiddenText: "account credentials",
               attributes: {
@@ -38,7 +38,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=username",
+              href: formatAccountPathsFor(routes.account.credentials.worldpay, currentGatewayAccount.external_id) + "?change=username",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }
@@ -56,7 +56,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=password",
+              href: formatAccountPathsFor(routes.account.credentials.worldpay, currentGatewayAccount.external_id) + "?change=password",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }

--- a/test/cypress/integration/settings/your-psp.cy.test.js
+++ b/test/cypress/integration/settings/your-psp.cy.test.js
@@ -86,6 +86,7 @@ describe('Your PSP settings page', () => {
       gatewayAccountId: gatewayAccountId,
       shouldReturnValid: true
     })
+    const postCheckWorldpayCredentials = gatewayAccountStubs.postCheckWorldpayCredentials({ credentials: opts.validateCredentials, gatewayAccountId })
     const postCheckWorldpay3dsFlexCredentialsReturnsInvalid = gatewayAccountStubs.postCheckWorldpay3dsFlexCredentials({
       gatewayAccountId: gatewayAccountId,
       shouldReturnValid: false
@@ -102,7 +103,8 @@ describe('Your PSP settings page', () => {
       postCheckWorldpay3dsFlexCredentialsReturnsValid,
       postCheckWorldpay3dsFlexCredentialsReturnsInvalid,
       postCheckWorldpay3dsFlexCredentialsFails,
-      postCheckWorldpay3dsFlexCredentialsReturnsBadResult
+      postCheckWorldpay3dsFlexCredentialsReturnsBadResult,
+      postCheckWorldpayCredentials
     ]
 
     cy.task('setupStubs', stubs)
@@ -127,7 +129,8 @@ describe('Your PSP settings page', () => {
   describe('When using a Worldpay account', () => {
     beforeEach(() => {
       setupYourPspStubs({
-        gateway: 'worldpay'
+        gateway: 'worldpay',
+        validateCredentials: testCredentials
       })
     })
 
@@ -149,7 +152,7 @@ describe('Your PSP settings page', () => {
 
     it('should allow account credentials to be configured and all values must be set', () => {
       cy.get('#credentials-change-link').click()
-      cy.get('#merchantId').type(testCredentials.merchant_id)
+      cy.get('#merchant_id').type(testCredentials.merchant_id)
       cy.get('#username').type(testCredentials.username)
       cy.get('#submitCredentials').click()
       cy.get('.govuk-error-summary').should('have.length', 1)

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -196,6 +196,14 @@ function postCheckWorldpay3dsFlexCredentials (opts) {
   }
 }
 
+function postCheckWorldpayCredentials (opts) {
+  const path = `/v1/api/accounts/${opts.gatewayAccountId}/worldpay/check-credentials`
+  return stubBuilder('POST', path, 200, {
+    request: opts.credentials,
+    response: { result: 'valid' }
+  })
+}
+
 function postCheckWorldpay3dsFlexCredentialsFailure (opts) {
   const path = `/v1/api/accounts/${opts.gatewayAccountId}/worldpay/check-3ds-flex-config`
   return stubBuilder('POST', path, 500, {
@@ -228,5 +236,6 @@ module.exports = {
   patchAccountEmailCollectionModeSuccess,
   postCheckWorldpay3dsFlexCredentials,
   postCheckWorldpay3dsFlexCredentialsFailure,
-  postCheckWorldpay3dsFlexCredentialsWithBadResult
+  postCheckWorldpay3dsFlexCredentialsWithBadResult,
+  postCheckWorldpayCredentials
 }


### PR DESCRIPTION
Use new `/worldpay/check-credentials` Connector route to make sure service users have provided correct credentials before allowing submission.

Also
- Implement worldpay credentials against current language best practices
- Simple backend form validation meets design system recommendations
- Page is covered by existing credentials Cypress tests
