### PR TITLE
BAU — Do not use inputmode="numeric" for demo payment amount

### DIFF
--- a/app/views/dashboard/demo-payment/edit-amount.njk
+++ b/app/views/dashboard/demo-payment/edit-amount.njk
@@ -42,7 +42,7 @@
             autofocus
             data-non-numeric
             type="text"
-            inputmode="numeric"
+            spellcheck="false"
             id="payment-amount"
             value="{{ paymentAmount | penceToPounds }}"
             data-trim


### PR DESCRIPTION
Do not use `inputmode="numeric"` for the input that asks for the demo payment amount because this will usually bring up an on-screen keyboard that does not have a decimal separator, preventing users from entering amounts that are not whole pounds.

Add `spellcheck="false"` to the input to bring it in to line with what the GOV.UK Design System recommends for decimal number inputs (`type="text"` and `spellcheck="false"`), which is what we already use where we ask for amounts elsewhere in the application (payment link amounts and prototype link amounts).