### PR TITLE
PP-10951: Update qs to 6.11.1 and @cypress/request to 2.88.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1771,9 +1771,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.10",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
-      "integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
+      "version": "2.88.11",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.11.tgz",
+      "integrity": "sha512-M83/wfQ1EkspjkE2lNWNV5ui2Cv7UCv1swW1DqljahbzLVWltcsexQh8jYtuS/vzFXP+HySntGM83ZXA9fn17w==",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -1789,7 +1789,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
+        "qs": "~6.10.3",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
@@ -1814,12 +1814,18 @@
       }
     },
     "node_modules/@cypress/request/node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
+      "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
       "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
       "engines": {
         "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@cypress/request/node_modules/uuid": {
@@ -18731,9 +18737,9 @@
       "requires": {}
     },
     "@cypress/request": {
-      "version": "2.88.10",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
-      "integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
+      "version": "2.88.11",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.11.tgz",
+      "integrity": "sha512-M83/wfQ1EkspjkE2lNWNV5ui2Cv7UCv1swW1DqljahbzLVWltcsexQh8jYtuS/vzFXP+HySntGM83ZXA9fn17w==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -18749,7 +18755,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
+        "qs": "~6.10.3",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
@@ -18768,10 +18774,13 @@
           }
         },
         "qs": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-          "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-          "dev": true
+          "version": "6.10.4",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
+          "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
         },
         "uuid": {
           "version": "8.3.2",
@@ -21266,7 +21275,7 @@
       "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
       "dev": true,
       "requires": {
-        "@cypress/request": "^2.88.10",
+        "@cypress/request": "2.88.11",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
         "@types/sinonjs__fake-timers": "8.1.1",
@@ -28360,7 +28369,7 @@
         "mime-types": "~2.1.19",
         "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
+        "qs": "6.11.1",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
@@ -28399,8 +28408,7 @@
           }
         },
         "qs": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+          "version": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
           "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
         },
         "uuid": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28407,10 +28407,6 @@
             "verror": "1.10.0"
           }
         },
-        "qs": {
-          "version": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-          "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,13 @@
     ]
   },
   "overrides": {
-    "minimist": "1.2.6"
+    "minimist": "1.2.6",
+    "request": {
+      "qs": "6.11.1"
+    },
+    "cypress": {
+      "@cypress/request": "2.88.11"
+    }
   },
   "dependencies": {
     "@govuk-pay/pay-js-commons": "3.8.9",


### PR DESCRIPTION
Cypress has its own fork of request as a dependency - we don't use this in our tests so it should be safe to override.

~TODO: figure out why the npm has mangled the package-lock version for `qs` in one place (`"version": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",`). [See equivalent in products-ui](https://github.com/alphagov/pay-products-ui/pull/2417/files).~ Fixed by refreshing the package-lock.json.
