### PR TITLE
PP-9542 Add agreements detail page

### DIFF
--- a/app/controllers/agreements/agreements.controller.js
+++ b/app/controllers/agreements/agreements.controller.js
@@ -1,3 +1,5 @@
+const url = require('url')
+
 const agreementsService = require('./agreements.service')
 
 const { response } = require('../../utils/response')
@@ -9,6 +11,7 @@ async function listAgreements(req, res, next) {
     ...req.query.status && { status: req.query.status },
     ...req.query.reference && { reference: req.query.reference }
   }
+  req.session.agreementsFilter = url.parse(req.url).query
 
   try {
     const agreements = await agreementsService.agreements(req.service.externalId, req.isLive, page, filters)
@@ -22,6 +25,20 @@ async function listAgreements(req, res, next) {
   }
 }
 
+async function agreementDetail(req, res, next) {
+  const listFilter = req.session.agreementsFilter
+  try {
+    const agreement = await agreementsService.agreement(req.params.agreementId, req.service.externalId)
+    response(req, res, 'agreements/detail', {
+      agreement,
+      listFilter
+    })
+  } catch (error) {
+    next(error)
+  }
+}
+
 module.exports = {
-  listAgreements
+  listAgreements,
+  agreementDetail
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -455,6 +455,7 @@ module.exports.bind = function (app) {
   account.get(stripe.addPspAccountDetails, permission('stripe-account-details:update'), restrictToStripeAccountContext, stripeSetupAddPspAccountDetailsController.get)
 
   futureAccountStrategy.get(agreements.index, permission('agreements:read'), agreementsController.listAgreements)
+  futureAccountStrategy.get(agreements.detail, permission('agreements:read'), agreementsController.agreementDetail)
 
   futureAccountStrategy.get(webhooks.index, permission('webhooks:read'), webhooksController.listWebhooksPage)
   futureAccountStrategy.get(webhooks.create, permission('webhooks:update'), webhooksController.createWebhookPage)

--- a/app/views/agreements/detail.njk
+++ b/app/views/agreements/detail.njk
@@ -1,0 +1,82 @@
+
+{% from "./macro/status.njk" import agreementStatusTag %}
+{% extends "../layout.njk" %}
+
+{% block pageTitle %}
+  Agreement details {{ agreement.external_id }} - {{ currentService.name }} - GOV.UK Pay
+{% endblock %}
+
+{% block mainContent %}
+
+{% set filter = ("?" + listFilter) if listFilter  %}
+<div class="govuk-grid-column-two-thirds">
+  {{ govukBackLink({
+    text: "Back to agreements",
+    classes: "govuk-!-margin-top-0",
+    href: formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.agreements.index, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id) + filter
+  }) }}
+
+  <h1 class="govuk-heading-l">Agreement detail</h1>
+
+  {{ govukSummaryList({
+    rows: [{
+      key: { text: "ID" },
+      value: { text: agreement.external_id }
+    },{
+      key: { text: "Reference" },
+      value: { text: agreement.reference }
+    },{
+      key: { text: "Status" },
+      value: { html: agreementStatusTag(agreement.status) }
+    },{
+      key: { text: "Description" },
+      value: { html: agreement.description },
+      attributes: {
+        id: "data-description"
+      }
+    },{
+      key: { text: "Date created" },
+      value: { html: agreement.created_date | datetime('datelong') }
+    }]
+  }) }}
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-9">Payment instrument</h2>
+  {% set paymentInstrument = agreement.payment_instrument %}
+
+  {% if paymentInstrument %}
+  {% set cardDetails = paymentInstrument.card_details %}
+
+  {% set cardMap = {
+    'visa': '/public/images/card_visa.png',
+    'master-card': '/public/images/card_mastercard.png',
+    'american-express': '/public/images/card_amex.png',
+    'unknown': '/public/images/card_unknown.png'
+  } %}
+  {% set imageUrl = cardMap[cardDetails.card_brand | lower] or cardMap.unknown %}
+  {% set image %}
+  <img src="{{ imageUrl }}" alt="Card brand {{ cardDetails.card_brand }}" height="22" class="" style="vertical-align: middle"></img>
+  {% endset %}
+  {{ govukSummaryList({
+    rows: [{
+      key: { text: "Brand" },
+      value: { html: image }
+    },{
+      key: { text: "Name on card" },
+      value: { text: cardDetails.cardholder_name }
+    },{
+      key: { text: "Card number" },
+      value: { text: "••••" + cardDetails.last_digits_card_number }
+    },{
+      key: { text: "Card expiry date" },
+      value: { text: cardDetails.expiry_date }
+    }],
+    attributes: {
+      id: "payment-instrument-list"
+    }
+  }) }}
+
+  {% else %}
+  <p id="empty-payment-instrument" class="govuk-body">No payment instrument set for this agreement.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/test/cypress/integration/agreements/agreements.cy.test.js
+++ b/test/cypress/integration/agreements/agreements.cy.test.js
@@ -40,7 +40,7 @@ const mockAgreements = [
   { external_id: 'a-valid-agreement-id-21', payment_instrument: { card_details: { card_brand: 'visa' }}}
 ]
 
-describe('Agreement list page', () => {
+describe('Agreements', () => {
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('session', 'gateway_account')
   })
@@ -83,6 +83,27 @@ describe('Agreement list page', () => {
     cy.get('.pagination.2').first().click()
 
     cy.get('.pagination.2').first().should('have.class', 'active')
+  })
+
+  it('should load the details page and preserve filter params', () => {
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs,
+      agreementStubs.getLedgerAgreementSuccess({ service_id: serviceExternalId, live: false, external_id: 'a-valid-agreement-id' })
+    ])
+
+    cy.get('[data-action=update]').then((links) => links[0].click())
+    cy.get('.govuk-heading-l').should('have.text', 'Agreement detail')
+    cy.get('.govuk-back-link').should('have.attr', 'href')
+      .and('include', 'page=2')
+      .and('include', 'status=CREATED')
+      .and('include', 'reference=a-valid-ref')
+
+    cy.get('#payment-instrument-list').should('exist')
+    cy.get('#empty-payment-instrument').should('not.exist')
+
+    cy.get('.govuk-summary-list__value').contains('Test User')
+    cy.get('.govuk-summary-list__value').contains('Reason shown to paying user for taking agreement')
+
   })
 
   it('should show no agreements content if filters return nothing', () => {

--- a/test/cypress/stubs/agreement-stubs.js
+++ b/test/cypress/stubs/agreement-stubs.js
@@ -16,14 +16,14 @@ function getLedgerAgreementsSuccess (opts) {
   })
 }
 
-function getLedgerAgreementSuccess(opts) {
-  const agreement = opts.agreement || {}
+function getLedgerAgreementSuccess(opts = {}) {
+  const agreement = agreementFixtures.validAgreementResponse(opts)
   const path = `/v1/agreement/${agreement.external_id}`
   return stubBuilder('GET', path, 200, {
     query: {
       service_id: opts.service_id
     },
-    response: agreementFixtures.validAgreementResponse(agreement)
+    response: agreement
   })
 }
 


### PR DESCRIPTION
Adds page to show agreement details and their payment instrument (if it
exists).

Agreement detail pages follows roughly the same pattern as transaction list -> transaction detail.

Caches the filters from the list page in the session to appropriately
return the user to their context.

Uses macros from the agreement list page for consistency.

---

**Agreement that needs payment instrument**

<img width="610" alt="Screenshot 2022-05-12 at 18 22 43" src="https://user-images.githubusercontent.com/2844572/168133101-f6773d8e-053d-422e-ad84-3d4c24200480.png">

---

**Active agreement**

<img width="609" alt="Screenshot 2022-05-12 at 18 22 28" src="https://user-images.githubusercontent.com/2844572/168133118-0b372797-0aaf-4a14-947b-e44dff625eb0.png">

