### PR TITLE
PP-11681 Encode URL when making axios call

### DIFF
--- a/app/services/clients/base/config.js
+++ b/app/services/clients/base/config.js
@@ -27,7 +27,7 @@ function onFailureResponse (context) {
 }
 
 function configureClient (client, baseUrl) {
-  client.configure(baseUrl, {
+  client.configure(encodeURI(baseUrl), {
     transformRequestAddHeaders,
     onRequestStart,
     onSuccessResponse,

--- a/app/services/clients/base/config.test.js
+++ b/app/services/clients/base/config.test.js
@@ -87,4 +87,34 @@ describe('Client config', () => {
       })
     })
   })
+
+  describe('Encoding URI', () => {
+    it('should encode URI', async () => {
+      const client = new Client(app)
+      const config = getConfigWithMocks('abc123')
+      const baseUrl = 'http://localhost:8000'
+
+      nock(baseUrl)
+      .get('/x?y=z%20z')
+      .reply(200)
+
+      const url = `${baseUrl}/x?y=z z`
+      config.configureClient(client, url)
+
+      const response = await client.get(url, 'do something', {
+        additionalLoggingFields: { foo: 'bar' }
+      })
+
+      expect(response.status).to.equal(200)
+      expect(response.request.path).to.equal('/x?y=z%20z')
+
+      sinon.assert.calledWith(logInfoSpy, 'Calling an-app to do something', {
+        service: app,
+        method: 'get',
+        url: 'http://localhost:8000/x?y=z z',
+        description: 'do something',
+        foo: 'bar'
+      })
+    })
+  })
 })

--- a/test/pact/adminusers-client/invite/get-invite.pact.test.js
+++ b/test/pact/adminusers-client/invite/get-invite.pact.test.js
@@ -61,4 +61,36 @@ describe('adminusers client - get an invite', function () {
       }).should.notify(done)
     })
   })
+
+  describe('success with encoded URI', () => {
+    const inviteCode = 'an- invite- code'
+    const encInviteCode = 'an-%20invite-%20code'
+
+
+    const getInviteResponse = inviteFixtures.validInviteResponse({
+      telephone_number: '0123456789'
+    })
+
+    before((done) => {
+      provider.addInteraction(
+        new PactInteractionBuilder(`${INVITES_PATH}/${encInviteCode}`)
+          .withState('a valid invite to add a user to a service exists with invite code an- invite- code')
+          .withUponReceiving('a valid get invite request')
+          .withStatusCode(200)
+          .withResponseBody(pactify(getInviteResponse))
+          .build()
+      ).then(() => done())
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should find an invite successfully', function (done) {
+      adminUsersClient.getValidatedInvite(inviteCode).should.be.fulfilled.then(function (invite) {
+        expect(invite.email).to.be.equal(getInviteResponse.email)
+        expect(invite.telephone_number).to.be.equal(getInviteResponse.telephone_number)
+        expect(invite.is_invite_to_join_service).to.be.equal(getInviteResponse.is_invite_to_join_service)
+        expect(invite.password_set).to.be.equal(getInviteResponse.password_set)
+      }).should.notify(done)
+    })
+  })
 })

--- a/test/pact/adminusers-client/invite/get-invite.pact.test.js
+++ b/test/pact/adminusers-client/invite/get-invite.pact.test.js
@@ -61,36 +61,4 @@ describe('adminusers client - get an invite', function () {
       }).should.notify(done)
     })
   })
-
-  describe('success with encoded URI', () => {
-    const inviteCode = 'an- invite- code'
-    const encInviteCode = 'an-%20invite-%20code'
-
-
-    const getInviteResponse = inviteFixtures.validInviteResponse({
-      telephone_number: '0123456789'
-    })
-
-    before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${INVITES_PATH}/${encInviteCode}`)
-          .withState('a valid invite to add a user to a service exists with invite code an- invite- code')
-          .withUponReceiving('a valid get invite request')
-          .withStatusCode(200)
-          .withResponseBody(pactify(getInviteResponse))
-          .build()
-      ).then(() => done())
-    })
-
-    afterEach(() => provider.verify())
-
-    it('should find an invite successfully', function (done) {
-      adminUsersClient.getValidatedInvite(inviteCode).should.be.fulfilled.then(function (invite) {
-        expect(invite.email).to.be.equal(getInviteResponse.email)
-        expect(invite.telephone_number).to.be.equal(getInviteResponse.telephone_number)
-        expect(invite.is_invite_to_join_service).to.be.equal(getInviteResponse.is_invite_to_join_service)
-        expect(invite.password_set).to.be.equal(getInviteResponse.password_set)
-      }).should.notify(done)
-    })
-  })
 })


### PR DESCRIPTION
## WHAT
When configuring `axios-base-client` call, encode the url passed in.
## HOW

- Amend `configureClient` function to encode url passed in from client code issuing axios call.
- Amend unit test to cover change.



