### PR TITLE
PP-10834 Fix webhooks pagination showing logic

### DIFF
--- a/app/controllers/webhooks/webhooks.service.js
+++ b/app/controllers/webhooks/webhooks.service.js
@@ -12,7 +12,7 @@ function sortByActiveStatus (a, b) {
 function formatPages (searchResponse) {
   const { page, count } = searchResponse
   const paginator = new Paginator(null, PAGE_SIZE, page)
-  const hasMultiplePages = count >= PAGE_SIZE
+  const hasMultiplePages = (count >= PAGE_SIZE) || (page > 1)
   const links = hasMultiplePages && paginator.buildNavigation(count)
   return {
     ...searchResponse,

--- a/test/cypress/stubs/webhooks-stubs.js
+++ b/test/cypress/stubs/webhooks-stubs.js
@@ -22,7 +22,9 @@ function getWebhookMessagesListSuccess (opts = {}) {
       page: opts.page || 1,
       ...opts.status && { status: opts.status }
     },
-    response: webhooksFixtures.webhookMessageSearchResponse(opts.messages || [])
+    response: webhooksFixtures.webhookMessageSearchResponse({
+      messages: opts.messages || []
+    })
   })
 }
 

--- a/test/fixtures/webhooks.fixtures.js
+++ b/test/fixtures/webhooks.fixtures.js
@@ -60,11 +60,12 @@ function webhookSigningSecretResponse (options = {}) {
   return validSigningSecret(options)
 }
 
-function webhookMessageSearchResponse (options = []) {
+function webhookMessageSearchResponse (options = {}) {
+  const messages = options.messages || []
   return {
-    count: options.length,
-    page: 1,
-    results: options.map(validWebhookMessage)
+    count: messages.length,
+    page: options.page || 1,
+    results: messages.map(validWebhookMessage)
   }
 }
 


### PR DESCRIPTION
Addresses an issue where the webhooks detail page will choose to not show pagination if there aren't eneough elements to move to a new page -- this logic should only stand if we're on the first page, otherwise "Previous" is a valid move from any non first page.

Correct this and add coverage to check pagination is being returned appropriately by the service.
