### PR TITLE
PP-10862 Combine add service Cypress tests

### DIFF
--- a/test/cypress/integration/my-services/add-new-service.cy.js
+++ b/test/cypress/integration/my-services/add-new-service.cy.js
@@ -11,49 +11,43 @@ const newServiceId = 'new-service-id'
 const newGatewayAccountId = 38
 
 const createGatewayAccountStub =
-  gatewayAccountStubs.postCreateGatewayAccountSuccess({ serviceName: newServiceName, serviceId: newServiceId, paymentProvider: 'sandbox', type: 'test', gatewayAccountId: newGatewayAccountId })
+  gatewayAccountStubs.postCreateGatewayAccountSuccess({
+    serviceName: newServiceName,
+    serviceId: newServiceId,
+    paymentProvider: 'sandbox',
+    type: 'test',
+    gatewayAccountId: newGatewayAccountId
+  })
 
 const assignUserRoleStub =
   userStubs.postAssignServiceRoleSuccess({ userExternalId: authenticatedUserId, serviceExternalId: newServiceId })
 
-function setupStubs (stubs = []) {
-  cy.task('setupStubs', [
-    ...stubs,
-    userStubs.getUserSuccess({ userExternalId: authenticatedUserId, gatewayAccountId: '1' }),
-    gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId: '1' })
-  ])
-}
-
 describe('Add a new service', () => {
-  beforeEach(() => {
-    // keep the same session for entire describe block
-    Cypress.Cookies.preserveOnce('session')
-  })
-
   describe('Add a new service without a Welsh name', () => {
     it('should display the my services page', () => {
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({ userExternalId: authenticatedUserId, gatewayAccountId: '1' }),
+        gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId: '1' }),
+        createGatewayAccountStub,
+        assignUserRoleStub,
+        serviceStubs.postCreateServiceSuccess({
+          serviceExternalId: newServiceId,
+          gatewayAccountId: newGatewayAccountId,
+          serviceName: { en: newServiceName }
+        }),
+        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId })
+      ])
+
       cy.setEncryptedCookies(authenticatedUserId)
-      setupStubs()
 
       cy.visit('/my-services')
       cy.title().should('eq', 'Choose service - GOV.UK Pay')
-    })
 
-    it('should navigate to the add new service form', () => {
-      setupStubs()
       cy.get('a').contains('Add a new service').click()
 
       cy.title().should('eq', 'Add a new service - GOV.UK Pay')
       cy.get('#checkbox-service-name-cy').should('have.attr', 'aria-expanded', 'false')
-    })
 
-    it('should add a service', () => {
-      setupStubs([
-        createGatewayAccountStub,
-        assignUserRoleStub,
-        serviceStubs.postCreateServiceSuccess({ serviceExternalId: newServiceId, gatewayAccountId: newGatewayAccountId, serviceName: { en: newServiceName } }),
-        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId })
-      ])
       cy.get('input#service-name').type(newServiceName)
       cy.get('button').contains('Add service').click()
 
@@ -64,29 +58,32 @@ describe('Add a new service', () => {
   describe('Add a new service with a Welsh name', () => {
     it('should display the my services page', () => {
       cy.setEncryptedCookies(authenticatedUserId)
-      setupStubs()
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({ userExternalId: authenticatedUserId, gatewayAccountId: '1' }),
+        gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId: '1' }),
+        createGatewayAccountStub,
+        assignUserRoleStub,
+        serviceStubs.postCreateServiceSuccess({
+          serviceExternalId: newServiceId,
+          gatewayAccountId: newGatewayAccountId,
+          serviceName: { en: newServiceName, cy: newServiceWelshName }
+        }),
+        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId })
+      ])
 
       cy.visit('/my-services')
       cy.title().should('eq', 'Choose service - GOV.UK Pay')
-    })
 
-    it('should navigate to the add new service form', () => {
-      setupStubs()
       cy.get('a').contains('Add a new service').click()
 
       cy.title().should('eq', 'Add a new service - GOV.UK Pay')
       cy.get('#checkbox-service-name-cy').should('have.attr', 'aria-expanded', 'false')
-    })
 
-    it('should display Welsh name input', () => {
-      setupStubs()
       cy.get('#checkbox-service-name-cy').click()
       cy.get('#checkbox-service-name-cy').should('have.attr', 'aria-expanded', 'true')
       cy.get('input#service-name-cy').should('exist')
-    })
 
-    it('should show a validation errors for service name and Welsh service name fields', () => {
-      setupStubs()
+      cy.log('Enter a name that is too long and check validation errors are displayed')
       cy.get('input#service-name-cy').type('Lorem ipsum dolor sit amet, consectetuer adipiscing', { delay: 0 })
       cy.get('button').contains('Add service').click()
 
@@ -103,15 +100,8 @@ describe('Add a new service', () => {
       cy.get('.govuk-form-group--error > input#service-name-cy').parent().should('exist').within(() => {
         cy.get('.govuk-error-message').should('contain', 'Welsh service name must be 50 characters or fewer')
       })
-    })
 
-    it('should add a service', () => {
-      setupStubs([
-        createGatewayAccountStub,
-        assignUserRoleStub,
-        serviceStubs.postCreateServiceSuccess({ serviceExternalId: newServiceId, gatewayAccountId: newGatewayAccountId, serviceName: { en: newServiceName, cy: newServiceWelshName } }),
-        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId })
-      ])
+      cy.log('Enter a valid name')
       cy.get('input#service-name').clear()
       cy.get('input#service-name-cy').clear()
       cy.get('input#service-name').type(newServiceName)

--- a/test/cypress/integration/my-services/my-services.cy.js
+++ b/test/cypress/integration/my-services/my-services.cy.js
@@ -82,26 +82,16 @@ describe('The user does not have any services', () => {
 })
 
 describe('Service has a live account that supports payouts', () => {
-  beforeEach(() => {
-    // keep the same session for entire describe block
-    Cypress.Cookies.preserveOnce('session')
-  })
-
   it('should display link to view payouts', () => {
-    cy.task('setupStubs', getUserAndAccountStubs('live', 'stripe'))
+    cy.task('setupStubs', [
+      ...getUserAndAccountStubs('live', 'stripe'),
+      payoutStubs.getLedgerPayoutSuccess({ gatewayAccountId: '1' })
+    ])
 
     cy.setEncryptedCookies(authenticatedUserId)
     cy.visit('/my-services')
     cy.title().should('eq', 'Choose service - GOV.UK Pay')
 
-    cy.contains('a', 'View payments to your bank account')
-  })
-
-  it('should direct to the list payouts page', () => {
-    cy.task('setupStubs', [
-      ...getUserAndAccountStubs('live', 'stripe'),
-      payoutStubs.getLedgerPayoutSuccess({ gatewayAccountId: '1' })
-    ])
     cy.contains('a', 'View payments to your bank account').click()
     cy.get('h1').contains('Payments to your bank account')
   })


### PR DESCRIPTION
Cypress best practices suggest that having tests rely on the state of previous tests is an anti-pattern.

Combine tests and remove use of Cypress.Cookies.preserveOnce() so that tests can be run independently.
