### PR TITLE
PP-10863 Add autocomplete="organization" to organisation name input

### DIFF
--- a/app/views/request-to-go-live/organisation-name.njk
+++ b/app/views/request-to-go-live/organisation-name.njk
@@ -42,7 +42,7 @@
         <input class="govuk-input  {% if errors['organisation-name'] %} govuk-input--error {% endif %}"
                id="request-to-go-live-organisation-name-input" name="organisation-name"
                type="text" aria-describedby="request-to-go-live-organisation-name-input-hint"
-               value="{{organisationName}}"/>
+               value="{{organisationName}}" autocomplete="organization">
       </div>
 
       {{ govukButton({ text: "Continue" }) }}


### PR DESCRIPTION
Add `autocomplete="organization"` to organisation name input, which might cause the right thing to be suggested.

There is the possibility it might autofill an inappropriate name but let’s hope the user reads the guidance and edits it as necessary.