### PR TITLE
BAU - Display stripe account setup banner when entity document task is not completed

### DIFF
--- a/app/controllers/dashboard/dashboard-activity.controller.js
+++ b/app/controllers/dashboard/dashboard-activity.controller.js
@@ -145,7 +145,7 @@ module.exports = async (req, res) => {
 
     const transactionsPeriodString = `fromDate=${encodeURIComponent(datetime(fromDateTime, 'date'))}&fromTime=${encodeURIComponent(datetime(fromDateTime, 'time'))}&toDate=${encodeURIComponent(datetime(toDateTime, 'date'))}&toTime=${encodeURIComponent(datetime(toDateTime, 'time'))}`
 
-    logger.info(`Successfully logged in`)
+    logger.info('Successfully logged in')
 
     try {
       const result = await LedgerClient.transactionSummary(gatewayAccountId, fromDateTime, toDateTime, { correlationId: correlationId })
@@ -216,9 +216,11 @@ async function getStripeAccountDetails (gatewayAccountId, correlationId) {
 
     try {
       const fullStripeAccountDetails = await retrieveAccountDetails(stripeAccountId)
+      const hasLegacyPaymentsCapability = fullStripeAccountDetails.capabilities && fullStripeAccountDetails.capabilities.legacy_payments !== undefined
 
       const formattedStripeAccount = {
-        charges_enabled: fullStripeAccountDetails.charges_enabled
+        charges_enabled: fullStripeAccountDetails.charges_enabled,
+        has_legacy_payments_capability: hasLegacyPaymentsCapability
       }
 
       if (fullStripeAccountDetails.requirements.current_deadline) {

--- a/app/views/dashboard/_stripe-account-setup-banner.njk
+++ b/app/views/dashboard/_stripe-account-setup-banner.njk
@@ -5,7 +5,8 @@
 
   {% set isStripeAccountRestricted = stripeAccount.charges_enabled === false %}
   {% set stripeAccountHasDeadline = stripeAccount.requirements.current_deadline %}
-  {% set isConnectorStripeJourneyComplete = connectorGatewayAccountStripeProgress.bankAccount and connectorGatewayAccountStripeProgress.vatNumber and connectorGatewayAccountStripeProgress.companyNumber and connectorGatewayAccountStripeProgress.responsiblePerson %}
+  {% set governmentEntityDocCompleteOrNotRequired = stripeAccount.has_legacy_payments_capability or (not stripeAccount.has_legacy_payments_capability and connectorGatewayAccountStripeProgress.governmentEntityDocument) %}
+  {% set isConnectorStripeJourneyComplete = connectorGatewayAccountStripeProgress.bankAccount and connectorGatewayAccountStripeProgress.vatNumber and connectorGatewayAccountStripeProgress.companyNumber and connectorGatewayAccountStripeProgress.responsiblePerson and governmentEntityDocCompleteOrNotRequired %}
 
   {% set panelModifierClass %}
     {% if isStripeAccountRestricted %}

--- a/test/unit/controller/dashboard/dashboard-activity.controller.ft.test.js
+++ b/test/unit/controller/dashboard/dashboard-activity.controller.ft.test.js
@@ -42,7 +42,7 @@ const mockConnectorGetGatewayAccount = (paymentProvider, type) => {
     }))
 }
 
-const mockConnectorGetStripeSetup = (bankAccount, responsiblePerson, vatNumber, companyNumber, director) => {
+const mockConnectorGetStripeSetup = (bankAccount, responsiblePerson, vatNumber, companyNumber, director, governmentEntitydocument) => {
   nock(CONNECTOR_URL)
     .get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}/stripe-setup`)
     .reply(200, {
@@ -50,7 +50,8 @@ const mockConnectorGetStripeSetup = (bankAccount, responsiblePerson, vatNumber, 
       responsible_person: responsiblePerson,
       vat_number: vatNumber,
       company_number: companyNumber,
-      director: director
+      director: director,
+      government_entity_document: governmentEntitydocument
     })
     .persist()
 }
@@ -525,7 +526,7 @@ describe('dashboard-activity-controller', () => {
       })
 
       it('it should not display account status panel when account is fully setup', async () => {
-        mockConnectorGetStripeSetup(true, true, true, true, true)
+        mockConnectorGetStripeSetup(true, true, true, true, true, true)
         mockStripeRetrieveAccount(true, null)
         let res = await getDashboard()
         let $ = cheerio.load(res.text)
@@ -554,7 +555,7 @@ describe('dashboard-activity-controller', () => {
       })
 
       it('it should display RESTRICTED account status panel when payouts=false, account is fully setup', async () => {
-        mockConnectorGetStripeSetup(true, true, true, true, true)
+        mockConnectorGetStripeSetup(true, true, true, true, true, true)
         mockStripeRetrieveAccount(false, null)
 
         let res = await getDashboard()


### PR DESCRIPTION
## WHAT

- Currently we ask for a `Government entity document` as part of stripe onboarding flow and it is not mandatory for all stripe accounts (accounts with `legacy_payments` capabilities). So we don't check if the `Government entity document` task is completed when displaying stripe-account-setup-banner.
- When the user doesn't complete the `Government entity document` immediately after the `company number` task, then the banner disappears if user logs in again i.e., stripe-account-setup-banner is not displayed if the `Government entity document` task is the only task due.
- so display the banner if ‘Government entity document’ is not completed for stripe accounts without `legacy_payments` capability.
- All accounts (with new capabilities) that are fully verified on stripe has GOVERNMENT_ENTITY_DOCUMENT task in connector
```
select
	gac.gateway_account_id,
	credentials->>'stripe_account_id' account_id, gass.task
from
	gateway_account_credentials gac
left outer join gateway_accounts_stripe_setup gass on
	gac.gateway_account_id = gass.gateway_account_id
	and task = 'GOVERNMENT_ENTITY_DOCUMENT'
where
	credentials->>'stripe_account_id' in (<list of stripe account ids from 27-Nov>) 
       and gass.task is null

result
------
0 rows
 ```