### PR TITLE
bau: Using singluar patch email method

### DIFF
--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -424,25 +424,6 @@ ConnectorClient.prototype = {
   },
 
   /**
-   * @param {string} serviceId
-   * @param {string} accountType
-   * @param {boolean} enabled
-   */
-  updateConfirmationEmailEnabledByServiceId: async function (serviceId, accountType, enabled) {
-    const url = `${this.connectorUrl}/v1/api/service/{serviceId}/account/{accountType}/email-notification`
-      .replace('{serviceId}', encodeURIComponent(serviceId))
-      .replace('{accountType}', encodeURIComponent(accountType))
-    const payload = {
-      op: 'replace',
-      path: '/payment_confirmed/enabled',
-      value: enabled
-    }
-    configureClient(client, url)
-    const response = await client.patch(url, payload, `update payment confirmation email enabled to ${enabled}`)
-    return response.data
-  },
-
-  /**
    *
    * @param {Object} params
    */
@@ -465,25 +446,6 @@ ConnectorClient.prototype = {
     }
     configureClient(client, url)
     const response = await client.patch(url, payload, 'update email collection mode')
-    return response.data
-  },
-
-  /**
-   * @param {string} serviceId
-   * @param {string} accountType
-   * @param {boolean} enabled
-   */
-  updateRefundEmailEnabledByServiceId: async function (serviceId, accountType, enabled) {
-    const url = `${this.connectorUrl}/v1/api/service/{serviceId}/account/{accountType}/email-notification`
-      .replace('{serviceId}', encodeURIComponent(serviceId))
-      .replace('{accountType}', encodeURIComponent(accountType))
-    const payload = {
-      op: 'replace',
-      path: '/refund_issued/enabled',
-      value: enabled
-    }
-    configureClient(client, url)
-    const response = await client.patch(url, payload, `update refund email enabled to ${enabled}`)
     return response.data
   },
 

--- a/app/services/email.service.js
+++ b/app/services/email.service.js
@@ -62,7 +62,8 @@ async function setConfirmationEnabled (accountID, enabled) {
 
 async function setConfirmationEnabledByServiceIdAndAccountType (serviceExternalId, accountType, enabled) {
   try {
-    await connectorClient.updateConfirmationEmailEnabledByServiceId(serviceExternalId, accountType, enabled)
+    const payload = { op: 'replace', path: '/payment_confirmed/enabled', value: enabled }
+    await connectorClient.patchEmailNotificationByServiceIdAndAccountType(serviceExternalId, accountType, payload)
   } catch (err) {
     clientFailure(err, 'PATCH', false)
   }
@@ -70,7 +71,8 @@ async function setConfirmationEnabledByServiceIdAndAccountType (serviceExternalI
 
 async function setRefundEmailEnabledByServiceIdAndAccountType (serviceExternalId, accountType, enabled) {
   try {
-    await connectorClient.updateRefundEmailEnabledByServiceId(serviceExternalId, accountType, enabled)
+    const payload = { op: 'replace', path: '/refund_issued/enabled', value: enabled }
+    await connectorClient.patchEmailNotificationByServiceIdAndAccountType(serviceExternalId, accountType, payload)
   } catch (err) {
     clientFailure(err, 'PATCH', false)
   }

--- a/app/services/email.service.js
+++ b/app/services/email.service.js
@@ -18,6 +18,11 @@ async function updateConfirmationTemplate (accountID, emailText) {
   }
 }
 
+/**
+ * @param {string} serviceExternalId
+ * @param {string} accountType
+ * @param {string} customParagraph
+ */
 async function updateCustomParagraphByServiceIdAndAccountType (serviceExternalId, accountType, customParagraph) {
   try {
     const payload = { op: 'replace', path: '/payment_confirmed/template_body', value: customParagraph }
@@ -60,6 +65,11 @@ async function setConfirmationEnabled (accountID, enabled) {
   }
 }
 
+/**
+ * @param {string} serviceExternalId
+ * @param {string} accountType
+ * @param {boolean} enabled
+ */
 async function setConfirmationEnabledByServiceIdAndAccountType (serviceExternalId, accountType, enabled) {
   try {
     const payload = { op: 'replace', path: '/payment_confirmed/enabled', value: enabled }
@@ -69,6 +79,11 @@ async function setConfirmationEnabledByServiceIdAndAccountType (serviceExternalI
   }
 }
 
+/**
+ * @param {string} serviceExternalId
+ * @param {string} accountType
+ * @param {boolean} enabled
+ */
 async function setRefundEmailEnabledByServiceIdAndAccountType (serviceExternalId, accountType, enabled) {
   try {
     const payload = { op: 'replace', path: '/refund_issued/enabled', value: enabled }


### PR DESCRIPTION
Use singular `patchEmailNotificationByServiceIdAndAccountType` method on the connector client. This helps with keeping things DRY.