### PR TITLE
PP-13234: Using latest run-amock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "@babel/core": "7.22.10",
         "@babel/polyfill": "7.12.1",
         "@babel/preset-env": "7.22.10",
-        "@govuk-pay/run-amock": "0.0.1",
+        "@govuk-pay/run-amock": "0.0.3",
         "@pact-foundation/pact": "^12.1.1",
         "@pact-foundation/pact-core": "^14.0.5",
         "chai": "4.3.8",
@@ -2159,13 +2159,13 @@
       }
     },
     "node_modules/@govuk-pay/run-amock": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.1.tgz",
-      "integrity": "sha512-IU5OqEKfOOENuX3aNtkk6OyD02dJdDx5p+9NzoK2nzCTpIqjz5gnLNg0xBPXKFD0stOEdr9vTwWc5MmcR9Yjag==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.3.tgz",
+      "integrity": "sha512-01DmzFJLGG282DStWe6B1jyh3npV6F5f6IHjdRFve1HcI5TjkcKtEYK7eeNRK9gPhPYYptjXF5zqA9eB/C3nBg==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "run-amock": "bin/run"
+        "run-amock": "bin/run.js"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -18837,9 +18837,9 @@
       }
     },
     "@govuk-pay/run-amock": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.1.tgz",
-      "integrity": "sha512-IU5OqEKfOOENuX3aNtkk6OyD02dJdDx5p+9NzoK2nzCTpIqjz5gnLNg0xBPXKFD0stOEdr9vTwWc5MmcR9Yjag==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.3.tgz",
+      "integrity": "sha512-01DmzFJLGG282DStWe6B1jyh3npV6F5f6IHjdRFve1HcI5TjkcKtEYK7eeNRK9gPhPYYptjXF5zqA9eB/C3nBg==",
       "dev": true
     },
     "@hapi/hoek": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@babel/core": "7.22.10",
     "@babel/polyfill": "7.12.1",
     "@babel/preset-env": "7.22.10",
-    "@govuk-pay/run-amock": "0.0.1",
+    "@govuk-pay/run-amock": "0.0.3",
     "@pact-foundation/pact": "^12.1.1",
     "@pact-foundation/pact-core": "^14.0.5",
     "chai": "4.3.8",

--- a/test/cypress/integration/webhooks/webhooks.cy.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.js
@@ -100,7 +100,7 @@ describe('Webhooks', () => {
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       webhooksStubs.postCreateWebhookSuccess(),
-      webhooksStubs.getWebhookMessagesListSuccess({ service_id: serviceExternalId, external_id: webhookExternalId, messages: [{ status: 'FAILED' }], status: 'failed' })
+      webhooksStubs.getWebhookMessagesListSuccess({ service_id: serviceExternalId, external_id: webhookExternalId, messages: [{ status: 'FAILED' }], status: 'FAILED' })
     ])
 
     cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')


### PR DESCRIPTION
## WHAT
Using the latest version of `run-amock` which uses case-sensitive query strings as we no longer have to maintain feature-compatibility with Mountebank.

This new version treats query strings as case-sensitive (as our production apps do) so one mock needed updating.
