### PR TITLE
PP-10047 Use constants for second factor method

### DIFF
--- a/app/controllers/login/otp-login.controller.js
+++ b/app/controllers/login/otp-login.controller.js
@@ -2,21 +2,22 @@
 
 const userService = require('../../services/user.service')
 const CORRELATION_HEADER = require('../../utils/correlation-header').CORRELATION_HEADER
+const secondFactorMethod = require('../../models/second-factor-method')
 
 module.exports = async function showOtpLogin (req, res, next) {
-  const PAGE_PARAMS = {}
+  const pageData = { secondFactorMethod }
   const correlationId = req.headers[CORRELATION_HEADER] || ''
-  PAGE_PARAMS.authenticatorMethod = req.user.secondFactor
+  pageData.authenticatorMethod = req.user.secondFactor
 
-  if (!req.session.sentCode && req.user.secondFactor === 'SMS') {
+  if (!req.session.sentCode && req.user.secondFactor === secondFactorMethod.SMS) {
     try {
       await userService.sendOTP(req.user, correlationId)
       req.session.sentCode = true
-      res.render('login/otp-login', PAGE_PARAMS)
+      res.render('login/otp-login', pageData)
     } catch (err) {
       next(err)
     }
   } else {
-    res.render('login/otp-login', PAGE_PARAMS)
+    res.render('login/otp-login', pageData)
   }
 }

--- a/app/controllers/login/send-again-post.controller.js
+++ b/app/controllers/login/send-again-post.controller.js
@@ -4,10 +4,11 @@ const userService = require('../../services/user.service')
 const paths = require('../../paths')
 const { renderErrorView } = require('../../utils/response')
 const CORRELATION_HEADER = require('../../utils/correlation-header').CORRELATION_HEADER
+const secondFactorMethod = require('../../models/second-factor-method')
 
 module.exports = async function resendOtp (req, res, next) {
   const correlationId = req.headers[CORRELATION_HEADER] || ''
-  if (req.user.secondFactor === 'SMS') {
+  if (req.user.secondFactor === secondFactorMethod.SMS) {
     try {
       await userService.sendOTP(req.user, correlationId)
       res.redirect(paths.user.otpLogIn)

--- a/app/controllers/service-users.controller.js
+++ b/app/controllers/service-users.controller.js
@@ -4,6 +4,7 @@ const { renderErrorView, response } = require('../utils/response.js')
 const userService = require('../services/user.service.js')
 const paths = require('../paths.js')
 const roles = require('../utils/roles').roles
+const secondFactorMethod = require('../models/second-factor-method')
 
 const formatServicePathsFor = require('../utils/format-service-paths-for')
 
@@ -155,6 +156,7 @@ async function profile (req, res, next) {
   try {
     const user = await userService.findByExternalId(req.user.externalId, req.correlationId)
     response(req, res, 'team-members/team-member-profile', {
+      secondFactorMethod,
       username: user.username,
       email: user.email,
       telephone_number: user.telephoneNumber,

--- a/app/controllers/user/two-factor-auth/get-configure.controller.js
+++ b/app/controllers/user/two-factor-auth/get-configure.controller.js
@@ -6,9 +6,10 @@ const qrcode = require('qrcode')
 const logger = require('../../../utils/logger')(__filename)
 const { response } = require('../../../utils/response.js')
 const paths = require('../../../paths')
+const secondFactorMethod = require('../../../models/second-factor-method')
 
 module.exports = async function showConfigureSecondFactorMethod (req, res) {
-  const method = lodash.get(req, 'session.pageData.twoFactorAuthMethod', 'APP')
+  const method = lodash.get(req, 'session.pageData.twoFactorAuthMethod', secondFactorMethod.APP)
   const recovered = lodash.get(req, 'session.pageData.configureTwoFactorAuthMethodRecovered', {})
   lodash.unset(req, 'session.pageData.configureTwoFactorAuthMethodRecovered')
 
@@ -21,7 +22,8 @@ module.exports = async function showConfigureSecondFactorMethod (req, res) {
       method,
       prettyPrintedSecret,
       qrCodeDataUrl,
-      errors: recovered.errors
+      errors: recovered.errors,
+      secondFactorMethod
     }
     return response(req, res, 'two-factor-auth/configure', pageData)
   } catch (err) {

--- a/app/controllers/user/two-factor-auth/get-index.controller.js
+++ b/app/controllers/user/two-factor-auth/get-index.controller.js
@@ -1,9 +1,11 @@
 'use strict'
 
 const { response } = require('../../../utils/response.js')
+const secondFactorMethod = require('../../../models/second-factor-method')
 
 module.exports = (req, res) => {
   return response(req, res, 'two-factor-auth/index', {
-    authenticatorMethod: req.user.secondFactor
+    authenticatorMethod: req.user.secondFactor,
+    secondFactorMethod
   })
 }

--- a/app/controllers/user/two-factor-auth/post-configure.controller.js
+++ b/app/controllers/user/two-factor-auth/post-configure.controller.js
@@ -5,10 +5,11 @@ const lodash = require('lodash')
 const logger = require('../../../utils/logger')(__filename)
 const paths = require('../../../paths')
 const userService = require('../../../services/user.service.js')
+const secondFactorMethod = require('../../../models/second-factor-method')
 
 module.exports = async function postUpdateSecondFactorMethod (req, res) {
   const code = req.body['code'] || ''
-  const method = lodash.get(req, 'session.pageData.twoFactorAuthMethod', 'APP')
+  const method = lodash.get(req, 'session.pageData.twoFactorAuthMethod', secondFactorMethod.APP)
 
   if (!code) {
     lodash.set(req, 'session.pageData.configureTwoFactorAuthMethodRecovered', {

--- a/app/controllers/user/two-factor-auth/post-index.controller.js
+++ b/app/controllers/user/two-factor-auth/post-index.controller.js
@@ -5,20 +5,21 @@ const lodash = require('lodash')
 const logger = require('../../../utils/logger')(__filename)
 const userService = require('../../../services/user.service.js')
 const paths = require('../../../paths')
+const secondFactorMethod = require('../../../models/second-factor-method')
 
 module.exports = async (req, res) => {
   const method = req.body['two-fa-method']
   lodash.set(req, 'session.pageData.twoFactorAuthMethod', method)
 
-  try {
-    const user = await userService.provisionNewOtpKey(req.user.externalId, req.correlationId)
-    if (method === 'SMS') {
-      await userService.sendProvisionalOTP(user, req.correlationId)
-    }
-    return res.redirect(paths.user.profile.twoFactorAuth.configure)
-  } catch (err) {
-    logger.error(`Provisioning new OTP key failed - ${err.message}`)
-    req.flash('genericError', 'Something went wrong. Please try again or contact support.')
-    return res.redirect(paths.user.profile.twoFactorAuth.index)
+    try {
+      const user = await userService.provisionNewOtpKey(req.user.externalId, req.correlationId)
+      if (method === secondFactorMethod.SMS) {
+        await userService.sendProvisionalOTP(user, req.correlationId)
+      }
+      return res.redirect(paths.user.profile.twoFactorAuth.configure)
+    } catch (err) {
+      logger.error(`Provisioning new OTP key failed - ${err.message}`)
+      req.flash('genericError', 'Something went wrong. Please try again or contact support.')
+      return res.redirect(paths.user.profile.twoFactorAuth.index)
   }
 }

--- a/app/models/second-factor-method.js
+++ b/app/models/second-factor-method.js
@@ -1,0 +1,6 @@
+'use strict'
+
+module.exports = {
+  APP: 'APP',
+  SMS: 'SMS'
+}

--- a/app/views/login/otp-login.njk
+++ b/app/views/login/otp-login.njk
@@ -19,18 +19,18 @@
   </div>
   {% endif %}
 
-  {% if authenticatorMethod === 'SMS' %}
+  {% if authenticatorMethod === secondFactorMethod.SMS %}
   <h1 class="govuk-heading-l page-title">Check your phone</h1>
   {% endif %}
-  {% if authenticatorMethod === 'APP' %}
+  {% if authenticatorMethod === secondFactorMethod.APP %}
   <h1 class="govuk-heading-l page-title">Use your authenticator app</h1>
   {% endif %}
   <form action="{{routes.user.otpLogIn}}" method="post" class="form submit-two-fa" id="otp-login-form" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
-    {% if authenticatorMethod === 'SMS' %}
+    {% if authenticatorMethod === secondFactorMethod.SMS %}
     <p class="govuk-body">We have sent you a text message with a verification code</p>
     {% endif %}
-    {% if authenticatorMethod === 'APP' %}
+    {% if authenticatorMethod === secondFactorMethod.APP %}
     <p class="govuk-body">Enter the verification code shown in your authenticator app</p>
     {% endif %}
 
@@ -67,7 +67,7 @@
       })
     }}
   </form>
-  {% if authenticatorMethod === 'SMS' %}
+  {% if authenticatorMethod === secondFactorMethod.SMS %}
   <p class="govuk-body"><a class="govuk-link text-messsage-link" href="{{routes.user.otpSendAgain}}">Not received a text message?</a></p>
   {% endif %}
   <p class="govuk-body"><a class="govuk-link cancel-link" href="{{routes.user.logOut}}">Cancel</a></p>

--- a/app/views/team-members/team-member-profile.njk
+++ b/app/views/team-members/team-member-profile.njk
@@ -11,7 +11,7 @@ My profile - GOV.UK Pay
     {% set html %}
       <p class="govuk-notification-banner__heading">Your sign-in method has been updated</p>
 
-      {% if flash.otpMethodUpdated[0] === "APP" %}
+      {% if flash.otpMethodUpdated[0] === secondFactorMethod.APP %}
         <p class="govuk-body">Use your authenticator app when you next sign in.</p>
       {% else %}
         <p class="govuk-body">We’ll send you a text message when you next sign in.</p>
@@ -57,10 +57,10 @@ My profile - GOV.UK Pay
         Sign-in method
       </dt>
       <dd class="profile-settings__value govuk-table__cell" id="two-factor-auth">
-          {% if two_factor_auth === 'APP' %}
+          {% if two_factor_auth === secondFactorMethod.APP %}
             Authenticator app
           {% endif %}
-          {% if two_factor_auth === 'SMS' %}
+          {% if two_factor_auth === secondFactorMethod.SMS %}
             Text message
           {% endif %}
           <span class="profile-settings__change-link">

--- a/app/views/two-factor-auth/configure.njk
+++ b/app/views/two-factor-auth/configure.njk
@@ -1,7 +1,7 @@
 {% extends "../layout.njk" %}
 {% from "../macro/error-summary.njk" import errorSummary %}
 
-{% if method === 'APP' %}
+{% if method === secondFactorMethod.APP %}
   {% set title = 'Set up an authenticator app' %}
 {% else %}
   {% set title = 'Check your phone' %}
@@ -36,7 +36,7 @@
   </h1>
 </div>
 <div class="govuk-grid-column-two-thirds">
-{% if method === 'APP' %}
+{% if method === secondFactorMethod.APP %}
   <p class="govuk-body">Scan the barcode with your authenticator app or enter the secret manually.</p>
   {{
     govukWarningText({
@@ -62,7 +62,7 @@
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {% set codeHint = "Enter the code shown in your app to complete the setup" %}
-    {% if method === 'SMS' %}
+    {% if method === secondFactorMethod.SMS %}
       {% set codeHint = "We have sent you a text message with a verification code" %}
     {% endif %}
 
@@ -90,7 +90,7 @@
     {{ govukButton({ text: "Complete" }) }}
   </form>
 
-  {% if method === 'SMS' %}
+  {% if method === secondFactorMethod.SMS %}
   <form method="post" action="{{routes.user.profile.twoFactorAuth.resend}}">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <div class="govuk-form-group">

--- a/app/views/two-factor-auth/index.njk
+++ b/app/views/two-factor-auth/index.njk
@@ -23,14 +23,14 @@
 <div class="govuk-grid-column-two-thirds">
   <form method="post" action="{{routes.user.profile.twoFactorAuth.index}}">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-    {% if authenticatorMethod === 'SMS' %}
+    {% if authenticatorMethod === secondFactorMethod.SMS %}
       <p class="govuk-body">You currently use text message codes to sign in to GOV.UK Pay.</p>
-        <input name="two-fa-method" type="hidden" value="APP"/>
+        <input name="two-fa-method" type="hidden" value="{{ secondFactorMethod.APP }}"/>
         {{
           govukButton({ text: "Use an authenticator app instead" })
         }}
     {% endif %}
-    {% if authenticatorMethod === 'APP' %}
+    {% if authenticatorMethod === secondFactorMethod.APP %}
       <p class="govuk-body">You currently use an authenticator app to sign in to GOV.UK Pay.</p>
 
       {{ govukRadios({
@@ -43,12 +43,12 @@
         },
         items: [
           {
-            value: "APP",
+            value: secondFactorMethod.APP,
             text: "A different authenticator app",
             checked: true
           },
           {
-            value: "SMS",
+            value: secondFactorMethod.SMS,
             text: "By text message"
           }
         ]

--- a/test/fixtures/user.fixtures.js
+++ b/test/fixtures/user.fixtures.js
@@ -4,6 +4,7 @@ const lodash = require('lodash')
 const goLiveStage = require('../../app/models/go-live-stage')
 const stripeTestAccountStage = require('../../app/models/psp-test-account-stage')
 const serviceFixtures = require('./service.fixtures')
+const secondFactorMethod = require('../../app/models/second-factor-method')
 
 // Constants
 const defaultPermissions = [
@@ -263,7 +264,7 @@ function buildUserWithDefaults (opts) {
     email: 'some-user@example.com',
     otp_key: 'krb6fcianbdjkt01ecvi08jcln',
     telephone_number: '9127979',
-    second_factor: 'SMS',
+    second_factor: secondFactorMethod.SMS,
     provisional_otp_key: 'a-provisional-key',
     provisional_otp_key_created_at: null,
     disabled: false,
@@ -333,7 +334,7 @@ module.exports = {
       disabled: opts.disabled || false,
       login_counter: opts.login_counter || 0,
       session_version: opts.session_version || 0,
-      second_factor: opts.second_factor || 'SMS',
+      second_factor: opts.second_factor || secondFactorMethod.SMS,
       provisional_otp_key: opts.provisional_otp_key || '60400'
     }
 

--- a/test/ui/team-member-details.ui.test.js
+++ b/test/ui/team-member-details.ui.test.js
@@ -1,5 +1,6 @@
-let path = require('path')
-let renderTemplate = require(path.join(__dirname, '/../test-helpers/html-assertions.js')).render
+const path = require('path')
+const renderTemplate = require(path.join(__dirname, '/../test-helpers/html-assertions.js')).render
+const secondFactorMethod = require('../../app/models/second-factor-method')
 
 describe('The team member details view', function () {
   it('should render team member details', function () {
@@ -11,7 +12,8 @@ describe('The team member details view', function () {
       removeTeamMemberLink: 'remove-link',
       permissions: {
         users_service_delete: true
-      }
+      },
+      secondFactorMethod
     }
 
     let body = renderTemplate('team-members/team-member-details', templateData)
@@ -31,7 +33,8 @@ describe('The team member details view', function () {
       role: 'View only',
       editPermissionsLink: 'some-link',
       removeTeamMemberLink: 'remove-link',
-      permissions: {}
+      permissions: {},
+      secondFactorMethod
     }
 
     let body = renderTemplate('team-members/team-member-details', templateData)
@@ -48,7 +51,8 @@ describe('The team member details view', function () {
       username: 'John Smith',
       email: 'john.smith@example.com',
       telephone_number: '+447769897329',
-      two_factor_auth: 'SMS'
+      two_factor_auth: secondFactorMethod.SMS,
+      secondFactorMethod
     }
 
     let body = renderTemplate('team-members/team-member-profile', templateData)

--- a/test/unit/controller/user/two-factor-auth/get-configure.controller.ft.test.js
+++ b/test/unit/controller/user/two-factor-auth/get-configure.controller.ft.test.js
@@ -9,6 +9,8 @@ const lodash = require('lodash')
 const { getApp } = require('../../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../../test-helpers/mock-session')
 const paths = require('../../../../../app/paths')
+const secondFactorMethod = require('../../../../../app/models/second-factor-method')
+
 const { CONNECTOR_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '929'
 
@@ -19,7 +21,7 @@ describe('Two factor authenticator configure page GET', () => {
       const user = getUser({
         gateway_account_ids: [GATEWAY_ACCOUNT_ID],
         permissions: [{ name: 'transactions:read' }],
-        second_factor: 'APP'
+        second_factor: secondFactorMethod.APP
       })
       nock(CONNECTOR_URL)
         .get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
@@ -28,7 +30,7 @@ describe('Two factor authenticator configure page GET', () => {
         })
 
       session = getMockSession(user)
-      lodash.set(session, 'pageData.twoFactorAuthMethod', 'APP')
+      lodash.set(session, 'pageData.twoFactorAuthMethod', secondFactorMethod.APP)
       supertest(createAppWithSession(getApp(), session))
         .get(paths.user.profile.twoFactorAuth.configure)
         .end((err, res) => {
@@ -63,7 +65,7 @@ describe('Two factor authenticator configure page GET', () => {
       const user = getUser({
         gateway_account_ids: [GATEWAY_ACCOUNT_ID],
         permissions: [{ name: 'transactions:read' }],
-        second_factor: 'APP'
+        second_factor: secondFactorMethod.APP
       })
       nock(CONNECTOR_URL)
         .get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
@@ -72,7 +74,7 @@ describe('Two factor authenticator configure page GET', () => {
         })
 
       session = getMockSession(user)
-      lodash.set(session, 'pageData.twoFactorAuthMethod', 'SMS')
+      lodash.set(session, 'pageData.twoFactorAuthMethod', secondFactorMethod.SMS)
       supertest(createAppWithSession(getApp(), session))
         .get(paths.user.profile.twoFactorAuth.configure)
         .end((err, res) => {
@@ -108,7 +110,7 @@ describe('Two factor authenticator configure page GET', () => {
       const user = getUser({
         gateway_account_ids: [GATEWAY_ACCOUNT_ID],
         permissions: [{ name: 'transactions:read' }],
-        second_factor: 'APP'
+        second_factor: secondFactorMethod.APP
       })
       nock(CONNECTOR_URL)
         .get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
@@ -117,7 +119,7 @@ describe('Two factor authenticator configure page GET', () => {
         })
 
       session = getMockSession(user)
-      lodash.set(session, 'pageData.twoFactorAuthMethod', 'SMS')
+      lodash.set(session, 'pageData.twoFactorAuthMethod', secondFactorMethod.SMS)
       lodash.set(session, 'pageData.configureTwoFactorAuthMethodRecovered', {
         errors: {
           verificationCode: verificationCodeError

--- a/test/unit/controller/user/two-factor-auth/get-index.controller.ft.test.js
+++ b/test/unit/controller/user/two-factor-auth/get-index.controller.ft.test.js
@@ -8,6 +8,8 @@ const nock = require('nock')
 const { getApp } = require('../../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../../test-helpers/mock-session')
 const paths = require('../../../../../app/paths')
+const secondFactorMethod = require('../../../../../app/models/second-factor-method')
+
 const { CONNECTOR_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '929'
 
@@ -61,7 +63,7 @@ describe('Two factor authenticator configure index GET', () => {
       const user = getUser({
         gateway_account_ids: [GATEWAY_ACCOUNT_ID],
         permissions: [{ name: 'transactions:read' }],
-        second_factor: 'APP'
+        second_factor: secondFactorMethod.APP
       })
       nock(CONNECTOR_URL)
         .get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)

--- a/test/unit/controller/user/two-factor-auth/post-index.controller.ft.test.js
+++ b/test/unit/controller/user/two-factor-auth/post-index.controller.ft.test.js
@@ -8,6 +8,8 @@ const nock = require('nock')
 const { getApp } = require('../../../../../server')
 const { getMockSession, createAppWithSession, getUser } = require('../../../../test-helpers/mock-session')
 const paths = require('../../../../../app/paths')
+const secondFactorMethod = require('../../../../../app/models/second-factor-method')
+
 const { ADMINUSERS_URL } = process.env
 const GATEWAY_ACCOUNT_ID = '929'
 const VALID_USER = getUser({
@@ -25,7 +27,7 @@ const VALID_USER_RESPONSE = {
   disabled: false,
   sessionVersion: 0,
   features: '',
-  secondFactor: 'SMS',
+  secondFactor: secondFactorMethod.SMS,
   provisionalOtpKey: '60400'
 }
 
@@ -45,7 +47,7 @@ describe('Two factor authenticator configure index POST', () => {
         .post(paths.user.profile.twoFactorAuth.index)
         .send({
           csrfToken: csrf().create('123'),
-          'two-fa-method': 'APP'
+          'two-fa-method': secondFactorMethod.APP
         })
         .end((err, res) => {
           result = res
@@ -83,7 +85,7 @@ describe('Two factor authenticator configure index POST', () => {
         .post(paths.user.profile.twoFactorAuth.index)
         .send({
           csrfToken: csrf().create('123'),
-          'two-fa-method': 'SMS'
+          'two-fa-method': secondFactorMethod.SMS
         })
         .end((err, res) => {
           result = res


### PR DESCRIPTION
Rather than hardcoding the strings "SMS" or "APP" for the second factor method in many places in the code, define constants that are used in all places.

