### PR TITLE
PP-10862 Make update service name Cypress tests standalone

### DIFF
--- a/test/cypress/integration/demo-payment/demo-payment.cy.js
+++ b/test/cypress/integration/demo-payment/demo-payment.cy.js
@@ -8,7 +8,6 @@ const gatewayAccountExternalId = 'a-valid-external-id'
 
 describe('Make a demo payment', () => {
   beforeEach(() => {
-    Cypress.Cookies.preserveOnce('session', 'gateway_account')
     cy.task('setupStubs', [
       userStubs.getUserSuccess({ gatewayAccountId, userExternalId }),
       gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId }),


### PR DESCRIPTION
Cypress best practices suggest that having tests rely on the state of previous tests is an anti-pattern.

Combine tests and remove use of Cypress.Cookies.preserveOnce() so that tests can be run independently.


