### PR TITLE
BAU: Fix Dependabot Docker ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,7 @@ updates:
   ignore:
   - dependency-name: node
     versions:
-    - ">= 18"
+    - ">= 19"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
## WHAT
We want updates for Node 18.x but not 19.x.


