### PR TITLE
PP-13255 Enforce live account only for live services on org details, add line width limit

### DIFF
--- a/app/simplified-account-routes.js
+++ b/app/simplified-account-routes.js
@@ -54,9 +54,9 @@ simplifiedAccount.post(paths.simplifiedAccount.settings.emailNotifications.custo
 simplifiedAccount.post(paths.simplifiedAccount.settings.emailNotifications.removeCustomParagraph, permission('email-notification-paragraph:update'), serviceSettingsController.emailNotifications.customParagraph.postRemoveCustomParagraph)
 
 // organisation details
-simplifiedAccount.get(paths.simplifiedAccount.settings.organisationDetails.index, permission('merchant-details:read'), serviceSettingsController.organisationDetails.get)
-simplifiedAccount.get(paths.simplifiedAccount.settings.organisationDetails.edit, permission('merchant-details:update'), serviceSettingsController.organisationDetails.edit.get)
-simplifiedAccount.post(paths.simplifiedAccount.settings.organisationDetails.edit, permission('merchant-details:update'), serviceSettingsController.organisationDetails.edit.post)
+simplifiedAccount.get(paths.simplifiedAccount.settings.organisationDetails.index, enforceLiveAccountOnly, permission('merchant-details:read'), serviceSettingsController.organisationDetails.get)
+simplifiedAccount.get(paths.simplifiedAccount.settings.organisationDetails.edit, enforceLiveAccountOnly, permission('merchant-details:update'), serviceSettingsController.organisationDetails.edit.get)
+simplifiedAccount.post(paths.simplifiedAccount.settings.organisationDetails.edit, enforceLiveAccountOnly, permission('merchant-details:update'), serviceSettingsController.organisationDetails.edit.post)
 
 // stripe details
 const stripeDetailsPath = paths.simplifiedAccount.settings.stripeDetails

--- a/app/views/simplified-account/settings/organisation-details/edit-organisation-details.njk
+++ b/app/views/simplified-account/settings/organisation-details/edit-organisation-details.njk
@@ -12,7 +12,7 @@
 
   <h1 class="govuk-heading-l">Organisation details</h1>
 
-  <p class="govuk-body govuk-!-margin-bottom-6">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
+  <p class="govuk-body govuk-!-margin-bottom-6 hint-and-body-width">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
 
   <form id="organisation-details-form" method="post" action="{{ submitLink }}" >
     <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
@@ -27,8 +27,10 @@
         name: "organisationName",
         errorMessage: { text: errors.formErrors['organisationName'] } if errors.formErrors['organisationName'] else false,
         hint: {
-          html: "<p>Enter the main name of your organisation, not your local office or individual department.</p>
-                <p>Write the organisation name in full. Only use acronyms that are widely understood (for example, NHS).</p>"
+          html: "<div class='hint-and-body-width'>
+            <p>Enter the main name of your organisation, not your local office or individual department.</p>
+            <p>Write the organisation name in full. Only use acronyms that are widely understood (for example, NHS).</p>
+          </div>"
         },
         classes: "govuk-!-width-two-thirds",
         value: organisationDetails.organisationName

--- a/app/views/simplified-account/settings/organisation-details/index.njk
+++ b/app/views/simplified-account/settings/organisation-details/index.njk
@@ -7,7 +7,7 @@
 {% block settingsContent %}
   <h1 class="govuk-heading-l">Organisation details</h1>
 
-  <p class="govuk-body govuk-!-margin-bottom-6">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
+  <p class="govuk-body govuk-!-margin-bottom-6 hint-and-body-width">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>
 
   {{ govukSummaryList({
     classes: "govuk-!-margin-bottom-9",


### PR DESCRIPTION
## WHAT
 - Enforce only allowing viewing/editing organisation details in live environment when a service is live
 - Add line width limit to content on organisation details pages


