### PR TITLE
PP-12764 Update jquery libraries

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -291,28 +295,42 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "app/views/transactions/index.njk",
-        "hashed_secret": "c12ec67dcf1e1939e1039d414d56a59c2c49cc87",
+        "hashed_secret": "8a764e7de8baf91c09a0141c9d0653d6c62300fa",
+        "is_verified": false,
+        "line_number": 17
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/views/transactions/index.njk",
+        "hashed_secret": "c15bfbed4cf339878d4c69339491df034b592627",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/views/transactions/index.njk",
+        "hashed_secret": "09ea33e2341efbf111c4eb12a709ae94c96a7e51",
         "is_verified": false,
         "line_number": 23
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/views/transactions/index.njk",
-        "hashed_secret": "e0eb70ddc8098d113dc566a9dc85c0e6a44de8d8",
+        "hashed_secret": "d9d993cc5556aa0fa6e18b26fdfd4fa8527db044",
         "is_verified": false,
         "line_number": 24
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/views/transactions/index.njk",
-        "hashed_secret": "6ee3b2a2f5eaeadb06c1dda26270cd1032420e79",
+        "hashed_secret": "ce50854e96f8dd430451450f2e7334e4b48db7f0",
         "is_verified": false,
         "line_number": 25
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/views/transactions/index.njk",
-        "hashed_secret": "2568e4443a80c3aaed753e6eecfa9dc742187ad9",
+        "hashed_secret": "34f47d2f3c482850fd7f6de8564a8aa73afe87bc",
         "is_verified": false,
         "line_number": 26
       }
@@ -908,5 +926,5 @@
       }
     ]
   },
-  "generated_at": "2024-07-22T12:47:01Z"
+  "generated_at": "2024-07-22T14:55:17Z"
 }

--- a/app/views/transactions/index.njk
+++ b/app/views/transactions/index.njk
@@ -14,16 +14,16 @@
 {% block classesOnBodyTag %}transactions index {% endblock %}
 
 {% block pageSpecificStyle %}
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.7.1/css/bootstrap-datepicker.standalone.min.css">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.10.0/jquery.timepicker.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.10.0/css/bootstrap-datepicker.standalone.min.css" integrity="sha512-D5/oUZrMTZE/y4ldsD6UOeuPR4lwjLnfNMWkjC0pffPTCVlqzcHTNvkn3dhL7C0gYifHQJAIrRTASbMvLmpEug==" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.14.1/jquery.timepicker.min.css" integrity="sha512-WlaNl0+Upj44uL9cq9cgIWSobsjEOD1H7GK1Ny1gmwl43sO0QAUxVpvX2x+5iQz/C60J3+bM7V07aC/CNWt/Yw==" crossorigin="anonymous" />
 {% endblock %}
 
 {% block pageSpecificJS %}
 <script src="/public/js/components/link-follower.js"></script>
-<script src="https://unpkg.com/jquery@3.3.1/dist/jquery.min.js" integrity="sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.7.1/js/bootstrap-datepicker.min.js" integrity="sha384-w48xMCwgWQu0zb3PvQI/rK5lfN6G+lSWu+qI4ukKZg3I5Xx3/VWA8IiaQ8O7tZur" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.10.0/jquery.timepicker.min.js" integrity="sha384-VCGGyImXZFrgsDyta1kgBiWdDqK5tFDLLQqkVmrAlMD75liEcrwWyHrlsOgWLpI+" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/datepair.js/0.4.15/jquery.datepair.min.js" integrity="sha384-n9nOljWGNI/Dtu7uK9ZIbiRrZZT3MhFq452zDmvmNZm1GPu5gGFXTPyHC09dDXis" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/jquery@3.7.1/dist/jquery.min.js" integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g==" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.10.0/js/bootstrap-datepicker.min.js" integrity="sha512-LsnSViqQyaXpD4mBBdRYeP6sRwJiJveh2ZIbW41EBrNmKxgr/LFZIiWT6yr+nycvhvauz8c2nYMhrP80YhG7Cw==" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.14.1/jquery.timepicker.min.js" integrity="sha512-TYfUH4Mbt6NcWkJI7RS5MoMqFSkpBCChADy2EjAiFr5ckAdTjOUUjnTA3GH8PQAIa2Nz7eR/4PR9xXY3uhnu/A==" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/datepair.js/0.4.17/jquery.datepair.min.js" integrity="sha512-dY39OLVn61yY3H9Iboby9hTzf4HyP7SdTuqPvWJzBmHqu+zbVQKEUPm+HmZT5/Mh9G/UV52nQ2PfcmG/OoRQdQ==" crossorigin="anonymous"></script>
 <script src="/public/js/components/datetime-picker.js"></script>
 {% endblock %}
 


### PR DESCRIPTION
## WHAT
Updated jQuery libraries to latest version.
- jQuery -> 3.7.1
- jQuery Timepicker -> 1.14.1
- jQuery Datepair -> 0.4.17
- Bootstrap Datepicker -> 1.10.0

## HOW 
Updating CDN links in the nunjucks transactions/index file.


