### PR TITLE
PP-9916 Change test card number in Stripe test accounts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -379,6 +375,15 @@
       {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/demo-payment/demo-payment.cy.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    "test/cypress/integration/demo-payment/mock-cards.cy.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/demo-payment/mock-cards.cy.js",
         "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
         "is_verified": false,
         "line_number": 5
@@ -894,5 +899,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-17T11:37:31Z"
+  "generated_at": "2023-10-19T14:35:18Z"
 }

--- a/app/views/dashboard/demo-payment/mock-card-details.njk
+++ b/app/views/dashboard/demo-payment/mock-card-details.njk
@@ -1,5 +1,13 @@
 {% extends "../../layout.njk" %}
 
+{% set card %}
+{% if currentGatewayAccount.payment_provider === 'stripe' %}
+   <p class="govuk-!-font-size-24 govuk-!-font-weight-bold">4000<span class="govuk-!-padding-left-3 govuk-!-padding-right-3">0582</span><span class="govuk-!-padding-right-3">6000</span>0005</p>
+{% else %}
+   <p class="govuk-!-font-size-24 govuk-!-font-weight-bold">4000<span class="govuk-!-padding-left-3 govuk-!-padding-right-3">0566</span><span class="govuk-!-padding-right-3">5566</span>5556</p>
+{% endif %}
+{% endset %}
+
 {% block pageTitle %}
   Mock card numbers for demo payment - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
 {% endblock %}
@@ -21,7 +29,7 @@
 
   {{
     govukInsetText({
-      html: '<p class="govuk-!-font-size-24 govuk-!-font-weight-bold">4000<span class="govuk-!-padding-left-3 govuk-!-padding-right-3">0566</span><span class="govuk-!-padding-right-3">5566</span>5556</p>'
+      html: card
     })
   }}
 

--- a/test/cypress/integration/demo-payment/mock-cards-stripe.cy.js
+++ b/test/cypress/integration/demo-payment/mock-cards-stripe.cy.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const userStubs = require('../../stubs/user-stubs')
+const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+const stripeAccountSetupStubs = require('../../stubs/stripe-account-setup-stub')
+const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e' // pragma: allowlist secret
+const gatewayAccountId = '42'
+const gatewayAccountExternalId = 'a-valid-external-id'
+
+function setupYourPspStubs (opts = {}) {
+  const user = userStubs.getUserSuccess({ userExternalId, gatewayAccountId })
+
+  const gatewayAccountByExternalId = gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+    gatewayAccountId,
+    gatewayAccountExternalId,
+    type: 'test',
+    paymentProvider: 'stripe',
+  })
+
+  const stripeAccountSetup = stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+    gatewayAccountId,
+  })
+
+  const stubs = [
+    user,
+    gatewayAccountByExternalId,
+    stripeAccountSetup,
+  ]
+
+  cy.task('setupStubs', stubs)
+}
+
+describe('Show Mock cards screen for stripe accounts', () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(userExternalId)
+  })
+
+  it('should display stripe settings page correctly', () => {
+    setupYourPspStubs()
+    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+    cy.log('Continue to Make a demo payment page via Dashboard')
+    cy.get('a').contains('Dashboard').click()
+    cy.get('a').contains('Make a demo payment').click()
+    cy.log('Continue to Mock Cards page')
+    cy.get('a').contains('Continue').click()
+    cy.get('h1').should('have.text', 'Mock card numbers')
+    cy.get('p').contains(/^4000058260000005/)
+  })
+})

--- a/test/cypress/integration/demo-payment/mock-cards.cy.js
+++ b/test/cypress/integration/demo-payment/mock-cards.cy.js
@@ -1,0 +1,36 @@
+const userStubs = require('../../stubs/user-stubs')
+const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+const transactionStubs = require('../../stubs/transaction-stubs')
+
+const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+const gatewayAccountId = '42'
+const gatewayAccountExternalId = 'a-valid-external-id'
+
+describe('Show Mock cards screen', () => {
+  beforeEach(() => {
+    cy.task('setupStubs', [
+      userStubs.getUserSuccess({ gatewayAccountId, userExternalId }),
+      gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+        gatewayAccountId,
+        gatewayAccountExternalId,
+        paymentProvider: 'sandbox'
+      }),
+      transactionStubs.getTransactionsSummarySuccess()
+    ])
+  })
+
+  it('should load the mock cards page and show non stripe card', () => {
+    cy.setEncryptedCookies(userExternalId)
+    cy.visit(`/account/${gatewayAccountExternalId}/dashboard`)
+    cy.get('a').contains('Make a demo payment').click()
+    cy.get('h1').should('have.text', 'Make a demo payment')
+
+    cy.get('#payment-description').contains('An example payment description')
+    cy.get('#payment-amount').contains('£20.00')
+
+    cy.log('Continue to Mock Cards page')
+    cy.get('a').contains('Continue').click()
+    cy.get('h1').should('have.text', 'Mock card numbers')
+    cy.get('p').contains(/^4000056655665556/)
+  })
+})


### PR DESCRIPTION
## WHAT
Change test card number in Stripe test accounts to UK issued test card

https://payments-platform.atlassian.net/browse/PP-9916

## HOW 
Update ‘Mock card numbers’ template to test for ‘stripe’ account and display UK issued test card.



