### PR TITLE
PP-8728 Service reg: no OTP pages without password on invite

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -230,7 +230,7 @@
         "filename": "test/fixtures/invite.fixtures.js",
         "hashed_secret": "c2326bf719e924050321d3adb8d8d3a99723ee95",
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 85,
         "is_secret": false
       },
       {
@@ -238,7 +238,7 @@
         "filename": "test/fixtures/invite.fixtures.js",
         "hashed_secret": "e5a7431b27dbc70d00c5ed873bd4d837bd65720c",
         "is_verified": false,
-        "line_number": 87,
+        "line_number": 92,
         "is_secret": false
       }
     ],
@@ -435,5 +435,5 @@
       }
     ]
   },
-  "generated_at": "2021-08-12T14:27:08Z"
+  "generated_at": "2021-10-06T10:38:06Z"
 }

--- a/app/errors.js
+++ b/app/errors.js
@@ -56,6 +56,13 @@ class RegistrationSessionMissingError extends DomainError {
 }
 
 /**
+ * Thrown when a user is trying to do something in the registration flow but has not yet
+ * completed the prerequisite steps.
+ */
+ class InvalidRegistationStateError extends DomainError {
+}
+
+/**
  * Thrown when account isn't correctly configured to access the resource
  */
 class InvalidConfigurationError extends DomainError {
@@ -69,5 +76,6 @@ module.exports = {
   NoServicesWithPermissionError,
   NotFoundError,
   RegistrationSessionMissingError,
+  InvalidRegistationStateError,
   InvalidConfigurationError
 }

--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -11,6 +11,7 @@ const {
   NoServicesWithPermissionError,
   NotFoundError,
   RegistrationSessionMissingError,
+  InvalidRegistationStateError,
   InvalidConfigurationError
 } = require('../errors')
 const paths = require('../paths')
@@ -56,7 +57,7 @@ module.exports = function errorHandler (err, req, res, next) {
     return response(req, res, '404')
   }
 
-  if (err instanceof RegistrationSessionMissingError) {
+  if (err instanceof RegistrationSessionMissingError || err instanceof InvalidRegistationStateError) {
     logger.info(`RegistrationSessionMissingError handled. Rendering error page`)
     return renderErrorView(req, res, 'There has been a problem proceeding with this registration. Please try again.', 400)
   }

--- a/test/fixtures/invite.fixtures.js
+++ b/test/fixtures/invite.fixtures.js
@@ -11,11 +11,16 @@ function buildInviteWithDefaults (opts = {}) {
     attempt_counter: 0,
     _links: [],
     user_exist: false,
-    expired: false
+    expired: false,
+    password_set: false
   })
 
   if (opts.telephone_number) {
     data.telephone_number = opts.telephone_number
+  }
+
+  if (opts.password_set) {
+    data.password_set = true
   }
 
   return data

--- a/test/integration/self-registration/self-registration-otp-resend.ft.test.js
+++ b/test/integration/self-registration/self-registration-otp-resend.ft.test.js
@@ -6,6 +6,7 @@ const csrf = require('csrf')
 const supertest = require('supertest')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
+const cheerio = require('cheerio')
 
 const mockSession = require('../../test-helpers/mock-session')
 const getApp = require('../../../server').getApp
@@ -14,38 +15,108 @@ const paths = require('../../../app/paths')
 
 // Constants
 const SERVICE_INVITE_OTP_RESEND_RESOURCE = '/v1/api/invites/otp/resend'
+const ADMINUSERS_INVITES_URL = '/v1/api/invites'
 const adminusersMock = nock(process.env.ADMINUSERS_URL)
 const expect = chai.expect
+const inviteCode = 'a-valid-invite-code'
 
 // Global setup
 chai.use(chaiAsPromised)
 
 let app
 
-describe('create service otp resend validation', function () {
+describe('create service OTP resend validation', function () {
   afterEach((done) => {
     nock.cleanAll()
     app = null
     done()
   })
 
-  describe('get otp resend page', function () {
+  describe('get OTP resend page', function () {
+    it('should render normally when register_invite cookie present and invite has password set', function (done) {
+      const mockAdminUsersInviteResponse = inviteFixtures.validInviteResponse({password_set: true})
+
+      adminusersMock.get(`${ADMINUSERS_INVITES_URL}/${inviteCode}`)
+        .reply(200, mockAdminUsersInviteResponse)
+
+      const telephoneNumber = '07700900000'
+
+      app = mockSession.getAppWithRegisterInvitesCookie(getApp(), {
+        code: inviteCode,
+        telephone_number: '07700900000',
+        email: 'test@test.test'
+      })
+      supertest(app)
+        .get(paths.selfCreateService.otpResend)
+        .expect(200)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('input#telephone-number').val()).to.equal(telephoneNumber)
+        })
+        .end(done)
+    })
+
     it('should return an error when register_invite cookie not present', function (done) {
       app = mockSession.getAppWithLoggedOutSession(getApp())
       supertest(app)
-        .get('/create-service/resend-otp')
+        .get(paths.selfCreateService.otpResend)
         .expect(400)
         .end(done)
     })
   })
 
-  describe('post to otp resend page', function () {
-    it('should redirect to otp verify page on valid telephone number submission', function (done) {
+  it('should render an error when the invite is not found', function (done) {
+    adminusersMock.get(`${ADMINUSERS_INVITES_URL}/${inviteCode}`).reply(404)
+
+    app = mockSession.getAppWithRegisterInvitesCookie(getApp(), {
+      code: inviteCode,
+      telephone_number: '07700900000',
+      email: 'test@test.test'
+    })
+    supertest(app)
+      .get(paths.selfCreateService.otpResend)
+      .expect(404)
+      .end(done)
+  })
+
+  it('should render an error when the invite is expired or disabled', function (done) {
+    adminusersMock.get(`${ADMINUSERS_INVITES_URL}/${inviteCode}`).reply(410)
+
+    app = mockSession.getAppWithRegisterInvitesCookie(getApp(), {
+      code: inviteCode,
+      telephone_number: '07700900000',
+      email: 'test@test.test'
+    })
+    supertest(app)
+      .get(paths.selfCreateService.otpResend)
+      .expect(410)
+      .end(done)
+  })
+
+  it('should render an error when the password is not set in the invite', function (done) {
+    const mockAdminUsersInviteResponse = inviteFixtures.validInviteResponse({password_set: false})
+
+    adminusersMock.get(`${ADMINUSERS_INVITES_URL}/${inviteCode}`)
+      .reply(200, mockAdminUsersInviteResponse)
+
+    app = mockSession.getAppWithRegisterInvitesCookie(getApp(), {
+      code: inviteCode,
+      telephone_number: '07700900000',
+      email: 'test@test.test'
+    })
+    supertest(app)
+      .get(paths.selfCreateService.otpResend)
+      .expect(400)
+      .end(done)
+  })
+
+  describe('post to OTP resend page', function () {
+    it('should redirect to OTP verify page on valid telephone number submission', function (done) {
       const validServiceInviteOtpResendRequestPlain = inviteFixtures.validResendOtpCodeRequest()
       const registerInviteData = {
         code: validServiceInviteOtpResendRequestPlain.code,
         telephone_number: validServiceInviteOtpResendRequestPlain.telephone_number,
-        email: 'bob@bob.com'
+        email: 'test@test.test'
       }
 
       adminusersMock.post(`${SERVICE_INVITE_OTP_RESEND_RESOURCE}`, validServiceInviteOtpResendRequestPlain)
@@ -69,7 +140,7 @@ describe('create service otp resend validation', function () {
       const registerInviteData = {
         code: validServiceInviteOtpResendRequestPlain.code,
         telephone_number: validServiceInviteOtpResendRequestPlain.telephone_number,
-        email: 'bob@bob.com'
+        email: 'test@test.test'
       }
 
       adminusersMock.post(`${SERVICE_INVITE_OTP_RESEND_RESOURCE}`, {

--- a/test/unit/clients/adminusers-client/invite/get-invite.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/get-invite.pact.test.js
@@ -59,6 +59,7 @@ describe('adminusers client - get a validated invite', function () {
         expect(invite.email).to.be.equal(getInviteResponse.email)
         expect(invite.telephone_number).to.be.equal(getInviteResponse.telephone_number)
         expect(invite.type).to.be.equal(getInviteResponse.type)
+        expect(invite.password_set).to.be.equal(getInviteResponse.password_set)
       }).should.notify(done)
     })
   })


### PR DESCRIPTION
In the service registration flow, when loading the page where the user enters the OTP or the page where the user can choose to resend the OTP, retrieve the invite (which will check it’s still valid) and make sure it has the flag indicating the password has been set.

This prepares us for a world where the invite may not have a password set when it is first created.