### PR TITLE
PP-11283 temporarily disbale some adminusers pact test

### DIFF
--- a/test/pact/adminusers-client/authenticate/authenticate.pact.test.js
+++ b/test/pact/adminusers-client/authenticate/authenticate.pact.test.js
@@ -21,7 +21,7 @@ const expect = chai.expect
 
 describe('adminusers client - authenticate', () => {
   const provider = new Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'adminusers',
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),

--- a/test/pact/adminusers-client/user/authenticate.pact.test.js
+++ b/test/pact/adminusers-client/user/authenticate.pact.test.js
@@ -17,7 +17,7 @@ let adminUsersClient
 
 describe('adminusers client - authenticate', function () {
   const provider = new Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'adminusers',
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),


### PR DESCRIPTION
## WHAT
Temporarily disable some pact test where the username is not an email address. We are re-factoring adminusers and username must be the email address.

- disable tests

