### PR TITLE
PP-10862 Make stripe setup tests standalone

### DIFF
--- a/test/cypress/integration/stripe-setup/update-org-details.cy.js
+++ b/test/cypress/integration/stripe-setup/update-org-details.cy.js
@@ -68,229 +68,173 @@ describe('The organisation address page', () => {
 
   describe('Stripe setup after `go live` request and there are no existing merchant details', () => {
     beforeEach(() => {
-      // keep the same session for entire describe block
-      Cypress.Cookies.preserveOnce('session')
+      cy.setEncryptedCookies(userExternalId)
     })
 
-    describe('Form validation', () => {
-      beforeEach(() => {
-        setupStubs(false)
-      })
-
-      it('should display form', () => {
-        cy.setEncryptedCookies(userExternalId)
-        cy.visit(pageUrl)
-
-        cy.get('h1').should('contain', `What is the name and address of your organisation on your government entity document?`)
-
-        cy.get('.govuk-back-link').should('contain', 'Back to check your organisation’s details')
-        cy.get('.govuk-back-link').should('have.attr', 'href', checkOrgDetailsUrl)
-
-        cy.get('#navigation-menu-your-psp')
-          .should('contain', 'Information for Stripe')
-          .parent().should('have.class', 'govuk-!-font-weight-bold')
-
-        cy.get('[data-cy=form]')
-          .should('exist')
-          .within(() => {
-            cy.get('[data-cy=label-org-name]').should('exist')
-            cy.get('[data-cy=input-org-name]').should('exist')
-
-            cy.get('[data-cy=label-address-line-1]').should('exist')
-            cy.get('[data-cy=input-address-line-1]').should('exist')
-            cy.get('[data-cy=input-address-line-2]').should('exist')
-
-            cy.get('[data-cy=label-address-city]').should('exist')
-            cy.get('[data-cy=input-address-city]').should('exist')
-
-            cy.get('[data-cy=label-address-country]').should('exist')
-            cy.get('[data-cy=input-address-country]').should('exist')
-
-            cy.get('[data-cy=label-address-postcode]').should('exist')
-            cy.get('[data-cy=input-address-postcode]').should('exist')
-
-            cy.get('[data-cy=continue-button]').should('exist')
-            cy.get('[data-cy=save-button]').should('not.exist')
-          })
-      })
-
-      it('should display the account sub nav', () => {
-        cy.get('[data-cy=account-sub-nav]')
-          .should('exist')
-      })
-
-      it('should not display the telephone or url fields', () => {
-        cy.get('[data-cy=form]')
-          .should('exist')
-          .within(() => {
-            cy.get('[data-cy=label-telephone-number]').should('not.exist')
-            cy.get('[data-cy=hint-telephone-number]').should('not.exist')
-            cy.get('[data-cy=input-telephone-number]').should('not.exist')
-
-            cy.get('[data-cy=label-url]').should('not.exist')
-            cy.get('[data-cy=hint-url]').should('not.exist')
-            cy.get('[data-cy=input-url]').should('not.exist')
-          })
-      })
-
-      it('should display errors when validation fails', () => {
-        cy.get('[data-cy=form]')
-          .within(() => {
-            // create errors by leaving fields blank or inputting invalid values
-            cy.get('[data-cy=input-address-postcode]').type(invalidPostcode)
-
-            cy.get('[data-cy=continue-button]').click()
-          })
-
-        cy.get('[data-cy=error-summary]').find('a').should('have.length', 4)
-        cy.get('[data-cy=error-summary]').should('exist').within(() => {
-          cy.get('a[href="#address-line1"]').should('contain', 'Enter a building and street')
-          cy.get('a[href="#address-city"]').should('contain', 'Enter a town or city')
-          cy.get('a[href="#address-postcode"]').should('contain', 'Enter a real postcode')
-        })
-
-        cy.get(`form[method=post]`)
-          .within(() => {
-            cy.get('[data-cy=input-address-line-1]').parent().should('exist').within(() => {
-              cy.get('.govuk-error-message').should('contain', 'Enter a building and street')
-            })
-            cy.get('[data-cy=input-address-city]').parent().should('exist').within(() => {
-              cy.get('.govuk-error-message').should('contain', 'Enter a town or city')
-            })
-            cy.get('[data-cy=input-address-postcode]').parent().should('exist').within(() => {
-              cy.get('.govuk-error-message').should('contain', 'Enter a real postcode')
-            })
-          })
-        
-        cy.get('#navigation-menu-your-psp')
-          .should('contain', 'Information for Stripe')
-          .parent().should('have.class', 'govuk-!-font-weight-bold')
-
-        cy.get('.govuk-back-link')
-          .should('contain', 'Back to check your organisation’s details')
-          .should('have.attr', 'href', checkOrgDetailsUrl)
-      })
-
-      it('should keep entered responses when validation fails', () => {
-        cy.get('[data-cy=form]')
-          .within(() => {
-            // fill in the rest of the form fields
-            cy.get('[data-cy=input-org-name]').type(validOrgName)
-            cy.get('[data-cy=input-address-line-1]').type(validLine1)
-            cy.get('[data-cy=input-address-line-2]').type(validLine2)
-            cy.get('[data-cy=input-address-city]').type(validCity)
-            cy.get('[data-cy=input-address-country]').select(countryGb)
-            cy.get('[data-cy=continue-button]').click()
-          })
-
-        cy.get('[data-cy=error-summary]').find('a').should('have.length', 1)
-        cy.get('[data-cy=error-summary]').should('exist').within(() => {
-          cy.get('a').should('contain', 'Enter a real postcode')
-        })
-
-        cy.get('[data-cy=form]')
-          .within(() => {
-            cy.get('#address-line1').should('have.value', validLine1)
-            cy.get('#address-line2').should('have.value', validLine2)
-            cy.get('#address-city').should('have.value', validCity)
-            cy.get('#address-country').should('have.value', countryGb)
-            cy.get('#address-postcode').should('have.value', invalidPostcode)
-          })
-      })
+    beforeEach(() => {
+      setupStubs(false)
     })
 
-    describe('Form submission', () => {
-      beforeEach(() => {
-        setupStubs({
-          organisationDetails: [false, true, true],
-          bankAccount: [true, true, true],
-          responsiblePerson: [true, true, true],
-          companyNumber: [true, true, true],
-          vatNumber: [true, true, true],
-          director: [true, true, true]
-        })
+    it('should allow updating organisation details', () => {
+      cy.visit(pageUrl)
+
+      cy.get('h1').should('contain', `What is the name and address of your organisation on your government entity document?`)
+
+      cy.get('.govuk-back-link').should('contain', 'Back to check your organisation’s details')
+      cy.get('.govuk-back-link').should('have.attr', 'href', checkOrgDetailsUrl)
+
+      cy.get('#navigation-menu-your-psp')
+        .should('contain', 'Information for Stripe')
+        .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+      cy.get('[data-cy=label-org-name]').should('exist')
+      cy.get('[data-cy=input-org-name]').should('exist')
+
+      cy.get('[data-cy=label-address-line-1]').should('exist')
+      cy.get('[data-cy=input-address-line-1]').should('exist')
+      cy.get('[data-cy=input-address-line-2]').should('exist')
+
+      cy.get('[data-cy=label-address-city]').should('exist')
+      cy.get('[data-cy=input-address-city]').should('exist')
+
+      cy.get('[data-cy=label-address-country]').should('exist')
+      cy.get('[data-cy=input-address-country]').should('exist')
+
+      cy.get('[data-cy=label-address-postcode]').should('exist')
+      cy.get('[data-cy=input-address-postcode]').should('exist')
+
+      cy.get('[data-cy=label-telephone-number]').should('not.exist')
+      cy.get('[data-cy=hint-telephone-number]').should('not.exist')
+      cy.get('[data-cy=input-telephone-number]').should('not.exist')
+
+      cy.get('[data-cy=label-url]').should('not.exist')
+      cy.get('[data-cy=hint-url]').should('not.exist')
+      cy.get('[data-cy=input-url]').should('not.exist')
+
+      cy.get('[data-cy=continue-button]').should('exist')
+      cy.get('[data-cy=save-button]').should('not.exist')
+
+      cy.get('[data-cy=account-sub-nav]')
+        .should('exist')
+
+      cy.log('Enter invalid values and check errors are displayed')
+      cy.get('[data-cy=input-address-postcode]').type(invalidPostcode)
+
+      cy.get('[data-cy=continue-button]').click()
+
+      cy.get('[data-cy=error-summary]').find('a').should('have.length', 4)
+      cy.get('[data-cy=error-summary]').should('exist').within(() => {
+        cy.get('a[href="#address-line1"]').should('contain', 'Enter a building and street')
+        cy.get('a[href="#address-city"]').should('contain', 'Enter a town or city')
+        cy.get('a[href="#address-postcode"]').should('contain', 'Enter a real postcode')
       })
 
-      it('should submit the form', () => {
-        cy.setEncryptedCookies(userExternalId)
-        cy.visit(pageUrl)
+      cy.get('[data-cy=input-address-line-1]').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'Enter a building and street')
+      })
+      cy.get('[data-cy=input-address-city]').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'Enter a town or city')
+      })
+      cy.get('[data-cy=input-address-postcode]').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'Enter a real postcode')
+      })
 
-        cy.get('h1').should('contain', `What is the name and address of your organisation on your government entity document?`)
+      cy.get('#navigation-menu-your-psp')
+        .should('contain', 'Information for Stripe')
+        .parent().should('have.class', 'govuk-!-font-weight-bold')
 
-        cy.get('[data-cy=form]')
-          .should('exist')
-          .within(() => {
-            cy.get('[data-cy=continue-button]').should('exist')
-          })
+      cy.get('.govuk-back-link')
+        .should('contain', 'Back to check your organisation’s details')
+        .should('have.attr', 'href', checkOrgDetailsUrl)
 
-        cy.get('[data-cy=form]')
-          .within(() => {
-            cy.get('[data-cy=input-org-name]').type(validOrgName)
-            cy.get('[data-cy=input-address-line-1]').type(validLine1)
-            cy.get('[data-cy=input-address-line-2]').type(validLine2)
-            cy.get('[data-cy=input-address-city]').type(validCity)
-            cy.get('[data-cy=input-address-country]').select(countryGb)
-            cy.get('#address-postcode').type(validPostcode)
-            cy.get('[data-cy=continue-button]').click()
+      cy.log('Fill in details for all fields to check values are displayed back when form is re-rendered with validation errors')
+      cy.get('[data-cy=input-org-name]').type(validOrgName)
+      cy.get('[data-cy=input-address-line-1]').type(validLine1)
+      cy.get('[data-cy=input-address-line-2]').type(validLine2)
+      cy.get('[data-cy=input-address-city]').type(validCity)
+      cy.get('[data-cy=input-address-country]').select(countryGb)
+      cy.get('[data-cy=continue-button]').click()
 
-            cy.location().should((location) => {
-              expect(location.pathname).to.eq(`/account/a-valid-external-id/your-psp/a-valid-credential-external-id`)
-            })
-          })
+      cy.get('[data-cy=error-summary]').find('a').should('have.length', 1)
+      cy.get('[data-cy=error-summary]').should('exist').within(() => {
+        cy.get('a').should('contain', 'Enter a real postcode')
+      })
+
+      cy.get('#address-line1').should('have.value', validLine1)
+      cy.get('#address-line2').should('have.value', validLine2)
+      cy.get('#address-city').should('have.value', validCity)
+      cy.get('#address-country').should('have.value', countryGb)
+      cy.get('#address-postcode').should('have.value', invalidPostcode)
+
+      // Set up stubs that return a different result for the stripe setup the first time the account is retrieved.
+      // This is necessary as it is not possible to submit the form if the organisation details step has already been
+      // completed.
+      cy.task('clearStubs')
+      setupStubs({
+        organisationDetails: [false, true, true]
+      })
+
+      cy.log('Enter valid details and submit')
+      cy.get('#address-postcode').clear()
+      cy.get('#address-postcode').type(validPostcode)
+      cy.get('[data-cy=continue-button]').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq(`/account/a-valid-external-id/your-psp/a-valid-credential-external-id`)
       })
     })
+  })
 
-    describe('when it is not a Stripe gateway account', () => {
-      beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId)
-      })
-
-      it('should show a 404 error when gateway account is not Stripe', () => {
-        setupStubs(false, 'live', 'sandbox')
-
-        cy.visit(pageUrl, {
-          failOnStatusCode: false
-        })
-        cy.get('h1').should('contain', 'Page not found')
-      })
+  describe('when it is not a Stripe gateway account', () => {
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId)
     })
 
-    describe('when it is not a live gateway account', () => {
-      beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId)
-      })
+    it('should show a 404 error when gateway account is not Stripe', () => {
+      setupStubs(false, 'live', 'sandbox')
 
-      it('should show a 404 error when gateway account is not live', () => {
-        setupStubs(false, 'test', 'stripe')
-
-        cy.visit(checkOrgDetailsUrl, {
-          failOnStatusCode: false
-        })
-        cy.get('h1').should('contain', 'Page not found')
+      cy.visit(pageUrl, {
+        failOnStatusCode: false
       })
+      cy.get('h1').should('contain', 'Page not found')
+    })
+  })
+
+  describe('when it is not a live gateway account', () => {
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId)
     })
 
-    describe('when the user does not have the correct permissions', () => {
-      beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId)
-      })
+    it('should show a 404 error when gateway account is not live', () => {
+      setupStubs(false, 'test', 'stripe')
 
-      it('should show a permission error when the user does not have enough permissions', () => {
-        cy.task('setupStubs', [
-          userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
-          gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
-            gatewayAccountId,
-            gatewayAccountExternalId: gatewayAccountExternalId,
-            type: 'live',
-            paymentProvider: 'stripe'
-          }),
-          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, vatNumber: true })
-        ])
-
-        cy.visit(checkOrgDetailsUrl, { failOnStatusCode: false })
-        cy.get('h1').should('contain', 'An error occurred')
-        cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+      cy.visit(checkOrgDetailsUrl, {
+        failOnStatusCode: false
       })
+      cy.get('h1').should('contain', 'Page not found')
+    })
+  })
+
+  describe('when the user does not have the correct permissions', () => {
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId)
+    })
+
+    it('should show a permission error when the user does not have enough permissions', () => {
+      cy.task('setupStubs', [
+        userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
+        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+          gatewayAccountId,
+          gatewayAccountExternalId: gatewayAccountExternalId,
+          type: 'live',
+          paymentProvider: 'stripe'
+        }),
+        stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, vatNumber: true })
+      ])
+
+      cy.visit(checkOrgDetailsUrl, { failOnStatusCode: false })
+      cy.get('h1').should('contain', 'An error occurred')
+      cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
     })
   })
 })


### PR DESCRIPTION
Cypress best practices suggest that having tests rely on the state of previous tests is an anti-pattern.

Combine tests and remove use of Cypress.Cookies.preserveOnce() so that tests can be run independently.

## Review note

Hiding whitespace from the diff will make this easier to review

