### PR TITLE
Spike - Add formatting help for payment link description

### DIFF
--- a/app/controllers/payment-links/get-reference.controller.js
+++ b/app/controllers/payment-links/get-reference.controller.js
@@ -16,6 +16,7 @@ module.exports = function showReferencePage (req, res, next) {
   const paymentReferenceType = recovered.type || sessionData.paymentReferenceType || ''
   const paymentReferenceLabel = recovered.label || sessionData.paymentReferenceLabel || ''
   const paymentReferenceHint = recovered.hint || sessionData.paymentReferenceHint || ''
+  const govUkFormsUrl = recovered.govUkFormsUrl || sessionData.govUkFormsUrl || ''
 
   const change = lodash.get(req, 'query.change', {})
 
@@ -24,6 +25,7 @@ module.exports = function showReferencePage (req, res, next) {
     paymentReferenceType,
     paymentReferenceLabel,
     paymentReferenceHint,
+    govUkFormsUrl,
     isWelsh: sessionData.isWelsh,
     errors: recovered.errors
   })

--- a/app/controllers/payment-links/post-reference.controller.js
+++ b/app/controllers/payment-links/post-reference.controller.js
@@ -18,6 +18,7 @@ module.exports = function postReference (req, res, next) {
   const type = req.body['reference-type-group']
   const label = req.body['reference-label'].trim()
   const hint = req.body['reference-hint-text'].trim()
+  const govUkFormsUrl = req.body['gov-uk-forms-url'].trim()
 
   const errors = {}
   if (!type) {
@@ -39,7 +40,8 @@ module.exports = function postReference (req, res, next) {
       errors,
       type,
       label,
-      hint
+      hint,
+      govUkFormsUrl
     }
     return res.redirect(formatAccountPathsFor(paths.account.paymentLinks.reference, req.account && req.account.external_id))
   }
@@ -47,6 +49,7 @@ module.exports = function postReference (req, res, next) {
   sessionData.paymentReferenceType = type
   sessionData.paymentReferenceLabel = type === 'custom' ? label : ''
   sessionData.paymentReferenceHint = type === 'custom' ? hint : ''
+  sessionData.govUkFormsUrl = type === 'govUkForms' ? govUkFormsUrl : ''
 
   if (req.body['change'] === 'true') {
     req.flash('generic', 'The details have been updated')

--- a/app/controllers/payment-links/post-review.controller.js
+++ b/app/controllers/payment-links/post-review.controller.js
@@ -10,6 +10,8 @@ const productTypes = require('../../utils/product-types')
 const publicAuthClient = require('../../services/clients/public-auth.client')
 const supportedLanguage = require('../../models/supported-language')
 
+const GOV_UK_FORMS_REFERENCE_LABEL = "Form reference number"
+
 module.exports = async function createPaymentLink (req, res) {
   const gatewayAccountId = req.account.gateway_account_id
   const {
@@ -23,7 +25,8 @@ module.exports = async function createPaymentLink (req, res) {
     paymentReferenceLabel,
     paymentReferenceHint,
     isWelsh,
-    metadata
+    metadata,
+    govUkFormsUrl
   } = lodash.get(req, 'session.pageData.createPaymentLink', {})
 
   if (!paymentLinkTitle) {
@@ -62,9 +65,14 @@ module.exports = async function createPaymentLink (req, res) {
       if (paymentReferenceHint) {
         productPayload.referenceHint = paymentReferenceHint
       }
+    } else if (paymentReferenceType === 'govUkForms') {
+      productPayload.referenceLabel = GOV_UK_FORMS_REFERENCE_LABEL
     }
     if (!paymentLinkAmount && amountHint) {
       productPayload.amountHint = amountHint
+    }
+    if (govUkFormsUrl) {
+      productPayload.returnUrl = govUkFormsUrl
     }
 
     await productsClient.product.create(productPayload)

--- a/app/views/payment-links/information.njk
+++ b/app/views/payment-links/information.njk
@@ -2,7 +2,7 @@
 {% from "../macro/error-summary.njk" import errorSummary %}
 
 {% block pageTitle %}
-  Set payment link information - Create a payment link - {{currentService.name}} {{currentGatewayAccount.full_type}} - GOV.UK Pay
+  Set payment link information - Create a payment link - {{ currentService.name }} {{ currentGatewayAccount.full_type }} - GOV.UK Pay
 {% endblock %}
 
 {% block side_navigation %}
@@ -11,52 +11,53 @@
 {% endblock %}
 
 {% block mainContent %}
-<section class="govuk-grid-column-two-thirds">
-  {{ errorSummary ({
-    errors: errors,
-    hrefs: {
-      title: "#payment-link-title",
-      description: "#payment-link-description"
-    }
-  }) }}
-
-  {% if isWelsh %}
-    <h1 class="govuk-heading-l">Set Welsh payment link information</h1>
-  {% else %}
-    <h1 class="govuk-heading-l">Set payment link information</h1>
-  {% endif %}
-
-  <form action="{{ formatAccountPathsFor(routes.account.paymentLinks.information, currentGatewayAccount.external_id) }}" class="form" method="post" novalidate>
-    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-    <input type="hidden" name="service-name-path" value="{{serviceName}}">
-    {% if change.length %}
-      <input name="change" type="hidden" value="true"/>
-    {% endif %}
-
-    {% set confirmationLabel %}{{friendlyURL}}/{{serviceName | removeIndefiniteArticles | slugify}}/{% endset %}
+  <section class="govuk-grid-column-two-thirds">
+    {{ errorSummary ({
+      errors: errors,
+      hrefs: {
+        title: "#payment-link-title",
+        description: "#payment-link-description"
+      }
+    }) }}
 
     {% if isWelsh %}
-      {% set titleLabel = 'Welsh title' %}
-      {% set titleHint = 'Briefly describe what the user is paying for. For example, <span lang="cy">“Talu am drwydded barcio”</span>. This will also be your website address. Do not include names or personal information.' %}
-      {% set detailsHint = 'Give your users more information in Welsh. For example, you could tell them how long it takes for their application to be processed.' %}
-      {% set lang = "cy" %}
+      <h1 class="govuk-heading-l">Set Welsh payment link information</h1>
     {% else %}
-      {% set titleLabel = 'Title' %}
-      {% set titleHint = 'Briefly describe what the user is paying for. For example, “Pay for a parking permit”. This will also be your website address. Do not include names or personal information.' %}
-      {% set detailsHint = 'Give your users more information. For example, you could tell them how long it takes for their application to be processed.' %}
-      {% set lang = "en" %}
+      <h1 class="govuk-heading-l">Set payment link information</h1>
     {% endif %}
 
-    {{
-      govukInput({
+    <form
+      action="{{ formatAccountPathsFor(routes.account.paymentLinks.information, currentGatewayAccount.external_id) }}"
+      class="form" method="post" novalidate>
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+      <input type="hidden" name="service-name-path" value="{{ serviceName }}">
+      {% if change.length %}
+        <input name="change" type="hidden" value="true"/>
+      {% endif %}
+
+      {% set confirmationLabel %}{{ friendlyURL }}/{{ serviceName | removeIndefiniteArticles | slugify }}/{% endset %}
+
+      {% if isWelsh %}
+        {% set titleLabel = 'Welsh title' %}
+        {% set titleHint = 'Briefly describe what the user is paying for. For example, <span lang="cy">“Talu am drwydded barcio”</span>. This will also be your website address. Do not include names or personal information.' %}
+        {% set detailsHint = 'Give your users more information in Welsh. For example, you could tell them how long it takes for their application to be processed.' %}
+        {% set lang = "cy" %}
+      {% else %}
+        {% set titleLabel = 'Title' %}
+        {% set titleHint = 'Briefly describe what the user is paying for. For example, “Pay for a parking permit”. This will also be your website address. Do not include names or personal information.' %}
+        {% set detailsHint = 'Give your users more information. For example, you could tell them how long it takes for their application to be processed.' %}
+        {% set lang = "en" %}
+      {% endif %}
+
+      {{ govukInput({
         id: 'payment-link-title',
         name: 'payment-link-title',
         value: paymentLinkTitle,
         spellcheck: true,
         classes: '',
         label: {
-            text: titleLabel,
-            classes: 'govuk-label--s'
+          text: titleLabel,
+          classes: 'govuk-label--s'
         },
         hint: {
           html: titleHint
@@ -71,19 +72,17 @@
           "data-confirmation-display": "onload" if change.length else false,
           "lang": lang
         }
-      })
-    }}
+      }) }}
 
-    {{
-      govukTextarea({
+      {{ govukTextarea({
         id: 'payment-link-description',
         name: 'payment-link-description',
         value: paymentLinkDescription,
         spellcheck: true,
         classes: '',
         label: {
-            text: 'Details (optional)',
-            classes: 'govuk-label--s'
+          text: 'Details (optional)',
+          classes: 'govuk-label--s'
         },
         hint: {
           text: detailsHint
@@ -94,24 +93,67 @@
           "rows": "5",
           "lang": lang
         }
-      })
-    }}
+      }) }}
 
-    {{
-      govukButton({
+      {% set formattingHelpHTML %}
+        <h3 class="govuk-heading-m">Links and URLs</h3>
+
+        <p>To add a link, use square brackets [ ] around the link text, and round brackets ( ) around the full URL. Make
+          sure there are no spaces between the two sets of brackets. For example:</p>
+
+        <div class="govuk-inset-text">
+          <pre class="app-markdown-editor__markdown-example-block"><code
+              class="app-markdown-editor__markdown-example-block-code">[Link text](https://www.gov.uk/link-text-url)</code></pre>
+        </div>
+        <h3 class="govuk-heading-m">Bulleted lists</h3>
+
+        <p>To add bullet points, start each item with * (asterisk) or - (dash). Make sure there is one space after the
+          asterisk or dash.</p>
+
+        <p>Leave one empty line before adding the first bullet point and another after the last bullet point. For
+          example:
+        </p>
+
+        <div class="govuk-inset-text">
+    <pre class="app-markdown-editor__markdown-example-block"><code class="app-markdown-editor__markdown-example-block-code">* First bullet point
+* Second bullet point
+* Third bullet point</code></pre>
+        </div>
+        <h3 class="govuk-heading-m">Numbered lists</h3>
+
+        <p>Use numbers for each list item, followed by a full stop. Make sure there is one space after the full
+          stop.</p>
+
+        <p>Leave one empty line before adding the first list item and another after the last list item. For example:
+        </p>
+
+        <div class="govuk-inset-text">
+    <pre class="app-markdown-editor__markdown-example-block"><code class="app-markdown-editor__markdown-example-block-code">1. First item
+2. Second item
+3. Third item</code></pre>
+        </div>
+      {% endset %}
+
+      {{ govukDetails({
+        summaryText: "Formatting help",
+        html: formattingHelpHTML
+      }) }}
+
+      {{ govukButton({
         text: 'Continue',
         classes: 'button'
-      })
-     }}
+      }) }}
 
-    <p class="govuk-body"><a class="govuk-link cancel govuk-link--no-visited-state" href="{{ formatAccountPathsFor(routes.account.paymentLinks.start, currentGatewayAccount.external_id) }}" data-cy="cancel-link">Cancel</a></p>
-  </form>
+      <p class="govuk-body"><a class="govuk-link cancel govuk-link--no-visited-state"
+                               href="{{ formatAccountPathsFor(routes.account.paymentLinks.start, currentGatewayAccount.external_id) }}"
+                               data-cy="cancel-link">Cancel</a></p>
+    </form>
 
-  {% if not isWelsh %}
-  <div class="govuk-!-margin-top-9" id="payment-link-example">
-    <h3 class="govuk-heading-s">Example of what the user will see</h3>
-    <img src="/public/images/payment-links/start-page.svg" alt="Screenshot of payment link landing page">
-  </div>
-  {% endif %}
-</section>
+    {% if not isWelsh %}
+      <div class="govuk-!-margin-top-9" id="payment-link-example">
+        <h3 class="govuk-heading-s">Example of what the user will see</h3>
+        <img src="/public/images/payment-links/start-page.svg" alt="Screenshot of payment link landing page">
+      </div>
+    {% endif %}
+  </section>
 {% endblock %}

--- a/app/views/payment-links/reference.njk
+++ b/app/views/payment-links/reference.njk
@@ -89,9 +89,34 @@
         })
       }}
     {% endset %}
+
     {% set standardReferenceHTML %}
     <p class="govuk-body">GOV.UK Pay will create a unique payment reference for each transaction.</p>
     {% endset %}
+
+    {% set govUkFormsHTML %}
+      {{
+        govukInput({
+          id: "gov-uk-forms-url",
+          name: "gov-uk-forms-url",
+          value: govUkFormsUrl,
+          spellcheck: true,
+          errorMessage: { text: errors.label } if errors.label else false,
+          classes: "govuk-input--width-20",
+          label: {
+              text: "GOV.UK Forms form URL",
+              classes: "govuk-label--s"
+          },
+          hint: {
+            text: "The user will be linked back to the form on the payment success screen"
+          },
+          attributes: {
+            "lang": lang
+          }
+        })
+      }}
+    {% endset %}
+
     {{
       govukRadios({
         idPrefix: "reference-type-group",
@@ -119,11 +144,20 @@
           },
           {
               value: "standard",
-              text: "No",
+              text: "No, create a reference for the transaction",
               checked: paymentReferenceType === 'standard',
               id: "reference-type-standard",
               conditional: {
                 html: standardReferenceHTML
+              }
+          },
+          {
+              value: "govUkForms",
+              text: "The user will be redirected from GOV.UK Forms",
+              checked: paymentReferenceType === "govUkForms",
+              id: "reference-type-forms",
+              conditional: {
+                html: govUkFormsHTML
               }
           }
         ]

--- a/app/views/payment-links/review.njk
+++ b/app/views/payment-links/review.njk
@@ -32,6 +32,8 @@
             {{ pageData.paymentReferenceHint | striptags(true) | escape | nl2br }}
           </span>
         {% endif %}
+      {% elif pageData.paymentReferenceType === "govUkForms" %}
+        <span>Created by GOV.UK Forms</span>
       {% else %}
         <span>Created by GOV.UK Pay</span>
       {% endif %}


### PR DESCRIPTION
Add a details section with information about how to add markdown to the payment link description.

This also needs to be added in `app/views/payment-links/edit-information.njk`. Although it's recommended that the create and edit views for payment links are merged to avoid duplication.

<img width="467" alt="Screenshot 2024-10-03 at 11 11 52" src="https://github.com/user-attachments/assets/34d12aa7-a4f6-45b8-9238-bc65f8715769">

