### PR TITLE
PP-11594 - Allow enabling Apple Pay and Google Pay for Sandbox gateway accounts

### DIFF
--- a/app/utils/display-converter.js
+++ b/app/utils/display-converter.js
@@ -122,8 +122,8 @@ module.exports = function (req, data, template) {
   convertedData.isTestGateway = _.get(convertedData, 'currentGatewayAccount.type') === 'test'
   convertedData.isSandbox = paymentProvider === 'sandbox'
   convertedData.isDigitalWalletSupported = paymentProvider === 'worldpay' ||
-    (paymentProvider === 'stripe' && process.env.ALLOW_ENABLING_DIGITAL_WALLETS_FOR_STRIPE_ACCOUNT === 'true') ||
-    (paymentProvider === 'stripe' && convertedData.isTestGateway === true)
+    (paymentProvider === 'sandbox' && process.env.ALLOW_ENABLING_DIGITAL_WALLETS_FOR_SANDBOX_ACCOUNT === 'true') ||
+    paymentProvider === 'stripe'
   convertedData.currentService = service
   convertedData.isLive = req.isLive
   convertedData.humanReadableEnvironment = convertedData.isLive ? 'Live' : 'Test'

--- a/app/utils/display-converter.test.js
+++ b/app/utils/display-converter.test.js
@@ -6,6 +6,7 @@ const expect = chai.expect
 describe('Display converter', function () {
   afterEach(() => {
     process.env.ALLOW_ENABLING_DIGITAL_WALLETS_FOR_STRIPE_ACCOUNT = undefined
+    process.env.ALLOW_ENABLING_DIGITAL_WALLETS_FOR_SANDBOX_ACCOUNT = undefined
   })
 
   it('should add full_type to account if type is test', function () {
@@ -38,29 +39,37 @@ describe('Display converter', function () {
     })
   })
 
-  it('should return isDigitalWalletSupported=false for Stripe account when ALLOW_ENABLING_DIGITAL_WALLETS_FOR_STRIPE_ACCOUNT is not set', () => {
-    const data = displayConverter({
+  it('should add full_type with value live to account if type is live', function () {
+    let data = displayConverter({
       account: {
         type: 'live',
         payment_provider: 'stripe'
       }
     }, {}, {})
-    expect(data.isDigitalWalletSupported).to.equal(false)
+
+    expect(data.currentGatewayAccount).to.deep.equal({
+      type: 'live',
+      payment_provider: 'stripe',
+      full_type: 'live'
+    })
   })
 
-  it('should return isDigitalWalletSupported=false for Stripe account when ALLOW_ENABLING_DIGITAL_WALLETS_FOR_STRIPE_ACCOUNT is false', () => {
-    process.env.ALLOW_ENABLING_DIGITAL_WALLETS_FOR_STRIPE_ACCOUNT = 'false'
-    const data = displayConverter({
+  it('should add full_type with value test to account if type is test', function () {
+    let data = displayConverter({
       account: {
-        type: 'live',
+        type: 'test',
         payment_provider: 'stripe'
       }
     }, {}, {})
-    expect(data.isDigitalWalletSupported).to.equal(false)
+
+    expect(data.currentGatewayAccount).to.deep.equal({
+      type: 'test',
+      payment_provider: 'stripe',
+      full_type: 'Stripe test'
+    })
   })
 
-  it('should return isDigitalWalletSupported=true for Stripe account when ALLOW_ENABLING_DIGITAL_WALLETS_FOR_STRIPE_ACCOUNT is true', () => {
-    process.env.ALLOW_ENABLING_DIGITAL_WALLETS_FOR_STRIPE_ACCOUNT = 'true'
+  it('should return isDigitalWalletSupported=true for Stripe account when when gateway type is live', () => {
     const data = displayConverter({
       account: {
         type: 'live',
@@ -70,12 +79,43 @@ describe('Display converter', function () {
     expect(data.isDigitalWalletSupported).to.equal(true)
   })
 
-  it('should return isDigitalWalletSupported=true for Stripe account when gateway type is test and ALLOW_ENABLING_DIGITAL_WALLETS_FOR_STRIPE_ACCOUNT is false', () => {
-    process.env.ALLOW_ENABLING_DIGITAL_WALLETS_FOR_STRIPE_ACCOUNT = 'false'
+  it('should return isDigitalWalletSupported=true for Stripe account when gateway type is test', () => {
     const data = displayConverter({
       account: {
         type: 'test',
         payment_provider: 'stripe'
+      }
+    }, {}, {})
+    expect(data.isDigitalWalletSupported).to.equal(true)
+  })
+
+  it('should return isDigitalWalletSupported=false for sandbox account when ALLOW_ENABLING_DIGITAL_WALLETS_FOR_SANDBOX_ACCOUNT is not set', () => {
+    const data = displayConverter({
+      account: {
+        type: 'test',
+        payment_provider: 'sandbox'
+      }
+    }, {}, {})
+    expect(data.isDigitalWalletSupported).to.equal(false)
+  })
+
+  it('should return isDigitalWalletSupported=false for sandbox account when ALLOW_ENABLING_DIGITAL_WALLETS_FOR_SANDBOX_ACCOUNT is false', () => {
+    process.env.ALLOW_ENABLING_DIGITAL_WALLETS_FOR_SANDBOX_ACCOUNT = 'false'
+    const data = displayConverter({
+      account: {
+        type: 'test',
+        payment_provider: 'sandbox'
+      }
+    }, {}, {})
+    expect(data.isDigitalWalletSupported).to.equal(false)
+  })
+
+  it('should return isDigitalWalletSupported=true for sandbox account when ALLOW_ENABLING_DIGITAL_WALLETS_FOR_SANDBOX_ACCOUNT is true', () => {
+    process.env.ALLOW_ENABLING_DIGITAL_WALLETS_FOR_SANDBOX_ACCOUNT = 'true'
+    const data = displayConverter({
+      account: {
+        type: 'test',
+        payment_provider: 'sandbox'
       }
     }, {}, {})
     expect(data.isDigitalWalletSupported).to.equal(true)

--- a/test/cypress/integration/demo-payment/mock-cards-stripe.cy.js
+++ b/test/cypress/integration/demo-payment/mock-cards-stripe.cy.js
@@ -14,17 +14,17 @@ function setupYourPspStubs (opts = {}) {
     gatewayAccountId,
     gatewayAccountExternalId,
     type: 'test',
-    paymentProvider: 'stripe',
+    paymentProvider: 'stripe'
   })
 
   const stripeAccountSetup = stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
-    gatewayAccountId,
+    gatewayAccountId
   })
 
   const stubs = [
     user,
     gatewayAccountByExternalId,
-    stripeAccountSetup,
+    stripeAccountSetup
   ]
 
   cy.task('setupStubs', stubs)

--- a/test/pact/connector-client/connector-patch-apple-pay-toggle.pact.test.js
+++ b/test/pact/connector-client/connector-patch-apple-pay-toggle.pact.test.js
@@ -12,7 +12,6 @@ const gatewayAccountFixtures = require('../../fixtures/gateway-account.fixtures'
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/api/accounts'
 let connectorClient
-const expect = chai.expect
 const existingGatewayAccountId = 666
 
 // Global setup
@@ -59,30 +58,6 @@ describe('connector client - patch apple pay toggle (enabled) request', () => {
       connectorClient.toggleApplePay(existingGatewayAccountId, true, null)
         .should.be.fulfilled
         .notify(done)
-    })
-  })
-
-  describe('apple pay toggle with unsupported payment provider request', () => {
-    const applePayToggleUnsupportedPaymentProviderState = `User ${existingGatewayAccountId} exists in the database`
-
-    before(() => {
-      return provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
-          .withUponReceiving('a valid patch apple pay toggle (enabled) request')
-          .withState(applePayToggleUnsupportedPaymentProviderState)
-          .withMethod('PATCH')
-          .withRequestBody(request)
-          .withStatusCode(400)
-          .build())
-    })
-
-    afterEach(() => provider.verify())
-
-    it('should respond bad request for unsupported payment provider', done => {
-      connectorClient.toggleApplePay(existingGatewayAccountId, true, null)
-        .should.be.rejected.then(response => {
-          expect(response.errorCode).to.equal(400)
-        }).should.notify(done)
     })
   })
 })

--- a/test/pact/connector-client/connector-patch-google-pay-toggle.pact.test.js
+++ b/test/pact/connector-client/connector-patch-google-pay-toggle.pact.test.js
@@ -12,7 +12,6 @@ const gatewayAccountFixtures = require('../../fixtures/gateway-account.fixtures'
 // Constants
 const ACCOUNTS_RESOURCE = '/v1/api/accounts'
 let connectorClient
-const expect = chai.expect
 const existingGatewayAccountId = 666
 
 // Global setup
@@ -59,30 +58,6 @@ describe('connector client - patch google pay toggle (enabled) request', () => {
       connectorClient.toggleGooglePay(existingGatewayAccountId, true, null)
         .should.be.fulfilled
         .notify(done)
-    })
-  })
-
-  describe('google pay toggle with unsupported payment provider request', () => {
-    const googlePayToggleUnsupportedPaymentProviderState = `User ${existingGatewayAccountId} exists in the database`
-
-    before(() => {
-      return provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
-          .withUponReceiving('a valid patch google pay toggle (enabled) request')
-          .withState(googlePayToggleUnsupportedPaymentProviderState)
-          .withMethod('PATCH')
-          .withRequestBody(request)
-          .withStatusCode(400)
-          .build())
-    })
-
-    afterEach(() => provider.verify())
-
-    it('should respond bad request for unsupported payment provider', done => {
-      connectorClient.toggleGooglePay(existingGatewayAccountId, true, null)
-        .should.be.rejected.then(response => {
-          expect(response.errorCode).to.equal(400)
-        }).should.notify(done)
     })
   })
 })


### PR DESCRIPTION
## WHAT
Allow enabling Apple Pay and Google Pay for Sandbox gateway accounts

[https://payments-platform.atlassian.net/browse/PP-11594](https://payments-platform.atlassian.net/browse/PP-11594)

### Note: 
This is a rework of original pull request [#4143](https://github.com/alphagov/pay-selfservice/pull/4143). Mainly to make clearer the commits relating to this change as previously, due to rebasing and merge commits,  they were spread amongst other unrelated changes.

Also, this PR addresses comments from that review.

## HOW 

- Extend existing ‘isDigitalWalletsSuported’ test for ‘Stripe’ and ‘Worldpay’ accounts to include ‘sandbox’ accounts
- Add feature flag ‘ALLOW_ENABLING_DIGITAL_WALLETS_FOR_SANDBOX_ACCOUNT’ as part of test condition
- Add unit tests for all sandbox feature flag states


