### PR TITLE
PP-12510 Specify format for transaction summary dates

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -354,7 +354,7 @@
         "filename": "test/cypress/integration/dashboard/dashboard-statistics.cy.js",
         "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
         "is_verified": false,
-        "line_number": 7
+        "line_number": 9
       }
     ],
     "test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.js": [
@@ -903,5 +903,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-20T13:39:41Z"
+  "generated_at": "2024-04-02T09:53:32Z"
 }

--- a/app/controllers/dashboard/dashboard-activity.controller.js
+++ b/app/controllers/dashboard/dashboard-activity.controller.js
@@ -174,9 +174,10 @@ module.exports = async (req, res) => {
 }
 
 function getTransactionDateRange (period) {
+  const dateTimeFormat = 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'
   const toDateTime = period === 'today'
-    ? moment().tz('Europe/London').format()
-    : moment().tz('Europe/London').startOf('day').format()
+    ? moment().tz('Europe/London').format(dateTimeFormat)
+    : moment().tz('Europe/London').startOf('day').format(dateTimeFormat)
   let daysAgo = 0
 
   switch (period) {
@@ -191,7 +192,7 @@ function getTransactionDateRange (period) {
       break
   }
 
-  const fromDateTime = moment().tz('Europe/London').startOf('day').subtract(daysAgo, 'days').format()
+  const fromDateTime = moment().tz('Europe/London').startOf('day').subtract(daysAgo, 'days').format(dateTimeFormat)
 
   return { fromDateTime, toDateTime }
 }

--- a/test/cypress/integration/dashboard/dashboard-statistics.cy.js
+++ b/test/cypress/integration/dashboard/dashboard-statistics.cy.js
@@ -3,6 +3,8 @@ const userStubs = require('../../stubs/user-stubs')
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 const transactionsSummaryStubs = require('../../stubs/transaction-summary-stubs')
 
+const dateTimeFormat = 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'
+
 describe('Account dashboard', () => {
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
   const gatewayAccountId = '42'
@@ -11,7 +13,7 @@ describe('Account dashboard', () => {
 
   beforeEach(() => {
     const todayStatisticsStub = transactionsSummaryStubs.getDashboardStatisticsWithFromDate(
-      moment().tz('Europe/London').startOf('day').format(),
+      moment().tz('Europe/London').startOf('day').format(dateTimeFormat),
       {
         paymentCount: 10,
         paymentTotal: 12000,
@@ -19,7 +21,7 @@ describe('Account dashboard', () => {
         refundTotal: 2300
       })
     const prevSevenDaysStatisticsStub = transactionsSummaryStubs.getDashboardStatisticsWithFromDate(
-      moment().subtract(7, 'days').tz('Europe/London').startOf('day').format(),
+      moment().subtract(7, 'days').tz('Europe/London').startOf('day').format(dateTimeFormat),
       {
         paymentCount: 50,
         paymentTotal: 70000,

--- a/test/integration/dashboard/dashboard-activity.controller.ft.test.js
+++ b/test/integration/dashboard/dashboard-activity.controller.ft.test.js
@@ -29,6 +29,7 @@ const DASHBOARD_RESPONSE = {
   net_income: 44000
 }
 const dashboardPath = `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/dashboard`
+const dateTimeFormat = 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'
 let app
 
 const mockConnectorGetGatewayAccount = (paymentProvider, type) => {
@@ -86,7 +87,7 @@ const mockLedgerGetTransactionsSummary = () => {
   nock(LEDGER_URL)
     .get('/v1/report/transactions-summary')
     .query(obj => {
-      return obj.from_date === moment().tz('Europe/London').startOf('day').format()
+      return obj.from_date === moment().tz('Europe/London').startOf('day').format(dateTimeFormat)
     })
     .reply(200)
 }
@@ -109,7 +110,7 @@ describe('dashboard-activity-controller', () => {
         nock(LEDGER_URL)
           .get('/v1/report/transactions-summary')
           .query(obj => {
-            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(0, 'days').format()
+            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(0, 'days').format(dateTimeFormat)
           })
           .reply(200, DASHBOARD_RESPONSE)
 
@@ -166,7 +167,7 @@ describe('dashboard-activity-controller', () => {
 
       it('it should print the time period in the summary box', () => {
         expect($('.dashboard-total-explainer').text())
-          .to.contain(moment().tz('Europe/London').startOf('day').subtract(0, 'days').format('D MMMM YYYY h:mm:ssa z'))
+          .to.contain(moment().utc().startOf('day').tz('Europe/London').format('D MMMM YYYY h:mm:ssa z'))
       })
     })
     describe('and the period is set to today explicitly', () => {
@@ -185,7 +186,7 @@ describe('dashboard-activity-controller', () => {
         nock(LEDGER_URL)
           .get('/v1/report/transactions-summary')
           .query(obj => {
-            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(0, 'days').format()
+            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(0, 'days').format(dateTimeFormat)
           })
           .reply(200, DASHBOARD_RESPONSE)
 
@@ -219,7 +220,7 @@ describe('dashboard-activity-controller', () => {
 
       it('it should print the time period in the summary box', () => {
         expect($('.dashboard-total-explainer').text())
-          .to.contain(moment().tz('Europe/London').startOf('day').format('D MMMM YYYY h:mm:ssa z'))
+          .to.contain(moment().utc().startOf('day').tz('Europe/London').format('D MMMM YYYY h:mm:ssa z'))
       })
     })
     describe('and the period is set to yesterday', () => {
@@ -238,7 +239,7 @@ describe('dashboard-activity-controller', () => {
         nock(LEDGER_URL)
           .get('/v1/report/transactions-summary')
           .query(obj => {
-            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(1, 'days').format()
+            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(1, 'days').format(dateTimeFormat)
           })
           .reply(200, DASHBOARD_RESPONSE)
 
@@ -272,7 +273,7 @@ describe('dashboard-activity-controller', () => {
 
       it('it should print the time period in the summary box', () => {
         expect($('.dashboard-total-explainer').text())
-          .to.contain(moment().tz('Europe/London').startOf('day').subtract(1, 'days').format('D MMMM YYYY h:mm:ssa z'))
+          .to.contain(moment().utc().startOf('day').tz('Europe/London').subtract(1, 'days').format('D MMMM YYYY h:mm:ssa z'))
       })
     })
     describe('and the period is set to previous 7 days', () => {
@@ -291,7 +292,7 @@ describe('dashboard-activity-controller', () => {
         nock(LEDGER_URL)
           .get('/v1/report/transactions-summary')
           .query(obj => {
-            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(7, 'days').format()
+            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(7, 'days').format(dateTimeFormat)
           })
           .reply(200, DASHBOARD_RESPONSE)
 
@@ -344,7 +345,7 @@ describe('dashboard-activity-controller', () => {
         nock(LEDGER_URL)
           .get('/v1/report/transactions-summary')
           .query(obj => {
-            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(30, 'days').format()
+            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(30, 'days').format(dateTimeFormat)
           })
           .reply(200, DASHBOARD_RESPONSE)
 
@@ -399,7 +400,7 @@ describe('dashboard-activity-controller', () => {
         nock(LEDGER_URL)
           .get('/v1/report/transactions-summary')
           .query(obj => {
-            return obj.from_date === moment().tz('Europe/London').startOf('day').format()
+            return obj.from_date === moment().tz('Europe/London').startOf('day').format(dateTimeFormat)
           })
           .reply(404)
 


### PR DESCRIPTION
## WHAT
- We don't specify a date format for `moment` which is returning dates in the format `2024-04-02T00:00:00+01:00` for transaction summary reporting causing Ledger to return an error. 
- Updated the date format to the one expected by the ledger transaction summary endpoint. The change will return date as `2024-04-02T00:00:00.000Z`
