### PR TITLE
PP-10862 Make request to go live tests standalone

### DIFF
--- a/test/cypress/integration/request-to-go-live/organisation-address.cy.js
+++ b/test/cypress/integration/request-to-go-live/organisation-address.cy.js
@@ -19,152 +19,115 @@ describe('The organisation address page', () => {
   const validUrl = 'https://www.example.com'
   const invalidUrl = 'invalid.url'
 
+  beforeEach(() => {
+    cy.setEncryptedCookies(userExternalId)
+  })
+
   describe('The go-live stage is ENTERED_ORGANISATION_NAME and there are no existing merchant details', () => {
-    beforeEach(() => {
-      // keep the same session for entire describe block
-      Cypress.Cookies.preserveOnce('session', 'gateway_account')
-    })
+    it('should allow submitting organisation address', () => {
+      const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')
+      utils.setupGetUserAndGatewayAccountStubs(serviceRole)
+      cy.visit(pageUrl)
 
-    describe('Form validation', () => {
-      beforeEach(() => {
-        const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')
-        utils.setupGetUserAndGatewayAccountStubs(serviceRole)
+      cy.get('h1').should('contain', `Enter your organisation’s contact details`)
+
+      cy.get('label[for="address-line1"]').should('exist')
+      cy.get('input#address-line1[name="address-line1"]').should('exist')
+      cy.get('input#address-line2[name="address-line2"]').should('exist')
+
+      cy.get('label[for="address-city"]').should('exist')
+      cy.get('input#address-city[name="address-city"]').should('exist')
+
+      cy.get('label[for="address-country"]').should('exist')
+      cy.get('select#address-country[name="address-country"]').should('exist')
+
+      cy.get('label[for="address-postcode"]').should('exist')
+      cy.get('input#address-postcode[name="address-postcode"]').should('exist')
+
+      cy.get('label[for="telephone-number"]').should('exist')
+      cy.get('#telephone-number-hint').should('exist')
+      cy.get('input#telephone-number[name="telephone-number"]').should('exist')
+
+      cy.get('label[for="url"]').should('exist')
+      cy.get('#url-hint').should('exist')
+      cy.get('input#url[name="url"]').should('exist')
+
+      cy.get('[data-cy=account-sub-nav]')
+        .should('not.exist')
+
+      cy.log('Check validation messages when invalid values are submitted')
+      cy.get('#address-postcode').type(invalidPostcode)
+      cy.get('#telephone-number').type(invalidTelephoneNumber)
+      cy.get('#url').type(invalidUrl)
+
+      cy.get('button').contains('Continue').click()
+
+      cy.get('.govuk-error-summary').find('a').should('have.length', 5)
+      cy.get('.govuk-error-summary').should('exist').within(() => {
+        cy.get('a[href="#address-line1"]').should('contain', 'Enter a building and street')
+        cy.get('a[href="#address-city"]').should('contain', 'Enter a town or city')
+        cy.get('a[href="#address-postcode"]').should('contain', 'Enter a real postcode')
+        cy.get('a[href="#telephone-number"]').should('contain', 'Enter a telephone number')
+        cy.get('a[href="#url"]').should('contain', 'Enter a valid website address')
       })
 
-      it('should display form', () => {
-        cy.setEncryptedCookies(userExternalId)
-        cy.visit(pageUrl)
-
-        cy.get('h1').should('contain', `Enter your organisation’s contact details`)
-
-        cy.get(`form[method=post]`)
-          .should('exist')
-          .within(() => {
-            cy.get('label[for="address-line1"]').should('exist')
-            cy.get('input#address-line1[name="address-line1"]').should('exist')
-            cy.get('input#address-line2[name="address-line2"]').should('exist')
-
-            cy.get('label[for="address-city"]').should('exist')
-            cy.get('input#address-city[name="address-city"]').should('exist')
-
-            cy.get('label[for="address-country"]').should('exist')
-            cy.get('select#address-country[name="address-country"]').should('exist')
-
-            cy.get('label[for="address-postcode"]').should('exist')
-            cy.get('input#address-postcode[name="address-postcode"]').should('exist')
-
-            cy.get('label[for="telephone-number"]').should('exist')
-            cy.get('#telephone-number-hint').should('exist')
-            cy.get('input#telephone-number[name="telephone-number"]').should('exist')
-
-            cy.get('label[for="url"]').should('exist')
-            cy.get('#url-hint').should('exist')
-            cy.get('input#url[name="url"]').should('exist')
-          })
+      cy.get('.govuk-form-group--error > input#address-line1').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'Enter a building and street')
+      })
+      cy.get('.govuk-form-group--error > input#address-city').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'Enter a town or city')
+      })
+      cy.get('.govuk-form-group--error > input#address-postcode').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'Enter a real postcode')
+      })
+      cy.get('.govuk-form-group--error > input#telephone-number').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'Enter a telephone number')
+      })
+      cy.get('.govuk-form-group--error > input#url').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'Enter a valid website address')
       })
 
-      it('should not display the account sub nav', () => {
-        cy.get('[data-cy=account-sub-nav]')
-          .should('not.exist')
+      cy.log('Fill in details for all fields to check values are displayed back when form is re-rendered with validation errors')
+      cy.get('#address-line1').type(validLine1)
+      cy.get('#address-line2').type(validLine2)
+      cy.get('#address-city').type(validCity)
+      cy.get('#address-country').select(countryGb)
+      cy.get('button').contains('Continue').click()
+
+      cy.get('.govuk-error-summary').find('a').should('have.length', 3)
+      cy.get('.govuk-error-summary').should('exist').within(() => {
+        cy.get('a[href="#address-postcode"]').should('contain', 'Enter a real postcode')
+        cy.get('a[href="#telephone-number"]').should('contain', 'Enter a telephone number')
+        cy.get('a[href="#url"]').should('contain', 'Enter a valid website address')
       })
 
-      it('should display errors when validation fails', () => {
-        cy.get(`form[method=post]`)
-          .within(() => {
-            // create errors by leaving fields blank or inputting invalid values
-            cy.get('#address-postcode').type(invalidPostcode)
-            cy.get('#telephone-number').type(invalidTelephoneNumber)
-            cy.get('#url').type(invalidUrl)
+      cy.get('#address-line1').should('have.value', validLine1)
+      cy.get('#address-line2').should('have.value', validLine2)
+      cy.get('#address-city').should('have.value', validCity)
+      cy.get('#address-country').should('have.value', countryGb)
+      cy.get('#address-postcode').should('have.value', invalidPostcode)
+      cy.get('#telephone-number').should('have.value', invalidTelephoneNumber)
+      cy.get('#url').should('have.value', invalidUrl)
 
-            cy.get('button').click()
-          })
+      const afterUpdateServiceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS')
 
-        cy.get('.govuk-error-summary').find('a').should('have.length', 5)
-        cy.get('.govuk-error-summary').should('exist').within(() => {
-          cy.get('a[href="#address-line1"]').should('contain', 'Enter a building and street')
-          cy.get('a[href="#address-city"]').should('contain', 'Enter a town or city')
-          cy.get('a[href="#address-postcode"]').should('contain', 'Enter a real postcode')
-          cy.get('a[href="#telephone-number"]').should('contain', 'Enter a telephone number')
-          cy.get('a[href="#url"]').should('contain', 'Enter a valid website address')
-        })
+      cy.task('clearStubs')
+      cy.task('setupStubs', [
+        utils.patchUpdateServiceSuccessCatchAllStub('ENTERED_ORGANISATION_ADDRESS'),
+        ...utils.getUserAndGatewayAccountStubs(afterUpdateServiceRole)
+      ])
 
-        cy.get(`form[method=post]`)
-          .within(() => {
-            cy.get('.govuk-form-group--error > input#address-line1').parent().should('exist').within(() => {
-              cy.get('.govuk-error-message').should('contain', 'Enter a building and street')
-            })
-            cy.get('.govuk-form-group--error > input#address-city').parent().should('exist').within(() => {
-              cy.get('.govuk-error-message').should('contain', 'Enter a town or city')
-            })
-            cy.get('.govuk-form-group--error > input#address-postcode').parent().should('exist').within(() => {
-              cy.get('.govuk-error-message').should('contain', 'Enter a real postcode')
-            })
-            cy.get('.govuk-form-group--error > input#telephone-number').parent().should('exist').within(() => {
-              cy.get('.govuk-error-message').should('contain', 'Enter a telephone number')
-            })
-            cy.get('.govuk-form-group--error > input#url').parent().should('exist').within(() => {
-              cy.get('.govuk-error-message').should('contain', 'Enter a valid website address')
-            })
-          })
-      })
+      cy.log('Enter valid values and submit')
+      cy.get('#address-postcode').clear()
+      cy.get('#telephone-number').clear()
+      cy.get('#url').clear()
+      cy.get('#address-postcode').type(validPostcodeGb)
+      cy.get('#telephone-number').type(validTelephoneNumber)
+      cy.get('#url').type(validUrl)
+      cy.get('button').contains('Continue').click()
 
-      it('should keep entered responses when validation fails', () => {
-        cy.get(`form[method=post]`)
-          .within(() => {
-            // fill in the rest of the form fields
-            cy.get('#address-line1').type(validLine1)
-            cy.get('#address-line2').type(validLine2)
-            cy.get('#address-city').type(validCity)
-            cy.get('#address-country').select(countryGb)
-            cy.get('button').click()
-          })
-
-        cy.get('.govuk-error-summary').find('a').should('have.length', 3)
-        cy.get('.govuk-error-summary').should('exist').within(() => {
-          cy.get('a[href="#address-postcode"]').should('contain', 'Enter a real postcode')
-          cy.get('a[href="#telephone-number"]').should('contain', 'Enter a telephone number')
-          cy.get('a[href="#url"]').should('contain', 'Enter a valid website address')
-        })
-
-        cy.get(`form[method=post]`)
-          .within(() => {
-            cy.get('#address-line1').should('have.value', validLine1)
-            cy.get('#address-line2').should('have.value', validLine2)
-            cy.get('#address-city').should('have.value', validCity)
-            cy.get('#address-country').should('have.value', countryGb)
-            cy.get('#address-postcode').should('have.value', invalidPostcode)
-            cy.get('#telephone-number').should('have.value', invalidTelephoneNumber)
-            cy.get('#url').should('have.value', invalidUrl)
-          })
-      })
-    })
-
-    describe('Valid details submitted', () => {
-      beforeEach(() => {
-        const afterUpdateServiceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS')
-
-        cy.task('setupStubs', [
-          utils.patchUpdateServiceSuccessCatchAllStub('ENTERED_ORGANISATION_ADDRESS'),
-          ...utils.getUserAndGatewayAccountStubs(afterUpdateServiceRole)
-        ])
-      })
-
-      it('should submit organisation address when validation succeeds', () => {
-        cy.get(`form[method=post]`)
-          .within(() => {
-            // correct the validation errors
-            cy.get('#address-postcode').clear()
-            cy.get('#telephone-number').clear()
-            cy.get('#url').clear()
-            cy.get('#address-postcode').type(validPostcodeGb)
-            cy.get('#telephone-number').type(validTelephoneNumber)
-            cy.get('#url').type(validUrl)
-            cy.get('button').click()
-          })
-
-        cy.location().should((location) => {
-          expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`)
-        })
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq(`/service/${serviceExternalId}/request-to-go-live/choose-how-to-process-payments`)
       })
     })
   })
@@ -183,7 +146,6 @@ describe('The organisation address page', () => {
     serviceRole.service.merchant_details = merchantDetails
 
     it('should display form with existing details pre-filled', () => {
-      cy.setEncryptedCookies(userExternalId)
       utils.setupGetUserAndGatewayAccountStubs(serviceRole)
       cy.visit(`/service/${serviceExternalId}/request-to-go-live/organisation-address`)
 
@@ -203,12 +165,9 @@ describe('The organisation address page', () => {
   describe('User does not have the correct permissions', () => {
     const serviceRole = utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_NAME')
     serviceRole.role = { permissions: [] }
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
-      utils.setupGetUserAndGatewayAccountStubs(serviceRole)
-    })
 
     it('should show an error when the user does not have enough permissions', () => {
+      utils.setupGetUserAndGatewayAccountStubs(serviceRole)
       cy.visit(pageUrl, { failOnStatusCode: false })
       cy.get('h1').should('contain', 'An error occurred')
       cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
@@ -217,12 +176,9 @@ describe('The organisation address page', () => {
 
   describe('Service has invalid go live stage', () => {
     const serviceRole = utils.buildServiceRoleForGoLiveStage('NOT_STARTED')
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
-      utils.setupGetUserAndGatewayAccountStubs(serviceRole)
-    })
 
     it('should redirect to "Request to go live: index" page when in wrong stage', () => {
+      utils.setupGetUserAndGatewayAccountStubs(serviceRole)
       cy.visit(pageUrl)
 
       cy.get('h1').should('contain', 'Request a live account')


### PR DESCRIPTION
Cypress best practices suggest that having tests rely on the state of previous tests is an anti-pattern.

Combine tests and remove use of Cypress.Cookies.preserveOnce() so that tests can be run independently.

## Review notes

Hiding whitespace changes from the diff will make this easier to review