### PR TITLE
PP-8210 - Update post-create-charge pact test to include payment_provider

### DIFF
--- a/test/unit/clients/connector-client/connector-post-create-charge.pact.test.js
+++ b/test/unit/clients/connector-client/connector-post-create-charge.pact.test.js
@@ -39,6 +39,7 @@ describe('connector client', function () {
     describe('success', () => {
       const validPostCreateChargeRequest = chargeFixture.validPostChargeRequestRequest({
         amount: 100,
+        payment_provider: 'stripe',
         return_url: 'https://somewhere.gov.uk/rainbow/1'
       })
 


### PR DESCRIPTION
Description:
- Previously no payment_provider was provided which didn't allow us to test the happy path
- PR adds the payment_provider field allowing us to test the happy path to Connector