### PR TITLE
Pp 10351 return user when government entity document complete cypress test

### DIFF
--- a/app/controllers/stripe-setup/government-entity-document/post.controller.js
+++ b/app/controllers/stripe-setup/government-entity-document/post.controller.js
@@ -47,7 +47,6 @@ async function postGovernmentEntityDocument (req, res, next) {
   } else {
     try {
       const stripeAccountId = await getStripeAccountId(req.account, isSwitchingCredentials)
-
       const stripeFile = await uploadFile(`entity_document_for_account_${req.account.gateway_account_id}`, file.mimetype, file.buffer)
       await updateAccount(stripeAccountId, { entity_verification_document_id: stripeFile.id })
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -7,7 +7,7 @@ module.exports = defineConfig({
     TEST_SESSION_ENCRYPTION_KEY:
       'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk',
     MOUNTEBANK_URL: 'http://localhost:2525',
-    MOUNTEBANK_IMPOSTERS_PORT: 8000,
+    MOUNTEBANK_IMPOSTERS_PORT: 8000
   },
   fileServerFolder: './test/cypress',
   screenshotsFolder: './test/cypress/screenshots',
@@ -16,11 +16,11 @@ module.exports = defineConfig({
   e2e: {
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
-    setupNodeEvents(on, config) {
+    setupNodeEvents (on, config) {
       return require('./test/cypress/plugins')(on, config)
     },
     baseUrl: 'http://localhost:3000',
     specPattern: './test/cypress/integration/**/*.cy.{js,jsx,ts,tsx}',
-    supportFile: './test/cypress/support',
-  },
+    supportFile: './test/cypress/support'
+  }
 })

--- a/test/cypress/integration/settings/your-psp-stripe-tasklist.cy.js
+++ b/test/cypress/integration/settings/your-psp-stripe-tasklist.cy.js
@@ -116,22 +116,6 @@ describe('Your PSP Stripe page', () => {
     cy.get('span').contains('Government entity document').should('not.have.attr', 'href')
   })
 
-  it('should have government entity document hyperlinked when all other tasks are complete', () => {
-    setupYourPspStubs({
-      bankAccount: true,
-      director: true,
-      vatNumber: true,
-      companyNumber: true,
-      responsiblePerson: true,
-      organisationDetails: true,
-      governmentEntityDocument: false
-    })
-
-    cy.setEncryptedCookies(userExternalId)
-    cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-    cy.get('span').contains('Government entity document').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/government-entity-document`)
-  })
-
   describe('Bank details task', () => {
     it('should click bank details task and redirect to task list when valid bank details is submitted', () => {
       setupYourPspStubs()
@@ -259,6 +243,26 @@ describe('Your PSP Stripe page', () => {
       cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
       cy.get('span').contains('Responsible person').should('not.have.attr', 'href')
       cy.get('strong[id="task-sro-status"]').should('contain', 'complete')
+    })
+  })
+
+  describe('Government entity task', () => {
+    it('should have Government entity document hyperlinked  when all other tasks are complete and should click Government entity task and display the correct page', () => {
+      setupYourPspStubs({
+        bankAccount: true,
+        director: true,
+        vatNumber: true,
+        companyNumber: true,
+        responsiblePerson: true,
+        organisationDetails: true,
+        governmentEntityDocument: false
+      })
+
+      cy.setEncryptedCookies(userExternalId)
+      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+      cy.get('span').contains('Government entity document').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/government-entity-document`)
+      cy.get('span').contains('Government entity document').click()
+      cy.get('h1').contains('Upload a government entity document')
     })
   })
 })


### PR DESCRIPTION
PP-10351 Check Government entity task page is correctly displayed after completing all other tasks

- Context: Originally we were meant to test that the user  is redirected to the task-list page after uploading correct document. However, this has become difficult as we need to stub out the stripe api to upload a file. This requires a lot of work and is currently complex to do. We do have a unit test that does redirect when correct document is passed. There will be a ticket created in the epic for later to test this part in the integration test.

- Update cypress test for Government entity task to be displayed correctly when all other tasks are completed.

