### PR TITLE
PP-8213 Switching PSP base page

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -45,3 +45,4 @@ $govuk-page-width: 1200px;
 @import "components/my-profile";
 @import "components/prototype-links";
 @import "components/my-services";
+@import "components/task-list";

--- a/app/assets/sass/components/task-list.scss
+++ b/app/assets/sass/components/task-list.scss
@@ -1,0 +1,76 @@
+.app-task-list {
+  list-style-type: none;
+  padding-left: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  @include govuk-media-query($from: tablet) {
+    min-width: 550px;
+  }
+}
+
+.app-task-list__section {
+  display: table;
+  @include govuk-font($size:24, $weight: bold);
+}
+
+.app-task-list__section-number {
+  display: table-cell;
+
+  @include govuk-media-query($from: tablet) {
+    min-width: govuk-spacing(6);
+    padding-right: 0;
+  }
+}
+
+.app-task-list__items {
+  @include govuk-font($size: 19);
+  @include govuk-responsive-margin(9, "bottom");
+  list-style: none;
+  padding-left: 0;
+  @include govuk-media-query($from: tablet) {
+    padding-left: govuk-spacing(6);
+  }
+}
+
+.app-task-list__flat_items {
+  @include govuk-font($size: 19);
+  @include govuk-responsive-margin(9, "bottom");
+  list-style: none;
+  padding-left: 0;
+}
+
+.app-task-list__flat_items .app-task-list__item {
+  border-top: none !important;
+  border-bottom: none !important;
+}
+
+.app-task-list__item {
+  border-bottom: 1px solid $govuk-border-colour;
+  margin-bottom: 0 !important;
+  padding-top: govuk-spacing(2);
+  padding-bottom: govuk-spacing(2);
+  @include govuk-clearfix;
+}
+
+.app-task-list__item:first-child {
+  border-top: 1px solid $govuk-border-colour;
+}
+
+.app-task-list__task-name {
+  display: block;
+  @include govuk-media-query($from: 450px) {
+    float: left;
+  }
+}
+
+.app-task-list__tag,
+.app-task-list__task-completed {
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
+
+  @include govuk-media-query($from: 450px) {
+    float: right;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}

--- a/app/controllers/switch-psp/switch-psp.controller.js
+++ b/app/controllers/switch-psp/switch-psp.controller.js
@@ -1,0 +1,14 @@
+'use strict'
+const { response } = require('../../utils/response')
+const { getSwitchingCredential } = require('../../utils/credentials')
+
+function switchPSPPage (req, res, next) {
+  try {
+    const targetCredential = getSwitchingCredential(req.account)
+    response(req, res, 'switch-psp/switch-psp', { targetCredential })
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = { switchPSPPage }

--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -10,7 +10,8 @@ const {
   PermissionDeniedError,
   NoServicesWithPermissionError,
   NotFoundError,
-  RegistrationSessionMissingError
+  RegistrationSessionMissingError,
+  InvalidConfigurationError
 } = require('../errors')
 const paths = require('../paths')
 const { renderErrorView, response } = require('../utils/response')
@@ -58,6 +59,11 @@ module.exports = function errorHandler (err, req, res, next) {
   if (err instanceof RegistrationSessionMissingError) {
     logger.info(`RegistrationSessionMissingError handled. Rendering error page`)
     return renderErrorView(req, res, 'There has been a problem proceeding with this registration. Please try again.', 400)
+  }
+
+  if (err instanceof InvalidConfigurationError) {
+    logger.info(`InvalidConigurationError handled: ${err.message}. Rendering error page`)
+    return renderErrorView(req, res, 'This account is not configured to perform this action. Please contact support the support team.', 400)
   }
 
   if (err && err.code === 'EBADCSRFTOKEN') {

--- a/app/middleware/restrict-to-switching-account.js
+++ b/app/middleware/restrict-to-switching-account.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const { NotFoundError } = require('../errors')
+
+module.exports = (req, res, next) => {
+  if (req.account.provider_switch_enabled) {
+    next()
+  } else {
+    next(new NotFoundError('This page is only available for accounts flagged for switching provider'))
+  }
+}

--- a/app/middleware/restrict-to-switching-account.test.js
+++ b/app/middleware/restrict-to-switching-account.test.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const sinon = require('sinon')
+const { expect } = require('chai')
+const { NotFoundError } = require('../errors')
+
+const gatewayAccountFixtures = require('../../test/fixtures/gateway-account.fixtures')
+const restrictToSwitchingAccount = require('./restrict-to-switching-account')
+
+describe('restrict-to-switching-account middleware', () => {
+  describe('when page is routing an account with provider switch enabled', () => {
+    let req, res, next
+    before(done => {
+      req = { account: gatewayAccountFixtures.validGatewayAccount({ provider_switch_enabled: true }) }
+      res = {}
+      next = sinon.spy(done)
+      restrictToSwitchingAccount(req, res, next)
+    })
+
+    it('should call next', () => {
+      expect(next.called).to.equal(true)
+      expect(next.lastCall.args.length).to.equal(0)
+    })
+  })
+
+  describe('when page is routing an account with provider switch disabled', () => {
+    let req, res, next
+    before(() => {
+      req = { account: gatewayAccountFixtures.validGatewayAccount({ provider_switch_enabled: false }) }
+      res = {}
+      next = sinon.spy()
+    })
+
+    it('should throw error with correct message', () => {
+      const expectedError = sinon.match.instanceOf(NotFoundError)
+        .and(sinon.match.has('message', 'This page is only available for accounts flagged for switching provider'))
+      restrictToSwitchingAccount(req, res, next)
+      sinon.assert.calledWith(next, expectedError)
+    })
+  })
+})

--- a/app/paths.js
+++ b/app/paths.js
@@ -101,6 +101,9 @@ module.exports = {
       vatNumber: '/vat-number',
       companyNumber: '/company-number'
     },
+    switchPSP: {
+      index: '/switch-psp'
+    },
     toggle3ds: {
       index: '/3ds'
     },

--- a/app/routes.js
+++ b/app/routes.js
@@ -20,6 +20,7 @@ const correlationIdMiddleware = require('./middleware/correlation-id')
 const getRequestContext = require('./middleware/get-request-context').middleware
 const restrictToSandboxOrStripeTestAccount = require('./middleware/restrict-to-sandbox-or-stripe-test-account')
 const restrictToLiveStripeAccount = require('./middleware/stripe-setup/restrict-to-live-stripe-account')
+const restrictToSwitchingAccount = require('./middleware/restrict-to-switching-account')
 
 // Controllers
 const staticController = require('./controllers/static.controller')
@@ -298,7 +299,7 @@ module.exports.bind = function (app) {
   account.get(yourPsp.flex, permission('gateway-credentials:update'), yourPspController.getFlex)
   account.post(yourPsp.flex, permission('gateway-credentials:update'), yourPspController.postFlex)
 
-  account.get(switchPSP.index, permission('gateway-credentials:update'), switchPSPController.switchPSPPage)
+  account.get(switchPSP.index, restrictToSwitchingAccount, permission('gateway-credentials:update'), switchPSPController.switchPSPPage)
 
   // Credentials
   account.get(credentials.worldpay, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)

--- a/app/routes.js
+++ b/app/routes.js
@@ -71,6 +71,7 @@ const paymentTypesController = require('./controllers/payment-types')
 const settingsController = require('./controllers/settings')
 const userPhoneNumberController = require('./controllers/user/phone-number')
 const yourPspController = require('./controllers/your-psp')
+const switchPSPController = require('./controllers/switch-psp/switch-psp.controller')
 const allTransactionsController = require('./controllers/all-service-transactions/index')
 const payoutsController = require('./controllers/payouts/payout-list.controller')
 const stripeSetupDashboardRedirectController = require('./controllers/stripe-setup/stripe-setup-link')
@@ -106,7 +107,8 @@ const {
   toggleBillingAddress,
   toggleMotoMaskCardNumberAndSecurityCode,
   transactions,
-  yourPsp
+  yourPsp,
+  switchPSP
 } = paths.account
 const {
   editServiceName,
@@ -295,6 +297,8 @@ module.exports.bind = function (app) {
   account.post(yourPsp.worldpay3dsFlex, permission('toggle-3ds:update'), yourPspController.postToggleWorldpay3dsFlex)
   account.get(yourPsp.flex, permission('gateway-credentials:update'), yourPspController.getFlex)
   account.post(yourPsp.flex, permission('gateway-credentials:update'), yourPspController.postFlex)
+
+  account.get(switchPSP.index, permission('gateway-credentials:update'), switchPSPController.switchPSPPage)
 
   // Credentials
   account.get(credentials.worldpay, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)

--- a/app/utils/credentials.js
+++ b/app/utils/credentials.js
@@ -24,16 +24,17 @@ function getSwitchingCredential (gatewayAccount = {}) {
   const credentials = gatewayAccount.gateway_account_credentials || []
 
   // make sure there's an active credential we're switching from
-  if (getCurrentCredential(gatewayAccount) && credentials.length > 1) {
+  if (getCurrentCredential(gatewayAccount)) {
     const pendingCredentials = credentials
       .filter((credential) => pendingCredentialStates.includes(credential.state))
 
-    if (pendingCredentials.length > 1) {
+    if (!pendingCredentials.length || pendingCredentials.length > 1) {
       throw new InvalidConfigurationError('Unable to determine which credentials are being switched to')
     }
-    return pendingCredentials[0] || null
+    return pendingCredentials[0]
+  } else {
+    throw new InvalidConfigurationError('No active credential on this account to switch from')
   }
-  return null
 }
 
 module.exports = { getCurrentCredential, getSwitchingCredential }

--- a/app/utils/credentials.js
+++ b/app/utils/credentials.js
@@ -10,6 +10,8 @@ const CREDENTIAL_STATE = {
   RETIRED: 'RETIRED'
 }
 
+const pendingCredentialStates = [ CREDENTIAL_STATE.CREATED, CREDENTIAL_STATE.ENTERED, CREDENTIAL_STATE.VERIFIED ]
+
 function getCurrentCredential (gatewayAccount = {}) {
   const credentials = gatewayAccount.gateway_account_credentials || []
   return credentials
@@ -24,7 +26,7 @@ function getSwitchingCredential (gatewayAccount = {}) {
   // make sure there's an active credential we're switching from
   if (getCurrentCredential(gatewayAccount) && credentials.length > 1) {
     const pendingCredentials = credentials
-      .filter((credential) => [ CREDENTIAL_STATE.CREATED, CREDENTIAL_STATE.ENTERED, CREDENTIAL_STATE.VERIFIED ].includes(credential.state))
+      .filter((credential) => pendingCredentialStates.includes(credential.state))
 
     if (pendingCredentials.length > 1) {
       throw new InvalidConfigurationError('Unable to determine which credentials are being switched to')

--- a/app/utils/credentials.test.js
+++ b/app/utils/credentials.test.js
@@ -32,11 +32,12 @@ describe('credentials utility', () => {
   })
 
   describe('get the credential service is switching to', () => {
-    it('returns nothing if no pending credentials available', () => {
+    it('throws an exception for upstream services/controllers if no pending credentials available', () => {
       const account = gatewayAccountFixtures.validGatewayAccount({
         gateway_account_credentials: [{ state: 'ACTIVE' }]
       })
-      expect(getSwitchingCredential(account)).to.equal(null)
+      const checkSwitchingCreds = () => getSwitchingCredential(account)
+      expect(checkSwitchingCreds).to.throw(InvalidConfigurationError)
     })
 
     it('gets the pending credential being switched to', () => {

--- a/app/utils/nav-builder.js
+++ b/app/utils/nav-builder.js
@@ -16,6 +16,7 @@ const mainSettingsPaths = [
 ]
 
 const yourPspPaths = [ 'your-psp', 'credentials', 'notification-credentials' ]
+const switchPspPaths = [ 'switch-psp' ]
 
 const serviceNavigationItems = (currentPath, permissions, type, account = {}) => {
   const navigationItems = []
@@ -46,7 +47,7 @@ const serviceNavigationItems = (currentPath, permissions, type, account = {}) =>
     id: 'navigation-menu-settings',
     name: 'Settings',
     url: formatAccountPathsFor(paths.account.settings.index, account.external_id),
-    current: currentPath !== '/' ? yourPspPaths.filter(path => currentPath.includes(path)).length || pathLookup(currentPath, [
+    current: currentPath !== '/' ? yourPspPaths.concat(switchPspPaths).filter(path => currentPath.includes(path)).length || pathLookup(currentPath, [
       ...mainSettingsPaths,
       paths.account.apiKeys,
       paths.account.paymentTypes
@@ -73,6 +74,13 @@ const adminNavigationItems = (currentPath, permissions, type, paymentProvider, a
       url: formatAccountPathsFor(paths.account.settings.index, account.external_id),
       current: pathLookup(currentPath, mainSettingsPaths),
       permissions: type === 'card'
+    },
+    {
+      id: 'navigation-menu-switch-psp',
+      name: 'Switch PSP',
+      url: formatAccountPathsFor(paths.account.switchPSP.index, account.external_id),
+      current: pathLookup(currentPath, paths.account.switchPSP.index),
+      permissions: permissions.gateway_credentials_update && account.provider_switch_enabled
     },
     {
       id: 'navigation-menu-api-keys',

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -1,0 +1,58 @@
+{#
+  - title, into paragraph, task list category headers, final paragraph and action button all just template in the provider going to
+  - description paragraph with what you'll need selected based on provider (set innline)
+  - task list items likely set by controller, content for it can be set inline? not exactly sure how that will look
+
+  {% set tasks %}
+  - manually <li> the tasks, they come with aria descriptions etc. that will take more effort to generalise
+  - should add a `tasks` to the context, it will be based on which psp is being switched to and have an interface like task[id] = { status: }
+ #}
+{% extends "layout.njk" %}
+
+{% block pageTitle %}
+  Switch PSP - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+{% endblock %}
+
+{% block side_navigation %}
+  {% include "includes/side-navigation.njk" %}
+{% endblock %}
+
+{% block mainContent %}
+<div class="govuk-grid-column-two-thirds">
+  <h1 class="govuk-heading-l page-title">Switch payment service provider (PSP)</h1>
+
+  <p class="govuk-body">This service is taking payments with {{ currentGatewayAccount.payment_provider | formatPSPname }}.</p>
+
+  <p class="govuk-body">To prepare for the switch, you need:</p>
+
+  {% switch targetCredential.payment_provider %}
+    {% case 'worldpay' %}
+      <ul class="govuk-list govuk-list--bullet">
+        <li>your Worldpay account credentials: Merchant code, username and password</li>
+        <li>a debit or credit card to make a nominal live payment (refundable)</li>
+      </ul>
+  {% endswitch %}
+
+  <ol class="app-task-list govuk-!-margin-top-8">
+    <li>
+        <h2 class="app-task-list__section">
+          <span class="app-task-list__section-number">1. </span> Get ready to switch PSP
+        </h2>
+        <ul class="app-task-list__items"></ul>
+      </li>
+
+      <li>
+        <h2 class="app-task-list__section" id="switch-psp-action-step">
+          <span class="app-task-list__section-number">2. </span> Switch PSP to {{ targetCredential.payment_provider | formatPSPname }}
+        </h2>
+        <ul class="app-task-list__flat_items">
+          <li class="app-task-list__item">
+            <p class="govuk-body">
+              After linking {{ targetCredential.payment_provider | formatPSPname }} and GOV.UK Pay, you can safely switch to taking payments with {{ targetCredential.payment_provider | formatPSPname }}.
+            </p>
+          </li>
+        </ul>
+      </li>
+    </ol>
+</div>
+{% endblock %}

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -1,12 +1,3 @@
-{#
-  - title, into paragraph, task list category headers, final paragraph and action button all just template in the provider going to
-  - description paragraph with what you'll need selected based on provider (set innline)
-  - task list items likely set by controller, content for it can be set inline? not exactly sure how that will look
-
-  {% set tasks %}
-  - manually <li> the tasks, they come with aria descriptions etc. that will take more effort to generalise
-  - should add a `tasks` to the context, it will be based on which psp is being switched to and have an interface like task[id] = { status: }
- #}
 {% extends "layout.njk" %}
 
 {% block pageTitle %}

--- a/test/cypress/integration/settings/switch-psp.cy.test.js
+++ b/test/cypress/integration/settings/switch-psp.cy.test.js
@@ -19,17 +19,17 @@ describe('Switch PSP settings page', () => {
     Cypress.Cookies.preserveOnce('session', 'gateway_account')
   })
 
-  // describe('When using an account with switching flag disabled', () => {
-  //   beforeEach(() => {
-  //     setupStubs('smartpay', false)
-  //   })
+  describe('When using an account with switching flag disabled', () => {
+    beforeEach(() => {
+      setupStubs('smartpay', false)
+    })
 
-  //   it('should not show link to Switch PSP in the side navigation', () => {
-  //     cy.setEncryptedCookies(userExternalId)
-  //     cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-  //     cy.get('#navigation-menu-switch-psp').should('have.length', 0)
-  //   })
-  // })
+    it('should not show link to Switch PSP in the side navigation', () => {
+      cy.setEncryptedCookies(userExternalId)
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+      cy.get('#navigation-menu-switch-psp').should('have.length', 0)
+    })
+  })
 
   describe('When using an account with switching flag enabled', () => {
     beforeEach(() => {

--- a/test/cypress/integration/settings/switch-psp.cy.test.js
+++ b/test/cypress/integration/settings/switch-psp.cy.test.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const userStubs = require('../../stubs/user-stubs')
+const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+
+const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+const gatewayAccountId = '42'
+const gatewayAccountExternalId = 'a-valid-external-id'
+
+function setupStubs (paymentProvider, providerSwitchEnabled, gatewayAccountCredentials) {
+  cy.task('setupStubs', [
+    userStubs.getUserSuccess({ gatewayAccountId, userExternalId }),
+    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, providerSwitchEnabled, paymentProvider, ...gatewayAccountCredentials && { gatewayAccountCredentials } })
+  ])
+}
+
+describe('Switch PSP settings page', () => {
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('session', 'gateway_account')
+  })
+
+  // describe('When using an account with switching flag disabled', () => {
+  //   beforeEach(() => {
+  //     setupStubs('smartpay', false)
+  //   })
+
+  //   it('should not show link to Switch PSP in the side navigation', () => {
+  //     cy.setEncryptedCookies(userExternalId)
+  //     cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+  //     cy.get('#navigation-menu-switch-psp').should('have.length', 0)
+  //   })
+  // })
+
+  describe('When using an account with switching flag enabled', () => {
+    beforeEach(() => {
+      setupStubs('smartpay', true, [
+        { payment_provider: 'smartpay', state: 'ACTIVE' },
+        { payment_provider: 'worldpay', state: 'CREATED' }
+      ])
+    })
+
+    it('should show the switch PSP page', () => {
+      cy.setEncryptedCookies(userExternalId)
+      cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
+      cy.get('#navigation-menu-switch-psp').should('have.length', 1)
+      cy.get('h1').should('contain', 'Switch payment service provider')
+      cy.get('#switch-psp-action-step').should('contain', 'Switch PSP to Worldpay')
+    })
+  })
+})

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -57,7 +57,7 @@ function parseGatewayAccountOptions (opts) {
     stubOptions.external_id = opts.gatewayAccountExternalId
   }
 
-  if (opts.providerSwitchEnabled) {
+  if (opts.providerSwitchEnabled !== undefined) {
     stubOptions.provider_switch_enabled = opts.providerSwitchEnabled
   }
 
@@ -78,7 +78,6 @@ function getGatewayAccountSuccess (opts) {
 
 function getGatewayAccountByExternalIdSuccess (opts) {
   const fixtureOpts = parseGatewayAccountOptions(opts)
-
   const path = `/v1/frontend/accounts/external-id/${opts.gatewayAccountExternalId}`
   return stubBuilder('GET', path, 200, {
     response: gatewayAccountFixtures.validGatewayAccountResponse(fixtureOpts)

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -57,6 +57,14 @@ function parseGatewayAccountOptions (opts) {
     stubOptions.external_id = opts.gatewayAccountExternalId
   }
 
+  if (opts.providerSwitchEnabled) {
+    stubOptions.provider_switch_enabled = opts.providerSwitchEnabled
+  }
+
+  if (opts.gatewayAccountCredentials) {
+    stubOptions.gateway_account_credentials = opts.gatewayAccountCredentials
+  }
+
   return stubOptions
 }
 
@@ -70,6 +78,7 @@ function getGatewayAccountSuccess (opts) {
 
 function getGatewayAccountByExternalIdSuccess (opts) {
   const fixtureOpts = parseGatewayAccountOptions(opts)
+
   const path = `/v1/frontend/accounts/external-id/${opts.gatewayAccountExternalId}`
   return stubBuilder('GET', path, 200, {
     response: gatewayAccountFixtures.validGatewayAccountResponse(fixtureOpts)

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -18,7 +18,7 @@ function validCredentials (opts = {}) {
 function validGatewayAccountCredential (credentialOpts = {}, gatewayAccountOpts = {}) {
   const gatewayAccountCredential = {
     gateway_account_credential_id: credentialOpts.id || 1,
-    payment_provider: gatewayAccountOpts.payment_provider || 'sandbox',
+    payment_provider: credentialOpts.payment_provider || 'sandbox',
     state: credentialOpts.state || 'ACTIVE',
     gateway_account_id: gatewayAccountOpts.gateway_account_id || 31,
     active_start_date: credentialOpts.active_start_date || null,


### PR DESCRIPTION
Add controllers, template and base test structure for the switching PSP page.

Future pull requests will add individual tasks and completion in conjunction with the backend specs becoming available.

* if an account is not configured to switch, navigating to the page `404`s 
* if an ambiguous switching configuration is found (too many or too few credentials to fill in) an invalid configuration error is raised and handled
* page descriptions and requirements templated in based on the provider being switched to
* cover new middleware and controllers

**Base page that can be integrated with individual future steps**

<img width="825" alt="Screenshot 2021-06-14 at 18 16 06" src="https://user-images.githubusercontent.com/2844572/121933122-9582ab80-cd3d-11eb-8aab-23a0f7375136.png">
