### PR TITLE
PP-13296 handle user already in team error

### DIFF
--- a/app/views/simplified-account/settings/team-members/invite.njk
+++ b/app/views/simplified-account/settings/team-members/invite.njk
@@ -27,7 +27,7 @@
           text: "Email address",
           classes: "govuk-label--s"
         },
-        id: "invitedUserEmail",
+        id: "invited-user-email",
         name: "invitedUserEmail",
         type: "email",
         value: invitedUserEmail,


### PR DESCRIPTION
Context: If the invited user is already in the team or has been invited recently by a different user, an error message should be displayed. The content is taken from the existing error message but will be updated if necessary in a subsequent PR.

- if adminusers returns 412, display an error in the same pattern as validation errors.
- unit test for this scenario

For subsequent PRs
- error content update if necessary
- Cypress tests

Screenshot of error page:

<img width="1155" alt="Screenshot 2024-11-27 at 13 07 09" src="https://github.com/user-attachments/assets/b60e04ab-19f8-4682-9c2f-5e97749806e9">



