### PR TITLE
PP-13296 invite post controller

### DIFF
--- a/app/controllers/simplified-account/settings/team-members/invite/invite.controller.js
+++ b/app/controllers/simplified-account/settings/team-members/invite/invite.controller.js
@@ -2,21 +2,64 @@ const { response } = require('@utils/response')
 const { getAvailableRolesForService } = require('@utils/roles')
 const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
 const paths = require('@root/paths')
+const { body, validationResult } = require('express-validator')
+const formatValidationErrors = require('@utils/simplified-account/format/format-validation-errors')
+const userService = require('@services/user.service')
+const lodash = require('lodash')
 
 async function get (req, res) {
   const serviceId = req.service.externalId
   const accountType = req.account.type
-  const serviceHasAgentInitiatedMotoEnabled = req.service.agentInitiatedMotoEnabled ?? false
-  const availableRoles = getAvailableRolesForService(serviceHasAgentInitiatedMotoEnabled)
   response(req, res, 'simplified-account/settings/team-members/invite',
     {
-      availableRoles,
+      availableRoles: getAvailableRolesForService(req.service.agentInitiatedMotoEnabled ?? false),
       backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.teamMembers.index, serviceId, accountType)
     })
 }
 
 async function post (req, res, next) {
-  // TODO
+  const externalServiceId = req.service.externalId
+  const accountType = req.account.type
+  const adminUserExternalId = req.user.externalId
+  const invitedUserEmail = req.body.invitedUserEmail
+  const invitedUserRole = req.body.invitedUserRole
+  const teamMembersIndexPath = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.teamMembers.index, externalServiceId, accountType)
+
+  const validations = [
+    body('invitedUserRole')
+      .not().isEmpty().withMessage('Select a permission level'),
+    body('invitedUserEmail').isEmail().withMessage('Enter a valid email address')
+  ]
+  await Promise.all(validations.map(validation => validation.run(req)))
+  const errors = validationResult(req)
+
+  if (!errors.isEmpty()) {
+    const formattedErrors = formatValidationErrors(errors)
+
+    return response(req, res, 'simplified-account/settings/team-members/invite', {
+      errors: {
+        summary: formattedErrors.errorSummary,
+        formErrors: formattedErrors.formErrors
+      },
+      invitedUserEmail,
+      checkedRole: invitedUserRole,
+      availableRoles: getAvailableRolesForService(req.service.agentInitiatedMotoEnabled ?? false),
+      backLink: teamMembersIndexPath
+    })
+  }
+
+  try {
+    await userService.createInviteToJoinService(invitedUserEmail, adminUserExternalId, externalServiceId, invitedUserRole)
+    if (lodash.has(req, 'session.pageData.invitee')) {
+      delete req.session.pageData.invitee
+    }
+    // send email
+    req.flash('messages', { state: 'success', icon: '&check;', heading: 'Team member invitation sent to ' + req.body.invitedUserEmail })
+    res.redirect(teamMembersIndexPath)
+  } catch (err) {
+    // TODO - handle 412 (user already invited or already a team member)
+    next(err)
+  }
 }
 
 module.exports = {

--- a/app/controllers/simplified-account/settings/team-members/invite/invite.controller.js
+++ b/app/controllers/simplified-account/settings/team-members/invite/invite.controller.js
@@ -5,7 +5,6 @@ const paths = require('@root/paths')
 const { body, validationResult } = require('express-validator')
 const formatValidationErrors = require('@utils/simplified-account/format/format-validation-errors')
 const userService = require('@services/user.service')
-const lodash = require('lodash')
 
 async function get (req, res) {
   const serviceId = req.service.externalId
@@ -28,7 +27,8 @@ async function post (req, res, next) {
   const validations = [
     body('invitedUserRole')
       .not().isEmpty().withMessage('Select a permission level'),
-    body('invitedUserEmail').isEmail().withMessage('Enter a valid email address')
+    body('invitedUserEmail')
+      .isEmail().withMessage('Enter a valid email address')
   ]
   await Promise.all(validations.map(validation => validation.run(req)))
   const errors = validationResult(req)
@@ -50,10 +50,6 @@ async function post (req, res, next) {
 
   try {
     await userService.createInviteToJoinService(invitedUserEmail, adminUserExternalId, externalServiceId, invitedUserRole)
-    if (lodash.has(req, 'session.pageData.invitee')) {
-      delete req.session.pageData.invitee
-    }
-    // send email
     req.flash('messages', { state: 'success', icon: '&check;', heading: 'Team member invitation sent to ' + req.body.invitedUserEmail })
     res.redirect(teamMembersIndexPath)
   } catch (err) {

--- a/app/controllers/simplified-account/settings/team-members/invite/invite.controller.test.js
+++ b/app/controllers/simplified-account/settings/team-members/invite/invite.controller.test.js
@@ -1,4 +1,3 @@
-const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
 const sinon = require('sinon')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')

--- a/app/controllers/simplified-account/settings/team-members/invite/invite.controller.test.js
+++ b/app/controllers/simplified-account/settings/team-members/invite/invite.controller.test.js
@@ -1,43 +1,101 @@
 const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
 const sinon = require('sinon')
 const { expect } = require('chai')
-
-const mockResponse = sinon.spy()
+const proxyquire = require('proxyquire')
+const User = require('@models/User.class')
+const userFixtures = require('@test/fixtures/user.fixtures')
+const paths = require('@root/paths')
 
 const ACCOUNT_TYPE = 'test'
 const SERVICE_ID = 'service-id-123abc'
 
-const {
-  req,
-  res,
-  call
-} = new ControllerTestBuilder('@controllers/simplified-account/settings/team-members/invite/invite.controller')
-  .withServiceExternalId(SERVICE_ID)
-  .withAccountType(ACCOUNT_TYPE)
-  .withStubs({
-    '@utils/response': { response: mockResponse }
+let req, res, responseStub, createInviteToJoinServiceStub, inviteController
+
+const getController = (stubs = {}) => {
+  return proxyquire('./invite.controller', {
+    '@utils/response': { response: stubs.response, renderErrorView: stubs.renderErrorView },
+    '@services/user.service':
+      { createInviteToJoinService: stubs.createInviteToJoinService }
   })
-  .build()
+}
+
+const adminUser = new User(userFixtures.validUserResponse({
+  external_id: 'user-id-for-admin-user',
+  email: 'admin-user@users.gov.uk',
+  service_roles: {
+    service: {
+      service: { external_id: SERVICE_ID },
+      role: { name: 'admin' }
+    }
+  }
+}))
+
+const setupTest = (method, additionalReqProps = {}) => {
+  responseStub = sinon.spy()
+  createInviteToJoinServiceStub = sinon.stub()
+
+  inviteController = getController({
+    response: responseStub,
+    createInviteToJoinService: createInviteToJoinServiceStub
+  })
+  res = {
+    redirect: sinon.spy()
+  }
+  req = {
+    user: adminUser,
+    service: {
+      externalId: SERVICE_ID
+    },
+    account: {
+      type: ACCOUNT_TYPE
+    },
+    ...additionalReqProps
+  }
+  inviteController[method](req, res)
+}
 
 describe('Controller: settings/team-members/invite', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
-    })
+    before(() => setupTest('get'))
 
     it('should call the response method', () => {
-      expect(mockResponse.called).to.be.true // eslint-disable-line
+      expect(responseStub.called).to.be.true // eslint-disable-line
     })
 
     it('should pass req, res and template path to the response method', () => {
-      expect(mockResponse.args[0][0]).to.deep.equal(req)
-      expect(mockResponse.args[0][1]).to.deep.equal(res)
-      expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/team-members/invite')
+      expect(responseStub.args[0][0]).to.deep.equal(req)
+      expect(responseStub.args[0][1]).to.deep.equal(res)
+      expect(responseStub.args[0][2]).to.equal('simplified-account/settings/team-members/invite')
     })
 
     it('should pass context data to the response method', () => {
-      expect(mockResponse.args[0][3]).to.have.property('availableRoles').to.have.length(3)
-      expect(mockResponse.args[0][3]).to.have.property('backLink').to.equal('/simplified/service/service-id-123abc/account/test/settings/team-members')
+      expect(responseStub.args[0][3]).to.have.property('availableRoles').to.have.length(3)
+      expect(responseStub.args[0][3]).to.have.property('backLink').to.equal('/simplified/service/service-id-123abc/account/test/settings/team-members')
+    })
+  })
+
+  describe('post', () => {
+    describe('success', () => {
+      before(() => setupTest('post',
+        {
+          body: { invitedUserEmail: 'user-to-invite@users.gov.uk', invitedUserRole: 'view-only' },
+          flash: sinon.stub()
+        }
+      ))
+
+      it('should call adminusers to send an invite', () => {
+        expect(createInviteToJoinServiceStub.calledWith('user-to-invite@users.gov.uk', adminUser.externalId, SERVICE_ID, 'view-only')).to.be.true // eslint-disable-line
+      })
+
+      it('should redirect to the team members index page', () => {
+        sinon.assert.calledWith(req.flash, 'messages', {
+          state: 'success',
+          icon: '&check;',
+          heading: 'Team member invitation sent to user-to-invite@users.gov.uk'
+        })
+        expect(res.redirect.calledOnce).to.be.true // eslint-disable-line
+        expect(res.redirect.args[0][0]).to.include(paths.simplifiedAccount.settings.teamMembers.index)
+      })
     })
   })
 })

--- a/app/views/simplified-account/settings/team-members/invite.njk
+++ b/app/views/simplified-account/settings/team-members/invite.njk
@@ -9,22 +9,30 @@
     text: "Back",
     href: backLink
   }) }}
+
+  {% if errors %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errors.summary
+    }) }}
+  {% endif %}
+
   <h1 class="govuk-heading-l">Invite a team member</h1>
   <div>
     <form method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-      <input type="hidden" name="userCurrentRoleName" value="{{ userCurrentRoleName }}"/>
 
       {{ govukInput({
         label: {
           text: "Email address",
           classes: "govuk-label--s"
         },
-        id: "invite-email",
-        name: "inviteEmail",
+        id: "invitedUserEmail",
+        name: "invitedUserEmail",
         type: "email",
+        value: invitedUserEmail,
         spellcheck: false,
-        errorMessage: { text: errors.formErrors['inviteEmail'] } if errors.formErrors['inviteEmail'] else false,
+        errorMessage: { text: errors.formErrors['invitedUserEmail'] } if errors.formErrors['invitedUserEmail'] else false,
         classes: "govuk-!-width-two-thirds"
       }) }}
 
@@ -35,14 +43,15 @@
           id: "role-" + role.name + "-input",
           html: "<label class=\"govuk-!-font-weight-bold\">" + role.description + "</label>",
           hint: { text: role.explanation },
-          checked: userCurrentRoleName === role.name
+          checked: role.name === checkedRole
         } %}
         {% set roleItems = (roleItems.push(roleItem), roleItems) %}
       {% endfor %}
 
       {{ govukRadios({
-        idPrefix: "newRole",
-        name: "newRole",
+        idPrefix: "invitedUserRole",
+        name: "invitedUserRole",
+        errorMessage: { text: errors.formErrors['invitedUserRole'] } if errors.formErrors['invitedUserRole'] else false,
         fieldset: {
           legend: {
             text: "Permission level",


### PR DESCRIPTION
- add the post controller to handle the invite user form, and a unit test for the happy path

To do in subsequent PRs:
- Error page for 412 response from admin for a user who is already a team member, and a corresponding unit test. I'm deferring this as it needs some UCD input.
- Cypress tests
- I've reverted from the ControllerTestBuilder back to the previous test setup but I will revisit this later to see if it's possible to use/adapt ControllerTestBuilder to use in this and other team-members controller tests.

Screenshots for validation errors:
----
![Screenshot 2024-11-25 at 17 16 14](https://github.com/user-attachments/assets/432daf5b-e7a7-4988-8bb9-c235e1b9e1bb)

Success notification:
-----
![Screenshot 2024-11-25 at 17 18 32](https://github.com/user-attachments/assets/110769c6-c15f-4f7d-94ff-80b952fe7a2f)


