### PR TITLE
BAU: Stripe: Mark responsible person as provided

### DIFF
--- a/app/controllers/stripe-setup/responsible-person/post.controller.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.js
@@ -25,7 +25,7 @@ const {
 } = require('../../../utils/validation/server-side-form-validations')
 const { formatPhoneNumberWithCountryCode } = require('../../../utils/telephone-number-utils')
 const { validationErrors } = require('../../../utils/validation/field-validation-checks')
-const { listPersons, updatePerson, createPerson } = require('../../../services/clients/stripe/stripe.client')
+const { listPersons, updatePerson, createPerson, updateCompany } = require('../../../services/clients/stripe/stripe.client')
 const { isKycTaskListComplete } = require('../../../controllers/your-psp/kyc-tasks.service')
 const { ConnectorClient } = require('../../../services/clients/connector.client')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
@@ -156,6 +156,9 @@ module.exports = async function submitResponsiblePerson (req, res, next) {
       } else {
         await createPerson(stripeAccountId, stripePerson)
       }
+
+      await updateCompany(stripeAccountId, { executives_provided: true })
+
       logger.info('Responsible person details submitted for Stripe account', {
         stripe_account_id: stripeAccountId,
         is_switching: isSwitchingCredentials,

--- a/app/controllers/stripe-setup/responsible-person/post.controller.test.js
+++ b/app/controllers/stripe-setup/responsible-person/post.controller.test.js
@@ -82,6 +82,7 @@ describe('Responsible person POST controller', () => {
   let listPersonsMock
   let updatePersonMock
   let createPersonMock
+  let updateCompanyMock
   let updatePersonAddAdditionalKYCDetailsMock
   let completeKycMock
 
@@ -91,6 +92,7 @@ describe('Responsible person POST controller', () => {
         listPersons: listPersonsMock,
         updatePerson: updatePersonMock,
         createPerson: createPersonMock,
+        updateCompany: updateCompanyMock,
         updatePersonAddAdditionalKYCDetails: updatePersonAddAdditionalKYCDetailsMock
       },
       '../../../services/clients/connector.client': {
@@ -135,6 +137,7 @@ describe('Responsible person POST controller', () => {
     }
     next = sinon.spy()
     updatePersonMock = sinon.spy(() => Promise.resolve())
+    updateCompanyMock = sinon.spy(() => Promise.resolve())
     updatePersonAddAdditionalKYCDetailsMock = sinon.spy(() => Promise.resolve())
     setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
     completeKycMock = sinon.spy(() => Promise.resolve())
@@ -177,6 +180,7 @@ describe('Responsible person POST controller', () => {
       email: emailNormalised
     })
     sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'responsible_person', req.correlationId)
+    sinon.assert.calledWith(updateCompanyMock, stripeAccountId, { executives_provided: true })
     sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripe.addPspAccountDetails}`)
   })
 
@@ -445,6 +449,7 @@ describe('Responsible person POST controller', () => {
       address_line2: addressLine2Normalised
     })
     sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'responsible_person', req.correlationId)
+    sinon.assert.calledWith(updateCompanyMock, stripeAccountId, { executives_provided: true })
     sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripe.addPspAccountDetails}`)
   })
 })


### PR DESCRIPTION
## WHAT
- For new accounts with Stripe we are confirming manually on the Stripe dashboard that all executives are provided. Do this as soon as services enter the responsible person's information.

