### PR TITLE
PP-10063: Refactor subscribe-service.controller

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -177,6 +177,9 @@ module.exports.bind = function (app) {
   app.get(user.forgottenPasswordReset, forgotPasswordController.newPasswordGet)
   app.post(user.forgottenPasswordReset, forgotPasswordController.newPasswordPost)
 
+  // Complete invite for existing user
+  app.get(invite.subscribeService, userIsAuthorised, inviteCookieIsPresent, registerController.subscribeService)
+
   // REGISTRATION
   app.get(register.email, registrationController.showEmailPage)
   app.post(register.email, registrationController.submitEmailPage)
@@ -210,9 +213,6 @@ module.exports.bind = function (app) {
   // -------------------------
   // OUTSIDE OF SERVICE ROUTES
   // -------------------------
-
-  // Complete invite for existing user
-  app.get(invite.subscribeService, userIsAuthorised, registerController.subscribeService)
 
   // Service switcher
   app.get(serviceSwitcher.index, userIsAuthorised, myServicesController.getIndex)


### PR DESCRIPTION
* Use middleware instead of checking session cookie in controller
* Change handling of 410 responses (pass an error to `next` instead of directly rendering an error page from the controller)