### PR TITLE
PP-10395 Show success page when registration is complete

### DIFF
--- a/app/controllers/registration/registration.controller.js
+++ b/app/controllers/registration/registration.controller.js
@@ -128,7 +128,7 @@ async function submitAuthenticatorAppPage (req, res, next) {
     const completeInviteResponse = await adminusersClient.completeInvite(sessionData.code, APP)
     // set user external ID on the session so the user is logged in upon redirect
     sessionData.userExternalId = completeInviteResponse.user_external_id
-    return res.redirect(paths.registerUser.logUserIn)
+    return res.redirect(paths.register.success)
   } catch (err) {
     if (err instanceof RESTClientError) {
       if (err.errorCode === 401) {
@@ -208,7 +208,7 @@ async function submitSmsSecurityCodePage (req, res, next) {
     const completeInviteResponse = await adminusersClient.completeInvite(sessionData.code, SMS)
     // set user external ID on the session so the user is logged in upon redirect
     sessionData.userExternalId = completeInviteResponse.user_external_id
-    return res.redirect(paths.registerUser.logUserIn)
+    return res.redirect(paths.register.success)
   } catch (err) {
     if (err instanceof RESTClientError) {
       if (err.errorCode === 401) {

--- a/app/controllers/registration/registration.controller.test.js
+++ b/app/controllers/registration/registration.controller.test.js
@@ -270,7 +270,7 @@ describe('Registration', () => {
       })
     })
 
-    it('should redirect to login when OTP code is valid', async () => {
+    it('should redirect to the success page when OTP code is valid', async () => {
       const otpCode = '123 456'
       const expectedSanitisedOtpCode = '123456'
       req.body = {
@@ -291,7 +291,7 @@ describe('Registration', () => {
       await controller.submitAuthenticatorAppPage(req, res, next)
       sinon.assert.calledWith(verifyOtpForInviteSpy, inviteCode, expectedSanitisedOtpCode)
       sinon.assert.calledWith(completeInviteSpy, inviteCode, APP)
-      sinon.assert.calledWith(res.redirect, paths.registerUser.logUserIn)
+      sinon.assert.calledWith(res.redirect, paths.register.success)
       sinon.assert.notCalled(next)
 
       expect(req.register_invite).to.have.property('userExternalId').to.equal(userExternalId)
@@ -536,7 +536,7 @@ describe('Registration', () => {
       })
     })
 
-    it('should redirect to login when OTP code is valid', async () => {
+    it('should redirect to the success page when OTP code is valid', async () => {
       const otpCode = '123 456'
       const expectedSanitisedOtpCode = '123456'
       req.body = {
@@ -557,7 +557,7 @@ describe('Registration', () => {
       await controller.submitSmsSecurityCodePage(req, res, next)
       sinon.assert.calledWith(verifyOtpForInviteSpy, inviteCode, expectedSanitisedOtpCode)
       sinon.assert.calledWith(completeInviteSpy, inviteCode, SMS)
-      sinon.assert.calledWith(res.redirect, paths.registerUser.logUserIn)
+      sinon.assert.calledWith(res.redirect, paths.register.success)
       sinon.assert.notCalled(next)
 
       expect(req.register_invite).to.have.property('userExternalId').to.equal(userExternalId)

--- a/app/routes.js
+++ b/app/routes.js
@@ -209,7 +209,7 @@ module.exports.bind = function (app) {
   app.post(register.smsCode, inviteCookeIsPresent, registrationController.submitSmsSecurityCodePage)
   app.get(register.resendCode, inviteCookeIsPresent, registrationController.showResendSecurityCodePage)
   app.post(register.resendCode, inviteCookeIsPresent, registrationController.submitResendSecurityCodePage)
-  app.get(register.success, inviteCookeIsPresent, registrationController.showSuccessPage)
+  app.get(register.success, inviteCookeIsPresent, loginController.loginAfterRegister, userIsAuthorised, registrationController.showSuccessPage)
 
   // ----------------------
   // AUTHENTICATED ROUTES

--- a/test/cypress/integration/registration/register.cy.test.js
+++ b/test/cypress/integration/registration/register.cy.test.js
@@ -169,7 +169,11 @@ describe('Register', () => {
       cy.get('#code').type('123456')
       cy.get('button').contains('Continue').click()
 
-      // should log user in and redirect to my services page
+      // should show the success page
+      cy.title().should('eq', 'You’ve created your account - GOV.UK Pay')
+      cy.get('a[role=button]').contains('Continue').click()
+
+      // should redirect to my services page
       cy.title().should('eq', 'Choose service - GOV.UK Pay')
     })
   })
@@ -240,7 +244,11 @@ describe('Register', () => {
       cy.get('#code').type('123456')
       cy.get('button').contains('Continue').click()
 
-      // should log user in and redirect to my services page
+      // should show the success page
+      cy.title().should('eq', 'You’ve created your account - GOV.UK Pay')
+      cy.get('a[role=button]').contains('Continue').click()
+
+      // should redirect to my services page
       cy.title().should('eq', 'Choose service - GOV.UK Pay')
     })
   })


### PR DESCRIPTION
After submitting a valid OTP code on either the page to configure SMS as the second factor method or Authenticator app as the second factor method, redirect to the success page. This page informs the user that registration was successful and has a button to continue to the "My services" page.

When the `/register/success` route is visited, call the middleware that will log the user in using the `userExternalId` from the `register_invite` cookie. Previously this was done as part of the redirect to `/proceed-to-login` which logged the user in then called the controller to render the "My services" page.