### PR TITLE
BAU Fix setup for flakey worldpay flex pact

### DIFF
--- a/test/unit/clients/connector-client/connector-post-worldpay-check-3ds-flex-config.pact.test.js
+++ b/test/unit/clients/connector-client/connector-post-worldpay-check-3ds-flex-config.pact.test.js
@@ -40,7 +40,7 @@ describe('connector client - check Worldpay 3DS Flex credentials', () => {
       const checkValidWorldpay3dsFlexCredentialsRequest = worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsRequest()
       const checkValidWorldpay3dsFlexCredentialsResponse = worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsResponse()
       before(() => {
-        provider.addInteraction(
+        return provider.addInteraction(
           new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${EXISTING_GATEWAY_ACCOUNT_ID}/${CHECK_WORLDPAY_3DS_FLEX_CREDENTIALS}`)
             .withState(`a gateway account ${EXISTING_GATEWAY_ACCOUNT_ID} with Worldpay 3DS Flex credentials exists`)
             .withUponReceiving('a request to check Worldpay 3DS Flex credentials')
@@ -54,11 +54,9 @@ describe('connector client - check Worldpay 3DS Flex credentials', () => {
         )
       })
 
-      it('should return valid', () => {
-        return connectorClient.postCheckWorldpay3dsFlexCredentials(checkValidWorldpay3dsFlexCredentialsRequest)
-          .should.be.fulfilled.then((response) => {
-            expect(response).to.deep.equal(checkValidWorldpay3dsFlexCredentialsResponse)
-          })
+      it('should return valid', async () => {
+        const response = await connectorClient.postCheckWorldpay3dsFlexCredentials(checkValidWorldpay3dsFlexCredentialsRequest)
+        expect(response).to.deep.equal(checkValidWorldpay3dsFlexCredentialsResponse)
       })
     })
   })

--- a/test/unit/clients/connector-client/connector-post-worldpay-check-credentials.pact.test.js
+++ b/test/unit/clients/connector-client/connector-post-worldpay-check-credentials.pact.test.js
@@ -38,7 +38,7 @@ describe('connector client - check Worldpay 3DS Flex credentials', () => {
       const checkValidWorldpayCredentialsRequest = worldpayCredentialsFixtures.checkValidWorldpayCredentialsRequest()
       const checkValidWorldpayCredentialsResponse = worldpayCredentialsFixtures.checkValidWorldpayCredentialsResponse()
       before(() => {
-        provider.addInteraction(
+        return provider.addInteraction(
           new PactInteractionBuilder(`/v1/api/accounts/${EXISTING_GATEWAY_ACCOUNT_ID}/worldpay/check-credentials`)
             .withState(`a Worldpay gateway account with id ${EXISTING_GATEWAY_ACCOUNT_ID} exists and stub for validating credentials is set up`)
             .withUponReceiving('a request to check Worldpay credentials')


### PR DESCRIPTION
I'm not familiar with the chai `should` syntax but this unit test seems
to fail every so often for no reason.

Use async/ await syntax to make it clearer what's going on and review
behaviour to make sure it will only return once the request and
assertion have completed.

### How to test
- test should pass 
- test should always pass, independent of CPU cycles, temperature, day of the week, alignment of the stars