### PR TITLE
PP-8190 Your PSP and credential pages use credentials list

### DIFF
--- a/app/controllers/credentials.controller.test.js
+++ b/app/controllers/credentials.controller.test.js
@@ -1,6 +1,6 @@
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
-
+const gatewayAccountFixture = require('../../test/fixtures/gateway-account.fixtures')
 const patchAccountSpy = sinon.spy(() => Promise.resolve())
 const postNotificationCredentialsSpy = sinon.spy(() => Promise.resolve())
 const connectorClientMock = {
@@ -19,6 +19,8 @@ const expressResponseStub = {
   redirect: sinon.spy(),
   render: sinon.spy()
 }
+const next = sinon.spy()
+const credentialId = 'a-valid-credential-id'
 describe('gateway credentials controller', () => {
   it('should remove leading and trailing whitespace from credentials when submitting them to the backend', async () => {
     const req = {
@@ -27,11 +29,15 @@ describe('gateway credentials controller', () => {
         password: ' password ',
         merchantId: ' merchant-id '
       },
-      account: {},
-      params: {},
+      account: gatewayAccountFixture.validGatewayAccount({
+        gateway_account_credentials: [{
+          external_id: credentialId
+        }]
+      }),
+      params: { credentialId },
       headers: {}
     }
-    await credentialsController.update(req, expressResponseStub)
+    await credentialsController.update(req, expressResponseStub, next)
     sinon.assert.calledWithMatch(patchAccountSpy, { payload: { credentials: { username: 'username', password: 'password', merchant_id: 'merchant-id' } } })
   })
 
@@ -41,12 +47,16 @@ describe('gateway credentials controller', () => {
         username: ' username       ',
         password: ' password '
       },
-      account: {},
+      account: gatewayAccountFixture.validGatewayAccount({
+        gateway_account_credentials: [{
+          external_id: credentialId
+        }]
+      }),
+      params: { credentialId },
       headers: {},
-      params: {},
       flash: sinon.spy()
     }
-    await credentialsController.updateNotificationCredentials(req, expressResponseStub)
+    await credentialsController.updateNotificationCredentials(req, expressResponseStub, next)
     sinon.assert.calledWithMatch(postNotificationCredentialsSpy, { payload: { username: 'username', password: 'password' } })
   })
 })

--- a/app/controllers/credentials/worldpay.controller.js
+++ b/app/controllers/credentials/worldpay.controller.js
@@ -1,9 +1,8 @@
 const paths = require('../../paths')
 const logger = require('../../utils/logger')(__filename)
 const { response } = require('../../utils/response')
-const { CORRELATION_HEADER } = require('../../utils/correlation-header')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
-const { isSwitchingCredentialsRoute, getSwitchingCredential } = require('../../utils/credentials')
+const { isSwitchingCredentialsRoute, getCredentialByExternalId } = require('../../utils/credentials')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { CredentialsForm, isNotEmpty, formatErrorsForSummaryList } = require('./credentials-form')
 const { CONNECTOR_URL, SKIP_PSP_CREDENTIAL_CHECKS } = process.env
@@ -17,29 +16,35 @@ const credentialsForm = new CredentialsForm([
 ])
 
 function showWorldpayCredentialsPage (req, res, next) {
-  const form = credentialsForm.from(req.account.credentials)
-  const switchingToCredentials = isSwitchingCredentialsRoute(req)
-  response(req, res, 'credentials/worldpay', { form, switchingToCredentials })
+  try {
+    const credential = getCredentialByExternalId(req.account, req.params.credentialId)
+    const form = credentialsForm.from(credential.credentials)
+    const switchingToCredentials = isSwitchingCredentialsRoute(req)
+    response(req, res, 'credentials/worldpay', { form, switchingToCredentials, credential })
+  } catch (error) {
+    next(error)
+  }
 }
 
 async function updateWorldpayCredentials (req, res, next) {
   const gatewayAccountId = req.account.gateway_account_id
   const switchingToCredentials = isSwitchingCredentialsRoute(req)
-  const correlationId = req.headers[CORRELATION_HEADER] || ''
-
-  const results = credentialsForm.validate(req.body)
-
-  if (results.errorSummaryList.length) {
-    return response(req, res, 'credentials/worldpay', { form: results, switchingToCredentials })
-  }
+  const correlationId = req.correlationId || ''
 
   try {
+    const credential = getCredentialByExternalId(req.account, req.params.credentialId)
+    const results = credentialsForm.validate(req.body)
+
+    if (results.errorSummaryList.length) {
+      return response(req, res, 'credentials/worldpay', { form: results, switchingToCredentials, credential })
+    }
+
     if (SKIP_PSP_CREDENTIAL_CHECKS !== 'true') {
       const checkCredentialsWithWorldpay = await connectorClient.postCheckWorldpayCredentials({ correlationId, gatewayAccountId, payload: results.values })
       if (checkCredentialsWithWorldpay.result !== 'valid') {
         logger.warn('Provided credentials failed validation with Worldpay')
         results.errorSummaryList = formatErrorsForSummaryList({ 'merchantId': 'Check your Worldpay credentials, failed to link your account to Worldpay with credentials provided' })
-        return response(req, res, 'credentials/worldpay', { form: results, switchingToCredentials })
+        return response(req, res, 'credentials/worldpay', { form: results, switchingToCredentials, credential })
       }
 
       logger.info('Successfully validated credentials with Worldpay')
@@ -47,7 +52,6 @@ async function updateWorldpayCredentials (req, res, next) {
 
     if (switchingToCredentials) {
       // @TODO(PP-8209) when `credentials` are removed from the top level account, this should always use new patch
-      const credential = getSwitchingCredential(req.account)
       await connectorClient.patchAccountGatewayAccountCredentials({
         correlationId,
         gatewayAccountId,
@@ -64,7 +68,7 @@ async function updateWorldpayCredentials (req, res, next) {
         payload: { credentials: results.values }
       })
       logger.info('Successfully updated credentials for Worldpay account')
-      return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, 'worldpay'))
+      return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, credential.external_id))
     }
   } catch (error) {
     next(error)

--- a/app/controllers/credentials/worldpay.controller.test.js
+++ b/app/controllers/credentials/worldpay.controller.test.js
@@ -18,8 +18,8 @@ describe('Worldpay credentials controller', () => {
     const account = gatewayAccountFixtures.validGatewayAccount({
       external_id: 'a-valid-external-id',
       gateway_account_credentials: [
-        { state: 'ACTIVE', payment_provider: 'smartpay', id: 100 },
-        { state: 'CREATED', payment_provider: 'worldpay', id: 200 }
+        { state: 'ACTIVE', payment_provider: 'smartpay', id: 100, external_id: 'a-valid-credential-id-smartpay' },
+        { state: 'CREATED', payment_provider: 'worldpay', id: 200, external_id: 'a-valid-credential-id-worldpay' }
       ]
     })
     req = {
@@ -33,8 +33,9 @@ describe('Worldpay credentials controller', () => {
       },
       flash: sinon.spy(),
       route: {
-        path: '/your-psp/credentials/worldpay'
+        path: '/your-psp/:credentialId/credentials-with-gateway-check'
       },
+      params: { credentialId: 'a-valid-credential-id-worldpay' },
       headers: {
         'x-request-id': 'correlation-id'
       }
@@ -54,19 +55,20 @@ describe('Worldpay credentials controller', () => {
 
   it('uses the legacy patch if on a your psp route', async () => {
     const controller = getControllerWithMocks()
-    req.route.path = '/your-psp/credentials/worldpay'
+    req.route.path = '/your-psp/credentials/a-valid-credential-id-worldpay'
 
     await controller.updateWorldpayCredentials(req, res, next)
 
     sinon.assert.called(checkCredentialsMock)
     sinon.assert.called(legacyUpdateCredentialsMock)
     sinon.assert.notCalled(updateCredentialsMock)
-    sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/your-psp/worldpay')
+    sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/your-psp/a-valid-credential-id-worldpay')
   })
 
   it('uses the new patch if on a switch psp route', async () => {
     const controller = getControllerWithMocks()
-    req.route.path = '/switch-psp/credentials/worldpay'
+
+    req.route.path = '/switch-psp/:credentialId/credentials-with-gateway-check'
 
     await controller.updateWorldpayCredentials(req, res, next)
 

--- a/app/controllers/switch-psp/switch-psp.controller.js
+++ b/app/controllers/switch-psp/switch-psp.controller.js
@@ -51,7 +51,7 @@ async function submitSwitchPSP (req, res, next) {
       'switchPSPSuccess',
       `All future payments will be taken with ${formatPSPName(targetCredential.payment_provider)}. Your ${formatPSPName(currentCredential.payment_provider)} account is still live for processing refunds of payments made before the switch.`
     )
-    res.redirect(formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, targetCredential.payment_provider))
+    res.redirect(formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, targetCredential.external_id))
   } catch (error) {
     next(error)
   }

--- a/app/controllers/switch-psp/switch-psp.controller.test.js
+++ b/app/controllers/switch-psp/switch-psp.controller.test.js
@@ -18,7 +18,7 @@ describe('Verify PSP integration controller', () => {
 
       sinon.assert.called(postAccountSwitchPSPMock)
       sinon.assert.calledWith(req.flash, 'switchPSPSuccess')
-      sinon.assert.calledWith(res.redirect, '/account/a-valid-external-id/your-psp/worldpay')
+      sinon.assert.calledWith(res.redirect, '/account/a-valid-external-id/your-psp/a-valid-external-id')
     })
   })
 

--- a/app/controllers/your-psp/get-flex.controller.js
+++ b/app/controllers/your-psp/get-flex.controller.js
@@ -1,37 +1,42 @@
 'use strict'
 
 const lodash = require('lodash')
+const { getCredentialByExternalId } = require('../../utils/credentials')
 
 const { response } = require('../../utils/response')
 
-module.exports = (req, res) => {
+module.exports = (req, res, next) => {
   const { change } = req.query || {}
-  const { paymentProvider } = req.params
 
-  const isFlexConfigured = req.account.worldpay_3ds_flex &&
-    req.account.worldpay_3ds_flex.organisational_unit_id !== undefined &&
-    req.account.worldpay_3ds_flex.organisational_unit_id.length > 0
+  try {
+    const credential = getCredentialByExternalId(req.account, req.params.credentialId)
+    const isFlexConfigured = req.account.worldpay_3ds_flex &&
+      req.account.worldpay_3ds_flex.organisational_unit_id !== undefined &&
+      req.account.worldpay_3ds_flex.organisational_unit_id.length > 0
 
-  let errors = false
-  let orgUnitId = lodash.get(req, 'account.worldpay_3ds_flex.organisational_unit_id' || '')
-  let issuer = lodash.get(req, 'account.worldpay_3ds_flex.issuer' || '')
+    let errors = false
+    let orgUnitId = lodash.get(req, 'account.worldpay_3ds_flex.organisational_unit_id' || '')
+    let issuer = lodash.get(req, 'account.worldpay_3ds_flex.issuer' || '')
 
-  let worldpay3dsFlexPageData = lodash.get(req, 'session.pageData.worldpay3dsFlex')
-  if (worldpay3dsFlexPageData) {
-    delete req.session.pageData.worldpay3dsFlex
+    let worldpay3dsFlexPageData = lodash.get(req, 'session.pageData.worldpay3dsFlex')
+    if (worldpay3dsFlexPageData) {
+      delete req.session.pageData.worldpay3dsFlex
 
-    if (worldpay3dsFlexPageData.errors) {
-      errors = worldpay3dsFlexPageData.errors
+      if (worldpay3dsFlexPageData.errors) {
+        errors = worldpay3dsFlexPageData.errors
 
-      if (worldpay3dsFlexPageData.orgUnitId) {
-        orgUnitId = worldpay3dsFlexPageData.orgUnitId
-      }
+        if (worldpay3dsFlexPageData.orgUnitId) {
+          orgUnitId = worldpay3dsFlexPageData.orgUnitId
+        }
 
-      if (worldpay3dsFlexPageData.issuer) {
-        issuer = worldpay3dsFlexPageData.issuer
+        if (worldpay3dsFlexPageData.issuer) {
+          issuer = worldpay3dsFlexPageData.issuer
+        }
       }
     }
-  }
 
-  return response(req, res, 'your-psp/flex', { errors, change, isFlexConfigured, orgUnitId, issuer, paymentProvider })
+    return response(req, res, 'your-psp/flex', { errors, change, isFlexConfigured, orgUnitId, issuer, credential })
+  } catch (error) {
+    next(error)
+  }
 }

--- a/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.js
+++ b/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.js
@@ -4,21 +4,22 @@ const paths = require('../../paths')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const { renderErrorView } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
+const { getCredentialByExternalId } = require('../../utils/credentials')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
 module.exports = async function toggleWorldpay3dsFlex (req, res, next) {
   const accountId = req.account.gateway_account_id
   const toggleWorldpay3dsFlex = req.body['toggle-worldpay-3ds-flex']
-  const indexUrl = formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, 'worldpay')
 
   if (req.body['toggle-worldpay-3ds-flex'] === 'on' || req.body['toggle-worldpay-3ds-flex'] === 'off') {
     const enabling3dsFlex = toggleWorldpay3dsFlex === 'on'
     const message = enabling3dsFlex ? '3DS Flex has been turned on.' : '3DS Flex has been turned off. Your payments will now use 3DS only.'
     const integrationVersion3ds = enabling3dsFlex ? 2 : 1
     try {
+      const credential = getCredentialByExternalId(req.account, req.params.credentialId)
       await connector.updateIntegrationVersion3ds(accountId, integrationVersion3ds, req.correlationId)
       req.flash('generic', message)
-      return res.redirect(303, indexUrl)
+      return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, credential.external_id))
     } catch (err) {
       next(err)
     }

--- a/app/paths.js
+++ b/app/paths.js
@@ -20,8 +20,8 @@ module.exports = {
       update: '/api-keys/update'
     },
     credentials: {
-      index: '/your-psp/credentials/:paymentProvider',
-      edit: '/your-psp/credentials/:paymentProvider/edit'
+      index: '/your-psp/:credentialId/credentials',
+      edit: '/your-psp/:credentialId/credentials/edit'
     },
     dashboard: {
       index: '/dashboard'
@@ -43,8 +43,8 @@ module.exports = {
       refund: '/email-settings-refund'
     },
     notificationCredentials: {
-      edit: '/notification-credentials/:paymentProvider/edit',
-      update: '/notification-credentials/:paymentProvider'
+      edit: '/your-psp/:credentialId/notification-credentials/edit',
+      update: '/your-psp/:credentialId/notification-credentials'
     },
     paymentLinks: {
       start: '/create-payment-link',
@@ -102,7 +102,7 @@ module.exports = {
     },
     switchPSP: {
       index: '/switch-psp',
-      worldpayCredentials: '/switch-psp/credentials/worldpay',
+      credentialsWithGatewayCheck: '/switch-psp/:credentialId/credentials-with-gateway-check',
       verifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration',
       receiveVerifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration/callback'
     },
@@ -123,10 +123,10 @@ module.exports = {
       refund: '/transactions/:chargeId/refund'
     },
     yourPsp: {
-      index: '/your-psp/:paymentProvider',
-      flex: '/your-psp/worldpay/flex',
-      worldpay3dsFlex: '/your-psp/worldpay-3ds-flex',
-      worldpayCredentials: '/your-psp/credentials/worldpay'
+      index: '/your-psp/:credentialId',
+      flex: '/your-psp/:credentialId/flex',
+      worldpay3dsFlex: '/your-psp/:credentialId/worldpay-3ds-flex',
+      credentialsWithGatewayCheck: '/your-psp/:credentialId/credentials-with-gateway-check'
     }
   },
   service: {

--- a/app/routes.js
+++ b/app/routes.js
@@ -307,10 +307,10 @@ module.exports.bind = function (app) {
   account.get(switchPSP.receiveVerifyPSPIntegrationPayment, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.completePaymentJourney)
 
   // Credentials
-  account.get(yourPsp.worldpayCredentials, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)
-  account.post(yourPsp.worldpayCredentials, permission('gateway-credentials:read'), worldpayCredentialsController.updateWorldpayCredentials)
-  account.get(switchPSP.worldpayCredentials, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)
-  account.post(switchPSP.worldpayCredentials, permission('gateway-credentials:read'), worldpayCredentialsController.updateWorldpayCredentials)
+  account.get(yourPsp.credentialsWithGatewayCheck, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)
+  account.post(yourPsp.credentialsWithGatewayCheck, permission('gateway-credentials:read'), worldpayCredentialsController.updateWorldpayCredentials)
+  account.get(switchPSP.credentialsWithGatewayCheck, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)
+  account.post(switchPSP.credentialsWithGatewayCheck, permission('gateway-credentials:read'), worldpayCredentialsController.updateWorldpayCredentials)
 
   account.get(credentials.index, permission('gateway-credentials:read'), credentialsController.index)
   account.get(credentials.edit, permission('gateway-credentials:update'), credentialsController.editCredentials)

--- a/app/utils/credentials.js
+++ b/app/utils/credentials.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const paths = require('../paths')
-const { InvalidConfigurationError } = require('../errors')
+const { InvalidConfigurationError, NotFoundError } = require('../errors')
 
 const CREDENTIAL_STATE = {
   CREATED: 'CREATED',
@@ -57,10 +57,20 @@ function getPSPPageLinks (gatewayAccount) {
   }
 }
 
+function getCredentialByExternalId (account, credentialExternalId) {
+  const credentials = account.gateway_account_credentials || []
+  const credential = credentials.filter((credential) => credential.external_id === credentialExternalId)
+  if (!credential.length) {
+    throw new NotFoundError('Credential not found on account')
+  }
+  return credential[0]
+}
+
 module.exports = {
   getCurrentCredential,
   getSwitchingCredential,
   isSwitchingCredentialsRoute,
   getPSPPageLinks,
+  getCredentialByExternalId,
   CREDENTIAL_STATE
 }

--- a/app/utils/credentials.js
+++ b/app/utils/credentials.js
@@ -42,4 +42,25 @@ function isSwitchingCredentialsRoute (req) {
   return Object.values(paths.account.switchPSP).includes(req.route && req.route.path)
 }
 
-module.exports = { getCurrentCredential, getSwitchingCredential, isSwitchingCredentialsRoute, CREDENTIAL_STATE }
+function getPSPPageLinks (gatewayAccount) {
+  const supportedYourPSPPageProviders = [ 'worldpay', 'smartpay', 'epdq' ]
+  const credentials = (gatewayAccount.gateway_account_credentials || [])
+    .filter((credential) => supportedYourPSPPageProviders.includes(credential.payment_provider))
+
+  if (credentials.length === 1) {
+    // if there's only one integration, that should always be shown
+    return credentials
+  } else {
+    // pending credentials should be managed through the switch process, only show terminal credential states
+    return credentials
+      .filter((credential) => [ CREDENTIAL_STATE.RETIRED, CREDENTIAL_STATE.ACTIVE ].includes(credential.state))
+  }
+}
+
+module.exports = {
+  getCurrentCredential,
+  getSwitchingCredential,
+  isSwitchingCredentialsRoute,
+  getPSPPageLinks,
+  CREDENTIAL_STATE
+}

--- a/app/utils/credentials.test.js
+++ b/app/utils/credentials.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const paths = require('../paths')
 const gatewayAccountFixtures = require('../../test/fixtures/gateway-account.fixtures')
 const { InvalidConfigurationError } = require('../errors')
-const { getCurrentCredential, getSwitchingCredential, isSwitchingCredentialsRoute, getPSPPageLinks } = require('./credentials')
+const { getCurrentCredential, getSwitchingCredential, isSwitchingCredentialsRoute, getPSPPageLinks, getCredentialByExternalId } = require('./credentials')
 
 describe('credentials utility', () => {
   describe('get services current credential', () => {
@@ -70,12 +70,12 @@ describe('credentials utility', () => {
 
   describe('credentials page utilities', () => {
     it('correctly identifies a switch psp route', () => {
-      const req = { route: { path: paths.account.switchPSP.worldpayCredentials } }
+      const req = { route: { path: paths.account.switchPSP.credentialsWithGatewayCheck } }
       expect(isSwitchingCredentialsRoute(req)).to.equal(true)
     })
 
     it('correctly identifies a non switch psp route', () => {
-      const req = { route: { path: paths.account.yourPsp.worldpayCredentials } }
+      const req = { route: { path: paths.account.yourPsp.credentialsWithGatewayCheck } }
       expect(isSwitchingCredentialsRoute(req)).to.equal(false)
     })
 
@@ -114,6 +114,17 @@ describe('credentials utility', () => {
       expect(linkCredentials).to.have.length(2)
       expect(linkCredentials[0].gateway_account_credential_id).to.equal(200)
       expect(linkCredentials[1].gateway_account_credential_id).to.equal(100)
+    })
+
+    it('finds credential by external id', () => {
+      const account = gatewayAccountFixtures.validGatewayAccount({
+        gateway_account_credentials: [
+          { state: 'CREATED', payment_provider: 'worldpay', id: 300, external_id: 'first-external-id' },
+          { state: 'ACTIVE', payment_provider: 'smartpay', id: 200, external_id: 'second-external-id' },
+          { state: 'RETIRED', payment_provider: 'epdq', id: 100, external_id: 'third-external-id' }
+        ]
+      })
+      expect(getCredentialByExternalId(account, 'second-external-id').gateway_account_credential_id).to.equal(200)
     })
   })
 })

--- a/app/utils/nav-builder.js
+++ b/app/utils/nav-builder.js
@@ -108,14 +108,11 @@ function yourPSPNavigationItems (account, currentPath = '') {
   const credentialsToLink = getPSPPageLinks(account)
   const isSingleCredential = credentialsToLink.length === 1
   return credentialsToLink.map((credential) => {
-    const id = (credential.state === CREDENTIAL_STATE.ACTIVE) || isSingleCredential ? 'navigation-menu-your-psp' : `navigation-menu-your-psp-${credential.external_id}`
     const prefix = credential.state === CREDENTIAL_STATE.RETIRED ? 'Old PSP' : 'Your PSP'
-    const name = `${prefix} - ${formatPSPname(credential.payment_provider)}`
-    const url = formatAccountPathsFor(paths.account.yourPsp.index, account.external_id, credential.external_id)
     return {
-      id,
-      name,
-      url,
+      id: (credential.state === CREDENTIAL_STATE.ACTIVE) || isSingleCredential ? 'navigation-menu-your-psp' : `navigation-menu-your-psp-${credential.external_id}`,
+      name: `${prefix} - ${formatPSPname(credential.payment_provider)}`,
+      url: formatAccountPathsFor(paths.account.yourPsp.index, account.external_id, credential.external_id),
       current: currentPath.includes(credential.external_id)
     }
   })
@@ -123,5 +120,6 @@ function yourPSPNavigationItems (account, currentPath = '') {
 
 module.exports = {
   serviceNavigationItems: serviceNavigationItems,
-  adminNavigationItems: adminNavigationItems
+  adminNavigationItems: adminNavigationItems,
+  yourPSPNavigationItems
 }

--- a/app/utils/nav-builder.test.js
+++ b/app/utils/nav-builder.test.js
@@ -1,0 +1,34 @@
+const { expect } = require('chai')
+const gatewayAccountFixtures = require('../../test/fixtures/gateway-account.fixtures')
+const { yourPSPNavigationItems } = require('./nav-builder')
+
+describe('navigation builder', () => {
+  describe('build links to psp pages', () => {
+    it('sets the default ID for a single credential regardless of state', () => {
+      const account = gatewayAccountFixtures.validGatewayAccount({
+        gateway_account_credentials: [
+          { payment_provider: 'smartpay', state: 'CREATED', external_id: 'a-valid-credential-id-smartpay' }
+        ]
+      })
+      expect(yourPSPNavigationItems(account)[0].id).to.equal('navigation-menu-your-psp')
+    })
+
+    it('correctly labels ids and names and returns valid schema', () => {
+      const account = gatewayAccountFixtures.validGatewayAccount({
+        gateway_account_credentials: [
+          { payment_provider: 'smartpay', state: 'ACTIVE', external_id: 'a-valid-credential-id-smartpay' },
+          { payment_provider: 'worldpay', state: 'RETIRED', external_id: 'another-valid-credential-id-worldpay' }
+        ]
+      })
+
+      const links = yourPSPNavigationItems(account, '/your-psp/a-valid-credential-id-smartpay')
+      expect(links).to.have.length(2)
+      expect(links[0].id).to.equal('navigation-menu-your-psp')
+      expect(links[0].name).to.equal('Your PSP - Smartpay')
+      expect(links[0].current).to.equal(true)
+      expect(links[1].id).to.equal('navigation-menu-your-psp-another-valid-credential-id-worldpay')
+      expect(links[1].name).to.equal('Old PSP - Worldpay')
+      expect(links[1].current).to.equal(false)
+    })
+  })
+})

--- a/app/views/credentials/epdq.njk
+++ b/app/views/credentials/epdq.njk
@@ -3,7 +3,7 @@
 {% block provider_content %}
 
   {% if permissions.gateway_credentials_update %}
-    <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.index, currentGatewayAccount.external_id, paymentProvider) }}" data-validate>
+    <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.index, currentGatewayAccount.external_id, credential.external_id) }}" data-validate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
       {{ govukInput({
@@ -17,7 +17,7 @@
           attributes: {
             "data-validate": "required"
           },
-          value: currentGatewayAccount.credentials.merchant_id
+          value: credential.credentials.merchant_id
         })
       }}
 
@@ -32,7 +32,7 @@
           attributes: {
             "data-validate": "required"
           },
-          value: currentGatewayAccount.credentials.username
+          value: credential.credentials.username
         })
       }}
 
@@ -47,7 +47,7 @@
           attributes: {
             "data-validate": "required"
           },
-          value: currentGatewayAccount.credentials.password
+          value: credential.credentials.password
         })
       }}
 

--- a/app/views/credentials/index.njk
+++ b/app/views/credentials/index.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  Account credentials - {{currentService.name}} {{ paymentProvider | formatPSPname }} - GOV.UK Pay
+  Account credentials - {{currentService.name}} {{ credential.payment_provider | formatPSPname }} - GOV.UK Pay
 {% endblock %}
 
 {% block side_navigation %}
@@ -11,9 +11,9 @@
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
   {% if editNotificationCredentialsMode %}
-    <h1 class="govuk-heading-l page-title" id="view-title">Your {{ paymentProvider | formatPSPname }} notification credentials</h1>
+    <h1 class="govuk-heading-l page-title" id="view-title">Your {{ credential.payment_provider | formatPSPname }} notification credentials</h1>
   {% else %}
-    <h1 class="govuk-heading-l page-title" id="view-title">Your {{ paymentProvider | formatPSPname }} credentials</h1>
+    <h1 class="govuk-heading-l page-title" id="view-title">Your {{ credential.payment_provider | formatPSPname }} credentials</h1>
   {% endif %}
 
   {% block provider_content %}

--- a/app/views/credentials/smartpay.njk
+++ b/app/views/credentials/smartpay.njk
@@ -2,7 +2,7 @@
 
 {% block provider_content %}
   {% if editNotificationCredentialsMode %}
-    <form id="notification_credentials_form" method="post" action="{{ formatAccountPathsFor(routes.account.notificationCredentials.update, currentGatewayAccount.external_id, paymentProvider) }}" data-validate>
+    <form id="notification_credentials_form" method="post" action="{{ formatAccountPathsFor(routes.account.notificationCredentials.update, currentGatewayAccount.external_id, credential.external_id) }}" data-validate>
       <input id="notification-csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
       {% set username %}{{lastNotificationsData.username or currentGatewayAccount.notificationCredentials.userName}}{% endset %}
@@ -47,7 +47,7 @@
     </form>
   {% else %}
     {% if permissions.gateway_credentials_update %}
-      <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.index, currentGatewayAccount.external_id, paymentProvider) }}" data-validate>
+      <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.index, currentGatewayAccount.external_id, credential.external_id) }}" data-validate>
           <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
         {{ govukInput({
@@ -61,7 +61,7 @@
             attributes: {
               "data-validate": "required"
             },
-            value: currentGatewayAccount.credentials.merchant_id
+            value: credential.credentials.merchant_id
           })
         }}
 
@@ -76,7 +76,7 @@
             attributes: {
               "data-validate": "required"
             },
-            value: currentGatewayAccount.credentials.username
+            value: credential.credentials.username
           })
         }}
 

--- a/app/views/credentials/worldpay.njk
+++ b/app/views/credentials/worldpay.njk
@@ -21,7 +21,7 @@
       {{ govukBackLink({
         text: "Back to Your PSP",
         classes: "govuk-!-margin-top-0",
-        href: formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, 'worldpay')
+        href: formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, credential.external_id)
       }) }}
     {% endif %}
 

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -75,7 +75,7 @@
       {% set tasks %}
         {{ taskListItem(
           "Link your Worldpay account with GOV.UK Pay",
-          formatAccountPathsFor(routes.account.switchPSP.worldpayCredentials, currentGatewayAccount.external_id),
+          formatAccountPathsFor(routes.account.switchPSP.credentialsWithGatewayCheck, currentGatewayAccount.external_id, targetCredential.external_id),
           taskList.LINK_CREDENTIALS
         ) }}
         {{ taskListItem(

--- a/app/views/your-psp/_epdq.njk
+++ b/app/views/your-psp/_epdq.njk
@@ -12,13 +12,13 @@
           text: "PSP ID"
         },
         value: {
-          text: currentGatewayAccount.credentials.merchant_id if isAccountCredentialsConfigured else "Not configured",
+          text: credential.credentials.merchant_id if isAccountCredentialsConfigured else "Not configured",
           classes: "value-merchant-id"
         },
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=merchantId",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, credential.external_id) + "?change=merchantId",
               text: "Change",
               visuallyHiddenText: "account credentials",
               attributes: {
@@ -33,13 +33,13 @@
           text: "Username"
         },
         value: {
-          text: currentGatewayAccount.credentials.username if isAccountCredentialsConfigured else "Not configured",
+          text: credential.credentials.username if isAccountCredentialsConfigured else "Not configured",
           classes: "value-username"
         },
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=username",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, credential.external_id) + "?change=username",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }
@@ -57,7 +57,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=password",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, credential.external_id) + "?change=password",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }
@@ -75,7 +75,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=password",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, credential.external_id) + "?change=password",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }
@@ -93,7 +93,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=password",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, credential.external_id) + "?change=password",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }

--- a/app/views/your-psp/_smartpay.njk
+++ b/app/views/your-psp/_smartpay.njk
@@ -11,13 +11,13 @@
           text: "Merchant account code"
         },
         value: {
-          text: currentGatewayAccount.credentials.merchant_id if isAccountCredentialsConfigured else "Not configured",
+          text: credential.credentials.merchant_id if isAccountCredentialsConfigured else "Not configured",
           classes: "value-merchant-id"
         },
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=merchantId",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, credential.external_id) + "?change=merchantId",
               text: "Change",
               visuallyHiddenText: "account credentials",
               attributes: {
@@ -32,13 +32,13 @@
           text: "Username"
         },
         value: {
-          text: currentGatewayAccount.credentials.username if isAccountCredentialsConfigured else "Not configured",
+          text: credential.credentials.username if isAccountCredentialsConfigured else "Not configured",
           classes: "value-username"
         },
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=username",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, credential.external_id) + "?change=username",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }
@@ -56,7 +56,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=password",
+              href: formatAccountPathsFor(routes.account.credentials.edit, currentGatewayAccount.external_id, credential.external_id) + "?change=password",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }
@@ -94,7 +94,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.notificationCredentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=username",
+              href: formatAccountPathsFor(routes.account.notificationCredentials.edit, currentGatewayAccount.external_id, credential.external_id) + "?change=username",
               text: "Change",
               visuallyHiddenText: "account credentials",
               attributes: {
@@ -115,7 +115,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.notificationCredentials.edit, currentGatewayAccount.external_id, paymentProvider) + "?change=password",
+              href: formatAccountPathsFor(routes.account.notificationCredentials.edit, currentGatewayAccount.external_id, credential.external_id) + "?change=password",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }

--- a/app/views/your-psp/_worldpay-flex.njk
+++ b/app/views/your-psp/_worldpay-flex.njk
@@ -25,7 +25,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, paymentProvider) + "?change=organisationalUnitId",
+              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, credential.external_id) + "?change=organisationalUnitId",
               text: "Change",
               visuallyHiddenText: "3DS Flex credentials",
               attributes: {
@@ -46,7 +46,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, paymentProvider) + "?change=issuer",
+              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, credential.external_id) + "?change=issuer",
               text: "Change",
               visuallyHiddenText: "3DS Flex credentials"
             }
@@ -64,7 +64,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, paymentProvider) + "?change=password",
+              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, credential.external_id) + "?change=password",
               text: "Change",
               visuallyHiddenText: "3DS Flex credentials"
             }
@@ -76,7 +76,7 @@
 }}
 
 {% if (is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured) or isWorldpay3dsFlexEnabled %}
-  <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.worldpay3dsFlex, currentGatewayAccount.external_id, paymentProvider) }}">
+  <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.worldpay3dsFlex, currentGatewayAccount.external_id, credential.external_id) }}">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}">
     {% if is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured and not isWorldpay3dsFlexEnabled %}
         <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="on">

--- a/app/views/your-psp/_worldpay.njk
+++ b/app/views/your-psp/_worldpay.njk
@@ -11,13 +11,13 @@
           text: "Merchant code"
         },
         value: {
-          text: currentGatewayAccount.credentials.merchant_id if isAccountCredentialsConfigured else "Not configured",
+          text: credential.credentials.merchant_id if isAccountCredentialsConfigured else "Not configured",
           classes: "value-merchant-id"
         },
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.yourPsp.worldpayCredentials, currentGatewayAccount.external_id) + "?change=merchantId",
+              href: formatAccountPathsFor(routes.account.yourPsp.credentialsWithGatewayCheck, currentGatewayAccount.external_id, credential.external_id) + "?change=merchantId",
               text: "Change",
               visuallyHiddenText: "account credentials",
               attributes: {
@@ -32,13 +32,13 @@
           text: "Username"
         },
         value: {
-          text: currentGatewayAccount.credentials.username if isAccountCredentialsConfigured else "Not configured",
+          text: credential.credentials.username if isAccountCredentialsConfigured else "Not configured",
           classes: "value-username"
         },
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.yourPsp.worldpayCredentials, currentGatewayAccount.external_id) + "?change=username",
+              href: formatAccountPathsFor(routes.account.yourPsp.credentialsWithGatewayCheck, currentGatewayAccount.external_id, credential.external_id) + "?change=username",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }
@@ -56,7 +56,7 @@
         actions: {
           items: [
             {
-              href: formatAccountPathsFor(routes.account.yourPsp.worldpayCredentials, currentGatewayAccount.external_id) + "?change=password",
+              href: formatAccountPathsFor(routes.account.yourPsp.credentialsWithGatewayCheck, currentGatewayAccount.external_id, credential.external_id) + "?change=password",
               text: "Change",
               visuallyHiddenText: "account credentials"
             }

--- a/app/views/your-psp/flex.njk
+++ b/app/views/your-psp/flex.njk
@@ -1,10 +1,9 @@
 {% extends "layout.njk" %}
-{% set paymentProvider = 'worldpay' %}
 {% block pageTitle %}
   {% if errors %}
     Error:
   {% endif %}
-  Your PSP - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+  Your PSP - {{currentService.name}} {{ credential.payment_provider | formatPSPname }} - GOV.UK Pay
 {% endblock %}
 
 {% block side_navigation %}
@@ -14,7 +13,7 @@
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Your Worldpay 3DS Flex credentials</h1>
-    <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, paymentProvider) }}">
+    <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, credential.external_id) }}">
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
         {% if errors %}
           {% set errorList = [] %}
@@ -174,7 +173,7 @@
       }}
     </form>
     <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, paymentProvider) }}">Cancel</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, credential.external_id) }}">Cancel</a>
     </p>
 </div>
 {% endblock %}

--- a/app/views/your-psp/index.njk
+++ b/app/views/your-psp/index.njk
@@ -2,7 +2,7 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  Your PSP - {{currentService.name}} {{ paymentProvider | formatPSPname }} - GOV.UK Pay
+  Your PSP - {{currentService.name}} {{ credential.payment_provider | formatPSPname }} - GOV.UK Pay
 {% endblock %}
 
 {% block side_navigation %}
@@ -26,16 +26,16 @@
       type: 'success'
     }) }}
   {% endif %}
-  <h1 class="govuk-heading-l page-title">Your payment service provider (PSP) - {{ paymentProvider | formatPSPname }}</h1>
+  <h1 class="govuk-heading-l page-title">Your payment service provider (PSP) - {{ credential.payment_provider | formatPSPname }}</h1>
 
-  {% if paymentProvider === "worldpay" %}
+  {% if credential.payment_provider === "worldpay" %}
     {% include "./_worldpay.njk" %}
     {% include "./_worldpay-flex.njk" %}
   {% endif %}
-  {% if paymentProvider === "smartpay" %}
+  {% if credential.payment_provider === "smartpay" %}
     {% include "./_smartpay.njk" %}
   {% endif %}
-  {% if paymentProvider === "epdq" %}
+  {% if credential.payment_provider === "epdq" %}
     {% include "./_epdq.njk" %}
   {% endif %}
 </div>

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -1,9 +1,14 @@
 'use strict'
 
 function validCredentials (opts = {}) {
-  const credentials = {
-    merchant_id: opts.merchant_id || 'merchant-id',
-    username: opts.username || 'username'
+  const credentials = {}
+
+  if (opts.merchant_id) {
+    credentials.merchant_id = opts.merchant_id
+  }
+
+  if (opts.username) {
+    credentials.username = opts.username
   }
 
   if (opts.sha_in_passphrase) {
@@ -18,6 +23,7 @@ function validCredentials (opts = {}) {
 function validGatewayAccountCredential (credentialOpts = {}, gatewayAccountOpts = {}) {
   const gatewayAccountCredential = {
     gateway_account_credential_id: credentialOpts.id || 1,
+    external_id: credentialOpts.external_id || 'a-valid-external-id',
     payment_provider: credentialOpts.payment_provider || 'sandbox',
     state: credentialOpts.state || 'ACTIVE',
     gateway_account_id: gatewayAccountOpts.gateway_account_id || 31,

--- a/test/ui/navigation.ui.test.js
+++ b/test/ui/navigation.ui.test.js
@@ -1,6 +1,7 @@
 const { render } = require('../test-helpers/html-assertions')
 const { serviceNavigationItems, adminNavigationItems } = require('../../app/utils/nav-builder')
 const formatAccountPathsFor = require('../../app/utils/format-account-paths-for')
+const gatewayAccountFixtures = require('../fixtures/gateway-account.fixtures')
 
 describe('navigation menu', function () {
   it('should render only Home link when user does have any of the required permissions to show the navigation links', function () {
@@ -89,6 +90,11 @@ describe('navigation menu', function () {
 
   it('should render Accounts credentials navigation link when user have gateway credentials read permission' +
   ' and payment provider is NOT `stripe` ', function () {
+    const account = gatewayAccountFixtures.validGatewayAccount({
+      gateway_account_credentials: [{
+        payment_provider: 'worldpay'
+      }]
+    })
     const testPermissions = {
       tokens_update: false,
       gateway_credentials_update: true,
@@ -100,7 +106,7 @@ describe('navigation menu', function () {
     const templateData = {
       permissions: testPermissions,
       showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'worldpay'),
+      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'worldpay', account),
       formatAccountPathsFor: formatAccountPathsFor
     }
 
@@ -201,32 +207,5 @@ describe('navigation menu', function () {
     body.should.not.contain('Card types')
     body.should.not.contain('Email notifications')
     body.should.not.contain('Billing address')
-  })
-
-  it('should not render direct debit navigation links when gateway account is card', function () {
-    const testPermissions = {
-      tokens_update: true,
-      gateway_credentials_update: true,
-      service_name_read: true,
-      merchant_details_read: true,
-      payment_types_read: true,
-      toggle_3ds_read: true,
-      email_notification_template_read: true,
-      connected_gocardless_account_update: true,
-      toggle_billing_address_read: true
-    }
-    const templateData = {
-      permissions: testPermissions,
-      showSettingsNav: true,
-      adminNavigationItems: adminNavigationItems('/api-keys', testPermissions, 'card', 'worldpay'),
-      formatAccountPathsFor: formatAccountPathsFor
-    }
-
-    const body = render('api-keys/index', templateData)
-
-    body.should.containSelector('.settings-navigation li:nth-child(1)').withExactText('Settings')
-    body.should.containSelector('.settings-navigation li:nth-child(2)').withExactText('API keys')
-    body.should.containSelector('.settings-navigation li:nth-child(3)').withExactText('Your PSP - Worldpay')
-    body.should.containSelector('.settings-navigation li:nth-child(4)').withExactText('Card types')
   })
 })


### PR DESCRIPTION
Existing psp pages use the top level gateway account `credentials` blob
to display and manage account credentials. Move this to be name-spaced by
the gateway account credential entity list to support switching.

Use the list of credentials to provide links in the settings menu.

The primary change is from `currentGatewayAccount.credentials` -> `getCredentialByExternalId().credentials`

Adds logic with coverage to make sure we're picking out terminal state credentials 
for when an account is switching.

Proposes a new URL structure to make things consistent and clear for devs 
`/your-psp/:id/`
`/your-psp/:id/credentials`
`/switch-psp/:id/credentials`