### PR TITLE
PP-10052 Use constants for invalid OTP error messages

### DIFF
--- a/app/controllers/register-service.controller.js
+++ b/app/controllers/register-service.controller.js
@@ -15,6 +15,7 @@ const {
   validateOtp
 } = require('../utils/validation/server-side-form-validations')
 const { RegistrationSessionMissingError, InvalidRegistationStateError } = require('../errors')
+const { validationErrors } = require('../utils/validation/field-validation-checks')
 
 const EXPIRED_ERROR_MESSAGE = 'This invitation is no longer valid'
 const INVITE_NOT_FOUND_ERROR_MESSAGE = 'There has been a problem proceeding with this registration. Please try again.'
@@ -161,7 +162,7 @@ async function submitOtpCode (req, res, next) {
     if (err.errorCode === 401) {
       sessionData.recovered = {
         errors: {
-          securityCode: 'The security code you’ve used is incorrect or has expired'
+          securityCode: validationErrors.invalidOrExpiredSecurityCodeSMS
         }
       }
       return res.redirect(303, paths.selfCreateService.otpVerify)

--- a/app/controllers/register-user.controller.js
+++ b/app/controllers/register-user.controller.js
@@ -12,6 +12,7 @@ const {
   validateOtp
 } = require('../utils/validation/server-side-form-validations')
 const { RegistrationSessionMissingError, ExpiredInviteError } = require('../errors')
+const { validationErrors } = require('../utils/validation/field-validation-checks')
 
 const EXPIRED_ERROR_MESSAGE = 'This invitation is no longer valid'
 
@@ -160,7 +161,7 @@ const submitOtpVerify = async function submitOtpVerify (req, res, next) {
     if (err.errorCode === 401) {
       sessionData.recovered = {
         errors: {
-          securityCode: 'The security code you’ve used is incorrect or has expired'
+          securityCode: validationErrors.invalidOrExpiredSecurityCodeSMS
         }
       }
       return res.redirect(303, paths.registerUser.otpVerify)

--- a/app/controllers/user/two-factor-auth/post-configure.controller.js
+++ b/app/controllers/user/two-factor-auth/post-configure.controller.js
@@ -7,6 +7,7 @@ const userService = require('../../../services/user.service.js')
 const secondFactorMethod = require('../../../models/second-factor-method')
 const { RESTClientError } = require('../../../errors')
 const { validateOtp } = require('../../../utils/validation/server-side-form-validations')
+const { validationErrors } = require('../../../utils/validation/field-validation-checks')
 
 module.exports = async function postUpdateSecondFactorMethod (req, res, next) {
   const code = req.body['code']
@@ -28,9 +29,12 @@ module.exports = async function postUpdateSecondFactorMethod (req, res, next) {
     return res.redirect(paths.user.profile.index)
   } catch (err) {
     if (err instanceof RESTClientError && (err.errorCode === 401 || err.errorCode === 400)) {
+      const error = method === secondFactorMethod.SMS
+        ? validationErrors.invalidOrExpiredSecurityCodeSMS
+        : validationErrors.invalidOrExpiredSecurityCodeApp
       lodash.set(req, 'session.pageData.configureTwoFactorAuthMethodRecovered', {
         errors: {
-          securityCode: 'The security code you’ve used is incorrect or has expired'
+          securityCode: error
         }
       })
       return res.redirect(paths.user.profile.twoFactorAuth.configure)

--- a/app/controllers/user/two-factor-auth/post-configure.controller.test.js
+++ b/app/controllers/user/two-factor-auth/post-configure.controller.test.js
@@ -86,7 +86,7 @@ describe('Configure new second factor method post controller', () => {
     })
 
     describe('Adminusers returns a 401 response', () => {
-      it('should call redirect with errors in session', async () => {
+      it('should call redirect with errors in session for SMS method', async () => {
         const error = new RESTClientError('An error', 'adminusers', 401)
         const adminusersRejectsStub = () => Promise.reject(error)
 
@@ -98,6 +98,24 @@ describe('Configure new second factor method post controller', () => {
         expect(req.session.pageData.configureTwoFactorAuthMethodRecovered).to.deep.equal({
           errors: {
             securityCode: 'The security code you’ve used is incorrect or has expired'
+          }
+        })
+      })
+
+      it('should call redirect with errors in session for APP method', async () => {
+        req.session.pageData.twoFactorAuthMethod = secondFactorMethod.APP
+
+        const error = new RESTClientError('An error', 'adminusers', 401)
+        const adminusersRejectsStub = () => Promise.reject(error)
+
+        const controllerWithAdminusersError = getController(adminusersRejectsStub)
+        await controllerWithAdminusersError(req, res, next)
+
+        sinon.assert.calledWith(res.redirect, paths.user.profile.twoFactorAuth.configure)
+        expect(req.session.pageData).to.have.property('configureTwoFactorAuthMethodRecovered')
+        expect(req.session.pageData.configureTwoFactorAuthMethodRecovered).to.deep.equal({
+          errors: {
+            securityCode: 'The security code you entered is not correct, try entering it again or wait for your authenticator app to give you a new code'
           }
         })
       })

--- a/app/utils/validation/field-validation-checks.js
+++ b/app/utils/validation/field-validation-checks.js
@@ -29,7 +29,7 @@ const validationErrors = {
   invalidDateOfBirth: 'Enter a valid date',
   invalidTelephoneNumber: 'Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192',
   invalidOrExpiredSecurityCodeSMS: 'The security code you’ve used is incorrect or has expired',
-  invalidOrExpiredSecurityCodeApp: 'The security code you entered is not correct, try entering it again or wait for for your authenticator app to give you a new code'
+  invalidOrExpiredSecurityCodeApp: 'The security code you entered is not correct, try entering it again or wait for your authenticator app to give you a new code'
 }
 
 exports.validationErrors = validationErrors


### PR DESCRIPTION
To ensure that we are using the same error message in all places that validate OTP codes, move the validation messages we display when adminusers returns a 401 response when verifying the code to shared constants.

Also, display an improved error message if the OTP method is to use an authenticator app. This message is taken from the GOV.UK Sign-in login/registration pages.

