### PR TITLE
BAU — Fix responsible person links

### DIFF
--- a/app/views/dashboard/_stripe-account-setup-banner.njk
+++ b/app/views/dashboard/_stripe-account-setup-banner.njk
@@ -40,7 +40,7 @@
             <li>organisation bank details</li>
           {% endif %}
           {% if not connectorGatewayAccountStripeProgress.responsiblePerson %}
-            <li>the name, date of birth and home address of the person in your organisation legally responsible for payments (called your ‘<a href="https://www.payments.service.gov.uk/what-being-a-responsible-person-means/" class="govuk-link">responsible person</a>’)</li>
+            <li>the name, date of birth and home address of the person in your organisation legally responsible for payments (called your ‘<a href="https://www.payments.service.gov.uk/required-responsible-person-and-director-information/" class="govuk-link">responsible person</a>’)</li>
           {% endif %}
           {% if not connectorGatewayAccountStripeProgress.director %}
             <li>the name, date of birth and work email address of the director of your service (or someone at director level)</li>

--- a/app/views/request-to-go-live/index.njk
+++ b/app/views/request-to-go-live/index.njk
@@ -20,7 +20,7 @@
 
         <ul class="govuk-list govuk-list--bullet">
           <li>organisation bank details</li>
-          <li>the name, date of birth and home address of the person in your organisation legally reponsible for payments (called your ‘<a href="https://www.payments.service.gov.uk/what-being-a-responsible-person-means/" class="govuk-link">responsible person</a>’)</li>
+          <li>the name, date of birth and home address of the person in your organisation legally reponsible for payments (called your ‘<a href="https://www.payments.service.gov.uk/required-responsible-person-and-director-information/" class="govuk-link">responsible person</a>’)</li>
           <li>the name, date of birth and work email address of the director of your service (or someone at director level)</li>
           <li>VAT number (if applicable)</li>
           <li>Company registration number (if applicable)</li>

--- a/app/views/stripe-setup/responsible-person/index.njk
+++ b/app/views/stripe-setup/responsible-person/index.njk
@@ -47,7 +47,7 @@
 
     <h1 class="govuk-heading-l">Enter responsible person details</h1>
 
-    <p class="govuk-body">We need details of a <a class="govuk-link" href="https://www.payments.service.gov.uk/what-being-a-responsible-person-means">responsible person</a> so that Stripe can run anti-money laundering checks. Liability stays at an organisational and not individual level.</p>
+    <p class="govuk-body">We need details of a <a class="govuk-link" href="https://www.payments.service.gov.uk/required-responsible-person-and-director-information/">responsible person</a> so that Stripe can run anti-money laundering checks. Liability stays at an organisational and not individual level.</p>
     <p class="govuk-body">The responsible person can be:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>someone in your organisation authorised to sign contracts</li>

--- a/app/views/switch-psp/switch-psp.njk
+++ b/app/views/switch-psp/switch-psp.njk
@@ -88,7 +88,7 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>organisation website address</li>
         <li>organisation bank details</li>
-        <li>the name, date of birth and home address of the person in your organisation legally reponsible for payments (called your ‘<a href="https://www.payments.service.gov.uk/what-being-a-responsible-person-means/" class="govuk-link">responsible person</a>’)</li>
+        <li>the name, date of birth and home address of the person in your organisation legally reponsible for payments (called your ‘<a href="https://www.payments.service.gov.uk/required-responsible-person-and-director-information/" class="govuk-link">responsible person</a>’)</li>
         <li>the name, date of birth and work email address of the director of your service (or someone at director level)</li>
         <li>VAT number (if applicable)</li>
         <li>Company registration number (if applicable)</li>


### PR DESCRIPTION
Change all links to https://www.payments.service.gov.uk/what-being-a-responsible-person-means/ (which no longer exists) to instead link to https://www.payments.service.gov.uk/required-responsible-person-and-director-information/ (which does exist).