### PR TITLE
PP-8190 Fix listing non-terminal credential pages

### DIFF
--- a/app/utils/credentials.js
+++ b/app/utils/credentials.js
@@ -44,10 +44,11 @@ function isSwitchingCredentialsRoute (req) {
 
 function getPSPPageLinks (gatewayAccount) {
   const supportedYourPSPPageProviders = [ 'worldpay', 'smartpay', 'epdq' ]
+  const numberOfAllCredentials = gatewayAccount.gateway_account_credentials && gatewayAccount.gateway_account_credentials.length
   const credentials = (gatewayAccount.gateway_account_credentials || [])
     .filter((credential) => supportedYourPSPPageProviders.includes(credential.payment_provider))
 
-  if (credentials.length === 1) {
+  if (numberOfAllCredentials === 1) {
     // if there's only one integration, that should always be shown
     return credentials
   } else {

--- a/app/utils/credentials.test.js
+++ b/app/utils/credentials.test.js
@@ -116,6 +116,18 @@ describe('credentials utility', () => {
       expect(linkCredentials[1].gateway_account_credential_id).to.equal(100)
     })
 
+    it('correctly returns nothing if moving from a non-credential page supported PSP', () => {
+      const account = gatewayAccountFixtures.validGatewayAccount({
+        gateway_account_credentials: [
+          { state: 'ACTIVE', payment_provider: 'stripe', id: 100 },
+          { state: 'CREATED', payment_provider: 'worldpay', id: 200 }
+        ]
+      })
+
+      const linkCredentials = getPSPPageLinks(account)
+      expect(linkCredentials).to.have.length(0)
+    })
+
     it('finds credential by external id', () => {
       const account = gatewayAccountFixtures.validGatewayAccount({
         gateway_account_credentials: [


### PR DESCRIPTION
When moving from a psp that doesn't support credential pages (currently
sandbox and stripe) the current algorithm returns a pending credential
as it assumes it is the only one on the account.

Guard against this by checking against the complete number of
credentials rather than one already filtered by provider.
