### PR TITLE
PP-11327 remove username from authentication

### DIFF
--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -68,19 +68,18 @@ module.exports = function (clientOptions = {}) {
   }
 
   /**
-   * @param username
+   * @param email
    * @param password
    * @returns {Promise<User>}
    */
-  function authenticateUser (username, password) {
+  function authenticateUser (email, password) {
     return baseClient.post(
       {
         baseUrl,
         url: `${userResource}/authenticate`,
         json: true,
         body: {
-          username: username,
-          email: username,
+          email: email,
           password: password
         },
         description: 'authenticate a user',

--- a/app/services/user.service.js
+++ b/app/services/user.service.js
@@ -6,15 +6,15 @@ const adminUsersClient = getAdminUsersClient()
 module.exports = {
 
   /**
-   * @param username
+   * @param email
    * @param submittedPassword
    * @returns {Promise<User>}
    */
-  authenticate: function (username, submittedPassword) {
-    if (!username || !submittedPassword) {
+  authenticate: function (email, submittedPassword) {
+    if (!email || !submittedPassword) {
       return Promise.reject(new Error('Failed to authenticate'))
     }
-    return adminUsersClient.authenticateUser(username, submittedPassword)
+    return adminUsersClient.authenticateUser(email, submittedPassword)
   },
 
   /**

--- a/test/cypress/integration/user/login.cy.js
+++ b/test/cypress/integration/user/login.cy.js
@@ -4,7 +4,7 @@ const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 describe('Login Page', () => {
   const gatewayAccountId = 42
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
-  const validUsername = 'some-user@example.com'
+  const validEmail = 'some-user@example.com'
   const validPassword = 'some-valid-password'
   const invalidPassword = 'some-invalid-password'
   const invalidCode = '654321'
@@ -14,8 +14,8 @@ describe('Login Page', () => {
     cy.task('setupStubs', [
       userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName: 'service-name' }),
       gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId }),
-      userStubs.postUserAuthenticateSuccess(userExternalId, validUsername, validPassword),
-      userStubs.postUserAuthenticateInvalidPassword(validUsername, invalidPassword),
+      userStubs.postUserAuthenticateSuccess(userExternalId, validEmail, validPassword),
+      userStubs.postUserAuthenticateInvalidPassword(validEmail, invalidPassword),
       userStubs.postSecondFactorSuccess(userExternalId),
       userStubs.postAuthenticateSecondFactorInvalidCode(userExternalId, invalidCode),
       userStubs.postAuthenticateSecondFactorSuccess(userExternalId, validCode)
@@ -45,7 +45,7 @@ describe('Login Page', () => {
 
       // enter a valid username and password and submit
       cy.getCookie('session')
-      cy.get('#username').type(validUsername)
+      cy.get('#username').type(validEmail)
       cy.get('#password').type(validPassword)
       cy.contains('Continue').click()
 
@@ -100,7 +100,7 @@ describe('Login Page', () => {
     })
 
     it('should deny access to selfservice if the password is incorrect', () => {
-      cy.get('#username').type(validUsername)
+      cy.get('#username').type(validEmail)
       cy.get('#password').type(invalidPassword)
       cy.contains('Continue').click()
       cy.title().should('eq', 'Sign in to GOV.UK Pay')

--- a/test/cypress/stubs/user-stubs.js
+++ b/test/cypress/stubs/user-stubs.js
@@ -64,7 +64,7 @@ function getUserWithNoPermissions (userExternalId, gatewayAccountId) {
 function postUserAuthenticateSuccess (userExternalId, username, password) {
   const fixtureOpts = {
     external_id: userExternalId,
-    username: username,
+    email: username,
     password: password
   }
   const path = '/v1/api/users/authenticate'

--- a/test/fixtures/user.fixtures.js
+++ b/test/fixtures/user.fixtures.js
@@ -344,21 +344,20 @@ module.exports = {
 
   validAuthenticateRequest: (options) => {
     return {
-      username: options.username || 'username',
-      email: options.username|| 'username@example.com',
+      email: options.email|| 'username@example.com',
       password: options.password || 'password'
     }
   },
 
   unauthorizedUserResponse: () => {
     return {
-      errors: ['invalid username and/or password']
+      errors: ['invalid email and/or password']
     }
   },
 
   badAuthenticateResponse: () => {
     return {
-      errors: ['Field [username] is required', 'Field [password] is required']
+      errors: ['Field [email] is required', 'Field [password] is required']
     }
   },
 
@@ -398,8 +397,7 @@ module.exports = {
 
   validPasswordAuthenticateRequest: (opts = {}) => {
     return {
-      username: opts.username || 'validuser',
-      email: opts.username || 'valid-email@example.com',
+      email: opts.email || 'valid-email@example.com',
       password: opts.password || 'validpassword'
     }
   },
@@ -414,7 +412,7 @@ module.exports = {
 
   invalidPasswordAuthenticateResponse: () => {
     return {
-      errors: ['invalid username and/or password']
+      errors: ['invalid email and/or password']
     }
   },
 

--- a/test/pact/adminusers-client/authenticate/authenticate.pact.test.js
+++ b/test/pact/adminusers-client/authenticate/authenticate.pact.test.js
@@ -39,9 +39,9 @@ describe('adminusers client - authenticate', () => {
   const validPassword = 'password'
 
   describe('user is authenticated successfully', () => {
-    const validPasswordResponse = userFixtures.validUserResponse({ username: existingUserEmail })
+    const validPasswordResponse = userFixtures.validUserResponse({ email: existingUserEmail })
     const request = userFixtures.validPasswordAuthenticateRequest({
-        username: existingUserEmail,
+        email: existingUserEmail,
         password: validPassword
       })
 
@@ -73,7 +73,7 @@ describe('adminusers client - authenticate', () => {
     const invalidPasswordResponse = userFixtures.invalidPasswordAuthenticateResponse()
     const request = userFixtures
       .validPasswordAuthenticateRequest({
-        username: existingUserEmail,
+        email: existingUserEmail,
         password: invalidPassword
       })
 

--- a/test/pact/adminusers-client/user/authenticate.pact.test.js
+++ b/test/pact/adminusers-client/user/authenticate.pact.test.js
@@ -32,7 +32,7 @@ describe('adminusers client - authenticate', function () {
   after(() => provider.finalize())
 
   describe('authenticate user API - success', () => {
-    const request = userFixtures.validAuthenticateRequest({ username: 'existing-user@example.com' })
+    const request = userFixtures.validAuthenticateRequest({ email: 'existing-user@example.com' })
     const validUserResponse = userFixtures.validUserResponse({
       username: 'existing-user@example.com',
       email: 'existing-user@example.com'})
@@ -53,7 +53,7 @@ describe('adminusers client - authenticate', function () {
     afterEach(() => provider.verify())
 
     it('should authenticate a user successfully', function (done) {
-      adminUsersClient.authenticateUser(request.username, request.password).should.be.fulfilled.then(function (user) {
+      adminUsersClient.authenticateUser(request.email, request.password).should.be.fulfilled.then(function (user) {
         expect(user.username).to.be.equal(validUserResponse.username)
         expect(user.email).to.be.equal(validUserResponse.email)
         expect(_.isEqual(user.serviceRoles[0].gatewayAccountIds, validUserResponse.service_roles[0].gateway_account_ids)).to.be.equal(true)
@@ -66,7 +66,7 @@ describe('adminusers client - authenticate', function () {
   })
 
   describe('authenticate user API - unauthorized', () => {
-    const request = userFixtures.validAuthenticateRequest({ username: 'nonexisting@example.com' })
+    const request = userFixtures.validAuthenticateRequest({ email: 'nonexisting@example.com' })
 
     const unauthorizedResponse = userFixtures.unauthorizedUserResponse()
 
@@ -86,7 +86,7 @@ describe('adminusers client - authenticate', function () {
     afterEach(() => provider.verify())
 
     it('should fail authentication if invalid username / password', function (done) {
-      adminUsersClient.authenticateUser(request.username, request.password).should.be.rejected.then(function (err) {
+      adminUsersClient.authenticateUser(request.email, request.password).should.be.rejected.then(function (err) {
         expect(err.errorCode).to.equal(401)
         expect(err.message).to.equal(unauthorizedResponse.errors[0])
       }).should.notify(done)
@@ -94,7 +94,7 @@ describe('adminusers client - authenticate', function () {
   })
 
   describe('authenticate user API - bad request', () => {
-    const request = { username: '', email: '', password: '' }
+    const request = { email: '', password: '' }
 
     const badAuthenticateResponse = userFixtures.badAuthenticateResponse()
 
@@ -114,7 +114,7 @@ describe('adminusers client - authenticate', function () {
     afterEach(() => provider.verify())
 
     it('should error bad request if mandatory fields are missing', function (done) {
-      adminUsersClient.authenticateUser(request.username, request.password).should.be.rejected.then(function (err) {
+      adminUsersClient.authenticateUser(request.email, request.password).should.be.rejected.then(function (err) {
         expect(err.errorCode).to.equal(400)
         expect(err.message).to.equal(badAuthenticateResponse.errors.join(', '))
       }).should.notify(done)


### PR DESCRIPTION
## WHAT

Authenticating against adminusers now requires email, not username

- remove username from authentication requests
- refactor tests accordingly
