### PR TITLE
PP-10269 Fix typos in Stripe onboarding update org details header

### DIFF
--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -11,7 +11,7 @@
 {% if isRequestToGoLive %}
   Enter your organisation’s contact details - Request a live account - {{ currentService.name }} - GOV.UK Pay
 {% elif isStripeSetupUserJourney %}
-  What is the name and address of you organisation on your government identity document? - {{ currentService.name }} - GOV.UK Pay 
+  What is the name and address of your organisation on your government entity document? - {{ currentService.name }} - GOV.UK Pay 
 {% else %}
   Organisation details - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endif %}
@@ -47,7 +47,7 @@
     <h1 class="govuk-heading-l">Enter your organisation’s contact details</h1>
     <p class="govuk-body govuk-!-margin-bottom-6">Your payment pages will automatically display this information. You can change the details later if needed.</p>
   {% elif isStripeSetupUserJourney %}
-    <h1 class="govuk-heading-l">What is the name and address of you organisation on your government identity document?</h1>
+    <h1 class="govuk-heading-l">What is the name and address of your organisation on your government entity document?</h1>
   {% else %}
     <h1 class="govuk-heading-l">Organisation details</h1>
     <p class="govuk-body" id="merchant-details-info">

--- a/test/cypress/integration/stripe-setup/update-org-details.cy.test.js
+++ b/test/cypress/integration/stripe-setup/update-org-details.cy.test.js
@@ -80,7 +80,7 @@ describe('The organisation address page', () => {
         cy.setEncryptedCookies(userExternalId)
         cy.visit(pageUrl)
 
-        cy.get('h1').should('contain', `What is the name and address of you organisation on your government identity document?`)
+        cy.get('h1').should('contain', `What is the name and address of your organisation on your government entity document?`)
 
         cy.get('[data-cy=form]')
           .should('exist')
@@ -199,7 +199,7 @@ describe('The organisation address page', () => {
         cy.setEncryptedCookies(userExternalId)
         cy.visit(pageUrl)
 
-        cy.get('h1').should('contain', `What is the name and address of you organisation on your government identity document?`)
+        cy.get('h1').should('contain', `What is the name and address of your organisation on your government entity document?`)
 
         cy.get('[data-cy=form]')
           .should('exist')


### PR DESCRIPTION
Change ‘you’ to ‘your’ and ‘identity’ to ‘entity’.

Before:
![image](https://user-images.githubusercontent.com/24316348/199014444-d0cf933d-6fed-4e67-a3be-43de3f4f58d1.png)

After:
![image](https://user-images.githubusercontent.com/24316348/199014541-a0f9ff88-9fe6-4883-9c80-39c15b13c52e.png)



