### PR TITLE
PP-8750 Remove unused route

### DIFF
--- a/app/controllers/credentials.controller.js
+++ b/app/controllers/credentials.controller.js
@@ -73,10 +73,6 @@ function credentialsPatchRequestValueOf (req) {
 }
 
 module.exports = {
-  index: function (req, res, next) {
-    loadIndex(req, res, next)
-  },
-
   editCredentials: function (req, res, next) {
     loadIndex(req, res, next, EDIT_CREDENTIALS_MODE)
   },

--- a/app/routes.js
+++ b/app/routes.js
@@ -316,7 +316,6 @@ module.exports.bind = function (app) {
   account.get(switchPSP.credentialsWithGatewayCheck, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)
   account.post(switchPSP.credentialsWithGatewayCheck, permission('gateway-credentials:read'), worldpayCredentialsController.updateWorldpayCredentials)
 
-  account.get(credentials.index, permission('gateway-credentials:read'), credentialsController.index)
   account.get(credentials.edit, permission('gateway-credentials:update'), credentialsController.editCredentials)
   account.post(credentials.index, permission('gateway-credentials:update'), credentialsController.update)
   account.get(notificationCredentials.edit, permission('gateway-credentials:update'), credentialsController.editNotificationCredentials)


### PR DESCRIPTION
There is a GET index route for credentials. However, this route is never accessed (we only POST to this path). Remove it to start cleaning up the credentials controller.
