### PR TITLE
PP-9846 Bring agreements list styling into line with transactions

### DIFF
--- a/app/views/agreements/detail.njk
+++ b/app/views/agreements/detail.njk
@@ -58,7 +58,10 @@
   {% endset %}
   {{ govukSummaryList({
     rows: [{
-      key: { text: "Brand" },
+      key: { text: "Type" },
+      value: { text: paymentInstrument.type | capitalize }
+    },{
+      key: { text: "Card brand" },
       value: { html: image }
     },{
       key: { text: "Name on card" },
@@ -69,6 +72,9 @@
     },{
       key: { text: "Card expiry date" },
       value: { text: cardDetails.expiry_date }
+    }, {
+      key: { text: "Card type" },
+      value: { text: cardDetails.card_type | capitalize }
     }],
     attributes: {
       id: "payment-instrument-list"

--- a/app/views/agreements/list.njk
+++ b/app/views/agreements/list.njk
@@ -19,7 +19,7 @@ Agreements - GOV.UK Pay
         selected: not filters.status
       },{
         value: 'CREATED',
-        text: 'Needs user details',
+        text: 'Needs payment details',
         selected: filters.status === 'CREATED'
       }, {
         value: 'ACTIVE',
@@ -119,7 +119,7 @@ Agreements - GOV.UK Pay
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col" id="id-header">ID</th>
         <th class="govuk-table__header" scope="col" id="reference-header">Reference</th>
-        <th class="govuk-table__header" hidden scope="col" id="status-header">Status</th>
+        <th class="govuk-table__header" scope="col" id="status-header">Status</th>
         <th class="govuk-table__header" scope="col" id="payment-instrumnet-header">Payment instrument</th>
         <th class="govuk-table__header" scope="col" id="brand-header">Date created</th>
       </tr>
@@ -127,28 +127,27 @@ Agreements - GOV.UK Pay
 
     <tbody class="govuk-table__body">
     {% for agreement in agreements.results %}
-      <td class="govuk-table__cell pay-text-grey">
+      <td class="govuk-table__cell govuk-!-font-size-14">
         {{ agreement.external_id }}
       </td>
-      <td class="govuk-table__cell  pay-text-grey">
+      <td class="govuk-table__cell govuk-!-font-size-14">
         <a
           class="govuk-link govuk-link__no-visited-state govuk-!-margin-right-1"
           data-action="update"
           href="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.agreements.detail, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, agreement.external_id) }}">
           {{ agreement.reference }}
         </a>
-        {{ agreementStatusTag(agreement.status) }}
       </td>
       {# included for screen readers #}
-      <td hidden>{{ agreement.status }}</td>
-      <td class="govuk-table__cell pay-text-grey">
+      <td class="govuk-table__cell govuk-!-font-size-14">
+        {{ agreementStatusTag(agreement.status) }}
+      </td>
+      <td class="govuk-table__cell govuk-!-font-size-14">
         {% if agreement.payment_instrument %}
           {{ paymentInstrument(agreement.payment_instrument) }}
-        {% else %}
-          (none set)
         {% endif %}
       </td>
-      <td class="govuk-table__cell pay-text-grey">
+      <td class="govuk-table__cell govuk-!-font-size-14">
         {{ agreement.created_date | datetime('datelong') }}
       </td>
       </tr>

--- a/app/views/agreements/macro/status.njk
+++ b/app/views/agreements/macro/status.njk
@@ -5,7 +5,7 @@
 "CANCELLED": "govuk-tag--yellow"
 } %}
 {% set statusTextMap = {
-"CREATED": "needs user details",
+"CREATED": "needs payment details",
 "ACTIVE": "active",
 "CANCELLED": "cancelled",
 "EXPIRED": "expired"

--- a/test/fixtures/agreement.fixtures.js
+++ b/test/fixtures/agreement.fixtures.js
@@ -5,9 +5,11 @@ function buildCardDetails (opts = {}) {
 
   return {
     last_digits_card_number: opts.last_digits_card_number || '0002',
+    first_digits_card_number: opts.first_digits_card_number || '424242',
     cardholder_name: opts.cardholder_name || 'Test User',
     expiry_date: opts.expiry_date || '08/23',
     card_brand: opts.card_brand || 'Visa',
+    card_type: opts.card_type || 'DEBIT',
     billing_address: {
       line1: billingAddressOpts.line1 || 'address line 1',
       line2: billingAddressOpts.line2 || 'address line 2',
@@ -20,7 +22,7 @@ function buildCardDetails (opts = {}) {
 
 function buildPaymentInstrument (opts = {}) {
   return {
-    method: opts.method || 'CARD',
+    type: opts.type || 'CARD',
     created_date: opts.created_date || '2022-03-01T01:00:00.000Z',
     gateway_expiration_date: opts.gateway_expiration_date || '2022-03-01T01:00:00.000Z',
     card_details: buildCardDetails(opts.card_details)


### PR DESCRIPTION
The transactions page adds some custom styling to reduce text size.
Update the agreements page to make the styling more consistent and put
statuses into columns to avoid table flow issues.

Add missing properties from agreement detail page.

**Before**

<img width="1251" alt="Screenshot 2022-07-28 at 09 22 03" src="https://user-images.githubusercontent.com/2844572/181459186-6bf9f045-6c8e-472e-b941-3f25f34a4b19.png">

**After**

<img width="693" alt="Screenshot 2022-07-28 at 09 22 28" src="https://user-images.githubusercontent.com/2844572/181459323-42ead8da-20b2-49a3-9588-88e7c374eed3.png">

