### PR TITLE
PP-13255 Add error summary to organisation details form

### DIFF
--- a/app/views/simplified-account/settings/organisation-details/edit-organisation-details.njk
+++ b/app/views/simplified-account/settings/organisation-details/edit-organisation-details.njk
@@ -10,6 +10,13 @@
     href: backLink
   }) if backLink }}
 
+  {% if errors %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errors.summary
+    }) }}
+  {% endif %}
+
   <h1 class="govuk-heading-l">Organisation details</h1>
 
   <p class="govuk-body govuk-!-margin-bottom-6 hint-and-body-width">Payment card schemes require the details of the organisation taking payment to be shown on payment pages.</p>

--- a/test/cypress/integration/simplified-account/service-settings/organisation-details/organisation-details.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/organisation-details/organisation-details.cy.js
@@ -226,6 +226,15 @@ describe('Organisation details settings', () => {
 
           cy.location('pathname').should('eq', `/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/organisation-details/edit`)
 
+          cy.get('.govuk-error-summary')
+            .should('exist')
+            .should('contain', 'Organisation name must be 100 characters or fewer')
+            .should('contain', 'Enter a building and street')
+            .should('contain', 'Enter a town or city')
+            .should('contain', 'Enter a real postcode')
+            .should('contain', 'Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
+            .should('contain', 'Enter a valid website address')
+
           cy.get('#organisation-name-error').should('contain.text', 'Organisation name must be 100 characters or fewer')
           cy.get('#address-line1-error').should('contain.text', 'Enter a building and street')
           cy.get('#address-city-error').should('contain.text', 'Enter a town or city')


### PR DESCRIPTION
## WHAT
 - Add error summary to organisation details form
 - update cypress tests to check for error summary

![Screenshot 2024-12-10 at 10-32-58 Settings - Organisation details - GOV UK Pay](https://github.com/user-attachments/assets/23933214-58e8-4bb8-ae9b-9a9791f48a3b)

