### PR TITLE
PP-8983 Stop setting default value for company number

### DIFF
--- a/app/controllers/stripe-setup/company-number/post.controller.js
+++ b/app/controllers/stripe-setup/company-number/post.controller.js
@@ -43,17 +43,22 @@ module.exports = async (req, res, next) => {
     })
   } else {
     try {
-      const stripeCompanyBody = {
-        tax_id: sanitisedCompanyNumber || 'NOTAPPLI'
-      }
       const stripeAccountId = await getStripeAccountId(req.account, isSwitchingCredentials, req.correlationId)
+      const companyNumberProvided = companyNumberDeclaration === 'true'
 
-      await updateCompany(stripeAccountId, stripeCompanyBody)
+      if (companyNumberProvided) {
+        const stripeCompanyBody = {
+          tax_id: sanitisedCompanyNumber
+        }
+        await updateCompany(stripeAccountId, stripeCompanyBody)
+      }
+
       await connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'company_number', req.correlationId)
 
       logger.info('Company number submitted for Stripe account', {
         stripe_account_id: stripeAccountId,
-        is_switching: isSwitchingCredentials
+        is_switching: isSwitchingCredentials,
+        company_number_provided: companyNumberProvided
       })
       if (isSwitchingCredentials) {
         return res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))


### PR DESCRIPTION
## WHAT
- We are creating new stripe accounts with capabilities -card_payments, transfers. Companies house registration number is no longer mandatory for accounts with these capabilities. It was mandatory for legacy_payments capabilities and we had to set something to enable stripe accounts.
