### PR TITLE
PP-11327 add email to authentication

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -759,7 +759,7 @@
         "filename": "test/pact/adminusers-client/authenticate/authenticate.pact.test.js",
         "hashed_secret": "5f6087367c3abd5ea9bc0d1650277b9f68b9b233",
         "is_verified": false,
-        "line_number": 73
+        "line_number": 72
       }
     ],
     "test/pact/adminusers-client/invite/complete-invite.pact.test.js": [
@@ -878,5 +878,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-27T13:15:05Z"
+  "generated_at": "2023-08-01T12:31:40Z"
 }

--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -80,6 +80,7 @@ module.exports = function (clientOptions = {}) {
         json: true,
         body: {
           username: username,
+          email: username,
           password: password
         },
         description: 'authenticate a user',

--- a/test/fixtures/user.fixtures.js
+++ b/test/fixtures/user.fixtures.js
@@ -345,6 +345,7 @@ module.exports = {
   validAuthenticateRequest: (options) => {
     return {
       username: options.username || 'username',
+      email: options.username|| 'username@example.com',
       password: options.password || 'password'
     }
   },
@@ -398,6 +399,7 @@ module.exports = {
   validPasswordAuthenticateRequest: (opts = {}) => {
     return {
       username: opts.username || 'validuser',
+      email: opts.username || 'valid-email@example.com',
       password: opts.password || 'validpassword'
     }
   },

--- a/test/pact/adminusers-client/authenticate/authenticate.pact.test.js
+++ b/test/pact/adminusers-client/authenticate/authenticate.pact.test.js
@@ -40,8 +40,7 @@ describe('adminusers client - authenticate', () => {
 
   describe('user is authenticated successfully', () => {
     const validPasswordResponse = userFixtures.validUserResponse({ username: existingUserEmail })
-    const request = userFixtures
-      .validPasswordAuthenticateRequest({
+    const request = userFixtures.validPasswordAuthenticateRequest({
         username: existingUserEmail,
         password: validPassword
       })

--- a/test/pact/adminusers-client/user/authenticate.pact.test.js
+++ b/test/pact/adminusers-client/user/authenticate.pact.test.js
@@ -94,7 +94,7 @@ describe('adminusers client - authenticate', function () {
   })
 
   describe('authenticate user API - bad request', () => {
-    const request = { username: '', password: '' }
+    const request = { username: '', email: '', password: '' }
 
     const badAuthenticateResponse = userFixtures.badAuthenticateResponse()
 


### PR DESCRIPTION
## WHAT

We are removing username from `adminusers` API and all consumers. We are going to use email instead. In the first iteration we send the email with all authentication requests.

- add email to authentication requests


