### PR TITLE
PP-8802 Org URL - Update error messages to be consistent with Design System

### DIFF
--- a/app/views/kyc/organisation-url.njk
+++ b/app/views/kyc/organisation-url.njk
@@ -1,4 +1,5 @@
 {% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
 
 {% block pageTitle %}
   Enter organisation website address - {{ currentService.name }} - GOV.UK Pay
@@ -18,22 +19,12 @@
     href: formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, currentCredential.external_id)
   }) }}
 
-  {% if errors %}
-      {% set errorList = [] %}
-
-      {% if errors['organisation-url'] %}
-        {% set errorList = (errorList.push({
-          text: 'Organisation URL',
-          href: '#organisation-url'
-        }), errorList) %}
-      {% endif %}
-
-      {{ govukErrorSummary({
-        titleText: 'There was a problem with the details you gave for:',
-        errorList: errorList
-      }) }}
-    {% endif %}
-
+  {{ errorSummary ({
+    errors: errors,
+    hrefs: {
+      'organisation-url': '#organisation-url'
+    }
+  }) }}
 
   <h1 class="govuk-heading-l govuk-!-margin-bottom-6">
     <label for="organisation-url">Enter organisation website address</label>

--- a/test/cypress/integration/settings/your-psp-stripe-kyc.cy.test.js
+++ b/test/cypress/integration/settings/your-psp-stripe-kyc.cy.test.js
@@ -96,6 +96,7 @@ describe('Your PSP - Stripe - KYC', () => {
 
       cy.get('#task-update-sro-status').should('have.html', 'completed')
     })
+
     it('should display director task as COMPLETED if details are updated on Stripe', () => {
       setupYourPspStubs({
         director: true
@@ -231,7 +232,7 @@ describe('Your PSP - Stripe - KYC', () => {
       })
 
       cy.get('.govuk-error-summary').should('exist').within(() => {
-        cy.get('a[href="#organisation-url"]').should('contain', 'Organisation URL')
+        cy.get('a[href="#organisation-url"]').should('contain', 'Enter a valid website address')
       })
     })
 


### PR DESCRIPTION


- Update the `organisation-url.njk` template
  - Use the `error-summary.njk` macro so the summary is consistent
    with Design System guidelines.
- Update Cypress test

