### PR TITLE
PP-10863 Appropriate attributes for organisation URL inputs

### DIFF
--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -201,6 +201,9 @@
         id: "url",
         name: "url",
         classes: "govuk-!-width-two-thirds",
+        type: "url",
+        autocomplete: "url",
+        spellcheck: false,
         attributes: { 'data-cy': 'input-url' }
       }) }}
     {% endif %}

--- a/app/views/switch-psp/organisation-url.njk
+++ b/app/views/switch-psp/organisation-url.njk
@@ -51,11 +51,9 @@
       hint: {
         text: "Enter the address in full like https://www.example.com"
       },
-      type: "text",
-      attributes: {
-        autocomplete: "off",
-        spellcheck: "false"
-      }
+      type: "url",
+      autocomplete: "url",
+      spellcheck: false
     }) }}
 
     {{ govukButton({ text: "Submit" }) }}


### PR DESCRIPTION
Where we expect the user to enter the URL of their own organisation, consistently use `type="url"`, `autocomplete="url"` and `spellcheck="false"`.