### PR TITLE
Update instructions for Node version and Cypress testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,32 +34,11 @@ nvm use
 nvm alias default 18.17.1
 ```
 
-Run the test server in one terminal tab:
+Run the following to build and start the app:
 
 ```
-npm run cypress:server
-```
-
-Run the tests in another terminal tab:
-
-```
-npm run cypress:test
-```
-
-To run the tests in a more visual way:
-
-```
-npm run cypress:test-headed
-```
-
-This will open a Cypress application window. Follow the instructions and when you have to choose mode, select `E2E Testing` and then select a browser, and then `Start E2E Testing in {browser}`.
-You will then be able to click on individual specs and see the tests running in the UI.
-
-Build the Selfservice app and start it
-
- ```
-  npm install && npm run compile
-  npm run start:dev
+npm run compile
+npm run start:dev
  ```
 
 Open application in browser: 
@@ -121,6 +100,10 @@ Run in two separate terminals:
 - `npm run cypress:test` to run headless 
 - `npm run cypress:test-headed` to run headed
 - `npm run cypress:test-no-watch` to run headed with auto-running of tests when the test file is edited turned off
+
+Selecting headed tests, with  `npm run cypress:test-headed`, will open a Cypress application window. 
+Follow the instructions and when you have to choose mode, select `E2E Testing` and then select a browser, and then `Start E2E Testing in {browser}`.
+You will then be able to click on individual specs and see the tests running in the UI.
 
 See [About Cypress tests in selfservice](./test/cypress/cypress-testing.md) for more information about running and writing Cypress tests.
 


### PR DESCRIPTION
With this change, we are adding a few instructions to the README:

- how to check and set the correct Node version
- how to run Cypress tests in textual mode
- how to run Cypress tests in visual mode


