### PR TITLE
PP-10863 Better mark-up for telephone number inputs

### DIFF
--- a/app/views/registration/phone-number.njk
+++ b/app/views/registration/phone-number.njk
@@ -39,6 +39,8 @@
         },
         id: "phone",
         name: "phone",
+        type: "tel",
+        autocomplete: "mobile tel",
         errorMessage: { text: errors['phone'] } if errors['phone'] else false,
         value: phoneNumber
       }) }}

--- a/app/views/registration/resend-code.njk
+++ b/app/views/registration/resend-code.njk
@@ -39,6 +39,8 @@
         },
         id: "phone",
         name: "phone",
+        type: "tel",
+        autocomplete: "mobile tel",
         errorMessage: { text: errors['phone'] } if errors['phone'] else false,
         value: phoneNumber
       }) }}

--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -182,6 +182,7 @@
         name: "telephone-number",
         classes: "govuk-!-width-two-thirds",
         type: "tel",
+        autocomplete: "work tel",
         attributes: { 'data-cy': 'input-telephone-number' }
       }) }}
 

--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -247,7 +247,7 @@
         name: "telephone-number",
         value: telephone,
         type: "text",
-        autocomplete: "tel",
+        autocomplete: "work tel",
         errorMessage: { text: errors['telephone-number'] } if errors['telephone-number'] else false,
         classes: "govuk-!-width-two-thirds"
       }) }}

--- a/app/views/team-members/edit-phone-number.njk
+++ b/app/views/team-members/edit-phone-number.njk
@@ -41,6 +41,7 @@
         id: "phone",
         name: "phone",
         type: "tel",
+        autocomplete: "mobile tel",
         value: telephoneNumber,
         classes: "govuk-!-width-one-half",
         label: {

--- a/app/views/two-factor-auth/phone-number.njk
+++ b/app/views/two-factor-auth/phone-number.njk
@@ -31,6 +31,7 @@
         id: "phone",
         name: "phone",
         type: "tel",
+        autocomplete: "mobile tel",
         value: phone,
         classes: "govuk-!-width-one-half",
         label: {

--- a/app/views/two-factor-auth/resend-sms-code.njk
+++ b/app/views/two-factor-auth/resend-sms-code.njk
@@ -33,7 +33,7 @@
         id: "phone",
         name: "phone",
         type: "tel",
-        autocomplete: "tel",
+        autocomplete: "mobile tel",
         classes: "govuk-input--width-20",
         label: {
           text: "Mobile number",

--- a/test/cypress/integration/stripe-setup/responsible-person.cy.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.js
@@ -87,7 +87,7 @@ describe('Stripe setup: responsible person page', () => {
           cy.get('input#dob-year[name="dob-year"][autocomplete="bday-year"]').should('exist')
 
           cy.get('label[for="telephone-number"]').should('exist')
-          cy.get('input#telephone-number[name="telephone-number"][autocomplete="tel"]').should('exist')
+          cy.get('input#telephone-number[name="telephone-number"][autocomplete="work tel"]').should('exist')
 
           cy.get('label[for="email"]').should('exist')
           cy.get('input#email[name="email"][autocomplete="email"]').should('exist')


### PR DESCRIPTION
Use better mark-up for telephone number fields to help browsers display an appropriate on-screen keyboard for entering phone numbers and autofill appropriate phone numbers.

Specifically, when the input expects a user’s phone number for receiving text messages, use `type="tel"` and `autocomplete="mobile tel"`.

When the input expects a responsible person’s phone number, use `type="text"` and `autocomplete="work tel"`. We use `type="text"` as opposed to `type="text"` because a responsible person’s work phone number may have an extension and an on-screen keyboard triggered by `type="tel"` may not offer a way to enter this (though it’s unclear if Stripe accept extensions in phone numbers).

When the input expects an organisation’s phone number, use `type="tel"` and `autocomplete="work tel"`.