### PR TITLE
PP-11251 Worldpay credentials PACT tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -688,7 +688,7 @@
         "filename": "test/fixtures/gateway-account.fixtures.js",
         "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
         "is_verified": false,
-        "line_number": 300
+        "line_number": 301
       }
     ],
     "test/fixtures/invite.fixtures.js": [
@@ -878,5 +878,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-02T12:44:41Z"
+  "generated_at": "2023-08-03T16:29:58Z"
 }

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -247,16 +247,17 @@ function validCreateGatewayAccountRequest (opts = {}) {
 }
 
 function validUpdateGatewayAccountCredentialsRequest (opts = {}) {
-  const defaultCredentials = {
-    username: 'a-username',
-    password: 'a-password', // pragma: allowlist secret
-    merchant_code: 'a-merchant-id'
+  const credentials = {
+    username: (opts.credentials && opts.credentials.username) || 'a-username',
+    password: (opts.credentials && opts.credentials.password) || 'a-password',
+    merchant_code: (opts.credentials && opts.credentials.merchant_code) || 'a-merchant-id'
   }
+
   return [
     {
       op: 'replace',
       path: opts.path || 'credentials/worldpay/one_off_customer_initiated',
-      value: opts.credentials || defaultCredentials
+      value: credentials
     },
     {
       op: 'replace',

--- a/test/pact/connector-client/connector-get-gateway-account-by-external-id.pact.test.js
+++ b/test/pact/connector-client/connector-get-gateway-account-by-external-id.pact.test.js
@@ -42,6 +42,14 @@ describe('connector client - get gateway account by external id', function () {
           one_off_customer_initiated: {
             merchant_code: 'a-merchant-code',
             username: 'a-username'
+          },
+          recurring_customer_initiated: {
+            username: 'a-username',
+            merchant_code: 'a-merchant-code'
+          },
+          recurring_merchant_initiated: {
+            username: 'a-username',
+            merchant_code: 'a-merchant-code'
           }
         }
       }],

--- a/test/pact/connector-client/connector-patch-gateway-account-credentials-customer-initiated.pact.test.js
+++ b/test/pact/connector-client/connector-patch-gateway-account-credentials-customer-initiated.pact.test.js
@@ -8,13 +8,14 @@ const PactInteractionBuilder = require('../../test-helpers/pact/pact-interaction
 const Connector = require('../../../app/services/clients/connector.client').ConnectorClient
 const gatewayAccountFixtures = require('../../fixtures/gateway-account.fixtures')
 const { pactify } = require('../../test-helpers/pact/pactifier').defaultPactifier
+const { worldpayMerchantDetailOperations } = require('../../../app/utils/credentials')
 
 const existingGatewayAccountId = 333
 const existingGatewayAccountCredentialsId = 444
 
 let connectorClient
 
-describe('connector client - patch gateway account credentials', () => {
+describe('connector client - patch gateway account credentials for recurring customer initiated transactions', () => {
   const provider = new Pact({
     consumer: 'selfservice',
     provider: 'connector',
@@ -30,14 +31,14 @@ describe('connector client - patch gateway account credentials', () => {
   })
   after(() => provider.finalize())
 
-  describe('when a request to update credentials map for gateway account credentials is made', () => {
+  describe('when a request to update credentials map for recurring customer initiated credentials is made', () => {
     const credentialsInRequest = {
       username: 'a-username',
       password: 'a-password', // pragma: allowlist secret
       merchant_code: 'a-merchant-code'
     }
     const credentialsInResponse = {
-      one_off_customer_initiated: {
+      recurring_customer_initiated: {
         username: 'a-username',
         merchant_code: 'a-merchant-code'
       }
@@ -45,7 +46,7 @@ describe('connector client - patch gateway account credentials', () => {
     const userExternalId = 'a-user-external-id'
     const request = gatewayAccountFixtures.validUpdateGatewayAccountCredentialsRequest({
       credentials: credentialsInRequest,
-      path: 'credentials/worldpay/one_off_customer_initiated',
+      path: worldpayMerchantDetailOperations.RECURRING_CUSTOMER_INITIATED.patch,
       userExternalId
     })
     const response = gatewayAccountFixtures.validGatewayAccountCredentialsResponse({
@@ -57,7 +58,7 @@ describe('connector client - patch gateway account credentials', () => {
       return provider.addInteraction(
         new PactInteractionBuilder(`/v1/api/accounts/${existingGatewayAccountId}/credentials/${existingGatewayAccountCredentialsId}`)
           .withState(`a Worldpay gateway account with id ${existingGatewayAccountId} with gateway account credentials with id ${existingGatewayAccountCredentialsId}`)
-          .withUponReceiving('a request to update credentials map for a gateway account credentials')
+          .withUponReceiving('a request to update credentials map for recurring customer initiated credentials')
           .withMethod('PATCH')
           .withRequestHeaders({ 'Content-Type': 'application/json' })
           .withRequestBody(request)
@@ -69,12 +70,12 @@ describe('connector client - patch gateway account credentials', () => {
 
     afterEach(() => provider.verify())
 
-    it('should patch gateway account credentials', async () => {
+    it('should patch gateway account credentials for recurring customer initiated transactions', async () => {
       const connectorResponse = await connectorClient.patchAccountGatewayAccountCredentials({
         gatewayAccountId: existingGatewayAccountId,
         gatewayAccountCredentialsId: existingGatewayAccountCredentialsId,
         credentials: credentialsInRequest,
-        path: 'credentials/worldpay/one_off_customer_initiated',
+        path: worldpayMerchantDetailOperations.RECURRING_CUSTOMER_INITIATED.patch,
         userExternalId
       })
       expect(connectorResponse.credentials).to.deep.equal(credentialsInResponse)

--- a/test/pact/connector-client/connector-patch-gateway-account-credentials-merchant-initiated.pact.test.js
+++ b/test/pact/connector-client/connector-patch-gateway-account-credentials-merchant-initiated.pact.test.js
@@ -1,0 +1,84 @@
+'use strict'
+
+const { Pact } = require('@pact-foundation/pact')
+const { expect } = require('chai')
+const path = require('path')
+
+const PactInteractionBuilder = require('../../test-helpers/pact/pact-interaction-builder').PactInteractionBuilder
+const Connector = require('../../../app/services/clients/connector.client').ConnectorClient
+const gatewayAccountFixtures = require('../../fixtures/gateway-account.fixtures')
+const { pactify } = require('../../test-helpers/pact/pactifier').defaultPactifier
+const { worldpayMerchantDetailOperations } = require('../../../app/utils/credentials')
+
+const existingGatewayAccountId = 333
+const existingGatewayAccountCredentialsId = 444
+
+let connectorClient
+
+describe('connector client - patch gateway account credentials for recurring merchant initiated transactions', () => {
+  const provider = new Pact({
+    consumer: 'selfservice',
+    provider: 'connector',
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
+  after(() => provider.finalize())
+
+  describe('when a request to update credentials map for recurring merchant initiated credentials is made', () => {
+    const credentialsInRequest = {
+      username: 'a-username',
+      password: 'a-password', // pragma: allowlist secret
+      merchant_code: 'a-merchant-code'
+    }
+    const credentialsInResponse = {
+      recurring_merchant_initiated: {
+        username: 'a-username',
+        merchant_code: 'a-merchant-code'
+      }
+    }
+    const userExternalId = 'a-user-external-id'
+    const request = gatewayAccountFixtures.validUpdateGatewayAccountCredentialsRequest({
+      credentials: credentialsInRequest,
+      path: worldpayMerchantDetailOperations.RECURRING_MERCHANT_INITIATED.patch,
+      userExternalId
+    })
+    const response = gatewayAccountFixtures.validGatewayAccountCredentialsResponse({
+      credentials: credentialsInResponse,
+      lastUpdatedByUserExternalId: userExternalId
+    })
+
+    before(() => {
+      return provider.addInteraction(
+        new PactInteractionBuilder(`/v1/api/accounts/${existingGatewayAccountId}/credentials/${existingGatewayAccountCredentialsId}`)
+          .withState(`a Worldpay gateway account with id ${existingGatewayAccountId} with gateway account credentials with id ${existingGatewayAccountCredentialsId}`)
+          .withUponReceiving('a request to update credentials map for recurring merchant initiated credentials')
+          .withMethod('PATCH')
+          .withRequestHeaders({ 'Content-Type': 'application/json' })
+          .withRequestBody(request)
+          .withStatusCode(200)
+          .withResponseHeaders({ 'Content-Type': 'application/json' })
+          .withResponseBody(pactify(response))
+          .build())
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should patch gateway account credentials for recurring merchant initiated transactions', async () => {
+      const connectorResponse = await connectorClient.patchAccountGatewayAccountCredentials({
+        gatewayAccountId: existingGatewayAccountId,
+        gatewayAccountCredentialsId: existingGatewayAccountCredentialsId,
+        credentials: credentialsInRequest,
+        path: worldpayMerchantDetailOperations.RECURRING_MERCHANT_INITIATED.patch,
+        userExternalId
+      })
+      expect(connectorResponse.credentials).to.deep.equal(credentialsInResponse)
+    })
+  })
+})

--- a/test/pact/connector-client/connector-patch-gateway-account-credentials-one-off.pact.test.js
+++ b/test/pact/connector-client/connector-patch-gateway-account-credentials-one-off.pact.test.js
@@ -1,0 +1,84 @@
+'use strict'
+
+const { Pact } = require('@pact-foundation/pact')
+const { expect } = require('chai')
+const path = require('path')
+
+const PactInteractionBuilder = require('../../test-helpers/pact/pact-interaction-builder').PactInteractionBuilder
+const Connector = require('../../../app/services/clients/connector.client').ConnectorClient
+const gatewayAccountFixtures = require('../../fixtures/gateway-account.fixtures')
+const { pactify } = require('../../test-helpers/pact/pactifier').defaultPactifier
+const { worldpayMerchantDetailOperations } = require('../../../app/utils/credentials')
+
+const existingGatewayAccountId = 333
+const existingGatewayAccountCredentialsId = 444
+
+let connectorClient
+
+describe('connector client - patch gateway account credentials for one off transactions', () => {
+  const provider = new Pact({
+    consumer: 'selfservice',
+    provider: 'connector',
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(async () => {
+    const opts = await provider.setup()
+    connectorClient = new Connector(`http://localhost:${opts.port}`)
+  })
+  after(() => provider.finalize())
+
+  describe('when a request to update credentials map for one off credentials is made', () => {
+    const credentialsInRequest = {
+      username: 'a-username',
+      password: 'a-password', // pragma: allowlist secret
+      merchant_code: 'a-merchant-code'
+    }
+    const credentialsInResponse = {
+      one_off_customer_initiated: {
+        username: 'a-username',
+        merchant_code: 'a-merchant-code'
+      }
+    }
+    const userExternalId = 'a-user-external-id'
+    const request = gatewayAccountFixtures.validUpdateGatewayAccountCredentialsRequest({
+      credentials: credentialsInRequest,
+      path: worldpayMerchantDetailOperations.ONE_OFF_CUSTOMER_INITIATED.patch,
+      userExternalId
+    })
+    const response = gatewayAccountFixtures.validGatewayAccountCredentialsResponse({
+      credentials: credentialsInResponse,
+      lastUpdatedByUserExternalId: userExternalId
+    })
+
+    before(() => {
+      return provider.addInteraction(
+        new PactInteractionBuilder(`/v1/api/accounts/${existingGatewayAccountId}/credentials/${existingGatewayAccountCredentialsId}`)
+          .withState(`a Worldpay gateway account with id ${existingGatewayAccountId} with gateway account credentials with id ${existingGatewayAccountCredentialsId}`)
+          .withUponReceiving('a request to update credentials map for one off credentials')
+          .withMethod('PATCH')
+          .withRequestHeaders({ 'Content-Type': 'application/json' })
+          .withRequestBody(request)
+          .withStatusCode(200)
+          .withResponseHeaders({ 'Content-Type': 'application/json' })
+          .withResponseBody(pactify(response))
+          .build())
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should patch gateway account credentials for one off transactions', async () => {
+      const connectorResponse = await connectorClient.patchAccountGatewayAccountCredentials({
+        gatewayAccountId: existingGatewayAccountId,
+        gatewayAccountCredentialsId: existingGatewayAccountCredentialsId,
+        credentials: credentialsInRequest,
+        path: worldpayMerchantDetailOperations.ONE_OFF_CUSTOMER_INITIATED.patch,
+        userExternalId
+      })
+      expect(connectorResponse.credentials).to.deep.equal(credentialsInResponse)
+    })
+  })
+})


### PR DESCRIPTION
- Update existing PACT test for patching Worldpay credentials
  - Make it more specific for `one off` payments.
- Add 2 new PACT tests
  - 1 for patching `recurring customer initiated` credentials.
  - 1 for patching `recurring merchant initiated` credentials.
- Update existing PACT for `get gateway account by external id`
  - Test that `recurring customer initiated` and `recurring merchant initiated` transactions
   are returned.
  - This test requires that the connector PACT state `is gateway account 333 with Worldpay 3DS Flex credentials exists` is updated.