### PR TITLE
PP-8131 Use pact fixtures in Worldpay credentials validation tests

### DIFF
--- a/test/cypress/integration/settings/your-psp.cy.test.js
+++ b/test/cypress/integration/settings/your-psp.cy.test.js
@@ -86,7 +86,7 @@ describe('Your PSP settings page', () => {
       gatewayAccountId: gatewayAccountId,
       shouldReturnValid: true
     })
-    const postCheckWorldpayCredentials = gatewayAccountStubs.postCheckWorldpayCredentials({ credentials: opts.validateCredentials, gatewayAccountId })
+    const postCheckWorldpayCredentials = gatewayAccountStubs.postCheckWorldpayCredentials({ ...opts.validateCredentials, gatewayAccountId })
     const postCheckWorldpay3dsFlexCredentialsReturnsInvalid = gatewayAccountStubs.postCheckWorldpay3dsFlexCredentials({
       gatewayAccountId: gatewayAccountId,
       shouldReturnValid: false

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -3,6 +3,7 @@
 const gatewayAccountFixtures = require('../../fixtures/gateway-account.fixtures')
 const cardFixtures = require('../../fixtures/card.fixtures')
 const worldpay3dsFlexCredentialsFixtures = require('../../fixtures/worldpay-3ds-flex-credentials.fixtures')
+const worldpayCredentialsFixtures = require('../../fixtures/worldpay-credentials.fixtures')
 const { stubBuilder } = require('./stub-builder')
 
 function parseGatewayAccountOptions (opts) {
@@ -199,8 +200,8 @@ function postCheckWorldpay3dsFlexCredentials (opts) {
 function postCheckWorldpayCredentials (opts) {
   const path = `/v1/api/accounts/${opts.gatewayAccountId}/worldpay/check-credentials`
   return stubBuilder('POST', path, 200, {
-    request: opts.credentials,
-    response: { result: 'valid' }
+    request: worldpayCredentialsFixtures.checkValidWorldpayCredentialsRequest(opts).payload,
+    response: worldpayCredentialsFixtures.checkValidWorldpayCredentialsResponse(opts)
   })
 }
 

--- a/test/fixtures/worldpay-credentials.fixtures.js
+++ b/test/fixtures/worldpay-credentials.fixtures.js
@@ -3,8 +3,8 @@ function checkValidWorldpayCredentialsRequest (opts = {}) {
     gatewayAccountId: opts.gatewayAccountId || 333,
     payload: {
       merchant_id: opts.merchant_id || 'a-merchant-id',
-      username: opts.issuer || 'a-username',
-      password: opts.jwt_mac_key || 'a-password'
+      username: opts.username || 'a-username',
+      password: opts.password || 'a-password'
     }
   }
 }


### PR DESCRIPTION
Now that fixtures exist that are checked against consumer pacts, use those in the Worldpay credentials validation Cypress tests.