### PR TITLE
PP-10057 Add middleware to check registration cookie is present

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -145,21 +145,21 @@
         "filename": "app/controllers/registration/registration.controller.js",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 18
+        "line_number": 19
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.js",
         "hashed_secret": "cbb085747f0bcbeac56f2a583779b44c8f445d92",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 20
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.js",
         "hashed_secret": "7b652417979832c620feec2e89b92c56a291ae52",
         "is_verified": false,
-        "line_number": 61
+        "line_number": 51
       }
     ],
     "app/controllers/registration/registration.controller.test.js": [
@@ -168,56 +168,56 @@
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "9695086041c462c6598c6dd5e35d3a2c9cbbe5f8",
         "is_verified": false,
-        "line_number": 96
+        "line_number": 78
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "7b652417979832c620feec2e89b92c56a291ae52",
         "is_verified": false,
-        "line_number": 97
+        "line_number": 79
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "f5378ce7cd012d12a9be51e6be241b1e66240879",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 86
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "69c8d31085756bfd34bb8ca6d393289374b7d7c2",
         "is_verified": false,
-        "line_number": 111
+        "line_number": 93
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "3f3c2dca191782c9b8b2f513d16abaa66dc543bf",
         "is_verified": false,
-        "line_number": 118
+        "line_number": 100
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "0ee4c488221aee414cd9ae5300e28d11c2851fe5",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 115
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "d8fe3060b1c00ad00ece5d205e493764b113b94c",
         "is_verified": false,
-        "line_number": 139
+        "line_number": 121
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "a04fccdd7f93b63162cd0d3e015761cd3a24d86a",
         "is_verified": false,
-        "line_number": 249
+        "line_number": 222
       }
     ],
     "app/controllers/your-psp/worldpay-3ds-flex-validations.test.js": [
@@ -902,5 +902,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-23T17:12:32Z"
+  "generated_at": "2022-11-24T14:41:36Z"
 }

--- a/app/controllers/invite-validation.controller.js
+++ b/app/controllers/invite-validation.controller.js
@@ -4,6 +4,7 @@ const { renderErrorView } = require('../utils/response')
 const validateInviteService = require('../services/validate-invite.service')
 const serviceRegistrationService = require('../services/service-registration.service')
 const paths = require('../paths')
+const { INVITE_SESSION_COOKIE_NAME } = require('../utils/constants')
 
 /**
  * Intermediate endpoint which captures the invite code and validate.
@@ -19,22 +20,22 @@ async function validateInvite (req, res, next) {
 
   try {
     const invite = await validateInviteService.getValidatedInvite(code)
-    if (!req.register_invite) {
-      req.register_invite = {}
+    if (!req[INVITE_SESSION_COOKIE_NAME]) {
+      req[INVITE_SESSION_COOKIE_NAME] = {}
     }
 
-    req.register_invite.code = code
+    req[INVITE_SESSION_COOKIE_NAME].code = code
 
     if (invite.telephone_number) {
-      req.register_invite.telephone_number = invite.telephone_number
+      req[INVITE_SESSION_COOKIE_NAME].telephone_number = invite.telephone_number
     }
 
     if (invite.email) {
-      req.register_invite.email = invite.email
+      req[INVITE_SESSION_COOKIE_NAME].email = invite.email
     }
 
     if (invite.type === 'user') {
-      req.register_invite.email = invite.email
+      req[INVITE_SESSION_COOKIE_NAME].email = invite.email
       const redirectTarget = invite.user_exist ? paths.registerUser.subscribeService : paths.registerUser.registration
       res.redirect(302, redirectTarget)
     } else if (invite.type === 'service') {

--- a/app/controllers/login/setup-direct-login-after-register.controller.js
+++ b/app/controllers/login/setup-direct-login-after-register.controller.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { INVITE_SESSION_COOKIE_NAME } = require('../../utils/constants')
 const logger = require('../../utils/logger')(__filename)
 
 module.exports = (req, res, userExternalId) => {
@@ -9,5 +10,5 @@ module.exports = (req, res, userExternalId) => {
     return
   }
 
-  req.register_invite.userExternalId = userExternalId
+  req[INVITE_SESSION_COOKIE_NAME].userExternalId = userExternalId
 }

--- a/app/controllers/register-service.controller.js
+++ b/app/controllers/register-service.controller.js
@@ -17,6 +17,7 @@ const {
 const { RegistrationSessionMissingError, InvalidRegistationStateError } = require('../errors')
 const { validationErrors } = require('../utils/validation/field-validation-checks')
 const { sanitiseSecurityCode } = require('../utils/security-code-utils')
+const { INVITE_SESSION_COOKIE_NAME } = require('../utils/constants')
 
 const EXPIRED_ERROR_MESSAGE = 'This invitation is no longer valid'
 const INVITE_NOT_FOUND_ERROR_MESSAGE = 'There has been a problem proceeding with this registration. Please try again.'
@@ -107,7 +108,7 @@ function showConfirmation (req, res) {
 }
 
 async function showOtpVerify (req, res, next) {
-  const sessionData = req.register_invite
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
   if (!registrationSessionPresent(sessionData)) {
     return next(new RegistrationSessionMissingError())
   }
@@ -140,11 +141,11 @@ async function showOtpVerify (req, res, next) {
 }
 
 async function submitOtpCode (req, res, next) {
-  const sessionData = req.register_invite
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
   if (!registrationSessionPresent(sessionData)) {
     return next(new RegistrationSessionMissingError())
   }
-  const code = req.register_invite.code
+  const code = req[INVITE_SESSION_COOKIE_NAME].code
   const otpCode = sanitiseSecurityCode(req.body['verify-code'])
 
   const validOtp = validateOtp(otpCode)
@@ -175,7 +176,7 @@ async function submitOtpCode (req, res, next) {
   }
 
   try {
-    const userExternalId = await registrationService.completeInvite(req.register_invite.code)
+    const userExternalId = await registrationService.completeInvite(req[INVITE_SESSION_COOKIE_NAME].code)
     loginController.setupDirectLoginAfterRegister(req, res, userExternalId)
     return res.redirect(303, paths.registerUser.logUserIn)
   } catch (err) {
@@ -190,7 +191,7 @@ async function submitOtpCode (req, res, next) {
  * @param res
  */
 async function showOtpResend (req, res, next) {
-  const sessionData = req.register_invite
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
   if (!registrationSessionPresent(sessionData)) {
     return next(new RegistrationSessionMissingError())
   }
@@ -226,7 +227,7 @@ async function showOtpResend (req, res, next) {
  * @param res
  */
 async function submitOtpResend (req, res, next) {
-  const sessionData = req.register_invite
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
   if (!registrationSessionPresent(sessionData)) {
     return next(new RegistrationSessionMissingError())
   }

--- a/app/controllers/register-user.controller.js
+++ b/app/controllers/register-user.controller.js
@@ -14,6 +14,7 @@ const {
 const { RegistrationSessionMissingError, ExpiredInviteError } = require('../errors')
 const { validationErrors } = require('../utils/validation/field-validation-checks')
 const { sanitiseSecurityCode } = require('../utils/security-code-utils')
+const { INVITE_SESSION_COOKIE_NAME } = require('../utils/constants')
 
 const EXPIRED_ERROR_MESSAGE = 'This invitation is no longer valid'
 
@@ -22,7 +23,7 @@ const registrationSessionPresent = function registrationSessionPresent (sessionD
 }
 
 const showRegistration = function showRegistration (req, res, next) {
-  const sessionData = req.register_invite
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
   if (!registrationSessionPresent(sessionData)) {
     return next(new RegistrationSessionMissingError())
   }
@@ -42,7 +43,7 @@ const showRegistration = function showRegistration (req, res, next) {
  * @param res
  */
 const subscribeService = async function subscribeService (req, res, next) {
-  const sessionData = req.register_invite
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
   if (!sessionData || !sessionData.code || !sessionData.email) {
     return next(new RegistrationSessionMissingError())
   }
@@ -78,7 +79,7 @@ const submitRegistration = async function submitRegistration (req, res, next) {
   const telephoneNumber = req.body['telephone-number']
   const password = req.body['password']
 
-  const sessionData = req.register_invite
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
   if (!registrationSessionPresent(sessionData)) {
     return next(new RegistrationSessionMissingError())
   }
@@ -120,7 +121,7 @@ const submitRegistration = async function submitRegistration (req, res, next) {
  * @param res
  */
 const showOtpVerify = function showOtpVerify (req, res, next) {
-  const sessionData = req.register_invite
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
   if (!registrationSessionPresent(sessionData)) {
     return next(new RegistrationSessionMissingError())
   }
@@ -141,7 +142,7 @@ const showOtpVerify = function showOtpVerify (req, res, next) {
 const submitOtpVerify = async function submitOtpVerify (req, res, next) {
   const securityCode = sanitiseSecurityCode(req.body['verify-code'])
 
-  const sessionData = req.register_invite
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
   if (!registrationSessionPresent(sessionData)) {
     return next(new RegistrationSessionMissingError())
   }
@@ -192,7 +193,7 @@ const submitOtpVerify = async function submitOtpVerify (req, res, next) {
  * @param res
  */
 const showReVerifyPhone = function showReVerifyPhone (req, res, next) {
-  const sessionData = req.register_invite
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
   if (!registrationSessionPresent(sessionData)) {
     return next(new RegistrationSessionMissingError())
   }
@@ -214,7 +215,7 @@ const showReVerifyPhone = function showReVerifyPhone (req, res, next) {
 const submitReVerifyPhone = async function submitReVerifyPhone (req, res, next) {
   const telephoneNumber = req.body['telephone-number']
 
-  const sessionData = req.register_invite
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
   if (!registrationSessionPresent(sessionData)) {
     return next(new RegistrationSessionMissingError())
   }

--- a/app/controllers/registration/registration.controller.js
+++ b/app/controllers/registration/registration.controller.js
@@ -3,7 +3,7 @@
 const qrcode = require('qrcode')
 const lodash = require('lodash')
 
-const { RegistrationSessionMissingError, RESTClientError, ExpiredInviteError } = require('../../errors')
+const { RESTClientError, ExpiredInviteError } = require('../../errors')
 const adminusersClient = require('../../services/clients/adminusers.client')()
 const paths = require('../../paths')
 const {
@@ -14,21 +14,15 @@ const {
 const { isEmpty } = require('../../utils/validation/field-validation-checks')
 const { sanitiseSecurityCode } = require('../../utils/security-code-utils')
 const { validationErrors } = require('../../utils/validation/field-validation-checks')
+const { INVITE_SESSION_COOKIE_NAME } = require('../../utils/constants')
 
 const PASSWORD_INPUT_FIELD_NAME = 'password'
 const REPEAT_PASSWORD_INPUT_FIELD_NAME = 'repeat-password'
 const PHONE_NUMBER_INPUT_FIELD_NAME = 'phone'
 const OTP_CODE_FIELD_NAME = 'code'
 
-const registrationSessionPresent = function registrationSessionPresent (sessionData) {
-  return sessionData && sessionData.email && sessionData.code
-}
-
 async function showPasswordPage (req, res, next) {
-  const sessionData = req.register_invite
-  if (!registrationSessionPresent(sessionData)) {
-    return next(new RegistrationSessionMissingError())
-  }
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
 
   try {
     const invite = await adminusersClient.getValidatedInvite(sessionData.code)
@@ -43,11 +37,7 @@ async function showPasswordPage (req, res, next) {
 }
 
 async function submitPasswordPage (req, res, next) {
-  const sessionData = req.register_invite
-  if (!registrationSessionPresent(sessionData)) {
-    return next(new RegistrationSessionMissingError())
-  }
-
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
   const password = req.body[PASSWORD_INPUT_FIELD_NAME]
   const repeatPassword = req.body[REPEAT_PASSWORD_INPUT_FIELD_NAME]
 
@@ -97,10 +87,7 @@ function submitChooseSignInMethodPage (req, res) {
 }
 
 async function showAuthenticatorAppPage (req, res, next) {
-  const sessionData = req.register_invite
-  if (!registrationSessionPresent(sessionData)) {
-    return next(new RegistrationSessionMissingError())
-  }
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
 
   try {
     const invite = await adminusersClient.getValidatedInvite(sessionData.code)
@@ -124,11 +111,7 @@ async function showAuthenticatorAppPage (req, res, next) {
 }
 
 async function submitAuthenticatorAppPage (req, res, next) {
-  const sessionData = req.register_invite
-  if (!registrationSessionPresent(sessionData)) {
-    return next(new RegistrationSessionMissingError())
-  }
-
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
   const otpCode = sanitiseSecurityCode(req.body[OTP_CODE_FIELD_NAME])
   const validationResult = validateOtp(otpCode)
 
@@ -160,20 +143,11 @@ async function submitAuthenticatorAppPage (req, res, next) {
 }
 
 function showPhoneNumberPage (req, res, next) {
-  const sessionData = req.register_invite
-  if (!registrationSessionPresent(sessionData)) {
-    return next(new RegistrationSessionMissingError())
-  }
-
   res.render('registration/phone-number')
 }
 
 async function submitPhoneNumberPage (req, res, next) {
-  const sessionData = req.register_invite
-  if (!registrationSessionPresent(sessionData)) {
-    return next(new RegistrationSessionMissingError())
-  }
-
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
   const phoneNumber = req.body[PHONE_NUMBER_INPUT_FIELD_NAME]
 
   const errors = {}

--- a/app/controllers/registration/registration.controller.test.js
+++ b/app/controllers/registration/registration.controller.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon')
 const { expect } = require('chai')
 
 const inviteFixtures = require('../../../test/fixtures/invite.fixtures')
-const { RegistrationSessionMissingError, RESTClientError, ExpiredInviteError } = require('../../errors')
+const { RESTClientError, ExpiredInviteError } = require('../../errors')
 const { paths } = require('../../routes')
 const registrationController = require('./registration.controller')
 
@@ -28,15 +28,6 @@ describe('Registration', () => {
   })
 
   describe('show the password page', () => {
-    it('should call next with an error when the registration cookie is not set', async () => {
-      delete req.register_invite
-      await registrationController.showPasswordPage(req, res, next)
-
-      sinon.assert.calledWith(next, sinon.match.instanceOf(RegistrationSessionMissingError))
-      sinon.assert.notCalled(res.render)
-      sinon.assert.notCalled(res.redirect)
-    })
-
     it('should redirect to security codes page when password is already set for invite', async () => {
       const inviteWithPasswordSet = inviteFixtures.validInviteResponse({ password_set: true })
       const controller = getControllerWithMockedAdminusersClient({
@@ -75,15 +66,6 @@ describe('Registration', () => {
   })
 
   describe('submit the password page', () => {
-    it('should call next with an error when the registration cookie is not set', async () => {
-      delete req.register_invite
-      await registrationController.submitPasswordPage(req, res, next)
-
-      sinon.assert.calledWith(next, sinon.match.instanceOf(RegistrationSessionMissingError))
-      sinon.assert.notCalled(res.render)
-      sinon.assert.notCalled(res.redirect)
-    })
-
     it('should render the password page with an error when both password fields are empty', async () => {
       req.body = {
         password: '',
@@ -216,15 +198,6 @@ describe('Registration', () => {
   })
 
   describe('show the authenticator app page', () => {
-    it('should call next with an error when the registration cookie is not set', async () => {
-      delete req.register_invite
-      await registrationController.showAuthenticatorAppPage(req, res, next)
-
-      sinon.assert.calledWith(next, sinon.match.instanceOf(RegistrationSessionMissingError))
-      sinon.assert.notCalled(res.render)
-      sinon.assert.notCalled(res.redirect)
-    })
-
     it('should call next with an error if adminusers returns an error', async () => {
       const error = new Error('error from adminusers')
       const controller = getControllerWithMockedAdminusersClient({
@@ -412,14 +385,6 @@ describe('Registration', () => {
   })
 
   describe('show the phone number page', () => {
-    it('should call next with an error when the registration cookie is not set', async () => {
-      delete req.register_invite
-      await registrationController.showPhoneNumberPage(req, res, next)
-
-      sinon.assert.calledWith(next, sinon.match.instanceOf(RegistrationSessionMissingError))
-      sinon.assert.notCalled(res.render)
-    })
-
     it('should render the page', () => {
       registrationController.showPhoneNumberPage(req, res, next)
       sinon.assert.calledWith(res.render, 'registration/phone-number')
@@ -428,15 +393,6 @@ describe('Registration', () => {
   })
 
   describe('submit the phone number page', () => {
-    it('should call next with an error when the registration cookie is not set', async () => {
-      delete req.register_invite
-      await registrationController.submitPhoneNumberPage(req, res, next)
-
-      sinon.assert.calledWith(next, sinon.match.instanceOf(RegistrationSessionMissingError))
-      sinon.assert.notCalled(res.render)
-      sinon.assert.notCalled(res.redirect)
-    })
-
     it('should render the phone number page with an error when the phone number is invalid', async () => {
       req.body = {
         phone: 'not-a-phone-number'

--- a/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.test.js
+++ b/app/controllers/your-psp/post-toggle-worldpay-3ds-flex.controller.test.js
@@ -42,59 +42,59 @@ describe('Toggle Worldpay 3DS Flex controller', () => {
     it('should toggle 3DS Flex on by setting 3DS integration version to 2', async () => {
       updateIntegrationVersion3dsMock = sinon.spy(() => Promise.resolve())
       const controller = getControllerWithMocks()
-  
+
       req.body['toggle-worldpay-3ds-flex'] = 'on'
       await controller(req, res, next)
-  
+
       sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 2)
       sinon.assert.calledWith(req.flash, 'generic', '3DS Flex has been turned on.')
       sinon.assert.calledWith(res.redirect, 303, `/account/${gatewayAccountExternalId}/your-psp/${credentialId}`)
     })
-  
+
     it('should toggle 3DS Flex off by setting 3DS integration version to 1', async () => {
       updateIntegrationVersion3dsMock = sinon.spy(() => Promise.resolve())
       const controller = getControllerWithMocks()
-  
+
       req.body['toggle-worldpay-3ds-flex'] = 'off'
       await controller(req, res, next)
-  
+
       sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 1)
       sinon.assert.calledWith(req.flash, 'generic', '3DS Flex has been turned off. Your payments will now use 3DS only.')
       sinon.assert.calledWith(res.redirect, 303, `/account/${gatewayAccountExternalId}/your-psp/${credentialId}`)
     })
-  
+
     it('should call next with error if problem calling connector', async () => {
       const error = new Error()
       updateIntegrationVersion3dsMock = sinon.spy(() => Promise.reject(error))
       renderErrorViewMock = sinon.spy(() => Promise.resolve())
       const controller = getControllerWithMocks()
-  
+
       req.body['toggle-worldpay-3ds-flex'] = 'on'
       await controller(req, res, next)
-  
+
       sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 2)
       const expectedError = sinon.match.instanceOf(Error)
       sinon.assert.calledWith(next, expectedError)
-  
+
       sinon.assert.notCalled(req.flash)
       sinon.assert.notCalled(res.redirect)
     })
-  
+
     it('should render an error if an invalid value is provided', async () => {
       updateIntegrationVersion3dsMock = sinon.spy(() => Promise.reject(new Error()))
       renderErrorViewMock = sinon.spy(() => Promise.resolve())
       const controller = getControllerWithMocks()
-  
+
       req.body['toggle-worldpay-3ds-flex'] = 'oof'
       await controller(req, res, next)
-  
+
       sinon.assert.calledWith(renderErrorViewMock, req, res, false, 400)
-  
+
       sinon.assert.notCalled(updateIntegrationVersion3dsMock)
       sinon.assert.notCalled(req.flash)
       sinon.assert.notCalled(res.redirect)
     })
-  
+
     it('should render an error if no value is provided', async () => {
       updateIntegrationVersion3dsMock = sinon.spy(() => Promise.reject(new Error()))
       renderErrorViewMock = sinon.spy(() => Promise.resolve())
@@ -116,14 +116,14 @@ describe('Toggle Worldpay 3DS Flex controller', () => {
 
       updateIntegrationVersion3dsMock = sinon.spy(() => Promise.resolve())
       const controller = getControllerWithMocks()
-  
+
       req.body['toggle-worldpay-3ds-flex'] = 'on'
       await controller(req, res, next)
 
       const expectedError = sinon.match.instanceOf(Error)
         .and(sinon.match.has('message', `Cannot toggle Worldpay 3DS flex for live gateway account: ${req.account.external_id}`))
       sinon.assert.calledWith(next, expectedError)
-    }) 
+    })
   })
 
   function getControllerWithMocks () {

--- a/app/middleware/invite-cookie-is-present.js
+++ b/app/middleware/invite-cookie-is-present.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const { RegistrationSessionMissingError } = require('../errors')
+const { INVITE_SESSION_COOKIE_NAME } = require('../utils/constants')
+
+module.exports = function inviteCookieIsPresent (req, res, next) {
+  const cookie = req[INVITE_SESSION_COOKIE_NAME]
+  if (cookie && cookie.email && cookie.code) {
+    return next()
+  }
+  next(new RegistrationSessionMissingError('Registration cookie is not present for request'))
+}

--- a/app/middleware/invite-cookie-is-present.test.js
+++ b/app/middleware/invite-cookie-is-present.test.js
@@ -1,0 +1,50 @@
+const sinon = require('sinon')
+
+const inviteCookeIsPresent = require('./invite-cookie-is-present')
+const { RegistrationSessionMissingError } = require('../errors')
+
+const res = {}
+const next = sinon.spy()
+
+describe('Invite cookie is present middleware', () => {
+  beforeEach(() => {
+    next.resetHistory()
+  })
+
+  it('should call next if cookie is present with all fields', () => {
+    const req = {
+      register_invite: {
+        code: 'a-code',
+        email: 'foo@example.com'
+      }
+    }
+    inviteCookeIsPresent(req, res, next)
+    sinon.assert.calledWithExactly(next)
+  })
+
+  it('should call next with an error if cookie is not present', () => {
+    const req = {}
+    inviteCookeIsPresent(req, res, next)
+    sinon.assert.calledWithExactly(next, sinon.match.instanceOf(RegistrationSessionMissingError))
+  })
+
+  it('should call next with an error if code is not present on cookie', () => {
+    const req = {
+      register_invite: {
+        email: 'foo@example.com'
+      }
+    }
+    inviteCookeIsPresent(req, res, next)
+    sinon.assert.calledWithExactly(next, sinon.match.instanceOf(RegistrationSessionMissingError))
+  })
+
+  it('should call next with an error if email is not present on cookie', () => {
+    const req = {
+      register_invite: {
+        code: 'a-code'
+      }
+    }
+    inviteCookeIsPresent(req, res, next)
+    sinon.assert.calledWithExactly(next, sinon.match.instanceOf(RegistrationSessionMissingError))
+  })
+})

--- a/app/routes.js
+++ b/app/routes.js
@@ -20,6 +20,7 @@ const restrictToSandboxOrStripeTestAccount = require('./middleware/restrict-to-s
 const restrictToStripeAccountContext = require('./middleware/stripe-setup/restrict-to-stripe-account-context')
 const restrictToSwitchingAccount = require('./middleware/restrict-to-switching-account')
 const uploadGovernmentEntityDocument = require('./middleware/multer-middleware')
+const inviteCookeIsPresent = require('./middleware/invite-cookie-is-present')
 
 // Controllers
 const staticController = require('./controllers/static.controller')
@@ -196,17 +197,17 @@ module.exports.bind = function (app) {
   app.post(selfCreateService.otpResend, selfCreateServiceController.submitOtpResend)
 
   // NEW REGISTRATION JOURNEY
-  app.get(register.password, registrationController.showPasswordPage)
-  app.post(register.password, registrationController.submitPasswordPage)
-  app.get(register.securityCodes, registrationController.showChooseSignInMethodPage)
-  app.post(register.securityCodes, registrationController.submitChooseSignInMethodPage)
-  app.get(register.authenticatorApp, registrationController.showAuthenticatorAppPage)
-  app.post(register.authenticatorApp, registrationController.submitAuthenticatorAppPage)
-  app.get(register.phoneNumber, registrationController.showPhoneNumberPage)
-  app.post(register.phoneNumber, registrationController.submitPhoneNumberPage)
-  app.get(register.smsCode, registrationController.showSmsSecurityCodePage)
-  app.get(register.resendCode, registrationController.showResendSecurityCodePage)
-  app.get(register.success, registrationController.showSuccessPage)
+  app.get(register.password, inviteCookeIsPresent, registrationController.showPasswordPage)
+  app.post(register.password, inviteCookeIsPresent, registrationController.submitPasswordPage)
+  app.get(register.securityCodes, inviteCookeIsPresent, registrationController.showChooseSignInMethodPage)
+  app.post(register.securityCodes, inviteCookeIsPresent, registrationController.submitChooseSignInMethodPage)
+  app.get(register.authenticatorApp, inviteCookeIsPresent, registrationController.showAuthenticatorAppPage)
+  app.post(register.authenticatorApp, inviteCookeIsPresent, registrationController.submitAuthenticatorAppPage)
+  app.get(register.phoneNumber, inviteCookeIsPresent, registrationController.showPhoneNumberPage)
+  app.post(register.phoneNumber, inviteCookeIsPresent, registrationController.submitPhoneNumberPage)
+  app.get(register.smsCode, inviteCookeIsPresent, registrationController.showSmsSecurityCodePage)
+  app.get(register.resendCode, inviteCookeIsPresent, registrationController.showResendSecurityCodePage)
+  app.get(register.success, inviteCookeIsPresent, registrationController.showSuccessPage)
 
   // ----------------------
   // AUTHENTICATED ROUTES

--- a/app/services/auth.service.js
+++ b/app/services/auth.service.js
@@ -15,6 +15,7 @@ const { validationErrors } = require('./../utils/validation/field-validation-che
 const secondFactorMethod = require('../models/second-factor-method')
 const { validateOtp } = require('../utils/validation/server-side-form-validations')
 const { sanitiseSecurityCode } = require('../utils/security-code-utils')
+const { INVITE_SESSION_COOKIE_NAME } = require('../utils/constants')
 
 // Exports
 module.exports = {
@@ -90,16 +91,16 @@ async function localStrategy2Fa (req, done) {
 }
 
 function localDirectStrategy (req, done) {
-  return userService.findByExternalId(req.register_invite.userExternalId)
+  return userService.findByExternalId(req[INVITE_SESSION_COOKIE_NAME].userExternalId)
     .then((user) => {
       lodash.set(req, 'gateway_account.currentGatewayAccountId', lodash.get(user, 'serviceRoles[0].service.gatewayAccountIds[0]'))
       req.session.secondFactor = 'totp'
       setSessionVersion(req)
-      req.register_invite.destroy()
+      req[INVITE_SESSION_COOKIE_NAME].destroy()
       done(null, user)
     })
     .catch(() => {
-      req.register_invite.destroy()
+      req[INVITE_SESSION_COOKIE_NAME].destroy()
       done(null, false)
     })
 }

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -1,5 +1,6 @@
 'use strict'
 
 module.exports = {
-  DEFAULT_SERVICE_NAME: 'System Generated'
+  DEFAULT_SERVICE_NAME: 'System Generated',
+  INVITE_SESSION_COOKIE_NAME: 'register_invite'
 }


### PR DESCRIPTION
To avoid checking in every controller for the registration pages whether the session cookie for registration is present, add middleware to check it is present, else call next with an error so that an appropriate error page is displayed to the user.

Add a constant for the session cookie name to avoid hardcoding it in lots of places.


