### PR TITLE
PP-10037 GA redact any freely editable transaction search predicate

### DIFF
--- a/app/browsered/analytics.js
+++ b/app/browsered/analytics.js
@@ -26,11 +26,15 @@ function setupAnalytics () {
   ga('govuk_shared.send', 'pageview')
 }
 
-function getPathWithoutPII(){
-  var email_regex = /&email=([^\s=/?&]+(?:@|%40)[^\s=/?&]+)/gi;
+function getPathWithoutPII() {
+  var openTextFieldsInQueryString = [ 'reference', 'email', 'cardholdername', 'metadatavalue' ]
+  var queryStringKeyValuePairRegex = new RegExp(
+    '(' + openTextFieldsInQueryString.join('|') + ')=([^&]+)',
+    'gi'
+  )
 
   return document.location.pathname +
-    document.location.search.replace(email_regex, '&email=')
+    document.location.search.replace(queryStringKeyValuePairRegex, '$1=USER_PROVIDED_VALUE_WAS_REMOVED')
 }
 
 module.exports.init = () => {


### PR DESCRIPTION
The current method for stripping PII from the domain passed through to Google Analytics was to strip the email query string, if it existed.

These pages have been excluded from Google Analytics as users sometime mistakenly enter PII (email addresses) into other freely editable search fields like `reference`.

In addition, partial email addresses were allowed thorugh as the regex has a specific name @ domain . suffix group.

In order to allow these pages to go back through Google Analytics:

- Instead of removing values, replace them redacted text, this will give an idea of the frequency these fields are used
- Redact any fields that the user can freely input text for as users may put PII in these in error
- Don't just replace the email field, include other fields that could contain PII

