### PR TITLE
PP-6213 Make extremely long payment references not overflow

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -31,6 +31,7 @@ $govuk-page-width: 1200px;
 @import "components/transaction-filter";
 @import "components/multi-select";
 @import "components/pagination";
+@import "components/transaction-details";
 @import "components/transaction-refund";
 @import "components/vertical-align";
 @import "components/borders";

--- a/app/assets/sass/components/transaction-details.scss
+++ b/app/assets/sass/components/transaction-details.scss
@@ -1,0 +1,5 @@
+.transaction-details {
+  table-layout: fixed;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}

--- a/app/assets/sass/components/transaction-list.scss
+++ b/app/assets/sass/components/transaction-list.scss
@@ -1,5 +1,8 @@
-.transactions-list-table{
+.transactions-list-table {
   background-color: govuk-colour("white");
+  table-layout: fixed;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 tr[data-follow-link]{


### PR DESCRIPTION
Make extremely long payment references with no spaces not overflow on both the transactions list page and the transaction details page.

This has been a problem since forever but it’s more pressing now that we allow payment link references (which may be entered by paying users without oversight from the partner service that’s going to see them in the admin tool) to be up to 255 characters in length (up from 50).

We use `table-layout: fixed` and `overflow-wrap: break-word` to force jumbo references to wrap. For compatibility with browsers that do not support `overflow-wrap` (mostly IE11), we also use the legacy `word-wrap` property.

On the transaction details page, this will also stop extremely long email addresses and cardholder names from causing mischief.

![image](https://user-images.githubusercontent.com/24316348/188670206-4696c714-c649-4204-bfe9-faaed44dc3cd.png)
![image](https://user-images.githubusercontent.com/24316348/188670236-c6b49777-3a08-4f3a-b845-63f05bc978a1.png)
