### PR TITLE
PP-10977 remove expired status from agreement

### DIFF
--- a/app/views/agreements/list.njk
+++ b/app/views/agreements/list.njk
@@ -26,9 +26,9 @@ Agreements - GOV.UK Pay
         text: 'Active',
         selected: filters.status === 'ACTIVE'
       },{
-        value: 'EXPIRED',
-        text: 'Expired',
-        selected: filters.status ==='EXPIRED'
+        value: 'INACTIVE',
+        text: 'Inactive',
+        selected: filters.status ==='INACTIVE'
       }] %}
       <div class="govuk-grid-column-one-third inputs-less-margin">
       <fieldset class="govuk-fieldset">

--- a/app/views/agreements/macro/status.njk
+++ b/app/views/agreements/macro/status.njk
@@ -1,7 +1,6 @@
 {% set statusStyleMap = {
 "CREATED": "govuk-tag--grey",
 "ACTIVE": "govuk-tag--green",
-"EXPIRED": "govuk-tag--yellow",
 "CANCELLED": "govuk-tag--yellow",
 "INACTIVE": "govuk-tag--yellow"
 } %}
@@ -9,7 +8,6 @@
 "CREATED": "needs payment details",
 "ACTIVE": "active",
 "CANCELLED": "cancelled",
-"EXPIRED": "expired",
 "INACTIVE": "inactive"
 } %}
 


### PR DESCRIPTION
## WHAT 
We don’t have any process/code that sets the payment_instrument/agreement status to expired.
 Also, we don’t have any plans to set payment instruments to expired status.

 - remove `EXPIRED` from agreements.status
 - replace `EXPIRED` with `INACTIVE` (it was forgotten in PP-10949)
