### PR TITLE
PP-9239: Run pact tests post-merge

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,93 @@
+name: Post Merge
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - .github/workflows/post-merge.yml
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    uses: ./.github/workflows/run-tests.yml
+
+  publish-selfservice-consumer-contract-tests:
+    needs: tests
+    runs-on: ubuntu-18.04
+
+    name: Publish and tag selfservice consumer pact
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - name: Parse Node version
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: parse-node-version
+      - name: Setup
+        uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
+        with:
+          node-version: "${{ steps.parse-node-version.outputs.NVMRC }}"
+      - name: Cache build directories
+        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
+        with:
+          path: |
+            node_modules
+            govuk_modules
+            public
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}
+      - name: Cache pacts directory
+        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
+        with:
+          path: pacts
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}-pacts
+      - name: Publish and tag selfservice consumer pact
+        env:
+          PACT_BROKER_URL: https://pay-pact-broker.cloudapps.digital
+          PACT_CONSUMER_VERSION: ${{ github.sha }}
+          PACT_BROKER_USERNAME: ${{ secrets.pact_broker_username }}
+          PACT_BROKER_PASSWORD: ${{ secrets.pact_broker_password }}
+          PACT_CONSUMER_TAG: starling-test
+        run: npm run publish-pacts
+
+  adminusers-provider-contract-tests:
+    needs: publish-selfservice-consumer-contract-tests
+    uses: alphagov/pay-adminusers/.github/workflows/_run-pact-provider-tests.yml@master
+    with:
+      consumer: selfservice
+      consumer_tag: starling-test
+    secrets:
+      pact_broker_username: ${{ secrets.pact_broker_username }}
+      pact_broker_password: ${{ secrets.pact_broker_password }}
+
+  connector-provider-contract-tests:
+    needs: publish-selfservice-consumer-contract-tests
+    uses: alphagov/pay-connector/.github/workflows/_run-pact-provider-tests.yml@master
+    with:
+      consumer: selfservice
+      consumer_tag: starling-test
+    secrets:
+      pact_broker_username: ${{ secrets.pact_broker_username }}
+      pact_broker_password: ${{ secrets.pact_broker_password }}
+
+  ledger-provider-contract-tests:
+    needs: publish-selfservice-consumer-contract-tests
+    uses: alphagov/pay-ledger/.github/workflows/_run-pact-provider-tests.yml@master
+    with:
+      consumer: selfservice
+      consumer_tag: starling-test
+    secrets:
+      pact_broker_username: ${{ secrets.pact_broker_username }}
+      pact_broker_password: ${{ secrets.pact_broker_password }}
+
+  products-provider-contract-tests:
+    needs: publish-selfservice-consumer-contract-tests
+    uses: alphagov/pay-products/.github/workflows/_run-pact-provider-tests.yml@master
+    with:
+      consumer: selfservice
+      consumer_tag: starling-test
+    secrets:
+      pact_broker_username: ${{ secrets.pact_broker_username }}
+      pact_broker_password: ${{ secrets.pact_broker_password }}

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    paths:
-      - .github/workflows/post-merge.yml
 
 permissions:
   contents: read
@@ -49,7 +46,7 @@ jobs:
           PACT_CONSUMER_VERSION: ${{ github.sha }}
           PACT_BROKER_USERNAME: ${{ secrets.pact_broker_username }}
           PACT_BROKER_PASSWORD: ${{ secrets.pact_broker_password }}
-          PACT_CONSUMER_TAG: starling-test
+          PACT_CONSUMER_TAG: master
         run: npm run publish-pacts
 
   adminusers-provider-contract-tests:
@@ -57,7 +54,7 @@ jobs:
     uses: alphagov/pay-adminusers/.github/workflows/_run-pact-provider-tests.yml@master
     with:
       consumer: selfservice
-      consumer_tag: starling-test
+      consumer_tag: master
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}
@@ -67,7 +64,7 @@ jobs:
     uses: alphagov/pay-connector/.github/workflows/_run-pact-provider-tests.yml@master
     with:
       consumer: selfservice
-      consumer_tag: starling-test
+      consumer_tag: master
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}
@@ -77,7 +74,7 @@ jobs:
     uses: alphagov/pay-ledger/.github/workflows/_run-pact-provider-tests.yml@master
     with:
       consumer: selfservice
-      consumer_tag: starling-test
+      consumer_tag: master
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}
@@ -87,7 +84,7 @@ jobs:
     uses: alphagov/pay-products/.github/workflows/_run-pact-provider-tests.yml@master
     with:
       consumer: selfservice
-      consumer_tag: starling-test
+      consumer_tag: master
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,9 +1,7 @@
 name: Github Actions Tests
 
 on:
-  push:
-    branches:
-      - master
+  workflow_call:
   pull_request:
 
 permissions:
@@ -82,6 +80,11 @@ jobs:
             govuk_modules
             public
           key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}
+      - name: Cache pacts directory
+        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
+        with:
+          path: pacts
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}-pacts
       - name: Run unit tests
         run: npm test -- --forbid-only --forbid-pending
 


### PR DESCRIPTION
## WHAT
1. Cache consumer pact files from unit tests to use in post-merge
2. Add post-merge pact tests

## HOW 
Prior to removing the post-merge PR test this run completed succesfully with a `starling-test` pact tag: https://github.com/alphagov/pay-selfservice/actions/runs/1986521835
