### PR TITLE
PP-13159: Removing polyfills

### DIFF
--- a/app/browsered.js
+++ b/app/browsered.js
@@ -1,7 +1,5 @@
 'use strict'
 
-require('@babel/polyfill')
-
 const multiSelects = require('./browsered/multi-select')
 const targetToShow = require('./browsered/target-to-show')
 const analytics = require('gaap-analytics')

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
       },
       "devDependencies": {
         "@babel/core": "7.22.10",
-        "@babel/polyfill": "7.12.1",
         "@babel/preset-env": "7.22.10",
         "@govuk-pay/run-amock": "0.0.5",
         "@pact-foundation/pact": "^12.1.1",
@@ -1604,17 +1603,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/polyfill": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
-      "dev": true,
-      "dependencies": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
       }
     },
     "node_modules/@babel/preset-env": {
@@ -5317,14 +5305,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "dev": true,
-      "hasInstallScript": true
     },
     "node_modules/core-js-compat": {
       "version": "3.32.0",
@@ -14315,12 +14295,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
-    },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
@@ -18763,16 +18737,6 @@
         "@babel/helper-plugin-utils": "^7.22.5"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@babel/preset-env": {
       "version": "7.22.10",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.10.tgz",
@@ -21553,12 +21517,6 @@
           "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
         }
       }
-    },
-    "core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "dev": true
     },
     "core-js-compat": {
       "version": "3.32.0",
@@ -28251,12 +28209,6 @@
       "requires": {
         "regenerate": "^1.4.2"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
     },
     "regenerator-transform": {
       "version": "0.15.2",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
   },
   "devDependencies": {
     "@babel/core": "7.22.10",
-    "@babel/polyfill": "7.12.1",
     "@babel/preset-env": "7.22.10",
     "@govuk-pay/run-amock": "0.0.5",
     "@pact-foundation/pact": "^12.1.1",


### PR DESCRIPTION
## WHAT
The original task was to stop using a deprecated version of `core-js`.

## HOW 
After making enquiries with the team we agreed that the browser support for Self Service should follow the [Service Manual advice](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices) which lists recent enough browsers that the polyfill is not needed so I've fully removed the polyfill.


