### PR TITLE
[DO NOT MERGE] PP-12180 Add new crown logo and bump govuk-frontend

### DIFF
--- a/app/views/includes/header.njk
+++ b/app/views/includes/header.njk
@@ -61,6 +61,7 @@ govuk-width-container govuk-header__container--{{accountType}}
     homepageUrl: "/",
     containerClasses: payHeaderClasses,
     productName: "Pay",
-    navigation: payHeaderNavigation
+    navigation: payHeaderNavigation,
+    useTudorCrown: true
   })
 }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "csurf": "^1.11.0",
         "express": "4.18.x",
         "google-libphonenumber": "3.2.33",
-        "govuk-frontend": "^4.7.0",
+        "govuk-frontend": "^4.8.0",
         "http-proxy": "1.18.x",
         "https-proxy-agent": "5.0.1",
         "joi": "17.12.1",
@@ -7840,9 +7840,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -23593,9 +23593,9 @@
       "integrity": "sha512-1QKCvAlfq8zY1mviORI9lDzM3I/hwm9+h0CwYBTLq59DBbSHMd5zBOLqHZFiBLicRpwIz46Nynvbywj1XApKvA=="
     },
     "govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "csurf": "^1.11.0",
     "express": "4.18.x",
     "google-libphonenumber": "3.2.33",
-    "govuk-frontend": "^4.7.0",
+    "govuk-frontend": "^4.8.0",
     "http-proxy": "1.18.x",
     "https-proxy-agent": "5.0.1",
     "joi": "17.12.1",


### PR DESCRIPTION
    - Bump govuk-frontend to 4.8 so we have access to
      the crown logo.
    - Enable setting to use the tutor cronw as per design
      system instructions GOV.UK Design system:
      https://github.com/alphagov/govuk-frontend/releases/tag/v4.8.0
    - Do not merge this until we get approval from the
      #govuk-logo-crown-change team.
    - Which should be on Mon 19th Feb.

