### PR TITLE
PP-8995 Stripe KYC - Add get controller for organisation details

### DIFF
--- a/app/controllers/request-to-go-live/organisation-address/get.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/get.controller.js
@@ -7,9 +7,13 @@ const paths = require('../../../paths')
 const response = require('../../../utils/response')
 const { countries } = require('@govuk-pay/pay-js-commons').utils
 const formatServicePathsFor = require('../../../utils/format-service-paths-for')
+const { isSwitchingCredentialsRoute, isAdditionalKycDataRoute, getCurrentCredential } = require('../../../utils/credentials')
 
 module.exports = function getOrganisationAddress (req, res) {
   const isRequestToGoLive = Object.values(paths.service.requestToGoLive).includes(req.route && req.route.path)
+  const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
+  const collectingAdditionalKycData = isAdditionalKycDataRoute(req)
+  const currentCredential = getCurrentCredential(req.account)
 
   if (isRequestToGoLive) {
     if (req.service.currentGoLiveStage !== goLiveStage.ENTERED_ORGANISATION_NAME) {
@@ -34,6 +38,13 @@ module.exports = function getOrganisationAddress (req, res) {
     ]),
     isRequestToGoLive
   }
+
+  if (isSwitchingCredentials || collectingAdditionalKycData) {
+    pageData.currentCredential = currentCredential
+    pageData.isSwitchingCredentials = isSwitchingCredentials
+    pageData.collectingAdditionalKycData = collectingAdditionalKycData
+  }
+
   pageData.countries = countries.govukFrontendFormatted(lodash.get(pageData, 'address_country'))
   return response.response(req, res, 'request-to-go-live/organisation-address', pageData)
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -47,6 +47,7 @@ module.exports = {
     },
     kyc: {
       organisationUrl: '/kyc/:credentialId/organisation-url',
+      organisationDetails: '/kyc/:credentialId/organisation-details',
       responsiblePerson: '/kyc/:credentialId/responsible-person',
       changeResponsiblePerson: '/kyc/:credentialId/responsible-person/change',
       director: '/kyc/:credentialId/director',
@@ -110,6 +111,7 @@ module.exports = {
       verifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration',
       receiveVerifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration/callback',
       organisationUrl: '/switch-psp/:credentialId/organisation-url',
+      organisationDetails: '/switch-psp/:credentialId/organisation-details',
       stripeSetup: {
         bankDetails: '/switch-psp/:credentialId/bank-details',
         responsiblePerson: '/switch-psp/:credentialId/responsible-person',

--- a/app/routes.js
+++ b/app/routes.js
@@ -454,6 +454,8 @@ module.exports.bind = function (app) {
   account.post([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument, kyc.governmentEntityDocument], permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, upload.single('government-entity-document'), stripeSetupGovernmentEntityDocument.post)
   account.get(stripe.addPspAccountDetails, permission('stripe-account-details:update'), restrictToStripeAccountContext, stripeSetupAddPspAccountDetailsController.get)
 
+  account.get([kyc.organisationDetails, switchPSP.organisationDetails], permission('merchant-details:update'), restrictToStripeAccountContext, requestToGoLiveOrganisationAddressController.get)
+
   futureAccountStrategy.get(webhooks.index, permission('webhooks:read'), webhooksController.listWebhooksPage)
   futureAccountStrategy.get(webhooks.create, permission('webhooks:update'), webhooksController.createWebhookPage)
   futureAccountStrategy.post(webhooks.create, permission('webhooks:update'), webhooksController.createWebhook)

--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -1,6 +1,12 @@
 {% extends "../layout.njk" %}
 {% from "../macro/error-summary.njk" import errorSummary %}
 
+{% block side_navigation %}
+  {% if isSwitchingCredentials or collectingAdditionalKycData %}
+    {% include "includes/side-navigation.njk" %}
+  {% endif %}
+{% endblock %}
+
 {% block pageTitle %}
 {% if isRequestToGoLive %}
   Enter your organisation’s contact details - Request a live account - {{ currentService.name }} - GOV.UK Pay
@@ -11,6 +17,22 @@
 
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
+
+  {% if isSwitchingCredentials %}
+    {{ govukBackLink({
+      text: "Back to Switching payment service provider (PSP)",
+      classes: "govuk-!-margin-top-0",
+      href: formatAccountPathsFor(routes.account.switchPSP.index, currentGatewayAccount.external_id)
+    }) }}
+  {% endif %}
+  {% if collectingAdditionalKycData %}
+    {{ govukBackLink({
+      text: "Back",
+      classes: "govuk-!-margin-top-0",
+      href: formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, currentCredential.external_id)
+    }) }}
+  {% endif %}
+
   {{ errorSummary ({
     errors: errors,
     hrefs: {

--- a/test/cypress/integration/settings/your-psp-stripe-kyc.cy.test.js
+++ b/test/cypress/integration/settings/your-psp-stripe-kyc.cy.test.js
@@ -272,6 +272,22 @@ describe('Your PSP - Stripe - KYC', () => {
     })
   })
 
+  describe('Organisation details Page', () => {
+    beforeEach(() => {
+      setupYourPspStubs()
+    })
+
+    it('should show Organisation details page', () => {
+      cy.visit(`/account/${gatewayAccountExternalId}/kyc/${credentialExternalId}/organisation-details`)
+
+      cy.get('h1').should('contain', 'Organisation details')
+
+      cy.get('.govuk-back-link')
+        .should('have.text', 'Back')
+        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+    })
+  })
+
   describe('Government entity document', () => {
     beforeEach(() => {
       setupYourPspStubs()


### PR DESCRIPTION
## WHAT
- Added a new route `organisation-details` (for stripe kyc and switch PSP) which uses existing organisation details controller and .njk template.

with @stephencdaly, @sandorarpa, @nlsteers, @nimalank7
