### PR TITLE
PP-8929 Wrap multer upload with a Promise

### DIFF
--- a/app/middleware/multer-middleware.js
+++ b/app/middleware/multer-middleware.js
@@ -1,0 +1,22 @@
+const Multer = require('multer')
+const storage = Multer.memoryStorage()
+const multer = Multer({ storage })
+const upload = multer.single('government-entity-document')
+
+const multerPromise = (req, res) => {
+  return new Promise((resolve, reject) => {
+    upload(req, res, (err) => {
+      if (!err) resolve()
+      reject(err)
+    })
+  })
+}
+
+module.exports = async function uploadGovernmentEntityDocument (req, res, next) {
+  try {
+    await multerPromise(req, res)
+    next()
+  } catch (e) {
+    next(e)
+  }
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -2,10 +2,6 @@
 
 const { Router } = require('express')
 
-const multer = require('multer')
-const storage = multer.memoryStorage()
-const upload = multer({ storage })
-
 const logger = require('./utils/logger')(__filename)
 const response = require('./utils/response.js').response
 const generateRoute = require('./utils/generate-route')
@@ -25,6 +21,7 @@ const getRequestContext = require('./middleware/get-request-context').middleware
 const restrictToSandboxOrStripeTestAccount = require('./middleware/restrict-to-sandbox-or-stripe-test-account')
 const restrictToStripeAccountContext = require('./middleware/stripe-setup/restrict-to-stripe-account-context')
 const restrictToSwitchingAccount = require('./middleware/restrict-to-switching-account')
+const uploadGovernmentEntityDocument = require('./middleware/multer-middleware')
 
 // Controllers
 const staticController = require('./controllers/static.controller')
@@ -451,7 +448,7 @@ module.exports.bind = function (app) {
   account.get([ yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber ], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.get)
   account.post([ yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber ], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.post)
   account.get([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument, kyc.governmentEntityDocument], permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, stripeSetupGovernmentEntityDocument.get)
-  account.post([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument, kyc.governmentEntityDocument], permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, upload.single('government-entity-document'), stripeSetupGovernmentEntityDocument.post)
+  account.post([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument, kyc.governmentEntityDocument], permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, uploadGovernmentEntityDocument, stripeSetupGovernmentEntityDocument.post)
   account.get(stripe.addPspAccountDetails, permission('stripe-account-details:update'), restrictToStripeAccountContext, stripeSetupAddPspAccountDetailsController.get)
 
   futureAccountStrategy.get(webhooks.index, permission('webhooks:read'), webhooksController.listWebhooksPage)


### PR DESCRIPTION
## WHAT
- We are using multer for document upload and noticed request context (gateway_account_id, service id,...) added as part of middleware are missing from the logs. This works sometimes and not sure yet why.
- There is an open issue multer where content is lost #/multer/issues/814 and the work around is to wrap upload in a Promise.

with @stephencdaly, @sandorarpa, @nlsteers, @nimalank7

