### PR TITLE
BAU: Resolve ejs/mountebank-formatters conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "chai-arrays": "2.2.0",
         "chai-as-promised": "7.1.1",
         "cheerio": "1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "csrf": "^3.1.0",
         "cypress": "^12.12.0",
         "dotenv": "16.0.3",
@@ -11769,16 +11769,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/mountebank-formatters/node_modules/ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/mountebank-formatters/node_modules/fs-extra": {
@@ -26591,16 +26581,10 @@
       "integrity": "sha512-zNFk187W4crPPyGKWIZwkZItdf5B3+UtdSqkDcRwKg9BZRMNoNIBGg6y29kbWKFKh/neFLx9XcCXx06z7AWalA==",
       "dev": true,
       "requires": {
-        "ejs": "2.7.4",
+        "ejs": "3.1.8",
         "fs-extra": "9.0.1"
       },
       "dependencies": {
-        "ejs": {
-          "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-          "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-          "dev": true
-        },
         "fs-extra": {
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     },
     "cypress": {
       "@cypress/request": "2.88.11"
+    },
+    "mountebank-formatters": {
+      "ejs": "3.1.8"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## WHAT
Resolves a long running issue with `ejs` (see https://github.com/alphagov/pay-selfservice/security/dependabot/34). Solving this should reduce noise in our dependency alerts.

See the equivalent PR in products-ui: https://github.com/alphagov/pay-products-ui/pull/2471

## HOW 
Check if the cypress tests pass on this PR!


