### PR TITLE
PP-9984 Switch PSP > Check org details - update controllers

### DIFF
--- a/app/controllers/stripe-setup/check-org-details/get.controller.js
+++ b/app/controllers/stripe-setup/check-org-details/get.controller.js
@@ -1,10 +1,12 @@
 'use strict'
 
 const { response } = require('../../../utils/response')
+const { isSwitchingCredentialsRoute } = require('../../../utils/credentials')
 const { getAlreadySubmittedErrorPageData } = require('../stripe-setup.util')
 const lodash = require('lodash')
 
 module.exports = (req, res, next) => {
+  const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
 
   if (!stripeAccountSetup) {
@@ -24,7 +26,8 @@ module.exports = (req, res, next) => {
     orgAddressLine1: lodash.get(merchantDetails, 'address_line1', ''),
     orgAddressLine2: lodash.get(merchantDetails, 'address_line2', ''),
     orgCity: lodash.get(merchantDetails, 'address_city', ''),
-    orgPostcode: lodash.get(merchantDetails, 'address_postcode', '')
+    orgPostcode: lodash.get(merchantDetails, 'address_postcode', ''),
+    isSwitchingCredentials
   }
 
   return response(req, res, 'stripe-setup/check-org-details/index', data)

--- a/app/controllers/stripe-setup/check-org-details/get.controller.test.js
+++ b/app/controllers/stripe-setup/check-org-details/get.controller.test.js
@@ -95,6 +95,20 @@ describe('Check org details - get controller', () => {
     expect(pageData.orgPostcode).to.equal('')
   })
 
+  it('when it is `switch PSP` should render `check your organisation` form and set isSwitchingCredentials=true', async () => {
+    const updatedService = { ...req.service, merchantDetails: undefined }
+    req.service = updatedService
+    req.url = '/switch-psp/test-credential/bank-details'
+
+    req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
+
+    await getController(req, res)
+
+    const renderArgs = res.render.getCalls()[0]
+    const pageData = renderArgs.args[1]
+    expect(pageData.isSwitchingCredentials).to.equal(true)
+  })
+
   it('should render `check your organisation` form if details are not yet submitted and only the `merchantDetails.name` is empty', async () => {
     const updatedService = { ...req.service }
     updatedService.merchantDetails.name = undefined

--- a/app/controllers/stripe-setup/check-org-details/post.controller.test.js
+++ b/app/controllers/stripe-setup/check-org-details/post.controller.test.js
@@ -117,30 +117,62 @@ describe('Check org details - post controller', () => {
   })
 
   describe('radio buttons', () => {
-    it('when `no` radio button is selected, then it should redirect to org address page', () => {
-      req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
-
-      req.body = {
-        'confirm-org-details': 'no'
-      }
-
-      controller(req, res, next)
-
-      sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/your-psp/a-valid-credential-id/update-organisation-details')
+    describe('Stripe onboarding', () => {
+      it('when `no` radio button is selected, then it should redirect to `Stripe onboarding > org address` page', () => {
+        req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
+  
+        req.body = {
+          'confirm-org-details': 'no'
+        }
+  
+        controller(req, res, next)
+  
+        sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/your-psp/a-valid-credential-id/update-organisation-details')
+      })
+  
+      it('when `yes` radio button is selected, then it should redirect to the `Stripe onboarding > add psp account details` redirect route', async () => {
+        req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
+  
+        req.body = {
+          'confirm-org-details': 'yes'
+        }
+  
+        await controller(req, res, next)
+  
+        sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'organisation_details', req.correlationId)
+        sinon.assert.calledWith(loggerInfoMock, 'Organisation details confirmed for Stripe account', { stripe_account_id: stripeAcountId })
+        sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/stripe/add-psp-account-details')
+      })
     })
 
-    it('when `yes` radio button is selected, then it should redirect to the `Stripe > add psp account details` redirect route', async () => {
-      req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
-
-      req.body = {
-        'confirm-org-details': 'yes'
-      }
-
-      await controller(req, res, next)
-
-      sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'organisation_details', req.correlationId)
-      sinon.assert.calledWith(loggerInfoMock, 'Organisation details confirmed for Stripe account', { stripe_account_id: stripeAcountId })
-      sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/stripe/add-psp-account-details')
-    })
+    describe('Switch PSP to Stripe', () => {
+      it('when `no` radio button is selected, then it should redirect to `switch psp to Stripe > update org address` page', () => {
+        req.url = '/switch-psp/test-credential/check-organisation-details'
+        req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
+  
+        req.body = {
+          'confirm-org-details': 'no'
+        }
+  
+        controller(req, res, next)
+  
+        sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/switch-psp/a-valid-credential-id/update-organisation-details')
+      })
+  
+      it('when `yes` radio button is selected, then it should redirect to the `switch psp to Stripe > switch PSP index` redirect route', async () => {
+        req.url = '/switch-psp/test-credential/check-organisation-details'
+        req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
+  
+        req.body = {
+          'confirm-org-details': 'yes'
+        }
+  
+        await controller(req, res, next)
+  
+        sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'organisation_details', req.correlationId)
+        sinon.assert.calledWith(loggerInfoMock, 'Organisation details confirmed for Stripe account', { stripe_account_id: stripeAcountId })
+        sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/switch-psp')
+      })
+    }) 
   })
 })

--- a/app/paths.js
+++ b/app/paths.js
@@ -116,6 +116,8 @@ module.exports = {
         vatNumber: '/switch-psp/:credentialId/vat-number',
         companyNumber: '/switch-psp/:credentialId/company-number',
         director: '/switch-psp/:credentialId/director',
+        checkOrgDetails: '/switch-psp/:credentialId/check-organisation-details',
+        updateOrgDetails: '/switch-psp/:credentialId/update-organisation-details', 
         governmentEntityDocument: '/switch-psp/:credentialId/government-entity-document'
       }
     },


### PR DESCRIPTION
PP-9984 Switch PSP > Check org details - update controllers
    
Update the Check org details > Get controller:
- Add boolean - to let people know it is a switch psp url.
- Will use boolean to decide to show setting layout.
    
Update the Check org details > Post controller:
- On successful post, do the following:
  - When switch PSP - redirect to Switch PSP index page
  - When Stripe onboarding - redirect to the Stripe onboarding index
    controller.
    
- Add unit tests

