### PR TITLE
PP-13133 simplified account settings cypress test service name

### DIFF
--- a/app/controllers/simplified-account/settings/index.controller.js
+++ b/app/controllers/simplified-account/settings/index.controller.js
@@ -8,9 +8,9 @@ function get (req, res) {
   const isServiceAdmin = req.user.isAdminUserForService(service.externalId)
 
   if (!isServiceAdmin || (account.type === 'test' && service.currentGoLiveStage === LIVE)) {
-    res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.emailNotifications.index, req.account.service_id, req.account.type))
+    res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.emailNotifications.index, service.externalId, account.type))
   } else {
-    res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.index, req.account.service_id, req.account.type))
+    res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.index, service.externalId, account.type))
   }
 }
 

--- a/app/controllers/simplified-account/settings/index.controller.test.js
+++ b/app/controllers/simplified-account/settings/index.controller.test.js
@@ -27,10 +27,10 @@ describe('Controller: settings/index', () => {
           isAdminUserForService: () => false
         },
         account: {
-          service_id: SERVICE_ID,
           type: TEST_ACCOUNT_TYPE
         },
         service: {
+          externalId: SERVICE_ID,
           currentGoLiveStage: NOT_STARTED
         }
       }
@@ -39,38 +39,50 @@ describe('Controller: settings/index', () => {
     it('should redirect to service name index for test account on service with no live account when user is an admin', () => {
       req.user.isAdminUserForService = () => true
       indexController.get(req, res)
-      expect(res.redirect.calledWith(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.index, SERVICE_ID, TEST_ACCOUNT_TYPE))).to.be.true // eslint-disable-line
+      const actual = res.redirect.getCall(0).args[0]
+      const expected = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.index, SERVICE_ID, TEST_ACCOUNT_TYPE)
+      expect(actual).to.equal(expected)
     })
 
     it('should redirect to email notifications index for test account on service with no live account when user is not an admin', () => {
       indexController.get(req, res)
-      expect(res.redirect.calledWith(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.emailNotifications.index, SERVICE_ID, TEST_ACCOUNT_TYPE))).to.be.true // eslint-disable-line
+      const actual = res.redirect.getCall(0).args[0]
+      const expected = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.emailNotifications.index, SERVICE_ID, TEST_ACCOUNT_TYPE)
+      expect(actual).to.equal(expected)
     })
 
     it('should redirect to service name index for live account when user is an admin', () => {
       req.user.isAdminUserForService = () => true
-      req.account.type = 'live'
+      req.account.type = LIVE_ACCOUNT_TYPE
       indexController.get(req, res)
-      expect(res.redirect.calledWith(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.index, SERVICE_ID, LIVE_ACCOUNT_TYPE))).to.be.true // eslint-disable-line
+      const actual = res.redirect.getCall(0).args[0]
+      const expected = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.index, SERVICE_ID, LIVE_ACCOUNT_TYPE)
+      expect(actual).to.equal(expected)
     })
 
     it('should redirect to email notifications index for live account when user is not an admin', () => {
-      req.account.type = 'live'
+      req.account.type = LIVE_ACCOUNT_TYPE
       indexController.get(req, res)
-      expect(res.redirect.calledWith(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.emailNotifications.index, SERVICE_ID, LIVE_ACCOUNT_TYPE))).to.be.true // eslint-disable-line
+      const actual = res.redirect.getCall(0).args[0]
+      const expected = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.emailNotifications.index, SERVICE_ID, LIVE_ACCOUNT_TYPE)
+      expect(actual).to.equal(expected)
     })
 
     it('should redirect to email notifications index for test account on service with live account when user is an admin', () => {
       req.user.isAdminUserForService = () => true
       req.service.currentGoLiveStage = LIVE
       indexController.get(req, res)
-      expect(res.redirect.calledWith(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.emailNotifications.index, SERVICE_ID, TEST_ACCOUNT_TYPE))).to.be.true // eslint-disable-line
+      const actual = res.redirect.getCall(0).args[0]
+      const expected = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.emailNotifications.index, SERVICE_ID, TEST_ACCOUNT_TYPE)
+      expect(actual).to.equal(expected)
     })
 
     it('should redirect to email notifications index for test account on service with live account when user is not an admin', () => {
       req.service.currentGoLiveStage = LIVE
       indexController.get(req, res)
-      expect(res.redirect.calledWith(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.emailNotifications.index, SERVICE_ID, TEST_ACCOUNT_TYPE))).to.be.true // eslint-disable-line
+      const actual = res.redirect.getCall(0).args[0]
+      const expected = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.emailNotifications.index, SERVICE_ID, TEST_ACCOUNT_TYPE)
+      expect(actual).to.equal(expected)
     })
   })
 })

--- a/app/controllers/simplified-account/settings/service-name/service-name.controller.js
+++ b/app/controllers/simplified-account/settings/service-name/service-name.controller.js
@@ -65,10 +65,8 @@ async function postEditServiceName (req, res) {
 }
 
 async function postRemoveWelshServiceName (req, res) {
-  if (req.body.method === 'DELETE') {
-    await updateServiceName(req.service.externalId, req.service.serviceName.en, '')
-    req.flash('messages', { state: 'success', icon: '&check;', content: 'Welsh service name removed' })
-  }
+  await updateServiceName(req.service.externalId, req.service.serviceName.en, '')
+  req.flash('messages', { state: 'success', icon: '&check;', content: 'Welsh service name removed' })
   res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.index, req.service.externalId, req.account.type))
 }
 

--- a/app/controllers/simplified-account/settings/service-name/service-name.controller.js
+++ b/app/controllers/simplified-account/settings/service-name/service-name.controller.js
@@ -8,10 +8,11 @@ const formatValidationErrors = require('../../../../utils/simplified-account/for
 
 function get (req, res) {
   const context = {
+    messages: res.locals?.flash?.messages ?? [],
     service_name_en: req.service.serviceName.en,
     service_name_cy: req.service.serviceName.cy,
-    manage_en: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.edit, req.account.service_id, req.account.type),
-    manage_cy: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.edit, req.account.service_id, req.account.type) + '?cy=true'
+    manage_en: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.edit, req.service.externalId, req.account.type),
+    manage_cy: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.edit, req.service.externalId, req.account.type) + '?cy=true'
   }
   return response(req, res, 'simplified-account/settings/service-name/index', context)
 }
@@ -20,8 +21,9 @@ function getEditServiceName (req, res) {
   const editCy = req.query.cy === 'true'
   const context = {
     edit_cy: editCy,
-    back_link: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.index, req.account.service_id, req.account.type),
-    submit_link: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.edit, req.account.service_id, req.account.type)
+    back_link: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.index, req.service.externalId, req.account.type),
+    submit_link: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.edit, req.service.externalId, req.account.type),
+    remove_cy_link: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.removeCy, req.service.externalId, req.account.type)
   }
   if (editCy) {
     Object.assign(context, { service_name: req.service.serviceName.cy })
@@ -52,18 +54,27 @@ async function postEditServiceName (req, res) {
       },
       edit_cy: editCy,
       service_name: req.body['service-name-input'],
-      back_link: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.index, req.account.service_id, req.account.type),
-      submit_link: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.edit, req.account.service_id, req.account.type)
+      back_link: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.index, req.service.externalId, req.account.type),
+      submit_link: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.edit, req.service.externalId, req.account.type)
     })
   }
 
   const newServiceName = req.body['service-name-input']
-  editCy ? await updateServiceName(req.account.service_id, req.service.serviceName.en, newServiceName) : await updateServiceName(req.account.service_id, newServiceName, req.service.serviceName.cy)
-  res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.index, req.account.service_id, req.account.type))
+  editCy ? await updateServiceName(req.service.externalId, req.service.serviceName.en, newServiceName) : await updateServiceName(req.service.externalId, newServiceName, req.service.serviceName.cy)
+  res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.index, req.service.externalId, req.account.type))
+}
+
+async function postRemoveWelshServiceName (req, res) {
+  if (req.body.method === 'DELETE') {
+    await updateServiceName(req.service.externalId, req.service.serviceName.en, '')
+    req.flash('messages', { state: 'success', icon: '&check;', content: 'Welsh service name removed' })
+  }
+  res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.serviceName.index, req.service.externalId, req.account.type))
 }
 
 module.exports = {
   get,
   getEditServiceName,
+  postRemoveWelshServiceName,
   postEditServiceName
 }

--- a/app/controllers/simplified-account/settings/service-name/service-name.controller.test.js
+++ b/app/controllers/simplified-account/settings/service-name/service-name.controller.test.js
@@ -33,10 +33,10 @@ const setupTest = (method, additionalResProps = {}, additionalReqProps = {}, add
   }
   req = {
     account: {
-      service_id: SERVICE_ID,
       type: ACCOUNT_TYPE
     },
     service: {
+      externalId: SERVICE_ID,
       serviceName: {
         en: EN_SERVICE_NAME,
         cy: CY_SERVICE_NAME

--- a/app/controllers/simplified-account/settings/service-name/service-name.controller.test.js
+++ b/app/controllers/simplified-account/settings/service-name/service-name.controller.test.js
@@ -239,10 +239,7 @@ describe('Controller: settings/service-name', () => {
 
   describe('postRemoveWelshServiceName', () => {
     before(() => setupTest('postRemoveWelshServiceName', {}, {
-      flash: sinon.stub(),
-      body: {
-        method: 'DELETE'
-      }
+      flash: sinon.stub()
     }))
 
     it('should set Welsh service name to blank and redirect to the service name index page', () => {

--- a/app/paths.js
+++ b/app/paths.js
@@ -173,7 +173,8 @@ module.exports = {
       index: '/settings',
       serviceName: {
         index: '/settings/service-name',
-        edit: '/settings/service-name/edit'
+        edit: '/settings/service-name/edit',
+        removeCy: '/settings/service-name/cy/remove'
       },
       emailNotifications: {
         index: '/settings/email-notifications'

--- a/app/routes.js
+++ b/app/routes.js
@@ -505,6 +505,7 @@ module.exports.bind = function (app) {
   // service name
   simplifiedAccount.get(paths.simplifiedAccount.settings.serviceName.index, permission('service-name:update'), serviceSettingsController.serviceName.get)
   simplifiedAccount.get(paths.simplifiedAccount.settings.serviceName.edit, permission('service-name:update'), serviceSettingsController.serviceName.getEditServiceName)
+  simplifiedAccount.post(paths.simplifiedAccount.settings.serviceName.removeCy, permission('service-name:update'), serviceSettingsController.serviceName.postRemoveWelshServiceName)
   simplifiedAccount.post(paths.simplifiedAccount.settings.serviceName.edit, permission('service-name:update'), serviceSettingsController.serviceName.postEditServiceName)
   // email notifications
   simplifiedAccount.get(paths.simplifiedAccount.settings.emailNotifications.index, permission('transactions:read'), serviceSettingsController.emailNotifications.get) // TODO: add a more descriptive permission to adminsusers, all roles can view transactions so using as default for now

--- a/app/services/service.service.js
+++ b/app/services/service.service.js
@@ -30,6 +30,7 @@ async function updateServiceName (serviceExternalId, serviceName, serviceNameCy)
 
   const gatewayAccountIds = lodash.get(result, 'gateway_account_ids', [])
 
+  // TODO update this to use the service and account type model api endpoint
   await Promise.all(
     gatewayAccountIds.map(async gatewayAccountId => {
       if (gatewayAccountId) {

--- a/app/utils/display-converter.js
+++ b/app/utils/display-converter.js
@@ -145,7 +145,7 @@ module.exports = function (req, data, template) {
     convertedData.serviceNavigationItems = serviceNavigationItems(currentPath, permissions, paymentMethod, isDegatewayed, currentUrl, account)
     convertedData.adminNavigationItems = adminNavigationItems(currentPath, permissions, paymentMethod, paymentProvider, account, service)
     if (currentUrl.includes('simplified') && currentUrl.includes('settings')) {
-      convertedData.serviceSettings = serviceSettings(account, currentUrl, service.currentGoLiveStage, permissions)
+      convertedData.serviceSettings = serviceSettings(account, service, currentUrl, permissions)
     }
   }
   convertedData._features = {}

--- a/app/utils/simplified-account/settings/SettingsBuilder.class.js
+++ b/app/utils/simplified-account/settings/SettingsBuilder.class.js
@@ -1,7 +1,8 @@
 module.exports = class SettingsBuilder {
-  constructor (account, currentUrl, permissions, pathFormatter) {
+  constructor (account, service, currentUrl, permissions, pathFormatter) {
     this.categories = {}
     this.account = account
+    this.service = service
     this.currentUrl = currentUrl
     this.permissions = permissions
     this.pathFormatter = pathFormatter
@@ -26,7 +27,7 @@ module.exports = class SettingsBuilder {
       name,
       url: this.pathFormatter(
         path,
-        this.account.service_id,
+        this.service.externalId,
         this.account.type
       ),
       current: this.currentUrl.includes('simplified') && this.currentUrl.includes(`settings/${id}`),

--- a/app/utils/simplified-account/settings/service-settings.js
+++ b/app/utils/simplified-account/settings/service-settings.js
@@ -3,8 +3,8 @@ const formatSimplifiedAccountPathsFor = require('../format/format-simplified-acc
 const SettingsBuilder = require('./SettingsBuilder.class')
 const { LIVE } = require('../../../models/go-live-stage')
 
-module.exports = (account, currentUrl, goLiveStage, permissions) => {
-  const settingsBuilder = new SettingsBuilder(account, currentUrl, permissions, formatSimplifiedAccountPathsFor)
+module.exports = (account, service, currentUrl, permissions) => {
+  const settingsBuilder = new SettingsBuilder(account, service, currentUrl, permissions, formatSimplifiedAccountPathsFor)
   const serviceSettings = settingsBuilder
     .category('about your service')
     .add({
@@ -63,7 +63,7 @@ module.exports = (account, currentUrl, goLiveStage, permissions) => {
       alwaysViewable: true // viewable on test and live accounts
     })
     .build()
-  return getViewableSettings(serviceSettings, account, goLiveStage)
+  return getViewableSettings(serviceSettings, account, service.currentGoLiveStage)
 }
 
 const shouldShowSettingForAccountTypeAndGoLiveStage = (account, goLiveStage) => {

--- a/app/views/simplified-account/settings/email-notifications/index.njk
+++ b/app/views/simplified-account/settings/email-notifications/index.njk
@@ -10,7 +10,7 @@
 
 {% block mainContent %}
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Email notifications</h2>
+    <h1 class="govuk-heading-l">Email notifications</h1>
     <p class="govuk-body">coming soon...</p>
     <!-- TODO -->
   </div>

--- a/app/views/simplified-account/settings/service-name/edit-service-name.njk
+++ b/app/views/simplified-account/settings/service-name/edit-service-name.njk
@@ -60,8 +60,28 @@
           </a>
         {% endif %}
       </p>
-
-      {{ govukButton({ text: "Save changes" }) }}
     </form>
+
+    {% if edit_cy and service_name %}
+      <form id="remove-welsh-service-name-form" action="{{ remove_cy_link }}" method="POST">
+        <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+        <input type="hidden" name="method" value="DELETE">
+      </form>
+    {% endif %}
+
+    <div class="govuk-button-group">
+      {{ govukButton({
+        text: "Save changes",
+        attributes: { form: "edit-service-name-form" }
+      }) }}
+
+      {% if edit_cy and service_name %}
+        {{ govukButton({
+          text: "Remove Welsh service name",
+          classes: "govuk-button--secondary",
+          attributes: { form: "remove-welsh-service-name-form" }
+        }) }}
+      {% endif %}
+    </div>
   </div>
 {% endblock %}

--- a/app/views/simplified-account/settings/service-name/edit-service-name.njk
+++ b/app/views/simplified-account/settings/service-name/edit-service-name.njk
@@ -65,7 +65,6 @@
     {% if edit_cy and service_name %}
       <form id="remove-welsh-service-name-form" action="{{ remove_cy_link }}" method="POST">
         <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
-        <input type="hidden" name="method" value="DELETE">
       </form>
     {% endif %}
 

--- a/app/views/simplified-account/settings/service-name/index.njk
+++ b/app/views/simplified-account/settings/service-name/index.njk
@@ -1,8 +1,8 @@
 {% extends "../../../layout.njk" %}
-{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "includes/systemMessages.njk" import systemMessages %}
 
 {% block pageTitle %}
-  Settings - Service name
+  Settings - Service name - GOV.UK Pay
 {% endblock %}
 
 {% block side_navigation %}
@@ -10,12 +10,16 @@
 {% endblock %}
 
 {% set add_cy_link %}
-  <a class='govuk-link govuk-link--no-visited-state' href='{{ manage_cy }}'>Add Welsh service name</a>
+  <a class='govuk-link govuk-link--no-visited-state' href='{{ manage_cy }}' data-cy="add-welsh-name">Add Welsh service name</a>
 {% endset %}
 
 {% block mainContent %}
   <div class="govuk-grid-column-three-quarters">
-    <h2 class="govuk-heading-l">Service name</h2>
+    {% if messages is defined and messages is iterable and messages|length > 0 %}
+      {{ systemMessages({ messages: messages }) }}
+    {% endif %}
+
+    <h1 class="govuk-heading-l">Service name</h1>
 
     {{ govukSummaryList({
       classes: "govuk-!-margin-bottom-9",
@@ -33,7 +37,8 @@
               href: manage_en,
               text: "Change",
               classes: "govuk-link--no-visited-state",
-              visuallyHiddenText: "Edit English service name"
+              visuallyHiddenText: "Edit English service name",
+              attributes: { 'data-cy': 'edit-english-name' }
             }
           ]
         }
@@ -51,7 +56,8 @@
               href: manage_cy,
               text: "Change",
               classes: "govuk-link--no-visited-state",
-              visuallyHiddenText: "Edit Welsh service name"
+              visuallyHiddenText: "Edit Welsh service name",
+              attributes: { 'data-cy': 'edit-welsh-name' }
             } if service_name_cy else {}
           ]
         }

--- a/test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.js
+++ b/test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.js
@@ -24,7 +24,7 @@ describe('Request PSP test account: submit request', () => {
           pspTestAccountStage: pspTestAccountStageSecondResponse
         }
       ),
-      gatewayAccountStubs.getAccountByServiceIdAndAccountType(serviceExternalId, { gateway_account_id: sandboxGatewayAccountId }),
+      gatewayAccountStubs.getAccountByServiceIdAndAccountType(serviceExternalId, 'test', { gateway_account_id: sandboxGatewayAccountId }),
       gatewayAccountStubs.requestStripeTestAccount(serviceExternalId, { gateway_account_external_id: stripeGatewayAccountExternalId }),
       gatewayAccountStubs.addGatewayAccountsToService(serviceExternalId),
       serviceStubs.patchUpdateServicePspTestAccountStage({ serviceExternalId, gatewayAccountId: sandboxGatewayAccountId, pspTestAccountStage: 'REQUEST_SUBMITTED' }),

--- a/test/cypress/integration/simplified-account/service-settings/service-name-test-helpers.js
+++ b/test/cypress/integration/simplified-account/service-settings/service-name-test-helpers.js
@@ -1,0 +1,61 @@
+const checkDisplayedSettings = (length, expectedSettings) => {
+  cy.get('.govuk-summary-list__row').should('have.length', length).each((row, index) => {
+    const expected = expectedSettings[index]
+    cy.wrap(row).find('.govuk-summary-list__key')
+      .should('contain.text', expected.key)
+    cy.wrap(row).find('.govuk-summary-list__value')
+      .should('contain.text', expected.value)
+    if (expected.actions.length > 0) {
+      cy.wrap(row).find('.govuk-summary-list__actions')
+        .should('have.length', expected.actions.length)
+        .each((action, actionIndex) => {
+          const expectedAction = expected.actions[actionIndex]
+          cy.wrap(action).find('a')
+            .should('contain.text', expectedAction.text)
+            .and('have.attr', 'href', expectedAction.href)
+        })
+    }
+  })
+}
+
+const checkServiceNameValidation = (options) => {
+  const {
+    settingsUrl,
+    expectedInputValue,
+    expectedErrorMessage
+  } = options
+  cy.visit(settingsUrl)
+  cy.get('input[name="service-name-input"]').clear({ force: true })
+  if (expectedInputValue) {
+    cy.get('input[name="service-name-input"]').type(expectedInputValue)
+  }
+  cy.get('input[name="service-name-input"]').should('have.value', expectedInputValue)
+  cy.get('.govuk-error-summary').should('not.exist')
+  cy.get('button[form="edit-service-name-form"]').click()
+  cy.get('.govuk-error-summary').should('exist').should('contain', expectedErrorMessage)
+  cy.get('input[name="service-name-input"]').should('have.class', 'govuk-input--error')
+  cy.get('#service-name-input-error').should('contain.text', expectedErrorMessage)
+  cy.get('input[name="service-name-input"]').should('have.value', expectedInputValue)
+}
+
+const checkServiceNameEditActionNavigation = (options) => {
+  const {
+    selector,
+    expectedUrl,
+    expectedPageTitle,
+    expectedHeader
+  } = options
+  cy.get(selector).click()
+  cy.url().should('contain', expectedUrl)
+  cy.title().should('eq', expectedPageTitle)
+  cy.get('h1').should('contain.text', expectedHeader)
+  cy.get('.govuk-back-link').click()
+  cy.url().should('not.contain', expectedUrl)
+  cy.title().should('eq', 'Settings - Service name - GOV.UK Pay')
+}
+
+module.exports = {
+  checkDisplayedSettings,
+  checkServiceNameValidation,
+  checkServiceNameEditActionNavigation
+}

--- a/test/cypress/integration/simplified-account/service-settings/service-name.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/service-name.cy.js
@@ -1,0 +1,361 @@
+const userStubs = require('../../../stubs/user-stubs')
+const gatewayAccountStubs = require('../../../stubs/gateway-account-stubs')
+const serviceStubs = require('../../../stubs/service-stubs')
+const {
+  checkDisplayedSettings,
+  checkServiceNameValidation,
+  checkServiceNameEditActionNavigation
+} = require('./service-name-test-helpers')
+
+const USER_EXTERNAL_ID = 'user-123-abc'
+const SERVICE_EXTERNAL_ID = 'service-456-def'
+const SERVICE_NAME = {
+  en: 'My Cool Service',
+  cy: 'Fy Ngwasanaeth Cwl'
+}
+const TEST_ACCOUNT_TYPE = 'test'
+const TEST_GATEWAY_ACCOUNT_ID = 10
+
+const SERVICE_SETTINGS_URL = `/simplified/service/${SERVICE_EXTERNAL_ID}/account/${TEST_ACCOUNT_TYPE}/settings`
+
+const setStubs = (opts = {}, additionalStubs = []) => {
+  cy.task('setupStubs', [
+    userStubs.getUserSuccess({
+      userExternalId: USER_EXTERNAL_ID,
+      gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+      serviceName: opts.serviceName || SERVICE_NAME,
+      serviceExternalId: SERVICE_EXTERNAL_ID,
+      role: opts.role,
+      features: 'degatewayaccountification' // TODO remove features once simplified accounts are live
+    }),
+    gatewayAccountStubs.getAccountByServiceIdAndAccountType(SERVICE_EXTERNAL_ID, TEST_ACCOUNT_TYPE, { gateway_account_id: TEST_GATEWAY_ACCOUNT_ID }),
+    ...additionalStubs
+  ])
+}
+
+describe('Service name settings', () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
+  })
+  describe('The default settings page', () => {
+    describe('For an admin user', () => {
+      beforeEach(() => {
+        setStubs()
+        cy.visit(SERVICE_SETTINGS_URL)
+      })
+      it('should be Service name', () => {
+        cy.title().should('eq', 'Settings - Service name - GOV.UK Pay')
+      })
+      it('should show the correct heading', () => {
+        cy.get('h1').should('contain', 'Service name')
+      })
+      describe('The settings navigation', () => {
+        it('should show service name', () => {
+          cy.get('.service-settings-nav')
+            .find('li')
+            .should('contain', 'Service name')
+            .find('a')
+            .should('have.attr', 'href', `${SERVICE_SETTINGS_URL}/service-name`)
+        })
+      })
+    })
+    describe('For any other user', () => {
+      beforeEach(() => {
+        const role = {
+          name: 'view-only',
+          description: 'View only',
+          permissions: [
+            {
+              name: 'transactions:read',
+              description: 'Viewtransactionslist'
+            }
+          ]
+        }
+        setStubs({
+          role
+        })
+        cy.visit(SERVICE_SETTINGS_URL)
+      })
+      it('should be Email notifications', () => {
+        cy.title().should('eq', 'Settings - Email notifications')
+      })
+      it('should show the correct heading', () => {
+        cy.get('h1').should('contain', 'Email notifications')
+      })
+      describe('The settings navigation', () => {
+        it('should not show service name', () => {
+          cy.get('.service-settings-nav')
+            .find('li')
+            .should('not.contain', 'Service name')
+            .find('a')
+            .should('not.have.attr', 'href', `${SERVICE_SETTINGS_URL}/service-name`)
+        })
+      })
+    })
+  })
+  describe('Service name index', () => {
+    describe('When Welsh service name is set', () => {
+      beforeEach(() => {
+        setStubs()
+        cy.visit(SERVICE_SETTINGS_URL)
+      })
+      const expectedSettings = [
+        {
+          key: 'Service name',
+          value: SERVICE_NAME.en,
+          actions: [
+            { text: 'Change', href: `${SERVICE_SETTINGS_URL}/service-name/edit` }
+          ]
+        },
+        {
+          key: 'Welsh service name',
+          value: SERVICE_NAME.cy,
+          actions: [
+            { text: 'Change', href: `${SERVICE_SETTINGS_URL}/service-name/edit?cy=true` }
+          ]
+        }
+      ]
+
+      it('should correctly display the Service name settings', () => {
+        checkDisplayedSettings(2, expectedSettings)
+      })
+
+      it('should navigate to edit view for English service name when "Change" action is clicked', () => {
+        checkServiceNameEditActionNavigation({
+          selector: '[data-cy="edit-english-name"]',
+          expectedUrl: 'service-name/edit',
+          expectedPageTitle: 'Settings - Edit service name',
+          expectedHeader: 'Service name (English)'
+        })
+      })
+
+      it('should navigate to edit view for Welsh service name when "Change" action is clicked', () => {
+        checkServiceNameEditActionNavigation({
+          selector: '[data-cy="edit-welsh-name"]',
+          expectedUrl: 'service-name/edit?cy=true',
+          expectedPageTitle: 'Settings - Edit service name',
+          expectedHeader: 'Service name (Welsh)'
+        })
+      })
+    })
+    describe('When Welsh service name is not set', () => {
+      beforeEach(() => {
+        setStubs({
+          serviceName: {
+            en: SERVICE_NAME.en,
+            cy: undefined
+          }
+        })
+        cy.visit(SERVICE_SETTINGS_URL)
+      })
+      const expectedSettings = [
+        {
+          key: 'Service name',
+          value: SERVICE_NAME.en,
+          actions: [
+            { text: 'Change', href: `${SERVICE_SETTINGS_URL}/service-name/edit` }
+          ]
+        },
+        {
+          key: 'Welsh service name',
+          value: 'Add Welsh service name',
+          actions: []
+        }
+      ]
+
+      it('should correctly display the Service name settings', () => {
+        checkDisplayedSettings(2, expectedSettings)
+      })
+
+      it('should navigate to edit view for English service name when "Change" action is clicked', () => {
+        checkServiceNameEditActionNavigation({
+          selector: '[data-cy="edit-english-name"]',
+          expectedUrl: 'service-name/edit',
+          expectedPageTitle: 'Settings - Edit service name',
+          expectedHeader: 'Service name (English)'
+        })
+      })
+
+      it('should navigate to edit view for Welsh service name when "Add Welsh service name" link is clicked', () => {
+        checkServiceNameEditActionNavigation({
+          selector: '[data-cy="add-welsh-name"]',
+          expectedUrl: 'service-name/edit?cy=true',
+          expectedPageTitle: 'Settings - Edit service name',
+          expectedHeader: 'Service name (Welsh)'
+        })
+      })
+    })
+  })
+
+  describe('Service name edit', () => {
+    describe('Service name validation', () => {
+      beforeEach(() => {
+        setStubs({}, [
+          serviceStubs.patchUpdateServiceNameSuccess({
+            serviceExternalId: SERVICE_EXTERNAL_ID,
+            gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+            serviceName: {
+              en: SERVICE_NAME.en,
+              cy: ''
+            }
+          }),
+          gatewayAccountStubs.patchUpdateServiceNameSuccess(TEST_GATEWAY_ACCOUNT_ID, SERVICE_NAME.en) // connector doesn't store the Welsh name
+        ])
+      })
+
+      it('should show validation error when attempting to submit an English service name that is too long', () => {
+        checkServiceNameValidation({
+          settingsUrl: SERVICE_SETTINGS_URL + '/service-name/edit',
+          expectedInputValue: 'A'.repeat(51),
+          expectedErrorMessage: 'Service name must be 50 characters or fewer'
+        })
+      })
+
+      it('should show validation error when attempting to submit an empty English service name', () => {
+        checkServiceNameValidation({
+          settingsUrl: SERVICE_SETTINGS_URL + '/service-name/edit',
+          expectedInputValue: '',
+          expectedErrorMessage: 'Service name is required'
+        })
+      })
+
+      it('should show validation error when attempting to submit a Welsh service name that is too long', () => {
+        checkServiceNameValidation({
+          settingsUrl: SERVICE_SETTINGS_URL + '/service-name/edit?cy=true',
+          expectedInputValue: 'A'.repeat(51),
+          expectedErrorMessage: 'Service name must be 50 characters or fewer'
+        })
+      })
+
+      it('should not show validation error when attempting to submit an empty Welsh service name', () => {
+        cy.visit(SERVICE_SETTINGS_URL + '/service-name/edit?cy=true')
+        cy.get('input[name="service-name-input"]').clear({ force: true }).should('have.value', '')
+        cy.get('.govuk-error-summary').should('not.exist')
+        cy.get('button[form="edit-service-name-form"]').click()
+        cy.get('.govuk-error-summary').should('not.exist')
+        cy.get('#service-name-input-error').should('not.exist')
+      })
+    })
+    describe('English service name', () => {
+      beforeEach(() => {
+        setStubs({}, [
+          serviceStubs.patchUpdateServiceNameSuccess({
+            serviceExternalId: SERVICE_EXTERNAL_ID,
+            gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+            serviceName: {
+              en: 'My New Service Name',
+              cy: SERVICE_NAME.cy
+            }
+          }),
+          gatewayAccountStubs.patchUpdateServiceNameSuccess(TEST_GATEWAY_ACCOUNT_ID, 'My New Service Name')
+        ])
+        cy.visit(SERVICE_SETTINGS_URL + '/service-name/edit')
+      })
+      it('should show expected form elements', () => {
+        cy.get('h1').should('contain.text', 'Service name (English)')
+        cy.get('input[name="service-name-input"]').should('have.value', SERVICE_NAME.en)
+        cy.get('.govuk-button').should('contain.text', 'Save changes')
+        cy.get('.govuk-button').should('not.contain.text', 'Remove Welsh service name')
+      })
+      it('should submit form', () => {
+        cy.get('input[name="service-name-input"]').clear({ force: true }).type('My New Service Name')
+          .should('have.value', 'My New Service Name')
+        cy.get('button[form="edit-service-name-form"]').click()
+        cy.title().should('eq', 'Settings - Service name - GOV.UK Pay')
+      })
+    })
+    describe('Welsh service name', () => {
+      describe('When saving a new name', () => {
+        beforeEach(() => {
+          setStubs({}, [
+            serviceStubs.patchUpdateServiceNameSuccess({
+              serviceExternalId: SERVICE_EXTERNAL_ID,
+              gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+              serviceName: {
+                en: SERVICE_NAME.en,
+                cy: 'Fy Enw Gwasanaeth Newydd'
+              }
+            }),
+            gatewayAccountStubs.patchUpdateServiceNameSuccess(TEST_GATEWAY_ACCOUNT_ID, SERVICE_NAME.en) // connector doesn't store the Welsh name
+          ])
+          cy.visit(SERVICE_SETTINGS_URL + '/service-name/edit?cy=true')
+        })
+        it('should show expected form elements', () => {
+          cy.get('h1').should('contain.text', 'Service name (Welsh)')
+          cy.get('input[name="service-name-input"]').should('have.value', SERVICE_NAME.cy)
+          cy.get('.govuk-button').should('contain.text', 'Save changes')
+          cy.get('.govuk-button').should('contain.text', 'Remove Welsh service name')
+        })
+        it('should submit form', () => {
+          cy.get('input[name="service-name-input"]').clear({ force: true }).type('Fy Enw Gwasanaeth Newydd')
+            .should('have.value', 'Fy Enw Gwasanaeth Newydd')
+          cy.get('button[form="edit-service-name-form"]').click()
+          cy.title().should('eq', 'Settings - Service name - GOV.UK Pay')
+        })
+      })
+      describe('When removing the Welsh name', () => {
+        beforeEach(() => {
+          setStubs({}, [
+            serviceStubs.patchUpdateServiceNameSuccess({
+              serviceExternalId: SERVICE_EXTERNAL_ID,
+              gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+              serviceName: {
+                en: SERVICE_NAME.en,
+                cy: ''
+              }
+            }),
+            gatewayAccountStubs.patchUpdateServiceNameSuccess(TEST_GATEWAY_ACCOUNT_ID, SERVICE_NAME.en) // connector doesn't store the Welsh name
+          ])
+          cy.visit(SERVICE_SETTINGS_URL + '/service-name/edit?cy=true')
+        })
+        it('should show expected form elements', () => {
+          cy.get('h1').should('contain.text', 'Service name (Welsh)')
+          cy.get('input[name="service-name-input"]').should('have.value', SERVICE_NAME.cy)
+          cy.get('.govuk-button-group')
+            .find('button')
+            .should('have.length', 2)
+            .should('contain.text', 'Save changes')
+            .should('contain.text', 'Remove Welsh service name')
+        })
+        it('should submit form', () => {
+          cy.get('button[form="remove-welsh-service-name-form"]').click()
+          cy.title().should('eq', 'Settings - Service name - GOV.UK Pay')
+        })
+      })
+      describe('When Welsh service name is not set', () => {
+        beforeEach(() => {
+          setStubs({
+            serviceName: {
+              en: SERVICE_NAME.en,
+              cy: ''
+            }
+          }, [
+            serviceStubs.patchUpdateServiceNameSuccess({
+              serviceExternalId: SERVICE_EXTERNAL_ID,
+              gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+              serviceName: {
+                en: SERVICE_NAME.en,
+                cy: ''
+              }
+            }),
+            gatewayAccountStubs.patchUpdateServiceNameSuccess(TEST_GATEWAY_ACCOUNT_ID, SERVICE_NAME.en) // connector doesn't store the Welsh name
+          ])
+          cy.visit(SERVICE_SETTINGS_URL + '/service-name/edit?cy=true')
+        })
+        it('should not show "Remove Welsh service name" button', () => {
+          cy.get('h1').should('contain.text', 'Service name (Welsh)')
+          cy.get('input[name="service-name-input"]').should('have.value', '')
+          cy.get('.govuk-button-group')
+            .find('button')
+            .should('have.length', 1)
+            .should('contain.text', 'Save changes')
+            .should('not.contain.text', 'Remove Welsh service name')
+        })
+        it('should submit form', () => {
+          cy.get('button[form="edit-service-name-form"]').click()
+          cy.title().should('eq', 'Settings - Service name - GOV.UK Pay')
+        })
+      })
+    })
+  })
+})

--- a/test/cypress/integration/simplified-account/service-settings/service-name.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/service-name.cy.js
@@ -327,7 +327,7 @@ describe('Service name settings', () => {
           setStubs({
             serviceName: {
               en: SERVICE_NAME.en,
-              cy: ''
+              cy: undefined
             }
           }, [
             serviceStubs.patchUpdateServiceNameSuccess({

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -297,8 +297,8 @@ function postSwitchPspSuccess (gatewayAccountId) {
   return stubBuilder('POST', path, 200)
 }
 
-function getAccountByServiceIdAndAccountType (serviceExternalId, opts = {}) {
-  const path = `/v1/api/service/${serviceExternalId}/account/test`
+function getAccountByServiceIdAndAccountType (serviceExternalId, accountType = 'test', opts = {}) {
+  const path = `/v1/api/service/${serviceExternalId}/account/${accountType}`
   return stubBuilder('GET', path, 200, {
     response: gatewayAccountFixtures.validGatewayAccountResponse(opts)
   })


### PR DESCRIPTION
## WHAT

- add 'Remove Welsh service name' button when editing Welsh service name (if one is set)
- show a success message when clearing the Welsh service name via the new button
- add Cypress test for service name settings

### No Welsh name set for service

![Screenshot 2024-10-18 at 15 04 28](https://github.com/user-attachments/assets/9518cf9e-3e1a-4133-8a3f-3321021260b5)

![Screenshot 2024-10-18 at 15 04 34](https://github.com/user-attachments/assets/0e9d5d26-b19d-4fc5-8462-d901e6d946bb)

### Welsh service name set

![Screenshot 2024-10-18 at 15 05 39](https://github.com/user-attachments/assets/3a992b07-afe6-40bd-b3e7-db471a6468e3)

![Screenshot 2024-10-18 at 15 05 11](https://github.com/user-attachments/assets/1dd55904-f579-40f8-9413-a22ab51cd70b)

![Screenshot 2024-10-18 at 15 05 17](https://github.com/user-attachments/assets/4c0e5794-ce6b-40e0-af0c-618172178f67)

