### PR TITLE
PP-8216 Switch PSP - linking Worldpay credentials

### DIFF
--- a/app/controllers/credentials.controller.js
+++ b/app/controllers/credentials.controller.js
@@ -122,7 +122,7 @@ module.exports = {
     const correlationId = req.headers[CORRELATION_HEADER] || ''
 
     try {
-      await connectorClient.patchAccountCredentials({
+      await connectorClient.legacyPatchAccountCredentials({
         payload: credentialsPatchRequestValueOf(req), correlationId: correlationId, gatewayAccountId: accountId
       })
 

--- a/app/controllers/credentials.controller.test.js
+++ b/app/controllers/credentials.controller.test.js
@@ -5,7 +5,7 @@ const patchAccountSpy = sinon.spy(() => Promise.resolve())
 const postNotificationCredentialsSpy = sinon.spy(() => Promise.resolve())
 const connectorClientMock = {
   ConnectorClient: function () {
-    this.patchAccountCredentials = patchAccountSpy
+    this.legacyPatchAccountCredentials = patchAccountSpy
     this.postAccountNotificationCredentials = postNotificationCredentialsSpy
   }
 }

--- a/app/controllers/credentials/worldpay.controller.js
+++ b/app/controllers/credentials/worldpay.controller.js
@@ -55,6 +55,7 @@ async function updateWorldpayCredentials (req, res, next) {
         payload: { credentials: results.values }
       })
       logger.info('Successfully updated credentials for pending Worldpay credentials on account')
+      return res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
     } else {
       await connectorClient.legacyPatchAccountCredentials({
         correlationId,
@@ -62,9 +63,8 @@ async function updateWorldpayCredentials (req, res, next) {
         payload: { credentials: results.values }
       })
       logger.info('Successfully updated credentials for Worldpay account')
+      return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, 'worldpay'))
     }
-
-    return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, 'worldpay'))
   } catch (error) {
     next(error)
   }

--- a/app/controllers/credentials/worldpay.controller.test.js
+++ b/app/controllers/credentials/worldpay.controller.test.js
@@ -58,7 +58,7 @@ describe('Worldpay credentials controller', () => {
     sinon.assert.called(checkCredentialsMock)
     sinon.assert.called(legacyUpdateCredentialsMock)
     sinon.assert.notCalled(updateCredentialsMock)
-    sinon.assert.called(res.redirect)
+    sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/your-psp/worldpay')
   })
 
   it('uses the new patch if on a switch psp route', async () => {
@@ -70,7 +70,7 @@ describe('Worldpay credentials controller', () => {
     sinon.assert.called(checkCredentialsMock)
     sinon.assert.called(updateCredentialsMock)
     sinon.assert.notCalled(legacyUpdateCredentialsMock)
-    sinon.assert.called(res.redirect)
+    sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/switch-psp')
   })
 })
 

--- a/app/controllers/switch-psp/switch-psp.controller.js
+++ b/app/controllers/switch-psp/switch-psp.controller.js
@@ -6,7 +6,7 @@ const { getSwitchingCredential } = require('../../utils/credentials')
 function switchPSPPage (req, res, next) {
   try {
     const targetCredential = getSwitchingCredential(req.account)
-    const taskList = switchTasks.getStatusesFor(targetCredential, req.account)
+    const taskList = switchTasks.getTaskList(targetCredential, req.account)
 
     response(req, res, 'switch-psp/switch-psp', { targetCredential, taskList })
   } catch (error) {

--- a/app/controllers/switch-psp/switch-psp.controller.js
+++ b/app/controllers/switch-psp/switch-psp.controller.js
@@ -1,11 +1,14 @@
 'use strict'
 const { response } = require('../../utils/response')
+const switchTasks = require('./switch-tasks.service')
 const { getSwitchingCredential } = require('../../utils/credentials')
 
 function switchPSPPage (req, res, next) {
   try {
     const targetCredential = getSwitchingCredential(req.account)
-    response(req, res, 'switch-psp/switch-psp', { targetCredential })
+    const taskList = switchTasks.getStatusesFor(targetCredential, req.account)
+
+    response(req, res, 'switch-psp/switch-psp', { targetCredential, taskList })
   } catch (error) {
     next(error)
   }

--- a/app/controllers/switch-psp/switch-tasks.service.js
+++ b/app/controllers/switch-psp/switch-tasks.service.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const { CREDENTIAL_STATE } = require('../../utils/credentials')
+
+const defaultTrue = () => true
+
+const credentialsComplete = function credentialsComplete (targetCredential, account) {
+  return [ CREDENTIAL_STATE.ENTERED, CREDENTIAL_STATE.VERIFIED, CREDENTIAL_STATE.ACTIVE, CREDENTIAL_STATE.RETIRED ]
+    .includes(targetCredential.state)
+}
+
+const worldpayTaskList = [{
+  key: 'LINK_CREDENTIALS',
+  isEnabled: defaultTrue,
+  isComplete: credentialsComplete
+}]
+
+const providerTaskListMap = {
+  worldpay: worldpayTaskList
+}
+
+function getStatusesFor (targetCredential, account) {
+  const schema = providerTaskListMap[targetCredential.payment_provider]
+  const taskList = schema.reduce((aggregate, taskItem) => {
+    aggregate[taskItem.key] = {
+      enabled: taskItem.isEnabled(targetCredential, account),
+      complete: taskItem.isComplete(targetCredential, account)
+    }
+    return aggregate
+  }, {})
+  return taskList
+}
+
+function isComplete (taskList) {
+  return Object.entries(taskList)
+    .some(([ taskItemKey, taskItemStatus ]) => taskItemStatus.complete)
+}
+
+module.exports = { getStatusesFor, isComplete }

--- a/app/controllers/switch-psp/switch-tasks.service.test.js
+++ b/app/controllers/switch-psp/switch-tasks.service.test.js
@@ -1,0 +1,63 @@
+const { expect } = require('chai')
+const { getStatusesFor, isComplete } = require('./switch-tasks.service')
+const { getSwitchingCredential } = require('../../utils/credentials')
+const gatewayAccountFixtures = require('../../../test/fixtures/gateway-account.fixtures')
+
+describe('Switching PSP service', () => {
+  describe('parses a task list based on switching credential', () => {
+    describe('for supported Worldpay payment provider', () => {
+      it('gets an empty task list for an account with no progress', () => {
+        const account = gatewayAccountFixtures.validGatewayAccount({
+          gateway_account_credentials: [
+            { state: 'CREATED', payment_provider: 'worldpay', id: 100 },
+            { state: 'ACTIVE', payment_provider: 'smartpay', id: 100 }
+          ]
+        })
+        const targetCredential = getSwitchingCredential(account)
+        const taskList = getStatusesFor(targetCredential, account)
+        expect(Object.keys(taskList)).to.have.length(1)
+        expect(taskList.LINK_CREDENTIALS.enabled).to.equal(true)
+        expect(taskList.LINK_CREDENTIALS.complete).to.equal(false)
+      })
+      it('gets an complete task list for an account with progress', () => {
+        const account = gatewayAccountFixtures.validGatewayAccount({
+          gateway_account_credentials: [
+            { state: 'VERIFIED_WITH_LIVE_PAYMENT', payment_provider: 'worldpay', id: 100 },
+            { state: 'ACTIVE', payment_provider: 'smartpay', id: 100 }
+          ]
+        })
+        const targetCredential = getSwitchingCredential(account)
+        const taskList = getStatusesFor(targetCredential, account)
+        expect(Object.keys(taskList)).to.have.length(1)
+        expect(taskList.LINK_CREDENTIALS.enabled).to.equal(true)
+        expect(taskList.LINK_CREDENTIALS.complete).to.equal(true)
+      })
+    })
+  })
+
+  describe('reduces switch complete status', () => {
+    it('correctly calculates all conditions being met for Worldpay', () => {
+      const account = gatewayAccountFixtures.validGatewayAccount({
+        gateway_account_credentials: [
+          { state: 'VERIFIED_WITH_LIVE_PAYMENT', payment_provider: 'worldpay', id: 100 },
+          { state: 'ACTIVE', payment_provider: 'smartpay', id: 100 }
+        ]
+      })
+      const targetCredential = getSwitchingCredential(account)
+      const taskList = getStatusesFor(targetCredential, account)
+      expect(isComplete(taskList)).to.equal(true)
+    })
+
+    it('correctly calculates progress required for Worldpay', () => {
+      const account = gatewayAccountFixtures.validGatewayAccount({
+        gateway_account_credentials: [
+          { state: 'CREATED', payment_provider: 'worldpay', id: 100 },
+          { state: 'ACTIVE', payment_provider: 'smartpay', id: 100 }
+        ]
+      })
+      const targetCredential = getSwitchingCredential(account)
+      const taskList = getStatusesFor(targetCredential, account)
+      expect(isComplete(taskList)).to.equal(false)
+    })
+  })
+})

--- a/app/controllers/switch-psp/switch-tasks.service.test.js
+++ b/app/controllers/switch-psp/switch-tasks.service.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai')
-const { getStatusesFor, isComplete } = require('./switch-tasks.service')
+const { getTaskList, isComplete } = require('./switch-tasks.service')
 const { getSwitchingCredential } = require('../../utils/credentials')
 const gatewayAccountFixtures = require('../../../test/fixtures/gateway-account.fixtures')
 
@@ -14,7 +14,7 @@ describe('Switching PSP service', () => {
           ]
         })
         const targetCredential = getSwitchingCredential(account)
-        const taskList = getStatusesFor(targetCredential, account)
+        const taskList = getTaskList(targetCredential, account)
         expect(Object.keys(taskList)).to.have.length(1)
         expect(taskList.LINK_CREDENTIALS.enabled).to.equal(true)
         expect(taskList.LINK_CREDENTIALS.complete).to.equal(false)
@@ -27,7 +27,7 @@ describe('Switching PSP service', () => {
           ]
         })
         const targetCredential = getSwitchingCredential(account)
-        const taskList = getStatusesFor(targetCredential, account)
+        const taskList = getTaskList(targetCredential, account)
         expect(Object.keys(taskList)).to.have.length(1)
         expect(taskList.LINK_CREDENTIALS.enabled).to.equal(true)
         expect(taskList.LINK_CREDENTIALS.complete).to.equal(true)
@@ -44,7 +44,7 @@ describe('Switching PSP service', () => {
         ]
       })
       const targetCredential = getSwitchingCredential(account)
-      const taskList = getStatusesFor(targetCredential, account)
+      const taskList = getTaskList(targetCredential, account)
       expect(isComplete(taskList)).to.equal(true)
     })
 
@@ -56,8 +56,9 @@ describe('Switching PSP service', () => {
         ]
       })
       const targetCredential = getSwitchingCredential(account)
-      const taskList = getStatusesFor(targetCredential, account)
+      const taskList = getTaskList(targetCredential, account)
       expect(isComplete(taskList)).to.equal(false)
     })
+  
   })
 })

--- a/app/paths.js
+++ b/app/paths.js
@@ -20,9 +20,8 @@ module.exports = {
       update: '/api-keys/update'
     },
     credentials: {
-      worldpay: '/credentials/worldpay',
-      index: '/credentials/:paymentProvider',
-      edit: '/credentials/:paymentProvider/edit'
+      index: '/your-psp/credentials/:paymentProvider',
+      edit: '/your-psp/credentials/:paymentProvider/edit'
     },
     dashboard: {
       index: '/dashboard'
@@ -102,7 +101,8 @@ module.exports = {
       companyNumber: '/company-number'
     },
     switchPSP: {
-      index: '/switch-psp'
+      index: '/switch-psp',
+      worldpayCredentials: '/switch-psp/credentials/worldpay'
     },
     toggle3ds: {
       index: '/3ds'
@@ -123,7 +123,8 @@ module.exports = {
     yourPsp: {
       index: '/your-psp/:paymentProvider',
       flex: '/your-psp/worldpay/flex',
-      worldpay3dsFlex: '/your-psp/worldpay-3ds-flex'
+      worldpay3dsFlex: '/your-psp/worldpay-3ds-flex',
+      worldpayCredentials: '/your-psp/credentials/worldpay'
     }
   },
   service: {

--- a/app/routes.js
+++ b/app/routes.js
@@ -302,8 +302,10 @@ module.exports.bind = function (app) {
   account.get(switchPSP.index, restrictToSwitchingAccount, permission('gateway-credentials:update'), switchPSPController.switchPSPPage)
 
   // Credentials
-  account.get(credentials.worldpay, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)
-  account.post(credentials.worldpay, permission('gateway-credentials:read'), worldpayCredentialsController.updateWorldpayCredentials)
+  account.get(yourPsp.worldpayCredentials, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)
+  account.post(yourPsp.worldpayCredentials, permission('gateway-credentials:read'), worldpayCredentialsController.updateWorldpayCredentials)
+  account.get(switchPSP.worldpayCredentials, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)
+  account.post(switchPSP.worldpayCredentials, permission('gateway-credentials:read'), worldpayCredentialsController.updateWorldpayCredentials)
 
   account.get(credentials.index, permission('gateway-credentials:read'), credentialsController.index)
   account.get(credentials.edit, permission('gateway-credentials:update'), credentialsController.editCredentials)

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -23,6 +23,7 @@ const SERVICE_NAME_FRONTEND_PATH = ACCOUNT_FRONTEND_PATH + '/servicename'
 const ACCEPTED_CARD_TYPES_FRONTEND_PATH = ACCOUNT_FRONTEND_PATH + '/card-types'
 const ACCOUNT_NOTIFICATION_CREDENTIALS_PATH = '/v1/api/accounts' + '/{accountId}' + '/notification-credentials'
 const ACCOUNT_CREDENTIALS_PATH = ACCOUNT_FRONTEND_PATH + '/credentials'
+const ACCOUNT_GATEWAY_ACCOUNT_CREDENTIALS_PATH = '/v1/api/accounts/{accountId}/credentials/{credentialsId}'
 const EMAIL_NOTIFICATION__PATH = '/v1/api/accounts/{accountId}/email-notification'
 const CHECK_WORLDPAY_3DS_FLEX_CREDENTIALS_PATH = '/v1/api/accounts/{accountId}/worldpay/check-3ds-flex-config'
 const CHECK_WORLDPAY_CREDENTIALS_PATH = '/v1/api/accounts/{accountId}/worldpay/check-credentials'
@@ -200,8 +201,21 @@ ConnectorClient.prototype = {
    * @param {Object} params
    * @returns {ConnectorClient}
    */
-  patchAccountCredentials: function (params) {
+  legacyPatchAccountCredentials: function (params) {
     const url = _accountCredentialsUrlFor(params.gatewayAccountId, this.connectorUrl)
+
+    return baseClient.patch(url, {
+      body: params.payload,
+      correlationId: params.correlationId,
+      description: 'patch gateway account credentials',
+      service: SERVICE_NAME
+    })
+  },
+
+  patchAccountGatewayAccountCredentials: function (params) {
+    const url = this.connectorUrl + ACCOUNT_GATEWAY_ACCOUNT_CREDENTIALS_PATH
+      .replace('{accountId}', params.gatewayAccountId)
+      .replace('{credentialsId}', params.gatewayAccountCredentialsId)
 
     return baseClient.patch(url, {
       body: params.payload,

--- a/app/utils/credentials.js
+++ b/app/utils/credentials.js
@@ -37,4 +37,4 @@ function getSwitchingCredential (gatewayAccount = {}) {
   }
 }
 
-module.exports = { getCurrentCredential, getSwitchingCredential }
+module.exports = { getCurrentCredential, getSwitchingCredential, CREDENTIAL_STATE }

--- a/app/utils/credentials.js
+++ b/app/utils/credentials.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const paths = require('../paths')
 const { InvalidConfigurationError } = require('../errors')
 
 const CREDENTIAL_STATE = {
@@ -37,4 +38,8 @@ function getSwitchingCredential (gatewayAccount = {}) {
   }
 }
 
-module.exports = { getCurrentCredential, getSwitchingCredential, CREDENTIAL_STATE }
+function isSwitchingCredentialsRoute (req) {
+  return Object.values(paths.account.switchPSP).includes(req.route && req.route.path)
+}
+
+module.exports = { getCurrentCredential, getSwitchingCredential, isSwitchingCredentialsRoute, CREDENTIAL_STATE }

--- a/app/utils/credentials.test.js
+++ b/app/utils/credentials.test.js
@@ -1,7 +1,8 @@
 const { expect } = require('chai')
+const paths = require('../paths')
 const gatewayAccountFixtures = require('../../test/fixtures/gateway-account.fixtures')
 const { InvalidConfigurationError } = require('../errors')
-const { getCurrentCredential, getSwitchingCredential } = require('./credentials')
+const { getCurrentCredential, getSwitchingCredential, isSwitchingCredentialsRoute } = require('./credentials')
 
 describe('credentials utility', () => {
   describe('get services current credential', () => {
@@ -64,6 +65,17 @@ describe('credentials utility', () => {
 
       const checkSwitchingCreds = () => getSwitchingCredential(account)
       expect(checkSwitchingCreds).to.throw(InvalidConfigurationError)
+    })
+  })
+
+  describe('credentials page utilities', () => {
+    it('correctly identifies a switch psp route', () => {
+      const req = { route: { path: paths.account.switchPSP.worldpayCredentials } }
+      expect(isSwitchingCredentialsRoute(req)).to.equal(true)
+    })
+    it('correctly identifies a non switch psp route', () => {
+      const req = { route: { path: paths.account.yourPsp.worldpayCredentials } }
+      expect(isSwitchingCredentialsRoute(req)).to.equal(false)
     })
   })
 })

--- a/app/utils/nav-builder.js
+++ b/app/utils/nav-builder.js
@@ -15,7 +15,7 @@ const mainSettingsPaths = [
   paths.account.toggleMotoMaskCardNumberAndSecurityCode
 ]
 
-const yourPspPaths = [ 'your-psp', 'credentials', 'notification-credentials' ]
+const yourPspPaths = [ 'your-psp', 'notification-credentials' ]
 const switchPspPaths = [ 'switch-psp' ]
 
 const serviceNavigationItems = (currentPath, permissions, type, account = {}) => {

--- a/app/views/credentials/worldpay.njk
+++ b/app/views/credentials/worldpay.njk
@@ -10,6 +10,21 @@
 
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
+    {# back link should always go before <main> content so it can be skipped, settings page layouts should be adjusted to suport this #}
+    {% if switchingToCredentials %}
+      {{ govukBackLink({
+        text: "Back to Switching payment service provider (PSP)",
+        classes: "govuk-!-margin-top-0",
+        href: formatAccountPathsFor(routes.account.switchPSP.index, currentGatewayAccount.external_id)
+      }) }}
+    {% else %}
+      {{ govukBackLink({
+        text: "Back to Your PSP",
+        classes: "govuk-!-margin-top-0",
+        href: formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, 'worldpay')
+      }) }}
+    {% endif %}
+
     {% if form.errorSummaryList and form.errorSummaryList.length %}
       {{ govukErrorSummary({
         titleText: 'There is a problem',
@@ -19,7 +34,7 @@
     <h1 class="govuk-heading-l page-title" id="view-title">Your Worldpay credentials</h1>
 
   {% if permissions.gateway_credentials_update %}
-    <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.worldpay, currentGatewayAccount.external_id) }}" data-validate>
+    <form id="credentials-form" method="post" data-validate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
         {{ govukInput({
@@ -76,10 +91,6 @@
         })
       }}
     </form>
-
-    <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, 'worldpay') }}">Cancel</a>
-    </p>
   {% endif %}
 </div>
 {% endblock %}

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -30,7 +30,7 @@
               {# {{ taskListItem("The macro text", "/the/macro/link", "the-macro-id") }} #}
               {% set linkCredentialsText = "Link your Worldpay account with GOV.UK Pay" %}
               {% if linkCredentials.enabled %}
-              <a class="govuk-link" href="{{ formatAccountPathsFor(routes.account.credentials.worldpay, currentGatewayAccount.external_id) }}" aria-describedby="link-worldpay-account">
+              <a class="govuk-link" href="{{ formatAccountPathsFor(routes.account.switchPSP.worldpayCredentials, currentGatewayAccount.external_id) }}" aria-describedby="link-worldpay-account">
                 {{ linkCredentialsText }}
               </a>
               {% else %}

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -22,6 +22,32 @@
         <li>your Worldpay account credentials: Merchant code, username and password</li>
         <li>a debit or credit card to make a nominal live payment (refundable)</li>
       </ul>
+
+      {% set tasks %}
+        <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              {% set linkCredentials = taskList.LINK_CREDENTIALS %}
+              {# {{ taskListItem("The macro text", "/the/macro/link", "the-macro-id") }} #}
+              {% set linkCredentialsText = "Link your Worldpay account with GOV.UK Pay" %}
+              {% if linkCredentials.enabled %}
+              <a class="govuk-link" href="{{ formatAccountPathsFor(routes.account.credentials.worldpay, currentGatewayAccount.external_id) }}" aria-describedby="link-worldpay-account">
+                {{ linkCredentialsText }}
+              </a>
+              {% else %}
+                <span>{{ linkCredentialsText }}</span>
+              {% endif %}
+            </span>
+
+            {# {{ taskListStatus(taskListEntry) }} #}
+            {% if not linkCredentials.enabled %}
+            <strong class="govuk-tag app-task-list__tag govuk-tag--grey" id="link-worldpay-account-status">cannot start yet</strong>
+            {% elif not linkCredentials.complete %}
+            <strong class="govuk-tag app-task-list__tag govuk-tag--grey" id="link-worldpay-account-status">not started</strong>
+            {% elif linkCredentials.complete %}
+            <strong class="govuk-tag app-task-list__tag" id="link-worldpay-account-status">completed</strong>
+            {% endif %}
+          </li>
+      {% endset %}
   {% endswitch %}
 
   <ol class="app-task-list govuk-!-margin-top-8">
@@ -29,7 +55,7 @@
         <h2 class="app-task-list__section">
           <span class="app-task-list__section-number">1. </span> Get ready to switch PSP
         </h2>
-        <ul class="app-task-list__items"></ul>
+        <ul class="app-task-list__items">{{ tasks | safe }}</ul>
       </li>
 
       <li>

--- a/app/views/your-psp/_worldpay.njk
+++ b/app/views/your-psp/_worldpay.njk
@@ -17,7 +17,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.worldpay, currentGatewayAccount.external_id) + "?change=merchantId",
+              href: formatAccountPathsFor(routes.account.yourPsp.worldpayCredentials, currentGatewayAccount.external_id) + "?change=merchantId",
               text: "Change",
               visuallyHiddenText: "account credentials",
               attributes: {
@@ -38,7 +38,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.worldpay, currentGatewayAccount.external_id) + "?change=username",
+              href: formatAccountPathsFor(routes.account.yourPsp.worldpayCredentials, currentGatewayAccount.external_id) + "?change=username",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }
@@ -56,7 +56,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.worldpay, currentGatewayAccount.external_id) + "?change=password",
+              href: formatAccountPathsFor(routes.account.yourPsp.worldpayCredentials, currentGatewayAccount.external_id) + "?change=password",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }


### PR DESCRIPTION
As this is the first task added to the switching PSP process, propose a
basic interface for task lists:
- service to index required tasks indexed by payment provider
  - callable methods assigned to tasks to determine if they are enabled
  or complete
- template drives look of task items (link, status tag, aria, ids) --
this can be optimised with macros when there are more task list items
for more providers

Update the new worldpay credentials controller to be aware of switch account linking context.
- add branch to worldpay credential to use new connector route if
switching psp -- cover this well with unit assertions
- add context aware back link

<img width="671" alt="Screenshot 2021-06-15 at 13 50 03" src="https://user-images.githubusercontent.com/2844572/122056131-38403600-cde1-11eb-8fa4-aba22673fe85.png">

<img width="708" alt="Screenshot 2021-06-15 at 14 24 27" src="https://user-images.githubusercontent.com/2844572/122060430-7ccdd080-cde5-11eb-9afa-eb01280fd3f3.png">

