### PR TITLE
PP-9085: Reduce docker image size and increase security with multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.7-alpine3.12@sha256:99eaf1312b1926bc6db27d7230c8b3118d4ad2db64cc6a8a8304adeb8bad283b AS base
+FROM node:12.22.7-alpine3.12 as base
 
 RUN apk --no-cache upgrade && apk add --no-cache tini
 
@@ -7,11 +7,11 @@ RUN apk --no-cache upgrade && apk add --no-cache tini
 #############################
 FROM base as builder
 
-### Needed to build appmetrics and pact-mock-service
-COPY sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
-RUN ["apk", "--no-cache", "add", "ca-certificates", "python2", "build-base"]
-RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk && apk add --no-cache glibc-2.28-r0.apk && rm -f glibc-2.28-r0.apk
-###
+RUN apk add --no-cache --update \
+  build-base \
+  python2 \
+  libc6-compat \
+  libexecinfo-dev
 
 ADD package.json /tmp/package.json
 ADD package-lock.json /tmp/package-lock.json
@@ -27,7 +27,6 @@ EXPOSE 9000
 
 WORKDIR /app
 ADD . /app
-ENV LD_LIBRARY_PATH /app/node_modules/appmetrics
 COPY --from=builder /tmp/node_modules /app/node_modules
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
-FROM node:12.22.7-alpine3.12@sha256:99eaf1312b1926bc6db27d7230c8b3118d4ad2db64cc6a8a8304adeb8bad283b
+FROM node:12.22.7-alpine3.12 AS base
 
+RUN apk --no-cache upgrade && apk add --no-cache tini
+
+FROM base as builder
 ### Needed to run appmetrics and pact-mock-service
 COPY sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
 RUN ["apk", "--no-cache", "add", "ca-certificates", "python2", "build-base"]
 RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk && apk add --no-cache glibc-2.28-r0.apk && rm -f glibc-2.28-r0.apk
 ###
 
-RUN ["apk", "--no-cache", "upgrade"]
-
-RUN ["apk", "add", "--no-cache", "tini"]
-
 ADD package.json /tmp/package.json
 ADD package-lock.json /tmp/package-lock.json
 RUN cd /tmp && npm ci --production
+
+FROM base AS production
 
 ENV PORT 9000
 EXPOSE 9000
@@ -20,7 +21,7 @@ EXPOSE 9000
 WORKDIR /app
 ADD . /app
 ENV LD_LIBRARY_PATH /app/node_modules/appmetrics
-RUN ["ln", "-s", "/tmp/node_modules", "/app/node_modules"]
+COPY --from=builder /tmp/node_modules /app/node_modules
 
 ENTRYPOINT ["tini", "--"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ FROM base as builder
 RUN apk add --no-cache --update \
   build-base \
   python2 \
-  libc6-compat \
-  libexecinfo-dev
+  libc6-compat
 
 ADD package.json /tmp/package.json
 ADD package-lock.json /tmp/package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.7-alpine3.12 as base
+FROM node:12.22.7-alpine3.12@sha256:99eaf1312b1926bc6db27d7230c8b3118d4ad2db64cc6a8a8304adeb8bad283b as base
 
 RUN apk --no-cache upgrade && apk add --no-cache tini
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM node:12.22.7-alpine3.12 AS base
+FROM node:12.22.7-alpine3.12@sha256:99eaf1312b1926bc6db27d7230c8b3118d4ad2db64cc6a8a8304adeb8bad283b AS base
 
 RUN apk --no-cache upgrade && apk add --no-cache tini
 
+#############################
+# Dependency build stage
+#############################
 FROM base as builder
-### Needed to run appmetrics and pact-mock-service
+
+### Needed to build appmetrics and pact-mock-service
 COPY sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
 RUN ["apk", "--no-cache", "add", "ca-certificates", "python2", "build-base"]
 RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk && apk add --no-cache glibc-2.28-r0.apk && rm -f glibc-2.28-r0.apk
@@ -13,6 +17,9 @@ ADD package.json /tmp/package.json
 ADD package-lock.json /tmp/package-lock.json
 RUN cd /tmp && npm ci --production
 
+#############################
+# Production container stage
+#############################
 FROM base AS production
 
 ENV PORT 9000

--- a/Dockerfile.debian-slim
+++ b/Dockerfile.debian-slim
@@ -1,0 +1,39 @@
+FROM node:12.22.9-buster-slim@sha256:747221aac56152a04f000c74aeaaf2098f26274600b874e6c80df2c75aa197f9 AS base
+
+RUN apt-get update && apt-get upgrade -y \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    tini \
+  && rm -rf /var/lib/apt/lists/*
+
+############################################
+# Builder with toolchain to build appmetrics
+############################################
+FROM base AS builder
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    build-essential \
+    libc6 \
+    python3 \
+  && rm -rf /var/lib/apt/lists/* \
+  && ln -s /usr/bin/python3 /usr/bin/python 
+
+ADD package.json /tmp/package.json
+ADD package-lock.json /tmp/package-lock.json
+
+RUN cd /tmp && npm ci --production
+
+###################
+# Final prod build
+###################
+FROM base AS production
+
+ENV PORT 9000
+EXPOSE 9000
+
+WORKDIR /app
+ADD . /app
+COPY --from=builder /tmp/node_modules /app/node_modules
+
+ENTRYPOINT ["tini", "--"]
+
+CMD ["npm", "start"]


### PR DESCRIPTION
## WHAT
For now this is just a demo and part of thinking about future ci, upgrading alpine and improving image builds. I also included a Dockerfile which changes the build to a debian buster-slim (appmetrics wont build on bullseye) and bumps the patch node version to 12.22.9 for security updates.

Change the build to be a muilti-stage buiild. This allows appmetrics to be built and not to keep the installed tool-chain or any intermediate files in the build (object files etc). Copy the final installed node_modules into the production stage of the build. For comparison the current latest-master is 497MB, and this build is 223MB. The Debian build is 290MB

```
$ docker image ls | grep selfservice
govukpay/selfservice              multi-stage               6f0bc14f9932   14 seconds ago      223MB
govukpay/selfservice              latest-master             0127d28947be   2 days ago          497MB
govukpay/selfservice              debian-slim               796dc2052499   7 minutes ago       290MB
```

~This works for me in a pay local but that of course doe not guarantee it works on live.~

To check metrics are still sent locally I made a simple UDP socket listener in ruby
```
#!/usr/bin/env ruby

require "socket"

PORT = 8125

sock = UDPSocket.new
sock.bind("", PORT)
puts "Bound  socket on port #{PORT}"

loop do
  data, _ = sock.recvfrom(1024)
  puts "[#{data}]"
end
```

and ran this.

I modified the pay-local docker-compose template to set the env var `METRICS_HOST=host.docker.internal` and to use my custom build of selfservice instead of latest-master.

Then I ran self-service and I can see the stats getting sent as expected:

```
[selfservice.memory.process.private:302825472|g]
[selfservice.memory.process.physical:109064192|g]
[selfservice.memory.process.virtual:334819328|g]
[selfservice.memory.system.used:7730221056|g]
[selfservice.memory.system.total:8346603520|g]
[selfservice.cpu.process:0.000555362|g]
[selfservice.cpu.system:0.0211038|g]
[selfservice.eventloop.latency.max:0.3438|g]
[selfservice.eventloop.latency.min:0.1182|g]
[selfservice.eventloop.latency.avg:0.19147|g]
```
