### PR TITLE
PP-10244 Render "My services" page for no services

### DIFF
--- a/app/controllers/my-services/get-index.controller.js
+++ b/app/controllers/my-services/get-index.controller.js
@@ -56,7 +56,10 @@ module.exports = async function getServiceList (req, res) {
   const aggregatedGatewayAccountIds = servicesRoles
     .flatMap(servicesRole => servicesRole.service.gatewayAccountIds)
 
-  const aggregatedGatewayAccounts = await serviceService.getGatewayAccounts(aggregatedGatewayAccountIds)
+  let aggregatedGatewayAccounts = []
+  if (aggregatedGatewayAccountIds.length) {
+    aggregatedGatewayAccounts = await serviceService.getGatewayAccounts(aggregatedGatewayAccountIds)
+  }
   const servicesData = servicesRoles
     .map(serviceRole => {
       const gatewayAccounts = aggregatedGatewayAccounts.filter(gatewayAccount =>

--- a/app/views/services/index.njk
+++ b/app/views/services/index.njk
@@ -70,34 +70,38 @@
     {% endif %}
 
     <h1 class="govuk-heading-l govuk-!-margin-bottom-6">Overview</h1>
-
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-6">Reports</h2>
-
-    {% set allServiceTransactionsPath = routes.allServiceTransactions.index if has_live_account else
-      routes.formattedPathFor(routes.allServiceTransactions.indexStatusFilter, 'test') %}
-
-    <p class="govuk-body">
-      <a href="{{ allServiceTransactionsPath }}" class="govuk-link govuk-!-margin-right-3 govuk-link--no-visited-state govuk-!-font-weight-bold">
-        View transactions for all your services
-      </a>
-    </p>
-
-    {% set payoutsPath = routes.payouts.list if has_live_account else
-      routes.formattedPathFor(routes.payouts.listStatusFilter, 'test') %}
-
-    {% if has_account_with_payouts %}
-      <p class="govuk-body">
-        <a href="{{ payoutsPath }}" class="govuk-link govuk-!-margin-right-3 govuk-link--no-visited-state govuk-!-font-weight-bold">
-          View payments to your bank account
-        </a>
-      </p>
-    {% endif %}
-
   </div>
 
-  <div class="govuk-grid-column-full">
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible overview-divider">
-  </div>
+  {% if services.length %}
+    <div class="govuk-grid-column-two-thirds" data-cy="reports-section">
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-6">Reports</h2>
+
+        {% set allServiceTransactionsPath = routes.allServiceTransactions.index if has_live_account else
+          routes.formattedPathFor(routes.allServiceTransactions.indexStatusFilter, 'test') %}
+
+        <p class="govuk-body">
+          <a href="{{ allServiceTransactionsPath }}" class="govuk-link govuk-!-margin-right-3 govuk-link--no-visited-state govuk-!-font-weight-bold">
+            View transactions for all your services
+          </a>
+        </p>
+
+        {% set payoutsPath = routes.payouts.list if has_live_account else
+          routes.formattedPathFor(routes.payouts.listStatusFilter, 'test') %}
+
+        {% if has_account_with_payouts %}
+          <p class="govuk-body">
+            <a href="{{ payoutsPath }}" class="govuk-link govuk-!-margin-right-3 govuk-link--no-visited-state govuk-!-font-weight-bold">
+              View payments to your bank account
+            </a>
+          </p>
+        {% endif %}
+
+    </div>
+
+    <div class="govuk-grid-column-full" data-cy="divider">
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible overview-divider">
+    </div>
+  {% endif %}
 
   <div class="govuk-grid-column-two-thirds">
 
@@ -111,22 +115,31 @@
         }) }}
     </p>
 
-    {% if services.length > 7 %}
-      <div class="js-show flex-grid--row">
-        <div class="flex-grid--column-two-thirds tight">
-          <label class="govuk-label" for="service-filter">Filter services</label>
-          <div id="service-filter-container" class="autocomplete-container"></div>
+    {% if services.length %}
+      {% if services.length > 7 %}
+        <div class="js-show flex-grid--row" data-cy="service-filter">
+          <div class="flex-grid--column-two-thirds tight">
+            <label class="govuk-label" for="service-filter">Filter services</label>
+            <div id="service-filter-container" class="autocomplete-container"></div>
+          </div>
+          <div class="flex-grid--column-third tight">
+            <button class="govuk-link pay-button--as-link govuk-!-margin-top-7" id="clear-filters">Clear filter</button>
+          </div>
         </div>
-        <div class="flex-grid--column-third tight">
-          <button class="govuk-link pay-button--as-link govuk-!-margin-top-7" id="clear-filters">Clear filter</button>
-        </div>
-      </div>
-    {% endif %}
+      {% endif %}
 
-    <div class="flex-grid">
-      {% for service in services %}
-        {% include "./_service-section.njk" %}
-      {% endfor %}
-    </div>
+      <div class="flex-grid" data-cy="service-list">
+        {% for service in services %}
+          {% include "./_service-section.njk" %}
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="govuk-body">
+        You do not have any services set up at the moment. Either
+        <a href="{{ routes.serviceSwitcher.create }}" class="govuk-link govuk-link--no-visited-state">create a new one</a>
+        or contact an administrator of an existing service to be added to it.
+      </p>
+  {% endif %}
+
   </div>
 {% endblock %}

--- a/test/cypress/integration/my-services/my-services.cy.test.js
+++ b/test/cypress/integration/my-services/my-services.cy.test.js
@@ -8,9 +8,78 @@ const authenticatedUserId = 'authenticated-user-id'
 
 function getUserAndAccountStubs (type, paymentProvider) {
   return [userStubs.getUserSuccess({ userExternalId: authenticatedUserId, gatewayAccountId: '1' }),
-    gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId: '1', type, paymentProvider, requiresAdditionalKycData: true })
+    gatewayAccountStubs.getGatewayAccountsSuccess({
+      gatewayAccountId: '1',
+      type,
+      paymentProvider,
+      requiresAdditionalKycData: true
+    })
   ]
 }
+
+describe('The user has fewer than 8 services', () => {
+  it('should show the reports section and list services, but not display the service filter', () => {
+    cy.task('setupStubs', getUserAndAccountStubs('live', 'sandbox'))
+    cy.setEncryptedCookies(authenticatedUserId)
+
+    cy.visit('/my-services')
+
+    cy.get('h1').should('contain', 'Overview')
+    cy.get('[data-cy=reports-section]').should('exist')
+    cy.get('[data-cy=divider]').should('exist')
+    cy.get('[data-cy=service-list]').should('exist')
+
+    cy.get('[data-cy=service-filter]').should('not.exist')
+    cy.get('p').contains('You do not have any services').should('not.exist')
+  })
+})
+
+describe('The user has 8 services', () => {
+  it('should show the services filter', () => {
+    cy.task('setupStubs', [
+      userStubs.getUserSuccessWithMultipleServices(authenticatedUserId, [
+        { serviceName: 'Service 1', gatewayAccountIds: ['1'] },
+        { serviceName: 'Service 2', gatewayAccountIds: ['2'] },
+        { serviceName: 'Service 3', gatewayAccountIds: ['3'] },
+        { serviceName: 'Service 4', gatewayAccountIds: ['4'] },
+        { serviceName: 'Service 5', gatewayAccountIds: ['5'] },
+        { serviceName: 'Service 6', gatewayAccountIds: ['6'] },
+        { serviceName: 'Service 7', gatewayAccountIds: ['7'] },
+        { serviceName: 'Service 8', gatewayAccountIds: ['8'] }
+      ]),
+      gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
+        { gatewayAccountId: 1 },
+        { gatewayAccountId: 2 },
+        { gatewayAccountId: 3 },
+        { gatewayAccountId: 4 },
+        { gatewayAccountId: 5 },
+        { gatewayAccountId: 6 },
+        { gatewayAccountId: 7 },
+        { gatewayAccountId: 8 }
+      ])
+    ])
+    cy.setEncryptedCookies(authenticatedUserId)
+
+    cy.visit('/my-services')
+    cy.get('[data-cy=service-filter]').should('exist')
+  })
+})
+
+describe('The user does not have any services', () => {
+  it('should not display reports or service list', () => {
+    cy.task('setupStubs', [userStubs.getUserSuccessWithNoServices(authenticatedUserId)])
+    cy.setEncryptedCookies(authenticatedUserId)
+
+    cy.visit('/my-services')
+
+    cy.get('h1').should('contain', 'Overview')
+    cy.get('[data-cy=reports-section]').should('not.exist')
+    cy.get('[data-cy=divider]').should('not.exist')
+    cy.get('[data-cy=service-filter]').should('not.exist')
+    cy.get('[data-cy=service-list]').should('not.exist')
+    cy.get('p').contains('You do not have any services').should('exist')
+  })
+})
 
 describe('Service has a live account that supports payouts', () => {
   beforeEach(() => {

--- a/test/cypress/stubs/user-stubs.js
+++ b/test/cypress/stubs/user-stubs.js
@@ -26,6 +26,10 @@ function getUserSuccess (opts) {
   return buildGetUserSuccessStub(opts.userExternalId, fixtureOpts)
 }
 
+function getUserSuccessWithNoServices (externalId) {
+  return buildGetUserSuccessStub(externalId, { service_roles: [] })
+}
+
 function getUserSuccessWithMultipleServices (externalId, serviceRoles) {
   const serviceRoleFixtureOpts = serviceRoles.map(buildServiceRoleOpts)
   const fixtureOpts = {
@@ -248,6 +252,7 @@ module.exports = {
   buildGetUserSuccessStub,
   getUserSuccess,
   getUsersSuccess,
+  getUserSuccessWithNoServices,
   getUserWithNoPermissions,
   getUserSuccessWithServiceRole,
   getUserWithServiceRoleStubOpts,


### PR DESCRIPTION
A user can be a member of no services if they have been removed from all services they were a member of. Currently the controller for showing the "My services" page throws an error if the user is a member of no services and an error page is rendered.

Fix this so that the controller does not throw an error, and the page is rendered. The rendered page does not include the "Reports" section and has an additional paragraph instructing the user on what to do next.

Add some additional Cypress tests to check we're displaying the "My services" page correctly in different scenarios.

## Review note

Hiding whitespace changes in the diff should make it easier to see what's changed in the template.

## Page

<img width="1306" alt="Screenshot 2022-11-08 at 16 13 31" src="https://user-images.githubusercontent.com/5648592/200617611-b9dc70ab-fb32-4ef0-971e-b46d784a2171.png">


