### PR TITLE
PP-8498 Create/ update Webhook page

### DIFF
--- a/app/controllers/webhooks/webhooks.controller.js
+++ b/app/controllers/webhooks/webhooks.controller.js
@@ -1,10 +1,14 @@
 'use strict'
 
+const { constants } = require('@govuk-pay/pay-js-commons')
+
 const { response } = require('../../utils/response.js')
+const paths = require('../../paths')
+const formatFutureStrategyAccountPathsFor = require('../../utils/format-future-strategy-account-paths-for')
 
 const webhooksService = require('./webhooks.service')
 
-async function listWebhooksPage (req, res, next) {
+async function listWebhooksPage(req, res, next) {
   try {
     const webhooks = await webhooksService.listWebhooks(req.service.externalId, req.isLive)
     response(req, res, 'webhooks/list', { webhooks })
@@ -13,6 +17,21 @@ async function listWebhooksPage (req, res, next) {
   }
 }
 
+async function createWebhookPage(req, res, next) {
+  response(req, res, 'webhooks/edit', { eventTypes: constants.webhooks.humanReadableSubscriptions })
+}
+
+async function createWebhook(req, res, next) {
+  try {
+    await webhooksService.createWebhook(req.service.externalId, req.isLive, req.body)
+    res.redirect(formatFutureStrategyAccountPathsFor(paths.futureAccountStrategy.webhooks.index, req.account.type, req.service.externalId, req.account.external_id))
+  } catch (error) {
+    next(error)
+  }
+}
+
 module.exports = {
-  listWebhooksPage
+  listWebhooksPage,
+  createWebhookPage,
+  createWebhook
 }

--- a/app/controllers/webhooks/webhooks.controller.js
+++ b/app/controllers/webhooks/webhooks.controller.js
@@ -21,6 +21,15 @@ async function createWebhookPage(req, res, next) {
   response(req, res, 'webhooks/edit', { eventTypes: constants.webhooks.humanReadableSubscriptions })
 }
 
+async function updateWebhookPage(req, res, next) {
+  try {
+    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId)
+    response(req, res, 'webhooks/edit', { eventTypes: constants.webhooks.humanReadableSubscriptions, isEditing: true, webhook })
+  } catch (error) {
+    next(error)
+  }
+}
+
 async function createWebhook(req, res, next) {
   try {
     await webhooksService.createWebhook(req.service.externalId, req.isLive, req.body)
@@ -30,8 +39,19 @@ async function createWebhook(req, res, next) {
   }
 }
 
+async function updateWebhook(req, res, next) {
+  try {
+    await webhooksService.updateWebhook(req.params.webhookId, req.service.externalId, req.body)
+    res.redirect(formatFutureStrategyAccountPathsFor(paths.futureAccountStrategy.webhooks.detail, req.account.type, req.service.externalId, req.account.external_id, req.params.webhookId))
+  } catch (error) {
+    next(error)
+  }
+}
+
 module.exports = {
   listWebhooksPage,
   createWebhookPage,
-  createWebhook
+  createWebhook,
+  updateWebhookPage,
+  updateWebhook
 }

--- a/app/controllers/webhooks/webhooks.service.js
+++ b/app/controllers/webhooks/webhooks.service.js
@@ -2,21 +2,32 @@
 
 const webhooksClient = require('./../../services/clients/webhooks.client')
 
-function sortByActiveStatus (a, b) {
+function sortByActiveStatus(a, b) {
   return Number(b.status === 'ACTIVE') - Number(a.status === 'ACTIVE')
 }
 
-async function listWebhooks (serviceId, isLive) {
+async function listWebhooks(serviceId, isLive) {
   const webhooks = await webhooksClient.webhooks(serviceId, isLive)
   return webhooks.sort(sortByActiveStatus)
 }
 
-function createWebhook (serviceId, isLive, options = {}) {
+function createWebhook(serviceId, isLive, options = {}) {
   options.subscriptions = typeof options.subscriptions === 'string' ? [ options.subscriptions ] : options.subscriptions
   return webhooksClient.createWebhook(serviceId, isLive, options)
 }
 
+function updateWebhook(id, serviceId, options = {}) {
+  options.subscriptions = typeof options.subscriptions === 'string' ? [ options.subscriptions ] : options.subscriptions
+  return webhooksClient.updateWebhook(id, serviceId, options)
+}
+
+function getWebhook(id, serviceId) {
+  return webhooksClient.webhook(id, serviceId)
+}
+
 module.exports = {
   listWebhooks,
-  createWebhook
+  createWebhook,
+  updateWebhook,
+  getWebhook
 }

--- a/app/controllers/webhooks/webhooks.service.js
+++ b/app/controllers/webhooks/webhooks.service.js
@@ -11,6 +11,12 @@ async function listWebhooks (serviceId, isLive) {
   return webhooks.sort(sortByActiveStatus)
 }
 
+function createWebhook (serviceId, isLive, options = {}) {
+  options.subscriptions = typeof options.subscriptions === 'string' ? [ options.subscriptions ] : options.subscriptions
+  return webhooksClient.createWebhook(serviceId, isLive, options)
+}
+
 module.exports = {
-  listWebhooks
+  listWebhooks,
+  createWebhook
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -152,7 +152,8 @@ module.exports = {
     root: `/:${keys.ENVIRONMENT_ID}(test|live)/service/:${keys.SERVICE_EXTERNAL_ID}/account/:${keys.GATEWAY_ACCOUNT_EXTERNAL_ID}`,
     webhooks: {
       index: '/webhooks',
-      detail: '/webhook/:webhookId'
+      detail: '/webhooks/:webhookId',
+      create: '/webhooks/create'
     }
   },
   service: {

--- a/app/paths.js
+++ b/app/paths.js
@@ -153,6 +153,7 @@ module.exports = {
     webhooks: {
       index: '/webhooks',
       detail: '/webhooks/:webhookId',
+      update: '/webhooks/:webhookId/update',
       create: '/webhooks/create'
     }
   },

--- a/app/routes.js
+++ b/app/routes.js
@@ -448,10 +448,10 @@ module.exports.bind = function (app) {
   account.get(stripe.addPspAccountDetails, permission('stripe-account-details:update'), restrictToStripeAccountContext, stripeSetupAddPspAccountDetailsController.get)
 
   futureAccountStrategy.get(webhooks.index, permission('webhooks:read'), webhooksController.listWebhooksPage)
-  futureAccountStrategy.get(webhooks.create, permission('webhooks:read'), webhooksController.createWebhookPage)
-  futureAccountStrategy.post(webhooks.create, permission('webhooks:read'), webhooksController.createWebhook)
-  futureAccountStrategy.get(webhooks.update, permission('webhooks:read'), webhooksController.updateWebhookPage)
-  futureAccountStrategy.post(webhooks.update, permission('webhooks:read'), webhooksController.updateWebhook)
+  futureAccountStrategy.get(webhooks.create, permission('webhooks:update'), webhooksController.createWebhookPage)
+  futureAccountStrategy.post(webhooks.create, permission('webhooks:update'), webhooksController.createWebhook)
+  futureAccountStrategy.get(webhooks.update, permission('webhooks:update'), webhooksController.updateWebhookPage)
+  futureAccountStrategy.post(webhooks.update, permission('webhooks:update'), webhooksController.updateWebhook)
 
   app.use(paths.account.root, account)
   app.use(paths.service.root, service)

--- a/app/routes.js
+++ b/app/routes.js
@@ -448,6 +448,8 @@ module.exports.bind = function (app) {
   account.get(stripe.addPspAccountDetails, permission('stripe-account-details:update'), restrictToStripeAccountContext, stripeSetupAddPspAccountDetailsController.get)
 
   futureAccountStrategy.get(webhooks.index, permission('webhooks:read'), webhooksController.listWebhooksPage)
+  futureAccountStrategy.get(webhooks.create, permission('webhooks:read'), webhooksController.createWebhookPage)
+  futureAccountStrategy.post(webhooks.create, permission('webhooks:read'), webhooksController.createWebhook)
 
   app.use(paths.account.root, account)
   app.use(paths.service.root, service)

--- a/app/routes.js
+++ b/app/routes.js
@@ -450,6 +450,8 @@ module.exports.bind = function (app) {
   futureAccountStrategy.get(webhooks.index, permission('webhooks:read'), webhooksController.listWebhooksPage)
   futureAccountStrategy.get(webhooks.create, permission('webhooks:read'), webhooksController.createWebhookPage)
   futureAccountStrategy.post(webhooks.create, permission('webhooks:read'), webhooksController.createWebhook)
+  futureAccountStrategy.get(webhooks.update, permission('webhooks:read'), webhooksController.updateWebhookPage)
+  futureAccountStrategy.post(webhooks.update, permission('webhooks:read'), webhooksController.updateWebhook)
 
   app.use(paths.account.root, account)
   app.use(paths.service.root, service)

--- a/app/services/clients/webhooks.client.js
+++ b/app/services/clients/webhooks.client.js
@@ -9,10 +9,13 @@ const defaultRequestOptions = {
   service: 'webhooks'
 }
 
-function webhook (id, options = {}) {
+function webhook(id, serviceId, options = {}) {
   const url = urlJoin('/v1/webhook', id)
   const request = {
     url,
+    qs: {
+      service_id: serviceId
+    },
     description: 'Get one webhook',
     ...defaultRequestOptions,
     ...options
@@ -20,7 +23,7 @@ function webhook (id, options = {}) {
   return baseClient.get(request)
 }
 
-function webhooks (serviceId, isLive, options = {}) {
+function webhooks(serviceId, isLive, options = {}) {
   const url = '/v1/webhook'
   const request = {
     url,
@@ -35,7 +38,7 @@ function webhooks (serviceId, isLive, options = {}) {
   return baseClient.get(request)
 }
 
-function createWebhook (serviceId, isLive, options = {}) {
+function createWebhook(serviceId, isLive, options = {}) {
   const url = '/v1/webhook'
   const request = {
     url,
@@ -48,14 +51,34 @@ function createWebhook (serviceId, isLive, options = {}) {
     },
     ...defaultRequestOptions,
     ...options,
-    description: 'Create a webhook',
+    description: 'Create a Webhook',
   }
-  console.log(request)
   return baseClient.post(request)
+}
+
+function updateWebhook(id, serviceId, options = {}) {
+  const url = urlJoin('/v1/webhook', id)
+  const body = [
+    { op: 'replace', path: 'callback_url', value: options.callback_url },
+    { op: 'replace', path: 'subscriptions', value: options.subscriptions },
+    { op: 'replace', path: 'description', value: options.description }
+  ]
+  const request = {
+    url,
+    qs: {
+      service_id: serviceId
+    },
+    body,
+    ...defaultRequestOptions,
+    ...options,
+    description: 'Update a Webhook'
+  }
+  return baseClient.patch(request)
 }
 
 module.exports = {
   webhook,
   webhooks,
-  createWebhook
+  createWebhook,
+  updateWebhook
 }

--- a/app/services/clients/webhooks.client.js
+++ b/app/services/clients/webhooks.client.js
@@ -46,10 +46,11 @@ function createWebhook (serviceId, isLive, options = {}) {
       subscriptions: options.subscriptions,
       description: options.description
     },
-    description: 'Create a webhook',
     ...defaultRequestOptions,
-    ...options
+    ...options,
+    description: 'Create a webhook',
   }
+  console.log(request)
   return baseClient.post(request)
 }
 

--- a/app/utils/display-converter.js
+++ b/app/utils/display-converter.js
@@ -118,6 +118,8 @@ module.exports = function (req, data, template) {
   convertedData.isDigitalWalletSupported = _.get(convertedData, 'currentGatewayAccount.payment_provider') === 'worldpay'
   const paymentProvider = _.get(convertedData, 'currentGatewayAccount.payment_provider')
   convertedData.currentService = service
+  convertedData.isLive = req.isLive
+  convertedData.humanReadableEnvironment = convertedData.isLive ? 'Live' : 'Test'
   const currentPath = (relativeUrl && url.parse(relativeUrl).pathname.replace(/([a-z])\/$/g, '$1')) || '' // remove query params and trailing slash
   if (permissions) {
     convertedData.serviceNavigationItems = serviceNavigationItems(currentPath, permissions, paymentMethod, account)

--- a/app/views/webhooks/edit.njk
+++ b/app/views/webhooks/edit.njk
@@ -4,7 +4,7 @@
 {% set submitURL = formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.update, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id) if isEditing else formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.create, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id) %}
 
 {% block pageTitle %}
-  {{ heading }} - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+  {{ heading }} - {{currentService.name}} {{ humanReadableEnvironment }} - GOV.UK Pay
 {% endblock %}
 
 {% block side_navigation %}

--- a/app/views/webhooks/edit.njk
+++ b/app/views/webhooks/edit.njk
@@ -1,6 +1,7 @@
 {% extends "layout.njk" %}
 
 {% set heading = "Update your Webhook details" if isEditing else "Create a new Webhook" %}
+{% set submitURL = formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.update, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id) if isEditing else formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.create, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id) %}
 
 {% block pageTitle %}
   {{ heading }} - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
@@ -19,26 +20,29 @@
   }) }}
   <h1 class="govuk-heading-l page-title">{{ heading }}</h1>
 
-  <form method="POST" action="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.create, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id) }}">
+  <form method="POST" action="{{ submitURL }}">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {% set items = [] %}
     {% for key, name in eventTypes %}
-      {% set items = (items.push({ value: key | lower, text: name }), items) %}
+      {% set checked = key | lower in webhook.subscriptions if isEditing else false %}
+      {% set items = (items.push({ value: key | lower, text: name, checked: checked }), items) %}
     {% endfor %}
 
     {{ govukInput({
       label: { text: "Callback URL" },
       hint: { text: "The URL GOV.UK Pay will send payment events to" },
       id: "callback_url",
-      name: "callback_url"
+      name: "callback_url",
+      value: webhook.callback_url
     }) }}
 
     {{ govukInput({
       label: { text: "Description" },
       hint: { text: "Short summary of what this Webhook will be used for" },
       id: "description",
-      name: "description"
+      name: "description",
+      value: webhook.description
     }) }}
     {{ govukCheckboxes({
       idPrefix: "subscriptions",
@@ -54,7 +58,7 @@
     }) }}
 
     {{ govukButton({
-      text: "Create Webhook",
+      text: "Update Webhook" if isEditing else "Create Webhook",
       type: "submit"
     }) }}
   </form>

--- a/app/views/webhooks/edit.njk
+++ b/app/views/webhooks/edit.njk
@@ -1,0 +1,62 @@
+{% extends "layout.njk" %}
+
+{% set heading = "Update your Webhook details" if isEditing else "Create a new Webhook" %}
+
+{% block pageTitle %}
+  {{ heading }} - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+{% endblock %}
+
+{% block side_navigation %}
+  {% include "includes/side-navigation.njk" %}
+{% endblock %}
+
+{% block mainContent %}
+<div class="govuk-grid-column-two-thirds">
+  {{ govukBackLink({
+    text: "Back to Webhooks",
+    classes: "govuk-!-margin-top-0",
+    href: formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.index, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id)
+  }) }}
+  <h1 class="govuk-heading-l page-title">{{ heading }}</h1>
+
+  <form method="POST" action="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.create, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id) }}">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+
+    {% set items = [] %}
+    {% for key, name in eventTypes %}
+      {% set items = (items.push({ value: key | lower, text: name }), items) %}
+    {% endfor %}
+
+    {{ govukInput({
+      label: { text: "Callback URL" },
+      hint: { text: "The URL GOV.UK Pay will send payment events to" },
+      id: "callback_url",
+      name: "callback_url"
+    }) }}
+
+    {{ govukInput({
+      label: { text: "Description" },
+      hint: { text: "Short summary of what this Webhook will be used for" },
+      id: "description",
+      name: "description"
+    }) }}
+    {{ govukCheckboxes({
+      idPrefix: "subscriptions",
+      name: "subscriptions",
+      classes: "govuk-checkboxes--small",
+      fieldset: {
+        legend: {
+          text: "What payment events should we send?",
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: items
+    }) }}
+
+    {{ govukButton({
+      text: "Create Webhook",
+      type: "submit"
+    }) }}
+  </form>
+</div>
+{% endblock %}

--- a/app/views/webhooks/list.njk
+++ b/app/views/webhooks/list.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  Webhooks - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+  Webhooks - {{currentService.name}} {{ humanReadableEnvironment }} - GOV.UK Pay
 {% endblock %}
 
 {% block side_navigation %}
@@ -27,7 +27,7 @@
       </p>
       <p class="govuk-body">{{ webhook.description }}</p>
       <div>
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.detail, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id) }}">Manage Webhook</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.detail, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id) }}" data-action="update">Manage Webhook</a>
       </div>
     </div>
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/app/views/webhooks/list.njk
+++ b/app/views/webhooks/list.njk
@@ -33,9 +33,14 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   {% endfor %}
 
+  {# @TODO(sfount) all of the detail (other than account id) should come from the service and live context rather than the account, this will make it easier move off when the account is removed #}
   {{ govukButton({
     text: "Create a new Webhook",
-    classes: "govuk-button--secondary"
+    classes: "govuk-button--secondary",
+    href: formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.create, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id),
+    attributes: {
+      "data-action": "create"
+    }
   }) }}
 </div>
 {% endblock %}

--- a/test/cypress/integration/webhooks/webhooks.cy.test.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.test.js
@@ -32,4 +32,21 @@ describe('Webhooks', () => {
 
     cy.get('[data-webhook-entry]').should('have.length', 1)
   })
+
+  it('should create a webhook with a valid properties', () => {
+    const callbackUrl = 'https://some-valid-callback-url.com'
+    const description = 'A valid Webhook description'
+    const subscriptions = [ 'card_payment_captured' ]
+
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs
+    ])
+
+    cy.get('[data-action=create').contains('Create a new Webhook').click()
+    cy.get('#callback_url').type(callbackUrl)
+    cy.get('#description').type(description)
+    cy.get('[value=card_payment_captured]').click()
+
+    cy.get('button').contains('Create Webhook').click()
+  })
 })

--- a/test/cypress/integration/webhooks/webhooks.cy.test.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.test.js
@@ -36,7 +36,6 @@ describe('Webhooks', () => {
   it('should create a webhook with a valid properties', () => {
     const callbackUrl = 'https://some-valid-callback-url.com'
     const description = 'A valid Webhook description'
-    const subscriptions = [ 'card_payment_captured' ]
 
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs

--- a/test/cypress/integration/webhooks/webhooks.cy.test.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.test.js
@@ -11,7 +11,8 @@ const webhookExternalId = 'webhook-id'
 const userAndGatewayAccountStubs = [
   userStubs.getUserSuccess({ userExternalId, serviceExternalId, gatewayAccountId }),
   gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, serviceExternalId }),
-  webhooksStubs.getWebhooksListSuccess({ service_id: serviceExternalId, live: false, webhooks: [{ external_id: webhookExternalId }] })
+  webhooksStubs.getWebhooksListSuccess({ service_id: serviceExternalId, live: false, webhooks: [{ external_id: webhookExternalId }] }),
+  webhooksStubs.getWebhookSuccess({ service_id: serviceExternalId, external_id: webhookExternalId })
 ]
 
 describe('Webhooks', () => {
@@ -47,5 +48,21 @@ describe('Webhooks', () => {
     cy.get('[value=card_payment_captured]').click()
 
     cy.get('button').contains('Create Webhook').click()
+  })
+
+  it('should update a webhook with valid properties', () => {
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs
+    ])
+
+    // TODO(sfount) should navigate to update through details page when implemented
+    // cy.get('[data-action=update').then((links) => links[0].click())
+    cy.visit('/test/service/service-id/account/gateway-account-id/webhooks/webhook-id/update')
+
+    cy.get('#callback_url').should('have.value', 'https://some-callback-url.com')
+    cy.get('#description').should('have.value', 'a valid webhook description')
+    cy.get('[value=card_payment_captured]').should('be.checked')
+
+    cy.get('button').contains('Update Webhook').click()
   })
 })

--- a/test/cypress/stubs/webhooks-stubs.js
+++ b/test/cypress/stubs/webhooks-stubs.js
@@ -3,7 +3,7 @@
 const webhooksFixtures = require('../../fixtures/webhooks.fixtures')
 const { stubBuilder } = require('./stub-builder')
 
-function getWebhooksListSuccess (opts) {
+function getWebhooksListSuccess(opts) {
   const path = '/v1/webhook'
   return stubBuilder('GET', path, 200, {
     query: {
@@ -14,6 +14,18 @@ function getWebhooksListSuccess (opts) {
   })
 }
 
+function getWebhookSuccess(opts = {}) {
+  const webhook = webhooksFixtures.webhookResponse(opts)
+  const path = `/v1/webhook/${webhook.external_id}`
+  return stubBuilder('GET', path, 200, {
+    query: {
+      service_id: webhook.service_id
+    },
+    response: webhook
+  })
+}
+
 module.exports = {
-  getWebhooksListSuccess
+  getWebhooksListSuccess,
+  getWebhookSuccess
 }

--- a/test/fixtures/webhooks.fixtures.js
+++ b/test/fixtures/webhooks.fixtures.js
@@ -1,4 +1,4 @@
-function validWebhook (options = {}) {
+function validWebhook(options = {}) {
   return {
     external_id: options.external_id || 'valid-webhooks-external-id',
     service_id: options.service_id || 'valid-service-id',
@@ -11,10 +11,15 @@ function validWebhook (options = {}) {
   }
 }
 
-function webhooksListResponse (options = []) {
+function webhooksListResponse(options = []) {
   return options.map((option) => validWebhook(option))
 }
 
+function webhookResponse(options = {}) {
+  return validWebhook(options)
+}
+
 module.exports = {
-  webhooksListResponse
+  webhooksListResponse,
+  webhookResponse
 }

--- a/test/unit/clients/webhooks-client/webhooks.pact.test.js
+++ b/test/unit/clients/webhooks-client/webhooks.pact.test.js
@@ -61,4 +61,37 @@ describe('webhooks client', function () {
         })
     })
   })
+
+  describe('create webhooks', () => {
+    const callbackUrl = 'https://a-callback-url.com'
+    const description = 'A valid Webhook description'
+    const subscriptions = [ 'card_payment_captured' ]
+    before(() => {
+      return provider.addInteraction(
+        new PactInteractionBuilder(`/v1/webhook`)
+          .withRequestBody({
+            service_id: serviceId,
+            callback_url: callbackUrl,
+            live: isLive,
+            description,
+            subscriptions
+          })
+          .withUponReceiving('a valid request for a new webhooks')
+          .withState('service and environment provided')
+          .withMethod('POST')
+          .withStatusCode(200)
+          .withResponseBody(pactify(webhookFixtures.webhookResponse({ external_id: webhookId })))
+          .build()
+      )
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should submit details to create a webhook', () => {
+      return webhooksClient.createWebhook(serviceId, isLive, { callback_url: callbackUrl, description, subscriptions, baseUrl: webhooksUrl })
+        .then((response) => {
+          expect(response.external_id).to.equal(webhookId)
+        })
+    })
+  })
 })


### PR DESCRIPTION
Controller, paths and routes to connect the create and update routes.

Use the same template with an `isEditing` flag to reduce boilerplate. Explicit controllers for creating and updating call separate backend endpoints.

- bump pay js commons dependency to bring in new Webhooks constants definitions
- add simple service method to normalise frontend checkbox form
formatting to always send an array of subscriptions to the backend

This pull request doesn't do any validation on the create/ update inputs. If this should be done as a one off (following a similar example to other admin tool pages) or used as the first instance of a shared forms validation library should be discussed.

<img width="810" alt="Screenshot 2021-10-29 at 16 45 58" src="https://user-images.githubusercontent.com/2844572/139464522-51ac833b-6bf3-423c-9f0b-f70bbcb83b57.png">

<img width="813" alt="Screenshot 2021-10-29 at 16 45 21" src="https://user-images.githubusercontent.com/2844572/139464571-0263b597-5df5-480d-973d-e7edb948a48c.png">


