### PR TITLE
PP-9846 show transactions related to agreement

### DIFF
--- a/app/utils/get-query-string-for-params.js
+++ b/app/utils/get-query-string-for-params.js
@@ -16,7 +16,8 @@ function getQueryStringForParams (params = {}, removeEmptyParams = false, flatte
     to_date: dates.toDateToApiFormat(params.toDate, params.toTime),
     ...params.feeHeaders && { fee_headers: params.feeHeaders },
     ...params.motoHeader && { moto_header: params.motoHeader },
-    metadata_value: params.metadataValue
+    metadata_value: params.metadataValue,
+    agreement_id: params.agreementId
   }
 
   if (!ignorePagination) {

--- a/app/utils/transaction-view.js
+++ b/app/utils/transaction-view.js
@@ -74,22 +74,24 @@ module.exports = {
       delete element.created_date
     })
 
-    connectorData.downloadTransactionLink = router.generateRoute(
-      route, {
-        reference: filtersResult.reference,
-        email: filtersResult.email,
-        payment_states: filtersResult.payment_states,
-        refund_states: filtersResult.refund_states,
-        dispute_states: filtersResult.dispute_states,
-        brand: filtersResult.brand,
-        fromDate: filtersResult.fromDate,
-        toDate: filtersResult.toDate,
-        fromTime: filtersResult.fromTime,
-        toTime: filtersResult.toTime,
-        cardholderName: filtersResult.cardholderName,
-        lastDigitsCardNumber: filtersResult.lastDigitsCardNumber,
-        metadataValue: filtersResult.metadataValue
-      })
+    if (route) {
+      connectorData.downloadTransactionLink = router.generateRoute(
+        route, {
+          reference: filtersResult.reference,
+          email: filtersResult.email,
+          payment_states: filtersResult.payment_states,
+          refund_states: filtersResult.refund_states,
+          dispute_states: filtersResult.dispute_states,
+          brand: filtersResult.brand,
+          fromDate: filtersResult.fromDate,
+          toDate: filtersResult.toDate,
+          fromTime: filtersResult.fromTime,
+          toTime: filtersResult.toTime,
+          cardholderName: filtersResult.cardholderName,
+          lastDigitsCardNumber: filtersResult.lastDigitsCardNumber,
+          metadataValue: filtersResult.metadataValue
+        })
+    }
 
     return connectorData
   },

--- a/app/utils/transaction-view.js
+++ b/app/utils/transaction-view.js
@@ -89,7 +89,8 @@ module.exports = {
           toTime: filtersResult.toTime,
           cardholderName: filtersResult.cardholderName,
           lastDigitsCardNumber: filtersResult.lastDigitsCardNumber,
-          metadataValue: filtersResult.metadataValue
+          metadataValue: filtersResult.metadataValue,
+          agreementId: filtersResult.agreementId
         })
     }
 

--- a/app/views/agreements/detail.njk
+++ b/app/views/agreements/detail.njk
@@ -84,5 +84,38 @@
   {% else %}
   <p id="empty-payment-instrument" class="govuk-body">No payment instrument set for this agreement.</p>
   {% endif %}
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-9">Transactions</h2>
+  <table id="transactions-list" class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col" id="reference-header">Reference number</th>
+        <th class="govuk-table__header" scope="col" id="state-header">State</th>
+        <th class="govuk-table__header" scope="col" id="amount-header">Amount</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col" id="time-header">Date created</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    {% for transaction in transactions.results %}
+      <tr class="govuk-table__row vertical-align-top">
+        <th scope="row" class="charge-column reference govuk-table__header" data-gateway-transaction-id="{{transaction.gateway_transaction_id}}">
+          <span class="govuk-!-font-weight-regular govuk-!-font-size-14 reference govuk-!-display-block" id="charge-id-{{transaction.charge_id}}" data-charge-id="{{transaction.charge_id}}">{{transaction.reference}}</span>
+        </th>
+        <td class="govuk-table__cell transactions-list--item govuk-!-font-size-14 state">{{transaction.state_friendly}}</td>
+        <td class="govuk-table__cell transactions-list--item amount govuk-!-font-size-14" id="amount"><span style="white-space: pre">{{transaction.amount}}</span></td>
+        <td class="govuk-table__cell transactions-list--item govuk-!-font-size-14 govuk-table__cell--numeric time">{{transaction.created}}</td>
+      </tr>
+    {% else %}
+      <tr class="govuk-table__row">
+        <td colspan="4" class="govuk-table__cell govuk-!-font-size-14">No transactions found for this agreement.</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+  <p class="govuk-body">
+    <a class="govuk-link govuk-link__no-visited-state" href="#">Show all transactions for this agreement</a>
+  </p>
+
 </div>
 {% endblock %}

--- a/app/views/agreements/detail.njk
+++ b/app/views/agreements/detail.njk
@@ -114,7 +114,7 @@
   </table>
 
   <p class="govuk-body">
-    <a class="govuk-link govuk-link__no-visited-state" href="#">Show all transactions for this agreement</a>
+    <a class="govuk-link govuk-link__no-visited-state" href="{{ formatAccountPathsFor(routes.account.transactions.index, currentGatewayAccount.external_id) }}?agreementId={{ agreement.external_id }}">Show all transactions for this agreement</a>
   </p>
 
 </div>

--- a/app/views/transactions/filter.njk
+++ b/app/views/transactions/filter.njk
@@ -210,7 +210,7 @@
         </fieldset>
       </fieldset>
     </div>
-    {% if filters.metadataValue %}
+    {% if filters.metadataValue or filters.agreementId %}
       {% set detailsElementOpenHtml = 'open="true"' %}
     {% endif %}
     <div class="govuk-grid-column-full">
@@ -223,21 +223,37 @@
           </summary>
           <div class="govuk-details__text">
             {{
-                govukInput({
-                  id: 'metadataValue',
-                  name: 'metadataValue',
-                  value: filters.metadataValue,
-                  classes: 'govuk-!-font-size-16',
-                  label: {
-                    text: 'Search by metadata or reporting column',
-                    classes: 'govuk-label--s govuk-!-font-size-16 govuk-!-margin-bottom-0'
-                  },
-                  hint: {
-                    text: 'Enter full value',
-                    classes: 'govuk-!-font-size-14'
-                  }
-                })
-              }}
+              govukInput({
+                id: 'metadataValue',
+                name: 'metadataValue',
+                value: filters.metadataValue,
+                classes: 'govuk-!-font-size-16',
+                label: {
+                  text: 'Search by metadata or reporting column',
+                  classes: 'govuk-label--s govuk-!-font-size-16 govuk-!-margin-bottom-0'
+                },
+                hint: {
+                  text: 'Enter full value',
+                  classes: 'govuk-!-font-size-14'
+                }
+              })
+            }}
+            {{
+              govukInput({
+                id: 'agreementId',
+                name: 'agreementId',
+                value: filters.agreementId,
+                classes: 'govuk-!-font-size-16',
+                label: {
+                  text: 'Search by agreement identifier',
+                  classes: 'govuk-label--s govuk-!-font-size-16 govuk-!-margin-bottom-0'
+                },
+                hint: {
+                  text: 'Enter agreement identifier',
+                  classes: 'govuk-!-font-size-14'
+                }
+              })
+            }}
           </div>
         </details>
       </div>

--- a/test/cypress/integration/agreements/agreements.cy.test.js
+++ b/test/cypress/integration/agreements/agreements.cy.test.js
@@ -1,6 +1,7 @@
 const userStubs = require('../../stubs/user-stubs')
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 const agreementStubs = require('../../stubs/agreement-stubs')
+const transactionStubs = require('../../stubs/transaction-stubs')
 
 const userExternalId = 'some-user-id'
 const gatewayAccountId = 10
@@ -88,7 +89,18 @@ describe('Agreements', () => {
   it('should load the details page and preserve filter params', () => {
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
-      agreementStubs.getLedgerAgreementSuccess({ service_id: serviceExternalId, live: false, external_id: 'a-valid-agreement-id' })
+      agreementStubs.getLedgerAgreementSuccess({ service_id: serviceExternalId, live: false, external_id: 'a-valid-agreement-id' }),
+      transactionStubs.getLedgerTransactionsSuccess({
+        gatewayAccountId,
+        transactions: [
+          { reference: 'payment-reference', amount: 1000, type: 'payment' },
+          { reference: 'second-reference', amount: 20000, type: 'payment' }
+        ],
+        filters: {
+          agreement_id: 'a-valid-agreement-id',
+          display_size: 5
+        }
+      })
     ])
 
     cy.get('[data-action=update]').then((links) => links[0].click())
@@ -103,6 +115,8 @@ describe('Agreements', () => {
 
     cy.get('.govuk-summary-list__value').contains('Test User')
     cy.get('.govuk-summary-list__value').contains('Reason shown to paying user for taking agreement')
+
+    cy.get('.govuk-table__body').children().should('have.length', 2)
   })
 
   it('should show no agreements content if filters return nothing', () => {

--- a/test/cypress/integration/all-service-transactions/all-service-transactions.cy.test.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions.cy.test.js
@@ -246,7 +246,7 @@ describe('All service transactions', () => {
     it('should have correct back link', () => {
       cy.get('.govuk-back-link')
         .should('have.text', 'Back to transactions for all services')
-        .should('have.attr', 'href', '/all-service-transactions/test?reference=ref3&email=&cardholderName=&lastDigitsCardNumber=&fromDate=&fromTime=&toDate=&toTime=&metadataValue=')
+        .should('have.attr', 'href', '/all-service-transactions/test?reference=ref3&email=&cardholderName=&lastDigitsCardNumber=&fromDate=&fromTime=&toDate=&toTime=&metadataValue=&agreementId=')
     })
 
     it('should refund a payment', () => {
@@ -271,7 +271,7 @@ describe('All service transactions', () => {
 
       cy.get('.govuk-back-link')
         .should('have.text', 'Back to transactions for all services')
-        .should('have.attr', 'href', '/all-service-transactions/test?reference=ref3&email=&cardholderName=&lastDigitsCardNumber=&fromDate=&fromTime=&toDate=&toTime=&metadataValue=')
+        .should('have.attr', 'href', '/all-service-transactions/test?reference=ref3&email=&cardholderName=&lastDigitsCardNumber=&fromDate=&fromTime=&toDate=&toTime=&metadataValue=&agreementId=')
     })
   })
 

--- a/test/cypress/integration/transactions/transaction-search.cy.test.js
+++ b/test/cypress/integration/transactions/transaction-search.cy.test.js
@@ -270,7 +270,8 @@ describe('Transactions List', () => {
             last_digits_card_number: '4242',
             cardholder_name: 'doe',
             refund_states: 'submitted',
-            metadata_value: 'test'
+            metadata_value: 'test',
+            agreement_id: 'an-agreement-id'
           }
         })
       ])
@@ -294,7 +295,7 @@ describe('Transactions List', () => {
 
       cy.contains('Advanced filters').click()
       cy.get('#metadataValue').type('test')
-
+      cy.get('#agreementId').type('an-agreement-id')
       cy.get('#filter').click()
 
       // Ensure the right number of transactions is displayed


### PR DESCRIPTION
Show the 5 most recent transactions on the agreement details page.

![Screenshot 2022-08-24 at 12 31 15](https://user-images.githubusercontent.com/2844572/186409816-dad98448-d56d-4bf1-abf9-d2de3bf363f5.png)

Transactions can be filtered by their agreement identifier, if
they've been taken on behalf of a recurring card payment agreement.

This adds an additional filter to the "Advanced filter" element, this
has the benefit of not confusing users which this filter has no
relevance for however where and how this filter fits in the with the
larger transactions page should be considered in future design.

![Screenshot 2022-08-24 at 12 43 30](https://user-images.githubusercontent.com/2844572/186410073-15c64294-6935-46f4-82d4-17184755f0d5.png)