### PR TITLE
PP-10863 Appropriate attributes for 2FA OTP inputs

### DIFF
--- a/app/views/login/otp-login.njk
+++ b/app/views/login/otp-login.njk
@@ -49,11 +49,11 @@
         name: "code",
         classes: "govuk-!-width-one-third",
         type: "text",
+        inputmode: "numeric",
+        pattern: "[0-9]*",
+        autocomplete: "one-time-code",
         attributes: {
-          "autofocus": "true",
-          "autocomplete": "off",
-          "inputmode": "numeric",
-          "pattern": "[0-9]*"
+          "autofocus": "true"
         }
       })
     }}

--- a/app/views/registration/authenticator-app.njk
+++ b/app/views/registration/authenticator-app.njk
@@ -42,6 +42,9 @@
         },
         id: "code",
         name: "code",
+        inputmode: "numeric",
+        pattern: "[0-9]*",
+        autocomplete: "one-time-code",
         classes: "govuk-input--width-10",
         errorMessage: { text: errors['code'] } if errors['code'] else false
       }) }}


### PR DESCRIPTION
For inputs where we expect the user to provide a second-factor authentication one-time password (security code), consistently use `type="text"`, `inputmode="numeric"` and `pattern="[0+9]+"` (as recommended by the GOV.UK Design System for non-decimal numbers), along with `autocomplete="one-time-code"`.

Previously we used `autocomplete="off"` in some places. Switching to `autocomplete="one-time-code"` may cause browsers to suggest old OTPs where they did not before but this is a fairly minor issue.