### PR TITLE
PP-13135: Restrict hint text length

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -54,4 +54,4 @@ $govuk-page-width: 1200px;
 @import "components/system-messages";
 @import "components/spinner";
 @import "components/service-settings";
-@import "components/hint-text";
+@import "components/hint-and-body-width";

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -54,3 +54,4 @@ $govuk-page-width: 1200px;
 @import "components/system-messages";
 @import "components/spinner";
 @import "components/service-settings";
+@import "components/hint-text";

--- a/app/assets/sass/components/hint-and-body-width.scss
+++ b/app/assets/sass/components/hint-and-body-width.scss
@@ -1,4 +1,4 @@
-.hint-text {
+.hint-and-body-width {
   max-width: 630px;
   word-wrap: break-word;
 }

--- a/app/assets/sass/components/hint-text.scss
+++ b/app/assets/sass/components/hint-text.scss
@@ -1,0 +1,4 @@
+.hint-text {
+  max-width: 630px;
+  word-wrap: break-word;
+}

--- a/app/views/simplified-account/settings/email-notifications/collect-email-page.njk
+++ b/app/views/simplified-account/settings/email-notifications/collect-email-page.njk
@@ -35,7 +35,7 @@
                 checked: emailCollectionMode === emailCollectionModes.mandatory,
                 hint: {
                   text: 'Users must enter an email address to complete a payment – they can receive notifications',
-                  classes: 'hint-text'
+                  classes: 'hint-and-body-width'
                 }
             },
             {
@@ -47,7 +47,7 @@
                 checked: emailCollectionMode === emailCollectionModes.optional,
                 hint: {
                   text: 'Users can choose to enter an email address – if they do, they can receive notifications',
-                  classes: 'hint-text'
+                  classes: 'hint-and-body-width'
                 }
             },
             {
@@ -59,7 +59,7 @@
                 checked: emailCollectionMode === emailCollectionModes.no,
                 hint: {
                   text: 'Users do not have the option to enter an email address – they will not receive notifications',
-                  classes: 'hint-text'
+                  classes: 'hint-and-body-width'
                 }
             }
           ]

--- a/app/views/simplified-account/settings/email-notifications/collect-email-page.njk
+++ b/app/views/simplified-account/settings/email-notifications/collect-email-page.njk
@@ -34,7 +34,8 @@
                 },
                 checked: emailCollectionMode === emailCollectionModes.mandatory,
                 hint: {
-                  text: 'Users must enter an email address to complete a payment – they can receive notifications'
+                  text: 'Users must enter an email address to complete a payment – they can receive notifications',
+                  classes: 'hint-text'
                 }
             },
             {
@@ -45,7 +46,8 @@
                 },
                 checked: emailCollectionMode === emailCollectionModes.optional,
                 hint: {
-                  text: 'Users can choose to enter an email address – if they do, they can receive notifications'
+                  text: 'Users can choose to enter an email address – if they do, they can receive notifications',
+                  classes: 'hint-text'
                 }
             },
             {
@@ -56,7 +58,8 @@
                 },
                 checked: emailCollectionMode === emailCollectionModes.no,
                 hint: {
-                  text: 'Users do not have the option to enter an email address – they will not receive notifications'
+                  text: 'Users do not have the option to enter an email address – they will not receive notifications',
+                  classes: 'hint-text'
                 }
             }
           ]

--- a/app/views/simplified-account/settings/email-notifications/payment-confirmation-email-toggle.njk
+++ b/app/views/simplified-account/settings/email-notifications/payment-confirmation-email-toggle.njk
@@ -38,7 +38,8 @@
           } if emailCollectionMode === 'OPTIONAL',
           checked: confirmationEnabled === true,
           hint: {
-            text: 'Entering an email address is currently optional so users might not get a payment confirmation'
+            text: 'Entering an email address is currently optional so users might not get a payment confirmation',
+            classes: 'hint-text'
           } if emailCollectionMode === 'OPTIONAL'
         },
         {

--- a/app/views/simplified-account/settings/email-notifications/payment-confirmation-email-toggle.njk
+++ b/app/views/simplified-account/settings/email-notifications/payment-confirmation-email-toggle.njk
@@ -39,7 +39,7 @@
           checked: confirmationEnabled === true,
           hint: {
             text: 'Entering an email address is currently optional so users might not get a payment confirmation',
-            classes: 'hint-text'
+            classes: 'hint-and-body-width'
           } if emailCollectionMode === 'OPTIONAL'
         },
         {

--- a/app/views/simplified-account/settings/email-notifications/refund-email-toggle.njk
+++ b/app/views/simplified-account/settings/email-notifications/refund-email-toggle.njk
@@ -39,7 +39,7 @@
           checked: refundEmailEnabled === true,
           hint: {
             text: 'Entering an email address is currently optional so users might not get a refund confirmation',
-            classes: 'hint-text'
+            classes: 'hint-and-body-width'
           } if emailCollectionMode === 'OPTIONAL'
         },
         {

--- a/app/views/simplified-account/settings/email-notifications/refund-email-toggle.njk
+++ b/app/views/simplified-account/settings/email-notifications/refund-email-toggle.njk
@@ -38,7 +38,8 @@
           } if emailCollectionMode === 'OPTIONAL',
           checked: refundEmailEnabled === true,
           hint: {
-            text: 'Entering an email address is currently optional so users might not get a refund confirmation'
+            text: 'Entering an email address is currently optional so users might not get a refund confirmation',
+            classes: 'hint-text'
           } if emailCollectionMode === 'OPTIONAL'
         },
         {


### PR DESCRIPTION
As per the designers [recommendation](https://payments-platform.atlassian.net/browse/PP-13135?focusedCommentId=58875), the hint text should be restricted to a width of 630px. 

Old view:
<img width="813" alt="Screenshot 2024-11-27 at 16 19 51" src="https://github.com/user-attachments/assets/ad845135-d2b0-4d5d-8d4d-2771054a15ed">

New view:
<img width="690" alt="Screenshot 2024-11-27 at 16 19 24" src="https://github.com/user-attachments/assets/fce25a85-3425-4035-b1bb-8ecda14e7eb3">
