### PR TITLE
PP-10052: Fix: pass second factor method through for invite client

### DIFF
--- a/app/controllers/register-user.controller.js
+++ b/app/controllers/register-user.controller.js
@@ -59,7 +59,7 @@ const subscribeService = async function subscribeService (req, res, next) {
   }
 
   try {
-    const completeResponse = await registrationService.completeInvite(inviteCode)
+    const completeResponse = await registrationService.completeInvite(inviteCode, SMS)
     req.flash('inviteSuccessServiceId', completeResponse.service_external_id)
     return res.redirect(303, paths.serviceSwitcher.index)
   } catch (err) {

--- a/app/controllers/register-user.controller.test.js
+++ b/app/controllers/register-user.controller.test.js
@@ -59,7 +59,7 @@ describe('Register user controller', () => {
       it('should accept invite and redirect to "My services', async () => {
         const controller = getController(completeInviteSuccessStub)
         await controller.subscribeService(req, res, next)
-        sinon.assert.called(completeInviteSuccessStub)
+        sinon.assert.calledWith(completeInviteSuccessStub, inviteCode, 'SMS')
         sinon.assert.calledWith(flashSpy, 'inviteSuccessServiceId', serviceExternalId)
         sinon.assert.calledWith(completeInviteSuccessStub, inviteCode)
       })

--- a/app/services/user-registration.service.js
+++ b/app/services/user-registration.service.js
@@ -3,6 +3,8 @@
 const getAdminUsersClient = require('./clients/adminusers.client')
 const adminUsersClient = getAdminUsersClient()
 
+const { SMS } = require('../models/second-factor-method')
+
 module.exports = {
 
   /**
@@ -25,8 +27,8 @@ module.exports = {
     return adminUsersClient.resendOtpCode(code, phoneNumber)
   },
 
-  completeInvite: function completeInvite (code) {
-    return adminUsersClient.completeInvite(code)
+  completeInvite: function completeInvite (code, secondFactorMethod = SMS) {
+    return adminUsersClient.completeInvite(code, secondFactorMethod)
   }
 
 }


### PR DESCRIPTION
Now that second factor method will only be included in the invite complete request if it is passed into the client method, all consuming code should set the value.

Propagate the value through the client method but also set a default to SMS which is currently used for all invites.
