### PR TITLE
PP-13133: Permissions strategy for new settings pages

### DIFF
--- a/app/controllers/settings/service-name.controller.js
+++ b/app/controllers/settings/service-name.controller.js
@@ -1,0 +1,12 @@
+'use strict'
+
+// const { response } = require('../../utils/response')
+const responses = require('../../utils/response')
+
+function getServiceNamePage (req, res) {
+  return responses.response(req, res, 'settings/service-name')
+}
+
+module.exports = {
+  getServiceNamePage: getServiceNamePage
+}

--- a/app/middleware/check-degateway-parameters.js
+++ b/app/middleware/check-degateway-parameters.js
@@ -1,0 +1,9 @@
+const { NotAuthorisedError } = require('../errors')
+
+module.exports = function checkDegatewayParameters (req, res, next) {
+  const user = req.user
+  if (process.env.DEGATEWAY_FLAG === 'true' && user.features.includes('degatewayaccountification')) {
+    return next()
+  }
+  return next(new NotAuthorisedError(`User with id ${user.externalId} not authorised to view page.`))
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -11,6 +11,7 @@ const accountUrls = require('./utils/gateway-account-urls')
 
 const userIsAuthorised = require('./middleware/user-is-authorised')
 const getServiceAndAccount = require('./middleware/get-service-and-gateway-account.middleware')
+const checkDegatewayParameters = require('./middleware/check-degateway-parameters')
 const { NotFoundError } = require('./errors')
 
 // Middleware
@@ -141,6 +142,11 @@ const {
 module.exports.generateRoute = generateRoute
 module.exports.paths = paths
 
+const keys = {
+  SERVICE_EXTERNAL_ID: 'serviceExternalId',
+  ACCOUNT_TYPE: 'gatewayAccountExternalId'
+}
+
 module.exports.bind = function (app) {
   const account = new Router({ mergeParams: true })
   account.use(getServiceAndAccount, userIsAuthorised)
@@ -152,6 +158,14 @@ module.exports.bind = function (app) {
   service.use(getServiceAndAccount, userIsAuthorised)
 
   app.get('/style-guide', (req, res) => response(req, res, 'style_guide'))
+
+  // -------------------------------------------------------------------------------
+  // ROUTES BY SERVICE ID AND ACCOUNT TYPE - ACCOUNT SIMPLIFICATION
+  // checkDegatewayParameters middleware is temporary and will eventually be deleted
+  // -------------------------------------------------------------------------------
+
+  service.get(`/:${keys.ACCOUNT_TYPE}/settings/service-name`,
+    checkDegatewayParameters, permission('service-name:read'), editServiceNameController.get)
 
   // ----------------------
   // UNAUTHENTICATED ROUTES

--- a/app/routes.js
+++ b/app/routes.js
@@ -92,6 +92,9 @@ const organisationUrlController = require('./controllers/switch-psp/organisation
 const registrationController = require('./controllers/registration/registration.controller')
 const privacyController = require('./controllers/privacy/privacy.controller')
 
+// Simplified Accounts controllers
+const serviceNameController = require('./controllers/settings/service-name.controller')
+
 // Assignments
 const {
   allServiceTransactions,
@@ -165,7 +168,7 @@ module.exports.bind = function (app) {
   // -------------------------------------------------------------------------------
 
   service.get(`/:${keys.ACCOUNT_TYPE}/settings/service-name`,
-    checkDegatewayParameters, permission('service-name:read'), editServiceNameController.get)
+    checkDegatewayParameters, permission('service-name:read'), serviceNameController.getServiceNamePage)
 
   // ----------------------
   // UNAUTHENTICATED ROUTES

--- a/app/views/settings/service-name.njk
+++ b/app/views/settings/service-name.njk
@@ -1,0 +1,5 @@
+{% extends "../layout.njk" %}
+
+{% block pageTitle %}
+  Settings - {{ currentService.name }} - GOV.UK Pay
+{% endblock %}


### PR DESCRIPTION
Introduce a `checkDegatewayParameters` middleware to ensure users with the "degatewayaccountification" feature can visit URLs beginning with `/service/{serviceId}/{accountType}/`.

At the moment `/service/{serviceId}/{accountType}/settings/service-name` returns a blank page. 

This permissions strategy will free up the ability to work on different settings pages in parallel.