### PR TITLE
PP-8296 Improve view payment links page for view-only users

### DIFF
--- a/app/controllers/switch-psp/switch-tasks.service.js
+++ b/app/controllers/switch-psp/switch-tasks.service.js
@@ -12,7 +12,7 @@ function verifyPSPIntegrationComplete (targetCredential) {
     .includes(targetCredential.state)
 }
 
-function stripeSetupStageComplete(account, stage) {
+function stripeSetupStageComplete (account, stage) {
   if (account.connectorGatewayAccountStripeProgress) {
     return account.connectorGatewayAccountStripeProgress[stage]
   }

--- a/app/utils/nav-builder.js
+++ b/app/utils/nav-builder.js
@@ -6,6 +6,7 @@ const formatAccountPathsFor = require('./format-account-paths-for')
 const pathLookup = require('./path-lookup')
 const formatPSPname = require('./format-PSP-name')
 const { getPSPPageLinks, CREDENTIAL_STATE } = require('./credentials')
+const flattenNestedValues = require('./flatten-nested-values')
 
 const mainSettingsPaths = [
   paths.account.settings,
@@ -16,8 +17,8 @@ const mainSettingsPaths = [
   paths.account.toggleMotoMaskCardNumberAndSecurityCode
 ]
 
-const yourPspPaths = [ 'your-psp', 'notification-credentials' ]
-const switchPspPaths = [ 'switch-psp' ]
+const yourPspPaths = ['your-psp', 'notification-credentials']
+const switchPspPaths = ['switch-psp']
 
 const serviceNavigationItems = (currentPath, permissions, type, account = {}) => {
   const navigationItems = []
@@ -39,9 +40,10 @@ const serviceNavigationItems = (currentPath, permissions, type, account = {}) =>
     navigationItems.push({
       id: 'navigation-menu-payment-links',
       name: 'Payment links',
-      url: formatAccountPathsFor(paths.account.paymentLinks.start, account.external_id),
-      current: pathLookup(currentPath, paths.account.paymentLinks.start),
-      permissions: permissions.tokens_create
+      url: (permissions.token_create && formatAccountPathsFor(paths.account.paymentLinks.start, account.external_id)) ||
+        formatAccountPathsFor(paths.account.paymentLinks.manage.index, account.external_id),
+      current: currentPath !== '/' && flattenNestedValues(paths.account.paymentLinks).filter(path => currentPath.includes(path)).length,
+      permissions: permissions.transactions_read
     })
   }
   navigationItems.push({

--- a/app/views/payment-links/manage.njk
+++ b/app/views/payment-links/manage.njk
@@ -6,7 +6,9 @@
 {% endblock %}
 
 {% block side_navigation %}
-  {% include "./_nav.njk" %}
+  {% if permissions.tokens_create %}
+    {% include "./_nav.njk" %}
+  {% endif%}
 {% endblock %}
 
 {% block mainContent %}
@@ -38,12 +40,14 @@
   }) }}
 {% endif %}
 
-{% if not permissions.tokens_create %}
+  <h1 class="govuk-heading-l">{% if permissions.tokens_create %}Manage{% else %}View{% endif %} payment links</h1>
+
+  {% if not permissions.tokens_create %}
   <aside class="pay-info-warning-box">
     <p class="govuk-body">You don’t have permission to create or edit payment links. Contact your service admin if you would like to manage payment links.</p>
   </aside>
-{% endif %}
-  <h1 class="govuk-heading-l govuk-!-margin-top-6">{% if permissions.tokens_create %}Manage{% else %}View{% endif %} payment links</h1>
+  {% endif %}
+
   <p class="govuk-body payment-links-list--header">
     {% if productsLength === 1 %}
       There is 1 payment link
@@ -56,6 +60,7 @@
     {% endif %}
   </p>
 
+  {% if permissions.tokens_create %}
   <h2 class="govuk-heading-m">Add metadata for reconciliation and reporting</h2>
 
   <p class="govuk-body">You can add metadata like cost centre codes or business area to your payment links. To add these:</p>
@@ -64,6 +69,7 @@
     <li>Find the Payment link you want and select <span class="govuk-!-font-weight-bold">Edit</span>.</li>
     <li>Select <span class="govuk-!-font-weight-bold">Add a reporting column<span>.</li>
   </ol>
+  {% endif %}
 
   {% if englishPaymentLinks.length %}
   <ul class="govuk-list pay-!-border-top govuk-!-padding-top-3 govuk-!-padding-bottom-3 payment-links-list">

--- a/test/cypress/integration/settings/switch-psp.cy.test.js
+++ b/test/cypress/integration/settings/switch-psp.cy.test.js
@@ -65,7 +65,7 @@ describe('Switch PSP settings page', () => {
         cy.get('h1').should('contain', 'Switch payment service provider')
         cy.get('li').contains('your Worldpay account credentials: Merchant code, username and password').should('exist')
         cy.get('#switch-psp-action-step').should('contain', 'Switch PSP to Worldpay')
-        cy.get('.govuk-warning-text').should('contain','Once you switch, Worldpay will immediately start taking payments. You can refund previous payments through Smartpay.')
+        cy.get('.govuk-warning-text').should('contain', 'Once you switch, Worldpay will immediately start taking payments. You can refund previous payments through Smartpay.')
       })
 
       it('should have task list for Worldpay with correct tags', () => {
@@ -263,7 +263,7 @@ describe('Switch PSP settings page', () => {
             true,
             [
               { payment_provider: 'smartpay', state: 'ACTIVE' },
-              { payment_provider: 'stripe', state: 'CREATED', credentials: { 'stripe_account_id': 'a-valid-stripe-account-id' }}
+              { payment_provider: 'stripe', state: 'CREATED', credentials: { 'stripe_account_id': 'a-valid-stripe-account-id' } }
             ]
           ),
           stripeAccountSetupStubs.getGatewayAccountStripeSetupFlagForMultipleCalls({
@@ -288,7 +288,7 @@ describe('Switch PSP settings page', () => {
             true,
             [
               { payment_provider: 'smartpay', state: 'ACTIVE' },
-              { payment_provider: 'stripe', state: 'VERIFIED_WITH_LIVE_PAYMENT', credentials: { 'stripe_account_id': 'a-valid-stripe-account-id' }}
+              { payment_provider: 'stripe', state: 'VERIFIED_WITH_LIVE_PAYMENT', credentials: { 'stripe_account_id': 'a-valid-stripe-account-id' } }
             ]
           ),
           stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({

--- a/test/cypress/integration/stripe-setup/company-number.cy.test.js
+++ b/test/cypress/integration/stripe-setup/company-number.cy.test.js
@@ -31,8 +31,6 @@ function setupStubs (companyNumber, type = 'live', paymentProvider = 'stripe') {
     external_id: gatewayAccountCredentialExternalId
   }]
 
-
-
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId: gatewayAccountExternalId, type, paymentProvider, gatewayAccountCredentials }),

--- a/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
@@ -44,7 +44,6 @@ function setupStubs (responsiblePerson, type = 'live', paymentProvider = 'stripe
     external_id: gatewayAccountCredentialExternalId
   }]
 
-
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId: gatewayAccountExternalId, type, paymentProvider, gatewayAccountCredentials }),


### PR DESCRIPTION
- Show the "Payment links" option in the account navigation for view-only users and make it link to the "View payment links" page.
- Hide the left hand nav for view-only users as they are not able to create payment links.
- Hide the text about adding metadata for view-only users.
- Move the warning text for view only users below the h1.

<img width="888" alt="Screenshot 2021-08-04 at 16 27 53" src="https://user-images.githubusercontent.com/5648592/128210249-ec7c7fab-d001-4687-8728-fa2028772914.png">

