### PR TITLE
PP-13335 PP-13335 Transactions details page - display corporate exemptions data.

### DIFF
--- a/src/controllers/transactions/transaction-detail.controller.js
+++ b/src/controllers/transactions/transaction-detail.controller.js
@@ -8,7 +8,8 @@ module.exports = async function showTransactionDetails (req, res, next) {
   const accountId = req.account.gateway_account_id
   const chargeId = req.params.chargeId
   try {
-    const data = await ledgerFindWithEvents(accountId, chargeId)
+    const isCorporateExemptionsEnabled = req.account?.worldpay_3ds_flex?.corporate_exemptions_enabled
+    const data = await ledgerFindWithEvents(accountId, chargeId, isCorporateExemptionsEnabled)
     data.indexFilters = req.session.filters
     if (req.session.contextIsAllServiceTransactions) {
       data.contextIsAllServiceTransactions = req.session.contextIsAllServiceTransactions

--- a/src/controllers/transactions/transaction-detail.controller.test.js
+++ b/src/controllers/transactions/transaction-detail.controller.test.js
@@ -1,0 +1,102 @@
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+const ledgerTransactionFixture = require('../../../test/fixtures/ledger-transaction.fixtures')
+const { validGatewayAccountResponse } = require('../../../test/fixtures/gateway-account.fixtures')
+
+describe('Transaction details - GET', () => {
+  let res, next, transaction, transactionServiceSpy
+
+  const gatewayAccountId = '15486734'
+
+  const EXTERNAL_GATEWAY_ACCOUNT_ID = 'an-external-id'
+
+  const transactionId = 'a-transaction-id'
+
+  const account = validGatewayAccountResponse(
+    {
+      external_id: EXTERNAL_GATEWAY_ACCOUNT_ID,
+      gateway_account_id: gatewayAccountId,
+      payment_provider: 'sandbox',
+      credentials: { username: 'a-username' }
+    }
+  )
+
+  const req = {
+    account,
+    session: {},
+    params: { chargeId: transactionId }
+  }
+
+  const responseSpy = {
+    response: sinon.spy()
+  }
+
+  beforeEach(() => {
+    res = {
+      render: sinon.spy()
+    }
+
+    next = sinon.spy()
+
+    transaction = ledgerTransactionFixture.validTransactionDetailsResponse()
+    responseSpy.response.resetHistory()
+  })
+
+  describe('passing the isCorporateExemptionsEnabled flag correctly when calling ledgerFindWithEvents', () => {
+    it('should not set flag when worldpay_3ds_flag is UNDEFINED on the gateway account', async () => {
+      req.account.worldpay_3ds_flex = undefined
+
+      const controller = getControllerWithMocks(transaction, responseSpy)
+
+      await controller(req, res, next)
+
+      sinon.assert.called(responseSpy.response)
+      sinon.assert.called(transactionServiceSpy.ledgerFindWithEvents)
+
+      sinon.assert.match(transactionServiceSpy.ledgerFindWithEvents.firstCall.args[2], undefined)
+    })
+
+    it('should set flag=false when corporate exemptions = false on the gateway account', async () => {
+      req.account.worldpay_3ds_flex = {
+        corporate_exemptions_enabled: false
+      }
+
+      const controller = getControllerWithMocks(transaction, responseSpy)
+
+      await controller(req, res, next)
+
+      sinon.assert.called(responseSpy.response)
+      sinon.assert.called(transactionServiceSpy.ledgerFindWithEvents)
+
+      sinon.assert.match(transactionServiceSpy.ledgerFindWithEvents.firstCall.args[2], false)
+    })
+
+    it('should set flag=true when corporate exemptions = true on the gateway account', async () => {
+      req.account.worldpay_3ds_flex = {
+        corporate_exemptions_enabled: true
+      }
+
+      const controller = getControllerWithMocks(transaction, responseSpy)
+
+      await controller(req, res, next)
+
+      sinon.assert.called(responseSpy.response)
+      sinon.assert.called(transactionServiceSpy.ledgerFindWithEvents)
+
+      sinon.assert.match(transactionServiceSpy.ledgerFindWithEvents.firstCall.args[2], true)
+    })
+  })
+
+  function getControllerWithMocks (transaction, responseSpy) {
+    transactionServiceSpy = {
+      ledgerFindWithEvents: sinon.spy(() => {
+        return transaction
+      })
+    }
+
+    return proxyquire('./transaction-detail.controller', {
+      '../../services/transaction.service': transactionServiceSpy,
+      '../../utils/response.js': responseSpy
+    })
+  }
+})

--- a/src/services/transaction.service.js
+++ b/src/services/transaction.service.js
@@ -69,7 +69,7 @@ const logCsvFileStreamComplete = function logCsvFileStreamComplete (timestampStr
   })
 }
 
-const ledgerFindWithEvents = async function ledgerFindWithEvents (accountId, chargeId) {
+const ledgerFindWithEvents = async function ledgerFindWithEvents (accountId, chargeId, isCorporateExemptionsEnabled) {
   try {
     const charge = await Ledger.transaction(chargeId, accountId)
     const transactionEvents = await Ledger.events(chargeId, accountId)
@@ -88,9 +88,9 @@ const ledgerFindWithEvents = async function ledgerFindWithEvents (accountId, cha
 
     if (userIds.length !== 0) {
       const users = await userService.findMultipleByExternalIds(userIds)
-      return transactionView.buildPaymentView(charge, transactionEvents, disputeTransaction, users)
+      return transactionView.buildPaymentView(charge, transactionEvents, disputeTransaction, isCorporateExemptionsEnabled, users)
     } else {
-      return transactionView.buildPaymentView(charge, transactionEvents, disputeTransaction)
+      return transactionView.buildPaymentView(charge, transactionEvents, disputeTransaction, isCorporateExemptionsEnabled)
     }
   } catch (error) {
     throw getStatusCodeForError(error)

--- a/src/views/transaction-detail/_details.njk
+++ b/src/views/transaction-detail/_details.njk
@@ -124,6 +124,20 @@
     <td class="govuk-table__cell govuk-!-font-size-16" id="date-created">{{updated}}</td>
   </tr>
 
+  {% if three_d_secure %}
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">3D Secure (3DS):</th>
+      <td class="govuk-table__cell govuk-!-font-size-16" id="three-d-secure">{{three_d_secure}}</td>
+    </tr> 
+  {% endif %}
+
+  {% if corporate_exemption_requested %}
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">Corporate exemption requested:</th>
+      <td class="govuk-table__cell govuk-!-font-size-16" id="date-created">{{corporate_exemption_requested}}</td>
+    </tr>
+  {% endif %}
+
   <tr class="govuk-table__row">
     <th class="govuk-table__header govuk-!-width-one-third govuk-!-font-size-16" scope="row">Provider:</th>
     <td class="govuk-table__cell govuk-!-font-size-16" id="provider">{{payment_provider}}</td>

--- a/test/fixtures/ledger-transaction.fixtures.js
+++ b/test/fixtures/ledger-transaction.fixtures.js
@@ -152,6 +152,15 @@ const buildTransactionDetails = (opts = {}) => {
   if (opts.total_amount) data.total_amount = opts.total_amount
   if (opts.wallet_type) data.wallet_type = opts.wallet_type
   if (opts.metadata) data.metadata = opts.metadata
+
+  if (opts.authorisation_summary) {
+    data.authorisation_summary = opts.authorisation_summary
+  }
+
+  if (opts.exemption) {
+    data.exemption = opts.exemption
+  }
+
   return data
 }
 


### PR DESCRIPTION
- Updating the transaction details controller to append the following
  - Add 3DS secure information about the transaction.
  - Add information about corporate exemptions.
    - If corporate exemptions are disabled on the gateway, then we only show information older transactions when a corporate exemption has been requested.
    - If corporate exemptions are enabled, then it will show information at all times about the transaction.
      - It will show `not requested`, if a corporate exemption was not not requested for the current transaction.
- This PR is only for updating the controllers.
- A future PR will add the fields to the Nunjucks file to display the fields correctly.

<img width="955" alt="image" src="https://github.com/user-attachments/assets/9ece8573-4ea7-4f9f-82b1-bdbd597690e0" />



