### PR TITLE
PP-9077 Bump commons for webhook event type update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1426,43 +1426,15 @@
       "dev": true
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.3.4.tgz",
-      "integrity": "sha512-jXuHjD0f/9xWPIpUQPEUCruLHUxW606duyVXVrvJdk71s9Jod1vhQomE2JRIuyY3SLy7fg5JpdSY9NCxz+frhg==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.3.5.tgz",
+      "integrity": "sha512-U7DpIGv01I3jj8Y+CSajS21nGF6RUsMBy837JJTzTSyPCTdEnvL1RhLNgVkU3qaVZJoXa2tGBrLqn9+hPt1YLA==",
       "requires": {
         "lodash": "4.17.21",
         "moment-timezone": "0.5.34",
         "rfc822-validate": "1.0.0",
-        "slugify": "1.6.2",
-        "winston": "3.3.3"
-      },
-      "dependencies": {
-        "async": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-          "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
-        },
-        "is-stream": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
-        },
-        "winston": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
-          "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
-          "requires": {
-            "@dabh/diagnostics": "^2.0.2",
-            "async": "^3.1.0",
-            "is-stream": "^2.0.0",
-            "logform": "^2.2.0",
-            "one-time": "^1.0.0",
-            "readable-stream": "^3.4.0",
-            "stack-trace": "0.0.x",
-            "triple-beam": "^1.3.0",
-            "winston-transport": "^4.4.0"
-          }
-        }
+        "slugify": "1.6.5",
+        "winston": "3.4.0"
       }
     },
     "@hapi/bourne": {
@@ -14767,9 +14739,9 @@
       "dev": true
     },
     "slugify": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.2.tgz",
-      "integrity": "sha512-XMtI8qD84LwCpthLMBHlIhcrj10cgA+U/Ot8G6FD6uFuWZtMfKK75JO7l81nzpFJsPlsW6LT+VKqWQJW3+6New=="
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
     },
     "smart-buffer": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-pay/pay-js-commons": "3.3.4",
+    "@govuk-pay/pay-js-commons": "3.3.5",
     "@sentry/node": "6.12.0",
     "accessible-autocomplete": "2.0.3",
     "appmetrics": "5.1.1",


### PR DESCRIPTION
Bring in the latest supported webhook event types.

Lines admin tool up with https://github.com/alphagov/pay-webhooks/pull/55