### PR TITLE
[ZD-4775772] Fix heading in refund email example

### DIFF
--- a/app/views/email-notifications/email-refund-body.njk
+++ b/app/views/email-notifications/email-refund-body.njk
@@ -24,7 +24,7 @@
     </span>
   </div>
   <div class="pay-email-template-body">
-    <h3 class="govuk-heading-m email-heading">Your payment of £<span class="govuk-grey-text">[amount]</span> to <span class="govuk-grey-text">{{ serviceName }}</span> was successful</h3>
+    <h3 class="govuk-heading-m email-heading">You have been refunded £<span class="govuk-grey-text">[amount]</span> by <span class="govuk-grey-text">{{ serviceName }}</span></h3>
     <ul class="govuk-list govuk-list--bullet">
       <li>Refund for: <span class="govuk-grey-text">[description]</span></li>
       <li>Reference: <span class="govuk-grey-text">[service reference]</span></li>


### PR DESCRIPTION
## What?
We discovered a copy issue with the header text in the Self-Service UI email example template. This should correct the example to match what we send in production.

This was discovered by a user and reported via our Helpdesk.