### PR TITLE
PP-11152 Fix loading credentials page

### DIFF
--- a/app/controllers/credentials/worldpay.controller.js
+++ b/app/controllers/credentials/worldpay.controller.js
@@ -18,7 +18,7 @@ const credentialsForm = new CredentialsForm([
 function showWorldpayCredentialsPage (req, res, next) {
   try {
     const credential = getCredentialByExternalId(req.account, req.params.credentialId)
-    const form = credentialsForm.from(credential.credentials && credential.credentials.one_off_customer_initiated)
+    const form = credentialsForm.from((credential.credentials && credential.credentials.one_off_customer_initiated) || {})
     const isSwitchingCredentials = isSwitchingCredentialsRoute(req)
     response(req, res, 'credentials/worldpay', { form, isSwitchingCredentials, credential })
   } catch (error) {


### PR DESCRIPTION
The configure Worldpay credentials page was not loading when no Worldpay credentials are set. The code was expecting the `one_off_customer_initiated` key to not exist in the credentials JSON from connector.

We should change connector so that it doesn't return fields with null values, but making this change makes the handling of the JSON from connector a bit more robust.


