### PR TITLE
PP-9673 Update all-service-transactions to display dispute statuses

### DIFF
--- a/app/controllers/all-service-transactions/get.controller.js
+++ b/app/controllers/all-service-transactions/get.controller.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash')
 const url = require('url')
+const moment = require('moment')
 
 const { response } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client.js')
@@ -17,6 +18,20 @@ const { NoServicesWithPermissionError } = require('../../errors')
 
 const { CORRELATION_HEADER } = require('../../utils/correlation-header.js')
 
+const enableDisputesSearchForTestAccountsFromDate = process.env.ENABLE_TEST_TXS_SEARCH_BY_DISPUTE_STATUSES_FROM_DATE || 1659916800 // Aug 08 2022 00:00:00 GMT
+const enableDisputesSearchForLiveAccountsFromDate = process.env.ENABLE_LIVE_TXS_SEARCH_BY_DISPUTE_STATUSES_FROM_DATE || 1659916800 // Aug 08 2022 00:00:00 GMT
+
+function includeDisputeStatuses (filterLiveAccounts, hasStripeAccount) {
+  if (!hasStripeAccount) {
+    return false
+  }
+  const enableDisputesFromDateForAccountType = (filterLiveAccounts
+    ? enableDisputesSearchForLiveAccountsFromDate
+    : enableDisputesSearchForTestAccountsFromDate)
+
+  return moment().isAfter(moment.unix(enableDisputesFromDateForAccountType))
+}
+
 module.exports = async function getTransactionsForAllServices (req, res, next) {
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   const filters = getFilters(req)
@@ -28,7 +43,6 @@ module.exports = async function getTransactionsForAllServices (req, res, next) {
 
   req.session.filters = url.parse(req.url).query
   req.session.allServicesTransactionsStatusFilter = statusFilter
-
   try {
     const userPermittedAccountsSummary = await permissions.getGatewayAccountsFor(req.user, filterLiveAccounts, 'transactions:read')
 
@@ -48,7 +62,8 @@ module.exports = async function getTransactionsForAllServices (req, res, next) {
     delete req.session.backPath
     model.search_path = filterLiveAccounts ? paths.allServiceTransactions.index : paths.formattedPathFor(paths.allServiceTransactions.indexStatusFilter, 'test')
     model.filtersDescription = describeFilters(filters.result)
-    model.eventStates = states.allDisplayStateSelectorObjects()
+    const includeDisputeStatusesInTransactionStates = includeDisputeStatuses(filterLiveAccounts, userPermittedAccountsSummary.hasStripeAccount)
+    model.eventStates = states.allDisplayStateSelectorObjects(includeDisputeStatusesInTransactionStates)
       .map(state => {
         return {
           value: state.key,

--- a/app/controllers/all-service-transactions/get.controller.test.js
+++ b/app/controllers/all-service-transactions/get.controller.test.js
@@ -1,0 +1,152 @@
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+const User = require('../../models/User.class')
+const userFixtures = require('../../../test/fixtures/user.fixtures')
+const gatewayAccountFixture = require('../../../test/fixtures/gateway-account.fixtures')
+const Service = require('../../models/Service.class')
+const serviceFixtures = require('../../../test/fixtures/service.fixtures')
+const ledgerTransactionFixture = require('../../../test/fixtures/ledger-transaction.fixtures')
+
+describe('All service transactions - GET', () => {
+  let req, res, next
+  let allDisplayStateSelectorObjectsMock
+  const user = new User(userFixtures.validUserResponse())
+  const service = new Service(serviceFixtures.validServiceResponse({}))
+  const transactionSearchResponse = ledgerTransactionFixture.validTransactionSearchResponse(
+    { transactions: [] })
+  let userPermittedAccountsSummary = {
+    gatewayAccountIds: [31],
+    headers: { shouldGetStripeHeaders: true, shouldGetMotoHeaders: true },
+    hasLiveAccounts: false,
+    hasStripeAccount: true,
+    hasTestStripeAccount: false
+  }
+
+  beforeEach(() => {
+    req = {
+      account: gatewayAccountFixture.validGatewayAccount({ 'payment_provider': 'stripe' }),
+      flash: sinon.spy(),
+      service: service,
+      user: user,
+      params: {},
+      url: 'http://selfservice/all-servce-transactions',
+      session: {},
+      headers: {
+        'x-request-id': 'correlation-id'
+      }
+    }
+    res = {
+      render: sinon.spy()
+    }
+    next = sinon.spy()
+    allDisplayStateSelectorObjectsMock = sinon.spy(() => ([{}]))
+  })
+
+  describe('Stripe account', () => {
+    it('should get dispute states for test transactions page - if dispute transactions search is enabled for test', async () => {
+      process.env.ENABLE_TEST_TXS_SEARCH_BY_DISPUTE_STATUSES_FROM_DATE = '1627156355'
+      userPermittedAccountsSummary.hasStripeAccount = true
+      req.params.statusFilter = 'test'
+
+      await getController()(req, res, next)
+
+      sinon.assert.calledWith(allDisplayStateSelectorObjectsMock, true)
+      sinon.assert.called(res.render)
+    })
+
+    it('should NOT get dispute states for test transactions page - if dispute transactions search is not enabled for test', async () => {
+      process.env.ENABLE_TEST_TXS_SEARCH_BY_DISPUTE_STATUSES_FROM_DATE = '1753386755'
+      userPermittedAccountsSummary.hasStripeAccount = true
+      req.params.statusFilter = 'test'
+
+      await getController()(req, res, next)
+
+      sinon.assert.calledWith(allDisplayStateSelectorObjectsMock, false)
+      sinon.assert.called(res.render)
+    })
+
+    it('should NOT get dispute states for test transactions page - if dispute transactions search is only enabled for live', async () => {
+      process.env.ENABLE_LIVE_TXS_SEARCH_BY_DISPUTE_STATUSES_FROM_DATE = '1627156355'
+      process.env.ENABLE_LIVE_TXS_SEARCH_BY_DISPUTE_STATUSES_FROM_DATE = '1753386755'
+      userPermittedAccountsSummary.hasStripeAccount = true
+      req.params.statusFilter = 'test'
+
+      await getController()(req, res, next)
+
+      sinon.assert.calledWith(allDisplayStateSelectorObjectsMock, false)
+      sinon.assert.called(res.render)
+    })
+
+    it('should get dispute states for live transactions page - if dispute transactions search is enabled for live', async () => {
+      process.env.ENABLE_LIVE_TXS_SEARCH_BY_DISPUTE_STATUSES_FROM_DATE = '1627156355'
+      userPermittedAccountsSummary.hasStripeAccount = true
+      req.params.statusFilter = 'live'
+
+      await getController()(req, res, next)
+
+      sinon.assert.calledWith(allDisplayStateSelectorObjectsMock, true)
+      sinon.assert.called(res.render)
+    })
+
+    it('should NOT get dispute states for live transactions page - if dispute transactions search is enabled for live', async () => {
+      process.env.ENABLE_LIVE_TXS_SEARCH_BY_DISPUTE_STATUSES_FROM_DATE = '1753386755'
+      userPermittedAccountsSummary.hasStripeAccount = true
+      req.params.statusFilter = 'live'
+
+      await getController()(req, res, next)
+
+      sinon.assert.calledWith(allDisplayStateSelectorObjectsMock, false)
+      sinon.assert.called(res.render)
+    })
+
+    it('should NOT get dispute states for live transactions page - if dispute transactions search is only enabled for test', async () => {
+      process.env.ENABLE_TEST_TXS_SEARCH_BY_DISPUTE_STATUSES_FROM_DATE = '1627156355'
+      process.env.ENABLE_LIVE_TXS_SEARCH_BY_DISPUTE_STATUSES_FROM_DATE = '1753386755'
+      userPermittedAccountsSummary.hasStripeAccount = true
+      req.params.statusFilter = 'live'
+
+      await getController()(req, res, next)
+
+      sinon.assert.calledWith(allDisplayStateSelectorObjectsMock, false)
+      sinon.assert.called(res.render)
+    })
+  })
+  describe('Non stripe account', () => {
+    it('should NOT get dispute states for TEST transactions page - if dispute transactions search is enabled for test', async () => {
+      process.env.ENABLE_TEST_TXS_SEARCH_BY_DISPUTE_STATUSES_FROM_DATE = '1627156355'
+      userPermittedAccountsSummary.hasStripeAccount = false
+      req.params.statusFilter = 'test'
+      await getController()(req, res, next)
+
+      sinon.assert.calledWith(allDisplayStateSelectorObjectsMock, false)
+      sinon.assert.called(res.render)
+    })
+
+    it('should NOT get dispute states for LIVE transactions page - if dispute transactions search is enabled for live', async () => {
+      process.env.ENABLE_LIVE_TXS_SEARCH_BY_DISPUTE_STATUSES_FROM_DATE = '1627156355'
+      userPermittedAccountsSummary.hasStripeAccount = false
+      req.params.statusFilter = 'test'
+      await getController()(req, res, next)
+
+      sinon.assert.calledWith(allDisplayStateSelectorObjectsMock, false)
+      sinon.assert.called(res.render)
+    })
+  })
+
+  function getController () {
+    return proxyquire('./get.controller', {
+      '../../utils/permissions': {
+        getGatewayAccountsFor: sinon.spy(() => Promise.resolve(userPermittedAccountsSummary))
+      },
+      '../../services/transaction.service': {
+        search: sinon.spy(() => Promise.resolve(transactionSearchResponse))
+      },
+      '../../services/clients/connector.client.js': {
+        ConnectorClient: class {async getAllCardTypes () { return {} }}
+      },
+      '../../utils/states': {
+        allDisplayStateSelectorObjects: allDisplayStateSelectorObjectsMock
+      }
+    })
+  }
+})

--- a/app/utils/permissions.js
+++ b/app/utils/permissions.js
@@ -15,6 +15,7 @@ const getGatewayAccountsFor = async function getGatewayAccountsFor (user, filter
     gatewayAccountIds: filterGatewayAccountIds(userGatewayAccounts, filterLiveAccounts),
     headers: getAllAccountDetailHeaders(userGatewayAccounts),
     hasLiveAccounts: filterGatewayAccountIds(userGatewayAccounts, true).length > 0,
+    hasStripeAccount: hasStripeAccount(userGatewayAccounts, filterLiveAccounts),
     hasTestStripeAccount: userGatewayAccounts.filter((account) => account.type === 'test' && account.payment_provider === 'stripe').length > 0
   }
 }
@@ -50,6 +51,14 @@ const filterGatewayAccountIds = function filterGatewayAccountIds (gatewayAccount
   return gatewayAccounts
     .filter((account) => account.type === gatewayAccountTypeFilter)
     .map((account) => account.gateway_account_id)
+}
+
+const hasStripeAccount = function hasStripeAccount (gatewayAccounts, filterLiveAccounts = true) {
+  const gatewayAccountTypeFilter = filterLiveAccounts ? 'live' : 'test'
+  return gatewayAccounts
+    .filter((account) => account.type === gatewayAccountTypeFilter)
+    .filter((account) => account.payment_provider === 'stripe')
+    .length > 0
 }
 
 module.exports = {

--- a/test/unit/utils/permissions.test.js
+++ b/test/unit/utils/permissions.test.js
@@ -60,12 +60,13 @@ describe('gateway account filter utiltiies', () => {
           }
         }
       })
-      const result = await getGatewayAccountsFor(user, true, 'perm-1')
+      const result = await getGatewayAccountsFor(user, false, 'perm-1')
 
       expect(result.headers.shouldGetStripeHeaders).to.be.true // eslint-disable-line
       expect(result.headers.shouldGetMotoHeaders).to.be.true // eslint-disable-line
       expect(result.hasLiveAccounts).to.equal(false)
       expect(result.hasTestStripeAccount).to.equal(true)
+      expect(result.hasStripeAccount).to.equal(true)
     })
 
     it('correctly identifies non stripe and moto headers', async () => {
@@ -120,6 +121,7 @@ describe('gateway account filter utiltiies', () => {
       expect(testResult.gatewayAccountIds).to.deep.equal([ '2' ])
       expect(testResult.hasLiveAccounts).to.equal(true)
       expect(testResult.hasTestStripeAccount).to.equal(false)
+      expect(testResult.hasStripeAccount).to.equal(false)
     })
 
     it('correctly filters services by users permission role', async () => {


### PR DESCRIPTION
## WHAT
- Displays dispute statuses on all services transactions page if service has stripe account and if relevant (live/test) environment is set to display dispute statuses
