### PR TITLE
PP-9671 Display not refundable message when payment disputed

### DIFF
--- a/app/utils/transaction-view.js
+++ b/app/utils/transaction-view.js
@@ -125,6 +125,7 @@ module.exports = {
 
     chargeData.card_details.first_digits_card_number = formatFirstSixDigitsCardNumber(chargeData.card_details.first_digits_card_number)
     chargeData.refundable = chargeData.refund_summary.status === 'available' || chargeData.refund_summary.status === 'error'
+    chargeData.refund_unavailable_due_to_dispute = chargeData.refund_summary.status === 'unavailable' && chargeData.disputed === true
     chargeData.refundable_amount = (chargeData.refund_summary.amount_available / 100).toFixed(2)
     chargeData.refunded_amount = asGBP(chargeData.refund_summary.amount_submitted || 0)
     chargeData.refunded = chargeData.refund_summary.amount_submitted !== 0

--- a/app/views/transaction-detail/index.njk
+++ b/app/views/transaction-detail/index.njk
@@ -81,8 +81,11 @@
     {% endif %}
   </div>
 
-  <div class="govuk-grid-column-one-third">
-    {% if refundable %}
+  <div class="govuk-grid-column-one-third" data-cy="refund-container">
+    {% if refund_unavailable_due_to_dispute %}
+      <h2 class="govuk-heading-m govuk-!-margin-top-1">Refund</h2>
+      <p class="govuk-body">You cannot refund this payment because it is being disputed.</p>
+    {% elif refundable %}
       {% if permissions.refunds_create %}
         {% include "./_refund.njk" %}
         <div class="target-to-show--toggle-container {% if not flash.genericError %}active{% endif %}">

--- a/test/cypress/integration/transactions/transaction-details.cy.test.js
+++ b/test/cypress/integration/transactions/transaction-details.cy.test.js
@@ -296,6 +296,8 @@ describe('Transaction details page', () => {
 
       cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
 
+      cy.get('#refundForm').should('exist')
+
       // Click the refund button
       cy.get('.target-to-show--toggle').click()
 
@@ -393,6 +395,24 @@ describe('Transaction details page', () => {
 
       // Assert refund message
       cy.get('.govuk-radios__hint').first().should('contain', `Refund the full amount of ${convertPenceToPoundsFormatted(transactionDetails.refund_summary_available)}`)
+    })
+  })
+
+  describe('Disputed payment', () => {
+    it('should show refund unavailable message', () => {
+      const disputedPaymentDetails = defaultTransactionDetails()
+      disputedPaymentDetails.disputed = true
+      disputedPaymentDetails.refund_summary_status = "unavailable"
+
+      cy.task('setupStubs', getStubs(disputedPaymentDetails))
+      cy.visit(`${transactionsUrl}/${disputedPaymentDetails.transaction_id}`)
+
+      cy.get('[data-cy=refund-container]').within(() => {
+        cy.get('h2').contains('Refund').should('exist')
+        cy.get('#refundForm').should('not.exist')
+    
+        cy.get('p').contains('You cannot refund this payment because it is being disputed.')
+      })
     })
   })
 })

--- a/test/fixtures/ledger-transaction.fixtures.js
+++ b/test/fixtures/ledger-transaction.fixtures.js
@@ -75,6 +75,10 @@ const buildTransactionDetails = (opts = {}) => {
     live: opts.live || false
   }
 
+  if (data.transaction_type.toLowerCase() === 'payment') {
+    data.disputed = opts.disputed || false
+  }
+
   if (opts.gateway_transaction_id) {
     data.gateway_transaction_id = opts.gateway_transaction_id
   }

--- a/test/unit/utils/transaction-view.test.js
+++ b/test/unit/utils/transaction-view.test.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const { expect } = require('chai')
+
+const { buildPaymentView } = require('../../../app/utils/transaction-view')
+const transactionFixtures = require('../../fixtures/ledger-transaction.fixtures')
+
+describe('Transaction view utilities', () => {
+  describe('disputed payment refundable', () => {
+    const testCases = [
+      {refund_summary_status: "unavailable", expectations: { refund_unavailable_due_to_dispute: true, refundable: false } },
+      {refund_summary_status: "available", expectations: { refund_unavailable_due_to_dispute: false, refundable: true } },
+      {refund_summary_status: "error", expectations: { refund_unavailable_due_to_dispute: false, refundable: true } },
+      {refund_summary_status: "full", expectations: { refund_unavailable_due_to_dispute: false, refundable: false } },
+      {refund_summary_status: "pending", expectations: { refund_unavailable_due_to_dispute: false, refundable: false } },
+    ]
+
+    testCases.forEach(testCase => {
+      it(`should return correct refundable fields for disputed payment with refund status ${testCase.refund_summary_status}`, () => {
+        const transaction = transactionFixtures.validTransactionDetailsResponse({
+          disputed: true,
+          refund_summary_status: testCase.refund_summary_status
+        })
+        const events = transactionFixtures.validTransactionEventsResponse()
+        const view = buildPaymentView(transaction, events)
+    
+        expect(view.refund_unavailable_due_to_dispute).to.equal(testCase.expectations.refund_unavailable_due_to_dispute)
+        expect(view.refundable).to.equal(testCase.expectations.refundable)
+      })
+    })
+  })
+})


### PR DESCRIPTION
When a payment has "disputed"=true and the refund_summary status of
"unavailable", display a paragraph on the transaction view indicating
that it is not possible to refund the payment.

Add validation that the "disputed" field exists on transactions
retrieved from ledger to the Pact tests. This is done by updating the
fixture that is used to build the Pact.


