### PR TITLE
PP-8804 Add StripeDirector class

### DIFF
--- a/app/services/clients/stripe/StripeDirector.class.js
+++ b/app/services/clients/stripe/StripeDirector.class.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const Joi = require('joi')
+
+const schema = {
+  first_name: Joi.string().required(),
+  last_name: Joi.string().required(),
+  email: Joi.string().required(),
+  dob_day: Joi.number().integer().strict().min(1).max(31),
+  dob_month: Joi.number().integer().strict().min(1).max(12),
+  dob_year: Joi.number().integer().strict().min(1900).max(2100),
+  relationship: Joi.string().optional()
+}
+
+class StripeDirector {
+  constructor (body) {
+    const params = Object.assign({}, body)
+
+    const { error, value: model } = Joi.validate(params, schema, { allowUnknown: true, stripUnknown: true })
+
+    if (error) {
+      throw new Error(`StripeDirector ${error.details[0].message}`)
+    }
+
+    Object.assign(this, build(model))
+  }
+
+  basicObject () {
+    return Object.assign({}, this)
+  }
+}
+
+function build (params) {
+  return {
+    first_name: params.first_name,
+    last_name: params.last_name,
+    dob: {
+      day: params.dob_day,
+      month: params.dob_month,
+      year: params.dob_year
+    },
+    email: params.email,
+    relationship: {
+      director: true
+    }
+  }
+}
+
+module.exports = StripeDirector

--- a/app/services/clients/stripe/StripeDirector.class.test.js
+++ b/app/services/clients/stripe/StripeDirector.class.test.js
@@ -1,0 +1,168 @@
+'use strict'
+
+const { expect } = require('chai')
+
+const StripePerson = require('./StripeDirector.class')
+
+const firstName = 'Jane'
+const lastName = 'Doe'
+const dobDay = 1
+const dobMonth = 1
+const dobYear = 1990
+const email = 'test@example.org'
+
+describe('StripeDirector', () => {
+  it('should successfully create a stripe director for valid payload', () => {
+    const stripePerson = new StripePerson({
+      first_name: firstName,
+      last_name: lastName,
+      dob_day: dobDay,
+      dob_month: dobMonth,
+      dob_year: dobYear,
+      email: email
+    })
+
+    expect(stripePerson.basicObject()).to.deep.equal({
+      first_name: firstName,
+      last_name: lastName,
+      dob: {
+        day: dobDay,
+        month: dobMonth,
+        year: dobYear
+      },
+      email: email,
+      relationship: {
+        director: true
+      }
+    })
+  })
+
+  describe('First name validation', () => {
+    [12345, '', null].forEach(async function (value) {
+      it('Should throw error for invalid value \'' + value + '\'', async () => {
+        expect(() => new StripePerson({
+          first_name: value,
+          last_name: lastName,
+          email: email,
+          dob_day: dobDay,
+          dob_month: dobMonth,
+          dob_year: dobYear
+        })).to.throw(/StripeDirector "first_name" (must be a string|is not allowed to be empty)/)
+      })
+    })
+  })
+
+  describe('Last name validation', () => {
+    [12345, '', null].forEach(async function (value) {
+      it('Should throw error for invalid value \'' + value + '\'', async () => {
+        expect(() => new StripePerson({
+          first_name: firstName,
+          last_name: value,
+          email: email,
+          dob_day: dobDay,
+          dob_month: dobMonth,
+          dob_year: dobYear
+        })).to.throw(/StripeDirector "last_name" (must be a string|is not allowed to be empty)/)
+      })
+    })
+  })
+
+  describe('Email validation', () => {
+    [12345, '', null].forEach(async function (value) {
+      it('Should throw error for invalid value \'' + value + '\'', async () => {
+        expect(() => new StripePerson({
+          first_name: firstName,
+          last_name: lastName,
+          email: value,
+          dob_day: dobDay,
+          dob_month: dobMonth,
+          dob_year: dobYear
+        })).to.throw(/StripeDirector "email" (must be a string|is not allowed to be empty)/)
+      })
+    })
+  })
+
+  describe('Date of birth - Day validation', () => {
+    ['8', 8.1, null].forEach(async function (value) {
+      it('Should throw error for invalid value \'' + value + '\'', async () => {
+        expect(() => new StripePerson({
+          first_name: firstName,
+          last_name: lastName,
+          email: email,
+          dob_day: value,
+          dob_month: dobMonth,
+          dob_year: dobYear
+        })).to.throw(/StripeDirector "dob_day" must be (a number|an integer)/)
+      })
+    })
+
+    it('Should throw error when day is less than 1', () => {
+      expect(() => new StripePerson({
+        first_name: firstName,
+        last_name: lastName,
+        email: email,
+        dob_day: 0,
+        dob_month: dobMonth,
+        dob_year: dobYear
+      })).to.throw('StripeDirector "dob_day" must be larger than or equal to 1')
+    })
+
+    it('Should throw error when day is more than 31', () => {
+      expect(() => new StripePerson({
+        first_name: firstName,
+        last_name: lastName,
+        email: email,
+        dob_day: 32,
+        dob_month: dobMonth,
+        dob_year: dobYear
+      })).to.throw('StripeDirector "dob_day" must be less than or equal to 31')
+    })
+  })
+
+  describe('Date of birth - Month validation', () => {
+    it('Should throw error when month is less than 1', () => {
+      expect(() => new StripePerson({
+        first_name: firstName,
+        last_name: lastName,
+        email: email,
+        dob_day: dobDay,
+        dob_month: 0,
+        dob_year: dobYear
+      })).to.throw('StripeDirector "dob_month" must be larger than or equal to 1')
+    })
+
+    it('Should throw error when month is larger than 12', () => {
+      expect(() => new StripePerson({
+        first_name: firstName,
+        last_name: lastName,
+        email: email,
+        dob_day: dobDay,
+        dob_month: 13,
+        dob_year: dobYear
+      })).to.throw('StripeDirector "dob_month" must be less than or equal to 12')
+    })
+  })
+  describe('Date of birth - Year validation', () => {
+    it('Should throw error when year is less than 1000', () => {
+      expect(() => new StripePerson({
+        first_name: firstName,
+        last_name: lastName,
+        email: email,
+        dob_day: dobDay,
+        dob_month: dobMonth,
+        dob_year: 999
+      })).to.throw('StripeDirector "dob_year" must be larger than or equal to 1900')
+    })
+
+    it('Should throw error when year is more than 9999', () => {
+      expect(() => new StripePerson({
+        first_name: firstName,
+        last_name: lastName,
+        email: email,
+        dob_day: dobDay,
+        dob_month: dobMonth,
+        dob_year: 10000
+      })).to.throw('StripeDirector "dob_year" must be less than or equal to 2100')
+    })
+  })
+})

--- a/app/services/clients/stripe/stripe.client.js
+++ b/app/services/clients/stripe/stripe.client.js
@@ -5,6 +5,7 @@ const ProxyAgent = require('https-proxy-agent')
 const StripeBankAccount = require('./StripeBankAccount.class')
 const StripeCompany = require('./StripeCompany.class')
 const StripePerson = require('./StripePerson.class')
+const StripeDirector = require('./StripeDirector.class')
 
 // Constants
 const STRIPE_HOST = process.env.STRIPE_HOST
@@ -56,6 +57,16 @@ module.exports = {
   createPerson: function (stripeAccountId, body) {
     const stripePerson = new StripePerson(body)
     return stripe.accounts.createPerson(stripeAccountId, stripePerson.basicObject())
+  },
+
+  updateDirector: function (stripeAccountId, stripeDirectorId, body) {
+    const stripeDirector = new StripeDirector(body)
+    return stripe.accounts.updatePerson(stripeAccountId, stripeDirectorId, stripeDirector.basicObject())
+  },
+
+  createDirector: function (stripeAccountId, body) {
+    const stripeDirector = new StripeDirector(body)
+    return stripe.accounts.createPerson(stripeAccountId, stripeDirector.basicObject())
   },
 
   retrieveAccountDetails: function (stripeAccountId) {


### PR DESCRIPTION
## WHAT
- Added new class for StripeDirector which will be used when adding new director for stripe accounts.
   - Separate class instead of using StripePerson to keep classes simple. 
        - Other options could be i) to use StripePerson for both responsible person and director ii) define base class and inherit as needed.
- Added new stripe client method to create and update director.
