### PR TITLE
BAU Fix custom email paragraph validation length

### DIFF
--- a/app/controllers/email-notifications/email-notifications.controller.js
+++ b/app/controllers/email-notifications/email-notifications.controller.js
@@ -11,7 +11,7 @@ const humaniseEmailMode = require('../../utils/humanise-email-mode')
 const CORRELATION_HEADER = require('../../utils/correlation-header.js').CORRELATION_HEADER
 const { validateOptionalField } = require('../../utils/validation/server-side-form-validations')
 
-const CUSTOM_PARAGRAPH_MAX_LENGTH = 500
+const CUSTOM_PARAGRAPH_MAX_LENGTH = 5000
 
 async function toggleConfirmationEmail (req, res, next, enabled) {
   const accountID = req.account.gateway_account_id


### PR DESCRIPTION
Client side validation was refined and improved in
https://github.com/alphagov/pay-selfservice/pull/2966.

It looks like the maximum paragraph length for custom emails was set in
error, revert it to its previous value.
