### PR TITLE
PP-8696: Remove unneeded stages from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,24 +100,6 @@ pipeline {
         }
       }
     }
-    stage('Check pact compatability') {
-      failFast true
-      when {
-        branch 'master'
-      }
-      steps {
-        checkPactCompatibility("selfservice", gitCommit(), "test")
-      }
-    }
-    stage('Pact Tag') {
-      when {
-        branch 'master'
-      }
-      steps {
-        echo 'Tagging consumer pact with "test"'
-        tagPact("selfservice", gitCommit(), "test")
-      }
-    }
     stage('Complete') {
       failFast true
       parallel {
@@ -127,14 +109,6 @@ pipeline {
           }
           steps {
             tagDeployment("selfservice")
-          }
-        }
-        stage('Trigger Deploy Notification') {
-          when {
-            branch 'master'
-          }
-          steps {
-            triggerGraphiteDeployEvent("selfservice")
           }
         }
       }


### PR DESCRIPTION
Given Jenkins doesn't do deployment anymore, these stages aren't needed.