### PR TITLE
PP-13091 select organisation type view/controller

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -51,3 +51,4 @@ $govuk-page-width: 1200px;
 @import "components/contract";
 @import "components/sub-navigation";
 @import "components/additional-information";
+@import "components/messages";

--- a/app/assets/sass/components/messages.scss
+++ b/app/assets/sass/components/messages.scss
@@ -1,0 +1,11 @@
+.messages {
+  .success {
+    color: $govuk-success-colour;
+  }
+  .info {
+    color: $govuk-brand-colour;
+  }
+  .error {
+    color: $govuk-error-colour;
+  }
+}

--- a/app/controllers/create-service/create-service.controller.js
+++ b/app/controllers/create-service/create-service.controller.js
@@ -7,9 +7,7 @@ const paths = require('../../paths')
 const logger = require('../../utils/logger')(__filename)
 const serviceService = require('../../services/service.service')
 const userService = require('../../services/user.service')
-const { ConnectorClient } = require('../../services/clients/connector.client')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
-const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 
 function get (req, res) {
   const createServiceState = _.get(req, 'session.pageData.createService', {})
@@ -37,7 +35,7 @@ async function post (req, res, next) {
       const { service, externalAccountId } = await serviceService.createService(serviceName, serviceNameCy, organisationType)
       await userService.assignServiceRole(req.user.externalId, service.externalId, 'admin')
       _.unset(req, 'session.pageData.createService')
-      req.flash('messages', { icon: '&check;', content: 'We\'ve created your service.' })
+      req.flash('messages', { state: 'success', icon: '&check;', content: 'We\'ve created your service.' })
       res.redirect(formatAccountPathsFor(paths.account.dashboard.index, externalAccountId))
     } catch (err) {
       next(err)

--- a/app/controllers/create-service/create-service.controller.js
+++ b/app/controllers/create-service/create-service.controller.js
@@ -24,21 +24,21 @@ async function post (req, res, next) {
   const serviceName = createServiceState.current_name.trim()
   const serviceNameCy = createServiceState.service_selected_cy && createServiceState.current_name_cy ? createServiceState.current_name_cy.trim() : ''
   const organisationType = req.body['select-org-type']
-  if (organisationType && (organisationType === 'central' || organisationType === 'local')) {
-    try {
-      const { service, externalAccountId } = await serviceService.createService(serviceName, serviceNameCy, organisationType)
-      await userService.assignServiceRole(req.user.externalId, service.externalId, 'admin')
-      _.unset(req, 'session.pageData.createService')
-      req.flash('messages', { state: 'success', icon: '&check;', content: 'We\'ve created your service.' })
-      res.redirect(formatAccountPathsFor(paths.account.dashboard.index, externalAccountId))
-    } catch (err) {
-      next(err)
-    }
-  } else {
+  if (!organisationType || organisationType !== 'central' || organisationType !== 'local') {
     _.set(req, 'session.pageData.createService.errors', {
       organisation_type: 'Organisation type is required'
     })
     return res.redirect(paths.serviceSwitcher.create.selectOrgType)
+  }
+
+  try {
+    const { service, externalAccountId } = await serviceService.createService(serviceName, serviceNameCy, organisationType)
+    await userService.assignServiceRole(req.user.externalId, service.externalId, 'admin')
+    _.unset(req, 'session.pageData.createService')
+    req.flash('messages', { state: 'success', icon: '&check;', content: 'We\'ve created your service.' })
+    res.redirect(formatAccountPathsFor(paths.account.dashboard.index, externalAccountId))
+  } catch (err) {
+    next(err)
   }
 }
 

--- a/app/controllers/create-service/create-service.controller.js
+++ b/app/controllers/create-service/create-service.controller.js
@@ -4,7 +4,6 @@ const _ = require('lodash')
 
 const { response } = require('../../utils/response')
 const paths = require('../../paths')
-const logger = require('../../utils/logger')(__filename)
 const serviceService = require('../../services/service.service')
 const userService = require('../../services/user.service')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
@@ -26,11 +25,6 @@ async function post (req, res, next) {
   const serviceNameCy = createServiceState.service_selected_cy && createServiceState.current_name_cy ? createServiceState.current_name_cy.trim() : ''
   const organisationType = req.body['select-org-type']
   if (organisationType && (organisationType === 'central' || organisationType === 'local')) {
-    logger.info(`creating service with following details: ${JSON.stringify({
-      serviceName,
-      serviceNameCy,
-      organisationType
-    })}`)
     try {
       const { service, externalAccountId } = await serviceService.createService(serviceName, serviceNameCy, organisationType)
       await userService.assignServiceRole(req.user.externalId, service.externalId, 'admin')

--- a/app/controllers/create-service/create-service.controller.js
+++ b/app/controllers/create-service/create-service.controller.js
@@ -24,7 +24,7 @@ async function post (req, res, next) {
   const serviceName = createServiceState.current_name.trim()
   const serviceNameCy = createServiceState.service_selected_cy && createServiceState.current_name_cy ? createServiceState.current_name_cy.trim() : ''
   const organisationType = req.body['select-org-type']
-  if (!organisationType || organisationType !== 'central' || organisationType !== 'local') {
+  if (!organisationType && (organisationType !== 'central' || organisationType !== 'local')) {
     _.set(req, 'session.pageData.createService.errors', {
       organisation_type: 'Organisation type is required'
     })

--- a/app/controllers/create-service/create-service.controller.js
+++ b/app/controllers/create-service/create-service.controller.js
@@ -7,6 +7,9 @@ const paths = require('../../paths')
 const logger = require('../../utils/logger')(__filename)
 const serviceService = require('../../services/service.service')
 const userService = require('../../services/user.service')
+const { ConnectorClient } = require('../../services/clients/connector.client')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
+const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 
 function get (req, res) {
   const createServiceState = _.get(req, 'session.pageData.createService', {})
@@ -30,16 +33,15 @@ async function post (req, res, next) {
       serviceNameCy,
       organisationType
     })}`)
-    // todo create stripe / sandbox account depending on org type
-    // try {
-    //   const service = await serviceService.createService(serviceName, serviceNameCy, req.user)
-    //   await userService.assignServiceRole(req.user.externalId, service.externalId, 'admin')
-    //   res.redirect(paths.serviceSwitcher.index)
-    // } catch (err) {
-    //   next(err)
-    // }
-    _.unset(req, 'session.pageData.createService')
-    res.redirect(paths.serviceSwitcher.index)
+    try {
+      const { service, externalAccountId } = await serviceService.createService(serviceName, serviceNameCy, organisationType)
+      await userService.assignServiceRole(req.user.externalId, service.externalId, 'admin')
+      _.unset(req, 'session.pageData.createService')
+      req.flash('messages', { icon: '&check;', content: 'We\'ve created your service.' })
+      res.redirect(formatAccountPathsFor(paths.account.dashboard.index, externalAccountId))
+    } catch (err) {
+      next(err)
+    }
   } else {
     _.set(req, 'session.pageData.createService.errors', {
       organisation_type: 'Organisation type is required'

--- a/app/controllers/create-service/get.controller.test.js
+++ b/app/controllers/create-service/get.controller.test.js
@@ -37,8 +37,8 @@ describe('Controller: createService, Method: get', () => {
     })
 
     it(`should pass pageData to the responses.response method that has properly formatted 'submit_link' and 'my_services' properties`, () => {
-      expect(mockResponses.response.args[0][3]).to.have.property('submit_link').to.equal(`/my-services/create`)
-      expect(mockResponses.response.args[0][3]).to.have.property('my_services').to.equal('/my-services')
+      expect(mockResponses.response.args[0][3]).to.have.property('submit_link').to.equal(`/my-services/create/select-org-type`)
+      expect(mockResponses.response.args[0][3]).to.have.property('back_link').to.equal('/my-services')
     })
   })
 
@@ -50,7 +50,7 @@ describe('Controller: createService, Method: get', () => {
       req = {
         session: {
           pageData: {
-            createServiceName: {
+            createService: {
               current_name: 'Blah',
               current_name_cy: 'Some Cymraeg service name',
               errors: {

--- a/app/controllers/create-service/post.controller.test.js
+++ b/app/controllers/create-service/post.controller.test.js
@@ -3,9 +3,15 @@
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const { expect } = require('chai')
+const formatAccountPathsFor = require('../../utils/format-account-paths-for')
+const paths = require('../../paths')
 const mockResponses = {}
 const mockServiceService = {}
 const mockUserService = {}
+
+const SERVICE_NAME = 'A brand spanking new service name'
+const WELSH_SERVICE_NAME = 'Some Cymraeg new service name'
+
 let req, res, next
 
 const getController = function (mockResponses, mockServiceService, mockUserService) {
@@ -25,41 +31,62 @@ function initialiseSpies () {
 }
 
 describe('Controller: createService, Method: post', () => {
-  describe('when the service name is not empty', () => {
-    mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
+  describe('when organisation type is provided', () => {
+    mockServiceService.createService = sinon.stub().resolves({
+      service: {
+        externalId: 'def456'
+      },
+      externalAccountId: 'abc123'
+    })
     mockUserService.assignServiceRole = sinon.stub().resolves()
-    const serviceName = 'A brand spanking new service name'
-    const welshServiceName = 'Some Cymraeg new service name'
 
     before(async () => {
       const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)
       req = {
         user: { externalId: '38475y38q4758ow4' },
+        session: {
+          pageData: {
+            createService: {
+              current_name: SERVICE_NAME,
+              current_name_cy: WELSH_SERVICE_NAME,
+              service_selected_cy: true
+            }
+          }
+        },
         body: {
-          'service-name': serviceName,
-          'service-name-cy': welshServiceName,
-          'welsh-service-name-bool': true
-        }
+          'select-org-type': 'central'
+        },
+        flash: sinon.spy()
       }
       initialiseSpies()
       await addServiceCtrl.post(req, res, next)
     })
 
-    it(`should call 'res.redirect' with '/my-service'`, () => {
+    it(`should redirect to newly created service dashboard`, () => {
+      sinon.assert.calledWith(mockServiceService.createService, SERVICE_NAME, WELSH_SERVICE_NAME, 'central')
+      sinon.assert.calledWith(mockUserService.assignServiceRole, '38475y38q4758ow4', 'def456', 'admin')
+      sinon.assert.calledWith(req.flash, 'messages', { state: 'success', icon: '&check;', content: 'We\'ve created your service.' })
       expect(res.redirect.called).to.equal(true)
-      expect(res.redirect.args[0]).to.include('/my-services')
-      sinon.assert.calledWith(mockServiceService.createService, serviceName, welshServiceName, req.user)
+      expect(res.redirect.args[0][0]).to.equal(formatAccountPathsFor(paths.account.dashboard.index, 'abc123'))
     })
   })
 
-  describe('when the service name is not empty, but the update call fails', () => {
+  describe('when organisation type is provided, but create service fails', () => {
     before(async () => {
       mockServiceService.createService = sinon.stub().rejects(new Error('something went wrong'))
       const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)
       req = {
+        session: {
+          pageData: {
+            createService: {
+              current_name: SERVICE_NAME,
+              current_name_cy: WELSH_SERVICE_NAME,
+              service_selected_cy: true
+            }
+          }
+        },
         body: {
-          'service-name': 'A brand spanking new service name',
-          'service-name-cy': 'Some Cymraeg new service name'
+          'select-org-type': 'central'
         }
       }
       initialiseSpies()
@@ -72,16 +99,29 @@ describe('Controller: createService, Method: post', () => {
     })
   })
 
-  describe('when the service name is not empty, and the create service succeeds, but the assign service role call fails', () => {
+  describe('when organisation type is provided, and the create service succeeds, but the assign service role call fails', () => {
     before(async () => {
-      mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
+      mockServiceService.createService = sinon.stub().resolves({
+        service: {
+          externalId: 'def456'
+        },
+        externalAccountId: 'abc123'
+      })
       mockUserService.assignServiceRole = sinon.stub().rejects(new Error('something went wrong'))
       const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)
       req = {
         user: { externalId: '38475y38q4758ow4' },
+        session: {
+          pageData: {
+            createService: {
+              current_name: SERVICE_NAME,
+              current_name_cy: WELSH_SERVICE_NAME,
+              service_selected_cy: true
+            }
+          }
+        },
         body: {
-          'service-name': 'A brand spanking new service name',
-          'service-name-cy': 'Some Cymraeg new service name'
+          'select-org-type': 'central'
         }
       }
       initialiseSpies()
@@ -94,82 +134,37 @@ describe('Controller: createService, Method: post', () => {
     })
   })
 
-  describe('when the service name is empty', () => {
+  describe('when organisation type is not provided', () => {
     before(async () => {
-      mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
-      mockUserService.assignServiceRole = sinon.stub().resolves()
+      mockServiceService.createService = sinon.stub()
+      mockUserService.assignServiceRole = sinon.stub()
       const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)
       req = {
         user: { externalId: '38475y38q4758ow4' },
-        body: {
-          'service-name': ''
-        }
+        session: {
+          pageData: {
+            createService: {
+              current_name: SERVICE_NAME,
+              current_name_cy: WELSH_SERVICE_NAME,
+              service_selected_cy: true
+            }
+          }
+        },
+        body: {}
       }
       initialiseSpies()
       await addServiceCtrl.post(req, res, next)
     })
 
-    it(`should call 'res.redirect' with a to create service`, () => {
-      expect(res.redirect.called).to.equal(true)
-      expect(res.redirect.args[0]).to.include(`/my-services/create`)
+    it('should redirect back to select org type', () => {
+      sinon.assert.calledWith(res.redirect, paths.serviceSwitcher.create.selectOrgType)
     })
 
-    it(`should set prexisting pageData that includes the 'current_name' and errors`, () => {
-      expect(req.session.pageData.createServiceName).to.have.property('current_name').to.equal(req.body['service-name'])
-      expect(req.session.pageData.createServiceName).to.have.property('errors').to.deep.equal({ service_name: 'Enter a service name' })
-    })
-  })
-
-  describe('when the service name is too long', () => {
-    before(async () => {
-      mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
-      mockUserService.assignServiceRole = sinon.stub().resolves()
-      const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)
-      req = {
-        user: { externalId: '38475y38q4758ow4' },
-        body: {
-          'service-name': 'Lorem ipsum dolor sit amet, consectetuer adipiscing',
-          'service-name-cy': 'Lorem ipsum dolor sit amet, consectetuer adipiscing',
-          'welsh-service-name-bool': true
-        }
-      }
-      initialiseSpies()
-      await addServiceCtrl.post(req, res, next)
-    })
-
-    it(`should call 'res.redirect' with a to create service`, () => {
-      expect(res.redirect.called).to.equal(true)
-      expect(res.redirect.args[0]).to.include(`/my-services/create`)
-    })
-
-    it(`should set prexisting pageData that includes the 'current_name' and errors`, () => {
-      expect(req.session.pageData.createServiceName).to.have.property('current_name').to.equal(req.body['service-name'])
-      expect(req.session.pageData.createServiceName).to.have.property('errors').to.deep.equal({
-        service_name: 'Service name must be 50 characters or fewer',
-        service_name_cy: 'Welsh service name must be 50 characters or fewer'
-      })
-    })
-  })
-
-  describe('when the Welsh service name is empty', () => {
-    before(async () => {
-      mockServiceService.createService = sinon.stub().resolves({ external_id: 'r378y387y8weriyi' })
-      mockUserService.assignServiceRole = sinon.stub().resolves()
-      const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)
-      req = {
-        user: { externalId: '38475y38q4758ow4' },
-        body: {
-          'service-name': 'A brand spanking new service name',
-          'service-name-cy': ''
-        }
-      }
-      initialiseSpies()
-      await addServiceCtrl.post(req, res, next)
-    })
-
-    it(`should call 'res.redirect' with '/my-service'`, () => {
-      expect(res.redirect.called).to.equal(true)
-      expect(res.redirect.args[0]).to.include('/my-services')
+    it('should set error information on the session', () => {
+      expect(req.session.pageData.createService).to.have.property('current_name').to.equal(SERVICE_NAME)
+      expect(req.session.pageData.createService).to.have.property('current_name_cy').to.equal(WELSH_SERVICE_NAME)
+      expect(req.session.pageData.createService).to.have.property('service_selected_cy').to.equal(true)
+      expect(req.session.pageData.createService).to.have.property('errors').to.deep.equal({ organisation_type: 'Organisation type is required' })
     })
   })
 })

--- a/app/controllers/create-service/select-organisation-type/select-organisation-type.controller.js
+++ b/app/controllers/create-service/select-organisation-type/select-organisation-type.controller.js
@@ -1,0 +1,62 @@
+const _ = require('lodash')
+const paths = require('../../../paths')
+const { response } = require('../../../utils/response')
+const {
+  validateMandatoryField,
+  SERVICE_NAME_MAX_LENGTH,
+  validateOptionalField
+} = require('../../../utils/validation/server-side-form-validations')
+const logger = require('../../../utils/logger')(__filename)
+
+function get (req, res) {
+  const createServiceState = _.get(req, 'session.pageData.createService', {})
+  if (!createServiceState.current_name) {
+    logger.info('Page accessed out of sequence, redirecting to my-services/create')
+    return res.redirect(paths.serviceSwitcher.create.index)
+  }
+  const context = {
+    ...createServiceState,
+    back_link: paths.serviceSwitcher.create.index,
+    submit_link: paths.serviceSwitcher.create.index
+  }
+  _.unset(req, 'session.pageData.createService.errors')
+  return response(req, res, 'services/select-org-type', context)
+}
+
+function post (req, res) {
+  _.set(req, 'session.pageData.createService', {
+    current_name: req.body['service-name'],
+    service_selected_cy: req.body['welsh-service-name-bool'],
+    current_name_cy: req.body['service-name-cy']
+  })
+  const errors = validateServiceName(req.body['service-name'], req.body['service-name-cy'])
+  if (!_.isEmpty(errors)) {
+    _.set(req, 'session.pageData.createService.errors', errors)
+    return res.redirect(paths.serviceSwitcher.create.index)
+  }
+  const context = {
+    back_link: paths.serviceSwitcher.create.index,
+    submit_link: paths.serviceSwitcher.create.index
+  }
+  return response(req, res, 'services/select-org-type', context)
+}
+
+// --- PRIVATE
+
+function validateServiceName (serviceName, serviceNameCy) {
+  const errors = {}
+  const nameValidationResult = validateMandatoryField(serviceName, SERVICE_NAME_MAX_LENGTH, 'service name')
+  if (!nameValidationResult.valid) {
+    errors['service_name'] = nameValidationResult.message
+  }
+  const welshNameValidationResult = validateOptionalField(serviceNameCy, SERVICE_NAME_MAX_LENGTH, 'welsh service name')
+  if (!welshNameValidationResult.valid) {
+    errors['service_name_cy'] = welshNameValidationResult.message
+  }
+  return errors
+}
+
+module.exports = {
+  post,
+  get
+}

--- a/app/controllers/create-service/select-organisation-type/select-organisation-type.test.js
+++ b/app/controllers/create-service/select-organisation-type/select-organisation-type.test.js
@@ -1,0 +1,125 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const { expect } = require('chai')
+const paths = require('../../../paths')
+const mockResponse = {}
+
+const controller = function (mockResponses) {
+  return proxyquire('./select-organisation-type.controller', {
+    '../../../utils/response': mockResponses
+  })
+}
+
+const SERVICE_NAME = 'Garden Gnome Removal Service'
+const WELSH_SERVICE_NAME = 'Gwasanaeth Tynnu Corachod Gardd'
+
+let req, res
+
+describe('Controller: selectOrganisationType, Method: get', () => {
+  describe('when there is no pre-existing pageData', () => {
+    it('should redirect to the create service controller', () => {
+      const selectOrganisationTypeController = controller(mockResponse)
+      res = {
+        redirect: sinon.spy()
+      }
+      selectOrganisationTypeController.get(req, res)
+      sinon.assert.calledWith(res.redirect, paths.serviceSwitcher.create.index)
+    })
+  })
+
+  describe('when there is pre-existing pageData', () => {
+    before(() => {
+      mockResponse.response = sinon.spy()
+      const selectOrganisationTypeController = controller(mockResponse)
+      res = {
+        render: sinon.spy()
+      }
+      req = {
+        session: {
+          pageData: {
+            createService: {
+              current_name: SERVICE_NAME,
+              current_name_cy: WELSH_SERVICE_NAME,
+              errors: {
+                organisation_type: 'Organisation type is required'
+              }
+            }
+          }
+        }
+      }
+      selectOrganisationTypeController.get(req, res)
+    })
+
+    it('should call the response method with appropriate context', () => {
+      expect(mockResponse.response.called).to.equal(true)
+      const responseContext = mockResponse.response.args[0][3]
+      expect(responseContext).to.have.property('current_name').to.equal(SERVICE_NAME)
+      expect(responseContext).to.have.property('current_name_cy').to.equal(WELSH_SERVICE_NAME)
+      expect(responseContext).to.have.property('errors').to.deep.equal({
+        organisation_type: 'Organisation type is required'
+      })
+      expect(responseContext).to.have.property('back_link').to.equal(paths.serviceSwitcher.create.index)
+      expect(responseContext).to.have.property('submit_link').to.equal(paths.serviceSwitcher.create.index)
+    })
+
+    it(`should remove errors pageData from the session`, () => {
+      expect(req.session.pageData.createService).to.not.have.property('errors')
+    })
+  })
+})
+
+describe('Controller: selectOrganisationType, Method: post', () => {
+  describe('when request passes validation', () => {
+    before(async () => {
+      mockResponse.response = sinon.spy()
+      const selectOrganisationTypeController = controller(mockResponse)
+      res = {}
+      req = {
+        body: {
+          'service-name': SERVICE_NAME,
+          'service-name-cy': WELSH_SERVICE_NAME,
+          'welsh-service-name-bool': true
+        }
+      }
+      selectOrganisationTypeController.post(req, res)
+    })
+
+    it('should call the response method with appropriate context and set the session data', () => {
+      expect(mockResponse.response.called).to.equal(true)
+      const createServiceState = req.session.pageData.createService
+      expect(createServiceState).to.have.property('current_name').to.equal(SERVICE_NAME)
+      expect(createServiceState).to.have.property('current_name_cy').to.equal(WELSH_SERVICE_NAME)
+      expect(createServiceState).to.have.property('service_selected_cy').to.equal(true)
+      const responseContext = mockResponse.response.args[0][3]
+      expect(responseContext).to.have.property('back_link').to.equal(paths.serviceSwitcher.create.index)
+      expect(responseContext).to.have.property('submit_link').to.equal(paths.serviceSwitcher.create.index)
+    })
+  })
+  describe('when request fails validation', () => {
+    before(async () => {
+      mockResponse.response = sinon.spy()
+      const selectOrganisationTypeController = controller(mockResponse)
+      res = {
+        redirect: sinon.spy()
+      }
+      req = {
+        body: {
+          'service-name': 'a veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long service name oh nooooooooo!!!',
+          'service-name-cy': 'a veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long welsh service name oh nooooooooo!!!',
+          'welsh-service-name-bool': true
+        }
+      }
+      selectOrganisationTypeController.post(req, res)
+    })
+
+    it('should redirect to the create service controller and set the session data', () => {
+      expect(mockResponse.response.called).to.equal(false)
+      sinon.assert.calledWith(res.redirect, paths.serviceSwitcher.create.index)
+      const expectedErrors = req.session.pageData.createService.errors
+      expect(expectedErrors).to.have.property('service_name').to.equal('Service name must be 50 characters or fewer')
+      expect(expectedErrors).to.have.property('service_name_cy').to.equal('Welsh service name must be 50 characters or fewer')
+    })
+  })
+})

--- a/app/controllers/dashboard/dashboard-activity.controller.js
+++ b/app/controllers/dashboard/dashboard-activity.controller.js
@@ -99,7 +99,7 @@ const displayRequestTestStripeAccountLink = (service, account, user) => {
 
 module.exports = async (req, res) => {
   const gatewayAccountId = req.account.gateway_account_id
-
+  const messages = res.locals.flash.messages
   const period = _.get(req, 'query.period', 'today')
   const telephonePaymentLink = await getTelephonePaymentLink(req.user, req.service, gatewayAccountId)
   const linksToDisplay = getLinksToDisplay(req.service, req.account, req.user, telephonePaymentLink)
@@ -139,6 +139,7 @@ module.exports = async (req, res) => {
       const result = await LedgerClient.transactionSummary(gatewayAccountId, fromDateTimeInUTC, toDateTimeInUTC)
       response(req, res, 'dashboard/index', Object.assign(model, {
         activity: result,
+        messages,
         fromDateTime: fromDateTimeInUTC,
         toDateTime: toDateTimeInUTC,
         transactionsPeriodString,

--- a/app/controllers/dashboard/dashboard-activity.controller.test.js
+++ b/app/controllers/dashboard/dashboard-activity.controller.test.js
@@ -41,7 +41,10 @@ describe('Controller: Dashboard activity', () => {
 
       res = {
         status: sinon.spy(),
-        render: sinon.spy()
+        render: sinon.spy(),
+        locals: {
+          flash: sinon.spy()
+        }
       }
     })
 

--- a/app/paths.js
+++ b/app/paths.js
@@ -230,7 +230,10 @@ module.exports = {
   serviceSwitcher: {
     index: '/my-services',
     switch: '/my-services/switch',
-    create: '/my-services/create'
+    create: {
+      index: '/my-services/create',
+      selectOrgType: '/my-services/create/select-org-type'
+    }
   },
   invite: {
     validateInvite: '/invites/:code',

--- a/app/routes.js
+++ b/app/routes.js
@@ -49,6 +49,7 @@ const serviceRolesUpdateController = require('./controllers/service-roles-update
 const toggleMotoMaskCardNumber = require('./controllers/toggle-moto-mask-card-number')
 const toggleMotoMaskSecurityCode = require('./controllers/toggle-moto-mask-security-code')
 const createServiceController = require('./controllers/create-service/create-service.controller')
+const selectOrgTypeController = require('./controllers/create-service/select-organisation-type/select-organisation-type.controller')
 const inviteValidationController = require('./controllers/invite-validation.controller')
 const testWithYourUsersController = require('./controllers/test-with-your-users')
 const makeADemoPaymentController = require('./controllers/make-a-demo-payment')
@@ -224,8 +225,10 @@ module.exports.bind = function (app) {
   // Service switcher
   app.get(serviceSwitcher.index, userIsAuthorised, myServicesController.getIndex)
   app.post(serviceSwitcher.switch, userIsAuthorised, myServicesController.postIndex)
-  app.get(serviceSwitcher.create, userIsAuthorised, createServiceController.get)
-  app.post(serviceSwitcher.create, userIsAuthorised, createServiceController.post)
+  app.get(serviceSwitcher.create.index, userIsAuthorised, createServiceController.get)
+  app.post(serviceSwitcher.create.index, userIsAuthorised, createServiceController.post)
+  app.post(serviceSwitcher.create.selectOrgType, userIsAuthorised, selectOrgTypeController.post)
+  app.get(serviceSwitcher.create.selectOrgType, userIsAuthorised, selectOrgTypeController.get)
 
   // All service transactions
   app.get(allServiceTransactions.index, userIsAuthorised, allTransactionsController.getController)

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -482,6 +482,11 @@ ConnectorClient.prototype = {
     return responseBodyToStripeAccountTransformer(response.data)
   },
 
+  /**
+   * Returns an object of account ids for the newly created Stripe test gateway account
+   * @param serviceId
+   * @returns {Promise<{stripe_connect_account_id: string, gateway_account_id: string, gateway_account_external_id: string}>}
+   */
   requestStripeTestAccount: async function (serviceId) {
     const url = `${this.connectorUrl}/v1/api/service/${encodeURIComponent(serviceId)}/request-stripe-test-account`
     configureClient(client, url)

--- a/app/services/service.create-service.test.js
+++ b/app/services/service.create-service.test.js
@@ -1,0 +1,77 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const sinon = require('sinon')
+const { CREATED } = require('../models/psp-test-account-stage')
+const expect = chai.expect
+chai.use(chaiAsPromised)
+
+describe('service service', function () {
+  describe('when creating a service', function () {
+    const SERVICE_NAME = 'Garden Gnome Removal Service'
+    const WELSH_SERVICE_NAME = 'Gwasanaeth Tynnu Corachod Gardd'
+    const SERVICE_EXTERNAL_ID = 'service-external-id'
+    const createService = sinon.stub().resolves({
+      externalId: SERVICE_EXTERNAL_ID
+    })
+    const addGatewayAccountsToService = sinon.stub().resolves()
+    const updatePspTestAccountStage = sinon.stub().resolves()
+    const adminUsersStub = () => {
+      return {
+        createService: createService,
+        addGatewayAccountsToService: addGatewayAccountsToService,
+        updatePspTestAccountStage: updatePspTestAccountStage
+      }
+    }
+
+    const createGatewayAccount = sinon.stub().resolves({
+      gateway_account_id: '1',
+      external_id: 'sandbox-external-id'
+    })
+    const requestStripeTestAccount = sinon.stub().resolves({
+      gateway_account_id: '2',
+      gateway_account_external_id: 'stripe-test-external-id'
+    })
+    const connectorStub = {
+      ConnectorClient: function () {
+        return {
+          createGatewayAccount: createGatewayAccount,
+          requestStripeTestAccount: requestStripeTestAccount
+        }
+      }
+    }
+    const serviceService = proxyquire('./service.service',
+      {
+        './clients/connector.client': connectorStub,
+        './clients/adminusers.client': adminUsersStub
+      })
+
+    afterEach(() => {
+      sinon.resetHistory()
+    })
+
+    it('should return external id of stripe account if org type is local', async function () {
+      const { externalAccountId } = await serviceService.createService(SERVICE_NAME, WELSH_SERVICE_NAME, 'local')
+      expect(externalAccountId).to.equal('stripe-test-external-id')
+      expect(requestStripeTestAccount.callCount).to.equal(1)
+      expect(updatePspTestAccountStage.callCount).to.equal(1)
+      sinon.assert.calledWith(createService, SERVICE_NAME, WELSH_SERVICE_NAME)
+      sinon.assert.calledWith(createGatewayAccount, 'sandbox', 'test', SERVICE_NAME, null, SERVICE_EXTERNAL_ID)
+      sinon.assert.calledWith(requestStripeTestAccount, SERVICE_EXTERNAL_ID)
+      sinon.assert.calledWith(addGatewayAccountsToService, SERVICE_EXTERNAL_ID, ['2'])
+      sinon.assert.calledWith(updatePspTestAccountStage, SERVICE_EXTERNAL_ID, CREATED)
+    })
+
+    it('should return external id of sandbox account if org type is central', async function () {
+      const { externalAccountId } = await serviceService.createService(SERVICE_NAME, WELSH_SERVICE_NAME, 'central')
+      expect(externalAccountId).to.equal('sandbox-external-id')
+      sinon.assert.calledWith(createService, SERVICE_NAME, WELSH_SERVICE_NAME)
+      sinon.assert.calledWith(createGatewayAccount, 'sandbox', 'test', SERVICE_NAME, null, SERVICE_EXTERNAL_ID)
+      sinon.assert.calledWith(addGatewayAccountsToService, SERVICE_EXTERNAL_ID, ['1'])
+      sinon.assert.notCalled(requestStripeTestAccount)
+      sinon.assert.notCalled(updatePspTestAccountStage)
+    })
+  })
+})

--- a/app/services/service.service.js
+++ b/app/services/service.service.js
@@ -10,6 +10,7 @@ const Service = require('../models/Service.class')
 const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 const adminUsersClient = getAdminUsersClient()
 const { DEFAULT_SERVICE_NAME } = require('../utils/constants')
+const { CREATED } = require('../models/psp-test-account-stage')
 
 async function getGatewayAccounts (gatewayAccountIds) {
   const cardGatewayAccounts = await connectorClient.getAccounts({
@@ -66,6 +67,9 @@ async function createService (serviceName, serviceNameCy, serviceOrgType = 'cent
 
   const actualAccountId = stripeTestGatewayAccount ? stripeTestGatewayAccount.gateway_account_id : gatewayAccount.gateway_account_id
   await adminUsersClient.addGatewayAccountsToService(service.externalId, [actualAccountId])
+  if (stripeTestGatewayAccount) {
+    await adminUsersClient.updatePspTestAccountStage(service.externalId, CREATED)
+  }
   logger.info('Service associated with internal gateway account ID with legacy mapping')
 
   return {

--- a/app/services/service.service.js
+++ b/app/services/service.service.js
@@ -53,7 +53,7 @@ async function createService (serviceName, serviceNameCy, serviceOrgType = 'cent
   const service = await adminUsersClient.createService(serviceName, serviceNameCy)
   logger.info('New service added by existing user')
 
-  const gatewayAccount = await connectorClient.createGatewayAccount('sandbox', 'test', serviceName, null, service.externalId)
+  const sandboxGatewayAccount = await connectorClient.createGatewayAccount('sandbox', 'test', serviceName, null, service.externalId)
   logger.info('New test card gateway account registered with service')
 
   let stripeTestGatewayAccount
@@ -65,7 +65,7 @@ async function createService (serviceName, serviceNameCy, serviceOrgType = 'cent
   // @TODO(sfount) PP-8438 support existing method of associating services with internal card accounts, this should be
   //               removed once connector integration indexed by services have been migrated
 
-  const actualAccountId = stripeTestGatewayAccount ? stripeTestGatewayAccount.gateway_account_id : gatewayAccount.gateway_account_id
+  const actualAccountId = stripeTestGatewayAccount ? stripeTestGatewayAccount.gateway_account_id : sandboxGatewayAccount.gateway_account_id
   await adminUsersClient.addGatewayAccountsToService(service.externalId, [actualAccountId])
   if (stripeTestGatewayAccount) {
     await adminUsersClient.updatePspTestAccountStage(service.externalId, CREATED)
@@ -74,7 +74,7 @@ async function createService (serviceName, serviceNameCy, serviceOrgType = 'cent
 
   return {
     service,
-    externalAccountId: stripeTestGatewayAccount ? stripeTestGatewayAccount.gateway_account_external_id : gatewayAccount.external_id
+    externalAccountId: stripeTestGatewayAccount ? stripeTestGatewayAccount.gateway_account_external_id : sandboxGatewayAccount.external_id
   }
 }
 

--- a/app/services/service.service.js
+++ b/app/services/service.service.js
@@ -59,7 +59,7 @@ async function createService (serviceName, serviceNameCy, serviceOrgType = 'cent
   let stripeTestGatewayAccount
   if (serviceOrgType === 'local') {
     stripeTestGatewayAccount = await connectorClient.requestStripeTestAccount(service.externalId)
-    logger.info(stripeTestGatewayAccount)
+    logger.info('Sandbox gateway account converted to Stripe Test gateway account')
   }
 
   // @TODO(sfount) PP-8438 support existing method of associating services with internal card accounts, this should be

--- a/app/utils/display-converter.js
+++ b/app/utils/display-converter.js
@@ -23,6 +23,8 @@ const hideServiceHeaderTemplates = [
 
 const hideServiceNavTemplates = [
   'services/edit-service-name',
+  'services/add-service',
+  'services/select-org-type',
   'merchant-details/merchant-details',
   'merchant-details/edit-merchant-details',
   'team-members/team-members',

--- a/app/views/dashboard/index.njk
+++ b/app/views/dashboard/index.njk
@@ -1,8 +1,9 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "includes/systemMessages.njk" import systemMessages %}
 {% extends "../layout.njk" %}
 
 {% block pageTitle %}
-Dashboard - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+  Dashboard - {{ currentService.name }} {{ currentGatewayAccount.full_type }} - GOV.UK Pay
 {% endblock %}
 
 {% block mainContent %}
@@ -15,11 +16,20 @@ Dashboard - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK
         If you use the GOV.UK Pay API, you will need to <a href="{{ apiKeysLink }}">create new API keys</a>.
       </p>
     {% endset %}
-    {{ govukNotificationBanner({
-      html: html,
-      type: 'success'
-    }) }}
+    <div class="govuk-grid-column-full">
+      {{ govukNotificationBanner({
+        html: html,
+        type: 'success'
+      }) }}
+    </div>
   {% endif %}
+
+  <div class="govuk-grid-column-full">
+    {% if messages is defined and messages is iterable and messages|length > 0 %}
+      {{ systemMessages({ messages: messages }) }}
+    {% endif %}
+  </div>
+
   {% if currentGatewayAccount.disabled %}
     {% include "./_account-disabled-banner.njk" %}
   {% else %}

--- a/app/views/includes/systemMessages.njk
+++ b/app/views/includes/systemMessages.njk
@@ -1,11 +1,27 @@
 {% macro systemMessages(params) %}
-  <div class="govuk-notification-banner govuk-notification-banner--success" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-    <div class="govuk-notification-banner__content">
-      {% for message in params.messages %}
-        <p class="govuk-notification-banner__heading">
-          <span style="color: #00703c">{{ message.icon | safe }}</span> {{ message.content | safe }}
-        </p>
-      {% endfor %}
-    </div>
+  <div class="messages">
+    {% for message in params.messages %}
+      {% if message.state === 'error' %}
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
+          <div role="alert">
+            <h2 class="govuk-error-summary__title govuk-!-margin-bottom-0">
+              <span class="error">{{ message.icon | safe }}</span> {{ message.content | safe }}
+            </h2>
+          </div>
+        </div>
+      {% else %}
+        <div
+          class="govuk-notification-banner {% if message.state === 'success' %}govuk-notification-banner--success{% endif %}"
+          role="region"
+          aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+          <div class="govuk-notification-banner__content">
+            <p class="govuk-notification-banner__heading">
+            <span
+              class="{% if message.state === 'success' %}success{% else %}info{% endif %}">{{ message.icon | safe }}</span> {{ message.content | safe }}
+            </p>
+          </div>
+        </div>
+      {% endif %}
+    {% endfor %}
   </div>
 {% endmacro %}

--- a/app/views/includes/systemMessages.njk
+++ b/app/views/includes/systemMessages.njk
@@ -1,5 +1,5 @@
 {% macro systemMessages(params) %}
-  <div class="messages">
+  <div id="system-messages" class="messages">
     {% for message in params.messages %}
       {% if message.state === 'error' %}
         <div class="govuk-error-summary" data-module="govuk-error-summary">

--- a/app/views/includes/systemMessages.njk
+++ b/app/views/includes/systemMessages.njk
@@ -1,0 +1,11 @@
+{% macro systemMessages(params) %}
+  <div class="govuk-notification-banner govuk-notification-banner--success" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__content">
+      {% for message in params.messages %}
+        <p class="govuk-notification-banner__heading">
+          <span style="color: #00703c">{{ message.icon | safe }}</span> {{ message.content | safe }}
+        </p>
+      {% endfor %}
+    </div>
+  </div>
+{% endmacro %}

--- a/app/views/services/add-service.njk
+++ b/app/views/services/add-service.njk
@@ -5,6 +5,16 @@
   Add a new service - GOV.UK Pay
 {% endblock %}
 
+{% block beforeContent %}
+  {{
+  govukBackLink({
+    text: "Back",
+    classes: "govuk-!-margin-bottom-0",
+    href: routes.serviceSwitcher.index
+  })
+  }}
+{% endblock %}
+
 {% block mainContent %}
   <div class="govuk-grid-column-two-thirds">
     {{ errorSummary ({
@@ -69,9 +79,9 @@
         ]
       }) }}
 
-      {{ govukButton({ text: "Add service" })}}
+      {{ govukButton({ text: "Continue" })}}
       <p class="govuk-body">
-        <a class="govuk-link govuk-link--no-visited-state" id="service-name-cancel-link" href="{{my_services}}">
+        <a class="govuk-link govuk-link--no-visited-state" id="service-name-cancel-link" href="{{back_link}}">
             Cancel
         </a>
       </p>

--- a/app/views/services/index.njk
+++ b/app/views/services/index.njk
@@ -52,7 +52,7 @@
     {{ govukButton({
       classes: "govuk-button--secondary",
       text: "Add a new service",
-      href: routes.serviceSwitcher.create
+      href: routes.serviceSwitcher.create.index
     }) }}
     {% if services.length %}
       {% if services.length > 7 %}

--- a/app/views/services/select-org-type.njk
+++ b/app/views/services/select-org-type.njk
@@ -21,6 +21,7 @@
 
     <form id="add-service-form" method="post" action="{{ submit_link }}" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+      <p class="govuk-body"></p>
 
       {{ govukRadios({
         idPrefix: "select-org-type",
@@ -58,7 +59,7 @@
 
       {{ govukDetails({
         summaryText: "Help with choosing",
-        text: "¯\\_(ツ)_/¯"
+        html: "<p class=\"govuk-body\">Contact <a class=\"govuk-link\" href=\"mailto:govuk-pay-support@digital.cabinet-office.gov.uk\">govuk-pay-support@digital.cabinet-office.gov.uk</a> for help deciding which provider you should use.</p>"
       }) }}
 
       {{ govukButton({ text: "Continue" })}}

--- a/app/views/services/select-org-type.njk
+++ b/app/views/services/select-org-type.njk
@@ -1,0 +1,70 @@
+{% extends "../layout.njk" %}
+{% from "../macro/error-summary.njk" import errorSummary %}
+
+{% block pageTitle %}
+  Select your organisation type - GOV.UK Pay
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    classes: "govuk-!-margin-bottom-0",
+    href: back_link
+  }) }}
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-column-two-thirds">
+    {{ errorSummary ({
+      errors: errors
+    }) }}
+
+    <form id="add-service-form" method="post" action="{{ submit_link }}" novalidate>
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+
+      {{ govukRadios({
+        idPrefix: "select-org-type",
+        name: "select-org-type",
+        fieldset: {
+          legend: {
+            text: "Which type of organisation do you work for?",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        hint: {
+          text: "This tells us which payment provider to use to take payments for your service. You can change it later if you need to."
+        },
+        errorMessage: errors.organisation_type,
+        items: [
+          {
+            value: "local",
+            html: "<h3 class=\"govuk-heading-s govuk-!-margin-bottom-0\">Local authority, armed forces or police</h3>",
+            hint: {
+            text: 'We use Stripe for card payments.'
+          },
+            id: "org-type-local"
+          },
+          {
+            value: "central",
+            html: "<h3 class=\"govuk-heading-s govuk-!-margin-bottom-0\">Central government, NHS or Arms Length Body (ALB)</h3>",
+            hint: {
+            text: 'We use Government Banking\'s contract with Worldpay for card payments. You will need to set up an agreement with Government Banking. You can do this later.'
+          },
+            id: "org-type-central"
+          }
+        ]
+      }) }}
+
+      {{ govukDetails({
+        summaryText: "Help with choosing",
+        text: "¯\\_(ツ)_/¯"
+      }) }}
+
+      {{ govukButton({ text: "Continue" })}}
+
+
+    </form>
+
+  </div>
+{% endblock %}

--- a/app/views/services/select-org-type.njk
+++ b/app/views/services/select-org-type.njk
@@ -63,8 +63,6 @@
       }) }}
 
       {{ govukButton({ text: "Continue" })}}
-
-
     </form>
 
   </div>

--- a/app/views/team-members/team-member-profile.njk
+++ b/app/views/team-members/team-member-profile.njk
@@ -36,7 +36,7 @@ My profile - GOV.UK Pay
         Email
       </dt>
       <dd class="profile-settings__value govuk-table__cell" id="email">
-        {{email}}
+        {{email | truncate(10, true)}}
       </dd>
     </div>
     {% if telephone_number %}

--- a/app/views/team-members/team-member-profile.njk
+++ b/app/views/team-members/team-member-profile.njk
@@ -36,7 +36,7 @@ My profile - GOV.UK Pay
         Email
       </dt>
       <dd class="profile-settings__value govuk-table__cell" id="email">
-        {{email | truncate(10, true)}}
+        {{email}}
       </dd>
     </div>
     {% if telephone_number %}

--- a/test/cypress/integration/my-services/add-new-service.cy.js
+++ b/test/cypress/integration/my-services/add-new-service.cy.js
@@ -126,6 +126,15 @@ describe('Add a new service', () => {
       cy.get('button').contains('Continue').click()
       cy.title().should('eq', 'Select your organisation type - GOV.UK Pay')
 
+      cy.get('button').contains('Continue').click()
+
+      cy.title().should('eq', 'Select your organisation type - GOV.UK Pay')
+
+      cy.get('.govuk-error-summary').find('li').should('have.length', 1)
+      cy.get('.govuk-error-summary').should('exist').within(() => {
+        cy.get('li').should('contain', 'Organisation type is required')
+      })
+
       cy.get('input#org-type-central').click()
       cy.get('button').contains('Continue').click()
 

--- a/test/cypress/integration/my-services/add-new-service.cy.js
+++ b/test/cypress/integration/my-services/add-new-service.cy.js
@@ -3,6 +3,7 @@
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 const userStubs = require('../../stubs/user-stubs')
 const serviceStubs = require('../../stubs/service-stubs')
+const transactionsSummaryStubs = require('../../stubs/transaction-summary-stubs')
 
 const authenticatedUserId = 'authenticated-user-id'
 const newServiceName = 'Pay for a thing'
@@ -24,7 +25,7 @@ const assignUserRoleStub =
 
 describe('Add a new service', () => {
   describe('Add a new service without a Welsh name', () => {
-    it('should display the my services page', () => {
+    it('should display the service dashboard', () => {
       cy.task('setupStubs', [
         userStubs.getUserSuccess({ userExternalId: authenticatedUserId, gatewayAccountId: '1' }),
         gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId: '1' }),
@@ -35,7 +36,12 @@ describe('Add a new service', () => {
           gatewayAccountId: newGatewayAccountId,
           serviceName: { en: newServiceName }
         }),
-        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId })
+        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId }),
+        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+          gatewayAccountExternalId: 'a-valid-external-id',
+          gatewayAccountId: '1'
+        }),
+        transactionsSummaryStubs.getDashboardStatistics()
       ])
 
       cy.setEncryptedCookies(authenticatedUserId)
@@ -49,14 +55,20 @@ describe('Add a new service', () => {
       cy.get('#checkbox-service-name-cy').should('have.attr', 'aria-expanded', 'false')
 
       cy.get('input#service-name').type(newServiceName)
-      cy.get('button').contains('Add service').click()
+      cy.get('button').contains('Continue').click()
 
-      cy.title().should('eq', 'My services - GOV.UK Pay')
+      cy.title().should('eq', 'Select your organisation type - GOV.UK Pay')
+
+      cy.get('input#org-type-central').click()
+      cy.get('button').contains('Continue').click()
+
+      cy.title().should('contain', 'Dashboard')
+      cy.get('#system-messages').contains("We've created your service")
     })
   })
 
   describe('Add a new service with a Welsh name', () => {
-    it('should display the my services page', () => {
+    it('should display the service dashboard', () => {
       cy.setEncryptedCookies(authenticatedUserId)
       cy.task('setupStubs', [
         userStubs.getUserSuccess({ userExternalId: authenticatedUserId, gatewayAccountId: '1' }),
@@ -68,7 +80,12 @@ describe('Add a new service', () => {
           gatewayAccountId: newGatewayAccountId,
           serviceName: { en: newServiceName, cy: newServiceWelshName }
         }),
-        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId })
+        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId }),
+        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+          gatewayAccountExternalId: 'a-valid-external-id',
+          gatewayAccountId: '1'
+        }),
+        transactionsSummaryStubs.getDashboardStatistics()
       ])
 
       cy.visit('/my-services')
@@ -85,7 +102,7 @@ describe('Add a new service', () => {
 
       cy.log('Enter a name that is too long and check validation errors are displayed')
       cy.get('input#service-name-cy').type('Lorem ipsum dolor sit amet, consectetuer adipiscing', { delay: 0 })
-      cy.get('button').contains('Add service').click()
+      cy.get('button').contains('Continue').click()
 
       cy.title().should('eq', 'Add a new service - GOV.UK Pay')
 
@@ -106,9 +123,14 @@ describe('Add a new service', () => {
       cy.get('input#service-name-cy').clear()
       cy.get('input#service-name').type(newServiceName)
       cy.get('input#service-name-cy').type(newServiceWelshName)
-      cy.get('button').contains('Add service').click()
+      cy.get('button').contains('Continue').click()
+      cy.title().should('eq', 'Select your organisation type - GOV.UK Pay')
 
-      cy.title().should('eq', 'My services - GOV.UK Pay')
+      cy.get('input#org-type-central').click()
+      cy.get('button').contains('Continue').click()
+
+      cy.title().should('contain', 'Dashboard')
+      cy.get('#system-messages').contains("We've created your service")
     })
   })
 })

--- a/test/ui/team-member-details.ui.test.js
+++ b/test/ui/team-member-details.ui.test.js
@@ -54,7 +54,7 @@ describe('The team member details view', function () {
 
     let body = renderTemplate('team-members/team-member-profile', templateData)
 
-    body.should.containSelector('#email').withExactText('john.smith@example.com')
+    body.should.containSelector('#email').withExactText('john.smith...') // should truncate strings longer than 10 chars and append ellipsis
     body.should.containSelector('#telephone-number').withText('+447769897329')
     body.should.containSelector('#two-factor-auth').withText('Text message')
   })

--- a/test/ui/team-member-details.ui.test.js
+++ b/test/ui/team-member-details.ui.test.js
@@ -54,7 +54,7 @@ describe('The team member details view', function () {
 
     let body = renderTemplate('team-members/team-member-profile', templateData)
 
-    body.should.containSelector('#email').withExactText('john.smith...') // should truncate strings longer than 10 chars and append ellipsis
+    body.should.containSelector('#email').withExactText('john.smith@example.com')
     body.should.containSelector('#telephone-number').withText('+447769897329')
     body.should.containSelector('#two-factor-auth').withText('Text message')
   })


### PR DESCRIPTION
## WHAT

- add new view and controller to enable user to select what type of organisation they work for when creating a new service
- create Stripe test account by default when selecting 'local' government, sandbox when selecting 'central'
- redirect user to new service on creation (was previously the 'My Services' overview)
- update psp test account stage when creating new stripe service
- introduce new 'SystemMessages' macro for displaying simple notifications to users
- show 'Service created successfully' message on successful creation of a new service
- layout bug fixes