### PR TITLE
PP-10395 Show logged in nav on success page

### DIFF
--- a/app/controllers/registration/registration.controller.js
+++ b/app/controllers/registration/registration.controller.js
@@ -312,7 +312,7 @@ async function submitResendSecurityCodePage (req, res, next) {
 }
 
 function showSuccessPage (req, res) {
-  res.render('registration/success')
+  res.render('registration/success', { loggedIn: true })
 }
 
 module.exports = {

--- a/app/routes.js
+++ b/app/routes.js
@@ -173,7 +173,8 @@ module.exports.bind = function (app) {
   app.get(
     registerUser.logUserIn,
     passport.authenticate('localStrategyLoginDirectAfterRegistration', { failureRedirect: user.logIn }),
-    userIsAuthorised, rootController.get)
+    userIsAuthorised,
+    rootController.get)
 
   // LOGIN
   app.get(user.logIn, redirectLoggedInUser, loginController.loginGet)
@@ -219,7 +220,9 @@ module.exports.bind = function (app) {
   app.get(
     register.success,
     passport.authenticate('localStrategyLoginDirectAfterRegistration', { failureRedirect: user.logIn }),
-    registrationController.showSuccessPage)
+    userIsAuthorised,
+    registrationController.showSuccessPage
+  )
 
   // ----------------------
   // AUTHENTICATED ROUTES

--- a/app/routes.test.js
+++ b/app/routes.test.js
@@ -37,8 +37,7 @@ const pathsNotRequiringAuthentication = [
   paths.register.authenticatorApp,
   paths.register.phoneNumber,
   paths.register.smsCode,
-  paths.register.resendCode,
-  paths.register.success
+  paths.register.resendCode
 ]
 
 describe('The Express router', () => {

--- a/app/views/includes/phase-banner.njk
+++ b/app/views/includes/phase-banner.njk
@@ -51,7 +51,7 @@
 {{ breadcrumbs(breadcrumbItems) }}
 
 {% if not hideServiceNav and not hideServiceHeader %}
-<div class="govuk-phase-banner govuk-clearfix pay-top-navigation">
+<div class="govuk-phase-banner govuk-clearfix pay-top-navigation" data-cy="service-nav">
   <nav role="navigation" class="service-navigation" data-cy="account-sub-nav">
     <ul class="service-navigation--list">
       {% for item in serviceNavigationItems %}

--- a/app/views/macro/breadcrumbs.njk
+++ b/app/views/macro/breadcrumbs.njk
@@ -1,6 +1,6 @@
 {% macro breadcrumbs(items) %}
 <div class="govuk-phase-banner govuk-clearfix pay-top-navigation">
-  <div class="govuk-breadcrumbs">
+  <div class="govuk-breadcrumbs" data-cy="breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
     {% for item in items %}
       <li class="govuk-breadcrumbs__list-item govuk-!-font-size-19">

--- a/app/views/registration/success.njk
+++ b/app/views/registration/success.njk
@@ -5,6 +5,8 @@
   You’ve created your account - GOV.UK Pay
 {% endblock %}
 
+{% block beforeContent %}{% endblock %}
+
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">You’ve created your GOV.UK Pay account</h1>

--- a/test/cypress/integration/registration/complete-registration.cy.test.js
+++ b/test/cypress/integration/registration/complete-registration.cy.test.js
@@ -174,6 +174,10 @@ describe('Complete registration after following link in invite email', () => {
 
       // should show the success page
       cy.title().should('eq', 'You’ve created your account - GOV.UK Pay')
+      cy.get('nav').contains('Sign out').should('exist')
+      cy.get('[data-cy=breadcrumbs]').should('not.exist')
+      cy.get('[data-cy=service-nav').should('not.exist')
+
       cy.get('a[role=button]').contains('Continue').click()
 
       // should redirect to my services page


### PR DESCRIPTION
When the user is shown the registration success page, at this point they have been logged in. Make it so that the navigation bar reflects this by displaying the links for a logged in user.

Ensure that the  phase banner containing the service navigation and breadcrumbs is not shown for this page.

