### PR TITLE
PP-9161 Transaction Table - update styling in the mobile view

### DIFF
--- a/app/assets/sass/components/transaction-list.scss
+++ b/app/assets/sass/components/transaction-list.scss
@@ -1,3 +1,7 @@
+.transactions-list-table{
+  background-color: govuk-colour("white");
+}
+
 tr[data-follow-link]{
   cursor: pointer;
 

--- a/app/views/transactions/list.njk
+++ b/app/views/transactions/list.njk
@@ -1,5 +1,5 @@
 {% if results.length %}
-<table id="transactions-list" class="govuk-table">
+<table id="transactions-list" class="govuk-table transactions-list-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col" id="reference-header">Reference number</th>


### PR DESCRIPTION
- Set the background colour of the table to white so that in smaller
  screens, you do not get the grey overlap.
- Tables with an overflow do not style well on small screens.
  So cannot add a right margin.  So have just left it to go
  to the edge of the screen.

