### PR TITLE
PP-10601 Cancel agreement - add Cypress test

### DIFF
--- a/app/views/agreements/detail.njk
+++ b/app/views/agreements/detail.njk
@@ -134,14 +134,15 @@
 </div>
 
 {% if isShowCancelAgreementFunctionality %}
-  <div class="govuk-grid-column-one-third">
+  <div class="govuk-grid-column-one-third" data-cy="cancel-agreement-container">
     <h2 class="govuk-heading-m">Cancel</h2>
 
     <div class="target-to-show--toggle-container {% if not flash.genericError %}active{% endif %}">
       {{ govukButton({
         text: "Cancel this agreement",
         classes: "govuk-button--secondary target-to-show--toggle",
-        href: "#cancel-form"
+        href: "#cancel-form",
+        attributes: { 'data-cy': 'cancel-agreement-button' }
       }) }}
     </div>
 
@@ -159,7 +160,8 @@
         {{ govukButton({
           text: "Confirm cancellation",
           classes: "govuk-button--warning",
-          type: "submit"
+          type: "submit",
+          attributes: { 'data-cy': 'confirm-cancel-agreement-button' }
         }) }}
 
         <p class="govuk-body govuk-!-display-inline">

--- a/app/views/includes/flash.njk
+++ b/app/views/includes/flash.njk
@@ -21,7 +21,8 @@
 
       {{ govukNotificationBanner({
         html: html,
-        type: 'success'
+        type: 'success',
+        attributes: { 'data-cy': 'success-notifcation' }
       }) }}
     </div>
   {% endif %}

--- a/test/cypress/integration/agreements/agreement.cy.js
+++ b/test/cypress/integration/agreements/agreement.cy.js
@@ -1,0 +1,78 @@
+const userStubs = require('../../stubs/user-stubs')
+const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+const agreementStubs = require('../../stubs/agreement-stubs')
+const transactionStubs = require('../../stubs/transaction-stubs')
+
+const userExternalId = 'some-user-id'
+const gatewayAccountId = 10
+const gatewayAccountExternalId = 'gateway-account-id'
+const serviceExternalId = 'service-id'
+
+const userAndGatewayAccountStubs = [
+  userStubs.getUserSuccess({ userExternalId, serviceExternalId, gatewayAccountId }),
+  gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+    gatewayAccountId,
+    gatewayAccountExternalId,
+    serviceExternalId,
+    recurringEnabled: true
+  })
+]
+
+const transactionsStub = transactionStubs.getLedgerTransactionsSuccess({
+  gatewayAccountId,
+  transactions: [
+    { reference: 'payment-reference', amount: 1000, type: 'payment' },
+    { reference: 'second-reference', amount: 20000, type: 'payment' }
+  ],
+  filters: {
+    agreement_id: 'a-valid-agreement-id',
+    display_size: 5
+  }
+})
+
+describe('Agreements', () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(userExternalId)
+  })
+
+  it('should display agreement detail page and allow cancelling agreement', () => {
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs,
+      agreementStubs.getLedgerAgreementSuccess({
+        service_id: serviceExternalId,
+        live: false,
+        gatewayAccountId,
+        external_id: 'a-valid-agreement-id'
+      }),
+      transactionsStub
+    ])
+
+    cy.visit('/test/service/service-id/account/gateway-account-id/agreements/a-valid-agreement-id')
+
+    cy.get('h1').contains('Agreement detail')
+
+    cy.task('clearStubs')
+
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs,
+      agreementStubs.postConectorCancelAgreementSuccess({
+        gatewayAccountId,
+        external_id: 'a-valid-agreement-id'
+      }),
+      agreementStubs.getLedgerAgreementSuccess({
+        service_id: serviceExternalId,
+        live: false,
+        gatewayAccountId,
+        external_id: 'a-valid-agreement-id',
+        status: 'CANCELLED'
+      }),
+      transactionsStub
+    ])
+
+    cy.get('[data-cy=cancel-agreement-button]').click()
+    cy.get('[data-cy=confirm-cancel-agreement-button]').click()
+
+    cy.get('[data-cy=success-notifcation]').contains('Agreement cancelled')
+    cy.get('[data-cy=cancel-agreement-container]').should('not.exist')
+  })
+})

--- a/test/cypress/stubs/agreement-stubs.js
+++ b/test/cypress/stubs/agreement-stubs.js
@@ -28,7 +28,13 @@ function getLedgerAgreementSuccess (opts = {}) {
   })
 }
 
+function postConectorCancelAgreementSuccess (opts = {}) {
+  const path = `/v1/api/accounts/${opts.gatewayAccountId}/agreements/${opts.external_id}/cancel`
+  return stubBuilder('POST', path, 200)
+}
+
 module.exports = {
   getLedgerAgreementsSuccess,
-  getLedgerAgreementSuccess
+  getLedgerAgreementSuccess,
+  postConectorCancelAgreementSuccess
 }


### PR DESCRIPTION
- Create new Cypress test for the agreement detail page.
- Make one big Cypress test as per best practises from the team manual: https://pay-team-manual.cloudapps.digital/manual/how-to/write-cypress-tests.html#having-tests-rely-on-the-state-of-previous-tests
  - Load the agreement detail page.
  - Cancel the agreement
  - Reload the agreement detail page and make sure the cancel functionality is no longer available.

