### PR TITLE
PP-8801 Fix KYC tasks spacing

### DIFF
--- a/app/views/your-psp/_stripe.njk
+++ b/app/views/your-psp/_stripe.njk
@@ -53,10 +53,10 @@
     ) }}
   {% endset %}
 
-  <ol class="app-task-list govuk-!-margin-top-8">
-    <li>
-      <ul class="app-task-list__items">{{ tasks | safe }}</ul>
-    </li>
-  </ol>
+  <div class="app-task-list govuk-body">
+    <div>
+      <span class="app-task-list__items">{{ tasks | safe }}</span>
+    </div>
+  </div>
 
 {% endif %}


### PR DESCRIPTION
## WHAT
- Changes `<ol>` to `<div>` tag to remove left padding for KYC tasks

### New
![image](https://user-images.githubusercontent.com/40598480/140035584-52c3e7d8-619e-4c50-81e7-8017b477c904.png)

### Previous
![image](https://user-images.githubusercontent.com/40598480/140035704-3134535a-5dfe-47a3-bec7-0a89606a3e48.png)
