### PR TITLE
PP-8860 Stripe KYC: Set additional required fields and remove legacy capabilities

### DIFF
--- a/app/services/clients/stripe/StripePersonAdditionalKYCDetails.class.js
+++ b/app/services/clients/stripe/StripePersonAdditionalKYCDetails.class.js
@@ -27,7 +27,11 @@ class StripePersonAdditionalKYCDetails {
 function build (params) {
   return {
     phone: params.phone,
-    email: params.email
+    email: params.email,
+    relationship: {
+      executive: true,
+      representative: true
+    }
   }
 }
 

--- a/app/services/clients/stripe/StripePersonAdditionalKYCDetails.class.test.js
+++ b/app/services/clients/stripe/StripePersonAdditionalKYCDetails.class.test.js
@@ -16,7 +16,11 @@ describe('StripePerson', () => {
 
     expect(stripePerson.basicObject()).to.deep.equal({
       phone: phone,
-      email: email
+      email: email,
+      relationship: {
+        executive: true,
+        representative: true
+      }
     })
   })
 })

--- a/app/services/clients/stripe/stripe.client.js
+++ b/app/services/clients/stripe/stripe.client.js
@@ -98,7 +98,7 @@ module.exports = {
     })
   },
 
-  addNewCapabilities: function (stripeAccountId, organisationName) {
+  addNewCapabilities: function (stripeAccountId, organisationName, phoneNumber) {
     const payload = {
       business_profile: {
         mcc: '9399',
@@ -113,6 +113,18 @@ module.exports = {
         }
       }
     }
+
+    if (phoneNumber) {
+      payload.company = {
+        phone: phoneNumber
+      }
+    }
     return stripe.accounts.update(stripeAccountId, payload)
+  },
+
+  removeLegacyPaymentsCapability: function (stripeAccountId) {
+    return stripe.accounts.updateCapability(stripeAccountId,
+      'legacy_payments', { requested: false }
+    )
   }
 }


### PR DESCRIPTION
## WHAT
- Set responsible person as executive when updating only phone number and email address.
- For stripe accounts switched to new capabilities (card_payments) company phone number is mandatory. We provided organisation phone number at the time of creating stripe account (accounts with legacy_payments capabilities) but this appears in a different place (business_profile.support_phone_number) for accounts switched to new capabilities.
- Also remove legacy_payments capability (if exists on account) once new capabilities (card_payments, transfers) are enabled - stripe api https://stripe.com/docs/api/capabilities/update?lang=node to update capability