### PR TITLE
PP-13174 Update cutoff time for removing link to request stripe test account

### DIFF
--- a/app/controllers/dashboard/dashboard-activity.controller.js
+++ b/app/controllers/dashboard/dashboard-activity.controller.js
@@ -92,9 +92,10 @@ const displayGoLiveLink = (service, account, user) => {
 }
 
 const displayRequestTestStripeAccountLink = (service, account, user) => {
-  //Since 29/08/2024, services that identified as local govt were automatically allocated Stripe test accounts
-  //So services created after that date don't need a link to create a Stripe test account
-  const serviceCreatedBeforeOrgTypeCaptured = new Date(service.createdDate) <= new Date('2024-08-29');
+  // Since 29/08/2024, services that identified as local govt were automatically allocated Stripe test accounts
+  // So services created after that date don't need a link to create a Stripe test account
+  // this change was deployed in selfservice PR #4256 at approx. 10:08 UTC so this time is used as the cutoff
+  const serviceCreatedBeforeOrgTypeCaptured = new Date(service.createdDate) <= new Date('2024-08-29T10:08:00Z')
   return account.payment_provider === 'sandbox' && service.currentGoLiveStage !== LIVE && serviceCreatedBeforeOrgTypeCaptured &&
     service.currentPspTestAccountStage !== pspTestAccountStage.CREATED &&
     user.hasPermission(service.externalId, 'psp-test-account-stage:update')


### PR DESCRIPTION
## WHAT
 - Updates the cutoff time added in #4284 to approximately the time when the change to create a Stripe test account as part of the onboarding flow was deployed.
 - This is approx. `2024-08-29T10:08:00Z`, the time PR  #4256 was deployed (release tag `alpha_release-3056`, concourse build `698`)
 - There was one service created on  2024-08-29 before the above change went live which currently would be unable to request a Stripe test account, this change should rectify that


