### PR TITLE
PP-13090 Service Name design changes

### DIFF
--- a/app/views/services/add-service.njk
+++ b/app/views/services/add-service.njk
@@ -2,7 +2,7 @@
 {% from "../macro/error-summary.njk" import errorSummary %}
 
 {% block pageTitle %}
-  Add a new service - GOV.UK Pay
+  Service name - GOV.UK Pay
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/services/add-service.njk
+++ b/app/views/services/add-service.njk
@@ -9,7 +9,6 @@
   {{
   govukBackLink({
     text: "Back",
-    classes: "govuk-!-margin-bottom-0",
     href: routes.serviceSwitcher.index
   })
   }}
@@ -25,24 +24,24 @@
       }
     }) }}
 
-    <h1 class="govuk-heading-l">What service will you be taking payments for?</h1>
-    <p class="govuk-body">
-      This is what your users will see when making a payment. You can change this&nbsp;later.
-    </p>
-
     <form id="add-service-form" method="post" action="{{submit_link}}" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
       {{ govukInput({
           label: {
-            text: "Service name"
+            text: "Service name",
+            classes: "govuk-label--l",
+            isPageHeading: true
           },
           errorMessage: { text: errors.service_name } if errors.service_name else false,
           id: "service-name",
           name: "service-name",
           value: current_name,
           classes: "govuk-!-width-one-half",
-          type: "text"
+          type: "text",
+          hint: {
+            text: "This is what your users will see when making a payment. You can change this later."
+          }
         })
       }}
 
@@ -61,7 +60,9 @@
             "lang": "cy"
           }
         }) }}
-        <div class="govuk-hint">To turn on Welsh translations, follow the instructions in our&nbsp;documentation</div>
+        <a class="govuk-link govuk-!-margin-top-2 govuk-!-display-inline-block" href="https://docs.payments.service.gov.uk/optional_features/welsh_language/#use-welsh-on-your-payment-pages">
+          Read our documentation on how to use Welsh on your payment pages
+        </a>
       {% endset -%}
 
       {{ govukCheckboxes({
@@ -79,17 +80,13 @@
         ]
       }) }}
 
-      {{ govukButton({ text: "Continue" })}}
       <p class="govuk-body">
-        <a class="govuk-link govuk-link--no-visited-state" id="service-name-cancel-link" href="{{back_link}}">
-            Cancel
-        </a>
-      </p>
-      <p class="govuk-body">
-        <a class="govuk-link" id="service-nam-guidance" href="https://www.gov.uk/service-manual/design/naming-your-service">
+        <a class="govuk-link" id="service-name-guidance" href="https://www.gov.uk/service-manual/design/naming-your-service">
           Get guidance on choosing a name for your service
         </a>
       </p>
+
+      {{ govukButton({ text: "Continue" })}}
     </form>
   </div>
 {% endblock %}

--- a/app/views/services/edit-service-name.njk
+++ b/app/views/services/edit-service-name.njk
@@ -80,7 +80,7 @@
         </a>
       </p>
       <p class="govuk-body">
-        <a class="govuk-link" id="service-nam-guidance" href="https://www.gov.uk/service-manual/design/naming-your-service">
+        <a class="govuk-link" id="service-name-guidance" href="https://www.gov.uk/service-manual/design/naming-your-service">
           Get guidance on choosing a name for your service
         </a>
       </p>

--- a/app/views/services/select-org-type.njk
+++ b/app/views/services/select-org-type.njk
@@ -8,7 +8,6 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    classes: "govuk-!-margin-bottom-0",
     href: back_link
   }) }}
 {% endblock %}

--- a/test/cypress/integration/my-services/add-new-service.cy.js
+++ b/test/cypress/integration/my-services/add-new-service.cy.js
@@ -51,7 +51,7 @@ describe('Add a new service', () => {
 
       cy.get('a').contains('Add a new service').click()
 
-      cy.title().should('eq', 'Add a new service - GOV.UK Pay')
+      cy.title().should('eq', 'Service name - GOV.UK Pay')
       cy.get('#checkbox-service-name-cy').should('have.attr', 'aria-expanded', 'false')
 
       cy.get('input#service-name').type(newServiceName)
@@ -93,7 +93,7 @@ describe('Add a new service', () => {
 
       cy.get('a').contains('Add a new service').click()
 
-      cy.title().should('eq', 'Add a new service - GOV.UK Pay')
+      cy.title().should('eq', 'Service name - GOV.UK Pay')
       cy.get('#checkbox-service-name-cy').should('have.attr', 'aria-expanded', 'false')
 
       cy.get('#checkbox-service-name-cy').click()
@@ -104,7 +104,7 @@ describe('Add a new service', () => {
       cy.get('input#service-name-cy').type('Lorem ipsum dolor sit amet, consectetuer adipiscing', { delay: 0 })
       cy.get('button').contains('Continue').click()
 
-      cy.title().should('eq', 'Add a new service - GOV.UK Pay')
+      cy.title().should('eq', 'Service name - GOV.UK Pay')
 
       cy.get('.govuk-error-summary').find('a').should('have.length', 2)
       cy.get('.govuk-error-summary').should('exist').within(() => {


### PR DESCRIPTION
## WHAT
 - Some design changes to the Service Name page in the 'Add Service' flow
   - Update page title
   - Update page heading
   - Move paragraph text to hint text on text input
   - Replace text about Welsh translation documentation with link to documentation
   - Remove 'cancel' link
   - Fix padding on 'back' link to be 15px above and below

 - Some of the design changes have already been addressed in #4256 & #4258

This is what the current Service Name page looks like:

![Screenshot 2024-08-30 at 11 05 42](https://github.com/user-attachments/assets/c5dc936e-0873-499c-ab06-c9bfd1ef7e9e)

![Screenshot 2024-08-30 at 11 05 53](https://github.com/user-attachments/assets/5d7c2d8a-8ccb-473e-bd82-7a972c19002c)

This is the updated version (with these changes)

![Screenshot 2024-08-30 at 11 02 58](https://github.com/user-attachments/assets/beeba5c4-3ca7-4618-9713-ab6570a7af39)

![Screenshot 2024-08-30 at 11 03 54](https://github.com/user-attachments/assets/d59c3d4b-4e63-44d2-8ab8-838e80ebcb4a)

