### PR TITLE
PP-8929 Stripe KYC: enable new capabilities

### DIFF
--- a/app/controllers/stripe-setup/stripe-setup.util.js
+++ b/app/controllers/stripe-setup/stripe-setup.util.js
@@ -90,7 +90,7 @@ async function completeKyc (gatewayAccountId, service, stripeAccountId, correlat
     connector.disableCollectAdditionalKyc(gatewayAccountId, correlationId)
   ])
 
-  logger.info('KYC additional information completed for Stripe account (but not moved to new capabilities)', {
+  logger.info('KYC additional information completed for Stripe account (added new capabilities)', {
     stripe_account_id: stripeAccountId
   })
 }

--- a/app/controllers/stripe-setup/stripe-setup.util.test.js
+++ b/app/controllers/stripe-setup/stripe-setup.util.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon')
 const { assert, expect } = require('chai')
 const { validateMandatoryField } = require('../../utils/validation/server-side-form-validations')
 
-let addNewCapabilitiesMock, removeLegacyPaymentsCapabilityMock, retrieveAccountDetailsMock
+let addNewCapabilitiesMock, retrieveAccountDetailsMock
 let setStripeAccountSetupFlagMock, disableCollectAdditionalKycMock
 
 describe('Stripe setup util', () => {
@@ -110,7 +110,6 @@ describe('Stripe setup util', () => {
       addNewCapabilitiesMock = sinon.spy(() => Promise.resolve())
       setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
       disableCollectAdditionalKycMock = sinon.spy(() => Promise.resolve())
-      removeLegacyPaymentsCapabilityMock = sinon.spy(() => Promise.resolve())
       retrieveAccountDetailsMock = sinon.spy(() => Promise.resolve())
     })
 
@@ -118,7 +117,6 @@ describe('Stripe setup util', () => {
       await getStripeSetupUtil().completeKyc(gatewayAccountId, service, stripeAccountId, correlationId)
 
       sinon.assert.calledWith(addNewCapabilitiesMock, 'stripe-connect-account-id', 'service-name', undefined, false)
-      sinon.assert.notCalled(removeLegacyPaymentsCapabilityMock)
       sinon.assert.calledWith(setStripeAccountSetupFlagMock, 'gateway-accnt-id-124', 'additional_kyc_data', 'x-request-id')
       sinon.assert.calledWith(disableCollectAdditionalKycMock, 'gateway-accnt-id-124', 'x-request-id')
     })
@@ -128,7 +126,6 @@ describe('Stripe setup util', () => {
       await getStripeSetupUtil().completeKyc(gatewayAccountId, service, stripeAccountId, correlationId)
 
       sinon.assert.calledWith(addNewCapabilitiesMock, 'stripe-connect-account-id', 'service-name', '+44 113 496 0000', false)
-      sinon.assert.notCalled(removeLegacyPaymentsCapabilityMock)
       sinon.assert.calledWith(setStripeAccountSetupFlagMock, 'gateway-accnt-id-124', 'additional_kyc_data', 'x-request-id')
       sinon.assert.calledWith(disableCollectAdditionalKycMock, 'gateway-accnt-id-124', 'x-request-id')
     })
@@ -154,8 +151,6 @@ describe('Stripe setup util', () => {
       }))
       await getStripeSetupUtil().completeKyc(gatewayAccountId, service, stripeAccountId, correlationId)
 
-      sinon.assert.notCalled(removeLegacyPaymentsCapabilityMock)
-
       sinon.assert.calledWith(addNewCapabilitiesMock, 'stripe-connect-account-id', 'service-name', undefined, true)
       sinon.assert.calledWith(setStripeAccountSetupFlagMock, 'gateway-accnt-id-124', 'additional_kyc_data', 'x-request-id')
       sinon.assert.calledWith(disableCollectAdditionalKycMock, 'gateway-accnt-id-124', 'x-request-id')
@@ -168,7 +163,6 @@ function getStripeSetupUtil () {
   return proxyquire('./stripe-setup.util', {
     '../../services/clients/stripe/stripe.client': {
       addNewCapabilities: addNewCapabilitiesMock,
-      removeLegacyPaymentsCapability: removeLegacyPaymentsCapabilityMock,
       retrieveAccountDetails: retrieveAccountDetailsMock
     },
     '../../services/clients/connector.client': {

--- a/app/services/clients/stripe/stripe.client.js
+++ b/app/services/clients/stripe/stripe.client.js
@@ -102,6 +102,14 @@ module.exports = {
     const payload = {
       business_profile: {
         product_description: `Payments for public sector services for organisation ${organisationName}`
+      },
+      capabilities: {
+        card_payments: {
+          requested: true
+        },
+        transfers: {
+          requested: true
+        }
       }
     }
 
@@ -115,11 +123,5 @@ module.exports = {
       }
     }
     return stripe.accounts.update(stripeAccountId, payload)
-  },
-
-  removeLegacyPaymentsCapability: function (stripeAccountId) {
-    return stripe.accounts.updateCapability(stripeAccountId,
-      'legacy_payments', { requested: false }
-    )
   }
 }


### PR DESCRIPTION
## WHAT
- Enable new capabilities for stripe accounts when services submits all info (but does not remove legacy payments capabilities). legacy_payments capability will be removed (manually and in batch) after verifying that the stripe accounts do not have any information due.
