### PR TITLE
BAU Fix Welsh service name validation

### DIFF
--- a/app/controllers/edit-service-name.controller.js
+++ b/app/controllers/edit-service-name.controller.js
@@ -30,10 +30,11 @@ async function postEditServiceName (req, res, next) {
   const serviceName = lodash.get(req, 'body.service-name')
   const hasServiceNameCy = lodash.get(req, 'body.welsh-service-name-bool', true)
   const serviceNameCy = hasServiceNameCy ? lodash.get(req, 'body.service-name-cy') : ''
-  const validationErrors = validateServiceName(serviceName, 'service_name', true)
-  const validationErrorsCy = validateServiceName(serviceNameCy, 'service_name_cy', false)
-
-  if (Object.keys(validationErrors).length || Object.keys(validationErrorsCy).length) {
+  const validationErrors = {
+    ...validateServiceName(serviceName, 'service_name', true),
+    ...validateServiceName(serviceNameCy, 'service_name_cy', false)
+  }
+  if (Object.keys(validationErrors).length) {
     lodash.set(req, 'session.pageData.editServiceName', {
       errors: validationErrors,
       current_name: lodash.merge({}, { en: serviceName, cy: serviceNameCy })

--- a/app/controllers/register-service.controller.js
+++ b/app/controllers/register-service.controller.js
@@ -330,21 +330,19 @@ const showNameYourService = function showNameYourService (req, res) {
 const submitYourServiceName = async function submitYourServiceName (req, res, next) {
   const correlationId = req.correlationId
   const serviceName = req.body['service-name']
-  const serviceNameCy = req.body['service-name-cy']
-  const validationErrors = validateServiceName(serviceName, 'service-name-en', true)
-  const validationErrorsCy = validateServiceName(serviceNameCy, 'service-name-cy', false)
+  const validationErrors = validateServiceName(serviceName, 'service_name', true)
 
-  if (Object.keys(validationErrors).length || Object.keys(validationErrorsCy).length) {
+  if (Object.keys(validationErrors).length) {
     lodash.set(req, 'session.pageData.submitYourServiceName', {
       errors: validationErrors,
-      current_name: lodash.merge({}, { en: serviceName, cy: serviceNameCy })
+      current_name: lodash.merge({}, { en: serviceName })
     })
     res.redirect(303, paths.selfCreateService.serviceNaming)
   } else {
     try {
       const { service } = req.user.serviceRoles[0]
       const account = await connectorClient.getAccount({ gatewayAccountId: service.gatewayAccountIds[0] })
-      await serviceService.updateServiceName(service.externalId, serviceName, serviceNameCy, correlationId)
+      await serviceService.updateServiceName(service.externalId, serviceName, null, correlationId)
       lodash.unset(req, 'session.pageData.submitYourServiceName')
       res.redirect(303, formatAccountPathsFor(paths.account.dashboard.index, account.external_id))
     } catch (err) {

--- a/app/views/services/add-service.njk
+++ b/app/views/services/add-service.njk
@@ -18,7 +18,7 @@
             <li><a href="#service-name">Service name</a></li>
             {% endif %}
             {% if errors.service_name_cy %}
-              <li><a href="#service-name-cy">Welsh Service name</a></li>
+              <li><a href="#service-name-cy">Welsh service name</a></li>
             {% endif %}
           </ul>
         </div>
@@ -33,18 +33,11 @@
     <form id="add-service-form" method="post" action="{{submit_link}}">
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
-      {% set enNameError = false %}
-      {% if errors.service_name %}
-        {% set enNameError = {
-          text: errors.service_name
-        } %}
-      {% endif %}
-
       {{ govukInput({
           label: {
             text: "Service name"
           },
-          errorMessage: enNameError,
+          errorMessage: { text: errors.service_name } if errors.service_name else false,
           id: "service-name",
           name: "service-name",
           value: current_name,
@@ -53,20 +46,13 @@
         })
       }}
 
-      {% set cyNameError = false %}
-      {% if errors.service_name %}
-        {% set cyNameError = {
-          text: errors.service_name_cy
-        } %}
-      {% endif %}
-
       {% set welshServiceNameHTML %}
         {{ govukInput({
           id: "service-name-cy",
           name: "service-name-cy",
           type: "text",
           value: current_name_cy,
-          errorMessage: cyNameError,
+          errorMessage: { text: errors.service_name_cy } if errors.service_name_cy else false,
           classes: "govuk-!-width-two-thirds",
           label: {
             text: "Welsh service name"
@@ -87,7 +73,8 @@
             text: "Add a Welsh (Cymraeg) service name",
             conditional: {
               html: welshServiceNameHTML
-            }
+            },
+            checked: true if current_name_cy else false 
           }
         ]
       }) }}

--- a/app/views/services/edit-service-name.njk
+++ b/app/views/services/edit-service-name.njk
@@ -31,18 +31,11 @@
     <form id="edit-service-name-form" method="post" action="{{submit_link}}">
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
-      {% set enNameError = false %}
-      {% if errors.service_name %}
-        {% set enNameError = {
-          text: errors.service_name
-        } %}
-      {% endif %}
-
       {{ govukInput({
           label: {
             text: "Service name"
           },
-          errorMessage: enNameError,
+          errorMessage: { text: errors.service_name } if errors.service_name else false,
           id: "service-name",
           name: "service-name",
           value: current_name.en,
@@ -51,20 +44,13 @@
         })
       }}
 
-      {% set cyNameError = false %}
-      {% if errors.service_name %}
-        {% set cyNameError = {
-          text: errors.service_name_cy
-        } %}
-      {% endif %}
-
       {% set welshServiceNameHTML %}
         {{ govukInput({
           id: "service-name-cy",
           name: "service-name-cy",
           type: "text",
           value: current_name.cy,
-          errorMessage: cyNameError,
+          errorMessage: { text: errors.service_name_cy } if errors.service_name_cy else false,
           classes: "govuk-!-width-two-thirds",
           label: {
             text: "Welsh service name"

--- a/test/cypress/integration/my-services/add-new-service.cy.test.js
+++ b/test/cypress/integration/my-services/add-new-service.cy.test.js
@@ -85,6 +85,26 @@ describe('Add a new service', () => {
       cy.get('input#service-name-cy').should('exist')
     })
 
+    it('should show a validation errors for service name and Welsh service name fields', () => {
+      setupStubs()
+      cy.get('input#service-name-cy').type('Lorem ipsum dolor sit amet, consectetuer adipiscing', { delay: 0 })
+      cy.get('button').contains('Add service').click()
+
+      cy.title().should('eq', 'Add a new service - GOV.UK Pay')
+
+      cy.get('.govuk-error-summary').find('a').should('have.length', 2)
+      cy.get('.govuk-error-summary').should('exist').within(() => {
+        cy.get('a[href="#service-name"]').should('contain', 'Service name')
+        cy.get('a[href="#service-name-cy"]').should('contain', 'Welsh service name')
+      })
+      cy.get('.govuk-form-group--error > input#service-name').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'This field cannot be blank')
+      })
+      cy.get('.govuk-form-group--error > input#service-name-cy').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'The text is too long')
+      })
+    })
+
     it('should add a service', () => {
       setupStubs([
         createGatewayAccountStub,
@@ -92,6 +112,8 @@ describe('Add a new service', () => {
         serviceStubs.postCreateServiceSuccess({ serviceExternalId: newServiceId, gatewayAccountId: newGatewayAccountId, serviceName: { en: newServiceName, cy: newServiceWelshName } }),
         serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId })
       ])
+      cy.get('input#service-name').clear()
+      cy.get('input#service-name-cy').clear()
       cy.get('input#service-name').type(newServiceName)
       cy.get('input#service-name-cy').type(newServiceWelshName)
       cy.get('button').contains('Add service').click()

--- a/test/cypress/integration/my-services/update-service-name.cy.test.js
+++ b/test/cypress/integration/my-services/update-service-name.cy.test.js
@@ -15,7 +15,7 @@ const welshServiceName = {
   cy: 'Cymru'
 }
 
-function setupStubs (serviceName, stubs = []) {
+function setupStubs(serviceName, stubs = []) {
   cy.task('setupStubs', [
     ...stubs,
     userStubs.getUserSuccess({ userExternalId: authenticatedUserId, gatewayAccountId: '1', serviceExternalId, serviceName }),
@@ -47,22 +47,6 @@ describe('Update service name', () => {
       cy.get('#checkbox-service-name-cy').should('have.attr', 'aria-expanded', 'false')
     })
 
-    it('should show a validation error when service name is empty', () => {
-      setupStubs(serviceName)
-      cy.get('input#service-name').clear()
-      cy.get('button').contains('Save').click()
-
-      cy.title().should('eq', 'Edit service name - GOV.UK Pay')
-
-      cy.get('.govuk-error-summary').find('a').should('have.length', 1)
-      cy.get('.govuk-error-summary').should('exist').within(() => {
-        cy.get('a[href="#service-name"]').should('contain', 'Service name')
-      })
-      cy.get('.govuk-form-group--error > input#service-name').parent().should('exist').within(() => {
-        cy.get('.govuk-error-message').should('contain', 'This field cannot be blank')
-      })
-    })
-
     it('should update service name to Updated Service', () => {
       setupStubs(serviceName,
         [serviceStubs.patchUpdateServiceNameSuccess({ serviceExternalId, serviceName: { en: newServiceName } })])
@@ -90,6 +74,27 @@ describe('Update service name', () => {
       cy.title().should('eq', 'Edit service name - GOV.UK Pay')
       cy.get('#service-name').should('have.attr', 'value', 'My Service')
       cy.get('#service-name-cy').should('have.attr', 'value', 'Cymru')
+    })
+
+    it('should show a validation errors for service name and Welsh service name fields', () => {
+      setupStubs(welshServiceName)
+      cy.get('input#service-name').clear()
+      cy.get('input#service-name-cy').type('Lorem ipsum dolor sit amet, consectetuer adipiscing', { delay: 0 })
+      cy.get('button').contains('Save').click()
+
+      cy.title().should('eq', 'Edit service name - GOV.UK Pay')
+
+      cy.get('.govuk-error-summary').find('a').should('have.length', 2)
+      cy.get('.govuk-error-summary').should('exist').within(() => {
+        cy.get('a[href="#service-name"]').should('contain', 'Service name')
+        cy.get('a[href="#service-name-cy"]').should('contain', 'Welsh service name')
+      })
+      cy.get('.govuk-form-group--error > input#service-name').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'This field cannot be blank')
+      })
+      cy.get('.govuk-form-group--error > input#service-name-cy').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'The text is too long')
+      })
     })
 
     it('should update Welsh service name to Cymraeg', () => {


### PR DESCRIPTION
If there were validation errors when adding a Welsh service name, these were not being passed correctly through to the view, and not displayed inline correctly.

This affects adding new services and editing service names.

Remove validation for Welsh service names from the controller for naming a service when registering an account, as the page shown for this does not have an option to add a Welsh name.

Also fix the page for adding a new service so that the checkbox for adding a Welsh name is checked if a Welsh name has been entered but  there are errors.

<img width="617" alt="Screenshot 2021-12-08 at 16 07 12" src="https://user-images.githubusercontent.com/5648592/145242053-8533b3b1-9fa8-45d1-aa26-85bc718cc4bb.png">


