### PR TITLE
PP-10048 Don't display phone number when not present

### DIFF
--- a/app/views/team-members/team-member-profile.njk
+++ b/app/views/team-members/team-member-profile.njk
@@ -31,7 +31,7 @@ My profile - GOV.UK Pay
 </div>
 <div class="govuk-grid-column-two-thirds">
   <dl class="profile-settings govuk-table">
-    <div class="profile-settings__row">  
+    <div class="profile-settings__row">
       <dt class="profile-settings__setting govuk-table__cell govuk-heading-s">
         Email
       </dt>
@@ -39,18 +39,20 @@ My profile - GOV.UK Pay
         {{email}}
       </dd>
     </div>
-    <div class="profile-settings__row">
+    {% if telephone_number %}
+    <div class="profile-settings__row" data-cy="telephone-number-row">
       <dt class="profile-settings__setting govuk-table__cell govuk-heading-s">
         Mobile number
       </dt>
       <dd class="profile-settings__value govuk-table__cell" id="telephone-number">
-        {{telephone_number}} 
+        {{telephone_number}}
         <span class="profile-settings__change-link">
           <a class="govuk-link" href="{{routes.user.profile.phoneNumber }}" id="change-phone-link">Change <span class="govuk-visually-hidden">mobile number</span></a>
-        </span> 
+        </span>
       </dd>
     </div>
-    <div class="profile-settings__row">  
+    {% endif %}
+    <div class="profile-settings__row">
       <dt class="profile-settings__setting govuk-table__cell govuk-heading-s">
         Sign-in method
       </dt>
@@ -66,7 +68,7 @@ My profile - GOV.UK Pay
           </span>
       </dd>
     </div>
-  </dl> 
+  </dl>
 </div>
 <div class="govuk-grid-column-one-third">
   <div class="related-information">

--- a/test/cypress/integration/user/my-profile.cy.test.js
+++ b/test/cypress/integration/user/my-profile.cy.test.js
@@ -1,0 +1,41 @@
+const userStubs = require('../../stubs/user-stubs')
+const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+
+describe('My profile page', () => {
+  const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+  const gatewayAccountId = 42
+  const serviceName = 'Purchase a positron projection permit'
+  const testPhoneNumber = '+441234567890'
+
+  describe('User does not have telephone number', () => {
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId)
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName, telephoneNumber: null }),
+        gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId })
+      ])
+    })
+
+    it('should not show telephone number row', () => {
+      cy.visit('/my-profile')
+      cy.get('[data-cy=telephone-number-row]').should('not.exist')
+    })
+  })
+
+  describe('User has a telephone number', () => {
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId)
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName, telephoneNumber: testPhoneNumber }),
+        gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId })
+      ])
+    })
+
+    it('should show telephone number row', () => {
+      cy.visit('/my-profile')
+      cy.get('[data-cy=telephone-number-row]').should('exist')
+      cy.get('[data-cy=telephone-number-row]>dd').should('contain', testPhoneNumber)
+    })
+  })
+})
+


### PR DESCRIPTION
It will be possible for a User to not have a telephone number set if they have registered using an Authenticator App as their second factor method.

If a phone number isn't set, don't display the phone number row on the "My profile" screen. In future, we will amend the user journey to change the second factor method SMS to ask for a phone number if the user does not have one set.
