### PR TITLE
PP-10055 Add routes and templates for new registration journey

### DIFF
--- a/app/controllers/registration/registration.controller.js
+++ b/app/controllers/registration/registration.controller.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const qrcode = require('qrcode')
+
+function showPasswordPage (req, res) {
+  res.render('registration/password')
+}
+
+function showChooseSignInMethodPage (req, res) {
+  res.render('registration/get-security-codes')
+}
+
+async function showAuthenticatorAppPage (req, res) {
+  const exampleSecretKey = 'ANEXAMPLESECRETSECONDFACTORCODE1' // pragma: allowlist secret
+  const prettyPrintedSecret = exampleSecretKey.match(/.{4}/g).join(' ')
+  const otpUrl = `otpauth://totp/GOV.UK%20Pay:${encodeURIComponent('username')}?secret=${encodeURIComponent(exampleSecretKey)}&issuer=GOV.UK%20Pay&algorithm=SHA1&digits=6&period=30`
+  const qrCodeDataUrl = await qrcode.toDataURL(otpUrl)
+
+  res.render('registration/authenticator-app', {
+    prettyPrintedSecret,
+    qrCodeDataUrl
+  })
+}
+
+function showPhoneNumberPage (req, res) {
+  res.render('registration/phone-number')
+}
+
+function showSmsSecurityCodePage (req, res) {
+  res.render('registration/sms-code', { redactedPhoneNumber: '*******1111' })
+}
+
+function showResendSecurityCodePage (req, res) {
+  res.render('registration/resend-code')
+}
+
+function showSuccessPage (req, res) {
+  res.render('registration/success')
+}
+
+module.exports = {
+  showPasswordPage,
+  showChooseSignInMethodPage,
+  showAuthenticatorAppPage,
+  showPhoneNumberPage,
+  showSmsSecurityCodePage,
+  showResendSecurityCodePage,
+  showSuccessPage
+}

--- a/app/paths.js
+++ b/app/paths.js
@@ -252,6 +252,15 @@ module.exports = {
     logUserIn: '/create-service/proceed-to-login',
     serviceNaming: '/service/set-name'
   },
+  register: {
+    password: '/register/password',
+    securityCodes: '/register/get-security-codes',
+    authenticatorApp: '/register/authenticator-app',
+    phoneNumber: '/register/phone-number',
+    smsCode: '/register/sms-code',
+    resendCode: '/register/resend-code',
+    success: '/register/success'
+  },
   healthcheck: {
     path: '/healthcheck'
   },

--- a/app/routes.js
+++ b/app/routes.js
@@ -83,6 +83,7 @@ const defaultBillingAddressCountryController = require('./controllers/settings/d
 const webhooksController = require('./controllers/webhooks/webhooks.controller')
 const agreementsController = require('./controllers/agreements/agreements.controller')
 const kycOrganisationUrlController = require('./controllers/kyc/organisation-url')
+const registrationController = require('./controllers/registration/registration.controller')
 
 // Assignments
 const {
@@ -92,6 +93,7 @@ const {
   policyPage,
   payouts,
   registerUser,
+  register,
   selfCreateService,
   serviceSwitcher,
   staticPaths,
@@ -183,7 +185,6 @@ module.exports.bind = function (app) {
   app.get(user.passwordRequested, forgotPasswordController.passwordRequested)
   app.get(user.forgottenPasswordReset, forgotPasswordController.newPasswordGet)
   app.post(user.forgottenPasswordReset, forgotPasswordController.newPasswordPost)
-
   // SELF CREATE SERVICE
   app.get(selfCreateService.register, selfCreateServiceController.showRegistration)
   app.post(selfCreateService.register, trimUsername, selfCreateServiceController.submitRegistration)
@@ -195,6 +196,14 @@ module.exports.bind = function (app) {
   app.get(selfCreateService.logUserIn, loginController.loginAfterRegister, userIsAuthorised, selfCreateServiceController.loggedIn)
   app.get(selfCreateService.serviceNaming, userIsAuthorised, selfCreateServiceController.showNameYourService)
   app.post(selfCreateService.serviceNaming, userIsAuthorised, selfCreateServiceController.submitYourServiceName)
+
+  app.get(register.password, registrationController.showPasswordPage)
+  app.get(register.securityCodes, registrationController.showChooseSignInMethodPage)
+  app.get(register.authenticatorApp, registrationController.showAuthenticatorAppPage)
+  app.get(register.phoneNumber, registrationController.showPhoneNumberPage)
+  app.get(register.smsCode, registrationController.showSmsSecurityCodePage)
+  app.get(register.resendCode, registrationController.showResendSecurityCodePage)
+  app.get(register.success, registrationController.showSuccessPage)
 
   // ----------------------
   // AUTHENTICATED ROUTES
@@ -431,18 +440,18 @@ module.exports.bind = function (app) {
   account.post([kyc.organisationUrl, switchPSP.organisationUrl], permission('merchant-details:update'), restrictToStripeAccountContext, kycOrganisationUrlController.post)
 
   // Stripe setup
-  account.get([ yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails ], permission('stripe-bank-details:update'), restrictToStripeAccountContext, stripeSetupBankDetailsController.get)
-  account.post([ yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails ], permission('stripe-bank-details:update'), restrictToStripeAccountContext, stripeSetupBankDetailsController.post)
-  account.get([ yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson, kyc.changeResponsiblePerson ], permission('stripe-responsible-person:update'), restrictToStripeAccountContext, stripeSetupResponsiblePersonController.get)
-  account.post([ yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson, kyc.changeResponsiblePerson ], permission('stripe-responsible-person:update'), restrictToStripeAccountContext, stripeSetupResponsiblePersonController.post)
+  account.get([yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails], permission('stripe-bank-details:update'), restrictToStripeAccountContext, stripeSetupBankDetailsController.get)
+  account.post([yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails], permission('stripe-bank-details:update'), restrictToStripeAccountContext, stripeSetupBankDetailsController.post)
+  account.get([yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson, kyc.changeResponsiblePerson], permission('stripe-responsible-person:update'), restrictToStripeAccountContext, stripeSetupResponsiblePersonController.get)
+  account.post([yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson, kyc.changeResponsiblePerson], permission('stripe-responsible-person:update'), restrictToStripeAccountContext, stripeSetupResponsiblePersonController.post)
   account.get(kyc.responsiblePerson, permission('stripe-responsible-person:update'), restrictToStripeAccountContext, stripeSetupResponsiblePersonController.getAdditionalDetails)
   account.post(kyc.responsiblePerson, permission('stripe-responsible-person:update'), restrictToStripeAccountContext, stripeSetupResponsiblePersonController.postAdditionalDetails)
   account.get([yourPsp.stripeSetup.director, switchPSP.stripeSetup.director, kyc.director], permission('stripe-director:update'), restrictToStripeAccountContext, stripeSetupDirectorController.get)
-  account.post([ yourPsp.stripeSetup.director, switchPSP.stripeSetup.director, kyc.director ], permission('stripe-director:update'), restrictToStripeAccountContext, stripeSetupDirectorController.post)
-  account.get([ yourPsp.stripeSetup.vatNumber, switchPSP.stripeSetup.vatNumber ], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupVatNumberController.get)
-  account.post([ yourPsp.stripeSetup.vatNumber, switchPSP.stripeSetup.vatNumber ], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupVatNumberController.post)
-  account.get([ yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber ], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.get)
-  account.post([ yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber ], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.post)
+  account.post([yourPsp.stripeSetup.director, switchPSP.stripeSetup.director, kyc.director], permission('stripe-director:update'), restrictToStripeAccountContext, stripeSetupDirectorController.post)
+  account.get([yourPsp.stripeSetup.vatNumber, switchPSP.stripeSetup.vatNumber], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupVatNumberController.get)
+  account.post([yourPsp.stripeSetup.vatNumber, switchPSP.stripeSetup.vatNumber], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupVatNumberController.post)
+  account.get([yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.get)
+  account.post([yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.post)
   account.get([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument, kyc.governmentEntityDocument], permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, stripeSetupGovernmentEntityDocument.get)
   account.post([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument, kyc.governmentEntityDocument], permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, uploadGovernmentEntityDocument, stripeSetupGovernmentEntityDocument.post)
   account.get([yourPsp.stripeSetup.checkOrgDetails, switchPSP.stripeSetup.checkOrgDetails], permission('stripe-organisation-details:update'), restrictToStripeAccountContext, stripeSetupCheckOrgDetailsController.get)

--- a/app/views/registration/authenticator-app.njk
+++ b/app/views/registration/authenticator-app.njk
@@ -1,0 +1,79 @@
+{% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
+
+{% block pageTitle %}
+  Set up an authenticator app - GOV.UK Pay
+{% endblock %}
+
+{% block beforeContent %}
+  {{ super() }}
+  {{
+  govukBackLink({
+    text: "Back",
+    href: routes.register.securityCodes
+  })
+  }}
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">Set up an authenticator app</h1>
+
+    <p class="govuk-body">1. Open your authenticator app on your smartphone, tablet or computer.</p>
+
+    {% set detailsHTML %}
+      <p class="govuk-body">Instead of text message codes, you can use an authenticator app to sign in to GOV.UK Pay. This is an app (usually installed on your phone) that generates a security code whenever you need to sign in. If you choose to use an authenticator app, you will only be able to sign in to GOV.UK Pay using that app.</p>
+      <p class="govuk-body">GOV.UK Pay works with most authenticator apps. If you do not have one installed already, there are several available. These include:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li><a class="govuk-link" href="https://authy.com/">Authy</a></li>
+        <li><a class="govuk-link" href="https://duo.com/product/multi-factor-authentication-mfa/duo-mobile-app">Duo Mobile</a></li>
+        <li><a class="govuk-link" href="https://freeotp.github.io/">FreeOTP</a></li>
+        <li><a class="govuk-link" href="https://support.google.com/accounts/answer/1066447">Google Authenticator</a></li>
+        <li><a class="govuk-link" href="https://www.microsoft.com/en-gb/security/mobile-authenticator-app">Microsoft Authenticator</a></li>
+      </ul>
+    {% endset %}
+
+    {{ govukDetails({
+      summaryText: "What is an authenticator app?",
+      html: detailsHTML
+    }) }}
+
+    <p class="govuk-body">2. Use your authenticator app to scan the QR code or type the secret key into your authenticator app. Some authenticator apps call the secret key a ‘code’</p>
+
+    <figure class="govuk-!-margin-top-0 govuk-!-margin-left-0 govuk-!-margin-bottom-6">
+      <img class="qr-code pay-!-negative-margin-h-3" src="{{qrCodeDataUrl}}" alt="If you cannot view or scan the barcode, please enter the secret manually">
+      <figcaption>
+        <h4 class="govuk-body">Secret key:</h4>
+        <code class="code" data-cy="otp-secret">{{prettyPrintedSecret}}</code>
+      </figcaption>
+    </figure>
+
+    <p class="govuk-body">3. The authenticator app will show a security code.</p>
+
+    <p class="govuk-body">4. Enter the security code.</p>
+
+    <form method="post">
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+
+      {{ govukInput({
+        label: {
+          text: "Security code",
+          isPageHeading: false
+        },
+        hint: {
+          text: 'This is the 6-digit number shown in your authenticator app'
+        },
+        id: "code",
+        name: "code",
+        classes: "govuk-input--width-10"
+      }) }}
+
+      {{ govukButton({ text: "Continue" }) }}
+
+      <p class="govuk-body">
+        <a href="{{ routes.register.securityCodes }}" class="govuk-link govuk-link--no-visited-state">Get a code another way</a>
+      </p>
+    </form>
+  </div>
+{% endblock %}

--- a/app/views/registration/get-security-codes.njk
+++ b/app/views/registration/get-security-codes.njk
@@ -1,0 +1,58 @@
+{% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
+
+{% block pageTitle %}
+  Choose how to get security codes - GOV.UK Pay
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-column-one-half">
+
+    <form method="post">
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+
+      {{ govukRadios({
+        name: "where-do-you-live",
+        fieldset: {
+          legend: {
+            text: "Choose how to get security codes",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        hint: {
+          text: "To finish creating your account, you need to choose a way to prove it's you when you sign in."
+        },
+        items: [
+          {
+            value: "SMS",
+            text: "Text message"
+          },
+          {
+            value: "APP",
+            text: "Authenticator app for your smartphone, tablet or computer"
+          }
+        ]
+      }) }}
+
+      {% set detailsHTML %}
+      <p class="govuk-body">Instead of text message codes, you can use an authenticator app to sign in to GOV.UK Pay. This is an app (usually installed on your phone) that generates a security code whenever you need to sign in. If you choose to use an authenticator app, you will only be able to sign in to GOV.UK Pay using that app.</p>
+      <p class="govuk-body">GOV.UK Pay works with most authenticator apps. If you do not have one installed already, there are several available. These include:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li><a class="govuk-link" href="https://authy.com/">Authy</a></li>
+        <li><a class="govuk-link" href="https://duo.com/product/multi-factor-authentication-mfa/duo-mobile-app">Duo Mobile</a></li>
+        <li><a class="govuk-link" href="https://freeotp.github.io/">FreeOTP</a></li>
+        <li><a class="govuk-link" href="https://support.google.com/accounts/answer/1066447">Google Authenticator</a></li>
+        <li><a class="govuk-link" href="https://www.microsoft.com/en-gb/security/mobile-authenticator-app">Microsoft Authenticator</a></li>
+      </ul>
+      {% endset %}
+
+      {{ govukDetails({
+        summaryText: "What is an authenticator app?",
+        html: detailsHTML
+      }) }}
+
+      {{ govukButton({ text: "Continue" }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/app/views/registration/password.njk
+++ b/app/views/registration/password.njk
@@ -1,0 +1,55 @@
+{% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
+
+{% block pageTitle %}
+  Create your password - GOV.UK Pay
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-column-one-half">
+
+    <h1 class="govuk-heading-l">Create your password</h1>
+
+    <p class="govuk-body">Your password must:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>be at least 10 characters long</li>
+    </ul>
+
+    <p class="govuk-body">Do not use a very common password, such as ‘password’ or a sequence of numbers.</p>
+
+    <form method="post">
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+
+      {{ govukInput({
+        label: {
+          text: "Enter a password",
+          isPageHeading: false
+        },
+        id: "password",
+        name: "password",
+        classes: "govuk-!-width-two-thirds",
+        type: "password",
+        autocomplete: "new-password"
+      }) }}
+
+      {{ govukInput({
+        label: {
+          text: "Re-type password",
+          isPageHeading: false
+        },
+        id: "password-2",
+        name: "password-2",
+        classes: "govuk-!-width-two-thirds",
+        type: "password",
+        autocomplete: "new-password"
+      }) }}
+
+      {{ govukDetails({
+        summaryText: "How to create a secure password",
+        text: "A good way to create a secure and memorable password is to use 3 random words. You can use numbers, symbols and spaces."
+      }) }}
+
+      {{ govukButton({ text: "Continue" }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/app/views/registration/phone-number.njk
+++ b/app/views/registration/phone-number.njk
@@ -1,0 +1,40 @@
+{% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
+
+{% block pageTitle %}
+  Enter your mobile phone number - GOV.UK Pay
+{% endblock %}
+
+{% block beforeContent %}
+  {{ super() }}
+  {{
+  govukBackLink({
+    text: "Back",
+    href: routes.register.securityCodes
+  })
+  }}
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-column-one-half">
+
+    <form method="post">
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+
+      {{ govukInput({
+        label: {
+          text: "Enter your mobile phone number",
+          classes: "govuk-label--l",
+          isPageHeading: true
+        },
+        hint: {
+          text: "We will send a 6 digit security code to the number you give us."
+        },
+        id: "phone",
+        name: "phone"
+      }) }}
+
+      {{ govukButton({ text: "Continue" }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/app/views/registration/resend-code.njk
+++ b/app/views/registration/resend-code.njk
@@ -1,0 +1,40 @@
+{% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
+
+{% block pageTitle %}
+  Check your mobile phone number - GOV.UK Pay
+{% endblock %}
+
+{% block beforeContent %}
+  {{ super() }}
+  {{
+  govukBackLink({
+    text: "Back",
+    href: routes.register.smsCode
+  })
+  }}
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-column-one-half">
+
+    <h1 class="govuk-heading-l">Check your mobile phone number</h1>
+
+    <p class="govuk-body">Check your mobile phone number is correct, then resend the security code.</p>
+
+    <form method="post">
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+
+      {{ govukInput({
+        label: {
+          text: "Mobile phone number",
+          classes: "govuk-label--s"
+        },
+        id: "phone",
+        name: "phone"
+      }) }}
+
+      {{ govukButton({ text: "Resend security code" }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/app/views/registration/sms-code.njk
+++ b/app/views/registration/sms-code.njk
@@ -1,0 +1,52 @@
+{% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
+
+{% block pageTitle %}
+  Check your phone - GOV.UK Pay
+{% endblock %}
+
+{% block beforeContent %}
+  {{ super() }}
+  {{
+  govukBackLink({
+    text: "Back",
+    href: routes.register.phoneNumber
+  })
+  }}
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-column-one-half">
+
+    <h1 class="govuk-heading-l">Check your phone</h1>
+
+    {{ govukInsetText({
+      text: "We have sent a code to " + redactedPhoneNumber + "."
+    }) }}
+
+    <form method="post">
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+
+      {{ govukInput({
+        label: {
+          text: "Enter the 6 digit security code",
+          isPageHeading: false
+        },
+        id: "code",
+        name: "code",
+        classes: "govuk-input--width-10"
+      }) }}
+
+      {% set detailsHTML %}
+      <p class="govuk-body">Try to <a class="govuk-link govuk-link govuk-link--no-visited-state" href="{{ routes.register.resendCode }}">send the code again</a>, or <a class="govuk-link govuk-link govuk-link--no-visited-state" href="{{ routes.register.securityCodes }}">get a code another way</a>.
+      {% endset %}
+
+      {{ govukDetails({
+        summaryText: "Problems with the code?",
+        html: detailsHTML
+      }) }}
+
+      {{ govukButton({ text: "Continue" }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/app/views/registration/success.njk
+++ b/app/views/registration/success.njk
@@ -1,0 +1,21 @@
+{% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
+
+{% block pageTitle %}
+  You’ve created your account - GOV.UK Pay
+{% endblock %}
+
+{% block mainContent %}
+<div class="govuk-grid-column-two-thirds">
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">You’ve created your GOV.UK Pay account</h1>
+
+  <p class="govuk-body">Now continue to use the service</p>
+
+  {{
+    govukButton({
+      text: "Continue",
+      href: routes.serviceSwitcher.index
+    })
+  }}
+</div>
+{% endblock %}

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -29,7 +29,14 @@ const pathsNotRequiringAuthentication = [
   paths.selfCreateService.otpVerify,
   paths.selfCreateService.otpResend,
   paths.healthcheck.path,
-  paths.staticPaths.naxsiError
+  paths.staticPaths.naxsiError,
+  paths.register.password,
+  paths.register.securityCodes,
+  paths.register.authenticatorApp,
+  paths.register.phoneNumber,
+  paths.register.smsCode,
+  paths.register.resendCode,
+  paths.register.success
 ]
 
 describe('The Express router', () => {


### PR DESCRIPTION
Add the GET routes and the basic templates for the new registration journey that includes the ability to select an authenticator app to get 2FA codes.

Currently when the routes are visited, the templates are just rendered with dummy data and no other logic is performed.

