### PR TITLE
PP-9004 `Check org details page` - update tests and add functionality…

### DIFF
--- a/app/controllers/stripe-setup/check-org-details/get.controller.test.js
+++ b/app/controllers/stripe-setup/check-org-details/get.controller.test.js
@@ -3,34 +3,36 @@
 const sinon = require('sinon')
 const { expect } = require('chai')
 const getController = require('./get.controller')
+const Service = require('../../../models/Service.class')
+const User = require('../../../models/User.class')
+const serviceFixtures = require('../../../../test/fixtures/service.fixtures')
+const userFixtures = require('../../../../test/fixtures/user.fixtures')
+const gatewayAccountFixture = require('../../../../test/fixtures/gateway-account.fixtures')
 
 describe('Check org details - get controller', () => {
   let req
   let res
   let next
 
+  const service = new Service(serviceFixtures.validServiceResponse({
+    merchant_details: {
+      name: 'Test organisation',
+      address_line1: 'Test address line 1',
+      address_line2: 'Test address line 2',
+      address_city: 'London',
+      address_postcode: 'N1 1NN'
+    }
+  }))
+
+  const user = new User(userFixtures.validUserResponse())
+
   beforeEach(() => {
     req = {
       correlationId: 'correlation-id',
-      account: {
-        gateway_account_id: '1',
-        external_id: 'a-valid-external-id',
-        connectorGatewayAccountStripeProgress: {}
-      },
+      account: gatewayAccountFixture.validGatewayAccount({}),
       flash: sinon.spy(),
-      service: {
-        merchantDetails: {
-          name: 'Test organisation',
-          address_line1: 'Test address line 1',
-          address_line2: 'Test address line 2',
-          address_city: 'London',
-          address_postcode: 'N1 1NN'
-        }
-      },
-      user: {
-        getPermissionsForService: sinon.stub().returns(null),
-        isAdminUserForService: sinon.stub().returns(null)
-      }
+      service: service,
+      user: user
     }
     res = {
       redirect: sinon.spy(),

--- a/app/controllers/stripe-setup/check-org-details/post.controller.test.js
+++ b/app/controllers/stripe-setup/check-org-details/post.controller.test.js
@@ -1,35 +1,70 @@
 'use strict'
 
 const sinon = require('sinon')
+const proxyquire = require('proxyquire')
 const { expect } = require('chai')
-const controller = require('./post.controller')
+const Service = require('../../../models/Service.class')
+const User = require('../../../models/User.class')
+const serviceFixtures = require('../../../../test/fixtures/service.fixtures')
+const userFixtures = require('../../../../test/fixtures/user.fixtures')
+const gatewayAccountFixture = require('../../../../test/fixtures/gateway-account.fixtures')
 
 describe('Check org details - post controller', () => {
   let req
   let res
   let next
 
-  beforeEach(() => {
-    req = {
-      correlationId: 'correlation-id',
-      account: {
-        gateway_account_id: '1',
-        external_id: 'a-valid-external-id',
-        connectorGatewayAccountStripeProgress: {}
-      },
-      service: {
-        merchantDetails: {
-          name: 'Test organisation',
-          address_line1: 'Test address line 1',
-          address_line2: 'Test address line 2',
-          address_city: 'London',
-          address_postcode: 'N1 1NN'
+  const setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
+  const loggerInfoMock = sinon.spy(() => Promise.resolve())
+  const stripeAcountId = 'acct_123example123'
+
+  function getControllerWithMocks () {
+    return proxyquire('./post.controller', {
+      '../../../services/clients/connector.client': {
+        ConnectorClient: function () {
+          this.setStripeAccountSetupFlag = setStripeAccountSetupFlagMock
         }
       },
-      user: {
-        getPermissionsForService: sinon.stub().returns(null),
-        isAdminUserForService: sinon.stub().returns(null)
+      '../stripe-setup.util': {
+        getStripeAccountId: () => {
+          return Promise.resolve(stripeAcountId)
+        }
       },
+      '../../../utils/logger': function (filename) {
+        return {
+          info: loggerInfoMock
+        }
+      }
+    })
+  }
+
+  const service = new Service(serviceFixtures.validServiceResponse({
+    merchant_details: {
+      name: 'Test organisation',
+      address_line1: 'Test address line 1',
+      address_line2: 'Test address line 2',
+      address_city: 'London',
+      address_postcode: 'N1 1NN'
+    }
+  }))
+
+  const user = new User(userFixtures.validUserResponse())
+
+  const credentialId = 'a-valid-credential-id'
+
+  const controller = getControllerWithMocks()
+
+  beforeEach(() => {
+    req = {
+      params: { credentialId },
+      correlationId: 'correlation-id',
+      account: gatewayAccountFixture.validGatewayAccount({
+        gateway_account_credentials: [{
+          external_id: credentialId
+        }]
+      }),
+      service: service,
+      user: user,
       flash: sinon.spy()
     }
     res = {
@@ -40,9 +75,12 @@ describe('Check org details - post controller', () => {
     }
 
     next = sinon.spy()
+
+    setStripeAccountSetupFlagMock.resetHistory()
+    loggerInfoMock.resetHistory()
   })
 
-  it('should render error page when stripe setup is not available on request', async () => {
+  it('should render error page when stripe setup is not available on request', () => {
     req.account.connectorGatewayAccountStripeProgress = undefined
 
     controller(req, res, next)
@@ -53,7 +91,7 @@ describe('Check org details - post controller', () => {
     sinon.assert.calledWith(next, expectedError)
   })
 
-  it('when organisation details are already provided, should display an error', async () => {
+  it('when organisation details are already provided, should display an error', () => {
     req.account.connectorGatewayAccountStripeProgress = { organisationDetails: true }
 
     controller(req, res, next)
@@ -61,7 +99,7 @@ describe('Check org details - post controller', () => {
     sinon.assert.calledWith(res.render, 'error-with-link')
   })
 
-  it('when no radio button is selected, then it should display the page with an error and the org name and address', async () => {
+  it('when no radio button is selected, then it should display the page with an error and the org name and address', () => {
     req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
 
     controller(req, res, next)
@@ -76,5 +114,33 @@ describe('Check org details - post controller', () => {
     expect(pageData.orgAddressLine2).to.equal('Test address line 2')
     expect(pageData.orgCity).to.equal('London')
     expect(pageData.orgPostcode).to.equal('N1 1NN')
+  })
+
+  describe('radio buttons', () => {
+    it('when `no` radio button is selected, then it should redirect to org address page', () => {
+      req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
+
+      req.body = {
+        'confirm-org-details': 'no'
+      }
+
+      controller(req, res, next)
+
+      sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/your-psp/a-valid-credential-id/update-organisation-details')
+    })
+
+    it('when `yes` radio button is selected, then it should redirect to the `Stripe > add psp account details` redirect route', async () => {
+      req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
+
+      req.body = {
+        'confirm-org-details': 'yes'
+      }
+
+      await controller(req, res, next)
+
+      sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'organisation_details', req.correlationId)
+      sinon.assert.calledWith(loggerInfoMock, 'Organisation details confirmed for Stripe account', { stripe_account_id: stripeAcountId })
+      sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/stripe/add-psp-account-details')
+    })
   })
 })

--- a/app/paths.js
+++ b/app/paths.js
@@ -147,7 +147,8 @@ module.exports = {
         companyNumber: '/your-psp/:credentialId/company-number',
         governmentEntityDocument: '/your-psp/:credentialId/government-entity-document',
         director: '/your-psp/:credentialId/director',
-        checkOrgDetails: '/your-psp/:credentialId/check-organisation-details'
+        checkOrgDetails: '/your-psp/:credentialId/check-organisation-details',
+        updateOrgDetails: '/your-psp/:credentialId/update-organisation-details'
       }
     }
   },

--- a/app/routes.js
+++ b/app/routes.js
@@ -455,6 +455,7 @@ module.exports.bind = function (app) {
   account.post([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument, kyc.governmentEntityDocument], permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, uploadGovernmentEntityDocument, stripeSetupGovernmentEntityDocument.post)
   account.get(yourPsp.stripeSetup.checkOrgDetails, permission('stripe-organisation-details:update'), stripeSetupCheckOrgDetailsController.get)
   account.post(yourPsp.stripeSetup.checkOrgDetails, permission('stripe-organisation-details:update'), stripeSetupCheckOrgDetailsController.post)
+  account.get(yourPsp.stripeSetup.updateOrgDetails, permission('stripe-organisation-details:update'), requestToGoLiveOrganisationAddressController.get)
 
   account.get(stripe.addPspAccountDetails, permission('stripe-account-details:update'), restrictToStripeAccountContext, stripeSetupAddPspAccountDetailsController.get)
 

--- a/app/views/stripe-setup/check-org-details/index.njk
+++ b/app/views/stripe-setup/check-org-details/index.njk
@@ -1,4 +1,4 @@
-{% extends "layout.njk" %}
+{% extends "../../layout.njk" %}
 {% from "../../macro/error-summary.njk" import errorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 


### PR DESCRIPTION
… for radio buttons

- Update Nunjuks file
  - Fix path to layout template.
- Add new route for the `your PSP > update org details` page
  - Will use the same controller as `request to go live > org address` page
  - Controller will be updated to handle new functionality in a future PR.
- Add functionality for radio buttons
  - When `yes` is clicked
    - Update `admin users > go live stage` to `ENTERED_ORGANISATION_ADDRESS`
    - goes to the `your PSP > index` page.
  - When `no` is clicked - goes to the new route - `your PSP - update org details` page.
- Update tests
  - Use the `user`, `service` and `account` stubs.
  - Stub out the `credential id`


