### PR TITLE
PP-10348 display back link for update organisation details page

### DIFF
--- a/app/controllers/request-to-go-live/organisation-address/get.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/get.controller.js
@@ -8,11 +8,12 @@ const { response } = require('../../../utils/response')
 const { countries } = require('@govuk-pay/pay-js-commons').utils
 const formatServicePathsFor = require('../../../utils/format-service-paths-for')
 const { getAlreadySubmittedErrorPageData } = require('../../stripe-setup/stripe-setup.util')
-const { isSwitchingCredentialsRoute, isEnableStripeOnboardingTaskListRoute } = require('../../../utils/credentials')
+const { isSwitchingCredentialsRoute, isEnableStripeOnboardingTaskListRoute, getCurrentCredential } = require('../../../utils/credentials')
 
 module.exports = function getOrganisationAddress (req, res) {
   const isRequestToGoLive = Object.values(paths.service.requestToGoLive).includes(req.route && req.route.path)
   const enableStripeOnboardingTaskList = isEnableStripeOnboardingTaskListRoute(req)
+  const currentCredential = getCurrentCredential(req.account)
   const isStripeUpdateOrgDetails = Boolean(req.url && req.url.startsWith('/your-psp/'))
   const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
 
@@ -56,7 +57,8 @@ module.exports = function getOrganisationAddress (req, res) {
     isStripeUpdateOrgDetails,
     isSwitchingCredentials,
     isStripeSetupUserJourney,
-    enableStripeOnboardingTaskList
+    enableStripeOnboardingTaskList,
+    currentCredential
   }
   pageData.countries = countries.govukFrontendFormatted(lodash.get(pageData, 'address_country'))
 

--- a/app/controllers/request-to-go-live/organisation-address/get.controller.test.js
+++ b/app/controllers/request-to-go-live/organisation-address/get.controller.test.js
@@ -145,7 +145,7 @@ describe('organisation address get controller', () => {
       it('should display the `update org details` form and set `enableStripeOnboardingTaskList=true` when ' +
       'Stripe task list flag is true', () => {
         process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
-        
+
         const req = {
           url: '/your-psp/:credentialId/update-organisation-details',
           account

--- a/app/utils/nav-builder.js
+++ b/app/utils/nav-builder.js
@@ -143,7 +143,7 @@ function yourPSPNavigationItems (account, currentPath = '') {
 function getPSPNavigationName (credential) {
   if (credential.state === CREDENTIAL_STATE.RETIRED) {
     return `Old PSP - ${formatPSPname(credential.payment_provider)}`
-  } else if ((process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST === 'true') && (credential.payment_provider === 'stripe'))  {
+  } else if ((process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST === 'true') && (credential.payment_provider === 'stripe')) {
     return 'Information for Stripe'
   } else {
     return `Your PSP - ${formatPSPname(credential.payment_provider)}`

--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -19,12 +19,17 @@
 
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
-
   {% if isSwitchingCredentials %}
     {{ govukBackLink({
       text: "Back to Switching payment service provider (PSP)",
       classes: "govuk-!-margin-top-0",
       href: formatAccountPathsFor(routes.account.switchPSP.index, currentGatewayAccount.external_id)
+    }) }}
+  {% elif enableStripeOnboardingTaskList %}
+    {{ govukBackLink({
+      text: "Back to check your organisation’s details",
+      classes: "govuk-!-margin-top-0",
+      href: formatAccountPathsFor(routes.account.yourPsp.stripeSetup.checkOrgDetails, currentGatewayAccount.external_id, currentCredential.external_id)
     }) }}
   {% endif %}
 

--- a/test/cypress/integration/stripe-setup/bank-details.cy.js
+++ b/test/cypress/integration/stripe-setup/bank-details.cy.js
@@ -58,8 +58,8 @@ describe('Stripe setup: bank details page', () => {
         cy.get('h1').should('contain', 'Enter your organisation’s banking details')
 
         cy.get('#navigation-menu-your-psp')
-        .should('contain', 'Information for Stripe')
-        .parent().should('have.class', 'govuk-!-font-weight-bold')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
 
         cy.get('#bank-details-form').should('exist')
           .within(() => {

--- a/test/cypress/integration/stripe-setup/check-org-details.cy.js
+++ b/test/cypress/integration/stripe-setup/check-org-details.cy.js
@@ -79,8 +79,8 @@ describe('Stripe setup: Check your organisation’s details', () => {
       cy.get('h1').should('contain', 'Check your organisation’s details')
 
       cy.get('#navigation-menu-your-psp')
-      .should('contain', 'Information for Stripe')
-      .parent().should('have.class', 'govuk-!-font-weight-bold')
+        .should('contain', 'Information for Stripe')
+        .parent().should('have.class', 'govuk-!-font-weight-bold')
 
       cy.get('[data-cy=org-details]').should('exist')
       cy.get('[data-cy=org-details]').find('dd').eq(0).should('contain', 'HMRC')

--- a/test/cypress/integration/stripe-setup/company-number.cy.js
+++ b/test/cypress/integration/stripe-setup/company-number.cy.js
@@ -54,9 +54,9 @@ describe('Stripe setup: company number page', () => {
         cy.get('h1').should('contain', 'Company registration number')
 
         cy.get('#navigation-menu-your-psp')
-        .should('contain', 'Information for Stripe')
-        .parent().should('have.class', 'govuk-!-font-weight-bold')
-        
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
+
         cy.get('#company-number-form').should('exist')
           .within(() => {
             cy.get('input#company-number-declaration[name="company-number-declaration"]').check()

--- a/test/cypress/integration/stripe-setup/director.cy.js
+++ b/test/cypress/integration/stripe-setup/director.cy.js
@@ -97,9 +97,9 @@ describe('Stripe setup: director page', () => {
       cy.get('h1').should('contain', 'Enter a director’s details')
 
       cy.get('#navigation-menu-your-psp')
-      .should('contain', 'Information for Stripe')
-      .parent().should('have.class', 'govuk-!-font-weight-bold')
-      
+        .should('contain', 'Information for Stripe')
+        .parent().should('have.class', 'govuk-!-font-weight-bold')
+
       cy.get('#director-form').should('exist')
         .within(() => {
           cy.get('label[for="first-name"]').should('exist')

--- a/test/cypress/integration/stripe-setup/government-entity-document.cy.js
+++ b/test/cypress/integration/stripe-setup/government-entity-document.cy.js
@@ -63,9 +63,9 @@ describe('Stripe setup: Government entity document', () => {
       cy.get('h1').should('contain', 'Upload a government entity document')
 
       cy.get('#navigation-menu-your-psp')
-      .should('contain', 'Information for Stripe')
-      .parent().should('have.class', 'govuk-!-font-weight-bold')
-      
+        .should('contain', 'Information for Stripe')
+        .parent().should('have.class', 'govuk-!-font-weight-bold')
+
       cy.get('#government-entity-document-form').should('exist')
         .within(() => {
           cy.get('input#government-entity-document').should('exist')

--- a/test/cypress/integration/stripe-setup/responsible-person.cy.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.js
@@ -56,8 +56,8 @@ describe('Stripe setup: responsible person page', () => {
       cy.get('h1').should('contain', 'Enter responsible person details')
 
       cy.get('#navigation-menu-your-psp')
-      .should('contain', 'Information for Stripe')
-      .parent().should('have.class', 'govuk-!-font-weight-bold')
+        .should('contain', 'Information for Stripe')
+        .parent().should('have.class', 'govuk-!-font-weight-bold')
 
       cy.get('#responsible-person-form').should('exist')
         .within(() => {

--- a/test/cypress/integration/stripe-setup/update-org-details.cy.js
+++ b/test/cypress/integration/stripe-setup/update-org-details.cy.js
@@ -83,9 +83,12 @@ describe('The organisation address page', () => {
 
         cy.get('h1').should('contain', `What is the name and address of your organisation on your government entity document?`)
 
+        cy.get('.govuk-back-link').should('contain', 'Back to check your organisation’s details')
+        cy.get('.govuk-back-link').should('have.attr', 'href', checkOrgDetailsUrl)
+
         cy.get('#navigation-menu-your-psp')
-        .should('contain', 'Information for Stripe')
-        .parent().should('have.class', 'govuk-!-font-weight-bold')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
 
         cy.get('[data-cy=form]')
           .should('exist')

--- a/test/cypress/integration/stripe-setup/vat-number.cy.js
+++ b/test/cypress/integration/stripe-setup/vat-number.cy.js
@@ -57,8 +57,8 @@ describe('Stripe setup: VAT number page', () => {
         cy.get('h1').should('contain', 'VAT registration number')
 
         cy.get('#navigation-menu-your-psp')
-        .should('contain', 'Information for Stripe')
-        .parent().should('have.class', 'govuk-!-font-weight-bold')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
 
         cy.get('#vat-number-form').should('exist')
           .within(() => {


### PR DESCRIPTION
- For Stripe onboarding task:  Update-org-details, when ENABLE_STRIPE_ONBOARDING_TASK_LIST is enabled:
  - display back link that redirects to check your organisation’s details page
  - updated cypress test to check this



