### PR TITLE
PP-8804 Add Stripe setup utility

### DIFF
--- a/app/controllers/stripe-setup/stripe-setup.util.js
+++ b/app/controllers/stripe-setup/stripe-setup.util.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const lodash = require('lodash')
+
+const { getSwitchingCredential } = require('../../utils/credentials')
+const { ConnectorClient } = require('../../services/clients/connector.client')
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+const { validateDateOfBirth } = require('../../utils/validation/server-side-form-validations')
+
+const trimField = (key, store) => lodash.get(store, key, '').trim()
+
+async function getStripeAccountId (account, isSwitchingCredentials, correlationId) {
+  if (isSwitchingCredentials) {
+    const switchingCredential = getSwitchingCredential(account)
+    return switchingCredential.credentials.stripe_account_id
+  } else {
+    const stripeAccount = await connector.getStripeAccount(account.gateway_account_id, correlationId)
+    return stripeAccount.stripeAccountId
+  }
+}
+
+function validateField (fieldValue, fieldValidator, maxLength) {
+  const isFieldValidValue = fieldValidator(fieldValue, maxLength)
+  if (!isFieldValidValue.valid) {
+    return isFieldValidValue.message
+  }
+  return null
+}
+
+function getFormFields (requestBody, listOfFields) {
+  return listOfFields.reduce((form, field) => {
+    form[field] = trimField(field, requestBody)
+    return form
+  }, {})
+}
+
+function validateDoB (day, month, year) {
+  const dateOfBirthValidationResult = validateDateOfBirth(day, month, year)
+  if (!dateOfBirthValidationResult.valid) {
+    return dateOfBirthValidationResult.message
+  }
+  return null
+}
+
+module.exports = {
+  getStripeAccountId: getStripeAccountId,
+  validateField: validateField,
+  validateDoB: validateDoB,
+  getFormFields: getFormFields
+}

--- a/app/controllers/stripe-setup/stripe-setup.util.test.js
+++ b/app/controllers/stripe-setup/stripe-setup.util.test.js
@@ -1,0 +1,109 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+const { assert, expect } = require('chai')
+const { validateMandatoryField } = require('../../utils/validation/server-side-form-validations')
+
+describe('Stripe setup util', () => {
+  const account = {
+    gateway_account_id: 'account-123',
+    gateway_account_credentials: [
+      {
+        payment_provider: 'worldpay',
+        state: 'ACTIVE'
+      },
+      {
+        payment_provider: 'stripe',
+        state: 'VERIFIED_WITH_LIVE_PAYMENT',
+        credentials: {
+          stripe_account_id: 'new-stripe-account-id-123'
+        }
+      }
+    ]
+  }
+
+  describe('Get Stripe account ID', () => {
+    it('should return stripe account ID for the account from connector', async () => {
+      const stripeAccountId = await getStripeSetupUtil().getStripeAccountId(account, false, 'req-id')
+      assert(stripeAccountId === 'acct_123example123')
+    })
+
+    it('should return stripe account ID from switching credential when switching PSP', async () => {
+      const stripeAccountId = await getStripeSetupUtil().getStripeAccountId(account, true, 'req-id')
+      assert(stripeAccountId === 'new-stripe-account-id-123')
+    })
+  })
+
+  describe('Validate DOB', () => {
+    it('should return error message for invalid date of birth', () => {
+      const result = getStripeSetupUtil().validateDoB(1, 1, 1)
+      assert(result === 'Year must have 4 numbers')
+    })
+    it('should not return error message for valid date of birth', () => {
+      const result = getStripeSetupUtil().validateDoB(1, 1, 1990)
+      assert(result === null)
+    })
+  })
+
+  describe('Get form fields from request body', () => {
+    it('should return form fields specified', () => {
+      const requestBody = {
+        first_name: 'Jane',
+        last_name: 'Doe',
+        csrfToken: 'csrf_123'
+      }
+      const formFields = ['first_name', 'last_name']
+      const result = getStripeSetupUtil().getFormFields(requestBody, formFields)
+
+      expect(result).to.deep.equal({ first_name: 'Jane', last_name: 'Doe' })
+    })
+    it('should return fields with spaces trimmed', () => {
+      const requestBody = {
+        first_name: '   Jane    ',
+        csrfToken: 'csrf_123'
+      }
+      const formFields = ['first_name']
+      const result = getStripeSetupUtil().getFormFields(requestBody, formFields)
+
+      expect(result).to.deep.equal({ first_name: 'Jane' })
+    })
+    it('should return empty value if field does not exist', () => {
+      const requestBody = {
+        csrfToken: 'csrf_123'
+      }
+      const formFields = ['non_existing_form_field']
+      const result = getStripeSetupUtil().getFormFields(requestBody, formFields)
+
+      expect(result).to.deep.equal({ non_existing_form_field: '' })
+    })
+    it('should return empty value for form field when request body is empty ', () => {
+      const formFields = ['first_name']
+      const result = getStripeSetupUtil().getFormFields(null, formFields)
+
+      expect(result).to.deep.equal({ first_name: '' })
+    })
+  })
+
+  describe('Validate field', () => {
+    it('should return error message if field validator returns value as not valid', () => {
+      const result = getStripeSetupUtil().validateField('', validateMandatoryField, 1)
+      assert(result === 'This field cannot be blank')
+    })
+    it('should not return error message for valid value', () => {
+      const result = getStripeSetupUtil().validateField('field_value_1', validateMandatoryField, 13)
+      assert(result === null)
+    })
+  })
+})
+
+function getStripeSetupUtil () {
+  return proxyquire('./stripe-setup.util', {
+    '../../services/clients/connector.client': {
+      ConnectorClient: function () {
+        this.getStripeAccount = () => Promise.resolve({
+          stripeAccountId: 'acct_123example123'
+        })
+      }
+    }
+  })
+}


### PR DESCRIPTION
## WHAT
- Added a new Stripe setup utility which has common functions used across stripe setup controllers (responsible person, director, bank details and so on).
  Some could possibly (like `getFormFields`) be used in all selfservice controllers.
