### PR TITLE
PP-10274 Worldpay 3DS Flex - auto toggle 3DS setting when LIVE account

### DIFF
--- a/app/controllers/your-psp/post-flex.controller.js
+++ b/app/controllers/your-psp/post-flex.controller.js
@@ -15,6 +15,7 @@ const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 const ORGANISATIONAL_UNIT_ID_FIELD = 'organisational-unit-id'
 const ISSUER_FIELD = 'issuer'
 const JWT_MAC_KEY_FIELD = 'jwt-mac-key'
+const INTEGRATION_VERSION_3DS = 2
 
 module.exports = async function submit3dsFlexCredentials (req, res, next) {
   const accountId = req.account.gateway_account_id
@@ -68,6 +69,11 @@ module.exports = async function submit3dsFlexCredentials (req, res, next) {
     }
 
     await connector.post3dsFlexAccountCredentials(flexParams)
+    
+    if (req.account.type === 'live'){
+      await connector.updateIntegrationVersion3ds(accountId, INTEGRATION_VERSION_3DS)      
+    }
+
     req.flash('generic', 'Your Worldpay 3DS Flex settings have been updated')
     return res.redirect(indexUrl)
   } catch (err) {

--- a/app/controllers/your-psp/post-flex.controller.test.js
+++ b/app/controllers/your-psp/post-flex.controller.test.js
@@ -1,0 +1,104 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+const gatewayAccountFixtures = require('../../../test/fixtures/gateway-account.fixtures')
+
+describe('Post 3DS Flex controller', () => {
+  const gatewayAccountExternalId = 'a-gateway-account-external-id'
+  const credentialId = 'a-valid-credential-id'
+  let req
+  let res
+  let next
+  let postCheckWorldpay3dsFlexCredentials
+  let post3dsFlexAccountCredentials 
+  let updateIntegrationVersion3dsMock
+  let renderErrorViewMock
+
+  beforeEach(() => {
+    req = {
+      params: { credentialId },
+      flash: sinon.spy(),
+      body: {
+        'organisational-unit-id': '111111111111111111111111',
+        'issuer': '111111111111111111111111',
+        'jwt-mac-key': '11111111-1111-1111-1111-111111111111'
+      }
+    }
+    res = {
+      setHeader: sinon.stub(),
+      status: sinon.spy(),
+      redirect: sinon.spy(),
+      render: sinon.spy()
+    }
+
+    next = sinon.spy()
+
+    postCheckWorldpay3dsFlexCredentials = sinon.spy(() => Promise.resolve({result: 'valid'}))
+    post3dsFlexAccountCredentials = sinon.spy(() => Promise.resolve())
+    updateIntegrationVersion3dsMock = sinon.spy(() => Promise.resolve())
+  })
+
+  it('should set 3DS integration version to 2 for LIVE account', async () => {
+    req.account = getGatewayAcountWithType('live')
+
+    const controller = getControllerWithMocks()
+
+    await controller(req, res, next)
+
+    sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 2)
+    sinon.assert.calledWith(req.flash, 'generic', 'Your Worldpay 3DS Flex settings have been updated')
+    sinon.assert.calledWith(res.redirect, `/account/${gatewayAccountExternalId}/your-psp/${credentialId}`)
+  })
+
+  it('should NOT set 3DS integration version to 2 for TEST account', async () => {
+    req.account = getGatewayAcountWithType('test')
+    
+    const controller = getControllerWithMocks()
+
+    await controller(req, res, next)
+
+    sinon.assert.notCalled(updateIntegrationVersion3dsMock)
+  })
+
+  it('should call next when there is an error updating the 3DS integration version to 2', async () => {
+    req.account = getGatewayAcountWithType('live')
+    const expectedError = new Error('error from adminusers')
+
+    updateIntegrationVersion3dsMock = sinon.stub().rejects(expectedError)
+    const controller = getControllerWithMocks()
+
+    await controller(req, res, next)
+
+    sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 2)
+    sinon.assert.calledWith(next, expectedError)
+  })
+
+  function getControllerWithMocks () {
+    return proxyquire('./post-flex.controller', {
+      '../../services/clients/connector.client': {
+        ConnectorClient: function () {
+          this.postCheckWorldpay3dsFlexCredentials = postCheckWorldpay3dsFlexCredentials
+          this.post3dsFlexAccountCredentials = post3dsFlexAccountCredentials
+          this.updateIntegrationVersion3ds = updateIntegrationVersion3dsMock
+        }
+      },
+      '../../utils/response': {
+        renderErrorView: renderErrorViewMock
+      }
+    })
+  }
+
+  function getGatewayAcountWithType(accountType) {
+    return gatewayAccountFixtures.validGatewayAccount({
+      gateway_account_id: '1',
+      type: accountType,
+      external_id: gatewayAccountExternalId,
+      gateway_account_credentials: [{
+        payment_provider: 'worldpay',
+        external_id: credentialId
+      }]
+    })
+  }
+})


### PR DESCRIPTION
- Update post-flex controller
  - Auto toggle the 3DS setting when a LIVE Account
- Add unit test.


