### PR TITLE
PP-10348 display side navigation in each task

### DIFF
--- a/app/views/stripe-setup/bank-details/index.njk
+++ b/app/views/stripe-setup/bank-details/index.njk
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block side_navigation %}
-  {% if isSwitchingCredentials %}
+  {% if isSwitchingCredentials or enableStripeOnboardingTaskList %}
     {% include "includes/side-navigation.njk" %}
   {% endif %}
 {% endblock %}

--- a/app/views/stripe-setup/check-org-details/index.njk
+++ b/app/views/stripe-setup/check-org-details/index.njk
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block side_navigation %}
-  {% if isSwitchingCredentials %}
+  {% if isSwitchingCredentials or enableStripeOnboardingTaskList %}
     {% include "includes/side-navigation.njk" %}
   {% endif %}
 {% endblock %}

--- a/app/views/stripe-setup/company-number/index.njk
+++ b/app/views/stripe-setup/company-number/index.njk
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block side_navigation %}
-  {% if isSwitchingCredentials %}
+  {% if isSwitchingCredentials or enableStripeOnboardingTaskList %}
     {% include "includes/side-navigation.njk" %}
   {% endif %}
 {% endblock %}

--- a/app/views/stripe-setup/director/index.njk
+++ b/app/views/stripe-setup/director/index.njk
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block side_navigation %}
-  {% if isSwitchingCredentials or collectingAdditionalKycData %}
+  {% if isSwitchingCredentials or collectingAdditionalKycData or enableStripeOnboardingTaskList %}
     {% include "includes/side-navigation.njk" %}
   {% endif %}
 {% endblock %}

--- a/app/views/stripe-setup/government-entity-document/index.njk
+++ b/app/views/stripe-setup/government-entity-document/index.njk
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block side_navigation %}
-  {% if isSwitchingCredentials or collectingAdditionalKycData %}
+  {% if isSwitchingCredentials or collectingAdditionalKycData or enableStripeOnboardingTaskList %}
     {% include "includes/side-navigation.njk" %}
   {% endif %}
 {% endblock %}

--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block side_navigation %}
-  {% if isSwitchingCredentials or isSubmittingAdditionalKycData %}
+  {% if isSwitchingCredentials or isSubmittingAdditionalKycData or enableStripeOnboardingTaskList %}
     {% include "includes/side-navigation.njk" %}
   {% endif %}
 {% endblock %}

--- a/app/views/stripe-setup/vat-number/index.njk
+++ b/app/views/stripe-setup/vat-number/index.njk
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block side_navigation %}
-  {% if isSwitchingCredentials %}
+  {% if isSwitchingCredentials or enableStripeOnboardingTaskList %}
     {% include "includes/side-navigation.njk" %}
   {% endif %}
 {% endblock %}

--- a/test/cypress/integration/stripe-setup/bank-details.cy.js
+++ b/test/cypress/integration/stripe-setup/bank-details.cy.js
@@ -57,6 +57,10 @@ describe('Stripe setup: bank details page', () => {
       it('should display page correctly', () => {
         cy.get('h1').should('contain', 'Enter your organisation’s banking details')
 
+        cy.get('#navigation-menu-your-psp')
+        .should('contain', 'Information for Stripe')
+        .parent().should('have.class', 'govuk-!-font-weight-bold')
+
         cy.get('#bank-details-form').should('exist')
           .within(() => {
             cy.get('input#account-number').should('exist')

--- a/test/cypress/integration/stripe-setup/check-org-details.cy.js
+++ b/test/cypress/integration/stripe-setup/check-org-details.cy.js
@@ -78,6 +78,10 @@ describe('Stripe setup: Check your organisation’s details', () => {
     it('should display page correctly', () => {
       cy.get('h1').should('contain', 'Check your organisation’s details')
 
+      cy.get('#navigation-menu-your-psp')
+      .should('contain', 'Information for Stripe')
+      .parent().should('have.class', 'govuk-!-font-weight-bold')
+
       cy.get('[data-cy=org-details]').should('exist')
       cy.get('[data-cy=org-details]').find('dd').eq(0).should('contain', 'HMRC')
       cy.get('[data-cy=org-details]').find('dd').eq(1)

--- a/test/cypress/integration/stripe-setup/company-number.cy.js
+++ b/test/cypress/integration/stripe-setup/company-number.cy.js
@@ -53,6 +53,10 @@ describe('Stripe setup: company number page', () => {
       it('should display page correctly', () => {
         cy.get('h1').should('contain', 'Company registration number')
 
+        cy.get('#navigation-menu-your-psp')
+        .should('contain', 'Information for Stripe')
+        .parent().should('have.class', 'govuk-!-font-weight-bold')
+        
         cy.get('#company-number-form').should('exist')
           .within(() => {
             cy.get('input#company-number-declaration[name="company-number-declaration"]').check()

--- a/test/cypress/integration/stripe-setup/director.cy.js
+++ b/test/cypress/integration/stripe-setup/director.cy.js
@@ -96,6 +96,10 @@ describe('Stripe setup: director page', () => {
     it('should display form with name, dob and email fields', () => {
       cy.get('h1').should('contain', 'Enter a director’s details')
 
+      cy.get('#navigation-menu-your-psp')
+      .should('contain', 'Information for Stripe')
+      .parent().should('have.class', 'govuk-!-font-weight-bold')
+      
       cy.get('#director-form').should('exist')
         .within(() => {
           cy.get('label[for="first-name"]').should('exist')

--- a/test/cypress/integration/stripe-setup/government-entity-document.cy.js
+++ b/test/cypress/integration/stripe-setup/government-entity-document.cy.js
@@ -62,6 +62,10 @@ describe('Stripe setup: Government entity document', () => {
     it('should display page correctly', () => {
       cy.get('h1').should('contain', 'Upload a government entity document')
 
+      cy.get('#navigation-menu-your-psp')
+      .should('contain', 'Information for Stripe')
+      .parent().should('have.class', 'govuk-!-font-weight-bold')
+      
       cy.get('#government-entity-document-form').should('exist')
         .within(() => {
           cy.get('input#government-entity-document').should('exist')

--- a/test/cypress/integration/stripe-setup/responsible-person.cy.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.js
@@ -55,6 +55,10 @@ describe('Stripe setup: responsible person page', () => {
     it('should display form', () => {
       cy.get('h1').should('contain', 'Enter responsible person details')
 
+      cy.get('#navigation-menu-your-psp')
+      .should('contain', 'Information for Stripe')
+      .parent().should('have.class', 'govuk-!-font-weight-bold')
+
       cy.get('#responsible-person-form').should('exist')
         .within(() => {
           cy.get('label[for="first-name"]').should('exist')

--- a/test/cypress/integration/stripe-setup/vat-number.cy.js
+++ b/test/cypress/integration/stripe-setup/vat-number.cy.js
@@ -56,6 +56,10 @@ describe('Stripe setup: VAT number page', () => {
       it('should display page correctly', () => {
         cy.get('h1').should('contain', 'VAT registration number')
 
+        cy.get('#navigation-menu-your-psp')
+        .should('contain', 'Information for Stripe')
+        .parent().should('have.class', 'govuk-!-font-weight-bold')
+
         cy.get('#vat-number-form').should('exist')
           .within(() => {
             cy.get('input#have-vat-number').should('exist')


### PR DESCRIPTION
- Context: For stripe onboarding tasks: when ENABLE_STRIPE_ONBOARDING_TASK_LIST is enabled:
  - Updated logic to display side navigation when on each task
  - Updated existing cypress tests to check for the navigation bar

- Further context
  - There will be a separate PR covering update organisation details.


