### PR TITLE
PP-9004 - Update `request to go live > org address page` so it works with Stripe setup user journey

### DIFF
--- a/app/controllers/request-to-go-live/organisation-address/get.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/get.controller.js
@@ -11,6 +11,8 @@ const formatServicePathsFor = require('../../../utils/format-service-paths-for')
 module.exports = function getOrganisationAddress (req, res) {
   const isRequestToGoLive = Object.values(paths.service.requestToGoLive).includes(req.route && req.route.path)
 
+  const isStripeUpdateOrgDetails = paths.account.yourPsp.stripeSetup.updateOrgDetails.includes(req.route && req.route.path)
+
   if (isRequestToGoLive) {
     if (req.service.currentGoLiveStage !== goLiveStage.ENTERED_ORGANISATION_NAME) {
       return res.redirect(
@@ -32,7 +34,8 @@ module.exports = function getOrganisationAddress (req, res) {
       'telephone_number',
       'url'
     ]),
-    isRequestToGoLive
+    isRequestToGoLive,
+    isStripeUpdateOrgDetails
   }
   pageData.countries = countries.govukFrontendFormatted(lodash.get(pageData, 'address_country'))
   return response.response(req, res, 'request-to-go-live/organisation-address', pageData)

--- a/app/controllers/request-to-go-live/organisation-address/get.controller.test.js
+++ b/app/controllers/request-to-go-live/organisation-address/get.controller.test.js
@@ -1,0 +1,126 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const { expect } = require('chai')
+
+const goLiveStage = require('../../../models/go-live-stage')
+const Service = require('../../../models/Service.class')
+const serviceFixtures = require('../../../../test/fixtures/service.fixtures')
+
+const mockResponse = sinon.spy()
+
+const getController = function getController () {
+  return proxyquire('./get.controller', {
+    '../../../utils/response': {
+      response: mockResponse
+    }
+  })
+}
+
+const correlationId = 'correlation-id'
+
+describe('organisation address get controller', () => {
+  describe('check validation', () => {
+    let res
+
+    beforeEach(() => {
+      res = {
+        redirect: sinon.spy(),
+        render: sinon.spy()
+      }
+      mockResponse.resetHistory()
+    })
+
+    describe('request to go Live', () => {
+      it('should display the org address page and set `isRequestToGoLive=true`', () => {
+        const service = new Service(serviceFixtures.validServiceResponse({
+          current_go_live_stage: goLiveStage.ENTERED_ORGANISATION_NAME
+        }))
+
+        const req = {
+          route: {
+            path: '/request-to-go-live/organisation-address'
+          },
+          correlationId,
+          service
+        }
+
+        const controller = getController()
+
+        controller(req, res)
+
+        const responseData = mockResponse.getCalls()[0]
+
+        expect(responseData.args[2]).to.equal('request-to-go-live/organisation-address')
+
+        const pageData = responseData.args[3]
+        expect(pageData.isRequestToGoLive).to.equal(true)
+        expect(pageData.isStripeUpdateOrgDetails).to.equal(false)
+      })
+
+      it('when the organisation name has not been entered, should redirect to the `request to go live index`', () => {
+        const service = new Service(serviceFixtures.validServiceResponse({
+          current_go_live_stage: null
+        }))
+
+        const req = {
+          route: {
+            path: '/request-to-go-live/organisation-address'
+          },
+          service
+        }
+
+        const controller = getController()
+
+        controller(req, res)
+
+        sinon.assert.calledWith(res.redirect, 303, '/service/cp5wa/request-to-go-live')
+      })
+    })
+
+    describe('view page when `Stripe setup`', () => {
+      it('should display the org address page and set `isStripeUpdateOrgDetails=true`', () => {
+        const req = {
+          route: {
+            path: '/your-psp/:credentialId/update-organisation-details'
+          }
+        }
+
+        const controller = getController()
+
+        controller(req, res)
+
+        const responseData = mockResponse.getCalls()[0]
+
+        expect(responseData.args[2]).to.equal('request-to-go-live/organisation-address')
+
+        const pageData = responseData.args[3]
+        expect(pageData.isStripeUpdateOrgDetails).to.equal(true)
+        expect(pageData.isRequestToGoLive).to.equal(false)
+      })
+    })
+
+    describe('view page when not `request to go live` or `Stripe setup`', () => {
+      it('should display the org address page and set `isStripeUpdateOrgDetails=false` & `isRequestToGoLive=false`', () => {
+        const req = {
+          route: {
+            path: '/organisation-details'
+          }
+        }
+
+        const controller = getController()
+
+        controller(req, res)
+
+        const responseData = mockResponse.getCalls()[0]
+
+        expect(responseData.args[2]).to.equal('request-to-go-live/organisation-address')
+
+        const pageData = responseData.args[3]
+        expect(pageData.isStripeUpdateOrgDetails).to.equal(false)
+        expect(pageData.isRequestToGoLive).to.equal(false)
+      })
+    })
+  })
+})

--- a/app/routes.js
+++ b/app/routes.js
@@ -453,9 +453,10 @@ module.exports.bind = function (app) {
   account.post([ yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber ], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.post)
   account.get([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument, kyc.governmentEntityDocument], permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, stripeSetupGovernmentEntityDocument.get)
   account.post([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument, kyc.governmentEntityDocument], permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, uploadGovernmentEntityDocument, stripeSetupGovernmentEntityDocument.post)
-  account.get(yourPsp.stripeSetup.checkOrgDetails, permission('stripe-organisation-details:update'), stripeSetupCheckOrgDetailsController.get)
-  account.post(yourPsp.stripeSetup.checkOrgDetails, permission('stripe-organisation-details:update'), stripeSetupCheckOrgDetailsController.post)
-  account.get(yourPsp.stripeSetup.updateOrgDetails, permission('stripe-organisation-details:update'), requestToGoLiveOrganisationAddressController.get)
+  account.get(yourPsp.stripeSetup.checkOrgDetails, permission('stripe-organisation-details:update'), restrictToStripeAccountContext, stripeSetupCheckOrgDetailsController.get)
+  account.post(yourPsp.stripeSetup.checkOrgDetails, permission('stripe-organisation-details:update'), restrictToStripeAccountContext, stripeSetupCheckOrgDetailsController.post)
+  account.get(yourPsp.stripeSetup.updateOrgDetails, permission('stripe-organisation-details:update'), restrictToStripeAccountContext, requestToGoLiveOrganisationAddressController.get)
+  account.post(yourPsp.stripeSetup.updateOrgDetails, permission('stripe-organisation-details:update'), restrictToStripeAccountContext, requestToGoLiveOrganisationAddressController.post)
 
   account.get(stripe.addPspAccountDetails, permission('stripe-account-details:update'), restrictToStripeAccountContext, stripeSetupAddPspAccountDetailsController.get)
 

--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -4,6 +4,8 @@
 {% block pageTitle %}
 {% if isRequestToGoLive %}
   Enter your organisation’s contact details - Request a live account - {{ currentService.name }} - GOV.UK Pay
+{% elif isStripeUpdateOrgDetails %}
+  What is the name and address of you organisation on your government identity document? - {{ currentService.name }} - GOV.UK Pay 
 {% else %}
   Organisation details - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endif %}
@@ -26,14 +28,16 @@
   }) }}
 
   {% if isRequestToGoLive %}
-  <span id="request-to-go-live-current-step" class="govuk-caption-l">Step 1 of 3</span>
-  <h1 class="govuk-heading-l">Enter your organisation’s contact details</h1>
-  <p class="govuk-body govuk-!-margin-bottom-6">Your payment pages will automatically display this information. You can change the details later if needed.</p>
+    <span id="request-to-go-live-current-step" class="govuk-caption-l">Step 1 of 3</span>
+    <h1 class="govuk-heading-l">Enter your organisation’s contact details</h1>
+    <p class="govuk-body govuk-!-margin-bottom-6">Your payment pages will automatically display this information. You can change the details later if needed.</p>
+  {% elif isStripeUpdateOrgDetails %}
+    <h1 class="govuk-heading-l">What is the name and address of you organisation on your government identity document?</h1>
   {% else %}
-  <h1 class="govuk-heading-l">Organisation details</h1>
-  <p class="govuk-body" id="merchant-details-info">
-      Payment card schemes require the details of the organisation taking payment to be shown on payment pages.
-  </p>
+    <h1 class="govuk-heading-l">Organisation details</h1>
+    <p class="govuk-body" id="merchant-details-info">
+        Payment card schemes require the details of the organisation taking payment to be shown on payment pages.
+    </p>
   {% endif %}
 
   <form id="request-to-go-live-organisation-address-form" method="post">
@@ -45,10 +49,13 @@
         Organisation name
       </label>
 
-      <div id="merchant-name-hint" class="govuk-hint govuk-!-width-two-thirds">
-        <p class="govuk-hint">Enter the main name of your organisation, not your local office or individual department.</p>
-        <p class="govuk-hint">Write the organisation name in full. Only use acronyms that are widely understood (for example, NHS).</p>
-      </div>
+      {% if not isStripeUpdateOrgDetails %} 
+        <div id="merchant-name-hint" class="govuk-hint govuk-!-width-two-thirds">
+          <p class="govuk-hint">Enter the main name of your organisation, not your local office or individual department.</p>
+          <p class="govuk-hint">Write the organisation name in full. Only use acronyms that are widely understood (for example, NHS).</p>
+        </div>
+      {% endif %}
+      
       {% if errors['merchant-name'] %}
       <span id="merchant-name-error" class="govuk-error-message">
         <span class="govuk-visually-hidden">Error:</span> {{errors["merchant-name"]}}
@@ -128,38 +135,40 @@
 
     {% endcall %}
 
-    {{ govukInput({
-      value: telephone_number,
-      label: {
-        text: "Telephone number",
-        classes: "govuk-label--m"
-      },
-      hint: {
-        text: "Include the country code for international numbers"
-      },
-      errorMessage: { text: errors['telephone-number'] } if errors['telephone-number'] else false,
-      id: "telephone-number",
-      name: "telephone-number",
-      classes: "govuk-!-width-two-thirds",
-      type: "tel"
-    }) }}
+    {% if not isStripeUpdateOrgDetails %}
+      {{ govukInput({
+        value: telephone_number,
+        label: {
+          text: "Telephone number",
+          classes: "govuk-label--m"
+        },
+        hint: {
+          text: "Include the country code for international numbers"
+        },
+        errorMessage: { text: errors['telephone-number'] } if errors['telephone-number'] else false,
+        id: "telephone-number",
+        name: "telephone-number",
+        classes: "govuk-!-width-two-thirds",
+        type: "tel"
+      }) }}
 
-    {{ govukInput({
-      value: url,
-      label: {
-        text: "Organisation website address",
-        classes: "govuk-label--m"
-      },
-      hint: {
-        text: "Enter the address in full like https://www.example.com"
-      },
-      errorMessage: { text: errors.url } if errors.url else false,
-      id: "url",
-      name: "url",
-      classes: "govuk-!-width-two-thirds"
-    }) }}
+      {{ govukInput({
+        value: url,
+        label: {
+          text: "Organisation website address",
+          classes: "govuk-label--m"
+        },
+        hint: {
+          text: "Enter the address in full like https://www.example.com"
+        },
+        errorMessage: { text: errors.url } if errors.url else false,
+        id: "url",
+        name: "url",
+        classes: "govuk-!-width-two-thirds"
+      }) }}
+    {% endif %}
 
-    {% if isRequestToGoLive %}
+    {% if isRequestToGoLive or isStripeUpdateOrgDetails %}
     {{ govukButton({ text: "Continue" }) }}
     {% else %}
     {{ govukButton({


### PR DESCRIPTION
- Update `org address` nunjucks file
  - When user is setting up Stripe
    - Only display fields that are required for Stripe setup.
- Get controller
  - When during `Stripe setup` - set a flag to be used by the Nunjucks template:
    `isStripeUpdateOrgDetails`
  - Add test coverage
- Post controller
  - Update to display correct error messages depending on the user journey
    the user is currently on.
    - `request to go live` - Require address, url, telephone.
    - `Stripe setup` - Require org name, address.
    - Otherwise - require all fields - name, address, url, telephone


