### PR TITLE
PP-8020 make clear to the service not to use a po box address

### DIFF
--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -96,7 +96,7 @@
         attributes: { 'data-cy': 'label-address-line-1' }
       },
       hint: {
-        text: "Enter the main building or office address"
+        text: "Cannot be a P.O. Box"
       },
       classes: "govuk-!-width-two-thirds",
       id: "address-line1",


### PR DESCRIPTION
## WHAT
- When a service goes live using Stripe, we send the service’s organisation address to Stripe. It turns out this has to be a physical address and cannot be a PO box.


