### PR TITLE
 PP-10331 add side navigation for stripe task list

### DIFF
--- a/app/utils/credentials.js
+++ b/app/utils/credentials.js
@@ -74,7 +74,8 @@ function getPSPPageLinks (gatewayAccount) {
   const supportedYourPSPPageProviders = ['worldpay', 'smartpay', 'epdq']
 
   if (gatewayAccount.requires_additional_kyc_data ||
-    (gatewayAccount.connectorGatewayAccountStripeProgress && gatewayAccount.connectorGatewayAccountStripeProgress.additionalKycData)) {
+    (gatewayAccount.connectorGatewayAccountStripeProgress && gatewayAccount.connectorGatewayAccountStripeProgress.additionalKycData) ||
+    process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST === 'true') {
     supportedYourPSPPageProviders.push('stripe')
   }
 

--- a/app/utils/credentials.test.js
+++ b/app/utils/credentials.test.js
@@ -213,6 +213,10 @@ describe('credentials utility', () => {
   })
 
   describe('getPSPPageLinks', () => {
+    afterEach(() => {
+      process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = undefined
+    })
+
     it('should return credential for stripe account when requires_additional_kyc_data is enabled for gateway account', () => {
       const account = gatewayAccountFixtures.validGatewayAccount({
         requires_additional_kyc_data: true,
@@ -231,6 +235,48 @@ describe('credentials utility', () => {
         ]
       })
       expect(getPSPPageLinks(account)).to.have.length(0)
+    })
+
+    it('should return credential for stripe account when ENABLE_STRIPE_ONBOARDING_TASK_LIST is enabled for gateway account', () => {
+      process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
+      const account = gatewayAccountFixtures.validGatewayAccount({
+        gateway_account_credentials: [
+          { state: 'ACTIVE', payment_provider: 'stripe', id: 20 }
+        ]
+      })
+      expect(getPSPPageLinks(account)).to.have.length(1)
+    })
+
+    it('should not return credential for stripe account when ENABLE_STRIPE_ONBOARDING_TASK_LIST is not enabled on gateway account', () => {
+      process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'false'
+      const account = gatewayAccountFixtures.validGatewayAccount({
+        gateway_account_credentials: [
+          { state: 'ACTIVE', payment_provider: 'stripe', id: 20 }
+        ]
+      })
+      expect(getPSPPageLinks(account)).to.have.length(0)
+    })
+
+    it('should not return credential for stripe account when ENABLE_STRIPE_ONBOARDING_TASK_LIST and requires_additional_kyc_data is not enabled on gateway account', () => {
+      process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'false'
+      const account = gatewayAccountFixtures.validGatewayAccount({
+        requires_additional_kyc_data: false,
+        gateway_account_credentials: [
+          { state: 'ACTIVE', payment_provider: 'stripe', id: 20 }
+        ]
+      })
+      expect(getPSPPageLinks(account)).to.have.length(0)
+    })
+
+    it('should return credential for stripe account when ENABLE_STRIPE_ONBOARDING_TASK_LIST and requires_additional_kyc_data is enabled on gateway account', () => {
+      process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
+      const account = gatewayAccountFixtures.validGatewayAccount({
+        requires_additional_kyc_data: true,
+        gateway_account_credentials: [
+          { state: 'ACTIVE', payment_provider: 'stripe', id: 20 }
+        ]
+      })
+      expect(getPSPPageLinks(account)).to.have.length(1)
     })
   })
 

--- a/app/utils/nav-builder.js
+++ b/app/utils/nav-builder.js
@@ -130,14 +130,24 @@ function yourPSPNavigationItems (account, currentPath = '') {
   const credentialsToLink = getPSPPageLinks(account)
   const isSingleCredential = credentialsToLink.length === 1
   return credentialsToLink.map((credential) => {
-    const prefix = credential.state === CREDENTIAL_STATE.RETIRED ? 'Old PSP' : 'Your PSP'
+    const navName = getPSPNavigationName(credential)
     return {
       id: (credential.state === CREDENTIAL_STATE.ACTIVE) || isSingleCredential ? 'navigation-menu-your-psp' : `navigation-menu-your-psp-${credential.external_id}`,
-      name: `${prefix} - ${formatPSPname(credential.payment_provider)}`,
+      name: navName,
       url: formatAccountPathsFor(paths.account.yourPsp.index, account.external_id, credential.external_id),
       current: currentPath.includes(credential.external_id)
     }
   })
+}
+
+function getPSPNavigationName (credential) {
+  if (credential.state === CREDENTIAL_STATE.RETIRED) {
+    return `Old PSP - ${formatPSPname(credential.payment_provider)}`
+  } else if ((process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST === 'true') && (credential.payment_provider === 'stripe'))  {
+    return 'Information for Stripe'
+  } else {
+    return `Your PSP - ${formatPSPname(credential.payment_provider)}`
+  }
 }
 
 module.exports = {

--- a/app/utils/nav-builder.test.js
+++ b/app/utils/nav-builder.test.js
@@ -4,31 +4,123 @@ const { yourPSPNavigationItems } = require('./nav-builder')
 
 describe('navigation builder', () => {
   describe('build links to psp pages', () => {
-    it('sets the default ID for a single credential regardless of state', () => {
-      const account = gatewayAccountFixtures.validGatewayAccount({
-        gateway_account_credentials: [
-          { payment_provider: 'smartpay', state: 'CREATED', external_id: 'a-valid-credential-id-smartpay' }
-        ]
+    describe('single credentials', () => {
+      afterEach(() => {
+        process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = undefined
       })
-      expect(yourPSPNavigationItems(account)[0].id).to.equal('navigation-menu-your-psp')
+
+      it('correctly labels ids and names and returns valid schema when there is only a smartpay credential', () => {
+        const account = gatewayAccountFixtures.validGatewayAccount({
+          gateway_account_credentials: [
+            { payment_provider: 'smartpay', state: 'ACTIVE', external_id: 'a-valid-credential-id-smartpay' }
+          ]
+        })
+
+        const links = yourPSPNavigationItems(account, '/your-psp/a-valid-credential-id-smartpay')
+        expect(links).to.have.length(1)
+        expect(links[0].id).to.equal('navigation-menu-your-psp')
+        expect(links[0].name).to.equal('Your PSP - Smartpay')
+        expect(links[0].current).to.equal(true)
+      })
+
+      it('correctly labels ids and names and returns valid schema when there is only a WorldPay credentials and ENABLE_STRIPE_ONBOARDING_TASK_LIST is true', () => {
+        process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
+        const account = gatewayAccountFixtures.validGatewayAccount({
+          gateway_account_credentials: [
+            { payment_provider: 'worldpay', state: 'ACTIVE', external_id: 'a-valid-credential-id-smartpay' }
+          ]
+        })
+
+        const links = yourPSPNavigationItems(account, '/your-psp/a-valid-credential-id-smartpay')
+        expect(links).to.have.length(1)
+        expect(links[0].name).to.equal('Your PSP - Worldpay')
+        expect(links[0].current).to.equal(true)
+      })
+
+      it('correctly labels ids and names and returns valid schema, when there is a Stripe KYC credential only', () => {
+        const account = gatewayAccountFixtures.validGatewayAccount({
+          requires_additional_kyc_data: true,
+          gateway_account_credentials: [
+            { payment_provider: 'stripe', state: 'ACTIVE', external_id: 'a-valid-credential-id-smartpay' }
+          ]
+        })
+
+        const links = yourPSPNavigationItems(account, '/your-psp/a-valid-credential-id-smartpay')
+        expect(links).to.have.length(1)
+        expect(links[0].name).to.equal('Your PSP - Stripe')
+        expect(links[0].current).to.equal(true)
+      })
+
+      it('correctly labels ids and names and returns valid schema when Stripe and ENABLE_STRIPE_ONBOARDING_TASK_LIST is true', () => {
+        process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
+        const account = gatewayAccountFixtures.validGatewayAccount({
+          gateway_account_credentials: [
+            { payment_provider: 'stripe', state: 'ACTIVE', external_id: 'a-valid-credential-id-smartpay' }
+          ]
+        })
+
+        const links = yourPSPNavigationItems(account, '/your-psp/a-valid-credential-id-smartpay')
+        expect(links).to.have.length(1)
+        expect(links[0].name).to.equal('Information for Stripe')
+        expect(links[0].current).to.equal(true)
+      })
     })
 
-    it('correctly labels ids and names and returns valid schema', () => {
-      const account = gatewayAccountFixtures.validGatewayAccount({
-        gateway_account_credentials: [
-          { payment_provider: 'smartpay', state: 'ACTIVE', external_id: 'a-valid-credential-id-smartpay' },
-          { payment_provider: 'worldpay', state: 'RETIRED', external_id: 'another-valid-credential-id-worldpay' }
-        ]
+    describe('switching credentials', () => {
+      afterEach(() => {
+        process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = undefined
       })
 
-      const links = yourPSPNavigationItems(account, '/your-psp/a-valid-credential-id-smartpay')
-      expect(links).to.have.length(2)
-      expect(links[0].id).to.equal('navigation-menu-your-psp')
-      expect(links[0].name).to.equal('Your PSP - Smartpay')
-      expect(links[0].current).to.equal(true)
-      expect(links[1].id).to.equal('navigation-menu-your-psp-another-valid-credential-id-worldpay')
-      expect(links[1].name).to.equal('Old PSP - Worldpay')
-      expect(links[1].current).to.equal(false)
+      it('correctly labels ids and names and returns valid schema', () => {
+        const account = gatewayAccountFixtures.validGatewayAccount({
+          gateway_account_credentials: [
+            { payment_provider: 'smartpay', state: 'ACTIVE', external_id: 'a-valid-credential-id-smartpay' },
+            { payment_provider: 'worldpay', state: 'RETIRED', external_id: 'another-valid-credential-id-worldpay' }
+          ]
+        })
+
+        const links = yourPSPNavigationItems(account, '/your-psp/a-valid-credential-id-smartpay')
+        expect(links).to.have.length(2)
+        expect(links[0].name).to.equal('Your PSP - Smartpay')
+        expect(links[0].current).to.equal(true)
+        expect(links[1].name).to.equal('Old PSP - Worldpay')
+        expect(links[1].current).to.equal(false)
+      })
+
+      it('correctly labels ids and names and returns valid schema, when requires_additional_kyc_data enabled', () => {
+        const account = gatewayAccountFixtures.validGatewayAccount({
+          requires_additional_kyc_data: true,
+          gateway_account_credentials: [
+            { payment_provider: 'stripe', state: 'ACTIVE', external_id: 'a-valid-credential-id-smartpay' },
+            { payment_provider: 'worldpay', state: 'RETIRED', external_id: 'another-valid-credential-id-worldpay' }
+          ]
+        })
+
+        const links = yourPSPNavigationItems(account, '/your-psp/a-valid-credential-id-smartpay')
+        expect(links).to.have.length(2)
+        expect(links[0].name).to.equal('Your PSP - Stripe')
+        expect(links[0].current).to.equal(true)
+        expect(links[1].name).to.equal('Old PSP - Worldpay')
+        expect(links[1].current).to.equal(false)
+      })
+
+      it('correctly labels ids and names and returns valid schema, when  ENABLE_STRIPE_ONBOARDING_TASK_LIST is true', () => {
+        process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
+        const account = gatewayAccountFixtures.validGatewayAccount({
+          requires_additional_kyc_data: true,
+          gateway_account_credentials: [
+            { payment_provider: 'stripe', state: 'ACTIVE', external_id: 'a-valid-credential-id-smartpay' },
+            { payment_provider: 'worldpay', state: 'RETIRED', external_id: 'another-valid-credential-id-worldpay' }
+          ]
+        })
+
+        const links = yourPSPNavigationItems(account, '/your-psp/a-valid-credential-id-smartpay')
+        expect(links).to.have.length(2)
+        expect(links[0].name).to.equal('Information for Stripe')
+        expect(links[0].current).to.equal(true)
+        expect(links[1].name).to.equal('Old PSP - Worldpay')
+        expect(links[1].current).to.equal(false)
+      })
     })
   })
 })

--- a/test/cypress/integration/settings/your-psp-stripe-kyc.cy.js
+++ b/test/cypress/integration/settings/your-psp-stripe-kyc.cy.js
@@ -87,11 +87,11 @@ describe('Your PSP - Stripe - KYC', () => {
   })
 
   describe('Task list', () => {
-    it('should display link to "Your PSP - Stripe" in the side navigation - when requires additional kyc data is enabled', () => {
+    it('should display link to "Information for Stripe" in the side navigation - when requires additional kyc data is enabled', () => {
       setupYourPspStubs({})
       cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Stripe')
+      cy.get('#navigation-menu-your-psp').should('contain', 'Information for Stripe')
     })
 
     it('should display responsible person task as COMPLETED if details are updated on Stripe', () => {
@@ -102,7 +102,7 @@ describe('Your PSP - Stripe - KYC', () => {
       })
       cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Stripe')
+      cy.get('#navigation-menu-your-psp').should('contain', 'Information for Stripe')
 
       cy.get('h2').contains('Know your customer (KYC) details').should('exist')
       cy.get('p').contains('Please review the responsible person').should('not.exist')
@@ -116,7 +116,7 @@ describe('Your PSP - Stripe - KYC', () => {
       })
       cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Stripe')
+      cy.get('#navigation-menu-your-psp').should('contain', 'Information for Stripe')
 
       cy.get('#task-add-director-status').should('have.html', 'completed')
     })
@@ -126,7 +126,7 @@ describe('Your PSP - Stripe - KYC', () => {
       })
       cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Stripe')
+      cy.get('#navigation-menu-your-psp').should('contain', 'Information for Stripe')
 
       cy.get('#task-organisation-url-status').should('have.html', 'completed')
     })
@@ -136,7 +136,7 @@ describe('Your PSP - Stripe - KYC', () => {
       })
       cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Stripe')
+      cy.get('#navigation-menu-your-psp').should('contain', 'Information for Stripe')
 
       cy.get('#task-upload-government-entity-document-status').should('have.html', 'completed')
     })
@@ -178,7 +178,7 @@ describe('Your PSP - Stripe - KYC', () => {
       cy.get('p').contains('Please review the responsible person')
 
       cy.get('.settings-navigation').within(() => {
-        cy.get('a').contains('Your PSP - Stripe').should('exist')
+        cy.get('a').contains('Information for Stripe').should('exist')
       })
     })
   })


### PR DESCRIPTION
    - For Stripe settings page:
      - When Stripe task-list flag is enabled, show 'Information for Stripe' in the side navigation.
      - Otherwise leave it 'Your PSP - Stripe'
    - Update the existing `Stripe KYC tests` - to check for the new name side navigation name - `Information for Stripe`.

