### PR TITLE
PP-12211: CodeQL config

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'app/**'
+      - 'test/**'
+  schedule:
+    # Weekly schedule
+    - cron: '43 7 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 360
+    permissions:
+      # required for CodeQL to raise security issues on the repo
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          fetch-depth: '0'
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@379614612a29c9e28f31f39a59013eb8012a51f0
+        with:
+          # CodeQL options: [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
+          languages: 'javascript-typescript'
+
+      - name: Parse Node version
+        id: parse-node-version
+        run: echo "nvmrc=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+      - name: Set up Node
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        with:
+          node-version: ${{ needs.version.outputs.node-version }}
+
+      - name: Install dependencies
+        run: npm ci
+      - name: Compile
+        run: npm run compile
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@379614612a29c9e28f31f39a59013eb8012a51f0
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
## WHAT
Adds CodeQL config file, to exclude non-Javascript files from scans.

This will reduce noise on e.g. Docker and package.json Dependabot PRs, where CodeQL can't find any Javascript to scan.

I've used updated SHA pins for v4 of actions/checkout and actions/setup-node, to remove deprecation warnings. These SHAs have been added to the repo settings.

