### PR TITLE
ZD5817027 Allow moto merchant code ending MOTOGBP

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -321,19 +321,19 @@
         "line_number": 26
       }
     ],
-    "test/cypress/integration/all-service-transactions/all-service-transactions.cy.js": [
+    "test/cypress/integration/all-service-transactions/all-service-transactions-no-autosearch.cy.js": [
       {
         "type": "Hex High Entropy String",
-        "filename": "test/cypress/integration/all-service-transactions/all-service-transactions.cy.js",
+        "filename": "test/cypress/integration/all-service-transactions/all-service-transactions-no-autosearch.cy.js",
         "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
         "is_verified": false,
         "line_number": 7
       }
     ],
-    "test/cypress/integration/all-service-transactions/all-service-transactions-no-autosearch.cy.js": [
+    "test/cypress/integration/all-service-transactions/all-service-transactions.cy.js": [
       {
         "type": "Hex High Entropy String",
-        "filename": "test/cypress/integration/all-service-transactions/all-service-transactions-no-autosearch.cy.js",
+        "filename": "test/cypress/integration/all-service-transactions/all-service-transactions.cy.js",
         "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
         "is_verified": false,
         "line_number": 7
@@ -583,28 +583,28 @@
         "filename": "test/cypress/integration/settings/your-psp.cy.js",
         "hashed_secret": "379f1968f09d8a343338667844e01a2f433f0a3f",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 35
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/settings/your-psp.cy.js",
         "hashed_secret": "abd006a3c55aebb9ffd8edca94531be22416e913",
         "is_verified": false,
-        "line_number": 35
+        "line_number": 41
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/settings/your-psp.cy.js",
         "hashed_secret": "d7e383a1a8aedd99245e46203e2a3065c1101b5b",
         "is_verified": false,
-        "line_number": 41
+        "line_number": 47
       },
       {
         "type": "Secret Keyword",
         "filename": "test/cypress/integration/settings/your-psp.cy.js",
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_verified": false,
-        "line_number": 456
+        "line_number": 486
       }
     ],
     "test/cypress/integration/switch-psp/organisation-url.cy.js": [
@@ -912,5 +912,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-10T15:39:24Z"
+  "generated_at": "2024-04-30T13:00:48Z"
 }

--- a/app/controllers/credentials/worldpay.controller.js
+++ b/app/controllers/credentials/worldpay.controller.js
@@ -49,7 +49,7 @@ async function updateWorldpayCredentials (req, res, next) {
 
     if (!results.errorSummaryList.length) {
       const merchantId = req.body.merchantId
-      if (req.account.allow_moto && !merchantId.endsWith('MOTO')) {
+      if (req.account.allow_moto && !merchantId.endsWith('MOTO') && !merchantId.endsWith('MOTOGBP')) {
         results.errors.merchantId = 'Enter a MOTO merchant code. MOTO payments are enabled for the account'
       } else if (!req.account.allow_moto && merchantId.endsWith('MOTO')) {
         results.errors.merchantId = 'MOTO merchant code not allowed. Please contact support if you would like MOTO payments enabled'

--- a/test/cypress/integration/settings/your-psp.cy.js
+++ b/test/cypress/integration/settings/your-psp.cy.js
@@ -24,6 +24,12 @@ describe('Your PSP settings page', () => {
     password: 'anti-matter'
   }
 
+  const testCredentialsMOTOGBP = {
+    merchant_code: 'merchant-code-ending-with-MOTOGBP',
+    username: 'user-name',
+    password: 'anti-matter'
+  }
+
   const testFlexCredentials = {
     organisational_unit_id: '5bd9b55e4444761ac0af1c80',
     issuer: '5bd9e0e4444dce153428c940',
@@ -348,6 +354,30 @@ describe('Your PSP settings page', () => {
       cy.get('#merchantId').type(testCredentialsMOTO.merchant_code)
       cy.get('#username').type(testCredentialsMOTO.username)
       cy.get('#password').type(testCredentialsMOTO.password)
+      cy.get('#submitCredentials').click()
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}`)
+      })
+      cy.get('h1').contains('Your payment service provider (PSP) - Worldpay').should('exist')
+    })
+
+    it('should allow MOTO merchant account code ending MOTOGBP', () => {
+      cy.task('setupStubs', [
+        ...getUserAndGatewayAccountStubs(gatewayAccountOpts),
+        gatewayAccountStubs.postCheckWorldpayCredentials({ ...testCredentialsMOTOGBP, gatewayAccountId }),
+        gatewayAccountStubs.patchUpdateWorldpayOneOffCredentialsSuccess({
+          gatewayAccountId,
+          credentialId: credentialsId,
+          userExternalId,
+          credentials: testCredentialsMOTOGBP
+        })
+      ])
+      cy.visit(`${yourPspPath}/${credentialExternalId}`)
+      cy.get('#credentials-change-link').click()
+      cy.get('#merchantId').clear()
+      cy.get('#merchantId').type(testCredentialsMOTOGBP.merchant_code)
+      cy.get('#username').type(testCredentialsMOTOGBP.username)
+      cy.get('#password').type(testCredentialsMOTOGBP.password)
       cy.get('#submitCredentials').click()
       cy.location().should((location) => {
         expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}`)


### PR DESCRIPTION
MOTO enabled services typically have merchant codes ending MOTO and this is validated in self-service.
Worldpay has started allocating codes that end MOTOGBP. This is preventing a service from onboarding ([Zendesk ticket 5817027](https://govuk.zendesk.com/agent/tickets/5817027))

- Allow MOTO-enabled services to enter merchant codes ending MOTOGBP