### PR TITLE
PP-10608: Correcting the number of days in transaction queries.

### DIFF
--- a/app/controllers/all-service-transactions/get.controller.js
+++ b/app/controllers/all-service-transactions/get.controller.js
@@ -40,7 +40,7 @@ module.exports = async function getTransactionsForAllServices (req, res, next) {
     const searchResultOutput = await transactionService.search(userPermittedAccountsSummary.gatewayAccountIds, filters.result)
     const cardTypes = await client.getAllCardTypes()
     const downloadRoute = filterLiveAccounts ? paths.allServiceTransactions.download : paths.formattedPathFor(paths.allServiceTransactions.downloadStatusFilter, 'test')
-    const model = buildPaymentList(searchResultOutput, cardTypes, null, filters.result,filters.dateRangeState, downloadRoute, req.session.backPath)
+    const model = buildPaymentList(searchResultOutput, cardTypes, null, filters.result, filters.dateRangeState, downloadRoute, req.session.backPath)
     delete req.session.backPath
     model.search_path = filterLiveAccounts ? paths.allServiceTransactions.index : paths.formattedPathFor(paths.allServiceTransactions.indexStatusFilter, 'test')
     model.filtersDescription = describeFilters(filters.result)

--- a/app/controllers/all-service-transactions/get.controller.test.js
+++ b/app/controllers/all-service-transactions/get.controller.test.js
@@ -75,11 +75,11 @@ describe('All service transactions - GET', () => {
     it('should return the response with the date-range failing validation with empty transaction results indicator', async () => {
       await getController()(request, response, next)
 
-      sinon.assert.calledWith(response.render,'transactions/index',sinon.match({
+      sinon.assert.calledWith(response.render, 'transactions/index', sinon.match({
         'isInvalidDateRange': true,
         'hasResults': false,
-        'fromDateParam': "03/5/2018",
-        'toDateParam': "01/5/2018",
+        'fromDateParam': '03/5/2018',
+        'toDateParam': '01/5/2018'
       }))
     })
   })

--- a/app/controllers/dashboard/dashboard-activity.controller.js
+++ b/app/controllers/dashboard/dashboard-activity.controller.js
@@ -184,10 +184,10 @@ function getTransactionDateRange (period) {
       daysAgo = 1
       break
     case 'previous-seven-days':
-      daysAgo = 8 // 7+1 because we count starting from yesterday
+      daysAgo = 7
       break
     case 'previous-thirty-days':
-      daysAgo = 31 // 30+1 because we count starting from yesterday
+      daysAgo = 30
       break
   }
 

--- a/app/controllers/transactions/transaction-list.controller.it.test.js
+++ b/app/controllers/transactions/transaction-list.controller.it.test.js
@@ -5,13 +5,13 @@ const paths = require('../../paths')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const { validGatewayAccountResponse } = require('../../../test/fixtures/gateway-account.fixtures')
 const transactionListController = require('./transaction-list.controller')
-const proxyquire = require("proxyquire");
-const ledgerTransactionFixture = require("../../../test/fixtures/ledger-transaction.fixtures");
-const gatewayAccountFixture = require("../../../test/fixtures/gateway-account.fixtures");
-const Service = require("../../models/Service.class");
-const serviceFixtures = require("../../../test/fixtures/service.fixtures");
-const User = require("../../models/User.class");
-const userFixtures = require("../../../test/fixtures/user.fixtures");
+const proxyquire = require('proxyquire')
+const ledgerTransactionFixture = require('../../../test/fixtures/ledger-transaction.fixtures')
+const gatewayAccountFixture = require('../../../test/fixtures/gateway-account.fixtures')
+const Service = require('../../models/Service.class')
+const serviceFixtures = require('../../../test/fixtures/service.fixtures')
+const User = require('../../models/User.class')
+const userFixtures = require('../../../test/fixtures/user.fixtures')
 
 // Setup
 const gatewayAccountId = '651342'
@@ -21,7 +21,7 @@ const headers = { 'x-request-id': requestId }
 
 describe('The /transactions endpoint', () => {
   const transactionSearchResponse = ledgerTransactionFixture.validTransactionSearchResponse(
-      { transactions: [] })
+    { transactions: [] })
   const account = validGatewayAccountResponse(
     {
       external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,
@@ -77,12 +77,12 @@ describe('The /transactions endpoint', () => {
     it('should return the response with the date-range failing validation with empty transaction results indicator', async () => {
       await getController()(request, response, next)
 
-      sinon.assert.calledWith(response.render,'transactions/index',sinon.match({
+      sinon.assert.calledWith(response.render, 'transactions/index', sinon.match({
         'isInvalidDateRange': true,
         'hasResults': false,
-        'fromDateParam': "03/5/2018",
-        'toDateParam': "01/5/2018",
-    }))
+        'fromDateParam': '03/5/2018',
+        'toDateParam': '01/5/2018'
+      }))
     })
   })
 
@@ -143,5 +143,4 @@ describe('The /transactions endpoint', () => {
       }
     })
   }
-
 })

--- a/app/controllers/transactions/transaction-list.controller.js
+++ b/app/controllers/transactions/transaction-list.controller.js
@@ -23,7 +23,7 @@ module.exports = async function showTransactionList (req, res, next) {
     page: 1,
     results: [],
     _links: {},
-    filters: {},
+    filters: {}
   }
   req.session.filters = url.parse(req.url).query
 
@@ -32,10 +32,10 @@ module.exports = async function showTransactionList (req, res, next) {
   }
 
   let result
-  let transactionSearchResults = (filters.dateRangeState.isInvalidDateRange) ?
-      EMPTY_TRANSACTION_SEARCH_RESULTS : transactionService.search([accountId], filters.result)
+  let transactionSearchResults = (filters.dateRangeState.isInvalidDateRange)
+    ? EMPTY_TRANSACTION_SEARCH_RESULTS : transactionService.search([accountId], filters.result)
   try {
-      result = await Promise.all([ transactionSearchResults, client.getAllCardTypes() ])
+    result = await Promise.all([ transactionSearchResults, client.getAllCardTypes() ])
   } catch (error) {
     return next(error)
   }

--- a/app/utils/filters.js
+++ b/app/utils/filters.js
@@ -25,14 +25,14 @@ function trimFilterValues (filters) {
   return filters
 }
 
-function validateDateRange(filters){
-  const result = moment(filters.fromDate, 'DD/MM/YYYY').isAfter(moment(filters.toDate, 'DD/MM/YYYY'))? 1: -1;
+function validateDateRange (filters) {
+  const result = moment(filters.fromDate, 'DD/MM/YYYY').isAfter(moment(filters.toDate, 'DD/MM/YYYY')) ? 1 : -1
   let isInvalid = false
 
-   if (result === 1) {
-     isInvalid = true
-   }
-   return {
+  if (result === 1) {
+    isInvalid = true
+  }
+  return {
     isInvalidDateRange: isInvalid,
     fromDateParam: filters.fromDate,
     toDateParam: filters.toDate

--- a/app/utils/transaction-view.js
+++ b/app/utils/transaction-view.js
@@ -34,7 +34,7 @@ module.exports = {
     connectorData.hasPageSizeLinks = hasPageSizeLinks(connectorData)
     connectorData.pageSizeLinks = getPageSizeLinks(connectorData)
 
-    if(filtersDateRangeState){
+    if (filtersDateRangeState) {
       connectorData.isInvalidDateRange = filtersDateRangeState.isInvalidDateRange === true
       connectorData.fromDateParam = filtersDateRangeState.fromDateParam
       connectorData.toDateParam = filtersDateRangeState.toDateParam

--- a/test/cypress/integration/dashboard/dashboard-statistics.cy.js
+++ b/test/cypress/integration/dashboard/dashboard-statistics.cy.js
@@ -19,7 +19,7 @@ describe('Account dashboard', () => {
         refundTotal: 2300
       })
     const prevSevenDaysStatisticsStub = transactionsSummaryStubs.getDashboardStatisticsWithFromDate(
-      moment().subtract(8, 'days').tz('Europe/London').startOf('day').format(),
+      moment().subtract(7, 'days').tz('Europe/London').startOf('day').format(),
       {
         paymentCount: 50,
         paymentTotal: 70000,

--- a/test/integration/dashboard/dashboard-activity.controller.ft.test.js
+++ b/test/integration/dashboard/dashboard-activity.controller.ft.test.js
@@ -291,7 +291,7 @@ describe('dashboard-activity-controller', () => {
         nock(LEDGER_URL)
           .get('/v1/report/transactions-summary')
           .query(obj => {
-            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(8, 'days').format()
+            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(7, 'days').format()
           })
           .reply(200, DASHBOARD_RESPONSE)
 
@@ -325,7 +325,7 @@ describe('dashboard-activity-controller', () => {
 
       it('it should print the time period in the summary box', () => {
         expect($('.dashboard-total-explainer').text())
-          .to.contain(moment().tz('Europe/London').startOf('day').subtract(8, 'days').format('D MMMM YYYY h:mm:ssa z'))
+          .to.contain(moment().tz('Europe/London').startOf('day').subtract(7, 'days').format('D MMMM YYYY h:mm:ssa z'))
       })
     })
     describe('and the period is set to previous 30 days', () => {
@@ -344,7 +344,7 @@ describe('dashboard-activity-controller', () => {
         nock(LEDGER_URL)
           .get('/v1/report/transactions-summary')
           .query(obj => {
-            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(31, 'days').format()
+            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(30, 'days').format()
           })
           .reply(200, DASHBOARD_RESPONSE)
 
@@ -378,7 +378,7 @@ describe('dashboard-activity-controller', () => {
 
       it('it should print the time period in the summary box', () => {
         expect($('.dashboard-total-explainer').text())
-          .to.contain(moment().tz('Europe/London').startOf('day').subtract(31, 'days').format('D MMMM YYYY h:mm:ssa z'))
+          .to.contain(moment().tz('Europe/London').startOf('day').subtract(30, 'days').format('D MMMM YYYY h:mm:ssa z'))
       })
     })
   })


### PR DESCRIPTION
## WHAT
As described in PP-10608 the number of days searched on the dashboard is currently out by one.  It was intentionally written (with comments describing it) but having looked deeper into it because of the use of midnight as the start of the period the extra day wasn't needed

## HOW 
On an account with transactions every day visit the dashboard and select "Previous 7 days" or "Previous 30 days", the query was previously showing a date range one day longer than requested for each of these categories.


