### PR TITLE
PP-8273 Always use new PATCH credentials endpoint

### DIFF
--- a/app/controllers/credentials.controller.js
+++ b/app/controllers/credentials.controller.js
@@ -128,22 +128,13 @@ module.exports = {
 
     try {
       const credential = getCredentialByExternalId(req.account, req.params.credentialId)
-
-      // @TODO(PP-8273) only use future strategy when backend no longer relies on top level credentials
-      const useFutureCredentialsUpdateStategy = req.account.gateway_account_credentials.length > 1
-      if (useFutureCredentialsUpdateStategy) {
-        await connectorClient.patchAccountGatewayAccountCredentials({
-          correlationId,
-          gatewayAccountId: accountId,
-          gatewayAccountCredentialsId: credential.gateway_account_credential_id,
-          userExternalId: req.user.externalId,
-          ...credentialsPatchRequestValueOf(req)
-        })
-      } else {
-        await connectorClient.legacyPatchAccountCredentials({
-          payload: credentialsPatchRequestValueOf(req), correlationId: correlationId, gatewayAccountId: accountId
-        })
-      }
+      await connectorClient.patchAccountGatewayAccountCredentials({
+        correlationId,
+        gatewayAccountId: accountId,
+        gatewayAccountCredentialsId: credential.gateway_account_credential_id,
+        userExternalId: req.user.externalId,
+        ...credentialsPatchRequestValueOf(req)
+      })
 
       return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, credential.external_id))
     } catch (err) {

--- a/app/controllers/credentials.controller.test.js
+++ b/app/controllers/credentials.controller.test.js
@@ -1,12 +1,10 @@
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const gatewayAccountFixture = require('../../test/fixtures/gateway-account.fixtures')
-const legacyPatchAccountSpy = sinon.spy(() => Promise.resolve())
 const patchAccountSpy = sinon.spy(() => Promise.resolve())
 const postNotificationCredentialsSpy = sinon.spy(() => Promise.resolve())
 const connectorClientMock = {
   ConnectorClient: function () {
-    this.legacyPatchAccountCredentials = legacyPatchAccountSpy
     this.patchAccountGatewayAccountCredentials = patchAccountSpy
     this.postAccountNotificationCredentials = postNotificationCredentialsSpy
   }
@@ -25,7 +23,6 @@ const next = sinon.spy()
 const credentialId = 'a-valid-credential-id'
 describe('gateway credentials controller', () => {
   beforeEach(() => {
-    legacyPatchAccountSpy.resetHistory()
     patchAccountSpy.resetHistory()
   })
   it('should remove leading and trailing whitespace from credentials when submitting them to the backend', async () => {
@@ -35,6 +32,7 @@ describe('gateway credentials controller', () => {
         password: ' password ',
         merchantId: ' merchant-id '
       },
+      user: { externalId: 'some-id' },
       account: gatewayAccountFixture.validGatewayAccount({
         gateway_account_credentials: [{
           external_id: credentialId
@@ -44,7 +42,7 @@ describe('gateway credentials controller', () => {
       headers: {}
     }
     await credentialsController.update(req, expressResponseStub, next)
-    sinon.assert.calledWithMatch(legacyPatchAccountSpy, { payload: { credentials: { username: 'username', password: 'password', merchant_id: 'merchant-id' } } })
+    sinon.assert.calledWithMatch(patchAccountSpy, { credentials: { username: 'username', password: 'password', merchant_id: 'merchant-id' } })
   })
 
   it('should remove leading and trailing whitespace from notification credentials when submitting them to the backend', async () => {
@@ -64,27 +62,5 @@ describe('gateway credentials controller', () => {
     }
     await credentialsController.updateNotificationCredentials(req, expressResponseStub, next)
     sinon.assert.calledWithMatch(postNotificationCredentialsSpy, { payload: { username: 'username', password: 'password' } })
-  })
-
-  it('should use future strategy if more than one credential is available', async () => {
-    const req = {
-      body: {
-        username: ' username       ',
-        password: ' password ',
-        merchantId: ' merchant-id '
-      },
-      user: { externalId: 'some-id' },
-      account: gatewayAccountFixture.validGatewayAccount({
-        gateway_account_credentials: [
-          { payment_provider: 'worldpay', state: 'CREATED', external_id: credentialId },
-          { payment_provider: 'smartpay', state: 'ACTIVE' }
-        ]
-      }),
-      params: { credentialId },
-      headers: {}
-    }
-    await credentialsController.update(req, expressResponseStub, next)
-    sinon.assert.notCalled(legacyPatchAccountSpy)
-    sinon.assert.calledWithMatch(patchAccountSpy, { credentials: { username: 'username', password: 'password', merchant_id: 'merchant-id' } })
   })
 })

--- a/app/controllers/credentials/worldpay.controller.js
+++ b/app/controllers/credentials/worldpay.controller.js
@@ -50,25 +50,14 @@ async function updateWorldpayCredentials (req, res, next) {
       logger.info('Successfully validated credentials with Worldpay')
     }
 
-    // @TODO(PP-8273) only use future strategy when backend no longer relies on top level credentials
-    const useFutureCredentialsUpdateStategy = req.account.gateway_account_credentials.length > 1
-    if (useFutureCredentialsUpdateStategy) {
-      await connectorClient.patchAccountGatewayAccountCredentials({
-        correlationId,
-        gatewayAccountId,
-        gatewayAccountCredentialsId: credential.gateway_account_credential_id,
-        credentials: results.values,
-        userExternalId: req.user.externalId
-      })
-      logger.info('Successfully updated credentials for pending Worldpay credentials on account')
-    } else {
-      await connectorClient.legacyPatchAccountCredentials({
-        correlationId,
-        gatewayAccountId,
-        payload: { credentials: results.values }
-      })
-      logger.info('Successfully updated credentials for Worldpay account')
-    }
+    await connectorClient.patchAccountGatewayAccountCredentials({
+      correlationId,
+      gatewayAccountId,
+      gatewayAccountCredentialsId: credential.gateway_account_credential_id,
+      credentials: results.values,
+      userExternalId: req.user.externalId
+    })
+    logger.info('Successfully updated Worldpay credentials on account')
 
     if (switchingToCredentials) {
       return res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))

--- a/app/controllers/digital-wallet/post-google-pay.controller.js
+++ b/app/controllers/digital-wallet/post-google-pay.controller.js
@@ -23,13 +23,7 @@ module.exports = async (req, res, next) => {
   if (enable) {
     try {
       const credential = getCurrentCredential(req.account)
-      // @TODO(PP-8273) only use future strategy when backend no longer relies on top level credentials
-      const useFutureCredentialsUpdateStategy = req.account.gateway_account_credentials.length > 1
-      if (useFutureCredentialsUpdateStategy) {
-        await connector.patchGooglePayGatewayMerchantId(gatewayAccountId, credential.gateway_account_credential_id, gatewayMerchantId, req.user && req.user.externalId, correlationId)
-      } else {
-        await connector.setGatewayMerchantId(gatewayAccountId, gatewayMerchantId, correlationId)
-      }
+      await connector.patchGooglePayGatewayMerchantId(gatewayAccountId, credential.gateway_account_credential_id, gatewayMerchantId, req.user && req.user.externalId, correlationId)
       logger.info('Set google pay merchant ID')
     } catch (error) {
       logger.info('Error setting google pay merchant ID', { error })

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -23,7 +23,6 @@ const ACCOUNT_BY_EXTERNAL_ID_PATH = ACCOUNTS_FRONTEND_PATH + '/external-id/{exte
 const SERVICE_NAME_FRONTEND_PATH = ACCOUNT_FRONTEND_PATH + '/servicename'
 const ACCEPTED_CARD_TYPES_FRONTEND_PATH = ACCOUNT_FRONTEND_PATH + '/card-types'
 const ACCOUNT_NOTIFICATION_CREDENTIALS_PATH = '/v1/api/accounts' + '/{accountId}' + '/notification-credentials'
-const ACCOUNT_CREDENTIALS_PATH = ACCOUNT_FRONTEND_PATH + '/credentials'
 const ACCOUNT_GATEWAY_ACCOUNT_CREDENTIALS_PATH = '/v1/api/accounts/{accountId}/credentials/{credentialsId}'
 const EMAIL_NOTIFICATION__PATH = '/v1/api/accounts/{accountId}/email-notification'
 const CHECK_WORLDPAY_3DS_FLEX_CREDENTIALS_PATH = '/v1/api/accounts/{accountId}/worldpay/check-3ds-flex-config'
@@ -57,11 +56,6 @@ function _accountsUrlFor (gatewayAccountIds, url) {
 /** @private */
 function _accountNotificationCredentialsUrlFor (gatewayAccountId, url) {
   return url + ACCOUNT_NOTIFICATION_CREDENTIALS_PATH.replace('{accountId}', gatewayAccountId)
-}
-
-/** @private */
-function _accountCredentialsUrlFor (gatewayAccountId, url) {
-  return url + ACCOUNT_CREDENTIALS_PATH.replace('{accountId}', gatewayAccountId)
 }
 
 /** @private */
@@ -194,22 +188,6 @@ ConnectorClient.prototype = {
       description: 'create a gateway account',
       service: SERVICE_NAME,
       baseClientErrorHandler: 'old'
-    })
-  },
-
-  /**
-   *
-   * @param {Object} params
-   * @returns {ConnectorClient}
-   */
-  legacyPatchAccountCredentials: function (params) {
-    const url = _accountCredentialsUrlFor(params.gatewayAccountId, this.connectorUrl)
-
-    return baseClient.patch(url, {
-      body: params.payload,
-      correlationId: params.correlationId,
-      description: 'patch gateway account credentials',
-      service: SERVICE_NAME
     })
   },
 

--- a/test/unit/clients/connector-client/connector-patch-gateway-account-merchant-id.pact.test.js
+++ b/test/unit/clients/connector-client/connector-patch-gateway-account-merchant-id.pact.test.js
@@ -14,7 +14,7 @@ const existingGatewayAccountCredentialsId = 555
 
 let connectorClient
 
-describe('connector client - patch gateway account credentials.merchant_id', () => {
+describe('connector client - patch gateway account credentials.gateway_merchant_id', () => {
   const provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',


### PR DESCRIPTION
We were using the old endpoints previously if not switching supplier, as connector was still reading credentials from the credentials column on the gateway account. Now we're no longer using that column we can just use the new endpoints to only update the `gateway_account_credentials` table.