### PR TITLE
PP-10063 Add Cypress test for completing existing user invite

### DIFF
--- a/test/cypress/integration/invite/complete-invite-for-existing-user.cy.test.js
+++ b/test/cypress/integration/invite/complete-invite-for-existing-user.cy.test.js
@@ -1,0 +1,41 @@
+const inviteStubs = require('../../stubs/invite-stubs')
+const userStubs = require('../../stubs/user-stubs')
+const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+
+const inviteCode = 'an-invite-code'
+const email = 'foo@example.com'
+const userExternalId = 'a-user-id'
+const serviceExternalId = 'a-service-external-id'
+const gatewayAccountId = '1'
+
+describe('Complete an invite for an existing user', () => {
+  it('Should redirect to the my services page with a success notification', () => {
+    cy.task('setupStubs', [
+      inviteStubs.getInviteSuccess({
+        code: inviteCode,
+        user_exist: true,
+        type: 'user',
+        email
+      }),
+      inviteStubs.completeInviteToServiceSuccess(inviteCode, userExternalId, serviceExternalId),
+      userStubs.getUserSuccess({
+        userExternalId,
+        email,
+        serviceExternalId,
+        serviceName: 'Cake service',
+        gatewayAccountId
+      }),
+      gatewayAccountStubs.getGatewayAccountsSuccess({
+        gatewayAccountId
+      })
+    ])
+
+    cy.setEncryptedCookies(userExternalId)
+
+    cy.visit(`/invites/${inviteCode}`)
+
+    cy.title().should('eq', 'Choose service - GOV.UK Pay')
+
+    cy.get('.govuk-notification-banner--success').should('exist').should('contain', 'You have been added to Cake service')
+  })
+})

--- a/test/cypress/integration/registration/complete-registration.cy.test.js
+++ b/test/cypress/integration/registration/complete-registration.cy.test.js
@@ -24,7 +24,6 @@ describe('Complete registration after following link in invite email', () => {
         })
       ])
 
-      // visit the invite link to get the register_invite cookie set
       cy.visit(`/invites/${inviteCode}`)
 
       cy.title().should('eq', 'Create your password - GOV.UK Pay')
@@ -200,7 +199,6 @@ describe('Complete registration after following link in invite email', () => {
         })
       ])
 
-      // visit the invite link to get the register_invite cookie set
       cy.visit(`/invites/${inviteCode}`)
 
       cy.title().should('eq', 'Create your password - GOV.UK Pay')

--- a/test/cypress/stubs/invite-stubs.js
+++ b/test/cypress/stubs/invite-stubs.js
@@ -45,6 +45,16 @@ function completeInviteSuccess (inviteCode, userExternalId) {
   })
 }
 
+function completeInviteToServiceSuccess (inviteCode, userExternalId, serviceExternalId) {
+  const path = `/v1/api/invites/${inviteCode}/complete`
+  return stubBuilder('POST', path, 200, {
+    response: inviteFixtures.validInviteCompleteResponse({
+      user_external_id: userExternalId,
+      service_external_id: serviceExternalId
+    })
+  })
+}
+
 function reprovisionOtpSuccess (opts) {
   const path = `/v1/api/invites/${opts.code}/reprovision-otp`
   return stubBuilder('POST', path, 200, {
@@ -58,5 +68,6 @@ module.exports = {
   getInvitedUsersSuccess,
   getInviteSuccess,
   completeInviteSuccess,
+  completeInviteToServiceSuccess,
   reprovisionOtpSuccess
 }


### PR DESCRIPTION
Cypress test checks that an invite for an existing user is successfully completed and a success banner is displayed on the My services page.


