### PR TITLE
PP-10862 Make organisation URL tests standalone

### DIFF
--- a/test/cypress/integration/switch-psp/organisation-url.cy.js
+++ b/test/cypress/integration/switch-psp/organisation-url.cy.js
@@ -27,7 +27,7 @@ function getUserAndAccountStubs (paymentProvider, providerSwitchEnabled, gateway
 
 describe('Switch PSP', () => {
   beforeEach(() => {
-    Cypress.Cookies.preserveOnce('session', 'gateway_account')
+    cy.setEncryptedCookies(userExternalId)
   })
 
   describe('Organisation URL', () => {
@@ -36,8 +36,6 @@ describe('Switch PSP', () => {
 
     describe('User is an admin user', () => {
       beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId)
-
         const stripeUpdateAccountStub = stripePspStubs.updateAccount({
           stripeAccountId: 'acct_123example123',
           url: validUrl


### PR DESCRIPTION
Cypress best practices suggest that having tests rely on the state of previous tests is an anti-pattern.

Combine tests and remove use of Cypress.Cookies.preserveOnce() so that tests can be run independently.
