### PR TITLE
PP-10057 Add route to submit the SMS security code page

### DIFF
--- a/app/controllers/registration/registration.controller.test.js
+++ b/app/controllers/registration/registration.controller.test.js
@@ -6,7 +6,7 @@ const inviteFixtures = require('../../../test/fixtures/invite.fixtures')
 const { RESTClientError, ExpiredInviteError } = require('../../errors')
 const { paths } = require('../../routes')
 const registrationController = require('./registration.controller')
-const { APP } = require('../../models/second-factor-method')
+const { APP, SMS } = require('../../models/second-factor-method')
 
 const inviteCode = 'a-code'
 let req, res, next
@@ -482,7 +482,8 @@ describe('Registration', () => {
 
       await controller.showSmsSecurityCodePage(req, res, next)
       sinon.assert.calledWith(res.render, 'registration/sms-code', {
-        redactedPhoneNumber: '••••••••••0192'
+        redactedPhoneNumber: '••••••••••0192',
+        errors: undefined
       })
       sinon.assert.notCalled(next)
     })
@@ -496,6 +497,157 @@ describe('Registration', () => {
       await controller.showSmsSecurityCodePage(req, res, next)
       sinon.assert.calledWith(next, error)
       sinon.assert.notCalled(res.render)
+    })
+
+    it('should render the page with errors if there is a recovered object in the session', async () => {
+      const sessionErrors = { 'key': 'An error' }
+      req.register_invite.recovered = { errors: sessionErrors }
+
+      const invite = inviteFixtures.validInviteResponse({ telephone_number: '+4408081570192' })
+      const controller = getControllerWithMockedAdminusersClient({
+        getValidatedInvite: () => Promise.resolve(invite)
+      })
+
+      await controller.showSmsSecurityCodePage(req, res, next)
+      sinon.assert.calledWith(res.render, 'registration/sms-code', {
+        redactedPhoneNumber: '••••••••••0192',
+        errors: sessionErrors
+      })
+      sinon.assert.notCalled(next)
+
+      expect(req.register_invite).to.not.have.property('recovered')
+    })
+  })
+
+  describe('submit the check your phone page', () => {
+    it('should call redirect with an error in the session when the OTP code fails validation', async () => {
+      req.body = {
+        code: 'aaa'
+      }
+
+      await registrationController.submitSmsSecurityCodePage(req, res, next)
+      sinon.assert.calledWith(res.redirect, paths.register.smsCode)
+      sinon.assert.notCalled(next)
+
+      expect(req.register_invite).to.have.property('recovered').to.deep.equal({
+        errors: {
+          code: 'The code must be 6 numbers'
+        }
+      })
+    })
+
+    it('should redirect to login when OTP code is valid', async () => {
+      const otpCode = '123 456'
+      const expectedSanitisedOtpCode = '123456'
+      req.body = {
+        code: otpCode
+      }
+
+      const userExternalId = 'a-user-id'
+      const completeInviteResponse = inviteFixtures.validInviteCompleteResponse({
+        user_external_id: userExternalId
+      })
+      const verifyOtpForInviteSpy = sinon.spy(() => Promise.resolve())
+      const completeInviteSpy = sinon.spy(() => Promise.resolve(completeInviteResponse))
+      const controller = getControllerWithMockedAdminusersClient({
+        verifyOtpForInvite: verifyOtpForInviteSpy,
+        completeInvite: completeInviteSpy
+      })
+
+      await controller.submitSmsSecurityCodePage(req, res, next)
+      sinon.assert.calledWith(verifyOtpForInviteSpy, inviteCode, expectedSanitisedOtpCode)
+      sinon.assert.calledWith(completeInviteSpy, inviteCode, SMS)
+      sinon.assert.calledWith(res.redirect, paths.registerUser.logUserIn)
+      sinon.assert.notCalled(next)
+
+      expect(req.register_invite).to.have.property('userExternalId').to.equal(userExternalId)
+    })
+
+    it('should call redirect with an error in the session when adminusers returns a 401', async () => {
+      const otpCode = '123456'
+      req.body = {
+        code: otpCode
+      }
+
+      const verifyOtpForInviteSpy = sinon.spy(() => Promise.reject(new RESTClientError('Error', 'adminusers', 401)))
+      const completeInviteSpy = sinon.spy(() => Promise.resolve())
+      const controller = getControllerWithMockedAdminusersClient({
+        verifyOtpForInvite: verifyOtpForInviteSpy,
+        completeInvite: completeInviteSpy
+      })
+
+      await controller.submitSmsSecurityCodePage(req, res, next)
+      sinon.assert.calledWith(verifyOtpForInviteSpy, inviteCode, otpCode)
+      sinon.assert.notCalled(completeInviteSpy)
+      sinon.assert.calledWith(res.redirect, paths.register.smsCode)
+      sinon.assert.notCalled(next)
+
+      expect(req.register_invite).to.have.property('recovered').to.deep.equal({
+        errors: {
+          code: 'The security code you’ve used is incorrect or has expired'
+        }
+      })
+    })
+
+    it('should call next with an error when adminusers returns a 410 when verifying the OTP code', async () => {
+      const otpCode = '123456'
+      req.body = {
+        code: otpCode
+      }
+
+      const verifyOtpForInviteSpy = sinon.spy(() => Promise.reject(new RESTClientError('Error', 'adminusers', 410)))
+      const completeInviteSpy = sinon.spy(() => Promise.resolve())
+      const controller = getControllerWithMockedAdminusersClient({
+        verifyOtpForInvite: verifyOtpForInviteSpy,
+        completeInvite: completeInviteSpy
+      })
+
+      await controller.submitSmsSecurityCodePage(req, res, next)
+      sinon.assert.calledWith(verifyOtpForInviteSpy, inviteCode, otpCode)
+      sinon.assert.notCalled(completeInviteSpy)
+      sinon.assert.calledWith(next, sinon.match.instanceOf(ExpiredInviteError))
+      sinon.assert.notCalled(res.redirect)
+    })
+
+    it('should call next with an error when adminusers returns a 410 when completing the invite', async () => {
+      const otpCode = '123456'
+      req.body = {
+        code: otpCode
+      }
+
+      const verifyOtpForInviteSpy = sinon.spy(() => Promise.resolve())
+      const completeInviteSpy = sinon.spy(() => Promise.reject(new RESTClientError('Error', 'adminusers', 410)))
+      const controller = getControllerWithMockedAdminusersClient({
+        verifyOtpForInvite: verifyOtpForInviteSpy,
+        completeInvite: completeInviteSpy
+      })
+
+      await controller.submitSmsSecurityCodePage(req, res, next)
+      sinon.assert.calledWith(verifyOtpForInviteSpy, inviteCode, otpCode)
+      sinon.assert.calledWith(completeInviteSpy, inviteCode)
+      sinon.assert.calledWith(next, sinon.match.instanceOf(ExpiredInviteError))
+      sinon.assert.notCalled(res.redirect)
+    })
+
+    it('should call next with an error when adminusers returns an unexpected error', async () => {
+      const otpCode = '123456'
+      req.body = {
+        code: otpCode
+      }
+
+      const error = new RESTClientError('Error', 'adminusers', 500)
+      const verifyOtpForInviteSpy = sinon.spy(() => Promise.resolve())
+      const completeInviteSpy = sinon.spy(() => Promise.reject(error))
+      const controller = getControllerWithMockedAdminusersClient({
+        verifyOtpForInvite: verifyOtpForInviteSpy,
+        completeInvite: completeInviteSpy
+      })
+
+      await controller.submitSmsSecurityCodePage(req, res, next)
+      sinon.assert.calledWith(verifyOtpForInviteSpy, inviteCode, otpCode)
+      sinon.assert.calledWith(completeInviteSpy, inviteCode)
+      sinon.assert.calledWith(next, error)
+      sinon.assert.notCalled(res.redirect)
     })
   })
 })

--- a/app/routes.js
+++ b/app/routes.js
@@ -206,6 +206,7 @@ module.exports.bind = function (app) {
   app.get(register.phoneNumber, inviteCookeIsPresent, registrationController.showPhoneNumberPage)
   app.post(register.phoneNumber, inviteCookeIsPresent, registrationController.submitPhoneNumberPage)
   app.get(register.smsCode, inviteCookeIsPresent, registrationController.showSmsSecurityCodePage)
+  app.post(register.smsCode, inviteCookeIsPresent, registrationController.submitSmsSecurityCodePage)
   app.get(register.resendCode, inviteCookeIsPresent, registrationController.showResendSecurityCodePage)
   app.get(register.success, inviteCookeIsPresent, registrationController.showSuccessPage)
 

--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -409,6 +409,7 @@ module.exports = function (clientOptions = {}) {
    * Complete a service invite
    *
    * @param inviteCode
+   * @param secondFactorMethod
    * @returns {*|promise|Constructor}
    */
   function completeInvite (inviteCode, secondFactorMethod) {

--- a/app/views/registration/sms-code.njk
+++ b/app/views/registration/sms-code.njk
@@ -18,6 +18,13 @@
 {% block mainContent %}
   <div class="govuk-grid-column-one-half">
 
+    {{ errorSummary ({
+      errors: errors,
+      hrefs: {
+        'code': '#code'
+      }
+    }) }}
+
     <h1 class="govuk-heading-l">Check your phone</h1>
 
     {{ govukInsetText({
@@ -34,7 +41,8 @@
         },
         id: "code",
         name: "code",
-        classes: "govuk-input--width-10"
+        classes: "govuk-input--width-10",
+        errorMessage: { text: errors['code'] } if errors['code'] else false
       }) }}
 
       {% set detailsHTML %}

--- a/test/cypress/integration/registration/register.cy.test.js
+++ b/test/cypress/integration/registration/register.cy.test.js
@@ -113,6 +113,30 @@ describe('Register', () => {
       // should show page to enter code
       cy.title().should('eq', 'Check your phone - GOV.UK Pay')
       cy.get('.govuk-inset-text').should('contain', 'We have sent a code to ••••••••••0192.')
+
+      // click continue without entering a code
+      cy.get('button').contains('Continue').click()
+
+      // check that error message is displayed
+      cy.get('.govuk-error-summary').should('exist').within(() => {
+        cy.get('h2').should('contain', 'There is a problem')
+        cy.get('[data-cy=error-summary-list-item]').should('have.length', 1)
+        cy.get('[data-cy=error-summary-list-item]').eq(0)
+          .contains('Enter your security code')
+          .should('have.attr', 'href', '#code')
+      })
+      cy.title().should('eq', 'Check your phone - GOV.UK Pay')
+
+      cy.get('#code').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'Enter your security code')
+      })
+
+      // enter a valid code and click continue
+      cy.get('#code').type('123456')
+      cy.get('button').contains('Continue').click()
+
+      // should log user in and redirect to my services page
+      cy.title().should('eq', 'Choose service - GOV.UK Pay')
     })
   })
 


### PR DESCRIPTION
When the page is submitted:
- Validate that the OTP code has a valid format
- Call adminusers to verify the OTP code
- Call adminusers to complete the invite, with a body containing `"second_factor": "SMS"`

If there are validation errors, or the code fails verification, redirect to the GET route with errors in the session that are displayed on the page.
