### PR TITLE
PP-13174 Do not show test stripe link for new services

### DIFF
--- a/app/controllers/dashboard/dashboard-activity.controller.js
+++ b/app/controllers/dashboard/dashboard-activity.controller.js
@@ -92,7 +92,10 @@ const displayGoLiveLink = (service, account, user) => {
 }
 
 const displayRequestTestStripeAccountLink = (service, account, user) => {
-  return account.payment_provider === 'sandbox' && service.currentGoLiveStage !== LIVE &&
+  //Since 29/08/2024, services that identified as local govt were automatically allocated Stripe test accounts
+  //So services created after that date don't need a link to create a Stripe test account
+  const serviceCreatedBeforeOrgTypeCaptured = new Date(service.createdDate) <= new Date('2024-08-29');
+  return account.payment_provider === 'sandbox' && service.currentGoLiveStage !== LIVE && serviceCreatedBeforeOrgTypeCaptured &&
     service.currentPspTestAccountStage !== pspTestAccountStage.CREATED &&
     user.hasPermission(service.externalId, 'psp-test-account-stage:update')
 }

--- a/test/cypress/integration/dashboard/dashboard-links.cy.js
+++ b/test/cypress/integration/dashboard/dashboard-links.cy.js
@@ -10,10 +10,10 @@ const gatewayAccountId = '42'
 const gatewayAccountExternalId = 'a-gateway-account-external-id'
 const dashboardUrl = `/account/${gatewayAccountExternalId}/dashboard`
 
-function getStubsForDashboard (gatewayAccountId, type, paymentProvider, goLiveStage, pspTestAccountStage) {
+function getStubsForDashboard (gatewayAccountId, type, paymentProvider, goLiveStage, pspTestAccountStage, createdDate) {
   let stubs = []
 
-  stubs.push(userStubs.getUserSuccess({ userExternalId, gatewayAccountId, goLiveStage, pspTestAccountStage }),
+  stubs.push(userStubs.getUserSuccess({ userExternalId, gatewayAccountId, goLiveStage, pspTestAccountStage, createdDate }),
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
       gatewayAccountId,
       gatewayAccountExternalId,
@@ -66,8 +66,25 @@ describe('the links are displayed correctly on the dashboard', () => {
       cy.get('#payment-links-link').should('have.class', 'flex-grid--column-half')
     })
 
-    it('should display 4 links for a test sandbox account', () => {
-      cy.task('setupStubs', getStubsForDashboard(gatewayAccountId, 'test', 'sandbox', 'NOT_STARTED'))
+    it('should display 3 links for a test sandbox account created since onboarding flow changed on 29/08/2024', () => {
+      cy.task('setupStubs', getStubsForDashboard(gatewayAccountId, 'test', 'sandbox', 'NOT_STARTED', null, '2024-08-30'))
+
+      cy.visit(dashboardUrl)
+      cy.get('.links__box').should('have.length', 3)
+
+      cy.get('#demo-payment-link').should('exist')
+      cy.get('#demo-payment-link').should('have.class', 'flex-grid--column-third')
+
+      cy.get('#test-payment-link-link').should('exist')
+      cy.get('#test-payment-link-link').should('have.class', 'flex-grid--column-third')
+
+      cy.get('#request-to-go-live-link').should('exist')
+      cy.get('#request-to-go-live-link').should('have.class', 'flex-grid--column-third')
+
+    })
+
+    it('should display 4 links for a test sandbox account created before 29/08/2024', () => {
+      cy.task('setupStubs', getStubsForDashboard(gatewayAccountId, 'test', 'sandbox', 'NOT_STARTED', null, '2024-08-28'))
 
       cy.visit(dashboardUrl)
       cy.get('.links__box').should('have.length', 4)
@@ -115,7 +132,7 @@ describe('the links are displayed correctly on the dashboard', () => {
     })
 
     it('should display `Stripe test account requested` section if request has been submitted', () => {
-      cy.task('setupStubs', getStubsForDashboard(gatewayAccountId, 'test', 'sandbox', 'NOT_STARTED', 'REQUEST_SUBMITTED'))
+      cy.task('setupStubs', getStubsForDashboard(gatewayAccountId, 'test', 'sandbox', 'NOT_STARTED', 'REQUEST_SUBMITTED', '2024-08-28'))
 
       cy.visit(dashboardUrl)
       cy.get('.links__box').should('have.length', 4)

--- a/test/cypress/integration/dashboard/dashboard-links.cy.js
+++ b/test/cypress/integration/dashboard/dashboard-links.cy.js
@@ -81,6 +81,8 @@ describe('the links are displayed correctly on the dashboard', () => {
       cy.get('#request-to-go-live-link').should('exist')
       cy.get('#request-to-go-live-link').should('have.class', 'flex-grid--column-third')
 
+      cy.get('#request-stripe-test-account').should('not.exist')
+
     })
 
     it('should display 4 links for a test sandbox account created before 29/08/2024', () => {

--- a/test/cypress/stubs/user-stubs.js
+++ b/test/cypress/stubs/user-stubs.js
@@ -265,6 +265,10 @@ function buildServiceRoleOpts (opts) {
     serviceRole.role = opts.role
   }
 
+  if (opts.createdDate) {
+    service.created_date = opts.createdDate
+  }
+
   return serviceRole
 }
 

--- a/test/fixtures/service.fixtures.js
+++ b/test/fixtures/service.fixtures.js
@@ -118,7 +118,8 @@ module.exports = {
       current_go_live_stage: 'NOT_STARTED',
       current_psp_test_account_stage: 'NOT_STARTED',
       agent_initiated_moto_enabled: false,
-      takes_payments_over_phone: false
+      takes_payments_over_phone: false,
+      created_date: '2024-08-30'
     })
 
     const service = {
@@ -133,7 +134,8 @@ module.exports = {
       experimental_features_enabled: true,
       current_psp_test_account_stage: opts.current_psp_test_account_stage,
       agent_initiated_moto_enabled: opts.agent_initiated_moto_enabled,
-      takes_payments_over_phone: opts.takes_payments_over_phone
+      takes_payments_over_phone: opts.takes_payments_over_phone,
+      created_date: opts.created_date
     }
 
     if (opts.merchant_details) {


### PR DESCRIPTION
Context: Changes to the onboarding flow on 29/08/2024 mean that local gov services are now automatically allocated a Stripe test account. Therefore the link to create a Stripe test account should not be displayed for services that onboarded since that date.

- add condition to only show the create Stripe test account link to services onboarding prior to 29/08/2024
- update Cypress tests accordingly