### PR TITLE
PP-11244 use /api/ endpoint for getting gateway accounts

### DIFF
--- a/app/controllers/service-switch.controller.it.test.js
+++ b/app/controllers/service-switch.controller.it.test.js
@@ -4,15 +4,18 @@ const chai = require('chai')
 const nock = require('nock')
 const sinon = require('sinon')
 const _ = require('lodash')
-const connectorMock = nock(process.env.CONNECTOR_URL)
-const ACCOUNTS_FRONTEND_PATH = '/v1/frontend/accounts'
+const chaiAsPromised = require('chai-as-promised')
+const { expect } = require('chai')
+
 const myServicesController = require('./my-services')
 const User = require('../models/User.class')
 const userFixtures = require('../../test/fixtures/user.fixtures')
 const gatewayAccountFixtures = require('../../test/fixtures/gateway-account.fixtures')
-const chaiAsPromised = require('chai-as-promised')
-const { expect } = require('chai')
+
 chai.use(chaiAsPromised)
+
+const connectorMock = nock(process.env.CONNECTOR_URL)
+const ACCOUNTS_API_PATH = '/v1/api/accounts'
 
 describe('My services controller', () => {
   describe('service list', function () {
@@ -90,7 +93,7 @@ describe('My services controller', () => {
     let res
 
     before(async () => {
-      connectorMock.get(ACCOUNTS_FRONTEND_PATH + `?accountIds=${accountIds.join(',')}`)
+      connectorMock.get(ACCOUNTS_API_PATH + `?accountIds=${accountIds.join(',')}`)
         .reply(200, gatewayAccountFixtures.validGatewayAccountsResponse({ accounts }))
 
       res = {
@@ -201,7 +204,7 @@ describe('My services controller', () => {
       const newServiceGatewayAccountIds = ['3', '6', '7']
       const gatewayAccountIds = _.concat(service1gatewayAccountIds, newServiceGatewayAccountIds)
 
-      connectorMock.get(ACCOUNTS_FRONTEND_PATH + `?accountIds=${gatewayAccountIds.join(',')}`)
+      connectorMock.get(ACCOUNTS_API_PATH + `?accountIds=${gatewayAccountIds.join(',')}`)
         .reply(200, {
           accounts: gatewayAccountIds.map(iter => gatewayAccountFixtures.validGatewayAccountResponse({
             gateway_account_id: iter,

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -40,7 +40,7 @@ function _accountApiUrlFor (gatewayAccountId) {
 
 /** @private */
 function _accountUrlFor (gatewayAccountId) {
-  return ACCOUNT_FRONTEND_PATH.replace('{accountId}', gatewayAccountId)
+  return ACCOUNT_API_PATH.replace('{accountId}', gatewayAccountId)
 }
 
 /** @private */
@@ -50,7 +50,7 @@ function _accountByExternalIdUrlFor (gatewayAccountExternalId) {
 
 /** @private */
 function _accountsUrlFor (gatewayAccountIds) {
-  return ACCOUNTS_FRONTEND_PATH + '?accountIds=' + gatewayAccountIds.join(',')
+  return ACCOUNTS_API_PATH + '?accountIds=' + gatewayAccountIds.join(',')
 }
 
 /** @private */

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -81,7 +81,7 @@ function parseGatewayAccountOptions (opts) {
 }
 
 function getGatewayAccountSuccess (opts) {
-  const path = `/v1/frontend/accounts/${opts.gatewayAccountId}`
+  const path = `/v1/api/accounts/${opts.gatewayAccountId}`
   const fixtureOpts = parseGatewayAccountOptions(opts)
   return stubBuilder('GET', path, 200, {
     response: gatewayAccountFixtures.validGatewayAccountResponse(fixtureOpts)
@@ -97,7 +97,7 @@ function getGatewayAccountByExternalIdSuccess (opts) {
 }
 
 function getGatewayAccountsSuccess (opts) {
-  const path = '/v1/frontend/accounts'
+  const path = '/v1/api/accounts'
   return stubBuilder('GET', path, 200, {
     query: {
       accountIds: opts.gatewayAccountId.toString()
@@ -114,7 +114,7 @@ function getGatewayAccountsSuccess (opts) {
 }
 
 function getGatewayAccountsSuccessForMultipleAccounts (accountsOpts) {
-  const path = '/v1/frontend/accounts'
+  const path = '/v1/api/accounts'
   return stubBuilder('GET', path, 200, {
     query: {
       accountIds: accountsOpts.map(account => account.gatewayAccountId).join(',')

--- a/test/integration/make-a-demo-payment/go-to-transactions.controller.ft.test.js
+++ b/test/integration/make-a-demo-payment/go-to-transactions.controller.ft.test.js
@@ -18,7 +18,7 @@ const EXTERNAL_GATEWAY_ACCOUNT_ID = 'an-external-id'
 const PRODUCT_EXTERNAL_ID = 'a-product-external-id'
 
 function mockConnectorGetAccount () {
-  nock(CONNECTOR_URL).get(`/v1/frontend/accounts/${GATEWAY_ACCOUNT_ID}`)
+  nock(CONNECTOR_URL).get(`/v1/api/accounts/${GATEWAY_ACCOUNT_ID}`)
     .reply(200, validGatewayAccountResponse(
       {
         external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,

--- a/test/integration/transaction-redirect-details.ft.test.js
+++ b/test/integration/transaction-redirect-details.ft.test.js
@@ -45,7 +45,7 @@ describe('The transaction view scenarios', function () {
 
     userCreator.mockUserResponse(user.toJson(), done)
 
-    connectorMock.get(`/v1/frontend/accounts/${gatewayAccountId}`)
+    connectorMock.get(`/v1/api/accounts/${gatewayAccountId}`)
       .reply(200, validGatewayAccountResponse(
         {
           external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,

--- a/test/pact/connector-client/connector-get-gateway-account.pact.test.js
+++ b/test/pact/connector-client/connector-get-gateway-account.pact.test.js
@@ -11,7 +11,7 @@ const gatewayAccountFixtures = require('../../fixtures/gateway-account.fixtures'
 const { pactify } = require('../../test-helpers/pact/pactifier').defaultPactifier
 
 // Constants
-const ACCOUNTS_RESOURCE = '/v1/frontend/accounts'
+const ACCOUNTS_RESOURCE = '/v1/api/accounts'
 let connectorClient
 const expect = chai.expect
 

--- a/test/pact/connector-client/connector-get-multiple-gateway-accounts.pact.test.js
+++ b/test/pact/connector-client/connector-get-multiple-gateway-accounts.pact.test.js
@@ -11,7 +11,7 @@ const gatewayAccountFixtures = require('../../fixtures/gateway-account.fixtures'
 const { pactify } = require('../../test-helpers/pact/pactifier').defaultPactifier
 
 // Constants
-const ACCOUNTS_RESOURCE = '/v1/frontend/accounts'
+const ACCOUNTS_RESOURCE = '/v1/api/accounts'
 let connectorClient
 const expect = chai.expect
 


### PR DESCRIPTION
Use the GET `/v1/api/accounts` and GET `/v1/api/accounts/{accountId}` endpoints rather than the `/v1/frontend/` variants.

The behaviour of the `/v1/api/` and `/v1/frontend/` endpoints is now identical and we intend to remove the `/v1/frontend` variants.

