### PR TITLE
Fix - Convert total_amount to GBP all the time

### DIFF
--- a/app/utils/transaction-view.js
+++ b/app/utils/transaction-view.js
@@ -52,7 +52,8 @@ module.exports = {
         element.net_amount = asGBP(element.net_amount)
       }
       element.amount = asGBP(element.amount)
-      if (element.total_amount && element.corporate_card_surcharge) {
+
+      if (element.total_amount) {
         element.total_amount = asGBP(element.total_amount)
       }
       element.email = (element.email && element.email.length > 20) ? element.email.substring(0, 20) + '…' : element.email


### PR DESCRIPTION
## WHAT
- Convert total_amount to GBP when listing transactions (as total_amount is displayed if net_amount is not available) not just when corporate_card_surcharge is available.
