### PR TITLE
PP-8767 - HTML Policy pages - update template

### DIFF
--- a/app/views/policy/policy-html.njk
+++ b/app/views/policy/policy-html.njk
@@ -44,16 +44,9 @@
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     </div>
 
-    <div>
-      <span class="govuk-caption-m">Contract</span>
-      <h2 class="govuk-heading-m">
+    <h2 class="govuk-heading-m">
         HTML Version: {% block policyHtmlTitle %}{% endblock %}
-      </h2>
-    </div>
-
-    <p class="govuk-body">
-      Last updated {% block lastUpdatedDate %}{% endblock %}
-    </p> 
+    </h2>
 
     <div class="print-button-wrapper">
       <button class="print-button-wrapper__button govuk-link govuk-!-font-size-19" data-print-button="true">


### PR DESCRIPTION
- Remove the `last updated date` for now.
  We may add this back in later once we know what the dates are.
- Remove the `contract` sub-heading - as these are policy pages
  and not contracts.  Easier to just remove them.



