### PR TITLE
PP-13255 Organisation details Cypress tests

### DIFF
--- a/app/controllers/simplified-account/settings/organisation-details/edit-organisation-details.controller.js
+++ b/app/controllers/simplified-account/settings/organisation-details/edit-organisation-details.controller.js
@@ -25,7 +25,7 @@ function get (req, res) {
     messages: res.locals?.flash?.messages ?? [],
     organisationDetails,
     submitLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.organisationDetails.edit, req.service.externalId, req.account.type),
-    countries: countries.govukFrontendFormatted()
+    countries: countries.govukFrontendFormatted(organisationDetails.addressCountry)
   }
   return response(req, res, 'simplified-account/settings/organisation-details/edit-organisation-details', context)
 }
@@ -41,7 +41,7 @@ async function post (req, res) {
       },
       organisationDetails: _.pick(req.body, ['organisationName', 'addressLine1', 'addressLine2', 'addressCity', 'addressPostcode', 'telephoneNumber', 'organisationUrl']),
       submitLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.organisationDetails.edit, req.service.externalId, req.account.type),
-      countries: countries.govukFrontendFormatted()
+      countries: countries.govukFrontendFormatted(req.body.addressCountry)
     })
   }
 
@@ -58,7 +58,7 @@ async function post (req, res) {
 
   await updateService(req.service.externalId, serviceUpdates)
 
-  res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.organisationDetails.index, req.service.externalId, req.account.type))
+  return res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.organisationDetails.index, req.service.externalId, req.account.type))
 }
 
 const postValidation = [

--- a/app/controllers/simplified-account/settings/organisation-details/edit-organisation-details.controller.js
+++ b/app/controllers/simplified-account/settings/organisation-details/edit-organisation-details.controller.js
@@ -25,7 +25,8 @@ function get (req, res) {
     messages: res.locals?.flash?.messages ?? [],
     organisationDetails,
     submitLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.organisationDetails.edit, req.service.externalId, req.account.type),
-    countries: countries.govukFrontendFormatted(organisationDetails.addressCountry)
+    countries: countries.govukFrontendFormatted(organisationDetails.addressCountry),
+    backLink: req.service?.merchantDetails && formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.organisationDetails.index, req.service.externalId, req.account.type)
   }
   return response(req, res, 'simplified-account/settings/organisation-details/edit-organisation-details', context)
 }
@@ -41,7 +42,8 @@ async function post (req, res) {
       },
       organisationDetails: _.pick(req.body, ['organisationName', 'addressLine1', 'addressLine2', 'addressCity', 'addressPostcode', 'telephoneNumber', 'organisationUrl']),
       submitLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.organisationDetails.edit, req.service.externalId, req.account.type),
-      countries: countries.govukFrontendFormatted(req.body.addressCountry)
+      countries: countries.govukFrontendFormatted(req.body.addressCountry),
+      backLink: req.service?.merchantDetails && formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.organisationDetails.index, req.service.externalId, req.account.type)
     })
   }
 

--- a/app/controllers/simplified-account/settings/organisation-details/edit-organisation-details.controller.test.js
+++ b/app/controllers/simplified-account/settings/organisation-details/edit-organisation-details.controller.test.js
@@ -64,7 +64,8 @@ describe('Controller: settings/organisation-details', () => {
           organisationUrl: 'https://www.cpghm.example.com'
         },
         submitLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.organisationDetails.edit, SERVICE_ID, ACCOUNT_TYPE),
-        countries: []
+        countries: [],
+        backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.organisationDetails.index, SERVICE_ID, ACCOUNT_TYPE)
       })
     })
   })

--- a/app/simplified-account-routes.js
+++ b/app/simplified-account-routes.js
@@ -54,9 +54,9 @@ simplifiedAccount.post(paths.simplifiedAccount.settings.emailNotifications.custo
 simplifiedAccount.post(paths.simplifiedAccount.settings.emailNotifications.removeCustomParagraph, permission('email-notification-paragraph:update'), serviceSettingsController.emailNotifications.customParagraph.postRemoveCustomParagraph)
 
 // organisation details
-simplifiedAccount.get(paths.simplifiedAccount.settings.organisationDetails.index, serviceSettingsController.organisationDetails.get)
-simplifiedAccount.get(paths.simplifiedAccount.settings.organisationDetails.edit, serviceSettingsController.organisationDetails.edit.get)
-simplifiedAccount.post(paths.simplifiedAccount.settings.organisationDetails.edit, serviceSettingsController.organisationDetails.edit.post)
+simplifiedAccount.get(paths.simplifiedAccount.settings.organisationDetails.index, permission('merchant-details:read'), serviceSettingsController.organisationDetails.get)
+simplifiedAccount.get(paths.simplifiedAccount.settings.organisationDetails.edit, permission('merchant-details:update'), serviceSettingsController.organisationDetails.edit.get)
+simplifiedAccount.post(paths.simplifiedAccount.settings.organisationDetails.edit, permission('merchant-details:update'), serviceSettingsController.organisationDetails.edit.post)
 
 // stripe details
 const stripeDetailsPath = paths.simplifiedAccount.settings.stripeDetails

--- a/app/views/simplified-account/settings/organisation-details/edit-organisation-details.njk
+++ b/app/views/simplified-account/settings/organisation-details/edit-organisation-details.njk
@@ -1,11 +1,11 @@
 {% extends "../settings-layout.njk" %}
 
 {% block settingsPageTitle %}
-  Organisation Details
+  Organisation details
 {% endblock %}
 
 {% block settingsContent %}
-  <h1 class="govuk-heading-l">Organisation Details</h1>
+  <h1 class="govuk-heading-l">Organisation details</h1>
 
   <p class="govuk-body govuk-!-margin-bottom-6">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
 

--- a/app/views/simplified-account/settings/organisation-details/edit-organisation-details.njk
+++ b/app/views/simplified-account/settings/organisation-details/edit-organisation-details.njk
@@ -5,6 +5,11 @@
 {% endblock %}
 
 {% block settingsContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLink
+  }) if backLink }}
+
   <h1 class="govuk-heading-l">Organisation details</h1>
 
   <p class="govuk-body govuk-!-margin-bottom-6">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>

--- a/app/views/simplified-account/settings/organisation-details/index.njk
+++ b/app/views/simplified-account/settings/organisation-details/index.njk
@@ -1,11 +1,11 @@
 {% extends "../settings-layout.njk" %}
 
 {% block settingsPageTitle %}
-  Organisation Details
+  Organisation details
 {% endblock %}
 
 {% block settingsContent %}
-  <h1 class="govuk-heading-l">Organisation Details</h1>
+  <h1 class="govuk-heading-l">Organisation details</h1>
 
   <p class="govuk-body govuk-!-margin-bottom-6">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
 
@@ -13,7 +13,7 @@
     classes: "govuk-!-margin-bottom-9",
     card: {
       title: {
-        text: "Organisation Details"
+        text: "Organisation details"
       },
       actions: {
         items: [

--- a/test/cypress/integration/simplified-account/service-settings/organisation-details/organisation-details.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/organisation-details/organisation-details.cy.js
@@ -139,6 +139,16 @@ describe('Organisation details settings', () => {
           setupStubs('admin', VALID_ORG_DETAILS)
         })
 
+        it('should show the back link to the organisation details landing page', () => {
+          cy.visit(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details/edit`)
+
+          cy.get('.govuk-back-link')
+            .should('be.visible')
+            .should('contain', 'Back')
+            .should('have.attr', 'href',
+              `/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details`)
+        })
+
         it('should populate the form with the existing organisation details', () => {
           cy.visit(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details/edit`)
 
@@ -162,6 +172,12 @@ describe('Organisation details settings', () => {
           cy.visit(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details/edit`)
           cy.get('h1').should('contain', 'Organisation details')
           cy.title().should('eq', 'Settings - Organisation details - GOV.UK Pay')
+        })
+
+        it('should not show the back link to the organisation details landing page', () => {
+          cy.visit(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details/edit`)
+
+          cy.get('.govuk-back-link').should('not.exist')
         })
 
         it('should show an empty form', () => {

--- a/test/cypress/integration/simplified-account/service-settings/organisation-details/organisation-details.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/organisation-details/organisation-details.cy.js
@@ -1,0 +1,250 @@
+const userStubs = require('@test/cypress/stubs/user-stubs')
+const gatewayAccountStubs = require('@test/cypress/stubs/gateway-account-stubs')
+const serviceStubs = require('@test/cypress/stubs/service-stubs')
+
+const USER_EXTERNAL_ID = 'user-123-abc'
+const SERVICE_EXTERNAL_ID = 'service-456-def'
+const GATEWAY_ACCOUNT_ID = 11
+const ADMIN_ROLE = {
+  description: 'Administrator',
+  name: 'admin',
+  permissions: [
+    {
+      description: 'Viewtransactionslist',
+      name: 'transactions:read'
+    },
+    {
+      description: 'Viewemailnotificationstemplate',
+      name: 'email-notification-template:read'
+    },
+    {
+      description: 'Turnemailnotificationson/off',
+      name: 'email-notification-toggle:update'
+    },
+    {
+      description: 'Editemailnotificationsparagraph',
+      name: 'email-notification-paragraph:update'
+    },
+    {
+      description: '',
+      name: 'merchant-details:read'
+    },
+    {
+      description: '',
+      name: 'merchant-details:update'
+    }
+  ]
+}
+const NON_ADMIN_ROLE = {
+  description: 'View only',
+  name: 'view-only',
+  permissions: [
+    {
+      description: 'Viewtransactionslist',
+      name: 'transactions:read'
+    },
+    {
+      description: 'Viewemailnotificationstemplate',
+      name: 'email-notification-template:read'
+    }
+  ]
+}
+const ACCOUNT_TYPE = 'test'
+const VALID_ORG_DETAILS = {
+  name: 'Compu-Global-Hyper-Mega-Net',
+  address_line1: '742 Evergreen Terrace',
+  address_line2: '',
+  address_city: 'Springfield',
+  address_postcode: 'SP21NG',
+  address_country: 'US',
+  telephone_number: '01234567890',
+  url: 'https://www.cghmn.example.com'
+}
+
+const setupStubs = (role = ADMIN_ROLE, merchantDetails) => {
+  cy.task('setupStubs', [
+    userStubs.getUserSuccess({
+      userExternalId: USER_EXTERNAL_ID,
+      gatewayAccountId: GATEWAY_ACCOUNT_ID,
+      serviceName: { en: 'My cool service' },
+      merchantDetails,
+      serviceExternalId: SERVICE_EXTERNAL_ID,
+      role,
+      features: 'degatewayaccountification' // TODO remove features once simplified accounts are live
+    }),
+    gatewayAccountStubs.getAccountByServiceIdAndAccountType(SERVICE_EXTERNAL_ID, ACCOUNT_TYPE, { gateway_account_id: GATEWAY_ACCOUNT_ID }),
+    serviceStubs.patchUpdateMerchantDetailsSuccess({
+      serviceExternalId: SERVICE_EXTERNAL_ID,
+      merchantDetails: {
+        name: 'Compu-Global-Hyper-Mega-Net',
+        address_line1: '742 Evergreen Terrace',
+        address_line2: '',
+        address_city: 'Springfield',
+        address_postcode: 'SP21NG',
+        address_country: 'US',
+        telephone_number: '01234567890',
+        url: 'https://www.cghmn.example.com'
+      }
+    })
+  ])
+}
+
+describe('Organisation details settings', () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
+  })
+
+  describe('Organisation details landing page', () => {
+    describe('for an admin user', () => {
+      describe('when organisation details have not been set', () => {
+        beforeEach(() => {
+          setupStubs()
+        })
+
+        it('should redirect to the edit organisation details page', () => {
+          cy.visit(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details`)
+          cy.location('pathname').should('eq', `/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details/edit`)
+        })
+      })
+
+      describe('when organisation details have been set', () => {
+        beforeEach(() => {
+          setupStubs(ADMIN_ROLE, VALID_ORG_DETAILS)
+        })
+
+        it('should not redirect to the edit organisation details page', () => {
+          cy.visit(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details`)
+          cy.location('pathname').should('eq', `/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details`)
+        })
+
+        it('should show the correct heading and title', () => {
+          cy.visit(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details`)
+          cy.get('h1').should('contain', 'Organisation details')
+          cy.title().should('eq', 'Settings - Organisation details - GOV.UK Pay')
+        })
+
+        it('should display the organisation details', () => {
+          cy.visit(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details`)
+          cy.get('.govuk-summary-card').within(() => {
+            cy.get('.govuk-summary-card__title-wrapper > h2').should('contain', 'Organisation details')
+            cy.get('.govuk-summary-list__row').eq(0).within(() => {
+              cy.get('dt').should('contain', 'Name')
+              cy.get('dd').should('contain', 'Compu-Global-Hyper-Mega-Net')
+            })
+            cy.get('.govuk-summary-list__row').eq(1).within(() => {
+              cy.get('dt').should('contain', 'Address')
+              cy.get('dd')
+                .should('contain', '742 Evergreen Terrace')
+                .should('contain', 'Springfield')
+                .should('contain', 'SP21NG')
+            })
+            cy.get('.govuk-summary-list__row').eq(2).within(() => {
+              cy.get('dt').should('contain', 'Telephone number')
+              cy.get('dd').should('contain', '01234567890')
+            })
+            cy.get('.govuk-summary-list__row').eq(3).within(() => {
+              cy.get('dt').should('contain', 'Website address')
+              cy.get('dd').should('contain', 'https://www.cghmn.example.com')
+            })
+          })
+        })
+
+        it('should show a link to edit the organisation details', () => {
+          cy.visit(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details`)
+          cy.get('.govuk-summary-card').within(() => {
+            cy.get('.govuk-summary-card__actions > a.govuk-link').should('contain', 'Change')
+              .should('have.attr', 'href',
+                `/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details/edit`)
+          })
+        })
+      })
+    })
+
+    describe('Edit organisation details', () => {
+      describe('when organisation details have been set', () => {
+        beforeEach(() => {
+          setupStubs(ADMIN_ROLE, VALID_ORG_DETAILS)
+        })
+
+        it('should populate the form with the existing organisation details', () => {
+          cy.visit(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details/edit`)
+
+          cy.get('input[name="organisationName"]').should('have.value', 'Compu-Global-Hyper-Mega-Net')
+          cy.get('input[name="addressLine1"]').should('have.value', '742 Evergreen Terrace')
+          cy.get('input[name="addressLine2"]').should('have.value', '')
+          cy.get('input[name="addressCity"]').should('have.value', 'Springfield')
+          cy.get('select[name="addressCountry"]').should('have.value', 'US')
+          cy.get('input[name="addressPostcode"]').should('have.value', 'SP21NG')
+          cy.get('input[name="telephoneNumber"]').should('have.value', '01234567890')
+          cy.get('input[name="organisationUrl"]').should('have.value', 'https://www.cghmn.example.com')
+        })
+      })
+
+      describe('when organisation details have not been set', () => {
+        beforeEach(() => {
+          setupStubs()
+        })
+
+        it('should show the correct heading and title', () => {
+          cy.visit(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details/edit`)
+          cy.get('h1').should('contain', 'Organisation details')
+          cy.title().should('eq', 'Settings - Organisation details - GOV.UK Pay')
+        })
+
+        it('should show an empty form', () => {
+          cy.visit(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details/edit`)
+
+          cy.get('input[name="organisationName"]').should('have.value', '')
+          cy.get('input[name="addressLine1"]').should('have.value', '')
+          cy.get('input[name="addressLine2"]').should('have.value', '')
+          cy.get('input[name="addressCity"]').should('have.value', '')
+          cy.get('select[name="addressCountry"]').should('have.value', 'GB')
+          cy.get('input[name="addressPostcode"]').should('have.value', '')
+          cy.get('input[name="telephoneNumber"]').should('have.value', '')
+          cy.get('input[name="organisationUrl"]').should('have.value', '')
+        })
+
+        it('should submit form and redirect to organisation details landing page if organisation details are valid', () => {
+          cy.visit(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details/edit`)
+
+          cy.get('input[name="organisationName"]').type('Compu-Global-Hyper-Mega-Net')
+          cy.get('input[name="addressLine1"]').type('742 Evergreen Terrace')
+          cy.get('input[name="addressCity"]').type('Springfield')
+          cy.get('select[name="addressCountry"]').select('United States')
+          cy.get('input[name="addressPostcode"]').type('SP21NG')
+          cy.get('input[name="telephoneNumber"]').type('01234567890')
+          cy.get('input[name="organisationUrl"]').type('https://www.cghmn.example.com')
+
+          // adminusers should now respond with the set organisation details
+          // otherwise it will redirect to the edit organisation details page
+          setupStubs(ADMIN_ROLE, VALID_ORG_DETAILS)
+
+          cy.get('button#save-merchant-details').click()
+
+          cy.location('pathname').should('eq', `/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details`)
+        })
+
+        it('should show validation errors on form submission if details are invalid', () => {
+          cy.visit(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details/edit`)
+
+          cy.get('input[name="organisationName"]').type('a'.repeat(101))
+          cy.get('select[name="addressCountry"]').select('GB')
+          cy.get('input[name="addressPostcode"]').type('NotAValidPostcode')
+          cy.get('input[name="telephoneNumber"]').type('1')
+          cy.get('input[name="organisationUrl"]').type('cghmn.example.com')
+
+          cy.get('#organisation-details-form').submit()
+
+          cy.location('pathname').should('eq', `/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details/edit`)
+
+          cy.get('#organisation-name-error').should('contain.text', 'Organisation name must be 100 characters or fewer')
+          cy.get('#address-line1-error').should('contain.text', 'Enter a building and street')
+          cy.get('#address-city-error').should('contain.text', 'Enter a town or city')
+          cy.get('#address-postcode-error').should('contain.text', 'Enter a real postcode')
+          cy.get('#telephone-number-error').should('contain.text', 'Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
+          cy.get('#url-error').should('contain.text', 'Enter a valid website address')
+        })
+      })
+    })
+  })
+})

--- a/test/fixtures/roles.fixtures.js
+++ b/test/fixtures/roles.fixtures.js
@@ -1,0 +1,786 @@
+module.exports = {
+  'view-only': {
+    name: 'view-only',
+    description: 'View only',
+    permissions: [
+      {
+        name: 'toggle-billing-address:read',
+        description: 'View Billing Address setting'
+      },
+      {
+        name: 'transactions-description:read',
+        description: 'Viewtransactiondescription'
+      },
+      {
+        name: 'transactions-by-fields:read',
+        description: 'Searchtransactionsbypaymentfields'
+      },
+      {
+        name: 'service-name:read',
+        description: 'Viewservicename'
+      },
+      {
+        name: 'moto-mask-input:read',
+        description: 'View MOTO mask input settings'
+      },
+      {
+        name: 'payouts:read',
+        description: 'View Payouts'
+      },
+      {
+        name: 'transactions-email:read',
+        description: 'Viewtransactionemail'
+      },
+      {
+        name: 'transactions-by-date:read',
+        description: 'Searchtransactionsbydate'
+      },
+      {
+        name: 'toggle-3ds:read',
+        description: 'View 3D Secure setting'
+      },
+      {
+        name: 'agreements:read',
+        description: 'View agreements'
+      },
+      {
+        name: 'transactions-details:read',
+        description: 'Viewtransactiondetails'
+      },
+      {
+        name: 'email-notification-template:read',
+        description: 'Viewemailnotificationstemplate'
+      },
+      {
+        name: 'transactions:read',
+        description: 'Viewtransactionslist'
+      },
+      {
+        name: 'transactions-download:read',
+        description: 'Downloadtransactions'
+      },
+      {
+        name: 'transactions-events:read',
+        description: 'Viewtransactionevents'
+      },
+      {
+        name: 'transactions-amount:read',
+        description: 'Viewtransactionamounts'
+      },
+      {
+        name: 'transactions-card-type:read',
+        description: 'Viewtransactioncardtype'
+      },
+      {
+        name: 'payment-types:read',
+        description: 'Viewpaymenttypes'
+      }
+    ]
+  },
+  'super-admin': {
+    name: 'super-admin',
+    description: 'Super Admin',
+    permissions: [
+      {
+        name: 'connected-gocardless-account:update',
+        description: 'Update Connected Go Cardless Account'
+      },
+      {
+        name: 'webhooks:read',
+        description: 'View webhooks'
+      },
+      {
+        name: 'tokens-revoked:read',
+        description: 'Viewrevokedkeys'
+      },
+      {
+        name: 'agreements:read',
+        description: 'View agreements'
+      },
+      {
+        name: 'transactions-details:read',
+        description: 'Viewtransactiondetails'
+      },
+      {
+        name: 'tokens:read',
+        description: 'View keys'
+      },
+      {
+        name: 'stripe-government-entity-document:update',
+        description: 'Stripe - Upload government entity document '
+      },
+      {
+        name: 'email-notification-toggle:update',
+        description: 'Turnemailnotificationson/off'
+      },
+      {
+        name: 'gateway-credentials:read',
+        description: 'Viewgatewayaccountcredentials'
+      },
+      {
+        name: 'email-notification-template:read',
+        description: 'Viewemailnotificationstemplate'
+      },
+      {
+        name: 'toggle-billing-address:read',
+        description: 'View Billing Address setting'
+      },
+      {
+        name: 'transactions-download:read',
+        description: 'Downloadtransactions'
+      },
+      {
+        name: 'service-name:read',
+        description: 'Viewservicename'
+      },
+      {
+        name: 'moto-mask-input:update',
+        description: 'Update MOTO mask input settings'
+      },
+      {
+        name: 'transactions-by-date:read',
+        description: 'Searchtransactionsbydate'
+      },
+      {
+        name: 'transactions-events:read',
+        description: 'Viewtransactionevents'
+      },
+      {
+        name: 'agreements:update',
+        description: 'Update agreements'
+      },
+      {
+        name: 'tokens-active:read',
+        description: 'Viewactivekeys'
+      },
+      {
+        name: 'webhooks:update',
+        description: 'Update webhooks'
+      },
+      {
+        name: 'transactions-card-type:read',
+        description: 'Viewtransactioncardtype'
+      },
+      {
+        name: 'stripe-director:read',
+        description: 'View Stripe director'
+      },
+      {
+        name: 'users-global:create',
+        description: 'Createuserinanyservice'
+      },
+      {
+        name: 'merchant-details:read',
+        description: 'View Merchant Details setting'
+      },
+      {
+        name: 'stripe-organisation-details:read',
+        description: 'View Organisation details on Stripe'
+      },
+      {
+        name: 'users-service:read',
+        description: 'Viewusersinservice'
+      },
+      {
+        name: 'toggle-3ds:read',
+        description: 'View 3D Secure setting'
+      },
+      {
+        name: 'stripe-organisation-details:update',
+        description: 'Update Organisation details on Stripe'
+      },
+      {
+        name: 'payouts:read',
+        description: 'View Payouts'
+      },
+      {
+        name: 'gateway-credentials:update',
+        description: 'Editgatewayaccountcredentials'
+      },
+      {
+        name: 'moto-mask-input:read',
+        description: 'View MOTO mask input settings'
+      },
+      {
+        name: 'psp-test-account-stage:update',
+        description: 'Update PSP Test Account stage'
+      },
+      {
+        name: 'payment-types:update',
+        description: 'Editpaymenttypes'
+      },
+      {
+        name: 'users-service:create',
+        description: 'Createuserinthisservice'
+      },
+      {
+        name: 'stripe-bank-details:update',
+        description: 'Update Stripe bank details'
+      },
+      {
+        name: 'tokens:delete',
+        description: 'Revokekey'
+      },
+      {
+        name: 'transactions-by-fields:read',
+        description: 'Searchtransactionsbypaymentfields'
+      },
+      {
+        name: 'stripe-vat-number-company-number:update',
+        description: 'Update Stripe vat number company number'
+      },
+      {
+        name: 'go-live-stage:update',
+        description: 'Update Go Live stage'
+      },
+      {
+        name: 'transactions-amount:read',
+        description: 'Viewtransactionamounts'
+      },
+      {
+        name: 'stripe-responsible-person:read',
+        description: 'View Stripe responsible person'
+      },
+      {
+        name: 'users-service:delete',
+        description: 'Remove user from a service'
+      },
+      {
+        name: 'merchant-details:update',
+        description: 'Edit Merchant Details setting'
+      },
+      {
+        name: 'payment-types:read',
+        description: 'Viewpaymenttypes'
+      },
+      {
+        name: 'go-live-stage:read',
+        description: 'View Go Live stage'
+      },
+      {
+        name: 'stripe-director:update',
+        description: 'Update Stripe director'
+      },
+      {
+        name: 'transactions:read',
+        description: 'Viewtransactionslist'
+      },
+      {
+        name: 'stripe-account-details:update',
+        description: 'UpdateStripeAccountDetails'
+      },
+      {
+        name: 'connected-gocardless-account:read',
+        description: 'View Connected Go Cardless Account'
+      },
+      {
+        name: 'stripe-bank-details:read',
+        description: 'View Stripe bank details'
+      },
+      {
+        name: 'stripe-responsible-person:update',
+        description: 'Update Stripe responsible person'
+      },
+      {
+        name: 'stripe-vat-number-company-number:read',
+        description: 'View Stripe vat number company number'
+      }
+    ]
+  },
+  admin: {
+    name: 'admin',
+    description: 'Administrator',
+    permissions: [
+      {
+        name: 'psp-test-account-stage:update',
+        description: 'Update PSP Test Account stage'
+      },
+      {
+        name: 'tokens:create',
+        description: 'Generatekey'
+      },
+      {
+        name: 'stripe-responsible-person:read',
+        description: 'View Stripe responsible person'
+      },
+      {
+        name: 'agent-initiated-moto:create',
+        description: 'Create payment from agent-initiated MOTO product'
+      },
+      {
+        name: 'transactions-by-date:read',
+        description: 'Searchtransactionsbydate'
+      },
+      {
+        name: 'transactions-download:read',
+        description: 'Downloadtransactions'
+      },
+      {
+        name: 'merchant-details:read',
+        description: 'View Merchant Details setting'
+      },
+      {
+        name: 'toggle-billing-address:update',
+        description: 'Edit Billing Address setting'
+      },
+      {
+        name: 'toggle-3ds:update',
+        description: 'Edit 3D Secure setting'
+      },
+      {
+        name: 'moto-mask-input:update',
+        description: 'Update MOTO mask input settings'
+      },
+      {
+        name: 'stripe-government-entity-document:update',
+        description: 'Stripe - Upload government entity document '
+      },
+      {
+        name: 'transactions-description:read',
+        description: 'Viewtransactiondescription'
+      },
+      {
+        name: 'email-notification-template:read',
+        description: 'Viewemailnotificationstemplate'
+      },
+      {
+        name: 'users-service:delete',
+        description: 'Remove user from a service'
+      },
+      {
+        name: 'payouts:read',
+        description: 'View Payouts'
+      },
+      {
+        name: 'connected-gocardless-account:read',
+        description: 'View Connected Go Cardless Account'
+      },
+      {
+        name: 'tokens:update',
+        description: 'Generatekey'
+      },
+      {
+        name: 'tokens:delete',
+        description: 'Revokekey'
+      },
+      {
+        name: 'transactions-events:read',
+        description: 'Viewtransactionevents'
+      },
+      {
+        name: 'refunds:create',
+        description: 'Issuerefund'
+      },
+      {
+        name: 'tokens:read',
+        description: 'View keys'
+      },
+      {
+        name: 'transactions:read',
+        description: 'Viewtransactionslist'
+      },
+      {
+        name: 'stripe-director:update',
+        description: 'Update Stripe director'
+      },
+      {
+        name: 'agreements:update',
+        description: 'Update agreements'
+      },
+      {
+        name: 'stripe-account-details:update',
+        description: 'UpdateStripeAccountDetails'
+      },
+      {
+        name: 'transactions-by-fields:read',
+        description: 'Searchtransactionsbypaymentfields'
+      },
+      {
+        name: 'transactions-card-type:read',
+        description: 'Viewtransactioncardtype'
+      },
+      {
+        name: 'email-notification-toggle:update',
+        description: 'Turnemailnotificationson/off'
+      },
+      {
+        name: 'connected-gocardless-account:update',
+        description: 'Update Connected Go Cardless Account'
+      },
+      {
+        name: 'tokens-revoked:read',
+        description: 'Viewrevokedkeys'
+      },
+      {
+        name: 'webhooks:update',
+        description: 'Update webhooks'
+      },
+      {
+        name: 'gateway-credentials:read',
+        description: 'Viewgatewayaccountcredentials'
+      },
+      {
+        name: 'toggle-3ds:read',
+        description: 'View 3D Secure setting'
+      },
+      {
+        name: 'email-notification-paragraph:update',
+        description: 'Editemailnotificationsparagraph'
+      },
+      {
+        name: 'go-live-stage:read',
+        description: 'View Go Live stage'
+      },
+      {
+        name: 'stripe-bank-details:update',
+        description: 'Update Stripe bank details'
+      },
+      {
+        name: 'stripe-director:read',
+        description: 'View Stripe director'
+      },
+      {
+        name: 'stripe-vat-number-company-number:read',
+        description: 'View Stripe vat number company number'
+      },
+      {
+        name: 'payment-types:read',
+        description: 'Viewpaymenttypes'
+      },
+      {
+        name: 'service-name:read',
+        description: 'Viewservicename'
+      },
+      {
+        name: 'merchant-details:update',
+        description: 'Edit Merchant Details setting'
+      },
+      {
+        name: 'stripe-bank-details:read',
+        description: 'View Stripe bank details'
+      },
+      {
+        name: 'transactions-amount:read',
+        description: 'Viewtransactionamounts'
+      },
+      {
+        name: 'tokens-active:read',
+        description: 'Viewactivekeys'
+      },
+      {
+        name: 'users-service:read',
+        description: 'Viewusersinservice'
+      },
+      {
+        name: 'go-live-stage:update',
+        description: 'Update Go Live stage'
+      },
+      {
+        name: 'moto-mask-input:read',
+        description: 'View MOTO mask input settings'
+      },
+      {
+        name: 'transactions-email:read',
+        description: 'Viewtransactionemail'
+      },
+      {
+        name: 'gateway-credentials:update',
+        description: 'Editgatewayaccountcredentials'
+      },
+      {
+        name: 'payment-types:update',
+        description: 'Editpaymenttypes'
+      },
+      {
+        name: 'users-service:create',
+        description: 'Createuserinthisservice'
+      },
+      {
+        name: 'service-name:update',
+        description: 'Editservicename'
+      },
+      {
+        name: 'stripe-responsible-person:update',
+        description: 'Update Stripe responsible person'
+      },
+      {
+        name: 'toggle-billing-address:read',
+        description: 'View Billing Address setting'
+      },
+      {
+        name: 'stripe-organisation-details:update',
+        description: 'Update Organisation details on Stripe'
+      },
+      {
+        name: 'stripe-vat-number-company-number:update',
+        description: 'Update Stripe vat number company number'
+      },
+      {
+        name: 'agreements:read',
+        description: 'View agreements'
+      },
+      {
+        name: 'transactions-details:read',
+        description: 'Viewtransactiondetails'
+      },
+      {
+        name: 'stripe-organisation-details:read',
+        description: 'View Organisation details on Stripe'
+      },
+      {
+        name: 'webhooks:read',
+        description: 'View webhooks'
+      }
+    ]
+  },
+  'view-and-refund': {
+    name: 'view-and-refund',
+    description: 'View and Refund',
+    permissions: [
+      {
+        name: 'transactions-card-type:read',
+        description: 'Viewtransactioncardtype'
+      },
+      {
+        name: 'transactions-amount:read',
+        description: 'Viewtransactionamounts'
+      },
+      {
+        name: 'payouts:read',
+        description: 'View Payouts'
+      },
+      {
+        name: 'transactions-download:read',
+        description: 'Downloadtransactions'
+      },
+      {
+        name: 'email-notification-template:read',
+        description: 'Viewemailnotificationstemplate'
+      },
+      {
+        name: 'transactions-by-fields:read',
+        description: 'Searchtransactionsbypaymentfields'
+      },
+      {
+        name: 'service-name:read',
+        description: 'Viewservicename'
+      },
+      {
+        name: 'transactions-description:read',
+        description: 'Viewtransactiondescription'
+      },
+      {
+        name: 'transactions-details:read',
+        description: 'Viewtransactiondetails'
+      },
+      {
+        name: 'payment-types:read',
+        description: 'Viewpaymenttypes'
+      },
+      {
+        name: 'transactions-by-date:read',
+        description: 'Searchtransactionsbydate'
+      },
+      {
+        name: 'toggle-3ds:read',
+        description: 'View 3D Secure setting'
+      },
+      {
+        name: 'transactions-events:read',
+        description: 'Viewtransactionevents'
+      },
+      {
+        name: 'toggle-billing-address:read',
+        description: 'View Billing Address setting'
+      },
+      {
+        name: 'agreements:read',
+        description: 'View agreements'
+      },
+      {
+        name: 'transactions:read',
+        description: 'Viewtransactionslist'
+      },
+      {
+        name: 'transactions-email:read',
+        description: 'Viewtransactionemail'
+      },
+      {
+        name: 'refunds:create',
+        description: 'Issuerefund'
+      },
+      {
+        name: 'moto-mask-input:read',
+        description: 'View MOTO mask input settings'
+      }
+    ]
+  },
+  'view-and-initiate-moto': {
+    name: 'view-and-initiate-moto',
+    description: 'View and create MOTO payments',
+    permissions: [
+      {
+        name: 'transactions-card-type:read',
+        description: 'Viewtransactioncardtype'
+      },
+      {
+        name: 'transactions-amount:read',
+        description: 'Viewtransactionamounts'
+      },
+      {
+        name: 'payouts:read',
+        description: 'View Payouts'
+      },
+      {
+        name: 'transactions-download:read',
+        description: 'Downloadtransactions'
+      },
+      {
+        name: 'email-notification-template:read',
+        description: 'Viewemailnotificationstemplate'
+      },
+      {
+        name: 'transactions-by-fields:read',
+        description: 'Searchtransactionsbypaymentfields'
+      },
+      {
+        name: 'service-name:read',
+        description: 'Viewservicename'
+      },
+      {
+        name: 'transactions-description:read',
+        description: 'Viewtransactiondescription'
+      },
+      {
+        name: 'agent-initiated-moto:create',
+        description: 'Create payment from agent-initiated MOTO product'
+      },
+      {
+        name: 'transactions-details:read',
+        description: 'Viewtransactiondetails'
+      },
+      {
+        name: 'payment-types:read',
+        description: 'Viewpaymenttypes'
+      },
+      {
+        name: 'transactions-by-date:read',
+        description: 'Searchtransactionsbydate'
+      },
+      {
+        name: 'toggle-3ds:read',
+        description: 'View 3D Secure setting'
+      },
+      {
+        name: 'transactions-events:read',
+        description: 'Viewtransactionevents'
+      },
+      {
+        name: 'toggle-billing-address:read',
+        description: 'View Billing Address setting'
+      },
+      {
+        name: 'agreements:read',
+        description: 'View agreements'
+      },
+      {
+        name: 'transactions:read',
+        description: 'Viewtransactionslist'
+      },
+      {
+        name: 'transactions-email:read',
+        description: 'Viewtransactionemail'
+      },
+      {
+        name: 'moto-mask-input:read',
+        description: 'View MOTO mask input settings'
+      }
+    ]
+  },
+  'view-refund-and-initiate-moto': {
+    name: 'view-refund-and-initiate-moto',
+    description: 'View, refund and create MOTO payments',
+    permissions: [
+      {
+        name: 'email-notification-template:read',
+        description: 'Viewemailnotificationstemplate'
+      },
+      {
+        name: 'toggle-billing-address:read',
+        description: 'View Billing Address setting'
+      },
+      {
+        name: 'payouts:read',
+        description: 'View Payouts'
+      },
+      {
+        name: 'transactions-events:read',
+        description: 'Viewtransactionevents'
+      },
+      {
+        name: 'payment-types:read',
+        description: 'Viewpaymenttypes'
+      },
+      {
+        name: 'service-name:read',
+        description: 'Viewservicename'
+      },
+      {
+        name: 'transactions-by-fields:read',
+        description: 'Searchtransactionsbypaymentfields'
+      },
+      {
+        name: 'transactions:read',
+        description: 'Viewtransactionslist'
+      },
+      {
+        name: 'agreements:read',
+        description: 'View agreements'
+      },
+      {
+        name: 'transactions-details:read',
+        description: 'Viewtransactiondetails'
+      },
+      {
+        name: 'refunds:create',
+        description: 'Issuerefund'
+      },
+      {
+        name: 'transactions-amount:read',
+        description: 'Viewtransactionamounts'
+      },
+      {
+        name: 'agent-initiated-moto:create',
+        description: 'Create payment from agent-initiated MOTO product'
+      },
+      {
+        name: 'transactions-card-type:read',
+        description: 'Viewtransactioncardtype'
+      },
+      {
+        name: 'moto-mask-input:read',
+        description: 'View MOTO mask input settings'
+      },
+      {
+        name: 'transactions-download:read',
+        description: 'Downloadtransactions'
+      },
+      {
+        name: 'transactions-by-date:read',
+        description: 'Searchtransactionsbydate'
+      },
+      {
+        name: 'transactions-email:read',
+        description: 'Viewtransactionemail'
+      },
+      {
+        name: 'toggle-3ds:read',
+        description: 'View 3D Secure setting'
+      },
+      {
+        name: 'transactions-description:read',
+        description: 'Viewtransactiondescription'
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## WHAT
 - Add Cypress tests for organisation details simplified account settings
 - Show back link on "edit organisation details" page when organisation details have already been set - since this requires navigating there from the index page
 - Add role fixtures for use in Cypress tests - with full permissions for each role

View without organisation details set - no back link:
![Screenshot 2024-11-29 at 11-06-28 Settings - Organisation details - GOV UK Pay](https://github.com/user-attachments/assets/d10df91d-d168-4bbe-b78f-f2bd777b7cbb)

View with organisation details set - showing back link:
![Screenshot 2024-11-29 at 11-06-49 Settings - Organisation details - GOV UK Pay](https://github.com/user-attachments/assets/b172ddae-0cc7-4a8d-8c5f-06d6cea4a4cf)
