### PR TITLE
PP-10862 Make settings Cypress tests standalone

### DIFF
--- a/test/cypress/integration/settings/default-billing-address-country.cy.js
+++ b/test/cypress/integration/settings/default-billing-address-country.cy.js
@@ -21,33 +21,13 @@ function getUserAndGatewayAccountStubs (defaultBillingAddressCountry) {
 
 describe('Default billing address country', () => {
   beforeEach(() => {
-    Cypress.Cookies.preserveOnce('session', 'gateway_account')
+    cy.setEncryptedCookies(userExternalId)
   })
 
   describe('User is an admin', () => {
-    it('should show default country as None', () => {
-      cy.task('setupStubs', getUserAndGatewayAccountStubs(null))
-
-      cy.setEncryptedCookies(userExternalId)
-      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-
-      cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Default billing address country')
-      cy.get('.govuk-summary-list__value').eq(1).should('contain', 'None')
-    })
-
-    it('should show setting as Off', () => {
-      cy.task('setupStubs', getUserAndGatewayAccountStubs(null))
-
-      cy.get('.govuk-summary-list__actions').eq(1).contains('Change').click()
-
-      cy.get('input[type="radio"]').should('have.length', 2)
-      cy.get('input[value="on"]').should('not.be.checked')
-      cy.get('input[value="off"]').should('be.checked')
-    })
-
-    it('should update to On', () => {
+    it('should show default country as None and allow updating', () => {
       cy.task('setupStubs', [
-        ...getUserAndGatewayAccountStubs('GB'),
+        ...getUserAndGatewayAccountStubs(null),
         serviceStubs.patchUpdateDefaultBillingAddressCountrySuccess({
           serviceExternalId,
           gatewayAccountId,
@@ -55,16 +35,35 @@ describe('Default billing address country', () => {
         })
       ])
 
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+
+      cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Default billing address country')
+      cy.get('.govuk-summary-list__value').eq(1).should('contain', 'None')
+
+      cy.get('.govuk-summary-list__actions').eq(1).contains('Change').click()
+
+      cy.get('input[type="radio"]').should('have.length', 2)
+      cy.get('input[value="on"]').should('not.be.checked')
+      cy.get('input[value="off"]').should('be.checked')
+
       cy.get('input[value="on"]').click()
       cy.get('.govuk-button').contains('Save changes').click()
 
       cy.location().should((location) => {
         expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
       })
-      cy.get('.govuk-notification-banner--success').should('contain', 'United Kingdom as the default billing address: On')
 
-      cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Default billing address country')
-      cy.get('.govuk-summary-list__value').eq(1).should('contain', 'United Kingdom')
+      it('should show default billing address country as "United Kingdom"', () => {
+        cy.task('setupStubs', [
+          ...getUserAndGatewayAccountStubs('GB'),
+        ])
+
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+        cy.get('.govuk-notification-banner--success').should('contain', 'United Kingdom as the default billing address: On')
+
+        cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Default billing address country')
+        cy.get('.govuk-summary-list__value').eq(1).should('contain', 'United Kingdom')
+      })
     })
   })
 

--- a/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.js
+++ b/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.js
@@ -55,28 +55,24 @@ describe('MOTO mask security section', () => {
   }
 
   beforeEach(() => {
-    Cypress.Cookies.preserveOnce('session', 'gateway_account')
+    cy.setEncryptedCookies(userExternalId)
   })
 
   describe('When accessing MOTO mask settings', () => {
     describe('when gateway account has allowMoto=false', () => {
-      beforeEach(() => {
-        setupMotoStubs({ allowMoto: false })
-      })
-
       it('should not show mask security section', () => {
-        cy.setEncryptedCookies(userExternalId)
+        setupMotoStubs({ allowMoto: false })
+
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('#moto-mask-security-settings-heading').should('not.exist')
       })
     })
 
     describe('mask card number - when user has read permission and card number mask disabled', () => {
-      beforeEach(() => {
-        setupMotoStubs({ readonly: true, allowMoto: true, motoMaskCardNumber: false })
-      })
 
       it('should show radios as disabled and card number mask disabled', () => {
+        setupMotoStubs({ readonly: true, allowMoto: true, motoMaskCardNumber: false })
+
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(5).should('contain', 'Hide card numbers')
         cy.get('.govuk-summary-list__value').eq(5).should('contain', 'Off')
@@ -92,11 +88,9 @@ describe('MOTO mask security section', () => {
     })
 
     describe('mask card number - when user has update permission and card number mask disabled', () => {
-      beforeEach(() => {
+      it('should show radios as enabled and card number mask disabled and allow updating', () => {
         setupMotoStubs({ readonly: false, allowMoto: true, motoMaskCardNumber: false })
-      })
 
-      it('should show radios as enabled and card number mask disabled', () => {
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(5).should('contain', 'Hide card numbers')
         cy.get('.govuk-summary-list__value').eq(5).should('contain', 'Off')
@@ -107,15 +101,7 @@ describe('MOTO mask security section', () => {
         cy.get('input[value="off"]').should('not.be.disabled')
         cy.get('input[value="on"]').should('not.be.checked')
         cy.get('input[value="off"]').should('be.checked')
-      })
-    })
 
-    describe('mask card number - when user has update permission and updates card number to enabled', () => {
-      beforeEach(() => {
-        setupMotoStubs({ readonly: false, allowMoto: true, motoMaskCardNumber: true })
-      })
-
-      it('should redirect to settings page and show success message', () => {
         cy.get('input[value="on"]').click()
         cy.get('#save-moto-mask-changes').click()
         cy.location().should((location) => {
@@ -126,11 +112,9 @@ describe('MOTO mask security section', () => {
     })
 
     describe('mask security code - when user has read permission and security code mask disabled', () => {
-      beforeEach(() => {
-        setupMotoStubs({ readonly: true, allowMoto: true, motoMaskSecurityCode: false })
-      })
-
       it('should show radios as disabled and card number mask disabled', () => {
+        setupMotoStubs({ readonly: true, allowMoto: true, motoMaskSecurityCode: false })
+
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(6).should('contain', 'Hide card security codes')
         cy.get('.govuk-summary-list__value').eq(6).should('contain', 'Off')
@@ -146,11 +130,9 @@ describe('MOTO mask security section', () => {
     })
 
     describe('mask security code - when user has update permission and security code mask disabled', () => {
-      beforeEach(() => {
+      it('should show radios as enabled and no masking and allow updating', () => {
         setupMotoStubs({ readonly: false, allowMoto: true, motoMaskSecurityCode: false })
-      })
 
-      it('should show radios as enabled and no masking', () => {
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
         cy.get('.govuk-summary-list__key').eq(6).should('contain', 'Hide card security codes')
         cy.get('.govuk-summary-list__value').eq(6).should('contain', 'Off')
@@ -161,15 +143,7 @@ describe('MOTO mask security section', () => {
         cy.get('input[value="off"]').should('not.be.disabled')
         cy.get('input[value="on"]').should('not.be.checked')
         cy.get('input[value="off"]').should('be.checked')
-      })
-    })
 
-    describe('mask security code - when user has update permission and updates security code to enabled', () => {
-      beforeEach(() => {
-        setupMotoStubs({ readonly: false, allowMoto: true, motoMaskSecurityCode: true })
-      })
-
-      it('should redirect to settings page and show success message', () => {
         cy.get('input[value="on"]').click()
         cy.get('#save-moto-mask-changes').click()
         cy.location().should((location) => {

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -169,13 +169,11 @@ function postCreateGatewayAccountSuccess (opts) {
 
 function getAcceptedCardTypesSuccess (opts) {
   const path = `/v1/frontend/accounts/${opts.gatewayAccountId}/card-types`
-  const response = opts.updated
-    ? cardFixtures.validUpdatedAcceptedCardTypesResponse()
-    : cardFixtures.validAcceptedCardTypesResponse({
-      account_id: opts.gatewayAccountId,
-      updated: opts.updated,
-      maestro: opts.maestro || ''
-    })
+  const response = cardFixtures.validAcceptedCardTypesResponse({
+    account_id: opts.gatewayAccountId,
+    updated: opts.updated,
+    maestro: opts.maestro || ''
+  })
   return stubBuilder('GET', path, 200, { response: response })
 }
 
@@ -211,6 +209,7 @@ function patchAccountEmailCollectionModeSuccess (opts) {
     request: gatewayAccountFixtures.validGatewayAccountEmailCollectionModeRequest('MANDATORY')
   })
 }
+
 function patchAccountUpdateApplePaySuccess (gatewayAccountId, allowApplePay) {
   const path = `/v1/api/accounts/${gatewayAccountId}`
   return stubBuilder('PATCH', path, 200, {
@@ -224,6 +223,7 @@ function patchAccountUpdateGooglePaySuccess (gatewayAccountId, allowGooglePay) {
     request: gatewayAccountFixtures.validUpdateToggleGooglePayRequest(allowGooglePay)
   })
 }
+
 function patchUpdateServiceNameSuccess (gatewayAccountId, serviceName) {
   const path = `/v1/frontend/accounts/${gatewayAccountId}/servicename`
   return stubBuilder('PATCH', path, 200, {

--- a/test/fixtures/card.fixtures.js
+++ b/test/fixtures/card.fixtures.js
@@ -112,46 +112,5 @@ module.exports = {
     }
 
     return data
-  },
-  validUpdatedAcceptedCardTypesResponse: () => {
-    return {
-      card_types: [{
-        id: 'a1200c73-204d-45f5-8fca-e4ee5ed1b1a7',
-        brand: 'visa',
-        label: 'Visa',
-        type: 'DEBIT',
-        requires3ds: false
-      }, {
-        id: 'd03f5008-f793-4ea5-8a23-87f40ceb6c81',
-        brand: 'visa',
-        label: 'Visa',
-        type: 'CREDIT',
-        requires3ds: false
-      }, {
-        id: '491df314-fcb1-428f-9ea8-320865cf2a29',
-        brand: 'master-card',
-        label: 'Mastercard',
-        type: 'DEBIT',
-        requires3ds: false
-      }, {
-        id: '667cad4d-8ef9-418b-8023-5c8922f82d7a',
-        brand: 'master-card',
-        label: 'Mastercard',
-        type: 'CREDIT',
-        requires3ds: false
-      }, {
-        id: 'fff66fd7-e1d6-4c65-846d-9199c906e368',
-        brand: 'american-express',
-        label: 'American Express',
-        type: 'CREDIT',
-        requires3ds: false
-      }, {
-        id: '2d5462a8-fb95-4a5a-b991-3891e40312f3',
-        brand: 'diners-club',
-        label: 'Diners Club',
-        type: 'CREDIT',
-        requires3ds: false
-      }]
-    }
   }
 }


### PR DESCRIPTION
Cypress best practices suggest that having tests rely on the state of previous tests is an anti-pattern.

Combine tests and remove use of Cypress.Cookies.preserveOnce() so that tests can be run independently.

Simplify payment-types.cy.js to not attempt to check what the new selected card types are after updating. This was only checking that the page has the enabled card types returned by connector selected and not any selfservice logic. Instead, just check that the page is successfully reloaded with a success message.

## Review notes

Hiding whitespace changes will make this slightly easier to review