### PR TITLE
PP-10240 Remove the "old" client error handler

### DIFF
--- a/app/controllers/register-service.controller.js
+++ b/app/controllers/register-service.controller.js
@@ -194,12 +194,7 @@ async function createPopulatedService (req, res, next) {
     loginController.setupDirectLoginAfterRegister(req, res, user.externalId)
     return res.redirect(303, paths.selfCreateService.logUserIn)
   } catch (err) {
-    if (err.errorCode === 409) {
-      const errorMessage = (err.message && err.message.errors) ? err.message.errors : 'Unable to process registration at this time'
-      renderErrorView(req, res, errorMessage, err.errorCode)
-    } else {
-      next(err)
-    }
+    next(err)
   }
 }
 

--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -43,7 +43,6 @@ module.exports = function (clientOptions = {}) {
         description: 'find a user',
         service: SERVICE_NAME,
         transform: responseBodyToUserTransformer,
-        baseClientErrorHandler: 'old'
       }
     )
   }
@@ -67,8 +66,7 @@ module.exports = function (clientOptions = {}) {
         correlationId: correlationId,
         description: 'find a user',
         service: SERVICE_NAME,
-        transform: responseBodyToUserListTransformer,
-        baseClientErrorHandler: 'old'
+        transform: responseBodyToUserListTransformer
       }
     )
   }
@@ -92,8 +90,7 @@ module.exports = function (clientOptions = {}) {
         correlationId: correlationId,
         description: 'authenticate a user',
         service: SERVICE_NAME,
-        transform: responseBodyToUserTransformer,
-        baseClientErrorHandler: 'old'
+        transform: responseBodyToUserTransformer
       }
     )
   }
@@ -117,8 +114,7 @@ module.exports = function (clientOptions = {}) {
         },
         correlationId: correlationId,
         description: 'increment session version for a user',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -140,8 +136,7 @@ module.exports = function (clientOptions = {}) {
         },
         correlationId: correlationId,
         description: 'create a forgotten password for a user',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -160,8 +155,7 @@ module.exports = function (clientOptions = {}) {
         json: true,
         correlationId: correlationId,
         description: 'get a forgotten password',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -185,8 +179,7 @@ module.exports = function (clientOptions = {}) {
         },
         correlationId: correlationId,
         description: 'update a password for a user',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -207,8 +200,7 @@ module.exports = function (clientOptions = {}) {
         body: { provisional },
         correlationId: correlationId,
         description: 'post a second factor auth token to the user',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -230,8 +222,7 @@ module.exports = function (clientOptions = {}) {
         correlationId: correlationId,
         description: 'authenticate a second factor auth token entered by user',
         service: SERVICE_NAME,
-        transform: responseBodyToUserTransformer,
-        baseClientErrorHandler: 'old'
+        transform: responseBodyToUserTransformer
       }
     )
   }
@@ -245,8 +236,7 @@ module.exports = function (clientOptions = {}) {
         correlationId: correlationId,
         description: 'get a services users',
         service: SERVICE_NAME,
-        transform: responseBodyToUserListTransformer,
-        baseClientErrorHandler: 'old'
+        transform: responseBodyToUserListTransformer
       }
     )
   }
@@ -271,8 +261,7 @@ module.exports = function (clientOptions = {}) {
         correlationId: correlationId,
         description: 'assigns user to a new service',
         service: SERVICE_NAME,
-        transform: responseBodyToUserTransformer,
-        baseClientErrorHandler: 'old'
+        transform: responseBodyToUserTransformer
       }
     )
   }
@@ -297,8 +286,7 @@ module.exports = function (clientOptions = {}) {
         correlationId: correlationId,
         description: 'update role of a service that currently belongs to a user',
         service: SERVICE_NAME,
-        transform: responseBodyToUserTransformer,
-        baseClientErrorHandler: 'old'
+        transform: responseBodyToUserTransformer
       }
     )
   }
@@ -326,8 +314,7 @@ module.exports = function (clientOptions = {}) {
         },
         correlationId: correlationId,
         description: 'invite a user to signup',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -349,8 +336,7 @@ module.exports = function (clientOptions = {}) {
         correlationId: correlationId,
         method: 'GET',
         description: 'get invited users for a service',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -368,8 +354,7 @@ module.exports = function (clientOptions = {}) {
         json: true,
         correlationId: correlationId,
         description: 'find a validated invitation',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -390,8 +375,7 @@ module.exports = function (clientOptions = {}) {
       json: true,
       correlationId: correlationId,
       description: 'generate otp code for invite',
-      service: SERVICE_NAME,
-      baseClientErrorHandler: 'old'
+      service: SERVICE_NAME
     }
 
     if (telephoneNumber || password) {
@@ -423,8 +407,7 @@ module.exports = function (clientOptions = {}) {
         body: {},
         correlationId: correlationId,
         description: 'complete invite',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -441,8 +424,7 @@ module.exports = function (clientOptions = {}) {
         },
         correlationId: correlationId,
         description: 'submit otp code',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -459,8 +441,7 @@ module.exports = function (clientOptions = {}) {
         },
         correlationId: correlationId,
         description: 'submit invite otp code',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -477,8 +458,7 @@ module.exports = function (clientOptions = {}) {
         },
         correlationId: correlationId,
         description: 'resend otp code',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -504,8 +484,7 @@ module.exports = function (clientOptions = {}) {
         },
         correlationId: correlationId,
         description: 'submit service registration details',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -528,8 +507,7 @@ module.exports = function (clientOptions = {}) {
         userRemover: removerExternalId,
         correlationId: correlationId,
         description: 'delete a user from a service',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -552,8 +530,7 @@ module.exports = function (clientOptions = {}) {
       correlationId: correlationId,
       description: 'create service',
       transform: responseBodyToServiceTransformer,
-      service: SERVICE_NAME,
-      baseClientErrorHandler: 'old'
+      service: SERVICE_NAME
     }
 
     if (serviceName) {
@@ -584,8 +561,7 @@ module.exports = function (clientOptions = {}) {
       correlationId: correlationId,
       description: 'update service',
       transform: responseBodyToServiceTransformer,
-      service: SERVICE_NAME,
-      baseClientErrorHandler: 'old'
+      service: SERVICE_NAME
     })
   }
 
@@ -618,8 +594,7 @@ module.exports = function (clientOptions = {}) {
         ],
         correlationId: correlationId,
         description: 'update service name',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -646,8 +621,7 @@ module.exports = function (clientOptions = {}) {
         },
         correlationId: correlationId,
         description: 'update collect billing address',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -666,8 +640,7 @@ module.exports = function (clientOptions = {}) {
         },
         correlationId: correlationId,
         description: 'update default billing address country',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -694,8 +667,7 @@ module.exports = function (clientOptions = {}) {
         correlationId: correlationId,
         description: 'update service name',
         service: SERVICE_NAME,
-        transform: responseBodyToServiceTransformer,
-        baseClientErrorHandler: 'old'
+        transform: responseBodyToServiceTransformer
       }
     )
   }
@@ -715,8 +687,7 @@ module.exports = function (clientOptions = {}) {
         correlationId: correlationId,
         description: 'create a new 2FA provisional OTP key',
         transform: responseBodyToUserTransformer,
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -741,8 +712,7 @@ module.exports = function (clientOptions = {}) {
         },
         correlationId: correlationId,
         description: 'configure a new OTP key and method',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -761,8 +731,7 @@ module.exports = function (clientOptions = {}) {
         correlationId: correlationId,
         description: 'update current go live stage',
         transform: responseBodyToServiceTransformer,
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -781,8 +750,7 @@ module.exports = function (clientOptions = {}) {
         correlationId: correlationId,
         description: 'update PSP test account stage',
         transform: responseBodyToServiceTransformer,
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -796,8 +764,7 @@ module.exports = function (clientOptions = {}) {
         body: { ip_address: ipAddress },
         correlationId: correlationId,
         description: 'post the ip address of the user who agreed to stripe terms',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -811,8 +778,7 @@ module.exports = function (clientOptions = {}) {
         body: { user_external_id: userExternalId },
         correlationId: correlationId,
         description: 'post the external id of the user who agreed to GovUk Pay terms',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }
@@ -837,8 +803,7 @@ module.exports = function (clientOptions = {}) {
         },
         correlationId: correlationId,
         description: 'update a phone number for a user',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   }

--- a/app/services/clients/base-client/wrapper.js
+++ b/app/services/clients/base-client/wrapper.js
@@ -34,9 +34,7 @@ module.exports = function (method, verb) {
 
     // Set up post response and error handling method
     const transform = opts.transform || false
-    const handleError = opts.baseClientErrorHandler || 'new'
     opts.transform = undefined
-    opts.baseClientErrorHandler = undefined
 
     // start request
     requestLogger.logRequestStart(context)
@@ -49,21 +47,13 @@ module.exports = function (method, verb) {
         body = transform ? transform(body) : body
         resolve(body)
       } else {
-        if (handleError === 'new') {
-          let errors = lodash.get(body, 'message') || lodash.get(body, 'errors')
-          if (errors && errors.constructor.name === 'Array') errors = errors.join(', ')
-          const err = new Error(errors || body || 'Unknown error')
-          err.errorCode = response.statusCode
-          err.errorIdentifier = lodash.get(body, 'error_identifier')
-          err.reason = lodash.get(body, 'reason')
-          reject(err)
-        } else {
-          // eslint-disable-next-line
-          reject({
-            errorCode: response.statusCode,
-            message: response.body
-          })
-        }
+        let errors = lodash.get(body, 'message') || lodash.get(body, 'errors')
+        if (errors && errors.constructor.name === 'Array') errors = errors.join(', ')
+        const err = new Error(errors || body || 'Unknown error')
+        err.errorCode = response.statusCode
+        err.errorIdentifier = lodash.get(body, 'error_identifier')
+        err.reason = lodash.get(body, 'reason')
+        reject(err)
       }
     })
     // Add event listeners for logging

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -183,8 +183,7 @@ ConnectorClient.prototype = {
       body: payload,
       correlationId: correlationId,
       description: 'create a gateway account',
-      service: SERVICE_NAME,
-      baseClientErrorHandler: 'old'
+      service: SERVICE_NAME
     })
   },
 
@@ -621,8 +620,7 @@ ConnectorClient.prototype = {
         correlationId,
         description: 'get stripe account setup flags for gateway account',
         service: SERVICE_NAME,
-        transform: responseBodyToStripeAccountSetupTransformer,
-        baseClientErrorHandler: 'old'
+        transform: responseBodyToStripeAccountSetupTransformer
       }
     )
   },
@@ -642,8 +640,7 @@ ConnectorClient.prototype = {
         ],
         correlationId,
         description: 'set stripe account setup flag to true for gateway account',
-        service: SERVICE_NAME,
-        baseClientErrorHandler: 'old'
+        service: SERVICE_NAME
       }
     )
   },
@@ -657,8 +654,7 @@ ConnectorClient.prototype = {
         correlationId,
         description: 'get stripe account for gateway account',
         service: SERVICE_NAME,
-        transform: responseBodyToStripeAccountTransformer,
-        baseClientErrorHandler: 'old'
+        transform: responseBodyToStripeAccountTransformer
       }
     )
   },

--- a/test/unit/clients/adminusers-client/authenticate/authenticate.pact.test.js
+++ b/test/unit/clients/adminusers-client/authenticate/authenticate.pact.test.js
@@ -98,7 +98,7 @@ describe('adminusers client - authenticate', () => {
         done('should not resolve here')
       }).catch(err => {
         expect(err.errorCode).to.equal(401)
-        expect(err.message.errors).to.deep.equal(invalidPasswordResponse.errors)
+        expect(err.message).to.deep.equal(invalidPasswordResponse.errors.join(', '))
         done()
       })
     })

--- a/test/unit/clients/adminusers-client/forgotten-password/create-forgotten-password.pact.test.js
+++ b/test/unit/clients/adminusers-client/forgotten-password/create-forgotten-password.pact.test.js
@@ -72,10 +72,9 @@ describe('adminusers client - create forgotten password', function () {
     afterEach(() => provider.verify())
 
     it('should error when forgotten password creation if mandatory fields are missing', function (done) {
-      adminUsersClient.createForgottenPassword(request.username).should.be.rejected.then(function (response) {
-        expect(response.errorCode).to.equal(400)
-        expect(response.message.errors.length).to.equal(1)
-        expect(response.message.errors).to.deep.equal(badForgottenPasswordResponse.errors)
+      adminUsersClient.createForgottenPassword(request.username).should.be.rejected.then(function (err) {
+        expect(err.errorCode).to.equal(400)
+        expect(err.message).to.equal(badForgottenPasswordResponse.errors[0])
       }).should.notify(done)
     })
   })

--- a/test/unit/clients/adminusers-client/invite/generate-invite-otp-code-user.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/generate-invite-otp-code-user.pact.test.js
@@ -81,10 +81,9 @@ describe('adminusers client - generate otp code for user invite', function () {
     afterEach(() => provider.verify())
 
     it('should 400 BAD REQUEST telephone number is not valid', function (done) {
-      adminUsersClient.generateInviteOtpCode(inviteCode, validRegistrationRequest.telephone_number, validRegistrationRequest.password).should.be.rejected.then(function (response) {
-        expect(response.errorCode).to.equal(400)
-        expect(response.message.errors.length).to.equal(1)
-        expect(response.message.errors[0]).to.equal('Field [telephone_number] is required')
+      adminUsersClient.generateInviteOtpCode(inviteCode, validRegistrationRequest.telephone_number, validRegistrationRequest.password).should.be.rejected.then(function (err) {
+        expect(err.errorCode).to.equal(400)
+        expect(err.message).to.equal('Field [telephone_number] is required')
       }).should.notify(done)
     })
   })

--- a/test/unit/clients/adminusers-client/invite/invite-user.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/invite-user.pact.test.js
@@ -103,8 +103,7 @@ describe('adminusers client - invite user', function () {
     it('should return bad request', function (done) {
       adminUsersClient.inviteUser(invalidInvite.email, invalidInvite.sender, externalServiceId, invalidInvite.role_name).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(400)
-        expect(response.message.errors.length).to.equal(1)
-        expect(response.message.errors).to.deep.equal(errorResponse.errors)
+        expect(response.message).to.equal(errorResponse.errors[0])
       }).should.notify(done)
     })
   })
@@ -129,10 +128,9 @@ describe('adminusers client - invite user', function () {
     afterEach(() => provider.verify())
 
     it('should return conflict', function (done) {
-      adminUsersClient.inviteUser(validInvite.email, validInvite.sender, externalServiceId, validInvite.role_name).should.be.rejected.then(function (response) {
-        expect(response.errorCode).to.equal(409)
-        expect(response.message.errors.length).to.equal(1)
-        expect(response.message.errors).to.deep.equal(errorResponse.errors)
+      adminUsersClient.inviteUser(validInvite.email, validInvite.sender, externalServiceId, validInvite.role_name).should.be.rejected.then(function (err) {
+        expect(err.errorCode).to.equal(409)
+        expect(err.message).to.equal(errorResponse.errors[0])
       }).should.notify(done)
     })
   })
@@ -157,10 +155,9 @@ describe('adminusers client - invite user', function () {
     afterEach(() => provider.verify())
 
     it('should return not permitted', function (done) {
-      adminUsersClient.inviteUser(validInvite.email, validInvite.sender, externalServiceId, validInvite.role_name).should.be.rejected.then(function (response) {
-        expect(response.errorCode).to.equal(403)
-        expect(response.message.errors.length).to.equal(1)
-        expect(response.message.errors).to.deep.equal(errorResponse.errors)
+      adminUsersClient.inviteUser(validInvite.email, validInvite.sender, externalServiceId, validInvite.role_name).should.be.rejected.then(function (err) {
+        expect(err.errorCode).to.equal(403)
+        expect(err.message).to.equal(errorResponse.errors[0])
       }).should.notify(done)
     })
   })

--- a/test/unit/clients/adminusers-client/invite/resend-otp-code.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/resend-otp-code.pact.test.js
@@ -78,10 +78,9 @@ describe('submit resend otp code API', function () {
     afterEach(() => provider.verify())
 
     it('should return 400 on missing fields', function (done) {
-      adminUsersClient.resendOtpCode(validOtpResend.code, validOtpResend.telephone_number).should.be.rejected.then(function (response) {
-        expect(response.errorCode).to.equal(400)
-        expect(response.message.errors.length).to.equal(1)
-        expect(response.message.errors[0]).to.equal('Field [code] is required')
+      adminUsersClient.resendOtpCode(validOtpResend.code, validOtpResend.telephone_number).should.be.rejected.then(function (err) {
+        expect(err.errorCode).to.equal(400)
+        expect(err.message).to.equal('Field [code] is required')
       }).should.notify(done)
     })
   })

--- a/test/unit/clients/adminusers-client/invite/submit-service-registration.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/submit-service-registration.pact.test.js
@@ -78,10 +78,9 @@ describe('adminusers client - self register service', function () {
     afterEach(() => provider.verify())
 
     it('should return bad request', function (done) {
-      adminUsersClient.submitServiceRegistration(invalidInvite.email, invalidInvite.telephone_number, invalidInvite.password).should.be.rejected.then(function (response) {
-        expect(response.errorCode).to.equal(400)
-        expect(response.message.errors.length).to.equal(1)
-        expect(response.message.errors).to.deep.equal(errorResponse.errors)
+      adminUsersClient.submitServiceRegistration(invalidInvite.email, invalidInvite.telephone_number, invalidInvite.password).should.be.rejected.then(function (err) {
+        expect(err.errorCode).to.equal(400)
+        expect(err.message).to.equal(errorResponse.errors[0])
       }).should.notify(done)
     })
   })

--- a/test/unit/clients/adminusers-client/invite/verify-otp-code.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/verify-otp-code.pact.test.js
@@ -73,10 +73,9 @@ describe('adminusers client - submit verification details', function () {
     afterEach(() => provider.verify())
 
     it('should return 400 on missing fields', function (done) {
-      adminUsersClient.verifyOtpAndCreateUser(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
-        expect(response.errorCode).to.equal(400)
-        expect(response.message.errors.length).to.equal(1)
-        expect(response.message.errors[0]).to.equal('Field [code] is required')
+      adminUsersClient.verifyOtpAndCreateUser(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (err) {
+        expect(err.errorCode).to.equal(400)
+        expect(err.message).to.equal('Field [code] is required')
       }).should.notify(done)
     })
   })

--- a/test/unit/clients/adminusers-client/invite/verify-service-otp-code.pact.test.js
+++ b/test/unit/clients/adminusers-client/invite/verify-service-otp-code.pact.test.js
@@ -74,10 +74,9 @@ describe('adminusers client - validate otp code for a service', function () {
     afterEach(() => provider.verify())
 
     it('should return 400 on missing fields', function (done) {
-      adminUsersClient.verifyOtpForInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
-        expect(response.errorCode).to.equal(400)
-        expect(response.message.errors.length).to.equal(1)
-        expect(response.message.errors[0]).to.equal('Field [code] is required')
+      adminUsersClient.verifyOtpForInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (err) {
+        expect(err.errorCode).to.equal(400)
+        expect(err.message).to.equal('Field [code] is required')
       }).should.notify(done)
     })
   })

--- a/test/unit/clients/adminusers-client/service/add-gateway-accounts-to-services.pact.test.js
+++ b/test/unit/clients/adminusers-client/service/add-gateway-accounts-to-services.pact.test.js
@@ -98,14 +98,9 @@ describe('admin users client - add gateway accounts to service', () => {
       result = adminUsersClient.addGatewayAccountsToService(serviceExternalId, gatewayAccountIds)
 
       return expect(result)
-        .to.be.rejected
-        .and.to.eventually.deep.equal({
-          errorCode: 409,
-          message: {
-            errors: [
-              'One or more of the following gateway account ids has already assigned to another service: [111]'
-            ]
-          }
+        .to.be.rejected.then(err => {
+          expect(err.errorCode).to.equal(409)
+          expect(err.message).to.equal('One or more of the following gateway account ids has already assigned to another service: [111]')
         })
     })
   })

--- a/test/unit/clients/adminusers-client/user/authenticate.pact.test.js
+++ b/test/unit/clients/adminusers-client/user/authenticate.pact.test.js
@@ -84,10 +84,9 @@ describe('adminusers client - authenticate', function () {
     afterEach(() => provider.verify())
 
     it('should fail authentication if invalid username / password', function (done) {
-      adminUsersClient.authenticateUser(request.username, request.password).should.be.rejected.then(function (response) {
-        expect(response.errorCode).to.equal(401)
-        expect(response.message.errors.length).to.equal(1)
-        expect(response.message.errors).to.deep.equal(unauthorizedResponse.errors)
+      adminUsersClient.authenticateUser(request.username, request.password).should.be.rejected.then(function (err) {
+        expect(err.errorCode).to.equal(401)
+        expect(err.message).to.equal(unauthorizedResponse.errors[0])
       }).should.notify(done)
     })
   })
@@ -113,10 +112,9 @@ describe('adminusers client - authenticate', function () {
     afterEach(() => provider.verify())
 
     it('should error bad request if mandatory fields are missing', function (done) {
-      adminUsersClient.authenticateUser(request.username, request.password).should.be.rejected.then(function (response) {
-        expect(response.errorCode).to.equal(400)
-        expect(response.message.errors.length).to.equal(2)
-        expect(response.message.errors).to.deep.equal(badAuthenticateResponse.errors)
+      adminUsersClient.authenticateUser(request.username, request.password).should.be.rejected.then(function (err) {
+        expect(err.errorCode).to.equal(400)
+        expect(err.message).to.equal(badAuthenticateResponse.errors.join(', '))
       }).should.notify(done)
     })
   })

--- a/test/unit/clients/connector-client/connector-client-create-gateway-account.pact.test.js
+++ b/test/unit/clients/connector-client/connector-client-create-gateway-account.pact.test.js
@@ -93,7 +93,7 @@ describe('connector client - create gateway account', function () {
         invalidCreateGatewayAccountRequest.analytics_id
       ).should.be.rejected.then(function (response) {
         expect(response.errorCode).to.equal(400)
-        expect(response.message).to.deep.equal(errorResponse)
+        expect(response.message).to.equal(errorResponse.message)
       }).should.notify(done)
     })
   })


### PR DESCRIPTION
There is currently the concept of an "old" and a "new" error handler.
The "old" error handler puts the entire response body in the message
field of the "error" object returned by the client.

There was only one place in the code where fields in the response body
was accessed - when attempting to complete a registration. Here we were
using the backend error message to display on the error page. We
shouldn't do this, so instead just display a generic error page.

Remove the "old" error handler so that the clients return an error
with a uniform signature when a request returns a non-success response.
This error contains the error message string extracted from the HTTP
response body.

