### PR TITLE
PP-9004 Stripe setup > Update Org details - add Cypress test

### DIFF
--- a/app/controllers/request-to-go-live/organisation-address/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.js
@@ -87,7 +87,7 @@ const validationRulesWithNameAndTelAndUrl = [
 
 const trimField = (key, store) => lodash.get(store, key, '').trim()
 
-const normaliseForm = (formBody) => {
+function normaliseForm (formBody) {
   const fields = [
     clientFieldNames.name,
     clientFieldNames.addressLine1,
@@ -104,7 +104,7 @@ const normaliseForm = (formBody) => {
   }, {})
 }
 
-const validateForm = function validate (form, isRequestToGoLive, isStripeUpdateOrgDetails) {
+function validateForm (form, isRequestToGoLive, isStripeUpdateOrgDetails) {
   const rules = isStripeUpdateOrgDetails ? validationRulesWithName : isRequestToGoLive ? validationRulesWithTelAndUrl : validationRulesWithNameAndTelAndUrl
 
   const errors = rules.reduce((errors, validationRule) => {
@@ -131,7 +131,7 @@ const validateForm = function validate (form, isRequestToGoLive, isStripeUpdateO
   return orderedErrors
 }
 
-const submitForm = async function (form, req, isRequestToGoLive, isStripeUpdateOrgDetails) {
+async function submitForm (form, req, isRequestToGoLive, isStripeUpdateOrgDetails) {
   if (isStripeUpdateOrgDetails) {
     const stripeAccountId = await getStripeAccountId(req.account, false, req.correlationId)
 
@@ -168,7 +168,7 @@ const submitForm = async function (form, req, isRequestToGoLive, isStripeUpdateO
   }
 }
 
-const buildErrorsPageData = (form, errors, isRequestToGoLive) => {
+function buildErrorsPageData (form, errors, isRequestToGoLive, isStripeUpdateOrgDetails) {
   return {
     errors: errors,
     name: form[clientFieldNames.name],
@@ -179,7 +179,8 @@ const buildErrorsPageData = (form, errors, isRequestToGoLive) => {
     telephone_number: form[clientFieldNames.telephoneNumber],
     url: form[clientFieldNames.url],
     countries: countries.govukFrontendFormatted(form[clientFieldNames.addressCountry]),
-    isRequestToGoLive
+    isRequestToGoLive,
+    isStripeUpdateOrgDetails
   }
 }
 

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.test.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.test.js
@@ -107,7 +107,8 @@ describe('organisation address post controller', () => {
     })
 
     describe('request to go live', () => {
-      it('when the required fields have not been populated, it should show the page with errors', () => {
+      it('when the required fields have not been populated, it should show the page with errors and set the ' +
+        'flags `isRequestToGoLive` and `isStripeUpdateOrgDetails` correctly', () => {
         const req = {
           route: {
             path: '/request-to-go-live/organisation-address'
@@ -132,11 +133,15 @@ describe('organisation address post controller', () => {
         expect(errors[errorKeysAndMessage.errorAddressPostcode.key]).to.equal(errorKeysAndMessage.errorAddressPostcode.text)
         expect(errors[errorKeysAndMessage.errorTelephoneNumber.key]).to.equal(errorKeysAndMessage.errorTelephoneNumber.text)
         expect(errors[errorKeysAndMessage.errorWebsiteAddress.key]).to.equal(errorKeysAndMessage.errorWebsiteAddress.text)
+
+        expect(responseData.args[3].isRequestToGoLive).to.equal(true)
+        expect(responseData.args[3].isStripeUpdateOrgDetails).to.equal(false)
       })
     })
 
     describe('view page when not `request to go live` or `Stripe setup`', () => {
-      it('when the required fields have not been populated, it should show the page with errors', () => {
+      it('when the required fields have not been populated, it should show the page with errors and set the ' +
+      'flags `isRequestToGoLive` and `isStripeUpdateOrgDetails` correctly', () => {
         const req = {
           route: {
             path: '/organisation-details'
@@ -162,11 +167,15 @@ describe('organisation address post controller', () => {
         expect(errors[errorKeysAndMessage.errorAddressPostcode.key]).to.equal(errorKeysAndMessage.errorAddressPostcode.text)
         expect(errors[errorKeysAndMessage.errorTelephoneNumber.key]).to.equal(errorKeysAndMessage.errorTelephoneNumber.text)
         expect(errors[errorKeysAndMessage.errorWebsiteAddress.key]).to.equal(errorKeysAndMessage.errorWebsiteAddress.text)
+
+        expect(responseData.args[3].isRequestToGoLive).to.equal(false)
+        expect(responseData.args[3].isStripeUpdateOrgDetails).to.equal(false)
       })
     })
 
     describe('view page when `Stripe setup`', () => {
-      it('when the required fields have not been populated, it should show the page with errors', () => {
+      it('when the required fields have not been populated, it should show the page with errors ' +
+        'flags `isRequestToGoLive` and `isStripeUpdateOrgDetails` correctly', () => {
         const req = {
           route: {
             path: '/your-psp/:credentialId/update-organisation-details'
@@ -190,6 +199,9 @@ describe('organisation address post controller', () => {
         expect(errors[errorKeysAndMessage.errorAddressLine1.key]).to.equal(errorKeysAndMessage.errorAddressLine1.text)
         expect(errors[errorKeysAndMessage.errorAddressCity.key]).to.equal(errorKeysAndMessage.errorAddressCity.text)
         expect(errors[errorKeysAndMessage.errorAddressPostcode.key]).to.equal(errorKeysAndMessage.errorAddressPostcode.text)
+
+        expect(responseData.args[3].isRequestToGoLive).to.equal(false)
+        expect(responseData.args[3].isStripeUpdateOrgDetails).to.equal(true)
       })
     })
   })
@@ -370,7 +382,7 @@ describe('organisation address post controller', () => {
     })
   })
 
-  describe('organisation details page not part of request to go live', () => {
+  describe('organisation details page not part of `request to go live` or `Stripe setup`', () => {
     const correlationId = 'correlation-id'
     const serviceExternalId = 'abc123'
     const validName = 'HMRC'

--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -40,12 +40,12 @@
     </p>
   {% endif %}
 
-  <form id="request-to-go-live-organisation-address-form" method="post">
+  <form id="request-to-go-live-organisation-address-form" method="post" data-cy="form">
     <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
     {% if not isRequestToGoLive %}
     <div class="govuk-form-group {% if errors['merchant-name'] %} govuk-form-group--error {% endif %}">
-      <label class="govuk-label govuk-label--m" for="merchant-name">
+      <label class="govuk-label govuk-label--m" for="merchant-name" data-cy="label-org-name">
         Organisation name
       </label>
 
@@ -62,7 +62,7 @@
       </span>
       {% endif %}
       <input class="govuk-input govuk-!-width-two-thirds {% if errors['merchant-name'] %} govuk-input--error {% endif %}"
-             id="merchant-name" name="merchant-name" type="text" aria-describedby="merchant-name-hint"
+             id="merchant-name" name="merchant-name" type="text" aria-describedby="merchant-name-hint" data-cy="input-org-name"
              value="{{name}}"/>
     </div>
     {% endif %}
@@ -77,7 +77,8 @@
 
     {{ govukInput({
       label: {
-        html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
+        html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>',
+        attributes: { 'data-cy': 'label-address-line-1' }
       },
       hint: {
         text: "Enter the main building or office address"
@@ -86,29 +87,34 @@
       id: "address-line1",
       name: "address-line1",
       errorMessage: { text: errors['address-line1'] } if errors['address-line1'] else false,
-      value: address_line1
+      value: address_line1,
+      attributes: { 'data-cy': 'input-address-line-1' }
     }) }}
 
     {{ govukInput({
       label: {
-        html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
+        html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>',
+        attributes: { 'data-cy': 'label-address-line-2' }
       },
       classes: "govuk-!-width-two-thirds",
       id: "address-line2",
       name: "address-line2",
       errorMessage: { text: errors['address-line2'] } if errors['address-line2'] else false,
-      value: address_line2
+      value: address_line2,
+      attributes: { 'data-cy': 'input-address-line-2' }
     }) }}
 
     {{ govukInput({
       label: {
-        text: "Town or city"
+        text: "Town or city",
+        attributes: { 'data-cy': 'label-address-city' }
       },
       classes: "govuk-!-width-one-half",
       id: "address-city",
       name: "address-city",
       errorMessage: { text: errors['address-city'] } if errors['address-city'] else false,
-      value: address_city
+      value: address_city,
+      attributes: { 'data-cy': 'input-address-city' }
     }) }}
 
     {{ govukSelect({
@@ -117,20 +123,24 @@
       name: "address-country",
       errorMessage: { text: errors['address-country'] } if errors['address-country'] else false,
       label: {
-        text: "Country"
+        text: "Country",
+         attributes: { 'data-cy': 'label-address-country' }
       },
-      items: countries
+      items: countries,
+      attributes: { 'data-cy': 'input-address-country' }
     }) }}
 
     {{ govukInput({
       label: {
-        text: "Postcode"
+        text: "Postcode",
+         attributes: { 'data-cy': 'label-address-postcode' }
       },
       classes: "govuk-input--width-10",
       id: "address-postcode",
       name: "address-postcode",
       errorMessage: { text: errors['address-postcode'] } if errors['address-postcode'] else false,
-      value: address_postcode
+      value: address_postcode,
+      attributes: { 'data-cy': 'input-address-postcode' }
     }) }}
 
     {% endcall %}
@@ -140,43 +150,53 @@
         value: telephone_number,
         label: {
           text: "Telephone number",
-          classes: "govuk-label--m"
+          classes: "govuk-label--m",
+          attributes: { 'data-cy': 'label-telephone-number' }
         },
         hint: {
-          text: "Include the country code for international numbers"
+          text: "Include the country code for international numbers",
+          attributes: { 'data-cy': 'hint-telephone-number' }
         },
         errorMessage: { text: errors['telephone-number'] } if errors['telephone-number'] else false,
         id: "telephone-number",
         name: "telephone-number",
         classes: "govuk-!-width-two-thirds",
-        type: "tel"
+        type: "tel",
+        attributes: { 'data-cy': 'input-telephone-number' }
       }) }}
 
       {{ govukInput({
         value: url,
         label: {
           text: "Organisation website address",
-          classes: "govuk-label--m"
+          classes: "govuk-label--m",
+          attributes: { 'data-cy': 'label-url' }
         },
         hint: {
-          text: "Enter the address in full like https://www.example.com"
+          text: "Enter the address in full like https://www.example.com",
+          attributes: { 'data-cy': 'hint-url' }
         },
         errorMessage: { text: errors.url } if errors.url else false,
         id: "url",
         name: "url",
-        classes: "govuk-!-width-two-thirds"
+        classes: "govuk-!-width-two-thirds",
+        attributes: { 'data-cy': 'input-url' }
       }) }}
     {% endif %}
 
     {% if isRequestToGoLive or isStripeUpdateOrgDetails %}
-    {{ govukButton({ text: "Continue" }) }}
+      {{ govukButton({ 
+        text: "Continue",
+        attributes: { 'data-cy': 'continue-button' } 
+      }) }}
     {% else %}
-    {{ govukButton({
-      text: "Save organisation details",
-      attributes: {
-        id: "save-merchant-details"
-      }
-    }) }}
+      {{ govukButton({
+        text: "Save organisation details",
+        attributes: {
+          id: "save-merchant-details",
+          attributes: { 'data-cy': 'save-button' }
+        }
+      }) }}
     {% endif %}
   </form>
 </div>

--- a/test/cypress/integration/stripe-setup/update-org-details.cy.test.js
+++ b/test/cypress/integration/stripe-setup/update-org-details.cy.test.js
@@ -1,0 +1,226 @@
+'use strict'
+
+const userStubs = require('../../stubs/user-stubs')
+const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+const transactionSummaryStubs = require('../../stubs/transaction-summary-stubs')
+const stripeAccountSetupStubs = require('../../stubs/stripe-account-setup-stub')
+const stripeAccountStubs = require('../../stubs/stripe-account-stubs')
+
+const gatewayAccountId = '42'
+const userExternalId = 'userExternalId'
+const gatewayAccountExternalId = 'a-valid-external-id'
+const gatewayAccountCredentialExternalId = 'a-valid-credential-external-id'
+const checkOrgDetailsUrl = `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}/check-organisation-details`
+const pageUrl = `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}/update-organisation-details`
+
+function setupStubs (organisationDetails, type = 'live', paymentProvider = 'stripe') {
+  let stripeSetupStub
+
+  if (Array.isArray(organisationDetails)) {
+    stripeSetupStub = stripeAccountSetupStubs.getGatewayAccountStripeSetupFlagForMultipleCalls({
+      gatewayAccountId,
+      organisationDetails: organisationDetails
+    })
+  } else {
+    stripeSetupStub = stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+      gatewayAccountId,
+      organisationDetails
+    })
+  }
+
+  const gatewayAccountCredentials = [{
+    gateway_account_id: gatewayAccountId,
+    payment_provider: paymentProvider,
+    external_id: gatewayAccountCredentialExternalId
+  }]
+
+  cy.task('setupStubs', [
+    userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),
+    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+      gatewayAccountId,
+      gatewayAccountExternalId: gatewayAccountExternalId,
+      type,
+      paymentProvider,
+      gatewayAccountCredentials
+    }),
+    stripeSetupStub,
+    stripeAccountStubs.getStripeAccountSuccess(gatewayAccountId, 'acct_123example123'),
+    transactionSummaryStubs.getDashboardStatistics()
+  ])
+}
+
+describe('The organisation address page', () => {
+  const validOrgName = 'An organisation name'
+  const validLine1 = 'A building'
+  const validLine2 = 'A street'
+  const validCity = 'A city'
+  const countryGb = 'GB'
+  const invalidPostcode = '123'
+
+  describe('Stripe setup and there are no existing merchant details', () => {
+    beforeEach(() => {
+      // keep the same session for entire describe block
+      Cypress.Cookies.preserveOnce('session', 'gateway_account')
+    })
+
+    describe('Form validation', () => {
+      beforeEach(() => {
+        setupStubs(false)
+      })
+
+      it('should display form', () => {
+        cy.setEncryptedCookies(userExternalId)
+        cy.visit(pageUrl)
+
+        cy.get('h1').should('contain', `What is the name and address of you organisation on your government identity document?`)
+
+        cy.get('[data-cy=form]')
+          .should('exist')
+          .within(() => {
+            cy.get('[data-cy=label-org-name]').should('exist')
+            cy.get('[data-cy=input-org-name]').should('exist')
+
+            cy.get('[data-cy=label-address-line-1]').should('exist')
+            cy.get('[data-cy=input-address-line-1]').should('exist')
+            cy.get('[data-cy=input-address-line-2]').should('exist')
+
+            cy.get('[data-cy=label-address-city]').should('exist')
+            cy.get('[data-cy=input-address-city]').should('exist')
+
+            cy.get('[data-cy=label-address-country]').should('exist')
+            cy.get('[data-cy=input-address-country]').should('exist')
+
+            cy.get('[data-cy=label-address-postcode]').should('exist')
+            cy.get('[data-cy=input-address-postcode]').should('exist')
+
+            cy.get('[data-cy=continue-button]').should('exist')
+            cy.get('[data-cy=save-button]').should('not.exist')
+          })
+      })
+
+      it('should not display the telephone or url fields', () => {
+        cy.get('[data-cy=form]')
+          .should('exist')
+          .within(() => {
+            cy.get('[data-cy=label-telephone-number]').should('not.exist')
+            cy.get('[data-cy=hint-telephone-number]').should('not.exist')
+            cy.get('[data-cy=input-telephone-number]').should('not.exist')
+
+            cy.get('[data-cy=label-url]').should('not.exist')
+            cy.get('[data-cy=hint-url]').should('not.exist')
+            cy.get('[data-cy=input-url]').should('not.exist')
+          })
+      })
+
+      it('should display errors when validation fails', () => {
+        cy.get('[data-cy=form]')
+          .within(() => {
+            // create errors by leaving fields blank or inputting invalid values
+            cy.get('[data-cy=input-address-postcode]').type(invalidPostcode)
+
+            cy.get('[data-cy=continue-button]').click()
+          })
+
+        cy.get('[data-cy=error-summary]').find('a').should('have.length', 4)
+        cy.get('[data-cy=error-summary]').should('exist').within(() => {
+          cy.get('a[href="#address-line1"]').should('contain', 'Enter a building and street')
+          cy.get('a[href="#address-city"]').should('contain', 'Enter a town or city')
+          cy.get('a[href="#address-postcode"]').should('contain', 'Enter a real postcode')
+        })
+
+        cy.get(`form[method=post]`)
+          .within(() => {
+            cy.get('[data-cy=input-address-line-1]').parent().should('exist').within(() => {
+              cy.get('.govuk-error-message').should('contain', 'Enter a building and street')
+            })
+            cy.get('[data-cy=input-address-city]').parent().should('exist').within(() => {
+              cy.get('.govuk-error-message').should('contain', 'Enter a town or city')
+            })
+            cy.get('[data-cy=input-address-postcode]').parent().should('exist').within(() => {
+              cy.get('.govuk-error-message').should('contain', 'Enter a real postcode')
+            })
+          })
+      })
+
+      it('should keep entered responses when validation fails', () => {
+        cy.get('[data-cy=form]')
+          .within(() => {
+            // fill in the rest of the form fields
+            cy.get('[data-cy=input-org-name]').type(validOrgName)
+            cy.get('[data-cy=input-address-line-1]').type(validLine1)
+            cy.get('[data-cy=input-address-line-2]').type(validLine2)
+            cy.get('[data-cy=input-address-city]').type(validCity)
+            cy.get('[data-cy=input-address-country]').select(countryGb)
+            cy.get('[data-cy=continue-button]').click()
+          })
+
+        cy.get('[data-cy=error-summary]').find('a').should('have.length', 1)
+        cy.get('[data-cy=error-summary]').should('exist').within(() => {
+          cy.get('a').should('contain', 'Enter a real postcode')
+        })
+
+        cy.get('[data-cy=form]')
+          .within(() => {
+            cy.get('#address-line1').should('have.value', validLine1)
+            cy.get('#address-line2').should('have.value', validLine2)
+            cy.get('#address-city').should('have.value', validCity)
+            cy.get('#address-country').should('have.value', countryGb)
+            cy.get('#address-postcode').should('have.value', invalidPostcode)
+          })
+      })
+    })
+
+    describe('when it is not a Stripe gateway account', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
+      })
+
+      it('should show a 404 error when gateway account is not Stripe', () => {
+        setupStubs(false, 'live', 'sandbox')
+
+        cy.visit(pageUrl, {
+          failOnStatusCode: false
+        })
+        cy.get('h1').should('contain', 'Page not found')
+      })
+    })
+
+    describe('when it is not a live gateway account', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
+      })
+
+      it('should show a 404 error when gateway account is not live', () => {
+        setupStubs(false, 'test', 'stripe')
+
+        cy.visit(checkOrgDetailsUrl, {
+          failOnStatusCode: false
+        })
+        cy.get('h1').should('contain', 'Page not found')
+      })
+    })
+
+    describe('when the user does not have the correct permissions', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
+      })
+
+      it('should show a permission error when the user does not have enough permissions', () => {
+        cy.task('setupStubs', [
+          userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
+          gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+            gatewayAccountId,
+            gatewayAccountExternalId: gatewayAccountExternalId,
+            type: 'live',
+            paymentProvider: 'stripe'
+          }),
+          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, vatNumber: true })
+        ])
+
+        cy.visit(checkOrgDetailsUrl, { failOnStatusCode: false })
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+      })
+    })
+  })
+})


### PR DESCRIPTION
- New Cypress test file -  `update-org-details.cy.test.js`
  - Check validation, user has correct permissions and is using a LIVE Stripe account.
  - Hide the telephone and URL fields.
- Update `organisation address > post controller`
  - When validation fails, make sure to corrretly pass down the `isRequestToGoLive` and
    `isStripeUpdateOrgDetails` flags correctly.
  - Rename functions so that the match up to our Node style guide.
  - Update unit test
    - When validation fails, test the `isRequestToGoLive` and
      `isStripeUpdateOrgDetails` flags correctly.