### PR TITLE
PP-13349 display year on payout pages

### DIFF
--- a/app/views/payouts/list.njk
+++ b/app/views/payouts/list.njk
@@ -54,8 +54,8 @@ Payments to your bank account - GOV.UK Pay
 {% set transactionsDownloadPath = routes.allServiceTransactions.download if filterLiveAccounts else routes.formattedPathFor(routes.allServiceTransactions.downloadStatusFilter, 'test') %}
 <div class="govuk-grid-column-two-thirds">
   {% for key, group in payoutSearchResult.groups %}
-    {% set dateString = group.date.format('DD MMMM') %}
-    <h2 class="govuk-heading-m">{{ dateString }}</h2>
+    {% set dateString = group.date.format('D MMMM YYYY') %}
+    <h2 class="govuk-heading-m" data-cy="payout-date">{{ dateString }}</h2>
 
     <table class="govuk-table" id="payout-list">
       <thead class="govuk-table__head">

--- a/test/cypress/integration/payouts/payouts-list.cy.js
+++ b/test/cypress/integration/payouts/payouts-list.cy.js
@@ -34,7 +34,7 @@ describe('Payout list page', () => {
 
   it('should correctly display payouts given a successful response from Ledger', () => {
     const payouts = [
-      { gatewayAccountId: liveGatewayAccountId, paidOutDate: '2019-01-29T08:00:00.000000Z' }
+      { gatewayAccountId: liveGatewayAccountId, paidOutDate: '2024-12-31T15:34:00.000000Z' }
     ]
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
@@ -43,6 +43,7 @@ describe('Payout list page', () => {
 
     cy.visit('/payments-to-your-bank-account')
     cy.get('h1').find('.govuk-tag').should('have.text', 'LIVE')
+    cy.get('[data-cy=payout-date]').should('have.text', '31 December 2024')
     cy.get('#payout-list').find('tr').should('have.length', 2)
     cy.get('#pagination').should('not.exist')
 


### PR DESCRIPTION
## WHAT

Payments into your bank accounts page only display the day & month (DD MON) of the payout date and we only support pagination to go back to previous months or years.

While adding some search boxes involves design and more work, we should at least display the year.

Changed dateformat to `D MMMM YYYY` to match other dateformat on page.


