### PR TITLE
PP-10863 Use appropriate attributes for email inputs

### DIFF
--- a/app/views/forgotten-password/index.njk
+++ b/app/views/forgotten-password/index.njk
@@ -19,7 +19,7 @@ Forgot your password - GOV.UK Pay
     <h1 class="govuk-heading-l page-title">
         Forgot your password?
     </h1>
-    <p class="govuk-body">We'll then send you an email which you can use to set up a new password.</p>
+    <p class="govuk-body">We’ll then send you an email which you can use to set up a new password.</p>
 
     {{ govukInput({
         label: {
@@ -29,7 +29,9 @@ Forgot your password - GOV.UK Pay
         errorMessage: { text: errors.username } if errors.username else false,
         name: "username",
         classes: "govuk-!-width-two-thirds",
-        type: "email"
+        type: "email",
+        autocomplete: "username",
+        spellcheck: "false"
       })
     }}
 

--- a/app/views/login/login.njk
+++ b/app/views/login/login.njk
@@ -31,7 +31,9 @@ Sign in to GOV.UK Pay
         id: "username",
         name: "username",
         classes: "govuk-!-width-two-thirds",
-        type: "email"
+        type: "email",
+        autocomplete: "username",
+        spellcheck: "false"
       })
     }}
 
@@ -45,9 +47,7 @@ Sign in to GOV.UK Pay
         name: "password",
         classes: "govuk-!-width-two-thirds",
         type: "password",
-        attributes: {
-          "autocomplete": "current-password"
-        }
+        autocomplete: "current-password"
       })
     }}
 

--- a/app/views/registration/email.njk
+++ b/app/views/registration/email.njk
@@ -30,7 +30,7 @@
         id: "email",
         name: "email",
         type: "email",
-        autocomplete: "email",
+        autocomplete: "work email",
         spellcheck: false,
         errorMessage: { text: errors['email'] } if errors['email'] else false,
         value: email

--- a/app/views/stripe-setup/director/index.njk
+++ b/app/views/stripe-setup/director/index.njk
@@ -156,8 +156,9 @@
         id: "email",
         name: "email",
         value: email,
-        type: "text",
-        autocomplete: "email",
+        type: "email",
+        autocomplete: "work email",
+        spellcheck: "false",
         errorMessage: emailError,
         classes: "govuk-!-width-two-thirds"
       }) }}

--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -260,8 +260,9 @@
         id: "email",
         name: "email",
         value: email,
-        type: "text",
-        autocomplete: "email",
+        type: "email",
+        autocomplete: "work email",
+        spellcheck: "false",
         errorMessage: { text: errors.email } if errors.email else false,
         classes: "govuk-!-width-two-thirds"
       }) }}

--- a/app/views/team-members/team-member-invite.njk
+++ b/app/views/team-members/team-member-invite.njk
@@ -31,7 +31,9 @@ Invite a new team member - GOV.UK Pay
       id: "invitee-email",
       name: "invitee-email",
       classes: "govuk-!-width-two-thirds",
-      type: "email"
+      type: "email",
+      autocomplete: "work email",
+      spellcheck: "false"
     }) }}
     {% if serviceHasAgentInitiatedMotoEnabled %}
       {{ govukRadios({

--- a/app/views/transactions/filter.njk
+++ b/app/views/transactions/filter.njk
@@ -25,6 +25,12 @@
           id: 'email',
           name: 'email',
           value: filters.email,
+          type: 'text',
+          inputmode: 'email',
+          spellcheck: 'false',
+          attributes: {
+            'autocapitalize': 'none'
+          },
           classes: 'govuk-!-font-size-16',
           label: {
             text: 'Email address',

--- a/test/cypress/integration/stripe-setup/director.cy.js
+++ b/test/cypress/integration/stripe-setup/director.cy.js
@@ -106,7 +106,7 @@ describe('Stripe setup: director page', () => {
           cy.get('input#last-name[name="last-name"][autocomplete="family-name"]').should('exist')
 
           cy.get('label[for="email"]').should('exist')
-          cy.get('input#email[name="email"][autocomplete="email"]').should('exist')
+          cy.get('input#email[name="email"][autocomplete="work email"]').should('exist')
 
           cy.get('label[for="dob-day"]').should('exist')
           cy.get('input#dob-day[name="dob-day"][autocomplete="bday-day"]').should('exist')

--- a/test/cypress/integration/stripe-setup/responsible-person.cy.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.js
@@ -90,7 +90,7 @@ describe('Stripe setup: responsible person page', () => {
           cy.get('input#telephone-number[name="telephone-number"][autocomplete="work tel"]').should('exist')
 
           cy.get('label[for="email"]').should('exist')
-          cy.get('input#email[name="email"][autocomplete="email"]').should('exist')
+          cy.get('input#email[name="email"][autocomplete="work email"]').should('exist')
 
           cy.get('button').should('exist')
         })


### PR DESCRIPTION
For all inputs where we expect a full email address, use `type="email"` and `spellcheck="false"` (the latter is recommended by the GOV.UK Design System for email addresses).

For all other inputs where we expect the user to enter the email address of themselves or a colleague, use `autocomplete="work email"`, except for on the sign in and forgotten password pages, where we use `autocomplete="username"` because we really want the username component of the user’s sign-in details to be filled in.

(An argument could be made that we could use `autocomplete="username"` on the page where the user enters their email address when registering. However, it would be more straightforward to include their email address in a hidden form field on the page where the user chooses their password to strongly hint that we want the username and password to be associated with each other. Therefore, use `autocomplete="work email"` on the page where the registering user enters their email address.)

The email input on the transactions search page is a special case because it allows partial email addresses. Therefore, both `type="email"` and and `autocomplete="email"` are inappropriate (the value might not be a full email address), so use `type="text"` with no autocomplete attribute. Use `inputmode="email"` to get a suitable on-screen keyboard etc., along with `spellcheck="false"` and `autocapitalize="none"` (which is not required for `type="email"` because auto-capitalisation should never be applied there).