### PR TITLE
PP-10038: Include 2FA method in invite complete requests

### DIFF
--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -371,7 +371,9 @@ module.exports = function (clientOptions = {}) {
         baseUrl,
         url: `/v1/api/invites/${inviteCode}/complete`,
         json: true,
-        body: {},
+        body: {
+          second_factor: 'SMS'
+        },
         description: 'complete invite',
         service: SERVICE_NAME
       }

--- a/test/fixtures/invite.fixtures.js
+++ b/test/fixtures/invite.fixtures.js
@@ -95,7 +95,9 @@ module.exports = {
   },
 
   validInviteCompleteRequest: (opts = {}) => {
-    return {}
+    return {
+      second_factor: 'SMS'
+    }
   },
 
   validInviteCompleteResponse: (opts = {}) => {


### PR DESCRIPTION
* Send `second_factor` parameter in body of requests the `/v1/api/invites/${inviteCode}/complete` adminusers endpoint
* Currently this will always be set to 'SMS'; this will be changed later.