### PR TITLE
PP-10862 Make wallet tests standalone

### DIFF
--- a/test/cypress/integration/settings/allow-apple-pay.cy.js
+++ b/test/cypress/integration/settings/allow-apple-pay.cy.js
@@ -18,58 +18,52 @@ function setupStubs (allowApplePay) {
     })
   ])
 }
+
 describe('Apple Pay', () => {
   beforeEach(() => {
-    Cypress.Cookies.preserveOnce('session', 'gateway_account')
+    cy.setEncryptedCookies(userExternalId)
   })
 
-  describe('is disabled when unsupported', () => {
-    beforeEach(() => {
-      setupStubs(false)
-    })
+  it('should show it is disabled', () => {
+    setupStubs(false)
 
-    it('should show it is disabled', () => {
-      cy.setEncryptedCookies(userExternalId)
-      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-      cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
-      cy.get('a').contains('Change Apple Pay settings').click()
-      cy.get('input[type="radio"]').should('have.length', 2)
-      cy.get('input[value="on"]').should('not.be.checked')
-      cy.get('input[value="off"]').should('be.checked')
-      cy.get('#navigation-menu-settings').click()
-      cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
-    })
+    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+    cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
+    cy.get('a').contains('Change Apple Pay settings').click()
+    cy.get('input[type="radio"]').should('have.length', 2)
+    cy.get('input[value="on"]').should('not.be.checked')
+    cy.get('input[value="off"]').should('be.checked')
+    cy.get('#navigation-menu-settings').click()
+    cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
   })
 
-  describe('but allow us to enable when supported', () => {
-    beforeEach(() => {
-      setupStubs(false)
-    })
+  it('should show it is enabled', () => {
+    setupStubs(true)
 
-    it('Show that is is disabled', () => {
-      cy.setEncryptedCookies(userExternalId)
-      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-      cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
-      cy.get('a').contains('Change Apple Pay settings').click()
-    })
+    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+    cy.get('.govuk-summary-list__value').first().should('contain', 'On')
+    cy.get('a').contains('Change Apple Pay settings').click()
+    cy.get('input[type="radio"]').should('have.length', 2)
+    cy.get('input[value="on"]').should('be.checked')
+    cy.get('input[value="off"]').should('not.be.checked')
+    cy.get('#navigation-menu-settings').click()
+    cy.get('.govuk-summary-list__value').first().should('contain', 'On')
   })
 
-  describe('Show enabled after turning on', () => {
-    beforeEach(() => {
-      setupStubs(true)
+  it('should allow us to enable', () => {
+    setupStubs(false)
+
+    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+    cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
+    cy.get('a').contains('Change Apple Pay settings').click()
+
+    cy.get('input[value="on"]').click()
+    cy.get('input[value="on"]').should('be.checked')
+    cy.get('.govuk-button').contains('Save changes').click()
+
+    cy.location().should((location) => {
+      expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
     })
-
-    it('should allow us to enable', () => {
-      cy.get('input[value="on"]').click()
-      cy.get('input[value="on"]').should('be.checked')
-      cy.get('.govuk-button').contains('Save changes').click()
-
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
-      })
-      cy.get('.govuk-notification-banner--success').should('contain', 'Apple Pay successfully enabled')
-
-      cy.get('.govuk-summary-list__value').first().should('contain', 'On')
-    })
+    cy.get('.govuk-notification-banner--success').should('contain', 'Apple Pay successfully enabled')
   })
 })

--- a/test/cypress/integration/settings/allow-google-pay.cy.js
+++ b/test/cypress/integration/settings/allow-google-pay.cy.js
@@ -26,57 +26,48 @@ function setupStubs (allowGooglePay) {
 
 describe('Google Pay', () => {
   beforeEach(() => {
-    Cypress.Cookies.preserveOnce('session', 'gateway_account')
+    cy.setEncryptedCookies(userExternalId)
   })
 
-  describe('is disabled', () => {
-    beforeEach(() => {
-      setupStubs(false)
-    })
-
-    it('should show it is disabled', () => {
-      cy.setEncryptedCookies(userExternalId)
-      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-      cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
-      cy.get('a').contains('Change Google Pay settings').click()
-      cy.get('input[type="radio"]').should('have.length', 2)
-      cy.get('input[value="on"]').should('not.be.checked')
-      cy.get('input[value="off"]').should('be.checked')
-      cy.get('#navigation-menu-settings').click()
-      cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
-    })
+  it('should show it is disabled', () => {
+    setupStubs(false)
+    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+    cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
+    cy.get('a').contains('Change Google Pay settings').click()
+    cy.get('input[type="radio"]').should('have.length', 2)
+    cy.get('input[value="on"]').should('not.be.checked')
+    cy.get('input[value="off"]').should('be.checked')
+    cy.get('#navigation-menu-settings').click()
+    cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
   })
 
-  describe('but allow us to enable when supported', () => {
-    beforeEach(() => {
-      setupStubs(false)
-    })
-
-    it('should allow us to enable', () => {
-      cy.setEncryptedCookies(userExternalId)
-      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-      cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
-      cy.get('a').contains('Change Google Pay settings').click()
-    })
+  it('should show it is enabled', () => {
+    setupStubs(true)
+    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+    cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On')
+    cy.get('a').contains('Change Google Pay settings').click()
+    cy.get('input[type="radio"]').should('have.length', 2)
+    cy.get('input[value="on"]').should('be.checked')
+    cy.get('input[value="off"]').should('not.be.checked')
+    cy.get('#navigation-menu-settings').click()
+    cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On')
   })
 
-  describe('Show enabled after turning on', () => {
-    beforeEach(() => {
-      setupStubs(true)
+  it('should allow us to enable', () => {
+    setupStubs(false)
+
+    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+    cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
+    cy.get('a').contains('Change Google Pay settings').click()
+
+    cy.get('input[value="on"]').click()
+    cy.get('input[value="on"]').should('be.checked')
+    cy.get('#merchantId').type('111111111111111')
+    cy.get('.govuk-button').contains('Save changes').click()
+
+    cy.location().should((location) => {
+      expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
     })
-
-    it('should allow us to enable', () => {
-      cy.get('input[value="on"]').click()
-      cy.get('input[value="on"]').should('be.checked')
-      cy.get('#merchantId').type('111111111111111')
-      cy.get('.govuk-button').contains('Save changes').click()
-
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
-      })
-      cy.get('.govuk-notification-banner--success').should('contain', 'Google Pay successfully enabled')
-
-      cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On')
-    })
+    cy.get('.govuk-notification-banner--success').should('contain', 'Google Pay successfully enabled')
   })
 })


### PR DESCRIPTION
Cypress best practices suggest that having tests rely on the state of previous tests is an anti-pattern.

Combine tests and remove use of Cypress.Cookies.preserveOnce() so that tests can be run independently.

## Review notes

Hiding whitespace diff will make this easier to review

