### PR TITLE
PP-8861 Show KYC task list after all tasks complete

### DIFF
--- a/app/controllers/your-psp/get.controller.js
+++ b/app/controllers/your-psp/get.controller.js
@@ -23,7 +23,8 @@ module.exports = async (req, res, next) => {
     let stripeData = {}
     if (activeCredential && activeCredential.payment_provider === 'stripe') {
       stripeData.requiresAdditionalKycData = req.account.requires_additional_kyc_data === true
-      if (stripeData.requiresAdditionalKycData) {
+      const kycCompleted = req.account.connectorGatewayAccountStripeProgress && req.account.connectorGatewayAccountStripeProgress.additionalKycData
+      if (stripeData.requiresAdditionalKycData || kycCompleted) {
         stripeData.kycTaskList = await getTaskList(activeCredential)
         stripeData.kycTaskListComplete = isComplete(stripeData.kycTaskList)
       }

--- a/app/controllers/your-psp/kyc-tasks.service.js
+++ b/app/controllers/your-psp/kyc-tasks.service.js
@@ -47,7 +47,6 @@ async function getTaskList (activeCredential) {
 }
 
 function isComplete (taskList) {
-  console.log('TASKLIST ' + JSON.stringify(taskList))
   return Object.values(taskList).every(task => task.complete)
 }
 

--- a/app/models/StripeAccountSetup.class.js
+++ b/app/models/StripeAccountSetup.class.js
@@ -7,6 +7,7 @@ class StripeAccountSetup {
     this.vatNumber = opts.vat_number
     this.companyNumber = opts.company_number
     this.director = opts.director
+    this.additionalKycData = opts.additional_kyc_data
   }
 }
 

--- a/app/utils/credentials.js
+++ b/app/utils/credentials.js
@@ -57,7 +57,8 @@ function isAdditionalKycDataRoute (req) {
 function getPSPPageLinks (gatewayAccount) {
   const supportedYourPSPPageProviders = ['worldpay', 'smartpay', 'epdq']
 
-  if (gatewayAccount.requires_additional_kyc_data) {
+  if (gatewayAccount.requires_additional_kyc_data ||
+    (gatewayAccount.connectorGatewayAccountStripeProgress && gatewayAccount.connectorGatewayAccountStripeProgress.additionalKycData)) {
     supportedYourPSPPageProviders.push('stripe')
   }
 

--- a/app/views/your-psp/_stripe.njk
+++ b/app/views/your-psp/_stripe.njk
@@ -12,14 +12,13 @@
 
     {% if not item.complete %}
       <strong class="govuk-tag app-task-list__tag govuk-tag--grey" id="{{ id }}-status">not started</strong>
-      {% elif item.complete %}
+    {% elif item.complete %}
       <strong class="govuk-tag app-task-list__tag" id="{{ id }}-status">completed</strong>
     {% endif %}
   </li>
 {% endmacro %}
 
 {% if requiresAdditionalKycData and not kycTaskListComplete %}
-
   <h2 class="govuk-heading-m govuk-!-margin-bottom-4">Know your customer (KYC) details</h2>
   <p class="govuk-body">You must add additional details about your organisation for Stripe's anti-money laundering
     checks. </p>
@@ -31,32 +30,34 @@
     text: warningText,
     iconFallbackText: "Warning"
   }) }}
-
-  {% set tasks %}
-    {{ taskListItem(
-      'task-organisation-url',
-      "Add organisation website address",
-      formatAccountPathsFor(routes.account.kyc.organisationUrl, currentGatewayAccount.external_id, activeCredential.external_id),
-      kycTaskList.ENTER_ORGANISATION_URL
-    ) }}
-    {{ taskListItem(
-      'task-update-sro',
-      "Add responsible person information",
-      formatAccountPathsFor(routes.account.kyc.responsiblePerson, currentGatewayAccount.external_id, activeCredential.external_id),
-      kycTaskList.UPDATE_RESPONSIBLE_PERSON
-    ) }}
-    {{ taskListItem(
-      'task-add-director',
-      "Add director of service information",
-      formatAccountPathsFor(routes.account.kyc.director, currentGatewayAccount.external_id, activeCredential.external_id),
-      kycTaskList.ENTER_DIRECTOR
-    ) }}
-  {% endset %}
-
-  <div class="app-task-list govuk-body">
-    <div>
-      <span class="app-task-list__items">{{ tasks | safe }}</span>
-    </div>
-  </div>
-
+{% else %}
+  <p class="govuk-body">Please review the responsible person and director information annually, and if either leaves or changes their role.
+  Email any changes to <a class="govuk-link" href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk" target="_top">govuk-pay-support@digital.cabinet-office.gov.uk</a></p>
 {% endif %}
+
+{% set tasks %}
+  {{ taskListItem(
+    'task-organisation-url',
+    "Add organisation website address",
+    formatAccountPathsFor(routes.account.kyc.organisationUrl, currentGatewayAccount.external_id, activeCredential.external_id),
+    kycTaskList.ENTER_ORGANISATION_URL
+  ) }}
+  {{ taskListItem(
+    'task-update-sro',
+    "Add responsible person information",
+    formatAccountPathsFor(routes.account.kyc.responsiblePerson, currentGatewayAccount.external_id, activeCredential.external_id),
+    kycTaskList.UPDATE_RESPONSIBLE_PERSON
+  ) }}
+  {{ taskListItem(
+    'task-add-director',
+    "Add director of service information",
+    formatAccountPathsFor(routes.account.kyc.director, currentGatewayAccount.external_id, activeCredential.external_id),
+    kycTaskList.ENTER_DIRECTOR
+  ) }}
+{% endset %}
+
+<div class="app-task-list govuk-body">
+  <div>
+    <span class="app-task-list__items">{{ tasks | safe }}</span>
+  </div>
+</div>

--- a/test/cypress/stubs/stripe-account-setup-stub.js
+++ b/test/cypress/stubs/stripe-account-setup-stub.js
@@ -23,6 +23,9 @@ function getGatewayAccountStripeSetupSuccess (opts) {
   if (opts.director !== undefined) {
     fixtureOpts.director = opts.director
   }
+  if (opts.additionalKycData !== undefined) {
+    fixtureOpts.additional_kyc_data = opts.additionalKycData
+  }
 
   const path = `/v1/api/accounts/${opts.gatewayAccountId}/stripe-setup`
   return stubBuilder('GET', path, 200, {

--- a/test/unit/clients/connector-client/connector-get-stripe-account-setup.pact.test.js
+++ b/test/unit/clients/connector-client/connector-get-stripe-account-setup.pact.test.js
@@ -42,7 +42,8 @@ describe('connector client - get stripe account setup', () => {
       bank_account: true,
       responsible_person: true,
       vat_number: false,
-      company_number: false
+      company_number: false,
+      additional_kyc_data: false
     }
     const response = stripeAccountSetupFixtures.buildGetStripeAccountSetupResponse(stripeSetupOpts)
 
@@ -70,6 +71,7 @@ describe('connector client - get stripe account setup', () => {
           expect(stripeAccountSetup.vatNumber).to.equal(stripeSetupOpts.vat_number)
           expect(stripeAccountSetup.companyNumber).to.equal(stripeSetupOpts.company_number)
           expect(stripeAccountSetup.responsiblePerson).to.equal(stripeSetupOpts.responsible_person)
+          expect(stripeAccountSetup.additionalKycData).to.equal(stripeSetupOpts.additional_kyc_data)
         }).should.notify(done)
     })
   })


### PR DESCRIPTION
Show the completed task list with a different paragraph above it when all KYC tasks have been completed.

Also continue to show the "Your PSP - Stripe" link in the settings navigation after tasks have been completed.

We disable the `requires_additional_kyc_data` flag after all tasks have been completed, but we set the `additional_kyc_data` Stripe setup task on the gateway account, so look at this to determine whether to show the navigation link.