### PR TITLE
PP-8499 Manage Webhook pages

### DIFF
--- a/app/assets/sass/components/colour.scss
+++ b/app/assets/sass/components/colour.scss
@@ -5,3 +5,11 @@
 .pay-text-black {
   color: $govuk-text-colour;
 }
+
+.pay-link-text-red {
+  color: govuk-colour("red") !important;
+}
+
+.pay-link-text-red:hover {
+  color: govuk-colour("red") !important;
+}

--- a/app/controllers/webhooks/webhooks.controller.js
+++ b/app/controllers/webhooks/webhooks.controller.js
@@ -83,12 +83,26 @@ async function updateWebhook (req, res, next) {
   }
 }
 
+async function toggleActiveWebhook(req, res, next) {
+  try {
+    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId)
+
+    await webhooksService.toggleStatus(req.params.webhookId, req.service.externalId, webhook.status)
+
+    req.flash('generic', 'Webhook status updated')
+    res.redirect(formatFutureStrategyAccountPathsFor(paths.futureAccountStrategy.webhooks.detail, req.account.type, req.service.externalId, req.account.external_id, req.params.webhookId))
+  } catch (error) {
+    next(error)
+  }
+}
+
 module.exports = {
   listWebhooksPage,
   createWebhookPage,
   createWebhook,
-  updateWebhookPage,
   updateWebhook,
+  toggleActiveWebhook,
+  updateWebhookPage,
   webhookDetailPage,
   signingSecretPage,
   toggleActivePage

--- a/app/controllers/webhooks/webhooks.controller.js
+++ b/app/controllers/webhooks/webhooks.controller.js
@@ -56,6 +56,15 @@ async function signingSecretPage (req, res, next) {
   }
 }
 
+async function toggleActivePage (req, res, next) {
+  try {
+    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId)
+    response(req, res, 'webhooks/toggle_active', { webhook })
+  } catch (error) {
+    next(error)
+  }
+}
+
 async function createWebhook (req, res, next) {
   try {
     await webhooksService.createWebhook(req.service.externalId, req.isLive, req.body)
@@ -81,5 +90,6 @@ module.exports = {
   updateWebhookPage,
   updateWebhook,
   webhookDetailPage,
-  signingSecretPage
+  signingSecretPage,
+  toggleActivePage
 }

--- a/app/controllers/webhooks/webhooks.controller.js
+++ b/app/controllers/webhooks/webhooks.controller.js
@@ -7,6 +7,7 @@ const paths = require('../../paths')
 const formatFutureStrategyAccountPathsFor = require('../../utils/format-future-strategy-account-paths-for')
 
 const webhooksService = require('./webhooks.service')
+const logger = require('../../utils/logger.js')(__filename)
 
 async function webhookDetailPage (req, res, next) {
   try {
@@ -39,6 +40,22 @@ async function updateWebhookPage (req, res, next) {
   }
 }
 
+async function signingSecretPage (req, res, next) {
+  try {
+    let signingSecret
+    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId)
+
+    try {
+      signingSecret = await webhooksService.getSigningSecret(req.params.webhookId, req.service.externalId)
+    } catch (error) {
+      logger.warn('Unable to fetch signing secret for Webhook')
+    }
+    response(req, res, 'webhooks/signing_secret', { webhook, signingSecret })
+  } catch (error) {
+    next(error)
+  }
+}
+
 async function createWebhook (req, res, next) {
   try {
     await webhooksService.createWebhook(req.service.externalId, req.isLive, req.body)
@@ -63,5 +80,6 @@ module.exports = {
   createWebhook,
   updateWebhookPage,
   updateWebhook,
-  webhookDetailPage
+  webhookDetailPage,
+  signingSecretPage
 }

--- a/app/controllers/webhooks/webhooks.service.js
+++ b/app/controllers/webhooks/webhooks.service.js
@@ -25,9 +25,19 @@ function getWebhook (id, serviceId) {
   return webhooksClient.webhook(id, serviceId)
 }
 
+function getSigningSecret(webhookId, serviceId) {
+  return webhooksClient.signingSecret(webhookId, serviceId)
+}
+
+function resetSigningSecret(webhookId, serviceId) {
+  return webhooksClient.resetSigningSecret(webhookId, serviceId)
+}
+
 module.exports = {
   listWebhooks,
   createWebhook,
   updateWebhook,
-  getWebhook
+  getWebhook,
+  getSigningSecret,
+  resetSigningSecret
 }

--- a/app/controllers/webhooks/webhooks.service.js
+++ b/app/controllers/webhooks/webhooks.service.js
@@ -33,11 +33,17 @@ function resetSigningSecret(webhookId, serviceId) {
   return webhooksClient.resetSigningSecret(webhookId, serviceId)
 }
 
+function toggleStatus(webhookId, serviceId, currentStatus) {
+  const status = currentStatus === 'ACTIVE' ? 'INACTIVE' : 'ACTIVE'
+  return webhooksClient.updateWebhook(webhookId, serviceId, { status })
+}
+
 module.exports = {
   listWebhooks,
   createWebhook,
   updateWebhook,
   getWebhook,
   getSigningSecret,
-  resetSigningSecret
+  resetSigningSecret,
+  toggleStatus
 }

--- a/app/controllers/webhooks/webhooks.service.test.js
+++ b/app/controllers/webhooks/webhooks.service.test.js
@@ -34,6 +34,20 @@ describe('webhooks service', () => {
       sinon.assert.calledWith(spy, 'some-service-id', true, { subscriptions: [ 'my-first-subscription', 'my-second-subscription' ] })
     })
   })
+  describe('Toggle webhook status', () => {
+    it('should deactivate given an active webhook', () => {
+      const spy = sinon.spy(async () => {})
+      const service = getWebhooksServiceWithStub({ updateWebhook: spy })
+      service.toggleStatus('webhook-id', 'service-id', 'ACTIVE')
+      sinon.assert.calledWith(spy, 'webhook-id', 'service-id', { status: 'INACTIVE' })
+    })
+    it('should active given an inactive webhook', () => {
+      const spy = sinon.spy(async () => {})
+      const service = getWebhooksServiceWithStub({ updateWebhook: spy })
+      service.toggleStatus('webhook-id', 'service-id', 'INACTIVE')
+      sinon.assert.calledWith(spy, 'webhook-id', 'service-id', { status: 'ACTIVE' })
+    })
+  })
 })
 
 function getWebhooksServiceWithStub (stub) {

--- a/app/paths.js
+++ b/app/paths.js
@@ -159,6 +159,7 @@ module.exports = {
       detail: '/webhooks/:webhookId',
       update: '/webhooks/:webhookId/update',
       signingSecret: '/webhooks/:webhookId/signing-secret',
+      toggleActive: '/webhooks/:webhookId/status',
       create: '/webhooks/create'
     }
   },

--- a/app/paths.js
+++ b/app/paths.js
@@ -158,6 +158,7 @@ module.exports = {
       index: '/webhooks',
       detail: '/webhooks/:webhookId',
       update: '/webhooks/:webhookId/update',
+      signingSecret: '/webhooks/:webhookId/signing-secret',
       create: '/webhooks/create'
     }
   },

--- a/app/routes.js
+++ b/app/routes.js
@@ -459,6 +459,7 @@ module.exports.bind = function (app) {
   futureAccountStrategy.get(webhooks.detail, permission('webhooks:read'), webhooksController.webhookDetailPage)
   futureAccountStrategy.get(webhooks.signingSecret, permission('webhooks:update'), webhooksController.signingSecretPage)
   futureAccountStrategy.get(webhooks.toggleActive, permission('webhooks:update'), webhooksController.toggleActivePage)
+  futureAccountStrategy.post(webhooks.toggleActive, permission('webhooks:update'), webhooksController.toggleActiveWebhook)
 
   app.use(paths.account.root, account)
   app.use(paths.service.root, service)

--- a/app/routes.js
+++ b/app/routes.js
@@ -458,6 +458,7 @@ module.exports.bind = function (app) {
   futureAccountStrategy.post(webhooks.update, permission('webhooks:update'), webhooksController.updateWebhook)
   futureAccountStrategy.get(webhooks.detail, permission('webhooks:read'), webhooksController.webhookDetailPage)
   futureAccountStrategy.get(webhooks.signingSecret, permission('webhooks:update'), webhooksController.signingSecretPage)
+  futureAccountStrategy.get(webhooks.toggleActive, permission('webhooks:update'), webhooksController.toggleActivePage)
 
   app.use(paths.account.root, account)
   app.use(paths.service.root, service)

--- a/app/routes.js
+++ b/app/routes.js
@@ -457,6 +457,7 @@ module.exports.bind = function (app) {
   futureAccountStrategy.get(webhooks.update, permission('webhooks:update'), webhooksController.updateWebhookPage)
   futureAccountStrategy.post(webhooks.update, permission('webhooks:update'), webhooksController.updateWebhook)
   futureAccountStrategy.get(webhooks.detail, permission('webhooks:read'), webhooksController.webhookDetailPage)
+  futureAccountStrategy.get(webhooks.signingSecret, permission('webhooks:update'), webhooksController.signingSecretPage)
 
   app.use(paths.account.root, account)
   app.use(paths.service.root, service)

--- a/app/services/clients/webhooks.client.js
+++ b/app/services/clients/webhooks.client.js
@@ -23,6 +23,34 @@ function webhook (id, serviceId, options = {}) {
   return baseClient.get(request)
 }
 
+function signingSecret (webhookId, serviceId, options = {}) {
+  const url = urlJoin('/v1/webhook/', webhookId, '/signing-key')
+  const request = {
+    url,
+    qs: {
+      service_id: serviceId
+    },
+    description: 'Get a Webhook signing secret',
+    ...defaultRequestOptions,
+    ...options
+  }
+  return baseClient.get(request)
+}
+
+function resetSigningSecret (webhookId, serviceId, options = {}) {
+  const url = urlJoin('/v1/webhook/', webhookId, '/signing-key')
+  const request = {
+    url,
+    qs: {
+      service_id: serviceId
+    },
+    description: 'Reset a Webhook signing secret',
+    ...defaultRequestOptions,
+    ...options
+  }
+  return baseClient.post(request)
+}
+
 function webhooks (serviceId, isLive, options = {}) {
   const url = '/v1/webhook'
   const request = {
@@ -80,5 +108,7 @@ module.exports = {
   webhook,
   webhooks,
   createWebhook,
-  updateWebhook
+  updateWebhook,
+  signingSecret,
+  resetSigningSecret
 }

--- a/app/views/webhooks/detail.njk
+++ b/app/views/webhooks/detail.njk
@@ -93,5 +93,9 @@
     {% endif %}
   </div>
 
+  <div class="govuk-!-margin-top-6">
+    {% set actionText = "Deactivate Webhook" if webhook.status == "ACTIVE" else "Activate Webhook" %}
+    <a class="govuk-link govuk-link--no-visited-state pay-link-text-red" href="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.toggleActive, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id) }}">{{ actionText }}</a>
+  </div>
 </div>
 {% endblock %}

--- a/app/views/webhooks/detail.njk
+++ b/app/views/webhooks/detail.njk
@@ -95,7 +95,7 @@
 
   <div class="govuk-!-margin-top-6">
     {% set actionText = "Deactivate Webhook" if webhook.status == "ACTIVE" else "Activate Webhook" %}
-    <a class="govuk-link govuk-link--no-visited-state pay-link-text-red" href="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.toggleActive, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id) }}">{{ actionText }}</a>
+    <a id="toggle-status" class="govuk-link govuk-link--no-visited-state pay-link-text-red" href="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.toggleActive, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id) }}">{{ actionText }}</a>
   </div>
 </div>
 {% endblock %}

--- a/app/views/webhooks/detail.njk
+++ b/app/views/webhooks/detail.njk
@@ -37,7 +37,11 @@
     }) }}
     {{ govukButton({
       text: "Manage signing secret",
-      classes: "govuk-button--secondary"
+      classes: "govuk-button--secondary",
+      href: formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.signingSecret, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id),
+      attributes: {
+        "id": "signing-secret"
+      }
     }) }}
   </div>
 

--- a/app/views/webhooks/signing_secret.njk
+++ b/app/views/webhooks/signing_secret.njk
@@ -1,0 +1,71 @@
+{% extends "layout.njk" %}
+
+{% block pageTitle %}
+  Webhook signing secret {{ webhook.callback_url }} - {{currentService.name}} {{ humanReadableEnvironment }} - GOV.UK Pay
+{% endblock %}
+
+{% block side_navigation %}
+  {% include "includes/side-navigation.njk" %}
+{% endblock %}
+
+{% block mainContent %}
+<div class="govuk-grid-column-two-thirds">
+  {{ govukBackLink({
+    text: "Back to Webhook",
+    classes: "govuk-!-margin-top-0",
+    href: formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.detail, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id)
+  }) }}
+
+  <h1 class="govuk-heading-l page-title">Manage signing secret</h1>
+
+  <p class="govuk-body">
+    The contents of Webhooks are encrypted with a signing secret. Only your application should store this secret to unencrypt Webhooks content.
+  </p>
+
+  <p class="govuk-body">
+    <a class="govuk-link" href="https://docs.payments.service.gov.uk/">Find out more about setting up Webhooks in your application</a>
+  </p>
+
+  <div class="govuk-!-margin-top-4">
+  {% if signingSecret %}
+    {{ govukSummaryList({
+      rows: [{
+        key: { text: "Callback URL" },
+        value: { text: webhook.callback_url }
+      }, {
+        key: { text: "Description" },
+        value: { text: webhook.description }
+      }]
+    }) }}
+
+    <div class="govuk-!-margin-top-6">
+      <h2 class="govuk-heading-m">Signing secret</h2>
+
+      <div>
+        <span id="secret" class="code copy-target">{{ signingSecret.signing_key }}</span>
+      </div>
+
+      {{
+        govukButton({
+          text: "Copy signing secret to clipboard",
+          classes: "govuk-button--secondary govuk-!-margin-top-4",
+          attributes: {
+            id: "copy-signing-secret",
+            "data-copy-text": true,
+            "data-target": "copy-target",
+            "data-success": "Webhook signing secret has been copied",
+            "data-notification-target": "copy-notification"
+          }
+        })
+      }}
+
+      <div class="copy-notification govuk-visually-hidden" aria-live="assertive"></div>
+    </div>
+  {% else %}
+    {{ govukWarningText({
+      text: "Unable to load signing secret for Webhook",
+      iconFallbackText: "Warning"
+    }) }}
+  {% endif %}
+</div>
+{% endblock %}

--- a/app/views/webhooks/toggle_active.njk
+++ b/app/views/webhooks/toggle_active.njk
@@ -39,16 +39,18 @@
       }]
     }) }}
 
-    <form method="POST" action="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.status, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id) }}">
-    {{
-      govukButton({
-        text: actionText,
-        classes: "govuk-button--warning govuk-!-margin-top-4",
-        attributes: {
-          id: "toggle-active-webhook"
-        }
-      })
-    }}
+    <form method="POST" action="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.toggleActive, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id) }}">
+
+      <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
+      {{
+        govukButton({
+          text: actionText,
+          classes: "govuk-button--warning govuk-!-margin-top-4",
+          attributes: {
+            id: "toggle-active-webhook"
+          }
+        })
+      }}
     </form>
   </div>
 </div>

--- a/app/views/webhooks/toggle_active.njk
+++ b/app/views/webhooks/toggle_active.njk
@@ -1,0 +1,55 @@
+{% extends "layout.njk" %}
+
+{% set actionText = "Deactivate Webhook" if webhook.status == "ACTIVE" else "Activate Webhook" %}
+
+{% block pageTitle %}
+  {{ actionText }} {{ webhook.callback_url }} - {{currentService.name}} {{ humanReadableEnvironment }} - GOV.UK Pay
+{% endblock %}
+
+{% block side_navigation %}
+  {% include "includes/side-navigation.njk" %}
+{% endblock %}
+
+{% block mainContent %}
+<div class="govuk-grid-column-two-thirds">
+  {{ govukBackLink({
+    text: "Back to Webhook",
+    classes: "govuk-!-margin-top-0",
+    href: formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.detail, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id)
+  }) }}
+
+  <h1 class="govuk-heading-l page-title">{{ actionText }}</h1>
+
+  <p class="govuk-body">
+    Inactive Webhooks will not send payment events to your callback URL.
+  </p>
+
+  <p class="govuk-body">
+    Webhooks can be activated again at any time.
+  </p>
+
+  <div class="govuk-!-margin-top-4">
+    {{ govukSummaryList({
+      rows: [{
+        key: { text: "Callback URL" },
+        value: { text: webhook.callback_url }
+      }, {
+        key: { text: "Description" },
+        value: { text: webhook.description }
+      }]
+    }) }}
+
+    <form method="POST" action="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.status, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id) }}">
+    {{
+      govukButton({
+        text: actionText,
+        classes: "govuk-button--warning govuk-!-margin-top-4",
+        attributes: {
+          id: "toggle-active-webhook"
+        }
+      })
+    }}
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/test/cypress/integration/webhooks/webhooks.cy.test.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.test.js
@@ -91,4 +91,18 @@ describe('Webhooks', () => {
 
     cy.get('#secret').contains('valid-signing-secret')
   })
+
+  it('should toggle a webhook status', () => {
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs
+    ])
+    cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
+    cy.get('[data-action=update]').then((links) => links[0].click())
+    cy.get('#toggle-status').click()
+
+    cy.get('h1').contains('Deactivate Webhook')
+
+    cy.get('#toggle-active-webhook').click()
+    cy.get('.govuk-notification-banner__heading').contains('Webhook status updated')
+  })
 })

--- a/test/cypress/integration/webhooks/webhooks.cy.test.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.test.js
@@ -12,7 +12,8 @@ const userAndGatewayAccountStubs = [
   userStubs.getUserSuccess({ userExternalId, serviceExternalId, gatewayAccountId }),
   gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, serviceExternalId }),
   webhooksStubs.getWebhooksListSuccess({ service_id: serviceExternalId, live: false, webhooks: [{ external_id: webhookExternalId }] }),
-  webhooksStubs.getWebhookSuccess({ service_id: serviceExternalId, external_id: webhookExternalId })
+  webhooksStubs.getWebhookSuccess({ service_id: serviceExternalId, external_id: webhookExternalId }),
+  webhooksStubs.getWebhookSigningSecret({ service_id: serviceExternalId, external_id: webhookExternalId })
 ]
 
 describe('Webhooks', () => {
@@ -78,5 +79,16 @@ describe('Webhooks', () => {
     cy.get('[value=card_payment_captured]').should('be.checked')
 
     cy.get('button').contains('Update Webhook').click()
+  })
+
+  it('should show a webhook signing secret', () => {
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs
+    ])
+    cy.get('#signing-secret').click()
+
+    cy.get('h1').contains('Manage signing secret')
+
+    cy.get('#secret').contains('valid-signing-secret')
   })
 })

--- a/test/cypress/stubs/webhooks-stubs.js
+++ b/test/cypress/stubs/webhooks-stubs.js
@@ -25,7 +25,18 @@ function getWebhookSuccess (opts = {}) {
   })
 }
 
+function getWebhookSigningSecret(opts = {}) {
+  const path = `/v1/webhook/${opts.external_id}/signing-key`
+  return stubBuilder('GET', path, 200, {
+    query: {
+      service_id: opts.service_id
+    },
+    response: webhooksFixtures.webhookSigningSecretResponse(opts)
+  })
+}
+
 module.exports = {
   getWebhooksListSuccess,
-  getWebhookSuccess
+  getWebhookSuccess,
+  getWebhookSigningSecret
 }

--- a/test/fixtures/webhooks.fixtures.js
+++ b/test/fixtures/webhooks.fixtures.js
@@ -11,6 +11,12 @@ function validWebhook (options = {}) {
   }
 }
 
+function validSigningSecret(options = {}) {
+  return {
+    signing_key: options.signing_key || 'valid-signing-secret'
+  }
+}
+
 function webhooksListResponse (options = []) {
   return options.map((option) => validWebhook(option))
 }
@@ -19,7 +25,12 @@ function webhookResponse (options = {}) {
   return validWebhook(options)
 }
 
+function webhookSigningSecretResponse(options = {}) {
+  return validSigningSecret(options)
+}
+
 module.exports = {
   webhooksListResponse,
-  webhookResponse
+  webhookResponse,
+  webhookSigningSecretResponse
 }


### PR DESCRIPTION
Adds pages to manage an individual webhooks, supporting
* accessing a given webhooks signing secret
* deactivating and activating a given webhook

Adds helper methods for accessing singing secret endpoint and service wrapper to toggle status.

Happy path Cypress coverage.

**Signing secret page**

<img width="979" alt="Screenshot 2021-12-14 at 13 16 18" src="https://user-images.githubusercontent.com/2844572/146006426-39f12177-9be9-4d23-bf40-9746a2c5616f.png">

**Toggle status page**

<img width="975" alt="Screenshot 2021-12-14 at 13 16 29" src="https://user-images.githubusercontent.com/2844572/146006440-c381298a-06e5-4696-83d0-1afe30672b1e.png">

**Detail page (following toggle status action**

<img width="817" alt="Screenshot 2021-12-14 at 13 16 42" src="https://user-images.githubusercontent.com/2844572/146006448-70853f80-1140-41b5-a722-c1c650ae2e19.png">

