### PR TITLE
PP-12039 Bump axios to 1.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@sentry/node": "6.12.0",
         "accessible-autocomplete": "2.0.4",
         "aws-sdk": "2.1440.0",
-        "axios": "^1.6.0",
+        "axios": "^1.6.4",
         "body-parser": "1.20.2",
         "change-case": "3.1.0",
         "check-types": "11.2.x",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@sentry/node": "6.12.0",
     "accessible-autocomplete": "2.0.4",
     "aws-sdk": "2.1440.0",
-    "axios": "^1.6.0",
+    "axios": "^1.6.4",
     "body-parser": "1.20.2",
     "change-case": "3.1.0",
     "check-types": "11.2.x",


### PR DESCRIPTION
## WHAT
- Bump axios to the latest version which includes updates to vulnerable indirect dependencies (follow_redirects, formToJSON) https://github.com/axios/axios/releases/tag/v1.6.4