### PR TITLE
PP-10397 Change mountebank imposter default response

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -713,7 +713,7 @@
         "filename": "test/fixtures/gateway-account.fixtures.js",
         "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
         "is_verified": false,
-        "line_number": 274
+        "line_number": 290
       }
     ],
     "test/fixtures/invite.fixtures.js": [
@@ -903,5 +903,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-08T14:40:43Z"
+  "generated_at": "2023-01-09T14:21:20Z"
 }

--- a/test/cypress/integration/settings/allow-apple-pay.cy.test.js
+++ b/test/cypress/integration/settings/allow-apple-pay.cy.test.js
@@ -9,6 +9,7 @@ const serviceName = 'My Awesome Service'
 function setupStubs (allowApplePay) {
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName }),
+    gatewayAccountStubs.patchAccountUpdateApplePaySuccess(gatewayAccountId, true),
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
       gatewayAccountId,
       gatewayAccountExternalId,
@@ -17,7 +18,6 @@ function setupStubs (allowApplePay) {
     })
   ])
 }
-
 describe('Apple Pay', () => {
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('session', 'gateway_account')

--- a/test/cypress/integration/settings/allow-google-pay.cy.test.js
+++ b/test/cypress/integration/settings/allow-google-pay.cy.test.js
@@ -5,10 +5,13 @@ const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
 const gatewayAccountId = 42
 const gatewayAccountExternalId = 'a-valid-external-id'
 const serviceName = 'My Awesome Service'
+const credentialId = 1
 
 function setupStubs (allowGooglePay) {
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName }),
+    gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, credentialId),
+    gatewayAccountStubs.patchAccountUpdateGooglePayPaySuccess(gatewayAccountId, true),
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
       gatewayAccountId,
       gatewayAccountExternalId,

--- a/test/cypress/integration/settings/switch-psp.cy.test.js
+++ b/test/cypress/integration/settings/switch-psp.cy.test.js
@@ -171,22 +171,22 @@ describe('Switch PSP settings page', () => {
       beforeEach(() => {
         cy.task('setupStubs', [
           ...getUserAndAccountStubs('smartpay', true, [
-              {
-                payment_provider: 'smartpay',
-                state: 'ACTIVE',
-                id: currentCredentialId,
-                external_id: currentCredentialExternalId
-              },
-              {
-                payment_provider: 'worldpay',
-                state: 'ENTERED',
-                id: switchingToCredentialId,
-                external_id: switchingToCredentialExternalId
-              }
-            ],
-            null,
-            true,
-            2),
+            {
+              payment_provider: 'smartpay',
+              state: 'ACTIVE',
+              id: currentCredentialId,
+              external_id: currentCredentialExternalId
+            },
+            {
+              payment_provider: 'worldpay',
+              state: 'ENTERED',
+              id: switchingToCredentialId,
+              external_id: switchingToCredentialExternalId
+            }
+          ],
+          null,
+          true,
+          2),
           gatewayAccountStubs.postCheckWorldpay3dsFlexCredentials({
             gatewayAccountId: gatewayAccountId,
             result: 'valid',
@@ -224,22 +224,22 @@ describe('Switch PSP settings page', () => {
       it('should now be clickable and navigate to the verify PSP integration page', () => {
         cy.task('setupStubs', [
           ...getUserAndAccountStubs('smartpay', true, [
-              {
-                payment_provider: 'smartpay',
-                state: 'ACTIVE',
-                id: currentCredentialId,
-                external_id: currentCredentialExternalId
-              },
-              {
-                payment_provider: 'worldpay',
-                state: 'ENTERED',
-                id: switchingToCredentialId,
-                external_id: switchingToCredentialExternalId
-              }
-            ],
-            null,
-            true,
-            2)
+            {
+              payment_provider: 'smartpay',
+              state: 'ACTIVE',
+              id: currentCredentialId,
+              external_id: currentCredentialExternalId
+            },
+            {
+              payment_provider: 'worldpay',
+              state: 'ENTERED',
+              id: switchingToCredentialId,
+              external_id: switchingToCredentialExternalId
+            }
+          ],
+          null,
+          true,
+          2)
         ])
 
         cy.get('.app-task-list__item').contains('Make a live payment to test your Worldpay PSP').click()
@@ -250,22 +250,22 @@ describe('Switch PSP settings page', () => {
       it('should create a charge and continue to charges next url on success', () => {
         cy.task('setupStubs', [
           ...getUserAndAccountStubs('smartpay', true, [
-              {
-                payment_provider: 'smartpay',
-                state: 'ACTIVE',
-                id: currentCredentialId,
-                external_id: currentCredentialExternalId
-              },
-              {
-                payment_provider: 'worldpay',
-                state: 'ENTERED',
-                id: switchingToCredentialId,
-                external_id: switchingToCredentialExternalId
-              }
-            ],
-            null,
-            true,
-            2),
+            {
+              payment_provider: 'smartpay',
+              state: 'ACTIVE',
+              id: currentCredentialId,
+              external_id: currentCredentialExternalId
+            },
+            {
+              payment_provider: 'worldpay',
+              state: 'ENTERED',
+              id: switchingToCredentialId,
+              external_id: switchingToCredentialExternalId
+            }
+          ],
+          null,
+          true,
+          2),
           connectorChargeStubs.postCreateChargeSuccess({
             gateway_account_id: gatewayAccountId,
             charge_id: 'a-valid-charge-external-id',
@@ -281,22 +281,22 @@ describe('Switch PSP settings page', () => {
       it('returning with a failed payment should present an error', () => {
         cy.task('setupStubs', [
           ...getUserAndAccountStubs('smartpay', true, [
-              {
-                payment_provider: 'smartpay',
-                state: 'ACTIVE',
-                id: currentCredentialId,
-                external_id: currentCredentialExternalId
-              },
-              {
-                payment_provider: 'worldpay',
-                state: 'ENTERED',
-                id: switchingToCredentialId,
-                external_id: switchingToCredentialExternalId
-              }
-            ],
-            null,
-            true,
-            2),
+            {
+              payment_provider: 'smartpay',
+              state: 'ACTIVE',
+              id: currentCredentialId,
+              external_id: currentCredentialExternalId
+            },
+            {
+              payment_provider: 'worldpay',
+              state: 'ENTERED',
+              id: switchingToCredentialId,
+              external_id: switchingToCredentialExternalId
+            }
+          ],
+          null,
+          true,
+          2),
           connectorChargeStubs.getChargeSuccess({
             gateway_account_id: gatewayAccountId,
             charge_id: 'a-valid-charge-external-id',
@@ -313,22 +313,22 @@ describe('Switch PSP settings page', () => {
       it('returning with a successful payment should present completion message', () => {
         cy.task('setupStubs', [
           ...getUserAndAccountStubs('smartpay', true, [
-              {
-                payment_provider: 'smartpay',
-                state: 'ACTIVE',
-                id: currentCredentialId,
-                external_id: currentCredentialExternalId
-              },
-              {
-                payment_provider: 'worldpay',
-                state: 'VERIFIED_WITH_LIVE_PAYMENT',
-                id: switchingToCredentialId,
-                external_id: switchingToCredentialExternalId
-              }
-            ],
-            null,
-            true,
-            2),
+            {
+              payment_provider: 'smartpay',
+              state: 'ACTIVE',
+              id: currentCredentialId,
+              external_id: currentCredentialExternalId
+            },
+            {
+              payment_provider: 'worldpay',
+              state: 'VERIFIED_WITH_LIVE_PAYMENT',
+              id: switchingToCredentialId,
+              external_id: switchingToCredentialExternalId
+            }
+          ],
+          null,
+          true,
+          2),
           connectorChargeStubs.postCreateChargeSuccess({
             gateway_account_id: gatewayAccountId,
             charge_id: 'a-valid-charge-external-id',
@@ -353,22 +353,22 @@ describe('Switch PSP settings page', () => {
     describe('Switch PSP', () => {
       beforeEach(() => {
         let userAndAccountStubs = getUserAndAccountStubs('smartpay', true, [
-            {
-              payment_provider: 'smartpay',
-              state: 'ACTIVE',
-              id: currentCredentialId,
-              external_id: currentCredentialExternalId
-            },
-            {
-              payment_provider: 'worldpay',
-              state: 'VERIFIED_WITH_LIVE_PAYMENT',
-              id: switchingToCredentialId,
-              external_id: switchingToCredentialExternalId
-            }
-          ],
-          null,
-          true,
-          2)
+          {
+            payment_provider: 'smartpay',
+            state: 'ACTIVE',
+            id: currentCredentialId,
+            external_id: currentCredentialExternalId
+          },
+          {
+            payment_provider: 'worldpay',
+            state: 'VERIFIED_WITH_LIVE_PAYMENT',
+            id: switchingToCredentialId,
+            external_id: switchingToCredentialExternalId
+          }
+        ],
+        null,
+        true,
+        2)
         cy.task('setupStubs', [
           ...userAndAccountStubs,
           gatewayAccountStubs.postSwitchPspSuccess(gatewayAccountId)
@@ -385,22 +385,22 @@ describe('Switch PSP settings page', () => {
     describe('Switched PSP', () => {
       beforeEach(() => {
         cy.task('setupStubs', getUserAndAccountStubs('smartpay', true, [
-            {
-              payment_provider: 'smartpay',
-              state: 'ACTIVE',
-              external_id: 'a-valid-external-id-smartpay',
-              active_start_date: '2018-05-03T00:00:00.000Z'
-            },
-            {
-              payment_provider: 'worldpay',
-              state: 'RETIRED',
-              active_end_date: '2018-05-03T00:00:00.000Z',
-              external_id: 'a-valid-external-id-worldpay'
-            }
-          ],
-          null,
-          true,
-          2))
+          {
+            payment_provider: 'smartpay',
+            state: 'ACTIVE',
+            external_id: 'a-valid-external-id-smartpay',
+            active_start_date: '2018-05-03T00:00:00.000Z'
+          },
+          {
+            payment_provider: 'worldpay',
+            state: 'RETIRED',
+            active_end_date: '2018-05-03T00:00:00.000Z',
+            external_id: 'a-valid-external-id-worldpay'
+          }
+        ],
+        null,
+        true,
+        2))
       })
 
       it('sets transitioned text on the old psp page', () => {

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -40,6 +40,11 @@ module.exports = (on, config) => {
         body: {
           port: config.env.MOUNTEBANK_IMPOSTERS_PORT,
           protocol: 'http',
+          defaultResponse: {
+            statusCode: 404,
+            body: 'No stub predicate matches the request',
+            headers: {}
+          },
           stubs
         }
       })

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -212,7 +212,19 @@ function patchAccountEmailCollectionModeSuccess (opts) {
     request: gatewayAccountFixtures.validGatewayAccountEmailCollectionModeRequest('MANDATORY')
   })
 }
+function patchAccountUpdateApplePaySuccess (gatewayAccountId, allowApplePay) {
+  const path = `/v1/api/accounts/${gatewayAccountId}`
+  return stubBuilder('PATCH', path, 200, {
+    request: gatewayAccountFixtures.validUpdateToggleApplePayRequest(allowApplePay)
+  })
+}
 
+function patchAccountUpdateGooglePayPaySuccess (gatewayAccountId, allowGooglePay) {
+  const path = `/v1/api/accounts/${gatewayAccountId}`
+  return stubBuilder('PATCH', path, 200, {
+    request: gatewayAccountFixtures.validUpdateToggleGooglePayRequest(allowGooglePay)
+  })
+}
 function patchUpdateServiceNameSuccess (gatewayAccountId, serviceName) {
   const path = `/v1/frontend/accounts/${gatewayAccountId}/servicename`
   return stubBuilder('PATCH', path, 200, {
@@ -321,5 +333,7 @@ module.exports = {
   postUpdateWorldpay3dsFlexCredentials,
   patchUpdateCredentialsSuccess,
   postUpdateNotificationCredentialsSuccess,
-  postSwitchPspSuccess
+  postSwitchPspSuccess,
+  patchAccountUpdateApplePaySuccess,
+  patchAccountUpdateGooglePayPaySuccess
 }

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -144,6 +144,22 @@ function validGatewayAccountEmailRefundToggleRequest (enabled = true) {
   }
 }
 
+function validUpdateToggleApplePayRequest (allowApplePay) {
+  return {
+    op: 'replace',
+    path: 'allow_apple_pay',
+    value: allowApplePay
+  }
+}
+
+function validUpdateToggleGooglePayRequest (allowGooglePay) {
+  return {
+    op: 'replace',
+    path: 'allow_google_pay',
+    value: allowGooglePay
+  }
+}
+
 function validGatewayAccountEmailConfirmationToggleRequest (enabled = true) {
   return {
     op: 'replace',
@@ -383,5 +399,7 @@ module.exports = {
   validPatchMaskCardNumberRequest,
   validPatchMaskSecurityCodeRequest,
   validPatchIntegrationVersion3dsRequest,
-  validPostAccountSwitchPSPRequest
+  validPostAccountSwitchPSPRequest,
+  validUpdateToggleApplePayRequest,
+  validUpdateToggleGooglePayRequest
 }

--- a/test/fixtures/worldpay-3ds-flex-credentials.fixtures.js
+++ b/test/fixtures/worldpay-3ds-flex-credentials.fixtures.js
@@ -36,7 +36,7 @@ function checkInvalidWorldpay3dsFlexCredentialsResponse (opts = {}) {
   }
 }
 
-function validUpdateWorldpay3dsCredentialsRequest(opts = {}) {
+function validUpdateWorldpay3dsCredentialsRequest (opts = {}) {
   return {
     organisational_unit_id: opts.organisational_unit_id || '5bd9b55e4444761ac0af1c80',
     issuer: opts.issuer || '5bd9e0e4444dce153428c940', // pragma: allowlist secret


### PR DESCRIPTION
Return a 404 when no stub matches a predicate, rather than a 200.

This means that all requests to external services will need to be stubbed when previously we didn't have to when we just expected a success response and didn't rely on the response having a non-empty body.

Add missing stubs to the final tests where we were previously relying on the 200 default response from Mountebank where stubs weren't set up.


