### PR TITLE
PP-8445 Add settings page for default country

### DIFF
--- a/app/controllers/settings/default-billing-address-country.controller.js
+++ b/app/controllers/settings/default-billing-address-country.controller.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const paths = require('../../paths')
+const { response } = require('../../utils/response')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
+const getAdminUsersClient = require('../../services/clients/adminusers.client')
+const adminUsersClient = getAdminUsersClient()
+
+const GB_COUNTRY_CODE = 'GB'
+
+function showDefaultBillingAddressCountry (req, res) {
+  const defaultToUK = req.service.defaultBillingAddressCountry === GB_COUNTRY_CODE
+  response(req, res, 'default-billing-address-country/index', { defaultToUK })
+}
+
+async function updateDefaultBillingAddressCountry (req, res, next) {
+  try {
+    const defaultToUK = req.body['uk-as-default-billing-address-country'] === 'on'
+    const countryCode = defaultToUK ? GB_COUNTRY_CODE : null
+    await adminUsersClient.updateDefaultBillingAddressCountry(req.service.externalId, countryCode, req.correlationId)
+    req.flash('generic', `United Kingdom as the default billing address: ${defaultToUK ? 'On' : 'Off'}`)
+    res.redirect(formatAccountPathsFor(paths.account.settings.index, req.account && req.account.external_id))
+  } catch (err) {
+    next(err)
+  }
+}
+
+module.exports = {
+  showDefaultBillingAddressCountry,
+  updateDefaultBillingAddressCountry
+}

--- a/app/controllers/settings/get.settings.controller.js
+++ b/app/controllers/settings/get.settings.controller.js
@@ -8,6 +8,7 @@ module.exports = (req, res) => {
     supports3ds: req.account.supports3ds,
     requires3ds: req.account.requires3ds,
     collectBillingAddress: req.service.collectBillingAddress,
+    defaultBillingAddressCountry: req.service.defaultBillingAddressCountry,
     emailCollectionMode: humaniseEmailMode(req.account.email_collection_mode),
     confirmationEmailEnabled: req.account.email_notifications.PAYMENT_CONFIRMED.enabled,
     refundEmailEnabled: req.account.email_notifications.REFUND_ISSUED && req.account.email_notifications.REFUND_ISSUED.enabled,

--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -14,6 +14,7 @@ class Service {
     this.createdDate = serviceData.created_date
     this.currentPspTestAccountStage = serviceData.current_psp_test_account_stage
     this.agentInitiatedMotoEnabled = serviceData.agent_initiated_moto_enabled
+    this.defaultBillingAddressCountry = serviceData.default_billing_address_country
   }
 
   /**
@@ -33,7 +34,8 @@ class Service {
       experimental_features_enabled: this.experimentalFeaturesEnabled,
       created_date: this.createdDate,
       current_psp_test_account_stage: this.currentPspTestAccountStage,
-      agent_initiated_moto_enabled: this.agentInitiatedMotoEnabled
+      agent_initiated_moto_enabled: this.agentInitiatedMotoEnabled,
+      default_billing_address_country: this.defaultBillingAddressCountry
     }
   }
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -26,6 +26,9 @@ module.exports = {
     dashboard: {
       index: '/dashboard'
     },
+    defaultBillingAddressCountry: {
+      index: '/default-billing-address-country'
+    },
     digitalWallet: {
       applePay: '/digital-wallet/apple-pay',
       googlePay: '/digital-wallet/google-pay'

--- a/app/routes.js
+++ b/app/routes.js
@@ -78,6 +78,7 @@ const allTransactionsController = require('./controllers/all-service-transaction
 const payoutsController = require('./controllers/payouts/payout-list.controller')
 const stripeSetupDashboardRedirectController = require('./controllers/stripe-setup/stripe-setup-link')
 const requestPspTestAccountController = require('./controllers/request-psp-test-account')
+const defaultBillingAddressCountryController = require('./controllers/settings/default-billing-address-country.controller')
 
 // Assignments
 const {
@@ -96,6 +97,7 @@ const {
   apiKeys,
   credentials,
   dashboard,
+  defaultBillingAddressCountry,
   digitalWallet,
   emailNotifications,
   notificationCredentials,
@@ -363,6 +365,9 @@ module.exports.bind = function (app) {
 
   account.get(toggleBillingAddress.index, permission('toggle-billing-address:read'), toggleBillingAddressController.getIndex)
   account.post(toggleBillingAddress.index, permission('toggle-billing-address:update'), toggleBillingAddressController.postIndex)
+
+  account.get(defaultBillingAddressCountry.index, permission('toggle-billing-address:read'), defaultBillingAddressCountryController.showDefaultBillingAddressCountry)
+  account.post(defaultBillingAddressCountry.index, permission('toggle-billing-address:update'), defaultBillingAddressCountryController.updateDefaultBillingAddressCountry)
 
   // Prototype links
   account.get(prototyping.demoService.index, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.index)

--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -640,13 +640,33 @@ module.exports = function (clientOptions = {}) {
         url: `${serviceResource}/${serviceExternalId}`,
         json: true,
         body:
-          {
-            op: 'replace',
-            path: 'collect_billing_address',
-            value: collectBillingAddress
-          },
+        {
+          op: 'replace',
+          path: 'collect_billing_address',
+          value: collectBillingAddress
+        },
         correlationId: correlationId,
         description: 'update collect billing address',
+        service: SERVICE_NAME,
+        baseClientErrorHandler: 'old'
+      }
+    )
+  }
+
+  const updateDefaultBillingAddressCountry = (serviceExternalId, countryCode, correlationId) => {
+    return baseClient.patch(
+      {
+        baseUrl,
+        url: `${serviceResource}/${serviceExternalId}`,
+        json: true,
+        body:
+        {
+          op: 'replace',
+          path: 'default_billing_address_country',
+          value: countryCode
+        },
+        correlationId: correlationId,
+        description: 'update default billing address country',
         service: SERVICE_NAME,
         baseClientErrorHandler: 'old'
       }
@@ -861,6 +881,7 @@ module.exports = function (clientOptions = {}) {
     updateService,
     updateServiceName,
     updateCollectBillingAddress,
+    updateDefaultBillingAddressCountry,
     addGatewayAccountsToService,
     updateCurrentGoLiveStage,
     addStripeAgreementIpAddress,

--- a/app/utils/nav-builder.js
+++ b/app/utils/nav-builder.js
@@ -14,7 +14,8 @@ const mainSettingsPaths = [
   paths.account.toggle3ds,
   paths.account.toggleBillingAddress,
   paths.account.emailNotifications,
-  paths.account.toggleMotoMaskCardNumberAndSecurityCode
+  paths.account.toggleMotoMaskCardNumberAndSecurityCode,
+  paths.account.defaultBillingAddressCountry
 ]
 
 const yourPspPaths = ['your-psp', 'notification-credentials']

--- a/app/views/default-billing-address-country/index.njk
+++ b/app/views/default-billing-address-country/index.njk
@@ -1,0 +1,63 @@
+{% extends "layout.njk" %}
+
+{% block pageTitle %}
+  Default billing address country - {{ currentService.name }} {{ currentGatewayAccount.full_type }} - GOV.UK Pay
+{% endblock %}
+
+{% block side_navigation %}
+  {% include "includes/side-navigation.njk" %}
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-column-two-thirds">
+    {% if not permissions.toggle_billing_address_update %}
+      {% include "../includes/settings-read-only.njk" %}
+    {% endif %}
+
+    <form class="permission-main" method="post">
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+      {{
+        govukRadios({
+          name: "uk-as-default-billing-address-country",
+          fieldset: {
+            legend: {
+              text: "Set United Kingdom as the default billing address country",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          hint: {
+            text: "By default, the country field in the user’s billing address will be automatically populated with United Kingdom. If your service frequently takes payments from overseas users, you can turn this off."
+            },
+          items: [
+            {
+              value: "on",
+              text: "On",
+              checked: defaultToUK,
+              disabled: true if not permissions.toggle_billing_address_update
+            },
+            {
+              value: "off",
+              text: "Off",
+              checked: true if not defaultToUK,
+              disabled: true if not permissions.toggle_billing_address_update
+            }
+          ]
+        })
+      }}
+
+      {{
+        govukButton({
+          text: "Save changes",
+          classes: "govuk-!-margin-bottom-4",
+          disabled: true if not permissions.toggle_billing_address_update
+        })
+      }}
+      <p class="govuk-body">
+        <a href="{{ formatAccountPathsFor(routes.account.settings.index, currentGatewayAccount.external_id) }}" class="govuk-link govuk-link--no-visited-state">
+          Cancel
+        </a>
+      </p>
+    </form>
+  </div>
+{% endblock %}

--- a/app/views/settings/index.njk
+++ b/app/views/settings/index.njk
@@ -128,6 +128,27 @@
                 }
               ]
             }
+          },
+                    {
+            key: {
+              text: 'Default billing address country',
+              classes: 'govuk-!-width-one-half'
+            },
+            value: {
+              text: 'United Kingdom' if defaultBillingAddressCountry == 'GB' else 'None',
+              classes: 'govuk-!-width-one-quarter'
+            },
+            actions: {
+              classes: 'govuk-!-width-one-quarter',
+              items: [
+                {
+                  href: formatAccountPathsFor(routes.account.defaultBillingAddressCountry.index, currentGatewayAccount.external_id),
+                  classes: 'govuk-link--no-visited-state',
+                  text: 'Change' if permissions.toggle_billing_address_update else 'View',
+                  visuallyHiddenText: 'default billing address country settings'
+                }
+              ]
+            }
           }
         ]
       })

--- a/test/cypress/integration/settings/default-billing-address-country.cy.test.js
+++ b/test/cypress/integration/settings/default-billing-address-country.cy.test.js
@@ -1,0 +1,95 @@
+const userStubs = require('../../stubs/user-stubs')
+const serviceStubs = require('../../stubs/service-stubs')
+const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+
+const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+const serviceExternalId = 'a-service--external-id'
+const gatewayAccountId = 42
+const gatewayAccountExternalId = 'a-gateway-account-external-id'
+
+function getUserAndGatewayAccountStubs(defaultBillingAddressCountry) {
+    return [
+        userStubs.getUserSuccess({
+            userExternalId,
+            gatewayAccountId,
+            defaultBillingAddressCountry
+        }),
+        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId })
+    ]
+}
+
+describe('Default billing address country', () => {
+    beforeEach(() => {
+        Cypress.Cookies.preserveOnce('session', 'gateway_account')
+    })
+
+    describe('User is an admin', () => {
+        it('should show default country as None', () => {
+            cy.task('setupStubs', getUserAndGatewayAccountStubs(null))
+
+            cy.setEncryptedCookies(userExternalId)
+            cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+
+            cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Default billing address country')
+            cy.get('.govuk-summary-list__value').eq(1).should('contain', 'None')
+        })
+
+        it('should show setting as Off', () => {
+            cy.task('setupStubs', getUserAndGatewayAccountStubs(null))
+
+            cy.get('.govuk-summary-list__actions').eq(1).contains('Change').click()
+
+            cy.get('input[type="radio"]').should('have.length', 2)
+            cy.get('input[value="on"]').should('not.be.checked')
+            cy.get('input[value="off"]').should('be.checked')
+        })
+
+        it('should update to On', () => {
+            cy.task('setupStubs', [
+                ...getUserAndGatewayAccountStubs('GB'),
+                serviceStubs.patchUpdateDefaultBillingAddressCountrySuccess({
+                    serviceExternalId,
+                    gatewayAccountId,
+                    country: 'GB',
+                    verifyTimesCalled: 1
+                })
+            ])
+
+            cy.get('input[value="on"]').click()
+            cy.get('.govuk-button').contains('Save changes').click()
+
+            cy.location().should((location) => {
+                expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
+            })
+            cy.get('.govuk-notification-banner--success').should('contain', 'United Kingdom as the default billing address: On')
+
+            cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Default billing address country')
+            cy.get('.govuk-summary-list__value').eq(1).should('contain', 'United Kingdom')
+        })
+    })
+
+    describe('User is view only', () => {
+        it('should have settings page disabled', () => {
+            cy.task('setupStubs', [
+                userStubs.getUserSuccess({
+                    userExternalId,
+                    gatewayAccountId,
+                    role: {
+                        permissions: [
+                            { name: 'transactions-details:read' },
+                            { name: 'toggle-billing-address:read' },
+                        ]
+                    }
+                }),
+                gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId })
+            ])
+
+            cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+            cy.get('.govuk-summary-list__actions').eq(1).contains('View').click()
+            cy.get('.pay-info-warning-box').contains('You don’t have permission')
+            cy.get('input[value="on"]').should('be.disabled')
+            cy.get('input[value="off"]').should('be.disabled')
+            cy.get('.govuk-button').should('be.disabled')
+        })
+    })
+})

--- a/test/cypress/integration/settings/email-notifications.cy.test.js
+++ b/test/cypress/integration/settings/email-notifications.cy.test.js
@@ -29,15 +29,15 @@ describe('Settings', () => {
 
     describe('Settings default page', () => {
       it(`should have the page title 'Settings - ${serviceName} - GOV.UK Pay'`, () => {
-        cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Enter an email address')
-        cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On (mandatory)')
-        cy.get('.govuk-summary-list__actions a').eq(1).contains('Change enter an email address settings')
-        cy.get('.govuk-summary-list__key').eq(2).should('contain', 'Payment confirmation emails')
-        cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
-        cy.get('.govuk-summary-list__actions a').eq(2).contains('Change payment confirmation emails settings')
-        cy.get('.govuk-summary-list__key').eq(3).should('contain', 'Refund emails')
+        cy.get('.govuk-summary-list__key').eq(2).should('contain', 'Enter an email address')
+        cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On (mandatory)')
+        cy.get('.govuk-summary-list__actions a').eq(2).contains('Change enter an email address settings')
+        cy.get('.govuk-summary-list__key').eq(3).should('contain', 'Payment confirmation emails')
         cy.get('.govuk-summary-list__value').eq(3).should('contain', 'On')
-        cy.get('.govuk-summary-list__actions a').eq(3).contains('Change refund emails settings')
+        cy.get('.govuk-summary-list__actions a').eq(3).contains('Change payment confirmation emails settings')
+        cy.get('.govuk-summary-list__key').eq(4).should('contain', 'Refund emails')
+        cy.get('.govuk-summary-list__value').eq(4).should('contain', 'On')
+        cy.get('.govuk-summary-list__actions a').eq(4).contains('Change refund emails settings')
       })
     })
 
@@ -57,8 +57,8 @@ describe('Settings', () => {
     describe('Email collection mode page', () => {
       it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
         // Access the collection mode page
-        cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Enter an email address')
-        cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On (mandatory)')
+        cy.get('.govuk-summary-list__key').eq(2).should('contain', 'Enter an email address')
+        cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On (mandatory)')
         cy.get('.email-notifications-toggle-collection').contains('Change enter an email address settings').click()
         cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
         cy.url().should('include', '/email-settings-collection')
@@ -81,8 +81,8 @@ describe('Settings', () => {
     describe('Confirmation email toggle page', () => {
       it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
         // Access the confirmation toggle page
-        cy.get('.govuk-summary-list__key').eq(2).should('contain', 'Payment confirmation emails')
-        cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
+        cy.get('.govuk-summary-list__key').eq(3).should('contain', 'Payment confirmation emails')
+        cy.get('.govuk-summary-list__value').eq(3).should('contain', 'On')
         cy.get('.email-notifications-toggle-confirmation').contains('Change payment confirmation emails settings').click()
         cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
 
@@ -103,8 +103,8 @@ describe('Settings', () => {
     describe('Refund email toggle page', () => {
       it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
         // Access the refund toggle page
-        cy.get('.govuk-summary-list__key').eq(3).should('contain', 'Refund emails')
-        cy.get('.govuk-summary-list__value').eq(3).should('contain', 'On')
+        cy.get('.govuk-summary-list__key').eq(4).should('contain', 'Refund emails')
+        cy.get('.govuk-summary-list__value').eq(4).should('contain', 'On')
         cy.get('.email-notifications-toggle-refund').contains('Change refund emails settings').click()
         cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
 
@@ -160,8 +160,8 @@ describe('Settings', () => {
     describe('Email collection mode page', () => {
       it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
         // Access the collection mode page
-        cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Enter an email address')
-        cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On (mandatory)')
+        cy.get('.govuk-summary-list__key').eq(2).should('contain', 'Enter an email address')
+        cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On (mandatory)')
         cy.get('.email-notifications-toggle-collection').contains('View enter an email address settings').click()
         cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
         cy.url().should('include', '/email-settings-collection')
@@ -179,8 +179,8 @@ describe('Settings', () => {
     describe('Confirmation email toggle page', () => {
       it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
         // Access the confirmation toggle page
-        cy.get('.govuk-summary-list__key').eq(2).should('contain', 'Payment confirmation emails')
-        cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
+        cy.get('.govuk-summary-list__key').eq(3).should('contain', 'Payment confirmation emails')
+        cy.get('.govuk-summary-list__value').eq(3).should('contain', 'On')
         cy.get('.email-notifications-toggle-confirmation').contains('View payment confirmation emails settings').click()
         cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
 
@@ -197,8 +197,8 @@ describe('Settings', () => {
     describe('Refund email toggle page', () => {
       it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
         // Access the refund toggle page
-        cy.get('.govuk-summary-list__key').eq(3).should('contain', 'Refund emails')
-        cy.get('.govuk-summary-list__value').eq(3).should('contain', 'On')
+        cy.get('.govuk-summary-list__key').eq(4).should('contain', 'Refund emails')
+        cy.get('.govuk-summary-list__value').eq(4).should('contain', 'On')
         cy.get('.email-notifications-toggle-refund').contains('View refund emails settings').click()
         cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
 

--- a/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js
+++ b/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js
@@ -69,10 +69,10 @@ describe('MOTO mask security section', () => {
 
       it('should show radios as disabled and card number mask disabled', () => {
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-        cy.get('.govuk-summary-list__key').eq(4).should('contain', 'Hide card numbers')
-        cy.get('.govuk-summary-list__value').eq(4).should('contain', 'Off')
-        cy.get('.govuk-summary-list__actions a').eq(4).contains('View')
-        cy.get('.govuk-summary-list__actions a').eq(4).click()
+        cy.get('.govuk-summary-list__key').eq(5).should('contain', 'Hide card numbers')
+        cy.get('.govuk-summary-list__value').eq(5).should('contain', 'Off')
+        cy.get('.govuk-summary-list__actions a').eq(5).contains('View')
+        cy.get('.govuk-summary-list__actions a').eq(5).click()
         cy.title().should('eq', `MOTO - hide card numbers for ${serviceName} - GOV.UK Pay`)
         cy.get('.pay-info-warning-box').should('exist')
         cy.get('input[value="on"]').should('be.disabled')
@@ -89,10 +89,10 @@ describe('MOTO mask security section', () => {
 
       it('should show radios as enabled and card number mask disabled', () => {
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-        cy.get('.govuk-summary-list__key').eq(4).should('contain', 'Hide card numbers')
-        cy.get('.govuk-summary-list__value').eq(4).should('contain', 'Off')
-        cy.get('.govuk-summary-list__actions a').eq(4).contains('Change')
-        cy.get('.govuk-summary-list__actions a').eq(4).click()
+        cy.get('.govuk-summary-list__key').eq(5).should('contain', 'Hide card numbers')
+        cy.get('.govuk-summary-list__value').eq(5).should('contain', 'Off')
+        cy.get('.govuk-summary-list__actions a').eq(5).contains('Change')
+        cy.get('.govuk-summary-list__actions a').eq(5).click()
         cy.title().should('eq', `MOTO - hide card numbers for ${serviceName} - GOV.UK Pay`)
         cy.get('input[value="on"]').should('not.be.disabled')
         cy.get('input[value="off"]').should('not.be.disabled')
@@ -123,10 +123,10 @@ describe('MOTO mask security section', () => {
 
       it('should show radios as disabled and card number mask disabled', () => {
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-        cy.get('.govuk-summary-list__key').eq(5).should('contain', 'Hide card security codes')
-        cy.get('.govuk-summary-list__value').eq(5).should('contain', 'Off')
-        cy.get('.govuk-summary-list__actions a').eq(5).contains('View')
-        cy.get('.govuk-summary-list__actions a').eq(5).click()
+        cy.get('.govuk-summary-list__key').eq(6).should('contain', 'Hide card security codes')
+        cy.get('.govuk-summary-list__value').eq(6).should('contain', 'Off')
+        cy.get('.govuk-summary-list__actions a').eq(6).contains('View')
+        cy.get('.govuk-summary-list__actions a').eq(6).click()
         cy.title().should('eq', `MOTO - hide security codes for ${serviceName} - GOV.UK Pay`)
         cy.get('.pay-info-warning-box').should('exist')
         cy.get('input[value="on"]').should('be.disabled')
@@ -143,10 +143,10 @@ describe('MOTO mask security section', () => {
 
       it('should show radios as enabled and no masking', () => {
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-        cy.get('.govuk-summary-list__key').eq(5).should('contain', 'Hide card security codes')
-        cy.get('.govuk-summary-list__value').eq(5).should('contain', 'Off')
-        cy.get('.govuk-summary-list__actions a').eq(5).contains('Change')
-        cy.get('.govuk-summary-list__actions a').eq(5).click()
+        cy.get('.govuk-summary-list__key').eq(6).should('contain', 'Hide card security codes')
+        cy.get('.govuk-summary-list__value').eq(6).should('contain', 'Off')
+        cy.get('.govuk-summary-list__actions a').eq(6).contains('Change')
+        cy.get('.govuk-summary-list__actions a').eq(6).click()
         cy.title().should('eq', `MOTO - hide security codes for ${serviceName} - GOV.UK Pay`)
         cy.get('input[value="on"]').should('not.be.disabled')
         cy.get('input[value="off"]').should('not.be.disabled')

--- a/test/cypress/stubs/service-stubs.js
+++ b/test/cypress/stubs/service-stubs.js
@@ -104,6 +104,19 @@ function patchUpdateServiceGatewayAccounts (opts) {
   })
 }
 
+function patchUpdateDefaultBillingAddressCountrySuccess (opts) {
+  const path = `/v1/api/services/${opts.serviceExternalId}`
+  return stubBuilder('PATCH', path, 200, {
+    request: serviceFixtures.validUpdateDefaultBillingAddressRequest(opts.country),
+    response: serviceFixtures.validServiceResponse({
+      external_id: opts.serviceExternalId,
+      gateway_account_ids: [opts.gatewayAccountId],
+      default_billing_address_country: opts.country
+    }),
+    verifyCalledTimes: opts.verifyCalledTimes
+  })
+}
+
 module.exports = {
   postCreateServiceSuccess,
   patchUpdateServiceNameSuccess,
@@ -112,5 +125,6 @@ module.exports = {
   patchUpdateServiceSuccessCatchAll,
   patchGoLiveStageFailure,
   patchUpdateServicePspTestAccountStage,
-  patchUpdateServiceGatewayAccounts
+  patchUpdateServiceGatewayAccounts,
+  patchUpdateDefaultBillingAddressCountrySuccess
 }

--- a/test/cypress/stubs/user-stubs.js
+++ b/test/cypress/stubs/user-stubs.js
@@ -180,7 +180,9 @@ function getUserSuccessRespondDifferentlySecondTime (userExternalId, firstRespon
 }
 
 function buildServiceRoleOpts (opts) {
-  const service = {}
+  const service = {
+    default_billing_address_country: opts.defaultBillingAddressCountry
+  }
 
   if (opts.gatewayAccountId) {
     service.gateway_account_ids = [String(opts.gatewayAccountId)]

--- a/test/fixtures/service.fixtures.js
+++ b/test/fixtures/service.fixtures.js
@@ -62,6 +62,14 @@ module.exports = {
     }
   },
 
+  validUpdateDefaultBillingAddressRequest: (countryCode) => {
+    return {
+      op: 'replace',
+      path: 'default_billing_address_country',
+      value: countryCode
+    }
+  },
+
   validUpdateRequestToGoLiveRequest: (value = 'AGREED_TO_STRIPE') => {
     return {
       op: 'replace',
@@ -137,6 +145,11 @@ module.exports = {
         'email',
         'telephone_number'
       ])
+    }
+
+    if (opts.default_billing_address_country !== null) {
+      service.default_billing_address_country = opts.default_billing_address_country === undefined ?
+        'GB' : opts.default_billing_address_country
     }
 
     return service

--- a/test/unit/clients/adminusers-client/service/update-default-billing-address-country.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/update-default-billing-address-country.pact.test.js
@@ -1,0 +1,90 @@
+'use strict'
+
+const { Pact } = require('@pact-foundation/pact')
+const { expect } = require('chai')
+
+const path = require('path')
+const PactInteractionBuilder = require('../../../../test-helpers/pact/pact-interaction-builder').PactInteractionBuilder
+const getAdminUsersClient = require('../../../../../app/services/clients/adminusers.client')
+const serviceFixtures = require('../../../../fixtures/service.fixtures')
+const { pactify } = require('../../../../test-helpers/pact/pactifier').defaultPactifier
+
+// Constants
+const SERVICE_RESOURCE = '/v1/api/services'
+let adminUsersClient
+const serviceExternalId = 'cp5wa'
+
+describe('adminusers client - patch collect billing address toggle', function () {
+  let provider = new Pact({
+    consumer: 'selfservice',
+    provider: 'adminusers',
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(async () => {
+    const opts = await provider.setup()
+    adminUsersClient = getAdminUsersClient({ baseUrl: `http://localhost:${opts.port}` })
+  })
+  after(() => provider.finalize())
+
+  describe('patch default billing address - valid country code', () => {
+    const request = serviceFixtures.validUpdateDefaultBillingAddressRequest('IE')
+    const response = serviceFixtures.validServiceResponse({
+      external_id: serviceExternalId,
+      default_billing_address_country: 'IE'
+    })
+
+    before(() => {
+      return provider.addInteraction(
+        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
+          .withUponReceiving('a valid patch default billing address country with valid country code request')
+          .withState(`a service exists with external id ${serviceExternalId}`)
+          .withMethod('PATCH')
+          .withRequestBody(request)
+          .withStatusCode(200)
+          .withResponseBody(pactify(response))
+          .build()
+      )
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should update successfully', async () => {
+      const service = await adminUsersClient.updateDefaultBillingAddressCountry(serviceExternalId, 'IE')
+      expect(service.external_id).to.equal(serviceExternalId)
+      expect(service.default_billing_address_country).to.equal('IE')
+    })
+  })
+
+  describe('patch default billing address - null value', () => {
+    const request = serviceFixtures.validUpdateDefaultBillingAddressRequest(null)
+    const response = serviceFixtures.validServiceResponse({
+      external_id: serviceExternalId,
+      default_billing_address_country: null
+    })
+
+    before(() => {
+      return provider.addInteraction(
+        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
+          .withUponReceiving('a valid patch default billing address country with null value request')
+          .withState(`a service exists with external id ${serviceExternalId}`)
+          .withMethod('PATCH')
+          .withRequestBody(request)
+          .withStatusCode(200)
+          .withResponseBody(pactify(response))
+          .build()
+      )
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should update successfully', async () => {
+      const service = await adminUsersClient.updateDefaultBillingAddressCountry(serviceExternalId, null)
+      expect(service.external_id).to.equal(serviceExternalId)
+      expect(service).to.not.have.property('default_billing_address_country')
+    })
+  })
+})

--- a/test/unit/controller/settings/default-billing-address-country.controller.test.js
+++ b/test/unit/controller/settings/default-billing-address-country.controller.test.js
@@ -1,0 +1,66 @@
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+const Service = require('../../../../app/models/Service.class')
+const serviceFixtures = require('../../../fixtures/service.fixtures')
+const gatewayAccountFixtures = require('../../../fixtures/gateway-account.fixtures')
+
+const updateDefaultBillingAddressCountrySpy = sinon.spy()
+const adminuUsersClientStub = () => {
+    return {
+        updateDefaultBillingAddressCountry: updateDefaultBillingAddressCountrySpy
+    }
+}
+const controller = proxyquire('../../../../app/controllers/settings/default-billing-address-country.controller',
+    {
+        '../../services/clients/adminusers.client': adminuUsersClientStub
+    }
+)
+
+const service = new Service(serviceFixtures.validServiceResponse())
+const account = gatewayAccountFixtures.validGatewayAccountResponse()
+const correlationId = 'a-request-id'
+
+
+describe('Default billing address country settings controller', () => {
+    let res, next
+    beforeEach(() => {
+        updateDefaultBillingAddressCountrySpy.resetHistory()
+        res = {
+            redirect: sinon.spy()
+        }
+        next = sinon.spy()
+    })
+
+    it('should set country code to GB when UK as default is true', async () => {
+        const req = {
+            service,
+            account,
+            correlationId,
+            body: {
+                'uk-as-default-billing-address-country': 'on'
+            },
+            flash: sinon.spy()
+        }
+        await controller.updateDefaultBillingAddressCountry(req, res, next)
+        sinon.assert.calledWith(updateDefaultBillingAddressCountrySpy, service.externalId, 'GB', req.correlationId)
+        sinon.assert.calledWith(req.flash, 'generic', 'United Kingdom as the default billing address: On')
+        sinon.assert.calledWith(res.redirect, `/account/${account.external_id}/settings`)
+    })
+
+    it('should set country code to null when UK as default is false', async () => {
+        const req = {
+            service,
+            account,
+            correlationId,
+            body: {
+                'uk-as-default-billing-address-country': 'off'
+            },
+            flash: sinon.spy()
+        }
+        await controller.updateDefaultBillingAddressCountry(req, res, next)
+        sinon.assert.calledWith(updateDefaultBillingAddressCountrySpy, service.externalId, null, req.correlationId)
+        sinon.assert.calledWith(req.flash, 'generic', 'United Kingdom as the default billing address: Off')
+        sinon.assert.calledWith(res.redirect, `/account/${account.external_id}/settings`)
+    })
+})


### PR DESCRIPTION
Add settings page to update the default billing address country for a service.

Currently, the 2 options are to set the pre-filled country either to 'United Kingdom' or to be blank.

<img width="1243" alt="Screenshot 2021-09-02 at 16 03 58" src="https://user-images.githubusercontent.com/5648592/131868295-b6591890-fda4-4460-b1ac-b9747362ee48.png">

<img width="1242" alt="Screenshot 2021-09-02 at 16 04 07" src="https://user-images.githubusercontent.com/5648592/131868303-7d0f08e4-5ae2-4d6c-a8fe-739e0eabd59e.png">

<img width="1242" alt="Screenshot 2021-09-02 at 16 04 44" src="https://user-images.githubusercontent.com/5648592/131868374-8d0f2a1b-21e4-4c60-b03c-5beae3873987.png">
