### PR TITLE
PP-8214 Switching PSP banners and labels

### DIFF
--- a/app/controllers/your-psp/get.controller.js
+++ b/app/controllers/your-psp/get.controller.js
@@ -1,13 +1,14 @@
 'use strict'
 
 const { response } = require('../../utils/response')
-const { getCredentialByExternalId } = require('../../utils/credentials')
+const { getCredentialByExternalId, getCurrentCredential } = require('../../utils/credentials')
 
 module.exports = (req, res, next) => {
   const { credentialId } = req.params
 
   try {
     const credential = getCredentialByExternalId(req.account, credentialId)
+    const activeCredential = getCurrentCredential(req.account)
     const isAccountCredentialsConfigured = credential.credentials && credential.credentials.merchant_id !== undefined
 
     const isWorldpay3dsFlexCredentialsConfigured = req.account.worldpay_3ds_flex &&
@@ -20,6 +21,7 @@ module.exports = (req, res, next) => {
 
     return response(req, res, 'your-psp/index', {
       credential,
+      activeCredential,
       isAccountCredentialsConfigured,
       is3dsEnabled,
       isWorldpay3dsFlexEnabled,

--- a/app/views/dashboard/_switching-psp-banner.njk
+++ b/app/views/dashboard/_switching-psp-banner.njk
@@ -1,0 +1,23 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% if currentGatewayAccount.provider_switch_enabled %}
+
+  <div class="govuk-grid-column-full">
+  {% set html %}
+    <p class="govuk-notification-banner__heading">
+    Switch your payment service provider (PSP) to {{ targetCredential.payment_provider | formatPSPname }}
+    </p>
+
+    <p class="govuk-body">Your service is taking payments with {{ activeCredential.payment_provider | formatPSPname }} and needs to switch to {{ targetCredential.payment_provider | formatPSPname }}.
+
+    <p class="govuk-body">
+      Find out <a class="govuk-notification-banner__link" href="{{ formatAccountPathsFor(routes.account.switchPSP.index, currentGatewayAccount.external_id) }}">how to switch to {{ targetCredential.payment_provider | formatPSPname }}</a>.
+    </p>
+
+  {% endset %}
+
+  {{ govukNotificationBanner({
+    html: html
+  }) }}
+  </div>
+{% endif %}

--- a/app/views/dashboard/index.njk
+++ b/app/views/dashboard/index.njk
@@ -7,6 +7,8 @@ Dashboard - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK
 {% block mainContent %}
   {% include "./_live-account-requested-banner.njk" %}
   {% include "./_stripe-account-setup-banner.njk" %}
+  {% include "./_switching-psp-banner.njk" %}
+
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l first-steps__title">Dashboard</h1>
   </div>

--- a/app/views/includes/phase-banner.njk
+++ b/app/views/includes/phase-banner.njk
@@ -12,6 +12,8 @@
         govuk-tag--grey
       {% elseif paymentProvider === 'stripe' and not stripeAccountIsSetup %}
         govuk-tag--blue
+      {% elseif currentGatewayAccount.provider_switch_enabled %}
+        govuk-tag--blue
       {% endif %}
     {% endset %}
 
@@ -26,6 +28,10 @@
         Live - information needed
       {% else %}
         Live
+      {% endif %}
+
+      {% if currentGatewayAccount.provider_switch_enabled %}
+      - switching psp
       {% endif %}
     {% endset %}
     <strong class="service-info--tag govuk-tag {{ tagModifierClass }}">{{ tagText }}</strong>

--- a/app/views/your-psp/index.njk
+++ b/app/views/your-psp/index.njk
@@ -29,7 +29,7 @@
   <h1 class="govuk-heading-l page-title">Your payment service provider (PSP) - {{ credential.payment_provider | formatPSPname }}</h1>
 
   {% if credential.active_end_date %}
-  <div class="govuk-inset-text">
+  <div id="switched-psp-status" class="govuk-inset-text">
     This service is taking payments with {{ activeCredential.payment_provider | formatPSPname }}. It switched from using {{ credential.payment_provider | formatPSPname }} on {{ credential.active_end_date | datetime('date') }}
   </div>
   {% endif %}

--- a/app/views/your-psp/index.njk
+++ b/app/views/your-psp/index.njk
@@ -28,6 +28,12 @@
   {% endif %}
   <h1 class="govuk-heading-l page-title">Your payment service provider (PSP) - {{ credential.payment_provider | formatPSPname }}</h1>
 
+  {% if credential.active_end_date %}
+  <div class="govuk-inset-text">
+    This service is taking payments with {{ activeCredential.payment_provider | formatPSPname }}. It switched from using {{ credential.payment_provider | formatPSPname }} on {{ credential.active_end_date | datetime('date') }}
+  </div>
+  {% endif %}
+
   {% if credential.payment_provider === "worldpay" %}
     {% include "./_worldpay.njk" %}
     {% include "./_worldpay-flex.njk" %}

--- a/test/cypress/integration/settings/switch-psp.cy.test.js
+++ b/test/cypress/integration/settings/switch-psp.cy.test.js
@@ -31,6 +31,7 @@ describe('Switch PSP settings page', () => {
     it('should not show link to Switch PSP in the side navigation', () => {
       cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+      cy.get('.service-info--tag').should('not.contain', 'switching psp')
       cy.get('#navigation-menu-switch-psp').should('have.length', 0)
     })
   })
@@ -44,9 +45,15 @@ describe('Switch PSP settings page', () => {
         ]))
       })
 
-      it('should show the switch PSP page for switching to Worldpay', () => {
+      it('should show dashboard message for switching psp', () => {
         cy.setEncryptedCookies(userExternalId)
+        cy.visit(`/account/${gatewayAccountExternalId}/dashboard`)
+        cy.get('.govuk-notification-banner__heading').should('contain', 'Switch your payment service provider (PSP) to Worldpay')
+      })
+
+      it('should show the switch PSP page for switching to Worldpay', () => {
         cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
+        cy.get('.service-info--tag').should('contain', 'switching psp')
         cy.get('#navigation-menu-switch-psp').should('have.length', 1)
         cy.get('h1').should('contain', 'Switch payment service provider')
         cy.get('li').contains('your Worldpay account credentials: Merchant code, username and password').should('exist')
@@ -189,6 +196,21 @@ describe('Switch PSP settings page', () => {
       it('submits and navigates through to success page with appropriate message', () => {
         cy.get('button').contains('Switch to Worldpay').click()
         cy.get('.govuk-notification-banner__heading').contains('You\'ve switched payment service provider')
+      })
+    })
+
+    describe('Switched PSP', () => {
+      beforeEach(() => {
+        cy.task('setupStubs', getUserAndAccountStubs('smartpay', true, [
+          { payment_provider: 'smartpay', state: 'ACTIVE', external_id: 'a-valid-external-id-smartpay' },
+          { payment_provider: 'worldpay', state: 'RETIRED', active_end_date: '2018-05-03T00:00:00.000Z', external_id: 'a-valid-external-id-worldpay' }
+        ]))
+      })
+
+      it('sets transitioned text on the your psp page', () => {
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+        cy.get('a').contains('Old PSP - Worldpay').click()
+        cy.get('#switched-psp-status').should('contain', 'This service is taking payments with Smartpay. It switched from using Worldpay on 03/05/2018')
       })
     })
   })


### PR DESCRIPTION
* notification banner on dashboard if switching
* account header for all account pages status label updated to factor in
switching progress
* end of switch status text added to your psp page
* cypress coverage for visual elements 

<img width="338" alt="Screenshot 2021-06-23 at 13 49 13" src="https://user-images.githubusercontent.com/2844572/123106035-348b5f80-d430-11eb-87e5-6672c9f9d7b7.png">
<img width="917" alt="Screenshot 2021-06-23 at 14 10 59" src="https://user-images.githubusercontent.com/2844572/123106047-36edb980-d430-11eb-8f20-c63b0833fe73.png">
<img width="617" alt="Screenshot 2021-06-23 at 13 57 30" src="https://user-images.githubusercontent.com/2844572/123106051-36edb980-d430-11eb-87fc-03738b68e047.png">

