### PR TITLE
PP-8215 Cypress coverage for payment validator task 

### DIFF
--- a/app/controllers/switch-psp/verify-psp-integration.controller.js
+++ b/app/controllers/switch-psp/verify-psp-integration.controller.js
@@ -36,7 +36,7 @@ async function startPaymentJourney (req, res, next) {
       payment_provider: targetCredential.payment_provider,
       description: 'Live payment to verify new PSP',
       reference: 'VERIFY_PSP_INTEGRATION',
-      return_url: urljoin(req.headers && req.headers.origin, formatAccountPathsFor(paths.account.switchPSP.recieveVerifyPSPIntegrationPayment, req.account.external_id))
+      return_url: urljoin(req.headers && req.headers.origin, formatAccountPathsFor(paths.account.switchPSP.receiveVerifyPSPIntegrationPayment, req.account.external_id))
     })
 
     req.session[VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY] = charge.charge_id

--- a/app/paths.js
+++ b/app/paths.js
@@ -104,7 +104,7 @@ module.exports = {
       index: '/switch-psp',
       worldpayCredentials: '/switch-psp/credentials/worldpay',
       verifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration',
-      recieveVerifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration/callback'
+      receiveVerifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration/callback'
     },
     toggle3ds: {
       index: '/3ds'

--- a/app/routes.js
+++ b/app/routes.js
@@ -303,7 +303,7 @@ module.exports.bind = function (app) {
   account.get(switchPSP.index, restrictToSwitchingAccount, permission('gateway-credentials:update'), switchPSPController.switchPSPPage)
   account.get(switchPSP.verifyPSPIntegrationPayment, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.verifyPSPIntegrationPaymentPage)
   account.post(switchPSP.verifyPSPIntegrationPayment, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.startPaymentJourney)
-  account.get(switchPSP.recieveVerifyPSPIntegrationPayment, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.completePaymentJourney)
+  account.get(switchPSP.receiveVerifyPSPIntegrationPayment, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.completePaymentJourney)
 
   // Credentials
   account.get(yourPsp.worldpayCredentials, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)

--- a/test/cypress/stubs/connector-charge-stubs.js
+++ b/test/cypress/stubs/connector-charge-stubs.js
@@ -1,0 +1,18 @@
+const connectorChargeFixtures = require('../../fixtures/connector-charge.fixtures')
+const { stubBuilder } = require('./stub-builder')
+
+function postCreateChargeSuccess (opts) {
+  const path = `/v1/api/accounts/${opts.gateway_account_id}/charges`
+  return stubBuilder('POST', path, 200, {
+    response: connectorChargeFixtures.validChargeResponse(opts)
+  })
+}
+
+function getChargeSuccess (opts) {
+  const path = `/v1/api/accounts/${opts.gateway_account_id}/charges/${opts.charge_id}`
+  return stubBuilder('GET', path, 200, {
+    response: connectorChargeFixtures.validChargeResponse(opts)
+  })
+}
+
+module.exports = { postCreateChargeSuccess, getChargeSuccess }


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-selfservice/pull/2793

Add Cypress coverage for task lisk item to verify PSP integration.
Asserts that high level success and non-success payment routes are
appropriately handled.