### PR TITLE
PP-10863 For govukInput, value of spellcheck is false not "false"

### DIFF
--- a/app/views/forgotten-password/index.njk
+++ b/app/views/forgotten-password/index.njk
@@ -31,7 +31,7 @@ Forgot your password - GOV.UK Pay
         classes: "govuk-!-width-two-thirds",
         type: "email",
         autocomplete: "username",
-        spellcheck: "false"
+        spellcheck: false
       })
     }}
 

--- a/app/views/login/login.njk
+++ b/app/views/login/login.njk
@@ -33,7 +33,7 @@ Sign in to GOV.UK Pay
         classes: "govuk-!-width-two-thirds",
         type: "email",
         autocomplete: "username",
-        spellcheck: "false"
+        spellcheck: false
       })
     }}
 

--- a/app/views/stripe-setup/director/index.njk
+++ b/app/views/stripe-setup/director/index.njk
@@ -158,7 +158,7 @@
         value: email,
         type: "email",
         autocomplete: "work email",
-        spellcheck: "false",
+        spellcheck: false,
         errorMessage: emailError,
         classes: "govuk-!-width-two-thirds"
       }) }}

--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -262,7 +262,7 @@
         value: email,
         type: "email",
         autocomplete: "work email",
-        spellcheck: "false",
+        spellcheck: false,
         errorMessage: { text: errors.email } if errors.email else false,
         classes: "govuk-!-width-two-thirds"
       }) }}

--- a/app/views/team-members/team-member-invite.njk
+++ b/app/views/team-members/team-member-invite.njk
@@ -33,7 +33,7 @@ Invite a new team member - GOV.UK Pay
       classes: "govuk-!-width-two-thirds",
       type: "email",
       autocomplete: "work email",
-      spellcheck: "false"
+      spellcheck: false
     }) }}
     {% if serviceHasAgentInitiatedMotoEnabled %}
       {{ govukRadios({

--- a/app/views/transactions/filter.njk
+++ b/app/views/transactions/filter.njk
@@ -27,7 +27,7 @@
           value: filters.email,
           type: 'text',
           inputmode: 'email',
-          spellcheck: 'false',
+          spellcheck: false,
           attributes: {
             'autocapitalize': 'none'
           },


### PR DESCRIPTION
The `govukInput` Nunjucks macro’s `spellcheck` option (which we presently only ever set to false) takes a boolean, not a string.

If quotation marks are used, the option is ignored and no `spellcheck` attribute is added to the generated HTML.

So change all instances of:

```javascript
spellcheck: "false"
```

…or:

```javascript
spellcheck: 'false'
```

… to:

```javascript
spellcheck: false
```

Slightly confusingly, within the `attributes` option, `"false"` does work, so leave those alone.