### PR TITLE
PP-11138: Set npm and Github Actions dependencies to security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: weekly
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   - govuk-pay
@@ -41,7 +41,7 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   - govuk-pay


### PR DESCRIPTION
## WHAT
- Set Dependabot config for Github Actions and npm dependencies to receive security updates only.
- Keep the existing 'ignores' for `change-case`, `joi` and `@sentry/node` as we can't currently update these