### PR TITLE
PP-8608 remove deprecated stripe contract fee handling

### DIFF
--- a/app/controllers/all-service-transactions/download-transactions.controller.js
+++ b/app/controllers/all-service-transactions/download-transactions.controller.js
@@ -6,8 +6,6 @@ const Stream = require('../../services/clients/stream.client')
 const { CORRELATION_HEADER } = require('../../utils/correlation-header')
 const permissions = require('../../utils/permissions')
 const { NoServicesWithPermissionError } = require('../../errors')
-const enableFeeBreakDownForTestAccounts = process.env.ENABLE_FEE_BREAKDOWN_IN_CSV_FOR_STRIPE_TEST_ACCOUNTS === 'true'
-const includeFeeBreakdownHeadersFromDate = process.env.INCLUDE_FEE_BREAKDOWN_HEADERS_IN_CSV_DATE || '1642982460'
 
 module.exports = async function dowmloadTransactions (req, res, next) {
   const filters = req.query
@@ -25,12 +23,6 @@ module.exports = async function dowmloadTransactions (req, res, next) {
       return next(new NoServicesWithPermissionError('You do not have any associated services with rights to view these transactions.'))
     }
     filters.feeHeaders = userPermittedAccountsSummary.headers.shouldGetStripeHeaders
-
-    if (filters.feeHeaders) {
-      filters.feeBreakdownHeaders = (Math.round(Date.now() / 1000) >= includeFeeBreakdownHeadersFromDate) ||
-        (!filterLiveAccounts && enableFeeBreakDownForTestAccounts)
-    }
-
     filters.motoHeader = userPermittedAccountsSummary.headers.shouldGetMotoHeaders
     const url = transactionService.csvSearchUrl(filters, userPermittedAccountsSummary.gatewayAccountIds)
 

--- a/app/controllers/transactions/transaction-download.controller.js
+++ b/app/controllers/transactions/transaction-download.controller.js
@@ -5,8 +5,6 @@ const date = require('../../utils/dates')
 const { renderErrorView } = require('../../utils/response')
 const { CORRELATION_HEADER } = require('../../utils/correlation-header')
 const Stream = require('../../services/clients/stream.client')
-const enableFeeBreakDownForTestAccounts = process.env.ENABLE_FEE_BREAKDOWN_IN_CSV_FOR_STRIPE_TEST_ACCOUNTS === 'true'
-const includeFeeBreakdownHeadersFromDate = process.env.INCLUDE_FEE_BREAKDOWN_HEADERS_IN_CSV_DATE || '1642982460'
 
 const fetchTransactionCsvWithHeader = function fetchTransactionCsvWithHeader (req, res) {
   const accountId = req.account.gateway_account_id
@@ -16,9 +14,6 @@ const fetchTransactionCsvWithHeader = function fetchTransactionCsvWithHeader (re
 
   if (req.account && req.account.payment_provider === 'stripe') {
     filters.feeHeaders = true
-
-    const includeFeeBreakdownHeaders = Math.round(Date.now() / 1000) >= includeFeeBreakdownHeadersFromDate
-    filters.feeBreakdownHeaders = includeFeeBreakdownHeaders || (req.account.type === 'test' && enableFeeBreakDownForTestAccounts)
   }
 
   filters.motoHeader = req.account && req.account.allow_moto

--- a/app/utils/get-query-string-for-params.js
+++ b/app/utils/get-query-string-for-params.js
@@ -15,7 +15,6 @@ function getQueryStringForParams (params = {}, removeEmptyParams = false, flatte
     from_date: dates.fromDateToApiFormat(params.fromDate, params.fromTime),
     to_date: dates.toDateToApiFormat(params.toDate, params.toTime),
     ...params.feeHeaders && { fee_headers: params.feeHeaders },
-    ...params.feeBreakdownHeaders && { fee_breakdown_headers: params.feeBreakdownHeaders },
     ...params.motoHeader && { moto_header: params.motoHeader },
     metadata_value: params.metadataValue
   }


### PR DESCRIPTION
## WHAT
- Stripe contract fee V2 is now applicable to all services which use Stripe as PSP, thus we no longer need `includeFeeBreakdownHeaders`. All Stripe csv download will contain the fee break down. Remove fee break down flag.
