### PR TITLE
Revert "PP-10041: Send OtpCode to 'complete' endpoint"

### DIFF
--- a/app/controllers/register-service.controller.js
+++ b/app/controllers/register-service.controller.js
@@ -190,7 +190,7 @@ async function createPopulatedService (req, res, next) {
   }
 
   try {
-    const user = await registrationService.createPopulatedService(req.register_invite.code, correlationId, otpCode)
+    const user = await registrationService.createPopulatedService(req.register_invite.code, correlationId)
     loginController.setupDirectLoginAfterRegister(req, res, user.externalId)
     return res.redirect(303, paths.selfCreateService.logUserIn)
   } catch (err) {

--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -412,18 +412,16 @@ module.exports = function (clientOptions = {}) {
    *
    * @param correlationId
    * @param inviteCode
-   * @param otpCode
+   * @param gatewayAccountIds
    * @returns {*|promise|Constructor}
    */
-  const completeInvite = (correlationId, inviteCode, otpCode = null) => {
+  const completeInvite = (correlationId, inviteCode) => {
     return baseClient.post(
       {
         baseUrl,
         url: `${inviteResource}/${inviteCode}/complete`,
         json: true,
-        body: {
-          otp: otpCode
-        },
+        body: {},
         correlationId: correlationId,
         description: 'complete invite',
         service: SERVICE_NAME,

--- a/app/services/service-registration.service.js
+++ b/app/services/service-registration.service.js
@@ -16,8 +16,8 @@ function submitServiceInviteOtpCode (code, otpCode, correlationId) {
   return adminUsersClient.verifyOtpForServiceInvite(code, otpCode, correlationId)
 }
 
-async function createPopulatedService (inviteCode, correlationId, otpCode) {
-  const completeInviteResponse = await adminUsersClient.completeInvite(correlationId, inviteCode, otpCode)
+async function createPopulatedService (inviteCode, correlationId) {
+  const completeInviteResponse = await adminUsersClient.completeInvite(correlationId, inviteCode)
   logger.info('Created new service during user registration')
 
   const gatewayAccount = await connectorClient.createGatewayAccount('sandbox', 'test', null, null, completeInviteResponse.service_external_id, correlationId)

--- a/test/fixtures/invite.fixtures.js
+++ b/test/fixtures/invite.fixtures.js
@@ -95,9 +95,7 @@ module.exports = {
   },
 
   validInviteCompleteRequest: (opts = {}) => {
-    return {
-      otp: opts.otp || '123456'
-    }
+    return {}
   },
 
   validInviteCompleteResponse: (opts = {}) => {

--- a/test/integration/service-registration.service.it.test.js
+++ b/test/integration/service-registration.service.it.test.js
@@ -30,7 +30,6 @@ describe('create populated service', function () {
     const userExternalId = 'f84b8210f93d455e97baeaf3fea72cf4'
     const serviceExternalId = '43a6818b522b4a628a14355614665ca3'
     const gatewayAccountId = '1'
-    const otpCode = '654321'
 
     const mockConnectorCreateGatewayAccountResponse =
       gatewayAccountFixtures.validGatewayAccountResponse({
@@ -38,7 +37,7 @@ describe('create populated service', function () {
       })
     const mockAdminUsersInviteCompleteRequest =
       inviteFixtures.validInviteCompleteRequest({
-        otp: otpCode
+        gateway_account_ids: [gatewayAccountId]
       })
     const mockAdminUsersInviteCompleteResponse =
       inviteFixtures.validInviteCompleteResponse({
@@ -61,7 +60,7 @@ describe('create populated service', function () {
     adminusersMock.patch(`/v1/api/services/${serviceExternalId}`)
       .reply(200, {})
 
-    serviceRegistrationService.createPopulatedService(inviteCode, null, otpCode).should.be.fulfilled.then(user => {
+    serviceRegistrationService.createPopulatedService(inviteCode).should.be.fulfilled.then(user => {
       expect(createGatewayAccountMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
       expect(completeServiceInviteMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
       expect(getUserMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
@@ -71,7 +70,6 @@ describe('create populated service', function () {
 
   it('should error if creation of a gateway account failed', function (done) {
     const inviteCode = 'a-valid-invite-code'
-    const otpCode = '654321'
     const mockAdminUsersInviteCompleteResponse =
       inviteFixtures.validInviteCompleteResponse({
         service_external_id: 'a-service-id'
@@ -82,7 +80,7 @@ describe('create populated service', function () {
     const mockConnectorCreateGatewayAccountResponse = connectorMock.post(CONNECTOR_ACCOUNTS_URL)
       .reply(500)
 
-    serviceRegistrationService.createPopulatedService(inviteCode, null, otpCode).should.be.rejected.then(error => {
+    serviceRegistrationService.createPopulatedService(inviteCode).should.be.rejected.then(error => {
       expect(mockConnectorCreateGatewayAccountResponse.isDone()).to.be.true // eslint-disable-line no-unused-expressions
       expect(error.errorCode).to.equal(500)
     }).should.notify(done)
@@ -91,7 +89,6 @@ describe('create populated service', function () {
   it('should error if creation of a gateway account succeeded, but complete invite failed', function (done) {
     const inviteCode = 'a-valid-invite-code'
     const gatewayAccountId = '1'
-    const otpCode = '654321'
 
     const mockConnectorCreateGatewayAccountResponse =
       gatewayAccountFixtures.validGatewayAccountResponse({
@@ -99,7 +96,7 @@ describe('create populated service', function () {
       })
     const mockAdminUsersInviteCompleteRequest =
       inviteFixtures.validInviteCompleteRequest({
-        otp: otpCode
+        gateway_account_ids: [gatewayAccountId]
       })
 
     connectorMock.post(CONNECTOR_ACCOUNTS_URL)
@@ -107,7 +104,7 @@ describe('create populated service', function () {
     const completeServiceInviteMock = adminusersMock.post(`${ADMINUSERS_INVITES_URL}/${inviteCode}/complete`, mockAdminUsersInviteCompleteRequest)
       .reply(500)
 
-    serviceRegistrationService.createPopulatedService(inviteCode, null, otpCode).then(() => {
+    serviceRegistrationService.createPopulatedService(inviteCode).then(() => {
       done('should not be called')
     }).catch(error => {
       expect(completeServiceInviteMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
@@ -119,7 +116,6 @@ describe('create populated service', function () {
   it('should error if creation of a gateway account succeeded and complete invite succeeded, but user already exists', function (done) {
     const inviteCode = 'a-valid-invite-code'
     const gatewayAccountId = '1'
-    const otpCode = '654321'
 
     const mockConnectorCreateGatewayAccountResponse =
       gatewayAccountFixtures.validGatewayAccountResponse({
@@ -127,7 +123,7 @@ describe('create populated service', function () {
       })
     const mockAdminUsersInviteCompleteRequest =
       inviteFixtures.validInviteCompleteRequest({
-        otp: otpCode
+        gateway_account_ids: [gatewayAccountId]
       })
 
     connectorMock.post(CONNECTOR_ACCOUNTS_URL)
@@ -135,7 +131,7 @@ describe('create populated service', function () {
     const completeServiceInviteMock = adminusersMock.post(`${ADMINUSERS_INVITES_URL}/${inviteCode}/complete`, mockAdminUsersInviteCompleteRequest)
       .reply(409)
 
-    serviceRegistrationService.createPopulatedService(inviteCode, null, otpCode).should.be.rejected.then(error => {
+    serviceRegistrationService.createPopulatedService(inviteCode).should.be.rejected.then(error => {
       expect(completeServiceInviteMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
       expect(error.errorCode).to.equal(409)
     }).should.notify(done)

--- a/test/unit/clients/adminusers-client/invite/complete-service-invite.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/complete-service-invite.pact.test.js
@@ -38,13 +38,8 @@ describe('adminusers client - complete an invite', function () {
     const inviteCode = '7d19aff33f8948deb97ed16b2912dcd3'
     const userExternalId = 'f84b8210f93d455e97baeaf3fea72cf4'
     const serviceExternalId = '43a6818b522b4a628a14355614665ca3'
-    const otpCode = '654321'
 
-    const validInviteCompleteRequest = inviteFixtures.validInviteCompleteRequest(
-      {
-        otp: otpCode
-      }
-    )
+    const validInviteCompleteRequest = inviteFixtures.validInviteCompleteRequest()
     const validInviteCompleteResponse = inviteFixtures.validInviteCompleteResponse({
       invite: {
         code: inviteCode,
@@ -72,7 +67,7 @@ describe('adminusers client - complete an invite', function () {
     afterEach(() => provider.verify())
 
     it('should complete a service invite successfully', function (done) {
-      adminUsersClient.completeInvite('correlation-id', inviteCode, otpCode).should.be.fulfilled.then(response => {
+      adminUsersClient.completeInvite('correlation-id', inviteCode).should.be.fulfilled.then(response => {
         expect(response.invite).to.deep.equal(validInviteCompleteResponse.invite)
         expect(response.user_external_id).to.equal(userExternalId)
         expect(response.service_external_id).to.equal(serviceExternalId)
@@ -82,13 +77,11 @@ describe('adminusers client - complete an invite', function () {
 
   describe('not found', () => {
     const nonExistingInviteCode = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
-    const otpCode = '654321'
 
-    const validInviteCompleteRequest = inviteFixtures.validInviteCompleteRequest(
-      {
-        otp: otpCode
-      }
-    )
+    const gatewayAccountIds = ['1']
+    const validInviteCompleteRequest = inviteFixtures.validInviteCompleteRequest({
+      gateway_account_ids: gatewayAccountIds
+    })
 
     before((done) => {
       provider.addInteraction(
@@ -105,7 +98,7 @@ describe('adminusers client - complete an invite', function () {
     afterEach(() => provider.verify())
 
     it('should 404 NOT FOUND if invite code not found', function (done) {
-      adminUsersClient.completeInvite('correlation-id', nonExistingInviteCode, otpCode).should.be.rejected.then(function (response) {
+      adminUsersClient.completeInvite('correlation-id', nonExistingInviteCode, gatewayAccountIds).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(404)
       }).should.notify(done)
     })
@@ -113,13 +106,11 @@ describe('adminusers client - complete an invite', function () {
 
   describe('complete service invite - 409 CONFLICT', () => {
     const inviteCode = '7d19aff33f8948deb97ed16b2912dcd3'
-    const otpCode = '654321'
 
-    const validInviteCompleteRequest = inviteFixtures.validInviteCompleteRequest(
-      {
-        otp: otpCode
-      }
-    )
+    const gatewayAccountIds = ['1']
+    const validInviteCompleteRequest = inviteFixtures.validInviteCompleteRequest({
+      gateway_account_ids: gatewayAccountIds
+    })
 
     before((done) => {
       provider.addInteraction(
@@ -136,8 +127,39 @@ describe('adminusers client - complete an invite', function () {
     afterEach(() => provider.verify())
 
     it('should 409 CONFLICT if user with same email exists', function (done) {
-      adminUsersClient.completeInvite('correlation-id', inviteCode, otpCode).should.be.rejected.then(function (response) {
+      adminUsersClient.completeInvite('correlation-id', inviteCode, gatewayAccountIds).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(409)
+      }).should.notify(done)
+    })
+  })
+
+  describe('bad request', () => {
+    const inviteCode = '7d19aff33f8948deb97ed16b2912dcd3'
+
+    const invalidGatewayAccountIds = ['non-numeric-id']
+    const invalidInviteCompleteRequest = inviteFixtures.validInviteCompleteRequest({
+      gateway_account_ids: invalidGatewayAccountIds
+    })
+    const errorResponse = inviteFixtures.badRequestResponseWhenNonNumericGatewayAccountIds(invalidGatewayAccountIds)
+
+    before((done) => {
+      provider.addInteraction(
+        new PactInteractionBuilder(`${INVITE_RESOURCE}/${inviteCode}/complete`)
+          .withState('invite expired for the given invite code')
+          .withUponReceiving('a valid complete service invite request of an expired invite')
+          .withMethod('POST')
+          .withRequestBody(invalidInviteCompleteRequest)
+          .withStatusCode(400)
+          .withResponseBody(pactify(errorResponse))
+          .build()
+      ).then(() => done())
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should 400 BAD REQUEST if gateway accounts are non numeric', function (done) {
+      adminUsersClient.completeInvite('correlation-id', inviteCode, invalidGatewayAccountIds).should.be.rejected.then(function (response) {
+        expect(response.errorCode).to.equal(400)
       }).should.notify(done)
     })
   })


### PR DESCRIPTION
Reverts alphagov/pay-selfservice#3506

We realised that unifying OTP validation and invite completion isn't a good idea (it makes it too difficult to define suitable test coverage).  So, #3506 is no longer helpful and should be reverted.  See https://payments-platform.atlassian.net/browse/PP-10041?focusedCommentId=48911