### PR TITLE
Pp 10242 privacy page show login status

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -49,3 +49,4 @@ $govuk-page-width: 1200px;
 @import "components/task-list";
 @import "components/print-button";
 @import "components/contract";
+@import "components/sub-navigation";

--- a/app/assets/sass/components/sub-navigation.scss
+++ b/app/assets/sass/components/sub-navigation.scss
@@ -1,0 +1,49 @@
+.sub-navigation-container {
+  position: sticky;
+  top: 0;
+}
+
+.sub-navigation {
+  margin-bottom: govuk-spacing(6);
+
+  ol,
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  &__item {
+    @include govuk-font($size: 16);
+
+    border-bottom: 1px $govuk-border-colour solid;
+    display: block;
+    padding: govuk-spacing(2) 0;
+
+    a:link {
+      text-decoration: none;
+    }
+
+    a:hover,
+    a:active {
+      text-decoration: underline;
+    }
+
+    &:last-child {
+      border-bottom: 0;
+    }
+  }
+
+  &__item--active {
+    @include govuk-font($size: 16, $weight: bold);
+
+    a:link,
+    a:visited {
+      color: $govuk-text-colour;
+    }
+  }
+
+  &__item--sub {
+    padding-left: govuk-spacing(6);
+  }
+}

--- a/app/controllers/privacy/privacy.controller.js
+++ b/app/controllers/privacy/privacy.controller.js
@@ -1,7 +1,14 @@
 'use strict'
 
+const sessionValidator = require('./../../services/session-validator')
+
 function getPage (req, res) {
-  return res.render('privacy/privacy')
+  const loggedIn = sessionValidator.validate(req.user, req.session)
+
+  return res.render('privacy/privacy', {
+    loggedIn,
+    hideServiceNav: true
+  })
 }
 
 module.exports = {

--- a/app/views/privacy/privacy.njk
+++ b/app/views/privacy/privacy.njk
@@ -5,42 +5,91 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Privacy notice</h1>
+  <div class="govuk-grid-column-one-third sub-navigation-container">
+    <nav class="sub-navigation" data-click-events data-click-category="Content" data-click-action="Link clicked"
+      data-cy="sub-navigation">
+      <ol itemscope itemtype="http://schema.org/ItemList">
+        <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+          <a class="govuk-link" itemprop="item" href="#who-we-are">
+            <span itemprop="name">Who we are</span></a>
+        </a>
+      </li>
+      <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+        <a class="govuk-link" itemprop="item" href="#why-we-need-your-data">
+          <span itemprop="name">Why we need your data</span></a>
+      </li>
+      <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+        <a class="govuk-link" itemprop="item" href="#what-data-we-need-from-public-sector-employees">
+          <span itemprop="name">What data we need from public sector employees</span></a>
+      </li>
+      <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+        <a class="govuk-link" itemprop="item" href="#what-we-do-with-your-data">
+          <span itemprop="name">What we do with your data</span></a>
+      </li>
+      <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+        <a class="govuk-link" itemprop="item" href="#how-long-we-keep-your-data">
+          <span itemprop="name">How long we keep your data</span></a>
+      </li>
+      <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+        <a class="govuk-link" itemprop="item" href="#childrens-privacy-protection">
+          <span itemprop="name">Children’s privacy protection</span></a>
+      </li>
+      <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+        <a class="govuk-link" itemprop="item" href="#who-your-data-might-be-shared-with">
+          <span itemprop="name">Who your data might be shared with</span></a>
+      </li>
+      <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+        <a class="govuk-link" itemprop="item" href="#how-we-protect-your-data-and-keep-it-secure">
+          <span itemprop="name">How we protect your data and keep it secure</span></a>
+      </li>
+      <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+        <a class="govuk-link" itemprop="item" href="#changes-to-this-notice">
+          <span itemprop="name">Changes to this notice</span></a>
+      </li>
+      <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+        <a class="govuk-link" itemprop="item" href="#questions-and-complaints">
+          <span itemprop="name">Questions and complaints</span></a>
+      </li>
+    </ol>
+  </nav>
+</div>
 
-    <p class="govuk-body-l">Last updated: 30 August 2022</p>
+<div class="govuk-grid-column-two-thirds">
+  <h1 class="govuk-heading-l">Privacy notice</h1>
 
-    <h2 class="govuk-heading-m">Who we are</h2>
+  <p class="govuk-body-l">Last updated: 30 August 2022</p>
 
-    <p class="govuk-body">
+  <h2 class="govuk-heading-m" id="who-we-are">Who we are</h2>
+
+  <p class="govuk-body">
       GOV.UK Pay is a payments service that’s built and maintained by the
       Government Digital Service, which is part of the Cabinet Office
       (“GDS”, “we”, “us”, “our”).
     </p>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       Public sector organisations use GOV.UK Pay to take payments online and over the phone. To do
       that, we collect, process and store certain data about paying users and public sector users.
     </p>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       If you’re an individual user making a payment to a public sector organisation
       please refer to our paying user privacy notice.
     </p>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       If you’re an employee or contractor for a public sector organisation using GOV.UK
       Pay as part of your role this privacy notice explains:
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>the kinds of data we collect and process in order to provide the payments service</li>
-      <li>how that data is used</li>
-      <li>how that data is protected </li>
-      <li>how you can find out what rights you have in relation to your data</li>
-    </ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>the kinds of data we collect and process in order to provide the payments service</li>
+    <li>how that data is used</li>
+    <li>how that data is protected </li>
+    <li>how you can find out what rights you have in relation to your data</li>
+  </ul>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       Read the
       <a class="govuk-link" href="https://ico.org.uk/ESDWebPages/Entry/Z7414053">
         Cabinet Office’s entry in the Data Protection Public Register
@@ -48,18 +97,18 @@
       for more information.
     </p>
 
-    <h2 class="govuk-heading-m">Why we need your data</h2>
+  <h2 class="govuk-heading-m" id="why-we-need-your-data">Why we need your data</h2>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       When a public sector organisation wants to use GOV.UK Pay, you, as the employee will need to
       create an account on GOV.UK Pay. We collect and process data about you, your colleagues and
       your organisation in order to facilitate the set up of payment services and the taking and
       managing of payments from your users.
     </p>
 
-    <h2 class="govuk-heading-m">What data we need from public sector employees</h2>
+  <h2 class="govuk-heading-m" id="what-data-we-need-from-public-sector-employees">What data we need from public sector employees</h2>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       When
       <a class="govuk-link" href="https://selfservice.payments.service.gov.uk/create-service/register">
         creating an account on GOV.UK Pay
@@ -67,227 +116,227 @@
       we will collect data that includes:
     </p>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       When creating an account on GOV.UK Pay we will collect data that includes:
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>your email address</li>
-      <li>your mobile phone number</li>
-      <li>the name of the organisation you work for</li>
-      <li>the IP address you use to access GOV.UK Pay</li>
-    </ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>your email address</li>
+    <li>your mobile phone number</li>
+    <li>the name of the organisation you work for</li>
+    <li>the IP address you use to access GOV.UK Pay</li>
+  </ul>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       We also record a user’s permission level which determines the activity and
       data any invited user has access to. When you request to make your payment
       service live on GOV.UK Pay, with our payment provider Stripe, we require
       the following additional information:
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>your organisation’s bank details</li>
-      <li>your organisation’s VAT number (if applicable)</li>
-      <li>your company registration number (if applicable)</li>
-    </ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>your organisation’s bank details</li>
+    <li>your organisation’s VAT number (if applicable)</li>
+    <li>your company registration number (if applicable)</li>
+  </ul>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       If you are an individual who holds a director and/or responsible person
       role we will also collect the following personal data about you to enable
       integration with our payment provider Stripe:
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>your name</li>
-      <li>your date of birth</li>
-      <li>your work email address</li>
-      <li>your work telephone number</li>
-      <li>a form of photographic identification (if applicable)</li>
-    </ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>your name</li>
+    <li>your date of birth</li>
+    <li>your work email address</li>
+    <li>your work telephone number</li>
+    <li>a form of photographic identification (if applicable)</li>
+  </ul>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       The legal basis for processing this data is ‘public task’ – allowing
       you to access GOV.UK Pay to take and manage payments from users of your public service.
     </p>
 
-    <h2 class="govuk-heading-m">What we do with your data</h2>
+  <h2 class="govuk-heading-m" id="what-we-do-with-your-data">What we do with your data</h2>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       To carry out our responsibilities to the public sector organisation that uses GOV.UK Pay, we will need
       to process data. This will allow us to:
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>ensure that the GOV.UK Pay service operates as expected</li>
-      <li>allow paying users to make one-off single payments to your service and organisation</li>
-      <li>allow paying users to make and manage recurring payments with you service and organisation</li>
-      <li>allow you and other employees to log in and administer payments and refunds</li>
-      <li>respond to any queries raised by the organisation or the payment provider in respect of the service</li>
-      <li>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>ensure that the GOV.UK Pay service operates as expected</li>
+    <li>allow paying users to make one-off single payments to your service and organisation</li>
+    <li>allow paying users to make and manage recurring payments with you service and organisation</li>
+    <li>allow you and other employees to log in and administer payments and refunds</li>
+    <li>respond to any queries raised by the organisation or the payment provider in respect of the service</li>
+    <li>
         contact employees who are responsible for managing and operating the service about any changes or
         issues and which may require action from them
       </li>
-      <li>inform users about changes and new features in GOV.UK Pay</li>
-    </ul>
+    <li>inform users about changes and new features in GOV.UK Pay</li>
+  </ul>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       Where you provide your consent, we use
       <a class="govuk-link" href="https://support.google.com/analytics/topic/2919631">
         Google Analytics
       </a> cookies to collect information about how you use GOV.UK Pay.
     </p>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       Google Analytics processes information about:
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>the pages you visit on GOV.UK Pay and when logged into the Pay admin tool</li>
-      <li>how long you spend on each page</li>
-      <li>how you got to the site</li>
-      <li>what you click on while you’re visiting the site</li>
-    </ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>the pages you visit on GOV.UK Pay and when logged into the Pay admin tool</li>
+    <li>how long you spend on each page</li>
+    <li>how you got to the site</li>
+    <li>what you click on while you’re visiting the site</li>
+  </ul>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       We also receive the same information from other government digital services and GOV.UK.
     </p>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       We make sure you cannot be directly identified by Google Analytics data. We do this by using Google Analytics
       <a class="govuk-link" href="https://support.google.com/analytics/answer/2763052">IP address anonymisation</a>
       feature.
     </p>
 
-    <h2 class="govuk-heading-m">How long we keep your data</h2>
+  <h2 class="govuk-heading-m" id="how-long-we-keep-your-data">How long we keep your data</h2>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       We will only retain your personal data for as long as:
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>it’s needed for the purposes set out in this document</li>
-      <li>is required by law</li>
-    </ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>it’s needed for the purposes set out in this document</li>
+    <li>is required by law</li>
+  </ul>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       In general, this means that we will only hold your personal data for a minimum of 1 year and a maximum of 7 years.
     </p>
 
-    <h2 class="govuk-heading-m">Children’s privacy protection</h2>
+  <h2 class="govuk-heading-m" id="childrens-privacy-protection">Children’s privacy protection</h2>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       Our services are not designed for, or intentionally targeted at, children 13 years of age or younger. It is not
       our policy to intentionally collect or maintain data about anyone under the age of 13.
     </p>
 
-    <h2 class="govuk-heading-m">Who your data might be shared with</h2>
+  <h2 class="govuk-heading-m" id="who-your-data-might-be-shared-with">Who your data might be shared with</h2>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       There are times when we need to share your data.
     </p>
 
-    <h3 class="govuk-heading-m">Payment provider / Financial regulations</h3>
+  <h3 class="govuk-heading-m">Payment provider / Financial regulations</h3>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       If you are a payer, your personal data will be provided to the relevant PSP that’s connected to the government
       organisation you are paying. You can find their privacy notices here:
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        <a class="govuk-link" href="https://online.worldpay.com/terms/privacy">WorldPay</a>
-      </li>
-    </ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>
+      <a class="govuk-link" href="https://online.worldpay.com/terms/privacy">WorldPay</a>
+    </li>
+  </ul>
 
-    <h3 class="govuk-heading-m">Third party service providers</h3>
+  <h3 class="govuk-heading-m">Third party service providers</h3>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       We will share your personal data with third parties if they need to know the information so that they can provide
       us, or the relevant government organisation, with a service. For example, a supplier of IT services like data
       storage.
     </p>
 
-    <h3 class="govuk-heading-m">Legal and regulatory entities</h3>
+  <h3 class="govuk-heading-m">Legal and regulatory entities</h3>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       We may have to share your personal data with law enforcement agencies or regulatory
       bodies if we have to comply with any legal obligation or court order.
     </p>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       These other entities may be based in the UK or they might be located in other countries that are not in
       the European Economic Area (“EEA”). Different privacy laws apply across the world. We will only transfer
       your data to another country if we are sure that there is enough protection in place to make sure that
       your data is secure.
     </p>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       We design, build and run our systems to make sure that your data is as safe as possible at any stage, both while
       it’s processed and when it’s stored.
     </p>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       Your personal data may, throughout the course of its processing at GDS, be transferred outside the UK. Where this
       is the case all appropriate technical and legal safeguards will be put in place to make sure that you are
       afforded the same level of protection as within the UK.
     </p>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       We will not:
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>sell or rent your data to third parties</li>
-      <li>share your data with third parties for marketing purposes</li>
-    </ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>sell or rent your data to third parties</li>
+    <li>share your data with third parties for marketing purposes</li>
+  </ul>
 
-    <h2 class="govuk-heading-m">How we protect your data and keep it secure</h2>
+  <h2 class="govuk-heading-m" id="how-we-protect-your-data-and-keep-it-secure">How we protect your data and keep it secure</h2>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       We are committed to doing all that we can to keep your data secure. We set up systems and processes to prevent
       unauthorised access or disclosure of the data we collect about you – for example, we protect your data using
       varying levels of encryption. All third parties who process personal data for GDS are required to keep that data
       secure. From time to time we will test the system for security vulnerabilities.
     </p>
 
-    <h3 class="govuk-heading-m">What are your rights</h3>
+  <h3 class="govuk-heading-m">What are your rights</h3>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       You have the right to:
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>information about how your personal data is processed</li>
-      <li>a copy of that personal data</li>
-      <li>that anything inaccurate in your personal data is corrected immediately</li>
-    </ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>information about how your personal data is processed</li>
+    <li>a copy of that personal data</li>
+    <li>that anything inaccurate in your personal data is corrected immediately</li>
+  </ul>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       You can also:
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>raise an objection about how your personal data is processed</li>
-      <li>request that your personal data is erased if there is no longer a justification for it</li>
-      <li>ask that the processing of your personal data is restricted in certain circumstances</li>
-    </ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>raise an objection about how your personal data is processed</li>
+    <li>request that your personal data is erased if there is no longer a justification for it</li>
+    <li>ask that the processing of your personal data is restricted in certain circumstances</li>
+  </ul>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       If you have any of these requests, get in contact with our Data Protection Officer - the contact details are at
       the bottom of the page.
     </p>
 
-    <h2 class="govuk-heading-m">Changes to this notice</h2>
+  <h2 class="govuk-heading-m" id="changes-to-this-notice">Changes to this notice</h2>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       We may change this privacy notice. In that case the ‘last updated’ date at the top of this page will also change.
       Any changes to this privacy notice will apply to you and your data immediately. If these changes affect how your
       personal data is processed, GDS will take reasonable steps to make sure you know.
     </p>
 
-    <h2 class="govuk-heading-m">Questions and complaints</h2>
+  <h2 class="govuk-heading-m" id="questions-and-complaints">Questions and complaints</h2>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       Contact
       <a class="govuk-link" href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk">
         gds-privacy-office@digital.cabinet-office.gov.uk
@@ -295,32 +344,32 @@
       if you either:
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>have questions about anything in this document</li>
-      <li>think that your personal data has been misused or mishandled</li>
-    </ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>have questions about anything in this document</li>
+    <li>think that your personal data has been misused or mishandled</li>
+  </ul>
 
-    <p class="govuk-body">Data Protection Officer<br/>
-      <a class="govuk-link" href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a><br/>
+  <p class="govuk-body">Data Protection Officer<br/>
+    <a class="govuk-link" href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a><br/>
       Cabinet Office<br/>
       70 Whitehall<br/>
       London SW1A 2AS
     </p>
 
-    <p class="govuk-body">
+  <p class="govuk-body">
       If you have a complaint, you can also contact the
       <a class="govuk-link" href="https://ico.org.uk/">
         Information Commissioner
       </a>, who is an independent regulator set up to uphold information rights.
     </p>
 
-    <p class="govuk-body">Information Commissioner’s Office<br/>
-      <a class="govuk-link" href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br/>
+  <p class="govuk-body">Information Commissioner’s Office<br/>
+    <a class="govuk-link" href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br/>
       0303 123 1113<br/>
       Wycliffe House<br/>
       Water Lane<br/>
       Wilmslow<br/>
       Cheshire SK9 5AF
     </p>
-  </div>
+</div>
 {% endblock %}

--- a/test/cypress/integration/privacy/privacy.cy.test.js
+++ b/test/cypress/integration/privacy/privacy.cy.test.js
@@ -1,14 +1,38 @@
 'use strict'
+const userStubs = require('../../stubs/user-stubs')
+
+const userExternalId = 'a-user-id'
+const gatewayAccountId = 42
+const gatewayAccountExternalId = 'a-valid-account-id'
 
 describe('Privacy page', () => {
-  it('should show the privacy page', () => {
-    cy.visit('/privacy')
+  describe('Logged out user', () => {
+    it('should show the privacy page correctly', () => {
+      cy.visit('/privacy')
 
-    cy.get('h1').should('contain', 'Privacy notice')
+      cy.get('h1').should('contain', 'Privacy notice')
 
-    cy.get('[data-cy=sub-navigation]').should('exist')
-    cy.get('[data-cy=sub-navigation] li').should('have.length', 10)
+      cy.get('[data-cy=sub-navigation]').should('exist')
+      cy.get('[data-cy=sub-navigation] li').should('have.length', 10)
 
-    cy.get('main h2').should('have.length', 10)
+      cy.get('main h2').should('have.length', 10)
+
+      cy.get('[data-cy=breadcrumbs]').should('not.exist')
+    })
+  })
+
+  describe('Logged in user', () => {
+    it('should show the privacy page correctly', () => {
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({ userExternalId, gatewayAccountId, gatewayAccountExternalId })
+      ])
+
+      cy.setEncryptedCookies(userExternalId)
+
+      cy.visit('/privacy')
+
+      cy.get('#navigation').should('contain', 'Sign out')
+      cy.get('[data-cy=breadcrumbs]').should('exist')
+    })
   })
 })

--- a/test/cypress/integration/privacy/privacy.cy.test.js
+++ b/test/cypress/integration/privacy/privacy.cy.test.js
@@ -1,9 +1,14 @@
 'use strict'
 
 describe('Privacy page', () => {
-  it('should show the privacy', () => {
+  it('should show the privacy page', () => {
     cy.visit('/privacy')
 
     cy.get('h1').should('contain', 'Privacy notice')
+
+    cy.get('[data-cy=sub-navigation]').should('exist')
+    cy.get('[data-cy=sub-navigation] li').should('have.length', 10)
+
+    cy.get('main h2').should('have.length', 10)
   })
 })


### PR DESCRIPTION
PP-10242 Privacy page - use login status
- Set page data so that the page is displayed correctly according
  to their login status
  - Header - show sign in / log link out depending on login status.
  - If logged in, show the `My services` nav bar.
  - Hide the account specific nav.
- Update Cypress tests.

