### PR TITLE
PP-9004 - Stripe Setup > Add Org details - Update Stripe and Setup flag

### DIFF
--- a/app/services/clients/stripe/StripeOrganisationDetails.class.js
+++ b/app/services/clients/stripe/StripeOrganisationDetails.class.js
@@ -9,8 +9,8 @@ const schema = {
   address_city: Joi.string().required(),
   address_postcode: Joi.string().required(),
   address_country: Joi.string().required(),
-  telephone_number: Joi.string().required(),
-  url: Joi.string().required()
+  telephone_number: Joi.string().optional(),
+  url: Joi.string().optional()
 }
 
 class StripeOrganisationDetails {
@@ -40,16 +40,22 @@ function build (params) {
         city: params.address_city,
         postal_code: params.address_postcode,
         country: params.address_country
-      },
-      phone: params.telephone_number
-    },
-    business_profile: {
-      url: params.url
+      }
     }
   }
 
   if (params.address_line2) {
     stripeOrganisationDetails.company.address.line2 = params.address_line2
+  }
+
+  if (params.telephone_number) {
+    stripeOrganisationDetails.company.phone = params.telephone_number
+  }
+
+  if (params.url) {
+    stripeOrganisationDetails.business_profile = {
+      url: params.url
+    }
   }
 
   return stripeOrganisationDetails

--- a/app/services/clients/stripe/StripeOrganisationDetails.class.test.js
+++ b/app/services/clients/stripe/StripeOrganisationDetails.class.test.js
@@ -71,4 +71,58 @@ describe('StripeOrganisationDetails', () => {
       }
     })
   })
+
+  it('should successfully create a StripeOrganisationDetails object without a telephone number', () => {
+    const stripeOrganisationDetails = new StripeOrganisationDetails({
+      name: validName,
+      address_line1: validLine1,
+      address_line2: validLine2,
+      address_city: validCity,
+      address_postcode: validPostcode,
+      address_country: validCountry,
+      url: validUrl
+    })
+
+    expect(stripeOrganisationDetails.basicObject()).to.deep.equal({
+      company: {
+        name: validName,
+        address: {
+          line1: validLine1,
+          line2: validLine2,
+          city: validCity,
+          postal_code: validPostcode,
+          country: validCountry
+        }
+      },
+      business_profile: {
+        url: validUrl
+      }
+    })
+  })
+
+  it('should successfully create a StripeOrganisationDetails object without a org URL', () => {
+    const stripeOrganisationDetails = new StripeOrganisationDetails({
+      name: validName,
+      address_line1: validLine1,
+      address_line2: validLine2,
+      address_city: validCity,
+      address_postcode: validPostcode,
+      address_country: validCountry,
+      telephone_number: validTelephoneNumber
+    })
+
+    expect(stripeOrganisationDetails.basicObject()).to.deep.equal({
+      company: {
+        name: validName,
+        address: {
+          line1: validLine1,
+          line2: validLine2,
+          city: validCity,
+          postal_code: validPostcode,
+          country: validCountry
+        },
+        phone: validTelephoneNumber
+      }
+    })
+  })
 })

--- a/app/services/clients/stripe/stripe.client.js
+++ b/app/services/clients/stripe/stripe.client.js
@@ -8,6 +8,7 @@ const StripePerson = require('./StripePerson.class')
 const StripeDirector = require('./StripeDirector.class')
 const StripeAccount = require('./StripeAccount.class')
 const StripePersonAdditionalKYCDetails = require('./StripePersonAdditionalKYCDetails.class')
+const StripeOrganisationDetails = require('./StripeOrganisationDetails.class')
 
 // Constants
 const STRIPE_HOST = process.env.STRIPE_HOST
@@ -40,6 +41,11 @@ module.exports = {
   updateBankAccount: function (stripeAccountId, body) {
     const bankAccount = new StripeBankAccount(body)
     return stripe.accounts.update(stripeAccountId, bankAccount.basicObject())
+  },
+
+  updateOrganisationDetails: function (stripeAccountId, body) {
+    const organisationDetails = new StripeOrganisationDetails(body)
+    return stripe.accounts.update(stripeAccountId, organisationDetails.basicObject())
   },
 
   updateCompany: function (stripeAccountId, body) {


### PR DESCRIPTION
- Update `StripeOrganisationDetails` model
  - Makes it so that Org name, tel and URL are optional.
  - So that it can be used for all user journey's used by the `Org address` controller.
- Update Stripe client
  - Add new method to update Organisation details.
- Stripe setup > Org address > POST Controller
  - Add code for a successful submission.
    - Update `Stripe` account with new Org details that match the government entity document.
    - Update the `Connector > Stripe setup flag` - set this to `organisation_details`
- Update unit tests.