### PR TITLE
PP-13282: Add overrides for cookie subdependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3023,6 +3023,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/@sentry/node/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/@sentry/tracing": {
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.12.0.tgz",
@@ -5595,14 +5603,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/cookie-parser": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
@@ -5916,9 +5916,9 @@
       }
     },
     "node_modules/csurf/node_modules/cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -20576,10 +20576,17 @@
         "@sentry/tracing": "6.12.0",
         "@sentry/types": "6.12.0",
         "@sentry/utils": "6.12.0",
-        "cookie": "^0.4.1",
+        "cookie": "0.7.2",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+          "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
+        }
       }
     },
     "@sentry/tracing": {
@@ -22678,11 +22685,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
-    },
     "cookie-parser": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
@@ -22927,16 +22929,16 @@
       "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
       "integrity": "sha512-UCtehyEExKTxgiu8UHdGvHj4tnpE/Qctue03Giq5gPgMQ9cg/ciod5blZQ5a4uCEenNQjxyGuzygLdKUmee/bQ==",
       "requires": {
-        "cookie": "0.4.0",
+        "cookie": "0.7.2",
         "cookie-signature": "1.0.6",
         "csrf": "3.1.0",
         "http-errors": "~1.7.3"
       },
       "dependencies": {
         "cookie": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+          "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
         },
         "depd": {
           "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,12 @@
     },
     "cli-color": {
       "ansi-regex": "3.0.1"
+    },
+    "csurf": {
+      "cookie": "0.7.2"
+    },
+    "@sentry/node": {
+      "cookie": "0.7.2"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## WHAT
We're currently blocked on upgrading `@sentry/node` and replacing the deprecated `csurf` package.

To resolve a vulnerability in the `cookie` subdependency of both these packages, I've added in an override. The overrided version 0.7.2 does not have any breaking changes [according to the changelog](https://github.com/jshttp/cookie/releases). 


