### PR TITLE
PP-8131 Fix lining up worldpay creds page with end to end selectors

### DIFF
--- a/app/views/credentials/worldpay.njk
+++ b/app/views/credentials/worldpay.njk
@@ -26,7 +26,7 @@
             label: {
               text: "Merchant code"
             },
-            id: "merchant_id",
+            id: "merchantId",
             name: "merchant_id",
             classes: "govuk-input--width-20",
             type: "text",

--- a/test/cypress/integration/settings/your-psp.cy.test.js
+++ b/test/cypress/integration/settings/your-psp.cy.test.js
@@ -152,7 +152,7 @@ describe('Your PSP settings page', () => {
 
     it('should allow account credentials to be configured and all values must be set', () => {
       cy.get('#credentials-change-link').click()
-      cy.get('#merchant_id').type(testCredentials.merchant_id)
+      cy.get('#merchantId').type(testCredentials.merchant_id)
       cy.get('#username').type(testCredentials.username)
       cy.get('#submitCredentials').click()
       cy.get('.govuk-error-summary').should('have.length', 1)


### PR DESCRIPTION
E2E select by ID https://github.com/alphagov/pay-endtoend/blob/8b3165297ec56f1a6d774bfac61d17be07d56abd/src/test/java/uk/gov/pay/endtoend/pages/selfservice/GatewayAccountEditCredentialsPage.java#L12

Even though this is inconsistent, remove the discrepancy 