### PR TITLE
PP-10052 Update authenticator app content

### DIFF
--- a/app/views/registration/authenticator-app.njk
+++ b/app/views/registration/authenticator-app.njk
@@ -27,38 +27,7 @@
 
     <h1 class="govuk-heading-l">Set up an authenticator app</h1>
 
-    <p class="govuk-body">1. Open your authenticator app on your smartphone, tablet or computer.</p>
-
-    {% set detailsHTML %}
-      <p class="govuk-body">Instead of text message codes, you can use an authenticator app to sign in to GOV.UK Pay. This is an app (usually installed on your phone) that generates a security code whenever you need to sign in. If you choose to use an authenticator app, you will only be able to sign in to GOV.UK Pay using that app.</p>
-      <p class="govuk-body">GOV.UK Pay works with most authenticator apps. If you do not have one installed already, there are several available. These include:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li><a class="govuk-link" href="https://authy.com/">Authy</a></li>
-        <li><a class="govuk-link" href="https://duo.com/product/multi-factor-authentication-mfa/duo-mobile-app">Duo Mobile</a></li>
-        <li><a class="govuk-link" href="https://freeotp.github.io/">FreeOTP</a></li>
-        <li><a class="govuk-link" href="https://support.google.com/accounts/answer/1066447">Google Authenticator</a></li>
-        <li><a class="govuk-link" href="https://www.microsoft.com/en-gb/security/mobile-authenticator-app">Microsoft Authenticator</a></li>
-      </ul>
-    {% endset %}
-
-    {{ govukDetails({
-      summaryText: "What is an authenticator app?",
-      html: detailsHTML
-    }) }}
-
-    <p class="govuk-body">2. Use your authenticator app to scan the QR code or type the secret key into your authenticator app. Some authenticator apps call the secret key a ‘code’</p>
-
-    <figure class="govuk-!-margin-top-0 govuk-!-margin-left-0 govuk-!-margin-bottom-6">
-      <img class="qr-code pay-!-negative-margin-h-3" src="{{qrCodeDataUrl}}" data-cy="qr" alt="If you cannot view or scan the barcode, please enter the secret manually">
-      <figcaption>
-        <h4 class="govuk-body">Secret key:</h4>
-        <code class="code" data-cy="otp-secret">{{prettyPrintedSecret}}</code>
-      </figcaption>
-    </figure>
-
-    <p class="govuk-body">3. The authenticator app will show a security code.</p>
-
-    <p class="govuk-body">4. Enter the security code.</p>
+    {% include "../two-factor-auth/_authenticator-app-instructions.njk" %}
 
     <form method="post">
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>

--- a/app/views/registration/get-security-codes.njk
+++ b/app/views/registration/get-security-codes.njk
@@ -52,22 +52,7 @@
         ]
       }) }}
 
-      {% set detailsHTML %}
-      <p class="govuk-body">Instead of text message codes, you can use an authenticator app to sign in to GOV.UK Pay. This is an app (usually installed on your phone) that generates a security code whenever you need to sign in. If you choose to use an authenticator app, you will only be able to sign in to GOV.UK Pay using that app.</p>
-      <p class="govuk-body">GOV.UK Pay works with most authenticator apps. If you do not have one installed already, there are several available. These include:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li><a class="govuk-link" href="https://authy.com/">Authy</a></li>
-        <li><a class="govuk-link" href="https://duo.com/product/multi-factor-authentication-mfa/duo-mobile-app">Duo Mobile</a></li>
-        <li><a class="govuk-link" href="https://freeotp.github.io/">FreeOTP</a></li>
-        <li><a class="govuk-link" href="https://support.google.com/accounts/answer/1066447">Google Authenticator</a></li>
-        <li><a class="govuk-link" href="https://www.microsoft.com/en-gb/security/mobile-authenticator-app">Microsoft Authenticator</a></li>
-      </ul>
-      {% endset %}
-
-      {{ govukDetails({
-        summaryText: "What is an authenticator app?",
-        html: detailsHTML
-      }) }}
+      {% include "../two-factor-auth/_authenticator-app-details.njk" %}
 
       {{ govukButton({ text: "Continue" }) }}
     </form>

--- a/app/views/two-factor-auth/_authenticator-app-details.njk
+++ b/app/views/two-factor-auth/_authenticator-app-details.njk
@@ -1,0 +1,17 @@
+{% set detailsHTML %}
+  <p class="govuk-body">An authenticator app creates a security code that helps confirm it’s you when you sign in.</p>
+  <p class="govuk-body">You can use an authenticator app on your smartphone, tablet or desktop computer. If you choose to use an authenticator app, you will only be able to sign in to GOV.UK Pay using that app.</p>
+  <p class="govuk-body">GOV.UK Pay works with most authenticator apps. If you do not have one installed already, there are several available. These include:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li><a class="govuk-link" href="https://authy.com/">Authy</a></li>
+    <li><a class="govuk-link" href="https://duo.com/product/multi-factor-authentication-mfa/duo-mobile-app">Duo Mobile</a></li>
+    <li><a class="govuk-link" href="https://freeotp.github.io/">FreeOTP</a></li>
+    <li><a class="govuk-link" href="https://support.google.com/accounts/answer/1066447">Google Authenticator</a></li>
+    <li><a class="govuk-link" href="https://www.microsoft.com/en-gb/security/mobile-authenticator-app">Microsoft Authenticator</a></li>
+  </ul>
+{% endset %}
+
+{{ govukDetails({
+  summaryText: "What is an authenticator app?",
+  html: detailsHTML
+}) }}

--- a/app/views/two-factor-auth/_authenticator-app-instructions.njk
+++ b/app/views/two-factor-auth/_authenticator-app-instructions.njk
@@ -1,0 +1,17 @@
+<p class="govuk-body">1. Open your authenticator app on your smartphone, tablet or computer.</p>
+
+{% include "./_authenticator-app-details.njk" %}
+
+<p class="govuk-body">2. Use your authenticator app to scan the QR code or type the secret key into your authenticator app. Some authenticator apps call the secret key a ‘code’</p>
+
+<figure class="govuk-!-margin-top-0 govuk-!-margin-left-0 govuk-!-margin-bottom-6">
+  <img class="qr-code pay-!-negative-margin-h-3" src="{{qrCodeDataUrl}}" data-cy="qr" alt="If you cannot view or scan the barcode, please enter the secret manually">
+  <figcaption>
+    <h4 class="govuk-body">Secret key:</h4>
+    <code class="code" data-cy="otp-secret">{{prettyPrintedSecret}}</code>
+  </figcaption>
+</figure>
+
+<p class="govuk-body">3. The authenticator app will show a security code.</p>
+
+<p class="govuk-body">4. Enter the security code.</p>

--- a/app/views/two-factor-auth/configure.njk
+++ b/app/views/two-factor-auth/configure.njk
@@ -37,20 +37,13 @@
 </div>
 <div class="govuk-grid-column-two-thirds">
 {% if method === secondFactorMethod.APP %}
-  <p class="govuk-body">Scan the barcode with your authenticator app or enter the secret manually.</p>
   {{
     govukWarningText({
-      text: "Once setup is complete, you will only be able to use this authenticator app to sign in.",
-      classes: "govuk-!-margin-bottom-0"
+      text: "Once setup is complete, you will only be able to use this authenticator app to sign in."
     })
   }}
-  <figure class="govuk-!-margin-top-0 govuk-!-margin-left-0 govuk-!-margin-bottom-6">
-    <img class="qr-code pay-!-negative-margin-h-3" src="{{qrCodeDataUrl}}" alt="If you cannot view or scan the barcode, please enter the secret manually">
-    <figcaption>
-      <h4 class="govuk-body">Secret</h4>
-      <code class="code" data-cy="otp-secret">{{prettyPrintedSecret}}</code>
-    </figcaption>
-  </figure>
+
+  {% include "./_authenticator-app-instructions.njk" %}
 {% else %}
   {{
     govukWarningText({
@@ -61,7 +54,7 @@
   <form method="post" action="{{routes.user.profile.twoFactorAuth.configure}}" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
-    {% set codeHint = "Enter the code shown in your app to complete the setup" %}
+    {% set codeHint = "This is the 6-digit number shown in your authenticator app" %}
     {% if method === secondFactorMethod.SMS %}
       {% set codeHint = "We have sent you a text message with a security code" %}
     {% endif %}

--- a/app/views/two-factor-auth/index.njk
+++ b/app/views/two-factor-auth/index.njk
@@ -58,23 +58,6 @@
       }}
     {% endif %}
   </form>
-  {% set detailsHTML %}
-    <h2 class="govuk-heading-s">Authenticator apps</h2>
-    <p class="govuk-body">Instead of text message codes, you can use an authenticator app to sign in to GOV.UK Pay. This is an app (usually installed on your phone) that generates a security code whenever you need to sign in. If you choose to use an authenticator app, you will only be able to sign in to GOV.UK Pay using that app and you will no longer receive text message codes.</p>
-    <p class="govuk-body">GOV.UK Pay works with most authenticator apps. If you do not have one installed already, there are several available. These include:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li><a class="govuk-link" href="https://authy.com/">Authy</a></li>
-      <li><a class="govuk-link" href="https://duo.com/product/multi-factor-authentication-mfa/duo-mobile-app">Duo Mobile</a></li>
-      <li><a class="govuk-link" href="https://freeotp.github.io/">FreeOTP</a></li>
-      <li><a class="govuk-link" href="https://support.google.com/accounts/answer/1066447">Google Authenticator</a></li>
-      <li><a class="govuk-link" href="https://www.microsoft.com/en-gb/security/mobile-authenticator-app">Microsoft Authenticator</a></li>
-    </ul>
-  {% endset %}
-  {{
-    govukDetails({
-      summaryText: "What is an authenticator app?",
-      html: detailsHTML
-    })
-  }}
+  {% include "./_authenticator-app-details.njk" %}
 </div>
 {% endblock %}

--- a/test/cypress/integration/user/change-sign-in-method.cy.test.js
+++ b/test/cypress/integration/user/change-sign-in-method.cy.test.js
@@ -190,7 +190,7 @@ describe('Change sign in method', () => {
         // check we're sent to a page for setting up the authenticator app
         cy.title().should('equal', 'Set up an authenticator app - GOV.UK Pay')
         cy.get('h1').should('contain', 'Set up an authenticator app')
-        cy.get('p.govuk-body').contains('Scan the barcode with your authenticator app').should('exist')
+        cy.get('p.govuk-body').contains('Open your authenticator app on your smartphone').should('exist')
 
         // should contain code with spaces every 4 characters
         cy.get('[data-cy=otp-secret]').should('have.text', 'GJMD 42XJ ZRUX EDFW WBDJ GQ4P ACPX Z6EF')


### PR DESCRIPTION
- Update the details hint text that explains what an authenticator app is on all pages it's displayed
- Update the page accessed from "My profile" to change sign-in method to use the same content as the new page in the registration journey.
- Use Nunjucks sub-templates to share content used in multiple templates

![Screenshot 2022-11-24 at 11 35 42](https://user-images.githubusercontent.com/5648592/203778510-d8759e5f-ac2c-4525-8099-80e4cfb23d87.png)
![Screenshot 2022-11-24 at 11 37 35](https://user-images.githubusercontent.com/5648592/203778538-fe8a52e9-6d6c-4319-991e-fd4a3a756875.png)
![Screenshot 2022-11-24 at 11 39 26](https://user-images.githubusercontent.com/5648592/203778563-d29d0894-4fc4-47d8-93d8-d7ef1b794d24.png)
![Screenshot 2022-11-24 at 11 45 47](https://user-images.githubusercontent.com/5648592/203778601-95987f84-68d6-4bbb-b2c1-c8c895402d25.png)

