### PR TITLE
PP-13111 Show spinner when creating a Stripe test account

### DIFF
--- a/app/assets/js/components/add-service-spinner.js
+++ b/app/assets/js/components/add-service-spinner.js
@@ -1,0 +1,19 @@
+
+(function () {
+  document.getElementById('submit-button').addEventListener('click', function () {
+    if (document.getElementById('org-type-local').checked) {
+      disableButtonAndShowSpinner()
+    }
+    document.getElementById('add-service-form').requestSubmit()
+  })
+
+  function disableButtonAndShowSpinner () {
+    document.getElementById('add-service-form').hidden = true
+    document.getElementById('spinner-container').hidden = false
+    document.getElementById('spinner-container').setAttribute('aria-hidden', false)
+
+    document.getElementById('submit-button').setAttribute('disabled', true)
+    document.getElementById('submit-button').setAttribute('aria-disabled', true)
+    document.getElementById('submit-button').setAttribute('class', 'govuk-button govuk-button--disabled')
+  }
+})()

--- a/app/assets/js/components/request-psp-test-account-spinner.js
+++ b/app/assets/js/components/request-psp-test-account-spinner.js
@@ -1,0 +1,18 @@
+(function () {
+  if (document.getElementById('submit-button')) {
+    document.getElementById('submit-button').addEventListener('click', function () {
+      disableButtonAndShowSpinner()
+      document.getElementById('submit-request-for-psp-test-account-form').requestSubmit()
+    })
+  }
+
+  function disableButtonAndShowSpinner () {
+    document.getElementById('submit-request-for-psp-test-account-form').hidden = true
+    document.getElementById('spinner-container').hidden = false
+    document.getElementById('spinner-container').setAttribute('aria-hidden', false)
+
+    document.getElementById('submit-button').setAttribute('disabled', true)
+    document.getElementById('submit-button').setAttribute('aria-disabled', true)
+    document.getElementById('submit-button').setAttribute('class', 'govuk-button govuk-button--disabled')
+  }
+})()

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -52,3 +52,4 @@ $govuk-page-width: 1200px;
 @import "components/sub-navigation";
 @import "components/additional-information";
 @import "components/messages";
+@import "components/spinner";

--- a/app/assets/sass/components/spinner.scss
+++ b/app/assets/sass/components/spinner.scss
@@ -1,0 +1,37 @@
+.spinner {
+  margin: 20px auto;
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  border: 16px solid govuk-colour("light-grey");
+  border-bottom-color: govuk-colour("light-blue"); /* Annulus sector colour */
+  animation: rotate 3s linear infinite;
+  will-change: transform;
+}
+
+
+button {
+  .spinner {
+    display: none;
+    width: 8px;
+    height: 8px;
+    border-width: 4px;
+    margin: 0 0 0 5px;
+  }
+
+  &:disabled {
+    .spinner {
+      display: inline-block;
+    }
+  }
+}
+
+
+@keyframes rotate {
+  from {
+    transform: rotate3d(0, 0, 1, -360deg) translate3d(0, 0, 0);
+  }
+  to {
+    transform: rotate3d(0, 0, 1, 360deg) translate3d(0, 0, 0);
+  }
+}

--- a/app/controllers/create-service/create-service.controller.js
+++ b/app/controllers/create-service/create-service.controller.js
@@ -31,19 +31,11 @@ async function post (req, res, next) {
     return res.redirect(paths.serviceSwitcher.create.selectOrgType)
   }
 
-  try {
-    // ADD THESE LINES BACK IN
-    // const { service, externalAccountId } = await serviceService.createService(serviceName, serviceNameCy, organisationType)
-    // await userService.assignServiceRole(req.user.externalId, service.externalId, 'admin')
-    // _.unset(req, 'session.pageData.createService')
-    req.flash('messages', { state: 'success', icon: '&check;', content: 'We\'ve created your service.' })
-    // res.redirect(formatAccountPathsFor(paths.account.dashboard.index, externalAccountId))
-    setTimeout(function () { // SIMULATE LONG RUNNING REQUEST
-      res.redirect(paths.serviceSwitcher.index)
-    }, 3000)
-  } catch (err) {
-    next(err)
-  }
+  const { service, externalAccountId } = await serviceService.createService(serviceName, serviceNameCy, organisationType)
+  await userService.assignServiceRole(req.user.externalId, service.externalId, 'admin')
+  _.unset(req, 'session.pageData.createService')
+  req.flash('messages', { state: 'success', icon: '&check;', content: 'We\'ve created your service.' })
+  res.redirect(formatAccountPathsFor(paths.account.dashboard.index, externalAccountId))
 }
 
 module.exports = {

--- a/app/controllers/create-service/create-service.controller.js
+++ b/app/controllers/create-service/create-service.controller.js
@@ -31,11 +31,18 @@ async function post (req, res, next) {
     return res.redirect(paths.serviceSwitcher.create.selectOrgType)
   }
 
-  const { service, externalAccountId } = await serviceService.createService(serviceName, serviceNameCy, organisationType)
-  await userService.assignServiceRole(req.user.externalId, service.externalId, 'admin')
-  _.unset(req, 'session.pageData.createService')
-  req.flash('messages', { state: 'success', icon: '&check;', content: 'We\'ve created your service.' })
-  res.redirect(formatAccountPathsFor(paths.account.dashboard.index, externalAccountId))
+  try {
+    const {
+      service,
+      externalAccountId
+    } = await serviceService.createService(serviceName, serviceNameCy, organisationType)
+    await userService.assignServiceRole(req.user.externalId, service.externalId, 'admin')
+    _.unset(req, 'session.pageData.createService')
+    req.flash('messages', { state: 'success', icon: '&check;', content: 'We\'ve created your service.' })
+    res.redirect(formatAccountPathsFor(paths.account.dashboard.index, externalAccountId))
+  } catch (err) {
+    next(err)
+  }
 }
 
 module.exports = {

--- a/app/controllers/create-service/create-service.controller.js
+++ b/app/controllers/create-service/create-service.controller.js
@@ -32,11 +32,15 @@ async function post (req, res, next) {
   }
 
   try {
-    const { service, externalAccountId } = await serviceService.createService(serviceName, serviceNameCy, organisationType)
-    await userService.assignServiceRole(req.user.externalId, service.externalId, 'admin')
-    _.unset(req, 'session.pageData.createService')
+    // ADD THESE LINES BACK IN
+    // const { service, externalAccountId } = await serviceService.createService(serviceName, serviceNameCy, organisationType)
+    // await userService.assignServiceRole(req.user.externalId, service.externalId, 'admin')
+    // _.unset(req, 'session.pageData.createService')
     req.flash('messages', { state: 'success', icon: '&check;', content: 'We\'ve created your service.' })
-    res.redirect(formatAccountPathsFor(paths.account.dashboard.index, externalAccountId))
+    // res.redirect(formatAccountPathsFor(paths.account.dashboard.index, externalAccountId))
+    setTimeout(function () { // SIMULATE LONG RUNNING REQUEST
+      res.redirect(paths.serviceSwitcher.index)
+    }, 3000)
   } catch (err) {
     next(err)
   }

--- a/app/views/includes/spinner.njk
+++ b/app/views/includes/spinner.njk
@@ -1,0 +1,7 @@
+{% macro spinner(params) %}
+  <div class="spinner"></div>
+  {% if params.text %}
+    <h3 class="govuk-heading-m" style="text-align: center">{{ params.text }}</h3>
+  {% endif %}
+{% endmacro %}
+

--- a/app/views/includes/spinner.njk
+++ b/app/views/includes/spinner.njk
@@ -1,7 +1,7 @@
 {% macro spinner(params) %}
   <div class="spinner"></div>
   {% if params.text %}
-    <h3 class="govuk-heading-m" style="text-align: center">{{ params.text }}</h3>
+    <h3 class="govuk-heading-m govuk-!-text-align-centre">{{ params.text }}</h3>
   {% endif %}
 {% endmacro %}
 

--- a/app/views/request-psp-test-account/index.njk
+++ b/app/views/request-psp-test-account/index.njk
@@ -42,6 +42,9 @@
           <p class="govuk-body">
             You will need to create new API keys and add them to your integration as your old keys will stop working.
           </p>
+          <p class="govuk-body">
+            Creating your Stripe account may take around ten seconds.
+          </p>
 
           {{ govukButton({
             html: "Get a Stripe test account",

--- a/app/views/request-psp-test-account/index.njk
+++ b/app/views/request-psp-test-account/index.njk
@@ -94,10 +94,12 @@
   </div>
 
   <script>
-    document.getElementById('submit-button').addEventListener('click', function () {
-      disableButtonAndShowSpinner()
-      document.getElementById('submit-request-for-psp-test-account-form').requestSubmit()
-    })
+    if (document.getElementById('submit-button')) {
+      document.getElementById('submit-button').addEventListener('click', function () {
+        disableButtonAndShowSpinner()
+        document.getElementById('submit-request-for-psp-test-account-form').requestSubmit()
+      })
+    }
 
     function disableButtonAndShowSpinner () {
       document.getElementById('submit-request-for-psp-test-account-form').hidden = true

--- a/app/views/request-psp-test-account/index.njk
+++ b/app/views/request-psp-test-account/index.njk
@@ -53,7 +53,7 @@
           }) }}
         </form>
 
-        <div id="spinner" hidden="hidden" aria-hidden="true">
+        <div id="spinner-container" hidden="hidden" aria-hidden="true">
           {{ spinner({
             text: "We're setting up your Stripe test account, please wait..."
           }) }}
@@ -106,8 +106,8 @@
 
     function disableButtonAndShowSpinner () {
       document.getElementById('submit-request-for-psp-test-account-form').hidden = true
-      document.getElementById('spinner').hidden = false
-      document.getElementById('spinner').setAttribute('aria-hidden', false)
+      document.getElementById('spinner-container').hidden = false
+      document.getElementById('spinner-container').setAttribute('aria-hidden', false)
 
       document.getElementById('submit-button').setAttribute('disabled', true)
       document.getElementById('submit-button').setAttribute('aria-disabled', true)

--- a/app/views/request-psp-test-account/index.njk
+++ b/app/views/request-psp-test-account/index.njk
@@ -96,7 +96,7 @@
   <script>
     document.getElementById('submit-button').addEventListener('click', function () {
       disableButtonAndShowSpinner()
-      document.getElementById('submit-request-for-psp-test-account-form').submit()
+      document.getElementById('submit-request-for-psp-test-account-form').requestSubmit()
     })
 
     function disableButtonAndShowSpinner () {

--- a/app/views/request-psp-test-account/index.njk
+++ b/app/views/request-psp-test-account/index.njk
@@ -96,22 +96,5 @@
 
   </div>
 
-  <script>
-    if (document.getElementById('submit-button')) {
-      document.getElementById('submit-button').addEventListener('click', function () {
-        disableButtonAndShowSpinner()
-        document.getElementById('submit-request-for-psp-test-account-form').requestSubmit()
-      })
-    }
-
-    function disableButtonAndShowSpinner () {
-      document.getElementById('submit-request-for-psp-test-account-form').hidden = true
-      document.getElementById('spinner-container').hidden = false
-      document.getElementById('spinner-container').setAttribute('aria-hidden', false)
-
-      document.getElementById('submit-button').setAttribute('disabled', true)
-      document.getElementById('submit-button').setAttribute('aria-disabled', true)
-      document.getElementById('submit-button').setAttribute('class', 'govuk-button govuk-button--disabled')
-    }
-  </script>
+  <script src="/public/js/components/request-psp-test-account-spinner.js"></script>
 {% endblock %}

--- a/app/views/request-psp-test-account/index.njk
+++ b/app/views/request-psp-test-account/index.njk
@@ -1,6 +1,7 @@
 {% extends "../layout.njk" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "includes/spinner.njk" import spinner %}
 
 {% block pageTitle %}
   Request Stripe test account - {{ currentService.name }} - GOV.UK Pay
@@ -9,77 +10,92 @@
 {% block mainContent %}
   <div class="govuk-grid-column-two-thirds">
 
-  {% if isServiceLive %}
-    <h1 class="govuk-heading-l">
-      Test account cannot be requested
-    <h1>
-    <p class="govuk-body">
-      Stripe test accounts cannot be requested for a live service. You can create another service and request a Stripe test account
-    </p>
-  {% else %}
-      {% if requestForPspTestAccountNotStarted %}
-        <form id="submit-request-for-psp-test-account-form" method="post" novalidate>
-            <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-            <h1 class="govuk-heading-l">Get a Stripe test account</h1>
-            <p class="govuk-body">
-              Test your end-to-end reporting process with a Stripe test account. The Stripe reports are different from
-              reports in a regular 'sandbox' account. You’ll be able to access new reports showing
-            </p>
-            <ul class="govuk-list govuk-list--bullet">
-                      <li>PSP fees, and gross and net payments</li>
-                      <li>payments into your bank account</li>
-            </ul>
-            <p class="govuk-body">
-              You can download the data as a CSV file or by integrating with our reporting and reconciliation API.
-            </p>
-            <p class="govuk-body">
-              If you choose to get a Stripe test account, it will replace your sandbox account
-              immediately. You will not be able to change your account back. If you have any existing API keys they
-              will be disabled.
-            </p>
-            <p class="govuk-body">
-              You will need to create new API keys and add them to your integration as your old keys will stop working.
-            </p>
-
-          <div class="button-group">
-            {{ govukButton({
-              text: "Get a Stripe test account",
-              classes: "govuk-!-margin-bottom-0",
-              preventDoubleClick: true
-            }) }}
-          </div>
-        </form>
-    {% elif requestForPspTestAccountSubmitted %}
+    {% if isServiceLive %}
       <h1 class="govuk-heading-l">
-        Account already requested
+        Test account cannot be requested
       </h1>
       <p class="govuk-body">
-        A user has requested a Stripe test account for this service. We usually set up the account within 2 working days.
+        Stripe test accounts cannot be requested for a live service. You can create another service and request a Stripe
+        test account
       </p>
-      <p class="govuk-body">
-        When it’s ready, you’ll find it in
-        <a class="govuk-link" href="{{ routes.serviceSwitcher.index }}">My services</a>
-      </p>
-    {% elif pspTestAccountCreated %}
-      <h1 class="govuk-heading-l">
-        Stripe test account already set up
-      <h1>
-      <p class="govuk-body">
-        There is a test account for this service. Find it in
-        <a class="govuk-link" href="{{ routes.serviceSwitcher.index }}">My services</a>
-      </p>
-    {% elif pspTestAccountRequestSubmitted %}
-      <h1 class="govuk-heading-l">
-        Thanks for requesting a Stripe test account
-      <h1>
-      <p class="govuk-body">
-        Your service’s test account will be ready within 1 working day. We’ll email with confirmation and further information.
-      </p>
-      <p class="govuk-body">
-        Access your live and test services in <a class="govuk-link" href="{{ routes.serviceSwitcher.index }}">My services</a>.
-      </p>
+    {% else %}
+      {% if requestForPspTestAccountNotStarted %}
+        <form id="submit-request-for-psp-test-account-form" method="post" novalidate>
+          <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+          <h1 class="govuk-heading-l">Get a Stripe test account</h1>
+          <p class="govuk-body">
+            Test your end-to-end reporting process with a Stripe test account. The Stripe reports are different from
+            reports in a regular 'sandbox' account. You’ll be able to access new reports showing
+          </p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>PSP fees, and gross and net payments</li>
+            <li>payments into your bank account</li>
+          </ul>
+          <p class="govuk-body">
+            You can download the data as a CSV file or by integrating with our reporting and reconciliation API.
+          </p>
+          <p class="govuk-body">
+            If you choose to get a Stripe test account, it will replace your sandbox account
+            immediately. You will not be able to change your account back. If you have any existing API keys they
+            will be disabled.
+          </p>
+          <p class="govuk-body">
+            You will need to create new API keys and add them to your integration as your old keys will stop working.
+          </p>
+
+          {{ govukButton({
+            html: "Get a Stripe test account <span class=\"spinner\"></span>",
+            id: "submit-button",
+            preventDoubleClick: true
+          }) }}
+        </form>
+        {% elif requestForPspTestAccountSubmitted %}
+        <h1 class="govuk-heading-l">
+          Account already requested
+        </h1>
+        <p class="govuk-body">
+          A user has requested a Stripe test account for this service. We usually set up the account within 2 working
+          days.
+        </p>
+        <p class="govuk-body">
+          When it’s ready, you’ll find it in
+          <a class="govuk-link" href="{{ routes.serviceSwitcher.index }}">My services</a>
+        </p>
+        {% elif pspTestAccountCreated %}
+        <h1 class="govuk-heading-l">
+          Stripe test account already set up
+        </h1>
+        <p class="govuk-body">
+          There is a test account for this service. Find it in
+          <a class="govuk-link" href="{{ routes.serviceSwitcher.index }}">My services</a>
+        </p>
+        {% elif pspTestAccountRequestSubmitted %}
+        <h1 class="govuk-heading-l">
+          Thanks for requesting a Stripe test account
+        </h1>
+        <p class="govuk-body">
+          Your service’s test account will be ready within 1 working day. We’ll email with confirmation and further
+          information.
+        </p>
+        <p class="govuk-body">
+          Access your live and test services in <a class="govuk-link" href="{{ routes.serviceSwitcher.index }}">My
+            services</a>.
+        </p>
+      {% endif %}
     {% endif %}
-  {% endif %}
 
   </div>
+
+  <script>
+    document.getElementById('submit-button').addEventListener('click', function () {
+      disableButtonAndShowSpinner()
+      document.getElementById('submit-request-for-psp-test-account-form').submit()
+    })
+
+    function disableButtonAndShowSpinner () {
+      document.getElementById('submit-button').setAttribute('disabled', true)
+      document.getElementById('submit-button').setAttribute('aria-disabled', true)
+      document.getElementById('submit-button').setAttribute('class', 'govuk-button govuk-button--disabled')
+    }
+  </script>
 {% endblock %}

--- a/app/views/request-psp-test-account/index.njk
+++ b/app/views/request-psp-test-account/index.njk
@@ -44,11 +44,18 @@
           </p>
 
           {{ govukButton({
-            html: "Get a Stripe test account <span class=\"spinner\"></span>",
+            html: "Get a Stripe test account",
             id: "submit-button",
             preventDoubleClick: true
           }) }}
         </form>
+
+        <div id="spinner" hidden="hidden" aria-hidden="true">
+          {{ spinner({
+            text: "We're setting up your Stripe test account, please wait..."
+          }) }}
+        </div>
+
         {% elif requestForPspTestAccountSubmitted %}
         <h1 class="govuk-heading-l">
           Account already requested
@@ -93,6 +100,10 @@
     })
 
     function disableButtonAndShowSpinner () {
+      document.getElementById('submit-request-for-psp-test-account-form').hidden = true
+      document.getElementById('spinner').hidden = false
+      document.getElementById('spinner').setAttribute('aria-hidden', false)
+
       document.getElementById('submit-button').setAttribute('disabled', true)
       document.getElementById('submit-button').setAttribute('aria-disabled', true)
       document.getElementById('submit-button').setAttribute('class', 'govuk-button govuk-button--disabled')

--- a/app/views/services/select-org-type.njk
+++ b/app/views/services/select-org-type.njk
@@ -1,5 +1,7 @@
 {% extends "../layout.njk" %}
 {% from "../macro/error-summary.njk" import errorSummary %}
+{% from "includes/spinner.njk" import spinner %}
+
 
 {% block pageTitle %}
   Select your organisation type - GOV.UK Pay
@@ -60,8 +62,33 @@
         html: "<p class=\"govuk-body\">Contact <a class=\"govuk-link\" href=\"mailto:govuk-pay-support@digital.cabinet-office.gov.uk\">govuk-pay-support@digital.cabinet-office.gov.uk</a> for help deciding which provider you should use.</p>"
       }) }}
 
-      {{ govukButton({ text: "Create service" })}}
+      {{ govukButton({
+        html: "Create service <span class=\"spinner\"></span>",
+        id: "submit-button",
+        preventDoubleClick: true
+      }) }}
     </form>
 
+    <div id="spinner" hidden="hidden">
+      {{ spinner({
+        text: "We're creating your service, please wait..."
+      }) }}
+    </div>
   </div>
+
+  <script>
+    document.getElementById('submit-button').addEventListener('click', function () {
+      disableButtonAndShowSpinner()
+      document.getElementById('add-service-form').submit()
+    })
+
+    function disableButtonAndShowSpinner () {
+      document.getElementById('add-service-form').hidden = true
+      document.getElementById('spinner').hidden = false
+
+      document.getElementById('submit-button').setAttribute('disabled', true)
+      document.getElementById('submit-button').setAttribute('aria-disabled', true)
+      document.getElementById('submit-button').setAttribute('class', 'govuk-button govuk-button--disabled')
+    }
+  </script>
 {% endblock %}

--- a/app/views/services/select-org-type.njk
+++ b/app/views/services/select-org-type.njk
@@ -79,7 +79,7 @@
   <script>
     document.getElementById('submit-button').addEventListener('click', function () {
       disableButtonAndShowSpinner()
-      document.getElementById('add-service-form').submit()
+      document.getElementById('add-service-form').requestSubmit()
     })
 
     function disableButtonAndShowSpinner () {

--- a/app/views/services/select-org-type.njk
+++ b/app/views/services/select-org-type.njk
@@ -69,7 +69,7 @@
       }) }}
     </form>
 
-    <div id="spinner" hidden="hidden">
+    <div id="spinner" hidden="hidden" aria-hidden="true">
       {{ spinner({
         text: "We're creating your service, please wait..."
       }) }}
@@ -85,6 +85,7 @@
     function disableButtonAndShowSpinner () {
       document.getElementById('add-service-form').hidden = true
       document.getElementById('spinner').hidden = false
+      document.getElementById('spinner').setAttribute('aria-hidden', false)
 
       document.getElementById('submit-button').setAttribute('disabled', true)
       document.getElementById('submit-button').setAttribute('aria-disabled', true)

--- a/app/views/services/select-org-type.njk
+++ b/app/views/services/select-org-type.njk
@@ -69,7 +69,7 @@
       }) }}
     </form>
 
-    <div id="spinner" hidden="hidden" aria-hidden="true">
+    <div id="spinner-container" hidden="hidden" aria-hidden="true">
       {{ spinner({
         text: "We're creating your service, please wait..."
       }) }}
@@ -86,8 +86,8 @@
 
     function disableButtonAndShowSpinner () {
       document.getElementById('add-service-form').hidden = true
-      document.getElementById('spinner').hidden = false
-      document.getElementById('spinner').setAttribute('aria-hidden', false)
+      document.getElementById('spinner-container').hidden = false
+      document.getElementById('spinner-container').setAttribute('aria-hidden', false)
 
       document.getElementById('submit-button').setAttribute('disabled', true)
       document.getElementById('submit-button').setAttribute('aria-disabled', true)

--- a/app/views/services/select-org-type.njk
+++ b/app/views/services/select-org-type.njk
@@ -42,7 +42,7 @@
             value: "local",
             html: "<h3 class=\"govuk-heading-s govuk-!-margin-bottom-0\">Local authority, armed forces or police</h3>",
             hint: {
-            text: 'We use Stripe for card payments.'
+            text: 'We use Stripe for card payments. Creating a Stripe service takes up to 10 seconds'
           },
             id: "org-type-local"
           },

--- a/app/views/services/select-org-type.njk
+++ b/app/views/services/select-org-type.njk
@@ -76,22 +76,5 @@
     </div>
   </div>
 
-  <script>
-    document.getElementById('submit-button').addEventListener('click', function () {
-      if (document.getElementById('org-type-local').checked) {
-        disableButtonAndShowSpinner()
-      }
-      document.getElementById('add-service-form').requestSubmit()
-    })
-
-    function disableButtonAndShowSpinner () {
-      document.getElementById('add-service-form').hidden = true
-      document.getElementById('spinner-container').hidden = false
-      document.getElementById('spinner-container').setAttribute('aria-hidden', false)
-
-      document.getElementById('submit-button').setAttribute('disabled', true)
-      document.getElementById('submit-button').setAttribute('aria-disabled', true)
-      document.getElementById('submit-button').setAttribute('class', 'govuk-button govuk-button--disabled')
-    }
-  </script>
+  <script src="/public/js/components/add-service-spinner.js"></script>
 {% endblock %}

--- a/app/views/services/select-org-type.njk
+++ b/app/views/services/select-org-type.njk
@@ -78,7 +78,9 @@
 
   <script>
     document.getElementById('submit-button').addEventListener('click', function () {
-      disableButtonAndShowSpinner()
+      if (document.getElementById('org-type-local').checked) {
+        disableButtonAndShowSpinner()
+      }
       document.getElementById('add-service-form').requestSubmit()
     })
 

--- a/test/cypress/integration/my-services/add-new-service.cy.js
+++ b/test/cypress/integration/my-services/add-new-service.cy.js
@@ -71,18 +71,7 @@ describe('Add a new service', () => {
         userStubs.getUserSuccess({ userExternalId: authenticatedUserId, gatewayAccountId: '1' }),
         gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId: '1' }),
         createGatewayAccountStub,
-        assignUserRoleStub,
-        serviceStubs.postCreateServiceSuccess({
-          serviceExternalId: newServiceId,
-          gatewayAccountId: newGatewayAccountId,
-          serviceName: { en: newServiceName }
-        }),
-        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId }),
-        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
-          gatewayAccountExternalId: 'a-valid-external-id',
-          gatewayAccountId: '1'
-        }),
-        transactionsSummaryStubs.getDashboardStatistics()
+        assignUserRoleStub
       ])
       cy.setEncryptedCookies(authenticatedUserId)
 
@@ -100,7 +89,7 @@ describe('Add a new service', () => {
 
       cy.get('button').contains('Create service').click()
 
-      cy.get('#spinner').should('be.visible')
+      cy.get('#spinner-container').should('be.visible')
     })
   })
 

--- a/test/cypress/integration/my-services/add-new-service.cy.js
+++ b/test/cypress/integration/my-services/add-new-service.cy.js
@@ -65,6 +65,43 @@ describe('Add a new service', () => {
       cy.title().should('contain', 'Dashboard')
       cy.get('#system-messages').contains("We've created your service")
     })
+
+    it('should show the loading spinner when the submit button is clicked', () => {
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({ userExternalId: authenticatedUserId, gatewayAccountId: '1' }),
+        gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId: '1' }),
+        createGatewayAccountStub,
+        assignUserRoleStub,
+        serviceStubs.postCreateServiceSuccess({
+          serviceExternalId: newServiceId,
+          gatewayAccountId: newGatewayAccountId,
+          serviceName: { en: newServiceName }
+        }),
+        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId }),
+        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+          gatewayAccountExternalId: 'a-valid-external-id',
+          gatewayAccountId: '1'
+        }),
+        transactionsSummaryStubs.getDashboardStatistics()
+      ])
+      cy.setEncryptedCookies(authenticatedUserId)
+
+      cy.visit('/my-services')
+      cy.get('a').contains('Add a new service').click()
+      cy.get('input#service-name').type(newServiceName)
+      cy.get('button').contains('Continue').click()
+      cy.get('input#org-type-local').click()
+
+      cy.get('form').then(form$ => {
+        form$.on('submit', e => {
+          e.preventDefault()
+        })
+      })
+
+      cy.get('button').contains('Create service').click()
+
+      cy.get('#spinner').should('be.visible')
+    })
   })
 
   describe('Add a new service with a Welsh name', () => {
@@ -140,43 +177,6 @@ describe('Add a new service', () => {
 
       cy.title().should('contain', 'Dashboard')
       cy.get('#system-messages').contains("We've created your service")
-    })
-
-    it('should show the loading spinner when the submit button is clicked', () => {
-      cy.task('setupStubs', [
-        userStubs.getUserSuccess({ userExternalId: authenticatedUserId, gatewayAccountId: '1' }),
-        gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId: '1' }),
-        createGatewayAccountStub,
-        assignUserRoleStub,
-        serviceStubs.postCreateServiceSuccess({
-          serviceExternalId: newServiceId,
-          gatewayAccountId: newGatewayAccountId,
-          serviceName: { en: newServiceName }
-        }),
-        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId }),
-        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
-          gatewayAccountExternalId: 'a-valid-external-id',
-          gatewayAccountId: '1'
-        }),
-        transactionsSummaryStubs.getDashboardStatistics()
-      ])
-      cy.setEncryptedCookies(authenticatedUserId)
-
-      cy.visit('/my-services')
-      cy.get('a').contains('Add a new service').click()
-      cy.get('input#service-name').type(newServiceName)
-      cy.get('button').contains('Continue').click()
-      cy.get('input#org-type-local').click()
-
-      cy.get('form').then(form$ => {
-        form$.on('submit', e => {
-          e.preventDefault()
-        })
-      })
-
-      cy.get('button').contains('Create service').click()
-
-      cy.get('#spinner').should('be.visible')
     })
   })
 })

--- a/test/cypress/integration/my-services/add-new-service.cy.js
+++ b/test/cypress/integration/my-services/add-new-service.cy.js
@@ -141,5 +141,42 @@ describe('Add a new service', () => {
       cy.title().should('contain', 'Dashboard')
       cy.get('#system-messages').contains("We've created your service")
     })
+
+    it('should show the loading spinner when the submit button is clicked', () => {
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({ userExternalId: authenticatedUserId, gatewayAccountId: '1' }),
+        gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId: '1' }),
+        createGatewayAccountStub,
+        assignUserRoleStub,
+        serviceStubs.postCreateServiceSuccess({
+          serviceExternalId: newServiceId,
+          gatewayAccountId: newGatewayAccountId,
+          serviceName: { en: newServiceName }
+        }),
+        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId }),
+        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+          gatewayAccountExternalId: 'a-valid-external-id',
+          gatewayAccountId: '1'
+        }),
+        transactionsSummaryStubs.getDashboardStatistics()
+      ])
+      cy.setEncryptedCookies(authenticatedUserId)
+
+      cy.visit('/my-services')
+      cy.get('a').contains('Add a new service').click()
+      cy.get('input#service-name').type(newServiceName)
+      cy.get('button').contains('Continue').click()
+      cy.get('input#org-type-local').click()
+
+      cy.get('form').then(form$ => {
+        form$.on('submit', e => {
+          e.preventDefault()
+        })
+      })
+
+      cy.get('button').contains('Create service').click()
+
+      cy.get('#spinner').should('be.visible')
+    })
   })
 })

--- a/test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.js
+++ b/test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.js
@@ -47,5 +47,20 @@ describe('Request PSP test account: submit request', () => {
         expect(location.pathname).to.eq(`/account/${stripeGatewayAccountExternalId}/dashboard`)
       })
     })
+
+    it('should show the loading spinner when the submit button is clicked', () => {
+      setupStubs('NOT_STARTED', 'NOT_STARTED')
+      cy.visit(requestStripeTestAccountUrl)
+
+      cy.get('form').then(form$ => {
+        form$.on('submit', e => {
+          e.preventDefault()
+        })
+      })
+
+      cy.get('button').contains('Get a Stripe test account').click()
+
+      cy.get('#spinner').should('be.visible')
+    })
   })
 })

--- a/test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.js
+++ b/test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.js
@@ -60,7 +60,7 @@ describe('Request PSP test account: submit request', () => {
 
       cy.get('button').contains('Get a Stripe test account').click()
 
-      cy.get('#spinner').should('be.visible')
+      cy.get('#spinner-container').should('be.visible')
     })
   })
 })


### PR DESCRIPTION
### WHAT
 - Add a loading spinner which shows when creating a Stripe test account. This shows in two scenarios:
   - When creating a new service for a local government organisation
   - When requesting a Stripe test account on a service with a Sandbox test account
     - The spinner does not show when creating a central government service, as this should not take long enough to warrant use of the spinner, and may cause issues for tools such as screen readers

### HOW TO TEST
 - There are some Cypress tests for this, but they aren't comprehensive as it doesn't seem possible to check both that the spinner shows and the form submits in one test. 
 - This can be tested locally by modifying a local instance of Connector to enforce a delay on the `/request-stripe-test-account` endpoint - see comment below for more info