### PR TITLE
PP-8131 Allow environments to skip PSP credential validation

### DIFF
--- a/app/controllers/credentials/credentials-form.js
+++ b/app/controllers/credentials/credentials-form.js
@@ -25,7 +25,7 @@ class CredentialsForm {
 
     this.fields.forEach((field) => {
       const valid = field.valid || []
-      values[field.id] = typeof formData[field.id] === 'string' ? formData[field.id].trim() : formData[field.id]
+      values[field.key || field.id] = typeof formData[field.id] === 'string' ? formData[field.id].trim() : formData[field.id]
       valid.some((validator) => {
         const valid = validator.method(formData[field.id])
         if (!valid) {

--- a/app/controllers/credentials/credentials-form.test.js
+++ b/app/controllers/credentials/credentials-form.test.js
@@ -27,7 +27,7 @@ describe('Credentials forms', () => {
     const results = form.validate({
       'some-id': 'some-value'
     })
-    expect(results.values['some-id']).to.equal('some-value')
+    expect(results.values['someId']).to.equal('some-value')
     expect(results.errors).to.deep.equal({})
     expect(results.errorSummaryList).to.have.length(0)
   })

--- a/app/controllers/credentials/worldpay.controller.js
+++ b/app/controllers/credentials/worldpay.controller.js
@@ -9,9 +9,9 @@ const { CONNECTOR_URL, SKIP_PSP_CREDENTIAL_CHECKS } = process.env
 const connectorClient = new ConnectorClient(CONNECTOR_URL)
 
 const credentialsForm = new CredentialsForm([
-  { id: 'merchant_id', valid: [{ method: isNotEmpty, message: 'Enter a merchant code' }] },
-  { id: 'username', valid: [{ method: isNotEmpty, message: 'Enter a username' }] },
-  { id: 'password', valid: [{ method: isNotEmpty, message: 'Enter a password' }] }
+  { id: 'merchant_id', valid: [{ method: isNotEmpty, message: 'Enter your merchant code' }] },
+  { id: 'username', valid: [{ method: isNotEmpty, message: 'Enter your username' }] },
+  { id: 'password', valid: [{ method: isNotEmpty, message: 'Enter your password' }] }
 ])
 
 function showWorldpayCredentialsPage (req, res, next) {
@@ -33,7 +33,7 @@ async function updateWorldpayCredentials (req, res, next) {
     if (SKIP_PSP_CREDENTIAL_CHECKS !== 'true') {
       const checkCredentialsWithWorldpay = await connectorClient.postCheckWorldpayCredentials({ correlationId, gatewayAccountId, payload: results.values })
       if (checkCredentialsWithWorldpay.result !== 'valid') {
-        results.errorSummaryList = formatErrorsForSummaryList({ 'merchant_id': 'Unable to use credentials with Worldpay, check entered credentials' })
+        results.errorSummaryList = formatErrorsForSummaryList({ 'merchant_id': 'Check your Worldpay credentials, failed to link your account to Worldpay with credentials provided' })
         return response(req, res, 'credentials/worldpay', { form: results })
       }
     }

--- a/app/views/credentials/worldpay.njk
+++ b/app/views/credentials/worldpay.njk
@@ -27,12 +27,12 @@
               text: "Merchant code"
             },
             id: "merchantId",
-            name: "merchant_id",
+            name: "merchantId",
             classes: "govuk-input--width-20",
             type: "text",
             value: form.values.merchant_id,
-            errorMessage: form.errors.merchant_id and {
-              text: form.errors.merchant_id
+            errorMessage: form.errors.merchantId and {
+              text: form.errors.merchantId
             }
           })
         }}


### PR DESCRIPTION
Allow environments to suppress PSP credential validation checks.

Set `SKIP_PSP_CREDENTIAL_CHECKS` to "true" in an environment to skip
checking the PSP credentials against the PSP before submitting them to
Connector.

This should allow the end to end environment to use fake credentials and
support to respond to issue in the case of network issues or a Worldpay
failure response incident

* Add logging for audit trail around error and validation on credentials
* Content updated to use instructions