### PR TITLE
PP-9016 Refine webhooks status tags

### DIFF
--- a/app/views/webhooks/_message_status.njk
+++ b/app/views/webhooks/_message_status.njk
@@ -1,0 +1,16 @@
+{% set statusStyleMap = {
+"PENDING": "govuk-tag--grey",
+"SUCCESSFUL": "govuk-tag--green",
+"FAILED": "govuk-tag--red",
+"WILL_NOT_SEND": "govuk-tag--yellow"
+} %}
+{% set statusTextMap = {
+"PENDING": "Pending",
+"SUCCESSFUL": "Successful",
+"FAILED": "Failed",
+"WILL_NOT_SEND": "Will not send"
+} %}
+
+{% macro messageStatusTag(status) %}
+<strong class="govuk-tag {{ statusStyleMap[status] }}">{{ statusTextMap[status] }}</strong>
+{% endmacro %}

--- a/app/views/webhooks/_webhook_status.njk
+++ b/app/views/webhooks/_webhook_status.njk
@@ -1,0 +1,14 @@
+{% set statusStyleMap = {
+"ACTIVE": "govuk-tag--blue",
+"INACTIVE": "govuk-tag--yellow",
+"DISABLED": "govuk-tag--red"
+} %}
+{% set statusTextMap = {
+"ACTIVE": "Active",
+"INACTIVE": "Inactive",
+"DISABLED": "Disabled"
+} %}
+
+{% macro webhookStatusTag(status) %}
+<strong class="govuk-tag {{ statusStyleMap[status] }}">{{ statusTextMap[status] }}</strong>
+{% endmacro %}

--- a/app/views/webhooks/detail.njk
+++ b/app/views/webhooks/detail.njk
@@ -1,3 +1,5 @@
+{% from "./_webhook_status.njk" import webhookStatusTag %}
+{% from "./_message_status.njk" import messageStatusTag %}
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
@@ -12,7 +14,7 @@
 <div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l page-title" title="{{ webhook.callback_url }}">
     {{ webhook.callback_url | truncate(40) }}
-    <strong class="govuk-tag govuk-tag--blue">{{ webhook.status }}</strong>
+    {{ webhookStatusTag(webhook.status) }}
   </h1>
 
   <p class="govuk-body">{{ webhook.description }}</p>
@@ -45,15 +47,6 @@
       }
     }) }}
   </div>
-
-  {% macro statusTag(status) %}
-    {% set map = {
-      "SUCCESSFUL": "govuk-tag--green",
-      "FAILED": "govuk-tag--red",
-      "PENDING": "govuk-tag--grey"
-    } %}
-    <strong class="govuk-tag {{ map[status] }}">{{ status }}</strong>
-  {% endmacro %}
 
   <div class="govuk-!-margin-top-6">
     <h2 class="govuk-heading-m">Events</h2>
@@ -91,7 +84,7 @@
                 {{ eventTypes[message.event_type | upper] }}
               </a>
             </td>
-            <td class="govuk-table__cell">{{ statusTag(message.latest_attempt and message.latest_attempt.status or 'PENDING') }}</td>
+            <td class="govuk-table__cell">{{ messageStatusTag(message.latest_attempt and message.latest_attempt.status or 'PENDING') }}</td>
             <td class="govuk-table__cell">
               {# @TODO(sfount) fragile set up to avoid seconds granularity, update commons with a new format #}
               {{ message.event_date | datetime('datelong') }} {{ message.event_date | datetime('time') | truncate(5, true, '') }}

--- a/app/views/webhooks/list.njk
+++ b/app/views/webhooks/list.njk
@@ -1,3 +1,4 @@
+{% from "./_webhook_status.njk" import webhookStatusTag %}
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
@@ -23,7 +24,7 @@
     <div data-webhook-entry>
       <p class="govuk-body">
         <span class="pay-text-grey">{{ webhook.callback_url }}</span>
-        <strong class="govuk-tag govuk-tag--blue">{{ webhook.status }}</strong>
+        {{ webhookStatusTag(webhook.status) }}
       </p>
       <p class="govuk-body">{{ webhook.description }}</p>
       <div>

--- a/app/views/webhooks/message.njk
+++ b/app/views/webhooks/message.njk
@@ -1,3 +1,4 @@
+{% from "./_message_status.njk" import messageStatusTag %}
 {% extends "layout.njk" %}
 
 {% set messageType = eventTypes[message.event_type | upper] %}
@@ -82,7 +83,7 @@
         {% for attempt in attempts %}
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">{{ attempt.send_at | datetime('datelong') }} {{ attempt.send_at | datetime('time') | truncate(5, true, '') }}</td>
-            <td class="govuk-table__cell">{{ attempt.status }}</td>
+            <td class="govuk-table__cell">{{ messageStatusTag(attempt.status) }}</td>
             <td class="govuk-table__cell">{{ attempt.status_code or '-' }}</td>
             <td class="govuk-table__cell">{{ attempt.result }}</td>
           </tr>

--- a/test/cypress/integration/webhooks/webhooks.cy.test.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.test.js
@@ -12,14 +12,14 @@ const messageExternalId = 'message-id'
 const userAndGatewayAccountStubs = [
   userStubs.getUserSuccess({ userExternalId, serviceExternalId, gatewayAccountId }),
   gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, serviceExternalId }),
-  webhooksStubs.getWebhooksListSuccess({ service_id: serviceExternalId, live: false, webhooks: [{ external_id: webhookExternalId }] }),
+  webhooksStubs.getWebhooksListSuccess({ service_id: serviceExternalId, live: false, webhooks: [{ external_id: webhookExternalId }, { status: 'INACTIVE' }, { status: 'DISABLED' }] }),
   webhooksStubs.getWebhookSuccess({ service_id: serviceExternalId, external_id: webhookExternalId, subscriptions: [ 'card_payment_captured', 'card_payment_succeeded', 'card_payment_refunded', 'card_payment_started' ] }),
   webhooksStubs.getWebhookMessagesListSuccess({ service_id: serviceExternalId,
     external_id: webhookExternalId,
     messages: [
       { latest_attempt: { status: 'PENDING' }, external_id: messageExternalId },
       { latest_attempt: { status: 'FAILED' } },
-      { latest_attempt: { status: 'SUCCESSFUL' } },
+      { latest_attempt: { status: 'WILL_NOT_SEND' } },
       { latest_attempt: { status: 'SUCCESSFUL' } },
       { latest_attempt: { status: 'SUCCESSFUL' } },
       { latest_attempt: { status: 'SUCCESSFUL' } },
@@ -50,7 +50,7 @@ describe('Webhooks', () => {
     cy.get('#navigation-menu-settings').parent().should('have.class', 'service-navigation--list-item-active')
     cy.get('#navigation-menu-webhooks').parent().should('have.class', 'govuk-!-margin-bottom-2')
 
-    cy.get('[data-webhook-entry]').should('have.length', 1)
+    cy.get('[data-webhook-entry]').should('have.length', 3)
   })
 
   it('should correctly display simple data consistency properties when creating', () => {


### PR DESCRIPTION
Following the pattern set by agreements for recurring card payments.
Move webhook and webhook message status tags to macros that can be
shared between templates. Add entries for new statuses.

**Webhook status**

<img width="674" alt="Screenshot 2022-08-15 at 16 09 41" src="https://user-images.githubusercontent.com/2844572/184665724-da832d1e-4433-437a-bbc1-cc1264ec635e.png">

**Message status**

<img width="662" alt="Screenshot 2022-08-15 at 17 46 10" src="https://user-images.githubusercontent.com/2844572/184678503-a3d5798e-ef13-45cd-828c-30df8d20de05.png">


