### PR TITLE
PP-12295 Add new Stripe terms and conditions page

### DIFF
--- a/app/controllers/stripeTermsAndConditions.controller.js
+++ b/app/controllers/stripeTermsAndConditions.controller.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const { response } = require('../utils/response')
+
+module.exports.get = function (req, res) {
+  return response(req, res, 'policy/stripe-terms-and-conditions/stripe-terms-and-conditions')
+}

--- a/app/controllers/stripeTermsAndConditions.controller.test.js
+++ b/app/controllers/stripeTermsAndConditions.controller.test.js
@@ -1,0 +1,14 @@
+const controller = require('./stripeTermsAndConditions.controller')
+const sinon = require('sinon')
+
+const req = {}
+const res = {
+  render: sinon.spy()
+}
+
+describe('Stripe terms and conditions controller', function () {
+  it('should render page', function () {
+    controller.get(req, res)
+    sinon.assert.calledWith(res.render, 'policy/stripe-terms-and-conditions/stripe-terms-and-conditions')
+  })
+})

--- a/app/paths.js
+++ b/app/paths.js
@@ -254,6 +254,7 @@ module.exports = {
   feedback: '/feedback',
   generateRoute: generateRoute,
   formattedPathFor: formattedPathFor,
+  stripeTermsAndConditions: '/policy/stripe-terms-and-conditions',
   policyPage: '/policy/:key',
   payouts: {
     list: '/payments-to-your-bank-account',

--- a/app/routes.js
+++ b/app/routes.js
@@ -62,6 +62,7 @@ const requestToGoLiveOrganisationAddressController = require('./controllers/requ
 const requestToGoLiveChooseHowToProcessPaymentsController = require('./controllers/request-to-go-live/choose-how-to-process-payments')
 const requestToGoLiveChooseTakesPaymentsOverPhoneController = require('./controllers/request-to-go-live/choose-takes-payments-over-phone')
 const requestToGoLiveAgreementController = require('./controllers/request-to-go-live/agreement')
+const stripeTermsAndConditionsController = require('./controllers/stripeTermsAndConditions.controller.js')
 const policyDocumentsController = require('./controllers/policy')
 const stripeSetupBankDetailsController = require('./controllers/stripe-setup/bank-details')
 const stripeSetupCheckOrgDetailsController = require('./controllers/stripe-setup/check-org-details')
@@ -94,6 +95,7 @@ const {
   demoPaymentFwd,
   index,
   invite,
+  stripeTermsAndConditions,
   policyPage,
   payouts,
   register,
@@ -237,6 +239,9 @@ module.exports.bind = function (app) {
   // Payouts
   app.get(payouts.list, userIsAuthorised, payoutsController.listAllServicesPayouts)
   app.get(payouts.listStatusFilter, userIsAuthorised, payoutsController.listAllServicesPayouts)
+
+  // Stripe terms and conditions
+  app.get(stripeTermsAndConditions, userIsAuthorised, stripeTermsAndConditionsController.get)
 
   // Policy document downloads
   app.get(policyPage, userIsAuthorised, policyDocumentsController.get)

--- a/app/utils/display-converter.js
+++ b/app/utils/display-converter.js
@@ -17,7 +17,8 @@ const hideServiceHeaderTemplates = [
   'policy/document/stripe-connected-account-agreement',
   'policy/document/v2/contract-for-non-crown-bodies',
   'policy/document/v2/memorandum-of-understanding-for-crown-bodies',
-  'policy/document/v2/stripe-connected-account-agreement'
+  'policy/document/v2/stripe-connected-account-agreement',
+  'policy/stripe-terms-and-conditions/stripe-terms-and-conditions'
 ]
 
 const hideServiceNavTemplates = [

--- a/app/views/policy/stripe-terms-and-conditions/stripe-terms-and-conditions.njk
+++ b/app/views/policy/stripe-terms-and-conditions/stripe-terms-and-conditions.njk
@@ -1,0 +1,27 @@
+{% extends "../../layout.njk" %}
+
+{% block pageTitle %}
+   Stripe terms and conditions - GOV.UK Pay
+{% endblock %}
+
+
+{% block mainContent %}
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Stripe terms and conditions
+    </h1>
+
+    <p class="govuk-body">
+      Last updated: 15 Dec 2023
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        <a class="govuk-link" href="https://stripe.com/gb/legal/connect-account">Stripe Connected Account Agreement</a>
+      </li>
+      <li>
+        <a class="govuk-link" href="https://stripe.com/gb/legal/ssa">Stripe services agreement</a>
+      </li>
+    </ul>
+  </div>
+{% endblock %}


### PR DESCRIPTION
- This page will contain the latest Stripe terms and conditons.
- This page will be on a brand new URL: /policy/stripe-terms-and-conditions
- Intend to put this live but hidden from real users.
  - This will allow the team to review the content and request updates.
  - We expect there to be some late edits as we are working with the legal team to finalise the content.
- This page is implemented differently from the other /policy/ pages:
  - The other pages generate a 1 hour link to a policy PDF file and follow a specific page layout.
  - This new page will look different and we need to release it quickly.
  - Making this work with the existing code would have required too much effort.
  - Therefore, this was implemented differently as a static page - which is quicker to implement without affecting the existing policy pages.



