### PR TITLE
PP-10054 Add choose second factor method routes

### DIFF
--- a/app/controllers/registration/registration.controller.js
+++ b/app/controllers/registration/registration.controller.js
@@ -71,6 +71,23 @@ function showChooseSignInMethodPage (req, res) {
   res.render('registration/get-security-codes')
 }
 
+function submitChooseSignInMethodPage (req, res) {
+  const signInMethod = req.body['sign-in-method']
+  if (!signInMethod) {
+    return res.render('registration/get-security-codes', {
+      errors: {
+        'sign-in-method': 'You need to select an option'
+      }
+    })
+  }
+
+  if (signInMethod === 'SMS') {
+    res.redirect(paths.register.phoneNumber)
+  } else {
+    res.redirect(paths.register.authenticatorApp)
+  }
+}
+
 async function showAuthenticatorAppPage (req, res) {
   const exampleSecretKey = 'ANEXAMPLESECRETSECONDFACTORCODE1' // pragma: allowlist secret
   const prettyPrintedSecret = exampleSecretKey.match(/.{4}/g).join(' ')
@@ -103,6 +120,7 @@ module.exports = {
   showPasswordPage,
   submitPasswordPage,
   showChooseSignInMethodPage,
+  submitChooseSignInMethodPage,
   showAuthenticatorAppPage,
   showPhoneNumberPage,
   showSmsSecurityCodePage,

--- a/app/controllers/registration/registration.controller.test.js
+++ b/app/controllers/registration/registration.controller.test.js
@@ -178,6 +178,39 @@ describe('Registration', () => {
       sinon.assert.notCalled(res.render)
     })
   })
+
+  describe('submit the choose how to get security codes page', () => {
+    it('should render page with an error when an option is not selected', () => {
+      req.body = {
+        'sign-in-method': ''
+      }
+      registrationController.submitChooseSignInMethodPage(req, res)
+      sinon.assert.calledWith(res.render, 'registration/get-security-codes', {
+        errors: {
+          'sign-in-method': 'You need to select an option'
+        }
+      })
+      sinon.assert.notCalled(res.redirect)
+    })
+
+    it('should redirect to the phone number page when SMS is chosen', () => {
+      req.body = {
+        'sign-in-method': 'SMS'
+      }
+      registrationController.submitChooseSignInMethodPage(req, res)
+      sinon.assert.calledWith(res.redirect, paths.register.phoneNumber)
+      sinon.assert.notCalled(res.render)
+    })
+
+    it('should redirect to the authenticator app page when APP is chosen', () => {
+      req.body = {
+        'sign-in-method': 'APP'
+      }
+      registrationController.submitChooseSignInMethodPage(req, res)
+      sinon.assert.calledWith(res.redirect, paths.register.authenticatorApp)
+      sinon.assert.notCalled(res.render)
+    })
+  })
 })
 
 function getControllerWithMockedAdminusersClient (mockedAdminusersClient) {

--- a/app/routes.js
+++ b/app/routes.js
@@ -198,6 +198,7 @@ module.exports.bind = function (app) {
   app.get(register.password, registrationController.showPasswordPage)
   app.post(register.password, registrationController.submitPasswordPage)
   app.get(register.securityCodes, registrationController.showChooseSignInMethodPage)
+  app.post(register.securityCodes, registrationController.submitChooseSignInMethodPage)
   app.get(register.authenticatorApp, registrationController.showAuthenticatorAppPage)
   app.get(register.phoneNumber, registrationController.showPhoneNumberPage)
   app.get(register.smsCode, registrationController.showSmsSecurityCodePage)

--- a/app/views/registration/get-security-codes.njk
+++ b/app/views/registration/get-security-codes.njk
@@ -8,11 +8,18 @@
 {% block mainContent %}
   <div class="govuk-grid-column-one-half">
 
+    {{ errorSummary ({
+      errors: errors,
+      hrefs: {
+        'sign-in-method': '#sign-in-method'
+      }
+    }) }}
+
     <form method="post">
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {{ govukRadios({
-        name: "where-do-you-live",
+        name: "sign-in-method",
         fieldset: {
           legend: {
             text: "Choose how to get security codes",
@@ -23,14 +30,24 @@
         hint: {
           text: "To finish creating your account, you need to choose a way to prove it's you when you sign in."
         },
+        errorMessage: { text: errors['sign-in-method'] } if errors['sign-in-method'] else false,
+        attributes: {
+          'data-cy': 'radios-security-code'
+        },
         items: [
           {
             value: "SMS",
-            text: "Text message"
+            text: "Text message",
+            attributes: {
+              'data-cy': 'radio-option-sms'
+            }
           },
           {
             value: "APP",
-            text: "Authenticator app for your smartphone, tablet or computer"
+            text: "Authenticator app for your smartphone, tablet or computer",
+            attributes: {
+            'data-cy': 'radio-option-app'
+          }
           }
         ]
       }) }}

--- a/test/cypress/integration/registration/register.cy.test.js
+++ b/test/cypress/integration/registration/register.cy.test.js
@@ -3,53 +3,115 @@ const inviteStubs = require('../../stubs/invite-stubs')
 const inviteCode = 'an-invite-code'
 
 describe('Register', () => {
-  it('should complete registration journey', () => {
-    cy.task('setupStubs', [
-      inviteStubs.getInviteSuccess({
-        code: inviteCode,
-        password_set: false
-      })
-    ])
+  describe('SMS is selected as method for getting security codes', () => {
+    it('should complete registration journey', () => {
+      cy.task('setupStubs', [
+        inviteStubs.getInviteSuccess({
+          code: inviteCode,
+          password_set: false
+        })
+      ])
 
-    // visit the invite link to get the register_invite cookie set
-    cy.visit(`/invites/${inviteCode}`)
+      // visit the invite link to get the register_invite cookie set
+      cy.visit(`/invites/${inviteCode}`)
 
-    // TODO: when the journey is hooked up, the previous route should redirect to the set password page but for now
+      // TODO: when the journey is hooked up, the previous route should redirect to the set password page but for now
     // we need to manually visit to start the new journey
-    cy.visit('/register/password')
+      cy.visit('/register/password')
 
-    cy.get('title').should('contain', 'Create your password - GOV.UK Pay')
-    cy.get('h1').should('contain', 'Create your password')
+      cy.get('title').should('contain', 'Create your password - GOV.UK Pay')
+      cy.get('h1').should('contain', 'Create your password')
 
-    // submit the page without entering anything
-    cy.get('button').contains('Continue').click()
+      // submit the page without entering anything
+      cy.get('button').contains('Continue').click()
 
-    // check that an error messages are displayed
-    cy.get('.govuk-error-summary').should('exist').within(() => {
-      cy.get('h2').should('contain', 'There is a problem')
-      cy.get('[data-cy=error-summary-list-item]').should('have.length', 2)
-      cy.get('[data-cy=error-summary-list-item]').eq(0)
-        .contains('Enter a password')
-        .should('have.attr', 'href', '#password')
-      cy.get('[data-cy=error-summary-list-item]').eq(1)
-        .contains('Re-type your password')
-        .should('have.attr', 'href', '#repeat-password')
+      // check that an error messages are displayed
+      cy.get('.govuk-error-summary').should('exist').within(() => {
+        cy.get('h2').should('contain', 'There is a problem')
+        cy.get('[data-cy=error-summary-list-item]').should('have.length', 2)
+        cy.get('[data-cy=error-summary-list-item]').eq(0)
+          .contains('Enter a password')
+          .should('have.attr', 'href', '#password')
+        cy.get('[data-cy=error-summary-list-item]').eq(1)
+          .contains('Re-type your password')
+          .should('have.attr', 'href', '#repeat-password')
+      })
+      cy.get('title').should('contain', 'Create your password - GOV.UK Pay')
+
+      cy.get('.govuk-form-group--error > input#password').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'Enter a password')
+      })
+      cy.get('.govuk-form-group--error > input#repeat-password').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'Re-type your password')
+      })
+
+      // enter valid values into both password fields and click continue
+      cy.get('#password').type('long-enough-password', { delay: 0 })
+      cy.get('#repeat-password').type('long-enough-password', { delay: 0 })
+      cy.get('button').contains('Continue').click()
+
+      // should redirect to next page
+      cy.get('title').should('contain', 'Choose how to get security codes - GOV.UK Pay')
+
+      // don't select an option and click continue
+      cy.get('button').contains('Continue').click()
+
+      // check that error messages are displayed
+      cy.get('.govuk-error-summary').should('exist').within(() => {
+        cy.get('h2').should('contain', 'There is a problem')
+        cy.get('[data-cy=error-summary-list-item]').should('have.length', 1)
+        cy.get('[data-cy=error-summary-list-item]').eq(0)
+          .contains('You need to select an option')
+          .should('have.attr', 'href', '#sign-in-method')
+      })
+      cy.get('title').should('contain', 'Choose how to get security codes - GOV.UK Pay')
+
+      cy.get('[data-cy=radios-security-code]').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'You need to select an option')
+      })
+
+      // select SMS and click continue
+      cy.get('[data-cy=radio-option-sms]').click()
+      cy.get('button').contains('Continue').click()
+
+      // should redirect to phone number page
+      cy.get('title').should('contain', 'Enter your mobile phone number - GOV.UK Pay')
     })
-    cy.get('title').should('contain', 'Create your password - GOV.UK Pay')
+  })
 
-    cy.get('.govuk-form-group--error > input#password').parent().should('exist').within(() => {
-      cy.get('.govuk-error-message').should('contain', 'Enter a password')
+  describe('APP is selected as method for getting security codes', () => {
+    it('should complete registration journey', () => {
+      cy.task('setupStubs', [
+        inviteStubs.getInviteSuccess({
+          code: inviteCode,
+          password_set: false
+        })
+      ])
+
+      // visit the invite link to get the register_invite cookie set
+      cy.visit(`/invites/${inviteCode}`)
+
+      // TODO: when the journey is hooked up, the previous route should redirect to the set password page but for now
+      // we need to manually visit to start the new journey
+      cy.visit('/register/password')
+
+      cy.get('title').should('contain', 'Create your password - GOV.UK Pay')
+      cy.get('h1').should('contain', 'Create your password')
+
+      // enter valid values into both password fields and click continue
+      cy.get('#password').type('long-enough-password', { delay: 0 })
+      cy.get('#repeat-password').type('long-enough-password', { delay: 0 })
+      cy.get('button').contains('Continue').click()
+
+      // should redirect to next page
+      cy.get('title').should('contain', 'Choose how to get security codes - GOV.UK Pay')
+
+      // select APP and click continue
+      cy.get('[data-cy=radio-option-app]').click()
+      cy.get('button').contains('Continue').click()
+
+      // should redirect to authenticator app page
+      cy.get('title').should('contain', 'Set up an authenticator app - GOV.UK Pay')
     })
-    cy.get('.govuk-form-group--error > input#repeat-password').parent().should('exist').within(() => {
-      cy.get('.govuk-error-message').should('contain', 'Re-type your password')
-    })
-
-    // enter valid values into both password fields and click continue
-    cy.get('#password').type('long-enough-password', { delay: 0 })
-    cy.get('#repeat-password').type('long-enough-password', { delay: 0 })
-    cy.get('button').contains('Continue').click()
-
-    // should redirect to next page
-    cy.get('title').should('contain', 'Choose how to get security codes - GOV.UK Pay')
   })
 })


### PR DESCRIPTION
Add a POST `/register/get-security-codes` route that validates that a radio button option has been selected and redirects to either the page to enter a phone number, or to set up an authenticator app depending on the option chosen.

## Review notes

Hiding whitespace changes from the diff will help with review, as indentation had changed in the cypress test.

