### PR TITLE
PP-10805 Send account id when getting agreements

### DIFF
--- a/app/controllers/agreements/agreements.controller.js
+++ b/app/controllers/agreements/agreements.controller.js
@@ -19,7 +19,7 @@ async function listAgreements (req, res, next) {
   req.session.agreementsFilter = url.parse(req.url).query
 
   try {
-    const agreements = await agreementsService.agreements(req.service.externalId, req.isLive, page, filters)
+    const agreements = await agreementsService.agreements(req.service.externalId, req.isLive, req.account.gateway_account_id, page, filters)
 
     response(req, res, 'agreements/list', {
       agreements,

--- a/app/controllers/agreements/agreements.controller.test.js
+++ b/app/controllers/agreements/agreements.controller.test.js
@@ -5,6 +5,7 @@ const proxyquire = require('proxyquire')
 const { expect } = require('chai')
 
 const serviceFixtures = require('../../../test/fixtures/service.fixtures')
+const gatewayAccountFixtures = require('../../../test/fixtures/gateway-account.fixtures')
 const agreementFixtures = require('../../../test/fixtures/agreement.fixtures')
 const Service = require('../../models/Service.class')
 const { RESTClientError, NotFoundError } = require('../../errors')
@@ -13,6 +14,7 @@ const agreements = agreementFixtures.validAgreementSearchResponse([{ reference: 
 const responseSpy = sinon.spy()
 
 const service = new Service(serviceFixtures.validServiceResponse())
+const account = gatewayAccountFixtures.validGatewayAccountResponse()
 let req, res, next
 
 describe('The agreements controller', () => {
@@ -22,6 +24,7 @@ describe('The agreements controller', () => {
       url: 'http://selfservice/agreements',
       isLive: true,
       service,
+      account,
       session: {}
     }
     res = {}
@@ -43,7 +46,7 @@ describe('The agreements controller', () => {
         status: 'a-status',
         reference: 'a ref'
       }
-      sinon.assert.calledWith(getAgreementsSpy, service.externalId, true, 1, expectedFilters)
+      sinon.assert.calledWith(getAgreementsSpy, service.externalId, true, account.gateway_account_id, 1, expectedFilters)
       sinon.assert.calledWith(responseSpy, req, res, 'agreements/list', {
         agreements,
         filters: expectedFilters

--- a/app/controllers/agreements/agreements.service.js
+++ b/app/controllers/agreements/agreements.service.js
@@ -12,8 +12,8 @@ function formatAgreementPages (agreementSearchResponse) {
   return { total, page, links, results }
 }
 
-async function agreements (serviceId, live, page = 1, filters = {}) {
-  const agreementSearchResponse = await Ledger.agreements(serviceId, live, page, { filters })
+async function agreements (serviceId, live, accountId, page = 1, filters = {}) {
+  const agreementSearchResponse = await Ledger.agreements(serviceId, live, accountId, page, { filters })
   return formatAgreementPages(agreementSearchResponse)
 }
 

--- a/app/controllers/agreements/agreements.service.test.js
+++ b/app/controllers/agreements/agreements.service.test.js
@@ -35,9 +35,10 @@ describe('agreements service', () => {
 
       const spy = sinon.spy(async () => agreementsResult)
       const service = getAgreementsService({ agreements: spy })
-      const result = await service.agreements('service-id', true)
+      const accountId = 42
+      const result = await service.agreements('service-id', true, accountId)
 
-      sinon.assert.calledWith(spy, 'service-id', true, 1)
+      sinon.assert.calledWith(spy, 'service-id', true, accountId, 1)
 
       expect(result.total).to.equal(21)
       expect(result.links.length).to.equal(3)

--- a/app/services/clients/ledger.client.js
+++ b/app/services/clients/ledger.client.js
@@ -121,14 +121,19 @@ const payouts = function payouts (gatewayAccountIds = [], page = 1, displaySize,
   return baseClient.get(configuration)
 }
 
-// agreements use new tuple of service identifier and live flag in favour of
-// internal connector gateway accounts
-const agreements = function agreements (serviceId, live, page = 1, options = {}) {
+/**
+ * The intention is that in the future, getting agreements will use a tuple of service id and live flag, in favour of
+ * the internal gateway account ID. However, this requires having a maximum of 1 test gateway account per service, which
+ * we haven't realised yet. For now, we additionally send the gateway account ID but the intention is to remove the need
+ * to send this.
+ */
+const agreements = function agreements (serviceId, live, accountId, page = 1, options = {}) {
   const config = {
     url: '/v1/agreement',
     qs: {
       service_id: serviceId,
       live,
+      account_id: accountId,
       page,
       ...options.filters
     },

--- a/test/cypress/integration/agreements/agreements.cy.js
+++ b/test/cypress/integration/agreements/agreements.cy.js
@@ -10,14 +10,23 @@ const serviceExternalId = 'service-id'
 
 const userAndGatewayAccountStubs = [
   userStubs.getUserSuccess({ userExternalId, serviceExternalId, gatewayAccountId }),
-  gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, serviceExternalId, recurringEnabled: true })
+  gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+    gatewayAccountId,
+    gatewayAccountExternalId,
+    serviceExternalId,
+    recurringEnabled: true
+  })
 ]
 
 const mockAgreements = [
   { external_id: 'a-valid-agreement-id', payment_instrument: false, status: 'CREATED' },
   { external_id: 'qgj1709v8t5mtlhd732otv19b1', payment_instrument: { card_details: { card_brand: 'visa' } } },
   { external_id: '3sfh76mobld3tc87lc608q667b', payment_instrument: { card_details: { card_brand: 'master-card' } } },
-  { external_id: 'm0spc7kmbo2ihlg602r9klgiqj', status: 'CANCELLED', payment_instrument: { card_details: { card_brand: 'american-express' } } },
+  {
+    external_id: 'm0spc7kmbo2ihlg602r9klgiqj',
+    status: 'CANCELLED',
+    payment_instrument: { card_details: { card_brand: 'american-express' } }
+  },
   { external_id: 'a-valid-agreement-id-1', payment_instrument: { card_details: { card_brand: 'visa' } } },
   { external_id: 'a-valid-agreement-id-2', payment_instrument: { card_details: { card_brand: 'visa' } } },
   { external_id: 'a-valid-agreement-id-3', payment_instrument: { card_details: { card_brand: 'visa' } } },
@@ -51,7 +60,12 @@ describe('Agreements', () => {
 
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
-      agreementStubs.getLedgerAgreementsSuccess({ service_id: serviceExternalId, live: false, agreements: mockAgreements })
+      agreementStubs.getLedgerAgreementsSuccess({
+        service_id: serviceExternalId,
+        live: false,
+        gatewayAccountId,
+        agreements: mockAgreements
+      })
     ])
 
     cy.visit('/test/service/service-id/account/gateway-account-id/agreements')
@@ -65,7 +79,13 @@ describe('Agreements', () => {
   it('should set and persist filters', () => {
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
-      agreementStubs.getLedgerAgreementsSuccess({ service_id: serviceExternalId, live: false, agreements: mockAgreements, filters: { status: statusFilter, reference: referenceFilter } })
+      agreementStubs.getLedgerAgreementsSuccess({
+        service_id: serviceExternalId,
+        live: false,
+        gatewayAccountId,
+        agreements: mockAgreements,
+        filters: { status: statusFilter, reference: referenceFilter }
+      })
     ])
 
     cy.get('#reference').type(referenceFilter)
@@ -78,7 +98,14 @@ describe('Agreements', () => {
   it('should set and persist pagination', () => {
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
-      agreementStubs.getLedgerAgreementsSuccess({ page: 2, service_id: serviceExternalId, live: false, agreements: mockAgreements, filters: { status: statusFilter, reference: referenceFilter } })
+      agreementStubs.getLedgerAgreementsSuccess({
+        page: 2,
+        service_id: serviceExternalId,
+        live: false,
+        gatewayAccountId,
+        agreements: mockAgreements,
+        filters: { status: statusFilter, reference: referenceFilter }
+      })
     ])
 
     cy.get('.pagination.2').first().click()
@@ -89,7 +116,12 @@ describe('Agreements', () => {
   it('should load the details page and preserve filter params', () => {
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
-      agreementStubs.getLedgerAgreementSuccess({ service_id: serviceExternalId, live: false, external_id: 'a-valid-agreement-id' }),
+      agreementStubs.getLedgerAgreementSuccess({
+        service_id: serviceExternalId,
+        live: false,
+        gatewayAccountId,
+        external_id: 'a-valid-agreement-id'
+      }),
       transactionStubs.getLedgerTransactionsSuccess({
         gatewayAccountId,
         transactions: [
@@ -122,7 +154,12 @@ describe('Agreements', () => {
   it('should show no agreements content if filters return nothing', () => {
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
-      agreementStubs.getLedgerAgreementsSuccess({ service_id: serviceExternalId, live: false, agreements: [] })
+      agreementStubs.getLedgerAgreementsSuccess({
+        service_id: serviceExternalId,
+        live: false,
+        gatewayAccountId,
+        agreements: []
+      })
     ])
 
     cy.visit('/test/service/service-id/account/gateway-account-id/agreements')

--- a/test/cypress/stubs/agreement-stubs.js
+++ b/test/cypress/stubs/agreement-stubs.js
@@ -9,6 +9,7 @@ function getLedgerAgreementsSuccess (opts) {
     query: {
       service_id: opts.service_id,
       live: opts.live,
+      account_id: opts.gatewayAccountId,
       page: opts.page || 1,
       ...opts.filters
     },


### PR DESCRIPTION
The original intention when agreements were added was to move away from identifying resources by the gateway account ID, but instead by the service ID and whether they are live/test.

However, a migration plan hasn't currently been made to move to a world where there is only one live/test gateway account per service. So for now, we want to send the account ID when searching for agreements so we can be sure we're only getting agreements for the current account.

This should be revisited when we can be sure there will only be one live/test account per service.