### PR TITLE
BAU Log invite code where it is present

### DIFF
--- a/app/middleware/invite-cookie-is-present.js
+++ b/app/middleware/invite-cookie-is-present.js
@@ -2,10 +2,12 @@
 
 const { RegistrationSessionMissingError } = require('../errors')
 const { INVITE_SESSION_COOKIE_NAME } = require('../utils/constants')
+const { addField } = require('../utils/request-context')
 
 module.exports = function inviteCookieIsPresent (req, res, next) {
   const cookie = req[INVITE_SESSION_COOKIE_NAME]
   if (cookie && cookie.email && cookie.code) {
+    addField('invite_code', cookie.code)
     return next()
   }
   next(new RegistrationSessionMissingError('Registration cookie is not present for request'))


### PR DESCRIPTION
For the new registration journey, add an invite_code field to the log context that is added in the middleware that checks the registration cookie is present. This will cause the invite_code to be logged for all lines logged for requests made to the registration routes.

