### PR TITLE
BAU - Ignore @sentry/node versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
     versions:
     - ">= 17.a"
     - "< 18"
-  - dependency-name: @sentry/node
+  - dependency-name: "@sentry/node"
     versions:
     - "> 6.12.0"
 - package-ecosystem: docker

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
     versions:
     - ">= 17.a"
     - "< 18"
+  - dependency-name: @sentry/node
+    versions:
+    - "> 6.12.0"
 - package-ecosystem: docker
   directory: "/"
   schedule:


### PR DESCRIPTION
## WHAT
- Due to recent update to `@sentry/node` version (https://github.com/alphagov/pay-selfservice/pull/2934), all requests to stripe started to fail.
- This could be due to the way sentry is set up in selfservice middleware.
- Ignoring new versions until this is looked into closely
