### PR TITLE
PP-9672 Re-order sections on transaction details

### DIFF
--- a/app/views/transaction-detail/_dispute.njk
+++ b/app/views/transaction-detail/_dispute.njk
@@ -1,4 +1,3 @@
-<h2 class="govuk-heading-m govuk-!-margin-top-1" data-cy="dispute-details">Dispute details</h2>
 <table class="dispute-details govuk-table" data-cy="dispute-details-container">
   <tbody class="govuk-table__body">
 

--- a/app/views/transaction-detail/index.njk
+++ b/app/views/transaction-detail/index.njk
@@ -67,16 +67,17 @@
     <h1 class="govuk-heading-l">Transaction details</h1>
     {% include "./_details.njk" %}
 
+    {% if dispute %}
+      <h2 class="govuk-heading-m govuk-!-margin-top-9" data-cy="dispute-details">Dispute details</h2>
+      {% include "./_dispute.njk" %}
+    {% endif %}
+
     <h2 class="govuk-heading-m govuk-!-margin-top-9">Payment method</h2>
     {% include "./_payment.njk" %}
 
     {% if metadata %}
       <h2 class="govuk-heading-m govuk-!-margin-top-9">Metadata</h2>
       {% include "./_metadata.njk" %}
-    {% endif %}
-
-    {% if dispute %}
-      {% include "./_dispute.njk" %}
     {% endif %}
 
     {% if permissions.transactions_events_read %}


### PR DESCRIPTION
The "Dispute details" section should come before the "Payment method" section.

Also fix the spacing of the sections.

