### PR TITLE
PP-10055 Add pact test for GET invite

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -581,14 +581,14 @@
         "filename": "test/fixtures/invite.fixtures.js",
         "hashed_secret": "c2326bf719e924050321d3adb8d8d3a99723ee95",
         "is_verified": false,
-        "line_number": 85
+        "line_number": 82
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/fixtures/invite.fixtures.js",
         "hashed_secret": "e5a7431b27dbc70d00c5ed873bd4d837bd65720c",
         "is_verified": false,
-        "line_number": 92
+        "line_number": 89
       }
     ],
     "test/integration/forgotten-password.ft.test.js": [
@@ -746,15 +746,6 @@
         "line_number": 38
       }
     ],
-    "test/unit/clients/adminusers-client/invite/get-invite.pact.test.js": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "test/unit/clients/adminusers-client/invite/get-invite.pact.test.js",
-        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
-        "is_verified": false,
-        "line_number": 36
-      }
-    ],
     "test/unit/clients/adminusers-client/service/govuk-pay-agreement-post-email-address.pact.test.js": [
       {
         "type": "Hex High Entropy String",
@@ -871,5 +862,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-15T14:52:17Z"
+  "generated_at": "2022-11-15T17:11:22Z"
 }

--- a/test/fixtures/invite.fixtures.js
+++ b/test/fixtures/invite.fixtures.js
@@ -3,17 +3,14 @@
 const _ = require('lodash')
 
 function buildInviteWithDefaults (opts = {}) {
-  const data = _.defaults(opts, {
-    type: 'user',
-    email: 'foo@example.com',
-    role: 'admin',
-    disabled: false,
-    attempt_counter: 0,
-    _links: [],
-    user_exist: false,
-    expired: false,
-    password_set: false
-  })
+  const data = {
+    type: opts.type || 'user',
+    email: opts.email || 'foo@example.com',
+    role: opts.role || 'admin',
+    disabled: opts.disabled || false,
+    user_exist: opts.user_exist || false,
+    expired: opts.expired || false
+  }
 
   if (opts.telephone_number) {
     data.telephone_number = opts.telephone_number

--- a/test/integration/service-users.ft.test.js
+++ b/test/integration/service-users.ft.test.js
@@ -421,16 +421,14 @@ describe('service users resource', () => {
       disabled: false,
       role: 'admin',
       expired: false,
-      user_exist: false,
-      attempt_counter: 0
+      user_exist: false
     }, {
       email: SECOND_EMAIL,
       telephone_number: '',
       disabled: false,
       role: 'view-only',
       expired: false,
-      user_exist: false,
-      attempt_counter: 0
+      user_exist: false
     }]
     const serviceUsersRes = userFixtures.validUsersResponse([{ service_roles: serviceRoles }])
     const getInvitesRes = inviteFixtures.validListInvitesResponse(invites)


### PR DESCRIPTION
Amend get-invite.pact.test.js which previously wouldn't be verified against adminusers as it had consumer `selfservice-to-be` so that it will successfully run against adminusers.

Remove tests that check error responses, as we handle these in a standard way.

Fix the invite fixture so that it will not insert properties that are not defined in the fixture  - using `lodash.defaults` was using any fields passed in in the `opts` object even if they were not defined in the fixture. Remove the fields from the fixture that selfservice does not consume.


