### PR TITLE
PP-9264 New Contract banner on My Services - update how long to show.

### DIFF
--- a/app/controllers/my-services/get-index.controller.js
+++ b/app/controllers/my-services/get-index.controller.js
@@ -8,7 +8,7 @@ const serviceService = require('../../services/service.service')
 const { filterGatewayAccountIds } = require('../../utils/permissions')
 const getHeldPermissions = require('../../utils/get-held-permissions')
 const { DEFAULT_SERVICE_NAME } = require('../../utils/constants')
-const showNewContractTermsBannerUntilDate = process.env.SHOW_NEW_CONTRACTS_BANNER_UNTIL_DATE || '1645488000'
+const showNewContractTermsBannerUntilDate = process.env.SHOW_NEW_CONTRACTS_BANNER_UNTIL_DATE || '1647907200'
 
 function hasStripeAccount (gatewayAccounts) {
   return gatewayAccounts.some(gatewayAccount =>


### PR DESCRIPTION
- Update the code to increase the time the banner  is displayed until:
  - Increase the display time of the banner until 21st Mar 2022.
  - Use the Unix date: 1647820800
- Not using the SHOW_NEW_CONTRACTS_BANNER_UNTIL_DATE env variable
   - as we currently do not set this in Terraform.
  - As easier to just update the code.
  - This code will also be removed soon anyway.


