### PR TITLE
PP-12510 Fix gateway account dashboard date ranges

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -354,7 +354,7 @@
         "filename": "test/cypress/integration/dashboard/dashboard-statistics.cy.js",
         "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
         "is_verified": false,
-        "line_number": 9
+        "line_number": 7
       }
     ],
     "test/cypress/integration/dashboard/dashboard-stripe-add-details.cy.js": [
@@ -903,5 +903,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-02T09:53:32Z"
+  "generated_at": "2024-04-08T21:15:15Z"
 }

--- a/test/cypress/integration/dashboard/dashboard-statistics.cy.js
+++ b/test/cypress/integration/dashboard/dashboard-statistics.cy.js
@@ -3,8 +3,6 @@ const userStubs = require('../../stubs/user-stubs')
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 const transactionsSummaryStubs = require('../../stubs/transaction-summary-stubs')
 
-const dateTimeFormat = 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'
-
 describe('Account dashboard', () => {
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
   const gatewayAccountId = '42'
@@ -13,7 +11,7 @@ describe('Account dashboard', () => {
 
   beforeEach(() => {
     const todayStatisticsStub = transactionsSummaryStubs.getDashboardStatisticsWithFromDate(
-      moment().tz('Europe/London').startOf('day').format(dateTimeFormat),
+      moment().tz('Europe/London').startOf('day').toISOString(),
       {
         paymentCount: 10,
         paymentTotal: 12000,
@@ -21,7 +19,7 @@ describe('Account dashboard', () => {
         refundTotal: 2300
       })
     const prevSevenDaysStatisticsStub = transactionsSummaryStubs.getDashboardStatisticsWithFromDate(
-      moment().subtract(7, 'days').tz('Europe/London').startOf('day').format(dateTimeFormat),
+      moment().subtract(7, 'days').tz('Europe/London').startOf('day').toISOString(),
       {
         paymentCount: 50,
         paymentTotal: 70000,

--- a/test/integration/dashboard/dashboard-activity.controller.ft.test.js
+++ b/test/integration/dashboard/dashboard-activity.controller.ft.test.js
@@ -29,7 +29,6 @@ const DASHBOARD_RESPONSE = {
   net_income: 44000
 }
 const dashboardPath = `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/dashboard`
-const dateTimeFormat = 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'
 let app
 
 const mockConnectorGetGatewayAccount = (paymentProvider, type) => {
@@ -87,7 +86,7 @@ const mockLedgerGetTransactionsSummary = () => {
   nock(LEDGER_URL)
     .get('/v1/report/transactions-summary')
     .query(obj => {
-      return obj.from_date === moment().tz('Europe/London').startOf('day').format(dateTimeFormat)
+      return obj.from_date === moment().tz('Europe/London').startOf('day').toISOString()
     })
     .reply(200)
 }
@@ -110,7 +109,7 @@ describe('dashboard-activity-controller', () => {
         nock(LEDGER_URL)
           .get('/v1/report/transactions-summary')
           .query(obj => {
-            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(0, 'days').format(dateTimeFormat)
+            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(0, 'days').toISOString()
           })
           .reply(200, DASHBOARD_RESPONSE)
 
@@ -167,7 +166,7 @@ describe('dashboard-activity-controller', () => {
 
       it('it should print the time period in the summary box', () => {
         expect($('.dashboard-total-explainer').text())
-          .to.contain(moment().utc().startOf('day').tz('Europe/London').format('D MMMM YYYY h:mm:ssa z'))
+          .to.contain(moment().tz('Europe/London').startOf('day').format('D MMMM YYYY h:mm:ssa z'))
       })
     })
     describe('and the period is set to today explicitly', () => {
@@ -186,7 +185,7 @@ describe('dashboard-activity-controller', () => {
         nock(LEDGER_URL)
           .get('/v1/report/transactions-summary')
           .query(obj => {
-            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(0, 'days').format(dateTimeFormat)
+            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(0, 'days').toISOString()
           })
           .reply(200, DASHBOARD_RESPONSE)
 
@@ -220,7 +219,7 @@ describe('dashboard-activity-controller', () => {
 
       it('it should print the time period in the summary box', () => {
         expect($('.dashboard-total-explainer').text())
-          .to.contain(moment().utc().startOf('day').tz('Europe/London').format('D MMMM YYYY h:mm:ssa z'))
+          .to.contain(moment().tz('Europe/London').startOf('day').format('D MMMM YYYY h:mm:ssa z'))
       })
     })
     describe('and the period is set to yesterday', () => {
@@ -239,7 +238,7 @@ describe('dashboard-activity-controller', () => {
         nock(LEDGER_URL)
           .get('/v1/report/transactions-summary')
           .query(obj => {
-            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(1, 'days').format(dateTimeFormat)
+            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(1, 'days').toISOString()
           })
           .reply(200, DASHBOARD_RESPONSE)
 
@@ -273,7 +272,7 @@ describe('dashboard-activity-controller', () => {
 
       it('it should print the time period in the summary box', () => {
         expect($('.dashboard-total-explainer').text())
-          .to.contain(moment().utc().startOf('day').tz('Europe/London').subtract(1, 'days').format('D MMMM YYYY h:mm:ssa z'))
+          .to.contain(moment().tz('Europe/London').startOf('day').subtract(1, 'days').format('D MMMM YYYY h:mm:ssa z'))
       })
     })
     describe('and the period is set to previous 7 days', () => {
@@ -292,7 +291,7 @@ describe('dashboard-activity-controller', () => {
         nock(LEDGER_URL)
           .get('/v1/report/transactions-summary')
           .query(obj => {
-            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(7, 'days').format(dateTimeFormat)
+            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(7, 'days').toISOString()
           })
           .reply(200, DASHBOARD_RESPONSE)
 
@@ -345,7 +344,7 @@ describe('dashboard-activity-controller', () => {
         nock(LEDGER_URL)
           .get('/v1/report/transactions-summary')
           .query(obj => {
-            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(30, 'days').format(dateTimeFormat)
+            return obj.from_date === moment().tz('Europe/London').startOf('day').subtract(30, 'days').toISOString()
           })
           .reply(200, DASHBOARD_RESPONSE)
 
@@ -400,7 +399,7 @@ describe('dashboard-activity-controller', () => {
         nock(LEDGER_URL)
           .get('/v1/report/transactions-summary')
           .query(obj => {
-            return obj.from_date === moment().tz('Europe/London').startOf('day').format(dateTimeFormat)
+            return obj.from_date === moment().tz('Europe/London').startOf('day').toISOString()
           })
           .reply(404)
 


### PR DESCRIPTION
## WHAT
- When getting the date range for transaction summary search, `moment.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')` returns datetime in the specified format but doesn't convert it to UTC.
   -  As a result, the ledger API call for transaction summary is using incorrect date ranges (BST date ranges instead of UTC)
   - in Nunjucks filters, `fromDateTime` and `toDateTime` are converted to BST (this is BST->BST instead of UTC->BST) which adds an hour to the BST date range. So date filters for the `successful payments` link on the dashboard and others are incorrect.

- Change gets date ranges in UTC and uses these fields
    - to query Ledger for transaction summary
    - in the dashboard explainer in the Nunjucks template. 
    - to create a transaction period string (in BST) to search for successful payments - Nunjucks template uses a filter which converts datetime to BST
