### PR TITLE
PP 11877 Validate date range entry on the transaction search page

### DIFF
--- a/app/controllers/all-service-transactions/get.controller.js
+++ b/app/controllers/all-service-transactions/get.controller.js
@@ -40,7 +40,7 @@ module.exports = async function getTransactionsForAllServices (req, res, next) {
     const searchResultOutput = await transactionService.search(userPermittedAccountsSummary.gatewayAccountIds, filters.result)
     const cardTypes = await client.getAllCardTypes()
     const downloadRoute = filterLiveAccounts ? paths.allServiceTransactions.download : paths.formattedPathFor(paths.allServiceTransactions.downloadStatusFilter, 'test')
-    const model = buildPaymentList(searchResultOutput, cardTypes, null, filters.result, downloadRoute, req.session.backPath)
+    const model = buildPaymentList(searchResultOutput, cardTypes, null, filters.result,filters.dateRangeState, downloadRoute, req.session.backPath)
     delete req.session.backPath
     model.search_path = filterLiveAccounts ? paths.allServiceTransactions.index : paths.formattedPathFor(paths.allServiceTransactions.indexStatusFilter, 'test')
     model.filtersDescription = describeFilters(filters.result)

--- a/app/controllers/all-service-transactions/get.controller.test.js
+++ b/app/controllers/all-service-transactions/get.controller.test.js
@@ -6,6 +6,7 @@ const gatewayAccountFixture = require('../../../test/fixtures/gateway-account.fi
 const Service = require('../../models/Service.class')
 const serviceFixtures = require('../../../test/fixtures/service.fixtures')
 const ledgerTransactionFixture = require('../../../test/fixtures/ledger-transaction.fixtures')
+const {expect} = require("chai");
 
 describe('All service transactions - GET', () => {
   let req, res, next
@@ -50,6 +51,37 @@ describe('All service transactions - GET', () => {
 
       sinon.assert.calledWith(allDisplayStateSelectorObjectsMock, true)
       sinon.assert.called(res.render)
+    })
+  })
+
+  describe('Error results when from date is later than to date', () => {
+    const request = {
+      account: gatewayAccountFixture.validGatewayAccount({ 'payment_provider': 'stripe' }),
+      service: service,
+      user: user,
+      params: {},
+      query: {
+        fromDate: '03/5/2018',
+        fromTime: '01:00:00',
+        toDate: '01/5/2018',
+        toTime: '01:00:00'
+      },
+      url: 'http://selfservice/all-servce-transactions',
+      session: {}
+    }
+    const response = {
+      render: sinon.spy()
+    }
+
+    it('should return the response with the date-range failing validation with empty transaction results indicator', async () => {
+      await getController()(request, response, next)
+
+      sinon.assert.called(response.render)
+      expect(response.render.firstCall.args[0]).to.equal('transactions/index')
+      expect(response.render.firstCall.args[1].hasResults).to.equal(false)
+      expect(response.render.firstCall.args[1].isInvalidDateRange).to.equal(true)
+      expect(response.render.firstCall.args[1].fromDateParam).to.equal('03/5/2018')
+      expect(response.render.firstCall.args[1].toDateParam).to.equal('01/5/2018')
     })
   })
 

--- a/app/controllers/all-service-transactions/get.controller.test.js
+++ b/app/controllers/all-service-transactions/get.controller.test.js
@@ -75,7 +75,7 @@ describe('All service transactions - GET', () => {
     it('should return the response with the date-range failing validation with empty transaction results indicator', async () => {
       await getController()(request, response, next)
 
-      sinon.assert.calledWith(response.render,'transactions/index',response.render.firstCall.args[1])
+      sinon.assert.calledWith(response.render,'transactions/index')
     })
   })
 

--- a/app/controllers/all-service-transactions/get.controller.test.js
+++ b/app/controllers/all-service-transactions/get.controller.test.js
@@ -76,12 +76,7 @@ describe('All service transactions - GET', () => {
     it('should return the response with the date-range failing validation with empty transaction results indicator', async () => {
       await getController()(request, response, next)
 
-      sinon.assert.called(response.render)
-      expect(response.render.firstCall.args[0]).to.equal('transactions/index')
-      expect(response.render.firstCall.args[1].hasResults).to.equal(false)
-      expect(response.render.firstCall.args[1].isInvalidDateRange).to.equal(true)
-      expect(response.render.firstCall.args[1].fromDateParam).to.equal('03/5/2018')
-      expect(response.render.firstCall.args[1].toDateParam).to.equal('01/5/2018')
+      sinon.assert.calledWith(response.render,'transactions/index',response.render.firstCall.args[1])
     })
   })
 

--- a/app/controllers/all-service-transactions/get.controller.test.js
+++ b/app/controllers/all-service-transactions/get.controller.test.js
@@ -75,7 +75,12 @@ describe('All service transactions - GET', () => {
     it('should return the response with the date-range failing validation with empty transaction results indicator', async () => {
       await getController()(request, response, next)
 
-      sinon.assert.calledWith(response.render,'transactions/index')
+      sinon.assert.calledWith(response.render,'transactions/index',sinon.match({
+        'isInvalidDateRange': true,
+        'hasResults': false,
+        'fromDateParam': "03/5/2018",
+        'toDateParam': "01/5/2018",
+      }))
     })
   })
 

--- a/app/controllers/all-service-transactions/get.controller.test.js
+++ b/app/controllers/all-service-transactions/get.controller.test.js
@@ -6,7 +6,6 @@ const gatewayAccountFixture = require('../../../test/fixtures/gateway-account.fi
 const Service = require('../../models/Service.class')
 const serviceFixtures = require('../../../test/fixtures/service.fixtures')
 const ledgerTransactionFixture = require('../../../test/fixtures/ledger-transaction.fixtures')
-const {expect} = require("chai");
 
 describe('All service transactions - GET', () => {
   let req, res, next

--- a/app/controllers/transactions/transaction-list.controller.it.test.js
+++ b/app/controllers/transactions/transaction-list.controller.it.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const sinon = require('sinon')
-const { expect } = require('chai')
 const paths = require('../../paths')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const { validGatewayAccountResponse } = require('../../../test/fixtures/gateway-account.fixtures')

--- a/app/controllers/transactions/transaction-list.controller.it.test.js
+++ b/app/controllers/transactions/transaction-list.controller.it.test.js
@@ -1,10 +1,18 @@
 'use strict'
 
 const sinon = require('sinon')
+const { expect } = require('chai')
 const paths = require('../../paths')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const { validGatewayAccountResponse } = require('../../../test/fixtures/gateway-account.fixtures')
 const transactionListController = require('./transaction-list.controller')
+const proxyquire = require("proxyquire");
+const ledgerTransactionFixture = require("../../../test/fixtures/ledger-transaction.fixtures");
+const gatewayAccountFixture = require("../../../test/fixtures/gateway-account.fixtures");
+const Service = require("../../models/Service.class");
+const serviceFixtures = require("../../../test/fixtures/service.fixtures");
+const User = require("../../models/User.class");
+const userFixtures = require("../../../test/fixtures/user.fixtures");
 
 // Setup
 const gatewayAccountId = '651342'
@@ -13,6 +21,8 @@ const requestId = 'unique-request-id'
 const headers = { 'x-request-id': requestId }
 
 describe('The /transactions endpoint', () => {
+  const transactionSearchResponse = ledgerTransactionFixture.validTransactionSearchResponse(
+      { transactions: [] })
   const account = validGatewayAccountResponse(
     {
       external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,
@@ -21,6 +31,9 @@ describe('The /transactions endpoint', () => {
       credentials: { 'username': 'a-username' }
     }
   )
+  const service = new Service(serviceFixtures.validServiceResponse({}))
+  const user = new User(userFixtures.validUserResponse())
+
   const req = {
     account,
     headers,
@@ -45,6 +58,35 @@ describe('The /transactions endpoint', () => {
     })
   })
 
+  describe('Error results when from date is later than to date', () => {
+    const request = {
+      account: gatewayAccountFixture.validGatewayAccount({ 'payment_provider': 'stripe' }),
+      service: service,
+      user: user,
+      query: {
+        fromDate: '03/5/2018',
+        fromTime: '01:00:00',
+        toDate: '01/5/2018',
+        toTime: '01:00:00'
+      },
+      url: 'http://selfservice/servce-transactions',
+      session: {}
+    }
+    const response = {
+      render: sinon.spy()
+    }
+    it('should return the response with the date-range failing validation with empty transaction results indicator', async () => {
+      await getController()(request, response, next)
+
+      sinon.assert.called(response.render)
+      expect(response.render.firstCall.args[0]).to.equal('transactions/index')
+      expect(response.render.firstCall.args[1].hasResults).to.equal(false)
+      expect(response.render.firstCall.args[1].isInvalidDateRange).to.equal(true)
+      expect(response.render.firstCall.args[1].fromDateParam).to.equal('03/5/2018')
+      expect(response.render.firstCall.args[1].toDateParam).to.equal('01/5/2018')
+    })
+  })
+
   describe('Pagination', () => {
     it('should return return error if page out of bounds', async () => {
       const reqWithInvalidPage = {
@@ -61,7 +103,7 @@ describe('The /transactions endpoint', () => {
       sinon.assert.calledWith(next, expectedError)
     })
 
-    it('should return return error if pageSize out of bounds 1', async () => {
+    it('should return error if pageSize out of bounds 1', async () => {
       const reqWithInvalidPageSize = {
         ...req,
         query: {
@@ -76,7 +118,7 @@ describe('The /transactions endpoint', () => {
       sinon.assert.calledWith(next, expectedError)
     })
 
-    it('should return return error if pageSize out of bounds 2', async () => {
+    it('should return error if pageSize out of bounds 2', async () => {
       const reqWithInvalidPageSize = {
         ...req,
         query: {
@@ -91,4 +133,16 @@ describe('The /transactions endpoint', () => {
       sinon.assert.calledWith(next, expectedError)
     })
   })
+
+  function getController () {
+    return proxyquire('./transaction-list.controller', {
+      '../../services/transaction.service': {
+        search: sinon.spy(() => Promise.resolve(transactionSearchResponse))
+      },
+      '../../services/clients/connector.client.js': {
+        ConnectorClient: class {async getAllCardTypes () { return {} }}
+      }
+    })
+  }
+
 })

--- a/app/controllers/transactions/transaction-list.controller.it.test.js
+++ b/app/controllers/transactions/transaction-list.controller.it.test.js
@@ -78,12 +78,7 @@ describe('The /transactions endpoint', () => {
     it('should return the response with the date-range failing validation with empty transaction results indicator', async () => {
       await getController()(request, response, next)
 
-      sinon.assert.called(response.render)
-      expect(response.render.firstCall.args[0]).to.equal('transactions/index')
-      expect(response.render.firstCall.args[1].hasResults).to.equal(false)
-      expect(response.render.firstCall.args[1].isInvalidDateRange).to.equal(true)
-      expect(response.render.firstCall.args[1].fromDateParam).to.equal('03/5/2018')
-      expect(response.render.firstCall.args[1].toDateParam).to.equal('01/5/2018')
+      sinon.assert.calledWith(response.render,'transactions/index',response.render.firstCall.args[1])
     })
   })
 

--- a/app/controllers/transactions/transaction-list.controller.it.test.js
+++ b/app/controllers/transactions/transaction-list.controller.it.test.js
@@ -77,7 +77,12 @@ describe('The /transactions endpoint', () => {
     it('should return the response with the date-range failing validation with empty transaction results indicator', async () => {
       await getController()(request, response, next)
 
-      sinon.assert.calledWith(response.render,'transactions/index')
+      sinon.assert.calledWith(response.render,'transactions/index',sinon.match({
+        'isInvalidDateRange': true,
+        'hasResults': false,
+        'fromDateParam': "03/5/2018",
+        'toDateParam': "01/5/2018",
+    }))
     })
   })
 

--- a/app/controllers/transactions/transaction-list.controller.it.test.js
+++ b/app/controllers/transactions/transaction-list.controller.it.test.js
@@ -77,7 +77,7 @@ describe('The /transactions endpoint', () => {
     it('should return the response with the date-range failing validation with empty transaction results indicator', async () => {
       await getController()(request, response, next)
 
-      sinon.assert.calledWith(response.render,'transactions/index',response.render.firstCall.args[1])
+      sinon.assert.calledWith(response.render,'transactions/index')
     })
   })
 

--- a/app/controllers/transactions/transaction-list.controller.js
+++ b/app/controllers/transactions/transaction-list.controller.js
@@ -16,16 +16,8 @@ const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 module.exports = async function showTransactionList (req, res, next) {
   const accountId = req.account.gateway_account_id
   const gatewayAccountExternalId = req.account.external_id
-
   const filters = getFilters(req)
-
-  req.session.filters = url.parse(req.url).query
-
-  if (!filters.valid) {
-    return next(new Error('Invalid search'))
-  }
-
-  let noTransactionSearchResults = {
+  const EMPTY_TRANSACTION_SEARCH_RESULTS = {
     total: 0,
     count: 0,
     page: 1,
@@ -33,9 +25,15 @@ module.exports = async function showTransactionList (req, res, next) {
     _links: {},
     filters: {},
   }
+  req.session.filters = url.parse(req.url).query
+
+  if (!filters.valid) {
+    return next(new Error('Invalid search'))
+  }
+
   let result
   let transactionSearchResults = (filters.dateRangeState.isInvalidDateRange) ?
-      noTransactionSearchResults : transactionService.search([accountId], filters.result)
+      EMPTY_TRANSACTION_SEARCH_RESULTS : transactionService.search([accountId], filters.result)
   try {
       result = await Promise.all([ transactionSearchResults, client.getAllCardTypes() ])
   } catch (error) {

--- a/app/controllers/transactions/transaction-list.controller.js
+++ b/app/controllers/transactions/transaction-list.controller.js
@@ -21,22 +21,26 @@ module.exports = async function showTransactionList (req, res, next) {
 
   req.session.filters = url.parse(req.url).query
 
-  // This ssort of error handling may not be appropriate
-  //if (!filters.dateRangeState.validDateRange) {
-  //  console.log('You have entered an invalid date range')
-  //  return next(new Error('You have entered an invalid date range'))
-  //}
-
   if (!filters.valid) {
     return next(new Error('Invalid search'))
   }
 
+  let noTransactionSearchResults = {
+    total: 0,
+    count: 0,
+    page: 1,
+    results: [],
+    _links: {},
+    filters: {},
+  }
   let result
+
   try {
-    result = await Promise.all([
-      transactionService.search([accountId], filters.result),
-      client.getAllCardTypes()
-    ])
+      result = await Promise.all([
+        (filters.dateRangeState.isInvalidDateRange) ?
+          noTransactionSearchResults : transactionService.search([accountId], filters.result) ,
+        client.getAllCardTypes()
+      ])
   } catch (error) {
     return next(error)
   }

--- a/app/controllers/transactions/transaction-list.controller.js
+++ b/app/controllers/transactions/transaction-list.controller.js
@@ -21,6 +21,12 @@ module.exports = async function showTransactionList (req, res, next) {
 
   req.session.filters = url.parse(req.url).query
 
+  // This ssort of error handling may not be appropriate
+  //if (!filters.dateRangeState.validDateRange) {
+  //  console.log('You have entered an invalid date range')
+  //  return next(new Error('You have entered an invalid date range'))
+  //}
+
   if (!filters.valid) {
     return next(new Error('Invalid search'))
   }
@@ -36,7 +42,7 @@ module.exports = async function showTransactionList (req, res, next) {
   }
 
   const transactionsDownloadLink = formatAccountPathsFor(router.paths.account.transactions.download, req.account.external_id)
-  const model = buildPaymentList(result[0], result[1], gatewayAccountExternalId, filters.result, transactionsDownloadLink)
+  const model = buildPaymentList(result[0], result[1], gatewayAccountExternalId, filters.result, filters.dateRangeState, transactionsDownloadLink)
   model.search_path = formatAccountPathsFor(router.paths.account.transactions.index, req.account.external_id)
   model.filtersDescription = describeFilters(filters.result)
 

--- a/app/controllers/transactions/transaction-list.controller.js
+++ b/app/controllers/transactions/transaction-list.controller.js
@@ -34,13 +34,10 @@ module.exports = async function showTransactionList (req, res, next) {
     filters: {},
   }
   let result
-
+  let transactionSearchResults = (filters.dateRangeState.isInvalidDateRange) ?
+      noTransactionSearchResults : transactionService.search([accountId], filters.result)
   try {
-      result = await Promise.all([
-        (filters.dateRangeState.isInvalidDateRange) ?
-          noTransactionSearchResults : transactionService.search([accountId], filters.result) ,
-        client.getAllCardTypes()
-      ])
+      result = await Promise.all([ transactionSearchResults, client.getAllCardTypes() ])
   } catch (error) {
     return next(error)
   }

--- a/app/utils/filters.js
+++ b/app/utils/filters.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const qs = require('qs')
+const moment = require('moment-timezone')
 const check = require('check-types')
 const Paginator = require('../utils/paginator.js')
 const states = require('../utils/states')
@@ -25,16 +26,14 @@ function trimFilterValues (filters) {
 }
 
 function validateDateRange(filters){
-  var fromDate = new Date(filters.fromDate).getTime()
-  var toDate = new Date(filters.toDate).getTime()
-  var isValid = false
+  let result = moment(filters.fromDate, 'DD/MM/YYYY').isAfter(moment(filters.toDate, 'DD/MM/YYYY'))? 1: -1;
+  var isInvalid = false
 
-   if (fromDate < toDate) {
-    isValid = true
+   if (result == 1) {
+     isInvalid = true
    }
-
    return {
-    validDateRange: isValid,
+    isInvalidDateRange: isInvalid,
     fromDateParam: filters.fromDate,
     toDateParam: filters.toDate
   }

--- a/app/utils/filters.js
+++ b/app/utils/filters.js
@@ -29,7 +29,7 @@ function validateDateRange(filters){
   let result = moment(filters.fromDate, 'DD/MM/YYYY').isAfter(moment(filters.toDate, 'DD/MM/YYYY'))? 1: -1;
   var isInvalid = false
 
-   if (result == 1) {
+   if (result === 1) {
      isInvalid = true
    }
    return {

--- a/app/utils/filters.js
+++ b/app/utils/filters.js
@@ -91,5 +91,6 @@ function describeFilters (filters) {
 
 module.exports = {
   getFilters: getFilters,
-  describeFilters: describeFilters
+  describeFilters: describeFilters,
+  validateDateRange: validateDateRange
 }

--- a/app/utils/filters.js
+++ b/app/utils/filters.js
@@ -26,8 +26,8 @@ function trimFilterValues (filters) {
 }
 
 function validateDateRange(filters){
-  let result = moment(filters.fromDate, 'DD/MM/YYYY').isAfter(moment(filters.toDate, 'DD/MM/YYYY'))? 1: -1;
-  var isInvalid = false
+  const result = moment(filters.fromDate, 'DD/MM/YYYY').isAfter(moment(filters.toDate, 'DD/MM/YYYY'))? 1: -1;
+  let isInvalid = false
 
    if (result === 1) {
      isInvalid = true

--- a/app/utils/filters.js
+++ b/app/utils/filters.js
@@ -24,6 +24,22 @@ function trimFilterValues (filters) {
   return filters
 }
 
+function validateDateRange(filters){
+  var fromDate = new Date(filters.fromDate).getTime()
+  var toDate = new Date(filters.toDate).getTime()
+  var isValid = false
+
+   if (fromDate < toDate) {
+    isValid = true
+   }
+
+   return {
+    validDateRange: isValid,
+    fromDateParam: filters.fromDate,
+    toDateParam: filters.toDate
+  }
+}
+
 function getFilters (req) {
   let filters = trimFilterValues(qs.parse(req.query))
   filters.selectedStates = []
@@ -41,6 +57,7 @@ function getFilters (req) {
 
   filters = _.omitBy(filters, _.isEmpty)
   return {
+    dateRangeState: validateDateRange(filters),
     valid: validateFilters(filters),
     result: filters
   }

--- a/app/utils/filters.test.js
+++ b/app/utils/filters.test.js
@@ -79,5 +79,18 @@ describe('filters', () => {
         expect(result.trim()).to.equal('from <strong>from-date</strong> to <strong>to-date</strong>')
       })
     })
+
+    describe('validateDateRange', () => {
+      it('should validate the date range filter and return an array with the result and the associated from and to date', function () {
+        const testFilter = {
+          fromDate: '03/03/2023',
+          toDate: '01/03/2023'
+        }
+        const result = filters.validateDateRange(testFilter)
+        expect(result.isInvalidDateRange).to.equal(true)
+        expect(result.fromDateParam).to.equal('03/03/2023')
+        expect(result.toDateParam).to.equal('01/03/2023')
+      })
+    })
   })
 })

--- a/app/utils/transaction-view.js
+++ b/app/utils/transaction-view.js
@@ -27,15 +27,18 @@ module.exports = {
     connectorData.total = connectorData.total || (connectorData.results && connectorData.results.length)
     connectorData.totalOverLimit = connectorData.total > LEDGER_TRANSACTION_COUNT_LIMIT
     connectorData.showCsvDownload = showCsvDownload(connectorData, filtersResult)
-    connectorData.isInvalidDateRange = filtersDateRangeState.isInvalidDateRange === true
-    connectorData.fromDateParam = filtersDateRangeState.fromDateParam
-    connectorData.toDateParam = filtersDateRangeState.toDateParam
     connectorData.totalFormatted = connectorData.total.toLocaleString()
     connectorData.maxLimitFormatted = parseInt(LEDGER_TRANSACTION_COUNT_LIMIT).toLocaleString()
     connectorData.paginationLinks = getPaginationLinks(connectorData)
     connectorData.hasPaginationLinks = !!getPaginationLinks(connectorData)
     connectorData.hasPageSizeLinks = hasPageSizeLinks(connectorData)
     connectorData.pageSizeLinks = getPageSizeLinks(connectorData)
+
+    if(filtersDateRangeState){
+      connectorData.isInvalidDateRange = filtersDateRangeState.isInvalidDateRange === true
+      connectorData.fromDateParam = filtersDateRangeState.fromDateParam
+      connectorData.toDateParam = filtersDateRangeState.toDateParam
+    }
 
     connectorData.cardBrands = lodash.uniqBy(allCards.card_types, 'brand')
       .map(card => {

--- a/app/utils/transaction-view.js
+++ b/app/utils/transaction-view.js
@@ -20,13 +20,14 @@ const LEDGER_TRANSACTION_COUNT_LIMIT = 5000
 
 module.exports = {
   /** prepares the transaction list view */
-  buildPaymentList: function (connectorData, allCards, gatewayAccountExternalId, filtersResult, route, backPath) {
+  buildPaymentList: function (connectorData, allCards, gatewayAccountExternalId, filtersResult, filtersDateRangeState, route, backPath) {
     connectorData.filters = filtersResult
     connectorData.hasFilters = Object.keys(filtersResult).length !== 0
     connectorData.hasResults = connectorData.results.length !== 0
     connectorData.total = connectorData.total || (connectorData.results && connectorData.results.length)
     connectorData.totalOverLimit = connectorData.total > LEDGER_TRANSACTION_COUNT_LIMIT
     connectorData.showCsvDownload = showCsvDownload(connectorData, filtersResult)
+    connectorData.filtersDateRangeState = filtersDateRangeState
     connectorData.totalFormatted = connectorData.total.toLocaleString()
     connectorData.maxLimitFormatted = parseInt(LEDGER_TRANSACTION_COUNT_LIMIT).toLocaleString()
     connectorData.paginationLinks = getPaginationLinks(connectorData)

--- a/app/utils/transaction-view.js
+++ b/app/utils/transaction-view.js
@@ -27,12 +27,13 @@ module.exports = {
     connectorData.total = connectorData.total || (connectorData.results && connectorData.results.length)
     connectorData.totalOverLimit = connectorData.total > LEDGER_TRANSACTION_COUNT_LIMIT
     connectorData.showCsvDownload = showCsvDownload(connectorData, filtersResult)
-    connectorData.filtersDateRangeState = filtersDateRangeState
+    connectorData.isInvalidDateRange = filtersDateRangeState.isInvalidDateRange === true
+    connectorData.fromDateParam = filtersDateRangeState.fromDateParam
+    connectorData.toDateParam = filtersDateRangeState.toDateParam
     connectorData.totalFormatted = connectorData.total.toLocaleString()
     connectorData.maxLimitFormatted = parseInt(LEDGER_TRANSACTION_COUNT_LIMIT).toLocaleString()
     connectorData.paginationLinks = getPaginationLinks(connectorData)
     connectorData.hasPaginationLinks = !!getPaginationLinks(connectorData)
-
     connectorData.hasPageSizeLinks = hasPageSizeLinks(connectorData)
     connectorData.pageSizeLinks = getPageSizeLinks(connectorData)
 

--- a/app/views/transactions/index.njk
+++ b/app/views/transactions/index.njk
@@ -65,7 +65,11 @@
 
   {% include "transactions/display-size.njk" %}
 
-  <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-top-3" id="total-results">
+  {% if (isInvalidDateRange) %}
+      <p class="govuk-body" id="invalid-date-range">End date must be after start date</p>
+      <p class="govuk-body" id="invalid-date-range">The from date entered is <strong>{{fromDateParam}}</strong> and the to date entered is <strong>{{toDateParam}}</strong> </p>
+   {% else %}
+    <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-top-3" id="total-results">
     {% if totalOverLimit %}
       Over {{maxLimitFormatted}} transactions
     {% else %}
@@ -73,6 +77,7 @@
     {% endif %}
     {{ filtersDescription | safe }}
   </h3>
+  {% endif %}
 
   {% if allServiceTransactions or permissions.transactions_download_read %}
 
@@ -92,11 +97,6 @@
   {% include "transactions/paginator.njk" %}
 
   {% include "transactions/list.njk" %}
-        
-  {% if (!filtersDateRangeState.isValid) %}
-      <p class="govuk-body" id="invalid-date-range">You have entered an invalid date range, the from date must be earlier than the to date.</p>
-      <p class="govuk-body" id="invalid-date-range">The from date entered is {{showInvalidDateRangeError.fromDateParam}} and the to date entered is {{showInvalidDateRangeError.toDateParam}} </p>
-  {% endif %}
 
   {% include "transactions/paginator.njk" %}
 </div>

--- a/app/views/transactions/index.njk
+++ b/app/views/transactions/index.njk
@@ -66,8 +66,8 @@
   {% include "transactions/display-size.njk" %}
 
   {% if (isInvalidDateRange) %}
-      <p class="govuk-body" id="invalid-date-range">End date must be after start date</p>
-      <p class="govuk-body" id="invalid-date-range">The from date entered is <strong>{{fromDateParam}}</strong> and the to date entered is <strong>{{toDateParam}}</strong> </p>
+      <p class="govuk-body" id="invalid-date-range-1">End date must be after start date</p>
+      <p class="govuk-body" id="invalid-date-range-2">The from date entered is <span class="govuk-body govuk-!-font-weight-bold">{{fromDateParam}}</span> and the to date entered is <span class="govuk-body govuk-!-font-weight-bold">{{toDateParam}}</span> </p>
    {% else %}
     <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-top-3" id="total-results">
     {% if totalOverLimit %}

--- a/app/views/transactions/index.njk
+++ b/app/views/transactions/index.njk
@@ -65,19 +65,19 @@
 
   {% include "transactions/display-size.njk" %}
 
+  <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-top-3" id="total-results">
   {% if (isInvalidDateRange) %}
-      <p class="govuk-body" id="invalid-date-range-1">End date must be after start date</p>
-      <p class="govuk-body" id="invalid-date-range-2">The from date entered is <span class="govuk-body govuk-!-font-weight-bold">{{fromDateParam}}</span> and the to date entered is <span class="govuk-body govuk-!-font-weight-bold">{{toDateParam}}</span> </p>
+      <p> End date must be after start date </p>
+      <p> The from date entered is <span class="govuk-body govuk-!-font-weight-bold">{{fromDateParam}}</span> and the to date entered is <span class="govuk-body govuk-!-font-weight-bold">{{toDateParam}}</span></p>
    {% else %}
-    <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-top-3" id="total-results">
     {% if totalOverLimit %}
       Over {{maxLimitFormatted}} transactions
     {% else %}
       {{totalFormatted}} transactions
     {% endif %}
     {{ filtersDescription | safe }}
-  </h3>
   {% endif %}
+  </h3>
 
   {% if allServiceTransactions or permissions.transactions_download_read %}
 

--- a/app/views/transactions/index.njk
+++ b/app/views/transactions/index.njk
@@ -92,6 +92,11 @@
   {% include "transactions/paginator.njk" %}
 
   {% include "transactions/list.njk" %}
+        
+  {% if (!filtersDateRangeState.isValid) %}
+      <p class="govuk-body" id="invalid-date-range">You have entered an invalid date range, the from date must be earlier than the to date.</p>
+      <p class="govuk-body" id="invalid-date-range">The from date entered is {{showInvalidDateRangeError.fromDateParam}} and the to date entered is {{showInvalidDateRangeError.toDateParam}} </p>
+  {% endif %}
 
   {% include "transactions/paginator.njk" %}
 </div>

--- a/app/views/transactions/list.njk
+++ b/app/views/transactions/list.njk
@@ -51,5 +51,8 @@
   </tbody>
 </table>
 {% else %}
-  <p class="govuk-body" id="no-results">There are no results for the filters you used.</p>
+   {% if (isInvalidDateRange) %}
+     {% else %}
+     <p class="govuk-body" id="no-results">There are no results for the filters you used.</p>
+  {% endif %}
 {% endif %}

--- a/app/views/transactions/list.njk
+++ b/app/views/transactions/list.njk
@@ -51,8 +51,10 @@
   </tbody>
 </table>
 {% else %}
-   {% if (isInvalidDateRange) %}
-     {% else %}
+  {% if not isInvalidDateRange %}
      <p class="govuk-body" id="no-results">There are no results for the filters you used.</p>
   {% endif %}
 {% endif %}
+
+
+

--- a/test/cypress/integration/transactions/transaction-search.cy.js
+++ b/test/cypress/integration/transactions/transaction-search.cy.js
@@ -335,7 +335,7 @@ describe('Transactions List', () => {
         'test@example.org', '–£15.00', 'Visa', 'Refund submitted')
     })
 
-    it('should be display error message when searching with from date later than to date', () => {
+    it('should display error message when searching with from date later than to date', () => {
       cy.task('setupStubs', [
         ...sharedStubs(),
         transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions }),
@@ -350,46 +350,33 @@ describe('Transactions List', () => {
       ])
       cy.visit(transactionsUrl)
 
-      // 1. Filtering FROM
-      // Ensure both the date/time pickers aren't showing
       cy.get('.datepicker').should('not.exist')
       cy.get('.ui-timepicker-wrapper').should('not.exist')
 
-      // Fill in a from date
       cy.get('#fromDate').type('03/5/2018')
 
-      // Ensure only the datepicker is showing
       cy.get('.datepicker').should('be.visible')
       cy.get('.ui-timepicker-wrapper').should('not.exist')
 
-      // Fill in a from time
       cy.get('#fromTime').type('01:00:00')
 
-      // Ensure only the timepicker is showing
       cy.get('.datepicker').should('not.exist')
       cy.get('.ui-timepicker-wrapper').should('be.visible')
 
-      // Fill in the to date
       cy.get('#toDate').type('02/5/2018')
 
-      // Ensure only the datepicker is showing
       cy.get('.datepicker').should('be.visible')
       cy.get('.ui-timepicker-wrapper').should('not.be.visible')
 
-      // Fill in the to time
       cy.get('#toTime').type('01:00:00')
 
-      // Ensure only the timepicker is showing
       cy.get('.datepicker').should('not.exist')
       cy.get('.ui-timepicker-wrapper').should('be.visible')
 
-      // Click the filter button
       cy.get('#filter').click()
 
-      // Ensure that transaction list is not displayed
       cy.get('#transactions-list tbody').should('not.exist')
 
-      // Ensure a filter failed validation message is displayed
       cy.get('h3').contains('End date must be after start date' )
     })
   })


### PR DESCRIPTION
## WHAT
When searching for transactions in SelfService between two dates, if the start date entered is later than the end date, no transactions are listed. 
We should be rendering an error here to show the user the input mistake and how to rectify it.
This fix is done on both the transactions and the all transactions search pages 

## HOW 
Test all existing filter combinations as well as the new date range validation 

