### PR TITLE
PP-9080 add pages for 2022 contracts

### DIFF
--- a/app/controllers/policy/policy.controller.js
+++ b/app/controllers/policy/policy.controller.js
@@ -27,7 +27,7 @@ async function viewPage (req, res, next) {
 
     const contentHtml = await getDocumentHtml(documentConfig, key)
 
-    return response(req, res, documentConfig.htmlTemplate, { link, contentHtml })
+    return response(req, res, documentConfig.template, { link, contentHtml })
   } catch (err) {
     next(err)
   }

--- a/app/controllers/policy/supported-policy-documents.js
+++ b/app/controllers/policy/supported-policy-documents.js
@@ -6,26 +6,37 @@ const supportedPolicyDocuments = [
   {
     key: 'memorandum-of-understanding-for-crown-bodies',
     title: 'Pay memorandum of understanding',
-    template: 'policy/document-downloads/memorandum-of-understanding-for-crown-bodies',
-    htmlTemplate: 'policy/document/memorandum-of-understanding-for-crown-bodies'
+    template: 'policy/document/memorandum-of-understanding-for-crown-bodies'
   },
   {
     key: 'contract-for-non-crown-bodies',
     title: 'Pay contract',
-    template: 'policy/document-downloads/contract-for-non-crown-bodies',
-    htmlTemplate: 'policy/document/contract-for-non-crown-bodies'
+    template: 'policy/document/contract-for-non-crown-bodies'
   },
   {
     key: 'stripe-connected-account-agreement',
     title: 'Stripe Connected Account Agreement',
-    template: 'policy/document-downloads/stripe-connected-account-agreement',
-    htmlTemplate: 'policy/document/stripe-connected-account-agreement'
+    template: 'policy/document/stripe-connected-account-agreement'
   },
   {
     key: 'pci-dss-attestation-of-compliance',
     title: 'Attestation of Compliance for PCI',
-    template: 'policy/document-downloads/pci-dss-attestation-of-compliance',
-    htmlTemplate: 'policy/document/pci-dss-attestation-of-compliance'
+    template: 'policy/document/pci-dss-attestation-of-compliance'
+  },
+  {
+    key: 'memorandum-of-understanding-for-crown-bodies-2022',
+    title: 'Pay memorandum of understanding from 24 January 2022',
+    template: 'policy/document/v2/memorandum-of-understanding-for-crown-bodies'
+  },
+  {
+    key: 'contract-for-non-crown-bodies-2022',
+    title: 'Pay contract from 24 January 2022',
+    template: 'policy/document/v2/contract-for-non-crown-bodies'
+  },
+  {
+    key: 'stripe-connected-account-agreement-2022',
+    title: 'Stripe Connected Account Agreement from 24 January 2022',
+    template: 'policy/document/v2/stripe-connected-account-agreement'
   }
 ]
 

--- a/app/utils/display-converter.js
+++ b/app/utils/display-converter.js
@@ -14,7 +14,10 @@ const hideServiceHeaderTemplates = [
   'policy/document/contract-for-non-crown-bodies',
   'policy/document/memorandum-of-understanding-for-crown-bodies',
   'policy/document/pci-dss-attestation-of-compliance',
-  'policy/document/stripe-connected-account-agreement'
+  'policy/document/stripe-connected-account-agreement',
+  'policy/document/v2/contract-for-non-crown-bodies',
+  'policy/document/v2/memorandum-of-understanding-for-crown-bodies',
+  'policy/document/v2/stripe-connected-account-agreement'
 ]
 
 const hideServiceNavTemplates = [

--- a/app/views/policy/document/v2/contract-for-non-crown-bodies.njk
+++ b/app/views/policy/document/v2/contract-for-non-crown-bodies.njk
@@ -1,0 +1,19 @@
+{% extends "./policy-no-html.njk" %}
+
+{% set policyTitleText = "Contract For Non-Crown Bodies" %}
+
+{% block policyTitle %}
+  {{ policyTitleText }}
+{% endblock %}
+
+{% block policyDescription %}
+  If you’re a non-Crown body, these contract terms apply from 24 January 2022 when you use GOV.UK Pay.
+{% endblock %}
+
+{% block policyHtmlTitle %}
+  {{ policyTitleText }} 
+{% endblock %}
+
+{% block downloadFileDetails %}
+  PDF, 431KB, 38 pages
+{% endblock %}

--- a/app/views/policy/document/v2/memorandum-of-understanding-for-crown-bodies.njk
+++ b/app/views/policy/document/v2/memorandum-of-understanding-for-crown-bodies.njk
@@ -1,0 +1,19 @@
+{% extends "./policy-no-html.njk" %}
+
+{% set policyTitleText = "Memorandum Of Understanding" %}
+
+{% block policyTitle %}
+  {{ policyTitleText }}
+{% endblock %}
+
+{% block policyDescription %}
+  If you’re a Crown body, the memorandum of understanding terms apply from 24 January 2022 when you use GOV.UK Pay.
+{% endblock %}
+
+{% block policyHtmlTitle %}
+  {{ policyTitleText }} 
+{% endblock %}
+
+{% block downloadFileDetails %}
+  PDF, 361KB, 32 pages
+{% endblock %}

--- a/app/views/policy/document/v2/policy-no-html.njk
+++ b/app/views/policy/document/v2/policy-no-html.njk
@@ -1,0 +1,43 @@
+{% extends "../../../layout.njk" %}
+
+{% block pageTitle %}
+   Policy Document - GOV.UK Pay
+{% endblock %}
+
+
+{% block mainContent %}
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-l">From 24 January 2022</span>
+    <h1 class="govuk-heading-l">
+      {% block policyTitle %} {% endblock %}
+    </h1>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      {% block policyDescription %} {% endblock %}
+    </p>
+    
+    {{ govukInsetText({
+      text: "These terms are confidential and should not be shared outside of your organisation."
+    }) }}
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <div class="contract-download-container">
+      <h2 class="govuk-heading-m">
+        <a class="govuk-link" href="{{ link }}">
+          Download PDF Version 
+        </a>
+      </h2>
+
+      <p class="govuk-body">
+        {% block downloadFileDetails %}{% endblock %}
+      </p>
+
+      <p class="govuk-body">
+        This file may not be suitable for users of accessible for users of assistive technologies.
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/policy/document/v2/stripe-connected-account-agreement.njk
+++ b/app/views/policy/document/v2/stripe-connected-account-agreement.njk
@@ -1,0 +1,19 @@
+{% extends "./policy-no-html.njk" %}
+
+{% set policyTitleText = "Stripe Connected Account Agreement" %}
+
+{% block policyTitle %}
+  {{ policyTitleText }}
+{% endblock %}
+
+{% block policyDescription %}
+  If you’re using our Payment Service Provider, Stripe, these legal terms apply to you from 24 January 2022.
+{% endblock %}
+
+{% block policyHtmlTitle %}
+  {{ policyTitleText }} 
+{% endblock %}
+
+{% block downloadFileDetails %}
+  PDF, 223KB, 39 pages
+{% endblock %}


### PR DESCRIPTION
## WHAT
Added accessible pages for the 2022 contracts, these are PDF download only for now with a view adding HTML at a later date.

Paired with @stephencdaly 