### PR TITLE
PP-8573 Pull policy document HTML from S3

### DIFF
--- a/app/controllers/policy/policy-html.controller.js
+++ b/app/controllers/policy/policy-html.controller.js
@@ -12,9 +12,10 @@ async function downloadDocumentsPolicyPage (req, res, next) {
   try {
     const documentConfig = await supportedPolicyDocuments.lookup(key)
     const link = await policyBucket.generatePrivateLink(documentConfig)
+    const contentHtml = await policyBucket.getDocumentHtmlFromS3(documentConfig)
 
     logger.info(`User ${req.user.externalId} signed private link for ${key}: ${link}`)
-    return response(req, res, documentConfig.htmlTemplate, { link })
+    return response(req, res, documentConfig.htmlTemplate, { link, contentHtml })
   } catch (err) {
     next(err)
   }

--- a/app/views/policy/policy-html.njk
+++ b/app/views/policy/policy-html.njk
@@ -60,5 +60,7 @@
         Print this page
       </button>
     </div>
+
+    {{ contentHtml | safe }}
   </div>
 {% endblock %}


### PR DESCRIPTION
The HTML for the policy documents lives in the same S3 bucket as the pdfs. For the new pages to display the contracts, pull the HTML from S3 and pass it in the template data to the view.
