### PR TITLE
PP-10351 return user when government entity document is submitted

### DIFF
--- a/app/controllers/stripe-setup/government-entity-document/post.controller.js
+++ b/app/controllers/stripe-setup/government-entity-document/post.controller.js
@@ -17,6 +17,7 @@ const GOVERNMENT_ENTITY_DOCUMENT_FIELD = 'government-entity-document'
 
 async function postGovernmentEntityDocument (req, res, next) {
   const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
+  const enabledStripeOnboardingTaskList = (process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST === 'true')
   const collectingAdditionalKycData = isAdditionalKycDataRoute(req)
   const currentCredential = getCurrentCredential(req.account)
 
@@ -60,6 +61,8 @@ async function postGovernmentEntityDocument (req, res, next) {
 
       if (isSwitchingCredentials) {
         return res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
+      } else if (enabledStripeOnboardingTaskList) {
+        return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account && req.account.external_id, req.params && req.params.credentialId))
       } else if (collectingAdditionalKycData) {
         const taskListComplete = await isKycTaskListComplete(currentCredential)
         if (taskListComplete) {

--- a/app/controllers/stripe-setup/government-entity-document/post.controller.test.js
+++ b/app/controllers/stripe-setup/government-entity-document/post.controller.test.js
@@ -304,4 +304,45 @@ describe('Government entity document POST controller', () => {
       sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/your-psp/credential-external-id`)
     })
   })
+
+  it('should redirect to the task list page when ENABLE_STRIPE_ONBOARDING_TASK_LIST is set to true ', async function () {
+    process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
+
+    uploadFileMock = sinon.spy(() => Promise.resolve({ id: 'file_id_123' }))
+    updateAccountMock = sinon.spy(() => Promise.resolve())
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
+
+    const controller = getControllerWithMocks()
+
+    req.params = {
+      credentialId: 'a-valid-credential-external-id'
+    }
+    req.file = { ...postBody }
+
+    await controller.postGovernmentEntityDocument(req, res, next)
+
+    sinon.assert.calledWith(uploadFileMock)
+    sinon.assert.calledWith(updateAccountMock)
+    sinon.assert.calledWith(setStripeAccountSetupFlagMock)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/your-psp/a-valid-credential-external-id`)
+  })
+
+  it('should redirect to add psp account details route when ENABLE_STRIPE_ONBOARDING_TASK_LIST is set to false ', async function () {
+    process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'false'
+
+    uploadFileMock = sinon.spy(() => Promise.resolve({ id: 'file_id_123' }))
+    updateAccountMock = sinon.spy(() => Promise.resolve())
+    setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
+
+    const controller = getControllerWithMocks()
+
+    req.file = { ...postBody }
+
+    await controller.postGovernmentEntityDocument(req, res, next)
+
+    sinon.assert.calledWith(uploadFileMock)
+    sinon.assert.calledWith(updateAccountMock)
+    sinon.assert.calledWith(setStripeAccountSetupFlagMock)
+    sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/stripe/add-psp-account-details`)
+  })
 })


### PR DESCRIPTION

- Updated government entity document's post controller so when ENABLE_STRIPE_ONBOARDING_TASK_LIST is set to true it redirects to task-list page
- Added unit test accordingly



