### PR TITLE
PP-12413: Temporarily disable request stripe test account pact test

### DIFF
--- a/test/pact/connector-client/connector-post-request-stripe-test-account.pact.test.js
+++ b/test/pact/connector-client/connector-post-request-stripe-test-account.pact.test.js
@@ -19,7 +19,7 @@ const serviceId = 'a-service-id'
 
 describe('connector client - request stripe test account', function () {
   const provider = new Pact({
-    consumer: 'selfservice',
+    consumer: 'selfservice-to-be',
     provider: 'connector',
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),


### PR DESCRIPTION
Temporarily disabling because the request stripe test account URL [has been changed](https://github.com/alphagov/pay-connector/pull/5505).
