### PR TITLE
PP-10887 Add novalidate to all forms

### DIFF
--- a/app/views/agreements/paginator.njk
+++ b/app/views/agreements/paginator.njk
@@ -2,7 +2,7 @@
 {% if links and links.length %}
 <div class="pagination" id="pagination">
   {% for paginationLink in links %}
-    <form class="paginationForm page-{{paginationLink.pageName}}" method="GET">
+    <form class="paginationForm page-{{paginationLink.pageName}}" method="GET" novalidate>
       <input type="hidden" name="page" value="{{paginationLink.pageNumber}}"/>
 
       {% for filterKey, filterValue in filters %}

--- a/app/views/api-keys/_key.njk
+++ b/app/views/api-keys/_key.njk
@@ -37,7 +37,7 @@
     {% endif %}
 
     {% if permissions.tokens_delete %}
-    <form class="target-to-show" id="delete-{{token.token_link}}" method="POST" action="{{formatAccountPathsFor(routes.account.apiKeys.revoke, currentGatewayAccount.external_id)}}">
+    <form class="target-to-show" id="delete-{{token.token_link}}" method="POST" action="{{formatAccountPathsFor(routes.account.apiKeys.revoke, currentGatewayAccount.external_id)}}" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
       <input type="hidden" name="token_link" value="{{token.token_link}}"/>
       <div class="govuk-error-summary govuk-!-margin-top-6" role="group" aria-labelledby="error-summary" tabindex="-1">
@@ -64,7 +64,7 @@ govuk-link--no-visited-state target-to-show--cancel" href="#main">Cancel</a>
     </form>
     {% endif %}
     {% if permissions.tokens_update %}
-      <form class="target-to-show govuk-!-margin-top-6" id="update-{{token.token_link}}" method="POST" action="{{formatAccountPathsFor(routes.account.apiKeys.update, currentGatewayAccount.external_id)}}">
+      <form class="target-to-show govuk-!-margin-top-6" id="update-{{token.token_link}}" method="POST" action="{{formatAccountPathsFor(routes.account.apiKeys.update, currentGatewayAccount.external_id)}}" novalidate>
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
         <input type="hidden" name="token_link" value="{{token.token_link}}"/>
         {{

--- a/app/views/api-keys/create.njk
+++ b/app/views/api-keys/create.njk
@@ -12,7 +12,7 @@ Create an API key - {{currentService.name}} {{currentGatewayAccount.full_type}} 
 <div class="govuk-grid-column-two-thirds">
   {% if not token %}
   <h1 class="govuk-heading-l page-title">Create an API key</h1>
-    <form class="form" method="post" action="{{formatAccountPathsFor(routes.account.apiKeys.create, currentGatewayAccount.external_id)}}">
+    <form class="form" method="post" action="{{formatAccountPathsFor(routes.account.apiKeys.create, currentGatewayAccount.external_id)}}" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
       {{

--- a/app/views/billing-address/index.njk
+++ b/app/views/billing-address/index.njk
@@ -39,7 +39,7 @@
       }}
     {% endif %}
 
-    <form class="permission-main" method="post">
+    <form class="permission-main" method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
       {{
         govukRadios({

--- a/app/views/credentials/epdq.njk
+++ b/app/views/credentials/epdq.njk
@@ -24,7 +24,7 @@
 
   <h1 class="govuk-heading-l page-title" id="view-title">Your ePDQ credentials</h1>
 
-  <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.index, currentGatewayAccount.external_id, credential.external_id) }}">
+  <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.index, currentGatewayAccount.external_id, credential.external_id) }}" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
     {{ govukInput({

--- a/app/views/credentials/smartpay-notification-credentials.njk
+++ b/app/views/credentials/smartpay-notification-credentials.njk
@@ -21,7 +21,7 @@
 
   <h1 class="govuk-heading-l page-title" id="view-title">Your Smartpay notification credentials</h1>
 
-  <form id="notification_credentials_form" method="post" action="{{ formatAccountPathsFor(routes.account.notificationCredentials.update, currentGatewayAccount.external_id, credential.external_id) }}">
+  <form id="notification_credentials_form" method="post" action="{{ formatAccountPathsFor(routes.account.notificationCredentials.update, currentGatewayAccount.external_id, credential.external_id) }}" novalidate>
     <input id="notification-csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
     {{ govukInput({

--- a/app/views/credentials/smartpay.njk
+++ b/app/views/credentials/smartpay.njk
@@ -22,7 +22,7 @@
 
   <h1 class="govuk-heading-l page-title" id="view-title">Your Smartpay credentials</h1>
 
-  <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.index, currentGatewayAccount.external_id, credential.external_id) }}">
+  <form id="credentials-form" method="post" action="{{ formatAccountPathsFor(routes.account.credentials.index, currentGatewayAccount.external_id, credential.external_id) }}" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
     {{ govukInput({

--- a/app/views/credentials/worldpay.njk
+++ b/app/views/credentials/worldpay.njk
@@ -34,7 +34,7 @@
     <h1 class="govuk-heading-l page-title" id="view-title">Your Worldpay credentials</h1>
 
   {% if permissions.gateway_credentials_update %}
-    <form id="credentials-form" method="post">
+    <form id="credentials-form" method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
 
         {{ govukInput({

--- a/app/views/dashboard/_activity.njk
+++ b/app/views/dashboard/_activity.njk
@@ -1,4 +1,4 @@
-<form class="govuk-grid-column-full" action="{{formatAccountPathsFor(routes.account.dashboard.index, currentGatewayAccount.external_id)}}" method="get">
+<form class="govuk-grid-column-full" action="{{formatAccountPathsFor(routes.account.dashboard.index, currentGatewayAccount.external_id)}}" method="get" novalidate>
 
   {{ govukSelect({
     formGroup: {

--- a/app/views/dashboard/demo-payment/edit-amount.njk
+++ b/app/views/dashboard/demo-payment/edit-amount.njk
@@ -25,7 +25,7 @@
     }) }}
 
     <h1 class="govuk-heading-l">Edit payment amount</h1>
-    <form method="post" action="{{formatAccountPathsFor(routes.account.prototyping.demoPayment.editAmount,  currentGatewayAccount.external_id)}}">
+    <form method="post" action="{{formatAccountPathsFor(routes.account.prototyping.demoPayment.editAmount,  currentGatewayAccount.external_id)}}" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
       <div class="currency-input govuk-form-group">

--- a/app/views/dashboard/demo-payment/edit-description.njk
+++ b/app/views/dashboard/demo-payment/edit-description.njk
@@ -25,7 +25,7 @@
     }) }}
 
     <h1 class="govuk-heading-l">Edit payment description</h1>
-    <form method="post" action="{{formatAccountPathsFor(routes.account.prototyping.demoPayment.editDescription,  currentGatewayAccount.external_id)}}">
+    <form method="post" action="{{formatAccountPathsFor(routes.account.prototyping.demoPayment.editDescription,  currentGatewayAccount.external_id)}}" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
       {{
         govukTextarea({

--- a/app/views/dashboard/demo-payment/mock-card-details.njk
+++ b/app/views/dashboard/demo-payment/mock-card-details.njk
@@ -28,7 +28,7 @@
   <p class="govuk-body">You can enter any valid value for the other details. For example, it doesn’t matter what expiry date you enter, but it must be in the future.</p>
   <p class="govuk-body">You can also use other card types and see errors. <a class="govuk-link" href="https://docs.payments.service.gov.uk/testing_govuk_pay/#mock-card-numbers-for-testing-purposes">See more card types in our documentation</a>.</p>
 
-  <form method="post" action="{{formatAccountPathsFor(routes.account.prototyping.demoPayment.goToPaymentScreens,  currentGatewayAccount.external_id)}}" >
+  <form method="post" action="{{formatAccountPathsFor(routes.account.prototyping.demoPayment.goToPaymentScreens,  currentGatewayAccount.external_id)}}" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {{
       govukButton({

--- a/app/views/dashboard/demo-service/create.njk
+++ b/app/views/dashboard/demo-service/create.njk
@@ -17,7 +17,7 @@
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">Create a prototype link</h1>
-  <form method="post" action="{{formatAccountPathsFor(routes.account.prototyping.demoService.confirm,  currentGatewayAccount.external_id)}}">
+  <form method="post" action="{{formatAccountPathsFor(routes.account.prototyping.demoService.confirm,  currentGatewayAccount.external_id)}}" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {{

--- a/app/views/default-billing-address-country/index.njk
+++ b/app/views/default-billing-address-country/index.njk
@@ -14,7 +14,7 @@
       {% include "../includes/settings-read-only.njk" %}
     {% endif %}
 
-    <form class="permission-main" method="post">
+    <form class="permission-main" method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
       {{
         govukRadios({

--- a/app/views/digital-wallet/apple-pay.njk
+++ b/app/views/digital-wallet/apple-pay.njk
@@ -22,7 +22,7 @@
         <li>corporate card fees cannot be applied to payments made with Apple Pay.</li>
       </ul>
 
-      <form method="post">
+      <form method="post" novalidate>
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
         {{
           govukRadios({

--- a/app/views/digital-wallet/google-pay.njk
+++ b/app/views/digital-wallet/google-pay.njk
@@ -27,7 +27,7 @@
         You’ll need a Google Pay merchant ID. Refer to the <a class="govuk-link" href="https://docs.payments.service.gov.uk/digital_wallets/#enable-google-pay">GOV.UK Pay documentation on enabling Google Pay</a> to learn where to find your merchant ID.
       </p>
 
-      <form method="post">
+      <form method="post" novalidate>
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
         {% set merchantID %}

--- a/app/views/email-notifications/collection-email-mode.njk
+++ b/app/views/email-notifications/collection-email-mode.njk
@@ -20,7 +20,7 @@
     {% include "includes/settings-read-only.njk" %}
   {% endif %}
 
-  <form id="collection-email-form" method="post">
+  <form id="collection-email-form" method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {{

--- a/app/views/email-notifications/confirm.njk
+++ b/app/views/email-notifications/confirm.njk
@@ -19,7 +19,7 @@ Confirm email notifications - {{currentService.name}} {{currentGatewayAccount.fu
     {% include "./email-confirmation-body.njk" %}
   </div>
 
-  <form method="post" action="{{ formatAccountPathsFor(routes.account.emailNotifications.update, currentGatewayAccount.external_id) }}">
+  <form method="post" action="{{ formatAccountPathsFor(routes.account.emailNotifications.update, currentGatewayAccount.external_id) }}" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <input type="hidden" value="{{customEmailText}}" name="custom-email-text" class="qa-custom-p" />
 

--- a/app/views/email-notifications/confirmation-email-toggle.njk
+++ b/app/views/email-notifications/confirmation-email-toggle.njk
@@ -20,7 +20,7 @@
     {% include "includes/settings-read-only.njk" %}
   {% endif %}
 
-  <form id="confirmation-email-form" method="post">
+  <form id="confirmation-email-form" method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset" aria-describedby="email-confirmation-enabled-hint">

--- a/app/views/email-notifications/edit.njk
+++ b/app/views/email-notifications/edit.njk
@@ -54,7 +54,7 @@ Change email notifications template - {{currentService.name}} {{currentGatewayAc
       <li>use redirects or tracking links</li>
   </ul>
 
-  <form method="post" action="{{ formatAccountPathsFor(routes.account.emailNotifications.confirm, currentGatewayAccount.external_id) }}">
+  <form method="post" action="{{ formatAccountPathsFor(routes.account.emailNotifications.confirm, currentGatewayAccount.external_id) }}" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {{

--- a/app/views/email-notifications/off-confirm.njk
+++ b/app/views/email-notifications/off-confirm.njk
@@ -20,7 +20,7 @@
     })
   }}
 
-  <form method="post" action="{{ formatAccountPathsFor(routes.account.emailNotifications.off, currentGatewayAccount.external_id) }}">
+  <form method="post" action="{{ formatAccountPathsFor(routes.account.emailNotifications.off, currentGatewayAccount.external_id) }}" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {{ govukButton({
         text: 'Turn off email notifications',

--- a/app/views/email-notifications/refund-email-toggle.njk
+++ b/app/views/email-notifications/refund-email-toggle.njk
@@ -20,7 +20,7 @@
     {% include "includes/settings-read-only.njk" %}
   {% endif %}
 
-  <form id="refund-email-form" method="post" action="{{ formatAccountPathsFor(routes.account.emailNotifications.refund, currentGatewayAccount.external_id) }}">
+  <form id="refund-email-form" method="post" action="{{ formatAccountPathsFor(routes.account.emailNotifications.refund, currentGatewayAccount.external_id) }}" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset" aria-describedby="email-confirmation-enabled-hint">

--- a/app/views/feedback/index.njk
+++ b/app/views/feedback/index.njk
@@ -8,7 +8,7 @@ Give feedback — GOV.UK Pay
 <div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">Give feedback</h1>
 
-  <form method="POST" action="{{routes.feedback}}">
+  <form method="POST" action="{{routes.feedback}}" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <input id="email" name="email" type="hidden" value="{{email}}"/>
     <input id="service-name" name="service-name" type="hidden" value="{{currentService.name}}"/>

--- a/app/views/forgotten-password/index.njk
+++ b/app/views/forgotten-password/index.njk
@@ -14,7 +14,7 @@ Forgot your password - GOV.UK Pay
     }
   }) }}
 
-  <form action="/reset-password" method="post" class="form submit-forgotten-email">
+  <form action="/reset-password" method="post" class="form submit-forgotten-email" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <h1 class="govuk-heading-l page-title">
         Forgot your password?

--- a/app/views/forgotten-password/new-password.njk
+++ b/app/views/forgotten-password/new-password.njk
@@ -14,7 +14,7 @@
     }
   }) }}
 
-  <form action="/reset-password/{{id}}"method="post" class="form submit-new-password">
+  <form action="/reset-password/{{id}}"method="post" class="form submit-new-password" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
     <h1 class="govuk-heading-l page-title">
       Create a new password

--- a/app/views/login/login.njk
+++ b/app/views/login/login.njk
@@ -19,7 +19,7 @@ Sign in to GOV.UK Pay
 
   <p class="govuk-body">If you do not have an account, you can <a href="{{ routes.register.email }}" class="register-link govuk-link">create one now</a>.</p>
 
-  <form action="/login" method="post" name="userLoginForm">
+  <form action="/login" method="post" name="userLoginForm" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {{ govukInput({

--- a/app/views/login/send-otp-again.njk
+++ b/app/views/login/send-otp-again.njk
@@ -15,7 +15,7 @@ Resend security code - GOV.UK Pay
   <p class="govuk-body">
     If you no longer have access to the phone with the number registered for this service, speak to your service manager to reset the number
   </p>
-  <form action="/otp-send-again" class="form" method="post">
+  <form action="/otp-send-again" class="form" method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
     <input type="hidden" name="send" value="true">
     {{ govukButton({

--- a/app/views/payment-links/amount.njk
+++ b/app/views/payment-links/amount.njk
@@ -25,7 +25,7 @@
     }
   }) }}
 
-  <form class="form" method="post">
+  <form class="form" method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {% set noSelectionError = false %}

--- a/app/views/payment-links/edit-information.njk
+++ b/app/views/payment-links/edit-information.njk
@@ -24,7 +24,7 @@
   </aside>
 
   <h1 class="govuk-heading-l">Edit payment link information</h1>
-  <form action="{{ self }}" class="form" method="post">
+  <form action="{{ self }}" class="form" method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {% if change.length %}
       <input name="change" type="hidden" value="true"/>

--- a/app/views/payment-links/edit-reference.njk
+++ b/app/views/payment-links/edit-reference.njk
@@ -20,7 +20,7 @@
     }
   }) }}
 
-  <form action="{{ self }}" class="form" method="post">
+  <form action="{{ self }}" class="form" method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {% if change.length %}
       <input name="change" type="hidden" value="true"/>

--- a/app/views/payment-links/edit.njk
+++ b/app/views/payment-links/edit.njk
@@ -131,7 +131,7 @@
 
   {% include "./reporting-columns/_manage-reporting-columns.njk" %}
 
-  <form action="{{ self }}" class="form" method="post">
+  <form action="{{ self }}" class="form" method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {{
       govukButton({

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -26,7 +26,7 @@
     <h1 class="govuk-heading-l">Set payment link information</h1>
   {% endif %}
 
-  <form action="{{ formatAccountPathsFor(routes.account.paymentLinks.information, currentGatewayAccount.external_id) }}" class="form" method="post">
+  <form action="{{ formatAccountPathsFor(routes.account.paymentLinks.information, currentGatewayAccount.external_id) }}" class="form" method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <input type="hidden" name="service-name-path" value="{{serviceName}}">
     {% if change.length %}

--- a/app/views/payment-links/reference.njk
+++ b/app/views/payment-links/reference.njk
@@ -21,7 +21,7 @@
     }
   }) }}
 
-  <form action="{{ formatAccountPathsFor(routes.account.paymentLinks.reference, currentGatewayAccount.external_id) }}" class="form" method="post">
+  <form action="{{ formatAccountPathsFor(routes.account.paymentLinks.reference, currentGatewayAccount.external_id) }}" class="form" method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {% if change.length %}
       <input name="change" type="hidden" value="true"/>

--- a/app/views/payment-links/reporting-columns/edit-reporting-columns.njk
+++ b/app/views/payment-links/reporting-columns/edit-reporting-columns.njk
@@ -20,7 +20,7 @@
 
   {% set pageHeading = ("Edit reporting column" if isEditing else "Add a reporting column") %}
   <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-  <form action="{{ self }}" class="form" method="post">
+  <form action="{{ self }}" class="form" method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <p class="govuk-body">Reporting columns are added to your CSV payment reports. They are not shown to the user making the payment.</p>
     <p class="govuk-body">If you are adding reporting columns to more than one service or payment link, use consistent wording. This will make it easier to read your payment report.</p>
@@ -85,7 +85,7 @@
     </form>
 
     {% if isEditing %}
-      <form method="post" action="{{ self }}/delete" style="display: inline">
+      <form method="post" action="{{ self }}/delete" style="display: inline" novalidate>
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
         {{
         govukButton({

--- a/app/views/payment-links/review.njk
+++ b/app/views/payment-links/review.njk
@@ -134,7 +134,7 @@
 
   {% include "./reporting-columns/_manage-reporting-columns.njk" %}
 
-  <form action="{{ formatAccountPathsFor(routes.account.paymentLinks.review, currentGatewayAccount.external_id) }}" class="form" method="post" data-virtual-pageview="/create-payment-link/success" data-parameters="dimension1:service-name">
+  <form action="{{ formatAccountPathsFor(routes.account.paymentLinks.review, currentGatewayAccount.external_id) }}" class="form" method="post" data-virtual-pageview="/create-payment-link/success" data-parameters="dimension1:service-name" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <input name="service-name" type="hidden" value="{{currentService.name}}"/>
 

--- a/app/views/payment-links/web-address.njk
+++ b/app/views/payment-links/web-address.njk
@@ -21,7 +21,7 @@
 
   <h1 class="govuk-heading-l">The website address is already taken</h1>
 
-  <form action="{{ formatAccountPathsFor(routes.account.paymentLinks.webAddress, currentGatewayAccount.external_id) }}" class="form" method="post">
+  <form action="{{ formatAccountPathsFor(routes.account.paymentLinks.webAddress, currentGatewayAccount.external_id) }}" class="form" method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     <div class="govuk-form-group {% if flash.genericError %}govuk-form-group--error{% endif %}">

--- a/app/views/payment-types/card-types.njk
+++ b/app/views/payment-types/card-types.njk
@@ -1,7 +1,7 @@
 {% extends "./index.njk" %}
 
 {% block page_content %}
-  <form method="post">
+  <form method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {{
       govukCheckboxes({

--- a/app/views/payouts/paginator.njk
+++ b/app/views/payouts/paginator.njk
@@ -2,7 +2,7 @@
 {% if links and links.length %}
 <div class="pagination" id="pagination">
   {% for paginationLink in links %}
-    <form class="paginationForm page-{{paginationLink.pageName}}" method="GET">
+    <form class="paginationForm page-{{paginationLink.pageName}}" method="GET" novalidate>
       <input type="hidden" name="page" value="{{paginationLink.pageNumber}}"/>
 
       <button class="pagination {{paginationLink.pageName}} {% if paginationLink.activePage %}active{% endif %}" type="submit">

--- a/app/views/registration/authenticator-app.njk
+++ b/app/views/registration/authenticator-app.njk
@@ -29,7 +29,7 @@
 
     {% include "../two-factor-auth/_authenticator-app-instructions.njk" %}
 
-    <form method="post">
+    <form method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {{ govukInput({

--- a/app/views/registration/email.njk
+++ b/app/views/registration/email.njk
@@ -15,7 +15,7 @@
       }
     }) }}
 
-    <form method="post">
+    <form method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {{ govukInput({

--- a/app/views/registration/get-security-codes.njk
+++ b/app/views/registration/get-security-codes.njk
@@ -15,7 +15,7 @@
       }
     }) }}
 
-    <form method="post">
+    <form method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {{ govukRadios({

--- a/app/views/registration/password.njk
+++ b/app/views/registration/password.njk
@@ -25,7 +25,7 @@
 
     <p class="govuk-body">Do not use a very common password, such as ‘password’ or a sequence of numbers.</p>
 
-    <form method="post">
+    <form method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {{ govukInput({

--- a/app/views/registration/phone-number.njk
+++ b/app/views/registration/phone-number.njk
@@ -25,7 +25,7 @@
       }
     }) }}
 
-    <form method="post">
+    <form method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {{ govukInput({

--- a/app/views/registration/resend-code.njk
+++ b/app/views/registration/resend-code.njk
@@ -29,7 +29,7 @@
 
     <p class="govuk-body">Check your mobile phone number is correct, then resend the security code.</p>
 
-    <form method="post">
+    <form method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {{ govukInput({

--- a/app/views/registration/sms-code.njk
+++ b/app/views/registration/sms-code.njk
@@ -31,7 +31,7 @@
       text: "We have sent a code to " + redactedPhoneNumber + "."
     }) }}
 
-    <form method="post">
+    <form method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {{ govukInput({

--- a/app/views/request-psp-test-account/index.njk
+++ b/app/views/request-psp-test-account/index.njk
@@ -16,7 +16,7 @@
     </p>
   {% else %}
       {% if requestForPspTestAccountNotStarted %}
-        <form id="submit-request-for-psp-test-account-form" method="post">
+        <form id="submit-request-for-psp-test-account-form" method="post" novalidate>
             <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
             <h1 class="govuk-heading-l">Request Stripe test account</h1>
             <p class="govuk-body">

--- a/app/views/request-to-go-live/index.njk
+++ b/app/views/request-to-go-live/index.njk
@@ -108,7 +108,7 @@
           </li>
         </ol>
 
-        <form id="request-to-go-live-index-form" method="post" action="{{formatServicePathsFor(routes.service.requestToGoLive.index, currentService.externalId)}}" class="govuk-!-margin-top-8">
+        <form id="request-to-go-live-index-form" method="post" action="{{formatServicePathsFor(routes.service.requestToGoLive.index, currentService.externalId)}}" class="govuk-!-margin-top-8" novalidate>
           <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
           {% if notStarted %}
             {{ govukButton({ text: "Start now" }) }}

--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -60,7 +60,7 @@
     </p>
   {% endif %}
 
-  <form id="request-to-go-live-organisation-address-form" method="post" data-cy="form">
+  <form id="request-to-go-live-organisation-address-form" method="post" data-cy="form" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
     {% if not isRequestToGoLive %}

--- a/app/views/services/_service-switch.njk
+++ b/app/views/services/_service-switch.njk
@@ -1,5 +1,5 @@
 <li class="service--{{ account.type }}">
-  <form method="post" action="{{routes.serviceSwitcher.switch}}">
+  <form method="post" action="{{routes.serviceSwitcher.switch}}" novalidate>
     <input name="csrfToken" type="hidden" value="{{csrf}}" />
     <input name="gatewayAccountId" type="hidden" value="{{ account.id }}"/>
     <input name="gatewayAccountExternalId" type="hidden" value="{{ account.external_id }}"/>

--- a/app/views/services/add-service.njk
+++ b/app/views/services/add-service.njk
@@ -20,7 +20,7 @@
       This is what your users will see when making a payment. You can change this&nbsp;later.
     </p>
 
-    <form id="add-service-form" method="post" action="{{submit_link}}">
+    <form id="add-service-form" method="post" action="{{submit_link}}" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
       {{ govukInput({

--- a/app/views/services/edit-service-name.njk
+++ b/app/views/services/edit-service-name.njk
@@ -19,7 +19,7 @@
     <p class="govuk-body">
         Changing your service name affects both live and test environments, including user-facing payment pages and emails.
     </p>
-    <form id="edit-service-name-form" method="post" action="{{submit_link}}">
+    <form id="edit-service-name-form" method="post" action="{{submit_link}}" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
       {{ govukInput({

--- a/app/views/stripe-setup/check-org-details/index.njk
+++ b/app/views/stripe-setup/check-org-details/index.njk
@@ -60,7 +60,7 @@
     <li>OSCR Scottish Charity Regulator</li>
   </ul>
 
-  <form method="post" data-cy="form">
+  <form method="post" data-cy="form" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {% set orgFullAddressHtml =  orgAddressLine1 %}

--- a/app/views/stripe-setup/company-number/index.njk
+++ b/app/views/stripe-setup/company-number/index.njk
@@ -38,7 +38,7 @@
     }) }}
 
     <h1 class="govuk-heading-l govuk-!-margin-bottom-6"><label for="company-number">Company registration number</label></h1>
-    <form id="company-number-form" method="post">
+    <form id="company-number-form" method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {% set companyNumberError = false %}

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -171,7 +171,7 @@
               iconFallbackText: "Warning"
             }) }}
 
-            <form method="POST">
+            <form method="POST" novalidate>
               {{ govukButton({
                 text: "Switch to " + (targetCredential.payment_provider | formatPSPname),
                 disabled: (not taskListIsComplete)

--- a/app/views/switch-psp/verify-psp-integration-payment.njk
+++ b/app/views/switch-psp/verify-psp-integration-payment.njk
@@ -40,7 +40,7 @@
 
   {% if targetCredential.payment_provider === 'worldpay' or allowTestPayment === true %}
     <p class="govuk-body">Make a live payment of £2 with a debit or credit card to check that the connection with {{ targetCredential.payment_provider | formatPSPname }} is working. You can refund the payment anytime.</p>
-    <form method="POST">
+    <form method="POST" novalidate>
       {{ govukButton ({
         text: "Continue to live payment"
       }) }}

--- a/app/views/team-members/edit-phone-number.njk
+++ b/app/views/team-members/edit-phone-number.njk
@@ -34,7 +34,7 @@
   } %}
   {% endif %}
 
-  <form method="post">
+  <form method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {{
       govukInput({

--- a/app/views/team-members/team-member-details.njk
+++ b/app/views/team-members/team-member-details.njk
@@ -48,7 +48,7 @@
       <h2 class="govuk-error-summary__title" id="error-summary">
         Are you sure you want to remove {{username}}?
       </h2>
-      <form id="remove-team-member-form" method="post" action="{{removeTeamMemberLink}}">
+      <form id="remove-team-member-form" method="post" action="{{removeTeamMemberLink}}" novalidate>
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
         {{

--- a/app/views/team-members/team-member-invite.njk
+++ b/app/views/team-members/team-member-invite.njk
@@ -22,7 +22,7 @@ Invite a new team member - GOV.UK Pay
         Invite a team member</h1>
     </div>
   </div>
-  <form id="invite-member-form" method="post" action="{{teamMemberInviteSubmitLink}}" class="govuk-grid-column-two-thirds">
+  <form id="invite-member-form" method="post" action="{{teamMemberInviteSubmitLink}}" class="govuk-grid-column-two-thirds" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {{ govukInput({
       label: {

--- a/app/views/team-members/team-member-permissions.njk
+++ b/app/views/team-members/team-member-permissions.njk
@@ -28,7 +28,7 @@ Edit team member permissions - GOV.UK Pay
     <dt class="govuk-heading-s govuk-!-margin-bottom-0">Email address</dt>
     <dd class="govuk-body govuk-!-margin-left-0" id="email">{{email}}</dd>
   </dl>
-  <form id="role-update-form" method="post" action="{{editPermissionsLink}}">
+  <form id="role-update-form" method="post" action="{{editPermissionsLink}}" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {% if serviceHasAgentInitiatedMotoEnabled %}
       {{

--- a/app/views/toggle-moto-mask-card-number/index.njk
+++ b/app/views/toggle-moto-mask-card-number/index.njk
@@ -20,7 +20,7 @@
 
       <p class="govuk-body-l">If you hide the card number, call agents will be unable to read the numbers entered on their screen.</p>
 
-      <form method="post">
+      <form method="post" novalidate>
         <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
         {{
           govukRadios({

--- a/app/views/toggle-moto-mask-security-code/index.njk
+++ b/app/views/toggle-moto-mask-security-code/index.njk
@@ -20,7 +20,7 @@
 
       <p class="govuk-body-l">If you hide security codes, call agents will be unable to read the numbers entered on their screen.</p>
 
-      <form method="post">
+      <form method="post" novalidate>
         <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
         {{
           govukRadios({

--- a/app/views/transaction-detail/_refund.njk
+++ b/app/views/transaction-detail/_refund.njk
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m govuk-!-margin-top-1">Refund</h2>
 
-<form id="refundForm" action="{{ formatAccountPathsFor(routes.account.transactions.refund, currentGatewayAccount.external_id, charge_id) }}" method="post" class="target-to-show {% if flash.genericError %}active{% endif %}">
+<form id="refundForm" action="{{ formatAccountPathsFor(routes.account.transactions.refund, currentGatewayAccount.external_id, charge_id) }}" method="post" class="target-to-show {% if flash.genericError %}active{% endif %}" novalidate>
   <input id="full-amount" type="hidden" name="full-amount" value="{{ refundable_amount }}" >
   <input id="amount-available" type="hidden" name="refund-amount-available-in-pence" value="{{ refund_summary.amount_available }}" />
   <input id="context-is-all-services-transactions" type="hidden" name="context-is-all-services-transactions" value="{{contextIsAllServiceTransactions}}" />

--- a/app/views/transactions/display-size.njk
+++ b/app/views/transactions/display-size.njk
@@ -6,7 +6,7 @@
     {% if pageSizeLink.active %}
       {{pageSizeLink.name}}
     {% else %}
-      <form class="displaySizeForm govuk-!-display-inline-block" method="get" action="{{pageSizeLink.search_path}}">
+      <form class="displaySizeForm govuk-!-display-inline-block" method="get" action="{{pageSizeLink.search_path}}" novalidate>
         {% include "transactions/common-hidden-search-fields.njk" %}
         <input type="hidden" name="page" value="1"/>
         <input type="hidden" name="pageSize" value="{{pageSizeLink.value}}"/>

--- a/app/views/transactions/paginator.njk
+++ b/app/views/transactions/paginator.njk
@@ -1,7 +1,7 @@
 {% if hasPaginationLinks %}
 <div class="pagination">
   {% for paginationLink in paginationLinks %}
-    <form class="paginationForm page-{{paginationLink.pageName}}" method="get" action="{{paginationLink.search_path}}">
+    <form class="paginationForm page-{{paginationLink.pageName}}" method="get" action="{{paginationLink.search_path}}" novalidate>
       {% include "transactions/common-hidden-search-fields.njk" %}
       <input type="hidden" name="page" value="{{paginationLink.pageNumber}}"/>
       <input type="hidden" name="pageSize" value="{{filters.pageSize}}"/>

--- a/app/views/two-factor-auth/index.njk
+++ b/app/views/two-factor-auth/index.njk
@@ -21,7 +21,7 @@
   </h1>
 </div>
 <div class="govuk-grid-column-two-thirds">
-  <form method="post" action="{{routes.user.profile.twoFactorAuth.index}}">
+  <form method="post" action="{{routes.user.profile.twoFactorAuth.index}}" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {% if authenticatorMethod === secondFactorMethod.SMS %}
       <p class="govuk-body">You currently use text message codes to sign in to GOV.UK Pay.</p>

--- a/app/views/two-factor-auth/phone-number.njk
+++ b/app/views/two-factor-auth/phone-number.njk
@@ -24,7 +24,7 @@
       }
     }) }}
 
-    <form method="post">
+    <form method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
       {{
       govukInput({

--- a/app/views/two-factor-auth/resend-sms-code.njk
+++ b/app/views/two-factor-auth/resend-sms-code.njk
@@ -26,7 +26,7 @@
 
     <h1 class="form-title govuk-heading-l">Check your mobile number</h1>
     <p class="govuk-body">Check your mobile phone number is correct, then resend the security code.</p>
-    <form class="form" method="post">
+    <form class="form" method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
       {{
       govukInput({

--- a/app/views/webhooks/_paginator.njk
+++ b/app/views/webhooks/_paginator.njk
@@ -2,7 +2,7 @@
 {% if links and links.length %}
 <div class="pagination" id="pagination">
   {% for paginationLink in links %}
-    <form class="paginationForm page-{{paginationLink.pageName}}" method="GET">
+    <form class="paginationForm page-{{paginationLink.pageName}}" method="GET" novalidate>
       <input type="hidden" name="page" value="{{paginationLink.pageNumber}}"/>
       <input type="hidden" name="status" value="{{status}}"/>
 

--- a/app/views/webhooks/edit.njk
+++ b/app/views/webhooks/edit.njk
@@ -27,7 +27,7 @@
   {% endif %}
   <h1 class="govuk-heading-l page-title">{{ heading }}</h1>
 
-  <form method="POST" action="{{ submitURL }}">
+  <form method="POST" action="{{ submitURL }}" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {% set items = [] %}

--- a/app/views/webhooks/message.njk
+++ b/app/views/webhooks/message.njk
@@ -24,7 +24,7 @@
 
   {# re-introduce when backend POST route enabled #}
   {# <div>
-    <form method="POST" action="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.resendMessage, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id, message.external_id) }}">
+    <form method="POST" action="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.resendMessage, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id, message.external_id) }}" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
       {{ govukButton({
         text: "Resend event",

--- a/app/views/webhooks/toggle_active.njk
+++ b/app/views/webhooks/toggle_active.njk
@@ -39,7 +39,7 @@
       }]
     }) }}
 
-    <form method="POST" action="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.toggleActive, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id) }}">
+    <form method="POST" action="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.webhooks.toggleActive, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, webhook.external_id) }}" novalidate>
 
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
       {{

--- a/app/views/your-psp/_worldpay-flex.njk
+++ b/app/views/your-psp/_worldpay-flex.njk
@@ -87,7 +87,7 @@
 
 {% if isTest %}
   {% if (is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured) or isWorldpay3dsFlexEnabled %}
-    <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.worldpay3dsFlex, currentGatewayAccount.external_id, credential.external_id) }}">
+    <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.worldpay3dsFlex, currentGatewayAccount.external_id, credential.external_id) }}" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}">
       {% if is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured and not isWorldpay3dsFlexEnabled %}
           <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="on">

--- a/app/views/your-psp/flex.njk
+++ b/app/views/your-psp/flex.njk
@@ -21,7 +21,7 @@
     {% endif %}
 
     <h1 class="govuk-heading-l">Your Worldpay 3DS Flex credentials</h1>
-    <form method="post">
+    <form method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
         {% if errors %}
           {% set errorList = [] %}


### PR DESCRIPTION
Add a `novalidate` attribute to all `form` elements to disable built-in HTML5 browser client-side validation.

The Design System says to do this at https://design-system.service.gov.uk/patterns/validation/:

> HTML5 validation is a type of client side validation built into browsers. Do not use it because:
> 
> • the visual style, placement and content of HTML5 error messages cannot be made consistent with the GOV.UK Design System
> • we know that the GOV.UK Design System error message and error summary components are accessible
> 
> To turn off HTML5 validation, add ‘novalidate’ to your form tags.

Strictly speaking, this only needs to be done for forms that contain validatable fields but it’s easiest just to add it to all `form` elements.

Commit 71b1355144a8fcafaa461757ecd551455140ecd3 made this problem worse by changing several form fields to be `type="email"` (which has default browser client-side validation), thus demonstrating the value of adding `novalidate` to all `form` elements.