### PR TITLE
PP-10413 remove legacy url reformatting

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -488,23 +488,15 @@ module.exports.bind = function (app) {
 
   app.all('*', (req, res, next) => {
     if (accountUrls.isLegacyAccountsUrl(req.url)) {
+      logger.info('Accounts URL utility forwarding a legacy account URL', {
+        url: req.originalUrl,
+        session_has_user: !!req.user
+      })
       if (!req.user) {
         if (req.session) {
           req.session.last_url = req.url
         }
         res.redirect(user.logIn)
-        return
-      }
-
-      const currentSessionAccountExternalId = req.gateway_account && req.gateway_account.currentGatewayAccountExternalId
-      if (currentSessionAccountExternalId) {
-        const upgradedPath = accountUrls.getUpgradedAccountStructureUrl(req.url, currentSessionAccountExternalId)
-        logger.info('Accounts URL utility upgraded a request to a legacy account URL', {
-          url: req.originalUrl,
-          redirected_url: upgradedPath,
-          session_has_user: !!req.user
-        })
-        res.redirect(upgradedPath)
         return
       }
 

--- a/app/utils/gateway-account-urls.js
+++ b/app/utils/gateway-account-urls.js
@@ -2,9 +2,7 @@
 // check if a missed URL (404) is a URL that has been upgraded during the
 // account URL structure change. When this utility is reporting few or no
 // upgrades it can be removed
-const urlJoin = require('url-join')
 const paths = require('../paths')
-const formattedPathFor = require('./replace-params-in-path')
 const flattenNestedValues = require('./flatten-nested-values')
 
 // only flatten paths once given the singleton module export patten, these
@@ -41,12 +39,6 @@ function isLegacyAccountsUrl (targetUrl) {
   }
 }
 
-function getUpgradedAccountStructureUrl (url, gatewayAccountExternalId) {
-  const base = formattedPathFor(paths.account.root, gatewayAccountExternalId)
-  return urlJoin(base, url)
-}
-
 module.exports = {
-  isLegacyAccountsUrl,
-  getUpgradedAccountStructureUrl
+  isLegacyAccountsUrl
 }

--- a/app/utils/gateway-account-urls.js.test.js
+++ b/app/utils/gateway-account-urls.js.test.js
@@ -13,10 +13,4 @@ describe('account URL checker', () => {
     const result = accountsUrl.isLegacyAccountsUrl(url)
     expect(result).to.be.true //eslint-disable-line
   })
-
-  it('correctly upgrades a URL to the account structure', () => {
-    const url = '/create-payment-link/manage/some-product-external-id/add-reporting-column/some-metadata-key'
-    const gatewayAccountExternalId = 'some-account-external-id'
-    expect(accountsUrl.getUpgradedAccountStructureUrl(url, gatewayAccountExternalId)).to.equal('/account/some-account-external-id/create-payment-link/manage/some-product-external-id/add-reporting-column/some-metadata-key')
-  })
 })


### PR DESCRIPTION
## WHAT
Since we no longer use gateway account cookie we don't reformat legacy urls. Instead we redirect the user to the `My services` page.
- removing reformatting, leaving redirect only.

