### PR TITLE
PP-10052 Send second factor method when completing invite

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -145,21 +145,21 @@
         "filename": "app/controllers/registration/registration.controller.js",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 20
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.js",
         "hashed_secret": "cbb085747f0bcbeac56f2a583779b44c8f445d92",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 21
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.js",
         "hashed_secret": "7b652417979832c620feec2e89b92c56a291ae52",
         "is_verified": false,
-        "line_number": 51
+        "line_number": 52
       }
     ],
     "app/controllers/registration/registration.controller.test.js": [
@@ -168,56 +168,56 @@
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "9695086041c462c6598c6dd5e35d3a2c9cbbe5f8",
         "is_verified": false,
-        "line_number": 78
+        "line_number": 79
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "7b652417979832c620feec2e89b92c56a291ae52",
         "is_verified": false,
-        "line_number": 79
+        "line_number": 80
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "f5378ce7cd012d12a9be51e6be241b1e66240879",
         "is_verified": false,
-        "line_number": 86
+        "line_number": 87
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "69c8d31085756bfd34bb8ca6d393289374b7d7c2",
         "is_verified": false,
-        "line_number": 93
+        "line_number": 94
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "3f3c2dca191782c9b8b2f513d16abaa66dc543bf",
         "is_verified": false,
-        "line_number": 100
+        "line_number": 101
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "0ee4c488221aee414cd9ae5300e28d11c2851fe5",
         "is_verified": false,
-        "line_number": 115
+        "line_number": 116
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "d8fe3060b1c00ad00ece5d205e493764b113b94c",
         "is_verified": false,
-        "line_number": 121
+        "line_number": 122
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "a04fccdd7f93b63162cd0d3e015761cd3a24d86a",
         "is_verified": false,
-        "line_number": 222
+        "line_number": 223
       }
     ],
     "app/controllers/your-psp/worldpay-3ds-flex-validations.test.js": [
@@ -783,14 +783,14 @@
         "filename": "test/pact/adminusers-client/invite/complete-invite.pact.test.js",
         "hashed_secret": "4def56874fa19eaaba377aa6ed3cdf5d70bd2c59",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 40
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/pact/adminusers-client/invite/complete-invite.pact.test.js",
         "hashed_secret": "73fab36036653ebf81d45c017039d0be4bc59e64",
         "is_verified": false,
-        "line_number": 72
+        "line_number": 73
       }
     ],
     "test/pact/adminusers-client/invite/generate-invite-otp-code-service.pact.test.js": [
@@ -902,5 +902,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-24T14:41:36Z"
+  "generated_at": "2022-11-25T11:40:10Z"
 }

--- a/app/controllers/register-user.controller.js
+++ b/app/controllers/register-user.controller.js
@@ -15,6 +15,7 @@ const { RegistrationSessionMissingError, ExpiredInviteError } = require('../erro
 const { validationErrors } = require('../utils/validation/field-validation-checks')
 const { sanitiseSecurityCode } = require('../utils/security-code-utils')
 const { INVITE_SESSION_COOKIE_NAME } = require('../utils/constants')
+const { SMS } = require('../models/second-factor-method')
 
 const EXPIRED_ERROR_MESSAGE = 'This invitation is no longer valid'
 
@@ -175,7 +176,7 @@ const submitOtpVerify = async function submitOtpVerify (req, res, next) {
   }
 
   try {
-    const completeResponse = await registrationService.completeInvite(sessionData.code)
+    const completeResponse = await registrationService.completeInvite(sessionData.code, SMS)
     loginController.setupDirectLoginAfterRegister(req, res, completeResponse.user_external_id)
     return res.redirect(303, paths.registerUser.logUserIn)
   } catch (err) {

--- a/app/controllers/registration/registration.controller.js
+++ b/app/controllers/registration/registration.controller.js
@@ -15,6 +15,7 @@ const { isEmpty } = require('../../utils/validation/field-validation-checks')
 const { sanitiseSecurityCode } = require('../../utils/security-code-utils')
 const { validationErrors } = require('../../utils/validation/field-validation-checks')
 const { INVITE_SESSION_COOKIE_NAME } = require('../../utils/constants')
+const { APP } = require('../../models/second-factor-method')
 
 const PASSWORD_INPUT_FIELD_NAME = 'password'
 const REPEAT_PASSWORD_INPUT_FIELD_NAME = 'repeat-password'
@@ -124,7 +125,7 @@ async function submitAuthenticatorAppPage (req, res, next) {
 
   try {
     await adminusersClient.verifyOtpForInvite(sessionData.code, otpCode)
-    const completeInviteResponse = await adminusersClient.completeInvite(sessionData.code)
+    const completeInviteResponse = await adminusersClient.completeInvite(sessionData.code, APP)
     // set user external ID on the session so the user is logged in upon redirect
     sessionData.userExternalId = completeInviteResponse.user_external_id
     return res.redirect(paths.registerUser.logUserIn)

--- a/app/controllers/registration/registration.controller.test.js
+++ b/app/controllers/registration/registration.controller.test.js
@@ -6,6 +6,7 @@ const inviteFixtures = require('../../../test/fixtures/invite.fixtures')
 const { RESTClientError, ExpiredInviteError } = require('../../errors')
 const { paths } = require('../../routes')
 const registrationController = require('./registration.controller')
+const { APP } = require('../../models/second-factor-method')
 
 const inviteCode = 'a-code'
 let req, res, next
@@ -289,7 +290,7 @@ describe('Registration', () => {
 
       await controller.submitAuthenticatorAppPage(req, res, next)
       sinon.assert.calledWith(verifyOtpForInviteSpy, inviteCode, expectedSanitisedOtpCode)
-      sinon.assert.calledWith(completeInviteSpy, inviteCode)
+      sinon.assert.calledWith(completeInviteSpy, inviteCode, APP)
       sinon.assert.calledWith(res.redirect, paths.registerUser.logUserIn)
       sinon.assert.notCalled(next)
 

--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -411,19 +411,21 @@ module.exports = function (clientOptions = {}) {
    * @param inviteCode
    * @returns {*|promise|Constructor}
    */
-  function completeInvite (inviteCode) {
-    return baseClient.post(
-      {
-        baseUrl,
-        url: `/v1/api/invites/${inviteCode}/complete`,
-        json: true,
-        body: {
-          second_factor: 'SMS'
-        },
-        description: 'complete invite',
-        service: SERVICE_NAME
+  function completeInvite (inviteCode, secondFactorMethod) {
+    const opts = {
+      baseUrl,
+      url: `/v1/api/invites/${inviteCode}/complete`,
+      json: true,
+      description: 'complete invite',
+      service: SERVICE_NAME
+    }
+    if (secondFactorMethod) {
+      opts.body = {
+        second_factor: secondFactorMethod
       }
-    )
+    }
+
+    return baseClient.post(opts)
   }
 
   function verifyOtpForInvite (inviteCode, securityCode) {

--- a/app/services/service-registration.service.js
+++ b/app/services/service-registration.service.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const getAdminUsersClient = require('./clients/adminusers.client')
+const { SMS } = require('../models/second-factor-method')
 
 const adminUsersClient = getAdminUsersClient()
 
@@ -13,7 +14,7 @@ function submitServiceInviteOtpCode (code, otpCode) {
 }
 
 async function completeInvite (inviteCode) {
-  const completeInviteResponse = await adminUsersClient.completeInvite(inviteCode)
+  const completeInviteResponse = await adminUsersClient.completeInvite(inviteCode, SMS)
   return completeInviteResponse.user_external_id
 }
 

--- a/test/fixtures/invite.fixtures.js
+++ b/test/fixtures/invite.fixtures.js
@@ -92,9 +92,9 @@ module.exports = {
     }
   },
 
-  validInviteCompleteRequest: (opts = {}) => {
+  validInviteCompleteRequest: (secondFactorMethod) => {
     return {
-      second_factor: 'SMS'
+      second_factor: secondFactorMethod || 'SMS'
     }
   },
 

--- a/test/pact/adminusers-client/invite/complete-invite.pact.test.js
+++ b/test/pact/adminusers-client/invite/complete-invite.pact.test.js
@@ -8,6 +8,7 @@ const path = require('path')
 const PactInteractionBuilder = require('../../../test-helpers/pact/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../app/services/clients/adminusers.client')
 const inviteFixtures = require('../../../fixtures/invite.fixtures')
+const secondFactorMethod = require('../../../../app/models/second-factor-method')
 const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPactifier
 
 // Constants
@@ -38,7 +39,7 @@ describe('adminusers client - complete an invite', function () {
     const inviteCode = 'an-invite-code'
     const userExternalId = 'f84b8210f93d455e97baeaf3fea72cf4'
 
-    const validInviteCompleteRequest = inviteFixtures.validInviteCompleteRequest()
+    const validInviteCompleteRequest = inviteFixtures.validInviteCompleteRequest(secondFactorMethod.APP)
     const validInviteCompleteResponse = inviteFixtures.inviteCompleteResponseWithNoServiceExternalId({
       user_external_id: userExternalId
     })
@@ -60,18 +61,18 @@ describe('adminusers client - complete an invite', function () {
     afterEach(() => provider.verify())
 
     it('should complete a service invite successfully', function (done) {
-      adminUsersClient.completeInvite(inviteCode).should.be.fulfilled.then(response => {
+      adminUsersClient.completeInvite(inviteCode, secondFactorMethod.APP).should.be.fulfilled.then(response => {
         expect(response.user_external_id).to.equal(userExternalId)
       }).should.notify(done)
     })
   })
 
-  describe('success for inviting a user to a service', () => {
+  describe('success for inviting a new user to a service', () => {
     const inviteCode = 'an-invite-code'
     const userExternalId = 'f84b8210f93d455e97baeaf3fea72cf4'
     const serviceExternalId = '43a6818b522b4a628a14355614665ca3'
 
-    const validInviteCompleteRequest = inviteFixtures.validInviteCompleteRequest()
+    const validInviteCompleteRequest = inviteFixtures.validInviteCompleteRequest(secondFactorMethod.APP)
     const validInviteCompleteResponse = inviteFixtures.validInviteCompleteResponse({
       user_external_id: userExternalId,
       service_external_id: serviceExternalId
@@ -84,6 +85,40 @@ describe('adminusers client - complete an invite', function () {
           .withUponReceiving('a valid request to complete an invite to add a user to a service')
           .withMethod('POST')
           .withRequestBody(validInviteCompleteRequest)
+          .withStatusCode(200)
+          .withResponseBody(pactify(validInviteCompleteResponse))
+          .build()
+      ).then(() => done())
+        .catch(done)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should complete a service invite successfully', function (done) {
+      adminUsersClient.completeInvite(inviteCode, secondFactorMethod.APP).should.be.fulfilled.then(response => {
+        expect(response.user_external_id).to.equal(userExternalId)
+        expect(response.service_external_id).to.equal(serviceExternalId)
+      }).should.notify(done)
+    })
+  })
+
+  describe('success for inviting an existing user to a service', () => {
+    const inviteCode = 'an-invite-code'
+    const userExternalId = 'f84b8210f93d455e97baeaf3fea72cf4'
+    const serviceExternalId = '43a6818b522b4a628a14355614665ca3'
+
+    const validInviteCompleteResponse = inviteFixtures.validInviteCompleteResponse({
+      user_external_id: userExternalId,
+      service_external_id: serviceExternalId
+    })
+
+    before((done) => {
+      provider.addInteraction(
+        new PactInteractionBuilder(`${INVITE_RESOURCE}/${inviteCode}/complete`)
+          .withState('an invite to add an existing user to a service exists with invite code an-invite-code')
+          .withUponReceiving('a valid request to complete an invite to add an existing user to a service')
+          .withMethod('POST')
+          .withRequestBody(null)
           .withStatusCode(200)
           .withResponseBody(pactify(validInviteCompleteResponse))
           .build()


### PR DESCRIPTION
After successfully verifying the OTP code on the page to configure an authenticator app, we make a request to
/v1/api/invites/${inviteCode}/complete on adminusers to complete the invite and create the user. Make it so that we send "second_factor": "APP" in the request body so that the user is created with "APP" set as their second factor method for logging in.

Add an additional Pact test to ensure that it's possible to provide no request body when completing an invite for an existing user. As in this case, we wouldn't need to set a second factor method.


