### PR TITLE
PP-10823 Check for PAN in reference field - add util methods

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -252,6 +252,15 @@
         "line_number": 29
       }
     ],
+    "app/utils/is-a-potential-pan.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "app/utils/is-a-potential-pan.test.js",
+        "hashed_secret": "b7195506cd55ef0c804669340edf26476adb8751",
+        "is_verified": false,
+        "line_number": 29
+      }
+    ],
     "app/utils/validation/field-validation-checks-worldpay-3ds-flex.test.js": [
       {
         "type": "Hex High Entropy String",
@@ -878,5 +887,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-03T16:29:58Z"
+  "generated_at": "2023-08-07T11:19:49Z"
 }

--- a/app/utils/is-a-potential-pan.js
+++ b/app/utils/is-a-potential-pan.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const Luhn = require('luhn-js')
+
+module.exports = function isAPotentialPAN (value) {
+  const referenceWithoutSpaceAndHyphen = value.replace(/[\s-]/g, '')
+
+  const NUMBERS_ONLY = /^\d+$/
+  if (NUMBERS_ONLY.test(referenceWithoutSpaceAndHyphen) &&
+      referenceWithoutSpaceAndHyphen.length >= 15 && referenceWithoutSpaceAndHyphen.length <= 16) {
+    return Luhn.isValid(referenceWithoutSpaceAndHyphen)
+  }
+
+  return false
+}

--- a/app/utils/is-a-potential-pan.test.js
+++ b/app/utils/is-a-potential-pan.test.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const isAPotentialPAN = require('./is-a-potential-pan')
+const { expect } = require('chai')
+
+describe('Is A Potential card number', () => {
+  it('should return true if reference is 15 digits passes luhn check', () => {
+    expect(isAPotentialPAN('424242424242424')).to.equal(true)
+  })
+  it('should return true if reference is 16 digits passes luhn check', () => {
+    expect(isAPotentialPAN('4242424242424242')).to.equal(true)
+  })
+  it('should return true if reference has characters [- or space] and passes luhn check', () => {
+    expect(isAPotentialPAN('4242 4242 4242-42-42')).to.equal(true)
+  })
+  it('should return false if reference is less than 15 digits', () => {
+    expect(isAPotentialPAN('42424242424242')).to.equal(false)
+  })
+  it('should return false if reference has more than 16 digits', () => {
+    expect(isAPotentialPAN('4242 4242 4242 42')).to.equal(false)
+  })
+  it('should return false if reference fails luhn check', () => {
+    expect(isAPotentialPAN('42424242424211')).to.equal(false)
+  })
+  it('should return false if reference has characters [- or space] and but fails luhn check', () => {
+    expect(isAPotentialPAN('4242-4242-4242-11')).to.equal(false)
+  })
+  it('should return false for reference with characters', () => {
+    expect(isAPotentialPAN('A12345678901234')).to.equal(false)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "https-proxy-agent": "5.0.1",
         "joi": "14.3.1",
         "lodash": "4.17.21",
+        "luhn-js": "^1.1.2",
         "minimist": "1.2.6",
         "moment-timezone": "0.5.43",
         "morgan": "1.10.0",
@@ -10805,6 +10806,11 @@
       "dependencies": {
         "es5-ext": "~0.10.2"
       }
+    },
+    "node_modules/luhn-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/luhn-js/-/luhn-js-1.1.2.tgz",
+      "integrity": "sha512-GdINoHY50s4Zkhvmt6Pss/8ZwVxIOLsMHuJCg6EDcT1heSt4hM2V+7aKCihemn8rI0n22+lxqomzgvWDzMyEuQ=="
     },
     "node_modules/mailparser": {
       "version": "3.5.0",
@@ -25946,6 +25952,11 @@
       "requires": {
         "es5-ext": "~0.10.2"
       }
+    },
+    "luhn-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/luhn-js/-/luhn-js-1.1.2.tgz",
+      "integrity": "sha512-GdINoHY50s4Zkhvmt6Pss/8ZwVxIOLsMHuJCg6EDcT1heSt4hM2V+7aKCihemn8rI0n22+lxqomzgvWDzMyEuQ=="
     },
     "mailparser": {
       "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "https-proxy-agent": "5.0.1",
     "joi": "14.3.1",
     "lodash": "4.17.21",
+    "luhn-js": "^1.1.2",
     "minimist": "1.2.6",
     "moment-timezone": "0.5.43",
     "morgan": "1.10.0",


### PR DESCRIPTION
- Add util methods to check if value is a potential PAN.
- These methods were taken from an older version of `products-ui` which use to check if a reference was a PAN using these methods.
- These methods will be used in a future PR to check if the user is searching for transactions with a potential PAN.


