### PR TITLE
PP-8715 Update authenticator app links

### DIFF
--- a/app/views/two-factor-auth/index.njk
+++ b/app/views/two-factor-auth/index.njk
@@ -64,10 +64,10 @@
     <p class="govuk-body">GOV.UK Pay works with most authenticator apps. If you do not have one installed already, there are several available. These include:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li><a class="govuk-link" href="https://authy.com/">Authy</a></li>
-      <li><a class="govuk-link" href="https://duo.com/">Duo</a></li>
+      <li><a class="govuk-link" href="https://duo.com/product/multi-factor-authentication-mfa/duo-mobile-app">Duo Mobile</a></li>
       <li><a class="govuk-link" href="https://support.google.com/accounts/answer/1066447">Google Authenticator</a></li>
       <li><a class="govuk-link" href="https://lastpass.com/auth/">LastPass Authenticator</a></li>
-      <li><a class="govuk-link" href="https://docs.microsoft.com/en-us/azure/multi-factor-authentication/end-user/microsoft-authenticator-app-how-to">Microsoft Authenticator</a></li>
+      <li><a class="govuk-link" href="https://support.microsoft.com/en-gb/account-billing/download-and-install-the-microsoft-authenticator-app-351498fc-850a-45da-b7b6-27e523b8702a">Microsoft Authenticator</a></li>
     </ul>
   {% endset %}
   {{


### PR DESCRIPTION
Update the authenticator app links (shown to a user on the page that lets them choose their sign-in method) to be more helpful.

The Duo homepage is very enterprisey, so link instead to the specific page for the Duo Mobile app, which still is not aimed at end users but a least has links to download the app.

Update the Microsoft Authenticator link (the old link redirects to the new one).