### PR TITLE
PP-8715 Better link for Microsoft Authenticator

### DIFF
--- a/app/views/two-factor-auth/index.njk
+++ b/app/views/two-factor-auth/index.njk
@@ -67,7 +67,7 @@
       <li><a class="govuk-link" href="https://duo.com/product/multi-factor-authentication-mfa/duo-mobile-app">Duo Mobile</a></li>
       <li><a class="govuk-link" href="https://support.google.com/accounts/answer/1066447">Google Authenticator</a></li>
       <li><a class="govuk-link" href="https://lastpass.com/auth/">LastPass Authenticator</a></li>
-      <li><a class="govuk-link" href="https://support.microsoft.com/en-gb/account-billing/download-and-install-the-microsoft-authenticator-app-351498fc-850a-45da-b7b6-27e523b8702a">Microsoft Authenticator</a></li>
+      <li><a class="govuk-link" href="https://www.microsoft.com/en-gb/security/mobile-authenticator-app">Microsoft Authenticator</a></li>
     </ul>
   {% endset %}
   {{


### PR DESCRIPTION
Update the Microsoft Authenticator app link (shown to a user on the page that lets them choose their sign-in method) so that it goes to a [friendly product page with obvious calls to action for installing the app](https://www.microsoft.com/en-gb/security/mobile-authenticator-app) rather than a [wordy support page that explains how to download and install it](https://support.microsoft.com/en-gb/account-billing/download-and-install-the-microsoft-authenticator-app-351498fc-850a-45da-b7b6-27e523b8702a).

This is still not perfect as the new page links to support docs that assume the user wants to use the app with a Microsoft account but the old page also suffered from this (and the [Google Authenticator page we direct users to](https://support.google.com/accounts/answer/1066447)  is even worse).