### PR TITLE
PP-10845 Upgrade to `govuk-frontend 4.7.0` (Design system v4)

### DIFF
--- a/app/views/email-notifications/confirmation-email-toggle.njk
+++ b/app/views/email-notifications/confirmation-email-toggle.njk
@@ -29,9 +29,9 @@
             Do you want to send payment confirmation emails?
           </h1>
         </legend>
-        <span id="email-confirmation-enabled-hint" class="govuk-hint">
+        <div id="email-confirmation-enabled-hint" class="govuk-hint">
           Users will receive an email confirming their payment from GOV.UK Pay
-        </span>
+        </div>
         <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
           <div class="govuk-radios__item">
             <input class="govuk-radios__input" id="email-confirmation-yes-input" name="email-confirmation-enabled" type="radio" value="true" {{'checked' if confirmationEnabled === true else ''}} {{'disabled' if isReadyOnly === true else ''}} data-aria-controls="conditional-email-confirmation-yes-input">

--- a/app/views/email-notifications/refund-email-toggle.njk
+++ b/app/views/email-notifications/refund-email-toggle.njk
@@ -29,9 +29,9 @@
           Do you want to send refund emails?
           </h1>
         </legend>
-        <span id="email-confirmation-enabled-hint" class="govuk-hint">
-        Users will receive an email confirming their refund from GOV.UK Pay
-        </span>
+        <div id="email-confirmation-enabled-hint" class="govuk-hint">
+          Users will receive an email confirming their refund from GOV.UK Pay
+        </div>
         <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
           <div class="govuk-radios__item">
             <input class="govuk-radios__input" id="email-confirmation-yes-input" name="email-refund-enabled" type="radio" value="true" {{'checked' if refundEmailEnabled === true else ''}} {{'disabled' if isReadyOnly === true else ''}} data-aria-controls="conditional-email-refund-yes-input">

--- a/app/views/includes/cookie-message.njk
+++ b/app/views/includes/cookie-message.njk
@@ -1,4 +1,4 @@
-<div id="pay-cookie-banner" class="pay-cookie-banner govuk-width-container" data-module="pay-cookie-banner" role="region" aria-label="cookie banner">
+<div id="pay-cookie-banner" class="pay-cookie-banner govuk-width-container" data-module="pay-cookie-banner" role="region" aria-label="cookie banner" data-nosnippet>
   <div class="pay-cookie-banner__wrapper">
     <h2 class="pay-cookie-banner__heading govuk-heading-m" id="pay-cookie-banner__heading">
       Can we store analytics cookies on your device?

--- a/app/views/includes/footer-categories.njk
+++ b/app/views/includes/footer-categories.njk
@@ -1,5 +1,11 @@
+{% if loggedIn %}
+  {% set footerSectionWidthCssClass = 'govuk-grid-column-one-third' %}
+{% else %}
+  {% set footerSectionWidthCssClass = 'govuk-grid-column-one-half' %}
+{% endif %}
+
 <div class="govuk-footer__navigation" data-click-events="data-click-events" data-click-category="Footer" data-click-action="Navigation link clicked">
-  <div class="govuk-footer__section">
+  <div class="govuk-footer__section {{footerSectionWidthCssClass}}">
     <h2 class="govuk-footer__heading govuk-heading-m govuk-!-margin-bottom-4 govuk-!-padding-bottom-0 pay-!-border-bottom-0">About</h2>
     <ul class="govuk-footer__list">
       <li class="govuk-footer__list-item">
@@ -22,7 +28,7 @@
       </li>
     </ul>
   </div>
-  <div class="govuk-footer__section">
+  <div class="govuk-footer__section {{footerSectionWidthCssClass}}">
     <h2 class="govuk-footer__heading govuk-heading-m govuk-!-margin-bottom-4 govuk-!-padding-bottom-0 pay-!-border-bottom-0">Support</h2>
     <ul class="govuk-footer__list">
       <li class="govuk-footer__list-item">
@@ -40,7 +46,7 @@
     </ul>
   </div>
   {% if loggedIn %}
-    <div class="govuk-footer__section">
+    <div class="govuk-footer__section {{footerSectionWidthCssClass}}">
       <h2 class="govuk-footer__heading govuk-heading-m govuk-!-margin-bottom-4 govuk-!-padding-bottom-0 pay-!-border-bottom-0">Legal Terms</h2>
       <ul class="govuk-footer__list">
         <li class="govuk-footer__list-item">

--- a/app/views/includes/footer.njk
+++ b/app/views/includes/footer.njk
@@ -11,7 +11,7 @@
             <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="https://www.payments.service.gov.uk/cookies/">Cookies</a></li>
             <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="https://www.payments.service.gov.uk/accessibility-statement/">Accessibility statement</a></li>
           </ul>
-        <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+        <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
           <path
             fill="currentColor"
             d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"

--- a/app/views/payment-links/amount.njk
+++ b/app/views/payment-links/amount.njk
@@ -41,9 +41,9 @@
           Enter the amount
           <span class="govuk-visually-hidden">in &pound;</span>
           {% if errors.amount %}
-          <span class="govuk-error-message">
+          <p class="govuk-error-message">
             Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”
-          </span>
+          </p>
           {% endif %}
         </label>
         <div class="currency-input__inner">
@@ -71,7 +71,7 @@
       {% set amountHintHint = 'Tell users how to work out how much they should pay, or where to find the payment amount.' %}
       {% set lang = 'en' %}
     {% endif %}
-    
+
     {% set userProvidedAmountHTML %}
       {{
         govukCharacterCount({

--- a/app/views/payment-links/web-address.njk
+++ b/app/views/payment-links/web-address.njk
@@ -28,16 +28,16 @@
       <label class="govuk-label govuk-label--s" for="payment-name-path">
         Please change the website address
       </label>
-      <span id="payment-name-path-hint" class="govuk-hint">
+      <div id="payment-name-path-hint" class="govuk-hint">
         This will not change the title<br>
-      </span>
+      </div>
       <span class="govuk-hint pay-text-black">
         {{friendlyURL}}/{{currentService.name | removeIndefiniteArticles | slugify}}/
       </span>
       {% if errors.path %}
-        <span id="payment-name-path-error" class="govuk-error-message">
+        <p id="payment-name-path-error" class="govuk-error-message">
           The website address is already taken
-        </span>
+        </p>
       {% endif %}
       <input class="govuk-input govuk-!-width-one-half {% if flash.genericError %}govuk-input--error{% endif %}" id="payment-name-path" name="payment-name-path" type="text" value="{{productNamePath}}" aria-describedby="payment-name-path-hint" spellcheck="false" autocapitalize="none" autofocus data-slugify="true">
 

--- a/app/views/request-to-go-live/organisation-address.njk
+++ b/app/views/request-to-go-live/organisation-address.njk
@@ -11,7 +11,7 @@
 {% if isRequestToGoLive %}
   Enter your organisation’s contact details - Request a live account - {{ currentService.name }} - GOV.UK Pay
 {% elif isStripeSetupUserJourney %}
-  What is the name and address of your organisation on your government entity document? - {{ currentService.name }} - GOV.UK Pay 
+  What is the name and address of your organisation on your government entity document? - {{ currentService.name }} - GOV.UK Pay
 {% else %}
   Organisation details - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endif %}
@@ -69,17 +69,17 @@
         Organisation name
       </label>
 
-      {% if not isStripeSetupUserJourney %} 
+      {% if not isStripeSetupUserJourney %}
         <div id="merchant-name-hint" class="govuk-hint govuk-!-width-two-thirds">
-          <p class="govuk-hint">Enter the main name of your organisation, not your local office or individual department.</p>
-          <p class="govuk-hint">Write the organisation name in full. Only use acronyms that are widely understood (for example, NHS).</p>
+          <div class="govuk-hint">Enter the main name of your organisation, not your local office or individual department.</div>
+          <div class="govuk-hint">Write the organisation name in full. Only use acronyms that are widely understood (for example, NHS).</div>
         </div>
       {% endif %}
-      
+
       {% if errors['merchant-name'] %}
-      <span id="merchant-name-error" class="govuk-error-message">
+      <p id="merchant-name-error" class="govuk-error-message">
         <span class="govuk-visually-hidden">Error:</span> {{errors["merchant-name"]}}
-      </span>
+      </p>
       {% endif %}
       <input class="govuk-input govuk-!-width-two-thirds {% if errors['merchant-name'] %} govuk-input--error {% endif %}"
              id="merchant-name" name="merchant-name" type="text" aria-describedby="merchant-name-hint" data-cy="input-org-name"
@@ -209,9 +209,9 @@
     {% endif %}
 
     {% if isRequestToGoLive or isStripeSetupUserJourney %}
-      {{ govukButton({ 
+      {{ govukButton({
         text: "Continue",
-        attributes: { 'data-cy': 'continue-button' } 
+        attributes: { 'data-cy': 'continue-button' }
       }) }}
     {% else %}
       {{ govukButton({

--- a/app/views/request-to-go-live/organisation-name.njk
+++ b/app/views/request-to-go-live/organisation-name.njk
@@ -27,16 +27,16 @@
           </label>
         </h1>
 
-        <span id="request-to-go-live-organisation-name-input-hint" class="govuk-hint">
+        <div id="request-to-go-live-organisation-name-input-hint" class="govuk-hint">
           <p>Your organisation's details must be shown on your payment pages.</p>
           <p>Enter the main name of your organisation, not your local office or individual department.</p>
             Enter the full name. Only use acronyms that are widely understood, like NHS.
-        </span>
+        </div>
 
         {% if errors['organisation-name'] %}
-          <span id="request-to-go-live-organisation-name-input-error" class="govuk-error-message">
+          <p id="request-to-go-live-organisation-name-input-error" class="govuk-error-message">
             <span class="govuk-visually-hidden">Error:</span> {{errors['organisation-name']}}
-          </span>
+          </p>
         {% endif %}
 
         <input class="govuk-input  {% if errors['organisation-name'] %} govuk-input--error {% endif %}"

--- a/app/views/services/add-service.njk
+++ b/app/views/services/add-service.njk
@@ -51,7 +51,7 @@
             "lang": "cy"
           }
         }) }}
-        <p class="govuk-hint">To turn on Welsh translations, follow the instructions in our&nbsp;documentation</p>
+        <div class="govuk-hint">To turn on Welsh translations, follow the instructions in our&nbsp;documentation</div>
       {% endset -%}
 
       {{ govukCheckboxes({
@@ -64,7 +64,7 @@
             conditional: {
               html: welshServiceNameHTML
             },
-            checked: true if current_name_cy else false 
+            checked: true if current_name_cy else false
           }
         ]
       }) }}

--- a/app/views/services/edit-service-name.njk
+++ b/app/views/services/edit-service-name.njk
@@ -52,7 +52,7 @@
             "lang": "cy"
           }
         }) }}
-        <p class="govuk-hint">To turn on Welsh translations, follow the instructions in our&nbsp;documentation</p>
+        <div class="govuk-hint">To turn on Welsh translations, follow the instructions in our&nbsp;documentation</div>
       {% endset -%}
 
       {% if current_name.cy %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "csurf": "^1.11.0",
         "express": "4.18.x",
         "google-libphonenumber": "3.2.32",
-        "govuk-frontend": "3.14.0",
+        "govuk-frontend": "^4.7.0",
         "http-proxy": "1.18.x",
         "https-proxy-agent": "5.0.1",
         "joi": "14.3.1",
@@ -62,7 +62,7 @@
         "chai-arrays": "2.2.0",
         "chai-as-promised": "7.1.1",
         "cheerio": "1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "csrf": "^3.1.0",
         "cypress": "^12.16.0",
         "dotenv": "16.3.1",
@@ -7699,9 +7699,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -23469,9 +23469,9 @@
       "integrity": "sha512-mcNgakausov/B/eTgVeX8qc8IwWjRrupk9UzZZ/QDEvdh5fAjE7Aa211bkZpZj42zKkeS6MTT8avHUwjcLxuGQ=="
     },
     "govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "csurf": "^1.11.0",
     "express": "4.18.x",
     "google-libphonenumber": "3.2.32",
-    "govuk-frontend": "3.14.0",
+    "govuk-frontend": "^4.7.0",
     "http-proxy": "1.18.x",
     "https-proxy-agent": "5.0.1",
     "joi": "14.3.1",

--- a/test/cypress/integration/stripe-setup/government-entity-document.cy.js
+++ b/test/cypress/integration/stripe-setup/government-entity-document.cy.js
@@ -90,7 +90,7 @@ describe('Stripe setup: Government entity document', () => {
 
       cy.get('.govuk-form-group--error > input#government-entity-document').parent().should('exist').within(() => {
         cy.get('.govuk-error-message').should('exist')
-        cy.get('span.govuk-error-message').should('contain', 'Select a file to upload')
+        cy.get('p.govuk-error-message').should('contain', 'Select a file to upload')
       })
 
       cy.get('#navigation-menu-your-psp')

--- a/test/cypress/integration/stripe-setup/vat-number.cy.js
+++ b/test/cypress/integration/stripe-setup/vat-number.cy.js
@@ -88,7 +88,7 @@ describe('Stripe setup: VAT number page', () => {
 
         cy.get('.govuk-form-group--error > input#vat-number').parent().should('exist').within(() => {
           cy.get('.govuk-error-message').should('exist')
-          cy.get('span.govuk-error-message').should('contain', 'Enter your VAT registration number')
+          cy.get('p.govuk-error-message').should('contain', 'Enter your VAT registration number')
         })
 
         cy.get('#navigation-menu-your-psp')


### PR DESCRIPTION
 Went through the release notes for version 4 and made the necessary updates:
  https://github.com/alphagov/govuk-frontend/releases/tag/v4.0.0
- Most changes are minor changes.
- Main bit of work was updating the footer - as CSS width classes must now be used.
- All changes have been checked using the Percy > Cypress integrations.
  - This is both the mobile and desktop view.
- Once this is merged, will pin the release and do a bit more testing in the test env.
- More details about the changes are below:

## Main changes 

The main changes are listed below

### Email payment confirmation emails toggle
Hint text uses a `<div>` instead of a `<span>`
<img width="1058" alt="Pasted Graphic 1" src="https://github.com/alphagov/pay-selfservice/assets/59831992/4b3d88c8-b57e-4f68-afc4-6a73be8055ca">

### Refund emails toggle
Hint text uses a `<div>` instead of a `<span>`
<img width="1058" alt="Pasted Graphic" src="https://github.com/alphagov/pay-selfservice/assets/59831992/d687ce4f-7e27-46a8-93ee-475044b106f8">

### Cookie banner:
Add the `data-nosnippet` attribute to the banner.

<img width="1058" alt="Pasted Graphic 2" src="https://github.com/alphagov/pay-selfservice/assets/59831992/b14d0190-4acb-450d-8082-f9b010885a2c">

### Footer
Have to add the width classes to the individual columns.
Also add `aria-hidden=true` for the OGL logo.

#### Logged in
<img width="1213" alt="Pasted Graphic 3" src="https://github.com/alphagov/pay-selfservice/assets/59831992/5c534969-1d16-4a50-9f64-5f757e04107c">

#### Logged out
<img width="1239" alt="image" src="https://github.com/alphagov/pay-selfservice/assets/59831992/536d1adc-845b-443e-a6c6-41d99ff34234">

###  Payment links - web address
Error message uses a `p` tag instead of a `span`.

<img width="1213" alt="Pasted Graphic 4" src="https://github.com/alphagov/pay-selfservice/assets/59831992/f2cbc5b4-350c-4ca0-b132-15bbcd9c51ce">

###  Payment links - Amount
Error message uses a `p` tag instead of a `span`.

<img width="1213" alt="Pasted Graphic 5" src="https://github.com/alphagov/pay-selfservice/assets/59831992/f3d9c88c-ceff-477b-89f2-5da4deaf83fd">

###  Request to go live - Organisation name 
Error message uses a `p` tag instead of a `span`.

<img width="1213" alt="Pasted Graphic 6" src="https://github.com/alphagov/pay-selfservice/assets/59831992/2a095e33-2dad-4509-8315-c29ae2a1455c">

### Create a new service
Hint text to use a `div` instead of a `p`.
<img width="1213" alt="Pasted Graphic 8" src="https://github.com/alphagov/pay-selfservice/assets/59831992/68c49d58-58e1-44ac-a841-70f2de40fc92">

### Edit a service name
Hint text to use a `div` instead of a `p`.
<img width="1213" alt="Pasted Graphic 7" src="https://github.com/alphagov/pay-selfservice/assets/59831992/d4abe5ca-2161-4ebd-9af1-789db7c80314">

### Stripe setup > Update org details
Organisation name section 
- update Hint text to use a `div` instead of a `p`.
- update error to use a `p` instead of a `span`.

<img width="626" alt="image" src="https://github.com/alphagov/pay-selfservice/assets/59831992/bfe6b878-4083-4626-9671-7f6645d3741b">





