### PR TITLE
PP-10358 Show new Stripe dashboard banner when tasks incomplete

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -363,7 +363,7 @@
         "filename": "test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.js",
         "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 13
       }
     ],
     "test/cypress/integration/dashboard/dashboard-worldpay-setup-banner.cy.js": [
@@ -903,5 +903,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-25T13:00:21Z"
+  "generated_at": "2023-03-16T12:20:53Z"
 }

--- a/app/views/dashboard/_stripe-account-setup-banner_tasklist.njk
+++ b/app/views/dashboard/_stripe-account-setup-banner_tasklist.njk
@@ -1,0 +1,61 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% if permissions.stripe_account_details_update %}
+  {% set connectorGatewayAccountStripeProgress = gatewayAccount.connectorGatewayAccountStripeProgress %}
+
+  {% set isStripeAccountRestricted = stripeAccount.charges_enabled === false %}
+  {% set stripeAccountHasDeadline = stripeAccount.requirements.current_deadline %}
+  {% set governmentEntityDocCompleteOrNotRequired = stripeAccount.has_legacy_payments_capability or (not stripeAccount.has_legacy_payments_capability and connectorGatewayAccountStripeProgress.governmentEntityDocument) %}
+  {% set isConnectorStripeJourneyComplete = connectorGatewayAccountStripeProgress.bankAccount and connectorGatewayAccountStripeProgress.vatNumber and connectorGatewayAccountStripeProgress.companyNumber and connectorGatewayAccountStripeProgress.responsiblePerson and governmentEntityDocCompleteOrNotRequired %}
+
+  {% if connectorGatewayAccountStripeProgress and gatewayAccount.payment_provider === 'stripe' and (not isConnectorStripeJourneyComplete) %}
+      <div class="govuk-grid-column-full">
+        {% set html %}
+
+        <p class="govuk-notification-banner__heading" data-cy="stripe-notification">
+          {% if isStripeAccountRestricted %}
+            Stripe has restricted your account. You need to
+            <a class="govuk-notification-banner__link"
+              href="{{formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, activeCredential.external_id)}}">
+              submit additional information to Stripe
+            </a>
+            to take payments.         
+          {% elif stripeAccountHasDeadline %}
+            {% set dateString = stripeAccount.requirements.current_deadline %}
+
+            You need to
+            <a class="govuk-notification-banner__link"
+              href="{{formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, activeCredential.external_id)}}">
+              submit additional information to Stripe
+            </a>
+            by {{dateString}} to continue taking payments.     
+          {% else %}    
+            You need to
+            <a class="govuk-notification-banner__link"
+              href="{{formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, activeCredential.external_id)}}">
+              submit additional information to Stripe
+            </a>
+              to be able to take payments
+          {% endif %}
+        </p>
+      {% endset %}
+      {{ govukNotificationBanner({
+          html: html
+      }) }}
+      </div>
+  {% elif  isStripeAccountRestricted %}
+    <div class="govuk-grid-column-full">
+    {% set html %}
+        <p class="govuk-notification-banner__heading" data-cy="stripe-notification">Stripe has restricted your account.
+        To start taking payments again, please contact support.
+          <a class="govuk-notification-banner__link" href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk" target="_top">
+            govuk-pay-support@digital.cabinet-office.gov.uk
+          </a>
+        </p>
+    {% endset %}
+    {{ govukNotificationBanner({
+      html: html
+    }) }}
+    </div>
+  {% endif %}
+{% endif %}

--- a/app/views/dashboard/index.njk
+++ b/app/views/dashboard/index.njk
@@ -9,7 +9,13 @@ Dashboard - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK
     {% include "./_account-disabled-banner.njk" %}
   {% else %}
     {% include "./_live-account-requested-banner.njk" %}
-    {% include "./_stripe-account-setup-banner.njk" %}
+
+    {% if enableStripeOnboardingTaskList %}
+      {% include "./_stripe-account-setup-banner_tasklist.njk" %}
+    {% else %}
+      {% include "./_stripe-account-setup-banner.njk" %}
+    {% endif %} 
+
     {% include "./_switching-psp-banner.njk" %}
     {% include "./_additional-kyc-info-banner.njk" %}
     {% include "./_worldpay_account_not_configured_banner.njk" %}

--- a/test/cypress/stubs/stripe-psp-stubs.js
+++ b/test/cypress/stubs/stripe-psp-stubs.js
@@ -19,7 +19,9 @@ function parseStripeAccountOptions (opts) {
   return {
     url: opts.url || null,
     stripe_account_id: opts.stripeAccountId || 'stripe-connect-account-id',
-    entity_verified: opts.entity_verified
+    entity_verified: opts.entity_verified,
+    charges_enabled: opts.charges_enabled,
+    current_deadline: opts.current_deadline
   }
 }
 

--- a/test/fixtures/stripe-psp.fixtures.js
+++ b/test/fixtures/stripe-psp.fixtures.js
@@ -11,7 +11,7 @@ function validRetrieveStripeAccountDetails (opts = {}) {
       'card_payments': 'active',
       'transfers': 'active'
     },
-    'charges_enabled': true,
+    'charges_enabled': opts.charges_enabled,
     'company': {
       'directors_provided': true,
       'executives_provided': true,
@@ -19,7 +19,10 @@ function validRetrieveStripeAccountDetails (opts = {}) {
       'tax_id_provided': true,
       'vat_id_provided': true
     },
-    'type': 'custom'
+    'type': 'custom',
+    'requirements': {
+      'current_deadline': opts.current_deadline
+    }
   }
 
   stripeAccount.id = opts.stripe_account_id


### PR DESCRIPTION
- For stripe onboarding tasks, when ENABLE_STRIPE_ONBOARDING_TASK_LIST is enabled, display Stripe notification banner:
  - Added new nunjucks page for the new Stripe banners
  - Added Cypress tests to check banner is shown depending on Stripe account credentials and a tasks complete

