### PR TITLE
PP-9846 Only show recurring filters to appropriate accounts

### DIFF
--- a/app/controllers/all-service-transactions/get.controller.js
+++ b/app/controllers/all-service-transactions/get.controller.js
@@ -71,6 +71,7 @@ module.exports = async function getTransactionsForAllServices (req, res, next) {
     model.allServiceTransactions = true
     model.filterLiveAccounts = filterLiveAccounts
     model.hasLiveAccounts = userPermittedAccountsSummary.hasLiveAccounts
+    model.recurringEnabled = userPermittedAccountsSummary.hasRecurringAccount
     model.isExperimentalFeaturesEnabled = req.user.serviceRoles.some(serviceRole => serviceRole.service.experimentalFeaturesEnabled)
 
     return response(req, res, 'transactions/index', model)

--- a/app/controllers/transactions/transaction-list.controller.js
+++ b/app/controllers/transactions/transaction-list.controller.js
@@ -67,6 +67,7 @@ module.exports = async function showTransactionList (req, res, next) {
   model.clearRedirect = formatAccountPathsFor(router.paths.account.transactions.index, req.account.external_id)
   model.isStripeAccount = req.account.payment_provider === 'stripe'
   model.isExperimentalFeaturesEnabled = req.service.experimentalFeaturesEnabled
+  model.recurringEnabled = req.account.recurring_enabled
 
   return response(req, res, 'transactions/index', model)
 }

--- a/app/utils/permissions.js
+++ b/app/utils/permissions.js
@@ -16,6 +16,7 @@ const getGatewayAccountsFor = async function getGatewayAccountsFor (user, filter
     headers: getAllAccountDetailHeaders(userGatewayAccounts),
     hasLiveAccounts: filterGatewayAccountIds(userGatewayAccounts, true).length > 0,
     hasStripeAccount: hasStripeAccount(userGatewayAccounts, filterLiveAccounts),
+    hasRecurringAccount: hasRecurringAccount(userGatewayAccounts, filterLiveAccounts),
     hasTestStripeAccount: userGatewayAccounts.filter((account) => account.type === 'test' && account.payment_provider === 'stripe').length > 0
   }
 }
@@ -59,6 +60,12 @@ const hasStripeAccount = function hasStripeAccount (gatewayAccounts, filterLiveA
     .filter((account) => account.type === gatewayAccountTypeFilter)
     .filter((account) => account.payment_provider === 'stripe')
     .length > 0
+}
+
+const hasRecurringAccount = function hasRecurringAccount (gatewayAccounts, filterLiveAccounts = true) {
+  const gatewayAccountTypeFilter = filterLiveAccounts ? 'live' : 'test'
+  return gatewayAccounts.filter((account) => account.type === gatewayAccountTypeFilter)
+    .some((account) => account.recurring_enabled)
 }
 
 module.exports = {

--- a/app/views/transactions/filter.njk
+++ b/app/views/transactions/filter.njk
@@ -238,7 +238,7 @@
                 }
               })
             }}
-            {% if currentGatewayAccount.recurring_enabled %}
+            {% if recurringEnabled %}
             {{
               govukInput({
                 id: 'agreementId',

--- a/app/views/transactions/filter.njk
+++ b/app/views/transactions/filter.njk
@@ -238,6 +238,7 @@
                 }
               })
             }}
+            {% if currentGatewayAccount.recurring_enabled %}
             {{
               govukInput({
                 id: 'agreementId',
@@ -245,7 +246,7 @@
                 value: filters.agreementId,
                 classes: 'govuk-!-font-size-16',
                 label: {
-                  text: 'Search by agreement identifier',
+                  text: 'Search by agreement',
                   classes: 'govuk-label--s govuk-!-font-size-16 govuk-!-margin-bottom-0'
                 },
                 hint: {
@@ -254,6 +255,7 @@
                 }
               })
             }}
+            {% endif %}
           </div>
         </details>
       </div>

--- a/test/cypress/integration/all-service-transactions/all-service-transactions.cy.test.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions.cy.test.js
@@ -12,17 +12,20 @@ describe('All service transactions', () => {
     gatewayAccountId: 42,
     gatewayAccountExternalId: 'a-valid-external-id-1',
     type: 'live',
-    paymentProvider: 'stripe'
+    paymentProvider: 'stripe',
+    recurringEnabled: true
   }
   const gatewayAccount2 = {
     gatewayAccountId: 43,
     gatewayAccountExternalId: 'a-valid-external-id-2',
-    type: 'live'
+    type: 'live',
+    recurringEnabled: true
   }
   const gatewayAccount3 = {
     gatewayAccountId: 44,
     gatewayAccountExternalId: 'a-valid-external-id-3',
-    type: 'test'
+    type: 'test',
+    recurringEnabled: true
   }
   const userStub = userStubs.getUserSuccessWithMultipleServices(userExternalId, [
     {

--- a/test/cypress/integration/transactions/transaction-search.cy.test.js
+++ b/test/cypress/integration/transactions/transaction-search.cy.test.js
@@ -121,12 +121,13 @@ const disputeTransactions = [
 const sharedStubs = (paymentProvider = 'sandbox') => {
   return [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName }),
-    gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId, paymentProvider }),
+    gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId, paymentProvider, recurringEnabled: true }),
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
       gatewayAccountId,
       gatewayAccountExternalId,
       paymentProvider,
-      type: 'live'
+      type: 'live',
+      recurringEnabled: true
     }),
     gatewayAccountStubs.getCardTypesSuccess(),
     stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId })

--- a/test/unit/utils/permissions.test.js
+++ b/test/unit/utils/permissions.test.js
@@ -67,6 +67,7 @@ describe('gateway account filter utiltiies', () => {
       expect(result.hasLiveAccounts).to.equal(false)
       expect(result.hasTestStripeAccount).to.equal(true)
       expect(result.hasStripeAccount).to.equal(true)
+      expect(result.hasRecurringAccount).to.equal(false)
     })
 
     it('correctly identifies non stripe and moto headers', async () => {
@@ -98,7 +99,8 @@ describe('gateway account filter utiltiies', () => {
                 accounts: [
                   validGatewayAccountResponse({
                     gateway_account_id: '1',
-                    type: 'live'
+                    type: 'live',
+                    recurring_enabled: true
                   }),
                   validGatewayAccountResponse({
                     gateway_account_id: '2',
@@ -116,12 +118,14 @@ describe('gateway account filter utiltiies', () => {
       })
       const liveResult = await getGatewayAccountsFor(user, true, 'perm-1')
       expect(liveResult.gatewayAccountIds).to.deep.equal([ '1', '3' ])
+      expect(liveResult.hasRecurringAccount).to.equal(true)
 
       const testResult = await getGatewayAccountsFor(user, false, 'perm-1')
       expect(testResult.gatewayAccountIds).to.deep.equal([ '2' ])
       expect(testResult.hasLiveAccounts).to.equal(true)
       expect(testResult.hasTestStripeAccount).to.equal(false)
       expect(testResult.hasStripeAccount).to.equal(false)
+      expect(testResult.hasRecurringAccount).to.equal(false)
     })
 
     it('correctly filters services by users permission role', async () => {


### PR DESCRIPTION
For the time being the admin tool only shows the agreement tab to
services with the `recurring_enabled` flag set to true (as managed by
Toolbox). Reflect this with the transactions filter until a decision is
made on if this should be shown to all users.

Update test scenarios that cover the agreement id filter to include the 
appropriate property on the stubbed account.

Update the content to read "Search by agreement" followed by the hint to
"Enter agreement identifier".

