### PR TITLE
PP-8190 Update credentials by ID future strategy

### DIFF
--- a/app/controllers/credentials.controller.js
+++ b/app/controllers/credentials.controller.js
@@ -128,9 +128,22 @@ module.exports = {
 
     try {
       const credential = getCredentialByExternalId(req.account, req.params.credentialId)
-      await connectorClient.legacyPatchAccountCredentials({
-        payload: credentialsPatchRequestValueOf(req), correlationId: correlationId, gatewayAccountId: accountId
-      })
+
+      // @TODO(PP-8273) only use future strategy when backend no longer relies on top level credentials
+      const useFutureCredentialsUpdateStategy = req.account.gateway_account_credentials.length > 1
+      if (useFutureCredentialsUpdateStategy) {
+        await connectorClient.patchAccountGatewayAccountCredentials({
+          correlationId,
+          gatewayAccountId: accountId,
+          gatewayAccountCredentialsId: credential.gateway_account_credential_id,
+          userExternalId: req.user.externalId,
+          ...credentialsPatchRequestValueOf(req)
+        })
+      } else {
+        await connectorClient.legacyPatchAccountCredentials({
+          payload: credentialsPatchRequestValueOf(req), correlationId: correlationId, gatewayAccountId: accountId
+        })
+      }
 
       return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, credential.external_id))
     } catch (err) {

--- a/app/controllers/credentials.controller.test.js
+++ b/app/controllers/credentials.controller.test.js
@@ -1,11 +1,13 @@
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const gatewayAccountFixture = require('../../test/fixtures/gateway-account.fixtures')
+const legacyPatchAccountSpy = sinon.spy(() => Promise.resolve())
 const patchAccountSpy = sinon.spy(() => Promise.resolve())
 const postNotificationCredentialsSpy = sinon.spy(() => Promise.resolve())
 const connectorClientMock = {
   ConnectorClient: function () {
-    this.legacyPatchAccountCredentials = patchAccountSpy
+    this.legacyPatchAccountCredentials = legacyPatchAccountSpy
+    this.patchAccountGatewayAccountCredentials = patchAccountSpy
     this.postAccountNotificationCredentials = postNotificationCredentialsSpy
   }
 }
@@ -22,6 +24,10 @@ const expressResponseStub = {
 const next = sinon.spy()
 const credentialId = 'a-valid-credential-id'
 describe('gateway credentials controller', () => {
+  beforeEach(() => {
+    legacyPatchAccountSpy.resetHistory()
+    patchAccountSpy.resetHistory()
+  })
   it('should remove leading and trailing whitespace from credentials when submitting them to the backend', async () => {
     const req = {
       body: {
@@ -38,7 +44,7 @@ describe('gateway credentials controller', () => {
       headers: {}
     }
     await credentialsController.update(req, expressResponseStub, next)
-    sinon.assert.calledWithMatch(patchAccountSpy, { payload: { credentials: { username: 'username', password: 'password', merchant_id: 'merchant-id' } } })
+    sinon.assert.calledWithMatch(legacyPatchAccountSpy, { payload: { credentials: { username: 'username', password: 'password', merchant_id: 'merchant-id' } } })
   })
 
   it('should remove leading and trailing whitespace from notification credentials when submitting them to the backend', async () => {
@@ -58,5 +64,27 @@ describe('gateway credentials controller', () => {
     }
     await credentialsController.updateNotificationCredentials(req, expressResponseStub, next)
     sinon.assert.calledWithMatch(postNotificationCredentialsSpy, { payload: { username: 'username', password: 'password' } })
+  })
+
+  it('should use future strategy if more than one credential is available', async () => {
+    const req = {
+      body: {
+        username: ' username       ',
+        password: ' password ',
+        merchantId: ' merchant-id '
+      },
+      user: { externalId: 'some-id' },
+      account: gatewayAccountFixture.validGatewayAccount({
+        gateway_account_credentials: [
+          { payment_provider: 'worldpay', state: 'CREATED', external_id: credentialId },
+          { payment_provider: 'smartpay', state: 'ACTIVE' }
+        ]
+      }),
+      params: { credentialId },
+      headers: {}
+    }
+    await credentialsController.update(req, expressResponseStub, next)
+    sinon.assert.notCalled(legacyPatchAccountSpy)
+    sinon.assert.calledWithMatch(patchAccountSpy, { credentials: { username: 'username', password: 'password', merchant_id: 'merchant-id' } })
   })
 })

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -239,6 +239,32 @@ ConnectorClient.prototype = {
     })
   },
 
+  patchGooglePayGatewayMerchantId: function (gatewayAccountId, gatewayAccountCredentialsId, googlePayGatewayMerchantId, userExternalId, correlationId = '') {
+    const url = this.connectorUrl + ACCOUNT_GATEWAY_ACCOUNT_CREDENTIALS_PATH
+      .replace('{accountId}', gatewayAccountId)
+      .replace('{credentialsId}', gatewayAccountCredentialsId)
+
+    const payload = [
+      {
+        op: 'replace',
+        path: 'credentials/gateway_merchant_id',
+        value: googlePayGatewayMerchantId
+      },
+      {
+        op: 'replace',
+        path: 'last_updated_by_user_external_id',
+        value: userExternalId
+      }
+    ]
+
+    return baseClient.patch(url, {
+      body: payload,
+      correlationId: correlationId,
+      description: 'patch gateway account credentials for google pay merchant id',
+      service: SERVICE_NAME
+    })
+  },
+
   patchAccountGatewayAccountCredentialsState: function (params) {
     const url = this.connectorUrl + ACCOUNT_GATEWAY_ACCOUNT_CREDENTIALS_PATH
       .replace('{accountId}', params.gatewayAccountId)

--- a/test/cypress/integration/settings/allow-google-pay.cy.test.js
+++ b/test/cypress/integration/settings/allow-google-pay.cy.test.js
@@ -13,7 +13,10 @@ function setupStubs (allowGooglePay) {
       gatewayAccountId,
       gatewayAccountExternalId,
       paymentProvider: 'worldpay',
-      allowGooglePay: allowGooglePay
+      allowGooglePay: allowGooglePay,
+      gatewayAccountCredentials: [{
+        payment_provider: 'worldpay'
+      }]
     })
   ])
 }


### PR DESCRIPTION
To interleave with backend releases, define a future strategy that will be used only when multiple credentials are available on an account -- this will make sure code that doesn't replace the top level `credentials` will only be run when a service opts-in to the new switching code. 

Once the backend is fully released in production the branching logic can be removed (PP-8723) and the future strategy will be default. 

Do this for credentials and patching google pay details.