### PR TITLE
PP-10862 Combine edit permissions Cypress tests

### DIFF
--- a/test/cypress/integration/manage-team-members/edit-permissions.cy.js
+++ b/test/cypress/integration/manage-team-members/edit-permissions.cy.js
@@ -7,24 +7,21 @@ const SERVICE_EXTERNAL_ID = 'service_abc_123'
 const AUTHENTICATED_USER_ID = 'authenticated-user-id'
 const EDITING_USER_ID = 'user-we-are-editing-id'
 
+const authenticatedUserStubOpts = {
+  userExternalId: AUTHENTICATED_USER_ID,
+  email: 'logged-in-user@example.com',
+  serviceExternalId: SERVICE_EXTERNAL_ID,
+  role: { name: 'admin' }
+}
+const userWeAreEditingStubOpts = {
+  userExternalId: EDITING_USER_ID,
+  email: 'other-user@example.com',
+  serviceExternalId: SERVICE_EXTERNAL_ID,
+  role: { name: 'admin' }
+}
+
 describe('Edit service user permissions', () => {
-  beforeEach(() => {
-    // keep the same session for entire describe block
-    Cypress.Cookies.preserveOnce('session', 'gateway_account')
-
-    const authenticatedUserStubOpts = {
-      userExternalId: AUTHENTICATED_USER_ID,
-      email: 'logged-in-user@example.com',
-      serviceExternalId: SERVICE_EXTERNAL_ID,
-      role: { name: 'admin' }
-    }
-    const userWeAreEditingStubOpts = {
-      userExternalId: EDITING_USER_ID,
-      email: 'other-user@example.com',
-      serviceExternalId: SERVICE_EXTERNAL_ID,
-      role: { name: 'admin' }
-    }
-
+  it('should be able to update a team members permissions', () => {
     cy.task('setupStubs', [
       userStubs.getUserSuccess(authenticatedUserStubOpts),
       userStubs.getUserSuccess(userWeAreEditingStubOpts),
@@ -39,32 +36,24 @@ describe('Edit service user permissions', () => {
         role: 'view-and-refund'
       })
     ])
-  })
 
-  it('should display team members page', () => {
     cy.setEncryptedCookies(AUTHENTICATED_USER_ID)
 
     cy.visit(`/service/${SERVICE_EXTERNAL_ID}/team-members`)
 
     cy.get('#team-members-admin-list').find('tr').first().find('td').first().find('a').contains('logged-in-user@example.com (you)')
     cy.get('#team-members-admin-list').find('tr').eq(1).find('td').first().find('a').contains('other-user@example.com')
-  })
 
-  it('should redirect to team member details page', () => {
     cy.get('a').contains('other-user@example.com').click()
 
     cy.get('h1').contains('Details for other-user@example.com')
     cy.get('table').find('tr').first().find('td').first().contains('other-user@example.com')
     cy.get('table').find('tr').eq(1).find('td').first().contains('Administrator')
     cy.get('table').find('tr').eq(1).find('td').eq(1).find('a').contains('Edit permissions')
-  })
 
-  it('should redirect to edit user permissions page', () => {
     cy.get('a').contains('Edit permissions').click()
     cy.get('#role-admin-input').should('exist').should('have.attr', 'checked')
-  })
 
-  it('should update permission', () => {
     cy.get('#role-view-and-refund-input').click()
     cy.get('button').contains('Save changes').click()
     cy.get('.govuk-notification-banner--success').contains('Permissions have been updated')


### PR DESCRIPTION
Cypress best practices suggest that having tests rely on the state of previous tests is an anti-pattern.

Combine tests and remove use of Cypress.Cookies.preserveOnce() so that tests can be run independently.


