### PR TITLE
PP-10052 Fix QR code for configuring authenticator app

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -168,56 +168,56 @@
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "9695086041c462c6598c6dd5e35d3a2c9cbbe5f8",
         "is_verified": false,
-        "line_number": 173
+        "line_number": 175
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "7b652417979832c620feec2e89b92c56a291ae52",
         "is_verified": false,
-        "line_number": 174
+        "line_number": 176
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "f5378ce7cd012d12a9be51e6be241b1e66240879",
         "is_verified": false,
-        "line_number": 181
+        "line_number": 183
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "69c8d31085756bfd34bb8ca6d393289374b7d7c2",
         "is_verified": false,
-        "line_number": 188
+        "line_number": 190
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "3f3c2dca191782c9b8b2f513d16abaa66dc543bf",
         "is_verified": false,
-        "line_number": 195
+        "line_number": 197
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "0ee4c488221aee414cd9ae5300e28d11c2851fe5",
         "is_verified": false,
-        "line_number": 210
+        "line_number": 212
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "d8fe3060b1c00ad00ece5d205e493764b113b94c",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 218
       },
       {
         "type": "Secret Keyword",
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "a04fccdd7f93b63162cd0d3e015761cd3a24d86a",
         "is_verified": false,
-        "line_number": 317
+        "line_number": 324
       }
     ],
     "app/controllers/your-psp/worldpay-3ds-flex-validations.test.js": [
@@ -902,5 +902,5 @@
       }
     ]
   },
-  "generated_at": "2022-12-01T11:01:51Z"
+  "generated_at": "2022-12-01T15:24:01Z"
 }

--- a/app/controllers/registration/registration.controller.js
+++ b/app/controllers/registration/registration.controller.js
@@ -148,7 +148,7 @@ async function showAuthenticatorAppPage (req, res, next) {
     const secretKey = invite.otp_key
 
     const prettyPrintedSecret = secretKey.match(/.{4}/g).join(' ')
-    const otpUrl = `otpauth://totp/GOV.UK%20Pay:${encodeURIComponent('username')}?secret=${encodeURIComponent(secretKey)}&issuer=GOV.UK%20Pay&algorithm=SHA1&digits=6&period=30`
+    const otpUrl = `otpauth://totp/GOV.UK%20Pay:${encodeURIComponent(invite.email)}?secret=${encodeURIComponent(secretKey)}&issuer=GOV.UK%20Pay&algorithm=SHA1&digits=6&period=30`
     const qrCodeDataUrl = await qrcode.toDataURL(otpUrl)
 
     const recovered = sessionData.recovered || {}


### PR DESCRIPTION
- When scanning the QR code with an authenticator app, the app was suggesting to create an account with name `GOV.UK Pay: username` rather than with the actual username. Fix this to use the email from the invite.

