### PR TITLE
PP-8215 Switching payment validator tool

### DIFF
--- a/app/controllers/credentials/worldpay.controller.js
+++ b/app/controllers/credentials/worldpay.controller.js
@@ -51,7 +51,7 @@ async function updateWorldpayCredentials (req, res, next) {
       await connectorClient.patchAccountGatewayAccountCredentials({
         correlationId,
         gatewayAccountId,
-        gatewayAccountCredentialId: credential.id,
+        gatewayAccountCredentialId: credential.gateway_account_credential_id,
         credentials: results.values,
         userExternalId: req.user.externalId
       })

--- a/app/controllers/credentials/worldpay.controller.js
+++ b/app/controllers/credentials/worldpay.controller.js
@@ -51,7 +51,7 @@ async function updateWorldpayCredentials (req, res, next) {
       await connectorClient.patchAccountGatewayAccountCredentials({
         correlationId,
         gatewayAccountId,
-        gatewayAccountCredentialId: credential.gateway_account_credential_id,
+        gatewayAccountCredentialsId: credential.gateway_account_credential_id,
         credentials: results.values,
         userExternalId: req.user.externalId
       })

--- a/app/controllers/switch-psp/switch-psp.controller.js
+++ b/app/controllers/switch-psp/switch-psp.controller.js
@@ -4,10 +4,11 @@ const switchTasks = require('./switch-tasks.service')
 const { getSwitchingCredential } = require('../../utils/credentials')
 const {
   VERIFY_PSP_INTEGRATION_STATUS_KEY,
+  VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY,
   VERIFY_PSP_INTEGRATION_STATUS
 } = require('../../utils/verify-psp-integration')
 
-async function switchPSPPage (req, res, next) {
+function switchPSPPage (req, res, next) {
   try {
     const targetCredential = getSwitchingCredential(req.account)
     const taskList = switchTasks.getTaskList(targetCredential, req.account)
@@ -16,6 +17,7 @@ async function switchPSPPage (req, res, next) {
     if (req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY]) {
       context.verifyPSPIntegrationResult = req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY]
       delete req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY]
+      delete req.session[VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY]
     }
     response(req, res, 'switch-psp/switch-psp', context)
   } catch (error) {

--- a/app/controllers/switch-psp/switch-psp.controller.js
+++ b/app/controllers/switch-psp/switch-psp.controller.js
@@ -2,13 +2,22 @@
 const { response } = require('../../utils/response')
 const switchTasks = require('./switch-tasks.service')
 const { getSwitchingCredential } = require('../../utils/credentials')
+const {
+  VERIFY_PSP_INTEGRATION_STATUS_KEY,
+  VERIFY_PSP_INTEGRATION_STATUS
+} = require('../../utils/verify-psp-integration')
 
-function switchPSPPage (req, res, next) {
+async function switchPSPPage (req, res, next) {
   try {
     const targetCredential = getSwitchingCredential(req.account)
     const taskList = switchTasks.getTaskList(targetCredential, req.account)
+    const context = { targetCredential, taskList, VERIFY_PSP_INTEGRATION_STATUS }
 
-    response(req, res, 'switch-psp/switch-psp', { targetCredential, taskList })
+    if (req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY]) {
+      context.verifyPSPIntegrationResult = req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY]
+      delete req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY]
+    }
+    response(req, res, 'switch-psp/switch-psp', context)
   } catch (error) {
     next(error)
   }

--- a/app/controllers/switch-psp/switch-tasks.service.js
+++ b/app/controllers/switch-psp/switch-tasks.service.js
@@ -7,12 +7,21 @@ function linkCredentialsComplete (targetCredential) {
     .includes(targetCredential.state)
 }
 
+function verifyPSPIntegrationComplete (targetCredential) {
+  return [CREDENTIAL_STATE.VERIFIED, CREDENTIAL_STATE.ACTIVE, CREDENTIAL_STATE.RETIRED]
+    .includes(targetCredential.state)
+}
+
 function getTaskList (targetCredential, account) {
   if (targetCredential.payment_provider === 'worldpay') {
     return {
       'LINK_CREDENTIALS': {
         enabled: true,
         complete: linkCredentialsComplete(targetCredential)
+      },
+      'VERIFY_PSP_INTEGRATION': {
+        enabled: linkCredentialsComplete(targetCredential),
+        complete: verifyPSPIntegrationComplete(targetCredential)
       }
     }
   }

--- a/app/controllers/switch-psp/switch-tasks.service.test.js
+++ b/app/controllers/switch-psp/switch-tasks.service.test.js
@@ -15,22 +15,24 @@ describe('Switching PSP service', () => {
         })
         const targetCredential = getSwitchingCredential(account)
         const taskList = getTaskList(targetCredential, account)
-        expect(Object.keys(taskList)).to.have.length(1)
+        expect(Object.keys(taskList)).to.have.length(2)
         expect(taskList.LINK_CREDENTIALS.enabled).to.equal(true)
         expect(taskList.LINK_CREDENTIALS.complete).to.equal(false)
       })
       it('gets an complete task list for an account with progress', () => {
         const account = gatewayAccountFixtures.validGatewayAccount({
           gateway_account_credentials: [
-            { state: 'VERIFIED_WITH_LIVE_PAYMENT', payment_provider: 'worldpay', id: 100 },
+            { state: 'ENTERED', payment_provider: 'worldpay', id: 100 },
             { state: 'ACTIVE', payment_provider: 'smartpay', id: 100 }
           ]
         })
         const targetCredential = getSwitchingCredential(account)
         const taskList = getTaskList(targetCredential, account)
-        expect(Object.keys(taskList)).to.have.length(1)
+        expect(Object.keys(taskList)).to.have.length(2)
         expect(taskList.LINK_CREDENTIALS.enabled).to.equal(true)
         expect(taskList.LINK_CREDENTIALS.complete).to.equal(true)
+        expect(taskList.VERIFY_PSP_INTEGRATION.enabled).to.equal(true)
+        expect(taskList.VERIFY_PSP_INTEGRATION.complete).to.equal(false)
       })
     })
   })

--- a/app/controllers/switch-psp/verify-psp-integration.controller.js
+++ b/app/controllers/switch-psp/verify-psp-integration.controller.js
@@ -1,0 +1,15 @@
+'use strict'
+const { response } = require('../../utils/response')
+const { getSwitchingCredential } = require('../../utils/credentials')
+
+function verifyPSPIntegrationPaymentPage (req, res, next) {
+  try {
+    const targetCredential = getSwitchingCredential(req.account)
+
+    response(req, res, 'switch-psp/verify-psp-integration-payment', { targetCredential })
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = { verifyPSPIntegrationPaymentPage }

--- a/app/controllers/switch-psp/verify-psp-integration.controller.js
+++ b/app/controllers/switch-psp/verify-psp-integration.controller.js
@@ -1,6 +1,21 @@
 'use strict'
+const urljoin = require('url-join')
+const paths = require('../../paths')
 const { response } = require('../../utils/response')
+const { ConnectorClient } = require('../../services/clients/connector.client')
 const { getSwitchingCredential } = require('../../utils/credentials')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
+const {
+  VERIFY_PSP_INTEGRATION_STATUS_KEY,
+  VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY,
+  VERIFY_PSP_INTEGRATION_STATUS,
+  filterNextUrl
+} = require('../../utils/verify-psp-integration')
+const logger = require('../../utils/logger')(__filename)
+
+const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
+
+const VERIFY_PAYMENT_AMOUNT_IN_PENCE = 200
 
 function verifyPSPIntegrationPaymentPage (req, res, next) {
   try {
@@ -12,4 +27,44 @@ function verifyPSPIntegrationPaymentPage (req, res, next) {
   }
 }
 
-module.exports = { verifyPSPIntegrationPaymentPage }
+async function startPaymentJourney (req, res, next) {
+  try {
+    const targetCredential = getSwitchingCredential(req.account)
+    const charge = await connectorClient.postChargeRequest(req.account.gateway_account_id, {
+      amount: VERIFY_PAYMENT_AMOUNT_IN_PENCE,
+      payment_provider: targetCredential.payment_provider,
+      description: 'Live payment to verify new PSP',
+      reference: 'VERIFY_PSP_INTEGRATION',
+      return_url: urljoin(req.headers && req.headers.origin, formatAccountPathsFor(paths.account.switchPSP.recieveVerifyPSPIntegrationPayment, req.account.external_id))
+    })
+
+    req.session[VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY] = charge.charge_id
+    res.redirect(filterNextUrl(charge))
+  } catch (error) {
+    next(error)
+  }
+}
+
+async function completePaymentJourney (req, res, next) {
+  try {
+    const chargeExternalId = req.session[VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY]
+    if (chargeExternalId) {
+      const charge = await connectorClient.getCharge(req.account.gateway_account_id, req.session.verify_psp_integration_charge_external_id)
+      if (charge.state.status === 'success') {
+        // PATCH update connector for credential state
+        req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY] = VERIFY_PSP_INTEGRATION_STATUS.SUCCESS
+      } else {
+        logger.info('Live payment to verify PSP integration had a non-success status')
+        req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY] = VERIFY_PSP_INTEGRATION_STATUS.FAILURE
+      }
+    } else {
+      throw new Error('No charge found on session')
+    }
+  } catch (error) {
+    logger.warn(`Exception raised during very PSP intgration callback: ${error.message}`)
+    req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY] = VERIFY_PSP_INTEGRATION_STATUS.FAILURE
+  }
+  res.redirect(formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
+}
+
+module.exports = { verifyPSPIntegrationPaymentPage, startPaymentJourney, completePaymentJourney }

--- a/app/controllers/switch-psp/verify-psp-integration.controller.test.js
+++ b/app/controllers/switch-psp/verify-psp-integration.controller.test.js
@@ -1,0 +1,106 @@
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+const gatewayAccountFixtures = require('../../../test/fixtures/gateway-account.fixtures')
+const connectorChargeFixtures = require('../../../test/fixtures/connector-charge.fixtures')
+const userFixtures = require('../../../test/fixtures/user.fixtures')
+const User = require('../../models/User.class')
+const { expect } = require('chai')
+
+const defaultCharge = connectorChargeFixtures.validChargeResponse()
+let postChargeRequestMock = sinon.spy(() => Promise.resolve(defaultCharge))
+let patchAccountGatewayAccountCredentialsStateMock = sinon.spy(() => Promise.resolve())
+let getChargeMock = sinon.spy(() => Promise.resolve(defaultCharge))
+
+describe('Verify PSP integration controller', () => {
+  let req, res, next
+
+  beforeEach(() => {
+    const account = gatewayAccountFixtures.validGatewayAccount({
+      external_id: 'a-valid-external-id',
+      gateway_account_credentials: [
+        { state: 'ACTIVE', payment_provider: 'smartpay', id: 100 },
+        { state: 'CREATED', payment_provider: 'worldpay', id: 200 }
+      ]
+    })
+    req = {
+      correlationId: 'correlation-id',
+      account: account,
+      user: new User(userFixtures.validUserResponse()),
+      flash: sinon.spy(),
+      session: {},
+      headers: {
+        origin: 'https://selfservice.some-origin.com'
+      }
+    }
+    res = {
+      setHeader: sinon.stub(),
+      status: sinon.spy(),
+      redirect: sinon.spy(),
+      render: sinon.spy()
+    }
+    next = sinon.spy()
+
+    postChargeRequestMock.resetHistory()
+    patchAccountGatewayAccountCredentialsStateMock.resetHistory()
+    getChargeMock.resetHistory()
+  })
+
+  it('sets up the session correctly and redirects to the charge nexturl to start the payment journey', async () => {
+    const controller = getControllerWithMocks()
+    const nextUrl = defaultCharge.links.filter((link) => link.rel === 'next_url')[0].href
+    await controller.startPaymentJourney(req, res, next)
+
+    sinon.assert.called(postChargeRequestMock)
+    expect(req.session.verify_psp_integration_charge_external_id).to.equal(defaultCharge.charge_id)
+    sinon.assert.calledWith(res.redirect, nextUrl)
+  })
+
+  it('configures the session correctly and redirects to the charge nexturl to start the payment journey', async () => {
+    const controller = getControllerWithMocks()
+    const nextUrl = defaultCharge.links.filter((link) => link.rel === 'next_url')[0].href
+    await controller.startPaymentJourney(req, res, next)
+
+    sinon.assert.called(postChargeRequestMock)
+    expect(req.session.verify_psp_integration_charge_external_id).to.equal(defaultCharge.charge_id)
+    sinon.assert.calledWith(res.redirect, nextUrl)
+  })
+
+  it('configures the session and redirects when the test payment was successful', async () => {
+    const charge = connectorChargeFixtures.validChargeResponse({ status: 'success' })
+    getChargeMock = sinon.spy(() => Promise.resolve(charge))
+    req.session.verify_psp_integration_charge_external_id = charge.charge_id
+    const controller = getControllerWithMocks()
+    await controller.completePaymentJourney(req, res, next)
+
+    sinon.assert.called(getChargeMock)
+    sinon.assert.called(patchAccountGatewayAccountCredentialsStateMock)
+    expect(req.session.verify_psp_integration_status_key).to.equal('SUCCESS')
+    sinon.assert.calledWith(res.redirect, '/account/a-valid-external-id/switch-psp')
+  })
+
+  it('configures the session and redirects when the test payment was unsuccessful', async () => {
+    const charge = connectorChargeFixtures.validChargeResponse({ status: 'cancelled' })
+    getChargeMock = sinon.spy(() => Promise.resolve(charge))
+    req.session.verify_psp_integration_charge_external_id = charge.charge_id
+    const controller = getControllerWithMocks()
+    await controller.completePaymentJourney(req, res, next)
+
+    sinon.assert.called(getChargeMock)
+    sinon.assert.notCalled(patchAccountGatewayAccountCredentialsStateMock)
+    expect(req.session.verify_psp_integration_status_key).to.equal('FAILURE')
+    sinon.assert.calledWith(res.redirect, '/account/a-valid-external-id/switch-psp')
+  })
+})
+
+function getControllerWithMocks () {
+  return proxyquire('./verify-psp-integration.controller', {
+    '../../services/clients/connector.client': {
+      ConnectorClient: function () {
+        this.postChargeRequest = postChargeRequestMock
+        this.patchAccountGatewayAccountCredentialsState = patchAccountGatewayAccountCredentialsStateMock
+        this.getCharge = getChargeMock
+      }
+    }
+  })
+}

--- a/app/paths.js
+++ b/app/paths.js
@@ -102,7 +102,8 @@ module.exports = {
     },
     switchPSP: {
       index: '/switch-psp',
-      worldpayCredentials: '/switch-psp/credentials/worldpay'
+      worldpayCredentials: '/switch-psp/credentials/worldpay',
+      verifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration'
     },
     toggle3ds: {
       index: '/3ds'

--- a/app/paths.js
+++ b/app/paths.js
@@ -103,7 +103,8 @@ module.exports = {
     switchPSP: {
       index: '/switch-psp',
       worldpayCredentials: '/switch-psp/credentials/worldpay',
-      verifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration'
+      verifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration',
+      recieveVerifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration/callback'
     },
     toggle3ds: {
       index: '/3ds'

--- a/app/routes.js
+++ b/app/routes.js
@@ -301,7 +301,9 @@ module.exports.bind = function (app) {
   account.post(yourPsp.flex, permission('gateway-credentials:update'), yourPspController.postFlex)
 
   account.get(switchPSP.index, restrictToSwitchingAccount, permission('gateway-credentials:update'), switchPSPController.switchPSPPage)
-  account.get(switchPSP.index, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.verifyPSPIntegrationPaymentPage)
+  account.get(switchPSP.verifyPSPIntegrationPayment, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.verifyPSPIntegrationPaymentPage)
+  account.post(switchPSP.verifyPSPIntegrationPayment, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.startPaymentJourney)
+  account.get(switchPSP.recieveVerifyPSPIntegrationPayment, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.completePaymentJourney)
 
   // Credentials
   account.get(yourPsp.worldpayCredentials, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)

--- a/app/routes.js
+++ b/app/routes.js
@@ -73,6 +73,7 @@ const settingsController = require('./controllers/settings')
 const userPhoneNumberController = require('./controllers/user/phone-number')
 const yourPspController = require('./controllers/your-psp')
 const switchPSPController = require('./controllers/switch-psp/switch-psp.controller')
+const verifyPSPIntegrationController = require('./controllers/switch-psp/verify-psp-integration.controller')
 const allTransactionsController = require('./controllers/all-service-transactions/index')
 const payoutsController = require('./controllers/payouts/payout-list.controller')
 const stripeSetupDashboardRedirectController = require('./controllers/stripe-setup/stripe-setup-link')
@@ -300,6 +301,7 @@ module.exports.bind = function (app) {
   account.post(yourPsp.flex, permission('gateway-credentials:update'), yourPspController.postFlex)
 
   account.get(switchPSP.index, restrictToSwitchingAccount, permission('gateway-credentials:update'), switchPSPController.switchPSPPage)
+  account.get(switchPSP.index, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.verifyPSPIntegrationPaymentPage)
 
   // Credentials
   account.get(yourPsp.worldpayCredentials, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -215,7 +215,7 @@ ConnectorClient.prototype = {
   patchAccountGatewayAccountCredentials: function (params) {
     const url = this.connectorUrl + ACCOUNT_GATEWAY_ACCOUNT_CREDENTIALS_PATH
       .replace('{accountId}', params.gatewayAccountId)
-      .replace('{credentialsId}', params.gatewayAccountCredentialsId)
+      .replace('{credentialsId}', params.gatewayAccountCredentialId)
 
     const payload = [
       {

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -675,6 +675,27 @@ ConnectorClient.prototype = {
         baseClientErrorHandler: 'old'
       }
     )
+  },
+
+  postChargeRequest: function (gatewayAccountId, payload) {
+    return baseClient.post(
+      {
+        baseUrl: this.connectorUrl,
+        url: CHARGES_API_PATH.replace('{accountId}', gatewayAccountId),
+        json: true,
+        body: payload,
+        description: 'create payment',
+        service: SERVICE_NAME
+      }
+    )
+  },
+
+  getCharge: function (gatewayAccountId, chargeExternalId) {
+    const url = this.connectorUrl + CHARGE_API_PATH.replace('{accountId}', gatewayAccountId).replace('{chargeId}', chargeExternalId)
+    return baseClient.get(url, {
+      description: 'get a charge',
+      service: SERVICE_NAME
+    })
   }
 }
 

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -215,7 +215,7 @@ ConnectorClient.prototype = {
   patchAccountGatewayAccountCredentials: function (params) {
     const url = this.connectorUrl + ACCOUNT_GATEWAY_ACCOUNT_CREDENTIALS_PATH
       .replace('{accountId}', params.gatewayAccountId)
-      .replace('{credentialsId}', params.gatewayAccountCredentialId)
+      .replace('{credentialsId}', params.gatewayAccountCredentialsId)
 
     const payload = [
       {
@@ -234,6 +234,25 @@ ConnectorClient.prototype = {
       body: payload,
       correlationId: params.correlationId,
       description: 'patch gateway account credentials',
+      service: SERVICE_NAME
+    })
+  },
+
+  patchAccountGatewayAccountCredentialsState: function (params) {
+    const url = this.connectorUrl + ACCOUNT_GATEWAY_ACCOUNT_CREDENTIALS_PATH
+      .replace('{accountId}', params.gatewayAccountId)
+      .replace('{credentialsId}', params.gatewayAccountCredentialsId)
+
+    const payload = [{
+      op: 'replace',
+      path: 'state',
+      value: params.state
+    }]
+
+    return baseClient.patch(url, {
+      body: payload,
+      correlationId: params.correlationId,
+      description: 'patch gateway account credentials state',
       service: SERVICE_NAME
     })
   },

--- a/app/utils/verify-psp-integration.js
+++ b/app/utils/verify-psp-integration.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const VERIFY_PSP_INTEGRATION_STATUS = {
+  SUCCESS: 'SUCCESS',
+  FAILURE: 'FAILURE'
+}
+const VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY = 'verify_psp_integration_charge_external_id'
+const VERIFY_PSP_INTEGRATION_STATUS_KEY = 'verify_psp_integration_status_key'
+
+function filterNextUrl (charge = {}) {
+  const nextUrlEntry = charge.links &&
+    charge.links.filter((link) => link.rel === 'next_url')[0]
+
+  return nextUrlEntry && nextUrlEntry.href
+}
+
+module.exports = {
+  VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY,
+  VERIFY_PSP_INTEGRATION_STATUS_KEY,
+  VERIFY_PSP_INTEGRATION_STATUS,
+  filterNextUrl
+}

--- a/app/utils/verify-psp-integration.test.js
+++ b/app/utils/verify-psp-integration.test.js
@@ -1,0 +1,16 @@
+const { expect } = require('chai')
+const connectorChargeFixtures = require('../../test/fixtures/connector-charge.fixtures')
+const { filterNextUrl } = require('./verify-psp-integration')
+
+describe('verify psp integration utility', () => {
+  it('gets the next url for a valid charge', () => {
+    const charge = connectorChargeFixtures.validChargeResponse({
+      next_url: 'some/next/url'
+    })
+    expect(filterNextUrl(charge)).to.equal('some/next/url')
+  })
+
+  it('safely returns nothing if next url missing', () => {
+    expect(filterNextUrl({})).to.equal(undefined)
+  })
+})

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -1,3 +1,4 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
@@ -10,6 +11,32 @@
 
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
+  {% if verifyPSPIntegrationResult === VERIFY_PSP_INTEGRATION_STATUS.SUCCESS %}
+    {% set bannerHtml %}
+      <h3 class="govuk-notification-banner__heading">
+        Your live payment has succeeded
+      </h3>
+      <p class="govuk-body">The connection between {{ targetCredential.payment_provider }} and GOV.UK Pay has been confirmed. You can <a class="govuk-notification-banner__link" href="{{ formatAccountPathsFor(routes.account.transactions.index, currentGatewayAccount.external_id) }}?reference=VERIFY_PSP_INTEGRATION">check the payment using reporting tools</a> and refund the payment at any time.</p>
+    {% endset %}
+
+    {{ govukNotificationBanner({
+      html: bannerHtml,
+      type: 'success'
+    }) }}
+  {% elif verifyPSPIntegrationResult === VERIFY_PSP_INTEGRATION_STATUS.FAILURE %}
+    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+        There is a problem
+      </h2>
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list">
+          <li>
+            <span>Your live payment was not successful. <a class="govuk-link" href="https://www.payments.service.gov.uk/support/">Contact support</a> to continue switching PSP.</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  {% endif %}
   <h1 class="govuk-heading-l page-title">Switch payment service provider (PSP)</h1>
 
   <p class="govuk-body">This service is taking payments with {{ currentGatewayAccount.payment_provider | formatPSPname }}.</p>

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -13,7 +13,7 @@
   <li class="app-task-list__item">
     <span class="app-task-list__task-name">
       {% if item.enabled %}
-      <a class="govuk-link" href="{{ url }}" aria-describedby="link-worldpay-account">
+      <a class="govuk-link" href="{{ url }}" aria-describedby="{{ label }}-status">
         {{ label }}
       </a>
       {% else %}
@@ -22,11 +22,11 @@
     </span>
 
     {% if not item.enabled %}
-    <strong class="govuk-tag app-task-list__tag govuk-tag--grey" id="link-worldpay-account-status">cannot start yet</strong>
+    <strong class="govuk-tag app-task-list__tag govuk-tag--grey" id="{{ label }}-status">cannot start yet</strong>
     {% elif not item.complete %}
-    <strong class="govuk-tag app-task-list__tag govuk-tag--grey" id="link-worldpay-account-status">not started</strong>
+    <strong class="govuk-tag app-task-list__tag govuk-tag--grey" id="{{ label }}-status">not started</strong>
     {% elif item.complete %}
-    <strong class="govuk-tag app-task-list__tag" id="link-worldpay-account-status">completed</strong>
+    <strong class="govuk-tag app-task-list__tag" id="{{ label }}-status">completed</strong>
     {% endif %}
   </li>
 {% endmacro %}

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -9,6 +9,28 @@
   {% include "includes/side-navigation.njk" %}
 {% endblock %}
 
+{% macro taskListItem(label, url, item) %}
+  <li class="app-task-list__item">
+    <span class="app-task-list__task-name">
+      {% if item.enabled %}
+      <a class="govuk-link" href="{{ url }}" aria-describedby="link-worldpay-account">
+        {{ label }}
+      </a>
+      {% else %}
+      <span>{{ label }}</span>
+      {% endif %}
+    </span>
+
+    {% if not item.enabled %}
+    <strong class="govuk-tag app-task-list__tag govuk-tag--grey" id="link-worldpay-account-status">cannot start yet</strong>
+    {% elif not item.complete %}
+    <strong class="govuk-tag app-task-list__tag govuk-tag--grey" id="link-worldpay-account-status">not started</strong>
+    {% elif item.complete %}
+    <strong class="govuk-tag app-task-list__tag" id="link-worldpay-account-status">completed</strong>
+    {% endif %}
+  </li>
+{% endmacro %}
+
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
   {% if verifyPSPIntegrationResult === VERIFY_PSP_INTEGRATION_STATUS.SUCCESS %}
@@ -51,29 +73,16 @@
       </ul>
 
       {% set tasks %}
-        <li class="app-task-list__item">
-            <span class="app-task-list__task-name">
-              {% set linkCredentials = taskList.LINK_CREDENTIALS %}
-              {# {{ taskListItem("The macro text", "/the/macro/link", "the-macro-id") }} #}
-              {% set linkCredentialsText = "Link your Worldpay account with GOV.UK Pay" %}
-              {% if linkCredentials.enabled %}
-              <a class="govuk-link" href="{{ formatAccountPathsFor(routes.account.switchPSP.worldpayCredentials, currentGatewayAccount.external_id) }}" aria-describedby="link-worldpay-account">
-                {{ linkCredentialsText }}
-              </a>
-              {% else %}
-                <span>{{ linkCredentialsText }}</span>
-              {% endif %}
-            </span>
-
-            {# {{ taskListStatus(taskListEntry) }} #}
-            {% if not linkCredentials.enabled %}
-            <strong class="govuk-tag app-task-list__tag govuk-tag--grey" id="link-worldpay-account-status">cannot start yet</strong>
-            {% elif not linkCredentials.complete %}
-            <strong class="govuk-tag app-task-list__tag govuk-tag--grey" id="link-worldpay-account-status">not started</strong>
-            {% elif linkCredentials.complete %}
-            <strong class="govuk-tag app-task-list__tag" id="link-worldpay-account-status">completed</strong>
-            {% endif %}
-          </li>
+        {{ taskListItem(
+          "Link your Worldpay account with GOV.UK Pay",
+          formatAccountPathsFor(routes.account.switchPSP.worldpayCredentials, currentGatewayAccount.external_id),
+          taskList.LINK_CREDENTIALS
+        ) }}
+        {{ taskListItem(
+          "Make a live payment to test your Worldpay PSP",
+          formatAccountPathsFor(routes.account.switchPSP.verifyPSPIntegrationPayment, currentGatewayAccount.external_id),
+          taskList.VERIFY_PSP_INTEGRATION
+        ) }}
       {% endset %}
   {% endswitch %}
 

--- a/app/views/switch-psp/verify-psp-integration-payment.njk
+++ b/app/views/switch-psp/verify-psp-integration-payment.njk
@@ -1,0 +1,32 @@
+{% extends "layout.njk" %}
+
+{% block pageTitle %}
+  Switch PSP - Verify PSP - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+{% endblock %}
+
+{% block side_navigation %}
+  {% include "includes/side-navigation.njk" %}
+{% endblock %}
+
+{% block mainContent %}
+<div class="govuk-grid-column-two-thirds">
+  {# back link should always go before <main> content so it can be skipped, settings page layouts should be adjusted to suport this #}
+  {{ govukBackLink({
+    text: "Back to Switching payment service provider (PSP)",
+    classes: "govuk-!-margin-top-0",
+    href: formatAccountPathsFor(routes.account.switchPSP.index, currentGatewayAccount.external_id)
+  }) }}
+
+  <h1 class="govuk-heading-l page-title">Test the connection between {{ targetCredential.payment_provider | formatPSPname }} and GOV.UK Pay</h1>
+
+  <p class="govuk-body">Check that your service can take payments with {{ targetCredential.payment_provider | formatPSPname }} by making a live payment.</p>
+
+  <p class="govuk-body">You need a debit or credit card and can refund the payment at anytime. The live payment will be for £2.</p>
+
+  <form method="POST">
+    {{ govukButton ({
+      text: "Continue to live payment"
+    }) }}
+  </form>
+</div>
+{% endblock %}

--- a/app/views/switch-psp/verify-psp-integration-payment.njk
+++ b/app/views/switch-psp/verify-psp-integration-payment.njk
@@ -27,6 +27,8 @@
     {{ govukButton ({
       text: "Continue to live payment"
     }) }}
+
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
   </form>
 </div>
 {% endblock %}

--- a/app/views/switch-psp/verify-psp-integration-payment.njk
+++ b/app/views/switch-psp/verify-psp-integration-payment.njk
@@ -21,7 +21,7 @@
 
   <p class="govuk-body">Check that your service can take payments with {{ targetCredential.payment_provider | formatPSPname }} by making a live payment.</p>
 
-  <p class="govuk-body">You need a debit or credit card and can refund the payment at anytime. The live payment will be for £2.</p>
+  <p class="govuk-body">You need a debit or credit card and can refund the payment at anytime.</p>
 
   <form method="POST">
     {{ govukButton ({

--- a/test/fixtures/connector-charge.fixtures.js
+++ b/test/fixtures/connector-charge.fixtures.js
@@ -6,7 +6,6 @@ function validLinks (opts = {}) {
   }]
 }
 
-// both POST new charge and GET one charge return the exact same shape of data
 function validChargeResponse (opts = {}) {
   const data = {
     charge_id: opts.charge_id || 'a-valid-charge-external-id',

--- a/test/fixtures/connector-charge.fixtures.js
+++ b/test/fixtures/connector-charge.fixtures.js
@@ -1,0 +1,22 @@
+function validLinks (opts = {}) {
+  return [{
+    rel: 'next_url',
+    method: 'GET',
+    href: opts.next_url || 'https://payments.a-next-url.com'
+  }]
+}
+
+// both POST new charge and GET one charge return the exact same shape of data
+function validChargeResponse (opts = {}) {
+  const data = {
+    charge_id: opts.charge_id || 'a-valid-charge-external-id',
+    state: {
+      finished: opts.finished || true,
+      status: opts.status || 'success'
+    },
+    links: validLinks(opts)
+  }
+  return data
+}
+
+module.exports = { validChargeResponse }


### PR DESCRIPTION
Adds pages
* verify PSP integration page, routes to start and receive test payment journey hooks

Extends connector helpers
* add helper methods to interact with Connector charges (creating and
checking in-flight status)
* fixtures for charge interaction (POST and GET return the same shape of
data)

Updates switching PSP tasks
* refactored to use a new `taskListItem` macro that will keep formatting consistent for all future tasks
* added task for verifying PSP integration

Proposed to add in a follow up PR
* pacts with Connector for new endpoints
* Cypress happy path for this task list item

Recommend stepping through commits as each piece was done in a logical order, happy to split into multiple PRs if more appropriate for reviewing.

Journey step page

<img width="599" alt="Screenshot 2021-06-18 at 11 56 03" src="https://user-images.githubusercontent.com/2844572/122551014-5483e300-d02c-11eb-887a-28aaef36f440.png">

Successful task item completion 

<img width="552" alt="Screenshot 2021-06-18 at 14 56 49" src="https://user-images.githubusercontent.com/2844572/122572352-91a89f00-d045-11eb-8f6f-af5e297cbf47.png">

Failed task item completion

<img width="544" alt="Screenshot 2021-06-18 at 14 57 04" src="https://user-images.githubusercontent.com/2844572/122572373-95d4bc80-d045-11eb-973a-cb2657500795.png">
