### PR TITLE
BAU — Remove LastPass Authenticator link and add FreeOTP link

### DIFF
--- a/app/views/two-factor-auth/index.njk
+++ b/app/views/two-factor-auth/index.njk
@@ -65,8 +65,8 @@
     <ul class="govuk-list govuk-list--bullet">
       <li><a class="govuk-link" href="https://authy.com/">Authy</a></li>
       <li><a class="govuk-link" href="https://duo.com/product/multi-factor-authentication-mfa/duo-mobile-app">Duo Mobile</a></li>
+      <li><a class="govuk-link" href="https://freeotp.github.io/">FreeOTP</a></li>
       <li><a class="govuk-link" href="https://support.google.com/accounts/answer/1066447">Google Authenticator</a></li>
-      <li><a class="govuk-link" href="https://lastpass.com/auth/">LastPass Authenticator</a></li>
       <li><a class="govuk-link" href="https://www.microsoft.com/en-gb/security/mobile-authenticator-app">Microsoft Authenticator</a></li>
     </ul>
   {% endset %}


### PR DESCRIPTION
In our list of suggested authenticator apps, remove LastPass Authenticator because the page we link to —
https://lastpass.com/auth/ — now redirects to https://www.lastpass.com/solutions/authentication and extols the virtues of ‘Customizable authentication methods with admin oversight’ and tries to persuade me to sign up for LastPass Business. There is no link to download LastPass Authenticator any more (the app does still seem to be available in the iOS App Store and Google Play but the only page on the LastPass site with download links seems to be a support page at https://support.lastpass.com/help/enroll-the-lastpass-authenticator-app where the download links are buried in the middle of a bunch of steps for enabling 2FA on a LastPass vault, which is not user-friendly).

Replace it with a link to FreeOTP, which is a simple authenticator app published by Red Hat.