### PR TITLE
PP-10863 Improve attributes for payment link config inputs

### DIFF
--- a/app/views/payment-links/amount.njk
+++ b/app/views/payment-links/amount.njk
@@ -55,7 +55,7 @@
             autofocus
             data-non-numeric
             type="text"
-            inputmode="numeric"
+            spellcheck="false"
             id="payment-amount"
             value="{{ amountInPence | penceToPounds if amountInPence else '' }}"
             data-trim
@@ -81,6 +81,7 @@
           errorMessage: { text: errors.hint } if errors.hint else false,
           classes: "govuk-input--width-20",
           maxlength: 255,
+          spellcheck: true,
           label: {
               text: "Hint text (optional)",
               classes: "govuk-label--s"

--- a/app/views/payment-links/edit-information.njk
+++ b/app/views/payment-links/edit-information.njk
@@ -74,6 +74,7 @@
           html: titleHint
         },
         value: paymentLinkTitle,
+        spellcheck: true,
         attributes: titleAttributes,
         errorMessage: { text: errors.title } if errors.title else false
       })
@@ -91,6 +92,7 @@
           text: detailsHint
         },
         value: paymentLinkDescription,
+        spellcheck: true,
         attributes: descriptionAttributes,
         errorMessage: { text: errors.description } if errors.description else false
       })

--- a/app/views/payment-links/edit-reference.njk
+++ b/app/views/payment-links/edit-reference.njk
@@ -49,6 +49,7 @@
           id: "reference-label",
           name: "reference-label",
           value: referenceLabel,
+          spellcheck: true,
           errorMessage: { text: errors.label } if errors.label else false,
           classes: "govuk-input--width-20",
           label: {
@@ -72,6 +73,7 @@
           errorMessage: { text: errors.hint } if errors.hint else false,
           classes: "govuk-input--width-20",
           maxlength: 255,
+          spellcheck: true,
           label: {
               text: "Hint text (optional)",
               classes: "govuk-label--s"

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -52,6 +52,7 @@
         id: 'payment-link-title',
         name: 'payment-link-title',
         value: paymentLinkTitle,
+        spellcheck: true,
         classes: '',
         label: {
             text: titleLabel,
@@ -78,6 +79,7 @@
         id: 'payment-link-description',
         name: 'payment-link-description',
         value: paymentLinkDescription,
+        spellcheck: true,
         classes: '',
         label: {
             text: 'Details (optional)',

--- a/app/views/payment-links/reference.njk
+++ b/app/views/payment-links/reference.njk
@@ -50,6 +50,7 @@
           id: "reference-label",
           name: "reference-label",
           value: paymentReferenceLabel,
+          spellcheck: true,
           errorMessage: { text: errors.label } if errors.label else false,
           classes: "govuk-input--width-20",
           label: {
@@ -70,6 +71,7 @@
           id: "reference-hint-text",
           name: "reference-hint-text",
           value: paymentReferenceHint,
+          spellcheck: true,
           errorMessage: { text: errors.hint } if errors.hint else false,
           classes: "govuk-input--width-20",
           maxlength: 255,

--- a/app/views/payment-links/web-address.njk
+++ b/app/views/payment-links/web-address.njk
@@ -39,7 +39,7 @@
           The website address is already taken
         </span>
       {% endif %}
-      <input class="govuk-input govuk-!-width-one-half {% if flash.genericError %}govuk-input--error{% endif %}" id="payment-name-path" name="payment-name-path" type="text" value="{{productNamePath}}" aria-describedby="payment-name-path-hint" autofocus="true" data-slugify="true">
+      <input class="govuk-input govuk-!-width-one-half {% if flash.genericError %}govuk-input--error{% endif %}" id="payment-name-path" name="payment-name-path" type="text" value="{{productNamePath}}" aria-describedby="payment-name-path-hint" spellcheck="false" autocapitalize="none" autofocus data-slugify="true">
 
       <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-top-3"><a class="govuk-link" href="https://www.gov.uk/guidance/content-design/url-standards-for-gov-uk">Get guidance on writing a web address (URL)</a></p>
     </div>


### PR DESCRIPTION
- Do not use `inputmode="decimal"` for the amount because the GOV.UK Design System recommends against it
- Add `spellcheck="true"` to everywhere we expect users to enter normal prose (titles, descriptions etc.)
- Where we expect the user to enter a path of a web address, use `autocapitalize="none"` and `spellcheck="false"` (but not `type="url"` or `inputmode="url"` because it’s not a full URL)