### PR TITLE
PP-11020 Update webhook calls to pass `gateway account id`

### DIFF
--- a/app/controllers/webhooks/webhooks.controller.js
+++ b/app/controllers/webhooks/webhooks.controller.js
@@ -17,7 +17,7 @@ async function webhookDetailPage (req, res, next) {
   const page = req.query.page || 1
 
   try {
-    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId)
+    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId, req.account.external_id)
     const messages = await webhooksService.getWebhookMessages(req.params.webhookId, { page, ...status && { status } })
 
     response(req, res, 'webhooks/detail', {
@@ -34,7 +34,7 @@ async function webhookDetailPage (req, res, next) {
 
 async function listWebhooksPage (req, res, next) {
   try {
-    const webhooks = await webhooksService.listWebhooks(req.service.externalId, req.isLive)
+    const webhooks = await webhooksService.listWebhooks(req.service.externalId, req.account.external_id, req.isLive)
     response(req, res, 'webhooks/list', { webhooks })
   } catch (error) {
     next(error)
@@ -47,7 +47,7 @@ async function createWebhookPage (req, res, next) {
 
 async function updateWebhookPage (req, res, next) {
   try {
-    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId)
+    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId, req.account.external_id)
     const form = webhooksFormSchema.from(webhook)
     response(req, res, 'webhooks/edit', { eventTypes: constants.webhooks.humanReadableSubscriptions, isEditing: true, webhook, form })
   } catch (error) {
@@ -58,10 +58,10 @@ async function updateWebhookPage (req, res, next) {
 async function signingSecretPage (req, res, next) {
   try {
     let signingSecret
-    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId)
+    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId, req.account.external_id)
 
     try {
-      signingSecret = await webhooksService.getSigningSecret(req.params.webhookId, req.service.externalId)
+      signingSecret = await webhooksService.getSigningSecret(req.params.webhookId, req.service.externalId, req.account.external_id)
     } catch (error) {
       logger.warn('Unable to fetch signing secret for Webhook')
     }
@@ -73,7 +73,7 @@ async function signingSecretPage (req, res, next) {
 
 async function toggleActivePage (req, res, next) {
   try {
-    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId)
+    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId, req.account.external_id)
     response(req, res, 'webhooks/toggle_active', { webhook })
   } catch (error) {
     next(error)
@@ -82,7 +82,7 @@ async function toggleActivePage (req, res, next) {
 
 async function webhookMessageDetailPage (req, res, next) {
   try {
-    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId)
+    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId, req.account.external_id)
     const message = await webhooksService.getWebhookMessage(req.params.messageId, req.params.webhookId)
     const attempts = await webhooksService.getWebhookMessageAttempts(req.params.messageId, req.params.webhookId)
     response(req, res, 'webhooks/message', { webhook, message, attempts, eventTypes: constants.webhooks.humanReadableSubscriptions })
@@ -99,7 +99,7 @@ async function createWebhook (req, res, next) {
       return
     }
     try {
-      await webhooksService.createWebhook(req.service.externalId, req.isLive, req.body)
+      await webhooksService.createWebhook(req.service.externalId, req.account.external_id, req.isLive, req.body)
     } catch (createWebhookError) {
       form = webhooksFormSchema.parseResponse(createWebhookError, req.body)
 
@@ -118,7 +118,7 @@ async function createWebhook (req, res, next) {
 
 async function updateWebhook (req, res, next) {
   try {
-    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId)
+    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId, req.account.external_id)
     let form = webhooksFormSchema.validate(req.body)
     if (form.errorSummaryList.length) {
       response(req, res, 'webhooks/edit', { eventTypes: constants.webhooks.humanReadableSubscriptions, isEditing: true, webhook, form })
@@ -126,7 +126,7 @@ async function updateWebhook (req, res, next) {
     }
 
     try {
-      await webhooksService.updateWebhook(req.params.webhookId, req.service.externalId, req.body)
+      await webhooksService.updateWebhook(req.params.webhookId, req.service.externalId, req.account.external_id, req.body)
     } catch (updateWebhookError) {
       form = webhooksFormSchema.parseResponse(updateWebhookError, req.body)
 
@@ -145,9 +145,9 @@ async function updateWebhook (req, res, next) {
 
 async function toggleActiveWebhook (req, res, next) {
   try {
-    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId)
+    const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId, req.account.external_id)
 
-    await webhooksService.toggleStatus(req.params.webhookId, req.service.externalId, webhook.status)
+    await webhooksService.toggleStatus(req.params.webhookId, req.service.externalId, req.account.external_id, webhook.status)
 
     req.flash('generic', 'Webhook status updated')
     res.redirect(formatFutureStrategyAccountPathsFor(paths.futureAccountStrategy.webhooks.detail, req.account.type, req.service.externalId, req.account.external_id, req.params.webhookId))

--- a/app/controllers/webhooks/webhooks.service.js
+++ b/app/controllers/webhooks/webhooks.service.js
@@ -20,23 +20,23 @@ function formatPages (searchResponse) {
   }
 }
 
-async function listWebhooks (serviceId, isLive) {
-  const webhooks = await webhooksClient.webhooks(serviceId, isLive)
+async function listWebhooks (serviceId, gatewayAccountId, isLive) {
+  const webhooks = await webhooksClient.webhooks(serviceId, gatewayAccountId, isLive)
   return webhooks.sort(sortByActiveStatus)
 }
 
-function createWebhook (serviceId, isLive, options = {}) {
+function createWebhook (serviceId, gatewayAccountId, isLive, options = {}) {
   options.subscriptions = typeof options.subscriptions === 'string' ? [ options.subscriptions ] : options.subscriptions
-  return webhooksClient.createWebhook(serviceId, isLive, options)
+  return webhooksClient.createWebhook(serviceId, gatewayAccountId, isLive, options)
 }
 
-function updateWebhook (id, serviceId, options = {}) {
+function updateWebhook (id, serviceId, gatewayAccountId, options = {}) {
   options.subscriptions = typeof options.subscriptions === 'string' ? [ options.subscriptions ] : options.subscriptions
-  return webhooksClient.updateWebhook(id, serviceId, options)
+  return webhooksClient.updateWebhook(id, serviceId, gatewayAccountId, options)
 }
 
-function getWebhook (id, serviceId) {
-  return webhooksClient.webhook(id, serviceId)
+function getWebhook (id, serviceId, gatewayAccountId) {
+  return webhooksClient.webhook(id, serviceId, gatewayAccountId)
 }
 
 function getWebhookMessage (id, webhookId) {
@@ -52,17 +52,17 @@ async function getWebhookMessages (id, options = {}) {
   return formatPages(searchResponse)
 }
 
-function getSigningSecret (webhookId, serviceId) {
-  return webhooksClient.signingSecret(webhookId, serviceId)
+function getSigningSecret (webhookId, serviceId, gatewayAccountId) {
+  return webhooksClient.signingSecret(webhookId, serviceId, gatewayAccountId)
 }
 
-function resetSigningSecret (webhookId, serviceId) {
-  return webhooksClient.resetSigningSecret(webhookId, serviceId)
+function resetSigningSecret (webhookId, serviceId, gatewayAccountId) {
+  return webhooksClient.resetSigningSecret(webhookId, serviceId, gatewayAccountId)
 }
 
-function toggleStatus (webhookId, serviceId, currentStatus) {
+function toggleStatus (webhookId, serviceId, gatewayAccountId, currentStatus) {
   const status = currentStatus === 'ACTIVE' ? 'INACTIVE' : 'ACTIVE'
-  return webhooksClient.updateWebhook(webhookId, serviceId, { status })
+  return webhooksClient.updateWebhook(webhookId, serviceId, gatewayAccountId, { status })
 }
 
 function resendWebhookMessage (webhookId, messageId) {

--- a/app/controllers/webhooks/webhooks.service.test.js
+++ b/app/controllers/webhooks/webhooks.service.test.js
@@ -16,7 +16,7 @@ describe('webhooks service', () => {
         { external_id: 5, status: 'ACTIVE' }
       ])
       const service = getWebhooksService(webhooks)
-      const result = await service.listWebhooks('some-service-id', true)
+      const result = await service.listWebhooks('some-service-id', 'some-gateway-account-id', true)
       expect(result.map(webhook => webhook.external_id)).to.deep.equal([ 2, 5, 1, 3, 4 ])
     })
   })
@@ -24,28 +24,28 @@ describe('webhooks service', () => {
     it('should normalise subscriptions from the frontend, uniformly submitting them as a list', () => {
       const spy = sinon.spy(async () => {})
       const service = getWebhooksServiceWithStub({ createWebhook: spy })
-      service.createWebhook('some-service-id', true, { subscriptions: 'my-subscription' })
-      sinon.assert.calledWith(spy, 'some-service-id', true, { subscriptions: [ 'my-subscription' ] })
+      service.createWebhook('some-service-id', 'some-gateway-account-id', true, { subscriptions: 'my-subscription' })
+      sinon.assert.calledWith(spy, 'some-service-id', 'some-gateway-account-id', true, { subscriptions: [ 'my-subscription' ] })
     })
     it('should not change a list of valid subscriptions', () => {
       const spy = sinon.spy(async () => {})
       const service = getWebhooksServiceWithStub({ createWebhook: spy })
-      service.createWebhook('some-service-id', true, { subscriptions: [ 'my-first-subscription', 'my-second-subscription' ] })
-      sinon.assert.calledWith(spy, 'some-service-id', true, { subscriptions: [ 'my-first-subscription', 'my-second-subscription' ] })
+      service.createWebhook('some-service-id', 'some-gateway-account-id', true, { subscriptions: [ 'my-first-subscription', 'my-second-subscription' ] })
+      sinon.assert.calledWith(spy, 'some-service-id', 'some-gateway-account-id', true, { subscriptions: [ 'my-first-subscription', 'my-second-subscription' ] })
     })
   })
   describe('Toggle webhook status', () => {
     it('should deactivate given an active webhook', () => {
       const spy = sinon.spy(async () => {})
       const service = getWebhooksServiceWithStub({ updateWebhook: spy })
-      service.toggleStatus('webhook-id', 'service-id', 'ACTIVE')
-      sinon.assert.calledWith(spy, 'webhook-id', 'service-id', { status: 'INACTIVE' })
+      service.toggleStatus('webhook-id', 'service-id', 'some-gateway-account-id', 'ACTIVE')
+      sinon.assert.calledWith(spy, 'webhook-id', 'service-id', 'some-gateway-account-id', { status: 'INACTIVE' })
     })
     it('should active given an inactive webhook', () => {
       const spy = sinon.spy(async () => {})
       const service = getWebhooksServiceWithStub({ updateWebhook: spy })
-      service.toggleStatus('webhook-id', 'service-id', 'INACTIVE')
-      sinon.assert.calledWith(spy, 'webhook-id', 'service-id', { status: 'ACTIVE' })
+      service.toggleStatus('webhook-id', 'service-id', 'some-gateway-account-id', 'INACTIVE')
+      sinon.assert.calledWith(spy, 'webhook-id', 'service-id', 'some-gateway-account-id', { status: 'ACTIVE' })
     })
   })
   describe('List webhook messages', () => {

--- a/app/services/clients/webhooks.client.js
+++ b/app/services/clients/webhooks.client.js
@@ -9,12 +9,13 @@ const defaultRequestOptions = {
   service: 'webhooks'
 }
 
-function webhook (id, serviceId, options = {}) {
+function webhook (id, serviceId, gatewayAccountId, options = {}) {
   const url = urlJoin('/v1/webhook', id)
   const request = {
     url,
     qs: {
-      service_id: serviceId
+      service_id: serviceId,
+      gateway_account_id: gatewayAccountId
     },
     description: 'Get one webhook',
     ...defaultRequestOptions,
@@ -23,12 +24,13 @@ function webhook (id, serviceId, options = {}) {
   return baseClient.get(request)
 }
 
-function signingSecret (webhookId, serviceId, options = {}) {
+function signingSecret (webhookId, serviceId, gatewayAccountId, options = {}) {
   const url = urlJoin('/v1/webhook/', webhookId, '/signing-key')
   const request = {
     url,
     qs: {
-      service_id: serviceId
+      service_id: serviceId,
+      gateway_account_id: gatewayAccountId
     },
     description: 'Get a Webhook signing secret',
     ...defaultRequestOptions,
@@ -37,12 +39,13 @@ function signingSecret (webhookId, serviceId, options = {}) {
   return baseClient.get(request)
 }
 
-function resetSigningSecret (webhookId, serviceId, options = {}) {
+function resetSigningSecret (webhookId, serviceId, gatewayAccountId, options = {}) {
   const url = urlJoin('/v1/webhook/', webhookId, '/signing-key')
   const request = {
     url,
     qs: {
-      service_id: serviceId
+      service_id: serviceId,
+      gateway_account_id: gatewayAccountId
     },
     description: 'Reset a Webhook signing secret',
     ...defaultRequestOptions,
@@ -51,12 +54,13 @@ function resetSigningSecret (webhookId, serviceId, options = {}) {
   return baseClient.post(request)
 }
 
-function webhooks (serviceId, isLive, options = {}) {
+function webhooks (serviceId, gatewayAccountId, isLive, options = {}) {
   const url = '/v1/webhook'
   const request = {
     url,
     qs: {
       service_id: serviceId,
+      gateway_account_id: gatewayAccountId,
       live: isLive
     },
     description: 'List webhooks for service',
@@ -103,12 +107,13 @@ function messages (id, options = {}) {
   return baseClient.get(request)
 }
 
-function createWebhook (serviceId, isLive, options = {}) {
+function createWebhook (serviceId, gatewayAccountId, isLive, options = {}) {
   const url = '/v1/webhook'
   const request = {
     url,
     body: {
       service_id: serviceId,
+      gateway_account_id: gatewayAccountId,
       live: isLive,
       callback_url: options.callback_url,
       subscriptions: options.subscriptions,
@@ -121,7 +126,7 @@ function createWebhook (serviceId, isLive, options = {}) {
   return baseClient.post(request)
 }
 
-function updateWebhook (id, serviceId, options = {}) {
+function updateWebhook (id, serviceId, gatewayAccountId, options = {}) {
   const url = urlJoin('/v1/webhook', id)
   const paths = [ 'callback_url', 'subscriptions', 'description', 'status' ]
   const body = []
@@ -133,7 +138,8 @@ function updateWebhook (id, serviceId, options = {}) {
   const request = {
     url,
     qs: {
-      service_id: serviceId
+      service_id: serviceId,
+      gateway_account_id: gatewayAccountId
     },
     body,
     ...defaultRequestOptions,

--- a/test/cypress/integration/webhooks/webhooks.cy.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.js
@@ -12,9 +12,10 @@ const messageExternalId = 'message-id'
 const userAndGatewayAccountStubs = [
   userStubs.getUserSuccess({ userExternalId, serviceExternalId, gatewayAccountId }),
   gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, serviceExternalId }),
-  webhooksStubs.getWebhooksListSuccess({ service_id: serviceExternalId, live: false, webhooks: [{ external_id: webhookExternalId }, { status: 'INACTIVE' }, { status: 'DISABLED' }] }),
-  webhooksStubs.getWebhookSuccess({ service_id: serviceExternalId, external_id: webhookExternalId, subscriptions: [ 'card_payment_captured', 'card_payment_succeeded', 'card_payment_refunded' ] }),
+  webhooksStubs.getWebhooksListSuccess({ service_id: serviceExternalId, gateway_account_id: gatewayAccountExternalId, live: false, webhooks: [{ external_id: webhookExternalId }, { status: 'INACTIVE' }, { status: 'DISABLED' }] }),
+  webhooksStubs.getWebhookSuccess({ service_id: serviceExternalId, gateway_account_id: gatewayAccountExternalId, external_id: webhookExternalId, subscriptions: [ 'card_payment_captured', 'card_payment_succeeded', 'card_payment_refunded' ] }),
   webhooksStubs.getWebhookMessagesListSuccess({ service_id: serviceExternalId,
+    gateway_account_id: gatewayAccountExternalId,
     external_id: webhookExternalId,
     messages: [
       { latest_attempt: { status: 'PENDING' }, external_id: messageExternalId },
@@ -29,7 +30,7 @@ const userAndGatewayAccountStubs = [
       { latest_attempt: { status: 'SUCCESSFUL' } },
       { latest_attempt: { status: 'SUCCESSFUL' } }
     ] }),
-  webhooksStubs.getWebhookSigningSecret({ service_id: serviceExternalId, external_id: webhookExternalId }),
+  webhooksStubs.getWebhookSigningSecret({ service_id: serviceExternalId, gateway_account_id: gatewayAccountExternalId, external_id: webhookExternalId }),
   webhooksStubs.getWebhookMessage({ external_id: messageExternalId, webhook_id: webhookExternalId }),
   webhooksStubs.getWebhookMessageAttempts({ message_id: messageExternalId, webhook_id: webhookExternalId, attempts: [ {} ] })
 ]

--- a/test/cypress/stubs/webhooks-stubs.js
+++ b/test/cypress/stubs/webhooks-stubs.js
@@ -8,6 +8,7 @@ function getWebhooksListSuccess (opts) {
   return stubBuilder('GET', path, 200, {
     query: {
       service_id: opts.service_id,
+      gateway_account_id: opts.gateway_account_id,
       live: opts.live
     },
     response: webhooksFixtures.webhooksListResponse(opts.webhooks || [])
@@ -33,7 +34,8 @@ function getWebhookSuccess (opts = {}) {
   const path = `/v1/webhook/${webhook.external_id}`
   return stubBuilder('GET', path, 200, {
     query: {
-      service_id: webhook.service_id
+      service_id: webhook.service_id,
+      gateway_account_id: opts.gateway_account_id
     },
     response: webhook
   })
@@ -43,7 +45,8 @@ function getWebhookSigningSecret (opts = {}) {
   const path = `/v1/webhook/${opts.external_id}/signing-key`
   return stubBuilder('GET', path, 200, {
     query: {
-      service_id: opts.service_id
+      service_id: opts.service_id,
+      gateway_account_id: opts.gateway_account_id
     },
     response: webhooksFixtures.webhookSigningSecretResponse(opts)
   })

--- a/test/pact/webhooks-client/webhooks.pact.test.js
+++ b/test/pact/webhooks-client/webhooks.pact.test.js
@@ -24,6 +24,7 @@ const provider = new Pact({
 })
 
 const serviceId = 'an-external-service-id'
+const gatewayAccountId = 'an-external-account-id'
 const isLive = true
 const webhookId = 'an-external-webhook-id'
 
@@ -41,6 +42,7 @@ describe('webhooks client', function () {
       return provider.addInteraction(
         new PactInteractionBuilder(`/v1/webhook`)
           .withQuery('service_id', serviceId)
+          .withQuery('gateway_account_id', gatewayAccountId)
           .withQuery('live', isLive.toString())
           .withUponReceiving('a valid list webhooks for service request')
           .withState('webhooks exist for given service id')
@@ -54,7 +56,7 @@ describe('webhooks client', function () {
     afterEach(() => provider.verify())
 
     it('should get list of webhooks for a given service', () => {
-      return webhooksClient.webhooks(serviceId, isLive, { baseUrl: webhooksUrl })
+      return webhooksClient.webhooks(serviceId, gatewayAccountId, isLive, { baseUrl: webhooksUrl })
         .then((response) => {
           // asserts that the client has correctly formatted the request to match the stubbed fixture provider
           expect(response[0].external_id).to.equal(webhookId)
@@ -71,6 +73,7 @@ describe('webhooks client', function () {
         new PactInteractionBuilder(`/v1/webhook`)
           .withRequestBody({
             service_id: serviceId,
+            gateway_account_id: gatewayAccountId,
             callback_url: callbackUrl,
             live: isLive,
             description,
@@ -88,7 +91,7 @@ describe('webhooks client', function () {
     afterEach(() => provider.verify())
 
     it('should submit details to create a webhook', () => {
-      return webhooksClient.createWebhook(serviceId, isLive, { callback_url: callbackUrl, description, subscriptions, baseUrl: webhooksUrl })
+      return webhooksClient.createWebhook(serviceId, gatewayAccountId, isLive, { callback_url: callbackUrl, description, subscriptions, baseUrl: webhooksUrl })
         .then((response) => {
           expect(response.external_id).to.equal(webhookId)
         })


### PR DESCRIPTION
- We now require the gateway account ID when calling webhook functions.
- This PR is to update calls to webhooks.
- The backend changes will be done once this is merged in.


