### PR TITLE
Pp 10313 switch psp flex tasklist

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -511,6 +511,20 @@
         "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
         "is_verified": false,
         "line_number": 8
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/settings/switch-psp.cy.test.js",
+        "hashed_secret": "d1dace01626802697073ed716dcb96fc5cfdea46",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/settings/switch-psp.cy.test.js",
+        "hashed_secret": "b2023a863d65bffae6af0d0e1c8a036fd3f3773d",
+        "is_verified": false,
+        "line_number": 15
       }
     ],
     "test/cypress/integration/settings/verify-psp-integration.cy.test.js": [
@@ -559,6 +573,27 @@
         "hashed_secret": "379f1968f09d8a343338667844e01a2f433f0a3f",
         "is_verified": false,
         "line_number": 31
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/settings/your-psp.cy.test.js",
+        "hashed_secret": "abd006a3c55aebb9ffd8edca94531be22416e913",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/settings/your-psp.cy.test.js",
+        "hashed_secret": "b2023a863d65bffae6af0d0e1c8a036fd3f3773d",
+        "is_verified": false,
+        "line_number": 41
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/settings/your-psp.cy.test.js",
+        "hashed_secret": "d7e383a1a8aedd99245e46203e2a3065c1101b5b",
+        "is_verified": false,
+        "line_number": 46
       }
     ],
     "test/cypress/integration/switch-psp/organisation-url.cy.test.js": [
@@ -859,5 +894,5 @@
       }
     ]
   },
-  "generated_at": "2022-12-12T16:58:27Z"
+  "generated_at": "2022-12-12T18:11:40Z"
 }

--- a/app/controllers/switch-psp/switch-psp.controller.test.js
+++ b/app/controllers/switch-psp/switch-psp.controller.test.js
@@ -42,7 +42,9 @@ function setupEnvironment (switchingCredentialState) {
     gateway_account_credentials: [
       { state: 'ACTIVE', payment_provider: 'smartpay', id: 100 },
       { state: switchingCredentialState, payment_provider: 'worldpay', id: 200 }
-    ]
+    ],
+    requires3ds: true,
+    integrationVersion3ds: 2
   })
   req = {
     account: account,

--- a/app/controllers/switch-psp/switch-tasks.service.js
+++ b/app/controllers/switch-psp/switch-tasks.service.js
@@ -8,6 +8,10 @@ function linkCredentialsComplete (targetCredential) {
     .includes(targetCredential.state)
 }
 
+function linkFlexCredentialsComplete (account) {
+  return ((account.requires3ds === true) && (account.integration_version_3ds === 2))
+}
+
 function verifyPSPIntegrationComplete (targetCredential) {
   return [CREDENTIAL_STATE.VERIFIED, CREDENTIAL_STATE.ACTIVE, CREDENTIAL_STATE.RETIRED]
     .includes(targetCredential.state)
@@ -32,8 +36,13 @@ function getTaskList (targetCredential, account, service) {
         enabled: true,
         complete: linkCredentialsComplete(targetCredential)
       },
+      'LINK_FLEX_CREDENTIALS': {
+        enabled: true,
+        complete: linkFlexCredentialsComplete(account)
+      },
       'VERIFY_PSP_INTEGRATION': {
-        enabled: linkCredentialsComplete(targetCredential),
+        enabled: linkCredentialsComplete(targetCredential) &&
+          linkFlexCredentialsComplete(account),
         complete: verifyPSPIntegrationComplete(targetCredential)
       }
     }

--- a/app/controllers/switch-psp/switch-tasks.service.test.js
+++ b/app/controllers/switch-psp/switch-tasks.service.test.js
@@ -15,22 +15,30 @@ describe('Switching PSP service', () => {
         })
         const targetCredential = getSwitchingCredential(account)
         const taskList = getTaskList(targetCredential, account)
-        expect(Object.keys(taskList)).to.have.length(2)
+        expect(Object.keys(taskList)).to.have.length(3)
         expect(taskList.LINK_CREDENTIALS.enabled).to.equal(true)
         expect(taskList.LINK_CREDENTIALS.complete).to.equal(false)
+        expect(taskList.LINK_FLEX_CREDENTIALS.enabled).to.equal(true)
+        expect(taskList.LINK_FLEX_CREDENTIALS.complete).to.equal(false)
+        expect(taskList.VERIFY_PSP_INTEGRATION.enabled).to.equal(false)
+        expect(taskList.VERIFY_PSP_INTEGRATION.complete).to.equal(false)
       })
       it('gets an complete task list for an account with progress', () => {
         const account = gatewayAccountFixtures.validGatewayAccount({
           gateway_account_credentials: [
             { state: 'ENTERED', payment_provider: 'worldpay', id: 100 },
             { state: 'ACTIVE', payment_provider: 'smartpay', id: 100 }
-          ]
+          ],
+          requires3ds: true,
+          integrationVersion3ds: 2
         })
         const targetCredential = getSwitchingCredential(account)
         const taskList = getTaskList(targetCredential, account)
-        expect(Object.keys(taskList)).to.have.length(2)
+        expect(Object.keys(taskList)).to.have.length(3)
         expect(taskList.LINK_CREDENTIALS.enabled).to.equal(true)
         expect(taskList.LINK_CREDENTIALS.complete).to.equal(true)
+        expect(taskList.LINK_FLEX_CREDENTIALS.enabled).to.equal(true)
+        expect(taskList.LINK_FLEX_CREDENTIALS.complete).to.equal(true)
         expect(taskList.VERIFY_PSP_INTEGRATION.enabled).to.equal(true)
         expect(taskList.VERIFY_PSP_INTEGRATION.complete).to.equal(false)
       })
@@ -43,7 +51,9 @@ describe('Switching PSP service', () => {
         gateway_account_credentials: [
           { state: 'VERIFIED_WITH_LIVE_PAYMENT', payment_provider: 'worldpay', id: 100 },
           { state: 'ACTIVE', payment_provider: 'smartpay', id: 100 }
-        ]
+        ],
+        requires3ds: true,
+        integrationVersion3ds: 2
       })
       const targetCredential = getSwitchingCredential(account)
       const taskList = getTaskList(targetCredential, account)
@@ -56,6 +66,34 @@ describe('Switching PSP service', () => {
           { state: 'CREATED', payment_provider: 'worldpay', id: 100 },
           { state: 'ACTIVE', payment_provider: 'smartpay', id: 100 }
         ]
+      })
+      const targetCredential = getSwitchingCredential(account)
+      const taskList = getTaskList(targetCredential, account)
+      expect(isComplete(taskList)).to.equal(false)
+    })
+
+    it('should correctly calculate progress required for Worldpay when 3ds is not enabled', () => {
+      const account = gatewayAccountFixtures.validGatewayAccount({
+        gateway_account_credentials: [
+          { state: 'ENTERED', payment_provider: 'worldpay', id: 100 },
+          { state: 'ACTIVE', payment_provider: 'smartpay', id: 100 }
+        ],
+        requires3ds: false,
+        integrationVersion3ds: 2
+      })
+      const targetCredential = getSwitchingCredential(account)
+      const taskList = getTaskList(targetCredential, account)
+      expect(isComplete(taskList)).to.equal(false)
+    })
+
+    it('should correctly calculate progress required for Worldpay when account 3ds version is 1', () => {
+      const account = gatewayAccountFixtures.validGatewayAccount({
+        gateway_account_credentials: [
+          { state: 'ENTERED', payment_provider: 'worldpay', id: 100 },
+          { state: 'ACTIVE', payment_provider: 'smartpay', id: 100 }
+        ],
+        requires3ds: true,
+        integrationVersion3ds: 1
       })
       const targetCredential = getSwitchingCredential(account)
       const taskList = getTaskList(targetCredential, account)

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -67,6 +67,11 @@
           taskList.LINK_CREDENTIALS
         ) }}
         {{ taskListItem(
+          "Link your Worldpay 3DS Flex account with GOV.UK Pay",
+          formatAccountPathsFor(routes.account.switchPSP.flex, currentGatewayAccount.external_id, targetCredential.external_id),
+          taskList.LINK_FLEX_CREDENTIALS
+        ) }}
+        {{ taskListItem(
           "Make a live payment to test your Worldpay PSP",
           formatAccountPathsFor(routes.account.switchPSP.verifyPSPIntegrationPayment, currentGatewayAccount.external_id),
           taskList.VERIFY_PSP_INTEGRATION

--- a/test/cypress/integration/settings/your-psp.cy.test.js
+++ b/test/cypress/integration/settings/your-psp.cy.test.js
@@ -33,17 +33,17 @@ describe('Your PSP settings page', () => {
   }
   const testInvalidFlexCredentials = {
     organisational_unit_id: '5bd9b55e4444761ac0af1c81',
-    issuer: '5bd9e0e4444dce153428c941', // pragma: allowlist secret
+    issuer: '5bd9e0e4444dce153428c941',
     jwt_mac_key: 'ffffffff-aaaa-1111-1111-52805d5cd9e1'
   }
   const testFailureFlexCredentials = {
     organisational_unit_id: '5bd9b55e4444761ac0af1c82',
-    issuer: '5bd9e0e4444dce153428c942', // pragma: allowlist secret
+    issuer: '5bd9e0e4444dce153428c942',
     jwt_mac_key: 'ffffffff-ffff-ffff-ffff-ffffffffffff'
   }
   const testBadResultFlexCredentials = {
     organisational_unit_id: '5bd9b55e4444761ac0af1c83',
-    issuer: '5bd9e0e4444dce153428c943', // pragma: allowlist secret
+    issuer: '5bd9e0e4444dce153428c943',
     jwt_mac_key: 'fa2daee2-1fbb-45ff-4444-52805d5cd9e3'
   }
 
@@ -98,7 +98,7 @@ describe('Your PSP settings page', () => {
     const card = gatewayAccountStubs.getAcceptedCardTypesSuccess({ gatewayAccountId, updated: false })
     const postCheckWorldpay3dsFlexCredentialsReturnsValid = gatewayAccountStubs.postCheckWorldpay3dsFlexCredentials({
       gatewayAccountId: gatewayAccountId,
-      shouldReturnValid: true
+      result: 'valid'
     })
     const postCheckWorldpayCredentials = gatewayAccountStubs.postCheckWorldpayCredentials({
       ...opts.validateCredentials,
@@ -106,7 +106,10 @@ describe('Your PSP settings page', () => {
     })
     const postCheckWorldpay3dsFlexCredentialsReturnsInvalid = gatewayAccountStubs.postCheckWorldpay3dsFlexCredentials({
       gatewayAccountId: gatewayAccountId,
-      shouldReturnValid: false
+      result: 'invalid',
+      organisational_unit_id: '5bd9b55e4444761ac0af1c81',
+      issuer: '5bd9e0e4444dce153428c941',
+      jwt_mac_key: 'ffffffff-aaaa-1111-1111-52805d5cd9e1'
     })
     const postCheckWorldpay3dsFlexCredentialsFails = gatewayAccountStubs.postCheckWorldpay3dsFlexCredentialsFailure({
       gatewayAccountId: gatewayAccountId, ...testFailureFlexCredentials

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -210,17 +210,10 @@ function patchAccountEmailCollectionModeSuccess (opts) {
 
 function postCheckWorldpay3dsFlexCredentials (opts) {
   const path = `/v1/api/accounts/${opts.gatewayAccountId}/worldpay/check-3ds-flex-config`
-  if (opts.shouldReturnValid) {
-    return stubBuilder('POST', path, 200, {
-      request: worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsRequest().payload,
-      response: worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsResponse()
-    })
-  } else {
-    return stubBuilder('POST', path, 200, {
-      request: worldpay3dsFlexCredentialsFixtures.checkInvalidWorldpay3dsFlexCredentialsRequest().payload,
-      response: worldpay3dsFlexCredentialsFixtures.checkInvalidWorldpay3dsFlexCredentialsResponse()
-    })
-  }
+  return stubBuilder('POST', path, 200, {
+    request: worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsRequest(opts).payload,
+    response: worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsResponse(opts)
+  })
 }
 
 function postCheckWorldpayCredentials (opts) {


### PR DESCRIPTION
- `Switch PSP` page - add new task when switching to Worldpay
  - Users must provide 3dS flex credentials.
  - This task links to the existing `3DS flex page`.
- Add Cypress tests to check this functionality.
  - Make sure it displays the tasks in the right state.
  - Should only enable the `verify with live payment` when all
    the right tasks have been completed.
  - Test it correctly goes to the 3DS flex page from the task.
- Update the `Cypress > gateway account stubs > post 3DS flex settings stub`
  - Clean up code.
  - Make it more flexible by passing down the options parameter to calling functions.
  - Update the `your psp` Cypress test - to work with the latest updates to this method.