### PR TITLE
PP-9038 Request CSV with fee breakdown headers if enabled

### DIFF
--- a/app/controllers/transactions/transaction-download.controller.js
+++ b/app/controllers/transactions/transaction-download.controller.js
@@ -5,6 +5,8 @@ const date = require('../../utils/dates')
 const { renderErrorView } = require('../../utils/response')
 const { CORRELATION_HEADER } = require('../../utils/correlation-header')
 const Stream = require('../../services/clients/stream.client')
+const enableFeeBreakDownForTestAccounts = process.env.ENABLE_FEE_BREAKDOWN_IN_CSV_FOR_STRIPE_TEST_ACCOUNTS === 'true'
+const includeFeeBreakdownHeadersFromDate = process.env.INCLUDE_FEE_BREAKDOWN_HEADERS_IN_CSV_DATE || '1642982460'
 
 const fetchTransactionCsvWithHeader = function fetchTransactionCsvWithHeader (req, res) {
   const accountId = req.account.gateway_account_id
@@ -12,7 +14,13 @@ const fetchTransactionCsvWithHeader = function fetchTransactionCsvWithHeader (re
   const name = `GOVUK_Pay_${date.dateToDefaultFormat(new Date()).replace(' ', '_')}.csv`
   const correlationId = req.headers[CORRELATION_HEADER]
 
-  filters.feeHeaders = req.account && req.account.payment_provider === 'stripe'
+  if (req.account && req.account.payment_provider === 'stripe') {
+    filters.feeHeaders = true
+
+    const includeFeeBreakdownHeaders = Math.round(Date.now() / 1000) >= includeFeeBreakdownHeadersFromDate
+    filters.feeBreakdownHeaders = includeFeeBreakdownHeaders || (req.account.type === 'test' && enableFeeBreakDownForTestAccounts)
+  }
+
   filters.motoHeader = req.account && req.account.allow_moto
   const url = transactionService.csvSearchUrl(filters, accountId)
 

--- a/app/utils/get-query-string-for-params.js
+++ b/app/utils/get-query-string-for-params.js
@@ -15,6 +15,7 @@ function getQueryStringForParams (params = {}, removeEmptyParams = false, flatte
     from_date: dates.fromDateToApiFormat(params.fromDate, params.fromTime),
     to_date: dates.toDateToApiFormat(params.toDate, params.toTime),
     ...params.feeHeaders && { fee_headers: params.feeHeaders },
+    ...params.feeBreakdownHeaders && { fee_breakdown_headers: params.feeBreakdownHeaders },
     ...params.motoHeader && { moto_header: params.motoHeader },
     metadata_value: params.metadataValue
   }


### PR DESCRIPTION
## WHAT
- Requests CSV for fee breakdown fields if
    - for test accounts, flag `ENABLE_FEE_BREAKDOWN_IN_CSV_FOR_STRIPE_TEST_ACCOUNTS` is set
    - or current date is on or after the env variable INCLUDE_FEE_BREAKDOWN_HEADERS_IN_CSV_DATE (timestamp). Defaults to 1642982460 (24-Jan-22).
