### PR TITLE
PP-8913 Render error page for Stripe details already submitted

### DIFF
--- a/app/controllers/stripe-setup/bank-details/get.controller.js
+++ b/app/controllers/stripe-setup/bank-details/get.controller.js
@@ -2,8 +2,7 @@
 
 const { response } = require('../../../utils/response')
 const { isSwitchingCredentialsRoute } = require('../../../utils/credentials')
-const paths = require('../../../paths')
-const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
+const { getAlreadySubmittedErrorPageData } = require('../stripe-setup.util')
 
 module.exports = (req, res, next) => {
   const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
@@ -13,8 +12,9 @@ module.exports = (req, res, next) => {
     return next(new Error('Stripe setup progress is not available on request'))
   }
   if (stripeAccountSetup.bankAccount) {
-    req.flash('genericError', 'You’ve already provided your bank details. Contact GOV.UK Pay support if you need to update them.')
-    return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
+    const errorPageData = getAlreadySubmittedErrorPageData(req.account.external_id,
+      'You’ve already provided your bank details. Contact GOV.UK Pay support if you need to update them.')
+    return response(req, res, 'error-with-link', errorPageData)
   }
 
   return response(req, res, 'stripe-setup/bank-details/index', { isSwitchingCredentials })

--- a/app/controllers/stripe-setup/bank-details/get.controller.test.js
+++ b/app/controllers/stripe-setup/bank-details/get.controller.test.js
@@ -36,13 +36,12 @@ describe('Bank details get controller', () => {
     sinon.assert.calledWith(next, expectedError)
   })
 
-  it('should redirect to dashboard if bank details are already provided ', async () => {
+  it('should render error if bank details are already provided ', async () => {
     req.account.connectorGatewayAccountStripeProgress = { bankAccount: true }
 
     await getController(req, res)
 
-    sinon.assert.calledWith(req.flash, 'genericError', 'You’ve already provided your bank details. Contact GOV.UK Pay support if you need to update them.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/dashboard`)
+    sinon.assert.calledWith(res.render, 'error-with-link')
   })
 
   it('should render bank account details form if details are not yet submitted', async () => {

--- a/app/controllers/stripe-setup/bank-details/post.controller.test.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.test.js
@@ -89,14 +89,13 @@ describe('Bank details post controller', () => {
     sinon.assert.calledWith(next, expectedError)
   })
 
-  it('should redirect to dashboard if bank details are already provided ', async () => {
+  it('should render error if bank details are already provided ', async () => {
     const controller = getControllerWithMocks()
     req.account.connectorGatewayAccountStripeProgress = { bankAccount: true }
 
     await controller(req, res, next)
 
-    sinon.assert.calledWith(req.flash, 'genericError', 'You’ve already provided your bank details. Contact GOV.UK Pay support if you need to update them.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/dashboard`)
+    sinon.assert.calledWith(res.render, 'error-with-link')
   })
 
   it('should re-render the form page when Stripe returns "routing_number_invalid" error', async () => {

--- a/app/controllers/stripe-setup/company-number/get.controller.js
+++ b/app/controllers/stripe-setup/company-number/get.controller.js
@@ -2,8 +2,7 @@
 
 const { response } = require('../../../utils/response')
 const { isSwitchingCredentialsRoute } = require('../../../utils/credentials')
-const paths = require('../../../paths')
-const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
+const { getAlreadySubmittedErrorPageData } = require('../stripe-setup.util')
 
 module.exports = (req, res, next) => {
   const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
@@ -12,8 +11,9 @@ module.exports = (req, res, next) => {
     return next(new Error('Stripe setup progress is not available on request'))
   }
   if (stripeAccountSetup.companyNumber) {
-    req.flash('genericError', 'You’ve already provided your company registration number. Contact GOV.UK Pay support if you need to update it.')
-    return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
+    const errorPageData = getAlreadySubmittedErrorPageData(req.account.external_id,
+      'You’ve already provided your company registration number. Contact GOV.UK Pay support if you need to update it.')
+    return response(req, res, 'error-with-link', errorPageData)
   }
 
   return response(req, res, 'stripe-setup/company-number/index', { isSwitchingCredentials })

--- a/app/controllers/stripe-setup/company-number/get.controller.test.js
+++ b/app/controllers/stripe-setup/company-number/get.controller.test.js
@@ -36,13 +36,12 @@ describe('Company number GET controller', () => {
     sinon.assert.calledWith(next, expectedError)
   })
 
-  it('should redirect to dashboard if company number is already provided ', async () => {
+  it('should render error if company number is already provided ', async () => {
     req.account.connectorGatewayAccountStripeProgress = { companyNumber: true }
 
     await getController(req, res)
 
-    sinon.assert.calledWith(req.flash, 'genericError', 'You’ve already provided your company registration number. Contact GOV.UK Pay support if you need to update it.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/dashboard`)
+    sinon.assert.calledWith(res.render, 'error-with-link')
   })
 
   it('should render company number form if details are not yet submitted', async () => {

--- a/app/controllers/stripe-setup/company-number/post.controller.js
+++ b/app/controllers/stripe-setup/company-number/post.controller.js
@@ -5,7 +5,7 @@ const lodash = require('lodash')
 const logger = require('../../../utils/logger')(__filename)
 const { response } = require('../../../utils/response')
 const { isSwitchingCredentialsRoute} = require('../../../utils/credentials')
-const { getStripeAccountId } = require('../stripe-setup.util')
+const { getStripeAccountId, getAlreadySubmittedErrorPageData } = require('../stripe-setup.util')
 const { updateCompany } = require('../../../services/clients/stripe/stripe.client')
 const companyNumberValidations = require('./company-number-validations')
 const { ConnectorClient } = require('../../../services/clients/connector.client')
@@ -24,8 +24,9 @@ module.exports = async (req, res, next) => {
     return next(new Error('Stripe setup progress is not available on request'))
   }
   if (stripeAccountSetup.companyNumber) {
-    req.flash('genericError', 'You’ve already provided your company registration number. Contact GOV.UK Pay support if you need to update it.')
-    return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
+    const errorPageData = getAlreadySubmittedErrorPageData(req.account.external_id,
+      'You’ve already provided your company registration number. Contact GOV.UK Pay support if you need to update it.')
+    return response(req, res, 'error-with-link', errorPageData)
   }
 
   const companyNumberDeclaration = lodash.get(req.body, COMPANY_NUMBER_DECLARATION_FIELD, '')

--- a/app/controllers/stripe-setup/company-number/post.controller.test.js
+++ b/app/controllers/stripe-setup/company-number/post.controller.test.js
@@ -86,14 +86,13 @@ describe('Company number POST controller', () => {
     sinon.assert.calledWith(next, expectedError)
   })
 
-  it('should redirect to dashboard if company number is already provided ', async () => {
+  it('should render error if company number is already provided ', async () => {
     const controller = getControllerWithMocks()
     req.account.connectorGatewayAccountStripeProgress = { companyNumber: true }
 
     await controller(req, res, next)
 
-    sinon.assert.calledWith(req.flash, 'genericError', 'You’ve already provided your company registration number. Contact GOV.UK Pay support if you need to update it.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/dashboard`)
+    sinon.assert.calledWith(res.render, 'error-with-link')
   })
 
   it('should render error when Stripe returns error, not call connector, and not redirect', async function () {

--- a/app/controllers/stripe-setup/director/get.controller.js
+++ b/app/controllers/stripe-setup/director/get.controller.js
@@ -2,8 +2,7 @@
 
 const { response } = require('../../../utils/response')
 const { isSwitchingCredentialsRoute, isAdditionalKycDataRoute, getCurrentCredential } = require('../../../utils/credentials')
-const paths = require('../../../paths')
-const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
+const { getAlreadySubmittedErrorPageData } = require('../stripe-setup.util')
 
 module.exports = (req, res, next) => {
   const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
@@ -16,8 +15,9 @@ module.exports = (req, res, next) => {
     return next(new Error('Stripe setup progress is not available on request'))
   }
   if (stripeAccountSetup.director) {
-    req.flash('genericError', 'You’ve already provided director details. Contact GOV.UK Pay support if you need to change them.')
-    return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
+    const errorPageData = getAlreadySubmittedErrorPageData(req.account.external_id,
+      'You’ve already provided director details. Contact GOV.UK Pay support if you need to change them.')
+    return response(req, res, 'error-with-link', errorPageData)
   }
 
   return response(req, res, 'stripe-setup/director/index',

--- a/app/controllers/stripe-setup/director/get.controller.test.js
+++ b/app/controllers/stripe-setup/director/get.controller.test.js
@@ -24,13 +24,12 @@ describe('Director GET controller', () => {
     next = sinon.spy()
   })
 
-  it('should redirect to dashboard if director details are already provided', async () => {
+  it('should render error if director details are already provided', async () => {
     req.account.connectorGatewayAccountStripeProgress = { director: true }
 
     await getController(req, res)
 
-    sinon.assert.calledWith(req.flash, 'genericError', 'You’ve already provided director details. Contact GOV.UK Pay support if you need to change them.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/dashboard`)
+    sinon.assert.calledWith(res.render, 'error-with-link')
   })
 
   it('should render error page when stripe setup is not available on request', async () => {

--- a/app/controllers/stripe-setup/director/post.controller.js
+++ b/app/controllers/stripe-setup/director/post.controller.js
@@ -9,7 +9,7 @@ const { isSwitchingCredentialsRoute, isAdditionalKycDataRoute, getCurrentCredent
 const { response } = require('../../../utils/response')
 const { validateMandatoryField, validateEmail } = require('../../../utils/validation/server-side-form-validations')
 const { listPersons, updateDirector, createDirector, updateCompany } = require('../../../services/clients/stripe/stripe.client')
-const { validateField, validateDoB, getFormFields, getStripeAccountId } = require('../stripe-setup.util')
+const { validateField, validateDoB, getFormFields, getStripeAccountId, getAlreadySubmittedErrorPageData } = require('../stripe-setup.util')
 const { ConnectorClient } = require('../../../services/clients/connector.client')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 const FIRST_NAME_FIELD = 'first-name'
@@ -48,8 +48,9 @@ module.exports = async function (req, res, next) {
     return next(new Error('Stripe setup progress is not available on request'))
   }
   if (stripeAccountSetup.director) {
-    req.flash('genericError', 'You’ve already provided director details. Contact GOV.UK Pay support if you need to change them.')
-    return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
+    const errorPageData = getAlreadySubmittedErrorPageData(req.account.external_id,
+      'You’ve already provided director details. Contact GOV.UK Pay support if you need to change them.')
+    return response(req, res, 'error-with-link', errorPageData)
   }
 
   const formFields = getFormFields(req.body, listOfFields)

--- a/app/controllers/stripe-setup/director/post.controller.test.js
+++ b/app/controllers/stripe-setup/director/post.controller.test.js
@@ -146,14 +146,13 @@ describe('Director POST controller', () => {
     sinon.assert.calledWith(next, expectedError)
   })
 
-  it('should redirect to dashboard if director details are already provided ', async () => {
+  it('should render error if director details are already provided ', async () => {
     const controller = getControllerWithMocks()
     req.account.connectorGatewayAccountStripeProgress = { director: true }
 
     await controller(req, res, next)
 
-    sinon.assert.calledWith(req.flash, 'genericError', 'You’ve already provided director details. Contact GOV.UK Pay support if you need to change them.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/dashboard`)
+    sinon.assert.calledWith(res.render, 'error-with-link')
   })
 
   it('should render error when Stripe returns error, not call connector, and not redirect', async function () {

--- a/app/controllers/stripe-setup/responsible-person/get.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/get.controller.js
@@ -2,8 +2,7 @@
 
 const { response } = require('../../../utils/response')
 const { isSwitchingCredentialsRoute } = require('../../../utils/credentials')
-const paths = require('../../../paths')
-const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
+const { getAlreadySubmittedErrorPageData } = require('../stripe-setup.util')
 
 const collectAdditionalKycData = process.env.COLLECT_ADDITIONAL_KYC_DATA === 'true'
 
@@ -15,8 +14,9 @@ module.exports = (req, res, next) => {
     return next(new Error('Stripe setup progress is not available on request'))
   }
   if (stripeAccountSetup.responsiblePerson) {
-    req.flash('genericError', 'You’ve already nominated your responsible person. Contact GOV.UK Pay support if you need to change them.')
-    return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
+    const errorPageData = getAlreadySubmittedErrorPageData(req.account.external_id,
+      'You’ve already nominated your responsible person. Contact GOV.UK Pay support if you need to change them.')
+    return response(req, res, 'error-with-link', errorPageData)
   }
 
   return response(req, res, 'stripe-setup/responsible-person/index', {

--- a/app/controllers/stripe-setup/responsible-person/get.controller.test.js
+++ b/app/controllers/stripe-setup/responsible-person/get.controller.test.js
@@ -24,13 +24,12 @@ describe('Responsible person GET controller', () => {
     next = sinon.spy()
   })
 
-  it('should redirect to dashboard if responsible person details are already provided ', async () => {
+  it('should render error if responsible person details are already provided ', async () => {
     req.account.connectorGatewayAccountStripeProgress = { responsiblePerson: true }
 
     await getController(req, res)
 
-    sinon.assert.calledWith(req.flash, 'genericError', 'You’ve already nominated your responsible person. Contact GOV.UK Pay support if you need to change them.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/dashboard`)
+    sinon.assert.calledWith(res.render, 'error-with-link')
   })
 
   it('should render error page when stripe setup is not available on request', async () => {

--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -7,7 +7,13 @@ const logger = require('../../../utils/logger')(__filename)
 const paths = require('../../../paths')
 const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
 const { isSwitchingCredentialsRoute } = require('../../../utils/credentials')
-const { validateField, validateDoB, getFormFields, getStripeAccountId } = require('../stripe-setup.util')
+const {
+  validateField,
+  validateDoB,
+  getFormFields,
+  getStripeAccountId,
+  getAlreadySubmittedErrorPageData
+} = require('../stripe-setup.util')
 const { response } = require('../../../utils/response')
 const {
   validateMandatoryField,
@@ -88,8 +94,9 @@ module.exports = async function (req, res, next) {
     return next(new Error('Stripe setup progress is not available on request'))
   }
   if (stripeAccountSetup.responsiblePerson) {
-    req.flash('genericError', 'You’ve already nominated your responsible person. Contact GOV.UK Pay support if you need to change them.')
-    return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
+    const errorPageData = getAlreadySubmittedErrorPageData(req.account.external_id,
+      'You’ve already nominated your responsible person. Contact GOV.UK Pay support if you need to change them.')
+    return response(req, res, 'error-with-link', errorPageData)
   }
 
   const fields = [

--- a/app/controllers/stripe-setup/responsible-person/post.controller.test.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.test.js
@@ -183,14 +183,13 @@ describe('Responsible person POST controller', () => {
     sinon.assert.calledWith(next, expectedError)
   })
 
-  it('should redirect to dashboard if bank details are already provided ', async () => {
+  it('should render error if bank details are already provided ', async () => {
     const controller = getControllerWithMocks()
     req.account.connectorGatewayAccountStripeProgress = { responsiblePerson: true }
 
     await controller(req, res, next)
 
-    sinon.assert.calledWith(req.flash, 'genericError', 'You’ve already nominated your responsible person. Contact GOV.UK Pay support if you need to change them.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/dashboard`)
+    sinon.assert.calledWith(res.render, 'error-with-link')
   })
 
   it('should render error when Stripe returns error, not call connector, and not redirect', async function () {

--- a/app/controllers/stripe-setup/stripe-setup.util.js
+++ b/app/controllers/stripe-setup/stripe-setup.util.js
@@ -6,6 +6,8 @@ const { getSwitchingCredential } = require('../../utils/credentials')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 const { validateDateOfBirth } = require('../../utils/validation/server-side-form-validations')
+const paths = require('../../paths')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 
 const trimField = (key, store) => lodash.get(store, key, '').trim()
 
@@ -42,9 +44,24 @@ function validateDoB (day, month, year) {
   return null
 }
 
+function getAlreadySubmittedErrorPageData(accountExternalId, errorMessage) {
+  return {
+    error: {
+      title: 'An error occurred',
+      message: errorMessage
+    },
+    link: {
+      link: formatAccountPathsFor(paths.account.dashboard.index, accountExternalId),
+      text: 'Back to dashboard'
+    },
+    enable_link: true
+  }
+}
+
 module.exports = {
-  getStripeAccountId: getStripeAccountId,
-  validateField: validateField,
-  validateDoB: validateDoB,
-  getFormFields: getFormFields
+  getStripeAccountId,
+  validateField,
+  validateDoB,
+  getFormFields,
+  getAlreadySubmittedErrorPageData
 }

--- a/app/controllers/stripe-setup/vat-number/get.controller.js
+++ b/app/controllers/stripe-setup/vat-number/get.controller.js
@@ -2,8 +2,7 @@
 
 const { response } = require('../../../utils/response')
 const { isSwitchingCredentialsRoute } = require('../../../utils/credentials')
-const paths = require('../../../paths')
-const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
+const { getAlreadySubmittedErrorPageData } = require('../stripe-setup.util')
 
 module.exports = (req, res, next) => {
   const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
@@ -13,8 +12,9 @@ module.exports = (req, res, next) => {
     return next(new Error('Stripe setup progress is not available on request'))
   }
   if (stripeAccountSetup.vatNumber) {
-    req.flash('genericError', 'You’ve already provided your VAT number. Contact GOV.UK Pay support if you need to update it.')
-    return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
+    const errorPageData = getAlreadySubmittedErrorPageData(req.account.external_id,
+      'You’ve already provided your VAT number. Contact GOV.UK Pay support if you need to update it.')
+    return response(req, res, 'error-with-link', errorPageData)
   }
 
   return response(req, res, 'stripe-setup/vat-number/index', { isSwitchingCredentials })

--- a/app/controllers/stripe-setup/vat-number/get.controller.test.js
+++ b/app/controllers/stripe-setup/vat-number/get.controller.test.js
@@ -36,13 +36,12 @@ describe('VAT number GET controller', () => {
     sinon.assert.calledWith(next, expectedError)
   })
 
-  it('should redirect to dashboard if VAT number is already provided ', async () => {
+  it('should render error if VAT number is already provided ', async () => {
     req.account.connectorGatewayAccountStripeProgress = { vatNumber: true }
 
     await getController(req, res)
 
-    sinon.assert.calledWith(req.flash, 'genericError', 'You’ve already provided your VAT number. Contact GOV.UK Pay support if you need to update it.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/dashboard`)
+    sinon.assert.calledWith(res.render, 'error-with-link')
   })
 
   it('should render vat number form if details are not yet submitted', async () => {

--- a/app/controllers/stripe-setup/vat-number/post.controller.js
+++ b/app/controllers/stripe-setup/vat-number/post.controller.js
@@ -5,7 +5,7 @@ const lodash = require('lodash')
 const logger = require('../../../utils/logger')(__filename)
 const { response } = require('../../../utils/response')
 const { isSwitchingCredentialsRoute } = require('../../../utils/credentials')
-const { getStripeAccountId } = require('../stripe-setup.util')
+const { getStripeAccountId, getAlreadySubmittedErrorPageData } = require('../stripe-setup.util')
 const { updateCompany } = require('../../../services/clients/stripe/stripe.client')
 const vatNumberValidations = require('./vat-number-validations')
 const { ConnectorClient } = require('../../../services/clients/connector.client')
@@ -25,8 +25,9 @@ module.exports = async (req, res, next) => {
     return next(new Error('Stripe setup progress is not available on request'))
   }
   if (stripeAccountSetup.vatNumber) {
-    req.flash('genericError', 'You’ve already provided your VAT number. Contact GOV.UK Pay support if you need to update it.')
-    return res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, req.account.external_id))
+    const errorPageData = getAlreadySubmittedErrorPageData(req.account.external_id,
+      'You’ve already provided your VAT number. Contact GOV.UK Pay support if you need to update it.')
+    return response(req, res, 'error-with-link', errorPageData)
   }
 
   const rawVatNumber = lodash.get(req.body, VAT_NUMBER_FIELD, '')

--- a/app/controllers/stripe-setup/vat-number/post.controller.test.js
+++ b/app/controllers/stripe-setup/vat-number/post.controller.test.js
@@ -102,14 +102,13 @@ describe('VAT number POST controller', () => {
     sinon.assert.calledWith(next, expectedError)
   })
 
-  it('should redirect to dashboard if VAT number is already provided ', async () => {
+  it('should render error if VAT number is already provided ', async () => {
     const controller = getControllerWithMocks()
     req.account.connectorGatewayAccountStripeProgress = { vatNumber: true }
 
     await controller(req, res, next)
 
-    sinon.assert.calledWith(req.flash, 'genericError', 'You’ve already provided your VAT number. Contact GOV.UK Pay support if you need to update it.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/dashboard`)
+    sinon.assert.calledWith(res.render, 'error-with-link')
   })
 
   it('should render error when Stripe returns error, not call connector, and not redirect', async function () {

--- a/test/cypress/integration/stripe-setup/bank-details.cy.test.js
+++ b/test/cypress/integration/stripe-setup/bank-details.cy.test.js
@@ -88,20 +88,18 @@ describe('Stripe setup: bank details page', () => {
     })
 
     describe('Bank account flag already true', () => {
-      it('should redirect to Dashboard with an error message when on Bank details page', () => {
+      it('should display an error when on Bank details page', () => {
         setupStubs(true)
 
         cy.visit(bankDetailsUrl)
 
-        cy.get('h1').should('contain', 'Dashboard')
-        cy.location().should((location) => {
-          expect(location.pathname).to.eq(dashboardUrl)
-        })
-        cy.get('.flash-container > .generic-error').should('contain', 'You’ve already provided your bank details.')
-        cy.get('.flash-container > .generic-error').should('contain', 'Contact GOV.UK Pay support if you need to update them.')
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#back-link').should('contain', 'Back to dashboard')
+        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+        cy.get('#error-message').should('contain', 'You’ve already provided your bank details. Contact GOV.UK Pay support if you need to update them.')
       })
 
-      it('should redirect to Dashboard with an error message when submitting Bank details page', () => {
+      it('should display an error when submitting Bank details page', () => {
         setupStubs([false, true], 'live', 'stripe')
 
         cy.visit(bankDetailsUrl)
@@ -110,12 +108,10 @@ describe('Stripe setup: bank details page', () => {
         cy.get('input#sort-code[name="sort-code"]').type(sortCode)
         cy.get('#bank-details-form > button').click()
 
-        cy.get('h1').should('contain', 'Dashboard')
-        cy.location().should((location) => {
-          expect(location.pathname).to.eq(dashboardUrl)
-        })
-        cy.get('.flash-container > .generic-error').should('contain', 'You’ve already provided your bank details.')
-        cy.get('.flash-container > .generic-error').should('contain', 'Contact GOV.UK Pay support if you need to update them.')
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#back-link').should('contain', 'Back to dashboard')
+        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+        cy.get('#error-message').should('contain', 'You’ve already provided your bank details. Contact GOV.UK Pay support if you need to update them.')
       })
     })
 

--- a/test/cypress/integration/stripe-setup/company-number.cy.test.js
+++ b/test/cypress/integration/stripe-setup/company-number.cy.test.js
@@ -13,7 +13,7 @@ const gatewayAccountCredentialExternalId = 'a-valid-credential-external-id'
 const companyNumberUrl = `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}/company-number`
 const dashboardUrl = `/account/${gatewayAccountExternalId}/dashboard`
 
-function setupStubs (companyNumber, type = 'live', paymentProvider = 'stripe') {
+function setupStubs(companyNumber, type = 'live', paymentProvider = 'stripe') {
   let stripeSetupStub
 
   if (Array.isArray(companyNumber)) {
@@ -116,20 +116,18 @@ describe('Stripe setup: company number page', () => {
         cy.setEncryptedCookies(userExternalId)
       })
 
-      it('should redirect to Dashboard with an error message when displaying the page', () => {
+      it('should display an error when displaying the page', () => {
         setupStubs(true)
 
         cy.visit(companyNumberUrl)
 
-        cy.get('h1').should('contain', 'Dashboard')
-        cy.location().should((location) => {
-          expect(location.pathname).to.eq(dashboardUrl)
-        })
-        cy.get('.flash-container > .generic-error').should('contain', 'You’ve already provided your company registration number.')
-        cy.get('.flash-container > .generic-error').should('contain', 'Contact GOV.UK Pay support if you need to update it.')
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#back-link').should('contain', 'Back to dashboard')
+        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+        cy.get('#error-message').should('contain', 'You’ve already provided your company registration number. Contact GOV.UK Pay support if you need to update it.')
       })
 
-      it('should redirect to Dashboard with an error message when submitting the form', () => {
+      it('should display an error when submitting the form', () => {
         setupStubs([false, true])
 
         cy.visit(companyNumberUrl)
@@ -142,12 +140,10 @@ describe('Stripe setup: company number page', () => {
             cy.get('button').click()
           })
 
-        cy.get('h1').should('contain', 'Dashboard')
-        cy.location().should((location) => {
-          expect(location.pathname).to.eq(dashboardUrl)
-        })
-        cy.get('.flash-container > .generic-error').should('contain', 'You’ve already provided your company registration number.')
-        cy.get('.flash-container > .generic-error').should('contain', 'Contact GOV.UK Pay support if you need to update it.')
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#back-link').should('contain', 'Back to dashboard')
+        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+        cy.get('#error-message').should('contain', 'You’ve already provided your company registration number. Contact GOV.UK Pay support if you need to update it.')
       })
     })
 

--- a/test/cypress/integration/stripe-setup/director.cy.test.js
+++ b/test/cypress/integration/stripe-setup/director.cy.test.js
@@ -23,7 +23,7 @@ const typedDobMonth = ' 02'
 const typedDobYear = '1971 '
 const typedEmail = 'test@example.com'
 
-function setupStubs (director, type = 'live', paymentProvider = 'stripe', requiresAdditionalKycData = false) {
+function setupStubs(director, type = 'live', paymentProvider = 'stripe', requiresAdditionalKycData = false) {
   let stripeSetupStub
 
   if (Array.isArray(director)) {
@@ -176,7 +176,7 @@ describe('Stripe setup: director page', () => {
       cy.visit(directorUrl)
     })
 
-    it('should redirect to dashboard with error message instead of saving details', () => {
+    it('should display an error instead of saving details', () => {
       cy.get('#director-form').within(() => {
         cy.get('#first-name').type(typedFirstName)
         cy.get('#last-name').type(typedLastName)
@@ -186,11 +186,10 @@ describe('Stripe setup: director page', () => {
         cy.get('button').click()
       })
 
-      cy.get('h1').should('contain', 'Dashboard')
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(dashboardUrl)
-      })
-      cy.get('.flash-container .generic-error').should('contain', 'You’ve already provided director details.')
+      cy.get('h1').should('contain', 'An error occurred')
+      cy.get('#back-link').should('contain', 'Back to dashboard')
+      cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+      cy.get('#error-message').should('contain', 'You’ve already provided director details.')
     })
   })
 

--- a/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
@@ -177,12 +177,11 @@ describe('Stripe setup: responsible person page', () => {
       cy.visit(responsiblePersonUrl)
     })
 
-    it('should redirect to dashboard with error message instead of showing form', () => {
-      cy.get('h1').should('contain', 'Dashboard')
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(dashboardUrl)
-      })
-      cy.get('.flash-container .generic-error').should('contain', 'responsible person')
+    it('should display an error instead of showing form', () => {
+      cy.get('h1').should('contain', 'An error occurred')
+      cy.get('#back-link').should('contain', 'Back to dashboard')
+      cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+      cy.get('#error-message').should('contain', 'You’ve already nominated your responsible person. Contact GOV.UK Pay support if you need to change them.')
     })
   })
 
@@ -193,16 +192,15 @@ describe('Stripe setup: responsible person page', () => {
       cy.visit(responsiblePersonUrl)
     })
 
-    it('should redirect to dashboard with error message instead of saving details', () => {
+    it('should display an error instead of saving details', () => {
       cy.get('#responsible-person-form').within(() => {
         cy.get('button').click()
       })
 
-      cy.get('h1').should('contain', 'Dashboard')
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(dashboardUrl)
-      })
-      cy.get('.flash-container .generic-error').should('contain', 'responsible person')
+      cy.get('h1').should('contain', 'An error occurred')
+      cy.get('#back-link').should('contain', 'Back to dashboard')
+      cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+      cy.get('#error-message').should('contain', 'You’ve already nominated your responsible person. Contact GOV.UK Pay support if you need to change them.')
     })
   })
 

--- a/test/cypress/integration/stripe-setup/vat-number.cy.test.js
+++ b/test/cypress/integration/stripe-setup/vat-number.cy.test.js
@@ -122,20 +122,18 @@ describe('Stripe setup: VAT number page', () => {
         cy.setEncryptedCookies(userExternalId)
       })
 
-      it('should redirect to Dashboard with an error message when displaying the page', () => {
+      it('should display an error when displaying the page', () => {
         setupStubs(true)
 
         cy.visit(vatNumberUrl)
 
-        cy.get('h1').should('contain', 'Dashboard')
-        cy.location().should((location) => {
-          expect(location.pathname).to.eq(dashboardUrl)
-        })
-        cy.get('.flash-container > .generic-error').should('contain', 'You’ve already provided your VAT number.')
-        cy.get('.flash-container > .generic-error').should('contain', 'Contact GOV.UK Pay support if you need to update it.')
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#back-link').should('contain', 'Back to dashboard')
+        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+        cy.get('#error-message').should('contain', 'You’ve already provided your VAT number. Contact GOV.UK Pay support if you need to update it.')
       })
 
-      it('should redirect to Dashboard with an error message when submitting the form', () => {
+      it('should display an error when submitting the form', () => {
         setupStubs([false, true])
 
         cy.visit(vatNumberUrl)
@@ -145,12 +143,10 @@ describe('Stripe setup: VAT number page', () => {
 
         cy.get('#vat-number-form > button').click()
 
-        cy.get('h1').should('contain', 'Dashboard')
-        cy.location().should((location) => {
-          expect(location.pathname).to.eq(dashboardUrl)
-        })
-        cy.get('.flash-container > .generic-error').should('contain', 'You’ve already provided your VAT number.')
-        cy.get('.flash-container > .generic-error').should('contain', 'Contact GOV.UK Pay support if you need to update it.')
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#back-link').should('contain', 'Back to dashboard')
+        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+        cy.get('#error-message').should('contain', 'You’ve already provided your VAT number. Contact GOV.UK Pay support if you need to update it.')
       })
     })
 


### PR DESCRIPTION
Previously, we were redirecting to the dashboard and displaying an
error message in an error summary banner. However, the banner was
appearing inside the blue banner asking to submit details.

Instead, render an error page displaying the error with a link to go to
the dashboard.

Before:
<img width="1248" alt="Screenshot 2021-11-11 at 11 37 44" src="https://user-images.githubusercontent.com/5648592/141469393-a3449f7d-f3ca-4427-b888-a93f8164631e.png">

After:

<img width="636" alt="Screenshot 2021-11-12 at 12 13 09" src="https://user-images.githubusercontent.com/5648592/141469439-91159c8c-e6a0-4e80-b3bd-ed551558c1ba.png">
<img width="636" alt="Screenshot 2021-11-12 at 12 13 33" src="https://user-images.githubusercontent.com/5648592/141469457-e306de04-dcc4-4961-9b2d-73693ed59d37.png">
<img width="636" alt="Screenshot 2021-11-12 at 12 17 03" src="https://user-images.githubusercontent.com/5648592/141469473-a54e9053-a4bb-457a-86cc-8043e66200bd.png">
<img width="636" alt="Screenshot 2021-11-12 at 12 17 23" src="https://user-images.githubusercontent.com/5648592/141469499-72e59d0b-b2ce-4c4d-bb6b-a0524a1baf13.png">
<img width="636" alt="Screenshot 2021-11-12 at 12 17 41" src="https://user-images.githubusercontent.com/5648592/141469508-ba06787d-3891-460b-8146-e232c20b9132.png">


