### PR TITLE
PP-9984 Switch PSP > Update org - get controller updates & update routes

### DIFF
--- a/app/controllers/request-to-go-live/organisation-address/get.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/get.controller.js
@@ -8,12 +8,15 @@ const { response } = require('../../../utils/response')
 const { countries } = require('@govuk-pay/pay-js-commons').utils
 const formatServicePathsFor = require('../../../utils/format-service-paths-for')
 const { getAlreadySubmittedErrorPageData } = require('../../stripe-setup/stripe-setup.util')
+const { isSwitchingCredentialsRoute } = require('../../../utils/credentials')
 
 module.exports = function getOrganisationAddress (req, res) {
   const isRequestToGoLive = Object.values(paths.service.requestToGoLive).includes(req.route && req.route.path)
+  const isStripeUpdateOrgDetails = Boolean(req.url && req.url.startsWith('/your-psp/'))
+  const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
 
-  const isStripeUpdateOrgDetails = paths.account.yourPsp.stripeSetup.updateOrgDetails.includes(req.route && req.route.path)
-
+  const isStripeSetupUserJourney = isStripeUpdateOrgDetails || isSwitchingCredentials
+  
   if (isRequestToGoLive) {
     if (req.service.currentGoLiveStage !== goLiveStage.ENTERED_ORGANISATION_NAME) {
       return res.redirect(
@@ -23,7 +26,7 @@ module.exports = function getOrganisationAddress (req, res) {
     }
   }
 
-  if (isStripeUpdateOrgDetails) {
+  if (isStripeSetupUserJourney) {
     const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
 
     if (stripeAccountSetup.organisationDetails) {
@@ -35,7 +38,7 @@ module.exports = function getOrganisationAddress (req, res) {
 
   const merchantDetails = lodash.get(req, 'service.merchantDetails')
 
-  const merchantFormDetails = !isStripeUpdateOrgDetails ? { ...lodash.pick(merchantDetails, [
+  const merchantFormDetails = !isStripeSetupUserJourney ? { ...lodash.pick(merchantDetails, [
     'name',
     'address_line1',
     'address_line2',
@@ -49,10 +52,12 @@ module.exports = function getOrganisationAddress (req, res) {
   const pageData = {
     ...merchantFormDetails,
     isRequestToGoLive,
-    isStripeUpdateOrgDetails
+    isStripeUpdateOrgDetails,
+    isSwitchingCredentials,
+    isStripeSetupUserJourney
   }
   pageData.countries = countries.govukFrontendFormatted(lodash.get(pageData, 'address_country'))
-  
-  const templatePath = isStripeUpdateOrgDetails ? 'stripe-setup/update-org-details/index' : 'request-to-go-live/organisation-address'
+
+  const templatePath = isStripeSetupUserJourney ? 'stripe-setup/update-org-details/index' : 'request-to-go-live/organisation-address'
   return response(req, res, templatePath, pageData)
 }

--- a/app/controllers/request-to-go-live/organisation-address/get.controller.test.js
+++ b/app/controllers/request-to-go-live/organisation-address/get.controller.test.js
@@ -20,12 +20,6 @@ const getController = function getController () {
 
 const correlationId = 'correlation-id'
 
-const account = {
-  connectorGatewayAccountStripeProgress: {
-    organisationDetails: false
-  }
-}
-
 const merchantDetails = {
   name: 'Test organisation',
   address_line1: 'Test address line 1',
@@ -39,8 +33,15 @@ const merchantDetails = {
 describe('organisation address get controller', () => {
   describe('check validation', () => {
     let res
+    let account
 
     beforeEach(() => {
+      account = {
+        connectorGatewayAccountStripeProgress: {
+          organisationDetails: false
+        }
+      }
+
       res = {
         redirect: sinon.spy(),
         render: sinon.spy()
@@ -75,6 +76,9 @@ describe('organisation address get controller', () => {
         const pageData = responseData.args[3]
         expect(pageData.isRequestToGoLive).to.equal(true)
         expect(pageData.isStripeUpdateOrgDetails).to.equal(false)
+        expect(pageData.isSwitchingCredentials).to.equal(false)
+        expect(pageData.isStripeSetupUserJourney).to.equal(false)
+
         expect(pageData.name).to.equal('Test organisation')
         expect(pageData.address_line1).to.equal('Test address line 1')
         expect(pageData.address_line2).to.equal('Test address line 2')
@@ -109,9 +113,7 @@ describe('organisation address get controller', () => {
       it('should display the `update org details` form and set `isStripeUpdateOrgDetails=true` ' +
       'and all form fields should be reset to empty', () => {
         const req = {
-          route: {
-            path: '/your-psp/:credentialId/update-organisation-details'
-          },
+          url: '/your-psp/:credentialId/update-organisation-details',
           account
         }
 
@@ -124,8 +126,10 @@ describe('organisation address get controller', () => {
         expect(responseData.args[2]).to.equal('stripe-setup/update-org-details/index')
 
         const pageData = responseData.args[3]
-        expect(pageData.isStripeUpdateOrgDetails).to.equal(true)
         expect(pageData.isRequestToGoLive).to.equal(false)
+        expect(pageData.isStripeUpdateOrgDetails).to.equal(true)
+        expect(pageData.isSwitchingCredentials).to.equal(false)
+        expect(pageData.isStripeSetupUserJourney).to.equal(true)
      
         expect(pageData.name).to.equal(undefined)
         expect(pageData.address_line1).to.equal(undefined)
@@ -138,9 +142,55 @@ describe('organisation address get controller', () => {
 
       it('should render error if organisation details have already been submitted', async () => {
         const req = {
-          route: {
-            path: '/your-psp/:credentialId/update-organisation-details'
-          },
+          url: '/your-psp/:credentialId/update-organisation-details',
+          account
+        }
+
+        req.account.connectorGatewayAccountStripeProgress.organisationDetails = true
+
+        const controller = getController()
+
+        controller(req, res)
+
+        const responseData = mockResponse.getCalls()[0]
+        expect(responseData.args[2]).to.equal('error-with-link')
+      })
+    })
+
+    describe('view page when `Switch PSP to Stripe`', () => {
+      it('should display the `update org details` form and set `isSwitchingCredentials=true` ' +
+      'and all form fields should be reset to empty', () => {
+        const req = {
+          url: '/switch-psp/:credentialId/update-organisation-details',
+          account
+        }
+
+        const controller = getController()
+
+        controller(req, res)
+
+        const responseData = mockResponse.getCalls()[0]
+
+        expect(responseData.args[2]).to.equal('stripe-setup/update-org-details/index')
+
+        const pageData = responseData.args[3]
+        expect(pageData.isRequestToGoLive).to.equal(false)
+        expect(pageData.isStripeUpdateOrgDetails).to.equal(false)
+        expect(pageData.isSwitchingCredentials).to.equal(true)
+        expect(pageData.isStripeSetupUserJourney).to.equal(true)
+     
+        expect(pageData.name).to.equal(undefined)
+        expect(pageData.address_line1).to.equal(undefined)
+        expect(pageData.address_line2).to.equal(undefined)
+        expect(pageData.address_city).to.equal(undefined)
+        expect(pageData.address_postcode).to.equal(undefined)
+        expect(pageData.telephone_number).to.equal(undefined)
+        expect(pageData.url).to.equal(undefined)
+      })
+
+      it('should render error if organisation details have already been submitted', async () => {
+        const req = {
+          url: '/switch-psp/:credentialId/update-organisation-details',
           account
         }
 
@@ -179,8 +229,10 @@ describe('organisation address get controller', () => {
         expect(responseData.args[2]).to.equal('request-to-go-live/organisation-address')
 
         const pageData = responseData.args[3]
-        expect(pageData.isStripeUpdateOrgDetails).to.equal(false)
         expect(pageData.isRequestToGoLive).to.equal(false)
+        expect(pageData.isStripeUpdateOrgDetails).to.equal(false)
+        expect(pageData.isSwitchingCredentials).to.equal(false)
+        expect(pageData.isStripeSetupUserJourney).to.equal(false)
 
         expect(pageData.name).to.equal('Test organisation')
         expect(pageData.address_line1).to.equal('Test address line 1')

--- a/app/routes.js
+++ b/app/routes.js
@@ -447,10 +447,10 @@ module.exports.bind = function (app) {
   account.post([ yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber ], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.post)
   account.get([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument, kyc.governmentEntityDocument], permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, stripeSetupGovernmentEntityDocument.get)
   account.post([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument, kyc.governmentEntityDocument], permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, uploadGovernmentEntityDocument, stripeSetupGovernmentEntityDocument.post)
-  account.get(yourPsp.stripeSetup.checkOrgDetails, permission('stripe-organisation-details:update'), restrictToStripeAccountContext, stripeSetupCheckOrgDetailsController.get)
-  account.post(yourPsp.stripeSetup.checkOrgDetails, permission('stripe-organisation-details:update'), restrictToStripeAccountContext, stripeSetupCheckOrgDetailsController.post)
-  account.get(yourPsp.stripeSetup.updateOrgDetails, permission('stripe-organisation-details:update'), restrictToStripeAccountContext, requestToGoLiveOrganisationAddressController.get)
-  account.post(yourPsp.stripeSetup.updateOrgDetails, permission('stripe-organisation-details:update'), restrictToStripeAccountContext, requestToGoLiveOrganisationAddressController.post)
+  account.get([yourPsp.stripeSetup.checkOrgDetails, switchPSP.stripeSetup.checkOrgDetails], permission('stripe-organisation-details:update'), restrictToStripeAccountContext, stripeSetupCheckOrgDetailsController.get)
+  account.post([yourPsp.stripeSetup.checkOrgDetails, switchPSP.stripeSetup.checkOrgDetails], permission('stripe-organisation-details:update'), restrictToStripeAccountContext, stripeSetupCheckOrgDetailsController.post)
+  account.get([yourPsp.stripeSetup.updateOrgDetails, switchPSP.stripeSetup.updateOrgDetails], permission('stripe-organisation-details:update'), restrictToStripeAccountContext, requestToGoLiveOrganisationAddressController.get)
+  account.post([yourPsp.stripeSetup.updateOrgDetails, switchPSP.stripeSetup.updateOrgDetails], permission('stripe-organisation-details:update'), restrictToStripeAccountContext, requestToGoLiveOrganisationAddressController.post)
 
   account.get(stripe.addPspAccountDetails, permission('stripe-account-details:update'), restrictToStripeAccountContext, stripeSetupAddPspAccountDetailsController.get)
 

--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -4,7 +4,7 @@
 {% block pageTitle %}
 {% if isRequestToGoLive %}
   Enter your organisation’s contact details - Request a live account - {{ currentService.name }} - GOV.UK Pay
-{% elif isStripeUpdateOrgDetails %}
+{% elif isStripeSetupUserJourney %}
   What is the name and address of you organisation on your government identity document? - {{ currentService.name }} - GOV.UK Pay 
 {% else %}
   Organisation details - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
@@ -31,7 +31,7 @@
     <span id="request-to-go-live-current-step" class="govuk-caption-l">Step 1 of 3</span>
     <h1 class="govuk-heading-l">Enter your organisation’s contact details</h1>
     <p class="govuk-body govuk-!-margin-bottom-6">Your payment pages will automatically display this information. You can change the details later if needed.</p>
-  {% elif isStripeUpdateOrgDetails %}
+  {% elif isStripeSetupUserJourney %}
     <h1 class="govuk-heading-l">What is the name and address of you organisation on your government identity document?</h1>
   {% else %}
     <h1 class="govuk-heading-l">Organisation details</h1>
@@ -49,7 +49,7 @@
         Organisation name
       </label>
 
-      {% if not isStripeUpdateOrgDetails %} 
+      {% if not isStripeSetupUserJourney %} 
         <div id="merchant-name-hint" class="govuk-hint govuk-!-width-two-thirds">
           <p class="govuk-hint">Enter the main name of your organisation, not your local office or individual department.</p>
           <p class="govuk-hint">Write the organisation name in full. Only use acronyms that are widely understood (for example, NHS).</p>
@@ -145,7 +145,7 @@
 
     {% endcall %}
 
-    {% if not isStripeUpdateOrgDetails %}
+    {% if not isStripeSetupUserJourney %}
       {{ govukInput({
         value: telephone_number,
         label: {
@@ -184,7 +184,7 @@
       }) }}
     {% endif %}
 
-    {% if isRequestToGoLive or isStripeUpdateOrgDetails %}
+    {% if isRequestToGoLive or isStripeSetupUserJourney %}
       {{ govukButton({ 
         text: "Continue",
         attributes: { 'data-cy': 'continue-button' } 


### PR DESCRIPTION
Get controller
- Update how we check to see if it the `Stripe onboarding` or `Switch PSP > Stripe`
- Display form when it is in the `switch PSP` user journey.
- Set the `isSwitchingCredentials` flag
- Update unit test.

Post controller
- Display form when it is `switch PSP` user journey.
- Set the right validation rules.
- Update unit test.

Routes.js
- Update routes - add Get & Post routes for:
  - Switch PSP > confirm org details
  - Switch PSP > update org details


