### PR TITLE
PP-9004 Show org details on the `check your org` details page

### DIFF
--- a/app/controllers/stripe-setup/check-org-details/get.controller.js
+++ b/app/controllers/stripe-setup/check-org-details/get.controller.js
@@ -16,5 +16,15 @@ module.exports = (req, res, next) => {
     return response(req, res, 'error-with-link', errorPageData)
   }
 
-  return response(req, res, 'stripe-setup/check-org-details/index')
+  const { merchantDetails } = req.service
+
+  const data = {
+    orgName: merchantDetails.name,
+    orgAddressLine1: merchantDetails.address_line1,
+    orgAddressLine2: merchantDetails.address_line2,
+    orgCity: merchantDetails.address_city,
+    orgPostcode: merchantDetails.address_postcode
+  }
+
+  return response(req, res, 'stripe-setup/check-org-details/index', data)
 }

--- a/app/controllers/stripe-setup/check-org-details/get.controller.test.js
+++ b/app/controllers/stripe-setup/check-org-details/get.controller.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const sinon = require('sinon')
+const { expect } = require('chai')
 const getController = require('./get.controller')
 
 describe('Check org details - get controller', () => {
@@ -16,7 +17,20 @@ describe('Check org details - get controller', () => {
         external_id: 'a-valid-external-id',
         connectorGatewayAccountStripeProgress: {}
       },
-      flash: sinon.spy()
+      flash: sinon.spy(),
+      service: {
+        merchantDetails: {
+          name: 'Test organisation',
+          address_line1: 'Test address line 1',
+          address_line2: 'Test address line 2',
+          address_city: 'London',
+          address_postcode: 'N1 1NN'
+        }
+      },
+      user: {
+        getPermissionsForService: sinon.stub().returns(null),
+        isAdminUserForService: sinon.stub().returns(null)
+      }
     }
     res = {
       redirect: sinon.spy(),
@@ -44,11 +58,19 @@ describe('Check org details - get controller', () => {
     sinon.assert.calledWith(res.render, 'error-with-link')
   })
 
-  it('should render `check your organisation` form if details are not yet submitted', async () => {
+  it('should render `check your organisation` form if details are not yet submitted with the org name and address', async () => {
     req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
 
     await getController(req, res)
 
-    sinon.assert.calledWith(res.render, `stripe-setup/check-org-details/index`)
+    const renderArgs = res.render.getCalls()[0]
+    expect(renderArgs.args[0]).to.equal('stripe-setup/check-org-details/index')
+
+    const pageData = renderArgs.args[1]
+    expect(pageData.orgName).to.equal('Test organisation')
+    expect(pageData.orgAddressLine1).to.equal('Test address line 1')
+    expect(pageData.orgAddressLine2).to.equal('Test address line 2')
+    expect(pageData.orgCity).to.equal('London')
+    expect(pageData.orgPostcode).to.equal('N1 1NN')
   })
 })

--- a/app/controllers/stripe-setup/check-org-details/post.controller.js
+++ b/app/controllers/stripe-setup/check-org-details/post.controller.js
@@ -26,7 +26,18 @@ module.exports = (req, res, next) => {
   const errors = validateConfirmOrgDetails(confirmOrgDetails)
 
   if (!lodash.isEmpty(errors)) {
-    return response(req, res, 'stripe-setup/check-org-details/index', { errors })
+    const { merchantDetails } = req.service
+
+    const data = {
+      errors: errors,
+      orgName: merchantDetails.name,
+      orgAddressLine1: merchantDetails.address_line1,
+      orgAddressLine2: merchantDetails.address_line2,
+      orgCity: merchantDetails.address_city,
+      orgPostcode: merchantDetails.address_postcode
+    }
+
+    return response(req, res, 'stripe-setup/check-org-details/index', data)
   }
 }
 

--- a/app/controllers/stripe-setup/check-org-details/post.controller.test.js
+++ b/app/controllers/stripe-setup/check-org-details/post.controller.test.js
@@ -17,6 +17,19 @@ describe('Check org details - post controller', () => {
         external_id: 'a-valid-external-id',
         connectorGatewayAccountStripeProgress: {}
       },
+      service: {
+        merchantDetails: {
+          name: 'Test organisation',
+          address_line1: 'Test address line 1',
+          address_line2: 'Test address line 2',
+          address_city: 'London',
+          address_postcode: 'N1 1NN'
+        }
+      },
+      user: {
+        getPermissionsForService: sinon.stub().returns(null),
+        isAdminUserForService: sinon.stub().returns(null)
+      },
       flash: sinon.spy()
     }
     res = {
@@ -48,15 +61,20 @@ describe('Check org details - post controller', () => {
     sinon.assert.calledWith(res.render, 'error-with-link')
   })
 
-  it('when no radio button is selected, then it should display the page with an error', async () => {
+  it('when no radio button is selected, then it should display the page with an error and the org name and address', async () => {
     req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
 
     controller(req, res, next)
 
-    sinon.assert.calledWith(res.render, `stripe-setup/check-org-details/index`)
-
     const renderArgs = res.render.getCalls()[0]
     expect(renderArgs.args[0]).to.equal('stripe-setup/check-org-details/index')
-    expect(renderArgs.args[1].errors['confirmOrgDetails']).to.equal('Select yes if your organisation’s details match the details on your government entity document')
+
+    const pageData = renderArgs.args[1]
+    expect(pageData.errors['confirmOrgDetails']).to.equal('Select yes if your organisation’s details match the details on your government entity document')
+    expect(pageData.orgName).to.equal('Test organisation')
+    expect(pageData.orgAddressLine1).to.equal('Test address line 1')
+    expect(pageData.orgAddressLine2).to.equal('Test address line 2')
+    expect(pageData.orgCity).to.equal('London')
+    expect(pageData.orgPostcode).to.equal('N1 1NN')
   })
 })

--- a/app/views/stripe-setup/check-org-details/index.njk
+++ b/app/views/stripe-setup/check-org-details/index.njk
@@ -26,6 +26,14 @@
   <form method="post">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
+    {% set orgFullAddressHtml =  orgAddressLine1 %}
+    
+    {% if orgAddressLine2 %}
+      {% set orgFullAddressHtml =  orgFullAddressHtml + '</br>' + orgAddressLine2 %}
+    {% endif %}
+
+    {% set orgFullAddressHtml =  orgFullAddressHtml  + '</br>' + orgCity + '</br>' + orgPostcode %}
+
     {{ govukSummaryList({
       rows: [
         {
@@ -33,7 +41,7 @@
             text: "Organisation name"
           },
           value: {
-            text: "TODO - Add org name"
+            text: orgName
           }
         },
         {
@@ -41,7 +49,7 @@
             text: "Address"
           },
           value: {
-            html: "TODO - add address"
+            html: orgFullAddressHtml
           }
         }
       ]


### PR DESCRIPTION
- Post & Get controllers
 - Get the org name and address from `req.service`
 - Add this to the page data.
- Nunjuks file
 - Get the org name and address from the page data.
 - Display this in the Summary table.
- Update unit tests


