### PR TITLE
 PP-10342 add back link for all tasks to redirect to task list page cypress test

### DIFF
--- a/test/cypress/integration/stripe-setup/bank-details.cy.js
+++ b/test/cypress/integration/stripe-setup/bank-details.cy.js
@@ -66,6 +66,11 @@ describe('Stripe setup: bank details page', () => {
           })
       })
 
+      it('should have a back link that redirects back to tasklist page', () => {
+        cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
+        cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+      })
+
       it('should display an error when all fields are blank', () => {
         cy.get('#bank-details-form > button').click()
 

--- a/test/cypress/integration/stripe-setup/check-org-details.cy.js
+++ b/test/cypress/integration/stripe-setup/check-org-details.cy.js
@@ -93,6 +93,11 @@ describe('Stripe setup: Check your organisation’s details', () => {
         })
     })
 
+    it('should have a back link that redirects back to tasklist page', () => {
+      cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
+      cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+    })
+
     it('should display the account sub nav', () => {
       cy.get('[data-cy=account-sub-nav]')
         .should('exist')

--- a/test/cypress/integration/stripe-setup/company-number.cy.js
+++ b/test/cypress/integration/stripe-setup/company-number.cy.js
@@ -66,6 +66,11 @@ describe('Stripe setup: company number page', () => {
           })
       })
 
+      it('should have a back link that redirects back to tasklist page', () => {
+        cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
+        cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+      })
+
       it('should display an error when no options are selected', () => {
         cy.get('#company-number-form > button').click()
 

--- a/test/cypress/integration/stripe-setup/director.cy.js
+++ b/test/cypress/integration/stripe-setup/director.cy.js
@@ -120,6 +120,11 @@ describe('Stripe setup: director page', () => {
         })
     })
 
+    it('should have a back link that redirects back to tasklist page', () => {
+      cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
+      cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+    })
+
     it('should show errors when validation fails', () => {
       cy.get('#director-form').within(() => {
         cy.get('#dob-day').type('29')

--- a/test/cypress/integration/stripe-setup/government-entity-document.cy.js
+++ b/test/cypress/integration/stripe-setup/government-entity-document.cy.js
@@ -72,6 +72,11 @@ describe('Stripe setup: Government entity document', () => {
         })
     })
 
+    it('should have a back link that redirects back to tasklist page', () => {
+      cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
+      cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+    })
+
     it('should display an error when file is not selected', () => {
       cy.get('#government-entity-document-form > button').click()
 

--- a/test/cypress/integration/stripe-setup/responsible-person.cy.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.js
@@ -92,6 +92,11 @@ describe('Stripe setup: responsible person page', () => {
         })
     })
 
+    it('should have a back link that redirects back to tasklist page', () => {
+      cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
+      cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+    })
+
     it('should show errors when validation fails', () => {
       cy.get('#responsible-person-form').within(() => {
         cy.get('#home-address-postcode').type('1')

--- a/test/cypress/integration/stripe-setup/vat-number.cy.js
+++ b/test/cypress/integration/stripe-setup/vat-number.cy.js
@@ -68,6 +68,11 @@ describe('Stripe setup: VAT number page', () => {
           })
       })
 
+      it('should have a back link that redirects back to tasklist page', () => {
+        cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
+        cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+      })
+
       it('should display an error when VAT number input is blank', () => {
         cy.get('input#have-vat-number').click()
         cy.get('#vat-number-form > button').click()


### PR DESCRIPTION
- Updated Cypress test for all seven tasks to test for a bank-link that redirects to task-list when ENABLE_STRIPE_ONBOARDING_TASK_LIST is true



