### PR TITLE
PP-11318 Hide merchant ID copy for Stripe account

### DIFF
--- a/app/views/digital-wallet/google-pay.njk
+++ b/app/views/digital-wallet/google-pay.njk
@@ -31,9 +31,11 @@
         <li>corporate card fees cannot be applied to payments made with Google Pay.</li>
       </ul>
 
-      <p class="govuk-body">
-        You’ll need a Google Pay merchant ID. Refer to the <a class="govuk-link" href="https://docs.payments.service.gov.uk/digital_wallets/#enable-google-pay">GOV.UK Pay documentation on enabling Google Pay</a> to learn where to find your merchant ID.
-      </p>
+      {% if currentGatewayAccount.payment_provider === "worldpay" %}
+        <p class="govuk-body">
+          You’ll need a Google Pay merchant ID. Refer to the <a class="govuk-link" href="https://docs.payments.service.gov.uk/digital_wallets/#enable-google-pay">GOV.UK Pay documentation on enabling Google Pay</a> to learn where to find your merchant ID.
+        </p>
+      {%  endif %}
 
       <form method="post" novalidate>
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>

--- a/test/cypress/integration/settings/allow-google-pay.cy.js
+++ b/test/cypress/integration/settings/allow-google-pay.cy.js
@@ -44,6 +44,8 @@ describe('Google Pay', () => {
     cy.get('input[value="off"]').should('be.checked')
     cy.get('#merchantId').should('not.be.visible')
 
+    cy.get('p').contains('You’ll need a Google Pay merchant ID').should('exist')
+
     cy.get('input[value="on"]').click()
     cy.get('input[value="on"]').should('be.checked')
 
@@ -86,6 +88,8 @@ describe('Google Pay', () => {
     cy.get('input[value="on"]').should('not.be.checked')
     cy.get('input[value="off"]').should('be.checked')
     cy.get('#merchantId').should('not.exist')
+
+    cy.get('p').contains('You’ll need a Google Pay merchant ID').should('not.exist')
 
     cy.get('input[value="on"]').click()
     cy.get('input[value="on"]').should('be.checked')


### PR DESCRIPTION
Hide the copy that says "You’ll need a Google Pay merchant ID" on the Google Pay settings page for Stripe accounts.

