### PR TITLE
PP-10863 Add spellcheck="true" to service name inputs

### DIFF
--- a/app/views/services/edit-service-name.njk
+++ b/app/views/services/edit-service-name.njk
@@ -31,7 +31,8 @@
           name: "service-name",
           value: current_name.en,
           classes: "govuk-!-width-one-half",
-          type: "text"
+          type: "text",
+          spellcheck: true
         })
       }}
 
@@ -46,6 +47,7 @@
           label: {
             text: "Welsh service name"
           },
+          spellcheck: true,
           attributes: {
             "lang": "cy"
           }


### PR DESCRIPTION
Add `spellcheck="true"` to service name inputs because the words in service names should generally be spell-checkable.

On the input for a Welsh service name, the `lang="cy"` attribute should ensure that a Welsh spell-checking dictionary is used if available.