### PR TITLE
PP-12237 Fix permissive regex

### DIFF
--- a/app/utils/validation/server-side-form-validations.js
+++ b/app/utils/validation/server-side-form-validations.js
@@ -113,7 +113,7 @@ function validatePostcode (postcode, countryCode) {
     return validReturnObject
   }
 
-  if (!/^[A-z0-9 ]+$/.test(postcode)) {
+  if (!/^[A-Za-z0-9 ]+$/.test(postcode)) {
     return notValidReturnObject('Enter a real postcode')
   }
 

--- a/app/utils/validation/server-side-form-validations.test.js
+++ b/app/utils/validation/server-side-form-validations.test.js
@@ -154,6 +154,13 @@ describe('Server side form validations', () => {
       })
     })
 
+    it('should not be valid when postcode is UK postcode with ^ character', () => {
+      expect(validations.validatePostcode('NW1^ 5GH')).to.deep.equal({
+        valid: false,
+        message: 'Enter a real postcode'
+      })
+    })
+
     it('should not be valid when postcode is not UK postcode and country not provided', () => {
       expect(validations.validatePostcode('CA90210')).to.deep.equal({
         valid: false,


### PR DESCRIPTION
Code QL flagged that the `A-z` in the regex was a "Suspicious character range that is equivalent to [A-Z\[\\]^_`a-z]."


