### PR TITLE
PP-10601 Cancel agreement - fix agreement service bug

### DIFF
--- a/app/controllers/agreements/agreements.service.js
+++ b/app/controllers/agreements/agreements.service.js
@@ -1,6 +1,9 @@
 const Ledger = require('../../services/clients/ledger.client')
-const Connector = require('../../services/clients/connector.client')
+const { ConnectorClient } = require('../../services/clients/connector.client')
 const Paginator = require('../../utils/paginator')
+const { CONNECTOR_URL } = process.env
+
+const connectorClient = new ConnectorClient(CONNECTOR_URL)
 
 const PAGE_SIZE = 20
 const MAX_PAGES = 2
@@ -22,7 +25,7 @@ function agreement (id, serviceId) {
   return Ledger.agreement(id, serviceId)
 }
 
-function cancelAgreement (gatewayAccountId, agreementId, userEmail, userExternalId) {
+async function cancelAgreement (gatewayAccountId, agreementId, userEmail, userExternalId) {
   const cancelAgreementParams = {
     gatewayAccountId,
     agreementId,
@@ -31,7 +34,7 @@ function cancelAgreement (gatewayAccountId, agreementId, userEmail, userExternal
       'user_external_id': userExternalId
     }
   }
-  return Connector.postCancelAgreement(cancelAgreementParams)
+  await connectorClient.postCancelAgreement(cancelAgreementParams)
 }
 
 module.exports = {

--- a/app/controllers/agreements/agreements.service.test.js
+++ b/app/controllers/agreements/agreements.service.test.js
@@ -57,7 +57,7 @@ describe('agreements service', () => {
 
   describe('cancel an agreement', () => {
     it('should cancel an agreement', async () => {
-      const gatewayAccountId = 'a-gateway-external-id'
+      const gatewayAccountId = '1'
       const agreementId = 'an-agreement-id'
       const userEmail = 'user@test.com'
       const userExternalId = 'a-user-external-id'


### PR DESCRIPTION
Update agreement service:
- Fix the call to `ConnectorClient > postCancelAgreement`.
- Update the test to use gateway account id instead of a gateway external id.

