### PR TITLE
PP-8499 Webhook messages table

### DIFF
--- a/app/controllers/webhooks/webhooks.controller.js
+++ b/app/controllers/webhooks/webhooks.controller.js
@@ -10,12 +10,15 @@ const webhooksService = require('./webhooks.service')
 const logger = require('../../utils/logger.js')(__filename)
 
 async function webhookDetailPage (req, res, next) {
+  const status = req.query.status || 'all'
+  const page = req.query.page || 1
+
   try {
     let search
     const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId)
 
     try {
-      search = await webhooksService.getWebhookMessages(req.params.webhookId, req.service.externalId)
+      search = await webhooksService.getWebhookMessages(req.params.webhookId, req.service.externalId, { page, status })
     } catch (messageSearchError) {
       logger.warn('Unable to fetch messages for Webhook')
     }
@@ -24,7 +27,9 @@ async function webhookDetailPage (req, res, next) {
       eventTypes: constants.webhooks.humanReadableSubscriptions,
       webhook,
       search,
-      ...search && { messages: search.results }
+      ...search && { messages: search.results },
+      status,
+      page
     })
   } catch (error) {
     next(error)

--- a/app/controllers/webhooks/webhooks.controller.js
+++ b/app/controllers/webhooks/webhooks.controller.js
@@ -11,8 +11,21 @@ const logger = require('../../utils/logger.js')(__filename)
 
 async function webhookDetailPage (req, res, next) {
   try {
+    let search
     const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId)
-    response(req, res, 'webhooks/detail', { eventTypes: constants.webhooks.humanReadableSubscriptions, webhook })
+
+    try {
+      search = await webhooksService.getWebhookMessages(req.params.webhookId, req.service.externalId)
+    } catch (messageSearchError) {
+      logger.warn('Unable to fetch messages for Webhook')
+    }
+
+    response(req, res, 'webhooks/detail', {
+      eventTypes: constants.webhooks.humanReadableSubscriptions,
+      webhook,
+      search,
+      ...search && { messages: search.results }
+    })
   } catch (error) {
     next(error)
   }

--- a/app/controllers/webhooks/webhooks.service.test.js
+++ b/app/controllers/webhooks/webhooks.service.test.js
@@ -48,6 +48,33 @@ describe('webhooks service', () => {
       sinon.assert.calledWith(spy, 'webhook-id', 'service-id', { status: 'ACTIVE' })
     })
   })
+  describe('List webhook messages', () => {
+    it('should get webhook messages with correctly formatted pagination', async () => {
+      const search = webhooksFixture.webhookMessageSearchResponse([
+        { status: 'SUCCEEDED' },
+        { status: 'SUCCEEDED' },
+        { status: 'SUCCEEDED' },
+        { status: 'SUCCEEDED' },
+        { status: 'SUCCEEDED' },
+        { status: 'SUCCEEDED' },
+        { status: 'SUCCEEDED' },
+        { status: 'SUCCEEDED' },
+        { status: 'SUCCEEDED' },
+        { status: 'SUCCEEDED' },
+        { status: 'SUCCEEDED' }
+      ])
+      const spy = sinon.spy(async () => search)
+      const service = getWebhooksServiceWithStub({ messages: spy })
+      const result = await service.getWebhookMessages('webhook-id', 'service-id', { status: 'failed' })
+
+      sinon.assert.calledWith(spy, 'webhook-id', 'service-id', { status: 'failed' })
+      expect(result.total).to.equal(11)
+
+      // 2 pages and a next button for constant service page settings
+      expect(result.links.length).to.equal(3)
+      expect(result.links[2].pageName).to.equal('next')
+    })
+  })
 })
 
 function getWebhooksServiceWithStub (stub) {

--- a/app/paths.js
+++ b/app/paths.js
@@ -160,6 +160,7 @@ module.exports = {
       update: '/webhooks/:webhookId/update',
       signingSecret: '/webhooks/:webhookId/signing-secret',
       toggleActive: '/webhooks/:webhookId/status',
+      message: '/webhooks/:webhookId/message/:messageId',
       create: '/webhooks/create'
     }
   },

--- a/app/services/clients/webhooks.client.js
+++ b/app/services/clients/webhooks.client.js
@@ -72,7 +72,8 @@ function messages(id, serviceId, options = {}) {
     url,
     qs: {
       service_id: serviceId,
-      status: options.status
+      status: options.status,
+      page: options.page
     },
     description: 'List messages for webhook',
     ...defaultRequestOptions,

--- a/app/services/clients/webhooks.client.js
+++ b/app/services/clients/webhooks.client.js
@@ -66,6 +66,21 @@ function webhooks (serviceId, isLive, options = {}) {
   return baseClient.get(request)
 }
 
+function messages(id, serviceId, options = {}) {
+  const url = urlJoin('/v1/webhook', id, 'message')
+  const request = {
+    url,
+    qs: {
+      service_id: serviceId,
+      status: options.status
+    },
+    description: 'List messages for webhook',
+    ...defaultRequestOptions,
+    ...options
+  }
+  return baseClient.get(request)
+}
+
 function createWebhook (serviceId, isLive, options = {}) {
   const url = '/v1/webhook'
   const request = {
@@ -110,5 +125,6 @@ module.exports = {
   createWebhook,
   updateWebhook,
   signingSecret,
-  resetSigningSecret
+  resetSigningSecret,
+  messages
 }

--- a/app/views/webhooks/_paginator.njk
+++ b/app/views/webhooks/_paginator.njk
@@ -4,6 +4,7 @@
   {% for paginationLink in links %}
     <form class="paginationForm page-{{paginationLink.pageName}}" method="GET">
       <input type="hidden" name="page" value="{{paginationLink.pageNumber}}"/>
+      <input type="hidden" name="status" value="{{status}}"/>
 
       <button class="pagination {{paginationLink.pageName}} {% if paginationLink.activePage %}active{% endif %}" type="submit">
         {% if paginationLink.hasSymbolicName %}

--- a/app/views/webhooks/_paginator.njk
+++ b/app/views/webhooks/_paginator.njk
@@ -1,0 +1,18 @@
+{% set links = search.links %}
+{% if links and links.length %}
+<div class="pagination" id="pagination">
+  {% for paginationLink in links %}
+    <form class="paginationForm page-{{paginationLink.pageName}}" method="GET">
+      <input type="hidden" name="page" value="{{paginationLink.pageNumber}}"/>
+
+      <button class="pagination {{paginationLink.pageName}} {% if paginationLink.activePage %}active{% endif %}" type="submit">
+        {% if paginationLink.hasSymbolicName %}
+          {{paginationLink.pageName}}<span class="govuk-visually-hidden"> page of results</span>
+        {% else %}
+          <span class="govuk-visually-hidden">Results page </span>{{paginationLink.pageName}}
+        {% endif %}
+      </button>
+    </form>
+  {% endfor %}
+</div>
+{% endif %}

--- a/app/views/webhooks/detail.njk
+++ b/app/views/webhooks/detail.njk
@@ -45,34 +45,51 @@
     }) }}
   </div>
 
+  {% macro statusTag(status) %}
+    {% set map = {
+      "SUCCEEDED": "govuk-tag--green",
+      "FAILED": "govuk-tag--red",
+      "PENDING": "govuk-tag--grey"
+    } %}
+    <strong class="govuk-tag {{ map[status] }}">{{ status }}</strong>
+  {% endmacro %}
+
   <div class="govuk-!-margin-top-6">
     <h2 class="govuk-heading-m">Events history</h2>
 
     <p class="govuk-body">Events sent to your Webhook are stored for 14 days.</p>
 
-    {% if events and events.length >= 0 %}
+    {% if messages and messages.length >= 0 %}
       {% set status = 'all' %}
+      <div class="govuk-body govuk-!-margin-top-4">
       <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-right-1 {% if status == 'succeeded' %} govuk-!-font-weight-bold {% endif %}" href="?status=succeeded&page={{ page }}">Succeeded</a>
       <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-right-1 {% if status == 'failed' %} govuk-!-font-weight-bold {% endif %}" href="?status=failed&page={{ page }}">Failed</a>
       <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-right-1 {% if status == 'all' %} govuk-!-font-weight-bold {% endif %}" href="?status=all&page={{ page }}">All</a>
+      </div>
 
-      <table class="govuk-table govuk-!-margin-top-6">
+      <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col">Name</th>
             <th class="govuk-table__header" scope="col">Delivery status</th>
             <th class="govuk-table__header" scope="col">Date</th>
-            <th class="govuk-table__header" scope="col">Pending retry</th>
+            {# <th class="govuk-table__header" scope="col">Pending retry</th> #}
           </tr>
         </thead>
 
         <tbody class="govuk-table__body">
-        {% for event in events %}
+        {% for message in messages %}
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell">{{ event.name }}</td>
-            <td class="govuk-table__cell">{{ event.status }}</td>
-            <td class="govuk-table__cell">{{ event.created_date }}</td>
-            <td class="govuk-table__cell">{{ event.retry_date }}</td>
+            <td class="govuk-table__cell">
+              <a
+                class="govuk-link"
+                href="{{  formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.message, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id, message.external_id) }}">
+                {{ eventTypes[message.event_type | upper] }}
+              </a>
+            </td>
+            <td class="govuk-table__cell">{{ statusTag(message.status) }}</td>
+            <td class="govuk-table__cell">{{ message.event_date | datetime('datelong') }} {{ message.event_date | datetime('time') }}</td>
+            {# <td class="govuk-table__cell">{{ message.retry_date }}</td> #}
           </tr>
 
         {% else %}
@@ -85,6 +102,9 @@
         </tbody>
       </table>
 
+      <div class="govuk-!-margin-top-1">
+        {% include "webhooks/_paginator.njk" %}
+      </div>
     {% else %}
       {{ govukWarningText({
         text: "Unable to load events for Webhook",
@@ -93,7 +113,8 @@
     {% endif %}
   </div>
 
-  <div class="govuk-!-margin-top-6">
+  {# spacing hack because the standard paginator template interrupts the page flow #}
+  <div class="govuk-column-two-thirds" {% if search.links and search.links.length %}style="margin-top: 100px"{% endif %}>
     {% set actionText = "Deactivate Webhook" if webhook.status == "ACTIVE" else "Activate Webhook" %}
     <a id="toggle-status" class="govuk-link govuk-link--no-visited-state pay-link-text-red" href="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.toggleActive, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id) }}">{{ actionText }}</a>
   </div>

--- a/app/views/webhooks/detail.njk
+++ b/app/views/webhooks/detail.njk
@@ -60,10 +60,9 @@
     <p class="govuk-body">Events sent to your Webhook are stored for 14 days.</p>
 
     {% if messages and messages.length >= 0 %}
-      {% set status = 'all' %}
       <div class="govuk-body govuk-!-margin-top-4">
       <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-right-1 {% if status == 'succeeded' %} govuk-!-font-weight-bold {% endif %}" href="?status=succeeded&page={{ page }}">Succeeded</a>
-      <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-right-1 {% if status == 'failed' %} govuk-!-font-weight-bold {% endif %}" href="?status=failed&page={{ page }}">Failed</a>
+      <a id="filter-failed" class="govuk-link govuk-link--no-visited-state govuk-!-margin-right-1 {% if status == 'failed' %} govuk-!-font-weight-bold {% endif %}" href="?status=failed&page={{ page }}">Failed</a>
       <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-right-1 {% if status == 'all' %} govuk-!-font-weight-bold {% endif %}" href="?status=all&page={{ page }}">All</a>
       </div>
 

--- a/test/cypress/integration/webhooks/webhooks.cy.test.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.test.js
@@ -13,6 +13,7 @@ const userAndGatewayAccountStubs = [
   gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, serviceExternalId }),
   webhooksStubs.getWebhooksListSuccess({ service_id: serviceExternalId, live: false, webhooks: [{ external_id: webhookExternalId }] }),
   webhooksStubs.getWebhookSuccess({ service_id: serviceExternalId, external_id: webhookExternalId }),
+  webhooksStubs.getWebhookMessagesListSuccess({ service_id: serviceExternalId, external_id: webhookExternalId, messages: [ { status: 'SUCCEEDED' }, { status: 'FAILED' }, { status: 'PENDING' } ] }),
   webhooksStubs.getWebhookSigningSecret({ service_id: serviceExternalId, external_id: webhookExternalId })
 ]
 

--- a/test/cypress/integration/webhooks/webhooks.cy.test.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.test.js
@@ -13,7 +13,10 @@ const userAndGatewayAccountStubs = [
   gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, serviceExternalId }),
   webhooksStubs.getWebhooksListSuccess({ service_id: serviceExternalId, live: false, webhooks: [{ external_id: webhookExternalId }] }),
   webhooksStubs.getWebhookSuccess({ service_id: serviceExternalId, external_id: webhookExternalId }),
-  webhooksStubs.getWebhookMessagesListSuccess({ service_id: serviceExternalId, external_id: webhookExternalId, messages: [ { status: 'SUCCEEDED' }, { status: 'FAILED' }, { status: 'PENDING' } ] }),
+  webhooksStubs.getWebhookMessagesListSuccess({ service_id: serviceExternalId, external_id: webhookExternalId, messages: [
+    { status: 'PENDING' }, { status: 'PENDING' }, { status: 'FAILED' }, { status: 'SUCCEEDED' }, { status: 'SUCCEEDED' }, { status: 'SUCCEEDED' },
+    { status: 'SUCCEEDED' }, { status: 'SUCCEEDED' }, { status: 'SUCCEEDED' }, { status: 'SUCCEEDED' }, { status: 'SUCCEEDED' }, { status: 'SUCCEEDED' }
+  ] }),
   webhooksStubs.getWebhookSigningSecret({ service_id: serviceExternalId, external_id: webhookExternalId })
 ]
 
@@ -54,13 +57,21 @@ describe('Webhooks', () => {
 
   it('should display a valid webhooks details', () => {
     cy.task('setupStubs', [
-      ...userAndGatewayAccountStubs
+      ...userAndGatewayAccountStubs,
+      webhooksStubs.getWebhookMessagesListSuccess({ service_id: serviceExternalId, external_id: webhookExternalId, messages: [{ status: 'FAILED' }], status: 'failed' })
     ])
 
     cy.get('[data-action=update]').then((links) => links[0].click())
 
     cy.get('h1').contains('https://some-callback-url.com')
     cy.get('.govuk-list.govuk-list--bullet > li').should('have.length', 1)
+
+    // based on number of rows stubbed and client pagination logic
+    cy.get('.govuk-table__body > .govuk-table__row').should('have.length', 12)
+    cy.get('.paginationForm').should('have.length', 3)
+
+    cy.get('a#filter-failed').click()
+    cy.get('a#filter-failed').should('have.class', 'govuk-!-font-weight-bold')
   })
 
   it('should update a webhook with valid properties', () => {

--- a/test/cypress/stubs/webhooks-stubs.js
+++ b/test/cypress/stubs/webhooks-stubs.js
@@ -14,6 +14,17 @@ function getWebhooksListSuccess (opts) {
   })
 }
 
+function getWebhookMessagesListSuccess(opts = {}) {
+  const webhook = webhooksFixtures.webhookResponse(opts)
+  const path = `/v1/webhook/${webhook.external_id}/message`
+  return stubBuilder('GET', path, 200, {
+    query: {
+      service_id: webhook.service_id
+    },
+    response: webhooksFixtures.webhookMessageSearchResponse(opts.messages || [])
+  })
+}
+
 function getWebhookSuccess (opts = {}) {
   const webhook = webhooksFixtures.webhookResponse(opts)
   const path = `/v1/webhook/${webhook.external_id}`
@@ -38,5 +49,6 @@ function getWebhookSigningSecret(opts = {}) {
 module.exports = {
   getWebhooksListSuccess,
   getWebhookSuccess,
-  getWebhookSigningSecret
+  getWebhookSigningSecret,
+  getWebhookMessagesListSuccess
 }

--- a/test/cypress/stubs/webhooks-stubs.js
+++ b/test/cypress/stubs/webhooks-stubs.js
@@ -19,7 +19,9 @@ function getWebhookMessagesListSuccess(opts = {}) {
   const path = `/v1/webhook/${webhook.external_id}/message`
   return stubBuilder('GET', path, 200, {
     query: {
-      service_id: webhook.service_id
+      service_id: webhook.service_id,
+      page: opts.page || 1,
+      status: opts.status || 'all'
     },
     response: webhooksFixtures.webhookMessageSearchResponse(opts.messages || [])
   })

--- a/test/fixtures/webhooks.fixtures.js
+++ b/test/fixtures/webhooks.fixtures.js
@@ -11,6 +11,27 @@ function validWebhook (options = {}) {
   }
 }
 
+function validWebhookMessageAttempt(options = {}) {
+  return {
+    status: options.status || 'SUCCEEDED', // 'FAILED', 'PENDING'
+    succeeded: options.succeeded || true,
+    send_at: options.event_date || '2021-08-20T14:00:00.000Z'
+  }
+}
+
+// mock webhook messages  -- should this have a pending retry date? does that have to be worked out? assuming yes
+// mock webhook message attempts -- do we need to derive status on the consumer? assuming no
+function validWebhookMessage(options = {}) {
+  return {
+    external_id: options.external_id || 'valid-webhook-message-external-id',
+    created_date: options.created_date || '2021-08-20T14:00:00.000Z',
+    event_date: options.event_date || '2021-08-20T14:00:00.000Z',
+    event_type: options.event_type || 'card_payment_captured',
+    status: options.status || 'SUCCEEDED', // 'FAILED', 'PENDING'
+    ...options.attempts && options.attempts.map(validWebhookMessageAttempt)
+  }
+}
+
 function validSigningSecret(options = {}) {
   return {
     signing_key: options.signing_key || 'valid-signing-secret'
@@ -29,8 +50,18 @@ function webhookSigningSecretResponse(options = {}) {
   return validSigningSecret(options)
 }
 
+function webhookMessageSearchResponse(options = []) {
+  return {
+    total: options.length,
+    count: options.length,
+    page: 1,
+    results: options.map(validWebhookMessage)
+  }
+}
+
 module.exports = {
   webhooksListResponse,
   webhookResponse,
-  webhookSigningSecretResponse
+  webhookSigningSecretResponse,
+  webhookMessageSearchResponse
 }


### PR DESCRIPTION
Implement webhook messages table on the details page.

Status tags to represent proposed message states, dates passed through commons formatting.

Support
* status filter propagated through to backend calls
* page query propagated through to backend calls
* pagination utility

<img width="413" alt="Screenshot 2021-12-14 at 15 45 16" src="https://user-images.githubusercontent.com/2844572/146033195-5a936b9c-5bb3-448d-8d8b-432b619a42bd.png">

