### PR TITLE
PP-9052 Fix name service during account creation bug

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -405,7 +405,7 @@
         "filename": "test/unit/controller/register-service-controller/register-service.controller.test.js",
         "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 68,
         "is_secret": false
       }
     ],
@@ -426,5 +426,5 @@
       }
     ]
   },
-  "generated_at": "2021-10-07T17:25:20Z"
+  "generated_at": "2022-01-26T18:12:13Z"
 }

--- a/app/controllers/my-services/get-index.controller.js
+++ b/app/controllers/my-services/get-index.controller.js
@@ -6,6 +6,7 @@ const { response } = require('../../utils/response')
 const serviceService = require('../../services/service.service')
 const { filterGatewayAccountIds } = require('../../utils/permissions')
 const getHeldPermissions = require('../../utils/get-held-permissions')
+const { DEFAULT_SERVICE_NAME } = require('../../utils/constants')
 
 function hasStripeAccount (gatewayAccounts) {
   return gatewayAccounts.some(gatewayAccount =>
@@ -42,7 +43,7 @@ module.exports = async function getServiceList (req, res) {
       const isAdminUser = req.user.isAdminUserForService(serviceRole.service.externalId)
 
       const serviceData = {
-        name: serviceRole.service.name === 'System Generated' ? 'Temporary Service Name' : serviceRole.service.name,
+        name: serviceRole.service.name === DEFAULT_SERVICE_NAME ? 'Temporary Service Name' : serviceRole.service.name,
         id: serviceRole.service.id,
         external_id: serviceRole.service.externalId,
         gatewayAccounts: lodash.sortBy(gatewayAccounts, 'type', 'asc'),

--- a/app/services/service.service.js
+++ b/app/services/service.service.js
@@ -9,6 +9,7 @@ const CardGatewayAccount = require('../models/GatewayAccount.class')
 const Service = require('../models/Service.class')
 const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 const adminUsersClient = getAdminUsersClient()
+const { DEFAULT_SERVICE_NAME } = require('../utils/constants')
 
 async function getGatewayAccounts (gatewayAccountIds, correlationId) {
   const cardGatewayAccounts = await connectorClient.getAccounts({
@@ -46,7 +47,7 @@ function updateService (serviceExternalId, serviceUpdateRequest, correlationId) 
 }
 
 async function createService (serviceName, serviceNameCy, user, correlationId) {
-  if (!serviceName) serviceName = 'System Generated'
+  if (!serviceName) serviceName = DEFAULT_SERVICE_NAME
   if (!serviceNameCy) serviceNameCy = ''
 
   const service = await adminUsersClient.createService(serviceName, serviceNameCy, correlationId)

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = {
+  DEFAULT_SERVICE_NAME: 'System Generated'
+}


### PR DESCRIPTION
Ensure that the service we are setting the name for as the last step of a user signing up for a user account is the test service created for them during the sign-up process.

There was an issue where if the user started registering for an account and then accepted an invite to join a service before completing it, they could end up changing the name of the service they were invited to by mistake, as our code was only expecting them to have one service at this point.

To avoid this, check for a service with the default name, which is always "System Generated", and rename that service. If the user does not have a service with the default name, show an error page.

If the user tries to access the page for setting the service name when they do not have a service with the default name, redirect to the "My services" page.

Extract the default service name, which is "System Generated" into a constant referenced from all places we use it in application code.

## Review notes

Hiding whitespace changes will make the tests easier to review, as there are indentation changes
<img width="613" alt="Screenshot 2022-01-27 at 15 06 44" src="https://user-images.githubusercontent.com/5648592/151387846-f13e827c-d717-4595-9a68-633c285c5c5e.png">

