### PR TITLE
PP-10465 Only reprovision OTP key if method has changed

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -208,7 +208,7 @@
         "filename": "app/controllers/registration/registration.controller.test.js",
         "hashed_secret": "a04fccdd7f93b63162cd0d3e015761cd3a24d86a",
         "is_verified": false,
-        "line_number": 324
+        "line_number": 326
       }
     ],
     "app/controllers/your-psp/worldpay-3ds-flex-validations.test.js": [
@@ -894,5 +894,5 @@
       }
     ]
   },
-  "generated_at": "2022-12-12T18:11:40Z"
+  "generated_at": "2022-12-19T13:23:13Z"
 }


### PR DESCRIPTION
We want to avoid the situation where the OTP key is re-provisioned when the page to configure an authenticator APP is reloaded - particularly if it is reloaded due to the security code entered being invalid. If the OTP key is re-provisioned, the user would have to set up a new account in their app with the new OTP, which they are likely to miss - meaning their invite will be disabled.

Store the last selected second factor method in the registration cookie, and only re-provision the OTP key if the method currently being configured does not match the method last time we re-provisioned the OTP key. This means we will only re-provision if the user goes back and selects a different method.

