### PR TITLE
PP-13145: Accept BIND_HOST env var and default to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ You will then be able to click on individual specs and see the tests running in 
 
 | Variable                    | required | default value | Description                               |
 | --------------------------- |:--------:|:-------------:| ----------------------------------------- |
+| BIND_HOST                   |   | 127.0.0.1 | The IP address for the application to bind to |
 | PORT                        | X | 9200 | The port number for the express server to be bound at runtime |
 | SESSION_ENCRYPTION_KEY      | X |      | Key to be used by the cookie encryption algorithm. Should be a large unguessable string ([More Info](https://www.npmjs.com/package/client-sessions)).  |
 | PUBLIC_AUTH_URL             | X |      | The publicauth endpoint to use when API Tokens. |

--- a/server.js
+++ b/server.js
@@ -27,6 +27,7 @@ const formatServicePathsFor = require('./app//utils/format-service-paths-for')
 const healthcheckController = require('./app/controllers/healthcheck.controller')
 const { healthcheck } = require('./app/paths.js')
 // Global constants
+const bind_host = (process.env.BIND_HOST || "127.0.0.1")
 const port = (process.env.PORT || 3000)
 const unconfiguredApp = express()
 const { NODE_ENV } = process.env
@@ -148,8 +149,8 @@ function initialiseErrorHandling (app) {
 
 function listen () {
   const app = initialise()
-  app.listen(port)
-  logger.info('Listening on port ' + port)
+  app.listen(port, bind_host)
+  logger.info(`Listening on ${bind_host}:${port}`)
 }
 
 /**

--- a/server.js
+++ b/server.js
@@ -27,7 +27,7 @@ const formatServicePathsFor = require('./app//utils/format-service-paths-for')
 const healthcheckController = require('./app/controllers/healthcheck.controller')
 const { healthcheck } = require('./app/paths.js')
 // Global constants
-const bind_host = (process.env.BIND_HOST || "127.0.0.1")
+const bindHost = (process.env.BIND_HOST || '127.0.0.1')
 const port = (process.env.PORT || 3000)
 const unconfiguredApp = express()
 const { NODE_ENV } = process.env
@@ -149,8 +149,8 @@ function initialiseErrorHandling (app) {
 
 function listen () {
   const app = initialise()
-  app.listen(port, bind_host)
-  logger.info(`Listening on ${bind_host}:${port}`)
+  app.listen(port, bindHost)
+  logger.info(`Listening on ${bindHost}:${port}`)
 }
 
 /**


### PR DESCRIPTION
Bind to 127.0.0.1 by default instead of 0.0.0.0 and allow override with BIND_HOST env var.

You can see this works, on master:

*  On master run `npm run start:dev`
* Then netstat:
    ```
    $ netstat -anl | grep 3000
    tcp46      0      0  *.3000                                        *.*                                           LISTEN
    ```
* Switch to this branch, then `npm run start:dev`
* Then netstat:
    ```
    $ netstat -anl | grep 3000
    tcp4       0      0  127.0.0.1.3000                                *.*                                           LISTEN
    ```
* Now `BIND_HOST=0.0.0.0 npm run start:dev`
* A final netstat to prove the override works
    ```
    $ netstat -anl | grep 3000
    tcp4       0      0  *.3000                                        *.*                                           LISTEN
    ```

Example of the updated logging:
```
{"@timestamp":"2024-09-06T11:08:27.278Z","@version":1,"container":"selfservice","level":"INFO","logger_name":"/Users/jonathan.harden/gitdevel/github.com/alphagov/pay-selfservice/server.js","message":"Listening on 127.0.0.1:3000"}
```


