### PR TITLE
PP-8217 Add button to switch provider

### DIFF
--- a/app/controllers/switch-psp/switch-psp.controller.js
+++ b/app/controllers/switch-psp/switch-psp.controller.js
@@ -1,18 +1,24 @@
 'use strict'
 const { response } = require('../../utils/response')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
+const formatPSPName = require('../../utils/format-PSP-name')
+const paths = require('../../paths')
 const switchTasks = require('./switch-tasks.service')
-const { getSwitchingCredential } = require('../../utils/credentials')
 const {
   VERIFY_PSP_INTEGRATION_STATUS_KEY,
   VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY,
   VERIFY_PSP_INTEGRATION_STATUS
 } = require('../../utils/verify-psp-integration')
+const { getSwitchingCredential, getCurrentCredential } = require('../../utils/credentials')
+const { ConnectorClient } = require('../../services/clients/connector.client')
+const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 
 function switchPSPPage (req, res, next) {
   try {
     const targetCredential = getSwitchingCredential(req.account)
     const taskList = switchTasks.getTaskList(targetCredential, req.account)
-    const context = { targetCredential, taskList, VERIFY_PSP_INTEGRATION_STATUS }
+    const taskListIsComplete = switchTasks.isComplete(taskList)
+    const context = { targetCredential, taskList, VERIFY_PSP_INTEGRATION_STATUS, taskListIsComplete }
 
     if (req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY]) {
       context.verifyPSPIntegrationResult = req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY]
@@ -25,4 +31,30 @@ function switchPSPPage (req, res, next) {
   }
 }
 
-module.exports = { switchPSPPage }
+async function submitSwitchPSP (req, res, next) {
+  try {
+    const currentCredential = getCurrentCredential(req.account)
+    const targetCredential = getSwitchingCredential(req.account)
+    const taskList = switchTasks.getTaskList(targetCredential, req.account)
+    const taskListIsComplete = switchTasks.isComplete(taskList)
+
+    if (!taskListIsComplete) {
+      req.flash('genericError', 'You cannot switch providers until all required tasks are completed')
+      return res.redirect(formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
+    }
+
+    await connectorClient.postAccountSwitchPSP(req.account.gateway_account_id, {
+      user_external_id: req.user.externalId,
+      gateway_account_credential_external_id: targetCredential.external_id
+    })
+    req.flash(
+      'switchPSPSuccess',
+      `All future payments will be taken with ${formatPSPName(targetCredential.payment_provider)}. Your ${formatPSPName(currentCredential.payment_provider)} account is still live for processing refunds of payments made before the switch.`
+    )
+    res.redirect(formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, targetCredential.payment_provider))
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = { switchPSPPage, submitSwitchPSP }

--- a/app/controllers/switch-psp/switch-psp.controller.test.js
+++ b/app/controllers/switch-psp/switch-psp.controller.test.js
@@ -1,0 +1,73 @@
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+const gatewayAccountFixtures = require('../../../test/fixtures/gateway-account.fixtures')
+const userFixtures = require('../../../test/fixtures/user.fixtures')
+const User = require('../../models/User.class')
+
+let postAccountSwitchPSPMock = sinon.spy(() => Promise.resolve())
+let req, res, next
+
+describe('Verify PSP integration controller', () => {
+  describe('for ready to switch accounts', () => {
+    beforeEach(() => setupEnvironment('VERIFIED_WITH_LIVE_PAYMENT'))
+
+    it('updates Connector backend and redirects to your psp page', async () => {
+      const controller = getControllerWithMocks()
+      await controller.submitSwitchPSP(req, res, next)
+
+      sinon.assert.called(postAccountSwitchPSPMock)
+      sinon.assert.calledWith(req.flash, 'switchPSPSuccess')
+      sinon.assert.calledWith(res.redirect, '/account/a-valid-external-id/your-psp/worldpay')
+    })
+  })
+
+  describe('for not yet ready to switch accounts', () => {
+    beforeEach(() => setupEnvironment('ENTERED'))
+
+    it('stops the session from going through and returns to switch psp page', async () => {
+      const controller = getControllerWithMocks()
+      await controller.submitSwitchPSP(req, res, next)
+
+      sinon.assert.notCalled(postAccountSwitchPSPMock)
+      sinon.assert.calledWith(req.flash, 'genericError', 'You cannot switch providers until all required tasks are completed')
+      sinon.assert.calledWith(res.redirect, '/account/a-valid-external-id/switch-psp')
+    })
+  })
+})
+
+function setupEnvironment (switchingCredentialState) {
+  const account = gatewayAccountFixtures.validGatewayAccount({
+    external_id: 'a-valid-external-id',
+    gateway_account_credentials: [
+      { state: 'ACTIVE', payment_provider: 'smartpay', id: 100 },
+      { state: switchingCredentialState, payment_provider: 'worldpay', id: 200 }
+    ]
+  })
+  req = {
+    correlationId: 'correlation-id',
+    account: account,
+    user: new User(userFixtures.validUserResponse()),
+    flash: sinon.spy(),
+    session: {}
+  }
+  res = {
+    setHeader: sinon.stub(),
+    status: sinon.spy(),
+    redirect: sinon.spy(),
+    render: sinon.spy()
+  }
+  next = sinon.spy()
+
+  postAccountSwitchPSPMock.resetHistory()
+}
+
+function getControllerWithMocks () {
+  return proxyquire('./switch-psp.controller', {
+    '../../services/clients/connector.client': {
+      ConnectorClient: function () {
+        this.postAccountSwitchPSP = postAccountSwitchPSPMock
+      }
+    }
+  })
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -301,6 +301,7 @@ module.exports.bind = function (app) {
   account.post(yourPsp.flex, permission('gateway-credentials:update'), yourPspController.postFlex)
 
   account.get(switchPSP.index, restrictToSwitchingAccount, permission('gateway-credentials:update'), switchPSPController.switchPSPPage)
+  account.post(switchPSP.index, restrictToSwitchingAccount, permission('gateway-credentials:update'), switchPSPController.submitSwitchPSP)
   account.get(switchPSP.verifyPSPIntegrationPayment, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.verifyPSPIntegrationPaymentPage)
   account.post(switchPSP.verifyPSPIntegrationPayment, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.startPaymentJourney)
   account.get(switchPSP.receiveVerifyPSPIntegrationPayment, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.completePaymentJourney)

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -15,6 +15,7 @@ const CHARGE_REFUNDS_API_PATH = CHARGE_API_PATH + '/refunds'
 const CARD_TYPES_API_PATH = '/v1/api/card-types'
 const STRIPE_ACCOUNT_SETUP_PATH = ACCOUNT_API_PATH + '/stripe-setup'
 const STRIPE_ACCOUNT_PATH = ACCOUNT_API_PATH + '/stripe-account'
+const SWITCH_PSP_PATH = ACCOUNT_API_PATH + '/switch-psp'
 
 const ACCOUNTS_FRONTEND_PATH = '/v1/frontend/accounts'
 const ACCOUNT_FRONTEND_PATH = ACCOUNTS_FRONTEND_PATH + '/{accountId}'
@@ -713,6 +714,16 @@ ConnectorClient.prototype = {
     const url = this.connectorUrl + CHARGE_API_PATH.replace('{accountId}', gatewayAccountId).replace('{chargeId}', chargeExternalId)
     return baseClient.get(url, {
       description: 'get a charge',
+      service: SERVICE_NAME
+    })
+  },
+
+  postAccountSwitchPSP: function (gatewayAccountId, payload, correlationId) {
+    const url = this.connectorUrl + SWITCH_PSP_PATH.replace('{accountId}', gatewayAccountId)
+    return baseClient.post(url, {
+      body: payload,
+      correlationId: correlationId,
+      description: 'switch account payment service provider',
       service: SERVICE_NAME
     })
   }

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -103,6 +103,14 @@
             <p class="govuk-body">
               After linking {{ targetCredential.payment_provider | formatPSPname }} and GOV.UK Pay, you can safely switch to taking payments with {{ targetCredential.payment_provider | formatPSPname }}.
             </p>
+
+            <form method="POST">
+              {{ govukButton({
+                text: "Switch to " + (targetCredential.payment_provider | formatPSPname),
+                disabled: (not taskListIsComplete)
+              }) }}
+              <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+            </form>
           </li>
         </ul>
       </li>

--- a/app/views/your-psp/index.njk
+++ b/app/views/your-psp/index.njk
@@ -1,3 +1,4 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
@@ -10,6 +11,21 @@
 
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
+  {% if flash.switchPSPSuccess %}
+    {% set html %}
+      <p class="govuk-notification-banner__heading">
+        You've switched payment service provider
+      </p>
+      <p class="govuk-body">
+        {{ flash.switchPSPSuccess }}
+      </p>
+    {% endset %}
+
+    {{ govukNotificationBanner({
+      html: html,
+      type: 'success'
+    }) }}
+  {% endif %}
   <h1 class="govuk-heading-l page-title">Your payment service provider (PSP) - {{ paymentProvider | formatPSPname }}</h1>
 
   {% if paymentProvider === "worldpay" %}

--- a/test/cypress/integration/settings/switch-psp.cy.test.js
+++ b/test/cypress/integration/settings/switch-psp.cy.test.js
@@ -61,6 +61,7 @@ describe('Switch PSP settings page', () => {
             cy.get('.app-task-list__item').eq(1).should('contain', 'Make a live payment to test your Worldpay PSP')
               .find('.app-task-list__tag').should('have.text', 'cannot start yet')
           })
+        cy.get('button').contains('Switch to Worldpay').should('have.disabled')
       })
 
       it('should navigate to link Worldpay account step', () => {
@@ -174,6 +175,20 @@ describe('Switch PSP settings page', () => {
         cy.get('button').contains('Continue to live payment').click()
         cy.visit(`/account/${gatewayAccountExternalId}/switch-psp/verify-psp-integration/callback`)
         cy.get('.govuk-notification-banner__content').contains('Your live payment has succeeded')
+      })
+    })
+
+    describe('Switch PSP', () => {
+      beforeEach(() => {
+        cy.task('setupStubs', getUserAndAccountStubs('smartpay', true, [
+          { payment_provider: 'smartpay', state: 'ACTIVE' },
+          { payment_provider: 'worldpay', state: 'VERIFIED_WITH_LIVE_PAYMENT' }
+        ]))
+      })
+
+      it('submits and navigates through to success page with appropriate message', () => {
+        cy.get('button').contains('Switch to Worldpay').click()
+        cy.get('.govuk-notification-banner__heading').contains('You\'ve switched payment service provider')
       })
     })
   })


### PR DESCRIPTION
Add button and POST endpoint to switch account payment service provider.
Button is only available if all of the required tasks are complete.

Add connector client helper to call new `switch-psp` endpoint.

Add coverage for POST switch controller and assertions on button state
for different end to end scenarios.

**Button blocked before task list is complete**
<img width="788" alt="Screenshot 2021-06-21 at 16 05 58" src="https://user-images.githubusercontent.com/2844572/122797718-af7d3a80-d2b7-11eb-98af-adf040b4b638.png">

**Button available when task list is complete**
<img width="640" alt="Screenshot 2021-06-21 at 16 10 25" src="https://user-images.githubusercontent.com/2844572/122797720-b0ae6780-d2b7-11eb-810c-b6c5ecae4b75.png">

**Navigates to your PSP on completion**
<img width="419" alt="Screenshot 2021-06-21 at 16 10 43" src="https://user-images.githubusercontent.com/2844572/122797722-b0ae6780-d2b7-11eb-93a8-d64998aba9a2.png">

