### PR TITLE
PP-8928 Fix link in error summary

### DIFF
--- a/app/views/stripe-setup/vat-number/index.njk
+++ b/app/views/stripe-setup/vat-number/index.njk
@@ -26,7 +26,7 @@
     {{ errorSummary ({
       errors: errors,
       hrefs: {
-        'vat-number-declaration': '#vat-number-declaration',
+        'vat-number-declaration': '#have-vat-number',
         'vat-number': '#vat-number'
       }
     }) }}
@@ -35,20 +35,6 @@
 
     <form id="vat-number-form" method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
-
-      {% set noSelectionError = false %}
-      {% if errors['vat-number-declaration'] %}
-        {% set noSelectionError = {
-          text: "Please choose an option"
-        } %}
-      {% endif %}
-
-      {% set vatNumberError = false %}
-      {% if errors['vat-number'] %}
-        {% set vatNumberError = {
-          text: errors['vat-number']
-        } %}
-      {% endif %}
 
       {% set vatNumberHTML %}
         {{ govukInput({
@@ -63,7 +49,7 @@
           classes: "govuk-input--width-30",
           value: vatNumber,
           type: "text",
-          errorMessage: vatNumberError,
+          errorMessage: { text: errors['vat-number'] } if errors['vat-number'] else false,
           attributes: {
             autocomplete: "off",
             spellcheck: "false"
@@ -82,7 +68,7 @@
               classes: 'govuk-fieldset__legend--m'
             }
           },
-          errorMessage: noSelectionError,
+          errorMessage: { text: errors['vat-number-declaration'] } if errors['vat-number-declaration'] else false,
           items: [
             {
               value: "true",

--- a/test/cypress/integration/stripe-setup/vat-number.cy.test.js
+++ b/test/cypress/integration/stripe-setup/vat-number.cy.test.js
@@ -96,7 +96,7 @@ describe('Stripe setup: VAT number page', () => {
 
         cy.get('h2').should('contain', 'There is a problem')
         cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'You must answer this question')
-        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#vat-number-declaration')
+        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#have-vat-number')
       })
     })
 


### PR DESCRIPTION
For radio buttons, there is no ID for the containing fieldset, so error summary messages need to link to the first radio button item. Fix the ID for the error on the VAT number page so it links to the first radio button item, which has a custom ID.

