### PR TITLE
PP-9984 Switch PSP > Update org details - bug creating Sentry error

### DIFF
--- a/app/controllers/request-to-go-live/organisation-address/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.js
@@ -132,9 +132,9 @@ function validateForm (form, isRequestToGoLive, isStripeSetupUserJourney) {
   return orderedErrors
 }
 
-async function submitForm (form, req, isRequestToGoLive, isStripeSetupUserJourney) {
+async function submitForm (form, req, isRequestToGoLive, isStripeSetupUserJourney, isSwitchingCredentials) {
   if (isStripeSetupUserJourney) {
-    const stripeAccountId = await getStripeAccountId(req.account, false, req.correlationId)
+    const stripeAccountId = await getStripeAccountId(req.account, isSwitchingCredentials, req.correlationId)
 
     const newOrgDetails = {
       name: form[clientFieldNames.name],
@@ -206,7 +206,7 @@ module.exports = async function submitOrganisationAddress (req, res, next) {
     const errors = validateForm(form, isRequestToGoLive, isStripeSetupUserJourney)
 
     if (lodash.isEmpty(errors)) {
-      const updatedService = await submitForm(form, req, isRequestToGoLive, isStripeSetupUserJourney)
+      const updatedService = await submitForm(form, req, isRequestToGoLive, isStripeSetupUserJourney, isSwitchingCredentials)
       if (isStripeUpdateOrgDetails) {
         res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account.external_id))
       } else if (isSwitchingCredentials) {


### PR DESCRIPTION
- Update `post controller`
  - Pass `isSwitchingCredentials` flag correctly when getting the Stripe account id.
  - Add unit tests to check this.
  - General clean up of the unit test.



