### PR TITLE
PP-8962 Add post controller for government entity document task

### DIFF
--- a/app/controllers/stripe-setup/government-entity-document/index.js
+++ b/app/controllers/stripe-setup/government-entity-document/index.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const { postGovernmentEntityDocument } = require('./post.controller')
+
 module.exports = {
-  get: require('./get.controller')
+  get: require('./get.controller'),
+  post: postGovernmentEntityDocument
 }

--- a/app/controllers/stripe-setup/government-entity-document/post.controller.js
+++ b/app/controllers/stripe-setup/government-entity-document/post.controller.js
@@ -1,0 +1,95 @@
+'use strict'
+
+const lodash = require('lodash')
+
+const logger = require('../../../utils/logger')(__filename)
+const { response } = require('../../../utils/response')
+const { isSwitchingCredentialsRoute, isAdditionalKycDataRoute, getCurrentCredential } = require('../../../utils/credentials')
+const { getStripeAccountId, getAlreadySubmittedErrorPageData, completeKyc } = require('../stripe-setup.util')
+const { uploadFile, updateAccount } = require('../../../services/clients/stripe/stripe.client')
+const { isKycTaskListComplete } = require('../../../controllers/your-psp/kyc-tasks.service')
+const { ConnectorClient } = require('../../../services/clients/connector.client')
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+const paths = require('../../../paths')
+const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
+
+const GOVERNMENT_ENTITY_DOCUMENT_FIELD = 'government-entity-document'
+
+async function postGovernmentEntityDocument (req, res, next) {
+  const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
+  const collectingAdditionalKycData = isAdditionalKycDataRoute(req)
+  const currentCredential = getCurrentCredential(req.account)
+
+  const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
+
+  if (!stripeAccountSetup) {
+    return next(new Error('Stripe setup progress is not available on request'))
+  }
+  if (stripeAccountSetup.governmentEntityDocument) {
+    const errorPageData = getAlreadySubmittedErrorPageData(req.account.external_id,
+      'You’ve already provided government entity document. Contact GOV.UK Pay support if you need to update it.')
+    return response(req, res, 'error-with-link', errorPageData)
+  }
+
+  let errors
+  const file = req.file
+
+  errors = validateFile(file)
+
+  if (!lodash.isEmpty(errors)) {
+    return response(req, res, 'stripe-setup/government-entity-document/index', {
+      isSwitchingCredentials,
+      errors
+    })
+  } else {
+    try {
+      const stripeAccountId = await getStripeAccountId(req.account, isSwitchingCredentials, req.correlationId)
+
+      const stripeFile = await uploadFile(`entity_document_for_account_${req.account.gateway_account_id}`, file.mimetype, file.buffer)
+      await updateAccount(stripeAccountId, { entity_verification_document_id: stripeFile.id })
+
+      await connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'government_entity_document', req.correlationId)
+
+      logger.info('Government entity document uploaded for Stripe account', {
+        stripe_account_id: stripeAccountId,
+        is_switching: isSwitchingCredentials,
+        collecting_additional_kyc_data: collectingAdditionalKycData
+      })
+
+      if (isSwitchingCredentials) {
+        return res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
+      } else if (collectingAdditionalKycData) {
+        const taskListComplete = await isKycTaskListComplete(currentCredential)
+        if (taskListComplete) {
+          await completeKyc(req.account.gateway_account_id, req.service, stripeAccountId, req.correlationId)
+          req.flash('generic', 'You’ve successfully added all the Know your customer details for this service.')
+        } else {
+          req.flash('generic', 'Document has been submitted successfully')
+        }
+        return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account && req.account.external_id, currentCredential.external_id))
+      }
+
+      return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))
+    } catch (err) {
+      next(err)
+    }
+  }
+}
+
+function validateFile (file) {
+  const errors = {}
+  const allowedMimeTypes = ['image/jpeg', 'application/pdf', 'image/png']
+
+  if (!file) {
+    errors[GOVERNMENT_ENTITY_DOCUMENT_FIELD] = 'Select a file to upload'
+  } else if (!file.mimetype || !allowedMimeTypes.includes(file.mimetype.toLowerCase())) {
+    errors[GOVERNMENT_ENTITY_DOCUMENT_FIELD] = 'File type must be pdf, jpeg or png'
+  } else if (file.size > 10000000) {
+    errors[GOVERNMENT_ENTITY_DOCUMENT_FIELD] = 'File size must be less than 10MB'
+  }
+  return errors
+}
+
+module.exports = {
+  postGovernmentEntityDocument
+}

--- a/app/controllers/stripe-setup/government-entity-document/post.controller.test.js
+++ b/app/controllers/stripe-setup/government-entity-document/post.controller.test.js
@@ -1,0 +1,284 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const paths = require('../../../paths')
+const assert = require('assert')
+
+describe('Government entity document POST controller', () => {
+  const postBody = {
+    'mimetype': 'image/jpeg',
+    'size': 100000
+  }
+
+  let req
+  let next
+  let res
+  let setStripeAccountSetupFlagMock
+  let uploadFileMock
+  let updateAccountMock
+  let completeKycMock
+
+  function getControllerWithMocks (isKycTaskListComplete) {
+    return proxyquire('./post.controller', {
+      '../../../services/clients/stripe/stripe.client': {
+        uploadFile: uploadFileMock,
+        updateAccount: updateAccountMock
+      },
+      '../../../services/clients/connector.client': {
+        ConnectorClient: function () {
+          this.setStripeAccountSetupFlag = setStripeAccountSetupFlagMock
+        }
+      },
+      '../stripe-setup.util': {
+        getStripeAccountId: () => {
+          return Promise.resolve('acct_123example123')
+        },
+        completeKyc: completeKycMock
+      },
+      '../../../controllers/your-psp/kyc-tasks.service': {
+        isKycTaskListComplete: () => isKycTaskListComplete
+      }
+    })
+  }
+
+  beforeEach(() => {
+    req = {
+      correlationId: 'correlation-id',
+      account: {
+        gateway_account_id: '1',
+        external_id: 'a-valid-external-id',
+        connectorGatewayAccountStripeProgress: {}
+      },
+      flash: sinon.spy()
+    }
+    res = {
+      setHeader: sinon.stub(),
+      status: sinon.spy(),
+      redirect: sinon.spy(),
+      render: sinon.spy(),
+      locals: {
+        stripeAccount: {
+          stripeAccountId: 'acct_123example123'
+        }
+      }
+    }
+    next = sinon.spy()
+  })
+
+  it('should upload file to Stripe, update account, update connector, then redirect to add psp account details route', async function () {
+    uploadFileMock = sinon.spy(() => Promise.resolve({ id: 'file_id_123' }))
+    updateAccountMock = sinon.spy(() => Promise.resolve())
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
+    const controller = getControllerWithMocks()
+
+    req.file = { ...postBody }
+    req.file.buffer = '0A 0B'
+
+    await controller.postGovernmentEntityDocument(req, res, next)
+
+    sinon.assert.calledWith(uploadFileMock, 'entity_document_for_account_1', 'image/jpeg', '0A 0B')
+    sinon.assert.calledWith(updateAccountMock, res.locals.stripeAccount.stripeAccountId, { 'entity_verification_document_id': 'file_id_123' })
+    sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'government_entity_document', req.correlationId)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripe.addPspAccountDetails}`)
+  })
+
+  it('should render error if file size is greater than 10MB', async function () {
+    uploadFileMock = sinon.spy(() => Promise.resolve({ id: 'file_id_123' }))
+    updateAccountMock = sinon.spy(() => Promise.resolve())
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
+    const controller = getControllerWithMocks()
+
+    req.file = { ...postBody }
+    req.file.size = 1000000001
+
+    await controller.postGovernmentEntityDocument(req, res, next)
+
+    sinon.assert.notCalled(uploadFileMock)
+    sinon.assert.notCalled(updateAccountMock)
+    sinon.assert.notCalled(setStripeAccountSetupFlagMock)
+    sinon.assert.calledWith(res.render, `stripe-setup/government-entity-document/index`)
+
+    assert.strictEqual(res.render.getCalls()[0].args[1].errors['government-entity-document'], 'File size must be less than 10MB')
+  })
+
+  it('should render error if file is not selected', async function () {
+    uploadFileMock = sinon.spy(() => Promise.resolve({ id: 'file_id_123' }))
+    updateAccountMock = sinon.spy(() => Promise.resolve())
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
+    const controller = getControllerWithMocks()
+
+    req.file = undefined
+
+    await controller.postGovernmentEntityDocument(req, res, next)
+
+    sinon.assert.notCalled(uploadFileMock)
+    sinon.assert.notCalled(updateAccountMock)
+    sinon.assert.notCalled(setStripeAccountSetupFlagMock)
+    sinon.assert.calledWith(res.render, `stripe-setup/government-entity-document/index`)
+
+    assert.strictEqual(res.render.getCalls()[0].args[1].errors['government-entity-document'], 'Select a file to upload')
+  })
+
+  it('should render error if file type is not supported', async function () {
+    uploadFileMock = sinon.spy(() => Promise.resolve({ id: 'file_id_123' }))
+    updateAccountMock = sinon.spy(() => Promise.resolve())
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
+    const controller = getControllerWithMocks()
+
+    req.file = { ...postBody }
+    req.file.mimetype = 'text/html'
+
+    await controller.postGovernmentEntityDocument(req, res, next)
+
+    sinon.assert.notCalled(uploadFileMock)
+    sinon.assert.notCalled(updateAccountMock)
+    sinon.assert.notCalled(setStripeAccountSetupFlagMock)
+    sinon.assert.calledWith(res.render, `stripe-setup/government-entity-document/index`)
+
+    assert.strictEqual(res.render.getCalls()[0].args[1].errors['government-entity-document'], 'File type must be pdf, jpeg or png')
+  })
+
+  it('should render error page when stripe setup is not available on request', async () => {
+    const controller = getControllerWithMocks()
+    req.account.connectorGatewayAccountStripeProgress = undefined
+
+    await controller.postGovernmentEntityDocument(req, res, next)
+
+    sinon.assert.notCalled(res.redirect)
+    const expectedError = sinon.match.instanceOf(Error)
+      .and(sinon.match.has('message', 'Stripe setup progress is not available on request'))
+    sinon.assert.calledWith(next, expectedError)
+  })
+
+  it('should render error if Government entity document is already provided ', async () => {
+    const controller = getControllerWithMocks()
+    req.account.connectorGatewayAccountStripeProgress = { governmentEntityDocument: true }
+
+    await controller.postGovernmentEntityDocument(req, res, next)
+
+    sinon.assert.calledWith(res.render, 'error-with-link')
+  })
+
+  it('should render error when Stripe returns error, not call connector, and not redirect', async function () {
+    uploadFileMock = sinon.spy(() => Promise.reject(new Error()))
+    updateAccountMock = sinon.spy(() => Promise.resolve())
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
+    const controller = getControllerWithMocks()
+
+    req.file = { ...postBody }
+
+    await controller.postGovernmentEntityDocument(req, res, next)
+
+    sinon.assert.called(uploadFileMock)
+    sinon.assert.notCalled(updateAccountMock)
+    sinon.assert.notCalled(setStripeAccountSetupFlagMock)
+    sinon.assert.notCalled(res.redirect)
+    const expectedError = sinon.match.instanceOf(Error)
+    sinon.assert.calledWith(next, expectedError)
+  })
+
+  it('should render error when connector returns error', async function () {
+    uploadFileMock = sinon.spy(() => Promise.resolve({ id: 'file_id_123' }))
+    updateAccountMock = sinon.spy(() => Promise.resolve())
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.reject(new Error()))
+    const controller = getControllerWithMocks()
+
+    req.file = { ...postBody }
+
+    await controller.postGovernmentEntityDocument(req, res, next)
+
+    sinon.assert.called(uploadFileMock)
+    sinon.assert.called(updateAccountMock)
+    sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'government_entity_document', req.correlationId)
+    sinon.assert.notCalled(res.redirect)
+    const expectedError = sinon.match.instanceOf(Error)
+    sinon.assert.calledWith(next, expectedError)
+  })
+
+  describe('Switching PSP', () => {
+    it('should redirect to switch PSP route for valid payload', async function () {
+      req.url = `/switch-psp/new-stripe-account-id-123/government-entity-document`
+
+      req.account.provider_switch_enabled = true
+      req.account.gateway_account_credentials = [
+        {
+          payment_provider: 'worldpay',
+          state: 'ACTIVE'
+        },
+        {
+          payment_provider: 'stripe',
+          state: 'ENTERED',
+          credentials: {
+            stripe_account_id: 'new-stripe-account-id-123'
+          }
+        }
+      ]
+
+      uploadFileMock = sinon.spy(() => Promise.resolve({ id: 'file_id_123' }))
+      updateAccountMock = sinon.spy(() => Promise.resolve())
+      setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
+      const controller = getControllerWithMocks()
+
+      req.file = { ...postBody }
+      req.file.buffer = '0A 0B'
+
+      await controller.postGovernmentEntityDocument(req, res, next)
+
+      sinon.assert.calledWith(uploadFileMock, 'entity_document_for_account_1', 'image/jpeg', '0A 0B')
+      sinon.assert.calledWith(updateAccountMock, res.locals.stripeAccount.stripeAccountId, { 'entity_verification_document_id': 'file_id_123' })
+      sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'government_entity_document', req.correlationId)
+      sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.switchPSP.index}`)
+    })
+  })
+  describe('Collecting additional KYC data', () => {
+    beforeEach(() => {
+      req.url = `/kyc/new-stripe-account-id-123/government-entity-document`
+
+      req.account.requires_additional_kyc_data = true
+      req.account.gateway_account_credentials = [
+        {
+          external_id: 'credential-external-id',
+          payment_provider: 'stripe',
+          state: 'ACTIVE',
+          credentials: {
+            stripe_account_id: 'new-stripe-account-id-123'
+          }
+        }
+      ]
+      req.file = { ...postBody }
+      req.file.buffer = '0A 0B'
+      req.service = { external_id: 'service-id' }
+
+      uploadFileMock = sinon.spy(() => Promise.resolve({ id: 'file_id_123' }))
+      updateAccountMock = sinon.spy(() => Promise.resolve())
+      setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
+      completeKycMock = sinon.spy(() => Promise.resolve())
+    })
+
+    it('should redirect to your PSP route for valid payload', async function () {
+      const controller = getControllerWithMocks(true)
+
+      await controller.postGovernmentEntityDocument(req, res, next)
+
+      sinon.assert.calledWith(uploadFileMock, 'entity_document_for_account_1', 'image/jpeg', '0A 0B')
+      sinon.assert.calledWith(updateAccountMock, res.locals.stripeAccount.stripeAccountId, { 'entity_verification_document_id': 'file_id_123' })
+      sinon.assert.calledWith(completeKycMock, req.account.gateway_account_id, req.service, res.locals.stripeAccount.stripeAccountId, 'correlation-id')
+      sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'government_entity_document', req.correlationId)
+      sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/your-psp/credential-external-id`)
+    })
+
+    it('should not complete KYC if kyc task list is not complete', async function () {
+      const controller = getControllerWithMocks(false)
+
+      await controller.postGovernmentEntityDocument(req, res, next)
+
+      sinon.assert.notCalled(completeKycMock)
+
+      sinon.assert.calledWith(uploadFileMock, 'entity_document_for_account_1', 'image/jpeg', '0A 0B')
+      sinon.assert.calledWith(updateAccountMock, res.locals.stripeAccount.stripeAccountId, { 'entity_verification_document_id': 'file_id_123' })
+      sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'government_entity_document', req.correlationId)
+      sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/your-psp/credential-external-id`)
+    })
+  })
+})

--- a/app/routes.js
+++ b/app/routes.js
@@ -2,6 +2,10 @@
 
 const { Router } = require('express')
 
+const multer = require('multer')
+const storage = multer.memoryStorage()
+const upload = multer({ storage })
+
 const logger = require('./utils/logger')(__filename)
 const response = require('./utils/response.js').response
 const generateRoute = require('./utils/generate-route')
@@ -447,6 +451,7 @@ module.exports.bind = function (app) {
   account.get([ yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber ], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.get)
   account.post([ yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber ], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.post)
   account.get([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument, kyc.governmentEntityDocument], permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, stripeSetupGovernmentEntityDocument.get)
+  account.post([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument, kyc.governmentEntityDocument], permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, upload.single('government-entity-document'), stripeSetupGovernmentEntityDocument.post)
   account.get(stripe.addPspAccountDetails, permission('stripe-account-details:update'), restrictToStripeAccountContext, stripeSetupAddPspAccountDetailsController.get)
 
   futureAccountStrategy.get(webhooks.index, permission('webhooks:read'), webhooksController.listWebhooksPage)

--- a/server.js
+++ b/server.js
@@ -47,7 +47,7 @@ function addCsrfMiddleware (app) {
   app.use(csrf({
     value: function (req) {
       // supports CSRF validation only through POST requests and ignores csrf tokens in headers/query strings.
-      return req.body && req.body.csrfToken
+      return (req.body && req.body.csrfToken) || (req.query && req.query.csrfToken)
     }
   }))
   // sets the csrf token on response local variable scoped to request, so token is available to the views

--- a/test/cypress/integration/stripe-setup/government-entity-document.cy.test.js
+++ b/test/cypress/integration/stripe-setup/government-entity-document.cy.test.js
@@ -71,6 +71,19 @@ describe('Stripe setup: Government entity document', () => {
           cy.get('#navigation-menu-switch-psp').should('not.exist')
         })
     })
+
+    it('should display an error when file is not selected', () => {
+      cy.get('#government-entity-document-form > button').click()
+
+      cy.get('h2').should('contain', 'There is a problem')
+      cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'Select a file to upload')
+      cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#government-entity-document')
+
+      cy.get('.govuk-form-group--error > input#government-entity-document').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('exist')
+        cy.get('span.govuk-error-message').should('contain', 'Select a file to upload')
+      })
+    })
   })
 
   describe('when user is admin, account is Stripe and "Government entity document" is already submitted', () => {


### PR DESCRIPTION
## WHAT
- Added post controller for new Stripe onboarding task (Proof of Government Entity document)
- Starts using csrfToken available on query param as for multipart form we will be specifying csrfToken as the query param
- Use multer middleware to handle multipart/form-data and configured to use in-memory storage by default.

Can't add Cypress tests for full post journey as stripe hardcodes hostname (files.stripe.com) for file upload and cannot be overridden. Unit tests asserts that correct payload is passed to stripe client methods.
