### PR TITLE
PP-10056 Display existing phone number on resend page

### DIFF
--- a/app/controllers/registration/registration.controller.js
+++ b/app/controllers/registration/registration.controller.js
@@ -223,8 +223,17 @@ async function submitSmsSecurityCodePage (req, res, next) {
   }
 }
 
-function showResendSecurityCodePage (req, res) {
-  res.render('registration/resend-code')
+async function showResendSecurityCodePage (req, res, next) {
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
+
+  try {
+    const invite = await adminusersClient.getValidatedInvite(sessionData.code)
+    res.render('registration/resend-code', {
+      phoneNumber: invite.telephone_number
+    })
+  } catch (err) {
+    next(err)
+  }
 }
 
 function showSuccessPage (req, res) {

--- a/app/controllers/registration/registration.controller.test.js
+++ b/app/controllers/registration/registration.controller.test.js
@@ -650,6 +650,33 @@ describe('Registration', () => {
       sinon.assert.notCalled(res.redirect)
     })
   })
+
+  describe('show the resend code page', () => {
+    it('should render the page when invite retrieved successfully', async () => {
+      let phoneNumber = '+4408081570192'
+      const invite = inviteFixtures.validInviteResponse({ telephone_number: phoneNumber })
+      const controller = getControllerWithMockedAdminusersClient({
+        getValidatedInvite: () => Promise.resolve(invite)
+      })
+
+      await controller.showResendSecurityCodePage(req, res, next)
+      sinon.assert.calledWith(res.render, 'registration/resend-code', {
+        phoneNumber
+      })
+      sinon.assert.notCalled(next)
+    })
+
+    it('should call next with an error if adminusers returns an error', async () => {
+      const error = new Error('error from adminusers')
+      const controller = getControllerWithMockedAdminusersClient({
+        getValidatedInvite: () => Promise.reject(error)
+      })
+
+      await controller.showResendSecurityCodePage(req, res, next)
+      sinon.assert.calledWith(next, error)
+      sinon.assert.notCalled(res.render)
+    })
+  })
 })
 
 function getControllerWithMockedAdminusersClient (mockedAdminusersClient) {

--- a/app/views/registration/resend-code.njk
+++ b/app/views/registration/resend-code.njk
@@ -31,7 +31,8 @@
           classes: "govuk-label--s"
         },
         id: "phone",
-        name: "phone"
+        name: "phone",
+        value: phoneNumber
       }) }}
 
       {{ govukButton({ text: "Resend security code" }) }}


### PR DESCRIPTION
The GET route and template for the page to resend the security code already exists. Make it so that the page will pre-fill the phone number field with the phone number the user has already entered for the invite.

Will check the phone number is pre-filled in the Cypress test for registration when the POST route is added.


