### PR TITLE
PP-10037 Fix google analytics set path

### DIFF
--- a/app/browsered/analytics.js
+++ b/app/browsered/analytics.js
@@ -21,7 +21,7 @@ function setupAnalytics () {
   ga('govuk_shared.linker.set', 'anonymizeIp', true)
   ga('govuk_shared.linker:autoLink', ['www.gov.uk'])
 
-  ga('set', 'page', getPathWithoutPII())
+  ga('set', 'location', getPathWithoutPII())
   ga('send', 'pageview')
   ga('govuk_shared.send', 'pageview')
 }
@@ -33,8 +33,7 @@ function getPathWithoutPII() {
     'gi'
   )
 
-  return document.location.pathname +
-    document.location.search.replace(queryStringKeyValuePairRegex, '$1=USER_PROVIDED_VALUE_WAS_REMOVED')
+  return document.location.href.replace(queryStringKeyValuePairRegex, '$1=USER_PROVIDED_VALUE_WAS_REMOVED')
 }
 
 module.exports.init = () => {

--- a/test/unit/browsered/analytics.test.js
+++ b/test/unit/browsered/analytics.test.js
@@ -25,20 +25,20 @@ describe('analytics setup', () => {
     expect(ga.getCall(5).calledWith('govuk_shared.require', 'linker')).equals(true)
     expect(ga.getCall(6).calledWith('govuk_shared.linker.set', 'anonymizeIp')).equals(true)
     expect(ga.getCall(7).calledWith('govuk_shared.linker:autoLink', ['www.gov.uk'])).equals(true)
-    expect(ga.getCall(8).calledWith('set', 'page', '/search?from_date=2020-01-01')).equals(true)
+    expect(ga.getCall(8).calledWith('set', 'location', 'https://selfservice.service.payments.gov.uk/search?from_date=2020-01-01')).equals(true)
   })
 
   describe('filter PII', () => {
     it('should redact fields where the user can freely enter text', () => {
       setupWindow('https://selfservice.service.payments.gov.uk/search?fromDate=2020-01-01&email=test@example.test&toDate=2020-01-01&reference=a-unique-reference&lastDigitsCardNumber=1234&cardholderName=A+Test+User')
       analytics.setupAnalytics()
-      sinon.assert.calledWith(ga, 'set', 'page', '/search?fromDate=2020-01-01&email=USER_PROVIDED_VALUE_WAS_REMOVED&toDate=2020-01-01&reference=USER_PROVIDED_VALUE_WAS_REMOVED&lastDigitsCardNumber=1234&cardholderName=USER_PROVIDED_VALUE_WAS_REMOVED')
+      sinon.assert.calledWith(ga, 'set', 'location', 'https://selfservice.service.payments.gov.uk/search?fromDate=2020-01-01&email=USER_PROVIDED_VALUE_WAS_REMOVED&toDate=2020-01-01&reference=USER_PROVIDED_VALUE_WAS_REMOVED&lastDigitsCardNumber=1234&cardholderName=USER_PROVIDED_VALUE_WAS_REMOVED')
     })
 
     it('should do nothing if freely editable fields are not used', () => {
       setupWindow('https://selfservice.service.payments.gov.uk/search?fromDate=2020-01-01&email=&toDate=2020-01-01&reference=&cardholderName=')
       analytics.setupAnalytics()
-      sinon.assert.calledWith(ga, 'set', 'page', '/search?fromDate=2020-01-01&email=&toDate=2020-01-01&reference=&cardholderName=')
+      sinon.assert.calledWith(ga, 'set', 'location', 'https://selfservice.service.payments.gov.uk/search?fromDate=2020-01-01&email=&toDate=2020-01-01&reference=&cardholderName=')
     })
   })
 })


### PR DESCRIPTION
We were previously setting the 'path' attribute on Google Analytics, this is submitted with a `dp=` attribute and had appropriately redacted values, however the full location is also sent through `dl=` which didn't included the full url.

These fields are documented
https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#location.

The "Document Path" which we were previously setting seems to be set up for "specify virtual page paths.", as we have no dynamic or client side managed navigation, "Document Location" feels like the appropriate place to redact and send this information.

Set the 'location' attribute instead to ensure everything that is sent to GA is appropriately redacted.

Any pages which may be impacted have been filtered out of GA until this ticket had been addressed.

