### PR TITLE
PP-10099 Add logging tracking to org url validation

### DIFF
--- a/app/controllers/request-to-go-live/organisation-address/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.js
@@ -76,7 +76,7 @@ const validationRulesWithTelAndUrl = [
   },
   {
     field: clientFieldNames.url,
-    validator: validateUrl
+    validator: validateURLWithTracking
   },
   ...validationRules
 ]
@@ -103,6 +103,14 @@ function normaliseForm (formBody) {
     form[field] = trimField(field, formBody)
     return form
   }, {})
+}
+
+function validateURLWithTracking (url) {
+  const result = validateUrl(url)
+  if (!result.valid) {
+    logger.info('Blocked provided URL', { url })
+  }
+  return result
 }
 
 function validateForm (form, isRequestToGoLive, isStripeSetupUserJourney) {


### PR DESCRIPTION
We've had report(s) of users confused when entering website addresses as part of the organisation detail requirements.

Now that we've updated the validation to try and catch more edge cases in https://github.com/alphagov/pay-selfservice/pull/3704, add some structured logging to measure how often we are blocking urls as well as what some common mistakes or misunderstandings might be.
