### PR TITLE
PP-11251 Update `Your PSP > Worldpay` with new styling

### DIFF
--- a/app/controllers/your-psp/get-flex.controller.js
+++ b/app/controllers/your-psp/get-flex.controller.js
@@ -7,8 +7,6 @@ const { isSwitchingCredentialsRoute } = require('../../utils/credentials')
 const { response } = require('../../utils/response')
 
 module.exports = (req, res, next) => {
-  const { change } = req.query || {}
-
   try {
     const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
     const credential = getCredentialByExternalId(req.account, req.params.credentialId)
@@ -37,7 +35,7 @@ module.exports = (req, res, next) => {
       }
     }
 
-    return response(req, res, 'your-psp/flex', { errors, change, isFlexConfigured, orgUnitId, issuer, credential, isSwitchingCredentials })
+    return response(req, res, 'your-psp/flex', { errors, isFlexConfigured, orgUnitId, issuer, credential, isSwitchingCredentials })
   } catch (error) {
     next(error)
   }

--- a/app/views/your-psp/_worldpay-flex.njk
+++ b/app/views/your-psp/_worldpay-flex.njk
@@ -21,8 +21,25 @@
   You’ll find these details in your <a class="govuk-link" href="https://secure.worldpay.com/sso/public/auth/login.html">Worldpay account</a>.
 </p>
 
-{{  govukSummaryList({
+{{govukSummaryList({
     attributes: {'data-cy': 'worldpay-flex-settings-summary-list'},
+    card: {
+      title: {
+        text: "3DS Flex credentials"
+      },
+      actions: {
+        items: [
+          {
+            href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, credential.external_id),
+            text: "Change",
+            visuallyHiddenText: "3DS Flex credentials",
+            attributes: {
+              id: "flex-credentials-change-link"
+            }
+          }
+        ]
+      }
+    },
     rows: [
       {
         key: {
@@ -31,18 +48,6 @@
         value: {
           text: currentGatewayAccount.worldpay_3ds_flex.organisational_unit_id if isWorldpay3dsFlexCredentialsConfigured else "Not configured",
           classes: "value-organisational-unit-id"
-        },
-        actions: {
-          items: [
-            {
-              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, credential.external_id) + "?change=organisationalUnitId",
-              text: "Change",
-              visuallyHiddenText: "3DS Flex credentials",
-              attributes: {
-                id: "flex-credentials-change-link"
-              }
-            }
-          ]
         }
       },
       {
@@ -52,15 +57,6 @@
         value: {
           text: currentGatewayAccount.worldpay_3ds_flex.issuer if isWorldpay3dsFlexCredentialsConfigured else "Not configured",
           classes: "value-issuer"
-        },
-        actions: {
-          items: [
-            {
-              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, credential.external_id) + "?change=issuer",
-              text: "Change",
-              visuallyHiddenText: "3DS Flex credentials"
-            }
-          ]
         }
       },
       {
@@ -70,15 +66,6 @@
         value: {
           text: '●●●●●●●●' if isWorldpay3dsFlexCredentialsConfigured else "Not configured",
           classes: "value-jwt-mac-key"
-        },
-        actions: {
-          items: [
-            {
-              href: formatAccountPathsFor(routes.account.yourPsp.flex, currentGatewayAccount.external_id, credential.external_id) + "?change=password",
-              text: "Change",
-              visuallyHiddenText: "3DS Flex credentials"
-            }
-          ]
         }
       }
     ]

--- a/app/views/your-psp/_worldpay.njk
+++ b/app/views/your-psp/_worldpay.njk
@@ -2,32 +2,35 @@
 
 <p class="govuk-body">Go to your <a class="govuk-link" href="https://secure.worldpay.com/sso/public/auth/login.html">Worldpay account</a> to get the details you need to enter here, or <a class="govuk-link" href="https://docs.payments.service.gov.uk/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay">read more in our documentation.</a></p>
 
-<h2 class="govuk-heading-m govuk-!-margin-top-9">Account credentials</h2>
-
 {% set isAccountCredentialsConfigured = (credential.credentials and credential.credentials.one_off_customer_initiated|length) %}
 
 {{
   govukSummaryList({
+    card: {
+      title: {
+        text: "Account credentials"
+      },
+      actions: {
+        items: [
+          {
+            href: formatAccountPathsFor(routes.account.yourPsp.credentialsWithGatewayCheck, currentGatewayAccount.external_id, credential.external_id),
+            text: "Change",
+            visuallyHiddenText: "account credentials",
+            attributes: {
+              id: "credentials-change-link"
+            }
+          }
+        ]
+      }
+    },
     rows: [
       {
         key: {
           text: "Merchant code"
         },
         value: {
-          text: credential.credentials.one_off_customer_initiated.merchant_code if isAccountCredentialsConfigured else "Not configured",
+        text: credential.credentials.one_off_customer_initiated.merchant_code if isAccountCredentialsConfigured else "Not configured",
           classes: "value-merchant-id"
-        },
-        actions: {
-          items: [
-            {
-              href: formatAccountPathsFor(routes.account.yourPsp.credentialsWithGatewayCheck, currentGatewayAccount.external_id, credential.external_id) + "?change=merchantId",
-              text: "Change",
-              visuallyHiddenText: "account credentials",
-              attributes: {
-                id: "credentials-change-link"
-              }
-            }
-          ]
         }
       },
       {
@@ -37,15 +40,6 @@
         value: {
           text: credential.credentials.one_off_customer_initiated.username if isAccountCredentialsConfigured else "Not configured",
           classes: "value-username"
-        },
-        actions: {
-          items: [
-            {
-              href: formatAccountPathsFor(routes.account.yourPsp.credentialsWithGatewayCheck, currentGatewayAccount.external_id, credential.external_id) + "?change=username",
-              text: "Change",
-              visuallyHiddenText: "account credentials"
-            }
-          ]
         }
       },
       {
@@ -55,15 +49,6 @@
         value: {
           text: '●●●●●●●●' if isAccountCredentialsConfigured else "Not configured",
           classes: "value-password"
-        },
-        actions: {
-          items: [
-            {
-              href: formatAccountPathsFor(routes.account.yourPsp.credentialsWithGatewayCheck, currentGatewayAccount.external_id, credential.external_id) + "?change=password",
-              text: "Change",
-              visuallyHiddenText: "account credentials"
-            }
-          ]
         }
       }
     ]

--- a/app/views/your-psp/flex.njk
+++ b/app/views/your-psp/flex.njk
@@ -23,46 +23,46 @@
     <h1 class="govuk-heading-l">Your Worldpay 3DS Flex credentials</h1>
     <form method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
-        {% if errors %}
-          {% set errorList = [] %}
 
-          {% if errors['organisational-unit-id'] %}
-            {% set errorList = (errorList.push({
-              text: 'Organisational unit ID may not be correct',
-              href: '#organisational-unit-id'
-            }), errorList) %}
-            {% set orgUnitIdError = {
-              text: errors["organisational-unit-id"]
-            } %}
-          {% endif %}
+      {% if errors %}
+        {% set errorList = [] %}
 
-          {% if errors['issuer'] %}
-            {% set errorList = (errorList.push({
-              text: 'Issuer may not be correct',
-              href: '#issuer'
-            }), errorList) %}
-            {% set issuerError = {
-              text: errors["issuer"]
-            } %}
-          {% endif %}
-
-          {% if errors['jwt-mac-key'] %}
-            {% set errorList = (errorList.push({
-              text: 'JWT MAC key may not be correct',
-              href: '#jwt-mac-key'
-            }), errorList) %}
-            {% set jwtMacKeyError = {
-              text: errors["jwt-mac-key"]
-            } %}
-          {% endif %}
-
-          {{ govukErrorSummary({
-            titleText: 'There is a problem',
-            errorList: errorList
-          }) }}
+        {% if errors['organisational-unit-id'] %}
+          {% set errorList = (errorList.push({
+            text: 'Organisational unit ID may not be correct',
+            href: '#organisational-unit-id'
+          }), errorList) %}
+          {% set orgUnitIdError = {
+            text: errors["organisational-unit-id"]
+          } %}
         {% endif %}
 
-      {% if change === 'organisationalUnitId' %}
+        {% if errors['issuer'] %}
+          {% set errorList = (errorList.push({
+            text: 'Issuer may not be correct',
+            href: '#issuer'
+          }), errorList) %}
+          {% set issuerError = {
+            text: errors["issuer"]
+          } %}
+        {% endif %}
+
+        {% if errors['jwt-mac-key'] %}
+          {% set errorList = (errorList.push({
+            text: 'JWT MAC key may not be correct',
+            href: '#jwt-mac-key'
+          }), errorList) %}
+          {% set jwtMacKeyError = {
+            text: errors["jwt-mac-key"]
+          } %}
+        {% endif %}
+
+        {{ govukErrorSummary({
+          titleText: 'There is a problem',
+          errorList: errorList
+        }) }}
+      {% endif %}
+
         {{ govukInput({
             label: {
               text: "Organisational unit ID"
@@ -75,101 +75,40 @@
             name: "organisational-unit-id",
             classes: "govuk-input--width-20",
             type: "text",
-            attributes: {
-              "autofocus": "autofocus"
-            },
             value: orgUnitId
           })
         }}
-      {% else %}
-        {{ govukInput({
-            label: {
-              text: "Organisational unit ID"
-            },
-            hint: {
-              text: "Provided to you by Worldpay. For example, ‘5bd9b55e4444761ac0af1c80’."
-            },
-            errorMessage: orgUnitIdError,
-            id: "organisational-unit-id",
-            name: "organisational-unit-id",
-            classes: "govuk-input--width-20",
-            type: "text",
-            value: orgUnitId
-          })
-        }}
-      {% endif %}
 
-      {% if change === 'issuer' %}
-        {{ govukInput({
-            label: {
-              text: "Issuer (API ID)"
-            },
-            hint: {
-              text: "Provided to you by Worldpay. For example, ‘5bd9e0e4444dce153428c940’."
-            },
-            errorMessage: issuerError,
-            id: "issuer",
-            name: "issuer",
-            classes: "govuk-input--width-20",
-            type: "text",
-            attributes: {
-              "autofocus": "autofocus"
-            },
-            value: issuer
-          })
-        }}
-      {% else %}
-        {{ govukInput({
-            label: {
-              text: "Issuer (API ID)"
-            },
-            hint: {
-              text: "Provided to you by Worldpay. For example, ‘5bd9e0e4444dce153428c940’."
-            },
-            errorMessage: issuerError,
-            id: "issuer",
-            name: "issuer",
-            classes: "govuk-input--width-20",
-            type: "text",
-            value: issuer
-          })
-        }}
-      {% endif %}
+      {{ govukInput({
+          label: {
+            text: "Issuer (API ID)"
+          },
+          hint: {
+            text: "Provided to you by Worldpay. For example, ‘5bd9e0e4444dce153428c940’."
+          },
+          errorMessage: issuerError,
+          id: "issuer",
+          name: "issuer",
+          classes: "govuk-input--width-20",
+          type: "text",
+          value: issuer
+        })
+      }}
 
-      {% if change === 'password' %}
-        {{ govukInput({
-            label: {
-              text: "JWT MAC key (API key)"
-            },
-            hint: {
-              text: "Provided to you by Worldpay. For example, ‘fa2daee2-1fbb-45ff-4444-52805d5cd9e0’."
-            },
-            errorMessage: jwtMacKeyError,
-            id: "jwt-mac-key",
-            name: "jwt-mac-key",
-            classes: "govuk-input--width-20",
-            type: "password",
-            attributes: {
-              "autofocus": "autofocus"
-            }
-          })
-        }}
-        {% else %}
-        {{ govukInput({
-            label: {
-              text: "JWT MAC key (API key)"
-            },
-            hint: {
-              text: "Provided to you by Worldpay. For example, ‘fa2daee2-1fbb-45ff-4444-52805d5cd9e0’."
-            },
-            errorMessage: jwtMacKeyError,
-            id: "jwt-mac-key",
-            name: "jwt-mac-key",
-            classes: "govuk-input--width-20",
-            type: "password"
-          })
-        }}
-      {% endif %}
+      {{ govukInput({
+          label: {
+            text: "JWT MAC key (API key)"
+          },
+          hint: {
+            text: "Provided to you by Worldpay. For example, ‘fa2daee2-1fbb-45ff-4444-52805d5cd9e0’."
+          },
+          errorMessage: jwtMacKeyError,
+          id: "jwt-mac-key",
+          name: "jwt-mac-key",
+          classes: "govuk-input--width-20",
+          type: "password"
+        })
+      }}
 
       {{
         govukButton({


### PR DESCRIPTION
- Update the page to use the new `Summary list card` styling from design system v4.
  - Update the `account credentials` and `3DS flex` sections.
  - No longer have a seperate change link for each entry in the `summary list`. Just one change link in the heading.
  - Remove the `?change=**` query parameter from the change link.  As this is no longer required as we only have 1 change link per section.
    - Update the `3DS flex` credentials nunjucks file to longer use the `change` query       parameter.
- Update the 3DS flex controller - Remove references to the `change` query parameter as  this is no longer used.

<img width="375" alt="image" src="https://github.com/alphagov/pay-selfservice/assets/59831992/94e1fb41-b3ae-4735-b529-e4c4bdd092dd">



