### PR TITLE
PP-10057 Add logic to controller to show check your phone page

### DIFF
--- a/app/controllers/registration/registration.controller.js
+++ b/app/controllers/registration/registration.controller.js
@@ -171,8 +171,16 @@ async function submitPhoneNumberPage (req, res, next) {
   }
 }
 
-function showSmsSecurityCodePage (req, res) {
-  res.render('registration/sms-code', { redactedPhoneNumber: '*******1111' })
+async function showSmsSecurityCodePage (req, res, next) {
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
+
+  try {
+    const invite = await adminusersClient.getValidatedInvite(sessionData.code)
+    const redactedPhoneNumber = invite.telephone_number.replace(/.(?=.{4})/g, '•')
+    res.render('registration/sms-code', { redactedPhoneNumber })
+  } catch (err) {
+    next(err)
+  }
 }
 
 function showResendSecurityCodePage (req, res) {

--- a/app/controllers/registration/registration.controller.test.js
+++ b/app/controllers/registration/registration.controller.test.js
@@ -471,6 +471,32 @@ describe('Registration', () => {
       sinon.assert.notCalled(res.render)
     })
   })
+
+  describe('show the check your phone page', () => {
+    it('should render the page when invite retrieved successfully', async () => {
+      const invite = inviteFixtures.validInviteResponse({ telephone_number: '+4408081570192' })
+      const controller = getControllerWithMockedAdminusersClient({
+        getValidatedInvite: () => Promise.resolve(invite)
+      })
+
+      await controller.showSmsSecurityCodePage(req, res, next)
+      sinon.assert.calledWith(res.render, 'registration/sms-code', {
+        redactedPhoneNumber: '••••••••••0192'
+      })
+      sinon.assert.notCalled(next)
+    })
+
+    it('should call next with an error if adminusers returns an error', async () => {
+      const error = new Error('error from adminusers')
+      const controller = getControllerWithMockedAdminusersClient({
+        getValidatedInvite: () => Promise.reject(error)
+      })
+
+      await controller.showSmsSecurityCodePage(req, res, next)
+      sinon.assert.calledWith(next, error)
+      sinon.assert.notCalled(res.render)
+    })
+  })
 })
 
 function getControllerWithMockedAdminusersClient (mockedAdminusersClient) {

--- a/test/cypress/integration/registration/register.cy.test.js
+++ b/test/cypress/integration/registration/register.cy.test.js
@@ -13,7 +13,8 @@ describe('Register', () => {
         inviteStubs.getInviteSuccess({
           code: inviteCode,
           password_set: false,
-          otp_key: otpKey
+          otp_key: otpKey,
+          telephone_number: '+4408081570192'
         }),
         inviteStubs.completeInviteSuccess(inviteCode, createdUserExternalId),
         userStubs.getUserSuccess({ userExternalId: createdUserExternalId, gatewayAccountId: '1' }),
@@ -109,7 +110,9 @@ describe('Register', () => {
       cy.get('#phone').type('+44 0808 157 0192', { delay: 0 })
       cy.get('button').contains('Continue').click()
 
+      // should show page to enter code
       cy.title().should('eq', 'Check your phone - GOV.UK Pay')
+      cy.get('.govuk-inset-text').should('contain', 'We have sent a code to ••••••••••0192.')
     })
   })
 


### PR DESCRIPTION
This controller and template for this page already existed, but it was rendered with dummy data.

Render the page, displaying a redacted phone number that the OTP code was sent to


![Screenshot 2022-11-24 at 15 58 16](https://user-images.githubusercontent.com/5648592/203829402-a2625ce6-9e27-4e36-802d-70e42214a460.png)

