### PR TITLE
PP-10397 Add missing stubs to more Cypress tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -402,6 +402,15 @@
         "line_number": 5
       }
     ],
+    "test/cypress/integration/registration/complete-registration.cy.test.js": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test/cypress/integration/registration/complete-registration.cy.test.js",
+        "hashed_secret": "9091b3ff82235d9f00a4522d825fad2a1634d02f",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
     "test/cypress/integration/request-psp-test-account/index.cy.test.js": [
       {
         "type": "Hex High Entropy String",
@@ -894,5 +903,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-05T16:07:09Z"
+  "generated_at": "2023-01-06T13:14:31Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -433,14 +433,14 @@
         "filename": "test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.test.js",
         "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
         "is_verified": false,
-        "line_number": 5
+        "line_number": 6
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.test.js",
         "hashed_secret": "631e4be72b31b1013671549f5f5daf2140c52293",
         "is_verified": false,
-        "line_number": 7
+        "line_number": 8
       }
     ],
     "test/cypress/integration/request-to-go-live/index.cy.test.js": [
@@ -903,5 +903,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-06T13:14:31Z"
+  "generated_at": "2023-01-06T13:23:21Z"
 }

--- a/test/cypress/integration/registration/complete-registration.cy.test.js
+++ b/test/cypress/integration/registration/complete-registration.cy.test.js
@@ -5,7 +5,9 @@ const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 const inviteCode = 'an-invite-code'
 const otpKey = 'ANEXAMPLESECRETSECONDFACTORCODE1'
 const createdUserExternalId = 'a-user-id'
+const validPassword = 'long-enough-password'
 const validPhoneNumber = '+4408081570192'
+const validOtpCode = '123456'
 
 describe('Complete registration after following link in invite email', () => {
   describe('SMS is selected as method for getting security codes', () => {
@@ -17,6 +19,14 @@ describe('Complete registration after following link in invite email', () => {
           otp_key: otpKey,
           telephone_number: validPhoneNumber
         }),
+        inviteStubs.patchUpdateInvitePasswordSuccess(inviteCode, validPassword),
+        inviteStubs.patchUpdateInvitePhoneNumberSuccess(inviteCode, validPhoneNumber),
+        inviteStubs.postReprovisionOtpSuccess({
+          code: inviteCode,
+          otp_key: otpKey
+        }),
+        inviteStubs.postSendOtpSuccess(inviteCode),
+        inviteStubs.postValidateOtpSuccess(inviteCode, validOtpCode),
         inviteStubs.completeInviteSuccess(inviteCode, createdUserExternalId),
         userStubs.getUserSuccess({ userExternalId: createdUserExternalId, gatewayAccountId: '1' }),
         gatewayAccountStubs.getGatewayAccountsSuccess({
@@ -54,8 +64,8 @@ describe('Complete registration after following link in invite email', () => {
       cy.title().should('eq', 'Create your password - GOV.UK Pay')
 
       // enter valid values into both password fields and click continue
-      cy.get('#password').type('long-enough-password', { delay: 0 })
-      cy.get('#repeat-password').type('long-enough-password', { delay: 0 })
+      cy.get('#password').type(validPassword, { delay: 0 })
+      cy.get('#repeat-password').type(validPassword, { delay: 0 })
       cy.get('button').contains('Continue').click()
 
       // should redirect to next page
@@ -105,7 +115,7 @@ describe('Complete registration after following link in invite email', () => {
       cy.title().should('eq', 'Enter your mobile phone number - GOV.UK Pay')
 
       // enter a valid phone number
-      cy.get('#phone').type(validPhoneNumber, { delay: 0 })
+      cy.get('#phone').clear().type(validPhoneNumber, { delay: 0 })
       cy.get('button').contains('Continue').click()
 
       // should show page to enter code
@@ -164,7 +174,7 @@ describe('Complete registration after following link in invite email', () => {
       cy.title().should('eq', 'Check your phone - GOV.UK Pay')
 
       // enter a valid code and click continue
-      cy.get('#code').type('123456')
+      cy.get('#code').type(validOtpCode)
       cy.get('button').contains('Continue').click()
 
       // should show the success page
@@ -188,10 +198,12 @@ describe('Complete registration after following link in invite email', () => {
           password_set: false,
           otp_key: otpKey
         }),
-        inviteStubs.reprovisionOtpSuccess({
+        inviteStubs.patchUpdateInvitePasswordSuccess(inviteCode, validPassword),
+        inviteStubs.postReprovisionOtpSuccess({
           code: inviteCode,
           otp_key: otpKey
         }),
+        inviteStubs.postValidateOtpSuccess(inviteCode, validOtpCode),
         inviteStubs.completeInviteSuccess(inviteCode, createdUserExternalId),
         userStubs.getUserSuccess({ userExternalId: createdUserExternalId, gatewayAccountId: '1' }),
         gatewayAccountStubs.getGatewayAccountsSuccess({

--- a/test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.test.js
+++ b/test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.test.js
@@ -1,5 +1,6 @@
 const userStubs = require('../../stubs/user-stubs')
 const serviceStubs = require('../../stubs/service-stubs')
+const zendeskStubs = require('../../stubs/zendesk-stubs')
 
 describe('Request PSP test account: submit request', () => {
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
@@ -21,6 +22,7 @@ describe('Request PSP test account: submit request', () => {
           pspTestAccountStage: pspTestAccountStageSecondResponse
         }
       ),
+      zendeskStubs.createTicketSuccess(),
       serviceStubs.patchUpdateServicePspTestAccountStage({ serviceExternalId, gatewayAccountId, pspTestAccountStage: 'REQUEST_SUBMITTED' })
     ])
   }

--- a/test/cypress/integration/settings/default-billing-address-country.cy.test.js
+++ b/test/cypress/integration/settings/default-billing-address-country.cy.test.js
@@ -3,7 +3,7 @@ const serviceStubs = require('../../stubs/service-stubs')
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 
 const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
-const serviceExternalId = 'a-service--external-id'
+const serviceExternalId = 'a-service-external-id'
 const gatewayAccountId = 42
 const gatewayAccountExternalId = 'a-gateway-account-external-id'
 
@@ -11,6 +11,7 @@ function getUserAndGatewayAccountStubs (defaultBillingAddressCountry) {
   return [
     userStubs.getUserSuccess({
       userExternalId,
+      serviceExternalId,
       gatewayAccountId,
       defaultBillingAddressCountry
     }),
@@ -50,8 +51,7 @@ describe('Default billing address country', () => {
         serviceStubs.patchUpdateDefaultBillingAddressCountrySuccess({
           serviceExternalId,
           gatewayAccountId,
-          country: 'GB',
-          verifyTimesCalled: 1
+          country: 'GB'
         })
       ])
 

--- a/test/cypress/stubs/go-live-request-stubs.js
+++ b/test/cypress/stubs/go-live-request-stubs.js
@@ -16,14 +16,9 @@ function postGovUkPayAgreement (opts) {
   })
 }
 
-function postStripeAgreementIpAddress (opts) {
-  const path = `/v1/api/services/${opts.serviceExternalId}/stripe-agreement`
-  return stubBuilder('POST', path, 201, {
-    request: goLiveRequestFixtures.validPostStripeAgreementRequest({
-      ip_address: '93.184.216.34'
-    }),
-    responseHeaders: {}
-  })
+function postStripeAgreementIpAddress (serviceExternalId) {
+  const path = `/v1/api/services/${serviceExternalId}/stripe-agreement`
+  return stubBuilder('POST', path, 201)
 }
 
 module.exports = {

--- a/test/cypress/stubs/invite-stubs.js
+++ b/test/cypress/stubs/invite-stubs.js
@@ -55,10 +55,34 @@ function completeInviteToServiceSuccess (inviteCode, userExternalId, serviceExte
   })
 }
 
-function reprovisionOtpSuccess (opts) {
+function postReprovisionOtpSuccess (opts) {
   const path = `/v1/api/invites/${opts.code}/reprovision-otp`
   return stubBuilder('POST', path, 200, {
     response: inviteFixtures.validInviteResponse(opts)
+  })
+}
+
+function postSendOtpSuccess (inviteCode) {
+  const path = `/v1/api/invites/${inviteCode}/send-otp`
+  return stubBuilder('POST', path, 200)
+}
+
+function postValidateOtpSuccess (inviteCode, otpCode) {
+  const path = `/v2/api/invites/otp/validate`
+  return stubBuilder('POST', path, 200)
+}
+
+function patchUpdateInvitePasswordSuccess (inviteCode, password) {
+  const path = `/v1/api/invites/${inviteCode}`
+  return stubBuilder('PATCH', path, 200, {
+    request: inviteFixtures.validUpdateInvitePasswordRequest(password)
+  })
+}
+
+function patchUpdateInvitePhoneNumberSuccess (inviteCode, phoneNumber) {
+  const path = `/v1/api/invites/${inviteCode}`
+  return stubBuilder('PATCH', path, 200, {
+    request: inviteFixtures.validUpdateInvitePhoneNumberRequest(phoneNumber)
   })
 }
 
@@ -69,5 +93,9 @@ module.exports = {
   getInviteSuccess,
   completeInviteSuccess,
   completeInviteToServiceSuccess,
-  reprovisionOtpSuccess
+  postReprovisionOtpSuccess,
+  postSendOtpSuccess,
+  postValidateOtpSuccess,
+  patchUpdateInvitePasswordSuccess,
+  patchUpdateInvitePhoneNumberSuccess
 }

--- a/test/cypress/stubs/service-stubs.js
+++ b/test/cypress/stubs/service-stubs.js
@@ -119,8 +119,7 @@ function patchUpdateDefaultBillingAddressCountrySuccess (opts) {
       external_id: opts.serviceExternalId,
       gateway_account_ids: [opts.gatewayAccountId],
       default_billing_address_country: opts.country
-    }),
-    verifyCalledTimes: opts.verifyCalledTimes
+    })
   })
 }
 

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -139,7 +139,7 @@ function validGatewayAccountPatchRequest (opts = {}) {
 function validGatewayAccountEmailRefundToggleRequest (enabled = true) {
   return {
     op: 'replace',
-    path: '/refund/enabled',
+    path: '/refund_issued/enabled',
     value: enabled
   }
 }
@@ -147,7 +147,7 @@ function validGatewayAccountEmailRefundToggleRequest (enabled = true) {
 function validGatewayAccountEmailConfirmationToggleRequest (enabled = true) {
   return {
     op: 'replace',
-    path: '/confirmation/enabled',
+    path: '/payment_confirmed/enabled',
     value: enabled
   }
 }

--- a/test/pact/connector-client/connector-patch-email-collection-mode.pact.test.js
+++ b/test/pact/connector-client/connector-patch-email-collection-mode.pact.test.js
@@ -18,11 +18,11 @@ const expect = chai.expect
 chai.use(chaiAsPromised)
 
 const existingGatewayAccountId = 42
-const defaultState = `Gateway account ${existingGatewayAccountId} exists in the database`
+const defaultState = `a stripe gateway account with external id ${existingGatewayAccountId} exists in the database`
 
 describe('connector client - patch email collection mode', function () {
   let provider = new Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'connector',
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
@@ -48,6 +48,7 @@ describe('connector client - patch email collection mode', function () {
           .withMethod('PATCH')
           .withRequestBody(validGatewayAccountEmailCollectionModeRequest)
           .withStatusCode(200)
+          .withResponseHeaders({})
           .build()
       )
         .then(() => done())
@@ -77,6 +78,7 @@ describe('connector client - patch email collection mode', function () {
           .withMethod('PATCH')
           .withRequestBody(validGatewayAccountEmailCollectionModeRequest)
           .withStatusCode(200)
+          .withResponseHeaders({})
           .build()
       )
         .then(() => done())
@@ -102,10 +104,11 @@ describe('connector client - patch email collection mode', function () {
       provider.addInteraction(
         new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
           .withUponReceiving('a valid patch email collection mode (off) request')
-          .withState(`Gateway account ${existingGatewayAccountId} exists in the database`)
+          .withState(defaultState)
           .withMethod('PATCH')
           .withRequestBody(validGatewayAccountEmailCollectionModeRequest)
           .withStatusCode(200)
+          .withResponseHeaders({})
           .build()
       )
         .then(() => done())

--- a/test/pact/connector-client/connector-patch-email-confirmation-toggle.pact.test.js
+++ b/test/pact/connector-client/connector-patch-email-confirmation-toggle.pact.test.js
@@ -18,11 +18,11 @@ const expect = chai.expect
 chai.use(chaiAsPromised)
 
 const existingGatewayAccountId = 42
-const defaultState = `Gateway account ${existingGatewayAccountId} exists in the database`
+const defaultState = `a stripe gateway account with external id ${existingGatewayAccountId} exists in the database`
 
 describe('connector client - patch email confirmation toggle', function () {
   let provider = new Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'connector',
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
@@ -47,6 +47,7 @@ describe('connector client - patch email confirmation toggle', function () {
           .withMethod('PATCH')
           .withRequestBody(validGatewayAccountEmailConfirmationToggleRequest)
           .withStatusCode(200)
+          .withResponseHeaders({})
           .build()
       )
         .then(() => done())

--- a/test/pact/connector-client/connector-patch-email-refund-toggle.pact.test.js
+++ b/test/pact/connector-client/connector-patch-email-refund-toggle.pact.test.js
@@ -18,11 +18,11 @@ const expect = chai.expect
 chai.use(chaiAsPromised)
 
 const existingGatewayAccountId = 42
-const defaultState = `Gateway account ${existingGatewayAccountId} exists in the database`
+const defaultState = `a stripe gateway account with external id ${existingGatewayAccountId} exists in the database`
 
 describe('connector client - patch email refund toggle', function () {
   let provider = new Pact({
-    consumer: 'selfservice-to-be',
+    consumer: 'selfservice',
     provider: 'connector',
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
@@ -47,6 +47,7 @@ describe('connector client - patch email refund toggle', function () {
           .withMethod('PATCH')
           .withRequestBody(validGatewayAccountEmailRefundToggleRequest)
           .withStatusCode(200)
+          .withResponseHeaders({})
           .build()
       )
         .then(() => done())


### PR DESCRIPTION
We are intending to change the default response when Mountebank does not match on a stub for a request from returning a 200 to returning a 404.

In order to do this, we need to setup some missing stubs for Cypress tests where we currently rely on the default behaviour of getting a 200 when there is no stub, as these tests would fail when the default is 404.

This PR adds missing stubs to several more Cypress tests and fixes some stubs which existed but weren't being successfully matched on.

