### PR TITLE
PP-11152 Update how we consume Worldpay credentials

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -548,39 +552,25 @@
         "line_number": 18
       },
       {
-        "type": "Secret Keyword",
-        "filename": "test/cypress/integration/settings/your-psp.cy.js",
-        "hashed_secret": "2c877f34a0f47f32a5f3c77e398938b3cdc32221",
-        "is_verified": false,
-        "line_number": 28
-      },
-      {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/settings/your-psp.cy.js",
         "hashed_secret": "379f1968f09d8a343338667844e01a2f433f0a3f",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 27
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/settings/your-psp.cy.js",
         "hashed_secret": "abd006a3c55aebb9ffd8edca94531be22416e913",
         "is_verified": false,
-        "line_number": 37
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "test/cypress/integration/settings/your-psp.cy.js",
-        "hashed_secret": "b2023a863d65bffae6af0d0e1c8a036fd3f3773d",
-        "is_verified": false,
-        "line_number": 42
+        "line_number": 32
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/settings/your-psp.cy.js",
         "hashed_secret": "d7e383a1a8aedd99245e46203e2a3065c1101b5b",
         "is_verified": false,
-        "line_number": 47
+        "line_number": 37
       }
     ],
     "test/cypress/integration/switch-psp/organisation-url.cy.js": [
@@ -691,7 +681,7 @@
         "filename": "test/fixtures/gateway-account.fixtures.js",
         "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
         "is_verified": false,
-        "line_number": 277
+        "line_number": 285
       }
     ],
     "test/fixtures/invite.fixtures.js": [
@@ -871,6 +861,15 @@
         "line_number": 35
       }
     ],
+    "test/pact/connector-client/connector-patch-gateway-account-worldpay-one-off-credentials.pact.test.js": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test/pact/connector-client/connector-patch-gateway-account-worldpay-one-off-credentials.pact.test.js",
+        "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
     "test/pact/ledger-client/ledger-get-dispute-transactions.pact.test.js": [
       {
         "type": "Hex High Entropy String",
@@ -881,5 +880,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-27T15:59:00Z"
+  "generated_at": "2023-07-21T11:27:43Z"
 }

--- a/app/controllers/my-services/get-index.controller.js
+++ b/app/controllers/my-services/get-index.controller.js
@@ -64,7 +64,7 @@ module.exports = async function getServiceList (req, res) {
     has_account_with_payouts: hasStripeAccount(aggregatedGatewayAccounts),
     has_live_account: filterGatewayAccountIds(aggregatedGatewayAccounts, true).length
   }
-  
+
   if (newServiceId) {
     servicesData.find(service => {
       if (service.external_id === newServiceId) {

--- a/app/controllers/payment-links/get-start.controller.js
+++ b/app/controllers/payment-links/get-start.controller.js
@@ -11,7 +11,7 @@ module.exports = (req, res) => {
   const credential = getCurrentCredential(req.account)
 
   const accountUsesWorldpayMotoMerchantCode = lodash.get(credential, 'payment_provider', '') === 'worldpay' &&
-      lodash.get(credential, 'credentials.merchant_id', '').endsWith('MOTO')
+      lodash.get(credential, 'credentials.one_off_customer_initiated.merchant_code', '').endsWith('MOTO')
 
   return response(req, res, 'payment-links/index', {
     accountUsesWorldpayMotoMerchantCode: accountUsesWorldpayMotoMerchantCode

--- a/app/controllers/payment-links/get-start.controller.test.js
+++ b/app/controllers/payment-links/get-start.controller.test.js
@@ -3,6 +3,9 @@
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const { expect } = require('chai')
+
+const gatewayAccountFixtures = require('../../../test/fixtures/gateway-account.fixtures')
+
 const mockResponses = {}
 
 const getController = function (mockResponses) {
@@ -25,15 +28,18 @@ describe('The Worldpay MOTO account warning', () => {
   describe('when the gateway account has a Worldpay credentials object with a merchant code ending with ‘MOTO’', () => {
     it('should pass accountUsesWorldpayMotoMerchantCode with a value of true', () => {
       req = {
-        account: {
+        account: gatewayAccountFixtures.validGatewayAccount({
           gateway_account_credentials: [{
             state: 'ACTIVE',
             payment_provider: 'worldpay',
             credentials: {
-              merchant_id: 'merchant-code-ends-with-MOTO'
+              one_off_customer_initiated: {
+                merchant_code: 'merchant-code-ends-with-MOTO',
+                username: 'a-username'
+              }
             }
           }]
-        }
+        })
       }
 
       createPaymentLinkStartController(req, res)
@@ -44,15 +50,18 @@ describe('The Worldpay MOTO account warning', () => {
   describe('when the gateway account has a Worldpay credentials object with a merchant code not ending with ‘MOTO’', () => {
     it('should pass accountUsesWorldpayMotoMerchantCode with a value of false', () => {
       req = {
-        account: {
+        account: gatewayAccountFixtures.validGatewayAccount({
           gateway_account_credentials: [{
             state: 'ACTIVE',
             payment_provider: 'worldpay',
             credentials: {
-              merchant_id: 'merchant-code-ends-with-MOTO-ah-no-it-does-not'
+              one_off_customer_initiated: {
+                merchant_code: 'merchant-code-ends-with-MOTO-ah-no-it-does-not',
+                username: 'a-username'
+              }
             }
           }]
-        }
+        })
       }
 
       createPaymentLinkStartController(req, res)
@@ -63,15 +72,18 @@ describe('The Worldpay MOTO account warning', () => {
   describe('when the gateway account has a non-Worldpay credentials object with a merchant code ending with ‘MOTO’', () => {
     it('should pass accountUsesWorldpayMotoMerchantCode with a value of false', () => {
       req = {
-        account: {
+        account: gatewayAccountFixtures.validGatewayAccount({
           gateway_account_credentials: [{
             state: 'ACTIVE',
             payment_provider: 'not-worldpay',
             credentials: {
-              merchant_id: 'merchant-code-ends-with-MOTO'
+              one_off_customer_initiated: {
+                merchant_code: 'merchant-code-ends-with-MOTO',
+                username: 'a-username'
+              }
             }
           }]
-        }
+        })
       }
 
       createPaymentLinkStartController(req, res)
@@ -82,13 +94,13 @@ describe('The Worldpay MOTO account warning', () => {
   describe('when the gateway account has a Worldpay credentials object without a merchant_id', () => {
     it('should pass accountUsesWorldpayMotoMerchantCode with a value of false', () => {
       req = {
-        account: {
+        account: gatewayAccountFixtures.validGatewayAccount({
           gateway_account_credentials: [{
             state: 'ACTIVE',
             payment_provider: 'worldpay',
             credentials: {}
           }]
-        }
+        })
       }
 
       createPaymentLinkStartController(req, res)
@@ -99,12 +111,12 @@ describe('The Worldpay MOTO account warning', () => {
   describe('when the gateway account has no credentials object', () => {
     it('should pass accountUsesWorldpayMotoMerchantCode with a value of false', () => {
       req = {
-        account: {
+        account: gatewayAccountFixtures.validGatewayAccount({
           gateway_account_credentials: [{
             state: 'ACTIVE',
             payment_provider: 'worldpay'
           }]
-        }
+        })
       }
 
       createPaymentLinkStartController(req, res)
@@ -115,9 +127,9 @@ describe('The Worldpay MOTO account warning', () => {
   describe('when the gateway account has no credentials at all', () => {
     it('should pass accountUsesWorldpayMotoMerchantCode with a value of false', () => {
       req = {
-        account: {
+        account: gatewayAccountFixtures.validGatewayAccount({
           gateway_account_credentials: []
-        }
+        })
       }
 
       createPaymentLinkStartController(req, res)

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.test.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.test.js
@@ -248,7 +248,6 @@ describe('organisation address - post controller', () => {
         expect(responseData.args[3].isStripeUpdateOrgDetails).to.equal(true)
         expect(responseData.args[3].isSwitchingCredentials).to.equal(false)
         expect(responseData.args[3].isStripeSetupUserJourney).to.equal(true)
-        console.log(1111, responseData.args[3])
         expect(responseData.args[3].enableStripeOnboardingTaskList).to.equal(true)
         expect(responseData.args[3].currentCredential).to.deep.equal({ external_id: 'a-valid-credential-external-id' })
       })

--- a/app/controllers/stripe-setup/bank-details/post.controller.test.js
+++ b/app/controllers/stripe-setup/bank-details/post.controller.test.js
@@ -183,16 +183,16 @@ describe('Bank details post controller', () => {
 
   it('should render error page with side navigation when ENABLE_STRIPE_ONBOARDING_TASK_LIST is true and on the your-psp route', async () => {
     process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
-    
+
     req.url = '/your-psp/:credentialId/bank-details'
     req.body = {}
 
     const controller = getControllerWithMocks()
 
     await controller(req, res, next)
-   
+
     const pageData = res.render.firstCall.args[1]
-    
+
     sinon.assert.called(res.render)
     expect(pageData.enableStripeOnboardingTaskList).equal(true)
     expect(pageData.currentCredential).to.deep.equal({ external_id: 'a-valid-credential-external-id' })
@@ -200,9 +200,9 @@ describe('Bank details post controller', () => {
 
   it('should re-render the form page when Stripe returns "routing_number_invalid" error when ENABLE_STRIPE_ONBOARDING_TASK_LIST is true and on the your-psp route', async () => {
     process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
-    
+
     req.url = '/your-psp/:credentialId/bank-details'
- 
+
     updateBankAccountMock = sinon.spy((stripeAccountId, body) => {
       return new Promise((resolve, reject) => {
         const error = new Error()
@@ -230,7 +230,7 @@ describe('Bank details post controller', () => {
 
   it('should re-render the form page when Stripe returns "account_number_invalid" error when ENABLE_STRIPE_ONBOARDING_TASK_LIST is true and on the your-psp route', async () => {
     process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
-    
+
     req.url = '/your-psp/:credentialId/bank-details'
 
     updateBankAccountMock = sinon.spy((stripeAccountId, body) => {

--- a/app/controllers/stripe-setup/check-org-details/post.controller.js
+++ b/app/controllers/stripe-setup/check-org-details/post.controller.js
@@ -45,7 +45,7 @@ module.exports = async function postCheckOrgDetails (req, res, next) {
       orgPostcode: merchantDetails.address_postcode,
       isSwitchingCredentials,
       enableStripeOnboardingTaskList,
-      currentCredential,
+      currentCredential
     }
 
     return response(req, res, 'stripe-setup/check-org-details/index', data)

--- a/app/controllers/stripe-setup/check-org-details/post.controller.test.js
+++ b/app/controllers/stripe-setup/check-org-details/post.controller.test.js
@@ -169,7 +169,7 @@ describe('Check org details - post controller', () => {
       })
       it('when ENABLE_STRIPE_ONBOARDING_TASK_LIST is true and `yes` radio button is selected, then it should redirect to tasklist page', async () => {
         process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
-        
+
         req.url = '/your-psp/:credentialId/check-organisation-details'
         req.account.connectorGatewayAccountStripeProgress = { organisationDetails: false }
 

--- a/app/controllers/stripe-setup/vat-number/post.controller.test.js
+++ b/app/controllers/stripe-setup/vat-number/post.controller.test.js
@@ -168,9 +168,9 @@ describe('VAT number POST controller', () => {
 
   it('should redirect to the task list page when ENABLE_STRIPE_ONBOARDING_TASK_LIST is set to true ', async function () {
     process.env.ENABLE_STRIPE_ONBOARDING_TASK_LIST = 'true'
-    
+
     req.url = '/your-psp/:credentialId/vat-number'
-    
+
     updateCompanyMock = sinon.spy(() => Promise.resolve())
     setStripeAccountSetupFlagMock = sinon.spy(() => Promise.resolve())
     const controller = getControllerWithMocks()

--- a/app/controllers/webhooks/webhooks.service.test.js
+++ b/app/controllers/webhooks/webhooks.service.test.js
@@ -111,7 +111,6 @@ describe('webhooks service', () => {
     expect(result.links[0].disabled).to.equal(undefined)
     expect(result.links[1].pageName).to.equal('Next')
     expect(result.links[1].disabled).to.equal(true)
-
   })
 })
 

--- a/app/controllers/your-psp/get.controller.js
+++ b/app/controllers/your-psp/get.controller.js
@@ -17,7 +17,6 @@ module.exports = async (req, res, next) => {
     const credential = getCredentialByExternalId(req.account, credentialId)
     const activeCredential = getCurrentCredential(req.account)
     const switchingCredential = getSwitchingCredentialIfExists(req.account)
-    const isAccountCredentialsConfigured = credential.credentials && credential.credentials.merchant_id !== undefined
     const switchedProvider = hasSwitchedProvider(req.account)
 
     const isWorldpay3dsFlexCredentialsConfigured = req.account.worldpay_3ds_flex &&
@@ -41,7 +40,6 @@ module.exports = async (req, res, next) => {
       activeCredential,
       switchingCredential,
       switchedProvider,
-      isAccountCredentialsConfigured,
       is3dsEnabled,
       isMotoEnabled,
       isWorldpay3dsFlexEnabled,

--- a/app/controllers/your-psp/get.controller.test.js
+++ b/app/controllers/your-psp/get.controller.test.js
@@ -90,4 +90,3 @@ describe('Your PSP GET controller', () => {
     sinon.assert.calledWith(res.render, 'your-psp/index')
   })
 })
-

--- a/app/controllers/your-psp/post-flex.controller.test.js
+++ b/app/controllers/your-psp/post-flex.controller.test.js
@@ -62,9 +62,22 @@ describe('Post 3DS Flex controller', () => {
     sinon.assert.notCalled(updateIntegrationVersion3dsMock)
   })
 
+  it('should call next when there is an error checking flex credentials', async () => {
+    req.account = getGatewayAcountWithType('live')
+    const expectedError = new Error('error from connector')
+
+    postCheckWorldpay3dsFlexCredentials = sinon.stub().rejects(expectedError)
+    const controller = getControllerWithMocks()
+
+    await controller(req, res, next)
+
+    sinon.assert.called(postCheckWorldpay3dsFlexCredentials)
+    sinon.assert.calledWith(next, expectedError)
+  })
+
   it('should call next when there is an error updating the 3DS integration version to 2', async () => {
     req.account = getGatewayAcountWithType('live')
-    const expectedError = new Error('error from adminusers')
+    const expectedError = new Error('error from connector')
 
     updateIntegrationVersion3dsMock = sinon.stub().rejects(expectedError)
     const controller = getControllerWithMocks()

--- a/app/views/credentials/worldpay.njk
+++ b/app/views/credentials/worldpay.njk
@@ -45,7 +45,7 @@
             name: "merchantId",
             classes: "govuk-input--width-20",
             type: "text",
-            value: form.values.merchant_id,
+            value: form.values.merchant_code,
             errorMessage: form.errors.merchantId and {
               text: form.errors.merchantId
             }

--- a/app/views/your-psp/_epdq.njk
+++ b/app/views/your-psp/_epdq.njk
@@ -4,6 +4,8 @@
 
 <h2 class="govuk-heading-m">Account credentials</h2>
 
+{% set isAccountCredentialsConfigured = (credential.credentials and credential.credentials.merchant_id) %}
+
 {{
   govukSummaryList({
     rows: [

--- a/app/views/your-psp/_worldpay.njk
+++ b/app/views/your-psp/_worldpay.njk
@@ -3,6 +3,9 @@
 <p class="govuk-body">Go to your <a class="govuk-link" href="https://secure.worldpay.com/sso/public/auth/login.html">Worldpay account</a> to get the details you need to enter here, or <a class="govuk-link" href="https://docs.payments.service.gov.uk/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay">read more in our documentation.</a></p>
 
 <h2 class="govuk-heading-m govuk-!-margin-top-9">Account credentials</h2>
+
+{% set isAccountCredentialsConfigured = (credential.credentials and credential.credentials.one_off_customer_initiated|length) %}
+
 {{
   govukSummaryList({
     rows: [
@@ -11,7 +14,7 @@
           text: "Merchant code"
         },
         value: {
-          text: credential.credentials.merchant_id if isAccountCredentialsConfigured else "Not configured",
+          text: credential.credentials.one_off_customer_initiated.merchant_code if isAccountCredentialsConfigured else "Not configured",
           classes: "value-merchant-id"
         },
         actions: {
@@ -32,7 +35,7 @@
           text: "Username"
         },
         value: {
-          text: credential.credentials.username if isAccountCredentialsConfigured else "Not configured",
+          text: credential.credentials.one_off_customer_initiated.username if isAccountCredentialsConfigured else "Not configured",
           classes: "value-username"
         },
         actions: {

--- a/test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.js
+++ b/test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.js
@@ -61,7 +61,7 @@ describe('The Stripe psp details banner', () => {
     cy.get('[data-cy=stripe-notification]')
       .contains('You need to submit additional information to Stripe to be able to take payments.')
       .within(() => {
-      cy.get('a').should('have.attr', 'href', '/account/a-valid-external-id/your-psp/a-valid-external-id')
+        cy.get('a').should('have.attr', 'href', '/account/a-valid-external-id/your-psp/a-valid-external-id')
       })
   })
 
@@ -81,7 +81,7 @@ describe('The Stripe psp details banner', () => {
     cy.get('[data-cy=stripe-notification]')
       .contains('Stripe has restricted your account. To start taking payments again, please contact support govuk-pay-support@digital.cabinet-office.gov.uk')
       .within(() => {
-      cy.get('a').should('have.attr', 'href', 'mailto:govuk-pay-support@digital.cabinet-office.gov.uk')
+        cy.get('a').should('have.attr', 'href', 'mailto:govuk-pay-support@digital.cabinet-office.gov.uk')
       })
   })
 

--- a/test/cypress/integration/payment-links/create-payment-link.cy.js
+++ b/test/cypress/integration/payment-links/create-payment-link.cy.js
@@ -40,7 +40,9 @@ describe('The create payment link start page for a Worldpay MOTO account', () =>
             payment_provider: 'worldpay',
             state: 'ACTIVE',
             credentials: {
-              merchant_id: 'worldpay-merchant-code-ending-with-MOTO'
+              one_off_customer_initiated: {
+                merchant_code: 'worldpay-merchant-code-ending-with-MOTO'
+              }
             }
           }
         ]

--- a/test/cypress/integration/request-to-go-live/organisation-name.cy.js
+++ b/test/cypress/integration/request-to-go-live/organisation-name.cy.js
@@ -56,7 +56,6 @@ describe('Request to go live: organisation name page', () => {
   })
 
   describe('Service has NOT_STARTED go live stage and organisation name is not pre-filled', () => {
-
     it('should display an empty form', () => {
       cy.task('setupStubs', utils.getUserAndGatewayAccountStubs(notStartedServiceRole))
 

--- a/test/cypress/integration/settings/default-billing-address-country.cy.js
+++ b/test/cypress/integration/settings/default-billing-address-country.cy.js
@@ -55,7 +55,7 @@ describe('Default billing address country', () => {
 
       it('should show default billing address country as "United Kingdom"', () => {
         cy.task('setupStubs', [
-          ...getUserAndGatewayAccountStubs('GB'),
+          ...getUserAndGatewayAccountStubs('GB')
         ])
 
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)

--- a/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.js
+++ b/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.js
@@ -69,7 +69,6 @@ describe('MOTO mask security section', () => {
     })
 
     describe('mask card number - when user has read permission and card number mask disabled', () => {
-
       it('should show radios as disabled and card number mask disabled', () => {
         setupMotoStubs({ readonly: true, allowMoto: true, motoMaskCardNumber: false })
 

--- a/test/cypress/integration/settings/switch-psp.cy.js
+++ b/test/cypress/integration/settings/switch-psp.cy.js
@@ -82,7 +82,7 @@ describe('Switch PSP settings page', () => {
         it('should show dashboard message for switching psp', () => {
           cy.task('setupStubs', [
             ...getUserAndAccountStubsForSwitchingNotStarted(),
-            transactionStubs.getTransactionsSummarySuccess(),
+            transactionStubs.getTransactionsSummarySuccess()
           ])
 
           cy.visit(`/account/${gatewayAccountExternalId}/dashboard`)
@@ -185,22 +185,22 @@ describe('Switch PSP settings page', () => {
         it('should show steps as completed', () => {
           cy.task('setupStubs', [
             ...getUserAndAccountStubs('smartpay', true, [
-                {
-                  payment_provider: 'smartpay',
-                  state: 'ACTIVE',
-                  id: currentCredentialId,
-                  external_id: currentCredentialExternalId
-                },
-                {
-                  payment_provider: 'worldpay',
-                  state: 'ENTERED',
-                  id: switchingToCredentialId,
-                  external_id: switchingToCredentialExternalId
-                }
-              ],
-              null,
-              true,
-              2)
+              {
+                payment_provider: 'smartpay',
+                state: 'ACTIVE',
+                id: currentCredentialId,
+                external_id: currentCredentialExternalId
+              },
+              {
+                payment_provider: 'worldpay',
+                state: 'ENTERED',
+                id: switchingToCredentialId,
+                external_id: switchingToCredentialExternalId
+              }
+            ],
+            null,
+            true,
+            2)
           ])
 
           cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
@@ -217,13 +217,13 @@ describe('Switch PSP settings page', () => {
         describe('When switching is not started', () => {
           beforeEach(() => {
             cy.task('setupStubs', getUserAndAccountStubs('smartpay', true, [
-                { payment_provider: 'smartpay', state: 'ACTIVE' },
-                { payment_provider: 'worldpay', state: 'CREATED' }
-              ],
-              null,
-              null,
-              null,
-              true))
+              { payment_provider: 'smartpay', state: 'ACTIVE' },
+              { payment_provider: 'worldpay', state: 'CREATED' }
+            ],
+            null,
+            null,
+            null,
+            true))
           })
 
           it('should have task list for Worldpay with correct tags', () => {
@@ -273,22 +273,22 @@ describe('Switch PSP settings page', () => {
         it('should now be clickable and navigate to the verify PSP integration page', () => {
           cy.task('setupStubs', [
             ...getUserAndAccountStubs('smartpay', true, [
-                {
-                  payment_provider: 'smartpay',
-                  state: 'ACTIVE',
-                  id: currentCredentialId,
-                  external_id: currentCredentialExternalId
-                },
-                {
-                  payment_provider: 'worldpay',
-                  state: 'ENTERED',
-                  id: switchingToCredentialId,
-                  external_id: switchingToCredentialExternalId
-                }
-              ],
-              null,
-              true,
-              2),
+              {
+                payment_provider: 'smartpay',
+                state: 'ACTIVE',
+                id: currentCredentialId,
+                external_id: currentCredentialExternalId
+              },
+              {
+                payment_provider: 'worldpay',
+                state: 'ENTERED',
+                id: switchingToCredentialId,
+                external_id: switchingToCredentialExternalId
+              }
+            ],
+            null,
+            true,
+            2),
             connectorChargeStubs.postCreateChargeSuccess({
               gateway_account_id: gatewayAccountId,
               charge_id: 'a-valid-charge-external-id',
@@ -310,22 +310,22 @@ describe('Switch PSP settings page', () => {
         it('returning with a failed payment should present an error', () => {
           cy.task('setupStubs', [
             ...getUserAndAccountStubs('smartpay', true, [
-                {
-                  payment_provider: 'smartpay',
-                  state: 'ACTIVE',
-                  id: currentCredentialId,
-                  external_id: currentCredentialExternalId
-                },
-                {
-                  payment_provider: 'worldpay',
-                  state: 'ENTERED',
-                  id: switchingToCredentialId,
-                  external_id: switchingToCredentialExternalId
-                }
-              ],
-              null,
-              true,
-              2),
+              {
+                payment_provider: 'smartpay',
+                state: 'ACTIVE',
+                id: currentCredentialId,
+                external_id: currentCredentialExternalId
+              },
+              {
+                payment_provider: 'worldpay',
+                state: 'ENTERED',
+                id: switchingToCredentialId,
+                external_id: switchingToCredentialExternalId
+              }
+            ],
+            null,
+            true,
+            2),
             connectorChargeStubs.getChargeSuccess({
               gateway_account_id: gatewayAccountId,
               charge_id: 'a-valid-charge-external-id',
@@ -342,22 +342,22 @@ describe('Switch PSP settings page', () => {
         it('returning with a successful payment should present completion message', () => {
           cy.task('setupStubs', [
             ...getUserAndAccountStubs('smartpay', true, [
-                {
-                  payment_provider: 'smartpay',
-                  state: 'ACTIVE',
-                  id: currentCredentialId,
-                  external_id: currentCredentialExternalId
-                },
-                {
-                  payment_provider: 'worldpay',
-                  state: 'VERIFIED_WITH_LIVE_PAYMENT',
-                  id: switchingToCredentialId,
-                  external_id: switchingToCredentialExternalId
-                }
-              ],
-              null,
-              true,
-              2),
+              {
+                payment_provider: 'smartpay',
+                state: 'ACTIVE',
+                id: currentCredentialId,
+                external_id: currentCredentialExternalId
+              },
+              {
+                payment_provider: 'worldpay',
+                state: 'VERIFIED_WITH_LIVE_PAYMENT',
+                id: switchingToCredentialId,
+                external_id: switchingToCredentialExternalId
+              }
+            ],
+            null,
+            true,
+            2),
             connectorChargeStubs.postCreateChargeSuccess({
               gateway_account_id: gatewayAccountId,
               charge_id: 'a-valid-charge-external-id',
@@ -383,22 +383,22 @@ describe('Switch PSP settings page', () => {
       describe('Switch PSP', () => {
         beforeEach(() => {
           let userAndAccountStubs = getUserAndAccountStubs('smartpay', true, [
-              {
-                payment_provider: 'smartpay',
-                state: 'ACTIVE',
-                id: currentCredentialId,
-                external_id: currentCredentialExternalId
-              },
-              {
-                payment_provider: 'worldpay',
-                state: 'VERIFIED_WITH_LIVE_PAYMENT',
-                id: switchingToCredentialId,
-                external_id: switchingToCredentialExternalId
-              }
-            ],
-            null,
-            true,
-            2)
+            {
+              payment_provider: 'smartpay',
+              state: 'ACTIVE',
+              id: currentCredentialId,
+              external_id: currentCredentialExternalId
+            },
+            {
+              payment_provider: 'worldpay',
+              state: 'VERIFIED_WITH_LIVE_PAYMENT',
+              id: switchingToCredentialId,
+              external_id: switchingToCredentialExternalId
+            }
+          ],
+          null,
+          true,
+          2)
           cy.task('setupStubs', [
             ...userAndAccountStubs,
             gatewayAccountStubs.postSwitchPspSuccess(gatewayAccountId)
@@ -416,22 +416,22 @@ describe('Switch PSP settings page', () => {
       describe('Switched PSP', () => {
         beforeEach(() => {
           cy.task('setupStubs', getUserAndAccountStubs('smartpay', true, [
-              {
-                payment_provider: 'smartpay',
-                state: 'ACTIVE',
-                external_id: 'a-valid-external-id-smartpay',
-                active_start_date: '2018-05-03T00:00:00.000Z'
-              },
-              {
-                payment_provider: 'worldpay',
-                state: 'RETIRED',
-                active_end_date: '2018-05-03T00:00:00.000Z',
-                external_id: 'a-valid-external-id-worldpay'
-              }
-            ],
-            null,
-            true,
-            2))
+            {
+              payment_provider: 'smartpay',
+              state: 'ACTIVE',
+              external_id: 'a-valid-external-id-smartpay',
+              active_start_date: '2018-05-03T00:00:00.000Z'
+            },
+            {
+              payment_provider: 'worldpay',
+              state: 'RETIRED',
+              active_end_date: '2018-05-03T00:00:00.000Z',
+              external_id: 'a-valid-external-id-worldpay'
+            }
+          ],
+          null,
+          true,
+          2))
         })
 
         it('sets transitioned text on the old psp page', () => {

--- a/test/cypress/integration/stripe-setup/check-org-details.cy.js
+++ b/test/cypress/integration/stripe-setup/check-org-details.cy.js
@@ -115,7 +115,7 @@ describe('Stripe setup: Check your organisation’s details', () => {
         .should('have.attr', 'href', '#confirm-org-details')
 
       cy.get('[data-cy=error-message]').should('contain', 'Select yes if your organisation’s details match the details on your government entity document')
-     
+
       cy.get('#navigation-menu-your-psp')
         .should('contain', 'Information for Stripe')
         .parent().should('have.class', 'govuk-!-font-weight-bold')

--- a/test/cypress/integration/stripe-setup/company-number.cy.js
+++ b/test/cypress/integration/stripe-setup/company-number.cy.js
@@ -83,7 +83,7 @@ describe('Stripe setup: company number page', () => {
         cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#company-number-declaration')
 
         cy.get('#company-number-declaration-error').should('contain', 'You must answer this question')
-        
+
         cy.get('#navigation-menu-your-psp')
           .should('contain', 'Information for Stripe')
           .parent().should('have.class', 'govuk-!-font-weight-bold')

--- a/test/cypress/integration/stripe-setup/government-entity-document.cy.js
+++ b/test/cypress/integration/stripe-setup/government-entity-document.cy.js
@@ -100,7 +100,7 @@ describe('Stripe setup: Government entity document', () => {
       cy.get('.govuk-back-link')
         .should('contain', 'Back to information for Stripe')
         .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
-     })
+    })
   })
 
   describe('when user is admin, account is Stripe and "Government entity document" is already submitted', () => {

--- a/test/cypress/integration/stripe-setup/responsible-person.cy.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.js
@@ -162,7 +162,7 @@ describe('Stripe setup: responsible person page', () => {
 
         cy.get('button').should('exist')
       })
-      
+
       cy.get('#navigation-menu-your-psp')
         .should('contain', 'Information for Stripe')
         .parent().should('have.class', 'govuk-!-font-weight-bold')

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -134,18 +134,6 @@ function getAccountAuthSuccess (opts) {
   })
 }
 
-function getDirectDebitGatewayAccountSuccess (opts) {
-  const path = `/v1/api/accounts/${opts.gatewayAccountId}`
-  return stubBuilder('GET', path, 200, {
-    response: gatewayAccountFixtures.validDirectDebitGatewayAccountResponse({
-      gateway_account_id: opts.gatewayAccountId,
-      type: opts.type,
-      payment_provider: opts.paymentProvider,
-      is_connected: opts.isConnected
-    })
-  })
-}
-
 function postCreateGatewayAccountSuccess (opts) {
   const fixtureOpts = {
     service_name: opts.serviceName,
@@ -243,7 +231,7 @@ function patchUpdateMaskSecurityCodeSuccess (gatewayAccountId, mask) {
 function patchUpdate3dsVersionSuccess (gatewayAccountId, version) {
   const path = `/v1/api/accounts/${gatewayAccountId}`
   return stubBuilder('PATCH', path, 200, {
-    requests: gatewayAccountFixtures.validPatchIntegrationVersion3dsRequest(version)
+    request: gatewayAccountFixtures.validPatchIntegrationVersion3dsRequest(version)
   })
 }
 
@@ -292,6 +280,13 @@ function patchUpdateCredentialsSuccess (gatewayAccountId, credentialId) {
   return stubBuilder('PATCH', path, 200)
 }
 
+function patchUpdateWorldpayOneOffCredentialsSuccess (opts = {}) {
+  const path = `/v1/api/accounts/${opts.gatewayAccountId}/credentials/${opts.credentialId}`
+  return stubBuilder('PATCH', path, 200, {
+    request: gatewayAccountFixtures.validUpdateGatewayAccountCredentialsRequest(opts)
+  })
+}
+
 function postUpdateNotificationCredentialsSuccess (gatewayAccountId) {
   const path = `/v1/api/accounts/${gatewayAccountId}/notification-credentials`
   return stubBuilder('POST', path, 200)
@@ -309,7 +304,6 @@ module.exports = {
   getGatewayAccountByExternalIdSuccess,
   getGatewayAccountsSuccessForMultipleAccounts,
   getAcceptedCardTypesSuccess,
-  getDirectDebitGatewayAccountSuccess,
   postCreateGatewayAccountSuccess,
   getCardTypesSuccess,
   postUpdateCardTypesSuccess,
@@ -326,6 +320,7 @@ module.exports = {
   postCheckWorldpayCredentials,
   postUpdateWorldpay3dsFlexCredentials,
   patchUpdateCredentialsSuccess,
+  patchUpdateWorldpayOneOffCredentialsSuccess,
   postUpdateNotificationCredentialsSuccess,
   postSwitchPspSuccess,
   patchAccountUpdateApplePaySuccess,

--- a/test/cypress/stubs/user-stubs.js
+++ b/test/cypress/stubs/user-stubs.js
@@ -275,7 +275,6 @@ function buildUserWithServiceRoleOpts (opts) {
 }
 
 module.exports = {
-  buildGetUserSuccessStub,
   getUserSuccess,
   getUsersSuccess,
   getUserSuccessWithNoServices,

--- a/test/fixtures/agreement.fixtures.js
+++ b/test/fixtures/agreement.fixtures.js
@@ -60,13 +60,13 @@ module.exports = {
       page: opts.page || 1
     }
   },
-  validAgreementNotFoundResponse: (opts = {}) =>  {
+  validAgreementNotFoundResponse: (opts = {}) => {
     return {
       code: 404,
       message: opts.message || 'HTTP 404 Not Found'
     }
   },
-  validAgreementsNotFoundResponse: () =>  {
+  validAgreementsNotFoundResponse: () => {
     return {
       results: [],
       total: 0,

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -3,14 +3,21 @@
 function validCredentials (opts = {}) {
   const credentials = {}
 
+  // Worldpay
+  if (opts.one_off_customer_initiated) {
+    credentials.one_off_customer_initiated = {
+      merchant_code: opts.one_off_customer_initiated.merchant_code,
+      username: opts.one_off_customer_initiated.username
+    }
+  }
+
+  // ePDQ
   if (opts.merchant_id) {
     credentials.merchant_id = opts.merchant_id
   }
-
   if (opts.username) {
     credentials.username = opts.username
   }
-
   if (opts.sha_in_passphrase) {
     credentials.sha_in_passphrase = opts.sha_in_passphrase
   }
@@ -18,6 +25,7 @@ function validCredentials (opts = {}) {
     credentials.sha_out_passphrase = opts.sha_out_passphrase
   }
 
+  // Stripe
   if (opts.stripe_account_id) {
     credentials.stripe_account_id = opts.stripe_account_id
   }
@@ -329,6 +337,25 @@ function validPatchIntegrationVersion3dsRequest (version) {
   }
 }
 
+function validPatchWorldpayOneOffCustomerInitiatedRequest (opts = {}) {
+  return [
+    {
+      op: 'replace',
+      path: 'credentials',
+      value: {
+        merchant_id: opts.merchantCode,
+        username: opts.username,
+        password: opts.password
+      }
+    },
+    {
+      op: 'replace',
+      path: 'last_updated_by_user_external_id',
+      value: opts.userExternalId
+    }
+  ]
+}
+
 function validPatchGatewayCredentialsResponse (opts = {}) {
   const defaultCredentials = {
     username: 'a-username',
@@ -379,6 +406,7 @@ module.exports = {
   validUpdateGatewayAccountCredentialsRequest,
   validGatewayAccountCredentialsResponse,
   validPatchGatewayMerchantIdRequest,
+  validPatchWorldpayOneOffCustomerInitiatedRequest,
   validPatchGatewayCredentialsResponse,
   validPatchAccountGatewayAccountCredentialsStateRequest,
   validPatchServiceNameRequest,

--- a/test/pact/connector-client/connector-get-gateway-account-by-external-id.pact.test.js
+++ b/test/pact/connector-client/connector-get-gateway-account-by-external-id.pact.test.js
@@ -37,6 +37,14 @@ describe('connector client - get gateway account by external id', function () {
       payment_provider: 'worldpay',
       description: 'A description',
       analytics_id: 'an-analytics-id',
+      gateway_account_credentials: [{
+        credentials: {
+          one_off_customer_initiated: {
+            merchant_code: 'a-merchant-code',
+            username: 'a-username'
+          }
+        }
+      }],
       worldpay_3ds_flex: {
         organisational_unit_id: 'an-org-id',
         issuer: 'an-issues'

--- a/test/pact/connector-client/connector-post-cancel-agreement.pact.test.js
+++ b/test/pact/connector-client/connector-post-cancel-agreement.pact.test.js
@@ -53,7 +53,7 @@ describe('connector client', function () {
       afterEach(() => provider.verify())
 
       it('should post cancel agreement successfully', async () => {
-        return  connectorClient.postCancelAgreement(cancelAgreementRequest).should.be.fulfilled
+        return connectorClient.postCancelAgreement(cancelAgreementRequest).should.be.fulfilled
       })
     })
   })

--- a/test/pact/ledger-client/ledger-get-one-agreement.pact.test.js
+++ b/test/pact/ledger-client/ledger-get-one-agreement.pact.test.js
@@ -46,7 +46,8 @@ describe('ledger client', function () {
           .withStatusCode(200)
           .withResponseBody(pactify(validGetOneAgreementResponse))
           .build()
-      )})
+      )
+    })
 
     afterEach(() => pactTestProvider.verify())
 

--- a/test/pact/ledger-client/ledger-search-agreements.pact.test.js
+++ b/test/pact/ledger-client/ledger-search-agreements.pact.test.js
@@ -50,7 +50,8 @@ describe('ledger client', function () {
           .withStatusCode(200)
           .withResponseBody(pactify(validSearchAgreementResponse))
           .build()
-      )})
+      )
+    })
 
     afterEach(() => pactTestProvider.verify())
 
@@ -63,7 +64,7 @@ describe('ledger client', function () {
   })
 
   describe('search agreement by status', () => {
-    const validSearchAgreementResponse = agreementFixtures.validAgreementSearchResponse([{ external_id: 'agreement-3', payment_instrument: false }]);
+    const validSearchAgreementResponse = agreementFixtures.validAgreementSearchResponse([{ external_id: 'agreement-3', payment_instrument: false }])
 
     before(() => {
       return pactTestProvider.addInteraction(
@@ -79,7 +80,8 @@ describe('ledger client', function () {
           .withStatusCode(200)
           .withResponseBody(pactify(validSearchAgreementResponse))
           .build()
-      )})
+      )
+    })
 
     afterEach(() => pactTestProvider.verify())
 
@@ -92,7 +94,7 @@ describe('ledger client', function () {
   })
 
   describe('search agreement not found', () => {
-    const validSearchAgreementResponse = agreementFixtures.validAgreementsNotFoundResponse();
+    const validSearchAgreementResponse = agreementFixtures.validAgreementsNotFoundResponse()
 
     before(() => {
       return pactTestProvider.addInteraction(
@@ -108,7 +110,8 @@ describe('ledger client', function () {
           .withStatusCode(200)
           .withResponseBody(pactify(validSearchAgreementResponse))
           .build()
-      )})
+      )
+    })
 
     afterEach(() => pactTestProvider.verify())
 

--- a/test/test-helpers/pact/pact-interaction-builder.js
+++ b/test/test-helpers/pact/pact-interaction-builder.js
@@ -53,7 +53,7 @@ class PactInteractionBuilder {
     return this
   }
 
-  withResponseWithoutHeaders() {
+  withResponseWithoutHeaders () {
     this.withoutHeaders = true
     return this
   }


### PR DESCRIPTION
Credentials for Worldpay one-off payments are now returned from connector in a nested `one_off_customer_initiated` field in the `credentials` object.

This will replace the credentials that are currently in the root of the `credentials` object.

Tidy up Cypress tests to only call the relevant stubs for each test.

## Review note

I ran the linter which changed a lot of whitespace. Hiding whitespace changes from the diff will probably make this easier to review.

