### PR TITLE
PP-10958 Use credential_id when creating a charge

### DIFF
--- a/app/controllers/switch-psp/verify-psp-integration.controller.js
+++ b/app/controllers/switch-psp/verify-psp-integration.controller.js
@@ -37,10 +37,10 @@ async function startPaymentJourney (req, res, next) {
     const targetCredential = getSwitchingCredential(req.account)
     const charge = await connectorClient.postChargeRequest(req.account.gateway_account_id, {
       amount: VERIFY_PAYMENT_AMOUNT_IN_PENCE,
-      payment_provider: targetCredential.payment_provider,
       description: 'Live payment to verify new PSP',
       reference: 'VERIFY_PSP_INTEGRATION',
-      return_url: urljoin(selfserviceURL, formatAccountPathsFor(paths.account.switchPSP.receiveVerifyPSPIntegrationPayment, req.account.external_id))
+      return_url: urljoin(selfserviceURL, formatAccountPathsFor(paths.account.switchPSP.receiveVerifyPSPIntegrationPayment, req.account.external_id)),
+      credential_id: targetCredential.gateway_account_credential_id
     })
 
     req.session[VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY] = charge.charge_id

--- a/test/fixtures/charge.fixtures.js
+++ b/test/fixtures/charge.fixtures.js
@@ -7,7 +7,8 @@ function validPostChargeRequestRequest (opts = {}) {
     amount: opts.amount || 100,
     reference: opts.reference || 'a reference',
     description: opts.description || 'a description',
-    return_url: opts.returnUrl || 'https://somewhere.gov.uk/rainbow/1'
+    return_url: opts.returnUrl || 'https://somewhere.gov.uk/rainbow/1',
+    credential_id: opts.credential_id
   }
 }
 

--- a/test/pact/connector-client/connector-post-create-charge.pact.test.js
+++ b/test/pact/connector-client/connector-post-create-charge.pact.test.js
@@ -17,7 +17,7 @@ const expect = chai.expect
 // Global setup
 chai.use(chaiAsPromised)
 
-const gatewayAccountId = 42
+const gatewayAccountId = 3456
 
 describe('connector client', function () {
   const provider = new Pact({
@@ -39,8 +39,8 @@ describe('connector client', function () {
     describe('success', () => {
       const validPostCreateChargeRequest = chargeFixture.validPostChargeRequestRequest({
         amount: 100,
-        payment_provider: 'stripe',
-        return_url: 'https://somewhere.gov.uk/rainbow/1'
+        return_url: 'https://somewhere.gov.uk/rainbow/1',
+        credential_id: 'creds123'
       })
 
       const validResponse = chargeFixture.validPostChargeRequestResponse()
@@ -49,7 +49,7 @@ describe('connector client', function () {
         return provider.addInteraction(
           new PactInteractionBuilder(`${CHARGES_RESOURCE}/${gatewayAccountId}/charges`)
             .withUponReceiving('a valid post create charge request')
-            .withState('a stripe gateway account with external id 42 exists in the database')
+            .withState('a Worldpay gateway account with id 3456, gateway account credentials with external_id creds123 exists')
             .withMethod('POST')
             .withRequestBody(validPostCreateChargeRequest)
             .withStatusCode(201)


### PR DESCRIPTION
## WHAT
- Connector now supports credential_id on create charge request https://github.com/alphagov/pay-connector/pull/4493
- Pass the credential_id when creating a charge to verify payment during PSP switching. Can remove `payment_provider` as credential_id will uniquely identify the gateway_credentials to use in connector.
- depends on https://github.com/alphagov/pay-connector/pull/4497