### PR TITLE
PP-10353 return user when service director task complete

### DIFF
--- a/app/controllers/stripe-setup/director/post.controller.js
+++ b/app/controllers/stripe-setup/director/post.controller.js
@@ -49,6 +49,7 @@ const validationRules = [
 
 module.exports = async function (req, res, next) {
   const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
+  const enabledStripeOnboardingTaskList = (process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST === 'true')
   const collectingAdditionalKycData = isAdditionalKycDataRoute(req)
   const currentCredential = getCurrentCredential(req.account)
 
@@ -104,6 +105,8 @@ module.exports = async function (req, res, next) {
 
       if (isSwitchingCredentials) {
         return res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
+      } else if (enabledStripeOnboardingTaskList) {
+        return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account && req.account.external_id, req.params && req.params.credentialId))
       } else if (collectingAdditionalKycData) {
         const taskListComplete = await isKycTaskListComplete(currentCredential)
         if (taskListComplete) {

--- a/app/controllers/stripe-setup/director/post.controller.test.js
+++ b/app/controllers/stripe-setup/director/post.controller.test.js
@@ -278,4 +278,39 @@ describe('Director POST controller', () => {
     const expectedError = sinon.match.instanceOf(Error)
     sinon.assert.calledWith(next, expectedError)
   })
+
+  it('should redirect to the task list page when ENABLE_STRIPE_ONBOARDING_TASK_LIST is set to true ', async function () {
+    process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
+
+    updateCompanyMock = sinon.spy(() => Promise.resolve())
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
+    const controller = getControllerWithMocks()
+
+    req.body = postBody
+    req.params = {
+      credentialId: 'a-valid-credential-external-id'
+    }
+
+    await controller(req, res, next)
+
+    sinon.assert.calledWith(updateCompanyMock)
+    sinon.assert.calledWith(setStripeAccountSetupFlagMock)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/your-psp/a-valid-credential-external-id`)
+  })
+
+  it('should redirect to add psp account details route when ENABLE_STRIPE_ONBOARDING_TASK_LIST is set to false ', async function () {
+    process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'false'
+
+    updateCompanyMock = sinon.spy(() => Promise.resolve())
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
+    const controller = getControllerWithMocks()
+
+    req.body = postBody
+
+    await controller(req, res, next)
+
+    sinon.assert.calledWith(updateCompanyMock)
+    sinon.assert.calledWith(setStripeAccountSetupFlagMock)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/stripe/add-psp-account-details`)
+  })
 })


### PR DESCRIPTION
- Updated post controller so that when ENABLE_STRIPE_ONBOARDING_TASK_LIST flag is on and service director task is  completed correctly it redirects to the task list page
- Updated unit tests accordingly



