### PR TITLE
PP-10862 Combine feedback Cypress tests

### DIFF
--- a/test/cypress/integration/feedback/feedback.cy.js
+++ b/test/cypress/integration/feedback/feedback.cy.js
@@ -5,30 +5,19 @@ const zendeskStubs = require('../../stubs/zendesk-stubs')
 
 const authenticatedUserId = 'authenticated-user-id'
 
-function getUserAndAccountStubs (type, paymentProvider) {
-  return [userStubs.getUserSuccess({ userExternalId: authenticatedUserId, gatewayAccountId: '1' })
-  ]
-}
-
 describe('Feedback page', () => {
-  beforeEach(() => {
-    // keep the same session for entire describe block
-    Cypress.Cookies.preserveOnce('session', 'gateway_account')
+  it('should display Feedback page and allow submitting feedback', () => {
     cy.task('setupStubs',
       [
-        ...getUserAndAccountStubs('live', 'stripe'),
+        userStubs.getUserSuccess({ userExternalId: authenticatedUserId, gatewayAccountId: '1' }),
         zendeskStubs.createTicketSuccess()
       ])
-  })
 
-  it('should display Feedback page', () => {
     cy.setEncryptedCookies(authenticatedUserId)
     cy.visit('/feedback')
 
     cy.title().should('eq', 'Give feedback — GOV.UK Pay')
-  })
 
-  it('should submit Feedback form and display Success notification', () => {
     cy.get('button').contains('Send feedback').click()
     cy.get('.govuk-notification-banner__content').contains('Thanks for your feedback')
   })


### PR DESCRIPTION
Cypress best practices suggest that having tests rely on the state of previous tests is an anti-pattern.

Combine tests and remove use of Cypress.Cookies.preserveOnce() so that tests can be run independently.
