### PR TITLE
PP-8860 Stripe KYC: Set `mcc` only when not available on account

### DIFF
--- a/app/controllers/stripe-setup/stripe-setup.util.js
+++ b/app/controllers/stripe-setup/stripe-setup.util.js
@@ -8,7 +8,7 @@ const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 const { validateDateOfBirth } = require('../../utils/validation/server-side-form-validations')
 const paths = require('../../paths')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
-const { listPersons, addNewCapabilities, removeLegacyPaymentsCapability } = require('../../services/clients/stripe/stripe.client')
+const { listPersons, addNewCapabilities, removeLegacyPaymentsCapability, retrieveAccountDetails } = require('../../services/clients/stripe/stripe.client')
 const logger = require('../../utils/logger')(__filename)
 const { formatPhoneNumberWithCountryCode } = require('../../utils/telephone-number-utils')
 
@@ -72,6 +72,8 @@ async function getExistingResponsiblePersonName (account, isSwitchingCredentials
 }
 
 async function completeKyc (gatewayAccountId, service, stripeAccountId, correlationId) {
+  const stripeAccount = await retrieveAccountDetails(stripeAccountId)
+
   let telephoneNumber = lodash.get(service, 'merchantDetails.telephone_number')
   let formattedPhoneNumber
 
@@ -79,13 +81,16 @@ async function completeKyc (gatewayAccountId, service, stripeAccountId, correlat
     formattedPhoneNumber = formatPhoneNumberWithCountryCode(telephoneNumber)
   }
 
-  const [stripeAccountResponse] = await Promise.all([
-    addNewCapabilities(stripeAccountId, service.merchantDetails.name, formattedPhoneNumber),
+  const mcc = lodash.get(stripeAccount, 'business_profile.mcc')
+  const hasMCC = !(mcc === undefined || mcc === null) && mcc.length > 0
+
+  await Promise.all([
+    addNewCapabilities(stripeAccountId, service.merchantDetails.name, formattedPhoneNumber, hasMCC),
     connector.setStripeAccountSetupFlag(gatewayAccountId, 'additional_kyc_data', correlationId),
     connector.disableCollectAdditionalKyc(gatewayAccountId, correlationId)
   ])
 
-  const stripeLegacyPayments = lodash.get(stripeAccountResponse, 'capabilities.legacy_payments')
+  const stripeLegacyPayments = lodash.get(stripeAccount, 'capabilities.legacy_payments')
   if (stripeLegacyPayments === 'active') {
     await removeLegacyPaymentsCapability(stripeAccountId)
   }

--- a/app/controllers/stripe-setup/stripe-setup.util.test.js
+++ b/app/controllers/stripe-setup/stripe-setup.util.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon')
 const { assert, expect } = require('chai')
 const { validateMandatoryField } = require('../../utils/validation/server-side-form-validations')
 
-let addNewCapabilitiesMock, removeLegacyPaymentsCapabilityMock
+let addNewCapabilitiesMock, removeLegacyPaymentsCapabilityMock, retrieveAccountDetailsMock
 let setStripeAccountSetupFlagMock, disableCollectAdditionalKycMock
 
 describe('Stripe setup util', () => {
@@ -111,12 +111,13 @@ describe('Stripe setup util', () => {
       setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
       disableCollectAdditionalKycMock = sinon.spy(() => Promise.resolve())
       removeLegacyPaymentsCapabilityMock = sinon.spy(() => Promise.resolve())
+      retrieveAccountDetailsMock = sinon.spy(() => Promise.resolve({}))
     })
 
     it('should update stripe account without telephone number, set connector task as complete, and disable kyc flag on connector', async () => {
       await getStripeSetupUtil().completeKyc(gatewayAccountId, service, stripeAccountId, correlationId)
 
-      sinon.assert.calledWith(addNewCapabilitiesMock, 'stripe-connect-account-id', 'service-name', undefined)
+      sinon.assert.calledWith(addNewCapabilitiesMock, 'stripe-connect-account-id', 'service-name', undefined, false)
       sinon.assert.notCalled(removeLegacyPaymentsCapabilityMock)
       sinon.assert.calledWith(setStripeAccountSetupFlagMock, 'gateway-accnt-id-124', 'additional_kyc_data', 'x-request-id')
       sinon.assert.calledWith(disableCollectAdditionalKycMock, 'gateway-accnt-id-124', 'x-request-id')
@@ -126,14 +127,14 @@ describe('Stripe setup util', () => {
       service.merchantDetails.telephone_number = '01134960000'
       await getStripeSetupUtil().completeKyc(gatewayAccountId, service, stripeAccountId, correlationId)
 
-      sinon.assert.calledWith(addNewCapabilitiesMock, 'stripe-connect-account-id', 'service-name', '+44 113 496 0000')
+      sinon.assert.calledWith(addNewCapabilitiesMock, 'stripe-connect-account-id', 'service-name', '+44 113 496 0000', false)
       sinon.assert.notCalled(removeLegacyPaymentsCapabilityMock)
       sinon.assert.calledWith(setStripeAccountSetupFlagMock, 'gateway-accnt-id-124', 'additional_kyc_data', 'x-request-id')
       sinon.assert.calledWith(disableCollectAdditionalKycMock, 'gateway-accnt-id-124', 'x-request-id')
     })
 
     it('should also disable legacy_payments capabilities if exists for a stripe account', async () => {
-      addNewCapabilitiesMock = sinon.spy(() => Promise.resolve({
+      retrieveAccountDetailsMock = sinon.spy(() => Promise.resolve({
         'capabilities': {
           'legacy_payments': 'active'
         }
@@ -142,7 +143,22 @@ describe('Stripe setup util', () => {
 
       sinon.assert.called(removeLegacyPaymentsCapabilityMock)
 
-      sinon.assert.calledWith(addNewCapabilitiesMock, 'stripe-connect-account-id', 'service-name', undefined)
+      sinon.assert.calledWith(addNewCapabilitiesMock, 'stripe-connect-account-id', 'service-name', undefined, false)
+      sinon.assert.calledWith(setStripeAccountSetupFlagMock, 'gateway-accnt-id-124', 'additional_kyc_data', 'x-request-id')
+      sinon.assert.calledWith(disableCollectAdditionalKycMock, 'gateway-accnt-id-124', 'x-request-id')
+    })
+
+    it('should call add new capabilities with hasMCC flag "true" if account has got MCC already set', async () => {
+      retrieveAccountDetailsMock = sinon.spy(() => Promise.resolve({
+        'business_profile': {
+          'mcc': '9399'
+        }
+      }))
+      await getStripeSetupUtil().completeKyc(gatewayAccountId, service, stripeAccountId, correlationId)
+
+      sinon.assert.notCalled(removeLegacyPaymentsCapabilityMock)
+
+      sinon.assert.calledWith(addNewCapabilitiesMock, 'stripe-connect-account-id', 'service-name', undefined, true)
       sinon.assert.calledWith(setStripeAccountSetupFlagMock, 'gateway-accnt-id-124', 'additional_kyc_data', 'x-request-id')
       sinon.assert.calledWith(disableCollectAdditionalKycMock, 'gateway-accnt-id-124', 'x-request-id')
     })
@@ -153,7 +169,8 @@ function getStripeSetupUtil () {
   return proxyquire('./stripe-setup.util', {
     '../../services/clients/stripe/stripe.client': {
       addNewCapabilities: addNewCapabilitiesMock,
-      removeLegacyPaymentsCapability: removeLegacyPaymentsCapabilityMock
+      removeLegacyPaymentsCapability: removeLegacyPaymentsCapabilityMock,
+      retrieveAccountDetails: retrieveAccountDetailsMock
     },
     '../../services/clients/connector.client': {
       ConnectorClient: function () {

--- a/app/services/clients/stripe/stripe.client.js
+++ b/app/services/clients/stripe/stripe.client.js
@@ -98,10 +98,9 @@ module.exports = {
     })
   },
 
-  addNewCapabilities: function (stripeAccountId, organisationName, phoneNumber) {
+  addNewCapabilities: function (stripeAccountId, organisationName, phoneNumber, hasMCC) {
     const payload = {
       business_profile: {
-        mcc: '9399',
         product_description: `Payments for public sector services for organisation ${organisationName}`
       },
       capabilities: {
@@ -112,6 +111,10 @@ module.exports = {
           requested: true
         }
       }
+    }
+
+    if (!hasMCC) {
+      payload.business_profile.mcc = '9399'
     }
 
     if (phoneNumber) {


### PR DESCRIPTION
## WHAT
- mcc is currently set when switching stripe accounts to new capabilities. But mcc cannot be updated if it is already set on account (some live accounts on Stripe has mcc set). So set mcc only when it is not available on stripe account.
