### PR TITLE
PP-13297 change permission layout corrections

### DIFF
--- a/app/controllers/simplified-account/settings/team-members/change-permission/change-permission.controller.js
+++ b/app/controllers/simplified-account/settings/team-members/change-permission/change-permission.controller.js
@@ -29,7 +29,6 @@ async function get (req, res, next) {
         availableRoles,
         userCurrentRoleName: userCurrentRole.name,
         email: user.email,
-        serviceHasAgentInitiatedMotoEnabled,
         backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.teamMembers.index, serviceId, accountType)
       })
   } catch (err) {

--- a/app/controllers/simplified-account/settings/team-members/change-permission/change-permission.controller.test.js
+++ b/app/controllers/simplified-account/settings/team-members/change-permission/change-permission.controller.test.js
@@ -87,7 +87,7 @@ describe('Controller: settings/team-members/change-permission', () => {
       })
 
       it('should pass context data to the response method', () => {
-        expect(responseStub.args[0][3]).to.have.property('availableRoles').to.have.all.keys('admin', 'view-and-refund', 'view-only')
+        expect(responseStub.args[0][3]).to.have.property('availableRoles').to.have.length(3)
         expect(responseStub.args[0][3]).to.have.property('userCurrentRoleName').to.equal('view-only')
         expect(responseStub.args[0][3]).to.have.property('email').to.equal('user-to-change-permission@users.gov.uk')
         expect(responseStub.args[0][3]).to.have.property('backLink').to.equal('/simplified/service/service-id-123abc/account/test/settings/team-members')

--- a/app/controllers/simplified-account/settings/team-members/change-permission/change-permission.controller.test.js
+++ b/app/controllers/simplified-account/settings/team-members/change-permission/change-permission.controller.test.js
@@ -87,8 +87,7 @@ describe('Controller: settings/team-members/change-permission', () => {
       })
 
       it('should pass context data to the response method', () => {
-        expect(responseStub.args[0][3]).to.have.property('availableRoles').to.have.length(3)
-        expect(responseStub.args[0][3]).to.have.property('serviceHasAgentInitiatedMotoEnabled').to.be.false // eslint-disable-line no-unused-expressions
+        expect(responseStub.args[0][3]).to.have.property('availableRoles').to.have.all.keys('admin', 'view-and-refund', 'view-only')
         expect(responseStub.args[0][3]).to.have.property('userCurrentRoleName').to.equal('view-only')
         expect(responseStub.args[0][3]).to.have.property('email').to.equal('user-to-change-permission@users.gov.uk')
         expect(responseStub.args[0][3]).to.have.property('backLink').to.equal('/simplified/service/service-id-123abc/account/test/settings/team-members')

--- a/app/utils/roles.js
+++ b/app/utils/roles.js
@@ -49,11 +49,11 @@ module.exports = {
     })
     return found
   },
-  getAvailableRolesForService: agentInitiatedMotoEnabled => {
+  getAvailableRolesForService: serviceHasAgentInitiatedMotoEnabled => {
     const availableRoles = {}
     for (const roleName in roles) {
       const role = roles[roleName]
-      if (agentInitiatedMotoEnabled) {
+      if (serviceHasAgentInitiatedMotoEnabled) {
         if (roleName === 'admin') {
           // for agent-initiated moto services, add 'take telephone payments' to the explanation content for the admin role
           availableRoles[roleName] = {

--- a/app/utils/roles.js
+++ b/app/utils/roles.js
@@ -8,18 +8,18 @@ const roles = {
     explanation: 'They can view transactions, refund payments and manage settings',
     agentInitiatedMotoServicesOnly: false
   },
+  'view-refund-and-initiate-moto': {
+    extId: 600,
+    name: 'view-refund-and-initiate-moto',
+    description: 'View, refund and take telephone payments',
+    explanation: 'They can view transactions, refund payments, and take telephone payments',
+    agentInitiatedMotoServicesOnly: true
+  },
   'view-and-refund': {
     extId: 300,
     name: 'view-and-refund',
     description: 'View and refund',
     explanation: 'They can view transactions and refund payments',
-    agentInitiatedMotoServicesOnly: false
-  },
-  'view-only': {
-    extId: 400,
-    name: 'view-only',
-    description: 'View only',
-    explanation: 'They can view transactions',
     agentInitiatedMotoServicesOnly: false
   },
   'view-and-initiate-moto': {
@@ -29,12 +29,12 @@ const roles = {
     explanation: 'They can view transactions and take telephone payments',
     agentInitiatedMotoServicesOnly: true
   },
-  'view-refund-and-initiate-moto': {
-    extId: 600,
-    name: 'view-refund-and-initiate-moto',
-    description: 'View, refund and take telephone payments',
-    explanation: 'They can view transactions, refund payments, and take telephone payments',
-    agentInitiatedMotoServicesOnly: true
+  'view-only': {
+    extId: 400,
+    name: 'view-only',
+    description: 'View only',
+    explanation: 'They can view transactions',
+    agentInitiatedMotoServicesOnly: false
   }
 }
 

--- a/app/utils/roles.js
+++ b/app/utils/roles.js
@@ -50,23 +50,16 @@ module.exports = {
     return found
   },
   getAvailableRolesForService: serviceHasAgentInitiatedMotoEnabled => {
-    const availableRoles = {}
-    for (const roleName in roles) {
-      const role = roles[roleName]
-      if (serviceHasAgentInitiatedMotoEnabled) {
-        if (roleName === 'admin') {
-          // for agent-initiated moto services, add 'take telephone payments' to the explanation content for the admin role
-          availableRoles[roleName] = {
-            description: role.description,
-            explanation: 'They can view transactions, refund payments, take telephone payments and manage settings'
-          }
-        } else {
-          availableRoles[roleName] = { description: role.description, explanation: role.explanation }
-        }
-      } else if (!role.agentInitiatedMotoServicesOnly) {
-        availableRoles[roleName] = { description: role.description, explanation: role.explanation }
-      }
-    }
-    return availableRoles
+    const roleDisplayOrder = ['admin', 'view-refund-and-initiate-moto', 'view-and-refund', 'view-and-initiate-moto', 'view-only']
+
+    return roleDisplayOrder.map(roleName => roles[roleName])
+      .filter(role => serviceHasAgentInitiatedMotoEnabled || !role.agentInitiatedMotoServicesOnly)
+      .map(role => _.pick(role, ['name', 'description', 'explanation']))
+      .map(role => {
+        // for agent-initiated moto services, add 'take telephone payments' to the explanation content for the admin role
+        return (role.name === 'admin' && serviceHasAgentInitiatedMotoEnabled)
+          ? { ...role, explanation: 'They can view transactions, refund payments, take telephone payments and manage settings' }
+          : role
+      })
   }
 }

--- a/app/utils/roles.js
+++ b/app/utils/roles.js
@@ -8,18 +8,18 @@ const roles = {
     explanation: 'They can view transactions, refund payments and manage settings',
     agentInitiatedMotoServicesOnly: false
   },
-  'view-refund-and-initiate-moto': {
-    extId: 600,
-    name: 'view-refund-and-initiate-moto',
-    description: 'View, refund and take telephone payments',
-    explanation: 'They can view transactions, refund payments, and take telephone payments',
-    agentInitiatedMotoServicesOnly: true
-  },
   'view-and-refund': {
     extId: 300,
     name: 'view-and-refund',
     description: 'View and refund',
     explanation: 'They can view transactions and refund payments',
+    agentInitiatedMotoServicesOnly: false
+  },
+  'view-only': {
+    extId: 400,
+    name: 'view-only',
+    description: 'View only',
+    explanation: 'They can view transactions',
     agentInitiatedMotoServicesOnly: false
   },
   'view-and-initiate-moto': {
@@ -29,12 +29,12 @@ const roles = {
     explanation: 'They can view transactions and take telephone payments',
     agentInitiatedMotoServicesOnly: true
   },
-  'view-only': {
-    extId: 400,
-    name: 'view-only',
-    description: 'View only',
-    explanation: 'They can view transactions',
-    agentInitiatedMotoServicesOnly: false
+  'view-refund-and-initiate-moto': {
+    extId: 600,
+    name: 'view-refund-and-initiate-moto',
+    description: 'View, refund and take telephone payments',
+    explanation: 'They can view transactions, refund payments, and take telephone payments',
+    agentInitiatedMotoServicesOnly: true
   }
 }
 
@@ -50,14 +50,23 @@ module.exports = {
     return found
   },
   getAvailableRolesForService: agentInitiatedMotoEnabled => {
-    return Object.values(roles)
-      .filter(role => agentInitiatedMotoEnabled || !role.agentInitiatedMotoServicesOnly)
-      .map(role => _.pick(role, ['name', 'description', 'explanation']))
-      .map(role => {
-        // for agent-initiated moto services, add 'take telephone payments' to the explanation content for the admin role
-        return (role.name === 'admin' && agentInitiatedMotoEnabled)
-          ? { ...role, explanation: 'They can view transactions, refund payments, take telephone payments and manage settings' }
-          : role
-      })
+    const availableRoles = {}
+    for (const roleName in roles) {
+      const role = roles[roleName]
+      if (agentInitiatedMotoEnabled) {
+        if (roleName === 'admin') {
+          // for agent-initiated moto services, add 'take telephone payments' to the explanation content for the admin role
+          availableRoles[roleName] = {
+            description: role.description,
+            explanation: 'They can view transactions, refund payments, take telephone payments and manage settings'
+          }
+        } else {
+          availableRoles[roleName] = { description: role.description, explanation: role.explanation }
+        }
+      } else if (!role.agentInitiatedMotoServicesOnly) {
+        availableRoles[roleName] = { description: role.description, explanation: role.explanation }
+      }
+    }
+    return availableRoles
   }
 }

--- a/app/utils/roles.test.js
+++ b/app/utils/roles.test.js
@@ -25,8 +25,9 @@ describe('roles module', function () {
   it('should return the correct roles for a service without agent-initiated moto', () => {
     const rolesForService = getAvailableRolesForService(false)
 
-    expect(rolesForService).to.have.all.keys('admin', 'view-and-refund', 'view-only')
-    expect(rolesForService).to.have.property('admin').to.deep.equal({
+    expect(rolesForService).to.have.length(3)
+    expect(rolesForService[0]).to.deep.equal({
+      name: 'admin',
       description: 'Administrator',
       explanation: 'They can view transactions, refund payments and manage settings'
     })
@@ -35,10 +36,16 @@ describe('roles module', function () {
   it('should return the correct roles for a service with agent-initiated moto', () => {
     const rolesForService = getAvailableRolesForService(true)
 
-    expect(rolesForService).to.have.all.keys('admin', 'view-and-refund', 'view-only', 'view-and-initiate-moto', 'view-refund-and-initiate-moto')
-    expect(rolesForService).to.have.property('admin').to.deep.equal({
+    expect(rolesForService).to.have.length(5)
+    expect(rolesForService[0]).to.deep.equal({
+      name: 'admin',
       description: 'Administrator',
       explanation: 'They can view transactions, refund payments, take telephone payments and manage settings'
+    })
+    expect(rolesForService[1]).to.deep.equal({
+      name: 'view-refund-and-initiate-moto',
+      description: 'View, refund and take telephone payments',
+      explanation: 'They can view transactions, refund payments, and take telephone payments'
     })
   })
 })

--- a/app/utils/roles.test.js
+++ b/app/utils/roles.test.js
@@ -25,9 +25,8 @@ describe('roles module', function () {
   it('should return the correct roles for a service without agent-initiated moto', () => {
     const rolesForService = getAvailableRolesForService(false)
 
-    expect(rolesForService).to.have.length(3)
-    expect(rolesForService[0]).to.deep.equal({
-      name: 'admin',
+    expect(rolesForService).to.have.all.keys('admin', 'view-and-refund', 'view-only')
+    expect(rolesForService).to.have.property('admin').to.deep.equal({
       description: 'Administrator',
       explanation: 'They can view transactions, refund payments and manage settings'
     })
@@ -36,9 +35,8 @@ describe('roles module', function () {
   it('should return the correct roles for a service with agent-initiated moto', () => {
     const rolesForService = getAvailableRolesForService(true)
 
-    expect(rolesForService).to.have.length(5)
-    expect(rolesForService[0]).to.deep.equal({
-      name: 'admin',
+    expect(rolesForService).to.have.all.keys('admin', 'view-and-refund', 'view-only', 'view-and-initiate-moto', 'view-refund-and-initiate-moto')
+    expect(rolesForService).to.have.property('admin').to.deep.equal({
       description: 'Administrator',
       explanation: 'They can view transactions, refund payments, take telephone payments and manage settings'
     })

--- a/app/views/simplified-account/settings/team-members/change-permission.njk
+++ b/app/views/simplified-account/settings/team-members/change-permission.njk
@@ -9,10 +9,10 @@
     text: "Back",
     href: backLink
   }) }}
-<div>
+
   <form method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-    <input type="hidden" name="userCurrentRoleName" value="{{ userCurrentRoleName }}"
+    <input type="hidden" name="userCurrentRoleName" value="{{ userCurrentRoleName }}"/>
 
     {% set roleItems = [] %}
     {% set roleDisplayOrder = ['admin', 'view-refund-and-initiate-moto', 'view-and-refund', 'view-and-initiate-moto', 'view-only'] %}
@@ -41,6 +41,7 @@
       },
       items: roleItems
     }) }}
+
     {{
     govukButton({
       text: "Save changes"
@@ -48,5 +49,5 @@
     }}
 
   </form>
-</div>
+
 {% endblock %}

--- a/app/views/simplified-account/settings/team-members/change-permission.njk
+++ b/app/views/simplified-account/settings/team-members/change-permission.njk
@@ -9,7 +9,7 @@
     text: "Back",
     href: backLink
   }) }}
-
+<div>
   <form method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     <input type="hidden" name="userCurrentRoleName" value="{{ userCurrentRoleName }}"
@@ -45,5 +45,5 @@
     }}
 
   </form>
-
+</div>
 {% endblock %}

--- a/app/views/simplified-account/settings/team-members/change-permission.njk
+++ b/app/views/simplified-account/settings/team-members/change-permission.njk
@@ -15,18 +15,15 @@
     <input type="hidden" name="userCurrentRoleName" value="{{ userCurrentRoleName }}"/>
 
     {% set roleItems = [] %}
-    {% set roleDisplayOrder = ['admin', 'view-refund-and-initiate-moto', 'view-and-refund', 'view-and-initiate-moto', 'view-only'] %}
-    {% for roleName in roleDisplayOrder %}
-      {% if availableRoles[roleName] %}
-        {% set roleItem = {
-          value: roleName,
-          id: "role-" + roleName + "-input",
-          html: "<label class=\"govuk-!-font-weight-bold\">" + availableRoles[roleName].description + "</label>",
-          hint: { text: availableRoles[roleName].explanation },
-          checked: userCurrentRoleName === roleName
-        } %}
-        {% set roleItems = (roleItems.push(roleItem), roleItems) %}
-      {% endif %}
+    {% for role in availableRoles %}
+      {% set roleItem = {
+        value: role.name,
+        id: "role-" + role.name + "-input",
+        html: "<label class=\"govuk-!-font-weight-bold\">" + role.description + "</label>",
+        hint: { text: role.explanation },
+        checked: userCurrentRoleName === role.name
+      } %}
+      {% set roleItems = (roleItems.push(roleItem), roleItems) %}
     {% endfor %}
 
     {{ govukRadios({

--- a/app/views/simplified-account/settings/team-members/change-permission.njk
+++ b/app/views/simplified-account/settings/team-members/change-permission.njk
@@ -15,15 +15,18 @@
     <input type="hidden" name="userCurrentRoleName" value="{{ userCurrentRoleName }}"
 
     {% set roleItems = [] %}
-    {% for role in availableRoles %}
-      {% set roleItem = {
-        value: role.name,
-        id: "role-" + role.name + "-input",
-        html: "<label class=\"govuk-!-font-weight-bold\">" + role.description + "</label>",
-        hint: { text: role.explanation },
-        checked: userCurrentRoleName === role.name
-      } %}
-      {% set roleItems = (roleItems.push(roleItem), roleItems) %}
+    {% set roleDisplayOrder = ['admin', 'view-refund-and-initiate-moto', 'view-and-refund', 'view-and-initiate-moto', 'view-only'] %}
+    {% for roleName in roleDisplayOrder %}
+      {% if availableRoles[roleName] %}
+        {% set roleItem = {
+          value: roleName,
+          id: "role-" + roleName + "-input",
+          html: "<label class=\"govuk-!-font-weight-bold\">" + availableRoles[roleName].description + "</label>",
+          hint: { text: availableRoles[roleName].explanation },
+          checked: userCurrentRoleName === roleName
+        } %}
+        {% set roleItems = (roleItems.push(roleItem), roleItems) %}
+      {% endif %}
     {% endfor %}
 
     {{ govukRadios({


### PR DESCRIPTION
- Refactor the display of roles in the change permissions form to ensure that the ordering of roles matches the design
- Correct spacing between radios and 'save changes' button.

Screenshot for service that doesn't have agent-initiated moto enabled:
-------
![Screenshot 2024-11-22 at 15 37 21](https://github.com/user-attachments/assets/61f7f444-4ece-46ce-907b-6f4a08fdb0fd)


Screenshot for service that has agent-initiated moto enabled:
--------
![Screenshot 2024-11-22 at 15 38 06](https://github.com/user-attachments/assets/576cf384-ae88-42cd-bab9-ffa047de77d8)

