### PR TITLE
PP-8901 `npm install` -> `npm ci`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN ["apk", "add", "--no-cache", "tini"]
 
 ADD package.json /tmp/package.json
 ADD package-lock.json /tmp/package-lock.json
-RUN cd /tmp && npm install --production
+RUN cd /tmp && npm ci --production
 
 ENV PORT 9000
 EXPOSE 9000


### PR DESCRIPTION
## WHAT
switched `npm install` to `npm ci`, as reported by @heathd, which creates reproducible builds.

## HOW 
`docker build .` observe how `package-lock.json is unmodified`

On my machine, both take 84s to build, so there appears to be no change in build time.


