### PR TITLE
PP-11251 Your PSP > Worldpay test accounts - Toggle 3DS flex content

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -577,7 +577,7 @@
         "filename": "test/cypress/integration/settings/your-psp.cy.js",
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_verified": false,
-        "line_number": 454
+        "line_number": 463
       }
     ],
     "test/cypress/integration/switch-psp/organisation-url.cy.js": [
@@ -878,5 +878,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-01T12:31:40Z"
+  "generated_at": "2023-08-02T08:34:30Z"
 }

--- a/app/views/your-psp/_worldpay-flex.njk
+++ b/app/views/your-psp/_worldpay-flex.njk
@@ -12,15 +12,17 @@
       text: "3DS Flex is turned on." if isWorldpay3dsFlexEnabled else "3DS Flex is turned off."
     }) }}
 
-    <p class="govuk-body">
-      To set up 3DS Flex on your Worldpay test account, you need to enter the following test details to turn 3DS Flex on.
-    </p>
+    {% if (not isWorldpay3dsFlexCredentialsConfigured) %}
+      <p class="govuk-body" data-cy="set-up-3ds-flex-credentials-text">
+        To set up 3DS Flex on your Worldpay test account, you need to enter the following test details to turn 3DS Flex on.
+      </p>
+    {% endif %}
 
     {% if (is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured) or isWorldpay3dsFlexEnabled %}
       <form method="post" action="{{ formatAccountPathsFor(routes.account.yourPsp.worldpay3dsFlex, currentGatewayAccount.external_id, credential.external_id) }}" novalidate>
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}">
         {% if is3dsEnabled and isWorldpay3dsFlexCredentialsConfigured and not isWorldpay3dsFlexEnabled %}
-            <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="on">
+            <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="on" data-cy="toggle-3ds-button">
             {{ govukButton({
               attributes: {
                 id: "enable-worldpay-3ds-flex-button"
@@ -29,7 +31,7 @@
               classes: "govuk-button--secondary"
             }) }}
         {% elif isWorldpay3dsFlexEnabled %}
-          <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="off">
+          <input id="toggle-worldpay-3ds-flex" name="toggle-worldpay-3ds-flex" type="hidden" value="off" data-cy="toggle-3ds-button">
           {{ govukButton({
             attributes: {
               id: "disable-worldpay-3ds-flex-button"

--- a/test/cypress/integration/settings/your-psp.cy.js
+++ b/test/cypress/integration/settings/your-psp.cy.js
@@ -180,6 +180,10 @@ describe('Your PSP settings page', () => {
         gatewayAccountStubs.postUpdateWorldpay3dsFlexCredentials({ gatewayAccountId, ...testFlexCredentials })
       ])
       cy.visit(`${yourPspPath}/${credentialExternalId}`)
+
+      cy.get('[data-cy=set-up-3ds-flex-credentials-text]').should('exist')
+      cy.get('[data-cy=toggle-3ds-button]').should('not.exist')
+
       cy.get('#flex-credentials-change-link').click()
       cy.get('#removeFlexCredentials').should('not.exist')
       cy.get('#organisational-unit-id').type('Invalid organisational unit ID')
@@ -276,10 +280,15 @@ describe('Your PSP settings page', () => {
           external_id: credentialExternalId,
           id: credentialsId
         }],
+        requires3ds: true,
         worldpay3dsFlex: testFlexCredentials
       }))
 
       cy.visit(`${yourPspPath}/${credentialExternalId}`)
+
+      cy.get('[data-cy=set-up-3ds-flex-credentials-text]').should('not.exist')
+      cy.get('[data-cy=toggle-3ds-button]').should('exist')
+
       cy.get('.value-merchant-id').should('contain', merchantCode)
       cy.get('.value-username').should('contain', username)
       cy.get('.value-password').should('contain', '●●●●●●●●')
@@ -571,6 +580,9 @@ describe('Your PSP settings page', () => {
         ])
 
         cy.visit(`${yourPspPath}/${credentialExternalId}`)
+
+        cy.get('[data-cy=set-up-3ds-flex-credentials-text]').should('not.exist')
+
         cy.get('#worldpay-3ds-flex-is-on').should('exist')
         cy.get('#worldpay-3ds-flex-is-off').should('not.exist')
 
@@ -598,6 +610,9 @@ describe('Your PSP settings page', () => {
         }))
 
         cy.visit(`${yourPspPath}/${credentialExternalId}`)
+
+        cy.get('[data-cy=set-up-3ds-flex-credentials-text]').should('exist')
+
         cy.get('#worldpay-3ds-flex-is-off').should('exist')
         cy.get('#worldpay-3ds-flex-is-on').should('not.exist')
         cy.get('#disable-worldpay-3ds-flex-button').should('not.exist')
@@ -619,6 +634,9 @@ describe('Your PSP settings page', () => {
         }))
 
         cy.visit(`${yourPspPath}/${credentialExternalId}`)
+
+        cy.get('[data-cy=set-up-3ds-flex-credentials-text]').should('not.exist')
+
         cy.get('#worldpay-3ds-flex-is-off').should('exist')
         cy.get('#worldpay-3ds-flex-is-on').should('not.exist')
         cy.get('#disable-worldpay-3ds-flex-button').should('not.exist')


### PR DESCRIPTION
Your PSP > Worldpay Test account
  - When 3DS flex crendentials already exist in a Worldpay test account, hide the content that tells the user to enter 3DS flex crendentials in order to enable 3DS flex.
  - As it is not relevant if 3DS flex settings are already configured.

