### PR TITLE
 PP-10358 updating stripe banners

### DIFF
--- a/app/views/dashboard/_stripe-account-setup-banner_tasklist.njk
+++ b/app/views/dashboard/_stripe-account-setup-banner_tasklist.njk
@@ -4,7 +4,6 @@
   {% set connectorGatewayAccountStripeProgress = gatewayAccount.connectorGatewayAccountStripeProgress %}
 
   {% set isStripeAccountRestricted = stripeAccount.charges_enabled === false %}
-  {% set stripeAccountHasDeadline = stripeAccount.requirements.current_deadline %}
   {% set governmentEntityDocCompleteOrNotRequired = stripeAccount.has_legacy_payments_capability or (not stripeAccount.has_legacy_payments_capability and connectorGatewayAccountStripeProgress.governmentEntityDocument) %}
   {% set isConnectorStripeJourneyComplete = connectorGatewayAccountStripeProgress.bankAccount and connectorGatewayAccountStripeProgress.vatNumber and connectorGatewayAccountStripeProgress.companyNumber and connectorGatewayAccountStripeProgress.responsiblePerson and governmentEntityDocCompleteOrNotRequired %}
 
@@ -12,31 +11,13 @@
       <div class="govuk-grid-column-full">
         {% set html %}
 
-        <p class="govuk-notification-banner__heading" data-cy="stripe-notification">
-          {% if isStripeAccountRestricted %}
-            Stripe has restricted your account. You need to
-            <a class="govuk-notification-banner__link"
-              href="{{formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, activeCredential.external_id)}}">
-              submit additional information to Stripe
-            </a>
-            to take payments.         
-          {% elif stripeAccountHasDeadline %}
-            {% set dateString = stripeAccount.requirements.current_deadline %}
-
-            You need to
-            <a class="govuk-notification-banner__link"
-              href="{{formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, activeCredential.external_id)}}">
-              submit additional information to Stripe
-            </a>
-            by {{dateString}} to continue taking payments.     
-          {% else %}    
-            You need to
-            <a class="govuk-notification-banner__link"
-              href="{{formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, activeCredential.external_id)}}">
-              submit additional information to Stripe
-            </a>
-              to be able to take payments.
-          {% endif %}
+        <p class="govuk-notification-banner__heading" data-cy="stripe-notification">   
+          You need to
+          <a class="govuk-notification-banner__link"
+            href="{{formatAccountPathsFor(routes.account.yourPsp.index, currentGatewayAccount.external_id, activeCredential.external_id)}}">
+            submit additional information to Stripe
+          </a>
+          to be able to take payments.
         </p>
       {% endset %}
       {{ govukNotificationBanner({

--- a/test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.js
+++ b/test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.js
@@ -65,28 +65,6 @@ describe('The Stripe psp details banner', () => {
       })
   })
 
-  it('should display the restricted banner for a restricted Stripe account', () => {
-    setupYourPspStubs({ charges_enabled: false })
-
-    cy.visit(`/account/${gatewayAccountExternalId}/dashboard`)
-    cy.get('[data-cy=stripe-notification]')
-      .contains('Stripe has restricted your account. You need to submit additional information to Stripe to take payments.')
-      .within(() => {
-      cy.get('a').should('have.attr', 'href', '/account/a-valid-external-id/your-psp/a-valid-external-id')
-      })
-  })
-
-  it('should display banner with DATE when account is not fully setup and there is a deadline ', () => {
-    setupYourPspStubs({ current_deadline: 1765793670 })
-
-    cy.visit(`/account/${gatewayAccountExternalId}/dashboard`)
-    cy.get('[data-cy=stripe-notification]')
-      .contains('You need to submit additional information to Stripe by 15 December 2025 to continue taking payments.')
-      .within(() => {
-      cy.get('a').should('have.attr', 'href', '/account/a-valid-external-id/your-psp/a-valid-external-id')
-      })
-  })
-
   it('should display restricted banner when account is fully setup but the Stripe account is restricted ', () => {
     setupYourPspStubs({
       charges_enabled: false,


### PR DESCRIPTION
- Before a service could take £2000 of payments before their account was restricted if they hadn’t filled in all the Stripe information.
- Now the account gets restricted striaght away.
- This means that currently the service would always see the 'Stripe has restricted your account. You need to submit additional information to Stripe to take payments.' if they haven’t completed the tasks.
- They will never see 'You need to submit additional information to Stripe to be able to take payments.'
- Therefore removing the restricted scenario when setting up a new Stripe account so that they see the standard Stripe task list banner.
- Also removing the new Stripe account > deadline scenario as in reality this will not occur anymore when the service hasn’t completed the task list.
- However, we are keeping the restricted scenario when a Stripe account has already been set up.

