### PR TITLE
PP-8803 Show all responsible person fields when change is clicked

### DIFF
--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -5,22 +5,30 @@
 {% endblock %}
 
 {% block side_navigation %}
-  {% if isSwitchingCredentials %}
+  {% if isSwitchingCredentials or isSubmittingAdditionalKycData %}
     {% include "includes/side-navigation.njk" %}
   {% endif %}
 {% endblock %}
 
 {% block mainContent %}
 
-  {% if isSwitchingCredentials %}
-    {{ govukBackLink({
-      text: "Back to Switching payment service provider (PSP)",
-      classes: "govuk-!-margin-top-0",
-      href: formatAccountPathsFor(routes.account.switchPSP.index, currentGatewayAccount.external_id)
-    }) }}
-  {% endif %}
-
   <div class="govuk-grid-column-two-thirds">
+
+    {% if isSwitchingCredentials %}
+      {{ govukBackLink({
+        text: "Back to Switching payment service provider (PSP)",
+        classes: "govuk-!-margin-top-0",
+        href: formatAccountPathsFor(routes.account.switchPSP.index, currentGatewayAccount.external_id)
+      }) }}
+    {% endif %}
+    {% if isSubmittingAdditionalKycData %}
+    {{ govukBackLink({
+        text: "Back",
+        classes: "govuk-!-margin-top-0",
+        href: formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, currentCredential.external_id)
+      }) }}
+    {% endif %}
+
     {% if errors %}
       {% set errorList = [] %}
 
@@ -314,7 +322,11 @@
         }) }}
       {% endif %}
 
+      {% if isSubmittingAdditionalKycData %}
+      {{ govukButton({ text: "Submit" }) }}
+      {% else %}
       {{ govukButton({ text: "Save and continue" }) }}
+      {% endif %}
     </form>
   </div>
 {% endblock %}

--- a/test/cypress/integration/settings/your-psp-stripe-kyc.cy.test.js
+++ b/test/cypress/integration/settings/your-psp-stripe-kyc.cy.test.js
@@ -149,8 +149,22 @@ describe('Your PSP - Stripe - KYC', () => {
     it('should redirect to the responsible person page with existing persons name displayed', () => {
       cy.get('a').contains('Add information about responsible person').click()
       cy.get('h1').should('contain', 'Enter details of your responsible person')
+      cy.get('.govuk-back-link')
+        .should('have.text', 'Back')
+        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
       cy.get('td#responsible-person-name').should('contain', 'Joe Pay')
       cy.get('input[type="text"]').should('have.length', 2)
+    })
+
+    it('should redirect to page with all fields when change is clicked', () => {
+      cy.get('a').contains('Change').click()
+      cy.get('input#first-name').should('exist')
+      cy.get('.govuk-back-link')
+        .should('have.text', 'Back')
+        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+      cy.get('form').within(() => {
+        cy.get('button').should('contain', 'Submit')
+      })
     })
   })
 })


### PR DESCRIPTION
When the "Change" button is clicked next to the name of the existing responsible person on the KYC additional information page, reload the responsible person page with all fields present.

<img width="646" alt="Screenshot 2021-11-18 at 12 14 51" src="https://user-images.githubusercontent.com/5648592/142414259-650fd2f1-5d0b-42f8-b5f0-eb862880efb7.png">
