### PR TITLE
PP-10052 Add logic for route to display authenticator app page

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -168,49 +168,56 @@
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "9695086041c462c6598c6dd5e35d3a2c9cbbe5f8",
         "is_verified": false,
-        "line_number": 93
+        "line_number": 95
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "7b652417979832c620feec2e89b92c56a291ae52",
         "is_verified": false,
-        "line_number": 94
+        "line_number": 96
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "f5378ce7cd012d12a9be51e6be241b1e66240879",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 103
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "69c8d31085756bfd34bb8ca6d393289374b7d7c2",
         "is_verified": false,
-        "line_number": 108
+        "line_number": 110
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "3f3c2dca191782c9b8b2f513d16abaa66dc543bf",
         "is_verified": false,
-        "line_number": 115
+        "line_number": 117
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "0ee4c488221aee414cd9ae5300e28d11c2851fe5",
         "is_verified": false,
-        "line_number": 130
+        "line_number": 132
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "d8fe3060b1c00ad00ece5d205e493764b113b94c",
         "is_verified": false,
-        "line_number": 136
+        "line_number": 138
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/controllers/registration/registration.controller.test.js",
+        "hashed_secret": "a04fccdd7f93b63162cd0d3e015761cd3a24d86a",
+        "is_verified": false,
+        "line_number": 248
       }
     ],
     "app/controllers/your-psp/worldpay-3ds-flex-validations.test.js": [
@@ -680,21 +687,21 @@
         "filename": "test/fixtures/invite.fixtures.js",
         "hashed_secret": "c2326bf719e924050321d3adb8d8d3a99723ee95",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 83
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/fixtures/invite.fixtures.js",
         "hashed_secret": "e5a7431b27dbc70d00c5ed873bd4d837bd65720c",
         "is_verified": false,
-        "line_number": 89
+        "line_number": 90
       },
       {
         "type": "Secret Keyword",
         "filename": "test/fixtures/invite.fixtures.js",
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_verified": false,
-        "line_number": 122
+        "line_number": 123
       }
     ],
     "test/integration/forgotten-password.ft.test.js": [
@@ -895,5 +902,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-21T17:08:02Z"
+  "generated_at": "2022-11-22T10:36:24Z"
 }

--- a/app/views/registration/authenticator-app.njk
+++ b/app/views/registration/authenticator-app.njk
@@ -42,7 +42,7 @@
     <p class="govuk-body">2. Use your authenticator app to scan the QR code or type the secret key into your authenticator app. Some authenticator apps call the secret key a ‘code’</p>
 
     <figure class="govuk-!-margin-top-0 govuk-!-margin-left-0 govuk-!-margin-bottom-6">
-      <img class="qr-code pay-!-negative-margin-h-3" src="{{qrCodeDataUrl}}" alt="If you cannot view or scan the barcode, please enter the secret manually">
+      <img class="qr-code pay-!-negative-margin-h-3" src="{{qrCodeDataUrl}}" data-cy="qr" alt="If you cannot view or scan the barcode, please enter the secret manually">
       <figcaption>
         <h4 class="govuk-body">Secret key:</h4>
         <code class="code" data-cy="otp-secret">{{prettyPrintedSecret}}</code>

--- a/test/cypress/integration/registration/register.cy.test.js
+++ b/test/cypress/integration/registration/register.cy.test.js
@@ -1,6 +1,7 @@
 const inviteStubs = require('../../stubs/invite-stubs')
 
 const inviteCode = 'an-invite-code'
+const otpKey = 'ANEXAMPLESECRETSECONDFACTORCODE1'
 
 describe('Register', () => {
   describe('SMS is selected as method for getting security codes', () => {
@@ -8,7 +9,8 @@ describe('Register', () => {
       cy.task('setupStubs', [
         inviteStubs.getInviteSuccess({
           code: inviteCode,
-          password_set: false
+          password_set: false,
+          otp_key: otpKey
         })
       ])
 
@@ -112,6 +114,11 @@ describe('Register', () => {
 
       // should redirect to authenticator app page
       cy.get('title').should('contain', 'Set up an authenticator app - GOV.UK Pay')
+
+      cy.get('[data-cy=qr]').should('have.attr', 'src').then(src => {
+        expect(src).to.contain('data:image')
+      })
+      cy.get('[data-cy=otp-secret]').should('have.text', 'ANEX AMPL ESEC RETS ECON DFAC TORC ODE1')
     })
   })
 })

--- a/test/fixtures/invite.fixtures.js
+++ b/test/fixtures/invite.fixtures.js
@@ -9,7 +9,8 @@ function buildInviteWithDefaults (opts = {}) {
     role: opts.role || 'admin',
     disabled: opts.disabled || false,
     user_exist: opts.user_exist || false,
-    expired: opts.expired || false
+    expired: opts.expired || false,
+    otp_key: opts.otp_key || 'ANEXAMPLESECRETSECONDFACTORCODE1'
   }
 
   if (opts.telephone_number) {


### PR DESCRIPTION
A route already existed for GET `/register/authenticator-app` which just displayed dummy data. Update the controller for this to retrieve the invite from adminusers and then render the page, displaying the OTP secret key from the invite and the QR code generated from this.


