### PR TITLE
PP-10047 Add page to provide phone number

### DIFF
--- a/app/controllers/user/two-factor-auth/get-phone-number.controller.js
+++ b/app/controllers/user/two-factor-auth/get-phone-number.controller.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const { response } = require('../../../utils/response.js')
+
+module.exports = function showPhoneNumberPage (req, res) {
+  return response(req, res, 'two-factor-auth/phone-number')
+}

--- a/app/controllers/user/two-factor-auth/index.js
+++ b/app/controllers/user/two-factor-auth/index.js
@@ -2,6 +2,8 @@
 
 exports.getIndex = require('./get-index.controller')
 exports.postIndex = require('./post-index.controller')
+exports.getPhoneNumber = require('./get-phone-number.controller')
+exports.postPhoneNumber = require('./post-phone-number.controller')
 exports.getConfigure = require('./get-configure.controller')
 exports.postConfigure = require('./post-configure.controller')
 exports.postResend = require('./post-resend.controller')

--- a/app/controllers/user/two-factor-auth/post-index.controller.test.js
+++ b/app/controllers/user/two-factor-auth/post-index.controller.test.js
@@ -1,0 +1,104 @@
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+
+const userFixtures = require('../../../../test/fixtures/user.fixtures')
+const User = require('../../../models/User.class')
+const paths = require('../../../paths')
+
+const userExternalId = 'user-id'
+const correlationId = 'correlation-id'
+
+describe('Select new second factor method post controller', () => {
+  let req, res, next
+  const provisionNewOtpKeySpy = sinon.spy(() => Promise.resolve())
+  const sendProvisionalOtpSpy = sinon.spy(() => Promise.resolve())
+  const controllerWithAdminusersSuccessSpies = getController(provisionNewOtpKeySpy, sendProvisionalOtpSpy)
+
+  beforeEach(() => {
+    req = {
+      correlationId,
+      body: {},
+      flash: sinon.spy()
+    }
+    res = {
+      redirect: sinon.spy()
+    }
+    next = sinon.spy()
+    provisionNewOtpKeySpy.resetHistory()
+    sendProvisionalOtpSpy.resetHistory()
+  })
+
+  describe('The user selects SMS as the new method', () => {
+    describe('The user has a phone number set', () => {
+      it('should make requests to adminusers and redirect to configure page', async () => {
+        req.user = new User(userFixtures.validUserResponse({
+          external_id: userExternalId,
+          telephone_number: '+441134960000'
+        }))
+        req.body['two-fa-method'] = 'SMS'
+
+        await controllerWithAdminusersSuccessSpies(req, res, next)
+
+        sinon.assert.calledWith(provisionNewOtpKeySpy, userExternalId, correlationId)
+        sinon.assert.calledWith(sendProvisionalOtpSpy, userExternalId, correlationId)
+        sinon.assert.calledWith(res.redirect, paths.user.profile.twoFactorAuth.configure)
+      })
+    })
+
+    describe('The user does not have a phone number set', () => {
+      it('should redirect to phone number page', async () => {
+        req.user = new User(userFixtures.validUserResponse({
+          external_id: userExternalId,
+          telephone_number: null
+        }))
+        req.body['two-fa-method'] = 'SMS'
+
+        await controllerWithAdminusersSuccessSpies(req, res, next)
+
+        sinon.assert.calledWith(res.redirect, paths.user.profile.twoFactorAuth.phoneNumber)
+        sinon.assert.notCalled(provisionNewOtpKeySpy)
+        sinon.assert.notCalled(sendProvisionalOtpSpy)
+      })
+    })
+  })
+
+  describe('The user selects APP as the new method', () => {
+    it('should call adminusers and redirect to the configure page', async () => {
+      req.user = new User(userFixtures.validUserResponse({
+        external_id: userExternalId
+      }))
+      req.body['two-fa-method'] = 'APP'
+
+      await controllerWithAdminusersSuccessSpies(req, res, next)
+
+      sinon.assert.calledWith(provisionNewOtpKeySpy, userExternalId, correlationId)
+      sinon.assert.calledWith(res.redirect, paths.user.profile.twoFactorAuth.configure)
+      sinon.assert.notCalled(sendProvisionalOtpSpy)
+    })
+  })
+
+  describe('There is an error contacting adminusers', () => {
+    it('should redirect to index with flash message', async () => {
+      req.user = new User(userFixtures.validUserResponse({
+        external_id: userExternalId
+      }))
+      req.body['two-fa-method'] = 'APP'
+
+      const adminusersRejectsStub = () => Promise.reject(new Error('Error from adminusers'))
+      const controllerWithAdminusersError = getController(adminusersRejectsStub, sendProvisionalOtpSpy)
+
+      await controllerWithAdminusersError(req, res, next)
+      sinon.assert.calledWith(req.flash, 'genericError', 'Something went wrong. Please try again or contact support.')
+      sinon.assert.calledWith(res.redirect, paths.user.profile.twoFactorAuth.index)
+    })
+  })
+
+  function getController (provisionNewOtpKeySpy, sendProvisionalOtpSpy) {
+    return proxyquire('./post-index.controller', {
+      '../../../services/user.service.js': {
+        provisionNewOtpKey: provisionNewOtpKeySpy,
+        sendProvisionalOTP: sendProvisionalOtpSpy
+      }
+    })
+  }
+})

--- a/app/controllers/user/two-factor-auth/post-phone-number.controller.js
+++ b/app/controllers/user/two-factor-auth/post-phone-number.controller.js
@@ -1,0 +1,29 @@
+'use string'
+
+const { response } = require('../../../utils/response')
+const paths = require('../../../paths')
+const { invalidTelephoneNumber } = require('../../../utils/telephone-number-utils')
+const { validationErrors } = require('../../../utils/validation/field-validation-checks')
+const userService = require('../../../services/user.service')
+
+module.exports = async function submitPhoneNumber (req, res, next) {
+  const { phone } = req.body
+  if (invalidTelephoneNumber(phone)) {
+    const pageData = {
+      phone,
+      errors: {
+        phone: validationErrors.invalidTelephoneNumber
+      }
+    }
+    return response(req, res, 'two-factor-auth/phone-number', pageData)
+  }
+
+  try {
+    await userService.updatePhoneNumber(req.user.externalId, phone, req.correlationId)
+    await userService.provisionNewOtpKey(req.user.externalId, req.correlationId)
+    await userService.sendProvisionalOTP(req.user.externalId, req.correlationId)
+    return res.redirect(paths.user.profile.twoFactorAuth.configure)
+  } catch (err) {
+    next(err)
+  }
+}

--- a/app/controllers/user/two-factor-auth/post-phone-number.controller.test.js
+++ b/app/controllers/user/two-factor-auth/post-phone-number.controller.test.js
@@ -1,0 +1,95 @@
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+
+const userFixtures = require('../../../../test/fixtures/user.fixtures')
+const User = require('../../../models/User.class')
+const paths = require('../../../paths')
+const { validationErrors } = require('../../../utils/validation/field-validation-checks')
+
+const userExternalId = 'user-id'
+const correlationId = 'correlation-id'
+
+describe('The POST set phone number for updating 2FA method controller', () => {
+  let req, res, next
+  const updatePhoneNumberSpy = sinon.spy(() => Promise.resolve())
+  const provisionNewOtpKeySpy = sinon.spy(() => Promise.resolve())
+  const sendProvisionalOTPSpy = sinon.spy(() => Promise.resolve())
+  const controllerWithAdminusersSuccess = getController(updatePhoneNumberSpy, provisionNewOtpKeySpy, sendProvisionalOTPSpy)
+
+  beforeEach(() => {
+    req = {
+      correlationId,
+      user: new User(userFixtures.validUserResponse({ external_id: userExternalId })),
+      body: {}
+    }
+    res = {
+      redirect: sinon.spy(),
+      render: sinon.spy()
+    }
+    next = sinon.spy()
+    updatePhoneNumberSpy.resetHistory()
+    provisionNewOtpKeySpy.resetHistory()
+    sendProvisionalOTPSpy.resetHistory()
+  })
+
+  describe('A valid phone number is entered', () => {
+    beforeEach(() => {
+      req.body.phone = '+441234567890'
+    })
+
+    describe('Requests to adminusers succeed', () => {
+      it('should make requests to adminusers then redirect', async () => {
+        await controllerWithAdminusersSuccess(req, res, next)
+
+        sinon.assert.calledWith(updatePhoneNumberSpy, userExternalId, req.body.phone, correlationId)
+        sinon.assert.calledWith(provisionNewOtpKeySpy, userExternalId, correlationId)
+        sinon.assert.calledWith(sendProvisionalOTPSpy, userExternalId, correlationId)
+        sinon.assert.calledWith(res.redirect, paths.user.profile.twoFactorAuth.configure)
+      })
+    })
+
+    describe('Request to adminusers fails', () => {
+      it('should make requests to adminusers then redirect', async () => {
+        const error = new Error('An error')
+        const updatePhoneNumberErrorSpy = sinon.spy(() => Promise.reject(error))
+
+        const controllerWithAdminusersError = getController(updatePhoneNumberErrorSpy, provisionNewOtpKeySpy, sendProvisionalOTPSpy)
+        await controllerWithAdminusersError(req, res, next)
+
+        sinon.assert.calledWith(updatePhoneNumberErrorSpy, userExternalId, req.body.phone, correlationId)
+        sinon.assert.notCalled(provisionNewOtpKeySpy)
+        sinon.assert.notCalled(sendProvisionalOTPSpy)
+        sinon.assert.calledWith(next, error)
+      })
+    })
+  })
+
+  describe('An invalid phone number is entered', () => {
+    it('should render the phone number page with an error', async () => {
+      req.body.phone = 'invalid-phone'
+
+      await controllerWithAdminusersSuccess(req, res, next)
+
+      sinon.assert.calledWithMatch(res.render, 'two-factor-auth/phone-number', {
+        phone: req.body.phone,
+        errors: {
+          phone: validationErrors.invalidTelephoneNumber
+        }
+      })
+
+      sinon.assert.notCalled(updatePhoneNumberSpy)
+      sinon.assert.notCalled(provisionNewOtpKeySpy)
+      sinon.assert.notCalled(sendProvisionalOTPSpy)
+    })
+  })
+})
+
+function getController (updatePhoneNumberSpy, provisionNewOtpKeySpy, sendProvisionalOTPSpy) {
+  return proxyquire('./post-phone-number.controller', {
+    '../../../services/user.service': {
+      updatePhoneNumber: updatePhoneNumberSpy,
+      provisionNewOtpKey: provisionNewOtpKeySpy,
+      sendProvisionalOTP: sendProvisionalOTPSpy
+    }
+  })
+}

--- a/app/paths.js
+++ b/app/paths.js
@@ -222,6 +222,7 @@ module.exports = {
       phoneNumber: '/my-profile/phone-number',
       twoFactorAuth: {
         index: '/my-profile/two-factor-auth',
+        phoneNumber: '/my-profile/two-factor-auth/phone-number',
         configure: '/my-profile/two-factor-auth/configure',
         resend: '/my-profile/two-factor-auth/resend'
       }

--- a/app/routes.js
+++ b/app/routes.js
@@ -248,6 +248,8 @@ module.exports.bind = function (app) {
   // Configure 2FA
   app.get(user.profile.twoFactorAuth.index, userIsAuthorised, twoFactorAuthController.getIndex)
   app.post(user.profile.twoFactorAuth.index, userIsAuthorised, twoFactorAuthController.postIndex)
+  app.get(user.profile.twoFactorAuth.phoneNumber, userIsAuthorised, twoFactorAuthController.getPhoneNumber)
+  app.post(user.profile.twoFactorAuth.phoneNumber, userIsAuthorised, twoFactorAuthController.postPhoneNumber)
   app.get(user.profile.twoFactorAuth.configure, userIsAuthorised, twoFactorAuthController.getConfigure)
   app.post(user.profile.twoFactorAuth.configure, userIsAuthorised, twoFactorAuthController.postConfigure)
   app.post(user.profile.twoFactorAuth.resend, userIsAuthorised, twoFactorAuthController.postResend)

--- a/app/utils/display-converter.js
+++ b/app/utils/display-converter.js
@@ -37,6 +37,7 @@ const hideServiceNavTemplates = [
   'request-to-go-live/organisation-name',
   'request-psp-test-account/index',
   'two-factor-auth/index',
+  'two-factor-auth/phone-number',
   'two-factor-auth/configure'
 ]
 

--- a/app/views/two-factor-auth/phone-number.njk
+++ b/app/views/two-factor-auth/phone-number.njk
@@ -1,0 +1,60 @@
+{% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
+
+{% block pageTitle %}
+  Enter your mobile phone number - GOV.UK Pay
+{% endblock %}
+
+{% block beforeContent %}
+  {{ super() }}
+  {{
+  govukBackLink({
+    text: "My profile",
+    href: routes.user.profile.index
+  })
+  }}
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-column-two-thirds">
+    {{ errorSummary ({
+      errors: errors,
+      hrefs: {
+        phone: "#phone"
+      }
+    }) }}
+
+    <form method="post">
+      <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+      {{
+      govukInput({
+        id: "phone",
+        name: "phone",
+        type: "tel",
+        value: phone,
+        classes: "govuk-!-width-one-half",
+        label: {
+          text: "Enter your mobile phone number",
+          classes: "govuk-label--l",
+          isPageHeading: true
+        },
+        hint: {
+          text: "We will send a 6 digit verification code to the number you give us."
+        },
+        errorMessage: { text: errors.phone } if errors.phone else false
+      })
+      }}
+      {{
+      govukButton({
+        text: "Continue"
+      })
+      }}
+    </form>
+
+    <p class="govuk-body">
+      <a class="govuk-link govuk-link--no-visited-state" href="{{routes.user.profile.twoFactorAuth.index}}">
+        Cancel
+      </a>
+    </p>
+  </div>
+{% endblock %}

--- a/test/cypress/integration/user/change-sign-in-method.cy.test.js
+++ b/test/cypress/integration/user/change-sign-in-method.cy.test.js
@@ -1,0 +1,82 @@
+const userStubs = require('../../stubs/user-stubs')
+
+const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+
+describe('Change sign in method', () => {
+  describe('Change method to SMS', () => {
+    describe('User does not have a phone number set', () => {
+      it('should ask for a phone number and complete change sign-in method', () => {
+        cy.setEncryptedCookies(userExternalId)
+
+        cy.task('setupStubs', [
+          userStubs.getUserSuccess({ userExternalId, telephoneNumber: null, secondFactor: 'APP' }),
+          userStubs.postProvisionSecondFactorSuccess(userExternalId)
+        ])
+
+        cy.visit('/my-profile/two-factor-auth')
+        cy.get('input[type="radio"][value="SMS"]').click()
+        cy.get('button').contains('Submit').click()
+
+        cy.title().should('equal', 'Enter your mobile phone number - GOV.UK Pay')
+        cy.get('h1').should('contain', 'Enter your mobile phone number')
+
+        // submit the page with an invalid a phone number
+        cy.get('input#phone').type('0')
+        cy.get('button').contains('Continue').click()
+        cy.title().should('equal', 'Enter your mobile phone number - GOV.UK Pay')
+
+        // check that an error message is displayed
+        cy.get('.govuk-error-summary').should('exist').within(() => {
+          cy.get('h2').should('contain', 'There is a problem')
+          cy.get('.govuk-error-summary__list').should('have.length', 1)
+          cy.get('.govuk-error-summary__list').first()
+            .contains('Enter a telephone number')
+            .should('have.attr', 'href', '#phone')
+        })
+
+        cy.get('.govuk-form-group--error > input#phone').parent().should('exist').within(() => {
+          cy.get('.govuk-error-message').should('contain', 'Enter a telephone number')
+        })
+
+        // check that invalid phone number is pre-filled
+        cy.get('input#phone').should('have.value', '0')
+        cy.get('input#phone').clear()
+
+        // enter a valid phone number and submit
+        cy.get('input#phone').type('+441234567890', { delay: 0 })
+
+        cy.get('button').contains('Continue').click()
+
+        // check we're on the page to enter a verification code
+        cy.title().should('equal', 'Check your phone - GOV.UK Pay')
+        cy.get('h1').should('contain', 'Check your phone')
+
+        // submit the page wihout entering a code
+        cy.get('button').contains('Complete').click()
+
+        // check that an error is displayed
+        cy.get('.govuk-error-summary').should('exist').within(() => {
+          cy.get('h2').should('contain', 'There is a problem')
+          cy.get('.govuk-error-summary__list').should('have.length', 1)
+          cy.get('.govuk-error-summary__list').first()
+            .contains('Enter a verification code')
+            .should('have.attr', 'href', '#code')
+        })
+
+        cy.get('.govuk-form-group--error > input#code').parent().should('exist').within(() => {
+          cy.get('.govuk-error-message').should('contain', 'Enter a verification code')
+        })
+
+        // enter a valid code and submit
+        cy.get('input#code').type('123456', { delay: 0 })
+        cy.get('button').contains('Complete').click()
+
+        // check we're redirected to the "My profile" page with a success message
+        cy.title().should('equal', 'My profile - GOV.UK Pay')
+        cy.get('.govuk-notification-banner--success').should('exist')
+        cy.get('.govuk-notification-banner--success > .govuk-notification-banner__content > p.govuk-notification-banner__heading').should('contain', 'Your sign-in method has been updated')
+        cy.get('.govuk-notification-banner--success > .govuk-notification-banner__content > p.govuk-body').should('contain', 'We’ll send you a text message when you next sign in.')
+      })
+    })
+  })
+})

--- a/test/cypress/integration/user/edit-phone-number.cy.test.js
+++ b/test/cypress/integration/user/edit-phone-number.cy.test.js
@@ -1,24 +1,16 @@
 const userStubs = require('../../stubs/user-stubs')
-const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
-
-function setupStubs (userExternalId, gatewayAccountId, serviceName, telephoneNumber) {
-  cy.task('setupStubs', [
-    userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName, telephoneNumber }),
-    gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId })
-  ])
-}
 
 describe('Edit phone number flow', () => {
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
-  const gatewayAccountId = 42
-  const serviceName = 'Purchase a positron projection permit'
   const testPhoneNumber = '+441234567890'
   const testPhoneNumberNew = '+441987654321'
 
   describe('Pre edit', () => {
     beforeEach(() => {
       cy.setEncryptedCookies(userExternalId)
-      setupStubs(userExternalId, gatewayAccountId, serviceName, testPhoneNumber)
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({ userExternalId, telephoneNumber: testPhoneNumber })
+      ])
     })
 
     describe('Profile page', () => {
@@ -47,7 +39,9 @@ describe('Edit phone number flow', () => {
   describe('Post edit', () => {
     beforeEach(() => {
       cy.setEncryptedCookies(userExternalId)
-      setupStubs(userExternalId, gatewayAccountId, serviceName, testPhoneNumberNew)
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({ userExternalId, telephoneNumber: testPhoneNumberNew })
+      ])
     })
 
     it('should save changes and redirect to my profile', () => {

--- a/test/cypress/integration/user/my-profile.cy.test.js
+++ b/test/cypress/integration/user/my-profile.cy.test.js
@@ -1,18 +1,14 @@
 const userStubs = require('../../stubs/user-stubs')
-const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 
 describe('My profile page', () => {
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
-  const gatewayAccountId = 42
-  const serviceName = 'Purchase a positron projection permit'
   const testPhoneNumber = '+441234567890'
 
   describe('User does not have telephone number', () => {
     beforeEach(() => {
       cy.setEncryptedCookies(userExternalId)
       cy.task('setupStubs', [
-        userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName, telephoneNumber: null }),
-        gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId })
+        userStubs.getUserSuccess({ userExternalId, telephoneNumber: null })
       ])
     })
 
@@ -26,8 +22,7 @@ describe('My profile page', () => {
     beforeEach(() => {
       cy.setEncryptedCookies(userExternalId)
       cy.task('setupStubs', [
-        userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName, telephoneNumber: testPhoneNumber }),
-        gatewayAccountStubs.getGatewayAccountSuccess({ gatewayAccountId })
+        userStubs.getUserSuccess({ userExternalId, telephoneNumber: testPhoneNumber })
       ])
     })
 

--- a/test/cypress/stubs/user-stubs.js
+++ b/test/cypress/stubs/user-stubs.js
@@ -87,6 +87,13 @@ function postSecondFactorSuccess (userExternalId) {
   return stubBuilder('POST', path, 200)
 }
 
+function postProvisionSecondFactorSuccess (userExternalId) {
+  const path = `/v1/api/users/${userExternalId}/second-factor/provision`
+  return stubBuilder('POST', path, 200, {
+    response: userFixtures.validUserResponse()
+  })
+}
+
 function getServiceUsersSuccess (opts) {
   const path = `/v1/api/services/${opts.serviceExternalId}/users`
   const fixtureOpts = opts.users.map(buildUserWithServiceRoleOpts)
@@ -231,7 +238,8 @@ function buildUserWithServiceRoleOpts (opts) {
     service_roles: [serviceRole],
     username: opts.email,
     email: opts.email,
-    telephone_number: opts.telephoneNumber
+    telephone_number: opts.telephoneNumber,
+    second_factor: opts.secondFactor
   }
 }
 
@@ -248,6 +256,7 @@ module.exports = {
   postUserAuthenticateSuccess,
   postUserAuthenticateInvalidPassword,
   postSecondFactorSuccess,
+  postProvisionSecondFactorSuccess,
   putUpdateServiceRoleSuccess,
   getUserSuccessWithMultipleServices
 }


### PR DESCRIPTION
When a user has registered their account using an authenticator app to get security codes, which is currently being implemented, they won't be asked for a phone number.

If they then go to change their sign-in method to "Text message" from their profile settings, add a page that asks for their phone number. This page is shown after selecting the new sign-in method, if "Text message" is selected and the user does not have a phone number set.

Upon submitting the new phone number, make a PATCH request to adminusers to update the phone number on the user, then make requests to provision a new provisional OTP key and to send a text message with a security code.

