### PR TITLE
PP-9004 Stripe setup > update org details - fix template bug

### DIFF
--- a/app/controllers/request-to-go-live/organisation-address/get.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/get.controller.js
@@ -52,5 +52,7 @@ module.exports = function getOrganisationAddress (req, res) {
     isStripeUpdateOrgDetails
   }
   pageData.countries = countries.govukFrontendFormatted(lodash.get(pageData, 'address_country'))
-  return response(req, res, 'request-to-go-live/organisation-address', pageData)
+  
+  const templatePath = isStripeUpdateOrgDetails ? 'stripe-setup/update-org-details/index' : 'request-to-go-live/organisation-address'
+  return response(req, res, templatePath, pageData)
 }

--- a/app/controllers/request-to-go-live/organisation-address/get.controller.test.js
+++ b/app/controllers/request-to-go-live/organisation-address/get.controller.test.js
@@ -106,7 +106,7 @@ describe('organisation address get controller', () => {
     })
 
     describe('view page when `Stripe setup`', () => {
-      it('should display the org address page and set `isStripeUpdateOrgDetails=true` ' +
+      it('should display the `update org details` form and set `isStripeUpdateOrgDetails=true` ' +
       'and all form fields should be reset to empty', () => {
         const req = {
           route: {
@@ -121,7 +121,7 @@ describe('organisation address get controller', () => {
 
         const responseData = mockResponse.getCalls()[0]
 
-        expect(responseData.args[2]).to.equal('request-to-go-live/organisation-address')
+        expect(responseData.args[2]).to.equal('stripe-setup/update-org-details/index')
 
         const pageData = responseData.args[3]
         expect(pageData.isStripeUpdateOrgDetails).to.equal(true)

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.js
@@ -209,7 +209,9 @@ module.exports = async function submitOrganisationAddress (req, res, next) {
       }
     } else {
       const pageData = buildErrorsPageData(form, errors, isRequestToGoLive, isStripeUpdateOrgDetails)
-      return response(req, res, 'request-to-go-live/organisation-address', pageData)
+
+      const templatePath = isStripeUpdateOrgDetails ? 'stripe-setup/update-org-details/index' : 'request-to-go-live/organisation-address'
+      return response(req, res, templatePath, pageData)
     }
   } catch (err) {
     next(err)

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.test.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.test.js
@@ -191,7 +191,7 @@ describe('organisation address post controller', () => {
 
         const responseData = mockResponse.getCalls()[0]
 
-        expect(responseData.args[2]).to.equal('request-to-go-live/organisation-address')
+        expect(responseData.args[2]).to.equal('stripe-setup/update-org-details/index')
 
         const errors = responseData.args[3].errors
         expect(Object.keys(errors).length).to.equal(4)

--- a/app/views/includes/phase-banner.njk
+++ b/app/views/includes/phase-banner.njk
@@ -52,7 +52,7 @@
 
 {% if not hideServiceNav and not hideServiceHeader %}
 <div class="govuk-phase-banner govuk-clearfix pay-top-navigation">
-  <nav role="navigation" class="service-navigation">
+  <nav role="navigation" class="service-navigation" data-cy="account-sub-nav">
     <ul class="service-navigation--list">
       {% for item in serviceNavigationItems %}
         {% if item.permissions %}

--- a/app/views/stripe-setup/update-org-details/index.njk
+++ b/app/views/stripe-setup/update-org-details/index.njk
@@ -1,0 +1,1 @@
+{% extends "../../request-to-go-live/organisation-address.njk" %}

--- a/test/cypress/integration/request-to-go-live/organisation-address.cy.test.js
+++ b/test/cypress/integration/request-to-go-live/organisation-address.cy.test.js
@@ -63,6 +63,11 @@ describe('The organisation address page', () => {
           })
       })
 
+      it('should not display the account sub nav', () => {
+        cy.get('[data-cy=account-sub-nav]')
+          .should('not.exist')
+      })
+
       it('should display errors when validation fails', () => {
         cy.get(`form[method=post]`)
           .within(() => {

--- a/test/cypress/integration/stripe-setup/check-org-details.cy.test.js
+++ b/test/cypress/integration/stripe-setup/check-org-details.cy.test.js
@@ -93,6 +93,11 @@ describe('Stripe setup: Check your organisation’s details', () => {
         })
     })
 
+    it('should display the account sub nav', () => {
+      cy.get('[data-cy=account-sub-nav]')
+        .should('exist')
+    })
+
     it('should display an error when a radio button is not clicked', () => {
       cy.get('[data-cy=continue-button]').click()
 

--- a/test/cypress/integration/stripe-setup/update-org-details.cy.test.js
+++ b/test/cypress/integration/stripe-setup/update-org-details.cy.test.js
@@ -98,6 +98,11 @@ describe('The organisation address page', () => {
           })
       })
 
+      it('should display the account sub nav', () => {
+        cy.get('[data-cy=account-sub-nav]')
+          .should('exist')
+      })
+
       it('should not display the telephone or url fields', () => {
         cy.get('[data-cy=form]')
           .should('exist')


### PR DESCRIPTION
- Bug - Stripe setup > Update Org details - was not showing `account sub nav`.
- This is because it uses the same controller and Nunjuks file as `request to go live` >
  `organisation address` - and that Nunjuks file is configured in the display converter
  to hide the `account sub nav`.
- Create a new template which extends the existing `organisation address` page.
  - New template - `update-org-details`
  - Use this template when in the `Stripe setup` journey.
  - This template will not be configured to hide the `service nav`.
- Update unit tests
- Update Cypress tests
  - `phase-banner.njk` - This is the `account sub nav`.  Add a Cypress
    data attribute to this - so it is easier to select in a Cypress test.
  - Update `Stripe setup` > `check-org-details` & `update-org-details` test to check that
    `account sub nav` exists.
  - Update the `request live` > `organisation details` test - to make sure that the
    account sub nav does not exist.

## Existing `request to go live` > `organsation address page` page - does not show account sub nav

<img width="776" alt="image" src="https://user-images.githubusercontent.com/59831992/182122160-47d19442-485c-4374-baed-e38744e3c91d.png">

## New `stripe setup` > `check org details` page - shows account sub nav

<img width="997" alt="image" src="https://user-images.githubusercontent.com/59831992/182122821-2c4d63b1-bcf5-457b-8b1f-8658b35243c7.png">

## New `stripe setup` > `update org details` page - shows account sub nav

<img width="997" alt="image" src="https://user-images.githubusercontent.com/59831992/182123241-9ee8a99a-c6a8-49c6-a97c-af9aa6beb587.png">
