### PR TITLE
PP-11152 Update pact tests to use new credentials structure

### DIFF
--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -357,10 +357,7 @@ function validPatchWorldpayOneOffCustomerInitiatedRequest (opts = {}) {
 }
 
 function validPatchGatewayCredentialsResponse (opts = {}) {
-  const defaultCredentials = {
-    username: 'a-username',
-    merchant_id: 'a-merchant-id'
-  }
+  const defaultCredentials = {}
   if (opts.gatewayMerchantId !== undefined) {
     defaultCredentials.gateway_merchant_id = opts.gatewayMerchantId
   }

--- a/test/pact/connector-client/connector-patch-gateway-account-credential-state.pact.test.js
+++ b/test/pact/connector-client/connector-patch-gateway-account-credential-state.pact.test.js
@@ -30,7 +30,7 @@ describe('connector client - patch gateway account credentials.state', () => {
   })
   after(() => provider.finalize())
 
-  describe('when a request to update google pay gateway merchant id for gateway account credentials is made', () => {
+  describe('when a request to update the state of gateway account credentials is made', () => {
     const state = 'VERIFIED_WITH_LIVE_PAYMENT'
     const userExternalId = 'a-user-external-id'
     const requestPayload = {

--- a/test/pact/connector-client/connector-patch-gateway-account-credentials.pact.test.js
+++ b/test/pact/connector-client/connector-patch-gateway-account-credentials.pact.test.js
@@ -34,11 +34,13 @@ describe('connector client - patch gateway account credentials', () => {
     const credentialsInRequest = {
       username: 'a-username',
       password: 'a-password', // pragma: allowlist secret
-      merchant_id: 'a-merchant-id'
+      merchant_id: 'a-merchant-code'
     }
     const credentialsInResponse = {
-      username: 'a-username',
-      merchant_id: 'a-merchant-id'
+      one_off_customer_initiated: {
+        username: 'a-username',
+        merchant_code: 'a-merchant-code'
+      }
     }
     const userExternalId = 'a-user-external-id'
     const request = gatewayAccountFixtures.validUpdateGatewayAccountCredentialsRequest({

--- a/test/pact/connector-client/connector-patch-gateway-account-merchant-id.pact.test.js
+++ b/test/pact/connector-client/connector-patch-gateway-account-merchant-id.pact.test.js
@@ -34,8 +34,6 @@ describe('connector client - patch gateway account credentials.gateway_merchant_
     const userExternalId = 'a-user-external-id'
     const googlePayGatewayMerchantId = 'abcdef123abcdef'
     const credentialsInResponse = {
-      username: 'a-username',
-      merchant_id: 'a-merchant-id',
       gateway_merchant_id: googlePayGatewayMerchantId
     }
     const request = gatewayAccountFixtures.validPatchGatewayMerchantIdRequest({


### PR DESCRIPTION
We now consume one-off Worldpay credentials from the nested `credentials.one_off_customer_initiated` field in responses from Connector. Update pact tests so connector can stop returning the legacy credentials fields.

We do not need to check the one-off credentials in responses to update other fields on the gateway credentials, so remove these from pact tests where they are unnecessary.
