### PR TITLE
BAU Fix flaky test

### DIFF
--- a/test/pact/connector-client/connector-get-charge.pact.test.js
+++ b/test/pact/connector-client/connector-get-charge.pact.test.js
@@ -49,7 +49,7 @@ describe('connector client - get single charge', () => {
     const response = chargeFixture.validGetChargeResponse(opts)
 
     before(() => {
-      provider.addInteraction(
+      return provider.addInteraction(
         new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/charges/${existingChargeExternalId}`)
           .withUponReceiving('a valid get charge request')
           .withState(defaultState)


### PR DESCRIPTION
The `before` wasn't waiting for a Promise to resolve. Return the Promise so it is awaited before the test is run.

