### PR TITLE
PP-9662 Display dispute info on transaction details page

### DIFF
--- a/app/models/DisputeTransaction.class.js
+++ b/app/models/DisputeTransaction.class.js
@@ -1,0 +1,49 @@
+'use strict'
+const lodash = require('lodash')
+const { penceToPoundsWithCurrency } = require('../utils/currency-formatter')
+
+const states = require('../utils/states')
+const dates = require('../utils/dates')
+
+const reasonToFriendlyString = new Map()
+
+reasonToFriendlyString.set('credit_not_processed', 'Credit not processed')
+reasonToFriendlyString.set('duplicate', 'Duplicate')
+reasonToFriendlyString.set('fraudulent', 'Fraudulent')
+reasonToFriendlyString.set('general', 'General')
+reasonToFriendlyString.set('product_not_received', 'Product not received')
+reasonToFriendlyString.set('product_unacceptable', 'Product unacceptable')
+reasonToFriendlyString.set('unrecognised', 'Unrecognised')
+reasonToFriendlyString.set('subscription_canceled', 'Subscription cancelled')
+reasonToFriendlyString.set('other', 'Other')
+
+class DisputeTransaction {
+  constructor (transactionData) {
+    this.created_date = dates.utcToDisplay(transactionData.created_date)
+    this.state = {
+      status: lodash.get(transactionData, 'state.status'),
+      finished: lodash.get(transactionData, 'state.finished')
+    }
+
+    if (this.state.status) {
+      this.state_friendly = states.getEventDisplayNameForConnectorState(this.state, 'dispute')
+    }
+    if (transactionData.reason) {
+      this.reason_friendly = reasonToFriendlyString.get(transactionData.reason)
+    }
+    if (transactionData.amount) {
+      this.amount_friendly = penceToPoundsWithCurrency(transactionData.amount)
+    }
+    if (transactionData.net_amount) {
+      this.net_amount_friendly = penceToPoundsWithCurrency(transactionData.net_amount)
+    }
+    if (transactionData.fee) {
+      this.fee_friendly = penceToPoundsWithCurrency(transactionData.fee)
+    }
+    if (transactionData.evidence_due_date) {
+      this.evidence_due_date_friendly = dates.utcToDisplay(transactionData.evidence_due_date)
+    }
+  }
+}
+
+module.exports = DisputeTransaction

--- a/app/models/DisputeTransaction.class.test.js
+++ b/app/models/DisputeTransaction.class.test.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const { expect } = require('chai')
+const DisputeTransaction = require('./DisputeTransaction.class')
+const dates = require('../utils/dates')
+
+describe('Dispute transaction model', () => {
+  it('should build dispute transaction correctly for full dispute data', () => {
+    const dispute = new DisputeTransaction({
+      'created_date': '2022-07-26T19:57:26.000Z',
+      'reason': 'fraudulent',
+      'state': {
+        'finished': true,
+        'status': 'won'
+      },
+      'amount': 20000,
+      'net_amount': -35000,
+      'fee': 1500,
+      'evidence_due_date': '2022-08-04T23:59:59.000Z'
+    })
+
+    expect(dispute.created_date).to.equal(dates.utcToDisplay('2022-07-26T19:57:26.000Z'))
+    expect(dispute.reason_friendly).to.equal('Fraudulent')
+    expect(dispute.amount_friendly).to.equal('£200.00')
+    expect(dispute.net_amount_friendly).to.equal('-£350.00')
+    expect(dispute.fee_friendly).to.equal('£15.00')
+    expect(dispute.state_friendly).to.equal('Dispute won in your favour')
+    expect(dispute.evidence_due_date_friendly).to.equal(dates.utcToDisplay('2022-08-04T23:59:59.000Z'))
+  })
+
+  it('should build dispute transaction correctly for minimum dispute data', () => {
+    const dispute = new DisputeTransaction({
+      'created_date': '2022-07-26T19:57:26.000Z',
+      'state': {
+        'finished': true,
+        'status': 'under_review'
+      }
+    })
+
+    expect(dispute.created_date).to.equal(dates.utcToDisplay('2022-07-26T19:57:26.000Z'))
+    expect(dispute.state_friendly).to.equal('Dispute under review')
+
+    expect(dispute.reason_friendly).to.be.undefined // eslint-disable-line
+    expect(dispute.amount_friendly).to.be.undefined // eslint-disable-line
+    expect(dispute.net_amount_friendly).to.be.undefined // eslint-disable-line
+    expect(dispute.fee_friendly).to.be.undefined // eslint-disable-line
+    expect(dispute.evidence_due_date_friendly).to.be.undefined // eslint-disable-line
+  })
+})

--- a/app/models/TransactionEvent.class.js
+++ b/app/models/TransactionEvent.class.js
@@ -22,7 +22,8 @@ class TransactionEvent {
     this.state_friendly = states.getEventDisplayNameForConnectorState(this.state, this.type)
     this.updated_friendly = dates.utcToDisplay(this.updated)
     this.amount_friendly = penceToPoundsWithCurrency(this.amount)
-    if (this.amount && this.type.toLowerCase() === 'refund') {
+    const transactionType = this.type.toLowerCase()
+    if (this.amount && (transactionType === 'refund' || transactionType === 'dispute')) {
       this.amount_friendly = `–${this.amount_friendly}`
     }
   }

--- a/app/services/clients/ledger.client.js
+++ b/app/services/clients/ledger.client.js
@@ -42,6 +42,18 @@ const transactionWithAccountOverride = function transactionWithAccountOverride (
   return baseClient.get(configuration)
 }
 
+function getDisputesForTransaction (id, gatewayAccountId) {
+  const configuration = Object.assign({
+    url: `/v1/transaction/${id}/transaction`,
+    qs: {
+      gateway_account_id: gatewayAccountId,
+      transaction_type: 'DISPUTE'
+    },
+    description: 'Get disputes for payment'
+  }, defaultOptions)
+  return baseClient.get(configuration)
+}
+
 const events = function events (transactionId, gatewayAccountId, options = {}) {
   const configuration = Object.assign({
     url: `/v1/transaction/${transactionId}/event`,
@@ -148,6 +160,7 @@ const agreement = function agreement (id, serviceId, options = {}) {
 module.exports = {
   transaction,
   transactions,
+  getDisputesForTransaction,
   payouts,
   transactionWithAccountOverride,
   events,

--- a/app/utils/transaction-view.js
+++ b/app/utils/transaction-view.js
@@ -11,6 +11,7 @@ const states = require('./states')
 const check = require('check-types')
 const url = require('url')
 const TransactionEvent = require('../models/TransactionEvent.class')
+const DisputeTransaction = require('../models/DisputeTransaction.class')
 const formatAccountPathsFor = require('../utils/format-account-paths-for')
 
 const DATA_UNAVAILABLE = 'Data unavailable'
@@ -93,7 +94,7 @@ module.exports = {
     return connectorData
   },
 
-  buildPaymentView: function (chargeData, eventsData, users = []) {
+  buildPaymentView: function (chargeData, eventsData, disputeTransactionData, users = []) {
     chargeData.state_friendly = states.getDisplayNameForConnectorState(chargeData.state, chargeData.transaction_type)
     chargeData.refund_summary = chargeData.refund_summary || {}
 
@@ -143,6 +144,11 @@ module.exports = {
         event.submitted_by_friendly = lodash.get(users.find(user => user.externalId === event.submitted_by) || {}, 'email')
       }
     })
+
+    if (disputeTransactionData) {
+      chargeData.dispute = new DisputeTransaction(disputeTransactionData)
+    }
+
     delete chargeData['links']
     delete chargeData['return_url']
     return chargeData

--- a/app/views/transaction-detail/_details.njk
+++ b/app/views/transaction-detail/_details.njk
@@ -23,7 +23,13 @@
 
   <tr class="govuk-table__row">
     <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16 vertical-align-top" scope="row">Payment status:</th>
-    <td class="govuk-table__cell govuk-!-font-size-16" id="state">{{state_friendly}}
+    <td class="govuk-table__cell govuk-!-font-size-16" id="state">
+      {% if dispute %}
+        {{dispute.state_friendly}}
+      {% else %}
+        {{state_friendly}}
+      {% endif %}
+
       {% if state_friendly === "Declined" %}
         {% set stateInfo %}
           <p class="govuk-!-font-size-16">The payment was declined. This may happen if:</p>

--- a/app/views/transaction-detail/_dispute.njk
+++ b/app/views/transaction-detail/_dispute.njk
@@ -1,0 +1,50 @@
+<h2 class="govuk-heading-m govuk-!-margin-top-1" data-cy="dispute-details">Dispute details</h2>
+<table class="dispute-details govuk-table" data-cy="dispute-details-container">
+  <tbody class="govuk-table__body">
+
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">Status:</th>
+    <td class="govuk-table__cell govuk-!-font-size-16" data-cy="dispute-state">{{ dispute.state_friendly }}</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">Date disputed:</th>
+    <td class="govuk-table__cell govuk-!-font-size-16" data-cy="dispute-date">{{ dispute.created_date }}</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">Disputed amount:</th>
+    <td class="govuk-table__cell govuk-!-font-size-16" data-cy="dispute-amount">{{ dispute.amount_friendly }} </td>
+  </tr>
+  {% if dispute.fee_friendly %}
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">PSP dispute fee:</th>
+      <td class="govuk-table__cell govuk-!-font-size-16" data-cy="dispute-fee">{{ dispute.fee_friendly }}
+        {% set disputeFeeInfo %}
+          <p class="govuk-!-font-size-16">If you lose a payment dispute, Stripe will deduct the disputed amount and an
+            additional {{ dispute.fee_friendly }} dispute fee from your account.</p>
+        {% endset %}
+        {{ govukDetails({
+          summaryText: "What is this fee?",
+          classes: "small-arrow govuk-!-font-size-16",
+          html: disputeFeeInfo
+        }) }}
+      </td>
+    </tr>
+  {% endif %}
+  {% if dispute.net_amount_friendly %}
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">Dispute net amount:</th>
+      <td class="govuk-table__cell govuk-!-font-size-16" data-cy="dispute-net-amount">{{ dispute.net_amount_friendly }}</td>
+    </tr>
+  {% endif %}
+
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">Reason:</th>
+    <td class="govuk-table__cell govuk-!-font-size-16" data-cy="dispute-reason">{{ dispute.reason_friendly }}</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">Evidence due by:</th>
+    <td class="govuk-table__cell govuk-!-font-size-16"
+        data-cy="dispute-evidence-due-date">{{ dispute.evidence_due_date_friendly }}</td>
+  </tr>
+  </tbody>
+</table>

--- a/app/views/transaction-detail/index.njk
+++ b/app/views/transaction-detail/index.njk
@@ -75,6 +75,10 @@
       {% include "./_metadata.njk" %}
     {% endif %}
 
+    {% if dispute %}
+      {% include "./_dispute.njk" %}
+    {% endif %}
+
     {% if permissions.transactions_events_read %}
       <h2 class="govuk-heading-m govuk-!-margin-top-9">Transaction events</h2>
       {% include "./_events.njk" %}

--- a/test/cypress/stubs/transaction-stubs.js
+++ b/test/cypress/stubs/transaction-stubs.js
@@ -12,6 +12,12 @@ function getLedgerTransactionSuccess (opts) {
     response: ledgerTransactionFixtures.validTransactionDetailsResponse(opts.transactionDetails)
   })
 }
+function getLedgerDisputeTransactionsSuccess (opts) {
+  const path = `/v1/transaction/${opts.disputeTransactionsDetails.parent_transaction_id}/transaction`
+  return stubBuilder('GET', path, 200, {
+    response: ledgerTransactionFixtures.validDisputeTransactionsResponse(opts.disputeTransactionsDetails)
+  })
+}
 
 function getLedgerEventsSuccess (opts) {
   const path = `/v1/transaction/${opts.transactionId}/event`
@@ -78,6 +84,7 @@ module.exports = {
   getLedgerEventsSuccess,
   getLedgerTransactionSuccess,
   getLedgerTransactionsSuccess,
+  getLedgerDisputeTransactionsSuccess,
   postRefundSuccess,
   postRefundAmountNotAvailable
 }

--- a/test/fixtures/ledger-transaction.fixtures.js
+++ b/test/fixtures/ledger-transaction.fixtures.js
@@ -181,7 +181,9 @@ const buildDisputeDetails = (opts = {}) => {
     created_date: opts.created_date || '2019-08-20T14:39:49.536Z',
     transaction_type: 'DISPUTE',
     transaction_id: opts.transaction_id || '1b5kia0u28ll2ic4obv26r5e4h',
-    parent_transaction_id: opts.parent_transaction_id || 'puuhl0gu7egigin7oh9c75p4m1'
+    parent_transaction_id: opts.parent_transaction_id || 'puuhl0gu7egigin7oh9c75p4m1',
+    evidence_due_date: opts.evidence_due_date || '2019-08-21T14:39:49.536Z',
+    reason: opts.reason || 'other'
   }
 
   if (opts.fee) result.fee = opts.fee
@@ -217,6 +219,19 @@ module.exports = {
     opts.includeSettlementSummary = true
     opts.includeAddress = opts.includeAddress || true
     return buildTransactionDetails(opts)
+  },
+  validDisputeTransactionDetails: (opts = {}) => {
+    return buildDisputeDetails(opts)
+  },
+  validDisputeTransactionsResponse: (opts = {}) => {
+    let transactions = []
+    opts.transactions.forEach(transaction => {
+      transactions.push(buildDisputeDetails(transaction))
+    })
+    return {
+      parent_transaction_id: opts.parent_transaction_id || 'adb123def456',
+      transactions: transactions
+    }
   },
   validTransactionCreatedDetailsResponse: (opts = {}) => {
     opts.includeRefundSummary = true

--- a/test/unit/utils/transaction-view.test.js
+++ b/test/unit/utils/transaction-view.test.js
@@ -8,11 +8,11 @@ const transactionFixtures = require('../../fixtures/ledger-transaction.fixtures'
 describe('Transaction view utilities', () => {
   describe('disputed payment refundable', () => {
     const testCases = [
-      {refund_summary_status: "unavailable", expectations: { refund_unavailable_due_to_dispute: true, refundable: false } },
-      {refund_summary_status: "available", expectations: { refund_unavailable_due_to_dispute: false, refundable: true } },
-      {refund_summary_status: "error", expectations: { refund_unavailable_due_to_dispute: false, refundable: true } },
-      {refund_summary_status: "full", expectations: { refund_unavailable_due_to_dispute: false, refundable: false } },
-      {refund_summary_status: "pending", expectations: { refund_unavailable_due_to_dispute: false, refundable: false } },
+      { refund_summary_status: 'unavailable', expectations: { refund_unavailable_due_to_dispute: true, refundable: false } },
+      { refund_summary_status: 'available', expectations: { refund_unavailable_due_to_dispute: false, refundable: true } },
+      { refund_summary_status: 'error', expectations: { refund_unavailable_due_to_dispute: false, refundable: true } },
+      { refund_summary_status: 'full', expectations: { refund_unavailable_due_to_dispute: false, refundable: false } },
+      { refund_summary_status: 'pending', expectations: { refund_unavailable_due_to_dispute: false, refundable: false } }
     ]
 
     testCases.forEach(testCase => {
@@ -22,11 +22,22 @@ describe('Transaction view utilities', () => {
           refund_summary_status: testCase.refund_summary_status
         })
         const events = transactionFixtures.validTransactionEventsResponse()
-        const view = buildPaymentView(transaction, events)
-    
+        const view = buildPaymentView(transaction, events, {})
+
         expect(view.refund_unavailable_due_to_dispute).to.equal(testCase.expectations.refund_unavailable_due_to_dispute)
         expect(view.refundable).to.equal(testCase.expectations.refundable)
       })
+    })
+  })
+
+  describe('dispute data', () => {
+    it('should build dispute data if dispute transaction is available', () => {
+      const transaction = transactionFixtures.validTransactionDetailsResponse()
+      const events = transactionFixtures.validTransactionEventsResponse()
+      const disputeData = transactionFixtures.validDisputeTransactionDetails({ 'amount': 1000 })
+      const paymentView = buildPaymentView(transaction, events, disputeData)
+
+      expect(paymentView.dispute.amount_friendly).to.equal('£10.00')
     })
   })
 })


### PR DESCRIPTION
## WHAT
- If payment is disputed, get and display dispute info on the transaction detail page
- Set payment status to the latest dispute status

## Preview

_Dispute details_

<img width="442" alt="image" src="https://user-images.githubusercontent.com/40598480/181233573-b1670308-5104-4358-96f5-e7d6d19eb4f0.png">

_Transaction events_

<img width="765" alt="image" src="https://user-images.githubusercontent.com/40598480/181238389-c783361d-6777-4ba8-8a27-6b25a6a70290.png">


_Payment status_

<img width="455" alt="image" src="https://user-images.githubusercontent.com/40598480/181233799-0314bae1-4752-4d3c-8462-20c42cd7a91a.png">

