### PR TITLE
PP-10402: POST route for enter email page

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -145,21 +145,21 @@
         "filename": "app/controllers/registration/registration.controller.js",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 22
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.js",
         "hashed_secret": "cbb085747f0bcbeac56f2a583779b44c8f445d92",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 23
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.js",
         "hashed_secret": "7b652417979832c620feec2e89b92c56a291ae52",
         "is_verified": false,
-        "line_number": 56
+        "line_number": 97
       }
     ],
     "app/controllers/registration/registration.controller.test.js": [
@@ -168,56 +168,56 @@
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "9695086041c462c6598c6dd5e35d3a2c9cbbe5f8",
         "is_verified": false,
-        "line_number": 79
+        "line_number": 153
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "7b652417979832c620feec2e89b92c56a291ae52",
         "is_verified": false,
-        "line_number": 80
+        "line_number": 154
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "f5378ce7cd012d12a9be51e6be241b1e66240879",
         "is_verified": false,
-        "line_number": 87
+        "line_number": 161
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "69c8d31085756bfd34bb8ca6d393289374b7d7c2",
         "is_verified": false,
-        "line_number": 94
+        "line_number": 168
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "3f3c2dca191782c9b8b2f513d16abaa66dc543bf",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 175
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "0ee4c488221aee414cd9ae5300e28d11c2851fe5",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 190
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "d8fe3060b1c00ad00ece5d205e493764b113b94c",
         "is_verified": false,
-        "line_number": 122
+        "line_number": 196
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "a04fccdd7f93b63162cd0d3e015761cd3a24d86a",
         "is_verified": false,
-        "line_number": 223
+        "line_number": 297
       }
     ],
     "app/controllers/your-psp/worldpay-3ds-flex-validations.test.js": [
@@ -902,5 +902,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-30T12:58:31Z"
+  "generated_at": "2022-11-30T17:36:39Z"
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -253,6 +253,7 @@ module.exports = {
   },
   register: {
     email: '/register/email-address',
+    checkEmail: '/register/check-email',
     password: '/register/password',
     securityCodes: '/register/get-security-codes',
     authenticatorApp: '/register/authenticator-app',

--- a/app/routes.js
+++ b/app/routes.js
@@ -198,6 +198,7 @@ module.exports.bind = function (app) {
 
   // NEW REGISTRATION JOURNEY
   app.get(register.email, registrationController.showEmailPage)
+  app.post(register.email, registrationController.submitEmailPage)
   app.get(register.password, inviteCookieIsPresent, registrationController.showPasswordPage)
   app.post(register.password, inviteCookieIsPresent, registrationController.submitPasswordPage)
   app.get(register.securityCodes, inviteCookieIsPresent, registrationController.showChooseSignInMethodPage)

--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -497,6 +497,26 @@ module.exports = function (clientOptions = {}) {
     )
   }
 
+  /**
+   * Create self-signup invite
+   *
+   * @param email
+   */
+  function createSelfSignupInvite (email) {
+    return baseClient.post(
+      {
+        baseUrl,
+        url: `/v1/api/invites/service`,
+        json: true,
+        body: {
+          email: email
+        },
+        description: 'submit service registration details',
+        service: SERVICE_NAME
+      }
+    )
+  }
+
   function deleteUser (serviceExternalId, removerExternalId, userExternalId) {
     let headers = {}
     headers[HEADER_USER_CONTEXT] = removerExternalId
@@ -816,6 +836,7 @@ module.exports = function (clientOptions = {}) {
     getServiceUsers,
 
     // Invite-related Methods
+    createSelfSignupInvite,
     verifyOtpForInvite,
     inviteUser,
     getInvitedUsersList,

--- a/app/utils/validation/field-validation-checks.js
+++ b/app/utils/validation/field-validation-checks.js
@@ -11,6 +11,7 @@ const validationErrors = {
   currency: 'Enter an amount in pounds and pence using digits and a decimal point. For example “10.50”',
   phoneNumber: 'Must be an 11 digit phone number',
   validEmail: 'Enter a valid email address',
+  notPublicSectorEmail: 'Enter a public sector email address',
   isHttps: 'URL must begin with https://',
   invalidUrl: 'Enter a valid website address',
   isAboveMaxAmount: `Enter an amount under £${MAX_AMOUNT.toLocaleString()}`,

--- a/test/cypress/integration/registration/complete-registration.cy.test.js
+++ b/test/cypress/integration/registration/complete-registration.cy.test.js
@@ -7,7 +7,7 @@ const otpKey = 'ANEXAMPLESECRETSECONDFACTORCODE1'
 const createdUserExternalId = 'a-user-id'
 const validPhoneNumber = '+4408081570192'
 
-describe('Register', () => {
+describe('Complete registration after following link in invite email', () => {
   describe('SMS is selected as method for getting security codes', () => {
     it('should complete registration journey', () => {
       cy.task('setupStubs', [
@@ -48,7 +48,6 @@ describe('Register', () => {
           .contains('Re-type your password')
           .should('have.attr', 'href', '#repeat-password')
       })
-      cy.title().should('eq', 'Create your password - GOV.UK Pay')
 
       cy.get('.govuk-form-group--error > input#password').parent().should('exist').within(() => {
         cy.get('.govuk-error-message').should('contain', 'Enter a password')
@@ -56,6 +55,8 @@ describe('Register', () => {
       cy.get('.govuk-form-group--error > input#repeat-password').parent().should('exist').within(() => {
         cy.get('.govuk-error-message').should('contain', 'Re-type your password')
       })
+
+      cy.title().should('eq', 'Create your password - GOV.UK Pay')
 
       // enter valid values into both password fields and click continue
       cy.get('#password').type('long-enough-password', { delay: 0 })
@@ -76,11 +77,12 @@ describe('Register', () => {
           .contains('You need to select an option')
           .should('have.attr', 'href', '#sign-in-method')
       })
-      cy.title().should('eq', 'Choose how to get security codes - GOV.UK Pay')
 
       cy.get('[data-cy=radios-security-code]').parent().should('exist').within(() => {
         cy.get('.govuk-error-message').should('contain', 'You need to select an option')
       })
+
+      cy.title().should('eq', 'Choose how to get security codes - GOV.UK Pay')
 
       // select SMS and click continue
       cy.get('[data-cy=radio-option-sms]').click()
@@ -159,11 +161,12 @@ describe('Register', () => {
           .contains('Enter your security code')
           .should('have.attr', 'href', '#code')
       })
-      cy.title().should('eq', 'Check your phone - GOV.UK Pay')
 
       cy.get('#code').parent().should('exist').within(() => {
         cy.get('.govuk-error-message').should('contain', 'Enter your security code')
       })
+
+      cy.title().should('eq', 'Check your phone - GOV.UK Pay')
 
       // enter a valid code and click continue
       cy.get('#code').type('123456')
@@ -238,11 +241,12 @@ describe('Register', () => {
           .contains('Enter your security code')
           .should('have.attr', 'href', '#code')
       })
-      cy.title().should('eq', 'Set up an authenticator app - GOV.UK Pay')
 
       cy.get('#code').parent().should('exist').within(() => {
         cy.get('.govuk-error-message').should('contain', 'Enter your security code')
       })
+
+      cy.title().should('eq', 'Set up an authenticator app - GOV.UK Pay')
 
       // enter a valid code and click continue
       cy.get('#code').type('123456')

--- a/test/cypress/integration/registration/start-self-signup-registration.cy.test.js
+++ b/test/cypress/integration/registration/start-self-signup-registration.cy.test.js
@@ -1,0 +1,46 @@
+const inviteStubs = require('../../stubs/invite-stubs')
+
+describe('Start self-signup registration', () => {
+  it('should rerender page if invalid email address', () => {
+    const invalidEmail = 'a@example.com'
+
+    cy.task('setupStubs', [
+      inviteStubs.createSelfSignupInviteNotPublicSectorEmail(invalidEmail)
+    ])
+
+    cy.visit('/register/email-address')
+
+    cy.title().should('eq', 'Enter your email address - GOV.UK Pay')
+    cy.get('h1').should('contain', 'Enter your email address')
+
+    // Submit invalid email address
+    cy.get('#email').type(invalidEmail, { delay: 0 })
+    cy.get('button').contains('Continue').click()
+
+    // Check that error messages are displayed
+    cy.get('.govuk-error-summary').should('exist').within(() => {
+      cy.get('h2').should('contain', 'There is a problem')
+      cy.get('[data-cy=error-summary-list-item]').should('have.length', 1)
+      cy.get('[data-cy=error-summary-list-item]').eq(0)
+        .contains('Enter a public sector email address')
+        .should('have.attr', 'href', '#email')
+    })
+
+    cy.get('.govuk-form-group--error > input#email').parent().should('exist').within(() => {
+      cy.get('.govuk-error-message').should('contain', 'Enter a public sector email address')
+    })
+    cy.get('#email').should('have.value', invalidEmail)
+
+    cy.title().should('eq', 'Enter your email address - GOV.UK Pay')
+  })
+
+  it('proceed to check email page if valid email address', () => {
+    cy.visit('/register/email-address')
+
+    cy.title().should('eq', 'Enter your email address - GOV.UK Pay')
+    cy.get('h1').should('contain', 'Enter your email address')
+
+    cy.get('#email').clear().type('b@example.com', { delay: 0 })
+    cy.get('button').contains('Continue').click()
+  })
+})

--- a/test/cypress/stubs/invite-stubs.js
+++ b/test/cypress/stubs/invite-stubs.js
@@ -3,6 +3,15 @@
 const inviteFixtures = require('../../fixtures/invite.fixtures')
 const { stubBuilder } = require('./stub-builder')
 
+function createSelfSignupInviteNotPublicSectorEmail (email) {
+  const path = '/v1/api/invites/service'
+  return stubBuilder('POST', path, 403, {
+    request: {
+      email
+    }
+  })
+}
+
 function getInvitedUsersSuccess (opts) {
   const path = '/v1/api/invites'
   return stubBuilder('GET', path, 200, {
@@ -35,6 +44,7 @@ function reprovisionOtpSuccess (opts) {
 }
 
 module.exports = {
+  createSelfSignupInviteNotPublicSectorEmail,
   getInvitedUsersSuccess,
   getInviteSuccess,
   completeInviteSuccess,


### PR DESCRIPTION
* Validate email address
* Handle 403 or 409 from call to `/v1/api/invites/service` on adminusers
* On success or 409 from adminusers, set `email` on session cookie and redirect to 'check email' page