### PR TITLE
PP-8445 Make settings redirects consistent

### DIFF
--- a/app/controllers/billing-address/toggle-billing-address.controller.js
+++ b/app/controllers/billing-address/toggle-billing-address.controller.js
@@ -29,7 +29,7 @@ async function postIndex (req, res, next) {
       req.flash('generic', 'Billing address is turned off for this service')
     }
     logger.info(`Updated collect billing address enabled(${req.body['billing-address-toggle']})`)
-    res.redirect(formatAccountPathsFor(paths.account.toggleBillingAddress.index, req.account && req.account.external_id))
+    res.redirect(formatAccountPathsFor(paths.account.settings.index, req.account && req.account.external_id))
   } catch (err) {
     next(err)
   }

--- a/app/controllers/digital-wallet/post-apple-pay.controller.js
+++ b/app/controllers/digital-wallet/post-apple-pay.controller.js
@@ -10,13 +10,12 @@ module.exports = async (req, res, next) => {
   const gatewayAccountId = req.account.gateway_account_id
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   const enable = req.body['apple-pay'] === 'on'
-  const formattedPath = formatAccountPathsFor(paths.account.digitalWallet.applePay, req.account && req.account.external_id)
 
   try {
     await connector.toggleApplePay(gatewayAccountId, enable, correlationId)
 
-    req.flash('generic', `Apple Pay successfully ${enable ? 'enabled' : 'disabled'}.`)
-    return res.redirect(formattedPath)
+    req.flash('generic', `Apple Pay successfully ${enable ? 'enabled' : 'disabled'}`)
+    return res.redirect(formatAccountPathsFor(paths.account.settings.index, req.account && req.account.external_id))
   } catch (err) {
     next(err)
   }

--- a/app/controllers/digital-wallet/post-google-pay.controller.js
+++ b/app/controllers/digital-wallet/post-google-pay.controller.js
@@ -13,11 +13,11 @@ module.exports = async (req, res, next) => {
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   const enable = req.body['google-pay'] === 'on'
   const gatewayMerchantId = req.body.merchantId
-  const formattedPath = formatAccountPathsFor(paths.account.digitalWallet.googlePay, req.account && req.account.external_id)
+  const googlePayPath = formatAccountPathsFor(paths.account.digitalWallet.googlePay, req.account && req.account.external_id)
 
   if (enable && !gatewayMerchantId) {
     req.flash('genericError', 'Enter a valid Merchant ID')
-    return res.redirect(formattedPath)
+    return res.redirect(googlePayPath)
   }
 
   if (enable) {
@@ -29,7 +29,7 @@ module.exports = async (req, res, next) => {
       logger.info('Error setting google pay merchant ID', { error })
       if (error.errorCode === 400) {
         req.flash('genericError', 'There was an error enabling google pay. Check that the Merchant ID you entered is correct and that your PSP account credentials have been set.')
-        return res.redirect(formattedPath)
+        return res.redirect(googlePayPath)
       } else {
         next(error)
       }
@@ -40,8 +40,8 @@ module.exports = async (req, res, next) => {
     await connector.toggleGooglePay(gatewayAccountId, enable, correlationId)
     logger.info(`${enable ? 'enabled' : 'disabled'} google pay boolean}`)
 
-    req.flash('generic', `Google Pay successfully ${enable ? 'enabled' : 'disabled'}.`)
-    return res.redirect(formattedPath)
+    req.flash('generic', `Google Pay successfully ${enable ? 'enabled' : 'disabled'}`)
+    return res.redirect(formatAccountPathsFor(paths.account.settings.index, req.account && req.account.external_id))
   } catch (error) {
     next(error)
   }

--- a/app/controllers/settings/get.settings.controller.js
+++ b/app/controllers/settings/get.settings.controller.js
@@ -1,13 +1,7 @@
 'use strict'
 
 const { response } = require('../../utils/response')
-
-const humaniseEmailMode = mode => {
-  if (mode !== 'OFF') {
-    return `On (${mode.toLowerCase()})`
-  }
-  return mode
-}
+const humaniseEmailMode = require('../../utils/humanise-email-mode')
 
 module.exports = (req, res) => {
   const pageData = {

--- a/app/controllers/toggle-3ds/3ds.post.controller.js
+++ b/app/controllers/toggle-3ds/3ds.post.controller.js
@@ -23,7 +23,7 @@ module.exports = async function submit3dsSettings (req, res, next) {
 
     await connector.update3dsEnabled(params)
     req.flash('generic', '3D secure settings have been updated')
-    return res.redirect(formatAccountPathsFor(paths.account.toggle3ds.index, req.account && req.account.external_id))
+    return res.redirect(formatAccountPathsFor(paths.account.settings.index, req.account && req.account.external_id))
   } catch (err) {
     next(err)
   }

--- a/app/controllers/toggle-moto-mask-card-number/toggleMotoMaskCardNumber.post.controller.js
+++ b/app/controllers/toggle-moto-mask-card-number/toggleMotoMaskCardNumber.post.controller.js
@@ -11,13 +11,12 @@ module.exports = async function toggleMaskCardNumber (req, res, next) {
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = req.account.gateway_account_id
   const enableMaskCardNumber = req.body['moto-mask-card-number-input-toggle'] === 'on'
-  const formattedPath = formatAccountPathsFor(paths.account.toggleMotoMaskCardNumberAndSecurityCode.cardNumber, req.account && req.account.external_id)
 
   try {
     await connector.toggleMotoMaskCardNumberInput(accountId, enableMaskCardNumber, correlationId)
 
     req.flash('generic', 'Your changes have saved')
-    return res.redirect(formattedPath)
+    return res.redirect(formatAccountPathsFor(paths.account.settings.index, req.account && req.account.external_id))
   } catch (err) {
     next(err)
   }

--- a/app/controllers/toggle-moto-mask-security-code/maskSecurityCode.post.controller.js
+++ b/app/controllers/toggle-moto-mask-security-code/maskSecurityCode.post.controller.js
@@ -11,13 +11,12 @@ module.exports = async function toggleMaskCardSecurityCode (req, res, next) {
   const correlationId = req.headers[correlationHeader] || ''
   const accountId = req.account.gateway_account_id
   const enableMaskSecurityCode = req.body['moto-mask-security-code-input-toggle'] === 'on'
-  const formattedPath = formatAccountPathsFor(paths.account.toggleMotoMaskCardNumberAndSecurityCode.securityCode, req.account && req.account.external_id)
 
   try {
     await connector.toggleMotoMaskSecurityCodeInput(accountId, enableMaskSecurityCode, correlationId)
 
     req.flash('generic', 'Your changes have saved')
-    return res.redirect(formattedPath)
+    return res.redirect(formatAccountPathsFor(paths.account.settings.index, req.account && req.account.external_id))
   } catch (err) {
     next(err)
   }

--- a/app/paths.js
+++ b/app/paths.js
@@ -37,7 +37,6 @@ module.exports = {
       confirm: '/email-notifications/confirm',
       update: '/email-notifications/update',
       off: '/email-notifications/off',
-      on: '/email-notifications/on',
       collection: '/email-settings-collection',
       confirmation: '/email-settings-confirmation',
       refund: '/email-settings-refund'

--- a/app/routes.js
+++ b/app/routes.js
@@ -338,17 +338,16 @@ module.exports.bind = function (app) {
   account.post(digitalWallet.googlePay, permission('payment-types:update'), digitalWalletController.postGooglePay)
 
   // Email notifications
-  account.get(emailNotifications.index, permission('email-notification-template:read'), emailNotificationsController.index)
-  account.get(emailNotifications.indexRefundTabEnabled, permission('email-notification-template:read'), emailNotificationsController.indexRefundTabEnabled)
-  account.get(emailNotifications.edit, permission('email-notification-paragraph:update'), emailNotificationsController.edit)
-  account.post(emailNotifications.confirm, permission('email-notification-paragraph:update'), emailNotificationsController.confirm)
-  account.post(emailNotifications.update, permission('email-notification-paragraph:update'), emailNotificationsController.update)
+  account.get(emailNotifications.index, permission('email-notification-template:read'), emailNotificationsController.showConfirmationEmailTemplate)
+  account.get(emailNotifications.indexRefundTabEnabled, permission('email-notification-template:read'), emailNotificationsController.showRefundEmailTemplate)
+  account.get(emailNotifications.edit, permission('email-notification-paragraph:update'), emailNotificationsController.editCustomParagraph)
+  account.post(emailNotifications.confirm, permission('email-notification-paragraph:update'), emailNotificationsController.confirmCustomParagraph)
+  account.post(emailNotifications.update, permission('email-notification-paragraph:update'), emailNotificationsController.updateCustomParagraph)
   account.get(emailNotifications.collection, permission('email-notification-template:read'), emailNotificationsController.collectionEmailIndex)
   account.post(emailNotifications.collection, permission('email-notification-toggle:update'), emailNotificationsController.collectionEmailUpdate)
   account.get(emailNotifications.confirmation, permission('email-notification-template:read'), emailNotificationsController.confirmationEmailIndex)
   account.post(emailNotifications.confirmation, permission('email-notification-toggle:update'), emailNotificationsController.confirmationEmailUpdate)
   account.post(emailNotifications.off, permission('email-notification-toggle:update'), emailNotificationsController.confirmationEmailOff)
-  account.post(emailNotifications.on, permission('email-notification-toggle:update'), emailNotificationsController.confirmationEmailOn)
   account.get(emailNotifications.refund, permission('email-notification-template:read'), emailNotificationsController.refundEmailIndex)
   account.post(emailNotifications.refund, permission('email-notification-toggle:update'), emailNotificationsController.refundEmailUpdate)
 

--- a/app/utils/humanise-email-mode.js
+++ b/app/utils/humanise-email-mode.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = function humaniseEmailMode (mode) {
+  if (mode === 'OFF') {
+    return 'Off'
+  }
+  return `On (${mode.toLowerCase()})`
+}

--- a/test/cypress/integration/settings/3ds.cy.test.js
+++ b/test/cypress/integration/settings/3ds.cy.test.js
@@ -148,7 +148,7 @@ describe('3DS settings page', () => {
         setup3dsStubs({ gateway: 'worldpay' })
       })
 
-      it('should show success message and radios should update', () => {
+      it('should have 3DS set to off', () => {
         cy.setEncryptedCookies(userExternalId)
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(2).should('contain', '3D Secure')
@@ -167,12 +167,12 @@ describe('3DS settings page', () => {
       setup3dsStubs({ requires3ds: true, gateway: 'worldpay' })
     })
 
-    it('should show success message and radios should update', () => {
+    it('should redirect to settings page and show success message', () => {
       cy.get('#save-3ds-changes').click()
-      cy.get('input[value="on"]').should('be.checked')
-      cy.get('input[value="off"]').should('not.be.checked')
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
+      })
       cy.get('.govuk-notification-banner--success').should('contain', '3D secure settings have been updated')
-      cy.get('#navigation-menu-settings').click()
       cy.get('.govuk-summary-list__key').eq(2).should('contain', '3D Secure')
       cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
     })

--- a/test/cypress/integration/settings/allow-apple-pay.cy.test.js
+++ b/test/cypress/integration/settings/allow-apple-pay.cy.test.js
@@ -63,9 +63,12 @@ describe('Apple Pay', () => {
       cy.get('input[value="on"]').click()
       cy.get('input[value="on"]').should('be.checked')
       cy.get('.govuk-button').contains('Save changes').click()
-      cy.get('.govuk-notification-banner--success').should('contain', 'Apple Pay successfully enabled.')
-      cy.get('input[value="on"]').should('be.checked')
-      cy.get('#navigation-menu-settings').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
+      })
+      cy.get('.govuk-notification-banner--success').should('contain', 'Apple Pay successfully enabled')
+
       cy.get('.govuk-summary-list__value').first().should('contain', 'On')
     })
   })

--- a/test/cypress/integration/settings/allow-google-pay.cy.test.js
+++ b/test/cypress/integration/settings/allow-google-pay.cy.test.js
@@ -67,9 +67,12 @@ describe('Google Pay', () => {
       cy.get('input[value="on"]').should('be.checked')
       cy.get('#merchantId').type('111111111111111')
       cy.get('.govuk-button').contains('Save changes').click()
-      cy.get('.govuk-notification-banner--success').should('contain', 'Google Pay successfully enabled.')
-      cy.get('input[value="on"]').should('be.checked')
-      cy.get('#navigation-menu-settings').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
+      })
+      cy.get('.govuk-notification-banner--success').should('contain', 'Google Pay successfully enabled')
+
       cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On')
     })
   })

--- a/test/cypress/integration/settings/email-notifications.cy.test.js
+++ b/test/cypress/integration/settings/email-notifications.cy.test.js
@@ -68,6 +68,7 @@ describe('Settings', () => {
         // Test the save button
         cy.contains('Save changes').click()
         cy.url().should('include', settingsUrl)
+        cy.get('.govuk-notification-banner--success').should('contain', 'Email address collection is set to on (mandatory)')
 
         // Access the collection mode page again
         cy.get('.email-notifications-toggle-collection').click()
@@ -89,6 +90,7 @@ describe('Settings', () => {
 
         cy.contains('Save changes').click()
         cy.url().should('include', settingsUrl)
+        cy.get('.govuk-notification-banner--success').should('contain', 'Payment confirmation emails are turned on')
 
         // Access the confirmation toggle page again
         cy.get('.email-notifications-toggle-confirmation').click()
@@ -110,6 +112,7 @@ describe('Settings', () => {
 
         cy.contains('Save changes').click()
         cy.url().should('include', settingsUrl)
+        cy.get('.govuk-notification-banner--success').should('contain', 'Refund emails are turned on')
 
         // Access the refund toggle page again
         cy.get('.email-notifications-toggle-refund').click()

--- a/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js
+++ b/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js
@@ -106,11 +106,12 @@ describe('MOTO mask security section', () => {
         setupMotoStubs({ readonly: false, allowMoto: true, motoMaskCardNumber: true })
       })
 
-      it(`should show 'save changes' notification`, () => {
+      it('should redirect to settings page and show success message', () => {
         cy.get('input[value="on"]').click()
         cy.get('#save-moto-mask-changes').click()
-        cy.get('input[value="on"]').should('be.checked')
-        cy.get('input[value="off"]').should('not.be.checked')
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
+        })
         cy.get('.govuk-notification-banner--success').contains('Your changes have saved')
       })
     })
@@ -159,12 +160,12 @@ describe('MOTO mask security section', () => {
         setupMotoStubs({ readonly: false, allowMoto: true, motoMaskSecurityCode: true })
       })
 
-      it('should show radios as enabled and hidden as checked', () => {
+      it('should redirect to settings page and show success message', () => {
         cy.get('input[value="on"]').click()
         cy.get('#save-moto-mask-changes').click()
-        cy.title().should('eq', `MOTO - hide security codes for ${serviceName} - GOV.UK Pay`)
-        cy.get('input[value="on"]').should('be.checked')
-        cy.get('input[value="off"]').should('not.be.checked')
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
+        })
         cy.get('.govuk-notification-banner--success').contains('Your changes have saved')
       })
     })

--- a/test/unit/controller/billing-address-controller/toggle-billing-address.controller.ft.test.js
+++ b/test/unit/controller/billing-address-controller/toggle-billing-address.controller.ft.test.js
@@ -30,6 +30,7 @@ describe('Toggle billing address collection controller', () => {
   const EXTERNAL_SERVICE_ID = 'dsfkbskjalksjdlk342'
   const EXTERNAL_GATEWAY_ACCOUNT_ID = 'an-external-id'
   const toggleBillingAddressPath = formatAccountPathsFor(paths.account.toggleBillingAddress.index, EXTERNAL_GATEWAY_ACCOUNT_ID)
+  const settingsPath = formatAccountPathsFor(paths.account.settings.index, EXTERNAL_GATEWAY_ACCOUNT_ID)
 
   const buildUserWithCollectBillingAddress = (collectBillingAddress) => {
     return userFixtures.validUserResponse({
@@ -90,7 +91,7 @@ describe('Toggle billing address collection controller', () => {
       expect($('#billing-address-toggle-2:checked').length).to.equal(1)
     })
   })
-  describe('should redirect to index on enable billing address', () => {
+  describe('should redirect to settings index on enable billing address', () => {
     before(done => {
       user = buildUserWithCollectBillingAddress(true)
       connectorMock.get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
@@ -121,10 +122,10 @@ describe('Toggle billing address collection controller', () => {
       expect(response.statusCode).to.equal(302)
     })
     it('should redirect to the index page', () => {
-      expect(response.headers).to.have.property('location').to.equal(toggleBillingAddressPath)
+      expect(response.headers).to.have.property('location').to.equal(settingsPath)
     })
   })
-  describe('should redirect to index on disable billing address', () => {
+  describe('should redirect to settings index on disable billing address', () => {
     before(done => {
       user = buildUserWithCollectBillingAddress(false)
       connectorMock.get(`/v1/frontend/accounts/external-id/${EXTERNAL_GATEWAY_ACCOUNT_ID}`)
@@ -155,7 +156,7 @@ describe('Toggle billing address collection controller', () => {
       expect(response.statusCode).to.equal(302)
     })
     it('should redirect to the index page', () => {
-      expect(response.headers).to.have.property('location').to.equal(toggleBillingAddressPath)
+      expect(response.headers).to.have.property('location').to.equal(settingsPath)
     })
   })
 })


### PR DESCRIPTION
Previously, some settings pages would stay on the same page and display an error message when submitted, and others would redirect back to the main settings page.

Make this consistent so that:
- We always redirect to the main settings page when setting is saved
- We always display a success message

Additionally, have refactored email-notifications.controller.js to adhere to our style guide.

