### PR TITLE
BAU — Fix ‘Request a live account’ link in payment link success box

### DIFF
--- a/app/views/payment-links/manage.njk
+++ b/app/views/payment-links/manage.njk
@@ -20,7 +20,7 @@
           Your Payment link is ready to test
         </p>
         <p class="govuk-body">
-          To start collecting payments, you need to <a class="govuk-link" href="{{formatServicePathsFor(routes.service.requestToGoLive.index, service.external_id)}}">Request a live account</a>. Once live, you’ll need to recreate your Payment link before you can give it to users.
+          To start collecting payments, you need to <a class="govuk-link" href="{{formatServicePathsFor(routes.service.requestToGoLive.index, currentService.externalId)}}">Request a live account</a>. Once live, you’ll need to recreate your Payment link before you can give it to users.
         </p>
     {% endset %}
   {% else %}

--- a/test/cypress/integration/payment-links/create-payment-link.cy.test.js
+++ b/test/cypress/integration/payment-links/create-payment-link.cy.test.js
@@ -5,6 +5,7 @@ const productStubs = require('../../stubs/products-stubs')
 const userExternalId = 'a-user-id'
 const gatewayAccountId = 42
 const gatewayAccountExternalId = 'a-valid-account-id'
+const serviceExternalId = 'a-valid-service-id'
 const serviceName = {
   en: 'pay for something',
   cy: 'talu am rywbeth'
@@ -13,7 +14,7 @@ const serviceName = {
 describe('The create payment link flow', () => {
   beforeEach(() => {
     cy.task('setupStubs', [
-      userStubs.getUserSuccess({ userExternalId: userExternalId, gatewayAccountId, serviceName }),
+      userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceExternalId, serviceName }),
       gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'test', paymentProvider: 'worldpay' }),
       tokenStubs.postCreateTokenForAccountSuccess({ gatewayAccountId }),
       productStubs.postCreateProductSuccess(),
@@ -272,6 +273,7 @@ describe('The create payment link flow', () => {
         })
 
         cy.get('.govuk-notification-banner--success').should('contain', 'Your Payment link is ready to test')
+        cy.get('.govuk-notification-banner--success a').should('have.attr', 'href', `/service/${serviceExternalId}/request-to-go-live`)
       })
     })
   })


### PR DESCRIPTION
Fix the ‘Request a live account’ link that appears in the success message after creating a test payment.