### PR TITLE
PP-13255 Add post functionality for organisation details settings form

### DIFF
--- a/app/controllers/request-to-go-live/choose-takes-payments-over-phone/post.controller.js
+++ b/app/controllers/request-to-go-live/choose-takes-payments-over-phone/post.controller.js
@@ -7,13 +7,13 @@ const goLiveStage = require('../../../models/go-live-stage')
 const formatServicePathsFor = require('../../../utils/format-service-paths-for')
 const { response } = require('../../../utils/response')
 const { requestToGoLive } = require('../../../paths').service
-const { validPaths, ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
+const { ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
 
 const CHOOSE_TAKES_PAYMENTS_OVER_PHONE = 'choose-takes-payments-over-phone'
 
 const updateServiceForTakesPaymentsOverPhone = async function (serviceExternalId, takesPaymentsOverPhone) {
   const updateRequest = new ServiceUpdateRequest()
-    .replace(validPaths.takesPaymentsOverPhone, takesPaymentsOverPhone)
+    .replace().takesPaymentsOverPhone(takesPaymentsOverPhone)
 
   return updateService(serviceExternalId, updateRequest.formatPayload())
 }

--- a/app/controllers/request-to-go-live/choose-takes-payments-over-phone/post.controller.js
+++ b/app/controllers/request-to-go-live/choose-takes-payments-over-phone/post.controller.js
@@ -2,12 +2,12 @@
 
 const lodash = require('lodash')
 
-const { updateCurrentGoLiveStage, updateService } = require('../../../services/service.service')
-const goLiveStage = require('../../../models/go-live-stage')
-const formatServicePathsFor = require('../../../utils/format-service-paths-for')
-const { response } = require('../../../utils/response')
-const { requestToGoLive } = require('../../../paths').service
-const { ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
+const { updateCurrentGoLiveStage, updateService } = require('@services/service.service')
+const goLiveStage = require('@models/go-live-stage')
+const formatServicePathsFor = require('@utils/format-service-paths-for')
+const { response } = require('@utils/response')
+const { requestToGoLive } = require('@root/paths').service
+const { ServiceUpdateRequest } = require('@models/ServiceUpdateRequest.class')
 
 const CHOOSE_TAKES_PAYMENTS_OVER_PHONE = 'choose-takes-payments-over-phone'
 

--- a/app/controllers/request-to-go-live/choose-takes-payments-over-phone/post.controller.test.js
+++ b/app/controllers/request-to-go-live/choose-takes-payments-over-phone/post.controller.test.js
@@ -3,21 +3,21 @@
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
-const User = require('../../../models/User.class')
-const userFixtures = require('../../../../test/fixtures/user.fixtures')
+const User = require('@models/User.class')
+const userFixtures = require('@test/fixtures/user.fixtures')
 const { expect } = require('chai')
-const { GOV_BANKING_MOTO_OPTION_COMPLETED } = require('../../../models/go-live-stage')
+const { GOV_BANKING_MOTO_OPTION_COMPLETED } = require('@models/go-live-stage')
 
 let updateServiceMock, updateCurrentGoLiveStageMock
 let mockResponse
 
 function postControllerWithMocks () {
   return proxyquire('./post.controller.js', {
-    '../../../services/service.service': {
+    '@services/service.service': {
       updateCurrentGoLiveStage: updateCurrentGoLiveStageMock,
       updateService: updateServiceMock
     },
-    '../../../utils/response': {
+    '@utils/response': {
       response: mockResponse
     }
   })

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.js
@@ -2,28 +2,28 @@
 
 const lodash = require('lodash')
 
-const logger = require('../../../utils/logger')(__filename)
+const logger = require('@utils/logger')(__filename)
 const goLiveStageToNextPagePath = require('../go-live-stage-to-next-page-path')
-const goLiveStage = require('../../../models/go-live-stage')
-const paths = require('../../../paths')
+const goLiveStage = require('@models/go-live-stage')
+const paths = require('@root/paths')
 const {
   validateMandatoryField,
   validateOptionalField,
   validatePostcode,
   validatePhoneNumber,
   validateUrl
-} = require('../../../utils/validation/server-side-form-validations')
-const { updateService } = require('../../../services/service.service')
-const { ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
-const formatServicePathsFor = require('../../../utils/format-service-paths-for')
-const { response } = require('../../../utils/response')
+} = require('@utils/validation/server-side-form-validations')
+const { updateService } = require('@services/service.service')
+const { ServiceUpdateRequest } = require('@models/ServiceUpdateRequest.class')
+const formatServicePathsFor = require('@utils/format-service-paths-for')
+const { response } = require('@utils/response')
 const { countries } = require('@govuk-pay/pay-js-commons').utils
-const { getStripeAccountId } = require('../../../controllers/stripe-setup/stripe-setup.util')
-const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
-const { ConnectorClient } = require('../../../services/clients/connector.client')
+const { getStripeAccountId } = require('@controllers/stripe-setup/stripe-setup.util')
+const formatAccountPathsFor = require('@utils/format-account-paths-for')
+const { ConnectorClient } = require('@services/clients/connector.client')
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
-const { updateOrganisationDetails } = require('../../../services/clients/stripe/stripe.client')
-const { isSwitchingCredentialsRoute, isEnableStripeOnboardingTaskListRoute, getCurrentCredential } = require('../../../utils/credentials')
+const { updateOrganisationDetails } = require('@services/clients/stripe/stripe.client')
+const { isSwitchingCredentialsRoute, isEnableStripeOnboardingTaskListRoute, getCurrentCredential } = require('@utils/credentials')
 
 const clientFieldNames = {
   name: 'merchant-name',

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.js
@@ -14,7 +14,7 @@ const {
   validateUrl
 } = require('../../../utils/validation/server-side-form-validations')
 const { updateService } = require('../../../services/service.service')
-const { validPaths, ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
+const { ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
 const formatServicePathsFor = require('../../../utils/format-service-paths-for')
 const { response } = require('../../../utils/response')
 const { countries } = require('@govuk-pay/pay-js-commons').utils
@@ -166,18 +166,18 @@ async function submitForm (form, req, isRequestToGoLive, isStripeSetupUserJourne
     })
   } else {
     const updateRequest = new ServiceUpdateRequest()
-      .replace(validPaths.merchantDetails.addressLine1, form[clientFieldNames.addressLine1])
-      .replace(validPaths.merchantDetails.addressLine2, form[clientFieldNames.addressLine2])
-      .replace(validPaths.merchantDetails.addressCity, form[clientFieldNames.addressCity])
-      .replace(validPaths.merchantDetails.addressPostcode, form[clientFieldNames.addressPostcode])
-      .replace(validPaths.merchantDetails.addressCountry, form[clientFieldNames.addressCountry])
-      .replace(validPaths.merchantDetails.telephoneNumber, form[clientFieldNames.telephoneNumber])
-      .replace(validPaths.merchantDetails.url, form[clientFieldNames.url])
+      .replace().merchantDetails.addressLine1(form[clientFieldNames.addressLine1])
+      .replace().merchantDetails.addressLine2(form[clientFieldNames.addressLine2])
+      .replace().merchantDetails.addressCity(form[clientFieldNames.addressCity])
+      .replace().merchantDetails.addressPostcode(form[clientFieldNames.addressPostcode])
+      .replace().merchantDetails.addressCountry(form[clientFieldNames.addressCountry])
+      .replace().merchantDetails.telephoneNumber(form[clientFieldNames.telephoneNumber])
+      .replace().merchantDetails.url(form[clientFieldNames.url])
 
     if (isRequestToGoLive) {
-      updateRequest.replace(validPaths.currentGoLiveStage, goLiveStage.ENTERED_ORGANISATION_ADDRESS)
+      updateRequest.replace().currentGoLiveStage(goLiveStage.ENTERED_ORGANISATION_ADDRESS)
     } else {
-      updateRequest.replace(validPaths.merchantDetails.name, form[clientFieldNames.name])
+      updateRequest.replace().merchantDetails.name(form[clientFieldNames.name])
     }
     return updateService(req.service.externalId, updateRequest.formatPayload())
   }

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.test.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.test.js
@@ -20,26 +20,26 @@ const stubGetStripeAccountId = sinon.stub().resolves(stripeAccountId)
 
 const getController = function getController (mockServiceService) {
   return proxyquire('./post.controller', {
-    '../../../services/service.service': mockServiceService,
-    '../../../services/clients/connector.client': {
+    '@services/service.service': mockServiceService,
+    '@services/clients/connector.client': {
       ConnectorClient: function () {
         this.setStripeAccountSetupFlag = setStripeAccountSetupFlagMock
       }
     },
-    '../../../utils/response': {
+    '@utils/response': {
       response: mockResponse
     },
-    '../../../controllers/stripe-setup/stripe-setup.util': {
+    '@controllers/stripe-setup/stripe-setup.util': {
       getStripeAccountId: (...params) => {
         return stubGetStripeAccountId(...params)
       }
     },
-    '../../../utils/logger': function (filename) {
+    '@utils/logger': function (filename) {
       return {
         info: loggerInfoMock
       }
     },
-    '../../../services/clients/stripe/stripe.client': {
+    '@services/clients/stripe/stripe.client': {
       updateOrganisationDetails: updateStripeAccountMock
     }
   })

--- a/app/controllers/request-to-go-live/organisation-address/post.controller.test.js
+++ b/app/controllers/request-to-go-live/organisation-address/post.controller.test.js
@@ -395,43 +395,43 @@ describe('organisation address - post controller', () => {
             const expectedUpdateServiceRequest = [
               {
                 op: 'replace',
-                path: 'merchant_details/address_line1',
-                value: validLine1
+                value: validLine1,
+                path: 'merchant_details/address_line1'
               },
               {
                 op: 'replace',
-                path: 'merchant_details/address_line2',
-                value: ''
+                value: '',
+                path: 'merchant_details/address_line2'
               },
               {
                 op: 'replace',
-                path: 'merchant_details/address_city',
-                value: validCity
+                value: validCity,
+                path: 'merchant_details/address_city'
               },
               {
                 op: 'replace',
-                path: 'merchant_details/address_postcode',
-                value: validPostcode
+                value: validPostcode,
+                path: 'merchant_details/address_postcode'
               },
               {
                 op: 'replace',
-                path: 'merchant_details/address_country',
-                value: validCountry
+                value: validCountry,
+                path: 'merchant_details/address_country'
               },
               {
                 op: 'replace',
-                path: 'merchant_details/telephone_number',
-                value: validTelephoneNumber
+                value: validTelephoneNumber,
+                path: 'merchant_details/telephone_number'
               },
               {
                 op: 'replace',
-                path: 'merchant_details/url',
-                value: validUrl
+                value: validUrl,
+                path: 'merchant_details/url'
               },
               {
                 op: 'replace',
-                path: 'current_go_live_stage',
-                value: goLiveStage.ENTERED_ORGANISATION_ADDRESS
+                value: goLiveStage.ENTERED_ORGANISATION_ADDRESS,
+                path: 'current_go_live_stage'
               }
             ]
 

--- a/app/controllers/request-to-go-live/organisation-name/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-name/post.controller.js
@@ -7,7 +7,7 @@ const goLiveStage = require('../../../models/go-live-stage')
 const paths = require('../../../paths')
 const { validateMandatoryField } = require('../../../utils/validation/server-side-form-validations')
 const { updateCurrentGoLiveStage, updateService } = require('../../../services/service.service')
-const { validPaths, ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
+const { ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
 const formatServicePathsFor = require('../../../utils/format-service-paths-for')
 
 const ORGANISATION_NAME_MAX_LENGTH = 100
@@ -17,7 +17,7 @@ module.exports = async function submitOrganisationName (req, res, next) {
   const validationResult = validateMandatoryField(organisationName, ORGANISATION_NAME_MAX_LENGTH, 'organisation name')
   if (validationResult.valid) {
     const updateServiceRequest = new ServiceUpdateRequest()
-      .replace(validPaths.merchantDetails.name, organisationName)
+      .replace().merchantDetails.name(organisationName)
       .formatPayload()
 
     try {

--- a/app/controllers/request-to-go-live/organisation-name/post.controller.js
+++ b/app/controllers/request-to-go-live/organisation-name/post.controller.js
@@ -3,12 +3,12 @@
 const lodash = require('lodash')
 
 const goLiveStageToNextPagePath = require('../go-live-stage-to-next-page-path')
-const goLiveStage = require('../../../models/go-live-stage')
-const paths = require('../../../paths')
-const { validateMandatoryField } = require('../../../utils/validation/server-side-form-validations')
-const { updateCurrentGoLiveStage, updateService } = require('../../../services/service.service')
-const { ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
-const formatServicePathsFor = require('../../../utils/format-service-paths-for')
+const goLiveStage = require('@models/go-live-stage')
+const paths = require('@root/paths')
+const { validateMandatoryField } = require('@utils/validation/server-side-form-validations')
+const { updateCurrentGoLiveStage, updateService } = require('@services/service.service')
+const { ServiceUpdateRequest } = require('@models/ServiceUpdateRequest.class')
+const formatServicePathsFor = require('@utils/format-service-paths-for')
 
 const ORGANISATION_NAME_MAX_LENGTH = 100
 

--- a/app/controllers/simplified-account/settings/organisation-details/organisation-details.controller.js
+++ b/app/controllers/simplified-account/settings/organisation-details/organisation-details.controller.js
@@ -1,14 +1,25 @@
-const { response } = require('../../../../utils/response')
-const paths = require('../../../../paths')
-const formatSimplifiedAccountPathsFor = require('../../../../utils/simplified-account/format/format-simplified-account-paths-for')
+const { response } = require('@utils/response')
+const paths = require('@root/paths')
+const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
+const { formatAddressAsParagraph } = require('@utils/format-address-as-paragraph')
 
 function get (req, res) {
-  const organisationDetails = {
-    organisationName: '',
-    address: '',
-    telephoneNumber: '',
-    websiteAddress: ''
+  if (!req.service?.merchantDetails) {
+    res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.organisationDetails.edit, req.service.externalId, req.account.type))
   }
+
+  const organisationDetails = {
+    organisationName: req.service.merchantDetails.name,
+    address: formatAddressAsParagraph({
+      line1: req.service.merchantDetails.address_line1,
+      line2: req.service.merchantDetails.address_line2,
+      city: req.service.merchantDetails.address_city,
+      postcode: req.service.merchantDetails.address_postcode
+    }),
+    telephoneNumber: req.service.merchantDetails.telephone_number,
+    url: req.service.merchantDetails.url
+  }
+
   const context = {
     messages: res.locals?.flash?.messages ?? [],
     organisationDetails,

--- a/app/controllers/simplified-account/settings/stripe-details/responsible-person/responsible-person-check-answers.controller.js
+++ b/app/controllers/simplified-account/settings/stripe-details/responsible-person/responsible-person-check-answers.controller.js
@@ -5,6 +5,7 @@ const { response } = require('@utils/response')
 const { updateStipeDetailsResponsiblePerson } = require('@services/stripe-details.service')
 const { formatPhoneNumberWithCountryCode } = require('@utils/telephone-number-utils')
 const { stripeDetailsTasks } = require('@utils/simplified-account/settings/stripe-details/tasks')
+const { formatAddressAsParagraph } = require('@utils/format-address-as-paragraph')
 const { FORM_STATE_KEY } = require('@controllers/simplified-account/settings/stripe-details/responsible-person/constants')
 const _ = require('lodash')
 
@@ -21,7 +22,7 @@ async function get (req, res) {
     answers: {
       name: `${name.firstName} ${name.lastName}`,
       dob: `${dob.dobYear}-${dob.dobMonth}-${dob.dobDay}`,
-      address: ['homeAddressLine1', 'homeAddressLine2', 'homeAddressCity', 'homeAddressPostcode'].map(k => address?.[k]).filter(v => v && v !== '').join('<br>'),
+      address: formatAddressAsParagraph({ line1: address.homeAddressLine1, line2: address.homeAddressLine2, city: address.homeAddressCity, postcode: address.homeAddressPostcode }),
       phone: formatPhoneNumberWithCountryCode(contact.workTelephoneNumber),
       email: contact.workEmail
     }

--- a/app/controllers/switch-psp/organisation-url/post.controller.js
+++ b/app/controllers/switch-psp/organisation-url/post.controller.js
@@ -12,7 +12,7 @@ const { isSwitchingCredentialsRoute, getCurrentCredential } = require('../../../
 const { updateAccount } = require('../../../services/clients/stripe/stripe.client')
 const logger = require('../../../utils/logger')(__filename)
 const { updateService } = require('../../../services/service.service')
-const { validPaths, ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
+const { ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
 
 const ORGANISATION_URL = 'organisation-url'
 
@@ -29,7 +29,7 @@ function validateOrgUrl (organisationUrl) {
 
 const updateServiceWithUrl = async function (organisationUrl, serviceExternalId) {
   const updateRequest = new ServiceUpdateRequest()
-    .replace(validPaths.merchantDetails.url, organisationUrl)
+    .replace().merchantDetails.url(organisationUrl)
 
   return updateService(serviceExternalId, updateRequest.formatPayload())
 }

--- a/app/controllers/switch-psp/organisation-url/post.controller.js
+++ b/app/controllers/switch-psp/organisation-url/post.controller.js
@@ -2,17 +2,17 @@
 
 const lodash = require('lodash')
 
-const paths = require('../../../paths')
-const formatAccountPathsFor = require('../../../utils/format-account-paths-for')
-const { validateUrl } = require('../../../utils/validation/server-side-form-validations')
-const { validationErrors } = require('../../../utils/validation/field-validation-checks')
+const paths = require('@root/paths')
+const formatAccountPathsFor = require('@utils/format-account-paths-for')
+const { validateUrl } = require('@utils/validation/server-side-form-validations')
+const { validationErrors } = require('@utils/validation/field-validation-checks')
 const { getStripeAccountId } = require('../../stripe-setup/stripe-setup.util')
-const { response } = require('../../../utils/response')
-const { isSwitchingCredentialsRoute, getCurrentCredential } = require('../../../utils/credentials')
-const { updateAccount } = require('../../../services/clients/stripe/stripe.client')
-const logger = require('../../../utils/logger')(__filename)
-const { updateService } = require('../../../services/service.service')
-const { ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
+const { response } = require('@utils/response')
+const { isSwitchingCredentialsRoute, getCurrentCredential } = require('@utils/credentials')
+const { updateAccount } = require('@services/clients/stripe/stripe.client')
+const logger = require('@utils/logger')(__filename)
+const { updateService } = require('@services/service.service')
+const { ServiceUpdateRequest } = require('@models/ServiceUpdateRequest.class')
 
 const ORGANISATION_URL = 'organisation-url'
 

--- a/app/controllers/switch-psp/organisation-url/post.controller.test.js
+++ b/app/controllers/switch-psp/organisation-url/post.controller.test.js
@@ -3,7 +3,7 @@
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const assert = require('assert')
-const { validPaths, ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
+const { ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
 const gatewayAccountFixtures = require('../../../../test/fixtures/gateway-account.fixtures')
 const userFixtures = require('../../../../test/fixtures/user.fixtures')
 const User = require('../../../models/User.class')
@@ -85,7 +85,7 @@ describe('Organisation URL POST controller', () => {
     sinon.assert.calledWith(updateAccountMock, res.locals.stripeAccount.stripeAccountId, { url: organisationUrl })
 
     const updateRequest = new ServiceUpdateRequest()
-      .replace(validPaths.merchantDetails.url, organisationUrl)
+      .replace().merchantDetails.url(organisationUrl)
     sinon.assert.calledWith(updateServiceMock, req.service.externalId, updateRequest.formatPayload())
     sinon.assert.calledWith(res.redirect, 303, `/account/${accountExternalId}/switch-psp`)
   })

--- a/app/controllers/switch-psp/organisation-url/post.controller.test.js
+++ b/app/controllers/switch-psp/organisation-url/post.controller.test.js
@@ -3,10 +3,10 @@
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const assert = require('assert')
-const { ServiceUpdateRequest } = require('../../../models/ServiceUpdateRequest.class')
-const gatewayAccountFixtures = require('../../../../test/fixtures/gateway-account.fixtures')
-const userFixtures = require('../../../../test/fixtures/user.fixtures')
-const User = require('../../../models/User.class')
+const { ServiceUpdateRequest } = require('@models/ServiceUpdateRequest.class')
+const gatewayAccountFixtures = require('@test/fixtures/gateway-account.fixtures')
+const userFixtures = require('@test/fixtures/user.fixtures')
+const User = require('@models/User.class')
 
 describe('Organisation URL POST controller', () => {
   const organisationUrl = 'https://www.example.com'
@@ -36,7 +36,7 @@ describe('Organisation URL POST controller', () => {
 
   function getControllerWithMocks () {
     return proxyquire('./post.controller', {
-      '../../../services/clients/stripe/stripe.client': {
+      '@services/clients/stripe/stripe.client': {
         updateAccount: updateAccountMock
       },
       '../../stripe-setup/stripe-setup.util': {
@@ -44,7 +44,7 @@ describe('Organisation URL POST controller', () => {
           return Promise.resolve(stripeAccountId)
         }
       },
-      '../../../services/service.service': {
+      '@services/service.service': {
         updateService: updateServiceMock
       }
     })

--- a/app/models/ServiceUpdateRequest.class.js
+++ b/app/models/ServiceUpdateRequest.class.js
@@ -1,58 +1,16 @@
 'use strict'
 
-const validPaths = {
-  merchantDetails: {
-    name: 'merchant_details/name',
-    addressLine1: 'merchant_details/address_line1',
-    addressLine2: 'merchant_details/address_line2',
-    addressCity: 'merchant_details/address_city',
-    addressPostcode: 'merchant_details/address_postcode',
-    addressCountry: 'merchant_details/address_country',
-    telephoneNumber: 'merchant_details/telephone_number',
-    email: 'merchant_details/email',
-    url: 'merchant_details/url'
-  },
-  currentGoLiveStage: 'current_go_live_stage',
-  currentPspTestAccountStage: 'current_psp_test_account_stage',
-  takesPaymentsOverPhone: 'takes_payments_over_phone'
-}
-
-const ops = {
-  add: 'add',
-  replace: 'replace'
-}
-
 class ServiceUpdateRequest {
   constructor () {
     this.updates = []
   }
 
-  /**
-   * Adds an update with op "replace" to the request
-   * @param path
-   * @param value
-   */
-  add (path, value) {
-    this.updates.push({
-      op: ops.add,
-      path,
-      value
-    })
-    return this
+  replace () {
+    return safeOperation('replace', this)
   }
 
-  /**
-   * Adds an update with op "add" to the request
-   * @param path
-   * @param value
-   */
-  replace (path, value) {
-    this.updates.push({
-      op: ops.replace,
-      path,
-      value
-    })
-    return this
+  add () {
+    return safeOperation('add', this)
   }
 
   formatPayload () {
@@ -60,4 +18,58 @@ class ServiceUpdateRequest {
   }
 }
 
-module.exports = { validPaths, ServiceUpdateRequest }
+const safeOperation = (op, request) => {
+  return {
+    merchantDetails: {
+      name: (value) => {
+        request.updates.push({ op, value, path: 'merchant_details/name' })
+        return request
+      },
+      addressLine1: (value) => {
+        request.updates.push({ op, value, path: 'merchant_details/address_line1' })
+        return request
+      },
+      addressLine2: (value) => {
+        request.updates.push({ op, value, path: 'merchant_details/address_line2' })
+        return request
+      },
+      addressCity: (value) => {
+        request.updates.push({ op, value, path: 'merchant_details/address_city' })
+        return request
+      },
+      addressPostcode: (value) => {
+        request.updates.push({ op, value, path: 'merchant_details/address_postcode' })
+        return request
+      },
+      addressCountry: (value) => {
+        request.updates.push({ op, value, path: 'merchant_details/address_country' })
+        return request
+      },
+      telephoneNumber: (value) => {
+        request.updates.push({ op, value, path: 'merchant_details/telephone_number' })
+        return request
+      },
+      email: (value) => {
+        request.updates.push({ op, value, path: 'merchant_details/email' })
+        return request
+      },
+      url: (value) => {
+        request.updates.push({ op, value, path: 'merchant_details/url' })
+        return request
+      }
+    },
+    currentGoLiveStage: (value) => {
+      request.updates.push({ op, value, path: 'current_go_live_stage' })
+      return request
+    },
+    currentPspTestAccountStage: (value) => {
+      request.updates.push({ op, value, path: 'current_psp_test_account_stage' })
+      return request
+    },
+    takesPaymentsOverPhone: (value) => {
+      request.updates.push({ op, value, path: 'takes_payments_over_phone' })
+      return request
+    }
+  }
+}
+module.exports = { ServiceUpdateRequest }

--- a/app/models/ServiceUpdateRequest.class.test.js
+++ b/app/models/ServiceUpdateRequest.class.test.js
@@ -1,50 +1,62 @@
-// 'use strict'
-//
-// const { expect } = require('chai')
-// const { ServiceUpdateRequest } = require('./ServiceUpdateRequest.class')
-//
-// describe('the ServiceUpdateRequest model', () => {
-//   it('should successfully add a "replace" request', () => {
-//     const payload = new ServiceUpdateRequest().replace('foo', 'bar').formatPayload()
-//     expect(payload).to.deep.equal([{
-//       op: 'replace',
-//       path: 'foo',
-//       value: 'bar'
-//     }])
-//   })
-//
-//   it('should successfully add an "add" request', () => {
-//     const payload = new ServiceUpdateRequest().add('foo', 'bar').formatPayload()
-//     expect(payload).to.deep.equal([{
-//       op: 'add',
-//       path: 'foo',
-//       value: 'bar'
-//     }])
-//   })
-//
-//   it('should successfully add multiple requests', () => {
-//     const payload = new ServiceUpdateRequest()
-//       .replace('replace-path-1', 'replace-value-1')
-//       .replace('replace-path-2', 'replace-value-2')
-//       .add('add-path', 'add-value')
-//       .formatPayload()
-//
-//     expect(payload).to.deep.equal([
-//       {
-//         op: 'replace',
-//         path: 'replace-path-1',
-//         value: 'replace-value-1'
-//       },
-//       {
-//         op: 'replace',
-//         path: 'replace-path-2',
-//         value: 'replace-value-2'
-//       },
-//       {
-//         op: 'add',
-//         path: 'add-path',
-//         value: 'add-value'
-//       }
-//     ])
-//   })
-// })
+'use strict'
+
+const { expect } = require('chai')
+const { ServiceUpdateRequest } = require('./ServiceUpdateRequest.class')
+
+describe('the ServiceUpdateRequest model', () => {
+  it('should successfully add a "replace" request', () => {
+    const payload = new ServiceUpdateRequest().replace().currentGoLiveStage('live').formatPayload()
+    expect(payload).to.deep.equal([{
+      op: 'replace',
+      path: 'current_go_live_stage',
+      value: 'live'
+    }])
+  })
+
+  it('should successfully add an "add" request', () => {
+    const payload = new ServiceUpdateRequest().add().currentGoLiveStage('live').formatPayload()
+    expect(payload).to.deep.equal([{
+      op: 'add',
+      path: 'current_go_live_stage',
+      value: 'live'
+    }])
+  })
+
+  it('should successfully add multiple requests', () => {
+    const payload = new ServiceUpdateRequest()
+      .replace().currentGoLiveStage('live')
+      .replace().currentPspTestAccountStage('a-stage')
+      .replace().merchantDetails.name('my-org')
+      .add().merchantDetails.addressPostcode('SW11AA')
+      .add().merchantDetails.addressCountry('GB')
+      .formatPayload()
+
+    expect(payload).to.deep.equal([
+      {
+        op: 'replace',
+        path: 'current_go_live_stage',
+        value: 'live'
+      },
+      {
+        op: 'replace',
+        path: 'current_psp_test_account_stage',
+        value: 'a-stage'
+      },
+      {
+        op: 'replace',
+        path: 'merchant_details/name',
+        value: 'my-org'
+      },
+      {
+        op: 'add',
+        path: 'merchant_details/address_postcode',
+        value: 'SW11AA'
+      },
+      {
+        op: 'add',
+        path: 'merchant_details/address_country',
+        value: 'GB'
+      }
+    ])
+  })
+})

--- a/app/models/ServiceUpdateRequest.class.test.js
+++ b/app/models/ServiceUpdateRequest.class.test.js
@@ -1,50 +1,50 @@
-'use strict'
-
-const { expect } = require('chai')
-const { ServiceUpdateRequest } = require('./ServiceUpdateRequest.class')
-
-describe('the ServiceUpdateRequest model', () => {
-  it('should successfully add a "replace" request', () => {
-    const payload = new ServiceUpdateRequest().replace('foo', 'bar').formatPayload()
-    expect(payload).to.deep.equal([{
-      op: 'replace',
-      path: 'foo',
-      value: 'bar'
-    }])
-  })
-
-  it('should successfully add an "add" request', () => {
-    const payload = new ServiceUpdateRequest().add('foo', 'bar').formatPayload()
-    expect(payload).to.deep.equal([{
-      op: 'add',
-      path: 'foo',
-      value: 'bar'
-    }])
-  })
-
-  it('should successfully add multiple requests', () => {
-    const payload = new ServiceUpdateRequest()
-      .replace('replace-path-1', 'replace-value-1')
-      .replace('replace-path-2', 'replace-value-2')
-      .add('add-path', 'add-value')
-      .formatPayload()
-
-    expect(payload).to.deep.equal([
-      {
-        op: 'replace',
-        path: 'replace-path-1',
-        value: 'replace-value-1'
-      },
-      {
-        op: 'replace',
-        path: 'replace-path-2',
-        value: 'replace-value-2'
-      },
-      {
-        op: 'add',
-        path: 'add-path',
-        value: 'add-value'
-      }
-    ])
-  })
-})
+// 'use strict'
+//
+// const { expect } = require('chai')
+// const { ServiceUpdateRequest } = require('./ServiceUpdateRequest.class')
+//
+// describe('the ServiceUpdateRequest model', () => {
+//   it('should successfully add a "replace" request', () => {
+//     const payload = new ServiceUpdateRequest().replace('foo', 'bar').formatPayload()
+//     expect(payload).to.deep.equal([{
+//       op: 'replace',
+//       path: 'foo',
+//       value: 'bar'
+//     }])
+//   })
+//
+//   it('should successfully add an "add" request', () => {
+//     const payload = new ServiceUpdateRequest().add('foo', 'bar').formatPayload()
+//     expect(payload).to.deep.equal([{
+//       op: 'add',
+//       path: 'foo',
+//       value: 'bar'
+//     }])
+//   })
+//
+//   it('should successfully add multiple requests', () => {
+//     const payload = new ServiceUpdateRequest()
+//       .replace('replace-path-1', 'replace-value-1')
+//       .replace('replace-path-2', 'replace-value-2')
+//       .add('add-path', 'add-value')
+//       .formatPayload()
+//
+//     expect(payload).to.deep.equal([
+//       {
+//         op: 'replace',
+//         path: 'replace-path-1',
+//         value: 'replace-value-1'
+//       },
+//       {
+//         op: 'replace',
+//         path: 'replace-path-2',
+//         value: 'replace-value-2'
+//       },
+//       {
+//         op: 'add',
+//         path: 'add-path',
+//         value: 'add-value'
+//       }
+//     ])
+//   })
+// })

--- a/app/utils/format-address-as-paragraph.js
+++ b/app/utils/format-address-as-paragraph.js
@@ -1,0 +1,10 @@
+/**
+ *
+ * @param {{ line1: string, line2: string, city: string, postcode: string }}
+ * @returns {string}
+ */
+const formatAddressAsParagraph = ({ line1, line2, city, postcode }) => {
+  return [line1, line2, city, postcode].filter(v => v && v !== '').join('<br>')
+}
+
+module.exports.formatAddressAsParagraph = formatAddressAsParagraph

--- a/app/views/simplified-account/settings/organisation-details/index.njk
+++ b/app/views/simplified-account/settings/organisation-details/index.njk
@@ -38,7 +38,7 @@
           text: "Address"
         },
         value: {
-          text: organisationDetails.address
+          html: organisationDetails.address
         }
       },
       {
@@ -54,7 +54,7 @@
           text: "Website address"
         },
         value: {
-          text: organisationDetails.websiteAddress
+          text: organisationDetails.url
         }
       }
     ]

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,7 +8,8 @@
       "@models/*": ["app/models/*"],
       "@services/*": ["app/services/*"],
       "@utils/*": ["app/utils/*"],
-      "@views/*": ["app/views/*"]
+      "@views/*": ["app/views/*"],
+      "@test/*": ["test/*"]
     }
   },
   "exclude": ["node_modules"]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@models": "app/models",
     "@services": "app/services",
     "@utils": "app/utils",
-    "@views": "app/views"
+    "@views": "app/views",
+    "@test": "test"
   },
   "standard": {
     "globals": [

--- a/test/pact/adminusers-client/service/update-service.pact.test.js
+++ b/test/pact/adminusers-client/service/update-service.pact.test.js
@@ -8,7 +8,7 @@ const path = require('path')
 const PactInteractionBuilder = require('../../../test-helpers/pact/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../app/services/clients/adminusers.client')
 const serviceFixtures = require('../../../fixtures/service.fixtures')
-const { validPaths, ServiceUpdateRequest } = require('../../../../app/models/ServiceUpdateRequest.class')
+const { ServiceUpdateRequest } = require('../../../../app/models/ServiceUpdateRequest.class')
 const goLiveStage = require('../../../../app/models/go-live-stage')
 const pspTestAccountStage = require('../../../../app/models/psp-test-account-stage')
 const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPactifier
@@ -42,7 +42,7 @@ describe('adminusers client - patch request to update service', function () {
   describe('a valid update service patch request to update single field', () => {
     const merchantDetailsName = 'updated-name'
     const validUpdateServiceRequest = new ServiceUpdateRequest()
-      .replace(validPaths.merchantDetails.name, merchantDetailsName)
+      .replace().merchantDetails.name(merchantDetailsName)
       .formatPayload()
 
     const validUpdateServiceResponse = serviceFixtures.validServiceResponse({
@@ -91,18 +91,18 @@ describe('adminusers client - patch request to update service', function () {
     const takesPaymentsOverPhone = true
 
     const validUpdateServiceRequest = new ServiceUpdateRequest()
-      .replace(validPaths.merchantDetails.name, merchantDetails.name)
-      .replace(validPaths.merchantDetails.addressLine1, merchantDetails.address_line1)
-      .replace(validPaths.merchantDetails.addressLine2, merchantDetails.address_line2)
-      .replace(validPaths.merchantDetails.addressCity, merchantDetails.address_city)
-      .replace(validPaths.merchantDetails.addressCountry, merchantDetails.address_country)
-      .replace(validPaths.merchantDetails.addressPostcode, merchantDetails.address_postcode)
-      .replace(validPaths.merchantDetails.telephoneNumber, merchantDetails.telephone_number)
-      .replace(validPaths.merchantDetails.email, merchantDetails.email)
-      .replace(validPaths.currentGoLiveStage, currentGoLiveStage)
-      .replace(validPaths.currentPspTestAccountStage, currentPspTestAccountStage)
-      .replace(validPaths.merchantDetails.url, merchantDetails.url)
-      .replace(validPaths.takesPaymentsOverPhone, takesPaymentsOverPhone)
+      .replace().merchantDetails.name(merchantDetails.name)
+      .replace().merchantDetails.addressLine1(merchantDetails.address_line1)
+      .replace().merchantDetails.addressLine2(merchantDetails.address_line2)
+      .replace().merchantDetails.addressCity(merchantDetails.address_city)
+      .replace().merchantDetails.addressPostcode(merchantDetails.address_postcode)
+      .replace().merchantDetails.addressCountry(merchantDetails.address_country)
+      .replace().merchantDetails.telephoneNumber(merchantDetails.telephone_number)
+      .replace().merchantDetails.email(merchantDetails.email)
+      .replace().merchantDetails.url(merchantDetails.url)
+      .replace().currentGoLiveStage(currentGoLiveStage)
+      .replace().currentPspTestAccountStage(currentPspTestAccountStage)
+      .replace().takesPaymentsOverPhone(takesPaymentsOverPhone)
       .formatPayload()
 
     const validUpdateServiceResponse = serviceFixtures.validServiceResponse({

--- a/test/pact/adminusers-client/service/update-service.pact.test.js
+++ b/test/pact/adminusers-client/service/update-service.pact.test.js
@@ -5,13 +5,13 @@ const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
 const path = require('path')
-const PactInteractionBuilder = require('../../../test-helpers/pact/pact-interaction-builder').PactInteractionBuilder
+const PactInteractionBuilder = require('@test/test-helpers/pact/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../app/services/clients/adminusers.client')
-const serviceFixtures = require('../../../fixtures/service.fixtures')
-const { ServiceUpdateRequest } = require('../../../../app/models/ServiceUpdateRequest.class')
-const goLiveStage = require('../../../../app/models/go-live-stage')
-const pspTestAccountStage = require('../../../../app/models/psp-test-account-stage')
-const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPactifier
+const serviceFixtures = require('@test/fixtures/service.fixtures')
+const { ServiceUpdateRequest } = require('@models/ServiceUpdateRequest.class')
+const goLiveStage = require('@models/go-live-stage')
+const pspTestAccountStage = require('@models/psp-test-account-stage')
+const { pactify } = require('@test/test-helpers/pact/pactifier').defaultPactifier
 
 // Constants
 const SERVICE_RESOURCE = '/v1/api/services'


### PR DESCRIPTION
## WHAT
- Implement POST functionality for organisation details settings form
   - implement patch request to adminusers to save POSTed organisation details
   - update ServiceUpdateRequest to be more robust by only allowing predefined paths to be used
   - redirect from organisation details index view to organisation details form when no organisation details have been set
   - abstract address formatter to util

