### PR TITLE
BAU: Dependabot ignore Node v18+

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,12 +35,7 @@ updates:
   ignore:
   - dependency-name: node
     versions:
-    - ">= 14.a"
-    - "< 15"
-  - dependency-name: node
-    versions:
-    - ">= 15.a"
-    - "< 16"
+    - ">= 18"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
Removing the v14 restriction should prompt Dependabot to restart updates for Node v16 again.

I did this the long way round in Frontend (where I removed the restrictions completely, ignored the major bump PR, then re-added the config):
- https://github.com/alphagov/pay-frontend/pull/3377
- https://github.com/alphagov/pay-frontend/pull/3380
- https://github.com/alphagov/pay-frontend/pull/3381
