### PR TITLE
PP-8095 Add security.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,6 @@ We use [Architecture Decision Records](http://thinkrelevance.com/blog/2011/11/15
 
 [MIT License](LICENSE)
 
-## Responsible Disclosure
+## Vulnerability Disclosure
 
-GOV.UK Pay aims to stay secure for everyone. If you are a security researcher and have discovered a security vulnerability in this code, we appreciate your help in disclosing it to us in a responsible manner. We will give appropriate credit to those reporting confirmed issues. Please e-mail gds-team-pay-security@digital.cabinet-office.gov.uk with details of any issue you find, we aim to reply quickly.
+GOV.UK Pay aims to stay secure for everyone. If you are a security researcher and have discovered a security vulnerability in this code, we appreciate your help in disclosing it to us in a responsible manner. Please refer to our [vulnerability disclosure policy](https://www.gov.uk/help/report-vulnerability) and our [security.txt](https://vdp.cabinetoffice.gov.uk/.well-known/security.txt) file for details.

--- a/app/routes.js
+++ b/app/routes.js
@@ -426,6 +426,11 @@ module.exports.bind = function (app) {
   app.use(paths.account.root, account)
   app.use(paths.service.root, service)
 
+  // security.txt — https://gds-way.cloudapps.digital/standards/vulnerability-disclosure.html
+  const securitytxt = 'https://vdp.cabinetoffice.gov.uk/.well-known/security.txt'
+  app.get('/.well-known/security.txt', (req, res) => res.redirect(securitytxt))
+  app.get('/security.txt', (req, res) => res.redirect(securitytxt))
+
   app.all('*', (req, res, next) => {
     if (accountUrls.isLegacyAccountsUrl(req.url)) {
       if (!req.user) {

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -8,6 +8,8 @@ const userIsAuthorised = require('../../app/middleware/user-is-authorised')
 
 const pathsNotRequiringAuthentication = [
   '/style-guide',
+  '/.well-known/security.txt',
+  '/security.txt',
   paths.user.logIn,
   paths.user.otpLogIn,
   paths.user.otpSendAgain,


### PR DESCRIPTION
Make `/.well-known/security.txt` and `/security.txt` redirect to https://vdp.cabinetoffice.gov.uk/.well-known/security.txt.

Update `README.md` to reference the Cabinet Office CDIO Cyber Security vulnerability disclosure policy and security.txt file rather than the GOV.UK Pay security vulnerability email address.