### PR TITLE
PP-10242 Privacy page - logged in status

### DIFF
--- a/app/controllers/privacy/privacy.controller.js
+++ b/app/controllers/privacy/privacy.controller.js
@@ -1,7 +1,14 @@
 'use strict'
 
+const sessionValidator = require('./../../services/session-validator')
+
 function getPage (req, res) {
-  return res.render('privacy/privacy')
+  const loggedIn = sessionValidator.validate(req.user, req.session)
+
+  return res.render('privacy/privacy', {
+    loggedIn,
+    hideServiceNav: true
+  })
 }
 
 module.exports = {

--- a/test/cypress/integration/privacy/privacy.cy.test.js
+++ b/test/cypress/integration/privacy/privacy.cy.test.js
@@ -1,14 +1,39 @@
 'use strict'
+const userStubs = require('../../stubs/user-stubs')
+
+const userExternalId = 'a-user-id'
+const gatewayAccountId = 42
+const gatewayAccountExternalId = 'a-valid-account-id'
 
 describe('Privacy page', () => {
-  it('should show the privacy page', () => {
-    cy.visit('/privacy')
+  describe('Logged out user', () => {
+    it('should show the privacy page correctly', () => {
+      cy.visit('/privacy')
 
-    cy.get('h1').should('contain', 'Privacy notice')
+      cy.get('h1').should('contain', 'Privacy notice')
 
-    cy.get('[data-cy=sub-navigation]').should('exist')
-    cy.get('[data-cy=sub-navigation] li').should('have.length', 10)
+      cy.get('[data-cy=sub-navigation]').should('exist')
+      cy.get('[data-cy=sub-navigation] li').should('have.length', 10)
 
-    cy.get('main h2').should('have.length', 10)
+      cy.get('main h2').should('have.length', 10)
+
+      cy.get('#navigation').should('contain', 'Sign in')
+      cy.get('[data-cy=breadcrumbs]').should('not.exist')
+    })
+  })
+
+  describe('Logged in user', () => {
+    it('should show the privacy page correctly', () => {
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({ userExternalId, gatewayAccountId, gatewayAccountExternalId })
+      ])
+
+      cy.setEncryptedCookies(userExternalId)
+
+      cy.visit('/privacy')
+
+      cy.get('#navigation').should('contain', 'Sign out')
+      cy.get('[data-cy=breadcrumbs]').should('exist')
+    })
   })
 })


### PR DESCRIPTION
- Update Privacy page show that it appears correctly whether a user is logged in or out
  - Header - show the sign in / sign out link correctly.
  - Only display the phase banner if the user is signed in.
- Update Cypress tests.


