### PR TITLE
PP-11598 Display appropriate text for redacted fields

### DIFF
--- a/app/utils/transaction-view.js
+++ b/app/utils/transaction-view.js
@@ -15,6 +15,7 @@ const DisputeTransaction = require('../models/DisputeTransaction.class')
 const formatAccountPathsFor = require('../utils/format-account-paths-for')
 
 const DATA_UNAVAILABLE = 'Data unavailable'
+const REDACTED_PII_FIELD_VALUE = '<DELETED>'
 const LEDGER_TRANSACTION_COUNT_LIMIT = 5000
 
 module.exports = {
@@ -114,9 +115,21 @@ module.exports = {
       chargeData.corporate_card_surcharge = asGBP(chargeData.corporate_card_surcharge)
     }
 
+    if (chargeData.reference === REDACTED_PII_FIELD_VALUE) {
+      chargeData.reference = DATA_UNAVAILABLE
+    }
+
+    if (chargeData.description === REDACTED_PII_FIELD_VALUE) {
+      chargeData.description = DATA_UNAVAILABLE
+    }
+
+    if (chargeData.email === REDACTED_PII_FIELD_VALUE) {
+      chargeData.email = DATA_UNAVAILABLE
+    }
+
     if (chargeData.card_details) {
       if (chargeData.card_details.card_brand == null) chargeData.card_details.card_brand = DATA_UNAVAILABLE
-      if (chargeData.card_details.cardholder_name == null) chargeData.card_details.cardholder_name = DATA_UNAVAILABLE
+      if (chargeData.card_details.cardholder_name == null || chargeData.card_details.cardholder_name === REDACTED_PII_FIELD_VALUE) chargeData.card_details.cardholder_name = DATA_UNAVAILABLE
       if (chargeData.card_details.expiry_date == null) chargeData.card_details.expiry_date = DATA_UNAVAILABLE
       if (chargeData.card_details.last_digits_card_number == null) chargeData.card_details.last_digits_card_number = '****'
       if (chargeData.card_details.first_digits_card_number == null) chargeData.card_details.first_digits_card_number = '**** **'

--- a/app/views/transaction-detail/_events.njk
+++ b/app/views/transaction-detail/_events.njk
@@ -1,16 +1,22 @@
-<table class="transaction-events govuk-table">
-  <tbody class="govuk-table__body">
+{% if events.length > 0 %}
+  <h2 class="govuk-heading-m govuk-!-margin-top-9">Transaction events</h2>
+  <table class="transaction-events govuk-table">
+    <tbody class="govuk-table__body">
     {% for event in events %}
-      <tr class="govuk-table__row" {% if event.refund_reference %} data-gateway-refund-id="{{ event.refund_reference }}" {% endif %}>
+      <tr
+        class="govuk-table__row" {% if event.refund_reference %} data-gateway-refund-id="{{ event.refund_reference }}" {% endif %}>
         <td class="govuk-table__cell govuk-!-width-one-third govuk-!-font-size-16">
           <span class="state">{{ event.state_friendly }}</span>
-          {% if event.state.message %}<br>{{ event.state.code}} - {{ event.state.message}}{% endif %}
+          {% if event.state.message %}<br>{{ event.state.code }} - {{ event.state.message }}{% endif %}
           {% if event.submitted_by_friendly %}by <br>{% endif %}
-          <span class="submitted-by">{% if event.submitted_by_friendly %}{{ event.submitted_by_friendly }}{% endif %}</span>
+          <span
+            class="submitted-by">{% if event.submitted_by_friendly %}{{ event.submitted_by_friendly }}{% endif %}</span>
         </td>
         <td class="govuk-table__cell amount govuk-!-font-size-16">{{ event.amount_friendly }}</td>
-        <td class="govuk-table__cell govuk-table__cell--numeric date govuk-!-font-size-16">{{ event.updated_friendly }}</td>
+        <td
+          class="govuk-table__cell govuk-table__cell--numeric date govuk-!-font-size-16">{{ event.updated_friendly }}</td>
       </tr>
     {% endfor %}
-  </tbody>
-</table>
+    </tbody>
+  </table>
+{% endif %}

--- a/app/views/transaction-detail/index.njk
+++ b/app/views/transaction-detail/index.njk
@@ -81,7 +81,6 @@
     {% endif %}
 
     {% if permissions.transactions_events_read %}
-      <h2 class="govuk-heading-m govuk-!-margin-top-9">Transaction events</h2>
       {% include "./_events.njk" %}
     {% endif %}
   </div>


### PR DESCRIPTION
## WHAT
- For the transaction fields redacted for personally identifiable information (PII), display the text as `Data unavailable' on the transaction details page
- Hides the transaction events section when there are no events (deleted when PII is redacted) for the transaction.
