### PR TITLE
PP-10099 Extend URL validation used for organisation website address

### DIFF
--- a/app/utils/validation/server-side-form-validations.js
+++ b/app/utils/validation/server-side-form-validations.js
@@ -4,6 +4,7 @@ const moment = require('moment-timezone')
 const ukPostcode = require('uk-postcode')
 const commonPassword = require('common-password')
 const lodash = require('lodash')
+const validator = require('validator')
 const { URL } = require('url')
 
 const {
@@ -241,10 +242,13 @@ function validateUrl (url) {
 
 function isValidUrl (url) {
   try {
-    const parsedUrl = new URL(url)
-    return parsedUrl.protocol
-      ? ['http:', 'https:'].includes(parsedUrl.protocol)
-      : false
+    // eslint-disable-next-line no-new
+    new URL(url)
+
+    return validator.isURL(url, {
+      protocols: [ 'http', 'https' ],
+      require_protocol: true
+    })
   } catch (err) {
     return false
   }

--- a/app/utils/validation/server-side-form-validations.test.js
+++ b/app/utils/validation/server-side-form-validations.test.js
@@ -411,5 +411,19 @@ describe('Server side form validations', () => {
         message: 'Enter a valid website address'
       })
     })
+
+    it('should not be valid for incomplete URLs', () => {
+      expect(validations.validateUrl('https://example')).to.deep.equal({
+        valid: false,
+        message: 'Enter a valid website address'
+      })
+    })
+
+    it('should not be valid for multiple URLs', () => {
+      expect(validations.validateUrl('https://example-one.test https://example-two.test')).to.deep.equal({
+        valid: false,
+        message: 'Enter a valid website address'
+      })
+    })
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "throng": "5.0.x",
         "uk-postcode": "0.1.x",
         "url-join": "4.0.1",
+        "validator": "^13.7.0",
         "winston": "3.8.2"
       },
       "devDependencies": {
@@ -17266,6 +17267,14 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -31222,6 +31231,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "throng": "5.0.x",
     "uk-postcode": "0.1.x",
     "url-join": "4.0.1",
+    "validator": "^13.7.0",
     "winston": "3.8.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Our current method of URL validation has allowed a number of invalid URLs to pass. This results in the URL being passed to downstream services which can reject it in an unpredictable way where the error isn't well handled.

The two outliers:
- spaces in the URL allowing multiple URLs to be enterered (neither expected nor wanted)
- incomplete URLs without a TLD specified

The `validatorjs/validator` library includes some fairly gnarly and well tested regex to ensure that TLD can be required and are well formed. This library is also actively maintained, quite popular and has no dependencies.

Include the validator library and use this to catch the exceptional cases provided above.