### PR TITLE
Pp 9004 org details page 6 cypress tests

### DIFF
--- a/app/models/StripeAccountSetup.class.js
+++ b/app/models/StripeAccountSetup.class.js
@@ -9,6 +9,7 @@ class StripeAccountSetup {
     this.director = opts.director
     this.additionalKycData = opts.additional_kyc_data
     this.governmentEntityDocument = opts.government_entity_document
+    this.organisationDetails = opts.organisation_details
   }
 }
 

--- a/app/services/clients/stripe/StripeOrganisationDetails.class.js
+++ b/app/services/clients/stripe/StripeOrganisationDetails.class.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 
 const schema = {
-  name: Joi.string().optional(),
+  name: Joi.string().required(),
   address_line1: Joi.string().required(),
   address_line2: Joi.string().optional(),
   address_city: Joi.string().required(),

--- a/app/services/clients/stripe/StripeOrganisationDetails.class.js
+++ b/app/services/clients/stripe/StripeOrganisationDetails.class.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 
 const schema = {
-  name: Joi.string().required(),
+  name: Joi.string().optional(),
   address_line1: Joi.string().required(),
   address_line2: Joi.string().optional(),
   address_city: Joi.string().required(),

--- a/app/views/macro/error-summary.njk
+++ b/app/views/macro/error-summary.njk
@@ -12,7 +12,10 @@
   {% if errorList | length %}
     {{ govukErrorSummary({
         titleText: "There is a problem",
-        errorList: errorList
+        errorList: errorList,
+        attributes: {
+          'data-cy': 'error-summary'
+        }
       }) }}
   {% endif %}
 {% endmacro %}

--- a/app/views/stripe-setup/check-org-details/index.njk
+++ b/app/views/stripe-setup/check-org-details/index.njk
@@ -23,7 +23,7 @@
     government entity document.
   </p>
 
-  <form method="post">
+  <form method="post" data-cy="form">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {% set orgFullAddressHtml =  orgAddressLine1 %}
@@ -35,22 +35,15 @@
     {% set orgFullAddressHtml =  orgFullAddressHtml  + '</br>' + orgCity + '</br>' + orgPostcode %}
 
     {{ govukSummaryList({
+      attributes: { 'data-cy': 'org-details' },
       rows: [
         {
-          key: {
-            text: "Organisation name"
-          },
-          value: {
-            text: orgName
-          }
+          key: { text: "Organisation name" },
+          value: { text: orgName }
         },
         {
-          key: {
-            text: "Address"
-          },
-          value: {
-            html: orgFullAddressHtml
-          }
+          key: { text: "Address" },
+          value: { html: orgFullAddressHtml }
         }
       ]
     }) }}
@@ -68,11 +61,13 @@
       items: [
         {
           value: "yes",
-          text: "Yes, these organisation details match"
+          text: "Yes, these organisation details match",
+          attributes: {'data-cy': 'yes-radio'}
         },
         {
           value: "no",
-          text: "No, these organisation details do not match"
+          text: "No, these organisation details do not match",
+          attributes: {'data-cy': 'no-radio'}
         }
       ],
       errorMessage: radioErrorMessage
@@ -82,7 +77,8 @@
       govukButton({
         text: "Continue",
         attributes: {
-          id: "continue-button"
+          id: "continue-button",
+          'data-cy': "continue-button"
         }
       })
     }}

--- a/test/cypress/integration/stripe-setup/check-org-details.cy.test.js
+++ b/test/cypress/integration/stripe-setup/check-org-details.cy.test.js
@@ -1,0 +1,176 @@
+'use strict'
+
+const userStubs = require('../../stubs/user-stubs')
+const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+const transactionSummaryStubs = require('../../stubs/transaction-summary-stubs')
+const stripeAccountSetupStubs = require('../../stubs/stripe-account-setup-stub')
+const stripeAccountStubs = require('../../stubs/stripe-account-stubs')
+
+const gatewayAccountId = '42'
+const userExternalId = 'userExternalId'
+const gatewayAccountExternalId = 'a-valid-external-id'
+const gatewayAccountCredentialExternalId = 'a-valid-credential-external-id'
+const checkOrgDetailsUrl = `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}/check-organisation-details`
+const dashboardUrl = `/account/${gatewayAccountExternalId}/dashboard`
+
+const validName = 'HMRC'
+const validLine1 = 'A building'
+const validLine2 = 'A street'
+const validCity = 'A city'
+const countryGb = 'GB'
+const validPostcodeGb = 'E1 8QS'
+
+function setupStubs (organisationDetails, type = 'live', paymentProvider = 'stripe') {
+  let stripeSetupStub
+
+  if (Array.isArray(organisationDetails)) {
+    stripeSetupStub = stripeAccountSetupStubs.getGatewayAccountStripeSetupFlagForMultipleCalls({
+      gatewayAccountId,
+      organisationDetails: organisationDetails
+    })
+  } else {
+    stripeSetupStub = stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+      gatewayAccountId,
+      organisationDetails
+    })
+  }
+
+  const gatewayAccountCredentials = [{
+    gateway_account_id: gatewayAccountId,
+    payment_provider: paymentProvider,
+    external_id: gatewayAccountCredentialExternalId
+  }]
+
+  const merchantDetails = {
+    name: validName,
+    address_line1: validLine1,
+    address_line2: validLine2,
+    address_city: validCity,
+    address_country: countryGb,
+    address_postcode: validPostcodeGb
+  }
+
+  cy.task('setupStubs', [
+    userStubs.getUserSuccess({ userExternalId, gatewayAccountId, merchantDetails }),
+    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+      gatewayAccountId,
+      gatewayAccountExternalId: gatewayAccountExternalId,
+      type,
+      paymentProvider,
+      gatewayAccountCredentials
+    }),
+    stripeSetupStub,
+    stripeAccountStubs.getStripeAccountSuccess(gatewayAccountId, 'acct_123example123'),
+    transactionSummaryStubs.getDashboardStatistics()
+  ])
+}
+
+describe('Stripe setup: Check your organisation’s details', () => {
+  describe('when user is admin, account is Stripe and "organisation details" is not already submitted', () => {
+    beforeEach(() => {
+      setupStubs(false)
+
+      cy.setEncryptedCookies(userExternalId, {})
+
+      cy.visit(checkOrgDetailsUrl)
+    })
+
+    it('should display page correctly', () => {
+      cy.get('h1').should('contain', 'Check your organisation’s details')
+
+      cy.get('[data-cy=org-details]').should('exist')
+      cy.get('[data-cy=org-details]').find('dd').eq(0).should('contain', 'HMRC')
+      cy.get('[data-cy=org-details]').find('dd').eq(1)
+        .should('contain', validLine1)
+        .should('contain', validLine2)
+        .should('contain', validCity)
+        .should('contain', validPostcodeGb)
+
+      cy.get(`[data-cy=form]`)
+        .within(() => {
+          cy.get('[data-cy=yes-radio]').should('exist')
+          cy.get('[data-cy=no-radio]').should('exist')
+        })
+    })
+
+    it('should display an error when a radio button is not clicked', () => {
+      cy.get('[data-cy=continue-button]').click()
+
+      cy.get('[data-cy=error-summary] a')
+        .should('contain', 'Select yes if your organisation’s details match the details on your government entity document')
+        .should('have.attr', 'href', '#confirm-org-details')
+
+      cy.get('[data-cy=error-message]').should('contain', 'Select yes if your organisation’s details match the details on your government entity document')
+    })
+  })
+
+  describe('when user is admin, account is Stripe and "organisation details" is already submitted', () => {
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId)
+    })
+
+    it('should display an error when displaying the page', () => {
+      setupStubs(true)
+
+      cy.visit(checkOrgDetailsUrl)
+
+      cy.get('h1').should('contain', 'An error occurred')
+      cy.get('#back-link').should('contain', 'Back to dashboard')
+      cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+      cy.get('#error-message').should('contain', 'You’ve already submitted your organisation details. Contact GOV.UK Pay support if you need to update them.')
+    })
+  })
+
+  describe('when it is not a Stripe gateway account', () => {
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId)
+    })
+
+    it('should show a 404 error when gateway account is not Stripe', () => {
+      setupStubs(false, 'live', 'sandbox')
+
+      cy.visit(checkOrgDetailsUrl, {
+        failOnStatusCode: false
+      })
+      cy.get('h1').should('contain', 'Page not found')
+    })
+  })
+
+  describe('when it is not a live gateway account', () => {
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId)
+    })
+
+    it('should show a 404 error when gateway account is not live', () => {
+      setupStubs(false, 'test', 'stripe')
+
+      cy.visit(checkOrgDetailsUrl, {
+        failOnStatusCode: false
+      })
+      cy.get('h1').should('contain', 'Page not found')
+    })
+  })
+
+  describe('when the user does not have the correct permissions', () => {
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId)
+    })
+
+    it('should show a permission error when the user does not have enough permissions', () => {
+      cy.task('setupStubs', [
+        userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
+        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+          gatewayAccountId,
+          gatewayAccountExternalId: gatewayAccountExternalId,
+          type: 'live',
+          paymentProvider: 'stripe'
+        }),
+        stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, vatNumber: true })
+      ])
+
+      cy.visit(checkOrgDetailsUrl, { failOnStatusCode: false })
+      cy.get('h1').should('contain', 'An error occurred')
+      cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+    })
+  })
+})

--- a/test/cypress/stubs/stripe-account-setup-stub.js
+++ b/test/cypress/stubs/stripe-account-setup-stub.js
@@ -30,6 +30,10 @@ function getGatewayAccountStripeSetupSuccess (opts) {
     fixtureOpts.government_entity_document = opts.governmentEntityDocument
   }
 
+  if (opts.organisationDetails !== undefined) {
+    fixtureOpts.organisation_details = opts.organisationDetails
+  }
+
   const path = `/v1/api/accounts/${opts.gatewayAccountId}/stripe-setup`
   return stubBuilder('GET', path, 200, {
     response: stripeAccountSetupFixtures.buildGetStripeAccountSetupResponse(fixtureOpts)
@@ -78,6 +82,13 @@ function getGatewayAccountStripeSetupFlagForMultipleCalls (opts) {
     data = opts.governmentEntityDocument.map(completed => (
       {
         government_entity_document: completed
+      }
+    ))
+  }
+  if (opts.organisationDetails) {
+    data = opts.organisationDetails.map(completed => (
+      {
+        organisation_details: completed
       }
     ))
   }

--- a/test/fixtures/stripe-account-setup.fixtures.js
+++ b/test/fixtures/stripe-account-setup.fixtures.js
@@ -47,7 +47,8 @@ module.exports = {
       'government_entity_document': opts.government_entity_document || false,
       'vat_number': opts.vat_number || false,
       'director': opts.director || false,
-      'additional_kyc_data': opts.additional_kyc_data || false
+      'additional_kyc_data': opts.additional_kyc_data || false,
+      'organisation_details': opts.organisation_details || false
     }
   }
 }

--- a/test/fixtures/user.fixtures.js
+++ b/test/fixtures/user.fixtures.js
@@ -196,6 +196,10 @@ const defaultPermissions = [
     description: 'Upload Government entity document'
   },
   {
+    name: 'stripe-organisation-details:update',
+    description: 'Check organisation details with Government entity document'
+  },
+  {
     name: 'connected-gocardless-account:read',
     description: 'View connected go cardless account'
   },


### PR DESCRIPTION
- `check-org-details.test.cy.js`
  -  Add new Cypress test file.
- Update Nunjuks files to use the `data-cy` attribute
  - This is recommended good practise from Cypress.
  - Added this to the `error-summary`, `check-org-details/index.njk` file.
  - Also makes it's easier to write test.
- Update `StripeAccountSetup` model
  - Add the `organisation_details` field.
- Update Cypress user stubs
  - Add new permission - 'stripe-organisation-details:update'
    - Required to access the page
- Update `stripe account setup` stub
  - Add new `organisation_details` response