### PR TITLE
PP-9264 Update Footer links to new versions of contracts.

### DIFF
--- a/app/controllers/policy/policy.controller.js
+++ b/app/controllers/policy/policy.controller.js
@@ -6,17 +6,6 @@ const { response } = require('../../utils/response')
 const supportedPolicyDocuments = require('./supported-policy-documents')
 const policyBucket = require('./aws-s3-policy-bucket')
 
-async function getDocumentHtml (documentConfig, key) {
-  let contentHtml
-  try {
-    contentHtml = await policyBucket.getDocumentHtmlFromS3(documentConfig)
-  } catch (err) {
-    logger.error(`Error getting HTML content for ${key}, error: ${err.message}`)
-    contentHtml = 'Error displaying content'
-  }
-  return contentHtml
-}
-
 async function viewPage (req, res, next) {
   const key = req.params.key
   try {
@@ -25,9 +14,7 @@ async function viewPage (req, res, next) {
     const link = await policyBucket.generatePrivateLink(documentConfig)
     logger.info(`User ${req.user.externalId} signed private link for ${key}: ${link}`)
 
-    const contentHtml = await getDocumentHtml(documentConfig, key)
-
-    return response(req, res, documentConfig.template, { link, contentHtml })
+    return response(req, res, documentConfig.template, { link })
   } catch (err) {
     next(err)
   }

--- a/app/controllers/policy/policy.controller.test.js
+++ b/app/controllers/policy/policy.controller.test.js
@@ -35,14 +35,9 @@ describe('policy HTML download controller', () => {
         resolve('html-url-link')
       })
     })
-    const mockBucketGetHTMLContent = sinon.spy(() => {
-      return new Promise(resolve => {
-        resolve('html content')
-      })
-    })
+
     const mockBucketService = {
-      generatePrivateLink: mockBucketGetLinkToPdf,
-      getDocumentHtmlFromS3: mockBucketGetHTMLContent
+      generatePrivateLink: mockBucketGetLinkToPdf
     }
     const controller = getController(mockBucketService)
     it('should call s3 policy bucket for private link and download document', async function () {
@@ -50,11 +45,9 @@ describe('policy HTML download controller', () => {
       await controller(req, res, next)
 
       sinon.assert.calledWith(mockBucketService.generatePrivateLink, documentConfig)
-      sinon.assert.calledWith(mockBucketService.getDocumentHtmlFromS3, documentConfig)
-      sinon.assert.calledWith(res.render, 'policy/document/stripe-connected-account-agreement',
+      sinon.assert.calledWith(res.render, 'policy/document/v2/stripe-connected-account-agreement',
         sinon.match({
-          link: 'html-url-link',
-          contentHtml: 'html content'
+          link: 'html-url-link'
         }))
       sinon.assert.notCalled(res.redirect)
       sinon.assert.notCalled(next)
@@ -71,8 +64,7 @@ describe('policy HTML download controller', () => {
       })
     })
     const mockBucketService = {
-      generatePrivateLink: mockBucketGetLinkToPdf,
-      getDocumentHtmlFromS3: sinon.spy()
+      generatePrivateLink: mockBucketGetLinkToPdf
     }
     const controller = getController(mockBucketService)
     it('should handle error with grace', async function () {
@@ -80,7 +72,6 @@ describe('policy HTML download controller', () => {
       await controller(req, res, next)
 
       sinon.assert.calledWith(mockBucketService.generatePrivateLink, documentConfig)
-      sinon.assert.notCalled(mockBucketService.getDocumentHtmlFromS3)
       sinon.assert.notCalled(res.render)
       sinon.assert.notCalled(res.redirect)
       sinon.assert.called(next)
@@ -93,17 +84,9 @@ describe('policy HTML download controller', () => {
         resolve('html-url-link')
       })
     })
-    const mockBucketGetHTMLContent = sinon.spy(() => {
-      return new Promise((resolve, reject) => {
-        const error = new Error()
-        error.code = '404'
-        error.message = 'invalid path'
-        reject(error)
-      })
-    })
+
     const mockBucketService = {
-      generatePrivateLink: mockBucketGetLinkToPdf,
-      getDocumentHtmlFromS3: mockBucketGetHTMLContent
+      generatePrivateLink: mockBucketGetLinkToPdf
     }
     const controller = getController(mockBucketService)
     it('should render page with link', async function () {
@@ -111,11 +94,9 @@ describe('policy HTML download controller', () => {
       await controller(req, res, next)
 
       sinon.assert.calledWith(mockBucketService.generatePrivateLink, documentConfig)
-      sinon.assert.calledWith(mockBucketService.getDocumentHtmlFromS3, documentConfig)
-      sinon.assert.calledWith(res.render, 'policy/document/stripe-connected-account-agreement',
+      sinon.assert.calledWith(res.render, 'policy/document/v2/stripe-connected-account-agreement',
         sinon.match({
-          link: 'html-url-link',
-          contentHtml: 'Error displaying content'
+          link: 'html-url-link'
         }))
       sinon.assert.notCalled(res.redirect)
       sinon.assert.notCalled(next)

--- a/app/controllers/policy/supported-policy-documents.js
+++ b/app/controllers/policy/supported-policy-documents.js
@@ -6,17 +6,17 @@ const supportedPolicyDocuments = [
   {
     key: 'memorandum-of-understanding-for-crown-bodies',
     title: 'Pay memorandum of understanding',
-    template: 'policy/document/memorandum-of-understanding-for-crown-bodies'
+    template: 'policy/document/v2/memorandum-of-understanding-for-crown-bodies'
   },
   {
     key: 'contract-for-non-crown-bodies',
     title: 'Pay contract',
-    template: 'policy/document/contract-for-non-crown-bodies'
+    template: 'policy/document/v2/contract-for-non-crown-bodies'
   },
   {
     key: 'stripe-connected-account-agreement',
     title: 'Stripe Connected Account Agreement',
-    template: 'policy/document/stripe-connected-account-agreement'
+    template: 'policy/document/v2/stripe-connected-account-agreement'
   },
   {
     key: 'pci-dss-attestation-of-compliance',

--- a/app/controllers/stripe-setup/company-number/post.controller.test.js
+++ b/app/controllers/stripe-setup/company-number/post.controller.test.js
@@ -80,7 +80,7 @@ describe('Company number POST controller', () => {
     const controller = getControllerWithMocks()
 
     req.body = {
-      'company-number-declaration': 'false',
+      'company-number-declaration': 'false'
     }
 
     await controller(req, res, next)

--- a/app/views/includes/footer-categories.njk
+++ b/app/views/includes/footer-categories.njk
@@ -44,13 +44,13 @@
       <h2 class="govuk-footer__heading govuk-heading-m govuk-!-margin-bottom-4 govuk-!-padding-bottom-0 pay-!-border-bottom-0">Legal Terms</h2>
       <ul class="govuk-footer__list">
         <li class="govuk-footer__list-item">
-          <a class="govuk-footer__link" href="/policy/memorandum-of-understanding-for-crown-bodies-2022">Memorandum of understanding for Crown bodies</a>
+          <a class="govuk-footer__link" href="/policy/memorandum-of-understanding-for-crown-bodies">Memorandum of understanding for Crown bodies</a>
         </li>
         <li class="govuk-footer__list-item">
-          <a class="govuk-footer__link" href="/policy/contract-for-non-crown-bodies-2022">Contract for non-Crown bodies</a>
+          <a class="govuk-footer__link" href="/policy/contract-for-non-crown-bodies">Contract for non-Crown bodies</a>
         </li>
         <li class="govuk-footer__list-item">
-          <a class="govuk-footer__link" href="/policy/stripe-connected-account-agreement-2022">Stripe Connected Account Agreement</a>
+          <a class="govuk-footer__link" href="/policy/stripe-connected-account-agreement">Stripe Connected Account Agreement</a>
         </li>
         <li class="govuk-footer__list-item">
           <a class="govuk-footer__link" href="/policy/pci-dss-attestation-of-compliance">Attestation of Compliance for PCI</a>


### PR DESCRIPTION
- Revert change with Footer links point to the new 2022 URL.
  - Make them link to the original URL.
- Update the orignal contract URLs to use the new V2 policy template files.
- policy.controller
  - Remove call to get HTML from S3.
  - We will add this back later once we have HTML versions of the contracts.



