### PR TITLE
PP-11251 Your PSP > Worldpay creds for test accounts - update design

### DIFF
--- a/app/views/your-psp/_worldpay-flex.njk
+++ b/app/views/your-psp/_worldpay-flex.njk
@@ -2,23 +2,47 @@
 {% set isTest = currentGatewayAccount.type === "test" %}
 
 {% if isTest %}
-  <h2 class="govuk-heading-m govuk-!-margin-top-9">3DS Flex</h2>
+  <div data-cy="3ds-flex-section-for-test-worldpay-accounts">
+    <h2 class="govuk-heading-m govuk-!-margin-top-9">3DS Flex</h2>
 
-  {{ govukInsetText({
-    "attributes": {
-      "id": "worldpay-3ds-flex-is-on" if isWorldpay3dsFlexEnabled else "worldpay-3ds-flex-is-off"
-    },
-    text: "3DS Flex is turned on." if isWorldpay3dsFlexEnabled else "3DS Flex is turned off."
-  }) }}
+    {{ govukInsetText({
+      "attributes": {
+        "id": "worldpay-3ds-flex-is-on" if isWorldpay3dsFlexEnabled else "worldpay-3ds-flex-is-off"
+      },
+      text: "3DS Flex is turned on." if isWorldpay3dsFlexEnabled else "3DS Flex is turned off."
+    }) }}
 
-  <p class="govuk-body">
-    {% if isTest %}
-      <span data-cy="3ds-flex-text-for-test-accounts">
-        If you have set up 3DS Flex on your Worldpay account, you need to enter the following details to turn 3DS Flex on.
-      </span>
+    <p class="govuk-body">
+      If you have set up 3DS Flex on your Worldpay account, you need to enter the following details to turn 3DS Flex on.
+      You’ll find these details in your <a class="govuk-link" href="https://secure.worldpay.com/sso/public/auth/login.html">Worldpay account</a>.
+    </p>
+
+    {% if (is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured) or isWorldpay3dsFlexEnabled %}
+      <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.worldpay3dsFlex, currentGatewayAccount.external_id, credential.external_id) }}" novalidate>
+        <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}">
+        {% if is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured and not isWorldpay3dsFlexEnabled %}
+            <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="on">
+            {{ govukButton({
+              attributes: {
+                id: "enable-worldpay-3ds-flex-button"
+              },
+              text: "Turn on 3DS Flex",
+              classes: "govuk-button--secondary"
+            }) }}
+        {% elif isWorldpay3dsFlexEnabled %}
+          <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="off">
+          {{ govukButton({
+            attributes: {
+              id: "disable-worldpay-3ds-flex-button"
+            },
+            text: "Turn off 3DS Flex",
+            classes: "govuk-button--secondary"
+          }) }}
+        {% endif %}
+      </form>
     {% endif %}
-    You’ll find these details in your <a class="govuk-link" href="https://secure.worldpay.com/sso/public/auth/login.html">Worldpay account</a>.
-  </p>
+
+  </div>
 {% endif %}
 
 {{govukSummaryList({
@@ -71,30 +95,3 @@
     ]
   })
 }}
-
-{% if isTest %}
-  {% if (is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured) or isWorldpay3dsFlexEnabled %}
-    <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.worldpay3dsFlex, currentGatewayAccount.external_id, credential.external_id) }}" novalidate>
-      <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}">
-      {% if is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured and not isWorldpay3dsFlexEnabled %}
-          <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="on">
-          {{ govukButton({
-            attributes: {
-              id: "enable-worldpay-3ds-flex-button"
-            },
-            text: "Turn on 3DS Flex",
-            classes: "govuk-button--secondary"
-          }) }}
-      {% elif isWorldpay3dsFlexEnabled %}
-        <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="off">
-        {{ govukButton({
-          attributes: {
-            id: "disable-worldpay-3ds-flex-button"
-          },
-          text: "Turn off 3DS Flex",
-          classes: "govuk-button--secondary"
-        }) }}
-      {% endif %}
-    </form>
-  {% endif %}
-{% endif %}

--- a/test/cypress/integration/settings/your-psp.cy.js
+++ b/test/cypress/integration/settings/your-psp.cy.js
@@ -535,17 +535,18 @@ describe('Your PSP settings page', () => {
 
         cy.visit(`${yourPspPath}/${credentialExternalId}`)
 
-        cy.get('#worldpay-3ds-flex-is-off').should('exist')
-
-        cy.get('[data-cy=3ds-flex-text-for-test-accounts]').should('exist')
+        cy.get('[data-cy=3ds-flex-section-for-test-worldpay-accounts]').should('exist')
 
         cy.get('#toggle-worldpay-3ds-flex').should('exist')
 
         cy.get('#worldpay-3ds-flex-is-off').should('exist')
         cy.get('#worldpay-3ds-flex-is-on').should('not.exist')
-        cy.get('#disable-worldpay-3ds-flex-button').should('not.exist')
 
-        cy.get('#enable-worldpay-3ds-flex-button').should('exist').click()
+        cy.get('#disable-worldpay-3ds-flex-button').should('not.exist')
+        cy.get('#enable-worldpay-3ds-flex-button')
+          .should('exist')
+          .click()
+
         cy.location().should((location) => {
           expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}`)
         })
@@ -572,9 +573,12 @@ describe('Your PSP settings page', () => {
         cy.visit(`${yourPspPath}/${credentialExternalId}`)
         cy.get('#worldpay-3ds-flex-is-on').should('exist')
         cy.get('#worldpay-3ds-flex-is-off').should('not.exist')
-        cy.get('#enable-worldpay-3ds-flex-button').should('not.exist')
 
-        cy.get('#disable-worldpay-3ds-flex-button').should('exist').click()
+        cy.get('#enable-worldpay-3ds-flex-button').should('not.exist')
+        cy.get('#disable-worldpay-3ds-flex-button')
+          .should('exist')
+          .click()
+
         cy.location().should((location) => {
           expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}`)
         })
@@ -640,14 +644,7 @@ describe('Your PSP settings page', () => {
 
         cy.visit(`${yourPspPath}/${credentialExternalId}`)
 
-        cy.get('#worldpay-3ds-flex-is-off').should('not.exist')
-        cy.get('#worldpay-3ds-flex-is-on').should('not.exist')
-
-        cy.get('[data-cy=worldpay-flex-settings-summary-list]').should('exist')
-
-        cy.get('[data-cy=3ds-flex-text-for-test-accounts]').should('not.exist')
-
-        cy.get('#toggle-worldpay-3ds-flex').should('not.exist')
+        cy.get('[data-cy=3ds-flex-section-for-test-worldpay-accounts]').should('not.exist')
       })
     })
   })


### PR DESCRIPTION
- Update the 3DS section for test Worldpay accounts.
- Move the `toggle 3DS` button higher.
- General clean up of code.

## Test Worldpay accounts - move the toggle button higher
![image](https://github.com/alphagov/pay-selfservice/assets/59831992/4d8ac345-c74b-4d93-9153-4364f7574a61)


