### PR TITLE
PP-12100 Allow users to apply filters to their transaction search if it times out

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -330,6 +330,15 @@
         "line_number": 7
       }
     ],
+    "test/cypress/integration/all-service-transactions/all-service-transactions-no-autosearch.cy.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/all-service-transactions/all-service-transactions-no-autosearch.cy.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
     "test/cypress/integration/dashboard/dashboard-disabled-account-banner.cy.js": [
       {
         "type": "Hex High Entropy String",
@@ -903,5 +912,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-08T21:15:15Z"
+  "generated_at": "2024-04-10T15:39:24Z"
 }

--- a/app/controllers/all-service-transactions/all-service-transactions-no-autosearch.controller.js
+++ b/app/controllers/all-service-transactions/all-service-transactions-no-autosearch.controller.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const { response } = require('../../utils/response')
+const { populateModel } = require('./populateModel')
+const { getFilters } = require('../../utils/filters')
+const permissions = require('../../utils/permissions')
+
+module.exports = async function getTransactionsForAllServicesNoSearch (req, res, next) {
+  const filters = getFilters(req)
+  const { statusFilter } = req.params
+  const filterLiveAccounts = statusFilter !== 'test'
+  const userPermittedAccountsSummary = await permissions.getGatewayAccountsFor(req.user, filterLiveAccounts, 'transactions:read')
+  const model = await populateModel(req, { results: [] }, filters, null, filterLiveAccounts, userPermittedAccountsSummary);
+  model.allServicesTimeout = true
+  try {
+    return response(req, res, 'transactions/index', model)
+  } catch (err) {
+    next(new Error('Unable to fetch transaction information'))
+  }
+}

--- a/app/controllers/all-service-transactions/get.controller.js
+++ b/app/controllers/all-service-transactions/get.controller.js
@@ -1,19 +1,16 @@
 'use strict'
 
-const _ = require('lodash')
 const url = require('url')
 
 const { response } = require('../../utils/response')
-const { ConnectorClient } = require('../../services/clients/connector.client.js')
 const transactionService = require('../../services/transaction.service')
-const { buildPaymentList } = require('../../utils/transaction-view.js')
 const permissions = require('../../utils/permissions')
-const { getFilters, describeFilters } = require('../../utils/filters.js')
+const { getFilters } = require('../../utils/filters.js')
 const paths = require('../../paths')
-const states = require('../../utils/states')
-const client = new ConnectorClient(process.env.CONNECTOR_URL)
+
 const logger = require('../../utils/logger')(__filename)
 const { NoServicesWithPermissionError } = require('../../errors')
+const { populateModel } = require('./populateModel.js')
 
 module.exports = async function getTransactionsForAllServices (req, res, next) {
   const filters = getFilters(req)
@@ -22,9 +19,9 @@ module.exports = async function getTransactionsForAllServices (req, res, next) {
   // default behaviour should be live
   const { statusFilter } = req.params
   const filterLiveAccounts = statusFilter !== 'test'
-
   req.session.filters = url.parse(req.url).query
   req.session.allServicesTransactionsStatusFilter = statusFilter
+
   try {
     const userPermittedAccountsSummary = await permissions.getGatewayAccountsFor(req.user, filterLiveAccounts, 'transactions:read')
 
@@ -37,39 +34,16 @@ module.exports = async function getTransactionsForAllServices (req, res, next) {
     if (!userPermittedAccountsSummary.gatewayAccountIds.length) {
       return next(new NoServicesWithPermissionError('You do not have any associated services with rights to view these transactions.'))
     }
-    const searchResultOutput = await transactionService.search(userPermittedAccountsSummary.gatewayAccountIds, filters.result)
-    const cardTypes = await client.getAllCardTypes()
-    const downloadRoute = filterLiveAccounts ? paths.allServiceTransactions.download : paths.formattedPathFor(paths.allServiceTransactions.downloadStatusFilter, 'test')
-    const model = buildPaymentList(searchResultOutput, cardTypes, null, filters.result, filters.dateRangeState, downloadRoute, req.session.backPath)
-    delete req.session.backPath
-    model.search_path = filterLiveAccounts ? paths.allServiceTransactions.index : paths.formattedPathFor(paths.allServiceTransactions.indexStatusFilter, 'test')
-    model.filtersDescription = describeFilters(filters.result)
-    model.eventStates = states.allDisplayStateSelectorObjects(userPermittedAccountsSummary.hasStripeAccount)
-      .map(state => {
-        return {
-          value: state.key,
-          text: state.name,
-          selected: filters.result.selectedStates && filters.result.selectedStates.includes(state.name)
-        }
-      })
-    model.eventStates.unshift({ value: '', text: 'Any', selected: false })
 
-    model.stateFiltersFriendly = model.eventStates
-      .filter(state => state.selected)
-      .map(state => state.text)
-      .join(', ')
-    if (_.has(filters.result, 'brand')) {
-      model.cardBrands.forEach(brand => {
-        brand.selected = filters.result.brand.includes(brand.value)
-      })
+    let searchResultOutput
+    try {
+      searchResultOutput = await transactionService.search(userPermittedAccountsSummary.gatewayAccountIds, filters.result, true)
+    } catch (error) {
+      return next(error)
     }
-    model.clearRedirect = model.search_path
-    model.isStripeAccount = userPermittedAccountsSummary.headers.shouldGetStripeHeaders
-    model.allServiceTransactions = true
-    model.filterLiveAccounts = filterLiveAccounts
-    model.hasLiveAccounts = userPermittedAccountsSummary.hasLiveAccounts
-    model.recurringEnabled = userPermittedAccountsSummary.hasRecurringAccount
-    model.isExperimentalFeaturesEnabled = req.user.serviceRoles.some(serviceRole => serviceRole.service.experimentalFeaturesEnabled)
+
+    const downloadRoute = filterLiveAccounts ? paths.allServiceTransactions.download : paths.formattedPathFor(paths.allServiceTransactions.downloadStatusFilter, 'test')
+    const model = await populateModel(req, searchResultOutput, filters, downloadRoute, filterLiveAccounts, userPermittedAccountsSummary)
 
     return response(req, res, 'transactions/index', model)
   } catch (err) {

--- a/app/controllers/all-service-transactions/index.js
+++ b/app/controllers/all-service-transactions/index.js
@@ -2,8 +2,10 @@
 
 const getController = require('./get.controller')
 const downloadTransactions = require('./download-transactions.controller')
+const noAutosearchTransactions = require('./all-service-transactions-no-autosearch.controller')
 
 module.exports = {
   getController,
-  downloadTransactions
+  downloadTransactions,
+  noAutosearchTransactions
 }

--- a/app/controllers/all-service-transactions/populateModel.js
+++ b/app/controllers/all-service-transactions/populateModel.js
@@ -1,0 +1,47 @@
+const { buildPaymentList } = require('../../utils/transaction-view')
+const paths = require('../../paths')
+const { describeFilters } = require('../../utils/filters')
+const states = require('../../utils/states')
+const _ = require('lodash')
+const { ConnectorClient } = require('../../services/clients/connector.client')
+const client = new ConnectorClient(process.env.CONNECTOR_URL)
+
+async function populateModel (req, searchResultOutput, filters, downloadRoute, filterLiveAccounts, userPermittedAccountsSummary) {
+  const cardTypes = await client.getAllCardTypes()
+  const model = buildPaymentList(searchResultOutput, cardTypes, null, filters.result, filters.dateRangeState, downloadRoute, req.session.backPath)
+  delete req.session.backPath
+  model.search_path = filterLiveAccounts ? paths.allServiceTransactions.index : paths.formattedPathFor(paths.allServiceTransactions.indexStatusFilter, 'test')
+  model.filtersDescription = describeFilters(filters.result)
+  model.eventStates = states.allDisplayStateSelectorObjects(userPermittedAccountsSummary.hasStripeAccount)
+    .map(state => {
+      return {
+        value: state.key,
+        text: state.name,
+        selected: filters.result.selectedStates && filters.result.selectedStates.includes(state.name)
+      }
+    })
+  model.eventStates.unshift({ value: '', text: 'Any', selected: false })
+
+  model.stateFiltersFriendly = model.eventStates
+    .filter(state => state.selected)
+    .map(state => state.text)
+    .join(', ')
+
+  if (_.has(filters.result, 'brand')) {
+    model.cardBrands.forEach(brand => {
+      brand.selected = filters.result.brand.includes(brand.value)
+    })
+  }
+
+  model.clearRedirect = model.search_path
+  model.isStripeAccount = userPermittedAccountsSummary.headers.shouldGetStripeHeaders
+  model.allServiceTransactions = true
+  model.filterLiveAccounts = filterLiveAccounts
+  model.hasLiveAccounts = userPermittedAccountsSummary.hasLiveAccounts
+  model.recurringEnabled = userPermittedAccountsSummary.hasRecurringAccount
+  model.isExperimentalFeaturesEnabled = req.user.serviceRoles.some(serviceRole => serviceRole.service.experimentalFeaturesEnabled)
+
+  return model
+}
+
+module.exports = { populateModel }

--- a/app/controllers/all-service-transactions/populateModel.test.js
+++ b/app/controllers/all-service-transactions/populateModel.test.js
@@ -1,0 +1,109 @@
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+const User = require('../../models/User.class')
+const userFixtures = require('../../../test/fixtures/user.fixtures')
+const gatewayAccountFixture = require('../../../test/fixtures/gateway-account.fixtures')
+const Service = require('../../models/Service.class')
+const serviceFixtures = require('../../../test/fixtures/service.fixtures')
+const { getFilters } = require('../../utils/filters.js')
+const { expect } = require('chai')
+
+describe('Populate Model', () => {
+  let req
+  let allDisplayStateSelectorObjectsMock
+  const user = new User(userFixtures.validUserResponse())
+  const service = new Service(serviceFixtures.validServiceResponse({}))
+
+  let userPermittedAccountsSummary = {
+    gatewayAccountIds: [31],
+    headers: { shouldGetStripeHeaders: true, shouldGetMotoHeaders: true },
+    hasLiveAccounts: false,
+    hasStripeAccount: true,
+    hasTestStripeAccount: false
+  }
+
+  beforeEach(() => {
+    req = {
+      account: gatewayAccountFixture.validGatewayAccount({ 'payment_provider': 'stripe' }),
+      flash: sinon.spy(),
+      service: service,
+      user: user,
+      params: {},
+      url: 'http://selfservice/all-service-transactions',
+      session: {},
+      headers: {
+        'x-request-id': 'correlation-id'
+      }
+    }
+    allDisplayStateSelectorObjectsMock = sinon.spy(() => ([{}]))
+  })
+
+  describe('Stripe account', () => {
+    it('should get dispute states', async () => {
+      const filters = getFilters(req)
+      const searchResultOutput = { results: [] }
+      const downloadRoute = 'download_route'
+      const filterLiveAccounts = true
+      await populateModel()(req, searchResultOutput, filters, downloadRoute, filterLiveAccounts, userPermittedAccountsSummary)
+
+      sinon.assert.calledWith(allDisplayStateSelectorObjectsMock, true)
+    })
+  })
+
+  describe('Non stripe account', () => {
+    it('should NOT get dispute states', async () => {
+      req.params.statusFilter = 'test'
+      const filters = getFilters(req)
+      const searchResultOutput = { results: [] }
+      const downloadRoute = 'download_route'
+      const filterLiveAccounts = true
+      userPermittedAccountsSummary.hasStripeAccount = false
+      await populateModel()(req, searchResultOutput, filters, downloadRoute, filterLiveAccounts, userPermittedAccountsSummary)
+      sinon.assert.calledWith(allDisplayStateSelectorObjectsMock, false)
+    })
+  })
+
+  describe('Error results when from date is later than to date', () => {
+    const invalidDatesReq = {
+      account: gatewayAccountFixture.validGatewayAccount({ 'payment_provider': 'stripe' }),
+      service: service,
+      user: user,
+      params: {},
+      query: {
+        fromDate: '03/5/2018',
+        fromTime: '01:00:00',
+        toDate: '01/5/2018',
+        toTime: '01:00:00'
+      },
+      url: 'http://selfservice/all-service-transactions',
+      session: {}
+    }
+
+    const filters = getFilters(invalidDatesReq)
+    const searchResultOutput = { results: [] }
+    const downloadRoute = 'download_route'
+    const filterLiveAccounts = true
+    userPermittedAccountsSummary.hasStripeAccount = true
+
+    it('should return a model including invalid date range', async () => {
+      const model = await populateModel()(req, searchResultOutput, filters, downloadRoute, filterLiveAccounts, userPermittedAccountsSummary)
+      expect(model).to.deep.include({
+        'isInvalidDateRange': true,
+        'hasResults': false,
+        'fromDateParam': '03/5/2018',
+        'toDateParam': '01/5/2018'
+      })
+    })
+  })
+
+  function populateModel () {
+    return proxyquire('./populateModel', {
+      '../../services/clients/connector.client.js': {
+        ConnectorClient: class {async getAllCardTypes () { return {} }}
+      },
+      '../../utils/states': {
+        allDisplayStateSelectorObjects: allDisplayStateSelectorObjectsMock
+      }
+    }).populateModel
+  }
+})

--- a/app/errors.js
+++ b/app/errors.js
@@ -27,6 +27,14 @@ class GatewayTimeoutError extends Error {
   }
 }
 
+class GatewayTimeoutForAllServicesSearchError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = this.constructor.name
+    Error.captureStackTrace(this, this.constructor)
+  }
+}
+
 /**
  * Thrown when there is no authentication session for the user.
  */
@@ -105,5 +113,6 @@ module.exports = {
   InvalidRegistationStateError,
   InvalidConfigurationError,
   ExpiredInviteError,
-  GatewayTimeoutError
+  GatewayTimeoutError,
+  GatewayTimeoutForAllServicesSearchError
 }

--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -16,7 +16,8 @@ const {
   InvalidConfigurationError,
   ExpiredInviteError,
   RESTClientError,
-  GatewayTimeoutError, GatewayTimeoutForAllServicesSearchError
+  GatewayTimeoutError,
+  GatewayTimeoutForAllServicesSearchError
 } = require('../errors')
 const paths = require('../paths')
 const { renderErrorView, response } = require('../utils/response')

--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -16,7 +16,7 @@ const {
   InvalidConfigurationError,
   ExpiredInviteError,
   RESTClientError,
-  GatewayTimeoutError
+  GatewayTimeoutError, GatewayTimeoutForAllServicesSearchError
 } = require('../errors')
 const paths = require('../paths')
 const { renderErrorView, response } = require('../utils/response')
@@ -84,6 +84,21 @@ module.exports = function errorHandler (err, req, res, next) {
   if (err instanceof GatewayTimeoutError) {
     logger.info('Gateway Time out Error occurred on Transactions Search Page. Rendering error page')
     return renderErrorView(req, res, err.message, 504)
+  }
+
+  if (err instanceof GatewayTimeoutForAllServicesSearchError) {
+    logger.info('Gateway Time out Error occurred on Transactions for All Services Search Page. Rendering error page')
+    let allServiceTransactionsNoSearchPath = paths.formattedPathFor(paths.allServiceTransactions.indexStatusFilterWithoutSearch, req.session.allServicesTransactionsStatusFilter)
+
+    const queryString = req.originalUrl.split('?')[1]
+    if (queryString) {
+      allServiceTransactionsNoSearchPath += '?' + queryString
+    }
+
+    return renderErrorView(req, res, err.message, 504, {
+      allServicesTimeout: true,
+      allServiceTransactionsNoSearchPath: allServiceTransactionsNoSearchPath
+    })
   }
 
   if (err instanceof RESTClientError) {

--- a/app/paths.js
+++ b/app/paths.js
@@ -200,6 +200,7 @@ module.exports = {
   allServiceTransactions: {
     index: '/all-service-transactions',
     indexStatusFilter: '/all-service-transactions/:statusFilter(test|live)',
+    indexStatusFilterWithoutSearch: '/all-service-transactions/nosearch/:statusFilter(test|live)',
     download: '/all-service-transactions/download',
     downloadStatusFilter: '/all-service-transactions/download/:statusFilter(test|live)',
     redirectDetail: '/redirect/transactions/:chargeId'

--- a/app/routes.js
+++ b/app/routes.js
@@ -229,6 +229,7 @@ module.exports.bind = function (app) {
   // All service transactions
   app.get(allServiceTransactions.index, userIsAuthorised, allTransactionsController.getController)
   app.get(allServiceTransactions.indexStatusFilter, userIsAuthorised, allTransactionsController.getController)
+  app.get(allServiceTransactions.indexStatusFilterWithoutSearch, userIsAuthorised, allTransactionsController.noAutosearchTransactions)
   app.get(allServiceTransactions.download, userIsAuthorised, allTransactionsController.downloadTransactions)
   app.get(allServiceTransactions.downloadStatusFilter, userIsAuthorised, allTransactionsController.downloadTransactions)
   app.get(allServiceTransactions.redirectDetail, userIsAuthorised, transactionDetailRedirectController)

--- a/app/utils/response.js
+++ b/app/utils/response.js
@@ -10,11 +10,11 @@ function response (req, res, template, data = {}) {
   render(req, res, template, convertedData)
 }
 
-function errorResponse (req, res, msg = ERROR_MESSAGE, status = 500) {
+function errorResponse (req, res, msg = ERROR_MESSAGE, status = 500, additionalModel) {
   if (typeof msg !== 'string') {
     msg = 'Please try again or contact support team.'
   }
-  let data = { 'message': msg }
+  const model = { 'message': msg, ...additionalModel }
 
   const errorMeta = {
     'status': status,
@@ -25,7 +25,7 @@ function errorResponse (req, res, msg = ERROR_MESSAGE, status = 500) {
   res.setHeader('Content-Type', 'text/html')
 
   res.status(status)
-  response(req, res, ERROR_VIEW, data)
+  response(req, res, ERROR_VIEW, model)
 }
 
 function render (req, res, template, data) {

--- a/app/views/error.njk
+++ b/app/views/error.njk
@@ -8,5 +8,11 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l page-title">An error occurred</h1>
     <div class="govuk-body" id="errorMsg">{{message}}</div>
+    {% if allServicesTimeout %}
+      <div>
+        <p class="govuk-body"><a class="govuk-link" href="{{ allServiceTransactionsNoSearchPath }}" id="linkToAllServicesSearch">Back to transactions search</a></p>
+      </div>
+    {% endif %}
   </div>
+
 {% endblock %}

--- a/app/views/transactions/index.njk
+++ b/app/views/transactions/index.njk
@@ -84,12 +84,14 @@
   {% include "transactions/display-size.njk" %}
 
   <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-top-3" id="total-results">
-    {% if totalOverLimit %}
-      Over {{maxLimitFormatted}} transactions
-    {% else %}
-      {{totalFormatted}} transactions
+    {% if not allServicesTimeout %}
+      {% if totalOverLimit %}
+        Over {{maxLimitFormatted}} transactions
+      {% else %}
+        {{totalFormatted}} transactions
+      {% endif %}
+      {{ filtersDescription | safe }}
     {% endif %}
-    {{ filtersDescription | safe }}
 
   </h3>
 

--- a/app/views/transactions/list.njk
+++ b/app/views/transactions/list.njk
@@ -52,7 +52,11 @@
 </table>
 {% else %}
   {% if not isInvalidDateRange %}
-     <p class="govuk-body" id="no-results">There are no results for the filters you used.</p>
+    {% if (allServicesTimeout) %}
+      <p class="govuk-body" id="update-filters-after-timeout">Update the filters and select the Filter button.</p>
+    {% else %}
+      <p class="govuk-body" id="no-results">There are no results for the filters you used.</p>
+    {% endif %}
   {% endif %}
 {% endif %}
 

--- a/test/cypress/integration/all-service-transactions/all-service-transactions-no-autosearch.cy.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions-no-autosearch.cy.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const userStubs = require('../../stubs/user-stubs')
+const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+const transactionStubs = require('../../stubs/transaction-stubs')
+
+const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+const liveTransactionsUrl = `/all-service-transactions/nosearch/live`
+
+const gatewayAccountStripe = {
+  gatewayAccountId: 42,
+  gatewayAccountExternalId: 'a-valid-external-id-1',
+  type: 'live',
+  paymentProvider: 'stripe',
+  recurringEnabled: true
+}
+const gatewayAccount2 = {
+  gatewayAccountId: 43,
+  gatewayAccountExternalId: 'a-valid-external-id-2',
+  type: 'live',
+  recurringEnabled: true
+}
+const gatewayAccount3 = {
+  gatewayAccountId: 44,
+  gatewayAccountExternalId: 'a-valid-external-id-3',
+  type: 'test',
+  recurringEnabled: true
+}
+const userStub = userStubs.getUserSuccessWithMultipleServices(userExternalId, [
+  {
+    gatewayAccountId: gatewayAccountStripe.gatewayAccountId,
+    serviceName: 'Service 1'
+  },
+  {
+    gatewayAccountIds: [gatewayAccount2.gatewayAccountId, gatewayAccount3.gatewayAccountId],
+    serviceName: 'Service 2'
+  }
+])
+
+const testTransactions = [
+  {
+    amount: 5000,
+    gateway_account_id: String(gatewayAccount3.gatewayAccountId),
+    reference: 'ref3',
+    transaction_id: 'transaction-id-3',
+    live: false,
+    state: { finished: true, status: 'success' },
+    refund_summary_status: 'available',
+    refund_summary_available: 5000,
+    refund_summary_submitted: 0
+  },
+  {
+    gateway_account_id: String(gatewayAccount3.gatewayAccountId),
+    reference: 'ref4',
+    transaction_id: 'transaction-id-4',
+    live: false
+  }
+]
+
+describe('All service transactions without automatic search', () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(userExternalId)
+  })
+
+  it('should display All Service Transactions list page with no live transactions and ability to view test transactions', () => {
+    cy.task('setupStubs', [
+      userStub,
+      gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccountStripe, gatewayAccount2, gatewayAccount3]),
+      transactionStubs.getLedgerTransactionsSuccess({
+        gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
+        transactions: testTransactions
+      }),
+      gatewayAccountStubs.getCardTypesSuccess()
+    ])
+
+    cy.visit(liveTransactionsUrl)
+    cy.title().should('eq', `Transactions for all services`)
+
+    cy.get('.govuk-breadcrumbs').within(() => {
+      cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
+      cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
+      cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'LIVE')
+    })
+
+    cy.get('.transactions-list--row').should('have.length', 0)
+    cy.get('#update-filters-after-timeout').should('have.text', 'Update the filters and select the Filter button.')
+
+    cy.visit(liveTransactionsUrl)
+    cy.log('Switch to view test transactions')
+    cy.get('a').contains('Switch to test accounts').click()
+
+    cy.get('.govuk-breadcrumbs').within(() => {
+      cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
+      cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
+      cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'TEST')
+    })
+
+    cy.get('.transactions-list--row').should('have.length', 2)
+    cy.get('#charge-id-transaction-id-3').should('exist')
+    cy.get('#charge-id-transaction-id-4').should('exist')
+  })
+})

--- a/test/cypress/integration/all-service-transactions/all-service-transactions.cy.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions.cy.js
@@ -179,4 +179,30 @@ describe('All service transactions', () => {
       .should('have.text', 'Back to transactions for all services')
       .should('have.attr', 'href', '/all-service-transactions/test?reference=ref3&email=&cardholderName=&lastDigitsCardNumber=&fromDate=&fromTime=&toDate=&toTime=&metadataValue=&agreementId=')
   })
+
+  it('should redirect to failure page when ledger returns 504 and allow user to navigate to no autosearch transactions page', () => {
+    cy.task('setupStubs', [
+      userStub,
+      gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccountStripe, gatewayAccount2, gatewayAccount3]),
+
+      transactionStubs.getLedgerTransactionsFailure({
+        account_id: `${gatewayAccountStripe.gatewayAccountId},${gatewayAccount2.gatewayAccountId}`,
+        page: 1,
+        display_size: 100,
+        limit_total: true,
+        limit_total_size: 5001
+      }, 504),
+      gatewayAccountStubs.getCardTypesSuccess()
+    ])
+
+    cy.visit('/all-service-transactions/live', { failOnStatusCode: false })
+
+    cy.get('.govuk-heading-l').should('have.text', "An error occurred")
+    cy.get('#errorMsg').should('have.text', "The search has timed out. Try searching for a specific date range or applying other filters.")
+
+    cy.get('.govuk-body').get('a').contains('Back to transactions search').click()
+
+    cy.location('pathname').should('eq', '/all-service-transactions/nosearch/live')
+  })
+
 })


### PR DESCRIPTION
- Add new error for a ledger timeout on all services transactions search
- Link from the error page to the all services transaction search page,  without the automatic search, to avoid a perpetual timeout
- Refactor to share the code that populates the model
- Update unit tests
- Update cypress tests

with @DomBelcher and @nataliecarey 