### PR TITLE
PP-13030: Show WORLDPAY TEST SERVICE label

### DIFF
--- a/app/controllers/my-services/get-index.controller.js
+++ b/app/controllers/my-services/get-index.controller.js
@@ -27,6 +27,11 @@ function sortServicesByLiveThenName (a, b) {
   return 0
 }
 
+function isWorldpayTestService (gatewayAccounts) {
+  return gatewayAccounts.length === 1 && gatewayAccounts[0].type === 'test' &&
+    gatewayAccounts[0].payment_provider.toUpperCase() === 'WORLDPAY'
+}
+
 module.exports = async function getServiceList (req, res) {
   const servicesRoles = lodash.get(req, 'user.serviceRoles', [])
   const newServiceId = res.locals.flash && res.locals.flash.inviteSuccessServiceId &&
@@ -51,7 +56,8 @@ module.exports = async function getServiceList (req, res) {
         external_id: serviceRole.service.externalId,
         gatewayAccounts: lodash.sortBy(gatewayAccounts, 'type', 'asc'),
         permissions: getHeldPermissions(serviceRole.role.permissions.map(permission => permission.name)),
-        isAdminUser: isAdminUser
+        isAdminUser: isAdminUser,
+        isWorldpayTestService: isWorldpayTestService(gatewayAccounts)
       }
       return serviceData
     })

--- a/app/views/services/_service-section.njk
+++ b/app/views/services/_service-section.njk
@@ -1,8 +1,16 @@
+{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+
 <div class="govuk-grid-row service_list_item" data-name="{{ service.name }}">
   <div class="govuk-grid-column-full">
     <hr/>
     <h3 class="govuk-heading-s service-name">
       {{ service.name }}
+      {% if service.isWorldpayTestService %}
+        {{govukTag({
+          text: "WORLDPAY TEST SERVICE",
+          classes: "govuk-tag--grey"
+        })}}
+      {% endif %}
       {% if service.permissions.service_name_update %}
       <a href="{{formatServicePathsFor(routes.service.editServiceName.index, service.external_id)}}" class="govuk-link govuk-!-font-size-14 govuk-!-font-weight-regular govuk-!-margin-left-2 edit-service-name">
         Edit name <span class="govuk-visually-hidden">for {{ service.name }}</span>
@@ -12,12 +20,12 @@
   </div>
   <div class="govuk-grid-column-two-thirds">
   {% if service.gatewayAccounts.length %}
-      <ul class="govuk-list">
-        {% for account in service.gatewayAccounts %}
-          {% include "./_service-switch.njk" %}
-        {% endfor %}
-      </ul>
-    {% endif %}
+    <ul class="govuk-list">
+      {% for account in service.gatewayAccounts %}
+        {% include "./_service-switch.njk" %}
+      {% endfor %}
+    </ul>
+  {% endif %}
   </div>
   <div id="team-members" class="govuk-grid-column-one-third">
     <ul class="govuk-list">

--- a/test/cypress/integration/my-services/my-services.cy.js
+++ b/test/cypress/integration/my-services/my-services.cy.js
@@ -17,6 +17,50 @@ function getUserAndAccountStubs (type, paymentProvider) {
   ]
 }
 
+describe('User has access to Worldpay services', () => {
+  it('should display WORLDPAY TEST SERVICE label on the Worldpay Test Service only', () => {
+    cy.task('setupStubs', [
+      userStubs.getUserSuccessWithMultipleServices(authenticatedUserId, [
+        { serviceName: 'Service with a Worldpay test account only', gatewayAccountIds: ['10'] }
+      ]),
+      gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId: '10', type: 'test', paymentProvider: 'worldpay' })
+    ])
+    cy.setEncryptedCookies(authenticatedUserId)
+
+    cy.visit('/my-services')
+    cy.get('strong').should('have.class', 'govuk-tag govuk-tag--grey').contains('WORLDPAY TEST SERVICE')
+  })
+
+  it('should not display WORLDPAY TEST SERVICE label where there is a Worldpay Live account', () => {
+    cy.task('setupStubs', [
+      userStubs.getUserSuccessWithMultipleServices(authenticatedUserId, [
+        { serviceName: 'Service with a Worldpay test account only', gatewayAccountIds: ['13'] }
+      ]),
+      gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId: '13', type: 'live', paymentProvider: 'worldpay' })
+    ])
+    cy.setEncryptedCookies(authenticatedUserId)
+
+    cy.visit('/my-services')
+    cy.get('h3').should('not.have.class', 'govuk-tag govuk-tag--grey')
+  })
+
+  it('should not display WORLDPAY TEST SERVICE label where there are Worldpay and sandbox accounts', () => {
+    cy.task('setupStubs', [
+      userStubs.getUserSuccessWithMultipleServices(authenticatedUserId, [
+        { serviceName: 'Old service with Worldpay and Sandbox test accounts', gatewayAccountIds: ['11', '12'] }
+      ]),
+      gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
+        { gatewayAccountId: '11', type: 'test', paymentProvider: 'sandbox' },
+        { gatewayAccountId: '12', type: 'test', paymentProvider: 'worldpay' }
+      ])
+    ])
+    cy.setEncryptedCookies(authenticatedUserId)
+
+    cy.visit('/my-services')
+    cy.get('h3').should('not.have.class', 'govuk-tag govuk-tag--grey')
+  })
+})
+
 describe('The user has fewer than 8 services', () => {
   it('should show the reports section and list services, but not display the service filter', () => {
     cy.task('setupStubs', getUserAndAccountStubs('live', 'sandbox'))


### PR DESCRIPTION
A service is a worldpay test service if it only has one test gateway account which has payment provider of "worldpay".

This will not break any current services because it used to be that when a service was created, a sandbox gateway account would be created. We would then create another worldpay test gateway account (via toolbox) on request. In this case there would be two test gateway accounts on the service.

A screenshot to show some local testing:
<img width="857" alt="Screenshot 2024-09-20 at 16 14 41" src="https://github.com/user-attachments/assets/49a3e351-3373-4792-8a9e-25bfbd553ef4">
