### PR TITLE
PP-13297 clickable text, layout, and Oxford commas

### DIFF
--- a/app/utils/roles.js
+++ b/app/utils/roles.js
@@ -5,7 +5,7 @@ const roles = {
     extId: 200,
     name: 'admin',
     description: 'Administrator',
-    explanation: 'They can view transactions, refund payments and manage settings',
+    explanation: 'They can view transactions, refund payments, and manage settings',
     agentInitiatedMotoServicesOnly: false
   },
   'view-and-refund': {
@@ -58,7 +58,7 @@ module.exports = {
       .map(role => {
         // for agent-initiated moto services, add 'take telephone payments' to the explanation content for the admin role
         return (role.name === 'admin' && serviceHasAgentInitiatedMotoEnabled)
-          ? { ...role, explanation: 'They can view transactions, refund payments, take telephone payments and manage settings' }
+          ? { ...role, explanation: 'They can view transactions, refund payments, take telephone payments, and manage settings' }
           : role
       })
   }

--- a/app/utils/roles.test.js
+++ b/app/utils/roles.test.js
@@ -11,7 +11,7 @@ describe('roles module', function () {
       extId: 200,
       name: 'admin',
       description: 'Administrator',
-      explanation: 'They can view transactions, refund payments and manage settings',
+      explanation: 'They can view transactions, refund payments, and manage settings',
       agentInitiatedMotoServicesOnly: false
     })
   })
@@ -29,7 +29,7 @@ describe('roles module', function () {
     expect(rolesForService[0]).to.deep.equal({
       name: 'admin',
       description: 'Administrator',
-      explanation: 'They can view transactions, refund payments and manage settings'
+      explanation: 'They can view transactions, refund payments, and manage settings'
     })
   })
 
@@ -40,7 +40,7 @@ describe('roles module', function () {
     expect(rolesForService[0]).to.deep.equal({
       name: 'admin',
       description: 'Administrator',
-      explanation: 'They can view transactions, refund payments, take telephone payments and manage settings'
+      explanation: 'They can view transactions, refund payments, take telephone payments, and manage settings'
     })
     expect(rolesForService[1]).to.deep.equal({
       name: 'view-refund-and-initiate-moto',

--- a/app/views/simplified-account/settings/team-members/change-permission.njk
+++ b/app/views/simplified-account/settings/team-members/change-permission.njk
@@ -19,8 +19,9 @@
       {% set roleItem = {
         value: role.name,
         id: "role-" + role.name + "-input",
-        html: "<label class=\"govuk-!-font-weight-bold\">" + role.description + "</label>",
-        hint: { text: role.explanation, classes: "hint-and-body-width" },
+        text: role.description,
+        label: { classes: "govuk-!-font-weight-bold" },
+        hint: { html: "<div class='hint-and-body-width'>" + role.explanation + "</div>" },
         checked: userCurrentRoleName === role.name
       } %}
       {% set roleItems = (roleItems.push(roleItem), roleItems) %}

--- a/app/views/simplified-account/settings/team-members/invite.njk
+++ b/app/views/simplified-account/settings/team-members/invite.njk
@@ -41,8 +41,9 @@
         {% set roleItem = {
           value: role.name,
           id: "role-" + role.name + "-input",
-          html: "<label class=\"govuk-!-font-weight-bold\">" + role.description + "</label>",
-          hint: { text: role.explanation, classes: "hint-and-body-width" },
+          text: role.description,
+          label: { classes: "govuk-!-font-weight-bold" },
+          hint: { html: "<div class='hint-and-body-width'>" + role.explanation + "</div>" },
           checked: role.name === checkedRole
         } %}
         {% set roleItems = (roleItems.push(roleItem), roleItems) %}


### PR DESCRIPTION
- The following changes are made to the Change Permissions page and Invite user page:
  - Fix a layout problem relating to hint text
  - Make radio button labels clickable
  - Add commas to role explanation text as indicated in design.

**Screenshot before fix, showing layout problem with the hint text for 'View only'**
-----
![Screenshot 2024-12-04 at 14-34-00 Settings - Team members - Change permission - GOV UK Pay](https://github.com/user-attachments/assets/8a2953de-3d32-47ee-af6b-877dba82ff09)
-----

**Screenshot for Change Permission (moto service)**
----
![Screenshot 2024-12-05 at 10 16 17](https://github.com/user-attachments/assets/ff3cd6fc-7c06-45f5-9914-83f4a386ad96)
----

**Screenshot for Invite User (moto service)**
----
![Screenshot 2024-12-05 at 10 16 06](https://github.com/user-attachments/assets/a680b514-09ae-4feb-9c3a-24f717760c0f)
----

**Screenshot for Change Permission (non-moto service)**
----
![Screenshot 2024-12-05 at 10 17 36](https://github.com/user-attachments/assets/da63f10e-d691-4472-99b4-71d919951bcf)
----


**Screenshot for Invite User (non-moto service)**
----
![Screenshot 2024-12-05 at 10 17 47](https://github.com/user-attachments/assets/11401059-3801-4806-b438-5947a04980df)
----


