### PR TITLE
PP-9784 Add cancelled filter value to agreement status filter

### DIFF
--- a/app/views/agreements/list.njk
+++ b/app/views/agreements/list.njk
@@ -26,6 +26,10 @@ Agreements - GOV.UK Pay
         text: 'Active',
         selected: filters.status === 'ACTIVE'
       },{
+        value: 'CANCELLED',
+        text: 'Cancelled',
+        selected: filters.status === 'CANCELLED'
+      },{
         value: 'EXPIRED',
         text: 'Expired',
         selected: filters.status ==='EXPIRED'


### PR DESCRIPTION
Include the `CANCELLED` status for filter values on agreement state.

This is propagated to Ledger and matches https://github.com/alphagov/pay-java-commons/blob/master/model/src/main/java/uk/gov/service/payments/commons/model/agreement/AgreementStatus.java

