### PR TITLE
PP-12098 Add robots noindex and nofollow to meta tag

### DIFF
--- a/app/views/includes/head.njk
+++ b/app/views/includes/head.njk
@@ -1,5 +1,6 @@
 <link href="{{ css_path }}" media="all" rel="stylesheet" />
 <meta name="Description" content="Take and process online payments from your users - GOV.UK Pay is a free and secure online payment service for government and public sector organisations." />
+<meta name="robots" content="noindex, nofollow">
 
 <!-- Google Analytics -->
 <script>


### PR DESCRIPTION
## WHAT
We want stop our sign in page from appearing in search engine results, so that citizens are less likely to navigate to [GOV.UK](http://gov.uk/) Pay and contact support about their PIP accounts.

## HOW 
The following meta tag has been added to the head.njk template.
`<meta name="robots" content="noindex, nofollow">`
