### PR TITLE
PP-10198 Validate merchant account code for MOTO and non-MOTO accounts

### DIFF
--- a/app/controllers/credentials/worldpay.controller.js
+++ b/app/controllers/credentials/worldpay.controller.js
@@ -34,6 +34,16 @@ async function updateWorldpayCredentials (req, res, next) {
     const credential = getCredentialByExternalId(req.account, req.params.credentialId)
     const results = credentialsForm.validate(req.body)
 
+    if (!results.errorSummaryList.length) {
+      const merchantId = req.body.merchantId
+      if (req.account.allow_moto && !merchantId.endsWith('MOTO')) {
+        results.errors.merchantId = 'Enter a MOTO merchant code. MOTO payments are enabled for the account'
+      } else if (!req.account.allow_moto && merchantId.endsWith('MOTO')) {
+        results.errors.merchantId = 'MOTO merchant code not allowed. Please contact support if you would like MOTO payments enabled'
+      }
+      results.errorSummaryList = formatErrorsForSummaryList(results.errors)
+    }
+
     if (results.errorSummaryList.length) {
       return response(req, res, 'credentials/worldpay', { form: results, isSwitchingCredentials, credential })
     }

--- a/app/controllers/your-psp/get.controller.js
+++ b/app/controllers/your-psp/get.controller.js
@@ -20,6 +20,7 @@ module.exports = async (req, res, next) => {
       req.account.worldpay_3ds_flex.organisational_unit_id.length > 0
 
     const is3dsEnabled = req.account.requires3ds === true
+    const isMotoEnabled = req.account.allow_moto === true
 
     let stripeData = {}
     if (activeCredential && activeCredential.payment_provider === 'stripe') {
@@ -40,6 +41,7 @@ module.exports = async (req, res, next) => {
       switchedProvider,
       isAccountCredentialsConfigured,
       is3dsEnabled,
+      isMotoEnabled,
       isWorldpay3dsFlexEnabled,
       isWorldpay3dsFlexCredentialsConfigured,
       ...stripeData,

--- a/app/views/your-psp/index.njk
+++ b/app/views/your-psp/index.njk
@@ -49,7 +49,9 @@
 
   {% if credential.payment_provider === "worldpay" %}
     {% include "./_worldpay.njk" %}
-    {% include "./_worldpay-flex.njk" %}
+    {% if not isMotoEnabled %}
+      {% include "./_worldpay-flex.njk" %}
+    {% endif %}
   {% endif %}
   {% if credential.payment_provider === "smartpay" %}
     {% include "./_smartpay.njk" %}


### PR DESCRIPTION
## WHAT
- Added validation to allow merchant IDs ending with MOTO only for moto enabled accounts, and allow non-MOTO IDs for non-moto accounts
