### PR TITLE
PP-8020 correct spelling of p.o. box

### DIFF
--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -96,7 +96,7 @@
         attributes: { 'data-cy': 'label-address-line-1' }
       },
       hint: {
-        text: "Cannot be a P.O. Box"
+        text: "Cannot be a PO Box"
       },
       classes: "govuk-!-width-two-thirds",
       id: "address-line1",


### PR DESCRIPTION
## WHAT
Correct spelling to PO Box, as per Style Guide (Do not use full stops in abbreviations: BBC, not B.B.C.)
