### PR TITLE
PP-10834 Replace webhooks numbered centered range with previous/ next pagination

### DIFF
--- a/app/controllers/webhooks/webhooks.service.js
+++ b/app/controllers/webhooks/webhooks.service.js
@@ -4,17 +4,16 @@ const webhooksClient = require('./../../services/clients/webhooks.client')
 const Paginator = require('../../utils/paginator')
 
 const PAGE_SIZE = 10
-const MAX_PAGES = 3
 
 function sortByActiveStatus (a, b) {
   return Number(b.status === 'ACTIVE') - Number(a.status === 'ACTIVE')
 }
 
 function formatPages (searchResponse) {
-  const { total, page } = searchResponse
-  const paginator = new Paginator(total, PAGE_SIZE, page)
-  const hasMultiplePages = paginator.getLast() > 1
-  const links = hasMultiplePages && paginator.getNamedCentredRange(MAX_PAGES, true, true)
+  const { page, count } = searchResponse
+  const paginator = new Paginator(null, PAGE_SIZE, page)
+  const hasMultiplePages = count >= PAGE_SIZE
+  const links = hasMultiplePages && paginator.buildNavigation(count)
   return {
     ...searchResponse,
     links

--- a/app/controllers/webhooks/webhooks.service.test.js
+++ b/app/controllers/webhooks/webhooks.service.test.js
@@ -68,11 +68,9 @@ describe('webhooks service', () => {
       const result = await service.getWebhookMessages('webhook-id', { status: 'failed' })
 
       sinon.assert.calledWith(spy, 'webhook-id', { status: 'failed' })
-      expect(result.total).to.equal(11)
 
-      // 2 pages and a next button for constant service page settings
-      expect(result.links.length).to.equal(3)
-      expect(result.links[2].pageName).to.equal('next')
+      expect(result.links.length).to.equal(2)
+      expect(result.links[1].pageName).to.equal('Next')
     })
   })
 })

--- a/app/utils/paginator.js
+++ b/app/utils/paginator.js
@@ -194,6 +194,22 @@ Paginator.prototype = {
     return namedPages
   },
 
+  buildNavigation: function buildNavigation (count) {
+    const namedPages = []
+    if (this.page > 1) {
+      namedPages.push(createPageObject(this.page - 1, 'Previous'))
+    } else {
+      namedPages.push(createPageObject(null, 'Previous', true))
+    }
+
+    if (count >= this.limit) {
+      namedPages.push(createPageObject(this.page + 1, 'Next'))
+    } else {
+      namedPages.push(createPageObject(null, 'Next', true))
+    }
+    return namedPages
+  },
+
   /**
    * @return {array}
    */

--- a/app/utils/paginator.test.js
+++ b/app/utils/paginator.test.js
@@ -66,4 +66,32 @@ describe('paginator', function () {
       { type: null, name: 'Show all', value: 100, active: false }
     ])
   })
+
+  describe('should return correct links by count', () => {
+    it('when this is the only page', () => {
+      const paginator1 = new Paginator(null, 10, 1)
+      const navigation1 = paginator1.buildNavigation(5)
+      expect(navigation1.length).to.equal(2)
+      expect(navigation1[0].pageName).to.equal('Previous')
+      expect(navigation1[0].disabled).to.equal(true)
+
+      expect(navigation1[1].pageName).to.equal('Next')
+      expect(navigation1[1].disabled).to.equal(true)
+      expect(navigation1[1].pageNumber).to.equal(null)
+    })
+
+    it('when there are surrounding pages', () => {
+      const paginator2 = new Paginator(null, 10, 4)
+      const navigation2 = paginator2.buildNavigation(10)
+
+      expect(navigation2.length).to.equal(2)
+      expect(navigation2[0].pageName).to.equal('Previous')
+      expect(navigation2[0].disabled).to.equal(undefined)
+      expect(navigation2[0].pageNumber).to.equal(3)
+
+      expect(navigation2[1].pageName).to.equal('Next')
+      expect(navigation2[1].disabled).to.equal(undefined)
+      expect(navigation2[1].pageNumber).to.equal(5)
+    })
+  })
 })

--- a/app/views/webhooks/_paginator.njk
+++ b/app/views/webhooks/_paginator.njk
@@ -6,12 +6,8 @@
       <input type="hidden" name="page" value="{{paginationLink.pageNumber}}"/>
       <input type="hidden" name="status" value="{{status}}"/>
 
-      <button class="pagination {{paginationLink.pageName}} {% if paginationLink.activePage %}active{% endif %}" type="submit">
-        {% if paginationLink.hasSymbolicName %}
-          {{paginationLink.pageName}}<span class="govuk-visually-hidden"> page of results</span>
-        {% else %}
-          <span class="govuk-visually-hidden">Results page </span>{{paginationLink.pageName}}
-        {% endif %}
+      <button class="pagination {{paginationLink.pageName}} {% if paginationLink.activePage %}active{% endif %} {% if paginationLink.disabled %}govuk-button--disabled {% endif %}" {% if paginationLink.disabled %} disabled="disabled" {% endif %}  type="submit">
+        <span class="govuk-visually-hidden">Results page </span>{{paginationLink.pageName}}
       </button>
     </form>
   {% endfor %}

--- a/test/cypress/integration/webhooks/webhooks.cy.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.js
@@ -121,7 +121,7 @@ describe('Webhooks', () => {
 
     // based on number of rows stubbed and client pagination logic
     cy.get('.govuk-table__body > .govuk-table__row').should('have.length', 11)
-    cy.get('.paginationForm').should('have.length', 3)
+    cy.get('.paginationForm').should('have.length', 2)
 
     cy.get('a#filter-failed').click()
     cy.get('a#filter-failed').should('have.class', 'govuk-!-font-weight-bold')

--- a/test/fixtures/webhooks.fixtures.js
+++ b/test/fixtures/webhooks.fixtures.js
@@ -62,7 +62,6 @@ function webhookSigningSecretResponse (options = {}) {
 
 function webhookMessageSearchResponse (options = []) {
   return {
-    total: options.length,
     count: options.length,
     page: 1,
     results: options.map(validWebhookMessage)


### PR DESCRIPTION
The webhooks details page currently shows a nubered centered range with a next/ previous button on either side for pagination. Replace this with just next/ pervious to
- bring it in line with the transactions pagination component
- remove the need for the total count performed by the backend
- represent that this is ephemeral data that is useful for debugging your webhook integrations but not a permanent management tool

Bring the pagination component in-line with the transactions page and update any expectations for the backend pagination response.

Uses the [same logic as backend resources](https://github.com/alphagov/pay-ledger/blob/d7793355168004d9ec99b0c280e63807715afbb1/src/main/java/uk/gov/pay/ledger/util/pagination/PaginationBuilder.java#L95-L97) to determine if there might be another page following this one.

<img width="631" alt="Screenshot 2023-03-23 at 11 52 53" src="https://user-images.githubusercontent.com/2844572/227195616-9cabd7fc-c78c-486b-814a-a24357d3a09a.png">

