### PR TITLE
PP-10199 Set latest go live stage in the Zendesk email

### DIFF
--- a/app/controllers/request-to-go-live/agreement/post.controller.js
+++ b/app/controllers/request-to-go-live/agreement/post.controller.js
@@ -67,7 +67,7 @@ module.exports = async (req, res, next) => {
         serviceName: req.service.name,
         merchantDetails: req.service.merchantDetails.name,
         serviceExternalId: req.service.externalId,
-        psp: req.service.currentGoLiveStage,
+        psp: stages[req.service.currentGoLiveStage],
         ipAddress: ipAddress || '',
         email: agreement.email,
         timestamp: agreement.agreement_time,


### PR DESCRIPTION
## WHAT
- Currently, zendesk emails for go-live requests include the last stage service is in (which is usually CHOOSEN_PSP..) rather than the new stage (TERMS_AGREED_..) that will be set when the terms are agreed.
- Updated so that the email will include TERMS_AGREED.. stage which will match with Toolbox.
