### PR TITLE
Pp 10840 fixing side nav disappearing when error on task page

### DIFF
--- a/app/controllers/stripe-setup/check-org-details/post.controller.js
+++ b/app/controllers/stripe-setup/check-org-details/post.controller.js
@@ -7,7 +7,7 @@ const { response } = require('../../../utils/response')
 const { getAlreadySubmittedErrorPageData } = require('../stripe-setup.util')
 const paths = require('../../../paths')
 const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
-const { getCredentialByExternalId, isSwitchingCredentialsRoute } = require('../../../utils/credentials')
+const { getCredentialByExternalId, isSwitchingCredentialsRoute, getCurrentCredential, isEnableStripeOnboardingTaskListRoute } = require('../../../utils/credentials')
 const { ConnectorClient } = require('../../../services/clients/connector.client')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 const { getStripeAccountId } = require('../stripe-setup.util')
@@ -17,7 +17,8 @@ const CONFIRM_ORG_DETAILS = 'confirm-org-details'
 
 module.exports = async function postCheckOrgDetails (req, res, next) {
   const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
-  const enabledStripeOnboardingTaskList = (process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST === 'true')
+  const enableStripeOnboardingTaskList = isEnableStripeOnboardingTaskListRoute(req)
+  const currentCredential = getCurrentCredential(req.account)
   const stripeAccountSetup = req.account.connectorGatewayAccountStripeProgress
 
   if (!stripeAccountSetup) {
@@ -42,7 +43,9 @@ module.exports = async function postCheckOrgDetails (req, res, next) {
       orgAddressLine2: merchantDetails.address_line2,
       orgCity: merchantDetails.address_city,
       orgPostcode: merchantDetails.address_postcode,
-      isSwitchingCredentials
+      isSwitchingCredentials,
+      enableStripeOnboardingTaskList,
+      currentCredential,
     }
 
     return response(req, res, 'stripe-setup/check-org-details/index', data)
@@ -62,7 +65,7 @@ module.exports = async function postCheckOrgDetails (req, res, next) {
     }
     if (isSwitchingCredentials) {
       return res.redirect(303, formatAccountPathsFor(paths.account.switchPSP.index, req.account.external_id))
-    } else if (enabledStripeOnboardingTaskList) {
+    } else if (enableStripeOnboardingTaskList) {
       return res.redirect(303, formatAccountPathsFor(paths.account.yourPsp.index, req.account && req.account.external_id, req.params && req.params.credentialId))
     } else {
       return res.redirect(303, formatAccountPathsFor(paths.account.stripe.addPspAccountDetails, req.account.external_id))

--- a/app/controllers/stripe-setup/check-org-details/post.controller.test.js
+++ b/app/controllers/stripe-setup/check-org-details/post.controller.test.js
@@ -154,8 +154,9 @@ describe('Check org details - post controller', () => {
       })
 
       it('when ENABLE_STRIPE_ONBOARDING_TASK_LIST is true and `no` radio button is selected, then it should redirect to `Stripe onboarding > org address` page', () => {
-        process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'false'
+        process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
 
+        req.url = '/your-psp/:credentialId/check-organisation-details'
         req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
 
         req.body = {
@@ -168,7 +169,8 @@ describe('Check org details - post controller', () => {
       })
       it('when ENABLE_STRIPE_ONBOARDING_TASK_LIST is true and `yes` radio button is selected, then it should redirect to tasklist page', async () => {
         process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
-
+        
+        req.url = '/your-psp/:credentialId/check-organisation-details'
         req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
 
         req.body = {
@@ -182,6 +184,23 @@ describe('Check org details - post controller', () => {
         sinon.assert.calledWith(setStripeAccountSetupFlagMock, req.account.gateway_account_id, 'organisation_details')
         sinon.assert.calledWith(loggerInfoMock, 'Organisation details confirmed for Stripe account', { stripe_account_id: stripeAcountId })
         sinon.assert.calledWith(res.redirect, 303, `/account/a-valid-external-id/your-psp/a-valid-credential-id`)
+      })
+
+      it('when ENABLE_STRIPE_ONBOARDING_TASK_LIST is true and nothing is selected, then it should render error page', async () => {
+        process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
+        req.url = '/your-psp/:credentialId/check-organisation-details'
+
+        req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
+
+        req.body = {}
+
+        await controller(req, res, next)
+
+        sinon.assert.called(res.render)
+
+        const pageData = res.render.firstCall.args[1]
+        expect(pageData.enableStripeOnboardingTaskList).to.equal(true)
+        expect(pageData.currentCredential.external_id).to.equal('a-valid-credential-id')
       })
     })
 


### PR DESCRIPTION
 - Context: For Stripe onboarding tasks, when ENABLE_STRIPE_ONBOARDING_TASK_LIST flag is on you're on a task and no data is submitted, the error page does not show the side navigation or the back link.
   - Updated post controllers for bank-details and check-org-details to check for ENABLE_STRIPE_ONBOARDING_TASK_LIST and pass variable to the error page
   - added the necessary unit tests

