### PR TITLE
PP-12659 Bump pay-js-commons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
-        "@govuk-pay/pay-js-commons": "4.0.16",
+        "@govuk-pay/pay-js-commons": "^6.0.2",
         "@govuk-pay/pay-js-metrics": "^1.0.6",
         "@sentry/node": "6.12.0",
         "accessible-autocomplete": "2.0.4",
@@ -1986,9 +1986,9 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-4.0.16.tgz",
-      "integrity": "sha512-CMXVvNlutG3SNeE3o/pgTML0YlXJ0BHPkojKQiaURhDGwjGVuiSAjP/3Gxvu/5ckA9O2dh4pIHzk3HM3dnzu1g==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.2.tgz",
+      "integrity": "sha512-OVJbI+/umP7hyRTWjL+9BP+uir9LioL52wDSISNtttJVOzVZ5Xr1yHZ8isSBEXlbVxt/QrKMuT7pjWLgoYkr7A==",
       "dependencies": {
         "axios": "^1.6.5",
         "lodash": "4.17.21",
@@ -18974,9 +18974,9 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-4.0.16.tgz",
-      "integrity": "sha512-CMXVvNlutG3SNeE3o/pgTML0YlXJ0BHPkojKQiaURhDGwjGVuiSAjP/3Gxvu/5ckA9O2dh4pIHzk3HM3dnzu1g==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.2.tgz",
+      "integrity": "sha512-OVJbI+/umP7hyRTWjL+9BP+uir9LioL52wDSISNtttJVOzVZ5Xr1yHZ8isSBEXlbVxt/QrKMuT7pjWLgoYkr7A==",
       "requires": {
         "axios": "^1.6.5",
         "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     }
   },
   "dependencies": {
-    "@govuk-pay/pay-js-commons": "4.0.16",
+    "@govuk-pay/pay-js-commons": "^6.0.2",
     "@govuk-pay/pay-js-metrics": "^1.0.6",
     "@sentry/node": "6.12.0",
     "accessible-autocomplete": "2.0.4",


### PR DESCRIPTION
- Pay-js-commons has been updated with the latest changes of Axios base client.
- The new changes do not affect this repository directly, but want update the version so that it is aligned with the other reporistories.


