### PR TITLE
Pp 10274 - worldpay flex show toggle for test account

### DIFF
--- a/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.js
+++ b/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.js
@@ -11,6 +11,10 @@ module.exports = async function toggleWorldpay3dsFlex (req, res, next) {
   const accountId = req.account.gateway_account_id
   const toggleWorldpay3dsFlex = req.body['toggle-worldpay-3ds-flex']
 
+  if (req.account.type === 'live') {
+    return next(new Error(`Cannot toggle Worldpay 3DS flex for live gateway account: ${req.account.external_id}`))
+  }
+
   if (req.body['toggle-worldpay-3ds-flex'] === 'on' || req.body['toggle-worldpay-3ds-flex'] === 'off') {
     const enabling3dsFlex = toggleWorldpay3dsFlex === 'on'
     const message = enabling3dsFlex ? '3DS Flex has been turned on.' : '3DS Flex has been turned off. Your payments will now use 3DS only.'

--- a/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.test.js
+++ b/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.test.js
@@ -22,7 +22,8 @@ describe('Toggle Worldpay 3DS Flex controller', () => {
         gateway_account_credentials: [{
           payment_provider: 'worldpay',
           external_id: credentialId
-        }]
+        }],
+        type: 'test'
       }),
       params: { credentialId },
       flash: sinon.spy(),
@@ -37,74 +38,92 @@ describe('Toggle Worldpay 3DS Flex controller', () => {
     next = sinon.spy()
   })
 
-  it('should toggle 3DS Flex on by setting 3DS integration version to 2', async () => {
-    updateIntegrationVersion3dsMock = sinon.spy(() => Promise.resolve())
-    const controller = getControllerWithMocks()
+  describe('Test gateway account', () => {
+    it('should toggle 3DS Flex on by setting 3DS integration version to 2', async () => {
+      updateIntegrationVersion3dsMock = sinon.spy(() => Promise.resolve())
+      const controller = getControllerWithMocks()
+  
+      req.body['toggle-worldpay-3ds-flex'] = 'on'
+      await controller(req, res, next)
+  
+      sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 2)
+      sinon.assert.calledWith(req.flash, 'generic', '3DS Flex has been turned on.')
+      sinon.assert.calledWith(res.redirect, 303, `/account/${gatewayAccountExternalId}/your-psp/${credentialId}`)
+    })
+  
+    it('should toggle 3DS Flex off by setting 3DS integration version to 1', async () => {
+      updateIntegrationVersion3dsMock = sinon.spy(() => Promise.resolve())
+      const controller = getControllerWithMocks()
+  
+      req.body['toggle-worldpay-3ds-flex'] = 'off'
+      await controller(req, res, next)
+  
+      sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 1)
+      sinon.assert.calledWith(req.flash, 'generic', '3DS Flex has been turned off. Your payments will now use 3DS only.')
+      sinon.assert.calledWith(res.redirect, 303, `/account/${gatewayAccountExternalId}/your-psp/${credentialId}`)
+    })
+  
+    it('should call next with error if problem calling connector', async () => {
+      const error = new Error()
+      updateIntegrationVersion3dsMock = sinon.spy(() => Promise.reject(error))
+      renderErrorViewMock = sinon.spy(() => Promise.resolve())
+      const controller = getControllerWithMocks()
+  
+      req.body['toggle-worldpay-3ds-flex'] = 'on'
+      await controller(req, res, next)
+  
+      sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 2)
+      const expectedError = sinon.match.instanceOf(Error)
+      sinon.assert.calledWith(next, expectedError)
+  
+      sinon.assert.notCalled(req.flash)
+      sinon.assert.notCalled(res.redirect)
+    })
+  
+    it('should render an error if an invalid value is provided', async () => {
+      updateIntegrationVersion3dsMock = sinon.spy(() => Promise.reject(new Error()))
+      renderErrorViewMock = sinon.spy(() => Promise.resolve())
+      const controller = getControllerWithMocks()
+  
+      req.body['toggle-worldpay-3ds-flex'] = 'oof'
+      await controller(req, res, next)
+  
+      sinon.assert.calledWith(renderErrorViewMock, req, res, false, 400)
+  
+      sinon.assert.notCalled(updateIntegrationVersion3dsMock)
+      sinon.assert.notCalled(req.flash)
+      sinon.assert.notCalled(res.redirect)
+    })
+  
+    it('should render an error if no value is provided', async () => {
+      updateIntegrationVersion3dsMock = sinon.spy(() => Promise.reject(new Error()))
+      renderErrorViewMock = sinon.spy(() => Promise.resolve())
+      const controller = getControllerWithMocks()
 
-    req.body['toggle-worldpay-3ds-flex'] = 'on'
-    await controller(req, res, next)
+      await controller(req, res, next)
 
-    sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 2)
-    sinon.assert.calledWith(req.flash, 'generic', '3DS Flex has been turned on.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/${gatewayAccountExternalId}/your-psp/${credentialId}`)
+      sinon.assert.calledWith(renderErrorViewMock, req, res, false, 400)
+
+      sinon.assert.notCalled(updateIntegrationVersion3dsMock)
+      sinon.assert.notCalled(req.flash)
+      sinon.assert.notCalled(res.redirect)
+    })
   })
 
-  it('should toggle 3DS Flex off by setting 3DS integration version to 1', async () => {
-    updateIntegrationVersion3dsMock = sinon.spy(() => Promise.resolve())
-    const controller = getControllerWithMocks()
+  describe('Live gateway account', () => {
+    it('should call next with error if trying to toggle 3DS on a live gateway account', async () => {
+      req.account.type = 'live'
 
-    req.body['toggle-worldpay-3ds-flex'] = 'off'
-    await controller(req, res, next)
+      updateIntegrationVersion3dsMock = sinon.spy(() => Promise.resolve())
+      const controller = getControllerWithMocks()
+  
+      req.body['toggle-worldpay-3ds-flex'] = 'on'
+      await controller(req, res, next)
 
-    sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 1)
-    sinon.assert.calledWith(req.flash, 'generic', '3DS Flex has been turned off. Your payments will now use 3DS only.')
-    sinon.assert.calledWith(res.redirect, 303, `/account/${gatewayAccountExternalId}/your-psp/${credentialId}`)
-  })
-
-  it('should call next with error if problem calling connector', async () => {
-    const error = new Error()
-    updateIntegrationVersion3dsMock = sinon.spy(() => Promise.reject(error))
-    renderErrorViewMock = sinon.spy(() => Promise.resolve())
-    const controller = getControllerWithMocks()
-
-    req.body['toggle-worldpay-3ds-flex'] = 'on'
-    await controller(req, res, next)
-
-    sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 2)
-    const expectedError = sinon.match.instanceOf(Error)
-    sinon.assert.calledWith(next, expectedError)
-
-    sinon.assert.notCalled(req.flash)
-    sinon.assert.notCalled(res.redirect)
-  })
-
-  it('should render an error if an invalid value is provided', async () => {
-    updateIntegrationVersion3dsMock = sinon.spy(() => Promise.reject(new Error()))
-    renderErrorViewMock = sinon.spy(() => Promise.resolve())
-    const controller = getControllerWithMocks()
-
-    req.body['toggle-worldpay-3ds-flex'] = 'oof'
-    await controller(req, res, next)
-
-    sinon.assert.calledWith(renderErrorViewMock, req, res, false, 400)
-
-    sinon.assert.notCalled(updateIntegrationVersion3dsMock)
-    sinon.assert.notCalled(req.flash)
-    sinon.assert.notCalled(res.redirect)
-  })
-
-  it('should render an error if no value is provided', async () => {
-    updateIntegrationVersion3dsMock = sinon.spy(() => Promise.reject(new Error()))
-    renderErrorViewMock = sinon.spy(() => Promise.resolve())
-    const controller = getControllerWithMocks()
-
-    await controller(req, res, next)
-
-    sinon.assert.calledWith(renderErrorViewMock, req, res, false, 400)
-
-    sinon.assert.notCalled(updateIntegrationVersion3dsMock)
-    sinon.assert.notCalled(req.flash)
-    sinon.assert.notCalled(res.redirect)
+      const expectedError = sinon.match.instanceOf(Error)
+        .and(sinon.match.has('message', `Cannot toggle Worldpay 3DS flex for live gateway account: ${req.account.external_id}`))
+      sinon.assert.calledWith(next, expectedError)
+    }) 
   })
 
   function getControllerWithMocks () {

--- a/app/views/your-psp/_worldpay-flex.njk
+++ b/app/views/your-psp/_worldpay-flex.njk
@@ -1,16 +1,28 @@
 {% set paymentProvider = 'worldpay' %}
+{% set isTest = currentGatewayAccount.type === "test" %}
+
 <h2 class="govuk-heading-m govuk-!-margin-top-9">3DS Flex</h2>
 
-{{ govukInsetText({
-  "attributes": {
-    "id": "worldpay-3ds-flex-is-on" if isWorldpay3dsFlexEnabled else "worldpay-3ds-flex-is-off"
-  },
-  text: "3DS Flex is turned on." if isWorldpay3dsFlexEnabled else "3DS Flex is turned off."
-}) }}
+{% if isTest %}
+  {{ govukInsetText({
+    "attributes": {
+      "id": "worldpay-3ds-flex-is-on" if isWorldpay3dsFlexEnabled else "worldpay-3ds-flex-is-off"
+    },
+    text: "3DS Flex is turned on." if isWorldpay3dsFlexEnabled else "3DS Flex is turned off."
+  }) }}
+{% endif %}
 
-<p class="govuk-body">If you have set up 3DS Flex on your Worldpay account, you need to enter the following details to turn 3DS Flex on. You’ll find these details in your <a class="govuk-link" href="https://secure.worldpay.com/sso/public/auth/login.html">Worldpay account</a>.</p>
+<p class="govuk-body">
+  {% if isTest %}
+    <span data-cy="3ds-flex-text-for-test-accounts">
+      If you have set up 3DS Flex on your Worldpay account, you need to enter the following details to turn 3DS Flex on.
+    </span>
+  {% endif %}
+  You’ll find these details in your <a class="govuk-link" href="https://secure.worldpay.com/sso/public/auth/login.html">Worldpay account</a>.
+</p>
 
 {{  govukSummaryList({
+    attributes: {'data-cy': 'worldpay-flex-settings-summary-list'},
     rows: [
       {
         key: {
@@ -73,27 +85,29 @@
   })
 }}
 
-{% if (is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured) or isWorldpay3dsFlexEnabled %}
-  <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.worldpay3dsFlex, currentGatewayAccount.external_id, credential.external_id) }}">
-    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}">
-    {% if is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured and not isWorldpay3dsFlexEnabled %}
-        <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="on">
+{% if isTest %}
+  {% if (is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured) or isWorldpay3dsFlexEnabled %}
+    <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.worldpay3dsFlex, currentGatewayAccount.external_id, credential.external_id) }}">
+      <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}">
+      {% if is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured and not isWorldpay3dsFlexEnabled %}
+          <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="on">
+          {{ govukButton({
+            attributes: {
+              id: "enable-worldpay-3ds-flex-button"
+            },
+            text: "Turn on 3DS Flex",
+            classes: "govuk-button--secondary"
+          }) }}
+      {% elif isWorldpay3dsFlexEnabled %}
+        <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="off">
         {{ govukButton({
           attributes: {
-            id: "enable-worldpay-3ds-flex-button"
+            id: "disable-worldpay-3ds-flex-button"
           },
-          text: "Turn on 3DS Flex",
+          text: "Turn off 3DS Flex",
           classes: "govuk-button--secondary"
         }) }}
-    {% elif isWorldpay3dsFlexEnabled %}
-      <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="off">
-      {{ govukButton({
-        attributes: {
-          id: "disable-worldpay-3ds-flex-button"
-        },
-        text: "Turn off 3DS Flex",
-        classes: "govuk-button--secondary"
-      }) }}
-    {% endif %}
-  </form>
+      {% endif %}
+    </form>
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
- Toggle 3DS post controller
  - Throw error if trying to toggle 3DS flex toggle for live account.
  - Live accounts have 3DS flex automatically enabled when they enter their flex credentials.
- Update `your psp > worldpay > 3DS flex` Nunjuks file
  - Hide the following then it is a live account
    - Info inset text.
    - Text in the description about enabling the 3DS flex settings.
    - Toggle 3DS flex button

