### PR TITLE
pp-7475 add labels to GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,7 @@ updates:
   labels:
   - dependencies
   - govuk-pay
-  - javascript
+  - docker
   ignore:
   - dependency-name: node
     versions:
@@ -41,8 +41,13 @@ updates:
     versions:
     - ">= 15.a"
     - "< 16"
-- package-ecosystem: "github-actions"
+- package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: daily
     time: "03:00"
+  open-pull-requests-limit: 10
+  labels:
+  - dependencies
+  - govuk-pay
+  - github_actions


### PR DESCRIPTION
## WHAT
Update dependabot config to correctly label github actions