### PR TITLE
PP-10958 Fix creating charge

### DIFF
--- a/app/controllers/switch-psp/verify-psp-integration.controller.js
+++ b/app/controllers/switch-psp/verify-psp-integration.controller.js
@@ -40,7 +40,7 @@ async function startPaymentJourney (req, res, next) {
       description: 'Live payment to verify new PSP',
       reference: 'VERIFY_PSP_INTEGRATION',
       return_url: urljoin(selfserviceURL, formatAccountPathsFor(paths.account.switchPSP.receiveVerifyPSPIntegrationPayment, req.account.external_id)),
-      credential_id: targetCredential.gateway_account_credential_id
+      credential_id: targetCredential.external_id
     })
 
     req.session[VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY] = charge.charge_id

--- a/app/controllers/switch-psp/verify-psp-integration.controller.test.js
+++ b/app/controllers/switch-psp/verify-psp-integration.controller.test.js
@@ -47,7 +47,14 @@ describe('Verify PSP integration controller', () => {
     const nextUrl = defaultCharge.links.filter((link) => link.rel === 'next_url')[0].href
     await controller.startPaymentJourney(req, res, next)
 
-    sinon.assert.called(postChargeRequestMock)
+    sinon.assert.calledWith(postChargeRequestMock, 31, {
+      amount: 200,
+      description: 'Live payment to verify new PSP',
+      reference: 'VERIFY_PSP_INTEGRATION',
+      return_url: 'https://selfservice.pymnt.localdomain/account/a-valid-external-id/switch-psp/verify-psp-integration/callback',
+      credential_id: 'a-valid-external-id'
+    })
+
     expect(req.session.verify_psp_integration_charge_external_id).to.equal(defaultCharge.charge_id)
     sinon.assert.calledWith(res.redirect, nextUrl)
   })


### PR DESCRIPTION
## WHAT
- Passes credential `external_id` when creating a charge instead of internal ID
