### PR TITLE
PP-9207 Stripe setup - add `check org details` to flow

### DIFF
--- a/app/controllers/stripe-setup/add-psp-account-details/get.controller.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/get.controller.js
@@ -27,6 +27,8 @@ module.exports = async function getPspAccountDetails (req, res, next) {
     res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.stripeSetup.vatNumber, accountExternalId, credentialId))
   } else if (!stripeAccountSetup.companyNumber) {
     res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.stripeSetup.companyNumber, accountExternalId, credentialId))
+  } else if (!stripeAccountSetup.organisationDetails) {
+    res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.stripeSetup.checkOrgDetails, accountExternalId, credentialId))
   } else if (!stripeAccountSetup.governmentEntityDocument) {
     res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.stripeSetup.governmentEntityDocument, accountExternalId, credentialId))
   } else {

--- a/app/controllers/stripe-setup/add-psp-account-details/get.controller.test.js
+++ b/app/controllers/stripe-setup/add-psp-account-details/get.controller.test.js
@@ -76,6 +76,19 @@ describe('Stripe setup get controller', () => {
     sinon.assert.calledWith(res.redirect, 303, `/account/${req.account.external_id}/your-psp/${req.credentialId}/director`)
   })
 
+  it('should redirect to check org details page', async () => {
+    req.account.connectorGatewayAccountStripeProgress = {
+      bankAccount: true,
+      responsiblePerson: true,
+      vatNumber: true,
+      companyNumber: true,
+      director: true,
+      organisationDetails: false
+    }
+    await getController(req, res, next)
+    sinon.assert.calledWith(res.redirect, 303, `/account/${req.account.external_id}/your-psp/${req.credentialId}/check-organisation-details`)
+  })
+
   it('should redirect to government entity document page', async () => {
     req.account.connectorGatewayAccountStripeProgress = {
       bankAccount: true,
@@ -83,6 +96,7 @@ describe('Stripe setup get controller', () => {
       vatNumber: true,
       companyNumber: true,
       director: true,
+      organisationDetails: true,
       governmentEntityDocument: false
     }
     await getController(req, res, next)
@@ -96,6 +110,7 @@ describe('Stripe setup get controller', () => {
       vatNumber: true,
       companyNumber: true,
       director: true,
+      organisationDetails: true,
       governmentEntityDocument: true
     }
     await getController(req, res, next)

--- a/app/views/dashboard/_stripe-account-setup-banner.njk
+++ b/app/views/dashboard/_stripe-account-setup-banner.njk
@@ -20,22 +20,22 @@
         {% if isStripeAccountRestricted %}
           <h2 class="govuk-heading-m">Stripe has restricted your account</h2>
 
-          <p class="govuk-body-m">To start taking payments again, please add:</p>
+          <p class="govuk-body">To start taking payments again, please add:</p>
         {% elif stripeAccountHasDeadline %}
           {% set dateString = stripeAccount.requirements.current_deadline %}
 
           <h2 class="govuk-heading-m">You must add more details by {{dateString}} to continue taking payments</h2>
-          <p class="govuk-body-m">
+          <p class="govuk-body">
             Your service can now take payments from users. You must add more details by {{dateString}} or Stripe will not pay the money into your bank account. Please add:
           </p>
         {% else %}
           <h2 class="govuk-heading-m">Enter more information to enable payments to your bank account</h2>
-          <p class="govuk-body-m">
+          <p class="govuk-body">
               Until you add this information, your service is restricted to taking a total of £2000 and you will not get payouts to your bank account. Please add:
           </p>
         {% endif %}
 
-        <ul class="govuk-list govuk-list--bullet">
+        <ul class="govuk-list govuk-list--bullet" data-cy="stripe-setup-list">
           {% if not connectorGatewayAccountStripeProgress.bankAccount %}
             <li>organisation bank details</li>
           {% endif %}
@@ -56,6 +56,12 @@
           {% endif %}
         </ul>
 
+        {% if not connectorGatewayAccountStripeProgress.organisationDetails %}
+          <p class="govuk-body" data-cy="stripe-setup-cofirm-org-details">
+            You must also confirm that the name and address of your organisation in GOV.UK Pay exactly match your government entity document.
+          </p>
+        {% endif %}
+
         {{
         govukButton({
           text: 'Add details',
@@ -75,7 +81,7 @@
     <div class="govuk-grid-column-full">
     {% set html %}
         <h2 class="govuk-heading-m">Stripe has restricted your account</h2>
-        <p class="govuk-body-m">To start taking payments again, please contact support.</p>
+        <p class="govuk-body">To start taking payments again, please contact support.</p>
         <p class="govuk-body">
           <a class="govuk-link" href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk" target="_top">govuk-pay-support@digital.cabinet-office.gov.uk</a>
         </p>

--- a/app/views/stripe-setup/check-org-details/index.njk
+++ b/app/views/stripe-setup/check-org-details/index.njk
@@ -23,6 +23,20 @@
     government entity document.
   </p>
 
+  <p class="govuk-body">
+    Match the information to the document you are going to use:
+  </p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>VAT Registration</li>
+    <li>Certificate of incorporation</li>
+    <li>Companies House Document</li>
+    <li>HM Revenue and Customs: VAT Certificate</li>
+    <li>HM Revenue and Customs: Account Statement</li>
+    <li>Charity Commission Document</li>
+    <li>OSCR Scottish Charity Regulator</li>
+  </ul>
+
   <form method="post" data-cy="form">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 

--- a/test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.test.js
+++ b/test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.test.js
@@ -27,7 +27,9 @@ describe('The Stripe psp details banner', () => {
         bankAccount: false,
         vatNumber: false,
         companyNumber: false,
-        director: false
+        director: false,
+        organisationDetails: false,
+        governmentEntityDocument: false
       }),
       stripeAccountStubs.getStripeAccountSuccess(gatewayAccountId, 'stripe-account-id')
     ])
@@ -37,8 +39,18 @@ describe('The Stripe psp details banner', () => {
     cy.visit(`/account/${gatewayAccountExternalId}/dashboard`)
 
     cy.get('h2').contains('Enter more information to enable payments to your bank account')
-    cy.get('#add-account-details').should('exist')
-    cy.get('.govuk-notification-banner__content').find('ul.govuk-list > li:nth-child(3)').contains('the name, date of birth and work email address of the director of your service (or someone at director level)').should('exist')
+
+    cy.get('[data-cy=stripe-setup-list]').within(() => {
+      cy.get('li').should('have.length', 6)
+      cy.get('li').eq(0).should('have.text', 'organisation bank details')
+      cy.get('li').eq(1).should('have.text', 'the name, date of birth and home address of the person in your organisation legally responsible for payments (called your ‘responsible person’)')
+      cy.get('li').eq(2).should('have.text', 'the name, date of birth and work email address of the director of your service (or someone at director level)')
+      cy.get('li').eq(3).should('have.text', 'VAT number (if applicable)')
+      cy.get('li').eq(4).should('have.text', 'Company registration number (if applicable)')
+      cy.get('li').eq(5).should('have.text', 'government entity document')
+    })
+
+    cy.get('[data-cy=stripe-setup-cofirm-org-details]').should('contain', 'You must also confirm that the name and address of your organisation in GOV.UK Pay exactly match your government entity document.')
   })
 
   it('should redirect to bank account details page when "Add details" button clicked', () => {

--- a/test/integration/add-psp-details.ft.test.js
+++ b/test/integration/add-psp-details.ft.test.js
@@ -50,6 +50,7 @@ describe('Add stripe psp details route', function () {
           vat_number: true,
           company_number: true,
           director: true,
+          organisation_details: true, 
           government_entity_document: true
         }))
         .persist()


### PR DESCRIPTION
- Update the `Stripe setup > add-psp-account-details` controller
  - Make the `check org details` page appear before the `gov entity doc upload process`
  - Update the `check org details` to have content about what a gov entity doc is.`
  - As we believe it's the doc upload which triggers the Stripe verification process - we want the user to confirm / update 
  org details before that.
- Dashboard `Nunjuks file > Stripe setup banner`:
  - show new content about the new step for `confirm org details`.
  - Clean up CSS classes - change `govuk-body-m` to `govuk-body`.
- Update Cypress tests
  - Increase test coverage of the Stripe setup banner.
  - Update unit tests.