### PR TITLE
PP-12624 Fix bug in timeout error page

### DIFF
--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -91,7 +91,7 @@ module.exports = function errorHandler (err, req, res, next) {
     logger.info('Gateway Time out Error occurred on Transactions for All Services Search Page. Rendering error page')
     let allServiceTransactionsNoSearchPath = req.session.allServicesTransactionsStatusFilter ?
       paths.formattedPathFor(paths.allServiceTransactions.indexStatusFilterWithoutSearch, req.session.allServicesTransactionsStatusFilter) :
-      paths.formattedPathFor(paths.allServiceTransactions.indexStatusFilterWithoutSearch, "live")
+      paths.formattedPathFor(paths.allServiceTransactions.indexStatusFilterWithoutSearch, 'live')
     const queryString = req.originalUrl.split('?')[1]
     if (queryString) {
       allServiceTransactionsNoSearchPath += '?' + queryString

--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -89,8 +89,9 @@ module.exports = function errorHandler (err, req, res, next) {
 
   if (err instanceof GatewayTimeoutForAllServicesSearchError) {
     logger.info('Gateway Time out Error occurred on Transactions for All Services Search Page. Rendering error page')
-    let allServiceTransactionsNoSearchPath = paths.formattedPathFor(paths.allServiceTransactions.indexStatusFilterWithoutSearch, req.session.allServicesTransactionsStatusFilter)
-
+    let allServiceTransactionsNoSearchPath = req.session.allServicesTransactionsStatusFilter ?
+      paths.formattedPathFor(paths.allServiceTransactions.indexStatusFilterWithoutSearch, req.session.allServicesTransactionsStatusFilter) :
+      paths.formattedPathFor(paths.allServiceTransactions.indexStatusFilterWithoutSearch, "live")
     const queryString = req.originalUrl.split('?')[1]
     if (queryString) {
       allServiceTransactionsNoSearchPath += '?' + queryString

--- a/test/cypress/integration/all-service-transactions/all-service-transactions.cy.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions.cy.js
@@ -180,7 +180,7 @@ describe('All service transactions', () => {
       .should('have.attr', 'href', '/all-service-transactions/test?reference=ref3&email=&cardholderName=&lastDigitsCardNumber=&fromDate=&fromTime=&toDate=&toTime=&metadataValue=&agreementId=')
   })
 
-  it('should redirect to failure page when ledger returns 504 and allow user to navigate to no autosearch transactions page', () => {
+  it('should redirect from /all-services-transactions/live to failure page when ledger returns 504 and allow user to navigate to no autosearch transactions page', () => {
     cy.task('setupStubs', [
       userStub,
       gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccountStripe, gatewayAccount2, gatewayAccount3]),
@@ -196,6 +196,56 @@ describe('All service transactions', () => {
     ])
 
     cy.visit('/all-service-transactions/live', { failOnStatusCode: false })
+
+    cy.get('.govuk-heading-l').should('have.text', "An error occurred")
+    cy.get('#errorMsg').should('have.text', "The search has timed out. Try searching for a specific date range or applying other filters.")
+
+    cy.get('.govuk-body').get('a').contains('Back to transactions search').click()
+
+    cy.location('pathname').should('eq', '/all-service-transactions/nosearch/live')
+  })
+
+  it('should redirect from /all-services-transactions/test to failure page when ledger returns 504 and allow user to navigate to no autosearch transactions page', () => {
+    cy.task('setupStubs', [
+      userStub,
+      gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccountStripe, gatewayAccount2, gatewayAccount3]),
+
+      transactionStubs.getLedgerTransactionsFailure({
+        account_id: `${gatewayAccount3.gatewayAccountId}`,
+        page: 1,
+        display_size: 100,
+        limit_total: true,
+        limit_total_size: 5001
+      }, 504),
+      gatewayAccountStubs.getCardTypesSuccess()
+    ])
+
+    cy.visit('/all-service-transactions/test', { failOnStatusCode: false })
+
+    cy.get('.govuk-heading-l').should('have.text', "An error occurred")
+    cy.get('#errorMsg').should('have.text', "The search has timed out. Try searching for a specific date range or applying other filters.")
+
+    cy.get('.govuk-body').get('a').contains('Back to transactions search').click()
+
+    cy.location('pathname').should('eq', '/all-service-transactions/nosearch/test')
+  })
+
+  it('should redirect from /all-services-transactions to failure page when ledger returns 504 and allow user to navigate to no autosearch transactions page', () => {
+    cy.task('setupStubs', [
+      userStub,
+      gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccountStripe, gatewayAccount2, gatewayAccount3]),
+
+      transactionStubs.getLedgerTransactionsFailure({
+        account_id: `${gatewayAccountStripe.gatewayAccountId},${gatewayAccount2.gatewayAccountId}`,
+        page: 1,
+        display_size: 100,
+        limit_total: true,
+        limit_total_size: 5001
+      }, 504),
+      gatewayAccountStubs.getCardTypesSuccess()
+    ])
+
+    cy.visit('/all-service-transactions', { failOnStatusCode: false })
 
     cy.get('.govuk-heading-l').should('have.text', "An error occurred")
     cy.get('#errorMsg').should('have.text', "The search has timed out. Try searching for a specific date range or applying other filters.")


### PR DESCRIPTION
Context: When there is a database timeout from a transactions search across all services, the resulting error page sometimes has a malformed url, because it relies on a parameter stored in the session, which is not present when a user of live services clicks on the 'View transactions for all my services' link on the My Services page.

- update the formation of the url in the link to the all services transactions 'no-search' page so that if the `live|test` parameter is not stored in the session, `live` is added to the url.
- update Cypress tests to cover all permutations of the all-services-transactions url.