### PR TITLE
BAU  Fix webhooks typo and events sort order

### DIFF
--- a/app/views/webhooks/detail.njk
+++ b/app/views/webhooks/detail.njk
@@ -15,11 +15,12 @@
     <strong class="govuk-tag govuk-tag--blue">{{ webhook.status }}</strong>
   </h1>
 
+  <p class="govuk-body">{{ webhook.description }}</p>
   <p class="govuk-body">This webhook sends updates after the following payment events:</p>
 
   <p class="govuk-body">
     <ul class="govuk-list govuk-list--bullet">
-    {% for subscription in webhook.subscriptions %}
+    {% for subscription in webhook.subscriptions | sort %}
       {% set key = subscription | upper %}
       <li>{{ eventTypes[key] }}</li>
     {% endfor %}
@@ -57,7 +58,7 @@
   <div class="govuk-!-margin-top-6">
     <h2 class="govuk-heading-m">Events</h2>
 
-    <p class="govuk-body">Events sent to your Webhook are stored for 14 days.</p>
+    <p class="govuk-body">Events sent to your webhook are stored for 14 days.</p>
 
       <div class="govuk-body govuk-!-margin-top-4">
       <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-right-1 {% if status == 'successful' %} govuk-!-font-weight-bold {% endif %}" href="?status=successful&page={{ page }}">Successful</a>

--- a/test/cypress/integration/webhooks/webhooks.cy.test.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.test.js
@@ -13,7 +13,7 @@ const userAndGatewayAccountStubs = [
   userStubs.getUserSuccess({ userExternalId, serviceExternalId, gatewayAccountId }),
   gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, serviceExternalId }),
   webhooksStubs.getWebhooksListSuccess({ service_id: serviceExternalId, live: false, webhooks: [{ external_id: webhookExternalId }] }),
-  webhooksStubs.getWebhookSuccess({ service_id: serviceExternalId, external_id: webhookExternalId }),
+  webhooksStubs.getWebhookSuccess({ service_id: serviceExternalId, external_id: webhookExternalId, subscriptions: [ 'card_payment_captured', 'card_payment_succeeded', 'card_payment_refunded', 'card_payment_started' ] }),
   webhooksStubs.getWebhookMessagesListSuccess({ service_id: serviceExternalId, external_id: webhookExternalId, messages: [
     { latest_attempt: { status: 'PENDING' }, external_id: messageExternalId },
     { latest_attempt: { status: 'FAILED' } },
@@ -76,7 +76,7 @@ describe('Webhooks', () => {
     cy.get('[data-action=update]').then((links) => links[0].click())
 
     cy.get('h1').contains('https://some-callback-url.com')
-    cy.get('.govuk-list.govuk-list--bullet > li').should('have.length', 1)
+    cy.get('.govuk-list.govuk-list--bullet > li').should('have.length', 4)
 
     // based on number of rows stubbed and client pagination logic
     cy.get('.govuk-table__body > .govuk-table__row').should('have.length', 11)


### PR DESCRIPTION
Webhooks typo, events sort order, add webhook description back onto the details page.

