### PR TITLE
PP-9274 Update webhook subscriptions

### DIFF
--- a/app/controllers/webhooks/webhooks-forms.test.js
+++ b/app/controllers/webhooks/webhooks-forms.test.js
@@ -28,7 +28,7 @@ describe('Webhooks forms', () => {
 
   it('correctly validates correct values', () => {
     const validDefaultSchemaForm = new WebhooksForm()
-    const validRadioInputs = [ [ 'card_payment_started', 'card_payment_captured' ], 'card_payment_started' ]
+    const validRadioInputs = [ [ 'card_payment_refunded', 'card_payment_captured' ], 'card_payment_refunded' ]
 
     validRadioInputs.forEach((validRadioInput) => {
       const formData = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
-        "@govuk-pay/pay-js-commons": "3.6.2",
+        "@govuk-pay/pay-js-commons": "3.7.0",
         "@sentry/node": "6.12.0",
         "accessible-autocomplete": "2.0.4",
         "aws-sdk": "2.1195.0",
@@ -62,7 +62,7 @@
         "chai-arrays": "2.2.0",
         "chai-as-promised": "7.1.1",
         "cheerio": "1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "csrf": "^3.1.0",
         "cypress": "5.0.0",
         "dotenv": "16.0.1",
@@ -1875,9 +1875,9 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.6.2.tgz",
-      "integrity": "sha512-ppn/MtCeKEl2u3mL8ugf5q9hBk7zIUI19uQWwe1/K0xwm0voIdyiBObrPIIQBmEsGlXNp/PRPnZvyatoyVE5TQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.7.0.tgz",
+      "integrity": "sha512-2+AKhfTYr29TQB+Ie315btxShMEDkY+xLg4wqvELlpphSUZ24ILh7Lv0FNxHyej02pPR5/5vJ8WSSUh6VVqBZg==",
       "dependencies": {
         "lodash": "4.17.21",
         "moment-timezone": "0.5.34",
@@ -19189,9 +19189,9 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.6.2.tgz",
-      "integrity": "sha512-ppn/MtCeKEl2u3mL8ugf5q9hBk7zIUI19uQWwe1/K0xwm0voIdyiBObrPIIQBmEsGlXNp/PRPnZvyatoyVE5TQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.7.0.tgz",
+      "integrity": "sha512-2+AKhfTYr29TQB+Ie315btxShMEDkY+xLg4wqvELlpphSUZ24ILh7Lv0FNxHyej02pPR5/5vJ8WSSUh6VVqBZg==",
       "requires": {
         "lodash": "4.17.21",
         "moment-timezone": "0.5.34",
@@ -22008,7 +22008,7 @@
       "requires": {
         "acorn-node": "^1.8.2",
         "defined": "^1.0.0",
-        "minimist": "^1.2.6"
+        "minimist": "1.2.6"
       }
     },
     "dezalgo": {
@@ -22557,7 +22557,7 @@
           "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.6"
+            "minimist": "1.2.6"
           }
         },
         "path-key": {
@@ -23556,7 +23556,7 @@
           "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.6"
+            "minimist": "1.2.6"
           }
         }
       }
@@ -24386,7 +24386,7 @@
         "deepmerge": "^4.2.2",
         "he": "^1.2.0",
         "htmlparser2": "^6.1.0",
-        "minimist": "^1.2.6",
+        "minimist": "1.2.6",
         "selderee": "^0.6.0"
       },
       "dependencies": {
@@ -30412,7 +30412,7 @@
       "integrity": "sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==",
       "dev": true,
       "requires": {
-        "minimist": "^1.1.0"
+        "minimist": "1.2.6"
       }
     },
     "sumchecker": {
@@ -31599,7 +31599,7 @@
           "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.6"
+            "minimist": "1.2.6"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "minimist": "1.2.6"
   },
   "dependencies": {
-    "@govuk-pay/pay-js-commons": "3.6.2",
+    "@govuk-pay/pay-js-commons": "3.7.0",
     "@sentry/node": "6.12.0",
     "accessible-autocomplete": "2.0.4",
     "aws-sdk": "2.1195.0",

--- a/test/cypress/integration/webhooks/webhooks.cy.test.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.test.js
@@ -13,7 +13,7 @@ const userAndGatewayAccountStubs = [
   userStubs.getUserSuccess({ userExternalId, serviceExternalId, gatewayAccountId }),
   gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, serviceExternalId }),
   webhooksStubs.getWebhooksListSuccess({ service_id: serviceExternalId, live: false, webhooks: [{ external_id: webhookExternalId }, { status: 'INACTIVE' }, { status: 'DISABLED' }] }),
-  webhooksStubs.getWebhookSuccess({ service_id: serviceExternalId, external_id: webhookExternalId, subscriptions: [ 'card_payment_captured', 'card_payment_succeeded', 'card_payment_refunded', 'card_payment_started' ] }),
+  webhooksStubs.getWebhookSuccess({ service_id: serviceExternalId, external_id: webhookExternalId, subscriptions: [ 'card_payment_captured', 'card_payment_succeeded', 'card_payment_refunded' ] }),
   webhooksStubs.getWebhookMessagesListSuccess({ service_id: serviceExternalId,
     external_id: webhookExternalId,
     messages: [
@@ -116,7 +116,7 @@ describe('Webhooks', () => {
     cy.get('[data-action=update]').then((links) => links[0].click())
 
     cy.get('h1').contains('https://some-callback-url.com')
-    cy.get('.govuk-list.govuk-list--bullet > li').should('have.length', 4)
+    cy.get('.govuk-list.govuk-list--bullet > li').should('have.length', 3)
 
     // based on number of rows stubbed and client pagination logic
     cy.get('.govuk-table__body > .govuk-table__row').should('have.length', 11)


### PR DESCRIPTION
Bump js commons to bring in the newly supported webhook subscriptions.

Remove fixture references to `card_payment_started` which isn't planned
to be included in the first round of events.

![Screenshot 2022-08-18 at 14 12 04](https://user-images.githubusercontent.com/2844572/185403737-80171a35-cbe0-4245-aacb-05430ed4dbb9.png)


