### PR TITLE
BAU Fix validation that invited user is logged in user

### DIFF
--- a/app/controllers/register-user.controller.js
+++ b/app/controllers/register-user.controller.js
@@ -47,7 +47,7 @@ const subscribeService = async function subscribeService (req, res, next) {
 
   const inviteCode = sessionData.code
 
-  if (sessionData.email !== req.user.email) {
+  if (sessionData.email.toLowerCase() !== req.user.email.toLowerCase()) {
     logger.info('Attempt to accept invite for a different user', {
       invite_code: inviteCode
     })


### PR DESCRIPTION
We have some validation to check that when a user clicks a link to invite an existing user from the invite email, that the invite is for them before accepting it. Without this, it was possible for a logged in user to accept an invite on behalf of a different user if they knew what the invite code was.

This validation was doing a case sensitive check that the email on the invite was the same as the user's email. However, emails should be case insensitive, and this was causing invites not to work for users when the email entered for the invite had a different case to the email on their account.

Make this check case insensitive.