### PR TITLE
PP-8929 Stripe KYC: stop moving stripe accounts to new capabilities

### DIFF
--- a/app/services/clients/stripe/stripe.client.js
+++ b/app/services/clients/stripe/stripe.client.js
@@ -98,20 +98,15 @@ module.exports = {
     })
   },
 
-  addNewCapabilities: function (stripeAccountId, organisationName, phoneNumber) {
+  addNewCapabilities: function (stripeAccountId, organisationName, phoneNumber, hasMCC) {
     const payload = {
       business_profile: {
-        mcc: '9399',
         product_description: `Payments for public sector services for organisation ${organisationName}`
-      },
-      capabilities: {
-        card_payments: {
-          requested: true
-        },
-        transfers: {
-          requested: true
-        }
       }
+    }
+
+    if (!hasMCC) {
+      payload.business_profile.mcc = '9399'
     }
 
     if (phoneNumber) {


### PR DESCRIPTION
## WHAT
- As stripe accounts are being restricted (both payments & payouts), stop moving accounts to new capabilities while stripe addresses the issue of providing grace period for services to provide missing info.
- mcc is currently set when switching stripe accounts to new capabilities. But mcc cannot be updated if it is already set on account (some live accounts on Stripe has mcc set). So set mcc only when it is not available on stripe account.
