### PR TITLE
PP-10601 Cancel agreement - add more Cypress test coverage

### DIFF
--- a/test/cypress/integration/agreements/agreement.cy.js
+++ b/test/cypress/integration/agreements/agreement.cy.js
@@ -8,15 +8,22 @@ const gatewayAccountId = 10
 const gatewayAccountExternalId = 'gateway-account-id'
 const serviceExternalId = 'service-id'
 
-const userAndGatewayAccountStubs = [
-  userStubs.getUserSuccess({ userExternalId, serviceExternalId, gatewayAccountId }),
-  gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
-    gatewayAccountId,
-    gatewayAccountExternalId,
-    serviceExternalId,
-    recurringEnabled: true
-  })
-]
+const userAndGatewayAccountStubs = function (role) {
+  return [
+    userStubs.getUserSuccess({
+      userExternalId,
+      serviceExternalId,
+      gatewayAccountId,
+      role: role
+    }),
+    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+      gatewayAccountId,
+      gatewayAccountExternalId,
+      serviceExternalId,
+      recurringEnabled: true
+    })
+  ]
+}
 
 const transactionsStub = transactionStubs.getLedgerTransactionsSuccess({
   gatewayAccountId,
@@ -30,14 +37,14 @@ const transactionsStub = transactionStubs.getLedgerTransactionsSuccess({
   }
 })
 
-describe('Agreements', () => {
+describe('Agreement detail page', () => {
   beforeEach(() => {
     cy.setEncryptedCookies(userExternalId)
   })
 
   it('should display agreement detail page and allow cancelling agreement', () => {
     cy.task('setupStubs', [
-      ...userAndGatewayAccountStubs,
+      ...userAndGatewayAccountStubs(),
       agreementStubs.getLedgerAgreementSuccess({
         service_id: serviceExternalId,
         live: false,
@@ -54,7 +61,7 @@ describe('Agreements', () => {
     cy.task('clearStubs')
 
     cy.task('setupStubs', [
-      ...userAndGatewayAccountStubs,
+      ...userAndGatewayAccountStubs(),
       agreementStubs.postConectorCancelAgreementSuccess({
         gatewayAccountId,
         external_id: 'a-valid-agreement-id'
@@ -73,6 +80,56 @@ describe('Agreements', () => {
     cy.get('[data-cy=confirm-cancel-agreement-button]').click()
 
     cy.get('[data-cy=success-notifcation]').contains('Agreement cancelled')
+    cy.get('[data-cy=cancel-agreement-container]').should('not.exist')
+  })
+
+  it('should display generic error page when cancelling an agreement fails', () => {
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs(),
+      agreementStubs.getLedgerAgreementSuccess({
+        service_id: serviceExternalId,
+        live: false,
+        gatewayAccountId,
+        external_id: 'a-valid-agreement-id'
+      }),
+      transactionsStub
+    ])
+
+    cy.visit('/test/service/service-id/account/gateway-account-id/agreements/a-valid-agreement-id')
+
+    cy.get('h1').contains('Agreement detail')
+
+    cy.task('clearStubs')
+
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs(),
+      agreementStubs.postConectorCancelAgreementFailure({
+        gatewayAccountId,
+        external_id: 'a-valid-agreement-id'
+      })
+    ])
+
+    cy.get('[data-cy=cancel-agreement-button]').click()
+    cy.get('[data-cy=confirm-cancel-agreement-button]').click()
+
+    cy.get('h1').contains('An error occurred')
+  })
+
+  it('should not display cancel agreement if the user does not have permissions', () => {
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs({ permissions: [{ name: 'agreements:read' }] }),
+      agreementStubs.getLedgerAgreementSuccess({
+        service_id: serviceExternalId,
+        live: false,
+        gatewayAccountId,
+        external_id: 'a-valid-agreement-id'
+      }),
+      transactionsStub
+    ])
+
+    cy.visit('/test/service/service-id/account/gateway-account-id/agreements/a-valid-agreement-id', { failOnStatusCode: false })
+
+    cy.get('h1').contains('Agreement detail')
     cy.get('[data-cy=cancel-agreement-container]').should('not.exist')
   })
 })

--- a/test/cypress/stubs/agreement-stubs.js
+++ b/test/cypress/stubs/agreement-stubs.js
@@ -33,8 +33,14 @@ function postConectorCancelAgreementSuccess (opts = {}) {
   return stubBuilder('POST', path, 200)
 }
 
+function postConectorCancelAgreementFailure (opts = {}) {
+  const path = `/v1/api/accounts/${opts.gatewayAccountId}/agreements/${opts.external_id}/cancel`
+  return stubBuilder('POST', path, 500)
+}
+
 module.exports = {
   getLedgerAgreementsSuccess,
   getLedgerAgreementSuccess,
-  postConectorCancelAgreementSuccess
+  postConectorCancelAgreementSuccess,
+  postConectorCancelAgreementFailure
 }


### PR DESCRIPTION
- Add tests for:
  - If the user does not have correct permissions.
  - If the cancel agreement call to connector fails.
- Some minor code cleanup

