### PR TITLE
 PP-10348 display side nav in-update org-details page

### DIFF
--- a/app/controllers/request-to-go-live/organisation-address/get.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/get.controller.js
@@ -8,10 +8,11 @@ const { response } = require('../../../utils/response')
 const { countries } = require('@govuk-pay/pay-js-commons').utils
 const formatServicePathsFor = require('../../../utils/format-service-paths-for')
 const { getAlreadySubmittedErrorPageData } = require('../../stripe-setup/stripe-setup.util')
-const { isSwitchingCredentialsRoute } = require('../../../utils/credentials')
+const { isSwitchingCredentialsRoute, isEnableStripeOnboardingTaskListRoute } = require('../../../utils/credentials')
 
 module.exports = function getOrganisationAddress (req, res) {
   const isRequestToGoLive = Object.values(paths.service.requestToGoLive).includes(req.route && req.route.path)
+  const enableStripeOnboardingTaskList = isEnableStripeOnboardingTaskListRoute(req)
   const isStripeUpdateOrgDetails = Boolean(req.url && req.url.startsWith('/your-psp/'))
   const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
 
@@ -54,7 +55,8 @@ module.exports = function getOrganisationAddress (req, res) {
     isRequestToGoLive,
     isStripeUpdateOrgDetails,
     isSwitchingCredentials,
-    isStripeSetupUserJourney
+    isStripeSetupUserJourney,
+    enableStripeOnboardingTaskList
   }
   pageData.countries = countries.govukFrontendFormatted(lodash.get(pageData, 'address_country'))
 

--- a/app/controllers/request-to-go-live/organisation-address/get.controller.test.js
+++ b/app/controllers/request-to-go-live/organisation-address/get.controller.test.js
@@ -107,6 +107,10 @@ describe('organisation address get controller', () => {
     })
 
     describe('view page when `Stripe setup`', () => {
+      afterEach(() => {
+        process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = undefined
+      })
+
       it('should display the `update org details` form and set `isStripeUpdateOrgDetails=true` ' +
       'and all form fields should be reset to empty', () => {
         const req = {
@@ -127,6 +131,7 @@ describe('organisation address get controller', () => {
         expect(pageData.isStripeUpdateOrgDetails).to.equal(true)
         expect(pageData.isSwitchingCredentials).to.equal(false)
         expect(pageData.isStripeSetupUserJourney).to.equal(true)
+        expect(pageData.enableStripeOnboardingTaskList).to.equal(false)
 
         expect(pageData.name).to.equal(undefined)
         expect(pageData.address_line1).to.equal(undefined)
@@ -135,6 +140,27 @@ describe('organisation address get controller', () => {
         expect(pageData.address_postcode).to.equal(undefined)
         expect(pageData.telephone_number).to.equal(undefined)
         expect(pageData.url).to.equal(undefined)
+      })
+
+      it('should display the `update org details` form and set `enableStripeOnboardingTaskList=true` when ' +
+      'Stripe task list flag is true', () => {
+        process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
+        
+        const req = {
+          url: '/your-psp/:credentialId/update-organisation-details',
+          account
+        }
+
+        const controller = getController()
+
+        controller(req, res)
+
+        const responseData = mockResponse.getCalls()[0]
+
+        expect(responseData.args[2]).to.equal('stripe-setup/update-org-details/index')
+
+        const pageData = responseData.args[3]
+        expect(pageData.enableStripeOnboardingTaskList).to.equal(true)
       })
 
       it('should render error if organisation details have already been submitted', async () => {

--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -2,7 +2,7 @@
 {% from "../macro/error-summary.njk" import errorSummary %}
 
 {% block side_navigation %}
-  {% if isSwitchingCredentials %}
+  {% if isSwitchingCredentials or enableStripeOnboardingTaskList %}
     {% include "includes/side-navigation.njk" %}
   {% endif %}
 {% endblock %}

--- a/test/cypress/integration/stripe-setup/update-org-details.cy.js
+++ b/test/cypress/integration/stripe-setup/update-org-details.cy.js
@@ -83,6 +83,10 @@ describe('The organisation address page', () => {
 
         cy.get('h1').should('contain', `What is the name and address of your organisation on your government entity document?`)
 
+        cy.get('#navigation-menu-your-psp')
+        .should('contain', 'Information for Stripe')
+        .parent().should('have.class', 'govuk-!-font-weight-bold')
+
         cy.get('[data-cy=form]')
           .should('exist')
           .within(() => {


### PR DESCRIPTION
- For Stripe onboarding task: Update-org-details, when ENABLE_STRIPE_ONBOARDING_TASK_LIST is enabled:
   - display side navigation



