### PR TITLE
PP-10697: Use GITHUB_OUTPUT to store env var rather than GITHUB_STATE

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,7 +55,7 @@ jobs:
           restore-keys: ${{ runner.os }}-node-
       - name: Parse Cypress version
         id: parse-cypress-version
-        run: echo "CYPRESS_VERSION=$(jq -r '.devDependencies.cypress' package.json)" >> $GITHUB_STATE
+        run: echo "CYPRESS_VERSION=$(jq -r '.devDependencies.cypress' package.json)" >> $GITHUB_OUTPUT
       - name: Cache Cypress
         uses: actions/cache@136d96b4aee02b1f0de3ba493b1d47135042d9c0
         with:
@@ -118,7 +118,7 @@ jobs:
           key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}
       - name: Parse Cypress version
         id: parse-cypress-version
-        run: echo "CYPRESS_VERSION=$(jq -r '.devDependencies.cypress' package.json)" >> $GITHUB_STATE
+        run: echo "CYPRESS_VERSION=$(jq -r '.devDependencies.cypress' package.json)" >> $GITHUB_OUTPUT
       - name: Cache Cypress
         uses: actions/cache@136d96b4aee02b1f0de3ba493b1d47135042d9c0
         with:


### PR DESCRIPTION
## WHAT
Fixes the caching steps for the Cypress tests.

Thanks @stephencdaly for spotting this.
