### PR TITLE
PP-9016 Validate webhooks form

### DIFF
--- a/app/controllers/webhooks/webhooks-form.js
+++ b/app/controllers/webhooks/webhooks-form.js
@@ -16,6 +16,9 @@ const defaultFieldsSchema = [
     }
   },
   {
+    id: 'description'
+  },
+  {
     id: 'subscriptions',
     valid: [{ method: isNotEmpty, message: 'Select a payment event' }]
   }

--- a/app/controllers/webhooks/webhooks-form.js
+++ b/app/controllers/webhooks/webhooks-form.js
@@ -1,0 +1,97 @@
+const CALLBACK_URL_MAX_LENGTH = 2048
+
+const defaultFieldsSchema = [
+  {
+    id: 'callback_url', 
+    valid: [{ method: isNotEmpty, message: 'Enter a callback URL' }],
+
+    // https://github.com/alphagov/pay-webhooks/blob/main/src/main/java/uk/gov/pay/webhooks/webhook/exception/WebhooksErrorIdentifier.java
+    errorIdentifiers: {
+      CALLBACK_URL_MALFORMED: 'Callback URL must be a valid URL',
+      CALLBACK_URL_PROTOCOL_NOT_SUPPORTED: 'Callback URL must use the protocol HTTPS',
+      CALLBACK_URL_NOT_ON_ALLOW_LIST: 'Callback URL must be on an approved list of domains for live accounts. PLease contact support'
+    }
+  },
+  {
+    id: 'subscriptions',
+    valid: [{ method: isNotEmpty, message: 'Select a payment event' }] 
+  }
+]
+
+class WebhooksForm {
+  constructor (fields = defaultFieldsSchema) {
+    this.fields = fields
+    this.values = {}
+  }
+
+  from (entity = {}) {
+    const values = this.fields.reduce((aggregate, field) => {
+      const key = field.key || field.id
+      aggregate[key] = entity[key]
+      return aggregate
+    }, {})
+    return { values }
+  }
+
+  validate (formData = {}) {
+    const errors = {}
+    const values = {}
+
+    this.fields.forEach((field) => {
+      const valid = field.valid || []
+      values[field.key || field.id] = trim(formData[field.id])
+      valid.some((validator) => {
+        const valid = validator.method(formData[field.id])
+        if (!valid) {
+          errors[field.id] = validator.message
+          return true
+        }
+      })
+    })
+    return {
+      values,
+      errors,
+      errorSummaryList: formatErrorsForSummaryList(errors)
+    }
+  }
+
+  parseResponse(error = {}, formData = {}) {
+    const errors = {}
+    const values = {}
+    this.fields.forEach((field) => {
+      const fieldSpecificErrorIdentifiers = field.errorIdentifiers || {}
+      values[field.key || field.id] = trim(formData[field.id])
+      
+      if (fieldSpecificErrorIdentifiers[error.errorIdentifier]) {
+        errors[field.id] = fieldSpecificErrorIdentifiers[error.errorIdentifier]
+      } 
+    })
+    return {
+      values,
+      errors,
+      errorSummaryList: formatErrorsForSummaryList(errors)
+    }
+  }
+}
+
+function isNotEmpty (value) {
+  return value && value.length !== 0
+}
+
+function isValidLength (value) {
+  return value && value.length <= CALLBACK_URL_MAX_LENGTH
+}
+
+function formatErrorsForSummaryList (errors = {}) {
+  return Object.entries(errors).map(([id, message]) => ({
+    href: `#${id}`,
+    text: message
+  }))
+}
+
+function trim(value) {
+  return typeof value === 'string' ? value.trim() : value
+}
+
+module.exports = { WebhooksForm, isNotEmpty, isValidLength }
+

--- a/app/controllers/webhooks/webhooks-form.js
+++ b/app/controllers/webhooks/webhooks-form.js
@@ -5,14 +5,14 @@ const defaultFieldsSchema = [
     id: 'callback_url',
     valid: [
       { method: isNotEmpty, message: 'Enter a callback URL' },
-      { method: isValidLength, message: `Callback URL must be ${CALLBACK_URL_MAX_LENGTH} or fewer` }
+      { method: isValidLength, message: `Callback URL must be ${CALLBACK_URL_MAX_LENGTH} characters or fewer` }
     ],
 
     // https://github.com/alphagov/pay-webhooks/blob/main/src/main/java/uk/gov/pay/webhooks/webhook/exception/WebhooksErrorIdentifier.java
     errorIdentifiers: {
-      CALLBACK_URL_MALFORMED: 'Callback URL must be a valid URL',
-      CALLBACK_URL_PROTOCOL_NOT_SUPPORTED: 'Callback URL must use the protocol HTTPS',
-      CALLBACK_URL_NOT_ON_ALLOW_LIST: 'Callback URL must be on an approved list of domains for live accounts. PLease contact support'
+      CALLBACK_URL_MALFORMED: 'Enter a valid callback URL',
+      CALLBACK_URL_PROTOCOL_NOT_SUPPORTED: 'Callback URL must begin with https://',
+      CALLBACK_URL_NOT_ON_ALLOW_LIST: 'Callback URL must be approved. Please contact support'
     }
   },
   {
@@ -20,7 +20,7 @@ const defaultFieldsSchema = [
   },
   {
     id: 'subscriptions',
-    valid: [{ method: isNotEmpty, message: 'Select a payment event' }]
+    valid: [{ method: isNotEmpty, message: 'Select at least one payment event' }]
   }
 ]
 

--- a/app/controllers/webhooks/webhooks-form.js
+++ b/app/controllers/webhooks/webhooks-form.js
@@ -2,8 +2,11 @@ const CALLBACK_URL_MAX_LENGTH = 2048
 
 const defaultFieldsSchema = [
   {
-    id: 'callback_url', 
-    valid: [{ method: isNotEmpty, message: 'Enter a callback URL' }],
+    id: 'callback_url',
+    valid: [
+      { method: isNotEmpty, message: 'Enter a callback URL' },
+      { method: isValidLength, message: `Callback URL must be ${CALLBACK_URL_MAX_LENGTH} or fewer` }
+    ],
 
     // https://github.com/alphagov/pay-webhooks/blob/main/src/main/java/uk/gov/pay/webhooks/webhook/exception/WebhooksErrorIdentifier.java
     errorIdentifiers: {
@@ -14,7 +17,7 @@ const defaultFieldsSchema = [
   },
   {
     id: 'subscriptions',
-    valid: [{ method: isNotEmpty, message: 'Select a payment event' }] 
+    valid: [{ method: isNotEmpty, message: 'Select a payment event' }]
   }
 ]
 
@@ -55,16 +58,17 @@ class WebhooksForm {
     }
   }
 
-  parseResponse(error = {}, formData = {}) {
+  parseResponse (error = {}, formData = {}) {
     const errors = {}
     const values = {}
     this.fields.forEach((field) => {
       const fieldSpecificErrorIdentifiers = field.errorIdentifiers || {}
+      const errorIdentifierValue = fieldSpecificErrorIdentifiers[error.errorIdentifier || error.error_identifier]
       values[field.key || field.id] = trim(formData[field.id])
-      
-      if (fieldSpecificErrorIdentifiers[error.errorIdentifier]) {
-        errors[field.id] = fieldSpecificErrorIdentifiers[error.errorIdentifier]
-      } 
+
+      if (errorIdentifierValue) {
+        errors[field.id] = errorIdentifierValue
+      }
     })
     return {
       values,
@@ -89,9 +93,8 @@ function formatErrorsForSummaryList (errors = {}) {
   }))
 }
 
-function trim(value) {
+function trim (value) {
   return typeof value === 'string' ? value.trim() : value
 }
 
-module.exports = { WebhooksForm, isNotEmpty, isValidLength }
-
+module.exports = { WebhooksForm }

--- a/app/controllers/webhooks/webhooks-forms.test.js
+++ b/app/controllers/webhooks/webhooks-forms.test.js
@@ -13,10 +13,10 @@ describe('Webhooks forms', () => {
 
   it('correctly validates for empty values', () => {
     const validDefaultSchemaForm = new WebhooksForm()
-    
+
     // no selected radio elements will have no value
     const formData = {
-        'callback_url': ''
+      'callback_url': ''
     }
     const results = validDefaultSchemaForm.validate(formData)
     expect(results.errors['callback_url']).to.equal('Enter a callback URL')
@@ -31,14 +31,14 @@ describe('Webhooks forms', () => {
     const validRadioInputs = [ [ 'card_payment_started', 'card_payment_captured' ], 'card_payment_started' ]
 
     validRadioInputs.forEach((validRadioInput) => {
-        const formData = {
-            'callback_url': 'https://a-valid-url.com',
-            'subscriptions': validRadioInput
-        }
-        const results = validDefaultSchemaForm.validate(formData)
+      const formData = {
+        'callback_url': 'https://a-valid-url.com',
+        'subscriptions': validRadioInput
+      }
+      const results = validDefaultSchemaForm.validate(formData)
         expect(results.errorSummaryList).to.be.empty // eslint-disable-line
-        expect(results.values['callback_url']).to.equal('https://a-valid-url.com')
-        expect(results.values['subscriptions']).to.deep.equal(validRadioInput)
+      expect(results.values['callback_url']).to.equal('https://a-valid-url.com')
+      expect(results.values['subscriptions']).to.deep.equal(validRadioInput)
     })
   })
 
@@ -52,10 +52,10 @@ describe('Webhooks forms', () => {
 
   it('parses known error identifiers from the backend', () => {
     const validDefaultSchemaForm = new WebhooksForm()
-    
+
     const formData = {
-        'callback_url': 'https://a-valid-url.com',
-        'subscriptions': 'card_payment_succeeded'
+      'callback_url': 'https://a-valid-url.com',
+      'subscriptions': 'card_payment_succeeded'
     }
 
     const expectedError = new Error('URL must be on allow list')

--- a/app/controllers/webhooks/webhooks-forms.test.js
+++ b/app/controllers/webhooks/webhooks-forms.test.js
@@ -1,0 +1,70 @@
+const { expect } = require('chai')
+
+const { WebhooksForm } = require('./webhooks-form')
+
+const webhooksFixtures = require('./../../../test/fixtures/webhooks.fixtures')
+
+describe('Webhooks forms', () => {
+  it('constructs a form with no fields', () => {
+    const formSchema = new WebhooksForm([])
+    expect(formSchema).to.not.be.null // eslint-disable-line
+    expect(formSchema.validate().errors).to.deep.equal({})
+  })
+
+  it('correctly validates for empty values', () => {
+    const validDefaultSchemaForm = new WebhooksForm()
+    
+    // no selected radio elements will have no value
+    const formData = {
+        'callback_url': ''
+    }
+    const results = validDefaultSchemaForm.validate(formData)
+    expect(results.errors['callback_url']).to.equal('Enter a callback URL')
+    expect(results.errors['subscriptions']).to.equal('Select a payment event')
+    expect(results.errorSummaryList[0]).to.have.keys('href', 'text')
+    expect(results.errorSummaryList[0].href).to.equal('#callback_url')
+    expect(results.errorSummaryList[0].text).to.equal('Enter a callback URL')
+  })
+
+  it('correctly validates correct values', () => {
+    const validDefaultSchemaForm = new WebhooksForm()
+    const validRadioInputs = [ [ 'card_payment_started', 'card_payment_captured' ], 'card_payment_started' ]
+
+    validRadioInputs.forEach((validRadioInput) => {
+        const formData = {
+            'callback_url': 'https://a-valid-url.com',
+            'subscriptions': validRadioInput
+        }
+        const results = validDefaultSchemaForm.validate(formData)
+        expect(results.errorSummaryList).to.be.empty // eslint-disable-line
+        expect(results.values['callback_url']).to.equal('https://a-valid-url.com')
+        expect(results.values['subscriptions']).to.deep.equal(validRadioInput)
+    })
+  })
+
+  it('correctly sets values for an existing webhook', () => {
+    const validDefaultSchemaForm = new WebhooksForm()
+    const webhook = webhooksFixtures.webhookResponse()
+    const form = validDefaultSchemaForm.from(webhook)
+    expect(form.values.callback_url).to.equal('https://some-callback-url.com')
+    expect(form.values.subscriptions).to.deep.equal([ 'card_payment_captured' ])
+  })
+
+  it('parses known error identifiers from the backend', () => {
+    const validDefaultSchemaForm = new WebhooksForm()
+    
+    const formData = {
+        'callback_url': 'https://a-valid-url.com',
+        'subscriptions': 'card_payment_succeeded'
+    }
+
+    const expectedError = new Error('URL must be on allow list')
+    expectedError.errorIdentifier = 'CALLBACK_URL_NOT_ON_ALLOW_LIST'
+
+    const result = validDefaultSchemaForm.parseResponse(expectedError, formData)
+    expect(result.errorSummaryList[0].href).to.equal('#callback_url')
+    expect(result.errorSummaryList[0].text).to.equal('Callback URL must be on an approved list of domains for live accounts. PLease contact support')
+    expect(result.values['callback_url']).to.equal('https://a-valid-url.com')
+    expect(result.values['subscriptions']).to.deep.equal('card_payment_succeeded')
+  })
+})

--- a/app/controllers/webhooks/webhooks-forms.test.js
+++ b/app/controllers/webhooks/webhooks-forms.test.js
@@ -20,7 +20,7 @@ describe('Webhooks forms', () => {
     }
     const results = validDefaultSchemaForm.validate(formData)
     expect(results.errors['callback_url']).to.equal('Enter a callback URL')
-    expect(results.errors['subscriptions']).to.equal('Select a payment event')
+    expect(results.errors['subscriptions']).to.equal('Select at least one payment event')
     expect(results.errorSummaryList[0]).to.have.keys('href', 'text')
     expect(results.errorSummaryList[0].href).to.equal('#callback_url')
     expect(results.errorSummaryList[0].text).to.equal('Enter a callback URL')
@@ -32,12 +32,12 @@ describe('Webhooks forms', () => {
 
     validRadioInputs.forEach((validRadioInput) => {
       const formData = {
-        'callback_url': 'https://a-valid-url.com',
+        'callback_url': 'https://a-valid-url.test',
         'subscriptions': validRadioInput
       }
       const results = validDefaultSchemaForm.validate(formData)
         expect(results.errorSummaryList).to.be.empty // eslint-disable-line
-      expect(results.values['callback_url']).to.equal('https://a-valid-url.com')
+      expect(results.values['callback_url']).to.equal('https://a-valid-url.test')
       expect(results.values['subscriptions']).to.deep.equal(validRadioInput)
     })
   })
@@ -63,7 +63,7 @@ describe('Webhooks forms', () => {
 
     const result = validDefaultSchemaForm.parseResponse(expectedError, formData)
     expect(result.errorSummaryList[0].href).to.equal('#callback_url')
-    expect(result.errorSummaryList[0].text).to.equal('Callback URL must be on an approved list of domains for live accounts. PLease contact support')
+    expect(result.errorSummaryList[0].text).to.equal('Callback URL must be approved. Please contact support')
     expect(result.values['callback_url']).to.equal('https://a-valid-url.com')
     expect(result.values['subscriptions']).to.deep.equal('card_payment_succeeded')
   })

--- a/app/views/webhooks/edit.njk
+++ b/app/views/webhooks/edit.njk
@@ -32,8 +32,14 @@
 
     {% set items = [] %}
     {% for key, name in eventTypes %}
-      {% set checked = key | lower in form.values.subscriptions if isEditing else false %}
-      {% set items = (items.push({ value: key | lower, text: name, checked: checked }), items) %}
+      {% set normalisedKey = key | lower %}
+      {% set subscriptions = form.values.subscriptions %}
+      {% if subscriptions | isList %}
+        {% set checked = normalisedKey in subscriptions %}
+      {% else %}
+        {% set checked = normalisedKey == subscriptions %}
+      {% endif %}
+      {% set items = (items.push({ value: normalisedKey, text: name, checked: checked }), items) %}
     {% endfor %}
 
     {{ govukInput({

--- a/app/views/webhooks/edit.njk
+++ b/app/views/webhooks/edit.njk
@@ -19,6 +19,12 @@
     classes: "govuk-!-margin-top-0",
     href: backURL
   }) }}
+  {% if form.errorSummaryList and form.errorSummaryList.length %}
+    {{ govukErrorSummary({
+      titleText: 'There is a problem',
+      errorList: form.errorSummaryList
+    }) }}
+  {% endif %}
   <h1 class="govuk-heading-l page-title">{{ heading }}</h1>
 
   <form method="POST" action="{{ submitURL }}">
@@ -26,7 +32,7 @@
 
     {% set items = [] %}
     {% for key, name in eventTypes %}
-      {% set checked = key | lower in webhook.subscriptions if isEditing else false %}
+      {% set checked = key | lower in form.values.subscriptions if isEditing else false %}
       {% set items = (items.push({ value: key | lower, text: name, checked: checked }), items) %}
     {% endfor %}
 
@@ -35,7 +41,10 @@
       hint: { text: "The HTTPS URL GOV.UK Pay will send webhook messages to" },
       id: "callback_url",
       name: "callback_url",
-      value: webhook.callback_url
+      value: form.values.callback_url,
+      errorMessage: form.errors.callback_url and {
+        text: form.errors.callback_url
+      }
     }) }}
 
     {{ govukInput({
@@ -43,7 +52,10 @@
       hint: { text: "Short summary of what this webhook will be used for" },
       id: "description",
       name: "description",
-      value: webhook.description
+      value: form.values.description,
+      errorMessage: form.errors.description and {
+        text: form.errors.description
+      }
     }) }}
     {{ govukCheckboxes({
       idPrefix: "subscriptions",
@@ -55,7 +67,10 @@
           classes: "govuk-fieldset__legend--m"
         }
       },
-      items: items
+      items: items,
+      errorMessage: form.errors.subscriptions and {
+        text: form.errors.subscriptions
+      }
     }) }}
 
     {{ govukButton({

--- a/server.js
+++ b/server.js
@@ -120,6 +120,7 @@ function initialiseTemplateEngine (app) {
     nunjucksEnvironment.addFilter(name, filter)
   }
   nunjucksEnvironment.addFilter('formatPSPname', formatPSPname)
+  nunjucksEnvironment.addFilter('isList', (n) => Array.isArray(n))
 }
 
 function initialisePublic (app) {

--- a/test/cypress/integration/webhooks/webhooks.cy.test.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.test.js
@@ -139,6 +139,7 @@ describe('Webhooks', () => {
     cy.get('[data-action=update]').click()
 
     cy.get('#callback_url').should('have.value', 'https://some-callback-url.com')
+    cy.get('#description').should('have.value', 'a valid webhook description')
     cy.get('[value=card_payment_captured]').should('be.checked')
 
     cy.get('button').contains('Update webhook').click()

--- a/test/cypress/integration/webhooks/webhooks.cy.test.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.test.js
@@ -53,6 +53,44 @@ describe('Webhooks', () => {
     cy.get('[data-webhook-entry]').should('have.length', 1)
   })
 
+  it('should correctly display simple data consistency properties when creating', () => {
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs
+    ])
+
+    cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
+    cy.get('[data-action=create').contains('Create a new webhook').click()
+
+    // no data has been provided
+    cy.get('button').contains('Create webhook').click()
+
+    cy.get('.govuk-error-summary').should('be.visible')
+    cy.get('.govuk-error-summary__list').children().should('have.length', 2)
+    cy.get('#callback_url-error').should('be.visible')
+    cy.get('#subscriptions-error').should('be.visible')
+  })
+
+  it('should correctly display backend validated error identifiers', () => {
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs,
+      webhooksStubs.createWebhookViolatesBackend()
+    ])
+
+    const callbackUrl = 'https://some-valid-callback-url.com'
+    const description = 'A valid Webhook description'
+
+    cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
+    cy.get('[data-action=create').contains('Create a new webhook').click()
+    cy.get('#callback_url').type(callbackUrl)
+    cy.get('#description').type(description)
+    cy.get('[value=card_payment_captured]').click()
+    cy.get('button').contains('Create webhook').click()
+
+    cy.get('.govuk-error-summary').should('be.visible')
+    cy.get('.govuk-error-summary__list').children().should('have.length', 1)
+    cy.get('#callback_url-error').should('be.visible')
+  })
+
   it('should create a webhook with valid properties', () => {
     const callbackUrl = 'https://some-valid-callback-url.com'
     const description = 'A valid Webhook description'
@@ -61,11 +99,11 @@ describe('Webhooks', () => {
       ...userAndGatewayAccountStubs
     ])
 
+    cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
     cy.get('[data-action=create').contains('Create a new webhook').click()
     cy.get('#callback_url').type(callbackUrl)
     cy.get('#description').type(description)
     cy.get('[value=card_payment_captured]').click()
-
     cy.get('button').contains('Create webhook').click()
   })
 

--- a/test/cypress/stubs/webhooks-stubs.js
+++ b/test/cypress/stubs/webhooks-stubs.js
@@ -61,11 +61,22 @@ function getWebhookMessageAttempts (opts = {}) {
   })
 }
 
+function createWebhookViolatesBackend (opts = {}) {
+  const path = `/v1/webhook`
+  return stubBuilder('POST', path, 400, {
+    response: {
+      error_identifier: 'CALLBACK_URL_NOT_ON_ALLOW_LIST',
+      message: 'Callback url violated security constraints'
+    }
+  })
+}
+
 module.exports = {
   getWebhooksListSuccess,
   getWebhookSuccess,
   getWebhookSigningSecret,
   getWebhookMessagesListSuccess,
   getWebhookMessage,
-  getWebhookMessageAttempts
+  getWebhookMessageAttempts,
+  createWebhookViolatesBackend
 }


### PR DESCRIPTION
This is directly copied from the Worldpay credentials from utility.

The change was delayed to allow form utilities to be moved to a
re-usable, well tested form library. As this hasn't happened yet this
directly copies an existing from and repurposes it for webhooks.

Responsibility of the frontend:
- required data to act on resource exists
- required data meets simple rules for create/ update request

<img width="556" alt="Screenshot 2022-08-11 at 18 20 47" src="https://user-images.githubusercontent.com/2844572/184195615-d5afbb9f-09dd-4d4a-9cc5-b5a60e77d9df.png">

<img width="546" alt="Screenshot 2022-08-11 at 18 20 57" src="https://user-images.githubusercontent.com/2844572/184195608-394e1d44-a9bf-4bd5-93b7-91ddbb5a832b.png">

Responsibility of the backend:
- data meets business rule constraints (valid URLs)

<img width="560" alt="Screenshot 2022-08-11 at 18 21 18" src="https://user-images.githubusercontent.com/2844572/184195672-c3ff6f2b-6114-4c45-ab33-4b119bd22763.png">


