### PR TITLE
PP-9207 Check organisation details - display empty string instead of 'null'

### DIFF
--- a/app/controllers/stripe-setup/check-org-details/get.controller.js
+++ b/app/controllers/stripe-setup/check-org-details/get.controller.js
@@ -20,11 +20,11 @@ module.exports = (req, res, next) => {
   const { merchantDetails } = req.service
 
   const data = {
-    orgName: lodash.get(merchantDetails, 'name', null),
-    orgAddressLine1: lodash.get(merchantDetails, 'address_line1', null),
-    orgAddressLine2: lodash.get(merchantDetails, 'address_line2', null),
-    orgCity: lodash.get(merchantDetails, 'address_city', null),
-    orgPostcode: lodash.get(merchantDetails, 'address_postcode', null)
+    orgName: lodash.get(merchantDetails, 'name', ''),
+    orgAddressLine1: lodash.get(merchantDetails, 'address_line1', ''),
+    orgAddressLine2: lodash.get(merchantDetails, 'address_line2', ''),
+    orgCity: lodash.get(merchantDetails, 'address_city', ''),
+    orgPostcode: lodash.get(merchantDetails, 'address_postcode', '')
   }
 
   return response(req, res, 'stripe-setup/check-org-details/index', data)

--- a/app/controllers/stripe-setup/check-org-details/get.controller.test.js
+++ b/app/controllers/stripe-setup/check-org-details/get.controller.test.js
@@ -88,11 +88,11 @@ describe('Check org details - get controller', () => {
     expect(renderArgs.args[0]).to.equal('stripe-setup/check-org-details/index')
 
     const pageData = renderArgs.args[1]
-    expect(pageData.orgName).to.equal(null)
-    expect(pageData.orgAddressLine1).to.equal(null)
-    expect(pageData.orgAddressLine2).to.equal(null)
-    expect(pageData.orgCity).to.equal(null)
-    expect(pageData.orgPostcode).to.equal(null)
+    expect(pageData.orgName).to.equal('')
+    expect(pageData.orgAddressLine1).to.equal('')
+    expect(pageData.orgAddressLine2).to.equal('')
+    expect(pageData.orgCity).to.equal('')
+    expect(pageData.orgPostcode).to.equal('')
   })
 
   it('should render `check your organisation` form if details are not yet submitted and only the `merchantDetails.name` is empty', async () => {
@@ -108,7 +108,7 @@ describe('Check org details - get controller', () => {
     expect(renderArgs.args[0]).to.equal('stripe-setup/check-org-details/index')
 
     const pageData = renderArgs.args[1]
-    expect(pageData.orgName).to.equal(null)
+    expect(pageData.orgName).to.equal('')
     expect(pageData.orgAddressLine1).to.equal('Test address line 1')
     expect(pageData.orgAddressLine2).to.equal('Test address line 2')
     expect(pageData.orgCity).to.equal('London')


### PR DESCRIPTION
## WHAT

- Stripe onboarding - check organisation details page currently displays string 'null' for the part of organisation details (name or address lines) empty. Display an empty string instead

