### PR TITLE
PP-10116 update secrets baseline, pre-commit conf

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,14 @@ permissions:
   contents: read
 
 jobs:
+  detect-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - name: Detect secrets
+        uses: alphagov/pay-ci/actions/detect-secrets@master
+
   version:
     runs-on: ubuntu-latest
     name: Parse versions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
-- repo: https://github.com/Yelp/detect-secrets
-  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
-  hooks:
-    - id: detect-secrets
-      args: ['--baseline', '.secrets.baseline']
-      exclude: package.lock.json
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args: [ '--baseline', '.secrets.baseline' ]
+        exclude: ^package-lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,11 +1,14 @@
 {
-  "version": "1.1.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
     },
     {
       "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
     },
     {
       "name": "Base64HighEntropyString",
@@ -18,8 +21,14 @@
       "name": "CloudantDetector"
     },
     {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
-      "limit": 3
+      "limit": 3.0
     },
     {
       "name": "IbmCloudIamDetector"
@@ -38,13 +47,22 @@
       "name": "MailchimpDetector"
     },
     {
+      "name": "NpmDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
     },
     {
       "name": "SlackDetector"
     },
     {
       "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
     },
     {
       "name": "StripeDetector"
@@ -56,10 +74,6 @@
   "filters_used": [
     {
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -91,33 +105,9 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.regex.should_exclude_file",
-      "pattern": [
-        "package-lock.json"
-      ]
     }
   ],
   "results": {
-    ".pre-commit-config.yaml": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".pre-commit-config.yaml",
-        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
-        "is_verified": false,
-        "line_number": 3
-      }
-    ],
-    "app/browsered/field-validation-checks.js": [
-      {
-        "type": "Secret Keyword",
-        "filename": "app/browsered/field-validation-checks.js",
-        "hashed_secret": "69c8d31085756bfd34bb8ca6d393289374b7d7c2",
-        "is_verified": false,
-        "line_number": 17
-      }
-    ],
     "app/controllers/credentials.controller.test.js": [
       {
         "type": "Secret Keyword",
@@ -127,14 +117,59 @@
         "line_number": 45
       }
     ],
+    "app/controllers/login/login-get.controller.js": [
+      {
+        "type": "Secret Keyword",
+        "filename": "app/controllers/login/login-get.controller.js",
+        "hashed_secret": "f2bdcadcf8d49d63835d1849f397c42a74e4d811",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
     "app/controllers/your-psp/worldpay-3ds-flex-validations.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "app/controllers/your-psp/worldpay-3ds-flex-validations.test.js",
+        "hashed_secret": "455151f5f2ca3b6b2d441e67eb1aa52a57c26a3d",
+        "is_verified": false,
+        "line_number": 10
+      },
       {
         "type": "Hex High Entropy String",
         "filename": "app/controllers/your-psp/worldpay-3ds-flex-validations.test.js",
         "hashed_secret": "379f1968f09d8a343338667844e01a2f433f0a3f",
         "is_verified": false,
-        "line_number": 25,
-        "is_secret": false
+        "line_number": 25
+      }
+    ],
+    "app/utils/validation/field-validation-checks-worldpay-3ds-flex.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "app/utils/validation/field-validation-checks-worldpay-3ds-flex.test.js",
+        "hashed_secret": "15b2c9b424ee41a90212461ec7231d9230200920",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "app/utils/validation/field-validation-checks-worldpay-3ds-flex.test.js",
+        "hashed_secret": "5eb946d796f4977105bed7a581b149fe085239d0",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "app/utils/validation/field-validation-checks-worldpay-3ds-flex.test.js",
+        "hashed_secret": "fe51df43f7b477a219f12f2eaea89e2baa4b5a21",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "app/utils/validation/field-validation-checks-worldpay-3ds-flex.test.js",
+        "hashed_secret": "345d3214d7921c9fd9db82a8f5f8d29d681a4a45",
+        "is_verified": false,
+        "line_number": 27
       }
     ],
     "app/views/transactions/index.njk": [
@@ -143,76 +178,379 @@
         "filename": "app/views/transactions/index.njk",
         "hashed_secret": "c12ec67dcf1e1939e1039d414d56a59c2c49cc87",
         "is_verified": false,
-        "line_number": 21,
-        "is_secret": false
+        "line_number": 21
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/views/transactions/index.njk",
         "hashed_secret": "e0eb70ddc8098d113dc566a9dc85c0e6a44de8d8",
         "is_verified": false,
-        "line_number": 22,
-        "is_secret": false
+        "line_number": 22
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/views/transactions/index.njk",
         "hashed_secret": "6ee3b2a2f5eaeadb06c1dda26270cd1032420e79",
         "is_verified": false,
-        "line_number": 23,
-        "is_secret": false
+        "line_number": 23
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/views/transactions/index.njk",
         "hashed_secret": "2568e4443a80c3aaed753e6eecfa9dc742187ad9",
         "is_verified": false,
-        "line_number": 24,
-        "is_secret": false
+        "line_number": 24
+      }
+    ],
+    "test/cypress/integration/all-service-transactions/all-service-transactions.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/all-service-transactions/all-service-transactions.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "test/cypress/integration/dashboard/dashboard-disabled-account-banner.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/dashboard/dashboard-disabled-account-banner.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "test/cypress/integration/dashboard/dashboard-kyc-add-details.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/dashboard/dashboard-kyc-add-details.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ],
+    "test/cypress/integration/dashboard/dashboard-links.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/dashboard/dashboard-links.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "test/cypress/integration/dashboard/dashboard-statistics.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/dashboard/dashboard-statistics.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ],
+    "test/cypress/integration/demo-payment/demo-payment.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/demo-payment/demo-payment.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 4
+      }
+    ],
+    "test/cypress/integration/index/index.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/index/index.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 6
+      }
+    ],
+    "test/cypress/integration/my-services/organisation-details.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/my-services/organisation-details.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    "test/cypress/integration/request-psp-test-account/index.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/request-psp-test-account/index.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/request-psp-test-account/index.cy.test.js",
+        "hashed_secret": "631e4be72b31b1013671549f5f5daf2140c52293",
+        "is_verified": false,
+        "line_number": 6
+      }
+    ],
+    "test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 5
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.test.js",
+        "hashed_secret": "631e4be72b31b1013671549f5f5daf2140c52293",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "test/cypress/integration/request-to-go-live/index.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/request-to-go-live/index.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 6
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/request-to-go-live/index.cy.test.js",
+        "hashed_secret": "631e4be72b31b1013671549f5f5daf2140c52293",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "test/cypress/integration/settings/allow-apple-pay.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/settings/allow-apple-pay.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 4
+      }
+    ],
+    "test/cypress/integration/settings/allow-google-pay.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/settings/allow-google-pay.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 4
+      }
+    ],
+    "test/cypress/integration/settings/default-billing-address-country.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/settings/default-billing-address-country.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    "test/cypress/integration/settings/email-notifications.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/settings/email-notifications.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 4
+      }
+    ],
+    "test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "test/cypress/integration/settings/payment-types.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/settings/payment-types.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "test/cypress/integration/settings/switch-psp.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/settings/switch-psp.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "test/cypress/integration/settings/verify-psp-integration.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/settings/verify-psp-integration.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "test/cypress/integration/settings/your-psp-stripe-kyc.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/settings/your-psp-stripe-kyc.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 9
       }
     ],
     "test/cypress/integration/settings/your-psp.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/settings/your-psp.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 7
+      },
       {
         "type": "Secret Keyword",
         "filename": "test/cypress/integration/settings/your-psp.cy.test.js",
         "hashed_secret": "d0be4e729498f4cfe8a72a28d4fceae35bd8bb27",
         "is_verified": false,
-        "line_number": 17,
-        "is_secret": false
+        "line_number": 17
       },
       {
         "type": "Secret Keyword",
         "filename": "test/cypress/integration/settings/your-psp.cy.test.js",
         "hashed_secret": "2c877f34a0f47f32a5f3c77e398938b3cdc32221",
         "is_verified": false,
-        "line_number": 22,
-        "is_secret": false
+        "line_number": 27
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/settings/your-psp.cy.test.js",
         "hashed_secret": "379f1968f09d8a343338667844e01a2f433f0a3f",
         "is_verified": false,
-        "line_number": 26,
-        "is_secret": false
+        "line_number": 31
+      }
+    ],
+    "test/cypress/integration/switch-psp/organisation-url.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/switch-psp/organisation-url.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 9
+      }
+    ],
+    "test/cypress/integration/transactions/transaction-details.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/transactions/transaction-details.cy.test.js",
+        "hashed_secret": "b6074fd0f44e42c49b7e514ee0994af8c8d3e24c",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/transactions/transaction-details.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 104
+      }
+    ],
+    "test/cypress/integration/transactions/transaction-list-pagination.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/transactions/transaction-list-pagination.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "test/cypress/integration/transactions/transaction-search.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/transactions/transaction-search.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "test/cypress/integration/user/change-sign-in-method.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/user/change-sign-in-method.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
+    "test/cypress/integration/user/edit-phone-number.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/user/edit-phone-number.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 4
       }
     ],
     "test/cypress/integration/user/login.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/user/login.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 6
+      },
       {
         "type": "Secret Keyword",
         "filename": "test/cypress/integration/user/login.cy.test.js",
         "hashed_secret": "14ed559063e41d9489e9aea395832aac3264766a",
         "is_verified": false,
-        "line_number": 8,
-        "is_secret": false
+        "line_number": 8
       },
       {
         "type": "Secret Keyword",
         "filename": "test/cypress/integration/user/login.cy.test.js",
         "hashed_secret": "b46b81d428e0a55824ce81c1e451afc784372c25",
         "is_verified": false,
-        "line_number": 9,
-        "is_secret": false
+        "line_number": 9
+      }
+    ],
+    "test/cypress/integration/user/my-profile.cy.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/user/my-profile.cy.test.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 4
+      }
+    ],
+    "test/cypress/utils/request-to-go-live-utils.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/utils/request-to-go-live-utils.js",
+        "hashed_secret": "631e4be72b31b1013671549f5f5daf2140c52293",
+        "is_verified": false,
+        "line_number": 11
+      }
+    ],
+    "test/fixtures/gateway-account.fixtures.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/fixtures/gateway-account.fixtures.js",
+        "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
+        "is_verified": false,
+        "line_number": 274
       }
     ],
     "test/fixtures/invite.fixtures.js": [
@@ -221,26 +559,30 @@
         "filename": "test/fixtures/invite.fixtures.js",
         "hashed_secret": "c2326bf719e924050321d3adb8d8d3a99723ee95",
         "is_verified": false,
-        "line_number": 85,
-        "is_secret": false
+        "line_number": 85
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/fixtures/invite.fixtures.js",
         "hashed_secret": "e5a7431b27dbc70d00c5ed873bd4d837bd65720c",
         "is_verified": false,
-        "line_number": 92,
-        "is_secret": false
+        "line_number": 92
       }
     ],
     "test/integration/forgotten-password.ft.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/integration/forgotten-password.ft.test.js",
+        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
+        "is_verified": false,
+        "line_number": 123
+      },
       {
         "type": "Secret Keyword",
         "filename": "test/integration/forgotten-password.ft.test.js",
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_verified": false,
-        "line_number": 181,
-        "is_secret": false
+        "line_number": 181
       },
       {
         "type": "Secret Keyword",
@@ -265,61 +607,48 @@
         "filename": "test/integration/register-user.controller.ft.test.js",
         "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
         "is_verified": false,
-        "line_number": 118,
-        "is_secret": false
+        "line_number": 118
       }
     ],
-    "test/ui/login.ui.test.js": [
-      {
-        "type": "Secret Keyword",
-        "filename": "test/ui/login.ui.test.js",
-        "hashed_secret": "0a6f4e1251c72c635e2bdfc6e1aa46d336d80d4f",
-        "is_verified": false,
-        "line_number": 13
-      }
-    ],
-    "test/unit/browsered/field-validation-checks-worldpay-3ds-flex.test.js": [
+    "test/integration/self-registration/self-registration-otp-verify.ft.test.js": [
       {
         "type": "Hex High Entropy String",
-        "filename": "test/unit/browsered/field-validation-checks-worldpay-3ds-flex.test.js",
-        "hashed_secret": "15b2c9b424ee41a90212461ec7231d9230200920",
+        "filename": "test/integration/self-registration/self-registration-otp-verify.ft.test.js",
+        "hashed_secret": "4def56874fa19eaaba377aa6ed3cdf5d70bd2c59",
         "is_verified": false,
-        "line_number": 33,
-        "is_secret": false
+        "line_number": 29
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/unit/browsered/field-validation-checks-worldpay-3ds-flex.test.js",
-        "hashed_secret": "6b5a612c10a8d0809d4fb09c638e1a6495823bb2",
+        "filename": "test/integration/self-registration/self-registration-otp-verify.ft.test.js",
+        "hashed_secret": "73fab36036653ebf81d45c017039d0be4bc59e64",
         "is_verified": false,
-        "line_number": 37,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "test/unit/browsered/field-validation-checks-worldpay-3ds-flex.test.js",
-        "hashed_secret": "fe51df43f7b477a219f12f2eaea89e2baa4b5a21",
-        "is_verified": false,
-        "line_number": 41,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "test/unit/browsered/field-validation-checks-worldpay-3ds-flex.test.js",
-        "hashed_secret": "345d3214d7921c9fd9db82a8f5f8d29d681a4a45",
-        "is_verified": false,
-        "line_number": 45,
-        "is_secret": false
+        "line_number": 30
       }
     ],
-    "test/unit/browsered/field-validation-checks.test.js": [
+    "test/integration/self-registration/self-registration-service-naming.ft.test.js": [
       {
         "type": "Hex High Entropy String",
-        "filename": "test/unit/browsered/field-validation-checks.test.js",
-        "hashed_secret": "0780c2a5237c0cdb830303326fb6c33c8297b876",
+        "filename": "test/integration/self-registration/self-registration-service-naming.ft.test.js",
+        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 45,
-        "is_secret": false
+        "line_number": 32
+      }
+    ],
+    "test/integration/service-registration.service.it.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/integration/service-registration.service.it.test.js",
+        "hashed_secret": "4def56874fa19eaaba377aa6ed3cdf5d70bd2c59",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/integration/service-registration.service.it.test.js",
+        "hashed_secret": "73fab36036653ebf81d45c017039d0be4bc59e64",
+        "is_verified": false,
+        "line_number": 31
       }
     ],
     "test/unit/clients/adminusers-client/authenticate/authenticate.pact.test.js": [
@@ -335,8 +664,7 @@
         "filename": "test/unit/clients/adminusers-client/authenticate/authenticate.pact.test.js",
         "hashed_secret": "5f6087367c3abd5ea9bc0d1650277b9f68b9b233",
         "is_verified": false,
-        "line_number": 73,
-        "is_secret": false
+        "line_number": 73
       }
     ],
     "test/unit/clients/adminusers-client/invite/complete-service-invite.pact.test.js": [
@@ -345,8 +673,21 @@
         "filename": "test/unit/clients/adminusers-client/invite/complete-service-invite.pact.test.js",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 38,
-        "is_secret": false
+        "line_number": 38
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/clients/adminusers-client/invite/complete-service-invite.pact.test.js",
+        "hashed_secret": "4def56874fa19eaaba377aa6ed3cdf5d70bd2c59",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/clients/adminusers-client/invite/complete-service-invite.pact.test.js",
+        "hashed_secret": "73fab36036653ebf81d45c017039d0be4bc59e64",
+        "is_verified": false,
+        "line_number": 40
       }
     ],
     "test/unit/clients/adminusers-client/invite/complete-user-invite.pact.test.js": [
@@ -355,8 +696,21 @@
         "filename": "test/unit/clients/adminusers-client/invite/complete-user-invite.pact.test.js",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 38,
-        "is_secret": false
+        "line_number": 38
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/clients/adminusers-client/invite/complete-user-invite.pact.test.js",
+        "hashed_secret": "4def56874fa19eaaba377aa6ed3cdf5d70bd2c59",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/clients/adminusers-client/invite/complete-user-invite.pact.test.js",
+        "hashed_secret": "73fab36036653ebf81d45c017039d0be4bc59e64",
+        "is_verified": false,
+        "line_number": 40
       }
     ],
     "test/unit/clients/adminusers-client/invite/generate-invite-otp-code-service.pact.test.js": [
@@ -365,8 +719,7 @@
         "filename": "test/unit/clients/adminusers-client/invite/generate-invite-otp-code-service.pact.test.js",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 36,
-        "is_secret": false
+        "line_number": 36
       }
     ],
     "test/unit/clients/adminusers-client/invite/generate-invite-otp-code-user.pact.test.js": [
@@ -375,8 +728,7 @@
         "filename": "test/unit/clients/adminusers-client/invite/generate-invite-otp-code-user.pact.test.js",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 38,
-        "is_secret": false
+        "line_number": 38
       }
     ],
     "test/unit/clients/adminusers-client/invite/get-invite.pact.test.js": [
@@ -385,8 +737,88 @@
         "filename": "test/unit/clients/adminusers-client/invite/get-invite.pact.test.js",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 36,
-        "is_secret": false
+        "line_number": 36
+      }
+    ],
+    "test/unit/clients/adminusers-client/service/govuk-pay-agreement-post-email-address.pact.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/clients/adminusers-client/service/govuk-pay-agreement-post-email-address.pact.test.js",
+        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
+    "test/unit/clients/adminusers-client/user/assign-servicerole.pact.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/clients/adminusers-client/user/assign-servicerole.pact.test.js",
+        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
+    "test/unit/clients/adminusers-client/user/get-user.pact.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/clients/adminusers-client/user/get-user.pact.test.js",
+        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
+        "is_verified": false,
+        "line_number": 37
+      }
+    ],
+    "test/unit/clients/adminusers-client/user/increment-session-version.pact.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/clients/adminusers-client/user/increment-session-version.pact.test.js",
+        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
+        "is_verified": false,
+        "line_number": 33
+      }
+    ],
+    "test/unit/clients/adminusers-client/user/second-factor.pact.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/clients/adminusers-client/user/second-factor.pact.test.js",
+        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
+    "test/unit/clients/adminusers-client/user/update-servicerole.pact.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/clients/adminusers-client/user/update-servicerole.pact.test.js",
+        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
+    "test/unit/clients/connector-client/connector-get-charge.pact.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/clients/connector-client/connector-get-charge.pact.test.js",
+        "hashed_secret": "d5662d7353c6257f68cab2a3b0f758cc79b1ac5e",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "test/unit/clients/connector-client/connector-patch-gateway-account-merchant-id.pact.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/clients/connector-client/connector-patch-gateway-account-merchant-id.pact.test.js",
+        "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
+        "is_verified": false,
+        "line_number": 35
+      }
+    ],
+    "test/unit/clients/ledger-client/ledger-get-dispute-transactions.pact.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/clients/ledger-client/ledger-get-dispute-transactions.pact.test.js",
+        "hashed_secret": "b6074fd0f44e42c49b7e514ee0994af8c8d3e24c",
+        "is_verified": false,
+        "line_number": 19
       }
     ],
     "test/unit/clients/ledger-client/legacy-connector-parity-util.test.js": [
@@ -395,8 +827,7 @@
         "filename": "test/unit/clients/ledger-client/legacy-connector-parity-util.test.js",
         "hashed_secret": "0724011c30d66fd9ce2f6cc22f6194cab69858d8",
         "is_verified": false,
-        "line_number": 29,
-        "is_secret": false
+        "line_number": 29
       }
     ],
     "test/unit/controller/register-service-controller/register-service.controller.test.js": [
@@ -405,8 +836,7 @@
         "filename": "test/unit/controller/register-service-controller/register-service.controller.test.js",
         "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
         "is_verified": false,
-        "line_number": 67,
-        "is_secret": false
+        "line_number": 65
       }
     ],
     "test/unit/services/auth.service.test.js": [
@@ -422,9 +852,9 @@
         "filename": "test/unit/services/auth.service.test.js",
         "hashed_secret": "232facd917e1b5696dc9b55b336a9bcb6bb43341",
         "is_verified": false,
-        "line_number": 179
+        "line_number": 178
       }
     ]
   },
-  "generated_at": "2022-04-12T08:32:57Z"
+  "generated_at": "2022-11-08T17:51:21Z"
 }


### PR DESCRIPTION
### WHAT

- added a new github action to run `detect-secrets`
- updated the pre-commit config to update the detect-secrets hook to version `1.4`
- rebaselined the repository's secrets baseline

#### For reviewers

- ensure your local version of `detect-secrets` matches the latest version in use on this branch
- run `detect-secrets scan` and ensure output matches the latest `.secrets.baseline`, the only change should be the generated timestamp