### PR TITLE
PP-10056 Add POST route for resend code page

### DIFF
--- a/app/controllers/registration/registration.controller.js
+++ b/app/controllers/registration/registration.controller.js
@@ -236,6 +236,27 @@ async function showResendSecurityCodePage (req, res, next) {
   }
 }
 
+async function submitResendSecurityCodePage (req, res, next) {
+  const sessionData = req[INVITE_SESSION_COOKIE_NAME]
+  const phoneNumber = req.body[PHONE_NUMBER_INPUT_FIELD_NAME]
+
+  const validPhoneNumber = validatePhoneNumber(phoneNumber)
+  const errors = {}
+  if (!validPhoneNumber.valid) {
+    errors[PHONE_NUMBER_INPUT_FIELD_NAME] = validPhoneNumber.message
+    return res.render('registration/resend-code', { errors, phoneNumber })
+  }
+
+  try {
+    await adminusersClient.updateInvitePhoneNumber(sessionData.code, phoneNumber)
+    await adminusersClient.sendOtp(sessionData.code)
+
+    res.redirect(paths.register.smsCode)
+  } catch (err) {
+    next(err)
+  }
+}
+
 function showSuccessPage (req, res) {
   res.render('registration/success')
 }
@@ -252,5 +273,6 @@ module.exports = {
   showSmsSecurityCodePage,
   submitSmsSecurityCodePage,
   showResendSecurityCodePage,
+  submitResendSecurityCodePage,
   showSuccessPage
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -208,6 +208,7 @@ module.exports.bind = function (app) {
   app.get(register.smsCode, inviteCookeIsPresent, registrationController.showSmsSecurityCodePage)
   app.post(register.smsCode, inviteCookeIsPresent, registrationController.submitSmsSecurityCodePage)
   app.get(register.resendCode, inviteCookeIsPresent, registrationController.showResendSecurityCodePage)
+  app.post(register.resendCode, inviteCookeIsPresent, registrationController.submitResendSecurityCodePage)
   app.get(register.success, inviteCookeIsPresent, registrationController.showSuccessPage)
 
   // ----------------------

--- a/app/views/registration/resend-code.njk
+++ b/app/views/registration/resend-code.njk
@@ -18,6 +18,13 @@
 {% block mainContent %}
   <div class="govuk-grid-column-one-half">
 
+    {{ errorSummary ({
+      errors: errors,
+      hrefs: {
+        'phone': '#phone'
+      }
+    }) }}
+
     <h1 class="govuk-heading-l">Check your mobile phone number</h1>
 
     <p class="govuk-body">Check your mobile phone number is correct, then resend the security code.</p>
@@ -32,6 +39,7 @@
         },
         id: "phone",
         name: "phone",
+        errorMessage: { text: errors['phone'] } if errors['phone'] else false,
         value: phoneNumber
       }) }}
 


### PR DESCRIPTION
Add a POST route for resending the OTP code. The page asks for the user to confirm their phone number before resending the code. When the submit button is clicked:
- Validate the phone number
- Make a PATCH request to adminusers to update the phone number on the invite
- Make a POST request to adminusers to send an OTP code to the entered phone number
- Redirect to the page for the user to enter their security code.

