### PR TITLE
PP-11251 Your PSP > Worldpay creds - add functionality for recurring …

### DIFF
--- a/app/controllers/your-psp/get.controller.js
+++ b/app/controllers/your-psp/get.controller.js
@@ -25,6 +25,7 @@ module.exports = async (req, res, next) => {
 
     const is3dsEnabled = req.account.requires3ds === true
     const isMotoEnabled = req.account.allow_moto === true
+    const isRecurringEnabled = req.account.recurring_enabled === true
 
     let stripeData = {}
     if (activeCredential && activeCredential.payment_provider === 'stripe') {
@@ -44,6 +45,7 @@ module.exports = async (req, res, next) => {
       isMotoEnabled,
       isWorldpay3dsFlexEnabled,
       isWorldpay3dsFlexCredentialsConfigured,
+      isRecurringEnabled,
       ...stripeData,
       enableStripeOnboardingTaskList
     })

--- a/app/views/your-psp/_worldpay-flex.njk
+++ b/app/views/your-psp/_worldpay-flex.njk
@@ -1,25 +1,25 @@
 {% set paymentProvider = 'worldpay' %}
 {% set isTest = currentGatewayAccount.type === "test" %}
 
-<h2 class="govuk-heading-m govuk-!-margin-top-9">3DS Flex</h2>
-
 {% if isTest %}
+  <h2 class="govuk-heading-m govuk-!-margin-top-9">3DS Flex</h2>
+
   {{ govukInsetText({
     "attributes": {
       "id": "worldpay-3ds-flex-is-on" if isWorldpay3dsFlexEnabled else "worldpay-3ds-flex-is-off"
     },
     text: "3DS Flex is turned on." if isWorldpay3dsFlexEnabled else "3DS Flex is turned off."
   }) }}
-{% endif %}
 
-<p class="govuk-body">
-  {% if isTest %}
-    <span data-cy="3ds-flex-text-for-test-accounts">
-      If you have set up 3DS Flex on your Worldpay account, you need to enter the following details to turn 3DS Flex on.
-    </span>
-  {% endif %}
-  You’ll find these details in your <a class="govuk-link" href="https://secure.worldpay.com/sso/public/auth/login.html">Worldpay account</a>.
-</p>
+  <p class="govuk-body">
+    {% if isTest %}
+      <span data-cy="3ds-flex-text-for-test-accounts">
+        If you have set up 3DS Flex on your Worldpay account, you need to enter the following details to turn 3DS Flex on.
+      </span>
+    {% endif %}
+    You’ll find these details in your <a class="govuk-link" href="https://secure.worldpay.com/sso/public/auth/login.html">Worldpay account</a>.
+  </p>
+{% endif %}
 
 {{govukSummaryList({
     attributes: {'data-cy': 'worldpay-flex-settings-summary-list'},

--- a/app/views/your-psp/_worldpay.njk
+++ b/app/views/your-psp/_worldpay.njk
@@ -2,55 +2,169 @@
 
 <p class="govuk-body">Go to your <a class="govuk-link" href="https://secure.worldpay.com/sso/public/auth/login.html">Worldpay account</a> to get the details you need to enter here, or <a class="govuk-link" href="https://docs.payments.service.gov.uk/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay">read more in our documentation.</a></p>
 
-{% set isAccountCredentialsConfigured = (credential.credentials and credential.credentials.one_off_customer_initiated|length) %}
+{% if isRecurringEnabled %}
+  {% set isCitCredentialsConfigured = (credential.credentials and credential.credentials.recurring_customer_initiated|length) %}
+  {% set isMitCredentialsConfigured = (credential.credentials and credential.credentials.recurring_merchant_initiated|length) %}
 
-{{
-  govukSummaryList({
-    card: {
-      title: {
-        text: "Account credentials"
+  {{
+    govukSummaryList({
+      attributes: {
+        "data-cy": "cit-credentials-summary-list"
       },
-      actions: {
-        items: [
-          {
-            href: formatAccountPathsFor(routes.account.yourPsp.credentialsWithGatewayCheck, currentGatewayAccount.external_id, credential.external_id),
-            text: "Change",
-            visuallyHiddenText: "account credentials",
-            attributes: {
-              id: "credentials-change-link"
+      card: {
+        title: {
+          text: "Recurring customer initiated transaction (CIT) credentials"
+        },
+        actions: {
+          items: [
+            {
+              href: '#',
+              text: "Change",
+              visuallyHiddenText: "Recurring customer initiated transaction (CIT) credentials",
+              attributes: {
+                "data-cy": "cit-credentials-change-link"
+              }
             }
+          ]
+        }
+      },
+      rows: [
+        {
+          key: {
+            text: "CIT merchant code"
+          },
+          value: {
+            text: credential.credentials.recurring_customer_initiated.merchant_code if isCitCredentialsConfigured else "Not configured",
+            classes: "value-merchant-id"
           }
-        ]
-      }
-    },
-    rows: [
-      {
-        key: {
-          text: "Merchant code"
         },
-        value: {
-        text: credential.credentials.one_off_customer_initiated.merchant_code if isAccountCredentialsConfigured else "Not configured",
-          classes: "value-merchant-id"
+        {
+          key: {
+            text: "Username"
+          },
+          value: {
+            text: credential.credentials.recurring_customer_initiated.username if isCitCredentialsConfigured else "Not configured",
+            classes: "value-username"
+          }
+        },
+        {
+          key: {
+            text: "Password"
+          },
+          value: {
+            text: '●●●●●●●●' if isCitCredentialsConfigured else "Not configured",
+            classes: "value-password"
+          }
+        }
+      ]
+    })
+  }}
+
+  {{
+    govukSummaryList({
+      attributes: {
+        'data-cy': 'mit-credentials-summary-list'
+      },
+      card: {
+        title: {
+          text: "Recurring merchant initiated transaction (MIT) credentials"
+        },
+        actions: {
+          items: [
+            {
+              href: '#',
+              text: "Change",
+              visuallyHiddenText: "Recurring merchant initiated transaction (MIT) credentials",
+              attributes: {
+                id: "mit-credentials-change-link"
+              }
+            }
+          ]
         }
       },
-      {
-        key: {
-          text: "Username"
+      rows: [
+        {
+          key: {
+            text: "MIT merchant code"
+          },
+          value: {
+            text: credential.credentials.recurring_merchant_initiated.merchant_code if isMitCredentialsConfigured else "Not configured",
+            classes: "value-merchant-id"
+          }
         },
-        value: {
-          text: credential.credentials.one_off_customer_initiated.username if isAccountCredentialsConfigured else "Not configured",
-          classes: "value-username"
+        {
+          key: {
+            text: "Username"
+          },
+          value: {
+            text: credential.credentials.recurring_merchant_initiated.username if isMitCredentialsConfigured else "Not configured",
+            classes: "value-username"
+          }
+        },
+        {
+          key: {
+            text: "Password"
+          },
+          value: {
+            text: '●●●●●●●●' if isMitCredentialsConfigured else "Not configured",
+            classes: "value-password"
+          }
+        }
+      ]
+    })
+  }}
+{% else %}
+  {% set isAccountCredentialsConfigured = (credential.credentials and credential.credentials.one_off_customer_initiated|length) %}
+
+  {{
+    govukSummaryList({
+      card: {
+        title: {
+          text: "Account credentials"
+        },
+        actions: {
+          items: [
+            {
+              href: formatAccountPathsFor(routes.account.yourPsp.credentialsWithGatewayCheck, currentGatewayAccount.external_id, credential.external_id),
+              text: "Change",
+              visuallyHiddenText: "account credentials",
+              attributes: {
+                id: "credentials-change-link"
+              }
+            }
+          ]
         }
       },
-      {
-        key: {
-          text: "Password"
+      rows: [
+        {
+          key: {
+            text: "Merchant code"
+          },
+          value: {
+            text: credential.credentials.one_off_customer_initiated.merchant_code if isAccountCredentialsConfigured else "Not configured",
+            classes: "value-merchant-id"
+          }
         },
-        value: {
-          text: '●●●●●●●●' if isAccountCredentialsConfigured else "Not configured",
-          classes: "value-password"
+        {
+          key: {
+            text: "Username"
+          },
+          value: {
+            text: credential.credentials.one_off_customer_initiated.username if isAccountCredentialsConfigured else "Not configured",
+            classes: "value-username"
+          }
+        },
+        {
+          key: {
+            text: "Password"
+          },
+          value: {
+            text: '●●●●●●●●' if isAccountCredentialsConfigured else "Not configured",
+            classes: "value-password"
+          }
         }
-      }
-    ]
-  })
-}}
+      ]
+    })
+  }}
+
+{% endif %}


### PR DESCRIPTION
- Allow users to enter `customer initiated` and `merchant initiated` credentials for
  gateway account with recurring enabled.
- Uses the design system v4 Summary card styling.

- Cypress test will be added in a future PR.

<img width="638" alt="image" src="https://github.com/alphagov/pay-selfservice/assets/59831992/479b20ec-e977-461d-bbb7-01e29ee849aa">
