### PR TITLE
PP-10862 Upgrade to Cypress 12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,9 +62,9 @@
         "chai-arrays": "2.2.0",
         "chai-as-promised": "7.1.1",
         "cheerio": "1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "csrf": "^3.1.0",
-        "cypress": "11.2.0",
+        "cypress": "^12.9.0",
         "dotenv": "16.0.3",
         "envfile": "5.2.0",
         "gaap-analytics": "3.1.0",
@@ -4863,9 +4863,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.9.0.tgz",
+      "integrity": "sha512-Ofe09LbHKgSqX89Iy1xen2WvpgbvNxDzsWx3mgU1mfILouELeXYGwIib3ItCwoRrRifoQwcBFmY54Vs0zw7QCg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4886,7 +4886,7 @@
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
@@ -4916,7 +4916,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
@@ -21213,9 +21213,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.9.0.tgz",
+      "integrity": "sha512-Ofe09LbHKgSqX89Iy1xen2WvpgbvNxDzsWx3mgU1mfILouELeXYGwIib3ItCwoRrRifoQwcBFmY54Vs0zw7QCg==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -21235,7 +21235,7 @@
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "cheerio": "1.0.0-rc.12",
     "chokidar-cli": "latest",
     "csrf": "^3.1.0",
-    "cypress": "11.2.0",
+    "cypress": "^12.9.0",
     "dotenv": "16.0.3",
     "envfile": "5.2.0",
     "gaap-analytics": "3.1.0",

--- a/test/cypress/integration/agreements/agreements.cy.js
+++ b/test/cypress/integration/agreements/agreements.cy.js
@@ -81,6 +81,12 @@ describe('Agreements', () => {
         service_id: serviceExternalId,
         live: false,
         gatewayAccountId,
+        agreements: mockAgreements
+      }),
+      agreementStubs.getLedgerAgreementsSuccess({
+        service_id: serviceExternalId,
+        live: false,
+        gatewayAccountId,
         agreements: mockAgreements,
         filters: { status: statusFilter, reference: referenceFilter }
       }),
@@ -111,6 +117,7 @@ describe('Agreements', () => {
       })
     ])
 
+    cy.visit('/test/service/service-id/account/gateway-account-id/agreements')
     cy.get('#reference').type(referenceFilter)
     cy.get('#status').select(statusFilter)
     cy.get('#filter').click()

--- a/test/cypress/integration/dashboard/dashboard-worldpay-setup-banner.cy.js
+++ b/test/cypress/integration/dashboard/dashboard-worldpay-setup-banner.cy.js
@@ -35,18 +35,13 @@ describe('Worldpay account setup banner', () => {
   }
 
   describe('Admin user', () => {
-    beforeEach(() => {
-      setupStubs('admin')
-    })
-
     it('should display banner if account is worldpay and the credentials are in CREATED state', () => {
+      setupStubs('admin')
       cy.visit(`/account/${gatewayAccountExternalId}/dashboard`)
 
       cy.get('.govuk-notification-banner__title').contains('Important')
       cy.get('.govuk-notification-banner__content').contains('You have not finished setting up your account. You will not be able to take payments unless you connect your Worldpay account to GOV.UK Pay.')
-    })
 
-    it('should display Your PSP page when "connect your Worldpay account to GOV.UK Pay" link is clicked', () => {
       cy.get('#connect-worldpay-account').click()
       cy.get('h1').contains('Your payment service provider (PSP) - Worldpay')
     })

--- a/test/cypress/integration/settings/switch-psp.cy.js
+++ b/test/cypress/integration/settings/switch-psp.cy.js
@@ -509,13 +509,14 @@ describe('Switch PSP settings page', () => {
         })
 
         it('loads the `VAT number` page', () => {
+          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
           cy.get('a').contains('Provide your organisation’s VAT number').click()
           cy.get('#navigation-menu-switch-psp').parent().should('have.class', 'govuk-!-font-weight-bold')
           cy.get('a').contains('Back to Switching payment service provider (PSP)').should('exist')
         })
 
         it('loads the `check org details` page', () => {
-          cy.get('a').contains('Back to Switching payment service provider (PSP)').click()
+          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
           cy.get('a').contains('Confirm your organisation details').click()
           cy.get('#navigation-menu-switch-psp').parent().should('have.class', 'govuk-!-font-weight-bold')
           cy.get('a').contains('Back to Switching payment service provider (PSP)').should('exist')

--- a/test/cypress/integration/transactions/transaction-list-pagination.cy.js
+++ b/test/cypress/integration/transactions/transaction-list-pagination.cy.js
@@ -64,13 +64,13 @@ describe('Transactions list pagination', () => {
         cy.visit(transactionsUrl + '?pageSize=5&page=')
         cy.title().should('eq', `Transactions - ${serviceName} Sandbox test - GOV.UK Pay`)
 
-        cy.get('form.paginationForm.page-Previous').should('exist').within(() => {
+        cy.get('form.paginationForm.page-Previous').should('have.length', 2).first().within(() => {
           cy.get('input[name="page"]').should('have.value', '')
         })
         cy.get('button.pagination.Previous').should('exist')
         cy.get('button.pagination.Previous').should('be.disabled')
 
-        cy.get('form.paginationForm.page-Next').should('exist').within(() => {
+        cy.get('form.paginationForm.page-Next').should('have.length', 2).first().within(() => {
           cy.get('input[name="page"]').should('have.value', '2')
         })
         cy.get('button.pagination.Next').should('exist')
@@ -88,12 +88,12 @@ describe('Transactions list pagination', () => {
         cy.visit(transactionsUrl + '?pageSize=5&page=3')
         cy.title().should('eq', `Transactions - ${serviceName} Sandbox test - GOV.UK Pay`)
 
-        cy.get('form.paginationForm.page-Previous').should('exist').within(() => {
+        cy.get('form.paginationForm.page-Previous').should('have.length', 2).first().within(() => {
           cy.get('input[name="page"]').should('have.value', '2')
         })
         cy.get('button.pagination.Previous').should('exist')
 
-        cy.get('form.paginationForm.page-Next').should('exist').within(() => {
+        cy.get('form.paginationForm.page-Next').should('have.length', 2).first().within(() => {
           cy.get('input[name="page"]').should('have.value', '4')
         })
         cy.get('button.pagination.Next').should('exist')
@@ -110,12 +110,12 @@ describe('Transactions list pagination', () => {
         cy.visit(transactionsUrl + '?pageSize=5&page=3')
         cy.title().should('eq', `Transactions - ${serviceName} Sandbox test - GOV.UK Pay`)
 
-        cy.get('form.paginationForm.page-Previous').should('exist').within(() => {
+        cy.get('form.paginationForm.page-Previous').should('have.length', 2).first().within(() => {
           cy.get('input[name="page"]').should('have.value', '2')
         })
         cy.get('button.pagination.Previous').should('exist')
 
-        cy.get('form.paginationForm.page-Next').should('exist').within(() => {
+        cy.get('form.paginationForm.page-Next').should('have.length', 2).first().within(() => {
           cy.get('input[name="page"]').should('have.value', '')
         })
         cy.get('button.pagination.Next').should('exist')

--- a/test/cypress/integration/transactions/transaction-search.cy.js
+++ b/test/cypress/integration/transactions/transaction-search.cy.js
@@ -186,6 +186,7 @@ describe('Transactions List', () => {
     it('should be able to filter using date-time pickers', () => {
       cy.task('setupStubs', [
         ...sharedStubs(),
+        transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions }),
         transactionsStubs.getLedgerTransactionsSuccess({
           gatewayAccountId,
           transactions: filteredByDatesTransactions,
@@ -195,6 +196,7 @@ describe('Transactions List', () => {
           }
         })
       ])
+      cy.visit(transactionsUrl)
 
       // 1. Filtering FROM
       // Ensure both the date/time pickers aren't showing
@@ -240,13 +242,8 @@ describe('Transactions List', () => {
       // Ensure the expected transactions are shown
       cy.get('#transactions-list tbody').find('tr').first().find('th').should('contain', filteredByDatesTransactions[0].reference)
       cy.get('#transactions-list tbody').find('tr').eq(1).find('th').should('contain', filteredByDatesTransactions[1].reference)
-    })
 
-    it('should clear filters when "Clear filter" button is clicked', () => {
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: [], filters: {} })
-      ])
+      // Ensure filters are cleared when "Clear filter" is clicked
       cy.get('a').contains('Clear filter').click()
 
       cy.get('#fromDate').should('be.empty')
@@ -258,6 +255,7 @@ describe('Transactions List', () => {
     it('should return results when filtering by all fields', () => {
       cy.task('setupStubs', [
         ...sharedStubs(),
+        transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions }),
         transactionsStubs.getLedgerTransactionsSuccess({
           gatewayAccountId,
           transactions: filteredByMultipleFieldsTransactions,
@@ -277,6 +275,7 @@ describe('Transactions List', () => {
         })
       ])
 
+      cy.visit(transactionsUrl)
       cy.get('#state').click()
       cy.get(`#list-of-sectors-state .govuk-checkboxes__input[value='Success']`).trigger('mouseover').click()
       cy.get(`#list-of-sectors-state .govuk-checkboxes__input[value='In progress']`).trigger('mouseover').click()

--- a/test/cypress/integration/user/edit-phone-number.cy.js
+++ b/test/cypress/integration/user/edit-phone-number.cy.js
@@ -5,52 +5,31 @@ describe('Edit phone number flow', () => {
   const testPhoneNumber = '+441234567890'
   const testPhoneNumberNew = '+441987654321'
 
-  describe('Pre edit', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
-      cy.task('setupStubs', [
-        userStubs.getUserSuccess({ userExternalId, telephoneNumber: testPhoneNumber })
-      ])
-    })
+  it('should allow a user to change their phone number', () => {
+    cy.setEncryptedCookies(userExternalId)
+    cy.task('setupStubs', [
+      userStubs.getUserSuccess({ userExternalId, telephoneNumber: testPhoneNumber }),
+      userStubs.patchUpdateUserPhoneNumberSuccess(userExternalId, testPhoneNumberNew)
+    ])
 
-    describe('Profile page', () => {
-      it('should show a link to change phone number', () => {
-        cy.visit('/my-profile')
-        cy.get('#telephone-number').should('contain', testPhoneNumber)
-        cy.get('#change-phone-link').should('exist').click()
-      })
-    })
+    cy.visit('/my-profile')
+    cy.get('#telephone-number').should('contain', testPhoneNumber)
+    cy.get('#change-phone-link').should('exist').click()
 
-    describe('Edit phone number page', () => {
-      it('should show current phone number in text input', () => {
-        cy.get('input[name="phone"]').should('exist')
-        cy.get('input[name="phone"]').should('have.attr', 'value', testPhoneNumber)
-      })
+    cy.get('input[name="phone"]').should('exist')
+    cy.get('input[name="phone"]').should('have.attr', 'value', testPhoneNumber)
 
-      it('should show an error if an invalid number is typed', () => {
-        cy.visit('/my-profile/phone-number')
-        cy.get('input[name="phone"]').clear().type('not a number')
-        cy.get('#save-phone-number').click()
-        cy.get('.govuk-error-summary').should('exist')
-        cy.get('input[name="phone"]').should('have.class', 'govuk-input--error')
-      })
-    })
-  })
-  describe('Post edit', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
-      cy.task('setupStubs', [
-        userStubs.getUserSuccess({ userExternalId, telephoneNumber: testPhoneNumberNew }),
-        userStubs.patchUpdateUserPhoneNumberSuccess(userExternalId, testPhoneNumberNew)
-      ])
-    })
+    cy.log('Check an error is displayed when an invalid number is entered')
+    cy.visit('/my-profile/phone-number')
+    cy.get('input[name="phone"]').clear().type('not a number')
+    cy.get('#save-phone-number').click()
+    cy.get('.govuk-error-summary').should('exist')
+    cy.get('input[name="phone"]').should('have.class', 'govuk-input--error')
 
-    it('should save changes and redirect to my profile', () => {
-      cy.visit('/my-profile/phone-number')
-      cy.get('input[name="phone"]').clear().type(testPhoneNumberNew)
-      cy.get('#save-phone-number').click()
-      cy.get('.govuk-notification-banner--success').should('exist').should('contain', 'Phone number updated')
-      cy.get('#telephone-number').should('contain', testPhoneNumberNew)
-    })
+    cy.log('Enter a valid phone number and submit')
+    cy.visit('/my-profile/phone-number')
+    cy.get('input[name="phone"]').clear().type(testPhoneNumberNew)
+    cy.get('#save-phone-number').click()
+    cy.get('.govuk-notification-banner--success').should('exist').should('contain', 'Phone number updated')
   })
 })


### PR DESCRIPTION
Make changes to make tests pass:
- Cannot call assertions on multiple elements - so when `cy.get` finds multiple matches need to call `first()` or `eq()` before doing assertions
- A blank page is now loaded at the start of each `it`, rather then the previous behaviour of starting on the page the last test loaded. Needed to make sure all tests call `cy.visit`. Combined some tests to deal with this.