### PR TITLE
PP-10875 Remove request library usage from tests

### DIFF
--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -7,7 +7,7 @@
 
 'use strict'
 
-const request = require('request-promise-native')
+const axios = require('axios')
 
 const cookieMonster = require('./cookie-monster')
 
@@ -33,11 +33,8 @@ module.exports = (on, config) => {
      * the same call.
      */
     setupStubs (stubs) {
-      return request({
-        method: 'POST',
-        url: mountebankImpostersUrl,
-        json: true,
-        body: {
+      return axios.post(mountebankImpostersUrl,
+        {
           port: config.env.MOUNTEBANK_IMPOSTERS_PORT,
           protocol: 'http',
           defaultResponse: {
@@ -46,14 +43,21 @@ module.exports = (on, config) => {
             headers: {}
           },
           stubs
-        }
-      })
+        })
+        .then(function () { return '' })
+        .catch(function (error) {
+          throw error
+        })
     },
     /**
      * Makes a request to Mountebank to delete the existing Imposter along with all stubs that have been set up.
      */
     clearStubs () {
-      return request.delete(mountebankImpostersUrl)
+      return axios.delete(mountebankImpostersUrl)
+        .then(function () { return '' })
+        .catch(function (error) {
+          throw error
+        })
     }
   })
 

--- a/test/integration/proxy.it.test.js
+++ b/test/integration/proxy.it.test.js
@@ -1,12 +1,12 @@
 process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
 
-var assert = require('assert')
-var portfinder = require('portfinder')
-var request = require('request')
-var winston = require('winston')
+const assert = require('assert')
+const portfinder = require('portfinder')
+const axios = require('axios')
+const winston = require('winston')
 
-var http = require('http')
-var httpProxy = require('http-proxy')
+const http = require('http')
+const httpProxy = require('http-proxy')
 
 /**
  * This test actually tests if request.js honour HTTP_PROXY, NO_PROXY var's as per the documentation.
@@ -19,7 +19,7 @@ var httpProxy = require('http-proxy')
  */
 
 describe('request.js client', function () {
-  var proxiedServer, proxyServer, nonProxiedServer,
+  let proxiedServer, proxyServer, nonProxiedServer,
     proxiedServerUrl, proxyUrl, nonProxiedServerUrl,
     nonProxiedServerPort
 
@@ -83,24 +83,26 @@ describe('request.js client', function () {
   })
 
   it('should proxy requests when HTTP_PROXY enabled', function (done) {
-    var client = request.defaults({ json: true })
-
-    client(proxiedServerUrl, function (error, response, body) {
-      if (error) { done(error) }
-      assert.strictEqual(response.headers['x-proxy-header'], 'touched by proxy')
-      assert.strictEqual(body.message, 'server-response')
-      done()
-    })
+    axios.get(proxiedServerUrl)
+      .then(function (response) {
+        assert.strictEqual(response.headers['x-proxy-header'], 'touched by proxy')
+        assert.strictEqual(response.data.message, 'server-response')
+        done()
+      })
+      .catch(function (error) {
+        done(error)
+      })
   })
 
   it('should not proxy requests for NO_PROXY hosts', function (done) {
-    var client = request.defaults({ json: true })
-
-    client(nonProxiedServerUrl, function (error, response, body) {
-      if (error) { done(error) }
-      assert.notStrictEqual(response.headers['x-proxy-header'], 'touched by proxy')
-      assert.strictEqual(body.message, 'non-proxied-server-response')
-      done()
-    })
+    axios.get(nonProxiedServerUrl)
+      .then(function (response) {
+        assert.notStrictEqual(response.headers['x-proxy-header'], 'touched by proxy')
+        assert.strictEqual(response.data.message, 'non-proxied-server-response')
+        done()
+      })
+      .catch(function (error) {
+        done(error)
+      })
   })
 })


### PR DESCRIPTION
## WHAT
- Replaced request library usage in tests with Axios. This is to eventually remove the request library dependency which is not maintained anymore
