### PR TITLE
PP-10313 - Switch PSP > Flex - update the Flex controller and page

### DIFF
--- a/app/controllers/your-psp/get-flex.controller.js
+++ b/app/controllers/your-psp/get-flex.controller.js
@@ -2,6 +2,7 @@
 
 const lodash = require('lodash')
 const { getCredentialByExternalId } = require('../../utils/credentials')
+const { isSwitchingCredentialsRoute } = require('../../utils/credentials')
 
 const { response } = require('../../utils/response')
 
@@ -9,6 +10,7 @@ module.exports = (req, res, next) => {
   const { change } = req.query || {}
 
   try {
+    const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
     const credential = getCredentialByExternalId(req.account, req.params.credentialId)
     const isFlexConfigured = req.account.worldpay_3ds_flex &&
       req.account.worldpay_3ds_flex.organisational_unit_id !== undefined &&
@@ -35,7 +37,7 @@ module.exports = (req, res, next) => {
       }
     }
 
-    return response(req, res, 'your-psp/flex', { errors, change, isFlexConfigured, orgUnitId, issuer, credential })
+    return response(req, res, 'your-psp/flex', { errors, change, isFlexConfigured, orgUnitId, issuer, credential, isSwitchingCredentials })
   } catch (error) {
     next(error)
   }

--- a/app/controllers/your-psp/get-flex.controller.test.js
+++ b/app/controllers/your-psp/get-flex.controller.test.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const sinon = require('sinon')
+const getController = require('./get-flex.controller')
+const gatewayAccountFixtures = require('../../../test/fixtures/gateway-account.fixtures')
+const { expect } = require('chai')
+const credentialId = 'a-valid-credential-id'
+
+describe('Flex credentials - GET controller', () => {
+  let req
+  let res
+  let next
+  const account = gatewayAccountFixtures.validGatewayAccount({
+    gateway_account_credentials: [
+      {
+        state: 'ACTIVE',
+        payment_provider: 'worldpay',
+        id: 100,
+        external_id: credentialId
+      }
+    ]
+  })
+
+  beforeEach(() => {
+    req = {
+      account: account,
+      params: { credentialId },
+      url: `/switch-psp/${credentialId}/flex`
+    }
+    res = {
+      redirect: sinon.spy(),
+      render: sinon.spy()
+    }
+    next = sinon.spy()
+  })
+
+  it('should set isSwitchingCredentials = true and pass it to the page data', async () => {
+    await getController(req, res, next)
+
+    const pageData = res.render.args[0][1]
+    expect(pageData.isSwitchingCredentials).to.equal(true)
+    sinon.assert.calledWith(res.render, 'your-psp/flex')
+  })
+})

--- a/app/controllers/your-psp/post-flex.controller.test.js
+++ b/app/controllers/your-psp/post-flex.controller.test.js
@@ -12,7 +12,7 @@ describe('Post 3DS Flex controller', () => {
   let res
   let next
   let postCheckWorldpay3dsFlexCredentials
-  let post3dsFlexAccountCredentials 
+  let post3dsFlexAccountCredentials
   let updateIntegrationVersion3dsMock
   let renderErrorViewMock
 
@@ -54,7 +54,7 @@ describe('Post 3DS Flex controller', () => {
 
   it('should NOT set 3DS integration version to 2 for TEST account', async () => {
     req.account = getGatewayAcountWithType('test')
-    
+
     const controller = getControllerWithMocks()
 
     await controller(req, res, next)
@@ -75,6 +75,19 @@ describe('Post 3DS Flex controller', () => {
     sinon.assert.calledWith(next, expectedError)
   })
 
+  it('should redirect to the `switch psp` index page when on the `switch psp` route', async () => {
+    req.account = getGatewayAcountWithType('live')
+    req.url = `/switch-psp/${credentialId}/flex`
+
+    const controller = getControllerWithMocks()
+
+    await controller(req, res, next)
+
+    sinon.assert.calledWith(updateIntegrationVersion3dsMock, req.account.gateway_account_id, 2)
+    sinon.assert.calledWith(req.flash, 'generic', 'Your Worldpay 3DS Flex settings have been updated')
+    sinon.assert.calledWith(res.redirect, `/account/${gatewayAccountExternalId}/switch-psp`)
+  })
+
   function getControllerWithMocks () {
     return proxyquire('./post-flex.controller', {
       '../../services/clients/connector.client': {
@@ -90,7 +103,7 @@ describe('Post 3DS Flex controller', () => {
     })
   }
 
-  function getGatewayAcountWithType(accountType) {
+  function getGatewayAcountWithType (accountType) {
     return gatewayAccountFixtures.validGatewayAccount({
       gateway_account_id: '1',
       type: accountType,

--- a/app/paths.js
+++ b/app/paths.js
@@ -106,6 +106,7 @@ module.exports = {
     },
     switchPSP: {
       index: '/switch-psp',
+      flex: '/switch-psp/:credentialId/flex',
       credentialsWithGatewayCheck: '/switch-psp/:credentialId/credentials-with-gateway-check',
       verifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration',
       receiveVerifyPSPIntegrationPayment: '/switch-psp/verify-psp-integration/callback',

--- a/app/routes.js
+++ b/app/routes.js
@@ -325,8 +325,8 @@ module.exports.bind = function (app) {
   // Your PSP
   account.get(yourPsp.index, permission('gateway-credentials:read'), yourPspController.getIndex)
   account.post(yourPsp.worldpay3dsFlex, permission('toggle-3ds:update'), yourPspController.postToggleWorldpay3dsFlex)
-  account.get(yourPsp.flex, permission('gateway-credentials:update'), yourPspController.getFlex)
-  account.post(yourPsp.flex, permission('gateway-credentials:update'), yourPspController.postFlex)
+  account.get([yourPsp.flex, switchPSP.flex], permission('gateway-credentials:update'), yourPspController.getFlex)
+  account.post([yourPsp.flex, switchPSP.flex], permission('gateway-credentials:update'), yourPspController.postFlex)
 
   account.get(switchPSP.index, restrictToSwitchingAccount, permission('gateway-credentials:update'), switchPSPController.switchPSPPage)
   account.post(switchPSP.index, restrictToSwitchingAccount, permission('gateway-credentials:update'), switchPSPController.submitSwitchPSP)

--- a/app/views/your-psp/flex.njk
+++ b/app/views/your-psp/flex.njk
@@ -12,8 +12,16 @@
 
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
+    {% if isSwitchingCredentials %}
+      {{ govukBackLink({
+        text: "Back to Switching payment service provider (PSP)",
+        classes: "govuk-!-margin-top-0",
+        href: formatAccountPathsFor(routes.account.switchPSP.index, currentGatewayAccount.external_id)
+      }) }}
+    {% endif %}
+
     <h1 class="govuk-heading-l">Your Worldpay 3DS Flex credentials</h1>
-    <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, credential.external_id) }}">
+    <form method="post">
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
         {% if errors %}
           {% set errorList = [] %}


### PR DESCRIPTION
- Add new path and routes for `switch psp > flex` journney.
- Update Flex credentials GET controller
  - Pass a flag to the Nunjuks file - which states if the user is on the `switch psp` journey.
- Update Flex credentials POST controller
  - When on the `switch psp` route, after a successful POST, redirect to the `switch psp` index page
- Update Nunjuks file
  - Add back link when on the `switch psp` route


