### PR TITLE
PP-10055 Add route to submit password page

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -130,6 +130,80 @@
         "line_number": 8
       }
     ],
+    "app/controllers/registration/registration.controller.js": [
+      {
+        "type": "Secret Keyword",
+        "filename": "app/controllers/registration/registration.controller.js",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/controllers/registration/registration.controller.js",
+        "hashed_secret": "cbb085747f0bcbeac56f2a583779b44c8f445d92",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/controllers/registration/registration.controller.js",
+        "hashed_secret": "7b652417979832c620feec2e89b92c56a291ae52",
+        "is_verified": false,
+        "line_number": 53
+      }
+    ],
+    "app/controllers/registration/registration.controller.test.js": [
+      {
+        "type": "Secret Keyword",
+        "filename": "app/controllers/registration/registration.controller.test.js",
+        "hashed_secret": "9695086041c462c6598c6dd5e35d3a2c9cbbe5f8",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/controllers/registration/registration.controller.test.js",
+        "hashed_secret": "7b652417979832c620feec2e89b92c56a291ae52",
+        "is_verified": false,
+        "line_number": 94
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/controllers/registration/registration.controller.test.js",
+        "hashed_secret": "f5378ce7cd012d12a9be51e6be241b1e66240879",
+        "is_verified": false,
+        "line_number": 101
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/controllers/registration/registration.controller.test.js",
+        "hashed_secret": "69c8d31085756bfd34bb8ca6d393289374b7d7c2",
+        "is_verified": false,
+        "line_number": 108
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/controllers/registration/registration.controller.test.js",
+        "hashed_secret": "3f3c2dca191782c9b8b2f513d16abaa66dc543bf",
+        "is_verified": false,
+        "line_number": 115
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/controllers/registration/registration.controller.test.js",
+        "hashed_secret": "0ee4c488221aee414cd9ae5300e28d11c2851fe5",
+        "is_verified": false,
+        "line_number": 130
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/controllers/registration/registration.controller.test.js",
+        "hashed_secret": "d8fe3060b1c00ad00ece5d205e493764b113b94c",
+        "is_verified": false,
+        "line_number": 136
+      }
+    ],
     "app/controllers/your-psp/worldpay-3ds-flex-validations.test.js": [
       {
         "type": "Hex High Entropy String",
@@ -812,5 +886,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-16T10:36:46Z"
+  "generated_at": "2022-11-17T14:44:40Z"
 }

--- a/app/controllers/registration/registration.controller.test.js
+++ b/app/controllers/registration/registration.controller.test.js
@@ -4,14 +4,16 @@ const sinon = require('sinon')
 const inviteFixtures = require('../../../test/fixtures/invite.fixtures')
 const { RegistrationSessionMissingError } = require('../../errors')
 const { paths } = require('../../routes')
+const registrationController = require('./registration.controller')
 
+const inviteCode = 'a-code'
 let req, res, next
 
 describe('Registration', () => {
   beforeEach(() => {
     req = {
       register_invite: {
-        code: 'a-code',
+        code: inviteCode,
         email: 'foo@example.com'
       }
     }
@@ -22,11 +24,10 @@ describe('Registration', () => {
     next = sinon.spy()
   })
 
-  describe('show password page', () => {
+  describe('show the password page', () => {
     it('should call next with an error when the registration cookie is not set', async () => {
       delete req.register_invite
-      const controller = getControllerWithMockedAdminusersClient({})
-      await controller.showPasswordPage(req, res, next)
+      await registrationController.showPasswordPage(req, res, next)
 
       sinon.assert.calledWith(next, sinon.match.instanceOf(RegistrationSessionMissingError))
       sinon.assert.notCalled(res.render)
@@ -67,6 +68,114 @@ describe('Registration', () => {
       sinon.assert.calledWith(next, error)
       sinon.assert.notCalled(res.render)
       sinon.assert.notCalled(res.redirect)
+    })
+  })
+
+  describe('submit the password page', () => {
+    it('should call next with an error when the registration cookie is not set', async () => {
+      delete req.register_invite
+      await registrationController.submitPasswordPage(req, res, next)
+
+      sinon.assert.calledWith(next, sinon.match.instanceOf(RegistrationSessionMissingError))
+      sinon.assert.notCalled(res.render)
+      sinon.assert.notCalled(res.redirect)
+    })
+
+    it('should render the password page with an error when both password fields are empty', async () => {
+      req.body = {
+        password: '',
+        'repeat-password': ''
+      }
+      await registrationController.submitPasswordPage(req, res, next)
+
+      sinon.assert.calledWith(res.render, 'registration/password', {
+        errors: {
+          password: 'Enter a password',
+          'repeat-password': 'Re-type your password'
+        }
+      })
+    })
+
+    it('should render the password page with an error when the password does not meet the requirements', async () => {
+      req.body = {
+        password: 'too-short',
+        'repeat-password': 'too-short'
+      }
+      await registrationController.submitPasswordPage(req, res, next)
+
+      sinon.assert.calledWith(res.render, 'registration/password', {
+        errors: {
+          password: 'Password must be 10 characters or more'
+        }
+      })
+    })
+
+    it('should render the password page with an error when the password is valid but the repeat password field is blank', async () => {
+      req.body = {
+        password: 'this-is-long-enough',
+        'repeat-password': ''
+      }
+      await registrationController.submitPasswordPage(req, res, next)
+
+      sinon.assert.calledWith(res.render, 'registration/password', {
+        errors: {
+          'repeat-password': 'Re-type your password'
+        }
+      })
+    })
+
+    it('should render the password page with an error when the repeat password field does not match', async () => {
+      req.body = {
+        password: 'this-is-long-enough',
+        'repeat-password': 'something-else'
+      }
+      await registrationController.submitPasswordPage(req, res, next)
+
+      sinon.assert.calledWith(res.render, 'registration/password', {
+        errors: {
+          password: 'Enter same password in both fields',
+          'repeat-password': 'Enter same password in both fields'
+        }
+      })
+    })
+
+    it('should call next with an error if adminusers returns an error', async () => {
+      const validPassword = 'this-is-long-enough'
+      req.body = {
+        password: validPassword,
+        'repeat-password': validPassword
+      }
+
+      const error = new Error('error from adminusers')
+      const updateInvitePasswordSpy = sinon.spy(() => Promise.reject(error))
+      const controller = getControllerWithMockedAdminusersClient({
+        updateInvitePassword: updateInvitePasswordSpy
+      })
+
+      await controller.submitPasswordPage(req, res, next)
+      sinon.assert.calledWith(updateInvitePasswordSpy, inviteCode, validPassword)
+      sinon.assert.calledWith(next, error)
+      sinon.assert.notCalled(res.render)
+      sinon.assert.notCalled(res.redirect)
+    })
+
+    it('should redirect to next page if updated password successfully', async () => {
+      const validPassword = 'this-is-long-enough'
+      req.body = {
+        password: validPassword,
+        'repeat-password': validPassword
+      }
+
+      const updateInvitePasswordSpy = sinon.spy(() => Promise.resolve())
+      const controller = getControllerWithMockedAdminusersClient({
+        updateInvitePassword: updateInvitePasswordSpy
+      })
+
+      await controller.submitPasswordPage(req, res, next)
+      sinon.assert.calledWith(updateInvitePasswordSpy, inviteCode, validPassword)
+      sinon.assert.calledWith(res.redirect, paths.register.securityCodes)
+      sinon.assert.notCalled(next)
+      sinon.assert.notCalled(res.render)
     })
   })
 })

--- a/app/routes.js
+++ b/app/routes.js
@@ -194,7 +194,9 @@ module.exports.bind = function (app) {
   app.get(selfCreateService.otpResend, selfCreateServiceController.showOtpResend)
   app.post(selfCreateService.otpResend, selfCreateServiceController.submitOtpResend)
 
+  // NEW REGISTRATION JOURNEY
   app.get(register.password, registrationController.showPasswordPage)
+  app.post(register.password, registrationController.submitPasswordPage)
   app.get(register.securityCodes, registrationController.showChooseSignInMethodPage)
   app.get(register.authenticatorApp, registrationController.showAuthenticatorAppPage)
   app.get(register.phoneNumber, registrationController.showPhoneNumberPage)

--- a/app/views/registration/password.njk
+++ b/app/views/registration/password.njk
@@ -8,6 +8,14 @@
 {% block mainContent %}
   <div class="govuk-grid-column-one-half">
 
+    {{ errorSummary ({
+      errors: errors,
+      hrefs: {
+        'password': '#password',
+        'repeat-password': '#repeat-password'
+      }
+    }) }}
+
     <h1 class="govuk-heading-l">Create your password</h1>
 
     <p class="govuk-body">Your password must:</p>
@@ -29,7 +37,8 @@
         name: "password",
         classes: "govuk-!-width-two-thirds",
         type: "password",
-        autocomplete: "new-password"
+        autocomplete: "new-password",
+        errorMessage: { text: errors['password'] } if errors['password'] else false
       }) }}
 
       {{ govukInput({
@@ -37,11 +46,12 @@
           text: "Re-type password",
           isPageHeading: false
         },
-        id: "password-2",
-        name: "password-2",
+        id: "repeat-password",
+        name: "repeat-password",
         classes: "govuk-!-width-two-thirds",
         type: "password",
-        autocomplete: "new-password"
+        autocomplete: "new-password",
+        errorMessage: { text: errors['repeat-password'] } if errors['repeat-password'] else false
       }) }}
 
       {{ govukDetails({


### PR DESCRIPTION
Add a POST `/register/password` route that is POSTed to when the password page is submitted. This does validation of the "Enter a password" and "Re-type your password" fields.

If the password is valid, a PATCH request is made to adminusers to update the password and we redirect to the next page in the journey.

