### PR TITLE
PP-10052 Strip spaces and dashes from OTP codes

### DIFF
--- a/app/controllers/register-service.controller.js
+++ b/app/controllers/register-service.controller.js
@@ -16,6 +16,7 @@ const {
 } = require('../utils/validation/server-side-form-validations')
 const { RegistrationSessionMissingError, InvalidRegistationStateError } = require('../errors')
 const { validationErrors } = require('../utils/validation/field-validation-checks')
+const { sanitiseSecurityCode } = require('../utils/security-code-utils')
 
 const EXPIRED_ERROR_MESSAGE = 'This invitation is no longer valid'
 const INVITE_NOT_FOUND_ERROR_MESSAGE = 'There has been a problem proceeding with this registration. Please try again.'
@@ -144,7 +145,7 @@ async function submitOtpCode (req, res, next) {
     return next(new RegistrationSessionMissingError())
   }
   const code = req.register_invite.code
-  const otpCode = req.body['verify-code']
+  const otpCode = sanitiseSecurityCode(req.body['verify-code'])
 
   const validOtp = validateOtp(otpCode)
   if (!validOtp.valid) {

--- a/app/controllers/register-user.controller.js
+++ b/app/controllers/register-user.controller.js
@@ -13,6 +13,7 @@ const {
 } = require('../utils/validation/server-side-form-validations')
 const { RegistrationSessionMissingError, ExpiredInviteError } = require('../errors')
 const { validationErrors } = require('../utils/validation/field-validation-checks')
+const { sanitiseSecurityCode } = require('../utils/security-code-utils')
 
 const EXPIRED_ERROR_MESSAGE = 'This invitation is no longer valid'
 
@@ -138,7 +139,7 @@ const showOtpVerify = function showOtpVerify (req, res, next) {
  * @param res
  */
 const submitOtpVerify = async function submitOtpVerify (req, res, next) {
-  const securityCode = req.body['verify-code']
+  const securityCode = sanitiseSecurityCode(req.body['verify-code'])
 
   const sessionData = req.register_invite
   if (!registrationSessionPresent(sessionData)) {

--- a/app/controllers/user/two-factor-auth/post-configure.controller.js
+++ b/app/controllers/user/two-factor-auth/post-configure.controller.js
@@ -8,9 +8,10 @@ const secondFactorMethod = require('../../../models/second-factor-method')
 const { RESTClientError } = require('../../../errors')
 const { validateOtp } = require('../../../utils/validation/server-side-form-validations')
 const { validationErrors } = require('../../../utils/validation/field-validation-checks')
+const { sanitiseSecurityCode } = require('../../../utils/security-code-utils')
 
 module.exports = async function postUpdateSecondFactorMethod (req, res, next) {
-  const code = req.body['code']
+  const code = sanitiseSecurityCode(req.body['code'])
   const method = lodash.get(req, 'session.pageData.twoFactorAuthMethod', secondFactorMethod.APP)
 
   const validationResult = validateOtp(code)

--- a/app/controllers/user/two-factor-auth/post-configure.controller.test.js
+++ b/app/controllers/user/two-factor-auth/post-configure.controller.test.js
@@ -51,7 +51,8 @@ describe('Configure new second factor method post controller', () => {
   })
 
   describe('A valid code is entered', () => {
-    const validCode = '123456'
+    const validCode = '123 456'
+    const expectedSanitisedCode = '123456'
 
     beforeEach(() => {
       req.body.code = validCode
@@ -61,7 +62,7 @@ describe('Configure new second factor method post controller', () => {
       it('should call adminusers to configure OTP key and redirect to profile', async () => {
         await controllerWithAdminusersSuccess(req, res, next)
 
-        sinon.assert.calledWith(configureNewOtpKeySpy, userExternalId, validCode, twoFactorAuthMethod)
+        sinon.assert.calledWith(configureNewOtpKeySpy, userExternalId, expectedSanitisedCode, twoFactorAuthMethod)
         sinon.assert.calledWith(req.flash, 'otpMethodUpdated', twoFactorAuthMethod)
         sinon.assert.calledWith(res.redirect, paths.user.profile.index)
       })

--- a/app/services/auth.service.js
+++ b/app/services/auth.service.js
@@ -14,6 +14,7 @@ const userService = require('./user.service.js')
 const { validationErrors } = require('./../utils/validation/field-validation-checks')
 const secondFactorMethod = require('../models/second-factor-method')
 const { validateOtp } = require('../utils/validation/server-side-form-validations')
+const { sanitiseSecurityCode } = require('../utils/security-code-utils')
 
 // Exports
 module.exports = {
@@ -72,7 +73,7 @@ function localStrategyAuth (req, username, password, done) {
 }
 
 async function localStrategy2Fa (req, done) {
-  const code = req.body.code
+  const code = sanitiseSecurityCode(req.body.code)
   const validationResult = validateOtp(code)
   if (!validationResult.valid) {
     return done(null, false, { message: validationResult.message })

--- a/app/utils/security-code-utils.js
+++ b/app/utils/security-code-utils.js
@@ -1,0 +1,9 @@
+'use strict'
+
+function sanitiseSecurityCode (code) {
+  return code && code.replace(/[\s-–]/g, '')
+}
+
+module.exports = {
+  sanitiseSecurityCode
+}

--- a/app/utils/security-code-utils.test.js
+++ b/app/utils/security-code-utils.test.js
@@ -1,0 +1,17 @@
+const { expect } = require('chai')
+
+const { sanitiseSecurityCode } = require('./security-code-utils')
+
+describe('Security code utilities', () => {
+  describe('sanitise security code', () => {
+    it('should remove spaces, dashes and hyphens from code', () => {
+      const output = sanitiseSecurityCode(' 01 23-34– - ')
+      expect(output).to.equal('012334')
+    })
+
+    it('should return undefined when undefined code is provided', () => {
+      const output = sanitiseSecurityCode(undefined)
+      expect(output).to.equal(undefined)
+    })
+  })
+})

--- a/test/unit/controller/register-user.controller.test.js
+++ b/test/unit/controller/register-user.controller.test.js
@@ -14,6 +14,8 @@ describe('Register user controller', () => {
   const email = 'invited-user@example.com'
   const inviteCode = 'a-code'
   const serviceExternalId = 'a-service-id'
+  const otpCode = '123 456'
+  const expectedSanitisedCode = '123456'
 
   const verifyOtpSuccessStub = sinon.spy(() => Promise.resolve())
   const completeInviteSuccessStub = sinon.spy(() => Promise.resolve(inviteFixtures.validInviteCompleteResponse({
@@ -28,7 +30,7 @@ describe('Register user controller', () => {
       register_invite: { code: inviteCode, email },
       user: new User(userFixtures.validUserResponse({ email })),
       body: {
-        'verify-code': '123456'
+        'verify-code': otpCode
       },
       flash: flashSpy
     }
@@ -120,9 +122,11 @@ describe('Register user controller', () => {
 
     describe('Submitted OTP code is correct', () => {
       it('should redirect to logUserIn with a 303', async () => {
-        const controllerWithVerifyOtpError = getController(verifyOtpSuccessStub, completeInviteSuccessStub)
-        await controllerWithVerifyOtpError.submitOtpVerify(req, res, next)
+        const controllerWithVerifyOtpSuccess = getController(verifyOtpSuccessStub, completeInviteSuccessStub)
+        await controllerWithVerifyOtpSuccess.submitOtpVerify(req, res, next)
 
+        sinon.assert.calledWith(verifyOtpSuccessStub, inviteCode, expectedSanitisedCode)
+        sinon.assert.calledWith(completeInviteSuccessStub, inviteCode)
         sinon.assert.calledWith(res.redirect, 303, paths.registerUser.logUserIn)
       })
     })

--- a/test/unit/services/auth.service.test.js
+++ b/test/unit/services/auth.service.test.js
@@ -228,16 +228,17 @@ describe('auth service', function () {
         }
       })
 
-      const otpCode = '123456'
+      const inputOtpCode = '123 456'
+      const expectedSanitisedCode = '123456'
       const req = {
         user,
         body: {
-          code: otpCode
+          code: inputOtpCode
         }
       }
 
       await authService.localStrategy2Fa(req, doneSpy)
-      sinon.assert.calledWith(authenticateSecondFactorSpy, user.externalId, otpCode)
+      sinon.assert.calledWith(authenticateSecondFactorSpy, user.externalId, expectedSanitisedCode)
       sinon.assert.calledWith(doneSpy, null, user)
     })
 


### PR DESCRIPTION
In the design system page for the pattern to enter OTP codes, it says to

"Let the user enter the code in whatever format is familiar to them. Allow additional spaces, hyphens and dashes."

The reasoning for this is that speech-to-text programs may cause spaces to be entered in the code, or authenticator apps might provide the code in a different format using spaces or dashes.

For all places where we ask the user to enter an OTP code, remove spaces and dashes before validating and submitting the code.