### PR TITLE
PP-10244 Handle service not created during registration

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -641,14 +645,14 @@
         "filename": "test/integration/service-registration.service.it.test.js",
         "hashed_secret": "4def56874fa19eaaba377aa6ed3cdf5d70bd2c59",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 31
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/integration/service-registration.service.it.test.js",
         "hashed_secret": "73fab36036653ebf81d45c017039d0be4bc59e64",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 32
       }
     ],
     "test/unit/clients/adminusers-client/authenticate/authenticate.pact.test.js": [
@@ -836,7 +840,7 @@
         "filename": "test/unit/controller/register-service-controller/register-service.controller.test.js",
         "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
         "is_verified": false,
-        "line_number": 65
+        "line_number": 66
       }
     ],
     "test/unit/services/auth.service.test.js": [
@@ -856,5 +860,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-08T17:51:21Z"
+  "generated_at": "2022-11-09T13:05:54Z"
 }

--- a/app/controllers/register-service.controller.js
+++ b/app/controllers/register-service.controller.js
@@ -150,7 +150,7 @@ async function showOtpVerify (req, res, next) {
   }
 }
 
-async function createPopulatedService (req, res, next) {
+async function submitOtpCode (req, res, next) {
   const sessionData = req.register_invite
   if (!registrationSessionPresent(sessionData)) {
     return next(new RegistrationSessionMissingError())
@@ -186,9 +186,13 @@ async function createPopulatedService (req, res, next) {
   }
 
   try {
-    const user = await registrationService.createPopulatedService(req.register_invite.code)
-    loginController.setupDirectLoginAfterRegister(req, res, user.externalId)
-    return res.redirect(303, paths.selfCreateService.logUserIn)
+    const completeInviteResponse = await registrationService.completeInvite(req.register_invite.code)
+    loginController.setupDirectLoginAfterRegister(req, res, completeInviteResponse.user_external_id)
+    if (completeInviteResponse.service_external_id) {
+      return res.redirect(303, paths.selfCreateService.logUserIn)
+    } else {
+      return res.redirect(303, paths.registerUser.logUserIn)
+    }
   } catch (err) {
     next(err)
   }
@@ -319,7 +323,7 @@ module.exports = {
   submitRegistration,
   showConfirmation,
   showOtpVerify,
-  createPopulatedService,
+  submitOtpCode,
   loggedIn,
   showOtpResend,
   submitOtpResend,

--- a/app/routes.js
+++ b/app/routes.js
@@ -189,7 +189,7 @@ module.exports.bind = function (app) {
   app.post(selfCreateService.register, trimUsername, selfCreateServiceController.submitRegistration)
   app.get(selfCreateService.confirm, selfCreateServiceController.showConfirmation)
   app.get(selfCreateService.otpVerify, selfCreateServiceController.showOtpVerify)
-  app.post(selfCreateService.otpVerify, selfCreateServiceController.createPopulatedService)
+  app.post(selfCreateService.otpVerify, selfCreateServiceController.submitOtpCode)
   app.get(selfCreateService.otpResend, selfCreateServiceController.showOtpResend)
   app.post(selfCreateService.otpResend, selfCreateServiceController.submitOtpResend)
   app.get(selfCreateService.logUserIn, loginController.loginAfterRegister, userIsAuthorised, selfCreateServiceController.loggedIn)

--- a/test/fixtures/invite.fixtures.js
+++ b/test/fixtures/invite.fixtures.js
@@ -110,6 +110,15 @@ module.exports = {
     }
   },
 
+  inviteCompleteResponseWithNoServiceExternalId: (opts = {}) => {
+    const invite = buildInviteWithDefaults(opts.invite)
+
+    return {
+      invite,
+      user_external_id: opts.user_external_id || '0e167175cd194333844fc415131aa5da'
+    }
+  },
+
   badRequestResponseWhenNonNumericGatewayAccountIds: (nonNumericGatewayAccountIds) => {
     const responseData = _.map(nonNumericGatewayAccountIds, (field) => {
       return `Field [${field}] must contain numeric values`

--- a/test/integration/service-registration.service.it.test.js
+++ b/test/integration/service-registration.service.it.test.js
@@ -19,121 +19,155 @@ const expect = chai.expect
 // Global setup
 chai.use(chaiAsPromised)
 
-describe('create populated service', function () {
+describe('complete invite', function () {
   afterEach((done) => {
     nock.cleanAll()
     done()
   })
 
-  it('should create a sandbox gateway account and complete invite successfully', function (done) {
-    const inviteCode = 'a-valid-invite-code'
-    const userExternalId = 'f84b8210f93d455e97baeaf3fea72cf4'
-    const serviceExternalId = '43a6818b522b4a628a14355614665ca3'
-    const gatewayAccountId = '1'
+  describe('the complete invite response from adminusers has a service_external_id', () => {
+    it('should create a sandbox gateway account and complete invite successfully', function (done) {
+      const inviteCode = 'a-valid-invite-code'
+      const userExternalId = 'f84b8210f93d455e97baeaf3fea72cf4'
+      const serviceExternalId = '43a6818b522b4a628a14355614665ca3'
+      const gatewayAccountId = '1'
 
-    const mockConnectorCreateGatewayAccountResponse =
-      gatewayAccountFixtures.validGatewayAccountResponse({
-        gateway_account_id: gatewayAccountId
+      const mockConnectorCreateGatewayAccountResponse =
+        gatewayAccountFixtures.validGatewayAccountResponse({
+          gateway_account_id: gatewayAccountId
+        })
+      const mockAdminUsersInviteCompleteRequest =
+        inviteFixtures.validInviteCompleteRequest({
+          gateway_account_ids: [gatewayAccountId]
+        })
+      const mockAdminUsersInviteCompleteResponse =
+        inviteFixtures.validInviteCompleteResponse({
+          invite: {
+            code: inviteCode,
+            type: 'service',
+            disabled: true
+          },
+          user_external_id: userExternalId,
+          service_external_id: serviceExternalId
+        })
+      const getUserResponse = userFixtures.validUserResponse({ external_id: userExternalId })
+
+      const createGatewayAccountMock = connectorMock.post(CONNECTOR_ACCOUNTS_URL)
+        .reply(201, mockConnectorCreateGatewayAccountResponse)
+      const completeServiceInviteMock = adminusersMock.post(`${ADMINUSERS_INVITES_URL}/${inviteCode}/complete`, mockAdminUsersInviteCompleteRequest)
+        .reply(200, mockAdminUsersInviteCompleteResponse)
+      const getUserMock = adminusersMock.get(`/v1/api/users/${userExternalId}`)
+        .reply(200, getUserResponse)
+      adminusersMock.patch(`/v1/api/services/${serviceExternalId}`)
+        .reply(200, {})
+
+      serviceRegistrationService.completeInvite(inviteCode).should.be.fulfilled.then(completeInviteResponse => {
+        expect(createGatewayAccountMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
+        expect(completeServiceInviteMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
+        expect(getUserMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
+        expect(completeInviteResponse.user_external_id).to.equal(userExternalId)
+      }).should.notify(done)
+    })
+
+    it('should error if creation of a gateway account failed', function (done) {
+      const inviteCode = 'a-valid-invite-code'
+      const mockAdminUsersInviteCompleteResponse =
+        inviteFixtures.validInviteCompleteResponse({
+          service_external_id: 'a-service-id'
+        })
+
+      adminusersMock.post(`${ADMINUSERS_INVITES_URL}/${inviteCode}/complete`)
+        .reply(200, mockAdminUsersInviteCompleteResponse)
+      const mockConnectorCreateGatewayAccountResponse = connectorMock.post(CONNECTOR_ACCOUNTS_URL)
+        .reply(500)
+
+      serviceRegistrationService.completeInvite(inviteCode).should.be.rejected.then(error => {
+        expect(mockConnectorCreateGatewayAccountResponse.isDone()).to.be.true // eslint-disable-line no-unused-expressions
+        expect(error.errorCode).to.equal(500)
+      }).should.notify(done)
+    })
+
+    it('should error if creation of a gateway account succeeded, but complete invite failed', function (done) {
+      const inviteCode = 'a-valid-invite-code'
+      const gatewayAccountId = '1'
+
+      const mockConnectorCreateGatewayAccountResponse =
+        gatewayAccountFixtures.validGatewayAccountResponse({
+          gateway_account_id: gatewayAccountId
+        })
+      const mockAdminUsersInviteCompleteRequest =
+        inviteFixtures.validInviteCompleteRequest({
+          gateway_account_ids: [gatewayAccountId]
+        })
+
+      connectorMock.post(CONNECTOR_ACCOUNTS_URL)
+        .reply(201, mockConnectorCreateGatewayAccountResponse)
+      const completeServiceInviteMock = adminusersMock.post(`${ADMINUSERS_INVITES_URL}/${inviteCode}/complete`, mockAdminUsersInviteCompleteRequest)
+        .reply(500)
+
+      serviceRegistrationService.completeInvite(inviteCode).then(() => {
+        done('should not be called')
+      }).catch(error => {
+        expect(completeServiceInviteMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
+        expect(error.errorCode).to.equal(500)
+        done()
       })
-    const mockAdminUsersInviteCompleteRequest =
-      inviteFixtures.validInviteCompleteRequest({
-        gateway_account_ids: [gatewayAccountId]
-      })
-    const mockAdminUsersInviteCompleteResponse =
-      inviteFixtures.validInviteCompleteResponse({
-        invite: {
-          code: inviteCode,
-          type: 'service',
-          disabled: true
-        },
-        user_external_id: userExternalId,
-        service_external_id: serviceExternalId
-      })
-    const getUserResponse = userFixtures.validUserResponse({ external_id: userExternalId })
+    })
 
-    const createGatewayAccountMock = connectorMock.post(CONNECTOR_ACCOUNTS_URL)
-      .reply(201, mockConnectorCreateGatewayAccountResponse)
-    const completeServiceInviteMock = adminusersMock.post(`${ADMINUSERS_INVITES_URL}/${inviteCode}/complete`, mockAdminUsersInviteCompleteRequest)
-      .reply(200, mockAdminUsersInviteCompleteResponse)
-    const getUserMock = adminusersMock.get(`/v1/api/users/${userExternalId}`)
-      .reply(200, getUserResponse)
-    adminusersMock.patch(`/v1/api/services/${serviceExternalId}`)
-      .reply(200, {})
+    it('should error if creation of a gateway account succeeded and complete invite succeeded, but user already exists', function (done) {
+      const inviteCode = 'a-valid-invite-code'
+      const gatewayAccountId = '1'
 
-    serviceRegistrationService.createPopulatedService(inviteCode).should.be.fulfilled.then(user => {
-      expect(createGatewayAccountMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
-      expect(completeServiceInviteMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
-      expect(getUserMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
-      expect(user.externalId).to.equal(userExternalId)
-    }).should.notify(done)
-  })
+      const mockConnectorCreateGatewayAccountResponse =
+        gatewayAccountFixtures.validGatewayAccountResponse({
+          gateway_account_id: gatewayAccountId
+        })
+      const mockAdminUsersInviteCompleteRequest =
+        inviteFixtures.validInviteCompleteRequest({
+          gateway_account_ids: [gatewayAccountId]
+        })
 
-  it('should error if creation of a gateway account failed', function (done) {
-    const inviteCode = 'a-valid-invite-code'
-    const mockAdminUsersInviteCompleteResponse =
-      inviteFixtures.validInviteCompleteResponse({
-        service_external_id: 'a-service-id'
-      })
+      connectorMock.post(CONNECTOR_ACCOUNTS_URL)
+        .reply(201, mockConnectorCreateGatewayAccountResponse)
+      const completeServiceInviteMock = adminusersMock.post(`${ADMINUSERS_INVITES_URL}/${inviteCode}/complete`, mockAdminUsersInviteCompleteRequest)
+        .reply(409)
 
-    adminusersMock.post(`${ADMINUSERS_INVITES_URL}/${inviteCode}/complete`)
-      .reply(200, mockAdminUsersInviteCompleteResponse)
-    const mockConnectorCreateGatewayAccountResponse = connectorMock.post(CONNECTOR_ACCOUNTS_URL)
-      .reply(500)
-
-    serviceRegistrationService.createPopulatedService(inviteCode).should.be.rejected.then(error => {
-      expect(mockConnectorCreateGatewayAccountResponse.isDone()).to.be.true // eslint-disable-line no-unused-expressions
-      expect(error.errorCode).to.equal(500)
-    }).should.notify(done)
-  })
-
-  it('should error if creation of a gateway account succeeded, but complete invite failed', function (done) {
-    const inviteCode = 'a-valid-invite-code'
-    const gatewayAccountId = '1'
-
-    const mockConnectorCreateGatewayAccountResponse =
-      gatewayAccountFixtures.validGatewayAccountResponse({
-        gateway_account_id: gatewayAccountId
-      })
-    const mockAdminUsersInviteCompleteRequest =
-      inviteFixtures.validInviteCompleteRequest({
-        gateway_account_ids: [gatewayAccountId]
-      })
-
-    connectorMock.post(CONNECTOR_ACCOUNTS_URL)
-      .reply(201, mockConnectorCreateGatewayAccountResponse)
-    const completeServiceInviteMock = adminusersMock.post(`${ADMINUSERS_INVITES_URL}/${inviteCode}/complete`, mockAdminUsersInviteCompleteRequest)
-      .reply(500)
-
-    serviceRegistrationService.createPopulatedService(inviteCode).then(() => {
-      done('should not be called')
-    }).catch(error => {
-      expect(completeServiceInviteMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
-      expect(error.errorCode).to.equal(500)
-      done()
+      serviceRegistrationService.completeInvite(inviteCode).should.be.rejected.then(error => {
+        expect(completeServiceInviteMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
+        expect(error.errorCode).to.equal(409)
+      }).should.notify(done)
     })
   })
 
-  it('should error if creation of a gateway account succeeded and complete invite succeeded, but user already exists', function (done) {
-    const inviteCode = 'a-valid-invite-code'
-    const gatewayAccountId = '1'
+  describe('the complete invite response from adminusers does not have a service_external_id', () => {
+    it('should not attempt to create a gateway account', (done) => {
+      const inviteCode = 'a-valid-invite-code'
+      const userExternalId = 'f84b8210f93d455e97baeaf3fea72cf4'
+      const serviceExternalId = '43a6818b522b4a628a14355614665ca3'
+      const gatewayAccountId = '1'
 
-    const mockConnectorCreateGatewayAccountResponse =
-      gatewayAccountFixtures.validGatewayAccountResponse({
-        gateway_account_id: gatewayAccountId
-      })
-    const mockAdminUsersInviteCompleteRequest =
-      inviteFixtures.validInviteCompleteRequest({
-        gateway_account_ids: [gatewayAccountId]
-      })
+      const mockAdminUsersInviteCompleteRequest =
+        inviteFixtures.validInviteCompleteRequest({
+          gateway_account_ids: [gatewayAccountId]
+        })
+      const mockAdminUsersInviteCompleteResponse =
+        inviteFixtures.inviteCompleteResponseWithNoServiceExternalId({
+          invite: {
+            code: inviteCode,
+            type: 'service',
+            disabled: true
+          },
+          user_external_id: userExternalId,
+          service_external_id: serviceExternalId
+        })
 
-    connectorMock.post(CONNECTOR_ACCOUNTS_URL)
-      .reply(201, mockConnectorCreateGatewayAccountResponse)
-    const completeServiceInviteMock = adminusersMock.post(`${ADMINUSERS_INVITES_URL}/${inviteCode}/complete`, mockAdminUsersInviteCompleteRequest)
-      .reply(409)
+      const completeServiceInviteMock = adminusersMock.post(`${ADMINUSERS_INVITES_URL}/${inviteCode}/complete`, mockAdminUsersInviteCompleteRequest)
+        .reply(200, mockAdminUsersInviteCompleteResponse)
 
-    serviceRegistrationService.createPopulatedService(inviteCode).should.be.rejected.then(error => {
-      expect(completeServiceInviteMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
-      expect(error.errorCode).to.equal(409)
-    }).should.notify(done)
+      serviceRegistrationService.completeInvite(inviteCode).should.be.fulfilled.then(completeInviteResponse => {
+        expect(completeServiceInviteMock.isDone()).to.be.true // eslint-disable-line no-unused-expressions
+        expect(completeInviteResponse.user_external_id).to.equal(userExternalId)
+      }).should.notify(done)
+    })
   })
 })


### PR DESCRIPTION
We are going to remove creating a service as part of a self-signup registration.

The service is currently created by adminusers when a request is made to the `/v1/api/invites/{code}/complete` endpoint, which also creates the user account. Selfservice then redirects the user to a page to name the created service.

We are going to stop creating a test service in adminusers when `/v1/api/invites/{code}/complete` is called. When we are no longer creating a service, the response from this endpoint will no longer include a `service_external_id` field.

Prepare for a service no longer being created by handling the case where `/v1/api/invites/{code}/complete` does not include a `service_external_id`. In this case, do not attempt to create a gateway account in connector. And instead of redirecting the user to the page to set the service name after logging them in, redirect the user to the "My services" page.

## Review note

Hiding whitespace changes in the diff will make this PR a lot easier to review.