### PR TITLE
PP-9155 disable making a live payment

### DIFF
--- a/app/controllers/switch-psp/verify-psp-integration.controller.js
+++ b/app/controllers/switch-psp/verify-psp-integration.controller.js
@@ -17,11 +17,16 @@ const selfserviceURL = process.env.SELFSERVICE_URL
 
 const VERIFY_PAYMENT_AMOUNT_IN_PENCE = 200
 
+const stripeTestPaymentStates = [CREDENTIAL_STATE.ENTERED, CREDENTIAL_STATE.VERIFIED, CREDENTIAL_STATE.ACTIVE]
+
 function verifyPSPIntegrationPaymentPage (req, res, next) {
   try {
     const targetCredential = getSwitchingCredential(req.account)
-
-    response(req, res, 'switch-psp/verify-psp-integration-payment', { targetCredential })
+    let allowTestPayment = true
+    if (targetCredential.payment_provider === 'stripe') {
+      allowTestPayment = stripeTestPaymentStates.includes(targetCredential.state)
+    }
+    response(req, res, 'switch-psp/verify-psp-integration-payment', { targetCredential, allowTestPayment })
   } catch (error) {
     next(error)
   }

--- a/app/views/switch-psp/verify-psp-integration-payment.njk
+++ b/app/views/switch-psp/verify-psp-integration-payment.njk
@@ -33,14 +33,17 @@
 
   <h1 class="govuk-heading-l page-title">Test the connection between {{ targetCredential.payment_provider | formatPSPname }} and GOV.UK Pay</h1>
 
-  <p class="govuk-body">Make a live payment of £2 with a debit or credit card to check that the connection with {{ targetCredential.payment_provider | formatPSPname }} is working. You can refund the payment anytime.</p>
+  {% if targetCredential.payment_provider === 'worldpay' or allowTestPayment === true %}
+    <p class="govuk-body">Make a live payment of £2 with a debit or credit card to check that the connection with {{ targetCredential.payment_provider | formatPSPname }} is working. You can refund the payment anytime.</p>
+    <form method="POST">
+      {{ govukButton ({
+        text: "Continue to live payment"
+      }) }}
 
-  <form method="POST">
-    {{ govukButton ({
-      text: "Continue to live payment"
-    }) }}
-
-    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
-  </form>
+      <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
+    </form>
+  {% else %}
+    <p class="govuk-body">Stripe is still verifying your details. You cannot make a test payment until this is complete. Please try again later.</p>
+  {% endif %}
 </div>
 {% endblock %}

--- a/test/cypress/integration/settings/verify-psp-integration.cy.test.js
+++ b/test/cypress/integration/settings/verify-psp-integration.cy.test.js
@@ -1,0 +1,88 @@
+'use strict'
+
+const userStubs = require('../../stubs/user-stubs')
+const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+const stripeAccountSetupStubs = require('../../stubs/stripe-account-setup-stub')
+
+const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+const gatewayAccountId = '42'
+const gatewayAccountExternalId = 'a-valid-external-id'
+
+function getUserAndAccountStubs (paymentProvider, providerSwitchEnabled, gatewayAccountCredentials, merchantDetails) {
+  return [
+    userStubs.getUserSuccess({ gatewayAccountId, userExternalId, merchantDetails }),
+    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, providerSwitchEnabled, paymentProvider, ...gatewayAccountCredentials && { gatewayAccountCredentials } })
+  ]
+}
+
+describe('Verify PSP Integration page', () => {
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('session', 'gateway_account')
+    cy.setEncryptedCookies(userExternalId)
+  })
+
+  describe('When switching to Worldpay', () => {
+    beforeEach(() => {
+      cy.task('setupStubs', getUserAndAccountStubs('smartpay', true, [
+        { payment_provider: 'smartpay', state: 'ACTIVE' },
+        { payment_provider: 'worldpay', state: 'ENTERED' }
+      ]),
+      stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+        gatewayAccountId
+      }))
+    })
+
+    it('should display enabled live payment button', () => {
+      cy.visit(`/account/${gatewayAccountExternalId}/switch-psp/verify-psp-integration`)
+      cy.get('h1').should('contain', 'Test the connection between Worldpay and GOV.UK Pay')
+      cy.get('p').contains('Make a live payment of £2 with a debit or credit card')
+      cy.get('button').should('exist')
+      cy.get('button').should('contain', 'Continue to live payment')
+      cy.get('button').should('be.not.disabled')
+    })
+  })
+
+  describe('When switching to Stripe and cannot make a test payment', () => {
+    beforeEach(() => {
+      cy.task('setupStubs', [
+        ...getUserAndAccountStubs('smartpay', true, [
+          { payment_provider: 'smartpay', state: 'ACTIVE' },
+          { payment_provider: 'stripe', state: 'CREATED' }
+        ]),
+        stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+          gatewayAccountId
+        })
+      ])
+    })
+
+    it('should display disabled live payment button', () => {
+      cy.visit(`/account/${gatewayAccountExternalId}/switch-psp/verify-psp-integration`)
+      cy.get('h1').should('contain', 'Test the connection between Stripe and GOV.UK Pay')
+      cy.get('p').contains('Stripe is still verifying your details.')
+      cy.get('button').contains('Continue to live payment').should('not.exist')
+    })
+  })
+
+  describe('When switching to Stripe and can make a test payment', () => {
+    beforeEach(() => {
+      cy.task('setupStubs', [
+        ...getUserAndAccountStubs('smartpay', true, [
+          { payment_provider: 'smartpay', state: 'ACTIVE' },
+          { payment_provider: 'stripe', state: 'ENTERED' }
+        ]),
+        stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+          gatewayAccountId
+        })
+      ])
+    })
+
+    it('should display enabled live payment button', () => {
+      cy.visit(`/account/${gatewayAccountExternalId}/switch-psp/verify-psp-integration`)
+      cy.get('h1').should('contain', 'Test the connection between Stripe and GOV.UK Pay')
+      cy.get('p').contains('Make a live payment of £2 with a debit or credit card')
+      cy.get('button').should('exist')
+      cy.get('button').should('contain', 'Continue to live payment')
+      cy.get('button').should('be.not.disabled')
+    })
+  })
+})


### PR DESCRIPTION
## WHAT
- Do not allow services switching to Stripe to make a test payment until they are verified. Once Stripe verified and enabled their account, they can make a test payment.
