### PR TITLE
PP-10338: Remove references to invite type

### DIFF
--- a/app/controllers/invite-validation.controller.js
+++ b/app/controllers/invite-validation.controller.js
@@ -30,12 +30,10 @@ async function validateInvite (req, res, next) {
     }
 
     if (invite.user_exist) {
-      if (invite.type === 'user') {
+      if (invite.is_invite_to_join_service) {
         res.redirect(paths.invite.subscribeService)
-      } else if (invite.type === 'service') {
-        res.redirect(paths.serviceSwitcher.index)
       } else {
-        next(new Error('Unrecognised invite type'))
+        res.redirect(paths.serviceSwitcher.index)
       }
     } else {
       res.redirect(paths.register.password)

--- a/app/controllers/invite-validation.controller.test.js
+++ b/app/controllers/invite-validation.controller.test.js
@@ -39,10 +39,10 @@ describe('Invite validation controller', function () {
     sinon.assert.notCalled(next)
   })
 
-  it('should redirect to /subscribe if user exists and invite has type "user"', async () => {
+  it('should redirect to /subscribe if user exists and is being invited to join a service', async () => {
     const invite = inviteFixtures.validInviteResponse({
       user_exist: true,
-      type: 'user'
+      is_invite_to_join_service: true
     })
 
     const getValidatedInviteSpy = sinon.spy(() => Promise.resolve(invite))
@@ -57,10 +57,10 @@ describe('Invite validation controller', function () {
     sinon.assert.notCalled(next)
   })
 
-  it('should redirect to /my-services if user exists and invite has type "service"', async () => {
+  it('should redirect to /my-services if user exists and the invite is for self-registration', async () => {
     const invite = inviteFixtures.validInviteResponse({
       user_exist: true,
-      type: 'service'
+      is_invite_to_join_service: false
     })
 
     const getValidatedInviteSpy = sinon.spy(() => Promise.resolve(invite))

--- a/app/controllers/your-psp/get.controller.js
+++ b/app/controllers/your-psp/get.controller.js
@@ -10,7 +10,6 @@ const {
 const { getTaskList, isComplete } = require('./kyc-tasks.service')
 const yourPspTasks = require('./your-psp-tasks.service')
 
-
 module.exports = async (req, res, next) => {
   const { credentialId } = req.params
   const enableStripeOnboardingTaskList = process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST === 'true'

--- a/app/controllers/your-psp/get.controller.test.js
+++ b/app/controllers/your-psp/get.controller.test.js
@@ -5,7 +5,7 @@ const getController = require('./get.controller')
 const gatewayAccountFixtures = require('../../../test/fixtures/gateway-account.fixtures')
 const { expect } = require('chai')
 const credentialId = 'a-valid-credential-id'
-const proxyquire = require("proxyquire");
+const proxyquire = require('proxyquire')
 
 describe('Your PSP GET controller', () => {
   let req
@@ -69,7 +69,6 @@ describe('Your PSP GET controller', () => {
   })
 
   it('should get stripe taskList when requiresAdditionalKycData is false', async () => {
-
     await getController(req, res, next)
 
     const pageData = res.render.args[0][1]
@@ -89,7 +88,6 @@ describe('Your PSP GET controller', () => {
   })
 
   it('should get KYC tasks when requiresAdditionalKycData is true', async () => {
-
     req.account.requires_additional_kyc_data = true
 
     const kycTasks = {

--- a/test/cypress/integration/invite/complete-invite-for-existing-user.cy.test.js
+++ b/test/cypress/integration/invite/complete-invite-for-existing-user.cy.test.js
@@ -14,7 +14,7 @@ describe('Complete an invite for an existing user', () => {
       inviteStubs.getInviteSuccess({
         code: inviteCode,
         user_exist: true,
-        type: 'user',
+        is_invite_to_join_service: true,
         email
       }),
       inviteStubs.completeInviteToServiceSuccess(inviteCode, userExternalId, serviceExternalId),

--- a/test/cypress/integration/settings/your-psp-stripe-tasklist.cy.test.js
+++ b/test/cypress/integration/settings/your-psp-stripe-tasklist.cy.test.js
@@ -50,7 +50,7 @@ describe('Your PSP Stripe page', () => {
     setupYourPspStubs({})
     cy.setEncryptedCookies(userExternalId)
     cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-  
+
     cy.get('span').contains('Bank Details').should('exist')
     cy.get('span').contains('Responsible person').should('exist')
     cy.get('span').contains('Service director').should('exist')
@@ -59,12 +59,12 @@ describe('Your PSP Stripe page', () => {
     cy.get('span').contains('Confirm your organisation’s name and address match your government entity document').should('exist')
     cy.get('span').contains('Government entity document').should('exist')
   })
-  
+
   it('should autamatically show government document as cannot start yet and the rest of the tasks as not started', () => {
     setupYourPspStubs({})
     cy.setEncryptedCookies(userExternalId)
     cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-    
+
     cy.get('strong[id="task-bank-details-status"]').should('contain', 'not started')
     cy.get('strong[id="task-sro-status"]').should('contain', 'not started')
     cy.get('strong[id="task-director-status"]').should('contain', 'not started')

--- a/test/fixtures/invite.fixtures.js
+++ b/test/fixtures/invite.fixtures.js
@@ -4,13 +4,13 @@ const _ = require('lodash')
 
 function buildInviteWithDefaults (opts = {}) {
   const data = {
-    type: opts.type || 'user',
     email: opts.email || 'foo@example.com',
     role: opts.role || 'admin',
     disabled: opts.disabled || false,
     user_exist: opts.user_exist || false,
     expired: opts.expired || false,
-    otp_key: opts.otp_key || 'ANEXAMPLESECRETSECONDFACTORCODE1'
+    otp_key: opts.otp_key || 'ANEXAMPLESECRETSECONDFACTORCODE1',
+    is_invite_to_join_service: opts.is_invite_to_join_service || false
   }
 
   if (opts.telephone_number) {

--- a/test/pact/adminusers-client/invite/get-invite.pact.test.js
+++ b/test/pact/adminusers-client/invite/get-invite.pact.test.js
@@ -56,7 +56,7 @@ describe('adminusers client - get an invite', function () {
       adminUsersClient.getValidatedInvite(inviteCode).should.be.fulfilled.then(function (invite) {
         expect(invite.email).to.be.equal(getInviteResponse.email)
         expect(invite.telephone_number).to.be.equal(getInviteResponse.telephone_number)
-        expect(invite.type).to.be.equal(getInviteResponse.type)
+        expect(invite.is_invite_to_join_service).to.be.equal(getInviteResponse.is_invite_to_join_service)
         expect(invite.password_set).to.be.equal(getInviteResponse.password_set)
       }).should.notify(done)
     })


### PR DESCRIPTION
The `type` field in invites returned from adminusers is going to be removed; use the `invite_to_join_service`
 flag instead.

N.b. The field is `isInviteToJoinService` in adminusers, but is getting serialised without the 'is' because it's a boolean.  I think this looks a bit confusing at the selfservice end - would it be worth me changing it in adminusers?  I presume I would be able to override the renaming there.
