### PR TITLE
Put examples on one line

### DIFF
--- a/app/views/payment-links/index.njk
+++ b/app/views/payment-links/index.njk
@@ -37,10 +37,8 @@
   <h2 class="govuk-heading-m">What to call your link</h2>
   <p class="govuk-body">Make sure the payment link name describes exactly what the user is paying for, and can be
     understood out of context. Use plain language and spell out acronyms in the description if necessary.</p>
-  <p class="govuk-body">Bad:</p>
-  <p class="govuk-body">R1</p>
-  <p class="govuk-body">Good:</p>
-  <p class="govuk-body">Pay for your registration on the Register of Overseas Entities (R1)</p>
+  <p class="govuk-body">Bad: R1</p>
+  <p class="govuk-body">Good: Pay for your registration on the Register of Overseas Entities (R1)</p>
 
   {{ govukButton({
       text: "Create a payment link",


### PR DESCRIPTION
Reformat text putting the examples of good and bad titles on one line rather than 2