### PR TITLE
PP-11119 - Grouping buttons - refactor and alignment issuses.

### DIFF
--- a/app/assets/sass/components/target-to-show.scss
+++ b/app/assets/sass/components/target-to-show.scss
@@ -9,10 +9,4 @@
   .govuk-button {
     margin-bottom: govuk-spacing(2);
   }
-
-  &--cancel {
-    position: absolute;
-    right: govuk-spacing(3);
-    bottom: govuk-spacing(3);
-  }
 }

--- a/app/views/agreements/detail.njk
+++ b/app/views/agreements/detail.njk
@@ -156,7 +156,7 @@
 
       <p class="govuk-body">The agreement will be cancelled immediately.</p>
 
-      <div class="govuk-form-group govuk-!-margin-top-6">
+      <div class="govuk-button-group">
         {{ govukButton({
           text: "Confirm cancellation",
           classes: "govuk-button--warning",
@@ -164,9 +164,7 @@
           attributes: { 'data-cy': 'confirm-cancel-agreement-button' }
         }) }}
 
-        <p class="govuk-body govuk-!-display-inline">
-          <a href="#main" class="govuk-link govuk-!-margin-left-3 target-to-show--cancel">Do not cancel</a>
-        </p>
+        <a href="#main" class="govuk-link target-to-show--cancel">Do not cancel</a>
       </div>
     </form>
   </div>

--- a/app/views/api-keys/_key.njk
+++ b/app/views/api-keys/_key.njk
@@ -47,7 +47,7 @@
         <p class="govuk-body">
           If revoked it will no longer enable integration with the platform.
         </p>
-        <div class="button-group">
+        <div class="govuk-button-group">
           {{
             govukButton({
               text: "Yes, revoke this API key",
@@ -57,8 +57,7 @@
               }
             })
           }}
-          <a class="govuk-link govuk-link--no-visited-state
-govuk-link--no-visited-state target-to-show--cancel" href="#main">Cancel</a>
+          <a class="govuk-link target-to-show--cancel govuk-link--no-visited-state" href="#main">Cancel</a>
         </div>
       </div>
     </form>
@@ -83,18 +82,20 @@ govuk-link--no-visited-state target-to-show--cancel" href="#main">Cancel</a>
           })
         }}
 
-        {% set buttonID %}update-token-{{token.token_link}}{% endset %}
-        {{
-          govukButton({
-            text: "Save changes",
-            classes: "js-save-description",
-            attributes: {
-              id: buttonID
-            }
-          })
-        }}
-        <a class="govuk-link govuk-link--no-visited-state
-govuk-link--no-visited-state target-to-show--cancel js-toggle-description" href="#main">Cancel</a>
+        <div class="govuk-button-group">
+          {% set buttonID %}update-token-{{token.token_link}}{% endset %}
+          {{
+            govukButton({
+              text: "Save changes",
+              classes: "js-save-description",
+              attributes: {
+                id: buttonID
+              }
+            })
+          }}
+
+          <a class="govuk-link target-to-show--cancel js-toggle-description govuk-link--no-visited-state" href="#main">Cancel</a>
+        </div>
       </form>
     {% endif %}
   </div>

--- a/app/views/payment-links/_product.njk
+++ b/app/views/payment-links/_product.njk
@@ -10,7 +10,7 @@
         <h3 class="govuk-visually-hidden">Reporting columns</h3>
         <dl class="reporting-columns govuk-body-s">
            {% for key, value in product.metadata|dictsort %}
-               <div class="reporting-columns__keypair"> 
+               <div class="reporting-columns__keypair">
                     <dt class="reporting-columns__key" id="metadata-key">{{key}}</dt>
                     <dd class="reporting-columns__value" id="metadata-value">{{value}}</dd>
                 </div>
@@ -33,7 +33,8 @@
                     <h2 tabindex="0" class="target-to-show__heading govuk-error-summary__title" id="error-summary">
                         Are you sure you want to delete this link?
                     </h2>
-                    <div class="button-group">
+
+                    <div class="govuk-button-group">
                       {{
                         govukButton({
                           text: "Yes, delete this link",
@@ -41,10 +42,9 @@
                           href: "manage/delete/" + product.externalId
                         })
                       }}
+
+                      <a class="govuk-link target-to-show--cancel govuk-link--no-visited-state" href="#main">Cancel</a>
                     </div>
-                    <a class="govuk-link govuk-link--no-visited-state govuk-link--no-visited-state target-to-show--cancel" href="#main">
-                        Cancel
-                    </a>
                 </div>
             </div>
         </div>

--- a/app/views/team-members/team-member-details.njk
+++ b/app/views/team-members/team-member-details.njk
@@ -51,17 +51,17 @@
       <form id="remove-team-member-form" method="post" action="{{removeTeamMemberLink}}" novalidate>
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
-        {{
-          govukButton({
-            text: "Yes, remove",
-            classes: "govuk-button--warning",
-            attributes: {
-              id: "remove-team-member-confirm"
-            }
-          })
-        }}
+        <div class="govuk-button-group">
+          {{govukButton({
+              text: "Yes, remove",
+              classes: "govuk-button--warning",
+              attributes: {
+                id: "remove-team-member-confirm"
+              }
+          })}}
 
-        <a class="govuk-link govuk-link--no-visited-state target-to-show--cancel" id="remove-team-member-cancel" href="#main">Cancel</a>
+          <a href="#main" class="govuk-link target-to-show--cancel" id="remove-team-member-cancel">Cancel</a>
+        </div>
       </form>
     </div>
   </div>

--- a/app/views/transaction-detail/_refund.njk
+++ b/app/views/transaction-detail/_refund.njk
@@ -94,7 +94,7 @@
   {% endif %}
 
 
-  <div class="govuk-form-group govuk-!-margin-top-6">
+  <div class="govuk-button-group govuk-!-margin-top-6">
     {{
       govukButton({
         text: 'Confirm refund',
@@ -105,8 +105,7 @@
         }
       })
     }}
-    <p class="govuk-body govuk-!-display-inline">
-      <a href="#main" class="govuk-link govuk-!-margin-left-3 target-to-show--cancel">cancel</a>
-    </p>
+
+    <a href="#main" class="govuk-link target-to-show--cancel">Cancel</a>
   </div>
 </form>


### PR DESCRIPTION
- Refactor the CSS that is used by the code to make functionality work without JS. This is the `target-to-show` CSS.
  - Clean up to make it simpler.
  - Make it consistent with the design system.  So that the cancel button is aligned to the left.
    - See this link from the Design system: https://design-system.service.gov.uk/components/button/ - Go to grouping buttons section.
- Update the code in the following places so that the `cancel` button is aligned correctly.
  - Cancel agreement
  - Refund transaction
  - Remove team member
  - Update API key
  - Revoke API key
  - Delete payment link

Updated the following pages with cancel buttons as per below:

## Refund transaction
![image](https://github.com/alphagov/pay-selfservice/assets/59831992/ce9a2117-c7f3-49ee-8f9f-19ddf53e8a7c)

## Delete payment link
![image](https://github.com/alphagov/pay-selfservice/assets/59831992/fa815bcc-1f09-4c2c-85aa-64555ffee7ba)

## Update API key
![image](https://github.com/alphagov/pay-selfservice/assets/59831992/56423273-1c39-49fc-a1e9-359afaa4c2e9)

## Revoke API key
![image](https://github.com/alphagov/pay-selfservice/assets/59831992/b15e451d-8b24-4563-aa55-5d6a551e1d17)

## Delete team member
![image](https://github.com/alphagov/pay-selfservice/assets/59831992/cc1bd014-97a3-4005-a235-9044f5ef24c4)

## Cancel agreement
![image](https://github.com/alphagov/pay-selfservice/assets/59831992/62961855-6436-4dc3-8c31-4b2565aad49c)


