### PR TITLE
PP-8218 Switch PSP to Stripe tasks

### DIFF
--- a/app/controllers/credentials/worldpay.controller.js
+++ b/app/controllers/credentials/worldpay.controller.js
@@ -19,8 +19,8 @@ function showWorldpayCredentialsPage (req, res, next) {
   try {
     const credential = getCredentialByExternalId(req.account, req.params.credentialId)
     const form = credentialsForm.from(credential.credentials)
-    const switchingToCredentials = isSwitchingCredentialsRoute(req)
-    response(req, res, 'credentials/worldpay', { form, switchingToCredentials, credential })
+    const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
+    response(req, res, 'credentials/worldpay', { form, isSwitchingCredentials, credential })
   } catch (error) {
     next(error)
   }
@@ -28,7 +28,7 @@ function showWorldpayCredentialsPage (req, res, next) {
 
 async function updateWorldpayCredentials (req, res, next) {
   const gatewayAccountId = req.account.gateway_account_id
-  const switchingToCredentials = isSwitchingCredentialsRoute(req)
+  const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
   const correlationId = req.correlationId || ''
 
   try {
@@ -36,7 +36,7 @@ async function updateWorldpayCredentials (req, res, next) {
     const results = credentialsForm.validate(req.body)
 
     if (results.errorSummaryList.length) {
-      return response(req, res, 'credentials/worldpay', { form: results, switchingToCredentials, credential })
+      return response(req, res, 'credentials/worldpay', { form: results, isSwitchingCredentials, credential })
     }
 
     if (SKIP_PSP_CREDENTIAL_CHECKS !== 'true') {
@@ -44,7 +44,7 @@ async function updateWorldpayCredentials (req, res, next) {
       if (checkCredentialsWithWorldpay.result !== 'valid') {
         logger.warn('Provided credentials failed validation with Worldpay')
         results.errorSummaryList = formatErrorsForSummaryList({ 'merchantId': 'Check your Worldpay credentials, failed to link your account to Worldpay with credentials provided' })
-        return response(req, res, 'credentials/worldpay', { form: results, switchingToCredentials, credential })
+        return response(req, res, 'credentials/worldpay', { form: results, isSwitchingCredentials, credential })
       }
 
       logger.info('Successfully validated credentials with Worldpay')
@@ -59,7 +59,7 @@ async function updateWorldpayCredentials (req, res, next) {
     })
     logger.info('Successfully updated Worldpay credentials on account')
 
-    if (switchingToCredentials) {
+    if (isSwitchingCredentials) {
       return res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
     } else {
       return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account.external_id, credential.external_id))

--- a/app/controllers/stripe-setup/add-psp-account-details/get.controller.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/get.controller.js
@@ -2,6 +2,7 @@
 
 const paths = require('../../../paths')
 const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
+const { getCurrentCredential } = require('../../../utils/credentials')
 const { response } = require('../../../utils/response')
 
 module.exports = async function getPspAccountDetails (req, res, next) {
@@ -12,14 +13,18 @@ module.exports = async function getPspAccountDetails (req, res, next) {
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
   const accountExternalId = req.account.external_id
 
+  // add psp account details flow is currently only used by the go live flow so will
+  // only factor in the accounts active credentials
+  const credentialId = getCurrentCredential(req.account).external_id
+
   if (!stripeAccountSetup.bankAccount) {
-    res.redirect(303, formatAccountPathsFor(paths.account.stripeSetup.bankDetails, accountExternalId))
+    res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.stripeSetup.bankDetails, accountExternalId, credentialId))
   } else if (!stripeAccountSetup.responsiblePerson) {
-    res.redirect(303, formatAccountPathsFor(paths.account.stripeSetup.responsiblePerson, accountExternalId))
+    res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.stripeSetup.responsiblePerson, accountExternalId, credentialId))
   } else if (!stripeAccountSetup.vatNumber) {
-    res.redirect(303, formatAccountPathsFor(paths.account.stripeSetup.vatNumber, accountExternalId))
+    res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.stripeSetup.vatNumber, accountExternalId, credentialId))
   } else if (!stripeAccountSetup.companyNumber) {
-    res.redirect(303, formatAccountPathsFor(paths.account.stripeSetup.companyNumber, accountExternalId))
+    res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.stripeSetup.companyNumber, accountExternalId, credentialId))
   } else {
     response(req, res, 'stripe-setup/go-live-complete')
   }

--- a/app/controllers/stripe-setup/add-psp-account-details/get.controller.test.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/get.controller.test.js
@@ -2,18 +2,23 @@
 
 const sinon = require('sinon')
 
+const gatewayAccountFixture = require('../../../../test/fixtures/gateway-account.fixtures')
 const getController = require('./get.controller')
 
 describe('get controller', () => {
   let req, res, next
 
   beforeEach(() => {
+    const account = gatewayAccountFixture.validGatewayAccount({
+      gateway_account_id: 'gatewayId',
+      external_id: 'a-valid-external-id',
+      gateway_account_credentials: [{
+        external_id: 'a-valid-credential-id'
+      }]
+    })
+    account.connectorGatewayAccountStripeProgress = {}
     req = {
-      account: {
-        gateway_account_id: 'gatewayId',
-        external_id: 'a-valid-external-id',
-        connectorGatewayAccountStripeProgress: {}
-      },
+      account,
       credentialId: 'a-valid-credential-id',
       correlationId: 'requestId'
     }

--- a/app/controllers/stripe-setup/add-psp-account-details/get.controller.test.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/get.controller.test.js
@@ -2,7 +2,6 @@
 
 const sinon = require('sinon')
 
-const paths = require('../../../paths')
 const getController = require('./get.controller')
 
 describe('get controller', () => {
@@ -15,6 +14,7 @@ describe('get controller', () => {
         external_id: 'a-valid-external-id',
         connectorGatewayAccountStripeProgress: {}
       },
+      credentialId: 'a-valid-credential-id',
       correlationId: 'requestId'
     }
     res = {
@@ -29,13 +29,13 @@ describe('get controller', () => {
   it('should redirect to bank account setup page', async () => {
     req.account.connectorGatewayAccountStripeProgress.bankAccount = false
     await getController(req, res, next)
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripeSetup.bankDetails}`)
+    sinon.assert.calledWith(res.redirect, 303, `/account/${req.account.external_id}/your-psp/${req.credentialId}/bank-details`)
   })
 
   it('should redirect to responsible person page', async () => {
     req.account.connectorGatewayAccountStripeProgress.bankAccount = true
     await getController(req, res, next)
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripeSetup.responsiblePerson}`)
+    sinon.assert.calledWith(res.redirect, 303, `/account/${req.account.external_id}/your-psp/${req.credentialId}/responsible-person`)
   })
 
   it('should redirect to VAT number page', async () => {
@@ -44,7 +44,7 @@ describe('get controller', () => {
       responsiblePerson: true
     }
     await getController(req, res, next)
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripeSetup.vatNumber}`)
+    sinon.assert.calledWith(res.redirect, 303, `/account/${req.account.external_id}/your-psp/${req.credentialId}/vat-number`)
   })
 
   it('should redirect to company registration number page', async () => {
@@ -54,7 +54,7 @@ describe('get controller', () => {
       vatNumber: true
     }
     await getController(req, res, next)
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripeSetup.companyNumber}`)
+    sinon.assert.calledWith(res.redirect, 303, `/account/${req.account.external_id}/your-psp/${req.credentialId}/company-number`)
   })
 
   it('should render go live complete page when all steps are completed', async () => {

--- a/app/controllers/stripe-setup/bank-details/get.controller.js
+++ b/app/controllers/stripe-setup/bank-details/get.controller.js
@@ -6,7 +6,7 @@ const paths = require('../../../paths')
 const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
 
 module.exports = (req, res, next) => {
-  const switchingToCredentials = isSwitchingCredentialsRoute(req)
+  const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
 
   if (!stripeAccountSetup) {
@@ -17,5 +17,5 @@ module.exports = (req, res, next) => {
     return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
   }
 
-  return response(req, res, 'stripe-setup/bank-details/index', { switchingToCredentials })
+  return response(req, res, 'stripe-setup/bank-details/index', { isSwitchingCredentials })
 }

--- a/app/controllers/stripe-setup/bank-details/get.controller.js
+++ b/app/controllers/stripe-setup/bank-details/get.controller.js
@@ -1,10 +1,12 @@
 'use strict'
 
 const { response } = require('../../../utils/response')
+const { isSwitchingCredentialsRoute } = require('../../../utils/credentials')
 const paths = require('../../../paths')
 const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
 
 module.exports = (req, res, next) => {
+  const switchingToCredentials = isSwitchingCredentialsRoute(req)
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
 
   if (!stripeAccountSetup) {
@@ -15,5 +17,5 @@ module.exports = (req, res, next) => {
     return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
   }
 
-  return response(req, res, 'stripe-setup/bank-details/index')
+  return response(req, res, 'stripe-setup/bank-details/index', { switchingToCredentials })
 }

--- a/app/controllers/stripe-setup/bank-details/post.controller.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.js
@@ -3,6 +3,7 @@
 const lodash = require('lodash')
 
 const { response } = require('../../../utils/response')
+const { isSwitchingCredentialsRoute, getSwitchingCredentialIfExists } = require('../../../utils/credentials')
 const bankDetailsValidations = require('./bank-details-validations')
 const { updateBankAccount } = require('../../../services/clients/stripe/stripe.client')
 const { ConnectorClient } = require('../../../services/clients/connector.client')
@@ -16,6 +17,7 @@ const ACCOUNT_NUMBER_FIELD = 'account-number'
 const SORT_CODE_FIELD = 'sort-code'
 
 module.exports = async (req, res, next) => {
+  const switchingToCredentials = isSwitchingCredentialsRoute(req)
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
   if (!stripeAccountSetup) {
     return next(new Error('Stripe setup progress is not available on request'))
@@ -35,20 +37,34 @@ module.exports = async (req, res, next) => {
     return response(req, res, 'stripe-setup/bank-details/index', {
       accountNumber: rawAccountNumber,
       sortCode: rawSortCode,
+      switchingToCredentials,
       errors
     })
   }
 
   try {
-    const stripeAccount = await connector.getStripeAccount(req.account.gateway_account_id, req.correlationId)
+    const switchingCredential = getSwitchingCredentialIfExists(req.account)
+    let stripeAccountId
 
-    await updateBankAccount(stripeAccount.stripeAccountId, {
+    if (switchingToCredentials) {
+      stripeAccountId = switchingCredential.credentials.stripe_account_id
+    } else {
+      const stripeAccount = await connector.getStripeAccount(req.account.gateway_account_id, req.correlationId)
+      stripeAccountId = stripeAccount.stripeAccountId
+    }
+
+    await updateBankAccount(stripeAccountId, {
       bank_account_sort_code: sanitisedSortCode,
       bank_account_number: sanitisedAccountNumber
     })
 
     await connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'bank_account', req.correlationId)
-    return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))
+
+    if (switchingToCredentials) {
+      return res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
+    } else {
+      return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))
+    }
   } catch (error) {
     // check if it is Stripe related error
     if (error.code) {
@@ -57,6 +73,7 @@ module.exports = async (req, res, next) => {
         return response(req, res, 'stripe-setup/bank-details/index', {
           accountNumber: rawAccountNumber,
           sortCode: rawSortCode,
+          switchingToCredentials,
           errors: {
             [SORT_CODE_FIELD]: fieldValidationChecks.validationErrors.invalidSortCode
           }
@@ -67,6 +84,7 @@ module.exports = async (req, res, next) => {
         return response(req, res, 'stripe-setup/bank-details/index', {
           accountNumber: rawAccountNumber,
           sortCode: rawSortCode,
+          switchingToCredentials,
           errors: {
             [ACCOUNT_NUMBER_FIELD]: fieldValidationChecks.validationErrors.invalidBankAccountNumber
           }

--- a/app/controllers/stripe-setup/company-number/get.controller.js
+++ b/app/controllers/stripe-setup/company-number/get.controller.js
@@ -1,10 +1,12 @@
 'use strict'
 
 const { response } = require('../../../utils/response')
+const { isSwitchingCredentialsRoute } = require('../../../utils/credentials')
 const paths = require('../../../paths')
 const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
 
 module.exports = (req, res, next) => {
+  const switchingToCredentials = isSwitchingCredentialsRoute(req)
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
   if (!stripeAccountSetup) {
     return next(new Error('Stripe setup progress is not available on request'))
@@ -14,5 +16,5 @@ module.exports = (req, res, next) => {
     return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
   }
 
-  return response(req, res, 'stripe-setup/company-number/index')
+  return response(req, res, 'stripe-setup/company-number/index', { switchingToCredentials })
 }

--- a/app/controllers/stripe-setup/company-number/get.controller.js
+++ b/app/controllers/stripe-setup/company-number/get.controller.js
@@ -6,7 +6,7 @@ const paths = require('../../../paths')
 const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
 
 module.exports = (req, res, next) => {
-  const switchingToCredentials = isSwitchingCredentialsRoute(req)
+  const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
   if (!stripeAccountSetup) {
     return next(new Error('Stripe setup progress is not available on request'))
@@ -16,5 +16,5 @@ module.exports = (req, res, next) => {
     return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
   }
 
-  return response(req, res, 'stripe-setup/company-number/index', { switchingToCredentials })
+  return response(req, res, 'stripe-setup/company-number/index', { isSwitchingCredentials })
 }

--- a/app/controllers/stripe-setup/company-number/post.controller.js
+++ b/app/controllers/stripe-setup/company-number/post.controller.js
@@ -3,7 +3,7 @@
 const lodash = require('lodash')
 
 const { response } = require('../../../utils/response')
-const { isSwitchingCredentialsRoute, getSwitchingCredentialIfExists } = require('../../../utils/credentials')
+const { isSwitchingCredentialsRoute, getSwitchingCredential } = require('../../../utils/credentials')
 const { updateCompany } = require('../../../services/clients/stripe/stripe.client')
 const companyNumberValidations = require('./company-number-validations')
 const { ConnectorClient } = require('../../../services/clients/connector.client')
@@ -16,7 +16,7 @@ const COMPANY_NUMBER_DECLARATION_FIELD = 'company-number-declaration'
 const COMPANY_NUMBER_FIELD = 'company-number'
 
 module.exports = async (req, res, next) => {
-  const switchingToCredentials = isSwitchingCredentialsRoute(req)
+  const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
   if (!stripeAccountSetup) {
     return next(new Error('Stripe setup progress is not available on request'))
@@ -35,7 +35,7 @@ module.exports = async (req, res, next) => {
     return response(req, res, 'stripe-setup/company-number/index', {
       companyNumberDeclaration: companyNumberDeclaration,
       companyNumber: rawCompanyNumber,
-      switchingToCredentials,
+      isSwitchingCredentials,
       errors
     })
   } else {
@@ -43,10 +43,10 @@ module.exports = async (req, res, next) => {
       const stripeCompanyBody = {
         tax_id: sanitisedCompanyNumber || 'NOTAPPLI'
       }
-      const switchingCredential = getSwitchingCredentialIfExists(req.account)
       let stripeAccountId
 
-      if (switchingToCredentials) {
+      if (isSwitchingCredentials) {
+        const switchingCredential = getSwitchingCredential(req.account)
         stripeAccountId = switchingCredential.credentials.stripe_account_id
       } else {
         const stripeAccount = await connector.getStripeAccount(req.account.gateway_account_id, req.correlationId)
@@ -55,7 +55,7 @@ module.exports = async (req, res, next) => {
       await updateCompany(stripeAccountId, stripeCompanyBody)
       await connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'company_number', req.correlationId)
 
-      if (switchingToCredentials) {
+      if (isSwitchingCredentials) {
         return res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
       } else {
         return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))

--- a/app/controllers/stripe-setup/responsible-person/get.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/get.controller.js
@@ -6,7 +6,7 @@ const paths = require('../../../paths')
 const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
 
 module.exports = (req, res, next) => {
-  const switchingToCredentials = isSwitchingCredentialsRoute(req)
+  const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
 
   if (!stripeAccountSetup) {
@@ -17,5 +17,5 @@ module.exports = (req, res, next) => {
     return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
   }
 
-  return response(req, res, 'stripe-setup/responsible-person/index', { switchingToCredentials })
+  return response(req, res, 'stripe-setup/responsible-person/index', { isSwitchingCredentials })
 }

--- a/app/controllers/stripe-setup/responsible-person/get.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/get.controller.js
@@ -1,10 +1,12 @@
 'use strict'
 
 const { response } = require('../../../utils/response')
+const { isSwitchingCredentialsRoute } = require('../../../utils/credentials')
 const paths = require('../../../paths')
 const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
 
 module.exports = (req, res, next) => {
+  const switchingToCredentials = isSwitchingCredentialsRoute(req)
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
 
   if (!stripeAccountSetup) {
@@ -15,5 +17,5 @@ module.exports = (req, res, next) => {
     return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
   }
 
-  return response(req, res, 'stripe-setup/responsible-person/index')
+  return response(req, res, 'stripe-setup/responsible-person/index', { switchingToCredentials })
 }

--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -5,7 +5,7 @@ const ukPostcode = require('uk-postcode')
 
 const paths = require('../../../paths')
 const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
-const { isSwitchingCredentialsRoute, getSwitchingCredentialIfExists } = require('../../../utils/credentials')
+const { isSwitchingCredentialsRoute, getSwitchingCredential } = require('../../../utils/credentials')
 const { response } = require('../../../utils/response')
 const {
   validateMandatoryField, validateOptionalField, validatePostcode, validateDateOfBirth
@@ -59,7 +59,7 @@ const validationRules = [
 const trimField = (key, store) => lodash.get(store, key, '').trim()
 
 module.exports = async function (req, res, next) {
-  const switchingToCredentials = isSwitchingCredentialsRoute(req)
+  const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
 
   if (!stripeAccountSetup) {
@@ -113,13 +113,13 @@ module.exports = async function (req, res, next) {
 
   if (!lodash.isEmpty(errors)) {
     pageData['errors'] = errors
-    return response(req, res, 'stripe-setup/responsible-person/index', { ...pageData, switchingToCredentials })
+    return response(req, res, 'stripe-setup/responsible-person/index', { ...pageData, isSwitchingCredentials })
   } else {
     try {
-      const switchingCredential = getSwitchingCredentialIfExists(req.account)
       let stripeAccountId
 
-      if (switchingToCredentials) {
+      if (isSwitchingCredentials) {
+        const switchingCredential = getSwitchingCredential(req.account)
         stripeAccountId = switchingCredential.credentials.stripe_account_id
       } else {
         const stripeAccount = await connector.getStripeAccount(req.account.gateway_account_id, req.correlationId)
@@ -130,7 +130,7 @@ module.exports = async function (req, res, next) {
       await updatePerson(stripeAccountId, person.id, buildStripePerson(formFields))
       await connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'responsible_person', req.correlationId)
 
-      if (switchingToCredentials) {
+      if (isSwitchingCredentials) {
         return res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
       } else {
         return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))

--- a/app/controllers/stripe-setup/vat-number/get.controller.js
+++ b/app/controllers/stripe-setup/vat-number/get.controller.js
@@ -6,7 +6,7 @@ const paths = require('../../../paths')
 const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
 
 module.exports = (req, res, next) => {
-  const switchingToCredentials = isSwitchingCredentialsRoute(req)
+  const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
 
   if (!stripeAccountSetup) {
@@ -17,5 +17,5 @@ module.exports = (req, res, next) => {
     return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
   }
 
-  return response(req, res, 'stripe-setup/vat-number/index', { switchingToCredentials })
+  return response(req, res, 'stripe-setup/vat-number/index', { isSwitchingCredentials })
 }

--- a/app/controllers/stripe-setup/vat-number/get.controller.js
+++ b/app/controllers/stripe-setup/vat-number/get.controller.js
@@ -1,10 +1,12 @@
 'use strict'
 
 const { response } = require('../../../utils/response')
+const { isSwitchingCredentialsRoute } = require('../../../utils/credentials')
 const paths = require('../../../paths')
 const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
 
 module.exports = (req, res, next) => {
+  const switchingToCredentials = isSwitchingCredentialsRoute(req)
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
 
   if (!stripeAccountSetup) {
@@ -15,5 +17,5 @@ module.exports = (req, res, next) => {
     return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
   }
 
-  return response(req, res, 'stripe-setup/vat-number/index')
+  return response(req, res, 'stripe-setup/vat-number/index', { switchingToCredentials })
 }

--- a/app/controllers/stripe-setup/vat-number/post.controller.js
+++ b/app/controllers/stripe-setup/vat-number/post.controller.js
@@ -3,7 +3,7 @@
 const lodash = require('lodash')
 
 const { response } = require('../../../utils/response')
-const { isSwitchingCredentialsRoute, getSwitchingCredentialIfExists } = require('../../../utils/credentials')
+const { isSwitchingCredentialsRoute, getSwitchingCredential } = require('../../../utils/credentials')
 const { updateCompany } = require('../../../services/clients/stripe/stripe.client')
 const vatNumberValidations = require('./vat-number-validations')
 const { ConnectorClient } = require('../../../services/clients/connector.client')
@@ -15,7 +15,7 @@ const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
 const VAT_NUMBER_FIELD = 'vat-number'
 
 module.exports = async (req, res, next) => {
-  const switchingToCredentials = isSwitchingCredentialsRoute(req)
+  const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
 
   if (!stripeAccountSetup) {
@@ -33,7 +33,7 @@ module.exports = async (req, res, next) => {
   if (!lodash.isEmpty(errors)) {
     return response(req, res, 'stripe-setup/vat-number/index', {
       vatNumber: rawVatNumber,
-      switchingToCredentials,
+      isSwitchingCredentials,
       errors
     })
   } else {
@@ -41,10 +41,10 @@ module.exports = async (req, res, next) => {
       const stripeCompanyBody = {
         vat_id: sanitisedVatNumber
       }
-      const switchingCredential = getSwitchingCredentialIfExists(req.account)
       let stripeAccountId
 
-      if (switchingToCredentials) {
+      if (isSwitchingCredentials) {
+        const switchingCredential = getSwitchingCredential(req.account)
         stripeAccountId = switchingCredential.credentials.stripe_account_id
       } else {
         const stripeAccount = await connector.getStripeAccount(req.account.gateway_account_id, req.correlationId)
@@ -53,7 +53,7 @@ module.exports = async (req, res, next) => {
       await updateCompany(stripeAccountId, stripeCompanyBody)
       await connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'vat_number', req.correlationId)
 
-      if (switchingToCredentials) {
+      if (isSwitchingCredentials) {
         return res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
       } else {
         return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))

--- a/app/controllers/switch-psp/switch-tasks.service.js
+++ b/app/controllers/switch-psp/switch-tasks.service.js
@@ -44,6 +44,10 @@ function getTaskList (targetCredential, account) {
       'ENTER_VAT_NUMBER': {
         enabled: !stripeSetupStageComplete(account, 'vatNumber'),
         complete: stripeSetupStageComplete(account, 'vatNumber')
+      },
+      'ENTER_COMPANY_NUMBER': {
+        enabled: !stripeSetupStageComplete(account, 'companyNumber'),
+        complete: stripeSetupStageComplete(account, 'companyNumber')
       }
     }
   }

--- a/app/controllers/switch-psp/switch-tasks.service.js
+++ b/app/controllers/switch-psp/switch-tasks.service.js
@@ -40,6 +40,10 @@ function getTaskList (targetCredential, account) {
       'ENTER_RESPONSIBLE_PERSON': {
         enabled: !stripeSetupStageComplete(account, 'responsiblePerson'),
         complete: stripeSetupStageComplete(account, 'responsiblePerson')
+      },
+      'ENTER_VAT_NUMBER': {
+        enabled: !stripeSetupStageComplete(account, 'vatNumber'),
+        complete: stripeSetupStageComplete(account, 'vatNumber')
       }
     }
   }

--- a/app/controllers/switch-psp/switch-tasks.service.js
+++ b/app/controllers/switch-psp/switch-tasks.service.js
@@ -36,6 +36,10 @@ function getTaskList (targetCredential, account) {
       'ENTER_BANK_DETAILS': {
         enabled: !stripeSetupStageComplete(account, 'bankAccount'),
         complete: stripeSetupStageComplete(account, 'bankAccount')
+      },
+      'ENTER_RESPONSIBLE_PERSON': {
+        enabled: !stripeSetupStageComplete(account, 'responsiblePerson'),
+        complete: stripeSetupStageComplete(account, 'responsiblePerson')
       }
     }
   }

--- a/app/controllers/switch-psp/switch-tasks.service.js
+++ b/app/controllers/switch-psp/switch-tasks.service.js
@@ -12,6 +12,13 @@ function verifyPSPIntegrationComplete (targetCredential) {
     .includes(targetCredential.state)
 }
 
+function stripeSetupStageComplete(account, stage) {
+  if (account.connectorGatewayAccountStripeProgress) {
+    return account.connectorGatewayAccountStripeProgress[stage]
+  }
+  return false
+}
+
 function getTaskList (targetCredential, account) {
   if (targetCredential.payment_provider === 'worldpay') {
     return {
@@ -22,6 +29,13 @@ function getTaskList (targetCredential, account) {
       'VERIFY_PSP_INTEGRATION': {
         enabled: linkCredentialsComplete(targetCredential),
         complete: verifyPSPIntegrationComplete(targetCredential)
+      }
+    }
+  } else if (targetCredential.payment_provider === 'stripe') {
+    return {
+      'ENTER_BANK_DETAILS': {
+        enabled: !stripeSetupStageComplete(account, 'bankAccount'),
+        complete: stripeSetupStageComplete(account, 'bankAccount')
       }
     }
   }

--- a/app/controllers/switch-psp/switch-tasks.service.js
+++ b/app/controllers/switch-psp/switch-tasks.service.js
@@ -48,6 +48,13 @@ function getTaskList (targetCredential, account) {
       'ENTER_COMPANY_NUMBER': {
         enabled: !stripeSetupStageComplete(account, 'companyNumber'),
         complete: stripeSetupStageComplete(account, 'companyNumber')
+      },
+      'VERIFY_PSP_INTEGRATION': {
+        enabled: stripeSetupStageComplete(account, 'bankAccount') &&
+          stripeSetupStageComplete(account, 'responsiblePerson') &&
+          stripeSetupStageComplete(account, 'vatNumber') &&
+          stripeSetupStageComplete(account, 'companyNumber'),
+        complete: verifyPSPIntegrationComplete(targetCredential)
       }
     }
   }

--- a/app/middleware/stripe-setup/restrict-to-live-stripe-account.js
+++ b/app/middleware/stripe-setup/restrict-to-live-stripe-account.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { getSwitchingCredentialIfExists } = require('../../utils/credentials')
 const { NotFoundError } = require('../../../app/errors')
 
 module.exports = function restrictRequestsToLiveAccounts (req, res, next) {
@@ -8,8 +9,10 @@ module.exports = function restrictRequestsToLiveAccounts (req, res, next) {
     req.account.payment_provider &&
     req.account.type.toLowerCase() === 'live' &&
     req.account.payment_provider.toLowerCase() === 'stripe'
+  const switchingCredential = getSwitchingCredentialIfExists(req.account)
+  const requestIsSwitchingToStripeAccount = switchingCredential && switchingCredential.payment_provider === 'stripe'
 
-  if (requestHasValidLiveStripeAccount) {
+  if (requestHasValidLiveStripeAccount || requestIsSwitchingToStripeAccount) {
     next()
   } else {
     // we display 404 error, because from user point of view this page should not exist

--- a/app/middleware/stripe-setup/restrict-to-stripe-account-context.js
+++ b/app/middleware/stripe-setup/restrict-to-stripe-account-context.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { getSwitchingCredentialIfExists } = require('../../utils/credentials')
-const { NotFoundError } = require('../../../app/errors')
+const { NotFoundError } = require('../../errors')
 
 module.exports = function restrictRequestsToLiveAccounts (req, res, next) {
   const requestHasValidLiveStripeAccount = req.account &&

--- a/app/middleware/stripe-setup/restrict-to-stripe-account-context.test.js
+++ b/app/middleware/stripe-setup/restrict-to-stripe-account-context.test.js
@@ -3,7 +3,7 @@
 const sinon = require('sinon')
 const { expect } = require('chai')
 
-const restrictToLiveStripeAccount = require('./restrict-to-live-stripe-account')
+const restrictToStripeAccountContext = require('./restrict-to-stripe-account-context')
 const { NotFoundError } = require('../../errors')
 
 describe('Restrict to live stripe account middleware', () => {
@@ -27,7 +27,7 @@ describe('Restrict to live stripe account middleware', () => {
       }
     }
 
-    restrictToLiveStripeAccount(req, res, next)
+    restrictToStripeAccountContext(req, res, next)
 
     expect(next.calledOnce).to.be.true // eslint-disable-line
     expect(res.status.notCalled).to.be.true // eslint-disable-line
@@ -37,7 +37,7 @@ describe('Restrict to live stripe account middleware', () => {
   it('should throw NotFoundError when the gateway account is not in the request', () => {
     const req = {}
 
-    restrictToLiveStripeAccount(req, res, next)
+    restrictToStripeAccountContext(req, res, next)
 
     const expectedError = sinon.match.instanceOf(NotFoundError)
     sinon.assert.calledWith(next, expectedError)
@@ -51,7 +51,7 @@ describe('Restrict to live stripe account middleware', () => {
       }
     }
 
-    restrictToLiveStripeAccount(req, res, next)
+    restrictToStripeAccountContext(req, res, next)
 
     const expectedError = sinon.match.instanceOf(NotFoundError)
     sinon.assert.calledWith(next, expectedError)
@@ -65,7 +65,7 @@ describe('Restrict to live stripe account middleware', () => {
       }
     }
 
-    restrictToLiveStripeAccount(req, res, next)
+    restrictToStripeAccountContext(req, res, next)
 
     const expectedError = sinon.match.instanceOf(NotFoundError)
     sinon.assert.calledWith(next, expectedError)

--- a/app/paths.js
+++ b/app/paths.js
@@ -94,17 +94,17 @@ module.exports = {
     stripe: {
       addPspAccountDetails: '/stripe/add-psp-account-details'
     },
-    stripeSetup: {
-      bankDetails: '/bank-details',
-      responsiblePerson: '/responsible-person',
-      vatNumber: '/vat-number',
-      companyNumber: '/company-number'
-    },
     switchPSP: {
       index: '/switch-psp',
       credentialsWithGatewayCheck: '/switch-psp/:credentialId/credentials-with-gateway-check',
       verifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration',
-      receiveVerifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration/callback'
+      receiveVerifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration/callback',
+      stripeSetup: {
+        bankDetails: '/switch-psp/:credentialId/bank-details',
+        responsiblePerson: '/switch-psp/:credentialId/responsible-person',
+        vatNumber: '/switch-psp/:credentialId/vat-number',
+        companyNumber: '/switch-psp/:credentialId/company-number'
+      }
     },
     toggle3ds: {
       index: '/3ds'
@@ -126,7 +126,13 @@ module.exports = {
       index: '/your-psp/:credentialId',
       flex: '/your-psp/:credentialId/flex',
       worldpay3dsFlex: '/your-psp/:credentialId/worldpay-3ds-flex',
-      credentialsWithGatewayCheck: '/your-psp/:credentialId/credentials-with-gateway-check'
+      credentialsWithGatewayCheck: '/your-psp/:credentialId/credentials-with-gateway-check',
+      stripeSetup: {
+        bankDetails: '/your-psp/:credentialId/bank-details',
+        responsiblePerson: '/your-psp/:credentialId/responsible-person',
+        vatNumber: '/your-psp/:credentialId/vat-number',
+        companyNumber: '/your-psp/:credentialId/company-number'
+      }
     }
   },
   service: {

--- a/app/routes.js
+++ b/app/routes.js
@@ -104,7 +104,6 @@ const {
   prototyping,
   settings,
   stripe,
-  stripeSetup,
   toggle3ds,
   toggleBillingAddress,
   toggleMotoMaskCardNumberAndSecurityCode,
@@ -414,14 +413,14 @@ module.exports.bind = function (app) {
   account.post(paymentLinks.manage.deleteMetadata, permission('tokens:create'), paymentLinksController.postUpdateReportingColumn.deleteMetadata)
 
   // Stripe setup
-  account.get(stripeSetup.bankDetails, permission('stripe-bank-details:update'), restrictToLiveStripeAccount, stripeSetupBankDetailsController.get)
-  account.post(stripeSetup.bankDetails, permission('stripe-bank-details:update'), restrictToLiveStripeAccount, stripeSetupBankDetailsController.post)
-  account.get(stripeSetup.responsiblePerson, permission('stripe-responsible-person:update'), restrictToLiveStripeAccount, stripeSetupResponsiblePersonController.get)
-  account.post(stripeSetup.responsiblePerson, permission('stripe-responsible-person:update'), restrictToLiveStripeAccount, stripeSetupResponsiblePersonController.post)
-  account.get(stripeSetup.vatNumber, permission('stripe-vat-number-company-number:update'), restrictToLiveStripeAccount, stripeSetupVatNumberController.get)
-  account.post(stripeSetup.vatNumber, permission('stripe-vat-number-company-number:update'), restrictToLiveStripeAccount, stripeSetupVatNumberController.post)
-  account.get(stripeSetup.companyNumber, permission('stripe-vat-number-company-number:update'), restrictToLiveStripeAccount, stripeSetupCompanyNumberController.get)
-  account.post(stripeSetup.companyNumber, permission('stripe-vat-number-company-number:update'), restrictToLiveStripeAccount, stripeSetupCompanyNumberController.post)
+  account.get([ yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails ], permission('stripe-bank-details:update'), restrictToLiveStripeAccount, stripeSetupBankDetailsController.get)
+  account.post([ yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails ], permission('stripe-bank-details:update'), restrictToLiveStripeAccount, stripeSetupBankDetailsController.post)
+  account.get([ yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson ], permission('stripe-responsible-person:update'), restrictToLiveStripeAccount, stripeSetupResponsiblePersonController.get)
+  account.post([ yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson ], permission('stripe-responsible-person:update'), restrictToLiveStripeAccount, stripeSetupResponsiblePersonController.post)
+  account.get([ yourPsp.stripeSetup.vatNumber, switchPSP.stripeSetup.vatNumber ], permission('stripe-vat-number-company-number:update'), restrictToLiveStripeAccount, stripeSetupVatNumberController.get)
+  account.post([ yourPsp.stripeSetup.vatNumber, switchPSP.stripeSetup.vatNumber ], permission('stripe-vat-number-company-number:update'), restrictToLiveStripeAccount, stripeSetupVatNumberController.post)
+  account.get([ yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber ], permission('stripe-vat-number-company-number:update'), restrictToLiveStripeAccount, stripeSetupCompanyNumberController.get)
+  account.post([ yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber ], permission('stripe-vat-number-company-number:update'), restrictToLiveStripeAccount, stripeSetupCompanyNumberController.post)
   account.get(stripe.addPspAccountDetails, permission('stripe-account-details:update'), restrictToLiveStripeAccount, stripeSetupAddPspAccountDetailsController.get)
 
   app.use(paths.account.root, account)

--- a/app/routes.js
+++ b/app/routes.js
@@ -19,7 +19,7 @@ const permission = require('./middleware/permission')
 const correlationIdMiddleware = require('./middleware/correlation-id')
 const getRequestContext = require('./middleware/get-request-context').middleware
 const restrictToSandboxOrStripeTestAccount = require('./middleware/restrict-to-sandbox-or-stripe-test-account')
-const restrictToLiveStripeAccount = require('./middleware/stripe-setup/restrict-to-live-stripe-account')
+const restrictToStripeAccountContext = require('./middleware/stripe-setup/restrict-to-stripe-account-context')
 const restrictToSwitchingAccount = require('./middleware/restrict-to-switching-account')
 
 // Controllers
@@ -413,15 +413,15 @@ module.exports.bind = function (app) {
   account.post(paymentLinks.manage.deleteMetadata, permission('tokens:create'), paymentLinksController.postUpdateReportingColumn.deleteMetadata)
 
   // Stripe setup
-  account.get([ yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails ], permission('stripe-bank-details:update'), restrictToLiveStripeAccount, stripeSetupBankDetailsController.get)
-  account.post([ yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails ], permission('stripe-bank-details:update'), restrictToLiveStripeAccount, stripeSetupBankDetailsController.post)
-  account.get([ yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson ], permission('stripe-responsible-person:update'), restrictToLiveStripeAccount, stripeSetupResponsiblePersonController.get)
-  account.post([ yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson ], permission('stripe-responsible-person:update'), restrictToLiveStripeAccount, stripeSetupResponsiblePersonController.post)
-  account.get([ yourPsp.stripeSetup.vatNumber, switchPSP.stripeSetup.vatNumber ], permission('stripe-vat-number-company-number:update'), restrictToLiveStripeAccount, stripeSetupVatNumberController.get)
-  account.post([ yourPsp.stripeSetup.vatNumber, switchPSP.stripeSetup.vatNumber ], permission('stripe-vat-number-company-number:update'), restrictToLiveStripeAccount, stripeSetupVatNumberController.post)
-  account.get([ yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber ], permission('stripe-vat-number-company-number:update'), restrictToLiveStripeAccount, stripeSetupCompanyNumberController.get)
-  account.post([ yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber ], permission('stripe-vat-number-company-number:update'), restrictToLiveStripeAccount, stripeSetupCompanyNumberController.post)
-  account.get(stripe.addPspAccountDetails, permission('stripe-account-details:update'), restrictToLiveStripeAccount, stripeSetupAddPspAccountDetailsController.get)
+  account.get([ yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails ], permission('stripe-bank-details:update'), restrictToStripeAccountContext, stripeSetupBankDetailsController.get)
+  account.post([ yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails ], permission('stripe-bank-details:update'), restrictToStripeAccountContext, stripeSetupBankDetailsController.post)
+  account.get([ yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson ], permission('stripe-responsible-person:update'), restrictToStripeAccountContext, stripeSetupResponsiblePersonController.get)
+  account.post([ yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson ], permission('stripe-responsible-person:update'), restrictToStripeAccountContext, stripeSetupResponsiblePersonController.post)
+  account.get([ yourPsp.stripeSetup.vatNumber, switchPSP.stripeSetup.vatNumber ], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupVatNumberController.get)
+  account.post([ yourPsp.stripeSetup.vatNumber, switchPSP.stripeSetup.vatNumber ], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupVatNumberController.post)
+  account.get([ yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber ], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.get)
+  account.post([ yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber ], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.post)
+  account.get(stripe.addPspAccountDetails, permission('stripe-account-details:update'), restrictToStripeAccountContext, stripeSetupAddPspAccountDetailsController.get)
 
   app.use(paths.account.root, account)
   app.use(paths.service.root, service)

--- a/app/utils/credentials.js
+++ b/app/utils/credentials.js
@@ -47,7 +47,7 @@ function getSwitchingCredentialIfExists (gatewayAccount) {
 }
 
 function isSwitchingCredentialsRoute (req) {
-  return Object.values(paths.account.switchPSP).includes(req.route && req.route.path) || req.url.startsWith('/switch-psp/')
+  return Object.values(paths.account.switchPSP).includes(req.route && req.route.path) || Boolean(req.url && req.url.startsWith('/switch-psp/'))
 }
 
 function getPSPPageLinks (gatewayAccount) {

--- a/app/utils/credentials.js
+++ b/app/utils/credentials.js
@@ -47,7 +47,7 @@ function getSwitchingCredentialIfExists (gatewayAccount) {
 }
 
 function isSwitchingCredentialsRoute (req) {
-  return Object.values(paths.account.switchPSP).includes(req.route && req.route.path)
+  return Object.values(paths.account.switchPSP).includes(req.route && req.route.path) || req.url.startsWith('/switch-psp/')
 }
 
 function getPSPPageLinks (gatewayAccount) {

--- a/app/views/credentials/worldpay.njk
+++ b/app/views/credentials/worldpay.njk
@@ -11,7 +11,7 @@
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
     {# back link should always go before <main> content so it can be skipped, settings page layouts should be adjusted to suport this #}
-    {% if switchingToCredentials %}
+    {% if isSwitchingCredentials %}
       {{ govukBackLink({
         text: "Back to Switching payment service provider (PSP)",
         classes: "govuk-!-margin-top-0",

--- a/app/views/dashboard/_stripe-account-setup-banner.njk
+++ b/app/views/dashboard/_stripe-account-setup-banner.njk
@@ -11,7 +11,7 @@
     {% endif %}
   {% endset %}
 
-  {% if connectorGatewayAccountStripeProgress and (not isConnectorStripeJourneyComplete) %}
+  {% if connectorGatewayAccountStripeProgress and gatewayAccount.payment_provider === 'stripe' and (not isConnectorStripeJourneyComplete) %}
     <div class="account-status-panel {{panelModifierClass}} govuk-grid-row govuk-!-margin-bottom-5">
       <div class="govuk-grid-column-two-thirds">
         {% if isStripeAccountRestricted %}

--- a/app/views/stripe-setup/bank-details/index.njk
+++ b/app/views/stripe-setup/bank-details/index.njk
@@ -4,7 +4,21 @@
   What are your bank details? - {{ currentService.name }} - GOV.UK Pay
 {% endblock %}
 
+{% block side_navigation %}
+  {% if switchingToCredentials %}
+    {% include "includes/side-navigation.njk" %}
+  {% endif %}
+{% endblock %}
+
 {% block mainContent %}
+
+  {% if switchingToCredentials %}
+    {{ govukBackLink({
+      text: "Back to Switching payment service provider (PSP)",
+      classes: "govuk-!-margin-top-0",
+      href: formatAccountPathsFor(routes.account.switchPSP.index, currentGatewayAccount.external_id)
+    }) }}
+  {% endif %}
   <div class="govuk-grid-column-two-thirds">
     {% if errors | length %}
       {% set errorList = [] %}

--- a/app/views/stripe-setup/bank-details/index.njk
+++ b/app/views/stripe-setup/bank-details/index.njk
@@ -5,14 +5,14 @@
 {% endblock %}
 
 {% block side_navigation %}
-  {% if switchingToCredentials %}
+  {% if isSwitchingCredentials %}
     {% include "includes/side-navigation.njk" %}
   {% endif %}
 {% endblock %}
 
 {% block mainContent %}
 
-  {% if switchingToCredentials %}
+  {% if isSwitchingCredentials %}
     {{ govukBackLink({
       text: "Back to Switching payment service provider (PSP)",
       classes: "govuk-!-margin-top-0",

--- a/app/views/stripe-setup/company-number/index.njk
+++ b/app/views/stripe-setup/company-number/index.njk
@@ -4,7 +4,22 @@
   What is your organisation’s Company registration number? - {{ currentService.name }} - GOV.UK Pay
 {% endblock %}
 
+{% block side_navigation %}
+  {% if switchingToCredentials %}
+    {% include "includes/side-navigation.njk" %}
+  {% endif %}
+{% endblock %}
+
 {% block mainContent %}
+
+  {% if switchingToCredentials %}
+    {{ govukBackLink({
+      text: "Back to Switching payment service provider (PSP)",
+      classes: "govuk-!-margin-top-0",
+      href: formatAccountPathsFor(routes.account.switchPSP.index, currentGatewayAccount.external_id)
+    }) }}
+  {% endif %}
+
   <div class="govuk-grid-column-two-thirds">
     {% if errors | length %}
       {% set errorList = [] %}

--- a/app/views/stripe-setup/company-number/index.njk
+++ b/app/views/stripe-setup/company-number/index.njk
@@ -5,14 +5,14 @@
 {% endblock %}
 
 {% block side_navigation %}
-  {% if switchingToCredentials %}
+  {% if isSwitchingCredentials %}
     {% include "includes/side-navigation.njk" %}
   {% endif %}
 {% endblock %}
 
 {% block mainContent %}
 
-  {% if switchingToCredentials %}
+  {% if isSwitchingCredentials %}
     {{ govukBackLink({
       text: "Back to Switching payment service provider (PSP)",
       classes: "govuk-!-margin-top-0",

--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -5,14 +5,14 @@
 {% endblock %}
 
 {% block side_navigation %}
-  {% if switchingToCredentials %}
+  {% if isSwitchingCredentials %}
     {% include "includes/side-navigation.njk" %}
   {% endif %}
 {% endblock %}
 
 {% block mainContent %}
 
-  {% if switchingToCredentials %}
+  {% if isSwitchingCredentials %}
     {{ govukBackLink({
       text: "Back to Switching payment service provider (PSP)",
       classes: "govuk-!-margin-top-0",

--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -4,7 +4,22 @@
   Who is your responsible person? - {{ currentService.name }} - GOV.UK Pay
 {% endblock %}
 
+{% block side_navigation %}
+  {% if switchingToCredentials %}
+    {% include "includes/side-navigation.njk" %}
+  {% endif %}
+{% endblock %}
+
 {% block mainContent %}
+
+  {% if switchingToCredentials %}
+    {{ govukBackLink({
+      text: "Back to Switching payment service provider (PSP)",
+      classes: "govuk-!-margin-top-0",
+      href: formatAccountPathsFor(routes.account.switchPSP.index, currentGatewayAccount.external_id)
+    }) }}
+  {% endif %}
+
   <div class="govuk-grid-column-two-thirds">
     {% if errors %}
       {% set errorList = [] %}

--- a/app/views/stripe-setup/vat-number/index.njk
+++ b/app/views/stripe-setup/vat-number/index.njk
@@ -4,7 +4,22 @@
   What is your organisation’s VAT number? - {{ currentService.name }} - GOV.UK Pay
 {% endblock %}
 
+{% block side_navigation %}
+  {% if switchingToCredentials %}
+    {% include "includes/side-navigation.njk" %}
+  {% endif %}
+{% endblock %}
+
 {% block mainContent %}
+
+  {% if switchingToCredentials %}
+    {{ govukBackLink({
+      text: "Back to Switching payment service provider (PSP)",
+      classes: "govuk-!-margin-top-0",
+      href: formatAccountPathsFor(routes.account.switchPSP.index, currentGatewayAccount.external_id)
+    }) }}
+  {% endif %}
+
   <div class="govuk-grid-column-two-thirds">
     {% if errors | length %}
       {% set errorList = [] %}

--- a/app/views/stripe-setup/vat-number/index.njk
+++ b/app/views/stripe-setup/vat-number/index.njk
@@ -5,14 +5,14 @@
 {% endblock %}
 
 {% block side_navigation %}
-  {% if switchingToCredentials %}
+  {% if isSwitchingCredentials %}
     {% include "includes/side-navigation.njk" %}
   {% endif %}
 {% endblock %}
 
 {% block mainContent %}
 
-  {% if switchingToCredentials %}
+  {% if isSwitchingCredentials %}
     {{ govukBackLink({
       text: "Back to Switching payment service provider (PSP)",
       classes: "govuk-!-margin-top-0",

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -97,6 +97,11 @@
           formatAccountPathsFor(routes.account.switchPSP.stripeSetup.vatNumber, currentGatewayAccount.external_id, targetCredential.external_id),
           taskList.ENTER_VAT_NUMBER
         ) }}
+        {{ taskListItem(
+          "Provide your company registration number",
+          formatAccountPathsFor(routes.account.switchPSP.stripeSetup.companyNumber, currentGatewayAccount.external_id, targetCredential.external_id),
+          taskList.ENTER_COMPANY_NUMBER
+        ) }}
       {% endset %}
   {% endswitch %}
 

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -46,7 +46,7 @@
       type: 'success'
     }) }}
   {% endif %}
-  
+
   <h1 class="govuk-heading-l page-title">Switch payment service provider (PSP)</h1>
 
   <p class="govuk-body">This service is taking payments with {{ currentGatewayAccount.payment_provider | formatPSPname }}.</p>
@@ -103,7 +103,7 @@
           taskList.ENTER_COMPANY_NUMBER
         ) }}
         {{ taskListItem(
-          "Make a live payment to test your Worldpay PSP",
+          "Make a live payment to test your Stripe PSP",
           formatAccountPathsFor(routes.account.switchPSP.verifyPSPIntegrationPayment, currentGatewayAccount.external_id),
           taskList.VERIFY_PSP_INTEGRATION
         ) }}

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -102,6 +102,11 @@
           formatAccountPathsFor(routes.account.switchPSP.stripeSetup.companyNumber, currentGatewayAccount.external_id, targetCredential.external_id),
           taskList.ENTER_COMPANY_NUMBER
         ) }}
+        {{ taskListItem(
+          "Make a live payment to test your Worldpay PSP",
+          formatAccountPathsFor(routes.account.switchPSP.verifyPSPIntegrationPayment, currentGatewayAccount.external_id),
+          taskList.VERIFY_PSP_INTEGRATION
+        ) }}
       {% endset %}
   {% endswitch %}
 

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -21,9 +21,9 @@
       {% endif %}
     </span>
 
-    {% if not item.enabled %}
+    {% if not item.enabled and not item.complete %}
     <strong class="govuk-tag app-task-list__tag govuk-tag--grey" id="{{ label }}-status">cannot start yet</strong>
-    {% elif not item.complete %}
+    {% elif item.enabled and not item.complete %}
     <strong class="govuk-tag app-task-list__tag govuk-tag--grey" id="{{ label }}-status">not started</strong>
     {% elif item.complete %}
     <strong class="govuk-tag app-task-list__tag" id="{{ label }}-status">completed</strong>
@@ -70,6 +70,22 @@
           "Make a live payment to test your Worldpay PSP",
           formatAccountPathsFor(routes.account.switchPSP.verifyPSPIntegrationPayment, currentGatewayAccount.external_id),
           taskList.VERIFY_PSP_INTEGRATION
+        ) }}
+      {% endset %}
+    {% case 'stripe' %}
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the name, date of birth and home address of the person in your organisation legally reponsible for payments (called your ‘<a href="https://www.payments.service.gov.uk/what-being-a-responsible-person-means/" class="govuk-link">responsible person</a>’)</li>
+        <li>your bank details</li>
+        <li>your VAT number</li>
+        <li>your company registration number if you’ve registered your company</li>
+        <li>a debit or credit card to make a nominal live payment (refundable)</li>
+      </ul>
+
+      {% set tasks %}
+        {{ taskListItem(
+          "Provide your bank details",
+          formatAccountPathsFor(routes.account.switchPSP.stripeSetup.bankDetails, currentGatewayAccount.external_id, targetCredential.external_id),
+          taskList.ENTER_BANK_DETAILS
         ) }}
       {% endset %}
   {% endswitch %}

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -87,6 +87,11 @@
           formatAccountPathsFor(routes.account.switchPSP.stripeSetup.bankDetails, currentGatewayAccount.external_id, targetCredential.external_id),
           taskList.ENTER_BANK_DETAILS
         ) }}
+        {{ taskListItem(
+          "Provide details about your repsonsible person",
+          formatAccountPathsFor(routes.account.switchPSP.stripeSetup.responsiblePerson, currentGatewayAccount.external_id, targetCredential.external_id),
+          taskList.ENTER_RESPONSIBLE_PERSON
+        ) }}
       {% endset %}
   {% endswitch %}
 

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -92,6 +92,11 @@
           formatAccountPathsFor(routes.account.switchPSP.stripeSetup.responsiblePerson, currentGatewayAccount.external_id, targetCredential.external_id),
           taskList.ENTER_RESPONSIBLE_PERSON
         ) }}
+        {{ taskListItem(
+          "Provide your organisation's VAT number",
+          formatAccountPathsFor(routes.account.switchPSP.stripeSetup.vatNumber, currentGatewayAccount.external_id, targetCredential.external_id),
+          taskList.ENTER_VAT_NUMBER
+        ) }}
       {% endset %}
   {% endswitch %}
 

--- a/test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.test.js
+++ b/test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.test.js
@@ -10,12 +10,16 @@ describe('The Stripe psp details banner', () => {
   const gatewayAccountId = '22'
   const gatewayAccountExternalId = 'a-valid-external-id'
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+
+  const gatewayAccountCredentials = [{
+    payment_provider: 'stripe'
+  }]
   beforeEach(() => {
     cy.setEncryptedCookies(userExternalId)
     cy.task('setupStubs', [
       userStubs.getUserSuccess({ userExternalId, gatewayAccountId, gatewayAccountExternalId }),
-      gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId, type: 'live', paymentProvider: 'stripe' }),
-      gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'live', paymentProvider: 'stripe' }),
+      gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId, type: 'live', paymentProvider: 'stripe', gatewayAccountCredentials }),
+      gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'live', paymentProvider: 'stripe', gatewayAccountCredentials }),
       transactionsSummaryStubs.getDashboardStatistics(),
       stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
         gatewayAccountId,

--- a/test/cypress/integration/stripe-setup/bank-details.cy.test.js
+++ b/test/cypress/integration/stripe-setup/bank-details.cy.test.js
@@ -8,10 +8,11 @@ const stripeAccountStubs = require('../../stubs/stripe-account-stubs')
 
 const gatewayAccountId = '42'
 const gatewayAccountExternalId = 'a-valid-external-id'
+const gatewayAccountCredentialExternalId = 'a-valid-credential-external-id'
 const userExternalId = 'userExternalId'
 const accountNumber = '00012345'
 const sortCode = '108800'
-const bankDetailsUrl = `/account/${gatewayAccountExternalId}/bank-details`
+const bankDetailsUrl = `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}/bank-details`
 const dashboardUrl = `/account/${gatewayAccountExternalId}/dashboard`
 
 function setupStubs (bankAccount, type = 'live', paymentProvider = 'stripe') {
@@ -26,9 +27,15 @@ function setupStubs (bankAccount, type = 'live', paymentProvider = 'stripe') {
     stripeSetupStub = stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, bankAccount })
   }
 
+  const gatewayAccountCredentials = [{
+    gateway_account_id: gatewayAccountId,
+    payment_provider: paymentProvider,
+    external_id: gatewayAccountCredentialExternalId
+  }]
+
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),
-    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type, paymentProvider }),
+    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type, paymentProvider, gatewayAccountCredentials }),
     stripeSetupStub,
     stripeAccountStubs.getStripeAccountSuccess(gatewayAccountId, 'acct_123example123'),
     transactionSummaryStubs.getDashboardStatistics()

--- a/test/cypress/integration/stripe-setup/company-number.cy.test.js
+++ b/test/cypress/integration/stripe-setup/company-number.cy.test.js
@@ -9,7 +9,8 @@ const stripeAccountStubs = require('../../stubs/stripe-account-stubs')
 const gatewayAccountId = 42
 const userExternalId = 'userExternalId'
 const gatewayAccountExternalId = 'a-valid-external-id'
-const companyNumberUrl = `/account/${gatewayAccountExternalId}/company-number`
+const gatewayAccountCredentialExternalId = 'a-valid-credential-external-id'
+const companyNumberUrl = `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}/company-number`
 const dashboardUrl = `/account/${gatewayAccountExternalId}/dashboard`
 
 function setupStubs (companyNumber, type = 'live', paymentProvider = 'stripe') {
@@ -24,9 +25,17 @@ function setupStubs (companyNumber, type = 'live', paymentProvider = 'stripe') {
     stripeSetupStub = stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, companyNumber })
   }
 
+  const gatewayAccountCredentials = [{
+    gateway_account_id: gatewayAccountId,
+    payment_provider: paymentProvider,
+    external_id: gatewayAccountCredentialExternalId
+  }]
+
+
+
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),
-    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId: gatewayAccountExternalId, type, paymentProvider }),
+    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId: gatewayAccountExternalId, type, paymentProvider, gatewayAccountCredentials }),
     stripeSetupStub,
     stripeAccountStubs.getStripeAccountSuccess(gatewayAccountId, 'acct_123example123'),
     transactionSummaryStubs.getDashboardStatistics()

--- a/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
@@ -9,7 +9,8 @@ const stripeAccountStubs = require('../../stubs/stripe-account-stubs')
 const gatewayAccountId = 42
 const userExternalId = 'userExternalId'
 const gatewayAccountExternalId = 'a-valid-external-id'
-const responsiblePersonUrl = `/account/${gatewayAccountExternalId}/responsible-person`
+const gatewayAccountCredentialExternalId = 'a-valid-credential-external-id'
+const responsiblePersonUrl = `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}/responsible-person`
 const dashboardUrl = `/account/${gatewayAccountExternalId}/dashboard`
 
 const firstName = 'William'
@@ -37,9 +38,16 @@ function setupStubs (responsiblePerson, type = 'live', paymentProvider = 'stripe
     stripeSetupStub = stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, responsiblePerson })
   }
 
+  const gatewayAccountCredentials = [{
+    gateway_account_id: gatewayAccountId,
+    payment_provider: paymentProvider,
+    external_id: gatewayAccountCredentialExternalId
+  }]
+
+
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),
-    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId: gatewayAccountExternalId, type, paymentProvider }),
+    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId: gatewayAccountExternalId, type, paymentProvider, gatewayAccountCredentials }),
     stripeSetupStub,
     stripeAccountStubs.getStripeAccountSuccess(gatewayAccountId, 'acct_123example123'),
     transactionSummaryStubs.getDashboardStatistics()

--- a/test/cypress/integration/stripe-setup/vat-number.cy.test.js
+++ b/test/cypress/integration/stripe-setup/vat-number.cy.test.js
@@ -9,7 +9,8 @@ const stripeAccountStubs = require('../../stubs/stripe-account-stubs')
 const gatewayAccountId = '42'
 const userExternalId = 'userExternalId'
 const gatewayAccountExternalId = 'a-valid-external-id'
-const vatNumberUrl = `/account/${gatewayAccountExternalId}/vat-number`
+const gatewayAccountCredentialExternalId = 'a-valid-credential-external-id'
+const vatNumberUrl = `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}/vat-number`
 const dashboardUrl = `/account/${gatewayAccountExternalId}/dashboard`
 
 function setupStubs (vatNumber, type = 'live', paymentProvider = 'stripe') {
@@ -24,9 +25,15 @@ function setupStubs (vatNumber, type = 'live', paymentProvider = 'stripe') {
     stripeSetupStub = stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, vatNumber })
   }
 
+  const gatewayAccountCredentials = [{
+    gateway_account_id: gatewayAccountId,
+    payment_provider: paymentProvider,
+    external_id: gatewayAccountCredentialExternalId
+  }]
+
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),
-    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId: gatewayAccountExternalId, type, paymentProvider }),
+    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId: gatewayAccountExternalId, type, paymentProvider, gatewayAccountCredentials }),
     stripeSetupStub,
     stripeAccountStubs.getStripeAccountSuccess(gatewayAccountId, 'acct_123example123'),
     transactionSummaryStubs.getDashboardStatistics()

--- a/test/integration/add-psp-details.ft.test.js
+++ b/test/integration/add-psp-details.ft.test.js
@@ -35,7 +35,11 @@ describe('Add stripe psp details route', function () {
           gateway_account_id: GATEWAY_ACCOUNT_ID,
           external_id: GATEWAY_ACCOUNT_EXTERNAL_ID,
           payment_provider: 'stripe',
-          type: 'live'
+          type: 'live',
+          gateway_account_credentials: [{
+            external_id: 'valid-credentials-id',
+            payment_provider: 'stripe'
+          }]
         }))
 
       connectorMock


### PR DESCRIPTION
Namespace Stripe account info pages by credential ID. Update pages to work contextually in the go live and switching PSP flows.
- add support for Stripe steps in the PSP switching page
- add stripe specific content for switching page
- updates task list item to support showing `completed` for items that
shouldn't be retry-able (disabled but completed items)
- add all stripe steps and update tests to work with new structure

<img width="611" alt="Screenshot 2021-07-13 at 10 05 41" src="https://user-images.githubusercontent.com/2844572/125424624-c1ca9510-2903-452f-b75d-01f5214b5477.png">

<img width="607" alt="Screenshot 2021-07-13 at 10 06 01" src="https://user-images.githubusercontent.com/2844572/125424642-5ab565d4-4686-499c-94b2-fdfd6d074f5e.png">

