### PR TITLE
PP-8803 Add page to add additional responsible person details

### DIFF
--- a/app/controllers/stripe-setup/responsible-person/get.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/get.controller.js
@@ -1,26 +1,48 @@
 'use strict'
 
 const { response } = require('../../../utils/response')
-const { isSwitchingCredentialsRoute } = require('../../../utils/credentials')
-const { getAlreadySubmittedErrorPageData } = require('../stripe-setup.util')
+const { isSwitchingCredentialsRoute, isAdditionalKycDataRoute, getCurrentCredential } = require('../../../utils/credentials')
+const { getAlreadySubmittedErrorPageData, getStripeAccountId } = require('../stripe-setup.util')
+const { listPersons } = require('../../../services/clients/stripe/stripe.client')
 
 const collectAdditionalKycData = process.env.COLLECT_ADDITIONAL_KYC_DATA === 'true'
 
-module.exports = (req, res, next) => {
-  const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
-  const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
+module.exports = async function showResponsiblePersonForm(req, res, next) {
+  try {
+    const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
+    const isSubmittingAdditionalKycData = isAdditionalKycDataRoute(req)
+    const currentCredential = getCurrentCredential(req.account)
 
-  if (!stripeAccountSetup) {
-    return next(new Error('Stripe setup progress is not available on request'))
-  }
-  if (stripeAccountSetup.responsiblePerson) {
-    const errorPageData = getAlreadySubmittedErrorPageData(req.account.external_id,
-      'You’ve already nominated your responsible person. Contact GOV.UK Pay support if you need to change them.')
-    return response(req, res, 'error-with-link', errorPageData)
-  }
+    if (isSubmittingAdditionalKycData) {
+      const stripeAccountId = await getStripeAccountId(req.account, isSwitchingCredentials, req.correlationId)
+      const personsResponse = await listPersons(stripeAccountId)
+      const responsiblePerson = personsResponse.data.filter(person => person.relationship && person.relationship.representative).pop()
+      const responsiblePersonName = `${responsiblePerson.first_name} ${responsiblePerson.last_name}`
+      if (!responsiblePerson) {
+        return next(new Error('No responsible person exists for Stripe account'))
+      }
+      return response(req, res, 'stripe-setup/responsible-person/kyc-additional-information', {
+        responsiblePersonName,
+        currentCredential
+      })
+    } else {
+      const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
 
-  return response(req, res, 'stripe-setup/responsible-person/index', {
-    isSwitchingCredentials,
-    collectAdditionalKycData
-  })
+      if (!stripeAccountSetup) {
+        return next(new Error('Stripe setup progress is not available on request'))
+      }
+      if (stripeAccountSetup.responsiblePerson) {
+        const errorPageData = getAlreadySubmittedErrorPageData(req.account.external_id,
+          'You’ve already nominated your responsible person. Contact GOV.UK Pay support if you need to change them.')
+        return response(req, res, 'error-with-link', errorPageData)
+      }
+
+      return response(req, res, 'stripe-setup/responsible-person/index', {
+        isSwitchingCredentials,
+        collectAdditionalKycData
+      })
+    }
+  } catch (err) {
+    next(err)
+  }
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -45,6 +45,11 @@ module.exports = {
       confirmation: '/email-settings-confirmation',
       refund: '/email-settings-refund'
     },
+    kyc: {
+      organisationUrl: '/kyc/:credentialId/organisation-url',
+      responsiblePerson: '/kyc/:credentialId/responsible-person',
+      director: '/kyc/:credentialId/director'
+    },
     notificationCredentials: {
       edit: '/your-psp/:credentialId/notification-credentials/edit',
       update: '/your-psp/:credentialId/notification-credentials'
@@ -109,11 +114,6 @@ module.exports = {
         companyNumber: '/switch-psp/:credentialId/company-number',
         director: '/switch-psp/:credentialId/director'
       }
-    },
-    kyc: {
-      organisationUrl: '/kyc/:credentialId/organisation-url',
-      responsiblePerson: '/kyc/:credentialId/responsible-person',
-      director: '/kyc/:credentialId/director'
     },
     toggle3ds: {
       index: '/3ds'

--- a/app/routes.js
+++ b/app/routes.js
@@ -434,7 +434,7 @@ module.exports.bind = function (app) {
   // Stripe setup
   account.get([ yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails ], permission('stripe-bank-details:update'), restrictToStripeAccountContext, stripeSetupBankDetailsController.get)
   account.post([ yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails ], permission('stripe-bank-details:update'), restrictToStripeAccountContext, stripeSetupBankDetailsController.post)
-  account.get([ yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson ], permission('stripe-responsible-person:update'), restrictToStripeAccountContext, stripeSetupResponsiblePersonController.get)
+  account.get([ yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson, kyc.responsiblePerson ], permission('stripe-responsible-person:update'), restrictToStripeAccountContext, stripeSetupResponsiblePersonController.get)
   account.post([ yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson ], permission('stripe-responsible-person:update'), restrictToStripeAccountContext, stripeSetupResponsiblePersonController.post)
   account.get([yourPsp.stripeSetup.director, switchPSP.stripeSetup.director, kyc.director], permission('stripe-director:update'), restrictToStripeAccountContext, stripeSetupDirectorController.get)
   account.post([ yourPsp.stripeSetup.director, switchPSP.stripeSetup.director, kyc.director ], permission('stripe-director:update'), restrictToStripeAccountContext, stripeSetupDirectorController.post)

--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -80,7 +80,7 @@
 
       {% if errors['email'] %}
         {% set errorList = (errorList.push({
-          text: 'Email address',
+          text: 'Work email address',
           href: '#email'
         }), errorList) %}
       {% endif %}

--- a/app/views/stripe-setup/responsible-person/kyc-additional-information.njk
+++ b/app/views/stripe-setup/responsible-person/kyc-additional-information.njk
@@ -1,0 +1,108 @@
+{% extends "../../layout.njk" %}
+
+{% block pageTitle %}
+  Enter details of your responsible person - {{ currentService.name }} - GOV.UK Pay
+{% endblock %}
+
+{% block side_navigation %}
+  {% include "includes/side-navigation.njk" %}
+{% endblock %}
+
+{% block mainContent %}
+
+  <div class="govuk-grid-column-two-thirds">
+    {{ govukBackLink({
+      text: "Back",
+      classes: "govuk-!-margin-top-0",
+      href: formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, currentCredential.external_id)
+    }) }}
+
+    {% if errors %}
+      {% set errorList = [] %}
+
+      {% if errors['telephone-number'] %}
+        {% set errorList = (errorList.push({
+          text: 'Work telephone number',
+          href: '#telephone-number'
+        }), errorList) %}
+      {% endif %}
+
+      {% if errors['email'] %}
+        {% set errorList = (errorList.push({
+          text: 'Work email address',
+          href: '#email'
+        }), errorList) %}
+      {% endif %}
+
+      {{ govukErrorSummary({
+        titleText: 'There was a problem with the details you gave for:',
+        errorList: errorList
+      }) }}
+    {% endif %}
+
+    <h1 class="govuk-heading-l">Enter details of your responsible person</h1>
+
+    <p class="govuk-body">We need details of a <a class="govuk-link" href="https://www.payments.service.gov.uk/what-being-a-responsible-person-means">responsible person</a> so that Stripe can run anti-money laundering checks. Liability stays at an organisational and not individual level.</p>
+    <p class="govuk-body">The responsible person can be:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>someone in your organisation authorised to sign contracts</li>
+      <li>the head of finance</li>
+      <li>the head of the organisation</li>
+    </ul>
+
+    <p class="govuk-body">Stripe will store the responsible person’s details, not GOV.UK Pay.</p>
+
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="row">
+            Name
+          </th>
+          <td class="govuk-table__cell" id="responsible-person-name">
+            {{responsiblePersonName}}
+          </td>
+          <td class="govuk-table__cell pay-text-align-right">
+            <a class="govuk-link govuk-link--no-visited-state" href="{{formatAccountPathsFor(routes.account.kyc.responsiblePerson, currentGatewayAccount.external_id)}}?change=true">Change<span class="govuk-visually-hidden">responsible person</span></a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <form method="post" class="govuk-!-margin-top-4" novalidate>
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+
+      {{ govukInput({
+        label: {
+          text: "Work telephone number",
+          classes: "govuk-label--m"
+        },
+        hint: {
+          text: "Include the country code for international numbers"
+        },
+        id: "telephone-number",
+        name: "telephone-number",
+        value: telephone,
+        type: "text",
+        autocomplete: "tel",
+        errorMessage: { text: errors['telephone-number'] } if errors['telephone-number'] else false,
+        classes: "govuk-!-width-two-thirds"
+      }) }}
+
+      {{ govukInput({
+        label: {
+          text: "Work email address",
+          classes: "govuk-label--m"
+        },
+        id: "email",
+        name: "email",
+        value: email,
+        type: "text",
+        autocomplete: "email",
+        errorMessage: { text: errors.email } if errors.email else false,
+        classes: "govuk-!-width-two-thirds"
+      }) }}
+
+      {{ govukButton({ text: "Submit" }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/test/cypress/integration/settings/your-psp-stripe-kyc.cy.test.js
+++ b/test/cypress/integration/settings/your-psp-stripe-kyc.cy.test.js
@@ -3,114 +3,154 @@
 const userStubs = require('../../stubs/user-stubs')
 const stripePspStubs = require('../../stubs/stripe-psp-stubs')
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+const stripeAccountSetupStubs = require('../../stubs/stripe-account-setup-stub')
+const stripeAccountStubs = require('../../stubs/stripe-account-stubs')
+
+const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+const gatewayAccountId = 42
+const gatewayAccountExternalId = 'a-valid-external-id'
+const credentialExternalId = 'a-credential-external-id'
+const serviceName = 'Purchase a positron projection permit'
+const stripeAccountId = `acct_123example123`
+const firstName = 'Joe'
+const lastName = 'Pay'
+
+function setupYourPspStubs(opts = {}) {
+  const user = userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName })
+
+  const gatewayAccountByExternalId = gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+    gatewayAccountId,
+    gatewayAccountExternalId,
+    requiresAdditionalKycData: true,
+    type: 'live',
+    paymentProvider: 'stripe',
+    gatewayAccountCredentials: [{
+      payment_provider: 'stripe',
+      credentials: { stripe_account_id: stripeAccountId },
+      external_id: credentialExternalId
+    }]
+  })
+  const stripeAccountSetup = stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+    gatewayAccountId,
+    responsiblePerson: true,
+    bankAccount: true,
+    vatNumber: true,
+    companyNumber: true,
+    director: false
+  })
+  const stripeAccount = stripeAccountStubs.getStripeAccountSuccess(gatewayAccountId, stripeAccountId)
+
+  const stripeAccountDetails = stripePspStubs.retrieveAccountDetails({ stripeAccountId, url: opts.url })
+  const stripePersons = stripePspStubs.listPersons({
+    stripeAccountId,
+    representative: opts.representative,
+    director: opts.director,
+    firstName,
+    lastName,
+    phone: opts.phone,
+    email: opts.email
+  })
+
+  const stubs = [user, gatewayAccountByExternalId, stripeAccountSetup, stripeAccount,
+    stripeAccountDetails, stripePersons]
+
+  cy.task('setupStubs', stubs)
+}
 
 describe('Your PSP - Stripe - KYC', () => {
-  const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
-  const gatewayAccountId = 42
-  const gatewayAccountExternalId = 'a-valid-external-id'
-  const credentialExternalId = 'a-credential-external-id'
-  const serviceName = 'Purchase a positron projection permit'
-  const stripeAccountId = `acct_123example123`
-
-  function setupYourPspStubs (opts = {}) {
-    let user = userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName })
-
-    const gatewayAccountByExternalId = gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
-      gatewayAccountId,
-      gatewayAccountExternalId,
-      requiresAdditionalKycData: true,
-      gatewayAccountCredentials: [{
-        payment_provider: 'stripe',
-        credentials: { stripe_account_id: stripeAccountId },
-        external_id: credentialExternalId
-      }]
-    })
-
-    const stripeAccountDetails = stripePspStubs.retrieveAccountDetails({ stripeAccountId, url: opts.url })
-    const stripePersons = stripePspStubs.listPersons({
-      stripeAccountId,
-      representative: opts.representative,
-      director: opts.director,
-      phone: opts.phone,
-      email: opts.email
-    })
-
-    const stubs = [user, gatewayAccountByExternalId,
-      stripeAccountDetails, stripePersons]
-
-    cy.task('setupStubs', stubs)
-  }
-
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('session', 'gateway_account')
   })
 
-  it('should display link to "Your PSP - Stripe" in the side navigation - when requires additional kyc data is enabled', () => {
-    setupYourPspStubs({})
-    cy.setEncryptedCookies(userExternalId)
-    cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-    cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Stripe')
+  describe('Task list', () => {
+    it('should display link to "Your PSP - Stripe" in the side navigation - when requires additional kyc data is enabled', () => {
+      setupYourPspStubs({})
+      cy.setEncryptedCookies(userExternalId)
+      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+      cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Stripe')
+    })
+
+    it('should display responsible person task as COMPLETED if details are updated on Stripe', () => {
+      setupYourPspStubs({
+        representative: true,
+        phone: '0000000',
+        email: 'test@example.org'
+      })
+      cy.setEncryptedCookies(userExternalId)
+      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+      cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Stripe')
+
+      cy.get('#task-update-sro-status').should('have.html', 'completed')
+    })
+    it('should display director task as COMPLETED if details are updated on Stripe', () => {
+      setupYourPspStubs({
+        director: true
+      })
+      cy.setEncryptedCookies(userExternalId)
+      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+      cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Stripe')
+
+      cy.get('#task-add-director-status').should('have.html', 'completed')
+    })
+    it('should display organisation URL task as COMPLETED if details are updated on Stripe', () => {
+      setupYourPspStubs({
+        'url': 'http://example.org'
+      })
+      cy.setEncryptedCookies(userExternalId)
+      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+      cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Stripe')
+
+      cy.get('#task-organisation-url-status').should('have.html', 'completed')
+    })
+
+    it('should display all tasks as NOT STARTED if details are not updated on Stripe', () => {
+      setupYourPspStubs({
+        representative: true,
+        phone: null,
+        director: false,
+        url: null
+      })
+      cy.setEncryptedCookies(userExternalId)
+      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+      cy.get('#task-update-sro-status').should('have.html', 'not started')
+      cy.get('#task-add-director-status').should('have.html', 'not started')
+      cy.get('#task-organisation-url-status').should('have.html', 'not started')
+    })
+
+    it('should not display tasks if all tasks are COMPLETED', () => {
+      setupYourPspStubs({
+        representative: true,
+        phone: '0000000',
+        email: 'test@example.org',
+        director: true,
+        url: 'http://example.org'
+      })
+      cy.setEncryptedCookies(userExternalId)
+      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+      cy.get('#task-update-sro-status').should('not.exist')
+      cy.get('#task-add-director-status').should('not.exist')
+      cy.get('#task-organisation-url-status').should('not.exist')
+    })
   })
 
-  it('should display responsible person task as COMPLETED if details are updated on Stripe', () => {
-    setupYourPspStubs({
-      representative: true,
-      phone: '0000000',
-      email: 'test@example.org'
+  describe('Responsible person page', () => {
+    beforeEach(() => {
+      setupYourPspStubs({
+        representative: true
+      })
     })
-    cy.setEncryptedCookies(userExternalId)
-    cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-    cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Stripe')
 
-    cy.get('#task-update-sro-status').should('have.html', 'completed')
-  })
-  it('should display director task as COMPLETED if details are updated on Stripe', () => {
-    setupYourPspStubs({
-      director: true
+    it('should show the task list with the responsible person task not completed', () => {
+      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+
+      cy.get('#task-update-sro-status').should('have.html', 'not started')
     })
-    cy.setEncryptedCookies(userExternalId)
-    cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-    cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Stripe')
 
-    cy.get('#task-add-director-status').should('have.html', 'completed')
-  })
-  it('should display organisation URL task as COMPLETED if details are updated on Stripe', () => {
-    setupYourPspStubs({
-      'url': 'http://example.org'
+    it('should redirect to the responsible person page with existing persons name displayed', () => {
+      cy.get('a').contains('Add information about responsible person').click()
+      cy.get('h1').should('contain', 'Enter details of your responsible person')
+      cy.get('td#responsible-person-name').should('contain', 'Joe Pay')
+      cy.get('input[type="text"]').should('have.length', 2)
     })
-    cy.setEncryptedCookies(userExternalId)
-    cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-    cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Stripe')
-
-    cy.get('#task-organisation-url-status').should('have.html', 'completed')
-  })
-
-  it('should display all tasks as NOT STARTED if details are not updated on Stripe', () => {
-    setupYourPspStubs({
-      representative: true,
-      phone: null,
-      director: false,
-      url: null
-    })
-    cy.setEncryptedCookies(userExternalId)
-    cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-    cy.get('#task-update-sro-status').should('have.html', 'not started')
-    cy.get('#task-add-director-status').should('have.html', 'not started')
-    cy.get('#task-organisation-url-status').should('have.html', 'not started')
-  })
-
-  it('should not display tasks if all tasks are COMPLETED', () => {
-    setupYourPspStubs({
-      representative: true,
-      phone: '0000000',
-      email: 'test@example.org',
-      director: true,
-      url: 'http://example.org'
-    })
-    cy.setEncryptedCookies(userExternalId)
-    cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-    cy.get('#task-update-sro-status').should('not.exist')
-    cy.get('#task-add-director-status').should('not.exist')
-    cy.get('#task-organisation-url-status').should('not.exist')
   })
 })

--- a/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.test.js
@@ -126,7 +126,7 @@ describe('Stripe setup: responsible person page', () => {
         cy.get('a[href="#dob-month"]').should('not.exist')
         cy.get('a[href="#dob-year"]').should('not.exist')
         cy.get('a[href="#telephone-number"]').should('contain', 'Work telephone number')
-        cy.get('a[href="#email"]').should('contain', 'Email address')
+        cy.get('a[href="#email"]').should('contain', 'Work email address')
       })
 
       cy.get('#responsible-person-form').should('exist').within(() => {

--- a/test/cypress/stubs/stripe-psp-stubs.js
+++ b/test/cypress/stubs/stripe-psp-stubs.js
@@ -8,6 +8,8 @@ function parseStripePersonOptions (opts) {
     director: opts.director || false,
     representative: opts.representative || false,
     stripe_account_id: opts.stripeAccountId || 'stripe-connect-account-id',
+    firstName: opts.firstName || null,
+    lastName: opts.lastName || null,
     phone: opts.phone || null,
     email: opts.email || null
   }

--- a/test/fixtures/stripe-psp.fixtures.js
+++ b/test/fixtures/stripe-psp.fixtures.js
@@ -45,8 +45,8 @@ function validListStripePersons (opts = {}) {
           'month': 8,
           'year': 1990
         },
-        'first_name': null,
-        'last_name': null,
+        'first_name': opts.firstName || null,
+        'last_name': opts.lastName || null,
         'relationship': {
           'owner': false,
           'percent_ownership': null,


### PR DESCRIPTION
Add a new view to add the additional fields for the responsible person,
showing the name of the existing responsible person with the option to
change it.

This commit only implements loading the page, not submission or loading
the form to change the responsible person.

## Review notes

Hiding whitespace changes will make this a lot easier to review, as the indentation in the cypress tests has changed.

<img width="286" alt="Screenshot 2021-11-18 at 10 18 04" src="https://user-images.githubusercontent.com/5648592/142396923-aa044135-9ce3-4c63-b8ab-995fe1696f55.png">

## How it looks

<img width="1155" alt="Screenshot 2021-11-18 at 10 50 32" src="https://user-images.githubusercontent.com/5648592/142401829-2ad528ea-f76a-4360-9f72-5bef86626682.png">
 
