### PR TITLE
PP-9858 Add classNames to agreements elements

### DIFF
--- a/app/views/agreements/list.njk
+++ b/app/views/agreements/list.njk
@@ -120,36 +120,37 @@ Agreements - GOV.UK Pay
         <th class="govuk-table__header" scope="col" id="id-header">ID</th>
         <th class="govuk-table__header" scope="col" id="reference-header">Reference</th>
         <th class="govuk-table__header" scope="col" id="status-header">Status</th>
-        <th class="govuk-table__header" scope="col" id="payment-instrumnet-header">Payment instrument</th>
-        <th class="govuk-table__header" scope="col" id="brand-header">Date created</th>
+        <th class="govuk-table__header" scope="col" id="payment-instrument-header">Payment instrument</th>
+        <th class="govuk-table__header" scope="col" id="date-created-header">Date created</th>
       </tr>
     </thead>
 
     <tbody class="govuk-table__body">
     {% for agreement in agreements.results %}
-      <td class="govuk-table__cell govuk-!-font-size-14">
-        {{ agreement.external_id }}
-      </td>
-      <td class="govuk-table__cell govuk-!-font-size-14">
-        <a
-          class="govuk-link govuk-link__no-visited-state govuk-!-margin-right-1"
-          data-action="update"
-          href="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.agreements.detail, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, agreement.external_id) }}">
-          {{ agreement.reference }}
-        </a>
-      </td>
-      {# included for screen readers #}
-      <td class="govuk-table__cell govuk-!-font-size-14">
-        {{ agreementStatusTag(agreement.status) }}
-      </td>
-      <td class="govuk-table__cell govuk-!-font-size-14">
-        {% if agreement.payment_instrument %}
-          {{ paymentInstrument(agreement.payment_instrument) }}
-        {% endif %}
-      </td>
-      <td class="govuk-table__cell govuk-!-font-size-14">
-        {{ agreement.created_date | datetime('datelong') }}
-      </td>
+      <tr class="agreements-list--row govuk-table__row">
+        <td class="govuk-table__cell agreements-list--item agreement-external-id govuk-!-font-size-14">
+          {{ agreement.external_id }}
+        </td>
+        <td class="govuk-table__cell agreements-list--item reference govuk-!-font-size-14">
+          <a
+            class="govuk-link govuk-link__no-visited-state govuk-!-margin-right-1"
+            data-action="update"
+            href="{{ formatFutureStrategyAccountPathsFor(routes.futureAccountStrategy.agreements.detail, currentGatewayAccount.type, currentGatewayAccount.service_id, currentGatewayAccount.external_id, agreement.external_id) }}">
+            {{ agreement.reference }}
+          </a>
+        </td>
+        {# included for screen readers #}
+        <td class="govuk-table__cell agreements-list--item status govuk-!-font-size-14">
+          {{ agreementStatusTag(agreement.status) }}
+        </td>
+        <td class="govuk-table__cell agreements-list--item payment-instrument govuk-!-font-size-14">
+          {% if agreement.payment_instrument %}
+            {{ paymentInstrument(agreement.payment_instrument) }}
+          {% endif %}
+        </td>
+        <td class="govuk-table__cell agreements-list--item date-created govuk-!-font-size-14">
+          {{ agreement.created_date | datetime('datelong') }}
+        </td>
       </tr>
     {% endfor %}
     </tbody>


### PR DESCRIPTION
Context: End-to-end tests require that certain elements on the agreements pages can be identified
- Add 'agreements-list' and 'agreements-list--items' class names to relevant elements so they can be identified
- Correct misleading ids for agreement list headers