### PR TITLE
PP-8834 Add director task to switch PSP

### DIFF
--- a/app/controllers/switch-psp/switch-tasks.service.js
+++ b/app/controllers/switch-psp/switch-tasks.service.js
@@ -41,6 +41,10 @@ function getTaskList (targetCredential, account) {
         enabled: !stripeSetupStageComplete(account, 'responsiblePerson'),
         complete: stripeSetupStageComplete(account, 'responsiblePerson')
       },
+      'ENTER_DIRECTOR': {
+        enabled: !stripeSetupStageComplete(account, 'director'),
+        complete: stripeSetupStageComplete(account, 'director')
+      },
       'ENTER_VAT_NUMBER': {
         enabled: !stripeSetupStageComplete(account, 'vatNumber'),
         complete: stripeSetupStageComplete(account, 'vatNumber')
@@ -52,6 +56,7 @@ function getTaskList (targetCredential, account) {
       'VERIFY_PSP_INTEGRATION': {
         enabled: stripeSetupStageComplete(account, 'bankAccount') &&
           stripeSetupStageComplete(account, 'responsiblePerson') &&
+          stripeSetupStageComplete(account, 'director') &&
           stripeSetupStageComplete(account, 'vatNumber') &&
           stripeSetupStageComplete(account, 'companyNumber'),
         complete: verifyPSPIntegrationComplete(targetCredential)

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -88,12 +88,17 @@
           taskList.ENTER_BANK_DETAILS
         ) }}
         {{ taskListItem(
-          "Provide details about your repsonsible person",
+          "Provide details about your responsible person",
           formatAccountPathsFor(routes.account.switchPSP.stripeSetup.responsiblePerson, currentGatewayAccount.external_id, targetCredential.external_id),
           taskList.ENTER_RESPONSIBLE_PERSON
         ) }}
         {{ taskListItem(
-          "Provide your organisation's VAT number",
+          "Provide details about the director of your organisation",
+          formatAccountPathsFor(routes.account.switchPSP.stripeSetup.director, currentGatewayAccount.external_id, targetCredential.external_id),
+          taskList.ENTER_DIRECTOR
+        ) }}
+        {{ taskListItem(
+          "Provide your organisation’s VAT number",
           formatAccountPathsFor(routes.account.switchPSP.stripeSetup.vatNumber, currentGatewayAccount.external_id, targetCredential.external_id),
           taskList.ENTER_VAT_NUMBER
         ) }}

--- a/test/cypress/integration/settings/switch-psp.cy.test.js
+++ b/test/cypress/integration/settings/switch-psp.cy.test.js
@@ -239,9 +239,8 @@ describe('Switch PSP settings page', () => {
             { payment_provider: 'smartpay', state: 'ACTIVE' },
             { payment_provider: 'stripe', state: 'CREATED' }
           ]),
-          stripeAccountSetupStubs.getGatewayAccountStripeSetupFlagForMultipleCalls({
-            gatewayAccountId,
-            bankAccount: [ true ]
+          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+            gatewayAccountId
           })
         ])
       })
@@ -250,8 +249,18 @@ describe('Switch PSP settings page', () => {
         cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
         cy.get('.govuk-heading-l').should('contain', 'Switch payment service provider (PSP)')
 
-        cy.get('strong[id="Provide your bank details-status"]').should('contain', 'completed')
+        cy.get('strong[id="Provide your bank details-status"]').should('contain', 'not started')
         cy.get('span').contains('Provide your bank details').should('exist')
+        cy.get('strong[id="Provide details about your responsible person-status"]').should('contain', 'not started')
+        cy.get('span').contains('Provide details about your responsible person').should('exist')
+        cy.get('strong[id="Provide details about the director of your organisation-status"]').should('contain', 'not started')
+        cy.get('span').contains('Provide details about the director of your organisation').should('exist')
+        cy.get('strong[id="Provide your organisation’s VAT number-status"]').should('contain', 'not started')
+        cy.get('span').contains('Provide your organisation’s VAT number').should('exist')
+        cy.get('strong[id="Provide your company registration number-status"]').should('contain', 'not started')
+        cy.get('span').contains('Provide your company registration number').should('exist')
+        cy.get('strong[id="Make a live payment to test your Stripe PSP-status"]').should('contain', 'cannot start yet')
+        cy.get('span').contains('Make a live payment to test your Stripe PSP').should('exist')
       })
     })
 
@@ -266,15 +275,14 @@ describe('Switch PSP settings page', () => {
               { payment_provider: 'stripe', state: 'CREATED', credentials: { 'stripe_account_id': 'a-valid-stripe-account-id' } }
             ]
           ),
-          stripeAccountSetupStubs.getGatewayAccountStripeSetupFlagForMultipleCalls({
-            gatewayAccountId,
-            bankAccount: [ true ]
+          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+            gatewayAccountId
           })
         ])
       })
 
       it('loads stripe pages for the switch flow', () => {
-        cy.get('a').contains('Provide your organisation\'s VAT number').click()
+        cy.get('a').contains('Provide your organisation’s VAT number').click()
         cy.get('#navigation-menu-switch-psp').parent().should('have.class', 'govuk-!-font-weight-bold')
         cy.get('a').contains('Back to Switching payment service provider (PSP)').should('exist')
       })
@@ -296,12 +304,21 @@ describe('Switch PSP settings page', () => {
             bankAccount: true,
             vatNumber: true,
             companyNumber: true,
-            responsiblePerson: true
+            responsiblePerson: true,
+            director: true
           })
         ])
       })
       it('all steps are complete', () => {
         cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
+
+        cy.get('strong[id="Provide your bank details-status"]').should('contain', 'completed')
+        cy.get('strong[id="Provide details about your responsible person-status"]').should('contain', 'completed')
+        cy.get('strong[id="Provide details about the director of your organisation-status"]').should('contain', 'completed')
+        cy.get('strong[id="Provide your organisation’s VAT number-status"]').should('contain', 'completed')
+        cy.get('strong[id="Provide your company registration number-status"]').should('contain', 'completed')
+        cy.get('strong[id="Make a live payment to test your Stripe PSP-status"]').should('contain', 'completed')
+
         cy.get('button').contains('Switch to Stripe').should('not.be.disabled')
       })
     })


### PR DESCRIPTION
Add the task to add director information to the switch PSP task list
when switching to Stripe.

Displaying the page with the back link and navigating back to the task
list after completion has already been implemented.

<img width="865" alt="Screenshot 2021-11-16 at 17 17 19" src="https://user-images.githubusercontent.com/5648592/142035275-5b80510e-57d3-4174-a987-a67c33b63a12.png">

<img width="991" alt="Screenshot 2021-11-16 at 17 16 00" src="https://user-images.githubusercontent.com/5648592/142035293-b58f8d05-44bc-46b5-a886-641ea5aad579.png">

<img width="865" alt="Screenshot 2021-11-16 at 17 26 23" src="https://user-images.githubusercontent.com/5648592/142035320-923001be-90fb-483f-b13d-3f61697e9bb0.png">


