### PR TITLE
PP-8750 Remove client side validation from payment links

### DIFF
--- a/app/controllers/payment-links/post-edit-information.controller.js
+++ b/app/controllers/payment-links/post-edit-information.controller.js
@@ -4,6 +4,9 @@ const lodash = require('lodash')
 
 const paths = require('../../paths')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
+const { validateMandatoryField, validateNaxsiSafe } = require('../../utils/validation/server-side-form-validations')
+
+const TITLE_MAX_LENGTH = 255
 
 module.exports = function postEditInformation (req, res) {
   const { productExternalId } = req.params
@@ -17,10 +20,17 @@ module.exports = function postEditInformation (req, res) {
   const name = req.body['payment-link-title']
   const description = req.body['payment-link-description']
 
-  if (name === '') {
-    const errors = {
-      title: 'Enter a title'
-    }
+  const errors = {}
+  const validateTitleResult = validateMandatoryField(name, TITLE_MAX_LENGTH, 'title', true)
+  if (!validateTitleResult.valid) {
+    errors.title = validateTitleResult.message
+  }
+  const validateDescriptionResult = validateNaxsiSafe(description, 'details')
+  if (!validateDescriptionResult.valid) {
+    errors.description = validateDescriptionResult.message
+  }
+
+  if (!lodash.isEmpty(errors)) {
     sessionData.informationPageRecovered = {
       errors,
       name,

--- a/app/controllers/payment-links/post-edit-reference.controller.js
+++ b/app/controllers/payment-links/post-edit-reference.controller.js
@@ -4,6 +4,10 @@ const lodash = require('lodash')
 
 const paths = require('../../paths')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
+const { validateOptionalField } = require('../../utils/validation/server-side-form-validations')
+
+const LABEL_MAX_LENGTH = 50
+const HINT_MAX_LENGTH = 255
 
 module.exports = function postEditReference (req, res) {
   const { productExternalId } = req.params
@@ -18,10 +22,20 @@ module.exports = function postEditReference (req, res) {
   const referenceLabel = req.body['reference-type-group'] === 'custom' ? req.body['reference-label'] : ''
   const referenceHint = req.body['reference-type-group'] === 'custom' ? req.body['reference-hint-text'] : ''
 
+  const errors = {}
   if (req.body['reference-type-group'] === 'custom' && req.body['reference-label'] === '') {
-    const errors = {
-      label: 'Enter a name for your payment reference'
-    }
+    errors.label = 'Enter a name for your payment reference'
+  }
+  const validateLabelResult = validateOptionalField(referenceLabel, LABEL_MAX_LENGTH, 'name of payment reference', true)
+  if (!validateLabelResult.valid) {
+    errors.label = validateLabelResult.message
+  }
+  const validateHintResult = validateOptionalField(referenceHint, HINT_MAX_LENGTH, 'hint text', true)
+  if (!validateHintResult.valid) {
+    errors.hint = validateHintResult.message
+  }
+
+  if (!lodash.isEmpty(errors)) {
     sessionData.referencePageRecovered = {
       errors,
       referenceEnabled,

--- a/app/controllers/payment-links/post-information.controller.js
+++ b/app/controllers/payment-links/post-information.controller.js
@@ -7,6 +7,9 @@ const paths = require('../../paths')
 
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const productsClient = require('../../services/clients/products.client.js')
+const { validateMandatoryField, validateNaxsiSafe } = require('../../utils/validation/server-side-form-validations')
+
+const TITLE_MAX_LENGTH = 255
 
 const makeNiceURL = string => {
   return slugify(removeIndefiniteArticles(string))
@@ -22,10 +25,17 @@ module.exports = async function postInformation (req, res, next) {
   const description = req.body['payment-link-description']
   const serviceNamePath = req.body['service-name-path']
 
-  if (title === '') {
-    const errors = {
-      title: 'Enter a title'
-    }
+  const errors = {}
+  const validateTitleResult = validateMandatoryField(title, TITLE_MAX_LENGTH, 'title', true)
+  if (!validateTitleResult.valid) {
+    errors.title = validateTitleResult.message
+  }
+  const validateDescriptionResult = validateNaxsiSafe(description, 'details')
+  if (!validateDescriptionResult.valid) {
+    errors.description = validateDescriptionResult.message
+  }
+
+  if (!lodash.isEmpty(errors)) {
     sessionData.informationPageRecovered = {
       errors,
       title,

--- a/app/controllers/payment-links/post-reference.controller.js
+++ b/app/controllers/payment-links/post-reference.controller.js
@@ -4,6 +4,10 @@ const lodash = require('lodash')
 const paths = require('../../paths')
 
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
+const { validateOptionalField } = require('../../utils/validation/server-side-form-validations')
+
+const LABEL_MAX_LENGTH = 50
+const HINT_MAX_LENGTH = 255
 
 module.exports = function postReference (req, res, next) {
   const sessionData = lodash.get(req, 'session.pageData.createPaymentLink')
@@ -20,6 +24,14 @@ module.exports = function postReference (req, res, next) {
     errors.type = 'Would you like us to create a payment reference number for your users?'
   } else if (type === 'custom' && label === '') {
     errors.label = 'Enter a name for your payment reference'
+  }
+  const validateLabelResult = validateOptionalField(label, LABEL_MAX_LENGTH, 'name of payment reference', true)
+  if (!validateLabelResult.valid) {
+    errors.label = validateLabelResult.message
+  }
+  const validateHintResult = validateOptionalField(hint, HINT_MAX_LENGTH, 'hint text', true)
+  if (!validateHintResult.valid) {
+    errors.hint = validateHintResult.message
   }
 
   if (!lodash.isEmpty(errors)) {

--- a/app/utils/validation/server-side-form-validations.test.js
+++ b/app/utils/validation/server-side-form-validations.test.js
@@ -25,6 +25,27 @@ describe('Server side form validations', () => {
         message: 'The text is too long'
       })
     })
+
+    it('should return error message with field name if provided', () => {
+      expect(validations.validateOptionalField(LOOOONG_TEXT, MAX_LENGTH, 'name')).to.deep.equal({
+        valid: false,
+        message: 'Name must be 25 characters or fewer'
+      })
+    })
+
+    it('should capitalise first letter of field name in message and leave other letters as provided', () => {
+      expect(validations.validateOptionalField(LOOOONG_TEXT, MAX_LENGTH, 'PSP ID')).to.deep.equal({
+        valid: false,
+        message: 'PSP ID must be 25 characters or fewer'
+      })
+    })
+
+    it('should return error if contains NAXSI not allowed characters', () => {
+      expect(validations.validateOptionalField('Brian|', MAX_LENGTH, 'name', true)).to.deep.equal({
+        valid: false,
+        message: 'Name must not include < > |'
+      })
+    })
   })
 
   describe('mandatory text field validations', () => {
@@ -43,6 +64,47 @@ describe('Server side form validations', () => {
       expect(validations.validateMandatoryField(LOOOONG_TEXT, MAX_LENGTH)).to.deep.equal({
         valid: false,
         message: 'The text is too long'
+      })
+    })
+
+    it('should return error message with field name if provided', () => {
+      expect(validations.validateMandatoryField(LOOOONG_TEXT, MAX_LENGTH, 'name')).to.deep.equal({
+        valid: false,
+        message: 'Name must be 25 characters or fewer'
+      })
+    })
+
+    it('should capitalise first letter of field name in message and leave other letters as provided', () => {
+      expect(validations.validateMandatoryField(LOOOONG_TEXT, MAX_LENGTH, 'PSP ID')).to.deep.equal({
+        valid: false,
+        message: 'PSP ID must be 25 characters or fewer'
+      })
+    })
+
+    it('should return error if contains NAXSI not allowed characters', () => {
+      expect(validations.validateMandatoryField('Brian|', MAX_LENGTH, 'name', true)).to.deep.equal({
+        valid: false,
+        message: 'Name must not include < > |'
+      })
+    })
+  })
+
+  describe('NAXSI safe validation', () => {
+    it('should be valid when does not contain not allowed characters', () => {
+      expect(validations.validateNaxsiSafe('Brian', 'name').valid).to.be.true // eslint-disable-line
+    })
+
+    it('should return error if contains NAXSI not allowed characters', () => {
+      expect(validations.validateNaxsiSafe('Brian|', 'name')).to.deep.equal({
+        valid: false,
+        message: 'Name must not include < > |'
+      })
+    })
+
+    it('should capitalise first letter of field name in message and leave other letters as provided', () => {
+      expect(validations.validateNaxsiSafe('ABC<>', 'PSP ID')).to.deep.equal({
+        valid: false,
+        message: 'PSP ID must not include < > |'
       })
     })
   })

--- a/app/views/payment-links/edit-information.njk
+++ b/app/views/payment-links/edit-information.njk
@@ -14,7 +14,8 @@
   {{ errorSummary ({
     errors: errors,
     hrefs: {
-      title: "#payment-link-title"
+      title: "#payment-link-title",
+      description: "#payment-link-description"
     }
   }) }}
 
@@ -27,13 +28,6 @@
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {% if change.length %}
       <input name="change" type="hidden" value="true"/>
-    {% endif %}
-
-    {% set titleError = false %}
-    {% if errors.title %}
-    {% set titleError = {
-      text: errors.title | safe
-    } %}
     {% endif %}
 
   {% if isWelsh %}
@@ -49,8 +43,6 @@
     {% endif %}
 
     {% set titleAttributes = {
-      "data-validate": "isFieldGreaterThanMaxLengthChars isNaxsiSafe",
-      "data-validate-max-length": "254",
       "lang": lang
     } %}
     {% set descriptionAttributes = {
@@ -59,8 +51,6 @@
     } %}
     {% if change !== 'payment-link-description' %}
       {% set titleAttributes = {
-        "data-validate": "isFieldGreaterThanMaxLengthChars isNaxsiSafe",
-        "data-validate-max-length": "254",
         "lang": lang,
         "autofocus": true
       } %}
@@ -85,7 +75,7 @@
         },
         value: paymentLinkTitle,
         attributes: titleAttributes,
-        errorMessage: titleError
+        errorMessage: { text: errors.title } if errors.title else false
       })
     }}
 
@@ -101,7 +91,8 @@
           text: detailsHint
         },
         value: paymentLinkDescription,
-        attributes: descriptionAttributes
+        attributes: descriptionAttributes,
+        errorMessage: { text: errors.description } if errors.description else false
       })
     }}
 

--- a/app/views/payment-links/edit-reference.njk
+++ b/app/views/payment-links/edit-reference.njk
@@ -16,7 +16,8 @@
     errors: errors,
     hrefs: {
       type: "#reference-type-custom",
-      label: "#reference-label"
+      label: "#reference-label",
+      hint: "#reference-hint-text"
     }
   }) }}
 
@@ -30,13 +31,6 @@
     {% if errors.type %}
     {% set noSelectionError = {
         text: "Please choose an option"
-    } %}
-    {% endif %}
-
-    {% set blankReferenceLabelError = false %}
-    {% if errors.label %}
-    {% set blankReferenceLabelError = {
-        text: errors.label
     } %}
     {% endif %}
 
@@ -56,7 +50,7 @@
           id: "reference-label",
           name: "reference-label",
           value: referenceLabel,
-          errorMessage: blankReferenceLabelError,
+          errorMessage: { text: errors.label } if errors.label else false,
           classes: "govuk-input--width-20",
           label: {
               text: "Name of payment reference",
@@ -66,7 +60,6 @@
             html: referenceNameHint
           },
           attributes: {
-            "data-validate": "isNaxsiSafe",
             "lang": lang
           }
         })
@@ -77,6 +70,7 @@
           id: "reference-hint-text",
           name: "reference-hint-text",
           value: referenceHint,
+          errorMessage: { text: errors.hint } if errors.hint else false,
           classes: "govuk-input--width-20",
           maxlength: 255,
           label: {
@@ -87,9 +81,7 @@
             text: referenceHintHint
           },
           attributes: {
-            "data-validate": "isFieldGreaterThanMaxLengthChars isNaxsiSafe",
             "maxlength": "255",
-            "data-validate-max-length": "255",
             "lang": lang
           }
         })

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -15,7 +15,8 @@
   {{ errorSummary ({
     errors: errors,
     hrefs: {
-      title: "#payment-link-title"
+      title: "#payment-link-title",
+      description: "#payment-link-description"
     }
   }) }}
 
@@ -32,12 +33,6 @@
       <input name="change" type="hidden" value="true"/>
     {% endif %}
 
-    {% set titleError = false %}
-    {% if errors.title %}
-      {% set titleError = {
-        text: errors.title | safe
-      } %}
-    {% endif %}
     {% set confirmationLabel %}{{friendlyURL}}/{{serviceName | removeIndefiniteArticles | slugify}}/{% endset %}
 
     {% if isWelsh %}
@@ -65,10 +60,8 @@
         hint: {
           html: titleHint
         },
-        errorMessage: titleError,
+        errorMessage: { text: errors.title } if errors.title else false,
         attributes: {
-          "data-validate": "isFieldGreaterThanMaxLengthChars isNaxsiSafe",
-          "data-validate-max-length": "254",
           "autofocus": change !== "payment-link-description",
           "data-confirmation": true,
           "data-confirmation-title": "The website address for this payment link will look like:",
@@ -93,8 +86,8 @@
         hint: {
           text: detailsHint
         },
+        errorMessage: { text: errors.description } if errors.description else false,
         attributes: {
-          "data-validate": "isNaxsiSafe",
           "autofocus": change !== "payment-link-description",
           "rows": "5",
           "lang": lang

--- a/app/views/payment-links/reference.njk
+++ b/app/views/payment-links/reference.njk
@@ -16,7 +16,8 @@
     errors: errors,
     hrefs: {
       type: "#reference-type-custom",
-      label: "#reference-label"
+      label: "#reference-label",
+      hint: "#reference-hint-text"
     }
   }) }}
 
@@ -30,13 +31,6 @@
     {% if errors.type %}
     {% set noSelectionError = {
         text: "Please choose an option"
-    } %}
-    {% endif %}
-
-    {% set blankReferenceLabelError = false %}
-    {% if errors.label %}
-    {% set blankReferenceLabelError = {
-        text: errors.label
     } %}
     {% endif %}
 
@@ -56,7 +50,7 @@
           id: "reference-label",
           name: "reference-label",
           value: paymentReferenceLabel,
-          errorMessage: blankReferenceLabelError,
+          errorMessage: { text: errors.label } if errors.label else false,
           classes: "govuk-input--width-20",
           label: {
               text: "Name of payment reference",
@@ -66,7 +60,6 @@
             html: referenceNameHint
           },
           attributes: {
-            "data-validate": "isNaxsiSafe",
             "lang": lang
           }
         })
@@ -77,6 +70,7 @@
           id: "reference-hint-text",
           name: "reference-hint-text",
           value: paymentReferenceHint,
+          errorMessage: { text: errors.hint } if errors.hint else false,
           classes: "govuk-input--width-20",
           maxlength: 255,
           label: {
@@ -87,9 +81,7 @@
             text: referenceHintHint
           },
           attributes: {
-            "data-validate": "isFieldGreaterThanMaxLengthChars isNaxsiSafe",
             "maxlength": "255",
-            "data-validate-max-length": "255",
             "lang": lang
           }
         })


### PR DESCRIPTION
Reproduce all client-side validation on the server side, and remove the client side validation from the payment links pages.

Removing client-side validation as it is against design system guidance, makes it difficult to test validation, and is not consistent with the server side validation.

Add some new functions to server-side-form-validations.js for this.

For checking whether fields contain characters not allowed by NAXSI, don't check for a ";", as we have this on the allow list for most routes

