### PR TITLE
PP-10240 Introduce RESTClientError type

### DIFF
--- a/app/errors.js
+++ b/app/errors.js
@@ -1,5 +1,16 @@
 'use strict'
 
+class RESTClientError extends Error {
+  constructor (message, service, errorCode, errorIdentifier, reason) {
+    super(message)
+    this.name = this.constructor.name
+    this.service = service
+    this.errorCode = errorCode
+    this.errorIdentifier = errorIdentifier
+    this.reason = reason
+  }
+}
+
 class DomainError extends Error {
   constructor (message) {
     super(message)
@@ -69,6 +80,7 @@ class InvalidConfigurationError extends DomainError {
 }
 
 module.exports = {
+  RESTClientError,
   NotAuthenticatedError,
   UserAccountDisabledError,
   NotAuthorisedError,

--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -12,7 +12,8 @@ const {
   NotFoundError,
   RegistrationSessionMissingError,
   InvalidRegistationStateError,
-  InvalidConfigurationError
+  InvalidConfigurationError,
+  RESTClientError
 } = require('../errors')
 const paths = require('../paths')
 const { renderErrorView, response } = require('../utils/response')
@@ -72,9 +73,16 @@ module.exports = function errorHandler (err, req, res, next) {
     return renderErrorView(req, res, 'There is a problem with the payments platform. Please contact the support team', 400)
   }
 
-  logger.info(`Unhandled error caught: ${err.message}`, {
-    stack: err.stack
-  })
+  if (err instanceof RESTClientError) {
+    logger.info(`Unhandled REST client error caught: ${err.message}`, {
+      service: err.service,
+      status: err.statusCode
+    })
+  } else {
+    logger.info(`Unhandled error caught: ${err.message}`, {
+      stack: err.stack
+    })
+  }
   Sentry.captureException(err)
   renderErrorView(req, res, 'There is a problem with the payments platform. Please contact the support team.', 500)
 }

--- a/test/unit/clients/base-client/wrapper.test.js
+++ b/test/unit/clients/base-client/wrapper.test.js
@@ -1,13 +1,25 @@
 'use strict'
 
-const { expect } = require('chai')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
-const requestLogger = {}
 const events = require('events')
+const { EventEmitter } = require('events')
 const util = require('util')
+const { RESTClientError } = require('../../../../app/errors')
+
+const expect = chai.expect
+chai.use(chaiAsPromised)
 
 const correlationId = 'a-correlation-id'
+const requestLogger = {
+  logRequestStart: sinon.spy(),
+  logRequestEnd: sinon.spy(),
+  logRequestFailure: sinon.spy(),
+  logRequestError: sinon.spy()
+}
+let requestOptions
 
 const wrapper = proxyquire('../../../../app/services/clients/base-client/wrapper', {
   '../../../utils/request-logger': requestLogger,
@@ -16,162 +28,212 @@ const wrapper = proxyquire('../../../../app/services/clients/base-client/wrapper
   }
 })
 
-describe('wrapper: request scenarios', () => {
-  describe('when the request returns successfully with statusCode 200', () => {
-    let resolved
-    let returnee
+function RequestSuccessStub (response, responseBody) {
+  const self = this
+  EventEmitter.call(self)
+  return function (options, callback) {
+    setTimeout(() => {
+      // Emit a response event which is handled in the wrapper to log the response
+      self.emit('response', response)
 
-    // Create a stubbed request object
-    function RequestStub () {
-      const self = this
-      events.EventEmitter.call(self)
-      return function (options, callback) {
-        setTimeout(() => {
-          const response = { statusCode: 200 }
-          // Put the request options in the body, as this allows us to do assertions on the options used
-          const body = { result: 'success', requestOptions: options }
-          // Emit a response event which is handled in the wrapper to log the response
-          self.emit('response', response)
-          // Execute callback to simulate the response from the service
-          callback(null, response, body)
-        }, 100)
-        return self
-      }
-    }
+      // Record the request options so we can do assertions on them in tests
+      requestOptions = options
 
-    // Wire the EventEmitter into it, so we can emit the event specified above to any watchers
-    util.inherits(RequestStub, events.EventEmitter)
+      // Execute callback to simulate the response from the service
+      callback(null, response, responseBody)
+    }, 100)
+    return self
+  }
+}
 
-    before(done => {
-      requestLogger.logRequestStart = sinon.spy()
-      requestLogger.logRequestEnd = sinon.spy()
-      requestLogger.logRequestFailure = sinon.spy()
-      requestLogger.logRequestError = sinon.spy()
-      returnee = wrapper(new RequestStub(), 'get')({ url: 'http://example.com/' })
-      returnee
-        .then(result => {
-          resolved = result
-          done()
+function RequestErrorStub () {
+  const self = this
+  events.EventEmitter.call(self)
+  return function (options, callback) {
+    setTimeout(() => {
+      // Emit an error event which is handled in the wrapper to log the request error
+      self.emit('error', new Error('something simply dreadful happened'))
+      callback(new Error('something simply dreadful happened'))
+    }, 100)
+    return self
+  }
+}
+
+// Wire the EventEmitter into the stubs to mimic the behaviour of the request library
+util.inherits(RequestSuccessStub, EventEmitter)
+util.inherits(RequestErrorStub, EventEmitter)
+
+describe('Client wrapper', () => {
+  beforeEach(() => {
+    requestLogger.logRequestStart.resetHistory()
+    requestLogger.logRequestEnd.resetHistory()
+    requestLogger.logRequestFailure.resetHistory()
+    requestLogger.logRequestError.resetHistory()
+    requestOptions = null
+  })
+
+  describe('Request returns a success response', () => {
+    const response = { statusCode: 200 }
+    const responseBody = { result: 'success' }
+    const requestStub = new RequestSuccessStub(response, responseBody)
+
+    it('should resolve with the response body', () => {
+      return expect(wrapper(requestStub, 'get')({ url: 'http://example.com/' })).to.be.fulfilled.then(resolved => {
+        expect(resolved).to.have.property('result', 'success')
+
+        expect(requestOptions).to.have.property('headers')
+        expect(requestOptions.headers).to.deep.equal({
+          'x-request-id': correlationId,
+          'Content-Type': 'application/json'
         })
-        .catch(done)
-    })
-    it('should return a promise', () => {
-      expect(returnee.constructor).to.equal(Promise)
-    })
-    it('should return a promise that is resolved with the body of the successful request', () => {
-      expect(resolved).to.have.property('result', 'success')
-    })
-    it('request should have been called with correct headers', () => {
-      expect(resolved.requestOptions).to.have.property('headers')
-      expect(resolved.requestOptions.headers).to.deep.equal({
-        'x-request-id': correlationId,
-        'Content-Type': 'application/json'
+
+        expect(requestLogger.logRequestStart.called).to.equal(true)
+        expect(requestLogger.logRequestEnd.called).to.equal(true)
+        expect(requestLogger.logRequestError.called).to.equal(false)
+        expect(requestLogger.logRequestFailure.called).to.equal(false)
       })
     })
-    it('should log the request start and request end but not a request failure or error', () => {
-      expect(requestLogger.logRequestStart.called).to.equal(true)
-      expect(requestLogger.logRequestEnd.called).to.equal(true)
-      expect(requestLogger.logRequestError.called).to.equal(false)
-      expect(requestLogger.logRequestFailure.called).to.equal(false)
-    })
-  })
-  describe('when the request fails', () => {
-    let rejected
-    let returnee
-
-    // Create a stubbed request object
-    function RequestStub () {
-      const self = this
-      events.EventEmitter.call(self)
-      return function (options, callback) {
-        setTimeout(() => {
-          // Emit a response event which is handled in the wrapper to log the response
-          self.emit('response', { statusCode: 404 })
-          // Execute callback to simulate the response from the service
-          callback(null, { statusCode: 404, request: options, body: 'not found' }, 'not found')
-        }, 100)
-        return self
-      }
-    }
-
-    // Wire the EventEmitter into it, so we can emit the event specified above to any watchers
-    util.inherits(RequestStub, events.EventEmitter)
-    before(done => {
-      requestLogger.logRequestStart = sinon.spy()
-      requestLogger.logRequestEnd = sinon.spy()
-      requestLogger.logRequestFailure = sinon.spy()
-      requestLogger.logRequestError = sinon.spy()
-
-      returnee = wrapper(new RequestStub(), 'get')({ url: 'http://example.com/' })
-      returnee
-        .then(done)
-        .catch(err => {
-          rejected = err
-          done()
-        })
-    })
-    it('should return a promise', () => {
-      expect(returnee.constructor).to.equal(Promise)
-    })
-    it('should return a promise that is rejected with an error with a message equal to the response body and an \'errorCode\' property equal to the response code', () => {
-      expect(rejected.constructor).to.equal(Error)
-      expect(rejected.message).to.equal('not found')
-      expect(rejected.errorCode).to.equal(404)
-    })
-    it('should log the request start, end and failure but not a request error', () => {
-      expect(requestLogger.logRequestStart.called).to.equal(true)
-      expect(requestLogger.logRequestEnd.called).to.equal(true)
-      expect(requestLogger.logRequestError.called).to.equal(false)
-      expect(requestLogger.logRequestFailure.called).to.equal(true)
-    })
   })
 
-  describe('when the request errors', () => {
-    let rejected
-    let returnee
+  describe('Request returns non-success response', () => {
+    describe('The request returns a non-success response with text content type', () => {
+      const response = { statusCode: 404 }
+      const responseBody = 'not found'
+      const requestStub = new RequestSuccessStub(response, responseBody)
 
-    // Create a stubbed request object
-    function RequestStub () {
-      const self = this
-      events.EventEmitter.call(self)
-      return function (options, callback) {
-        setTimeout(() => {
-          // Emit an error event which is handled in the wrapper to log the request error
-          self.emit('error', new Error('something simply dreadful happened'))
-          callback(new Error('something simply dreadful happened'))
-        }, 100)
-        return self
+      it('should reject with an error', () => {
+        return expect(wrapper(requestStub, 'get')({ url: 'http://example.com/' }))
+          .to.be.rejected.then(error => {
+            expect(error.constructor).to.equal(RESTClientError)
+            expect(error.message).to.equal('not found')
+            expect(error.errorCode).to.equal(404)
+            expect(error.errorIdentifier).to.equal(undefined)
+            expect(error.reason).to.equal(undefined)
+
+            expect(requestLogger.logRequestStart.called).to.equal(true)
+            expect(requestLogger.logRequestEnd.called).to.equal(true)
+            expect(requestLogger.logRequestError.called).to.equal(false)
+            expect(requestLogger.logRequestFailure.called).to.equal(true)
+          })
+      })
+    })
+
+    describe('The request returns a non-success response with JSON content type containing an "errors" field of type array', () => {
+      const response = { statusCode: 404 }
+      const responseBody = {
+        errors: ['First error', 'Second error'],
+        error_identifier: 'GENERIC',
+        reason: 'a reason'
       }
-    }
+      const requestStub = new RequestSuccessStub(response, responseBody)
 
-    // Wire the EventEmitter into it, so we can emit the event specified above to any watchers
-    util.inherits(RequestStub, events.EventEmitter)
-    before(done => {
-      requestLogger.logRequestStart = sinon.spy()
-      requestLogger.logRequestEnd = sinon.spy()
-      requestLogger.logRequestFailure = sinon.spy()
-      requestLogger.logRequestError = sinon.spy()
-      returnee = wrapper(new RequestStub(), 'get')({ url: 'http://example.com/' })
-      returnee
-        .then(done)
-        .catch(err => {
-          rejected = err
-          done()
+      it('should reject with an error', () => {
+        return expect(wrapper(requestStub, 'get')({ url: 'http://example.com/' }))
+          .to.be.rejected.then(error => {
+            expect(error.constructor).to.equal(RESTClientError)
+            expect(error.message).to.equal('First error, Second error')
+            expect(error.errorCode).to.equal(404)
+            expect(error.errorIdentifier).to.equal('GENERIC')
+            expect(error.reason).to.equal('a reason')
+
+            expect(requestLogger.logRequestStart.called).to.equal(true)
+            expect(requestLogger.logRequestEnd.called).to.equal(true)
+            expect(requestLogger.logRequestError.called).to.equal(false)
+            expect(requestLogger.logRequestFailure.called).to.equal(true)
+          })
+      })
+
+    })
+
+    describe('The request returns a non-success response with JSON content type containing a "message" field of type array', () => {
+      const response = { statusCode: 404 }
+      const responseBody = {
+        message: ['First error', 'Second error'],
+        error_identifier: 'GENERIC',
+        reason: 'a reason'
+      }
+      const requestStub = new RequestSuccessStub(response, responseBody)
+
+      it('should reject with an error', () => {
+        return expect(wrapper(requestStub, 'get')({ url: 'http://example.com/' }))
+          .to.be.rejected.then(error => {
+            expect(error.constructor).to.equal(RESTClientError)
+            expect(error.message).to.equal('First error, Second error')
+            expect(error.errorCode).to.equal(404)
+            expect(error.errorIdentifier).to.equal('GENERIC')
+            expect(error.reason).to.equal('a reason')
+
+            expect(requestLogger.logRequestStart.called).to.equal(true)
+            expect(requestLogger.logRequestEnd.called).to.equal(true)
+            expect(requestLogger.logRequestError.called).to.equal(false)
+            expect(requestLogger.logRequestFailure.called).to.equal(true)
+          })
+      })
+    })
+
+    describe('The request returns a non-success response with JSON content type containing a "message" field of type string', () => {
+      const response = { statusCode: 404 }
+      const responseBody = {
+        message: 'The only error',
+        error_identifier: 'GENERIC',
+        reason: 'a reason'
+      }
+      const requestStub = new RequestSuccessStub(response, responseBody)
+
+      it('should reject with an error', () => {
+        return expect(wrapper(requestStub, 'get')({ url: 'http://example.com/' }))
+          .to.be.rejected.then(error => {
+            expect(error.constructor).to.equal(RESTClientError)
+            expect(error.message).to.equal('The only error')
+            expect(error.errorCode).to.equal(404)
+            expect(error.errorIdentifier).to.equal('GENERIC')
+            expect(error.reason).to.equal('a reason')
+
+            expect(requestLogger.logRequestStart.called).to.equal(true)
+            expect(requestLogger.logRequestEnd.called).to.equal(true)
+            expect(requestLogger.logRequestError.called).to.equal(false)
+            expect(requestLogger.logRequestFailure.called).to.equal(true)
+          })
+      })
+    })
+
+    describe('The request returns a non-success response with no body', () => {
+      const response = { statusCode: 404 }
+      const requestStub = new RequestSuccessStub(response, null)
+
+      it('should reject with an error', () => {
+        return expect(wrapper(requestStub, 'get')({ url: 'http://example.com/' }))
+          .to.be.rejected.then(error => {
+            expect(error.constructor).to.equal(RESTClientError)
+            expect(error.message).to.equal('Unknown error')
+            expect(error.errorCode).to.equal(404)
+            expect(error.errorIdentifier).to.equal(null)
+            expect(error.reason).to.equal(null)
+
+            expect(requestLogger.logRequestStart.called).to.equal(true)
+            expect(requestLogger.logRequestEnd.called).to.equal(true)
+            expect(requestLogger.logRequestError.called).to.equal(false)
+            expect(requestLogger.logRequestFailure.called).to.equal(true)
+          })
+      })
+    })
+  })
+
+  describe('There is an expected error making a request', () => {
+    const requestStub = new RequestErrorStub()
+
+    it('should reject with a generic error', () => {
+      return expect(wrapper(requestStub, 'get')({ url: 'http://example.com/' }))
+        .to.be.rejected.then(error => {
+          expect(error.constructor).to.equal(Error)
+          expect(error.message).to.equal('something simply dreadful happened')
+          expect(error.errorCode).to.equal(undefined)
+
+          expect(requestLogger.logRequestStart.called).to.equal(true)
+          expect(requestLogger.logRequestEnd.called).to.equal(true)
+          expect(requestLogger.logRequestError.called).to.equal(true)
+          expect(requestLogger.logRequestFailure.called).to.equal(false)
         })
-    })
-    it('should return a promise', () => {
-      expect(returnee.constructor).to.equal(Promise)
-    })
-    it('should return a promise that is rejected with the error that the request module returned', () => {
-      expect(rejected.constructor).to.equal(Error)
-      expect(rejected.message).to.equal('something simply dreadful happened')
-      expect(rejected.errorCode).to.equal(undefined)
-    })
-    it('should log the request start, end and error but not a request failure', () => {
-      expect(requestLogger.logRequestStart.called).to.equal(true)
-      expect(requestLogger.logRequestEnd.called).to.equal(true)
-      expect(requestLogger.logRequestError.called).to.equal(true)
-      expect(requestLogger.logRequestFailure.called).to.equal(false)
     })
   })
 })


### PR DESCRIPTION
Introduce a new type which extends Error for representing errors thrown by the REST client. This makes the API of these errors clearer and makes it possible to handle these in a specific way.

Handle uncaught RESTClientErrors in the error handler middleware in order to log more detail about the error.

Rewrite `wrapper.test.js` to be easier to understand.


