### PR TITLE
Fix display of checkboxes in multi-selects

### DIFF
--- a/app/assets/sass/components/multi-select.scss
+++ b/app/assets/sass/components/multi-select.scss
@@ -109,10 +109,10 @@
   }
 
   .govuk-checkboxes__item [type=checkbox] + label::after {
-    top: 15px;
-    left: 12px;
+    top: 18px;
+    left: 14px;
     height: 5px;
-    width: 13px;
+    width: 12px;
     border-width: 0 0 3px 3px;
   }
 }


### PR DESCRIPTION
## WHAT

This has been bugging me since I spotted it and I thought it might be easiest just to open a PR.

Visually align the checkmarks within the checkbox for the tiny checkboxes that appear within the mutli-selects on the transactions page.

I've verified these changes by applying them in Chrome Dev Tools. I have not run the application locally to check.

## HOW 

Before the checkboxes looked like this:

![Screenshot 2024-06-05 at 09 40 40](https://github.com/alphagov/pay-selfservice/assets/121939/0c737af8-fab2-4124-9fd4-8724798e8cec)

Now they look like this: ✨ 

![Screenshot 2024-06-05 at 09 40 32](https://github.com/alphagov/pay-selfservice/assets/121939/c7c5d22d-8721-4fe0-b2e9-03a5bfbd08a1)