### PR TITLE
PP-10863 Better attributes for create prototype link inputs

### DIFF
--- a/app/views/dashboard/demo-service/create.njk
+++ b/app/views/dashboard/demo-service/create.njk
@@ -32,9 +32,7 @@
           text: "Tell users what they are paying for"
         },
         value: paymentDescription,
-        attributes: {
-          autofocus: true
-        }
+        spellcheck: true
       })
     }}
 
@@ -49,9 +47,9 @@
           class="govuk-input govuk-input--width-10"
           aria-label="Enter amount in pounds"
           name="payment-amount"
-          autofocus
           data-non-numeric
           type="text"
+          spellcheck="false"
           id="prototyping__links-input-amount"
           {% if paymentAmount %}
             value="{{ paymentAmount | penceToPounds }}"
@@ -72,9 +70,10 @@
         hint: {
           text: "Enter the secure URL users will go to after they have completed the test payment"
         },
+        type: "url",
+        spellcheck: false,
         value: confirmationPage,
         attributes: {
-          autofocus: true,
           "data-trim": true
         }
       })


### PR DESCRIPTION
On the create prototype link page, remove `autofocus` from all three inputs (it makes no sense to have it on more than one), use `type="url"` for the confirmation page URL input and add `spellcheck` attributes:

- `spellcheck="true"` for the payment description input
- `spellcheck="false"` for the amount input (recommended by the GOV.UK Design System for decimal numbers)
- `spellcheck="false"` for the confirmation page URL input