### PR TITLE
PP-9007: Limit "Last 4 card numbers" field in transactions search to …

### DIFF
--- a/app/views/transactions/filter.njk
+++ b/app/views/transactions/filter.njk
@@ -73,7 +73,8 @@
           attributes: {
             "autocomplete": "off",
             "inputmode": "numeric",
-            "pattern": "[0-9]*"
+            "pattern": "[0-9]*",
+            "maxlength": "4"
           }
         })
       }}


### PR DESCRIPTION
…4 chars

This is also to prevent users from entering full payment card numbers,
especially as we log search criteria.

I've tested this locally and verified adding the "maxlength" parameter works.