### PR TITLE
PP-9004 Check org details - fix bug with address line 2

### DIFF
--- a/app/controllers/request-to-go-live/organisation-address/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.js
@@ -135,14 +135,21 @@ async function submitForm (form, req, isRequestToGoLive, isStripeUpdateOrgDetail
   if (isStripeUpdateOrgDetails) {
     const stripeAccountId = await getStripeAccountId(req.account, false, req.correlationId)
 
-    await updateOrganisationDetails(stripeAccountId, {
+    const newOrgDetails = {
       name: form[clientFieldNames.name],
       address_line1: form[clientFieldNames.addressLine1],
-      address_line2: form[clientFieldNames.addressLine2],
       address_city: form[clientFieldNames.addressCity],
       address_postcode: form[clientFieldNames.addressPostcode],
       address_country: form[clientFieldNames.addressCountry]
-    })
+    }
+
+    const addressLine2 = form[clientFieldNames.addressLine2]
+
+    if (addressLine2) {
+      newOrgDetails.address_line2 = addressLine2
+    }
+
+    await updateOrganisationDetails(stripeAccountId, newOrgDetails)
 
     await connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'organisation_details', req.correlationId)
 


### PR DESCRIPTION
- When updating Org details.
  - If the user does not submit `address-line2`, then it was sending an empty string
    to the Stripe client as `address-line2`.
  - Updated code, if the `address-line2` is empty - then do not pass it to the Stripe
    client when updating the organisation details.
  - Only had to update `update org address` post controller.
