### PR TITLE
PP-10041: Switch to using new /otp/validate endpoint

### DIFF
--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -25,7 +25,6 @@ module.exports = function (clientOptions = {}) {
   const forgottenPasswordResource = `/v1/api/forgotten-passwords`
   const resetPasswordResource = `/v1/api/reset-password`
   const serviceResource = `/v1/api/services`
-  const inviteResource = `/v1/api/invites`
 
   /**
    * Get a User by external id
@@ -317,7 +316,7 @@ module.exports = function (clientOptions = {}) {
     return baseClient.post(
       {
         baseUrl,
-        url: `${inviteResource}/user`,
+        url: `/v1/api/invites/user`,
         json: true,
         body: {
           email: invitee,
@@ -342,7 +341,7 @@ module.exports = function (clientOptions = {}) {
     return baseClient.get(
       {
         baseUrl,
-        url: `${inviteResource}`,
+        url: `/v1/api/invites`,
         qs: {
           serviceId: serviceExternalId
         },
@@ -365,7 +364,7 @@ module.exports = function (clientOptions = {}) {
     return baseClient.get(
       {
         baseUrl,
-        url: `${inviteResource}/${inviteCode}`,
+        url: `/v1/api/invites/${inviteCode}`,
         json: true,
         correlationId: correlationId,
         description: 'find a validated invitation',
@@ -387,7 +386,7 @@ module.exports = function (clientOptions = {}) {
   const generateInviteOtpCode = (inviteCode, telephoneNumber, password, correlationId) => {
     let postData = {
       baseUrl,
-      url: `${inviteResource}/${inviteCode}/otp/generate`,
+      url: `/v1/api/invites/${inviteCode}/otp/generate`,
       json: true,
       correlationId: correlationId,
       description: 'generate otp code for invite',
@@ -419,7 +418,7 @@ module.exports = function (clientOptions = {}) {
     return baseClient.post(
       {
         baseUrl,
-        url: `${inviteResource}/${inviteCode}/complete`,
+        url: `/v1/api/invites/${inviteCode}/complete`,
         json: true,
         body: {},
         correlationId: correlationId,
@@ -434,7 +433,7 @@ module.exports = function (clientOptions = {}) {
     return baseClient.post(
       {
         baseUrl,
-        url: `${inviteResource}/otp/validate`,
+        url: `/v1/api/invites/otp/validate`,
         json: true,
         body: {
           code: code,
@@ -448,18 +447,18 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
-  const verifyOtpForServiceInvite = (inviteCode, verificationCode, correlationId) => {
+  const verifyOtpForInvite = (inviteCode, verificationCode, correlationId) => {
     return baseClient.post(
       {
         baseUrl,
-        url: `${inviteResource}/otp/validate/service`,
+        url: `/v2/api/invites/otp/validate`,
         json: true,
         body: {
           code: inviteCode,
           otp: verificationCode
         },
         correlationId: correlationId,
-        description: 'submit service invite otp code',
+        description: 'submit invite otp code',
         service: SERVICE_NAME,
         baseClientErrorHandler: 'old'
       }
@@ -470,7 +469,7 @@ module.exports = function (clientOptions = {}) {
     return baseClient.post(
       {
         baseUrl,
-        url: `${inviteResource}/otp/resend`,
+        url: `/v1/api/invites/otp/resend`,
         json: true,
         body: {
           code: code,
@@ -496,7 +495,7 @@ module.exports = function (clientOptions = {}) {
     return baseClient.post(
       {
         baseUrl,
-        url: `${inviteResource}/service`,
+        url: `/v1/api/invites/service`,
         json: true,
         body: {
           email: email,
@@ -868,7 +867,7 @@ module.exports = function (clientOptions = {}) {
     getServiceUsers,
 
     // Invite-related Methods
-    verifyOtpForServiceInvite,
+    verifyOtpForInvite,
     inviteUser,
     getInvitedUsersList,
     getValidatedInvite,

--- a/app/services/service-registration.service.js
+++ b/app/services/service-registration.service.js
@@ -13,7 +13,7 @@ function submitRegistration (email, phoneNumber, password, correlationId) {
 }
 
 function submitServiceInviteOtpCode (code, otpCode, correlationId) {
-  return adminUsersClient.verifyOtpForServiceInvite(code, otpCode, correlationId)
+  return adminUsersClient.verifyOtpForInvite(code, otpCode, correlationId)
 }
 
 async function createPopulatedService (inviteCode, correlationId) {

--- a/test/integration/self-registration/self-registration-otp-verify.ft.test.js
+++ b/test/integration/self-registration/self-registration-otp-verify.ft.test.js
@@ -15,7 +15,7 @@ const userFixtures = require('../../fixtures/user.fixtures')
 const paths = require('../../../app/paths')
 
 // Constants
-const SERVICE_INVITE_OTP_RESOURCE = '/v1/api/invites/otp/validate/service'
+const INVITE_OTP_RESOURCE = '/v2/api/invites/otp/validate'
 const CONNECTOR_ACCOUNTS_URL = '/v1/api/accounts'
 const ADMINUSERS_INVITES_URL = '/v1/api/invites'
 const adminusersMock = nock(process.env.ADMINUSERS_URL)
@@ -174,7 +174,7 @@ describe('create service OTP validation', function () {
       const validServiceInviteOtpRequest = inviteFixtures.validVerifyOtpCodeRequest({
         code: inviteCode
       })
-      adminusersMock.post(`${SERVICE_INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest)
+      adminusersMock.post(`${INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest)
         .reply(200)
 
       app = session.getAppWithRegisterInvitesCookie(getApp(), {
@@ -240,7 +240,7 @@ describe('create service OTP validation', function () {
         code: validServiceInviteOtpRequest.code,
         email: 'bob@bob.com'
       }
-      adminusersMock.post(`${SERVICE_INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest)
+      adminusersMock.post(`${INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest)
         .reply(401)
       app = session.getAppWithRegisterInvitesCookie(getApp(), registerInviteData)
       supertest(app)
@@ -269,7 +269,7 @@ describe('create service OTP validation', function () {
         email: 'bob@bob.com'
       }
 
-      adminusersMock.post(`${SERVICE_INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest)
+      adminusersMock.post(`${INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest)
         .reply(400)
 
       app = session.getAppWithRegisterInvitesCookie(getApp(), registerInviteData)
@@ -297,7 +297,7 @@ describe('create service OTP validation', function () {
         email: 'bob@bob.com'
       }
 
-      adminusersMock.post(`${SERVICE_INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest)
+      adminusersMock.post(`${INVITE_OTP_RESOURCE}`, validServiceInviteOtpRequest)
         .reply(410)
 
       app = session.getAppWithRegisterInvitesCookie(getApp(), registerInviteData)

--- a/test/unit/clients/adminusers-client/invite/verify-service-otp-code.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/verify-service-otp-code.pact.test.js
@@ -10,7 +10,7 @@ const { pactify } = require('../../../../test-helpers/pact/pactifier').defaultPa
 chai.use(chaiAsPromised)
 
 const expect = chai.expect
-const OTP_VALIDATE_RESOURCE = '/v1/api/invites/otp/validate/service'
+const OTP_VALIDATE_RESOURCE = '/v2/api/invites/otp/validate'
 let adminUsersClient
 
 describe('adminusers client - validate otp code for a service', function () {
@@ -47,8 +47,8 @@ describe('adminusers client - validate otp code for a service', function () {
 
     afterEach(() => provider.verify())
 
-    it('should verify service otp code successfully', function (done) {
-      adminUsersClient.verifyOtpForServiceInvite(validRequest.code, validRequest.otp).should.be.fulfilled
+    it('should verify invite otp code successfully', function (done) {
+      adminUsersClient.verifyOtpForInvite(validRequest.code, validRequest.otp).should.be.fulfilled
         .should.notify(done)
     })
   })
@@ -74,7 +74,7 @@ describe('adminusers client - validate otp code for a service', function () {
     afterEach(() => provider.verify())
 
     it('should return 400 on missing fields', function (done) {
-      adminUsersClient.verifyOtpForServiceInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
+      adminUsersClient.verifyOtpForInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(400)
         expect(response.message.errors.length).to.equal(1)
         expect(response.message.errors[0]).to.equal('Field [code] is required')
@@ -100,7 +100,7 @@ describe('adminusers client - validate otp code for a service', function () {
     afterEach(() => provider.verify())
 
     it('should return 404 if code cannot be found', function (done) {
-      adminUsersClient.verifyOtpForServiceInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
+      adminUsersClient.verifyOtpForInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(404)
       }).should.notify(done)
     })
@@ -124,7 +124,7 @@ describe('adminusers client - validate otp code for a service', function () {
     afterEach(() => provider.verify())
 
     it('return 410 if code locked', function (done) {
-      adminUsersClient.verifyOtpForServiceInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
+      adminUsersClient.verifyOtpForInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(410)
       }).should.notify(done)
     })


### PR DESCRIPTION
In `adminusers.client`, stop calling `/v1/api/invites/otp/validate/service` and instead call `/v2/api/invites/otp/validate`.