### PR TITLE
PP-10397 Add missing stubs to more Cypress test

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -567,42 +567,42 @@
         "filename": "test/cypress/integration/settings/your-psp.cy.test.js",
         "hashed_secret": "d0be4e729498f4cfe8a72a28d4fceae35bd8bb27",
         "is_verified": false,
-        "line_number": 17
+        "line_number": 18
       },
       {
         "type": "Secret Keyword",
         "filename": "test/cypress/integration/settings/your-psp.cy.test.js",
         "hashed_secret": "2c877f34a0f47f32a5f3c77e398938b3cdc32221",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 28
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/settings/your-psp.cy.test.js",
         "hashed_secret": "379f1968f09d8a343338667844e01a2f433f0a3f",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 32
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/settings/your-psp.cy.test.js",
         "hashed_secret": "abd006a3c55aebb9ffd8edca94531be22416e913",
         "is_verified": false,
-        "line_number": 36
+        "line_number": 37
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/settings/your-psp.cy.test.js",
         "hashed_secret": "b2023a863d65bffae6af0d0e1c8a036fd3f3773d",
         "is_verified": false,
-        "line_number": 41
+        "line_number": 42
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/settings/your-psp.cy.test.js",
         "hashed_secret": "d7e383a1a8aedd99245e46203e2a3065c1101b5b",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 47
       }
     ],
     "test/cypress/integration/switch-psp/organisation-url.cy.test.js": [
@@ -903,5 +903,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-06T18:35:49Z"
+  "generated_at": "2023-01-08T14:40:43Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -519,21 +519,21 @@
         "filename": "test/cypress/integration/settings/switch-psp.cy.test.js",
         "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
         "is_verified": false,
-        "line_number": 8
+        "line_number": 9
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/settings/switch-psp.cy.test.js",
         "hashed_secret": "d1dace01626802697073ed716dcb96fc5cfdea46",
         "is_verified": false,
-        "line_number": 14
+        "line_number": 15
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/settings/switch-psp.cy.test.js",
         "hashed_secret": "b2023a863d65bffae6af0d0e1c8a036fd3f3773d",
         "is_verified": false,
-        "line_number": 15
+        "line_number": 16
       }
     ],
     "test/cypress/integration/settings/verify-psp-integration.cy.test.js": [
@@ -903,5 +903,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-06T17:43:26Z"
+  "generated_at": "2023-01-06T18:35:49Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -510,7 +510,7 @@
         "filename": "test/cypress/integration/settings/payment-types.cy.test.js",
         "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
         "is_verified": false,
-        "line_number": 14
+        "line_number": 15
       }
     ],
     "test/cypress/integration/settings/switch-psp.cy.test.js": [
@@ -903,5 +903,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-06T13:23:21Z"
+  "generated_at": "2023-01-06T17:43:26Z"
 }

--- a/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js
+++ b/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.test.js
@@ -10,8 +10,7 @@ describe('MOTO mask security section', () => {
   const serviceName = 'Purchase a positron projection permit'
 
   function setupMotoStubs (opts = {}) {
-    let stubs = []
-    let user
+    let getUserStub
 
     if (opts.readonly) {
       const role = {
@@ -26,11 +25,11 @@ describe('MOTO mask security section', () => {
           }
         ]
       }
-      user = userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName, role })
+      getUserStub = userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName, role })
     } else {
-      user = userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName })
+      getUserStub = userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName })
     }
-    const gatewayAccountByExternalId = gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+    const getGatewayAccountByExternalIdStub = gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
       gatewayAccountId,
       gatewayAccountExternalId,
       paymentProvider: opts.gateway,
@@ -38,11 +37,21 @@ describe('MOTO mask security section', () => {
       motoMaskCardNumber: opts.motoMaskCardNumber,
       motoMaskSecurityCode: opts.motoMaskSecurityCode
     })
-    const card = gatewayAccountStubs.getAcceptedCardTypesSuccess({ gatewayAccountId, updated: false, maestro: opts.maestro })
+    const getCardTypesStub = gatewayAccountStubs.getAcceptedCardTypesSuccess({
+      gatewayAccountId,
+      updated: false,
+      maestro: opts.maestro
+    })
+    const patchUpdateMaskCardNumberStub = gatewayAccountStubs.patchUpdateMaskCardNumberSuccess(gatewayAccountId, true)
+    const patchUpdateMaskSecurityCodeStub = gatewayAccountStubs.patchUpdateMaskSecurityCodeSuccess(gatewayAccountId, true)
 
-    stubs.push(user, gatewayAccountByExternalId, card)
-
-    cy.task('setupStubs', stubs)
+    cy.task('setupStubs', [
+      getUserStub,
+      getGatewayAccountByExternalIdStub,
+      getCardTypesStub,
+      patchUpdateMaskCardNumberStub,
+      patchUpdateMaskSecurityCodeStub
+    ])
   }
 
   beforeEach(() => {

--- a/test/cypress/integration/settings/payment-types.cy.test.js
+++ b/test/cypress/integration/settings/payment-types.cy.test.js
@@ -6,7 +6,8 @@ function setupStubs (userExternalId, gatewayAccountId, gatewayAccountExternalId,
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName }),
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId }),
     gatewayAccountStubs.getAcceptedCardTypesSuccess({ gatewayAccountId, updated }),
-    gatewayAccountStubs.getCardTypesSuccess()
+    gatewayAccountStubs.getCardTypesSuccess(),
+    gatewayAccountStubs.postUpdateCardTypesSuccess(gatewayAccountId)
   ])
 }
 

--- a/test/cypress/integration/settings/your-psp.cy.test.js
+++ b/test/cypress/integration/settings/your-psp.cy.test.js
@@ -8,6 +8,7 @@ describe('Your PSP settings page', () => {
   const gatewayAccountId = 42
   const gatewayAccountExternalId = 'a-valid-external-id'
   const credentialExternalId = 'a-credential-external-id'
+  const credentialsId = 101
   const serviceName = 'Purchase a positron projection permit'
   const yourPspPath = `/account/${gatewayAccountExternalId}/your-psp`
 
@@ -117,6 +118,13 @@ describe('Your PSP settings page', () => {
     const postCheckWorldpay3dsFlexCredentialsReturnsBadResult = gatewayAccountStubs.postCheckWorldpay3dsFlexCredentialsWithBadResult({
       gatewayAccountId: gatewayAccountId, ...testBadResultFlexCredentials
     })
+    const patchUpdateCredentials = gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, credentialsId)
+    const postUpdateWorldpay3dsFlexCredentials = gatewayAccountStubs.postUpdateWorldpay3dsFlexCredentials({
+      gatewayAccountId,
+      ...testFlexCredentials
+    })
+    const patchUpdate3dsVersionSuccess = gatewayAccountStubs.patchUpdate3dsVersionSuccess(gatewayAccountId, 1)
+    const postUpdateNotificationCredentialsSuccess = gatewayAccountStubs.postUpdateNotificationCredentialsSuccess(gatewayAccountId)
     const stubs = [
       user,
       gatewayAccount,
@@ -126,7 +134,11 @@ describe('Your PSP settings page', () => {
       postCheckWorldpay3dsFlexCredentialsReturnsInvalid,
       postCheckWorldpay3dsFlexCredentialsFails,
       postCheckWorldpay3dsFlexCredentialsReturnsBadResult,
-      postCheckWorldpayCredentials
+      postCheckWorldpayCredentials,
+      patchUpdateCredentials,
+      postUpdateWorldpay3dsFlexCredentials,
+      patchUpdate3dsVersionSuccess,
+      postUpdateNotificationCredentialsSuccess
     ]
 
     cy.task('setupStubs', stubs)
@@ -156,6 +168,7 @@ describe('Your PSP settings page', () => {
         gatewayAccountCredentials: [{
           payment_provider: 'worldpay',
           external_id: credentialExternalId,
+          id: credentialsId,
           state: 'CREATED',
           credentials: {}
         }],
@@ -286,7 +299,8 @@ describe('Your PSP settings page', () => {
         gatewayAccountCredentials: [{
           payment_provider: 'worldpay',
           credentials: testCredentials,
-          external_id: credentialExternalId
+          external_id: credentialExternalId,
+          id: credentialsId
         }],
         worldpay3dsFlex: testFlexCredentials
       })
@@ -314,7 +328,8 @@ describe('Your PSP settings page', () => {
         gatewayAccountCredentials: [{
           payment_provider: 'worldpay',
           credentials: {},
-          external_id: credentialExternalId
+          external_id: credentialExternalId,
+          id: credentialsId
         }],
         validateCredentials: testCredentialsMOTO
       })
@@ -366,7 +381,8 @@ describe('Your PSP settings page', () => {
           gatewayAccountCredentials: [{
             payment_provider: 'worldpay',
             credentials: testCredentials,
-            external_id: credentialExternalId
+            external_id: credentialExternalId,
+            id: credentialsId
           }],
           worldpay3dsFlex: testFlexCredentials
         })
@@ -389,7 +405,8 @@ describe('Your PSP settings page', () => {
           gatewayAccountCredentials: [{
             payment_provider: 'worldpay',
             credentials: testCredentials,
-            external_id: credentialExternalId
+            external_id: credentialExternalId,
+            id: credentialsId
           }],
           worldpay3dsFlex: testFlexCredentials
         })
@@ -412,7 +429,8 @@ describe('Your PSP settings page', () => {
           gatewayAccountCredentials: [{
             payment_provider: 'worldpay',
             credentials: testCredentials,
-            external_id: credentialExternalId
+            external_id: credentialExternalId,
+            id: credentialsId
           }],
           worldpay3dsFlex: testFlexCredentials
         })
@@ -437,7 +455,8 @@ describe('Your PSP settings page', () => {
           gatewayAccountCredentials: [{
             payment_provider: 'worldpay',
             credentials: testCredentials,
-            external_id: credentialExternalId
+            external_id: credentialExternalId,
+            id: credentialsId
           }]
         })
 
@@ -457,7 +476,8 @@ describe('Your PSP settings page', () => {
           gatewayAccountCredentials: [{
             payment_provider: 'worldpay',
             credentials: testCredentials,
-            external_id: credentialExternalId
+            external_id: credentialExternalId,
+            id: credentialsId
           }],
           worldpay3dsFlex: testFlexCredentials
         })
@@ -480,7 +500,8 @@ describe('Your PSP settings page', () => {
           gatewayAccountCredentials: [{
             payment_provider: 'worldpay',
             credentials: testCredentials,
-            external_id: credentialExternalId
+            external_id: credentialExternalId,
+            id: credentialsId
           }],
           worldpay3dsFlex: testFlexCredentials,
           type: 'live'
@@ -508,7 +529,8 @@ describe('Your PSP settings page', () => {
         gatewayAccountCredentials: [{
           payment_provider: 'smartpay',
           credentials: {},
-          external_id: credentialExternalId
+          external_id: credentialExternalId,
+          id: credentialsId
         }]
       })
     })
@@ -559,7 +581,8 @@ describe('Your PSP settings page', () => {
         gatewayAccountCredentials: [{
           payment_provider: 'smartpay',
           credentials: testCredentials,
-          external_id: credentialExternalId
+          external_id: credentialExternalId,
+          id: credentialsId
         }],
         notificationCredentials: testNotificationCredentials
       })
@@ -583,7 +606,8 @@ describe('Your PSP settings page', () => {
         gatewayAccountCredentials: [{
           payment_provider: 'epdq',
           credentials: {},
-          external_id: credentialExternalId
+          external_id: credentialExternalId,
+          id: credentialsId
         }]
       })
     })
@@ -626,7 +650,8 @@ describe('Your PSP settings page', () => {
         gatewayAccountCredentials: [{
           payment_provider: 'epdq',
           credentials: testCredentials,
-          external_id: credentialExternalId
+          external_id: credentialExternalId,
+          id: credentialsId
         }]
       })
     })

--- a/test/cypress/integration/stripe-setup/director.cy.test.js
+++ b/test/cypress/integration/stripe-setup/director.cy.test.js
@@ -76,6 +76,7 @@ function setupStubs (director, type = 'live', paymentProvider = 'stripe', requir
     stripeListPersonsStub,
     stripeUpdateCompanyStub,
     stripeAccountStubs.getStripeAccountSuccess(gatewayAccountId, 'acct_123example123'),
+    stripeAccountSetupStubs.patchUpdateStripeSetupSuccess(gatewayAccountId),
     transactionSummaryStubs.getDashboardStatistics()
   ])
 }

--- a/test/cypress/integration/stripe-setup/update-org-details.cy.test.js
+++ b/test/cypress/integration/stripe-setup/update-org-details.cy.test.js
@@ -51,6 +51,7 @@ function setupStubs (stripeSetupOptions, type = 'live', paymentProvider = 'strip
     }),
     stripeSetupStub,
     stripeAccountStubs.getStripeAccountSuccess(gatewayAccountId, 'acct_123example123'),
+    stripeAccountSetupStubs.patchUpdateStripeSetupSuccess(gatewayAccountId),
     stripeUpdateCompanyStub,
     transactionSummaryStubs.getDashboardStatistics()
   ])

--- a/test/cypress/integration/stripe-setup/vat-number.cy.test.js
+++ b/test/cypress/integration/stripe-setup/vat-number.cy.test.js
@@ -37,6 +37,7 @@ function setupStubs (vatNumber, type = 'live', paymentProvider = 'stripe') {
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId: gatewayAccountExternalId, type, paymentProvider, gatewayAccountCredentials }),
     stripeSetupStub,
     stripeAccountStubs.getStripeAccountSuccess(gatewayAccountId, 'acct_123example123'),
+    stripeAccountSetupStubs.patchUpdateStripeSetupSuccess(gatewayAccountId),
     transactionSummaryStubs.getDashboardStatistics()
   ])
 }

--- a/test/cypress/integration/transactions/transaction-details.cy.test.js
+++ b/test/cypress/integration/transactions/transaction-details.cy.test.js
@@ -115,7 +115,13 @@ describe('Transaction details page', () => {
       }),
       transactionStubs.getLedgerTransactionSuccess({ transactionDetails }),
       transactionStubs.getLedgerEventsSuccess({ transactionId, events: transactionDetails.events }),
-      stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, bankAccount: true, responsiblePerson: true, vatNumber: true, companyNumber: true })
+      stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+        gatewayAccountId,
+        bankAccount: true,
+        responsiblePerson: true,
+        vatNumber: true,
+        companyNumber: true
+      })
     ]
     if (disputeTransactionsDetails) {
       stubs.push(transactionStubs.getLedgerDisputeTransactionsSuccess({ disputeTransactionsDetails }))
@@ -318,12 +324,17 @@ describe('Transaction details page', () => {
   describe('refunds', () => {
     it('should show success message when full refund is successful', () => {
       const transactionDetails = defaultTransactionDetails()
-      const refundAmount = transactionDetails.amount + 1
+      const refundAmount = transactionDetails.amount
       const stubs = [
         ...getStubs(transactionDetails),
         transactionStubs.postRefundSuccess(
           {
-            gatewayAccountId, userExternalId, userEmail, transactionId: transactionDetails.transaction_id, refundAmount, refundAmountAvailable: transactionDetails.amount
+            gatewayAccountId,
+            userExternalId,
+            userEmail,
+            transactionId: transactionDetails.transaction_id,
+            refundAmount,
+            refundAmountAvailable: transactionDetails.amount
           })
       ]
       cy.task('setupStubs', stubs)
@@ -353,7 +364,12 @@ describe('Transaction details page', () => {
         ...getStubs(transactionDetails),
         transactionStubs.postRefundAmountNotAvailable(
           {
-            gatewayAccountId, userExternalId, userEmail, transactionId: transactionDetails.transaction_id, refundAmount, refundAmountAvailable: transactionDetails.amount
+            gatewayAccountId,
+            userExternalId,
+            userEmail,
+            transactionId: transactionDetails.transaction_id,
+            refundAmount,
+            refundAmountAvailable: transactionDetails.amount
           })
       ]
       cy.task('setupStubs', stubs)
@@ -437,8 +453,9 @@ describe('Transaction details page', () => {
       const disputedPaymentDetails = defaultTransactionDetails()
       disputedPaymentDetails.disputed = true
       disputedPaymentDetails.refund_summary_status = 'unavailable'
+      const disputeTransactionDetails = defaultDisputeDetails()
 
-      cy.task('setupStubs', getStubs(disputedPaymentDetails))
+      cy.task('setupStubs', getStubs(disputedPaymentDetails, {}, disputeTransactionDetails))
       cy.visit(`${transactionsUrl}/${disputedPaymentDetails.transaction_id}`)
 
       cy.get('[data-cy=refund-container]').within(() => {

--- a/test/cypress/integration/webhooks/webhooks.cy.test.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.test.js
@@ -96,7 +96,8 @@ describe('Webhooks', () => {
     const description = 'A valid Webhook description'
 
     cy.task('setupStubs', [
-      ...userAndGatewayAccountStubs
+      ...userAndGatewayAccountStubs,
+      webhooksStubs.postCreateWebhookSuccess()
     ])
 
     cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
@@ -128,7 +129,8 @@ describe('Webhooks', () => {
 
   it('should update a webhook with valid properties', () => {
     cy.task('setupStubs', [
-      ...userAndGatewayAccountStubs
+      ...userAndGatewayAccountStubs,
+      webhooksStubs.patchUpdateWebhookSuccess(webhookExternalId)
     ])
     cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
 
@@ -158,7 +160,8 @@ describe('Webhooks', () => {
 
   it('should toggle a webhook status', () => {
     cy.task('setupStubs', [
-      ...userAndGatewayAccountStubs
+      ...userAndGatewayAccountStubs,
+      webhooksStubs.patchUpdateWebhookSuccess(webhookExternalId)
     ])
     cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
     cy.get('[data-action=update]').then((links) => links[0].click())

--- a/test/cypress/stubs/connector-charge-stubs.js
+++ b/test/cypress/stubs/connector-charge-stubs.js
@@ -15,4 +15,13 @@ function getChargeSuccess (opts) {
   })
 }
 
-module.exports = { postCreateChargeSuccess, getChargeSuccess }
+function postCreateRefundSuccess (gatewayAccountId, chargeId) {
+  const path = `/v1/api/accounts/${gatewayAccountId}/charges/${chargeId}/refunds`
+  return stubBuilder('POST', path, 200)
+}
+
+module.exports = {
+  postCreateChargeSuccess,
+  getChargeSuccess,
+  postCreateRefundSuccess
+}

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -215,6 +215,20 @@ function patchUpdateServiceNameSuccess (gatewayAccountId, serviceName) {
   })
 }
 
+function patchUpdateMaskCardNumberSuccess (gatewayAccountId, mask) {
+  const path = `/v1/api/accounts/${gatewayAccountId}`
+  return stubBuilder('PATCH', path, 200, {
+    request: gatewayAccountFixtures.validPatchMaskCardNumberRequest(mask)
+  })
+}
+
+function patchUpdateMaskSecurityCodeSuccess (gatewayAccountId, mask) {
+  const path = `/v1/api/accounts/${gatewayAccountId}`
+  return stubBuilder('PATCH', path, 200, {
+    request: gatewayAccountFixtures.validPatchMaskSecurityCodeRequest(mask)
+  })
+}
+
 function postCheckWorldpay3dsFlexCredentials (opts) {
   const path = `/v1/api/accounts/${opts.gatewayAccountId}/worldpay/check-3ds-flex-config`
   return stubBuilder('POST', path, 200, {
@@ -262,6 +276,8 @@ module.exports = {
   patchRefundEmailToggleSuccess,
   patchAccountEmailCollectionModeSuccess,
   patchUpdateServiceNameSuccess,
+  patchUpdateMaskCardNumberSuccess,
+  patchUpdateMaskSecurityCodeSuccess,
   postCheckWorldpay3dsFlexCredentials,
   postCheckWorldpay3dsFlexCredentialsFailure,
   postCheckWorldpay3dsFlexCredentialsWithBadResult,

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -187,6 +187,11 @@ function getCardTypesSuccess () {
   })
 }
 
+function postUpdateCardTypesSuccess (gatewayAccountId) {
+  const path = `/v1/frontend/accounts/${gatewayAccountId}/card-types`
+  return stubBuilder('POST', path, 200)
+}
+
 function patchConfirmationEmailToggleSuccess (opts) {
   const path = `/v1/api/accounts/${opts.gatewayAccountId}/email-notification`
   return stubBuilder('PATCH', path, 200, {
@@ -272,6 +277,7 @@ module.exports = {
   getDirectDebitGatewayAccountSuccess,
   postCreateGatewayAccountSuccess,
   getCardTypesSuccess,
+  postUpdateCardTypesSuccess,
   patchConfirmationEmailToggleSuccess,
   patchRefundEmailToggleSuccess,
   patchAccountEmailCollectionModeSuccess,

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -234,6 +234,13 @@ function patchUpdateMaskSecurityCodeSuccess (gatewayAccountId, mask) {
   })
 }
 
+function patchUpdate3dsVersionSuccess (gatewayAccountId, version) {
+  const path = `/v1/api/accounts/${gatewayAccountId}`
+  return stubBuilder('PATCH', path, 200, {
+    requests: gatewayAccountFixtures.validPatchIntegrationVersion3dsRequest(version)
+  })
+}
+
 function postCheckWorldpay3dsFlexCredentials (opts) {
   const path = `/v1/api/accounts/${opts.gatewayAccountId}/worldpay/check-3ds-flex-config`
   return stubBuilder('POST', path, 200, {
@@ -279,7 +286,12 @@ function patchUpdateCredentialsSuccess (gatewayAccountId, credentialId) {
   return stubBuilder('PATCH', path, 200)
 }
 
-function postSwitchPspSuccess(gatewayAccountId) {
+function postUpdateNotificationCredentialsSuccess (gatewayAccountId) {
+  const path = `/v1/api/accounts/${gatewayAccountId}/notification-credentials`
+  return stubBuilder('POST', path, 200)
+}
+
+function postSwitchPspSuccess (gatewayAccountId) {
   const path = `/v1/api/accounts/${gatewayAccountId}/switch-psp`
   return stubBuilder('POST', path, 200)
 }
@@ -301,11 +313,13 @@ module.exports = {
   patchUpdateServiceNameSuccess,
   patchUpdateMaskCardNumberSuccess,
   patchUpdateMaskSecurityCodeSuccess,
+  patchUpdate3dsVersionSuccess,
   postCheckWorldpay3dsFlexCredentials,
   postCheckWorldpay3dsFlexCredentialsFailure,
   postCheckWorldpay3dsFlexCredentialsWithBadResult,
   postCheckWorldpayCredentials,
   postUpdateWorldpay3dsFlexCredentials,
   patchUpdateCredentialsSuccess,
+  postUpdateNotificationCredentialsSuccess,
   postSwitchPspSuccess
 }

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -267,6 +267,23 @@ function postCheckWorldpay3dsFlexCredentialsWithBadResult (opts) {
   })
 }
 
+function postUpdateWorldpay3dsFlexCredentials (opts) {
+  const path = `/v1/api/accounts/${opts.gatewayAccountId}/3ds-flex-credentials`
+  return stubBuilder('POST', path, 200, {
+    request: worldpay3dsFlexCredentialsFixtures.validUpdateWorldpay3dsCredentialsRequest(opts)
+  })
+}
+
+function patchUpdateCredentialsSuccess (gatewayAccountId, credentialId) {
+  const path = `/v1/api/accounts/${gatewayAccountId}/credentials/${credentialId}`
+  return stubBuilder('PATCH', path, 200)
+}
+
+function postSwitchPspSuccess(gatewayAccountId) {
+  const path = `/v1/api/accounts/${gatewayAccountId}/switch-psp`
+  return stubBuilder('POST', path, 200)
+}
+
 module.exports = {
   getAccountAuthSuccess,
   getGatewayAccountSuccess,
@@ -287,5 +304,8 @@ module.exports = {
   postCheckWorldpay3dsFlexCredentials,
   postCheckWorldpay3dsFlexCredentialsFailure,
   postCheckWorldpay3dsFlexCredentialsWithBadResult,
-  postCheckWorldpayCredentials
+  postCheckWorldpayCredentials,
+  postUpdateWorldpay3dsFlexCredentials,
+  patchUpdateCredentialsSuccess,
+  postSwitchPspSuccess
 }

--- a/test/cypress/stubs/stripe-account-setup-stub.js
+++ b/test/cypress/stubs/stripe-account-setup-stub.js
@@ -137,7 +137,13 @@ function getGatewayAccountStripeSetupFlagForMultipleCalls (opts) {
   }
 }
 
+function patchUpdateStripeSetupSuccess (gatewayAccountId) {
+  const path = `/v1/api/accounts/${gatewayAccountId}/stripe-setup`
+  return stubBuilder('PATCH', path, 200)
+}
+
 module.exports = {
   getGatewayAccountStripeSetupSuccess,
-  getGatewayAccountStripeSetupFlagForMultipleCalls
+  getGatewayAccountStripeSetupFlagForMultipleCalls,
+  patchUpdateStripeSetupSuccess
 }

--- a/test/cypress/stubs/transaction-stubs.js
+++ b/test/cypress/stubs/transaction-stubs.js
@@ -64,8 +64,7 @@ function postRefundSuccess (opts) {
       refund_amount_available: opts.refundAmountAvailable,
       user_external_id: opts.userExternalId,
       user_email: opts.userEmail
-    }),
-    verifyCalledTimes: opts.verifyCalledTimes
+    })
   })
 }
 

--- a/test/cypress/stubs/webhooks-stubs.js
+++ b/test/cypress/stubs/webhooks-stubs.js
@@ -61,6 +61,11 @@ function getWebhookMessageAttempts (opts = {}) {
   })
 }
 
+function postCreateWebhookSuccess () {
+  const path = `/v1/webhook`
+  return stubBuilder('POST', path, 200)
+}
+
 function createWebhookViolatesBackend (opts = {}) {
   const path = `/v1/webhook`
   return stubBuilder('POST', path, 400, {
@@ -71,6 +76,11 @@ function createWebhookViolatesBackend (opts = {}) {
   })
 }
 
+function patchUpdateWebhookSuccess (webhookExternalId) {
+  const path = `/v1/webhook/${webhookExternalId}`
+  return stubBuilder('PATCH', path, 200)
+}
+
 module.exports = {
   getWebhooksListSuccess,
   getWebhookSuccess,
@@ -78,5 +88,7 @@ module.exports = {
   getWebhookMessagesListSuccess,
   getWebhookMessage,
   getWebhookMessageAttempts,
-  createWebhookViolatesBackend
+  postCreateWebhookSuccess,
+  createWebhookViolatesBackend,
+  patchUpdateWebhookSuccess
 }

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -318,6 +318,14 @@ function validPatchMaskSecurityCodeRequest (mask) {
   }
 }
 
+function validPatchIntegrationVersion3dsRequest (version) {
+  return {
+    op: 'replace',
+    path: 'integration_version_3ds',
+    value: version
+  }
+}
+
 function validPatchGatewayCredentialsResponse (opts = {}) {
   const defaultCredentials = {
     username: 'a-username',
@@ -374,5 +382,6 @@ module.exports = {
   validPatchServiceNameRequest,
   validPatchMaskCardNumberRequest,
   validPatchMaskSecurityCodeRequest,
+  validPatchIntegrationVersion3dsRequest,
   validPostAccountSwitchPSPRequest
 }

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -302,6 +302,22 @@ function validPatchServiceNameRequest (serviceName) {
   }
 }
 
+function validPatchMaskCardNumberRequest (mask) {
+  return {
+    op: 'replace',
+    path: 'moto_mask_card_number_input',
+    value: mask
+  }
+}
+
+function validPatchMaskSecurityCodeRequest (mask) {
+  return {
+    op: 'replace',
+    path: 'moto_mask_card_security_code_input',
+    value: mask
+  }
+}
+
 function validPatchGatewayCredentialsResponse (opts = {}) {
   const defaultCredentials = {
     username: 'a-username',
@@ -356,5 +372,7 @@ module.exports = {
   validPatchGatewayCredentialsResponse,
   validPatchAccountGatewayAccountCredentialsStateRequest,
   validPatchServiceNameRequest,
+  validPatchMaskCardNumberRequest,
+  validPatchMaskSecurityCodeRequest,
   validPostAccountSwitchPSPRequest
 }

--- a/test/fixtures/worldpay-3ds-flex-credentials.fixtures.js
+++ b/test/fixtures/worldpay-3ds-flex-credentials.fixtures.js
@@ -36,9 +36,18 @@ function checkInvalidWorldpay3dsFlexCredentialsResponse (opts = {}) {
   }
 }
 
+function validUpdateWorldpay3dsCredentialsRequest(opts = {}) {
+  return {
+    organisational_unit_id: opts.organisational_unit_id || '5bd9b55e4444761ac0af1c80',
+    issuer: opts.issuer || '5bd9e0e4444dce153428c940', // pragma: allowlist secret
+    jwt_mac_key: opts.jwt_mac_key || 'fa2daee2-1fbb-45ff-4444-52805d5cd9e0'
+  }
+}
+
 module.exports = {
   checkValidWorldpay3dsFlexCredentialsRequest,
   checkValidWorldpay3dsFlexCredentialsResponse,
   checkInvalidWorldpay3dsFlexCredentialsRequest,
-  checkInvalidWorldpay3dsFlexCredentialsResponse
+  checkInvalidWorldpay3dsFlexCredentialsResponse,
+  validUpdateWorldpay3dsCredentialsRequest
 }


### PR DESCRIPTION
We are intending to change the default response when Mountebank does not match on a stub for a request from returning a 200 to returning a 404.

In order to do this, we need to setup some missing stubs for Cypress tests where we currently rely on the default behaviour of getting a 200 when there is no stub, as these tests would fail when the default is 404.

This PR adds missing stubs to several more Cypress tests and fixes some stubs which existed but weren't being successfully matched on.

