### PR TITLE
PP-8438 Associate service ID when creating default test card account

### DIFF
--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -415,15 +415,13 @@ module.exports = function (clientOptions = {}) {
    * @param gatewayAccountIds
    * @returns {*|promise|Constructor}
    */
-  const completeInvite = (correlationId, inviteCode, gatewayAccountIds) => {
+  const completeInvite = (correlationId, inviteCode) => {
     return baseClient.post(
       {
         baseUrl,
         url: `${inviteResource}/${inviteCode}/complete`,
         json: true,
-        body: {
-          gateway_account_ids: gatewayAccountIds
-        },
+        body: {},
         correlationId: correlationId,
         description: 'complete invite',
         service: SERVICE_NAME,
@@ -546,7 +544,7 @@ module.exports = function (clientOptions = {}) {
    * @param correlationId
    * @returns {*|promise|Constructor}
    */
-  const createService = (serviceName, serviceNameCy, gatewayAccountIds, correlationId) => {
+  const createService = (serviceName, serviceNameCy, correlationId) => {
     let postBody = {
       baseUrl,
       url: `${serviceResource}`,
@@ -564,9 +562,6 @@ module.exports = function (clientOptions = {}) {
     }
     if (serviceNameCy) {
       postBody.body.service_name = lodash.merge(postBody.body.service_name, { cy: serviceNameCy })
-    }
-    if (gatewayAccountIds) {
-      postBody.body.gateway_account_ids = gatewayAccountIds
     }
     return baseClient.post(
       postBody

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -166,7 +166,7 @@ ConnectorClient.prototype = {
    *
    * @returns {Promise}
    */
-  createGatewayAccount: function (paymentProvider, type, serviceName, analyticsId, correlationId) {
+  createGatewayAccount: function (paymentProvider, type, serviceName, analyticsId, serviceId, correlationId) {
     const url = this.connectorUrl + ACCOUNTS_API_PATH
 
     let payload = {
@@ -177,6 +177,9 @@ ConnectorClient.prototype = {
     }
     if (serviceName) {
       payload.service_name = serviceName
+    }
+    if (serviceId) {
+      payload.service_id = serviceId
     }
     if (analyticsId) {
       payload.analytics_id = analyticsId

--- a/app/services/service-registration.service.js
+++ b/app/services/service-registration.service.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const logger = require('../utils/logger')(__filename)
+const { keys } = require('@govuk-pay/pay-js-commons').logging
 const getAdminUsersClient = require('./clients/adminusers.client')
 const ConnectorClient = require('./clients/connector.client').ConnectorClient
 const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
@@ -29,6 +30,13 @@ async function createPopulatedService (inviteCode, correlationId) {
 
   const user = await adminUsersClient.getUserByExternalId(completeInviteResponse.user_external_id, correlationId)
 
+  // handler called outside of service context, manually include newly created flags for logging
+  logger.info('Created new service with test account during user registration', {
+    [ keys.USER_EXTERNAL_ID ]: user.externalId,
+    [ keys.SERVICE_EXTERNAL_ID ]: completeInviteResponse.service_external_id,
+    [ keys.GATEWAY_ACCOUNT_ID ]: gatewayAccount.gateway_account_id,
+    internal_user: user.internalUser
+  })
   return user
 }
 

--- a/app/services/service.service.js
+++ b/app/services/service.service.js
@@ -54,7 +54,7 @@ async function createService (serviceName, serviceNameCy, user, correlationId) {
   if (!serviceNameCy) serviceNameCy = ''
 
   const service = await adminUsersClient.createService(serviceName, serviceNameCy, correlationId)
-  logger.info('New service created for existing user')
+  logger.info('New service added by existing user')
 
   const gatewayAccount = await connectorClient.createGatewayAccount('sandbox', 'test', serviceName, null, service.externalId, correlationId)
   logger.info('New test card gateway account registered with service')

--- a/app/services/service.service.js
+++ b/app/services/service.service.js
@@ -53,9 +53,16 @@ async function createService (serviceName, serviceNameCy, user, correlationId) {
   if (!serviceName) serviceName = 'System Generated'
   if (!serviceNameCy) serviceNameCy = ''
 
-  const gatewayAccount = await connectorClient.createGatewayAccount('sandbox', 'test', serviceName, null, correlationId)
-  const service = await adminUsersClient.createService(serviceName, serviceNameCy, [gatewayAccount.gateway_account_id], correlationId)
-  logger.info('New service added by existing user')
+  const service = await adminUsersClient.createService(serviceName, serviceNameCy, correlationId)
+  logger.info('New service created for existing user')
+
+  const gatewayAccount = await connectorClient.createGatewayAccount('sandbox', 'test', serviceName, null, service.externalId, correlationId)
+  logger.info('New test card gateway account registered with service')
+
+  // @TODO(sfount) PP-8438 support existing method of associating services with internal card accounts, this should be
+  //               removed once connector integration indexed by services have been migrated
+  await adminUsersClient.addGatewayAccountsToService(service.externalId, [ gatewayAccount.gateway_account_id ])
+  logger.info('Service associated with internal gateway account ID with legacy mapping')
 
   return service
 }

--- a/test/cypress/integration/my-services/add-new-service.cy.test.js
+++ b/test/cypress/integration/my-services/add-new-service.cy.test.js
@@ -11,7 +11,7 @@ const newServiceId = 'new-service-id'
 const newGatewayAccountId = 38
 
 const createGatewayAccountStub =
-  gatewayAccountStubs.postCreateGatewayAccountSuccess({ serviceName: newServiceName, paymentProvider: 'sandbox', type: 'test', gatewayAccountId: newGatewayAccountId, verifyCalledTimes: 1 })
+  gatewayAccountStubs.postCreateGatewayAccountSuccess({ serviceName: newServiceName, serviceId: newServiceId, paymentProvider: 'sandbox', type: 'test', gatewayAccountId: newGatewayAccountId, verifyCalledTimes: 1 })
 
 const assignUserRoleStub =
   userStubs.postAssignServiceRoleSuccess({ userExternalId: authenticatedUserId, serviceExternalId: newServiceId })
@@ -51,7 +51,8 @@ describe('Add a new service', () => {
       setupStubs([
         createGatewayAccountStub,
         assignUserRoleStub,
-        serviceStubs.postCreateServiceSuccess({ serviceExternalId: newServiceId, gatewayAccountId: newGatewayAccountId, serviceName: { en: newServiceName } })
+        serviceStubs.postCreateServiceSuccess({ serviceExternalId: newServiceId, gatewayAccountId: newGatewayAccountId, serviceName: { en: newServiceName } }),
+        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId })
       ])
       cy.get('input#service-name').type(newServiceName)
       cy.get('button').contains('Add service').click()
@@ -88,7 +89,8 @@ describe('Add a new service', () => {
       setupStubs([
         createGatewayAccountStub,
         assignUserRoleStub,
-        serviceStubs.postCreateServiceSuccess({ serviceExternalId: newServiceId, gatewayAccountId: newGatewayAccountId, serviceName: { en: newServiceName, cy: newServiceWelshName } })
+        serviceStubs.postCreateServiceSuccess({ serviceExternalId: newServiceId, gatewayAccountId: newGatewayAccountId, serviceName: { en: newServiceName, cy: newServiceWelshName } }),
+        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId })
       ])
       cy.get('input#service-name').type(newServiceName)
       cy.get('input#service-name-cy').type(newServiceWelshName)

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -137,6 +137,7 @@ function getDirectDebitGatewayAccountSuccess (opts) {
 function postCreateGatewayAccountSuccess (opts) {
   const fixtureOpts = {
     service_name: opts.serviceName,
+    service_id: opts.serviceId,
     payment_provider: opts.paymentProvider,
     type: opts.type,
     gateway_account_id: opts.gatewayAccountId

--- a/test/cypress/stubs/service-stubs.js
+++ b/test/cypress/stubs/service-stubs.js
@@ -97,6 +97,13 @@ function patchGoLiveStageFailure (opts) {
   })
 }
 
+function patchUpdateServiceGatewayAccounts (opts) {
+  const path = `/v1/api/services/${opts.serviceExternalId}`
+  return stubBuilder('PATCH', path, 200, {
+    response: serviceFixtures.validServiceResponse()
+  })
+}
+
 module.exports = {
   postCreateServiceSuccess,
   patchUpdateServiceNameSuccess,
@@ -104,5 +111,6 @@ module.exports = {
   patchUpdateMerchantDetailsSuccess,
   patchUpdateServiceSuccessCatchAll,
   patchGoLiveStageFailure,
-  patchUpdateServicePspTestAccountStage
+  patchUpdateServicePspTestAccountStage,
+  patchUpdateServiceGatewayAccounts
 }

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -192,6 +192,9 @@ function validCreateGatewayAccountRequest (opts = {}) {
   if (opts.analytics_id) {
     data.analytics_id = opts.analytics_id
   }
+  if (opts.service_id) {
+    data.service_id = opts.service_id
+  }
   return data
 }
 

--- a/test/fixtures/invite.fixtures.js
+++ b/test/fixtures/invite.fixtures.js
@@ -90,12 +90,7 @@ module.exports = {
   },
 
   validInviteCompleteRequest: (opts = {}) => {
-    opts = opts || {}
-
-    const gatewayAccountIds = opts.gateway_account_ids || []
-    return {
-      gateway_account_ids: gatewayAccountIds
-    }
+    return {}
   },
 
   validInviteCompleteResponse: (opts = {}) => {

--- a/test/fixtures/service.fixtures.js
+++ b/test/fixtures/service.fixtures.js
@@ -23,9 +23,6 @@ module.exports = {
     if (opts.service_name) {
       data.service_name = buildServiceNameWithDefaults(opts.service_name)
     }
-    if (opts.gateway_account_ids) {
-      data.gateway_account_ids = opts.gateway_account_ids
-    }
     return data
   },
 

--- a/test/integration/self-registration/self-registration-otp-verify.ft.test.js
+++ b/test/integration/self-registration/self-registration-otp-verify.ft.test.js
@@ -78,9 +78,7 @@ describe('create service otp validation', function () {
           gateway_account_id: gatewayAccountId
         })
       const mockAdminUsersInviteCompleteRequest =
-        inviteFixtures.validInviteCompleteRequest({
-          gateway_account_ids: [gatewayAccountId]
-        })
+        inviteFixtures.validInviteCompleteRequest()
       const mockAdminUsersInviteCompleteResponse =
         inviteFixtures.validInviteCompleteResponse({
           invite: {
@@ -99,6 +97,8 @@ describe('create service otp validation', function () {
         .reply(200, mockAdminUsersInviteCompleteResponse)
       adminusersMock.get(`/v1/api/users/${userExternalId}`)
         .reply(200, getUserResponse)
+      adminusersMock.patch(`/v1/api/services/${serviceExternalId}`)
+        .reply(200, {})
 
       const validServiceInviteOtpRequest = inviteFixtures.validVerifyOtpCodeRequest({
         code: inviteCode

--- a/test/unit/clients/adminusers-client/invite/complete-service-invite.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/complete-service-invite.pact.test.js
@@ -39,10 +39,7 @@ describe('adminusers client - complete an invite', function () {
     const userExternalId = 'f84b8210f93d455e97baeaf3fea72cf4'
     const serviceExternalId = '43a6818b522b4a628a14355614665ca3'
 
-    const gatewayAccountIds = ['1']
-    const validInviteCompleteRequest = inviteFixtures.validInviteCompleteRequest({
-      gateway_account_ids: gatewayAccountIds
-    })
+    const validInviteCompleteRequest = inviteFixtures.validInviteCompleteRequest()
     const validInviteCompleteResponse = inviteFixtures.validInviteCompleteResponse({
       invite: {
         code: inviteCode,
@@ -70,7 +67,7 @@ describe('adminusers client - complete an invite', function () {
     afterEach(() => provider.verify())
 
     it('should complete a service invite successfully', function (done) {
-      adminUsersClient.completeInvite('correlation-id', inviteCode, gatewayAccountIds).should.be.fulfilled.then(response => {
+      adminUsersClient.completeInvite('correlation-id', inviteCode).should.be.fulfilled.then(response => {
         expect(response.invite).to.deep.equal(validInviteCompleteResponse.invite)
         expect(response.user_external_id).to.equal(userExternalId)
         expect(response.service_external_id).to.equal(serviceExternalId)

--- a/test/unit/clients/adminusers-client/service/create-service.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/create-service.pact.test.js
@@ -69,17 +69,14 @@ describe('adminusers client - create a new service', function () {
     })
   })
 
-  describe('create a service sending gateway account ids - success', () => {
+  describe('create a service - success', () => {
     const name = 'Service name'
     const externalId = 'externalId'
-    const gatewayAccountIds = ['1', '5']
-    const validRequest = serviceFixtures.validCreateServiceRequest({
-      gateway_account_ids: gatewayAccountIds
-    })
+    const validRequest = serviceFixtures.validCreateServiceRequest({})
     const validCreateServiceResponse = serviceFixtures.validServiceResponse({
       name: name,
       external_id: externalId,
-      gateway_account_ids: gatewayAccountIds
+      gateway_account_ids: []
     })
 
     before((done) => {
@@ -99,10 +96,9 @@ describe('adminusers client - create a new service', function () {
     afterEach(() => provider.verify())
 
     it('should create a new service', function (done) {
-      adminUsersClient.createService(null, null, validRequest.gateway_account_ids).should.be.fulfilled.then(service => {
+      adminUsersClient.createService(null, null).should.be.fulfilled.then(service => {
         expect(service.externalId).to.equal(externalId)
         expect(service.name).to.equal(name)
-        expect(service.gatewayAccountIds).to.deep.equal(validCreateServiceResponse.gateway_account_ids)
       }).should.notify(done)
     })
   })


### PR DESCRIPTION
Test card gateway accounts are created by default when a new service is
created, this happens:
- when an existing user adds a new service
- when a new user signs up for Pay, either themselves or following an
invite link

We are now associating connector integrations with services rather than
storing the internal IDs of card connector gateway accounts in the
service object.

- send `service_id` through with all calls to create card gateway
account
- remove `gateway_account_ids` attribute from calls to create service
(backend resources set this as optional, nothing provided will still
result in a created service)
- change order of operations so that a service is created first,
followed by the test card gateway account
- pass the service id correctly to the call to create a default card
gateway account

In order to support the existing behaviour until the data migration is
carried out:
- make a separate call to admin users to associate the internal card
gateway account ID with the service