### PR TITLE
BAU Fix net amount display

### DIFF
--- a/app/utils/transaction-view.js
+++ b/app/utils/transaction-view.js
@@ -52,7 +52,7 @@ module.exports = {
         element.net_amount = asGBP(element.net_amount)
       }
       element.amount = asGBP(element.amount)
-      if (element.total_amount && element.corporate_card_surcharge) {
+      if (element.total_amount) {
         element.total_amount = asGBP(element.total_amount)
       }
       element.email = (element.email && element.email.length > 20) ? element.email.substring(0, 20) + '…' : element.email

--- a/test/cypress/integration/transactions/transaction-search.cy.test.js
+++ b/test/cypress/integration/transactions/transaction-search.cy.test.js
@@ -61,6 +61,15 @@ const filteredByMultipleFieldsTransactions = [
     parent_transaction_id: 'payment-transaction-id2'
   }
 ]
+const transactionWithTotalAmountButNotNetAmount = [
+  {
+    transaction_id: 'transaction_id',
+    reference: 'ref-1',
+    amount: 100,
+    total_amount: 100,
+    type: 'payment'
+  }
+]
 
 const transactionsWithAssociatedFees = [
   {
@@ -294,6 +303,14 @@ describe('Transactions List', () => {
 
       cy.get('#transactions-list tbody').find('tr').first().get('[data-cell-type="fee"]').eq(1).should('have.text', convertPenceToPoundsFormatted(transactionsWithAssociatedFees[1].fee))
       cy.get('#transactions-list tbody').find('tr').first().get('[data-cell-type="net"]').eq(1).find('span').should('have.text', convertPenceToPoundsFormatted(transactionsWithAssociatedFees[1].amount - transactionsWithAssociatedFees[1].fee))
+    })
+    it('should display net amount correctly for stripe transaction with total amount but not net amount set', () => {
+      cy.task('setupStubs', [
+        ...sharedStubs('stripe'),
+        transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: transactionWithTotalAmountButNotNetAmount })
+      ])
+      cy.visit(transactionsUrl)
+      cy.get('#transactions-list tbody').find('tr').first().get('[data-cell-type="net"]').eq(0).find('span').should('have.text', convertPenceToPoundsFormatted(transactionWithTotalAmountButNotNetAmount[0].total_amount))
     })
   })
   describe('csv download link', () => {

--- a/test/fixtures/ledger-transaction.fixtures.js
+++ b/test/fixtures/ledger-transaction.fixtures.js
@@ -145,6 +145,7 @@ const buildTransactionDetails = (opts = {}) => {
   }
   if (opts.fee) data.fee = opts.fee
   if (opts.net_amount) data.net_amount = opts.net_amount
+  if (opts.total_amount) data.total_amount = opts.total_amount
   if (opts.wallet_type) data.wallet_type = opts.wallet_type
   if (opts.metadata) data.metadata = opts.metadata
   return data


### PR DESCRIPTION
For stripe accounts we display net amount. Due to switching work, there are now accounts where net amount is displayed for payments not taken with stripe. These will sometimes have total amount set.

The bug was that in these cases, total amount would be displayed in net column (correct) but incorrectly formatted - see https://govuk.zendesk.com/agent/tickets/4708679

This PR adds test that recreates bug and fix - always format `total_amount` if set.
It also fixes small bug in tests, where total amount was not being passed through in ledger fixtures.