### PR TITLE
PP-13297 Add logic to roles and refactor template

### DIFF
--- a/app/controllers/simplified-account/settings/team-members/change-permission/change-permission.controller.js
+++ b/app/controllers/simplified-account/settings/team-members/change-permission/change-permission.controller.js
@@ -2,15 +2,18 @@ const { findByExternalId } = require('@services/user.service')
 const { response } = require('@utils/response')
 const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
 const paths = require('@root/paths')
+const { getAvailableRolesForService } = require('@utils/roles')
 
 async function get (req, res, next) {
   const serviceId = req.service.externalId
   const accountType = req.account.type
   const serviceHasAgentInitiatedMotoEnabled = req.service.agentInitiatedMotoEnabled
+  const availableRoles = getAvailableRolesForService(serviceHasAgentInitiatedMotoEnabled)
   try {
     const { email } = await findByExternalId(req.params.externalUserId)
     response(req, res, 'simplified-account/settings/team-members/change-permission',
       {
+        availableRoles,
         email,
         serviceHasAgentInitiatedMotoEnabled,
         backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.teamMembers.index, serviceId, accountType)

--- a/app/utils/roles.js
+++ b/app/utils/roles.js
@@ -1,17 +1,45 @@
 const _ = require('lodash')
 
 const roles = {
-  admin: { extId: 200, name: 'admin', description: 'Administrator' },
-  'view-and-refund': { extId: 300, name: 'view-and-refund', description: 'View and refund' },
-  'view-only': { extId: 400, name: 'view-only', description: 'View only' },
-  'view-and-initiate-moto': { extId: 500, name: 'view-and-initiate-moto', description: 'View and take telephone payments' },
-  'view-refund-and-initiate-moto': { extId: 600, name: 'view-refund-and-initiate-moto', description: 'View, refund and take telephone payments' }
+  admin: {
+    extId: 200,
+    name: 'admin',
+    description: 'Administrator',
+    explanation: 'They can view transactions, refund payments and manage settings',
+    agentInitiatedMotoServicesOnly: false
+  },
+  'view-and-refund': {
+    extId: 300,
+    name: 'view-and-refund',
+    description: 'View and refund',
+    explanation: 'They can view transactions and refund payments',
+    agentInitiatedMotoServicesOnly: false
+  },
+  'view-only': {
+    extId: 400,
+    name: 'view-only',
+    description: 'View only',
+    explanation: 'They can view transactions',
+    agentInitiatedMotoServicesOnly: false
+  },
+  'view-and-initiate-moto': {
+    extId: 500,
+    name: 'view-and-initiate-moto',
+    description: 'View and take telephone payments',
+    explanation: 'They can view transactions and take telephone payments',
+    agentInitiatedMotoServicesOnly: true
+  },
+  'view-refund-and-initiate-moto': {
+    extId: 600,
+    name: 'view-refund-and-initiate-moto',
+    description: 'View, refund and take telephone payments',
+    explanation: 'They can view transactions, refund payments, and take telephone payments',
+    agentInitiatedMotoServicesOnly: true
+  }
 }
 
 module.exports = {
-
   roles,
-
   getRoleByExtId: roleExtId => {
     let found
     _.toArray(roles).forEach(role => {
@@ -20,5 +48,16 @@ module.exports = {
       }
     })
     return found
+  },
+  getAvailableRolesForService: agentInitiatedMotoEnabled => {
+    return Object.values(roles)
+      .filter(role => agentInitiatedMotoEnabled ? true : !role.agentInitiatedMotoServicesOnly)
+      .map(role => _.pick(role, ['name', 'description', 'explanation']))
+      .map(role => {
+        // for agent-initiated moto services, add 'take telephone payments' to the explanation content for the admin role
+        return (role.name === 'admin' && agentInitiatedMotoEnabled)
+          ? { ...role, explanation: 'They can view transactions, refund payments, take telephone payments and manage settings' }
+          : role
+      })
   }
 }

--- a/app/utils/roles.js
+++ b/app/utils/roles.js
@@ -51,7 +51,7 @@ module.exports = {
   },
   getAvailableRolesForService: agentInitiatedMotoEnabled => {
     return Object.values(roles)
-      .filter(role => agentInitiatedMotoEnabled ? true : !role.agentInitiatedMotoServicesOnly)
+      .filter(role => agentInitiatedMotoEnabled || !role.agentInitiatedMotoServicesOnly)
       .map(role => _.pick(role, ['name', 'description', 'explanation']))
       .map(role => {
         // for agent-initiated moto services, add 'take telephone payments' to the explanation content for the admin role

--- a/app/utils/roles.test.js
+++ b/app/utils/roles.test.js
@@ -1,19 +1,46 @@
 const chai = require('chai')
 const roles = require('./roles')
+const { getAvailableRolesForService } = require('@utils/roles')
 const expect = chai.expect
 
 describe('roles module', function () {
-  it('should find get role by role id', function (done) {
+  it('should find get role by role id', () => {
     const role = roles.getRoleByExtId(200)
 
-    expect(role).to.deep.equal({ extId: 200, name: 'admin', description: 'Administrator' })
-    done()
+    expect(role).to.deep.equal({
+      extId: 200,
+      name: 'admin',
+      description: 'Administrator',
+      explanation: 'They can view transactions, refund payments and manage settings',
+      agentInitiatedMotoServicesOnly: false
+    })
   })
 
-  it('should return undefined for unknown role id', function (done) {
+  it('should return undefined for unknown role id', () => {
     const role = roles.getRoleByExtId('999')
 
     expect(role).to.equal(undefined)
-    done()
+  })
+
+  it('should return the correct roles for a service without agent-initiated moto', () => {
+    const rolesForService = getAvailableRolesForService(false)
+
+    expect(rolesForService).to.have.length(3)
+    expect(rolesForService[0]).to.deep.equal({
+      name: 'admin',
+      description: 'Administrator',
+      explanation: 'They can view transactions, refund payments and manage settings'
+    })
+  })
+
+  it('should return the correct roles for a service with agent-initiated moto', () => {
+    const rolesForService = getAvailableRolesForService(true)
+
+    expect(rolesForService).to.have.length(5)
+    expect(rolesForService[0]).to.deep.equal({
+      name: 'admin',
+      description: 'Administrator',
+      explanation: 'They can view transactions, refund payments, take telephone payments and manage settings'
+    })
   })
 })

--- a/app/views/simplified-account/settings/team-members/change-permission.njk
+++ b/app/views/simplified-account/settings/team-members/change-permission.njk
@@ -14,6 +14,17 @@
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <input type="hidden" name="email" value="{{ email }}" />
 
+    {% set roleItems = [] %}
+    {% for role in availableRoles %}
+      {% set roleItem = {
+        value: role.name,
+        id: "role-" + role.name + "-input",
+        html: "<label class=\"govuk-!-font-weight-bold\">" + role.description + "</label>",
+        hint: { text: role.explanation }
+      } %}
+      {% set roleItems = (roleItems.push(roleItem), roleItems) %}
+    {% endfor %}
+
     {{ govukRadios({
       idPrefix: "changePermission",
       name: "changePermission",
@@ -24,48 +35,7 @@
           classes: "govuk-fieldset__legend--l"
         }
       },
-      items: [
-        {
-          value: admin.id,
-          id: "role-admin-input",
-          text: 'Administrator',
-          hint: {
-            text: 'They can view transactions, refund payments, take telephone payments and manage settings' if serviceHasAgentInitiatedMotoEnabled else 'They can view transactions, refund payments and manage settings'
-          }
-        },
-        {
-          value: viewRefundAndInitiateMoto.id,
-          id: "role-view-refund-and-initiate-moto-input",
-          text: 'View, refund and take telephone payments',
-          hint: {
-            text: 'They can view transactions, refund payments, and take telephone payments'
-          }
-        } if serviceHasAgentInitiatedMotoEnabled,
-        {
-          value: viewAndRefund.id,
-          id: "role-view-and-refund-input",
-          text: 'View and refund',
-          hint: {
-            text: 'They can view transactions and refund payments'
-          }
-        },
-        {
-          value: viewAndInitiateMoto.id,
-          id: "role-view-and-initiate-moto-input",
-          text: 'View and take telephone payments',
-          hint: {
-            text: 'They can view transactions and take telephone payments'
-          }
-        } if serviceHasAgentInitiatedMotoEnabled,
-        {
-          value: view.id,
-          id: "role-view-input",
-          text: 'View only',
-          hint: {
-            text: 'They can view transactions'
-          }
-        }
-      ]
+      items: roleItems
     }) }}
     {{
     govukButton({


### PR DESCRIPTION
- Add the explanatory content about each role to the roles file and add a method to get the relevant role information for a service. 
- Iterate over the roles in the change permission template to reduce repetition
- The above changes will also make the 'invite team member' page simpler.
- Also, make the radio button labels bold to match the design.

It should be possible to simplify the roles.js file further; I don't think that the `extId` property is actually necessary although it is referred to elsewhere, I will see if this can be refactored in a subsequent PR.

Still to do: Implement the functionality in the post controller for changing permission (and lots of tests)

Screenshot as of 15-11-2024
------
<img width="1327" alt="Screenshot 2024-11-15 at 14 31 27" src="https://github.com/user-attachments/assets/c54340cd-6db4-4958-b34f-c59c85126f49">




