### PR TITLE
PP-10840 fix side nav disappearing when error for tasks cypress test

### DIFF
--- a/test/cypress/integration/stripe-setup/bank-details.cy.js
+++ b/test/cypress/integration/stripe-setup/bank-details.cy.js
@@ -93,6 +93,14 @@ describe('Stripe setup: bank details page', () => {
         cy.get('.govuk-form-group--error > input#sort-code').parent().should('exist').within(() => {
           cy.get('.govuk-error-message').should('contain', 'Enter a sort code')
         })
+
+        cy.get('#navigation-menu-your-psp')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+        cy.get('.govuk-back-link')
+          .should('contain', 'Back to information for Stripe')
+          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
       })
     })
 

--- a/test/cypress/integration/stripe-setup/check-org-details.cy.js
+++ b/test/cypress/integration/stripe-setup/check-org-details.cy.js
@@ -115,6 +115,14 @@ describe('Stripe setup: Check your organisation’s details', () => {
         .should('have.attr', 'href', '#confirm-org-details')
 
       cy.get('[data-cy=error-message]').should('contain', 'Select yes if your organisation’s details match the details on your government entity document')
+     
+      cy.get('#navigation-menu-your-psp')
+        .should('contain', 'Information for Stripe')
+        .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+      cy.get('.govuk-back-link')
+        .should('contain', 'Back to information for Stripe')
+        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
     })
   })
 

--- a/test/cypress/integration/stripe-setup/company-number.cy.js
+++ b/test/cypress/integration/stripe-setup/company-number.cy.js
@@ -83,6 +83,14 @@ describe('Stripe setup: company number page', () => {
         cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#company-number-declaration')
 
         cy.get('#company-number-declaration-error').should('contain', 'You must answer this question')
+        
+        cy.get('#navigation-menu-your-psp')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+        cy.get('.govuk-back-link')
+          .should('contain', 'Back to information for Stripe')
+          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
       })
 
       it('should display an error when company number input is blank and "Yes" option is selected', () => {

--- a/test/cypress/integration/stripe-setup/director.cy.js
+++ b/test/cypress/integration/stripe-setup/director.cy.js
@@ -168,6 +168,14 @@ describe('Stripe setup: director page', () => {
 
         cy.get('button').should('exist')
       })
+
+      cy.get('#navigation-menu-your-psp')
+        .should('contain', 'Information for Stripe')
+        .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+      cy.get('.govuk-back-link')
+        .should('contain', 'Back to information for Stripe')
+        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
     })
   })
 

--- a/test/cypress/integration/stripe-setup/government-entity-document.cy.js
+++ b/test/cypress/integration/stripe-setup/government-entity-document.cy.js
@@ -92,7 +92,15 @@ describe('Stripe setup: Government entity document', () => {
         cy.get('.govuk-error-message').should('exist')
         cy.get('span.govuk-error-message').should('contain', 'Select a file to upload')
       })
-    })
+
+      cy.get('#navigation-menu-your-psp')
+        .should('contain', 'Information for Stripe')
+        .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+      cy.get('.govuk-back-link')
+        .should('contain', 'Back to information for Stripe')
+        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+     })
   })
 
   describe('when user is admin, account is Stripe and "Government entity document" is already submitted', () => {

--- a/test/cypress/integration/stripe-setup/responsible-person.cy.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.js
@@ -162,6 +162,14 @@ describe('Stripe setup: responsible person page', () => {
 
         cy.get('button').should('exist')
       })
+      
+      cy.get('#navigation-menu-your-psp')
+        .should('contain', 'Information for Stripe')
+        .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+      cy.get('.govuk-back-link')
+        .should('contain', 'Back to information for Stripe')
+        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
     })
   })
 

--- a/test/cypress/integration/stripe-setup/update-org-details.cy.js
+++ b/test/cypress/integration/stripe-setup/update-org-details.cy.js
@@ -161,6 +161,14 @@ describe('The organisation address page', () => {
               cy.get('.govuk-error-message').should('contain', 'Enter a real postcode')
             })
           })
+        
+        cy.get('#navigation-menu-your-psp')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+        cy.get('.govuk-back-link')
+          .should('contain', 'Back to check your organisation’s details')
+          .should('have.attr', 'href', checkOrgDetailsUrl)
       })
 
       it('should keep entered responses when validation fails', () => {

--- a/test/cypress/integration/stripe-setup/vat-number.cy.js
+++ b/test/cypress/integration/stripe-setup/vat-number.cy.js
@@ -90,6 +90,14 @@ describe('Stripe setup: VAT number page', () => {
           cy.get('.govuk-error-message').should('exist')
           cy.get('span.govuk-error-message').should('contain', 'Enter your VAT registration number')
         })
+
+        cy.get('#navigation-menu-your-psp')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+        cy.get('.govuk-back-link')
+          .should('contain', 'Back to information for Stripe')
+          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
       })
 
       it('should redirect to tasklist page when "No" VAT number is chosen', () => {


### PR DESCRIPTION
 - Context: For Stripe onboarding tasks, when ENABLE_STRIPE_ONBOARDING_TASK_LIST flag is on you're on a task and no data is submitted, the error page does not show the side navigation or the back link.
   - Updated cypress to check nav bar and back links is shown on the error pages for all Stripe onboarding tasks



