### PR TITLE
BAU Fix creating zendesk ticket

### DIFF
--- a/app/controllers/dashboard/dashboard-activity.controller.js
+++ b/app/controllers/dashboard/dashboard-activity.controller.js
@@ -104,7 +104,6 @@ module.exports = async (req, res) => {
   const telephonePaymentLink = await getTelephonePaymentLink(req.user, req.service, gatewayAccountId)
   const linksToDisplay = getLinksToDisplay(req.service, req.account, req.user, telephonePaymentLink)
   const model = {
-    name: req.user.username,
     serviceId: req.service.externalId,
     period,
     links,

--- a/app/controllers/request-psp-test-account/post.controller.js
+++ b/app/controllers/request-psp-test-account/post.controller.js
@@ -17,7 +17,7 @@ async function submitRequestAndUpdatePspTestAccountStatus (req) {
 
   const zendeskOpts = {
     email: req.user.email,
-    name: req.user.username,
+    name: req.user.email,
     type: 'task',
     subject: `Request for Stripe test account from service (${req.service.name})`,
     tags: ['govuk_pay_support'],

--- a/app/controllers/request-to-go-live/agreement/post.controller.js
+++ b/app/controllers/request-to-go-live/agreement/post.controller.js
@@ -66,15 +66,15 @@ module.exports = async (req, res, next) => {
         serviceExternalId: req.service.externalId,
         psp: stages[req.service.currentGoLiveStage],
         ipAddress: ipAddress || '',
-        email: agreement.email,
+        email: req.user.email,
         timestamp: agreement.agreement_time,
         serviceCreated: req.service.createdDate || '(service was created before we captured this date)',
         takesPaymentsOverPhone: req.service.takesPaymentsOverPhone
       }
 
       const zendeskOpts = {
-        email: agreement.email,
-        name: req.user.username,
+        email: req.user.email,
+        name: req.user.email,
         type: 'task',
         subject: `Service (${req.service.name}) has finished go live request`,
         tags: ['govuk_pay_support'],

--- a/app/controllers/user/two-factor-auth/get-configure.controller.js
+++ b/app/controllers/user/two-factor-auth/get-configure.controller.js
@@ -14,7 +14,7 @@ module.exports = async function showConfigureSecondFactorMethod (req, res) {
   lodash.unset(req, 'session.pageData.configureTwoFactorAuthMethodRecovered')
 
   const prettyPrintedSecret = req.user.provisionalOtpKey.match(/.{4}/g).join(' ')
-  const otpUrl = `otpauth://totp/GOV.UK%20Pay:${encodeURIComponent(req.user.username)}?secret=${encodeURIComponent(req.user.provisionalOtpKey)}&issuer=GOV.UK%20Pay&algorithm=SHA1&digits=6&period=30`
+  const otpUrl = `otpauth://totp/GOV.UK%20Pay:${encodeURIComponent(req.user.email)}?secret=${encodeURIComponent(req.user.provisionalOtpKey)}&issuer=GOV.UK%20Pay&algorithm=SHA1&digits=6&period=30`
 
   try {
     const qrCodeDataUrl = await qrcode.toDataURL(otpUrl)

--- a/test/pact/adminusers-client/user/get-multiple-users.pact.test.js
+++ b/test/pact/adminusers-client/user/get-multiple-users.pact.test.js
@@ -70,7 +70,6 @@ describe('adminusers client - get users', function () {
       return result.to.be.fulfilled.then(function (users) {
         users.forEach((user, index) => {
           expect(user.externalId).to.be.equal(expectedUsers[index].external_id)
-          expect(user.username).to.be.equal(expectedUsers[index].username)
           expect(user.email).to.be.equal(expectedUsers[index].email)
           expect(user.serviceRoles.length).to.be.equal(1)
           expect(user.serviceRoles[0].service.gatewayAccountIds.length).to.be.equal(2)

--- a/test/pact/adminusers-client/user/get-user.pact.test.js
+++ b/test/pact/adminusers-client/user/get-user.pact.test.js
@@ -52,7 +52,6 @@ describe('adminusers client - get user', () => {
     it('should find a user successfully', done => {
       adminUsersClient.getUserByExternalId(getUserResponse.external_id).should.be.fulfilled.then(user => {
         expect(user.externalId).to.be.equal(getUserResponse.external_id)
-        expect(user.username).to.be.equal(getUserResponse.username)
         expect(user.email).to.be.equal(getUserResponse.email)
         expect(user.serviceRoles.length).to.be.equal(1)
         expect(user.serviceRoles[0].service.gatewayAccountIds.length).to.be.equal(1)


### PR DESCRIPTION
When creating a Zendesk ticket, we need to send the name of the requester. We were getting this from the `username` field on a User, but this field has been removed. Zendesk was returning a 422 when the name was empty in some cases.

Instead, get the name from the `email` field, which was the same as the `username` anyway when the username existed.

Remove/replace other places where we were still trying to access the `username` on the User.