### PR TITLE
PP-8571 Contract pages - hide download link section when printing

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -47,3 +47,4 @@ $govuk-page-width: 1200px;
 @import "components/my-services";
 @import "components/task-list";
 @import "components/print-button";
+@import "components/contract";

--- a/app/assets/sass/components/contract.scss
+++ b/app/assets/sass/components/contract.scss
@@ -1,0 +1,5 @@
+.contract-download-container{
+  @media print {
+    display: none;
+  }
+}

--- a/app/views/policy/policy-html.njk
+++ b/app/views/policy/policy-html.njk
@@ -22,25 +22,27 @@
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-    <h2 class="govuk-heading-m">
-      <a class="govuk-link" href="{{ link }}">
-        Download PDF Version 
-      </a>
-    </h2>
+    <div class="contract-download-container">
+      <h2 class="govuk-heading-m">
+        <a class="govuk-link" href="{{ link }}">
+          Download PDF Version 
+        </a>
+      </h2>
 
-    <p class="govuk-body">
-      {% block downloadFileDetails %}{% endblock %}
-    </p>
+      <p class="govuk-body">
+        {% block downloadFileDetails %}{% endblock %}
+      </p>
 
-    <p class="govuk-body">
-      This file may not be suitable for users of accessible for users of assistive technologies.
-    </p>
+      <p class="govuk-body">
+        This file may not be suitable for users of accessible for users of assistive technologies.
+      </p>
 
-    <p class="govuk-body">
-      Read below for a HTML version.
-    </p>
+      <p class="govuk-body">
+        Read below for a HTML version.
+      </p>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    </div>
 
     <div>
       <span class="govuk-caption-m">Contract</span>


### PR DESCRIPTION
- When printing - it displays the URL of the dowload link which is really long.
- This PR hides this section when printing as it is not required in the printed
  version.

![image](https://user-images.githubusercontent.com/59831992/134015544-2deb8cce-a6e7-4a06-ad56-c315108b0244.png)



