### PR TITLE
PP-10047 Refactor user service

### DIFF
--- a/app/controllers/forgotten-password.controller.js
+++ b/app/controllers/forgotten-password.controller.js
@@ -77,7 +77,7 @@ const newPasswordPost = async function newPasswordPost (req, res) {
 
     await userService.updatePassword(id, password, req.correlationId)
     try {
-      await userService.logOut(user, req.correlationId)
+      await userService.logOut(user.externalId, req.correlationId)
     } catch (err) {
       // treat as success even if updating session version fails
     }

--- a/app/controllers/login/logout.controller.js
+++ b/app/controllers/login/logout.controller.js
@@ -6,7 +6,7 @@ const router = require('../../routes')
 
 module.exports = (req, res) => {
   if (req.user) {
-    userService.logOut(req.user, req.correlationId)
+    userService.logOut(req.user.externalId, req.correlationId)
   }
 
   if (req.session) {

--- a/app/controllers/login/otp-login.controller.js
+++ b/app/controllers/login/otp-login.controller.js
@@ -11,7 +11,7 @@ module.exports = async function showOtpLogin (req, res, next) {
 
   if (!req.session.sentCode && req.user.secondFactor === secondFactorMethod.SMS) {
     try {
-      await userService.sendOTP(req.user, correlationId)
+      await userService.sendOTP(req.user.externalId, correlationId)
       req.session.sentCode = true
       res.render('login/otp-login', pageData)
     } catch (err) {

--- a/app/controllers/login/send-again-post.controller.js
+++ b/app/controllers/login/send-again-post.controller.js
@@ -10,7 +10,7 @@ module.exports = async function resendOtp (req, res, next) {
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   if (req.user.secondFactor === secondFactorMethod.SMS) {
     try {
-      await userService.sendOTP(req.user, correlationId)
+      await userService.sendOTP(req.user.externalId, correlationId)
       res.redirect(paths.user.otpLogIn)
     } catch (err) {
       next(err)

--- a/app/controllers/payment-links/get-start.controller.js
+++ b/app/controllers/payment-links/get-start.controller.js
@@ -10,11 +10,10 @@ module.exports = (req, res) => {
 
   const credential = getCurrentCredential(req.account)
 
-  const accountUsesWorldpayMotoMerchantCode = lodash.get(credential, 'payment_provider', '') === 'worldpay'
-      && lodash.get(credential, 'credentials.merchant_id', '').endsWith('MOTO')
+  const accountUsesWorldpayMotoMerchantCode = lodash.get(credential, 'payment_provider', '') === 'worldpay' &&
+      lodash.get(credential, 'credentials.merchant_id', '').endsWith('MOTO')
 
   return response(req, res, 'payment-links/index', {
     accountUsesWorldpayMotoMerchantCode: accountUsesWorldpayMotoMerchantCode
   })
-
 }

--- a/app/controllers/request-to-go-live/organisation-address/get.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/get.controller.js
@@ -16,7 +16,7 @@ module.exports = function getOrganisationAddress (req, res) {
   const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
 
   const isStripeSetupUserJourney = isStripeUpdateOrgDetails || isSwitchingCredentials
-  
+
   if (isRequestToGoLive) {
     if (req.service.currentGoLiveStage !== goLiveStage.ENTERED_ORGANISATION_NAME) {
       return res.redirect(

--- a/app/controllers/request-to-go-live/organisation-address/get.controller.test.js
+++ b/app/controllers/request-to-go-live/organisation-address/get.controller.test.js
@@ -130,7 +130,7 @@ describe('organisation address get controller', () => {
         expect(pageData.isStripeUpdateOrgDetails).to.equal(true)
         expect(pageData.isSwitchingCredentials).to.equal(false)
         expect(pageData.isStripeSetupUserJourney).to.equal(true)
-     
+
         expect(pageData.name).to.equal(undefined)
         expect(pageData.address_line1).to.equal(undefined)
         expect(pageData.address_line2).to.equal(undefined)
@@ -178,7 +178,7 @@ describe('organisation address get controller', () => {
         expect(pageData.isStripeUpdateOrgDetails).to.equal(false)
         expect(pageData.isSwitchingCredentials).to.equal(true)
         expect(pageData.isStripeSetupUserJourney).to.equal(true)
-     
+
         expect(pageData.name).to.equal(undefined)
         expect(pageData.address_line1).to.equal(undefined)
         expect(pageData.address_line2).to.equal(undefined)

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.js
@@ -200,7 +200,7 @@ module.exports = async function submitOrganisationAddress (req, res, next) {
     const isStripeUpdateOrgDetails = req.url ? req.url.startsWith('/your-psp/') : false
     const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
 
-    const isStripeSetupUserJourney = isStripeUpdateOrgDetails ? true : isSwitchingCredentials ? true : false
+    const isStripeSetupUserJourney = isStripeUpdateOrgDetails ? true : !!isSwitchingCredentials
 
     const form = normaliseForm(req.body)
     const errors = validateForm(form, isRequestToGoLive, isStripeSetupUserJourney)
@@ -210,7 +210,7 @@ module.exports = async function submitOrganisationAddress (req, res, next) {
       if (isStripeUpdateOrgDetails) {
         res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account.external_id))
       } else if (isSwitchingCredentials) {
-          res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
+        res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
       } else if (isRequestToGoLive) {
         res.redirect(303, formatServicePathsFor(goLiveStageToNextPagePath[updatedService.currentGoLiveStage], req.service.externalId))
       } else {

--- a/app/controllers/stripe-setup/check-org-details/post.controller.js
+++ b/app/controllers/stripe-setup/check-org-details/post.controller.js
@@ -64,13 +64,13 @@ module.exports = async function postCheckOrgDetails (req, res, next) {
       next(error)
     }
 
-    if (isSwitchingCredentials){
+    if (isSwitchingCredentials) {
       return res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
     } else {
       return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account.external_id))
-    }    
+    }
   } else {
-    if (isSwitchingCredentials){
+    if (isSwitchingCredentials) {
       return res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.stripeSetup.updateOrgDetails, req.account.external_id, credential.external_id))
     } else {
       return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.stripeSetup.updateOrgDetails, req.account.external_id, credential.external_id))

--- a/app/controllers/stripe-setup/check-org-details/post.controller.test.js
+++ b/app/controllers/stripe-setup/check-org-details/post.controller.test.js
@@ -120,25 +120,25 @@ describe('Check org details - post controller', () => {
     describe('Stripe onboarding', () => {
       it('when `no` radio button is selected, then it should redirect to `Stripe onboarding > org address` page', () => {
         req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
-  
+
         req.body = {
           'confirm-org-details': 'no'
         }
-  
+
         controller(req, res, next)
-  
+
         sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/your-psp/a-valid-credential-id/update-organisation-details')
       })
-  
+
       it('when `yes` radio button is selected, then it should redirect to the `Stripe onboarding > add psp account details` redirect route', async () => {
         req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
-  
+
         req.body = {
           'confirm-org-details': 'yes'
         }
-  
+
         await controller(req, res, next)
-  
+
         sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'organisation_details', req.correlationId)
         sinon.assert.calledWith(loggerInfoMock, 'Organisation details confirmed for Stripe account', { stripe_account_id: stripeAcountId })
         sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/stripe/add-psp-account-details')
@@ -149,30 +149,30 @@ describe('Check org details - post controller', () => {
       it('when `no` radio button is selected, then it should redirect to `switch psp to Stripe > update org address` page', () => {
         req.url = '/switch-psp/test-credential/check-organisation-details'
         req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
-  
+
         req.body = {
           'confirm-org-details': 'no'
         }
-  
+
         controller(req, res, next)
-  
+
         sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/switch-psp/a-valid-credential-id/update-organisation-details')
       })
-  
+
       it('when `yes` radio button is selected, then it should redirect to the `switch psp to Stripe > switch PSP index` redirect route', async () => {
         req.url = '/switch-psp/test-credential/check-organisation-details'
         req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
-  
+
         req.body = {
           'confirm-org-details': 'yes'
         }
-  
+
         await controller(req, res, next)
-  
+
         sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'organisation_details', req.correlationId)
         sinon.assert.calledWith(loggerInfoMock, 'Organisation details confirmed for Stripe account', { stripe_account_id: stripeAcountId })
         sinon.assert.calledWith(res.redirect, 303, '/account/a-valid-external-id/switch-psp')
       })
-    }) 
+    })
   })
 })

--- a/app/controllers/switch-psp/switch-tasks.service.js
+++ b/app/controllers/switch-psp/switch-tasks.service.js
@@ -76,7 +76,7 @@ function getTaskList (targetCredential, account, service) {
           stripeSetupStageComplete(account, 'bankAccount') &&
           stripeSetupStageComplete(account, 'responsiblePerson') &&
           stripeSetupStageComplete(account, 'director') &&
-          stripeSetupStageComplete(account, 'organisationDetails') && 
+          stripeSetupStageComplete(account, 'organisationDetails') &&
           stripeSetupStageComplete(account, 'governmentEntityDocument') &&
           stripeSetupStageComplete(account, 'vatNumber') &&
           stripeSetupStageComplete(account, 'companyNumber'),

--- a/app/controllers/user/two-factor-auth/post-index.controller.js
+++ b/app/controllers/user/two-factor-auth/post-index.controller.js
@@ -11,15 +11,15 @@ module.exports = async (req, res) => {
   const method = req.body['two-fa-method']
   lodash.set(req, 'session.pageData.twoFactorAuthMethod', method)
 
-    try {
-      const user = await userService.provisionNewOtpKey(req.user.externalId, req.correlationId)
-      if (method === secondFactorMethod.SMS) {
-        await userService.sendProvisionalOTP(user, req.correlationId)
-      }
-      return res.redirect(paths.user.profile.twoFactorAuth.configure)
-    } catch (err) {
-      logger.error(`Provisioning new OTP key failed - ${err.message}`)
-      req.flash('genericError', 'Something went wrong. Please try again or contact support.')
-      return res.redirect(paths.user.profile.twoFactorAuth.index)
+  try {
+    await userService.provisionNewOtpKey(req.user.externalId, req.correlationId)
+    if (method === secondFactorMethod.SMS) {
+      await userService.sendProvisionalOTP(req.user.externalId, req.correlationId)
+    }
+    return res.redirect(paths.user.profile.twoFactorAuth.configure)
+  } catch (err) {
+    logger.error(`Provisioning new OTP key failed - ${err.message}`)
+    req.flash('genericError', 'Something went wrong. Please try again or contact support.')
+    return res.redirect(paths.user.profile.twoFactorAuth.index)
   }
 }

--- a/app/controllers/user/two-factor-auth/post-resend.controller.js
+++ b/app/controllers/user/two-factor-auth/post-resend.controller.js
@@ -5,7 +5,7 @@ const userService = require('../../../services/user.service.js')
 const paths = require('../../../paths')
 
 module.exports = (req, res) => {
-  userService.sendProvisionalOTP(req.user, req.correlationId)
+  userService.sendProvisionalOTP(req.user.externalId, req.correlationId)
     .then(() => {
       req.flash('generic', 'Another verification code has been sent to your phone')
       return res.redirect(paths.user.profile.twoFactorAuth.configure)

--- a/app/paths.js
+++ b/app/paths.js
@@ -117,7 +117,7 @@ module.exports = {
         companyNumber: '/switch-psp/:credentialId/company-number',
         director: '/switch-psp/:credentialId/director',
         checkOrgDetails: '/switch-psp/:credentialId/check-organisation-details',
-        updateOrgDetails: '/switch-psp/:credentialId/update-organisation-details', 
+        updateOrgDetails: '/switch-psp/:credentialId/update-organisation-details',
         governmentEntityDocument: '/switch-psp/:credentialId/government-entity-document'
       }
     },

--- a/app/services/user.service.js
+++ b/app/services/user.service.js
@@ -55,21 +55,21 @@ module.exports = {
   },
 
   /**
-   * @param {User} user
-   * @param correlationId
+   * @param {String} userExternalId
+   * @param {String} correlationId
    * @returns {Promise}
    */
-  sendOTP: function (user, correlationId) {
-    return adminUsersClient.sendSecondFactor(user.externalId, false, correlationId)
+  sendOTP: function (userExternalId, correlationId) {
+    return adminUsersClient.sendSecondFactor(userExternalId, false, correlationId)
   },
 
   /**
-   * @param {User} user
-   * @param correlationId
+   * @param {String} userExternalId
+   * @param {String} correlationId
    * @returns {Promise}
    */
-  sendProvisionalOTP: function (user, correlationId) {
-    return adminUsersClient.sendSecondFactor(user.externalId, true, correlationId)
+  sendProvisionalOTP: function (userExternalId, correlationId) {
+    return adminUsersClient.sendSecondFactor(userExternalId, true, correlationId)
   },
 
   /**
@@ -91,12 +91,12 @@ module.exports = {
   },
 
   /**
-   * @param user
-   * @param correlationId
+   * @param {String} userExternalId
+   * @param {String} correlationId
    * @returns {Promise}
    */
-  logOut: function (user, correlationId) {
-    return adminUsersClient.incrementSessionVersionForUser(user.externalId, correlationId)
+  logOut: function (userExternalId, correlationId) {
+    return adminUsersClient.incrementSessionVersionForUser(userExternalId, correlationId)
   },
 
   /**

--- a/test/cypress/integration/payment-links/create-payment-link.cy.test.js
+++ b/test/cypress/integration/payment-links/create-payment-link.cy.test.js
@@ -29,18 +29,21 @@ describe('The create payment link start page for a Worldpay MOTO account', () =>
   it('Should display warning', () => {
     cy.task('setupStubs', [
       userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceExternalId, serviceName }),
-      gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'test', paymentProvider: 'worldpay',
-          gatewayAccountCredentials: [
-            {
-              gateway_account_id: gatewayAccountId,
-              payment_provider: 'worldpay',
-              state: 'ACTIVE',
-              credentials: {
-                merchant_id: 'worldpay-merchant-code-ending-with-MOTO'
-              }
+      gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId,
+        gatewayAccountExternalId,
+        type: 'test',
+        paymentProvider: 'worldpay',
+        gatewayAccountCredentials: [
+          {
+            gateway_account_id: gatewayAccountId,
+            payment_provider: 'worldpay',
+            state: 'ACTIVE',
+            credentials: {
+              merchant_id: 'worldpay-merchant-code-ending-with-MOTO'
             }
-          ]
-        }),
+          }
+        ]
+      })
     ])
     Cypress.Cookies.preserveOnce('session', 'gateway_account')
     cy.setEncryptedCookies(userExternalId)

--- a/test/cypress/integration/settings/switch-psp.cy.test.js
+++ b/test/cypress/integration/settings/switch-psp.cy.test.js
@@ -294,7 +294,7 @@ describe('Switch PSP settings page', () => {
       })
 
       it('loads the `check org details` page', () => {
-        cy.get('a').contains('Back to Switching payment service provider (PSP)').click() 
+        cy.get('a').contains('Back to Switching payment service provider (PSP)').click()
         cy.get('a').contains('Confirm your organisation details').click()
         cy.get('#navigation-menu-switch-psp').parent().should('have.class', 'govuk-!-font-weight-bold')
         cy.get('a').contains('Back to Switching payment service provider (PSP)').should('exist')

--- a/test/cypress/integration/stripe-setup/update-org-details.cy.test.js
+++ b/test/cypress/integration/stripe-setup/update-org-details.cy.test.js
@@ -18,8 +18,7 @@ const stripeAccountId = 'acct_123example123'
 function setupStubs (stripeSetupOptions, type = 'live', paymentProvider = 'stripe') {
   let stripeSetupStub
 
-  
-  if (!(typeof stripeSetupOptions === "boolean")) {
+  if (!(typeof stripeSetupOptions === 'boolean')) {
     stripeSetupStub = stripeAccountSetupStubs.getGatewayAccountStripeSetupFlagForMultipleCalls({
       gatewayAccountId,
       ...stripeSetupOptions
@@ -53,7 +52,7 @@ function setupStubs (stripeSetupOptions, type = 'live', paymentProvider = 'strip
     stripeSetupStub,
     stripeAccountStubs.getStripeAccountSuccess(gatewayAccountId, 'acct_123example123'),
     stripeUpdateCompanyStub,
-    transactionSummaryStubs.getDashboardStatistics(),
+    transactionSummaryStubs.getDashboardStatistics()
   ])
 }
 
@@ -77,7 +76,7 @@ describe('The organisation address page', () => {
         setupStubs(false)
       })
 
-      it('should display form', () => { 
+      it('should display form', () => {
         cy.setEncryptedCookies(userExternalId)
         cy.visit(pageUrl)
 
@@ -209,19 +208,19 @@ describe('The organisation address page', () => {
           })
 
         cy.get('[data-cy=form]')
-        .within(() => {
-          cy.get('[data-cy=input-org-name]').type(validOrgName)
-          cy.get('[data-cy=input-address-line-1]').type(validLine1)
-          cy.get('[data-cy=input-address-line-2]').type(validLine2)
-          cy.get('[data-cy=input-address-city]').type(validCity)
-          cy.get('[data-cy=input-address-country]').select(countryGb)
-          cy.get('#address-postcode').type(validPostcode)
-          cy.get('[data-cy=continue-button]').click()
+          .within(() => {
+            cy.get('[data-cy=input-org-name]').type(validOrgName)
+            cy.get('[data-cy=input-address-line-1]').type(validLine1)
+            cy.get('[data-cy=input-address-line-2]').type(validLine2)
+            cy.get('[data-cy=input-address-city]').type(validCity)
+            cy.get('[data-cy=input-address-country]').select(countryGb)
+            cy.get('#address-postcode').type(validPostcode)
+            cy.get('[data-cy=continue-button]').click()
 
-          cy.location().should((location) => {
-            expect(location.pathname).to.eq(`/account/a-valid-external-id/your-psp/a-valid-credential-external-id/government-entity-document`)
+            cy.location().should((location) => {
+              expect(location.pathname).to.eq(`/account/a-valid-external-id/your-psp/a-valid-credential-external-id/government-entity-document`)
+            })
           })
-        })
       })
     })
 

--- a/test/cypress/integration/user/my-profile.cy.test.js
+++ b/test/cypress/integration/user/my-profile.cy.test.js
@@ -38,4 +38,3 @@ describe('My profile page', () => {
     })
   })
 })
-

--- a/test/cypress/stubs/stripe-account-setup-stub.js
+++ b/test/cypress/stubs/stripe-account-setup-stub.js
@@ -94,23 +94,23 @@ function getGatewayAccountStripeSetupFlagForMultipleCalls (opts) {
 
   const optionKeys = Object.keys(stripeSetupStepOptions)
   const numberOfStripeSetupCalls = stripeSetupStepOptions[optionKeys[0]].length
-  
+
   const allStripeCallResponsesArray = []
 
   for (var i = 0; i < numberOfStripeSetupCalls; i++) {
     const singleStripeCallResponse = {}
-    
+
     optionKeys.forEach(function (key) {
-      const option =  stripeSetupStepOptions[key]
-      const optionInstance =  option[i]
-      singleStripeCallResponse[key] =  optionInstance[key]
+      const option = stripeSetupStepOptions[key]
+      const optionInstance = option[i]
+      singleStripeCallResponse[key] = optionInstance[key]
     })
-    
+
     allStripeCallResponsesArray[i] = singleStripeCallResponse
   }
 
   const responses = []
-  
+
   allStripeCallResponsesArray.forEach(item => {
     responses.push({
       is: {

--- a/test/integration/add-psp-details.ft.test.js
+++ b/test/integration/add-psp-details.ft.test.js
@@ -50,7 +50,7 @@ describe('Add stripe psp details route', function () {
           vat_number: true,
           company_number: true,
           director: true,
-          organisation_details: true, 
+          organisation_details: true,
           government_entity_document: true
         }))
         .persist()

--- a/test/unit/controller/payment-links/get-start.controller.test.js
+++ b/test/unit/controller/payment-links/get-start.controller.test.js
@@ -30,7 +30,7 @@ describe('The Worldpay MOTO account warning', () => {
             state: 'ACTIVE',
             payment_provider: 'worldpay',
             credentials: {
-                merchant_id: 'merchant-code-ends-with-MOTO'
+              merchant_id: 'merchant-code-ends-with-MOTO'
             }
           }]
         }
@@ -49,7 +49,7 @@ describe('The Worldpay MOTO account warning', () => {
             state: 'ACTIVE',
             payment_provider: 'worldpay',
             credentials: {
-                merchant_id: 'merchant-code-ends-with-MOTO-ah-no-it-does-not'
+              merchant_id: 'merchant-code-ends-with-MOTO-ah-no-it-does-not'
             }
           }]
         }
@@ -68,7 +68,7 @@ describe('The Worldpay MOTO account warning', () => {
             state: 'ACTIVE',
             payment_provider: 'not-worldpay',
             credentials: {
-                merchant_id: 'merchant-code-ends-with-MOTO'
+              merchant_id: 'merchant-code-ends-with-MOTO'
             }
           }]
         }
@@ -124,5 +124,4 @@ describe('The Worldpay MOTO account warning', () => {
       expect(mockResponses.response.args[0][3]).to.have.property('accountUsesWorldpayMotoMerchantCode').to.equal(false)
     })
   })
-
 })


### PR DESCRIPTION
Refactor methods in user.service to accept a user external ID rather than an entire user object. This will make testing controllers that call this service easier.

There are 2 commits in this PR, the second is to run the linter on the whole of selfservice.


