### PR TITLE
PP-10047 Render error page for errors updating 2FA method

### DIFF
--- a/app/controllers/user/two-factor-auth/post-configure.controller.test.js
+++ b/app/controllers/user/two-factor-auth/post-configure.controller.test.js
@@ -1,0 +1,127 @@
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+const { expect } = require('chai')
+
+const userFixtures = require('../../../../test/fixtures/user.fixtures')
+const User = require('../../../models/User.class')
+const paths = require('../../../paths')
+const { RESTClientError } = require('../../../errors')
+
+const userExternalId = 'user-id'
+const correlationId = 'correlation-id'
+const twoFactorAuthMethod = 'SMS'
+
+describe('Configure new second factor method post controller', () => {
+  let req, res, next
+  const configureNewOtpKeySpy = sinon.spy(() => Promise.resolve())
+  const controllerWithAdminusersSuccess = getController(configureNewOtpKeySpy)
+
+  beforeEach(() => {
+    req = {
+      correlationId,
+      user: new User(userFixtures.validUserResponse({ external_id: userExternalId })),
+      body: {},
+      flash: sinon.spy(),
+      session: {
+        pageData: {
+          twoFactorAuthMethod
+        }
+      }
+    }
+    res = {
+      redirect: sinon.spy()
+    }
+    next = sinon.spy()
+    configureNewOtpKeySpy.resetHistory()
+  })
+
+  describe('No code is entered', () => {
+    it('should redirect to the GET route with errors in the session', async () => {
+      req.body.code = ''
+
+      await controllerWithAdminusersSuccess(req, res, next)
+
+      sinon.assert.calledWith(res.redirect, paths.user.profile.twoFactorAuth.configure)
+      expect(req.session.pageData).to.have.property('configureTwoFactorAuthMethodRecovered')
+      expect(req.session.pageData.configureTwoFactorAuthMethodRecovered).to.deep.equal({
+        errors: {
+          verificationCode: 'Enter a verification code'
+        }
+      })
+    })
+  })
+
+  describe('A valid code is entered', () => {
+    const validCode = '123456'
+
+    beforeEach(() => {
+      req.body.code = validCode
+    })
+
+    describe('Success response from adminusers', () => {
+      it('should call adminusers to configure OTP key and redirect to profile', async () => {
+        await controllerWithAdminusersSuccess(req, res, next)
+
+        sinon.assert.calledWith(configureNewOtpKeySpy, userExternalId, validCode, twoFactorAuthMethod, correlationId)
+        sinon.assert.calledWith(req.flash, 'otpMethodUpdated', twoFactorAuthMethod)
+        sinon.assert.calledWith(res.redirect, paths.user.profile.index)
+      })
+    })
+
+    describe('Adminusers returns a 400 response', () => {
+      it('should call redirect with errors in session', async () => {
+        const error = new RESTClientError('An error', 'adminusers', 400)
+        const adminusersRejectsStub = () => Promise.reject(error)
+
+        const controllerWithAdminusersError = getController(adminusersRejectsStub)
+        await controllerWithAdminusersError(req, res, next)
+
+        sinon.assert.calledWith(res.redirect, paths.user.profile.twoFactorAuth.configure)
+        expect(req.session.pageData).to.have.property('configureTwoFactorAuthMethodRecovered')
+        expect(req.session.pageData.configureTwoFactorAuthMethodRecovered).to.deep.equal({
+          errors: {
+            verificationCode: 'The verification code you’ve used is incorrect or has expired'
+          }
+        })
+      })
+    })
+
+    describe('Adminusers returns a 401 response', () => {
+      it('should call redirect with errors in session', async () => {
+        const error = new RESTClientError('An error', 'adminusers', 401)
+        const adminusersRejectsStub = () => Promise.reject(error)
+
+        const controllerWithAdminusersError = getController(adminusersRejectsStub)
+        await controllerWithAdminusersError(req, res, next)
+
+        sinon.assert.calledWith(res.redirect, paths.user.profile.twoFactorAuth.configure)
+        expect(req.session.pageData).to.have.property('configureTwoFactorAuthMethodRecovered')
+        expect(req.session.pageData.configureTwoFactorAuthMethodRecovered).to.deep.equal({
+          errors: {
+            verificationCode: 'The verification code you’ve used is incorrect or has expired'
+          }
+        })
+      })
+    })
+
+    describe('Adminusers returns an unhandled error status code', () => {
+      it('should call next with the error', async () => {
+        const error = new RESTClientError('An error', 'adminusers', 500)
+        const adminusersRejectsStub = () => Promise.reject(error)
+
+        const controllerWithAdminusersError = getController(adminusersRejectsStub)
+        await controllerWithAdminusersError(req, res, next)
+
+        sinon.assert.calledWith(next, error)
+      })
+    })
+  })
+})
+
+function getController (configureNewOtpKeySpy) {
+  return proxyquire('./post-configure.controller', {
+    '../../../services/user.service.js': {
+      configureNewOtpKey: configureNewOtpKeySpy
+    }
+  })
+}

--- a/app/controllers/user/two-factor-auth/post-index.controller.js
+++ b/app/controllers/user/two-factor-auth/post-index.controller.js
@@ -2,12 +2,11 @@
 
 const lodash = require('lodash')
 
-const logger = require('../../../utils/logger')(__filename)
 const userService = require('../../../services/user.service.js')
 const paths = require('../../../paths')
 const secondFactorMethod = require('../../../models/second-factor-method')
 
-module.exports = async (req, res) => {
+module.exports = async (req, res, next) => {
   const method = req.body['two-fa-method']
   lodash.set(req, 'session.pageData.twoFactorAuthMethod', method)
 
@@ -21,9 +20,7 @@ module.exports = async (req, res) => {
       }
       return res.redirect(paths.user.profile.twoFactorAuth.configure)
     } catch (err) {
-      logger.error(`Provisioning new OTP key failed - ${err.message}`)
-      req.flash('genericError', 'Something went wrong. Please try again or contact support.')
-      return res.redirect(paths.user.profile.twoFactorAuth.index)
+      next(err)
     }
   }
 }

--- a/app/controllers/user/two-factor-auth/post-index.controller.test.js
+++ b/app/controllers/user/two-factor-auth/post-index.controller.test.js
@@ -78,18 +78,20 @@ describe('Select new second factor method post controller', () => {
   })
 
   describe('There is an error contacting adminusers', () => {
-    it('should redirect to index with flash message', async () => {
+    it('should call next with an error', async () => {
       req.user = new User(userFixtures.validUserResponse({
         external_id: userExternalId
       }))
       req.body['two-fa-method'] = 'APP'
 
-      const adminusersRejectsStub = () => Promise.reject(new Error('Error from adminusers'))
+      const error = new Error('Error from adminusers')
+      const adminusersRejectsStub = () => Promise.reject(error)
       const controllerWithAdminusersError = getController(adminusersRejectsStub, sendProvisionalOtpSpy)
 
       await controllerWithAdminusersError(req, res, next)
-      sinon.assert.calledWith(req.flash, 'genericError', 'Something went wrong. Please try again or contact support.')
-      sinon.assert.calledWith(res.redirect, paths.user.profile.twoFactorAuth.index)
+
+      sinon.assert.calledWith(next, error)
+      sinon.assert.notCalled(res.redirect)
     })
   })
 


### PR DESCRIPTION
Previously, if there were unexpected errors returned by adminusers in
the controllers for updating the second factor method, we redirected the
user back to the "My profile" page and showed an error notification box
at the top of the page.

This is not a pattern we use elsewhere anymore, instead we render an
error page. Make these controllers consistent with behaviour elsewhere
and render an error page.
