### PR TITLE
PP-10465 Change where we re-provision the OTP key

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -208,7 +208,7 @@
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "a04fccdd7f93b63162cd0d3e015761cd3a24d86a",
         "is_verified": false,
-        "line_number": 324
+        "line_number": 358
       }
     ],
     "app/controllers/your-psp/worldpay-3ds-flex-validations.test.js": [
@@ -894,5 +894,5 @@
       }
     ]
   },
-  "generated_at": "2022-12-12T18:11:40Z"
+  "generated_at": "2022-12-15T17:54:51Z"
 }

--- a/app/controllers/your-psp/get.controller.js
+++ b/app/controllers/your-psp/get.controller.js
@@ -10,7 +10,6 @@ const {
 const { getTaskList, isComplete } = require('./kyc-tasks.service')
 const yourPspTasks = require('./your-psp-tasks.service')
 
-
 module.exports = async (req, res, next) => {
   const { credentialId } = req.params
   const enableStripeOnboardingTaskList = process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST === 'true'

--- a/app/controllers/your-psp/get.controller.test.js
+++ b/app/controllers/your-psp/get.controller.test.js
@@ -5,7 +5,7 @@ const getController = require('./get.controller')
 const gatewayAccountFixtures = require('../../../test/fixtures/gateway-account.fixtures')
 const { expect } = require('chai')
 const credentialId = 'a-valid-credential-id'
-const proxyquire = require("proxyquire");
+const proxyquire = require('proxyquire')
 
 describe('Your PSP GET controller', () => {
   let req
@@ -69,7 +69,6 @@ describe('Your PSP GET controller', () => {
   })
 
   it('should get stripe taskList when requiresAdditionalKycData is false', async () => {
-
     await getController(req, res, next)
 
     const pageData = res.render.args[0][1]
@@ -89,7 +88,6 @@ describe('Your PSP GET controller', () => {
   })
 
   it('should get KYC tasks when requiresAdditionalKycData is true', async () => {
-
     req.account.requires_additional_kyc_data = true
 
     const kycTasks = {

--- a/test/cypress/integration/settings/your-psp-stripe-tasklist.cy.test.js
+++ b/test/cypress/integration/settings/your-psp-stripe-tasklist.cy.test.js
@@ -50,7 +50,7 @@ describe('Your PSP Stripe page', () => {
     setupYourPspStubs({})
     cy.setEncryptedCookies(userExternalId)
     cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-  
+
     cy.get('span').contains('Bank Details').should('exist')
     cy.get('span').contains('Responsible person').should('exist')
     cy.get('span').contains('Service director').should('exist')
@@ -59,12 +59,12 @@ describe('Your PSP Stripe page', () => {
     cy.get('span').contains('Confirm your organisation’s name and address match your government entity document').should('exist')
     cy.get('span').contains('Government entity document').should('exist')
   })
-  
+
   it('should autamatically show government document as cannot start yet and the rest of the tasks as not started', () => {
     setupYourPspStubs({})
     cy.setEncryptedCookies(userExternalId)
     cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-    
+
     cy.get('strong[id="task-bank-details-status"]').should('contain', 'not started')
     cy.get('strong[id="task-sro-status"]').should('contain', 'not started')
     cy.get('strong[id="task-director-status"]').should('contain', 'not started')


### PR DESCRIPTION
Previously we were reprovisioning the OTP key for an invite when:
- The user visited the configure authenticator app page
- The user submitted their phone number

The problem with this was that when the configure authenticator app page was reloaded due to an invalid security code being submitted, the OTP key would be regenerated. This would mean the user would have to configure a new account in their app using the new key, which is not obvious or user friendly.

Instead, reprovision the code when the user submits the page to choose their OTP method. This means that the OTP key would be reprovisioned if the user follows the in-page links to change their method.

There is a small risk that the OTP key wouldn't be provisioned if the user clicks back in their browser a few times after choosing one method and then a different method - or if the user visits the URL for configuring their authenticator app or phone number directly. However, the repercussions and risk if they were to do this are low.