### PR TITLE
PP-9984 - Switch PSP Stripe > Check org details - click 'yes' bug

### DIFF
--- a/app/controllers/stripe-setup/check-org-details/post.controller.js
+++ b/app/controllers/stripe-setup/check-org-details/post.controller.js
@@ -53,7 +53,7 @@ module.exports = async function postCheckOrgDetails (req, res, next) {
 
   if (confirmOrgDetails === 'yes') {
     try {
-      const stripeAccountId = await getStripeAccountId(req.account, false)
+      const stripeAccountId = await getStripeAccountId(req.account, isSwitchingCredentials)
 
       await connector.setStripeAccountSetupFlag(req.account.gateway_account_id, 'organisation_details')
 


### PR DESCRIPTION
- Post controller
  - Correctly pass the `isSwitchingCredentials` flag when getting the Stripe account ID.
- Add a check in the unit test to check for this.


