### PR TITLE
PP-10367: Re-provision OTP key

### DIFF
--- a/app/controllers/registration/registration.controller.js
+++ b/app/controllers/registration/registration.controller.js
@@ -91,7 +91,7 @@ async function showAuthenticatorAppPage (req, res, next) {
   const sessionData = req[INVITE_SESSION_COOKIE_NAME]
 
   try {
-    const invite = await adminusersClient.getValidatedInvite(sessionData.code)
+    const invite = await adminusersClient.reprovisionOtp(sessionData.code)
     const secretKey = invite.otp_key
 
     const prettyPrintedSecret = secretKey.match(/.{4}/g).join(' ')
@@ -164,6 +164,7 @@ async function submitPhoneNumberPage (req, res, next) {
 
   try {
     await adminusersClient.updateInvitePhoneNumber(sessionData.code, phoneNumber)
+    await adminusersClient.reprovisionOtp(sessionData.code)
     await adminusersClient.sendOtp(sessionData.code)
 
     res.redirect(paths.register.smsCode)

--- a/app/controllers/registration/registration.controller.test.js
+++ b/app/controllers/registration/registration.controller.test.js
@@ -202,7 +202,7 @@ describe('Registration', () => {
     it('should call next with an error if adminusers returns an error', async () => {
       const error = new Error('error from adminusers')
       const controller = getControllerWithMockedAdminusersClient({
-        getValidatedInvite: () => Promise.reject(error)
+        reprovisionOtp: () => Promise.reject(error)
       })
 
       await controller.showAuthenticatorAppPage(req, res, next)
@@ -215,7 +215,7 @@ describe('Registration', () => {
       const otpKey = 'ANEXAMPLESECRETSECONDFACTORCODE1'
       const invite = inviteFixtures.validInviteResponse({ otp_key: otpKey })
       const controller = getControllerWithMockedAdminusersClient({
-        getValidatedInvite: () => Promise.resolve(invite)
+        reprovisionOtp: () => Promise.resolve(invite)
       })
 
       await controller.showAuthenticatorAppPage(req, res, next)
@@ -237,7 +237,7 @@ describe('Registration', () => {
       const otpKey = 'ANEXAMPLESECRETSECONDFACTORCODE1'
       const invite = inviteFixtures.validInviteResponse({ otp_key: otpKey })
       const controller = getControllerWithMockedAdminusersClient({
-        getValidatedInvite: () => Promise.resolve(invite)
+        reprovisionOtp: () => Promise.resolve(invite)
       })
 
       await controller.showAuthenticatorAppPage(req, res, next)
@@ -429,6 +429,28 @@ describe('Registration', () => {
       sinon.assert.notCalled(res.redirect)
     })
 
+    it('should call next with an error if adminusers returns an error when reprovisioning OTP key', async () => {
+      const validPhoneNumber = '+44 0808 157 0192'
+      req.body = {
+        phone: validPhoneNumber
+      }
+
+      const error = new Error('error from adminusers')
+      const updateInvitePhoneNumberSpy = sinon.spy(() => Promise.resolve())
+      const reprovisionOtpSpy = sinon.spy(() => Promise.reject(error))
+      const controller = getControllerWithMockedAdminusersClient({
+        updateInvitePhoneNumber: updateInvitePhoneNumberSpy,
+        reprovisionOtp: reprovisionOtpSpy
+      })
+
+      await controller.submitPhoneNumberPage(req, res, next)
+      sinon.assert.calledWith(updateInvitePhoneNumberSpy, inviteCode, validPhoneNumber)
+      sinon.assert.calledWith(reprovisionOtpSpy, inviteCode)
+      sinon.assert.calledWith(next, error)
+      sinon.assert.notCalled(res.render)
+      sinon.assert.notCalled(res.redirect)
+    })
+
     it('should call next with an error if adminusers returns an error when sending OTP', async () => {
       const validPhoneNumber = '+44 0808 157 0192'
       req.body = {
@@ -437,14 +459,17 @@ describe('Registration', () => {
 
       const error = new Error('error from adminusers')
       const updateInvitePhoneNumberSpy = sinon.spy(() => Promise.resolve())
+      const reprovisionOtpSpy = sinon.spy(() => Promise.resolve())
       const sendOtpSpy = sinon.spy(() => Promise.reject(error))
       const controller = getControllerWithMockedAdminusersClient({
         updateInvitePhoneNumber: updateInvitePhoneNumberSpy,
+        reprovisionOtp: reprovisionOtpSpy,
         sendOtp: sendOtpSpy
       })
 
       await controller.submitPhoneNumberPage(req, res, next)
       sinon.assert.calledWith(updateInvitePhoneNumberSpy, inviteCode, validPhoneNumber)
+      sinon.assert.calledWith(reprovisionOtpSpy, inviteCode)
       sinon.assert.calledWith(sendOtpSpy, inviteCode)
       sinon.assert.calledWith(next, error)
       sinon.assert.notCalled(res.render)
@@ -458,14 +483,17 @@ describe('Registration', () => {
       }
 
       const updateInvitePhoneNumberSpy = sinon.spy(() => Promise.resolve())
+      const reprovisionOtpSpy = sinon.spy(() => Promise.resolve())
       const sendOtpSpy = sinon.spy(() => Promise.resolve())
       const controller = getControllerWithMockedAdminusersClient({
         updateInvitePhoneNumber: updateInvitePhoneNumberSpy,
+        reprovisionOtp: reprovisionOtpSpy,
         sendOtp: sendOtpSpy
       })
 
       await controller.submitPhoneNumberPage(req, res, next)
       sinon.assert.calledWith(updateInvitePhoneNumberSpy, inviteCode, validPhoneNumber)
+      sinon.assert.calledWith(reprovisionOtpSpy, inviteCode)
       sinon.assert.calledWith(sendOtpSpy, inviteCode)
       sinon.assert.calledWith(res.redirect, paths.register.smsCode)
       sinon.assert.notCalled(next)

--- a/test/cypress/integration/registration/register.cy.test.js
+++ b/test/cypress/integration/registration/register.cy.test.js
@@ -182,6 +182,10 @@ describe('Register', () => {
           password_set: false,
           otp_key: otpKey
         }),
+        inviteStubs.reprovisionOtpSuccess({
+          code: inviteCode,
+          otp_key: otpKey
+        }),
         inviteStubs.completeInviteSuccess(inviteCode, createdUserExternalId),
         userStubs.getUserSuccess({ userExternalId: createdUserExternalId, gatewayAccountId: '1' }),
         gatewayAccountStubs.getGatewayAccountsSuccess({

--- a/test/cypress/stubs/invite-stubs.js
+++ b/test/cypress/stubs/invite-stubs.js
@@ -27,8 +27,16 @@ function completeInviteSuccess (inviteCode, userExternalId) {
   })
 }
 
+function reprovisionOtpSuccess (opts) {
+  const path = `/v1/api/invites/${opts.code}/reprovision-otp`
+  return stubBuilder('POST', path, 200, {
+    response: inviteFixtures.validInviteResponse(opts)
+  })
+}
+
 module.exports = {
   getInvitedUsersSuccess,
   getInviteSuccess,
-  completeInviteSuccess
+  completeInviteSuccess,
+  reprovisionOtpSuccess
 }


### PR DESCRIPTION
* Call the POST `/v1/api/invites/{code}/reprovision-otp` when the `/register/phone-number` page is submitted, before calling the endpoint to send the SMS with the OTP code.
* Call the POST `/v1/api/invites/{code}/reprovision-otp` when the GET `/register/authenticator-app` route is called, before rendering the page. Use the new otp_key in the invite the endpoint returns to display the code when rendering the page.