### PR TITLE
PP-8519 Google Analytics - set cookie domain.

### DIFF
--- a/app/browsered/analytics.js
+++ b/app/browsered/analytics.js
@@ -1,3 +1,6 @@
+'use strict'
+
+const cookieFunctions = require('./cookie-functions')
 
 function loadGoogleAnalytics () { /* eslint-disable */
   (function(i, s, o, g, r, a, m){ i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
@@ -8,12 +11,12 @@ function loadGoogleAnalytics () { /* eslint-disable */
 
 function setupAnalytics () {
   // analyticsTrackingId is configurable and set globally in head.njk
-  ga('create', analyticsTrackingId, 'auto')
+  ga('create', analyticsTrackingId, cookieFunctions.getCookieDomain())
   ga('set', 'anonymizeIp', true)
   ga('set', 'displayFeaturesTask', null)
   ga('set', 'transport', 'beacon')
 
-  ga('create', linkedTrackingId, 'auto', 'govuk_shared', { 'allowLinker': true })
+  ga('create', linkedTrackingId, cookieFunctions.getCookieDomain(), 'govuk_shared', { 'allowLinker': true })
   ga('govuk_shared.require', 'linker')
   ga('govuk_shared.linker.set', 'anonymizeIp', true)
   ga('govuk_shared.linker:autoLink', ['www.gov.uk'])

--- a/test/unit/browsered/analytics.test.js
+++ b/test/unit/browsered/analytics.test.js
@@ -13,18 +13,18 @@ describe('analytics setup', () => {
   })
   it('should invoke analytics with correct params ', () => {
     window = new jsdom.JSDOM(``, {
-      url: 'https://example.org/search?from_date=2020-01-01'
+      url: 'https://selfservice.service.payments.gov.uk/search?from_date=2020-01-01'
     }).window
     document = window.document
     analytics.setupAnalytics()
     expect(ga.callCount).equals(11)
-    expect(ga.getCall(0).calledWith('create', 'test-analytics-id', 'auto')).equals(true)
+    expect(ga.getCall(0).calledWith('create', 'test-analytics-id', '.service.payments.gov.uk')).equals(true)
     expect(ga.getCall(1).calledWith('set', 'anonymizeIp', true)).equals(true)
     expect(ga.getCall(2).calledWith('set', 'displayFeaturesTask', null)).equals(true)
     expect(ga.getCall(3).calledWith('set', 'transport', 'beacon')).equals(true)
 
     expect(ga.getCall(4).calledWith('create',
-      'linked-tracking-id', 'auto', 'govuk_shared', { 'allowLinker': true })).equals(true)
+      'linked-tracking-id', '.service.payments.gov.uk', 'govuk_shared', { 'allowLinker': true })).equals(true)
     expect(ga.getCall(5).calledWith('govuk_shared.require', 'linker')).equals(true)
     expect(ga.getCall(6).calledWith('govuk_shared.linker.set', 'anonymizeIp')).equals(true)
     expect(ga.getCall(7).calledWith('govuk_shared.linker:autoLink', ['www.gov.uk'])).equals(true)
@@ -33,7 +33,7 @@ describe('analytics setup', () => {
 
   it('should filter PII correctly ', () => {
     window = new jsdom.JSDOM(``, {
-      url: 'https://example.org/search?from_date=2020-01-01&email=test@example.org&to_date=2020-01-01'
+      url: 'https://selfservice.service.payments.gov.uk/search?from_date=2020-01-01&email=test@example.org&to_date=2020-01-01'
     }).window
     document = window.document
     analytics.setupAnalytics()


### PR DESCRIPTION
- Fix bug so that when the Google Analytic cookies are created -
  we explicitly set a domain.
- Update the `ga('create'...)` to use the cookieFunctions.getDomainCookie
  method.


