### PR TITLE
PP-9882 Create payment link page: warn if Worldpay MOTO service

### DIFF
--- a/app/controllers/payment-links/get-start.controller.js
+++ b/app/controllers/payment-links/get-start.controller.js
@@ -3,9 +3,18 @@
 const lodash = require('lodash')
 
 const { response } = require('../../utils/response.js')
+const { getCurrentCredential } = require('../../utils/credentials')
 
 module.exports = (req, res) => {
   lodash.set(req, 'session.pageData.createPaymentLink', {})
 
-  return response(req, res, 'payment-links/index', {})
+  const credential = getCurrentCredential(req.account)
+
+  const accountUsesWorldpayMotoMerchantCode = lodash.get(credential, 'payment_provider', '') === 'worldpay'
+      && lodash.get(credential, 'credentials.merchant_id', '').endsWith('MOTO')
+
+  return response(req, res, 'payment-links/index', {
+    accountUsesWorldpayMotoMerchantCode: accountUsesWorldpayMotoMerchantCode
+  })
+
 }

--- a/app/views/payment-links/_pre-filled-payment-moto-content.njk
+++ b/app/views/payment-links/_pre-filled-payment-moto-content.njk
@@ -3,21 +3,18 @@
 <h2 class="govuk-heading-m">Create a prefilled payment link</h2>
 <p class="govuk-body">You can create prefilled links to send to users with the amount and reference already filled in. Learn <a href="https://docs.payments.service.gov.uk/prefill_payment_links/" class="govuk-link">how to create prefilled links</a>.</p>
 
-{% set warningTextHtml %}
-  <p class="govuk-body govuk-!-font-weight-bold">
-   If you want to take payment in a call centre or by post,
-  <a class="govuk-link" href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk"target="_top">
-    contact support
+{% set telephonePaymentLinksHtml %}
+  If you want to take payment in a call centre or by post,  
+  <a class="govuk-link" href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk" target="_top">
+    contact support 
   <a>
-    to request
+  to request
   <a href="https://docs.payments.service.gov.uk/moto_payments/#take-a-payment-over-the-phone-moto-payments" class="govuk-link">
     MOTO (mail order telephone order) payment links
   </a>
-    to be set up on your account.
-  </p>
+  to be set up on your account.
 {% endset %}
 
-{{ govukWarningText({
-   html: warningTextHtml,
-   iconFallbackText: "Warning"
+{{ govukInsetText({
+  html: telephonePaymentLinksHtml
 }) }}

--- a/app/views/payment-links/index.njk
+++ b/app/views/payment-links/index.njk
@@ -12,6 +12,22 @@
 {% block mainContent %}
 <section class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">Create a payment link</h1>
+
+  {% if accountUsesWorldpayMotoMerchantCode %}
+    {% set worldpayMotoMerchantCodeWarningHtml %}
+      Your service is set up to only use MOTO payments. Do not create payment links and send them to paying users. Use a non-MOTO service or 
+      <a class="govuk-link" href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk" target="_top">
+        contact support 
+      <a>
+      for help.
+    {% endset %}
+
+    {{ govukWarningText({
+      html: worldpayMotoMerchantCodeWarningHtml,
+      iconFallbackText: "Warning"
+    }) }}
+  {% endif %}
+
   <p class="govuk-body">You can create a payment link so that users can make online payments to your service. Even if you don’t have a digital service, GOV.UK Pay can still take payments for you.</p>
   <p class="govuk-body">It’s quick and easy to create a payment link and you don’t need any technical knowledge.</p>
   <p class="govuk-body">The same payment link can be used by all users of your service.</p>

--- a/test/cypress/integration/payment-links/create-payment-link.cy.test.js
+++ b/test/cypress/integration/payment-links/create-payment-link.cy.test.js
@@ -25,6 +25,30 @@ function assertCommonPageElements () {
   assertCancelLinkHref()
 }
 
+describe('The create payment link start page for a Worldpay MOTO account', () => {
+  it('Should display warning', () => {
+    cy.task('setupStubs', [
+      userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceExternalId, serviceName }),
+      gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'test', paymentProvider: 'worldpay',
+          gatewayAccountCredentials: [
+            {
+              gateway_account_id: gatewayAccountId,
+              payment_provider: 'worldpay',
+              state: 'ACTIVE',
+              credentials: {
+                merchant_id: 'worldpay-merchant-code-ending-with-MOTO'
+              }
+            }
+          ]
+        }),
+    ])
+    Cypress.Cookies.preserveOnce('session', 'gateway_account')
+    cy.setEncryptedCookies(userExternalId)
+    cy.visit(`/account/${gatewayAccountExternalId}/create-payment-link`)
+    cy.get('.govuk-warning-text').should('contain', 'Your service is set up to only use MOTO payments.')
+  })
+})
+
 describe('The create payment link flow', () => {
   beforeEach(() => {
     cy.task('setupStubs', [
@@ -50,6 +74,7 @@ describe('The create payment link flow', () => {
         cy.visit(`/account/${gatewayAccountExternalId}/create-payment-link`)
 
         cy.get('h1').should('contain', 'Create a payment link')
+        cy.get('.govuk-warning-text').should('not.exist')
         cy.get('a#create-payment-link').should('exist')
         cy.get(`a[href="/account/${gatewayAccountExternalId}/create-payment-link/information?language=cy"]`).should('exist')
           .should('contain', 'Create a payment link in Welsh')

--- a/test/unit/controller/payment-links/get-start.controller.test.js
+++ b/test/unit/controller/payment-links/get-start.controller.test.js
@@ -1,0 +1,128 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const { expect } = require('chai')
+const mockResponses = {}
+
+const getController = function (mockResponses) {
+  return proxyquire('../../../../app/controllers/payment-links/get-start.controller', {
+    '../../utils/response': mockResponses
+  })
+}
+
+describe('The Worldpay MOTO account warning', () => {
+  let req
+  let res
+  let createPaymentLinkStartController
+
+  beforeEach(() => {
+    mockResponses.response = sinon.spy()
+    createPaymentLinkStartController = getController(mockResponses)
+    res = {}
+  })
+
+  describe('when the gateway account has a Worldpay credentials object with a merchant code ending with ‘MOTO’', () => {
+    it('should pass accountUsesWorldpayMotoMerchantCode with a value of true', () => {
+      req = {
+        account: {
+          gateway_account_credentials: [{
+            state: 'ACTIVE',
+            payment_provider: 'worldpay',
+            credentials: {
+                merchant_id: 'merchant-code-ends-with-MOTO'
+            }
+          }]
+        }
+      }
+
+      createPaymentLinkStartController(req, res)
+      expect(mockResponses.response.args[0][3]).to.have.property('accountUsesWorldpayMotoMerchantCode').to.equal(true)
+    })
+  })
+
+  describe('when the gateway account has a Worldpay credentials object with a merchant code not ending with ‘MOTO’', () => {
+    it('should pass accountUsesWorldpayMotoMerchantCode with a value of false', () => {
+      req = {
+        account: {
+          gateway_account_credentials: [{
+            state: 'ACTIVE',
+            payment_provider: 'worldpay',
+            credentials: {
+                merchant_id: 'merchant-code-ends-with-MOTO-ah-no-it-does-not'
+            }
+          }]
+        }
+      }
+
+      createPaymentLinkStartController(req, res)
+      expect(mockResponses.response.args[0][3]).to.have.property('accountUsesWorldpayMotoMerchantCode').to.equal(false)
+    })
+  })
+
+  describe('when the gateway account has a non-Worldpay credentials object with a merchant code ending with ‘MOTO’', () => {
+    it('should pass accountUsesWorldpayMotoMerchantCode with a value of false', () => {
+      req = {
+        account: {
+          gateway_account_credentials: [{
+            state: 'ACTIVE',
+            payment_provider: 'not-worldpay',
+            credentials: {
+                merchant_id: 'merchant-code-ends-with-MOTO'
+            }
+          }]
+        }
+      }
+
+      createPaymentLinkStartController(req, res)
+      expect(mockResponses.response.args[0][3]).to.have.property('accountUsesWorldpayMotoMerchantCode').to.equal(false)
+    })
+  })
+
+  describe('when the gateway account has a Worldpay credentials object without a merchant_id', () => {
+    it('should pass accountUsesWorldpayMotoMerchantCode with a value of false', () => {
+      req = {
+        account: {
+          gateway_account_credentials: [{
+            state: 'ACTIVE',
+            payment_provider: 'worldpay',
+            credentials: {}
+          }]
+        }
+      }
+
+      createPaymentLinkStartController(req, res)
+      expect(mockResponses.response.args[0][3]).to.have.property('accountUsesWorldpayMotoMerchantCode').to.equal(false)
+    })
+  })
+
+  describe('when the gateway account has no credentials object', () => {
+    it('should pass accountUsesWorldpayMotoMerchantCode with a value of false', () => {
+      req = {
+        account: {
+          gateway_account_credentials: [{
+            state: 'ACTIVE',
+            payment_provider: 'worldpay'
+          }]
+        }
+      }
+
+      createPaymentLinkStartController(req, res)
+      expect(mockResponses.response.args[0][3]).to.have.property('accountUsesWorldpayMotoMerchantCode').to.equal(false)
+    })
+  })
+
+  describe('when the gateway account has no credentials at all', () => {
+    it('should pass accountUsesWorldpayMotoMerchantCode with a value of false', () => {
+      req = {
+        account: {
+          gateway_account_credentials: []
+        }
+      }
+
+      createPaymentLinkStartController(req, res)
+      expect(mockResponses.response.args[0][3]).to.have.property('accountUsesWorldpayMotoMerchantCode').to.equal(false)
+    })
+  })
+
+})


### PR DESCRIPTION
Add a warning to the create payment link page imploring the user to not create a payment link if and only if the gateway account has current credentials for Worldpay using a merchant code that ends in ‘MOTO’ (which is how Worldpay identify MOTO merchant codes).

The existing warning on the create payment link page, which informs users about the existence of telephone payment links (agent-initiated MOTO payments) is changed to inset text so we do not end up with two warnings on single page.

![image](https://user-images.githubusercontent.com/24316348/187468414-5eb4d6bd-8e60-4226-9ff8-1f7d49718730.png)