### PR TITLE
BAU Add webhooks permissions to experimental feature flag

### DIFF
--- a/app/utils/display-converter.js
+++ b/app/utils/display-converter.js
@@ -126,7 +126,7 @@ module.exports = function (req, data, template) {
   const currentPath = (relativeUrl && url.parse(relativeUrl).pathname.replace(/([a-z])\/$/g, '$1')) || '' // remove query params and trailing slash
   if (permissions) {
     convertedData.serviceNavigationItems = serviceNavigationItems(currentPath, permissions, paymentMethod, account)
-    convertedData.adminNavigationItems = adminNavigationItems(currentPath, permissions, paymentMethod, paymentProvider, account)
+    convertedData.adminNavigationItems = adminNavigationItems(currentPath, permissions, paymentMethod, paymentProvider, account, service)
   }
   convertedData._features = {}
   if (req.user && req.user.features) {

--- a/app/utils/nav-builder.js
+++ b/app/utils/nav-builder.js
@@ -81,7 +81,7 @@ const serviceNavigationItems = (currentPath, permissions, type, account = {}) =>
   return navigationItems
 }
 
-const adminNavigationItems = (currentPath, permissions, type, paymentProvider, account = {}) => {
+const adminNavigationItems = (currentPath, permissions, type, paymentProvider, account = {}, service = {}) => {
   const apiKeysPath = formatAccountPathsFor(paths.account.apiKeys.index, account.external_id)
 
   return [
@@ -104,7 +104,7 @@ const adminNavigationItems = (currentPath, permissions, type, paymentProvider, a
       name: 'Webhooks',
       url: formatFutureStrategyAccountPathsFor(paths.futureAccountStrategy.webhooks.index, account.type, account.service_id, account.external_id),
       current: pathLookup(currentPath, paths.futureAccountStrategy.webhooks.index),
-      permissions: permissions.webhooks_update && process.env.FEATURE_ENABLE_WEBHOOKS === 'true'
+      permissions: permissions.webhooks_update && (process.env.FEATURE_ENABLE_WEBHOOKS === 'true' || service.experimentalFeaturesEnabled)
     },
     ...yourPSPNavigationItems(account, currentPath).map((yourPSPNavigationItem) => ({
       ...yourPSPNavigationItem,


### PR DESCRIPTION
This generic flag will give us control to turn the administration of
webhooks on for specific services in a given environment (where the
feature flag for the entire env is off).


