### PR TITLE
PP-13312 Settings for card types get controller

### DIFF
--- a/app/controllers/simplified-account/settings/card-types/card-types.controller.js
+++ b/app/controllers/simplified-account/settings/card-types/card-types.controller.js
@@ -1,7 +1,20 @@
 const { response } = require('@utils/response')
+const { formatCardTypesForTemplate } = require('@utils/simplified-account/format/format-card-types')
+const { getAllCardTypes, getAcceptedCardTypesForServiceAndAccountType } = require('@services/card-types.service')
 
-function get (req, res) {
-  response(req, res, 'simplified-account/settings/card-types/index', { })
+async function get (req, res, next) {
+  const serviceId = req.service.externalId
+  const accountType = req.account.type
+  const isAdminUser = req.user.isAdminUserForService(serviceId)
+  try {
+    const { card_types: allCards } = await getAllCardTypes()
+    const { card_types: acceptedCards } = await getAcceptedCardTypesForServiceAndAccountType(serviceId, accountType)
+    const cardTypes = formatCardTypesForTemplate(allCards, acceptedCards, req.account, isAdminUser)
+    response(req, res, 'simplified-account/settings/card-types/index',
+      { cardTypes, isAdminUser })
+  } catch (err) {
+    next(err)
+  }
 }
 
 module.exports = {

--- a/app/controllers/simplified-account/settings/card-types/card-types.controller.test.js
+++ b/app/controllers/simplified-account/settings/card-types/card-types.controller.test.js
@@ -1,0 +1,131 @@
+const sinon = require('sinon')
+const { expect } = require('chai')
+const User = require('@models/User.class')
+const userFixtures = require('@test/fixtures/user.fixtures')
+const proxyquire = require('proxyquire')
+
+const ACCOUNT_TYPE = 'live'
+const SERVICE_ID = 'service-id-123abc'
+
+const adminUser = new User(userFixtures.validUserResponse({
+  external_id: 'user-id-for-admin-user',
+  service_roles: {
+    service: {
+      service: { external_id: SERVICE_ID },
+      role: { name: 'admin' }
+    }
+  }
+}))
+const viewOnlyUser = new User(userFixtures.validUserResponse(
+  {
+    external_id: 'user-id-for-view-only-user',
+    service_roles: {
+      service:
+        {
+          service: { external_id: SERVICE_ID },
+          role: { name: 'view-only' }
+        }
+    }
+  }))
+
+const allCardTypes = [{
+  id: 'id-001',
+  brand: 'visa',
+  label: 'Visa',
+  type: 'DEBIT',
+  requires3ds: false
+},
+{
+  id: 'id-002',
+  brand: 'visa',
+  label: 'Visa',
+  type: 'CREDIT',
+  requires3ds: false
+}]
+
+let req, res, responseStub, getAllCardTypesStub, getAcceptedCardTypesForServiceAndAccountTypeStub, cardTypesController
+
+const getController = (stubs = {}) => {
+  return proxyquire('./card-types.controller', {
+    '@utils/response': { response: stubs.response },
+    '@services/card-types.service': {
+      getAllCardTypes: stubs.getAllCardTypes,
+      getAcceptedCardTypesForServiceAndAccountType: stubs.getAcceptedCardTypesForServiceAndAccountType
+    }
+  })
+}
+
+const setupTest = (method, user, additionalReqProps = {}, additionalStubs = {}) => {
+  responseStub = sinon.spy()
+  getAllCardTypesStub = sinon.stub().returns({ card_types: allCardTypes })
+  getAcceptedCardTypesForServiceAndAccountTypeStub = sinon.stub().resolves({ card_types: [allCardTypes[0]] })
+
+  cardTypesController = getController({
+    response: responseStub,
+    getAllCardTypes: getAllCardTypesStub,
+    getAcceptedCardTypesForServiceAndAccountType: getAcceptedCardTypesForServiceAndAccountTypeStub,
+    ...additionalStubs
+  })
+  res = {
+    redirect: sinon.spy()
+  }
+  req = {
+    user: user,
+    service: {
+      externalId: SERVICE_ID
+    },
+    account: {
+      type: ACCOUNT_TYPE
+    },
+    ...additionalReqProps
+  }
+  cardTypesController[method](req, res)
+}
+
+describe('Controller: settings/card-types', () => {
+  describe('get for admin user', () => {
+    before(() => setupTest('get', adminUser))
+
+    it('should call the response method', () => {
+      expect(responseStub.called).to.be.true // eslint-disable-line
+    })
+
+    it('should pass req, res and template path to the response method', () => {
+      expect(responseStub.args[0][0]).to.deep.equal(req)
+      expect(responseStub.args[0][1]).to.deep.equal(res)
+      expect(responseStub.args[0][2]).to.equal('simplified-account/settings/card-types/index')
+    })
+
+    it('should pass context data to the response method', () => {
+      expect(responseStub.args[0][3]).to.have.property('cardTypes').to.have.property('debitCards').length(1)
+      expect(responseStub.args[0][3].cardTypes.debitCards[0]).to.have.property('text').to.equal('Visa debit')
+      expect(responseStub.args[0][3].cardTypes.debitCards[0]).to.have.property('checked').to.equal(true)
+      expect(responseStub.args[0][3]).to.have.property('cardTypes').to.have.property('creditCards').length(1)
+      expect(responseStub.args[0][3].cardTypes.creditCards[0]).to.have.property('text').to.equal('Visa credit')
+      expect(responseStub.args[0][3].cardTypes.creditCards[0]).to.have.property('checked').to.equal(false)
+      expect(responseStub.args[0][3]).to.have.property('isAdminUser').to.equal(true)
+    })
+  })
+
+  describe('get for non-admin user', () => {
+    before(() => setupTest('get', viewOnlyUser))
+
+    it('should call the response method', () => {
+      expect(responseStub.called).to.be.true // eslint-disable-line
+    })
+
+    it('should pass req, res and template path to the response method', () => {
+      expect(responseStub.args[0][0]).to.deep.equal(req)
+      expect(responseStub.args[0][1]).to.deep.equal(res)
+      expect(responseStub.args[0][2]).to.equal('simplified-account/settings/card-types/index')
+    })
+
+    it('should pass context data to the response method', () => {
+      expect(responseStub.args[0][3]).to.have.property('cardTypes').to.have.property('Enabled debit cards').to.have.length(1).to.include('Visa debit')
+      expect(responseStub.args[0][3].cardTypes).to.have.property('Not enabled debit cards').to.have.length(0)
+      expect(responseStub.args[0][3].cardTypes).to.have.property('Enabled credit cards').to.have.length(0)
+      expect(responseStub.args[0][3].cardTypes).to.have.property('Not enabled credit cards').to.have.length(1).to.include('Visa credit')
+      expect(responseStub.args[0][3]).to.have.property('isAdminUser').to.equal(false)
+    })
+  })
+})

--- a/app/services/card-types.service.js
+++ b/app/services/card-types.service.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const ConnectorClient = require('./clients/connector.client.js').ConnectorClient
+const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
+
+async function getAllCardTypes () {
+  return connectorClient.getAllCardTypes()
+}
+
+async function getAcceptedCardTypesForServiceAndAccountType (serviceId, accountType) {
+  return connectorClient.getAcceptedCardsForServiceAndAccountType(serviceId, accountType)
+}
+
+module.exports = {
+  getAllCardTypes,
+  getAcceptedCardTypesForServiceAndAccountType
+}

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -258,6 +258,21 @@ ConnectorClient.prototype = {
   },
 
   /**
+   * Retrieves the accepted card Types for the given account
+   * @param serviceId (required)
+   * @param accountType (required)
+   * @returns {Promise<Object>}
+   */
+  getAcceptedCardsForServiceAndAccountType: async function (serviceId, accountType) {
+    const url = `${this.connectorUrl}/v1/frontend/service/{serviceId}/account/{accountType}/card-types`
+      .replace('{serviceId}', encodeURIComponent(serviceId))
+      .replace('{accountType}', encodeURIComponent(accountType))
+    configureClient(client, url)
+    const response = await client.get(url, 'get accepted card types for account')
+    return response.data
+  },
+
+  /**
    * Updates the accepted card Types for to the given gateway account
    * @param gatewayAccountId (required)
    * @param payload (required)

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -258,7 +258,7 @@ ConnectorClient.prototype = {
   },
 
   /**
-   * Retrieves the accepted card Types for the given account
+   * Retrieves the accepted card Types for the given external service external id and account type
    * @param serviceId (required)
    * @param accountType (required)
    * @returns {Promise<Object>}

--- a/app/simplified-account-routes.js
+++ b/app/simplified-account-routes.js
@@ -69,6 +69,9 @@ simplifiedAccount.get(paths.simplifiedAccount.settings.worldpayDetails.index, pe
 simplifiedAccount.get(paths.simplifiedAccount.settings.worldpayDetails.credentials, permission('gateway-credentials:update'), serviceSettingsController.worldpayDetails.worldpayCredentials.get)
 simplifiedAccount.post(paths.simplifiedAccount.settings.worldpayDetails.credentials, permission('gateway-credentials:update'), serviceSettingsController.worldpayDetails.worldpayCredentials.post)
 
+// card types
+simplifiedAccount.get(paths.simplifiedAccount.settings.cardTypes.index, permission('transactions:read'), serviceSettingsController.cardTypes.get)
+
 // stripe details
 const stripeDetailsPath = paths.simplifiedAccount.settings.stripeDetails
 const stripeDetailsRouter = new Router({ mergeParams: true })

--- a/app/utils/simplified-account/format/format-card-types.js
+++ b/app/utils/simplified-account/format/format-card-types.js
@@ -1,0 +1,72 @@
+const formatLabel = (card) => {
+  if (card.brand === 'visa' || card.brand === 'master-card') {
+    return `${card.label} ${card.type.toLowerCase()}`
+  } else {
+    return card.brand === 'jcb' ? card.label.toUpperCase() : card.label
+  }
+}
+
+const formatCardTypesForAdminTemplate = (allCards, acceptedCards, account) => {
+  const cardDataChecklistItem = (card) => {
+    return {
+      value: card.id,
+      text: formatLabel(card),
+      checked: acceptedCards.filter(accepted => accepted.id === card.id).length !== 0,
+      requires3ds: card.requires3ds
+    }
+  }
+  const disableCheckboxIf3dsRequiredButNotEnabled = (cardTypeChecklistItem) => {
+    if (cardTypeChecklistItem.requires3ds && !account.requires3ds) {
+      cardTypeChecklistItem.disabled = true
+      cardTypeChecklistItem.hint = {
+        html: account.type === 'test' ? `${cardTypeChecklistItem.text} is not available on test accounts` : `${cardTypeChecklistItem.text} cannot be used because 3D Secure is not available. Please contact support`
+      }
+    }
+    return cardTypeChecklistItem
+  }
+  const addHintForAmexAndUnionpay = (cardTypeChecklistItem) => {
+    if (['American Express', 'Union Pay'].includes(cardTypeChecklistItem.text)) {
+      if (account.paymentProvider === 'worldpay') {
+        cardTypeChecklistItem.hint = {
+          html: 'You must have already enabled this with Worldpay'
+        }
+      }
+    }
+    return cardTypeChecklistItem
+  }
+  const debitCardChecklistItems = allCards.filter(card => card.type === 'DEBIT')
+    .map(card => cardDataChecklistItem(card))
+    .map(cardTypeChecklistItem => disableCheckboxIf3dsRequiredButNotEnabled(cardTypeChecklistItem))
+
+  const creditCardChecklistItems = allCards.filter(card => card.type === 'CREDIT')
+    .map(card => cardDataChecklistItem(card))
+    .map(cardTypeChecklistItem => addHintForAmexAndUnionpay(cardTypeChecklistItem))
+
+  return { debitCards: debitCardChecklistItems, creditCards: creditCardChecklistItems }
+}
+
+const formatCardTypesForNonAdminTemplate = (allCards, acceptedCards) => {
+  const acceptedCardTypeIds = acceptedCards.map(card => card.id)
+  const formattedCardTypes = {
+    'Enabled debit cards': [],
+    'Not enabled debit cards': [],
+    'Enabled credit cards': [],
+    'Not enabled credit cards': []
+  }
+  allCards.forEach(card => {
+    const cardIsEnabled = acceptedCardTypeIds.includes(card.id) ? 'Enabled' : 'Not enabled'
+    formattedCardTypes[`${cardIsEnabled} ${card.type.toLowerCase()} cards`].push(formatLabel(card))
+  })
+  return formattedCardTypes
+}
+
+const formatCardTypesForTemplate = (allCards, acceptedCards, account, isAdminUser) => {
+  if (isAdminUser) {
+    return formatCardTypesForAdminTemplate(allCards, acceptedCards, account)
+  }
+  return formatCardTypesForNonAdminTemplate(allCards, acceptedCards)
+}
+
+module.exports = {
+  formatCardTypesForTemplate
+}

--- a/app/utils/simplified-account/format/format-card-types.js
+++ b/app/utils/simplified-account/format/format-card-types.js
@@ -1,46 +1,52 @@
 const formatLabel = (card) => {
   if (card.brand === 'visa' || card.brand === 'master-card') {
     return `${card.label} ${card.type.toLowerCase()}`
-  } else {
-    return card.brand === 'jcb' ? card.label.toUpperCase() : card.label
+  }
+  return card.brand === 'jcb' ? card.label.toUpperCase() : card.label
+}
+
+const createCardTypeChecklistItem = (card, acceptedCards) => {
+  return {
+    value: card.id,
+    text: formatLabel(card),
+    checked: acceptedCards.filter(accepted => accepted.id === card.id).length !== 0,
+    requires3ds: card.requires3ds
   }
 }
 
-const formatCardTypesForAdminTemplate = (allCards, acceptedCards, account) => {
-  const cardDataChecklistItem = (card) => {
+const disableCheckboxIf3dsRequiredButNotEnabled = (cardTypeChecklistItem, accountType, accountRequires3ds) => {
+  if (cardTypeChecklistItem.requires3ds && !accountRequires3ds) {
     return {
-      value: card.id,
-      text: formatLabel(card),
-      checked: acceptedCards.filter(accepted => accepted.id === card.id).length !== 0,
-      requires3ds: card.requires3ds
-    }
-  }
-  const disableCheckboxIf3dsRequiredButNotEnabled = (cardTypeChecklistItem) => {
-    if (cardTypeChecklistItem.requires3ds && !account.requires3ds) {
-      cardTypeChecklistItem.disabled = true
-      cardTypeChecklistItem.hint = {
-        html: account.type === 'test' ? `${cardTypeChecklistItem.text} is not available on test accounts` : `${cardTypeChecklistItem.text} cannot be used because 3D Secure is not available. Please contact support`
+      ...cardTypeChecklistItem,
+      disabled: true,
+      hint: {
+        html: accountType === 'test' ? `${cardTypeChecklistItem.text} is not available on test accounts` : `${cardTypeChecklistItem.text} cannot be used because 3D Secure is not available. Please contact support`
       }
     }
-    return cardTypeChecklistItem
   }
-  const addHintForAmexAndUnionpay = (cardTypeChecklistItem) => {
-    if (['American Express', 'Union Pay'].includes(cardTypeChecklistItem.text)) {
-      if (account.paymentProvider === 'worldpay') {
-        cardTypeChecklistItem.hint = {
-          html: 'You must have already enabled this with Worldpay'
-        }
+  return cardTypeChecklistItem
+}
+
+const addHintForAmexAndUnionpayIfWorldpay = (cardTypeChecklistItem, paymentProvider) => {
+  if (['American Express', 'Union Pay'].includes(cardTypeChecklistItem.text) && paymentProvider === 'worldpay') {
+    return {
+      ...cardTypeChecklistItem,
+      hint: {
+        html: 'You must have already enabled this with Worldpay'
       }
     }
-    return cardTypeChecklistItem
   }
+  return cardTypeChecklistItem
+}
+
+const formatCardTypesForAdminTemplate = (allCards, acceptedCards, account) => {
   const debitCardChecklistItems = allCards.filter(card => card.type === 'DEBIT')
-    .map(card => cardDataChecklistItem(card))
-    .map(cardTypeChecklistItem => disableCheckboxIf3dsRequiredButNotEnabled(cardTypeChecklistItem))
+    .map(card => createCardTypeChecklistItem(card, acceptedCards))
+    .map(cardTypeChecklistItem => disableCheckboxIf3dsRequiredButNotEnabled(cardTypeChecklistItem, account.type, account.requires3ds))
 
   const creditCardChecklistItems = allCards.filter(card => card.type === 'CREDIT')
-    .map(card => cardDataChecklistItem(card))
-    .map(cardTypeChecklistItem => addHintForAmexAndUnionpay(cardTypeChecklistItem))
+    .map(card => createCardTypeChecklistItem(card, acceptedCards))
+    .map(cardTypeChecklistItem => addHintForAmexAndUnionpayIfWorldpay(cardTypeChecklistItem, account.paymentProvider))
 
   return { debitCards: debitCardChecklistItems, creditCards: creditCardChecklistItems }
 }

--- a/app/utils/simplified-account/format/format-card-types.js
+++ b/app/utils/simplified-account/format/format-card-types.js
@@ -1,3 +1,5 @@
+const cardsThatNeedToBeEnabledOnWorldpay = ['American Express', 'Union Pay']
+
 const formatLabel = (card) => {
   if (card.brand === 'visa' || card.brand === 'master-card') {
     return `${card.label} ${card.type.toLowerCase()}`
@@ -28,7 +30,7 @@ const disableCheckboxIf3dsRequiredButNotEnabled = (cardTypeChecklistItem, accoun
 }
 
 const addHintForAmexAndUnionpayIfWorldpay = (cardTypeChecklistItem, paymentProvider) => {
-  if (['American Express', 'Union Pay'].includes(cardTypeChecklistItem.text) && paymentProvider === 'worldpay') {
+  if (cardsThatNeedToBeEnabledOnWorldpay.includes(cardTypeChecklistItem.text) && paymentProvider === 'worldpay') {
     return {
       ...cardTypeChecklistItem,
       hint: {

--- a/app/utils/simplified-account/format/format-card-types.test.js
+++ b/app/utils/simplified-account/format/format-card-types.test.js
@@ -1,0 +1,111 @@
+const { expect } = require('chai')
+const { formatCardTypesForTemplate } = require('@utils/simplified-account/format/format-card-types')
+
+const allCards = [
+  {
+    id: 'id-001',
+    brand: 'visa',
+    label: 'Visa',
+    type: 'DEBIT',
+    requires3ds: false
+  },
+  {
+    id: 'id-002',
+    brand: 'visa',
+    label: 'Visa',
+    type: 'CREDIT',
+    requires3ds: false
+  },
+  {
+    id: 'id-003',
+    brand: 'master-card',
+    label: 'Mastercard',
+    type: 'DEBIT',
+    requires3ds: false
+  },
+  {
+    id: 'id-004',
+    brand: 'american-express',
+    label: 'American Express',
+    type: 'CREDIT',
+    requires3ds: false
+  },
+  {
+    id: 'id-005',
+    brand: 'jcb',
+    label: 'Jcb',
+    type: 'CREDIT',
+    requires3ds: false
+  },
+  {
+    id: 'id-006',
+    brand: 'maestro',
+    label: 'Maestro',
+    type: 'DEBIT',
+    requires3ds: true
+  }
+]
+describe('format-card-types for template', () => {
+  describe('present checkboxes for admin user', () => {
+    it('should return all card types with checked boxes if they are all accepted', () => {
+      const acceptedCards = [...allCards]
+      const account = { requires3ds: true }
+      const cards = formatCardTypesForTemplate(allCards, acceptedCards, account, true)
+      expect(cards).to.have.property('debitCards').to.have.length(3)
+      expect(cards.debitCards[0].text).to.equal('Visa debit')
+      expect(cards.debitCards[0].checked).to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards.debitCards[1].text).to.equal('Mastercard debit')
+      expect(cards.debitCards[1].checked).to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards.debitCards[2].text).to.equal('Maestro')
+      expect(cards.debitCards[2].checked).to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards).to.have.property('creditCards').to.have.length(3)
+      expect(cards.creditCards[0].text).to.equal('Visa credit')
+      expect(cards.creditCards[0].checked).to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards.creditCards[1].text).to.equal('American Express')
+      expect(cards.creditCards[1].checked).to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards.creditCards[2].text).to.equal('JCB')
+      expect(cards.creditCards[2].checked).to.be.true // eslint-disable-line no-unused-expressions
+    })
+
+    it('should return unchecked boxes for not accepted card types', () => {
+      const acceptedCards = [...allCards].filter(card => card.id !== 'id-001' && card.id !== 'id-002')
+      const account = { requires3ds: true }
+      const cards = formatCardTypesForTemplate(allCards, acceptedCards, account, true)
+      expect(cards).to.have.property('debitCards').to.have.length(3)
+      expect(cards.debitCards.filter(card => card.text === 'Visa debit')[0].checked).to.be.false // eslint-disable-line no-unused-expressions
+      expect(cards.debitCards.filter(card => card.text === 'Mastercard debit')[0].checked).to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards.debitCards.filter(card => card.text === 'Maestro')[0].checked).to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards).to.have.property('creditCards').to.have.length(3)
+      expect(cards.debitCards.filter(card => card.text === 'Visa credit')[0].checked).to.be.false // eslint-disable-line no-unused-expressions
+      expect(cards.debitCards.filter(card => card.text === 'American Express')[0].checked).to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards.debitCards.filter(card => card.text === 'JCB')[0].checked).to.be.true // eslint-disable-line no-unused-expressions
+    })
+
+    it('should set checkbox to disabled for requires3ds card types if 3ds not enabled on account', () => {
+      const acceptedCards = [...allCards]
+      const account = { requires3ds: false }
+      const cards = formatCardTypesForTemplate(allCards, acceptedCards, account, true)
+      expect(cards.debitCards.filter(card => card.text === 'Maestro')[0]).to.have.property('disabled').to.be.true // eslint-disable-line no-unused-expressions
+    })
+
+    it('should add hint to American Express if payment provider is Worldpay and account is live', () => {
+      const acceptedCards = [...allCards]
+      const account = { requires3ds: true, paymentProvider: 'worldpay', type: 'live' }
+      const cards = formatCardTypesForTemplate(allCards, acceptedCards, account, true)
+      expect(cards.creditCards.filter(card => card.text === 'American Express')[0])
+        .to.have.property('hint').to.deep.equal({ html: 'You must have already enabled this with Worldpay' })
+    })
+  })
+
+  describe('present read-only list for non-admin user', () => {
+    it('should return all card types arranged by type and whether accepted or not', () => {
+      const acceptedCards = [...allCards].filter(card => card.id !== 'id-001' && card.id !== 'id-002')
+      const account = { requires3ds: true }
+      const cards = formatCardTypesForTemplate(allCards, acceptedCards, account, false)
+      expect(cards['Enabled debit cards']).to.have.length(2).to.deep.equal(['Mastercard debit', 'Maestro'])
+      expect(cards['Not enabled debit cards']).to.have.length(1).to.deep.equal(['Visa debit'])
+      expect(cards['Enabled credit cards']).to.have.length(2).to.deep.equal(['American Express', 'JCB'])
+      expect(cards['Not enabled credit cards']).to.have.length(1).to.deep.equal(['Visa credit'])
+    })
+  })
+})

--- a/app/utils/simplified-account/format/format-card-types.test.js
+++ b/app/utils/simplified-account/format/format-card-types.test.js
@@ -52,19 +52,13 @@ describe('format-card-types for template', () => {
       const account = { requires3ds: true }
       const cards = formatCardTypesForTemplate(allCards, acceptedCards, account, true)
       expect(cards).to.have.property('debitCards').to.have.length(3)
-      expect(cards.debitCards[0].text).to.equal('Visa debit')
-      expect(cards.debitCards[0].checked).to.be.true // eslint-disable-line no-unused-expressions
-      expect(cards.debitCards[1].text).to.equal('Mastercard debit')
-      expect(cards.debitCards[1].checked).to.be.true // eslint-disable-line no-unused-expressions
-      expect(cards.debitCards[2].text).to.equal('Maestro')
-      expect(cards.debitCards[2].checked).to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards.debitCards[0]).to.deep.include({ text: 'Visa debit', checked: true })
+      expect(cards.debitCards[1]).to.deep.include({ text: 'Mastercard debit', checked: true })
+      expect(cards.debitCards[2]).to.deep.include({ text: 'Maestro', checked: true })
       expect(cards).to.have.property('creditCards').to.have.length(3)
-      expect(cards.creditCards[0].text).to.equal('Visa credit')
-      expect(cards.creditCards[0].checked).to.be.true // eslint-disable-line no-unused-expressions
-      expect(cards.creditCards[1].text).to.equal('American Express')
-      expect(cards.creditCards[1].checked).to.be.true // eslint-disable-line no-unused-expressions
-      expect(cards.creditCards[2].text).to.equal('JCB')
-      expect(cards.creditCards[2].checked).to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards.creditCards[0]).to.deep.include({ text: 'Visa credit', checked: true })
+      expect(cards.creditCards[1]).to.deep.include({ text: 'American Express', checked: true })
+      expect(cards.creditCards[2]).to.deep.include({ text: 'JCB', checked: true })
     })
 
     it('should return unchecked boxes for not accepted card types', () => {
@@ -72,13 +66,13 @@ describe('format-card-types for template', () => {
       const account = { requires3ds: true }
       const cards = formatCardTypesForTemplate(allCards, acceptedCards, account, true)
       expect(cards).to.have.property('debitCards').to.have.length(3)
-      expect(cards.debitCards.filter(card => card.text === 'Visa debit')[0].checked).to.be.false // eslint-disable-line no-unused-expressions
-      expect(cards.debitCards.filter(card => card.text === 'Mastercard debit')[0].checked).to.be.true // eslint-disable-line no-unused-expressions
-      expect(cards.debitCards.filter(card => card.text === 'Maestro')[0].checked).to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards.debitCards[0]).to.deep.include({ text: 'Visa debit', checked: false })
+      expect(cards.debitCards[1]).to.deep.include({ text: 'Mastercard debit', checked: true })
+      expect(cards.debitCards[2]).to.deep.include({ text: 'Maestro', checked: true })
       expect(cards).to.have.property('creditCards').to.have.length(3)
-      expect(cards.creditCards.filter(card => card.text === 'Visa credit')[0].checked).to.be.false // eslint-disable-line no-unused-expressions
-      expect(cards.creditCards.filter(card => card.text === 'American Express')[0].checked).to.be.true // eslint-disable-line no-unused-expressions
-      expect(cards.creditCards.filter(card => card.text === 'JCB')[0].checked).to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards.creditCards[0]).to.deep.include({ text: 'Visa credit', checked: false })
+      expect(cards.creditCards[1]).to.deep.include({ text: 'American Express', checked: true })
+      expect(cards.creditCards[2]).to.deep.include({ text: 'JCB', checked: true })
     })
 
     it('should set checkbox to disabled for requires3ds card types if 3ds not enabled for test account', () => {

--- a/app/utils/simplified-account/format/format-card-types.test.js
+++ b/app/utils/simplified-account/format/format-card-types.test.js
@@ -81,11 +81,22 @@ describe('format-card-types for template', () => {
       expect(cards.creditCards.filter(card => card.text === 'JCB')[0].checked).to.be.true // eslint-disable-line no-unused-expressions
     })
 
-    it('should set checkbox to disabled for requires3ds card types if 3ds not enabled on account', () => {
+    it('should set checkbox to disabled for requires3ds card types if 3ds not enabled for test account', () => {
       const acceptedCards = [...allCards]
-      const account = { requires3ds: false }
+      const account = { requires3ds: false, type: 'test' }
       const cards = formatCardTypesForTemplate(allCards, acceptedCards, account, true)
       expect(cards.debitCards.filter(card => card.text === 'Maestro')[0]).to.have.property('disabled').to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards.debitCards.filter(card => card.text === 'Maestro')[0]).to.have.property('hint')
+        .to.deep.equal({ html: 'Maestro is not available on test accounts' })
+    })
+
+    it('should set checkbox to disabled for requires3ds card types if 3ds not enabled for live account', () => {
+      const acceptedCards = [...allCards]
+      const account = { requires3ds: false, type: 'live' }
+      const cards = formatCardTypesForTemplate(allCards, acceptedCards, account, true)
+      expect(cards.debitCards.filter(card => card.text === 'Maestro')[0]).to.have.property('disabled').to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards.debitCards.filter(card => card.text === 'Maestro')[0]).to.have.property('hint')
+        .to.deep.equal({ html: 'Maestro cannot be used because 3D Secure is not available. Please contact support' })
     })
 
     it('should add hint to American Express if payment provider is Worldpay and account is live', () => {

--- a/app/utils/simplified-account/format/format-card-types.test.js
+++ b/app/utils/simplified-account/format/format-card-types.test.js
@@ -76,9 +76,9 @@ describe('format-card-types for template', () => {
       expect(cards.debitCards.filter(card => card.text === 'Mastercard debit')[0].checked).to.be.true // eslint-disable-line no-unused-expressions
       expect(cards.debitCards.filter(card => card.text === 'Maestro')[0].checked).to.be.true // eslint-disable-line no-unused-expressions
       expect(cards).to.have.property('creditCards').to.have.length(3)
-      expect(cards.debitCards.filter(card => card.text === 'Visa credit')[0].checked).to.be.false // eslint-disable-line no-unused-expressions
-      expect(cards.debitCards.filter(card => card.text === 'American Express')[0].checked).to.be.true // eslint-disable-line no-unused-expressions
-      expect(cards.debitCards.filter(card => card.text === 'JCB')[0].checked).to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards.creditCards.filter(card => card.text === 'Visa credit')[0].checked).to.be.false // eslint-disable-line no-unused-expressions
+      expect(cards.creditCards.filter(card => card.text === 'American Express')[0].checked).to.be.true // eslint-disable-line no-unused-expressions
+      expect(cards.creditCards.filter(card => card.text === 'JCB')[0].checked).to.be.true // eslint-disable-line no-unused-expressions
     })
 
     it('should set checkbox to disabled for requires3ds card types if 3ds not enabled on account', () => {

--- a/app/views/simplified-account/settings/card-types/cardTypesCheckboxes.njk
+++ b/app/views/simplified-account/settings/card-types/cardTypesCheckboxes.njk
@@ -1,0 +1,44 @@
+
+  <p class="govuk-body">Choose which credit and debit cards you want to accept.</p>
+
+  <form method="post" novalidate>
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    {{
+    govukCheckboxes({
+      idPrefix: "debit",
+      name: "debit",
+      classes: "with-border govuk-!-padding-top-3 pay-!-border-top",
+      fieldset: {
+        legend: {
+          text: "Debit cards",
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      items: cardTypes.debitCards
+    })
+    }}
+
+    {{
+    govukCheckboxes({
+      idPrefix: "credit",
+      name: "credit",
+      classes: "with-border govuk-!-padding-top-3 pay-!-border-top",
+      fieldset: {
+        legend: {
+          text: "Credit cards",
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      items: cardTypes.creditCards
+    })
+    }}
+
+    {{
+    govukButton({
+      text: 'Save changes',
+      attributes: {
+        id: "save-card-types"
+      }
+    })
+    }}
+  </form>

--- a/app/views/simplified-account/settings/card-types/cardTypesList.njk
+++ b/app/views/simplified-account/settings/card-types/cardTypesList.njk
@@ -1,0 +1,21 @@
+{% for category, items in cardTypes %}
+    {% if (items.length > 0) %}
+      <h3 class="govuk-heading-m">
+        {{ category }}
+      </h3>
+      {% set cardList = [] %}
+      {% for card in items %}
+        {% set cardListItem = {
+          key: {
+            text: card,
+            classes: "govuk-!-display-none"
+          },
+          value: {
+            html: card
+          }
+        } %}
+        {% set cardList = (cardList.push(cardListItem), cardList) %}
+      {% endfor %}
+      {{ govukSummaryList({ rows: cardList }) }}
+    {% endif %}
+{% endfor %}

--- a/app/views/simplified-account/settings/card-types/index.njk
+++ b/app/views/simplified-account/settings/card-types/index.njk
@@ -5,4 +5,20 @@
 {% endblock %}
 
 {% block settingsContent %}
-{%  endblock %}
+  {% if not isAdminUser %}
+    {{ govukInsetText({
+      text: "You don’t have permission to manage settings. Contact your service admin if you would like to manage 3D Secure,
+          accepted card types, email notifications, billing address or mask card numbers or security codes for MOTO services.",
+      classes: "service-settings-inset-text--grey"
+    }) }}
+  {% endif %}
+
+  <h1 class="govuk-heading-l page-title">Card types</h1>
+
+  {% if isAdminUser %}
+    {% include "./cardTypesCheckboxes.njk" %}
+  {% else %}
+    {% include "./cardTypesList.njk" %}
+  {% endif %}
+
+{% endblock %}

--- a/test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class.js
+++ b/test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class.js
@@ -24,11 +24,6 @@ module.exports = class ControllerTestBuilder {
     return this
   }
 
-  withUser (user) {
-    this.req.user = user
-    return this
-  }
-
   withAccount (account) {
     this.req.account = account
     return this

--- a/test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class.js
+++ b/test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class.js
@@ -24,6 +24,11 @@ module.exports = class ControllerTestBuilder {
     return this
   }
 
+  withUser (user) {
+    this.req.user = user
+    return this
+  }
+
   withAccount (account) {
     this.req.account = account
     return this


### PR DESCRIPTION
- Get controller for simplified settings / card types
- As design stipulates that admin users should see checkboxes and non-admins should see a simple list, implement two methods for formatting the card types data and two child templates to slot into the parent card types page.
- Retain existing logic to disable checkbox for Maestro if the service doesn't have 3ds enabled.
- Update existing logic to provide hint to enable with Worldpay for American Express and UnionPay - this is only necessary if it's a Worldpay service.

For subsequent PRs:
- implement the post controller
- Cypress tests

**Screenshot for admin user**
<img width="621" alt="Screenshot 2024-12-05 at 13 04 39" src="https://github.com/user-attachments/assets/9bcbc3ce-0021-4fce-8154-56837738b6e5">

**Screenshot for non-admin user**
<img width="621" alt="Screenshot 2024-12-05 at 13 04 16" src="https://github.com/user-attachments/assets/78f3580e-f0f1-4234-a0c3-ec799edfb5df">

