### PR TITLE
PP-10052 Improve validation messages for OTP codes

### DIFF
--- a/app/controllers/user/two-factor-auth/post-configure.controller.js
+++ b/app/controllers/user/two-factor-auth/post-configure.controller.js
@@ -6,15 +6,17 @@ const paths = require('../../../paths')
 const userService = require('../../../services/user.service.js')
 const secondFactorMethod = require('../../../models/second-factor-method')
 const { RESTClientError } = require('../../../errors')
+const { validateOtp } = require('../../../utils/validation/server-side-form-validations')
 
 module.exports = async function postUpdateSecondFactorMethod (req, res, next) {
-  const code = req.body['code'] || ''
+  const code = req.body['code']
   const method = lodash.get(req, 'session.pageData.twoFactorAuthMethod', secondFactorMethod.APP)
 
-  if (!code) {
+  const validationResult = validateOtp(code)
+  if (!validationResult.valid) {
     lodash.set(req, 'session.pageData.configureTwoFactorAuthMethodRecovered', {
       errors: {
-        securityCode: 'Enter a security code'
+        securityCode: validationResult.message
       }
     })
     return res.redirect(paths.user.profile.twoFactorAuth.configure)

--- a/app/controllers/user/two-factor-auth/post-configure.controller.test.js
+++ b/app/controllers/user/two-factor-auth/post-configure.controller.test.js
@@ -6,9 +6,10 @@ const userFixtures = require('../../../../test/fixtures/user.fixtures')
 const User = require('../../../models/User.class')
 const paths = require('../../../paths')
 const { RESTClientError } = require('../../../errors')
+const secondFactorMethod = require('../../../models/second-factor-method')
 
 const userExternalId = 'user-id'
-const twoFactorAuthMethod = 'SMS'
+const twoFactorAuthMethod = secondFactorMethod.SMS
 
 describe('Configure new second factor method post controller', () => {
   let req, res, next
@@ -43,7 +44,7 @@ describe('Configure new second factor method post controller', () => {
       expect(req.session.pageData).to.have.property('configureTwoFactorAuthMethodRecovered')
       expect(req.session.pageData.configureTwoFactorAuthMethodRecovered).to.deep.equal({
         errors: {
-          securityCode: 'Enter a security code'
+          securityCode: 'Enter your security code'
         }
       })
     })

--- a/app/utils/validation/field-validation-checks.js
+++ b/app/utils/validation/field-validation-checks.js
@@ -27,7 +27,9 @@ const validationErrors = {
   invalidWorldpay3dsFlexIssuer: 'Enter your issuer in the format you received it',
   invalidWorldpay3dsFlexJwtMacKey: 'Enter your JWT MAC key in the format you received it',
   invalidDateOfBirth: 'Enter a valid date',
-  invalidTelephoneNumber: 'Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192'
+  invalidTelephoneNumber: 'Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192',
+  invalidOrExpiredSecurityCodeSMS: 'The security code you’ve used is incorrect or has expired',
+  invalidOrExpiredSecurityCodeApp: 'The security code you entered is not correct, try entering it again or wait for for your authenticator app to give you a new code'
 }
 
 exports.validationErrors = validationErrors

--- a/app/utils/validation/server-side-form-validations.js
+++ b/app/utils/validation/server-side-form-validations.js
@@ -218,7 +218,13 @@ function validateOtp (otp) {
     return notValidReturnObject('Enter your security code')
   }
   if (!NUMBERS_ONLY.test(otp)) {
-    return notValidReturnObject('Enter numbers only')
+    return notValidReturnObject('The code must be 6 numbers')
+  }
+  if (otp.length > 6) {
+    return notValidReturnObject('You’ve entered too many numbers, the code must be 6 numbers')
+  }
+  if (otp.length < 6) {
+    return notValidReturnObject('You’ve not entered enough numbers, the code must be 6 numbers')
   }
   return validReturnObject
 }

--- a/app/utils/validation/server-side-form-validations.test.js
+++ b/app/utils/validation/server-side-form-validations.test.js
@@ -350,7 +350,7 @@ describe('Server side form validations', () => {
 
   describe('otp code validation', () => {
     it('should be valid for a valid OTP code', () => {
-      expect(validations.validateOtp('123').valid).to.be.true // eslint-disable-line
+      expect(validations.validateOtp('123456').valid).to.be.true // eslint-disable-line
     })
 
     it('should not be valid for empty OTP code', () => {
@@ -360,10 +360,24 @@ describe('Server side form validations', () => {
       })
     })
 
-    it('should not be valid for an invalid OTP code', () => {
-      expect(validations.validateOtp('abc')).to.deep.equal({
+    it('should not be valid for an OTP code that contains letters', () => {
+      expect(validations.validateOtp('abc123')).to.deep.equal({
         valid: false,
-        message: 'Enter numbers only'
+        message: 'The code must be 6 numbers'
+      })
+    })
+
+    it('should not be valid for a code that is too short', () => {
+      expect(validations.validateOtp('12345')).to.deep.equal({
+        valid: false,
+        message: 'You’ve not entered enough numbers, the code must be 6 numbers'
+      })
+    })
+
+    it('should not be valid for a code that is too long', () => {
+      expect(validations.validateOtp('1234567')).to.deep.equal({
+        valid: false,
+        message: 'You’ve entered too many numbers, the code must be 6 numbers'
       })
     })
   })

--- a/test/cypress/integration/registration/register.cy.test.js
+++ b/test/cypress/integration/registration/register.cy.test.js
@@ -16,7 +16,7 @@ describe('Register', () => {
       cy.visit(`/invites/${inviteCode}`)
 
       // TODO: when the journey is hooked up, the previous route should redirect to the set password page but for now
-    // we need to manually visit to start the new journey
+      // we need to manually visit to start the new journey
       cy.visit('/register/password')
 
       cy.get('title').should('contain', 'Create your password - GOV.UK Pay')

--- a/test/cypress/integration/user/change-sign-in-method.cy.test.js
+++ b/test/cypress/integration/user/change-sign-in-method.cy.test.js
@@ -122,13 +122,13 @@ describe('Change sign in method', () => {
             cy.get('h2').should('contain', 'There is a problem')
             cy.get('[data-cy=error-summary-list-item]').should('have.length', 1)
             cy.get('[data-cy=error-summary-list-item]').first()
-              .contains('Enter a security code')
+              .contains('Enter your security code')
               .should('have.attr', 'href', '#code')
           })
           cy.title().should('equal', 'Check your phone - GOV.UK Pay')
 
           cy.get('.govuk-form-group--error > input#code').parent().should('exist').within(() => {
-            cy.get('.govuk-error-message').should('contain', 'Enter a security code')
+            cy.get('.govuk-error-message').should('contain', 'Enter your security code')
           })
 
           // enter a valid code and submit

--- a/test/integration/self-registration/self-registration-otp-verify.ft.test.js
+++ b/test/integration/self-registration/self-registration-otp-verify.ft.test.js
@@ -227,7 +227,7 @@ describe('create service OTP validation', function () {
         .expect(() => {
           expect(registerInviteData).to.have.property('recovered').to.deep.equal({
             errors: {
-              securityCode: 'Enter numbers only'
+              securityCode: 'The code must be 6 numbers'
             }
           })
         })

--- a/test/unit/controller/register-user.controller.test.js
+++ b/test/unit/controller/register-user.controller.test.js
@@ -28,7 +28,7 @@ describe('Register user controller', () => {
       register_invite: { code: inviteCode, email },
       user: new User(userFixtures.validUserResponse({ email })),
       body: {
-        'verify-code': 123456
+        'verify-code': '123456'
       },
       flash: flashSpy
     }


### PR DESCRIPTION
Improve validation messages for OTP codes to be more specific about why a code is invalid if it does not have the correct format.

Uses the error messages from the design system page for this pattern https://design-system.service.gov.uk/patterns/confirm-a-phone-number/

Also, use this OTP validation when an OTP code is entered for changing the sign-in method. Previously we only checked whether the code was empty.