### PR TITLE
PP-10355 redirect user when bank details complete

### DIFF
--- a/app/controllers/stripe-setup/bank-details/post.controller.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.js
@@ -63,7 +63,7 @@ module.exports = async (req, res, next) => {
     if (isSwitchingCredentials) {
       return res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
     } else if (enabledStripeOnboardingTaskList) {
-      return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account && req.account.external_id))
+      return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account && req.account.external_id, req.account.gateway_account_credentials[0].external_id))
     } else {
       return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account && req.account.external_id))
     }

--- a/app/controllers/stripe-setup/bank-details/post.controller.test.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.test.js
@@ -21,7 +21,10 @@ describe('Bank details post controller', () => {
       account: {
         gateway_account_id: '1',
         external_id: 'a-valid-external-id',
-        connectorGatewayAccountStripeProgress: {}
+        connectorGatewayAccountStripeProgress: {},
+        gateway_account_credentials: [
+          { external_id: 'a-valid-credential-external-id' }
+        ]
       },
       body: {
         'account-number': rawAccountNumber,
@@ -169,7 +172,7 @@ describe('Bank details post controller', () => {
 
     sinon.assert.calledWith(updateBankAccountMock)
     sinon.assert.calledWith(setStripeAccountSetupFlagMock)
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.yourPsp.index}`)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/your-psp/a-valid-credential-external-id`)
   })
 
   it('should redirect to add psp account details route when ENABLE_STRIPE_ONBOARDING_TASK_LIST is set to false ', async () => {
@@ -183,7 +186,7 @@ describe('Bank details post controller', () => {
 
     sinon.assert.calledWith(updateBankAccountMock)
     sinon.assert.calledWith(setStripeAccountSetupFlagMock)
-    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id${paths.account.stripe.addPspAccountDetails}`)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/stripe/add-psp-account-details`)
   })
 
   function getControllerWithMocks () {

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -14,7 +14,7 @@ const CHARGE_API_PATH = CHARGES_API_PATH + '/{chargeId}'
 const CHARGE_REFUNDS_API_PATH = CHARGE_API_PATH + '/refunds'
 const CARD_TYPES_API_PATH = '/v1/api/card-types'
 const STRIPE_ACCOUNT_SETUP_PATH = ACCOUNT_API_PATH + '/stripe-setup'
-const STRIPE_ACCOUNT_PATH = ACCOUNT_API_PATH + '/stripe-account'
+const STRIPE_ACCOUNT_PATH = '/v1/api/accounts/{accountId}/stripe-account'
 const SWITCH_PSP_PATH = ACCOUNT_API_PATH + '/switch-psp'
 
 const ACCOUNTS_FRONTEND_PATH = '/v1/frontend/accounts'

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -14,7 +14,7 @@ const CHARGE_API_PATH = CHARGES_API_PATH + '/{chargeId}'
 const CHARGE_REFUNDS_API_PATH = CHARGE_API_PATH + '/refunds'
 const CARD_TYPES_API_PATH = '/v1/api/card-types'
 const STRIPE_ACCOUNT_SETUP_PATH = ACCOUNT_API_PATH + '/stripe-setup'
-const STRIPE_ACCOUNT_PATH = '/v1/api/accounts/{accountId}/stripe-account'
+const STRIPE_ACCOUNT_PATH = ACCOUNT_API_PATH + '/stripe-account'
 const SWITCH_PSP_PATH = ACCOUNT_API_PATH + '/switch-psp'
 
 const ACCOUNTS_FRONTEND_PATH = '/v1/frontend/accounts'


### PR DESCRIPTION
## WHAT
Updated post controller so that when ENABLE_STRIPE_ONBOARDING_TASK_LIST flag is on and bank details are completed correctly it redirects to the task list page
Added cypress test for redirecting to task list when bank details are completed




