### PR TITLE
PP-12876-Enable PACT test for create gateway account

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -736,7 +736,7 @@
         "filename": "test/fixtures/gateway-account.fixtures.js",
         "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
         "is_verified": false,
-        "line_number": 301
+        "line_number": 298
       }
     ],
     "test/fixtures/invite.fixtures.js": [
@@ -926,5 +926,5 @@
       }
     ]
   },
-  "generated_at": "2024-07-22T14:55:17Z"
+  "generated_at": "2024-08-14T10:20:34Z"
 }

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -234,14 +234,11 @@ function validCreateGatewayAccountRequest (opts = {}) {
   const data = {
     payment_provider: opts.payment_provider || 'sandbox',
     service_name: opts.service_name || 'This is an account for the GOV.UK Pay team',
-    type: opts.type || 'test'
+    type: opts.type || 'test',
+    service_id: opts.service_id || '46eb1b601348499196c99de90482ee68'
   }
-
   if (opts.analytics_id) {
     data.analytics_id = opts.analytics_id
-  }
-  if (opts.service_id) {
-    data.service_id = opts.service_id
   }
   return data
 }


### PR DESCRIPTION
Context: In a subsequent PR, serviceId will be made mandatory for create gateway account requests to connector. Selfservice already sends the serviceId but this isn't reflected in the PACT tests

- Enable PACT tests for create gateway account
- Update PACT tests for create gateway account to include serviceId
- Amend PACT test for failed create gateway account request to reflect that connector sends 422 for invalid parameter values

