### PR TITLE
PP-8272 Redirect to test connection page on payment failure

### DIFF
--- a/app/controllers/switch-psp/switch-psp.controller.js
+++ b/app/controllers/switch-psp/switch-psp.controller.js
@@ -4,11 +4,6 @@ const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const formatPSPName = require('../../utils/format-PSP-name')
 const paths = require('../../paths')
 const switchTasks = require('./switch-tasks.service')
-const {
-  VERIFY_PSP_INTEGRATION_STATUS_KEY,
-  VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY,
-  VERIFY_PSP_INTEGRATION_STATUS
-} = require('../../utils/verify-psp-integration')
 const { getSwitchingCredential, getCurrentCredential } = require('../../utils/credentials')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
@@ -18,13 +13,7 @@ function switchPSPPage (req, res, next) {
     const targetCredential = getSwitchingCredential(req.account)
     const taskList = switchTasks.getTaskList(targetCredential, req.account)
     const taskListIsComplete = switchTasks.isComplete(taskList)
-    const context = { targetCredential, taskList, VERIFY_PSP_INTEGRATION_STATUS, taskListIsComplete }
-
-    if (req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY]) {
-      context.verifyPSPIntegrationResult = req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY]
-      delete req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY]
-      delete req.session[VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY]
-    }
+    const context = { targetCredential, taskList, taskListIsComplete }
     response(req, res, 'switch-psp/switch-psp', context)
   } catch (error) {
     next(error)

--- a/app/controllers/switch-psp/switch-psp.controller.test.js
+++ b/app/controllers/switch-psp/switch-psp.controller.test.js
@@ -8,7 +8,7 @@ const User = require('../../models/User.class')
 let postAccountSwitchPSPMock = sinon.spy(() => Promise.resolve())
 let req, res, next
 
-describe('Verify PSP integration controller', () => {
+describe('Switch PSP controller', () => {
   describe('for ready to switch accounts', () => {
     beforeEach(() => setupEnvironment('VERIFIED_WITH_LIVE_PAYMENT'))
 

--- a/app/controllers/switch-psp/verify-psp-integration.controller.js
+++ b/app/controllers/switch-psp/verify-psp-integration.controller.js
@@ -7,9 +7,7 @@ const { getSwitchingCredential } = require('../../utils/credentials')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const { CREDENTIAL_STATE } = require('../../utils/credentials')
 const {
-  VERIFY_PSP_INTEGRATION_STATUS_KEY,
   VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY,
-  VERIFY_PSP_INTEGRATION_STATUS,
   filterNextUrl
 } = require('../../utils/verify-psp-integration')
 const logger = require('../../utils/logger')(__filename)
@@ -49,29 +47,32 @@ async function startPaymentJourney (req, res, next) {
 async function completePaymentJourney (req, res, next) {
   try {
     const chargeExternalId = req.session[VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY]
+    delete req.session[VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY]
     const targetCredential = getSwitchingCredential(req.account)
-    if (chargeExternalId) {
-      const charge = await connectorClient.getCharge(req.account.gateway_account_id, chargeExternalId)
-      if (charge.state.status === 'success') {
-        await connectorClient.patchAccountGatewayAccountCredentialsState({
-          correlationId: req.correlationId,
-          gatewayAccountId: req.account.gateway_account_id,
-          gatewayAccountCredentialsId: targetCredential.gateway_account_credential_id,
-          state: CREDENTIAL_STATE.VERIFIED
-        })
-        req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY] = VERIFY_PSP_INTEGRATION_STATUS.SUCCESS
-      } else {
-        logger.info('Live payment to verify PSP integration had a non-success status')
-        req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY] = VERIFY_PSP_INTEGRATION_STATUS.FAILURE
-      }
-    } else {
+    if (!chargeExternalId) {
       throw new Error('No charge found on session')
+    }
+
+    const charge = await connectorClient.getCharge(req.account.gateway_account_id, chargeExternalId)
+    if (charge.state.status === 'success') {
+      await connectorClient.patchAccountGatewayAccountCredentialsState({
+        correlationId: req.correlationId,
+        gatewayAccountId: req.account.gateway_account_id,
+        gatewayAccountCredentialsId: targetCredential.gateway_account_credential_id,
+        state: CREDENTIAL_STATE.VERIFIED
+      })
+      req.flash('verifyIntegrationPaymentSuccess', true)
+      res.redirect(formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
+    } else {
+      logger.info('Live payment to verify PSP integration had a non-success status')
+      req.flash('verifyIntegrationPaymentFailed', true)
+      res.redirect(formatAccountPathsFor(paths.account.switchPSP.verifyPSPIntegrationPayment, req.account.external_id))
     }
   } catch (error) {
     logger.warn(`Exception raised during very PSP intgration callback: ${error.message}`)
-    req.session[VERIFY_PSP_INTEGRATION_STATUS_KEY] = VERIFY_PSP_INTEGRATION_STATUS.FAILURE
+    req.flash('verifyIntegrationPaymentFailed', true)
+    res.redirect(formatAccountPathsFor(paths.account.switchPSP.verifyPSPIntegrationPayment, req.account.external_id))
   }
-  res.redirect(formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
 }
 
 module.exports = { verifyPSPIntegrationPaymentPage, startPaymentJourney, completePaymentJourney }

--- a/app/controllers/switch-psp/verify-psp-integration.controller.test.js
+++ b/app/controllers/switch-psp/verify-psp-integration.controller.test.js
@@ -75,7 +75,7 @@ describe('Verify PSP integration controller', () => {
 
     sinon.assert.called(getChargeMock)
     sinon.assert.called(patchAccountGatewayAccountCredentialsStateMock)
-    expect(req.session.verify_psp_integration_status_key).to.equal('SUCCESS')
+    sinon.assert.calledWith(req.flash, 'verifyIntegrationPaymentSuccess', true)
     sinon.assert.calledWith(res.redirect, '/account/a-valid-external-id/switch-psp')
   })
 
@@ -88,8 +88,8 @@ describe('Verify PSP integration controller', () => {
 
     sinon.assert.called(getChargeMock)
     sinon.assert.notCalled(patchAccountGatewayAccountCredentialsStateMock)
-    expect(req.session.verify_psp_integration_status_key).to.equal('FAILURE')
-    sinon.assert.calledWith(res.redirect, '/account/a-valid-external-id/switch-psp')
+    sinon.assert.calledWith(req.flash, 'verifyIntegrationPaymentFailed', true)
+    sinon.assert.calledWith(res.redirect, '/account/a-valid-external-id/switch-psp/verify-psp-integration')
   })
 })
 

--- a/app/utils/credentials.test.js
+++ b/app/utils/credentials.test.js
@@ -173,7 +173,7 @@ describe('credentials utility', () => {
         const hasSwitched = hasSwitchedProvider(account)
         expect(hasSwitched).to.equal(true)
       })
-  
+
       it('returns false if there are no retired credentials', () => {
         const account = gatewayAccountFixtures.validGatewayAccount({
           gateway_account_credentials: [
@@ -181,7 +181,7 @@ describe('credentials utility', () => {
             { state: 'ENTERED', id: 200 }
           ]
         })
-  
+
         const hasSwitched = hasSwitchedProvider(account)
         expect(hasSwitched).to.equal(false)
       })

--- a/app/utils/verify-psp-integration.js
+++ b/app/utils/verify-psp-integration.js
@@ -1,11 +1,6 @@
 'use strict'
 
-const VERIFY_PSP_INTEGRATION_STATUS = {
-  SUCCESS: 'SUCCESS',
-  FAILURE: 'FAILURE'
-}
 const VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY = 'verify_psp_integration_charge_external_id'
-const VERIFY_PSP_INTEGRATION_STATUS_KEY = 'verify_psp_integration_status_key'
 
 function filterNextUrl (charge = {}) {
   const nextUrlEntry = charge.links &&
@@ -16,7 +11,5 @@ function filterNextUrl (charge = {}) {
 
 module.exports = {
   VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY,
-  VERIFY_PSP_INTEGRATION_STATUS_KEY,
-  VERIFY_PSP_INTEGRATION_STATUS,
   filterNextUrl
 }

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -33,7 +33,7 @@
 
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
-  {% if verifyPSPIntegrationResult === VERIFY_PSP_INTEGRATION_STATUS.SUCCESS %}
+  {% if flash.verifyIntegrationPaymentSuccess %}
     {% set bannerHtml %}
       <h3 class="govuk-notification-banner__heading">
         Your live payment has succeeded
@@ -45,20 +45,8 @@
       html: bannerHtml,
       type: 'success'
     }) }}
-  {% elif verifyPSPIntegrationResult === VERIFY_PSP_INTEGRATION_STATUS.FAILURE %}
-    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-      <h2 class="govuk-error-summary__title" id="error-summary-title">
-        There is a problem
-      </h2>
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list">
-          <li>
-            <span>Your live payment was not successful. <a class="govuk-link" href="https://www.payments.service.gov.uk/support/">Contact support</a> to continue switching PSP.</span>
-          </li>
-        </ul>
-      </div>
-    </div>
   {% endif %}
+  
   <h1 class="govuk-heading-l page-title">Switch payment service provider (PSP)</h1>
 
   <p class="govuk-body">This service is taking payments with {{ currentGatewayAccount.payment_provider | formatPSPname }}.</p>

--- a/app/views/switch-psp/verify-psp-integration-payment.njk
+++ b/app/views/switch-psp/verify-psp-integration-payment.njk
@@ -9,13 +9,27 @@
 {% endblock %}
 
 {% block mainContent %}
+
 <div class="govuk-grid-column-two-thirds">
+
   {# back link should always go before <main> content so it can be skipped, settings page layouts should be adjusted to suport this #}
   {{ govukBackLink({
     text: "Back to Switching payment service provider (PSP)",
     classes: "govuk-!-margin-top-0",
     href: formatAccountPathsFor(routes.account.switchPSP.index, currentGatewayAccount.external_id)
   }) }}
+
+  {% if flash.verifyIntegrationPaymentFailed %}
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+      <p class="govuk-body">Please check your Worldpay credentials and try making another payment.</p> 
+      <p class="govuk-body">If this does not work, email us at <a class="govuk-link" href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk" target="_top">govuk-pay-support@digital.cabinet-office.gov.uk</a>.</p>
+    </div>
+  </div>
+  {% endif %}
 
   <h1 class="govuk-heading-l page-title">Test the connection between {{ targetCredential.payment_provider | formatPSPname }} and GOV.UK Pay</h1>
 

--- a/test/cypress/integration/settings/switch-psp.cy.test.js
+++ b/test/cypress/integration/settings/switch-psp.cy.test.js
@@ -147,7 +147,7 @@ describe('Switch PSP settings page', () => {
         })
       })
 
-      it('returning with a failed payment should present an error with request session charge id maintained', () => {
+      it('returning with a failed payment should present an error', () => {
         cy.task('setupStubs', [
           ...getUserAndAccountStubs('smartpay', true, [
             { payment_provider: 'smartpay', state: 'ACTIVE' },
@@ -162,10 +162,11 @@ describe('Switch PSP settings page', () => {
         ])
         cy.visit(`/account/${gatewayAccountExternalId}/switch-psp/verify-psp-integration/callback`)
 
-        cy.get('.govuk-error-summary__body').first().contains('Your live payment was not successful')
+        cy.get('.govuk-error-summary__body').first().contains('Please check your Worldpay credentials and try making another payment.')
+        cy.get('.govuk-back-link').click()
       })
 
-      it('returning with a successful payment should present completion message with request session charge id maintained', () => {
+      it('returning with a successful payment should present completion message', () => {
         cy.task('setupStubs', [
           ...getUserAndAccountStubs('smartpay', true, [
             { payment_provider: 'smartpay', state: 'ACTIVE' },


### PR DESCRIPTION
Previously, we were redirecting to the "Switch PSP" page if the test payment failed. Instead redirect to the "Test connection" page.

Use `req.flash` to display the error/success messages and remove some of the boiler plate as it makes less sense now they're displayed on different pages.


