### PR TITLE
PP-13090 Update size of link to Welsh language docs

### DIFF
--- a/app/views/services/add-service.njk
+++ b/app/views/services/add-service.njk
@@ -60,9 +60,11 @@
             "lang": "cy"
           }
         }) }}
-        <a class="govuk-link govuk-!-margin-top-2 govuk-!-display-inline-block" href="https://docs.payments.service.gov.uk/optional_features/welsh_language/#use-welsh-on-your-payment-pages">
-          Read our documentation on how to use Welsh on your payment pages
-        </a>
+        <p class="govuk-body">
+          <a class="govuk-link govuk-!-margin-top-2 govuk-!-display-inline-block" href="https://docs.payments.service.gov.uk/optional_features/welsh_language/#use-welsh-on-your-payment-pages">
+            Read our documentation on how to use Welsh on your payment pages
+          </a>
+        </p>
       {% endset -%}
 
       {{ govukCheckboxes({


### PR DESCRIPTION
## WHAT
 - Update the text size in link to "Use Welsh on your payment pages" documentation in Add Service flow

New appearance:
![Screenshot 2024-09-02 at 14 48 38](https://github.com/user-attachments/assets/706baffb-b6b5-4ab0-9954-aa3d6e528ee7)


See #4259 for previous appearance