### PR TITLE
PP-8832 make vat number optional

### DIFF
--- a/app/controllers/stripe-setup/vat-number/post.controller.test.js
+++ b/app/controllers/stripe-setup/vat-number/post.controller.test.js
@@ -6,7 +6,8 @@ const paths = require('../../../paths')
 
 describe('VAT number POST controller', () => {
   const postBody = {
-    'vat-number': 'GB999999973'
+    'vat-number': 'GB999999973',
+    'vat-number-declaration': 'true'
   }
 
   let req
@@ -67,6 +68,22 @@ describe('VAT number POST controller', () => {
     sinon.assert.calledWith(updateCompanyMock, res.locals.stripeAccount.stripeAccountId, {
       'vat_id': 'GB999999973'
     })
+    sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'vat_number', req.correlationId)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripe.addPspAccountDetails}`)
+  })
+
+  it('should not call Stripe when no vat number provided, should call connector, then redirect to add psp account details route', async function () {
+    updateCompanyMock = sinon.spy(() => Promise.resolve())
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
+    const controller = getControllerWithMocks()
+
+    req.body = {
+      'vat-number-declaration': 'false'
+    }
+
+    await controller(req, res, next)
+
+    sinon.assert.notCalled(updateCompanyMock)
     sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'vat_number', req.correlationId)
     sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripe.addPspAccountDetails}`)
   })

--- a/app/controllers/stripe-setup/vat-number/vat-number-validations.js
+++ b/app/controllers/stripe-setup/vat-number/vat-number-validations.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { isEmpty, isNotVatNumber } = require('../../../utils/validation/field-validation-checks')
+const { isEmpty, isNotVatNumber, validationErrors } = require('../../../utils/validation/field-validation-checks')
 
 exports.validateVatNumber = function validateVatNumber (value) {
   const isEmptyErrorMessage = isEmpty(value)
@@ -19,6 +19,19 @@ exports.validateVatNumber = function validateVatNumber (value) {
     }
   }
 
+  return {
+    valid: true,
+    message: null
+  }
+}
+
+exports.validateVatNumberDeclaration = function validateVatNumberDeclaration (value) {
+  if (typeof value === 'undefined') {
+    return {
+      valid: false,
+      message: validationErrors.mandatoryQuestion
+    }
+  }
   return {
     valid: true,
     message: null

--- a/app/controllers/stripe-setup/vat-number/vat-number-validations.test.js
+++ b/app/controllers/stripe-setup/vat-number/vat-number-validations.test.js
@@ -14,24 +14,38 @@ describe('VAT number validations', () => {
     expect(vatNumberValidations.validateVatNumber(standardVatNumber).valid).to.be.true // eslint-disable-line
   })
 
-  it('should not be valid when mandatory text is blank', () => {
+  it('should validate successfully when no vat number provided', () => {
     expect(vatNumberValidations.validateVatNumber('')).to.deep.equal({
       valid: false,
       message: 'This field cannot be blank'
     })
   })
 
-  it('should not be valid when mandatory text is invalid VAT number', () => {
+  it('should not be valid when text is invalid VAT number', () => {
     expect(vatNumberValidations.validateVatNumber(invalidVatNumber)).to.deep.equal({
       valid: false,
       message: 'Enter a valid VAT number, including ‘GB’ at the start'
     })
   })
 
-  it('should not be valid when mandatory text is too long', () => {
+  it('should not be valid when text is too long', () => {
     expect(vatNumberValidations.validateVatNumber(invalidLongVatNumber)).to.deep.equal({
       valid: false,
       message: 'Enter a valid VAT number, including ‘GB’ at the start'
+    })
+  })
+
+  it('should validate successfully when no vat number was chosen', () => {
+    expect(vatNumberValidations.validateVatNumberDeclaration('false')).to.deep.equal({
+      valid: true,
+      message: null
+    })
+  })
+
+  it('should not be valid if no option was chosen', () => {
+    expect(vatNumberValidations.validateVatNumberDeclaration()).to.deep.equal({
+      valid: false,
+      message: 'You must answer this question'
     })
   })
 })

--- a/app/views/stripe-setup/vat-number/index.njk
+++ b/app/views/stripe-setup/vat-number/index.njk
@@ -1,7 +1,7 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  What is your organisation’s VAT number? - {{ currentService.name }} - GOV.UK Pay
+  Does your organisation have a VAT number? - {{ currentService.name }} - GOV.UK Pay
 {% endblock %}
 
 {% block side_navigation %}
@@ -29,16 +29,28 @@
           href: '#vat-number'
         }), errorList) %}
       {% endif %}
+      {% if errors['vat-number-declaration'] %}
+        {% set errorList = (errorList.push({
+          text: errors['vat-number-declaration'],
+          href: '#vat-number-declaration'
+        }), errorList) %}
+      {% endif %}
       {{ govukErrorSummary({
         titleText: 'There is a problem',
         errorList: errorList
       }) }}
     {% endif %}
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-6"><label for="vat-number">What is your organisation’s VAT number?</label></h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-6"><label for="vat-number">Does your organisation have a VAT number?</label></h1>
 
-    <form id="vat-number-form" method="post"
-          novalidate>
+    <form id="vat-number-form" method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+
+      {% set noSelectionError = false %}
+      {% if errors['vat-number-declaration'] %}
+        {% set noSelectionError = {
+          text: "Please choose an option"
+        } %}
+      {% endif %}
 
       {% set vatNumberError = false %}
       {% if errors['vat-number'] %}
@@ -47,21 +59,61 @@
         } %}
       {% endif %}
 
-      {{ govukInput({
-        name: "vat-number",
-        id: "vat-number",
-        hint: {
-          text: "VAT numbers start with ‘GB’, for example ‘GBGD123’"
-        },
-        classes: "govuk-input--width-30",
-        value: vatNumber,
-        type: "text",
-        errorMessage: vatNumberError,
-        attributes: {
-          autocomplete: "off",
-          spellcheck: "false"
-        }
-      }) }}
+      {% set vatNumberHTML %}
+        {{ govukInput({
+          name: "vat-number",
+          id: "vat-number",
+          label: {
+            text: "What is your organisation's VAT number?",
+            classes: "govuk-label--s"
+          },
+          hint: {
+            text: "VAT numbers start with ‘GB’, for example ‘GBGD123’"
+          },
+          classes: "govuk-input--width-30",
+          value: vatNumber,
+          type: "text",
+          errorMessage: vatNumberError,
+          attributes: {
+            autocomplete: "off",
+            spellcheck: "false"
+          }
+        }) }}
+      {% endset %}
+
+      {{
+        govukRadios({
+          idPrefix: "vat-number-declaration",
+          name: "vat-number-declaration",
+          fieldset: {
+            legend: {
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          errorMessage: noSelectionError,
+          items: [
+            {
+              value: "true",
+              text: "Yes",
+              id: "have-vat-number",
+              hint: "VAT numbers start with ‘GB’. For example, ‘GBGD123’.",
+              conditional: {
+                html: vatNumberHTML
+              },
+              checked: (vatNumberDeclaration === 'true')
+            },
+            {
+              value: "false",
+              text: "No",
+              id: "not-have-vat-number",
+              checked: (vatNumberDeclaration === 'false')
+            }
+          ]
+        })
+      }}
+
+
 
       {{ govukButton({ text: "Save and continue" }) }}
     </form>


### PR DESCRIPTION
## WHAT
- At present, VAT number is mandatory for services onboarding with Stripe. Services will have enter a valid VAT number and if they don’t have one, we need to override tasks (manual update to DB). VAT is not a mandatory field as per Stripe. Thus make it optional in onboarding journey.
- update cypress tests
