### PR TITLE
PP-12444 unswallow unhandled errors

### DIFF
--- a/src/controllers/simplified-account/settings/stripe-details/bank-details/bank-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/bank-details/bank-details.controller.test.js
@@ -8,25 +8,25 @@ const ACCOUNT_TYPE = 'test'
 const SERVICE_ID = 'service-id-123abc'
 
 const STRIPE_DETAILS_INDEX_PATH = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.index, SERVICE_ID, ACCOUNT_TYPE)
-const STRIPE_DETAILS_BANK_ACCOUNT_PATH = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.bankAccount, SERVICE_ID, ACCOUNT_TYPE)
+const STRIPE_DETAILS_BANK_ACCOUNT_PATH = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.bankDetails, SERVICE_ID, ACCOUNT_TYPE)
 
-let req, res, next, responseStub, updateStripeDetailsBankAccountStub, bankAccountController
+let req, res, next, responseStub, updateStripeDetailsBankDetailsStub, bankDetailsController
 
 const getController = (stubs = {}) => {
-  return proxyquire('./bank-account.controller', {
+  return proxyquire('./bank-details.controller', {
     '@utils/response': { response: stubs.response },
     '@services/stripe-details.service': {
-      updateStripeDetailsBankAccount: stubs.updateStripeDetailsBankAccount
+      updateStripeDetailsBankDetails: stubs.updateStripeDetailsBankDetails
     }
   })
 }
 
 const setupTest = (method, additionalStubs = {}, additionalResProps = {}, additionalReqProps = {}) => {
   responseStub = sinon.spy()
-  updateStripeDetailsBankAccountStub = sinon.stub().resolves()
-  bankAccountController = getController({
+  updateStripeDetailsBankDetailsStub = sinon.stub().resolves()
+  bankDetailsController = getController({
     response: responseStub,
-    updateStripeDetailsBankAccount: updateStripeDetailsBankAccountStub,
+    updateStripeDetailsBankDetails: updateStripeDetailsBankDetailsStub,
     ...additionalStubs
   })
   res = {
@@ -43,10 +43,10 @@ const setupTest = (method, additionalStubs = {}, additionalResProps = {}, additi
     ...additionalReqProps
   }
   next = sinon.spy()
-  bankAccountController[method][1](req, res, next)
+  bankDetailsController[method][1](req, res, next)
 }
 
-describe('Controller: settings/stripe-details/bank-account', () => {
+describe('Controller: settings/stripe-details/bank-details', () => {
   describe('get', () => {
     before(() => setupTest('get'))
 
@@ -78,7 +78,7 @@ describe('Controller: settings/stripe-details/bank-account', () => {
       }))
 
       it('should submit bank details to the stripe details service', () => {
-        expect(updateStripeDetailsBankAccountStub.calledWith(req.service, req.account, VALID_SORT_CODE, VALID_ACCOUNT_NUMBER)).to.be.true // eslint-disable-line
+        expect(updateStripeDetailsBankDetailsStub.calledWith(req.service, req.account, VALID_SORT_CODE, VALID_ACCOUNT_NUMBER)).to.be.true // eslint-disable-line
       })
 
       it('should redirect to the stripe details index page', () => {
@@ -181,7 +181,7 @@ describe('Controller: settings/stripe-details/bank-account', () => {
       describe('for unusable bank account', () => {
         before(() => {
           setupTest('post',
-            { updateStripeDetailsBankAccount: sinon.stub().rejects({ code: 'bank_account_unusable' }) },
+            { updateStripeDetailsBankDetails: sinon.stub().rejects({ code: 'bank_account_unusable' }) },
             {},
             { body: { sortCode: VALID_SORT_CODE, accountNumber: VALID_ACCOUNT_NUMBER } }
           )
@@ -199,7 +199,7 @@ describe('Controller: settings/stripe-details/bank-account', () => {
       describe('for invalid sort code', () => {
         before(() => {
           setupTest('post',
-            { updateStripeDetailsBankAccount: sinon.stub().rejects({ code: 'routing_number_invalid' }) },
+            { updateStripeDetailsBankDetails: sinon.stub().rejects({ code: 'routing_number_invalid' }) },
             {},
             { body: { sortCode: VALID_SORT_CODE, accountNumber: VALID_ACCOUNT_NUMBER } }
           )
@@ -218,7 +218,7 @@ describe('Controller: settings/stripe-details/bank-account', () => {
       describe('for invalid account number', () => {
         before(() => {
           setupTest('post',
-            { updateStripeDetailsBankAccount: sinon.stub().rejects({ code: 'account_number_invalid' }) },
+            { updateStripeDetailsBankDetails: sinon.stub().rejects({ code: 'account_number_invalid' }) },
             {},
             { body: { sortCode: VALID_SORT_CODE, accountNumber: VALID_ACCOUNT_NUMBER } }
           )
@@ -237,7 +237,7 @@ describe('Controller: settings/stripe-details/bank-account', () => {
       describe('for unhandled errors with codes', () => {
         before(() => {
           setupTest('post',
-            { updateStripeDetailsBankAccount: sinon.stub().rejects({ code: 'unhandled_error' }) },
+            { updateStripeDetailsBankDetails: sinon.stub().rejects({ code: 'unhandled_error' }) },
             {},
             { body: { sortCode: VALID_SORT_CODE, accountNumber: VALID_ACCOUNT_NUMBER } }
           )
@@ -252,7 +252,7 @@ describe('Controller: settings/stripe-details/bank-account', () => {
       describe('for any other errors', () => {
         before(() => {
           setupTest('post',
-            { updateStripeDetailsBankAccount: sinon.stub().rejects({ foo: 'bar' }) },
+            { updateStripeDetailsBankDetails: sinon.stub().rejects({ foo: 'bar' }) },
             {},
             { body: { sortCode: VALID_SORT_CODE, accountNumber: VALID_ACCOUNT_NUMBER } }
           )

--- a/src/controllers/simplified-account/settings/stripe-details/company-number/company-number.controller.js
+++ b/src/controllers/simplified-account/settings/stripe-details/company-number/company-number.controller.js
@@ -44,19 +44,20 @@ async function post (req, res, next) {
     }
   }
 
-  try {
-    await updateStripeDetailsCompanyNumber(req.service, req.account, hasCompanyNumber
-      ? req.body.companyNumber.replace(/\s/g, '').toUpperCase()
-      : false)
-  } catch (err) {
-    if (err.type === 'StripeInvalidRequestError') {
-      return postErrorResponse(req, res, {
-        summary: [{ text: 'There is a problem with your Company number. Please check your answer and try again.' }]
-      })
-    }
-    next(err)
-  }
-  res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.index, req.service.externalId, req.account.type))
+  updateStripeDetailsCompanyNumber(req.service, req.account, hasCompanyNumber
+    ? req.body.companyNumber.replace(/\s/g, '').toUpperCase()
+    : false)
+    .then(() => {
+      res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.index, req.service.externalId, req.account.type))
+    })
+    .catch((err) => {
+      if (err.type === 'StripeInvalidRequestError') {
+        return postErrorResponse(req, res, {
+          summary: [{ text: 'There is a problem with your Company number. Please check your answer and try again.' }]
+        })
+      }
+      next(err)
+    })
 }
 
 const postErrorResponse = (req, res, errors) => {

--- a/src/controllers/simplified-account/settings/stripe-details/director/director.controller.js
+++ b/src/controllers/simplified-account/settings/stripe-details/director/director.controller.js
@@ -33,17 +33,18 @@ async function post (req, res, next) {
     email: req.body.workEmail.trim()
   }
 
-  try {
-    await updateStripeDetailsDirector(req.service, req.account, director)
-  } catch (err) {
-    if (err.type === 'StripeInvalidRequestError') {
-      return postErrorResponse(req, res, {
-        summary: [{ text: 'There is a problem with the information you\'ve submitted. We\'ve not been able to save your details. Email govuk-pay-support@digital.cabinet-office.gov.uk for help.' }]
-      })
-    }
-    next(err)
-  }
-  res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.index, req.service.externalId, req.account.type))
+  updateStripeDetailsDirector(req.service, req.account, director)
+    .then(() => {
+      res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.index, req.service.externalId, req.account.type))
+    })
+    .catch((err) => {
+      if (err.type === 'StripeInvalidRequestError') {
+        return postErrorResponse(req, res, {
+          summary: [{ text: 'There is a problem with the information you\'ve submitted. We\'ve not been able to save your details. Email govuk-pay-support@digital.cabinet-office.gov.uk for help.' }]
+        })
+      }
+      next(err)
+    })
 }
 
 const postErrorResponse = (req, res, errors) => {

--- a/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller.js
+++ b/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller.js
@@ -55,8 +55,10 @@ async function post (req, res) {
     ...(addressLine2 && { address_line2: addressLine2 })
   }
 
-  await updateStripeDetailsOrganisationNameAndAddress(req.service, req.account, newOrgDetails)
-  res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.index, req.service.externalId, req.account.type))
+  updateStripeDetailsOrganisationNameAndAddress(req.service, req.account, newOrgDetails)
+    .then(() => {
+      res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.index, req.service.externalId, req.account.type))
+    })
 }
 
 const postErrorResponse = (req, res, errors) => {

--- a/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details.controller.js
+++ b/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details.controller.js
@@ -38,11 +38,13 @@ async function post (req, res) {
   }
   const isCorrect = req.body.confirmOrgDetails === 'true'
   if (isCorrect) {
-    await updateConnectorStripeProgress(req.service, req.account, 'organisation_details')
+    updateConnectorStripeProgress(req.service, req.account, 'organisation_details')
+      .then(() => {
+        res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.index, req.service.externalId, req.account.type))
+      })
   } else {
     res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.organisationDetails.update, req.service.externalId, req.account.type))
   }
-  res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.index, req.service.externalId, req.account.type))
 }
 
 const postErrorResponse = (req, res, errors) => {

--- a/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.js
+++ b/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.js
@@ -25,7 +25,7 @@ async function get (req, res) {
 }
 
 module.exports.get = get
-module.exports.bankAccount = require('./bank-account/bank-account.controller')
+module.exports.bankDetails = require('./bank-details/bank-details.controller')
 module.exports.companyNumber = require('./company-number/company-number.controller')
 module.exports.director = require('./director/director.controller')
 module.exports.governmentEntityDocument = require('./government-entity-document/government-entity-document.controller')

--- a/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.test.js
@@ -67,7 +67,7 @@ describe('Controller: settings/stripe-details', () => {
         expect(stripeDetailsTasks).to.have.all.keys('bankAccount', 'vatNumber', 'governmentEntityDocument')
         expect(stripeDetailsTasks.bankAccount).to.deep.equal({
           friendlyName: 'Organisation\'s bank details',
-          href: `/simplified/service/${SERVICE_ID}/account/${ACCOUNT_TYPE}/settings/stripe-details/bank-account`,
+          href: `/simplified/service/${SERVICE_ID}/account/${ACCOUNT_TYPE}/settings/stripe-details/bank-details`,
           status: true
         })
         expect(stripeDetailsTasks.vatNumber).to.deep.equal({

--- a/src/controllers/simplified-account/settings/stripe-details/vat-number/vat-number.controller.js
+++ b/src/controllers/simplified-account/settings/stripe-details/vat-number/vat-number.controller.js
@@ -40,19 +40,20 @@ async function post (req, res, next) {
     }
   }
 
-  try {
-    await updateStripeDetailsVatNumber(req.service, req.account, hasVatNumber
-      ? req.body.vatNumber.replace(/\s/g, '').toUpperCase()
-      : false)
-  } catch (err) {
-    if (err.type === 'StripeInvalidRequestError') {
-      return postErrorResponse(req, res, {
-        summary: [{ text: 'There is a problem with your VAT number. Please check your answer and try again.' }]
-      })
-    }
-    next(err)
-  }
-  res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.index, req.service.externalId, req.account.type))
+  updateStripeDetailsVatNumber(req.service, req.account, hasVatNumber
+    ? req.body.vatNumber.replace(/\s/g, '').toUpperCase()
+    : false)
+    .then(() => {
+      res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.index, req.service.externalId, req.account.type))
+    })
+    .catch((err) => {
+      if (err.type === 'StripeInvalidRequestError') {
+        return postErrorResponse(req, res, {
+          summary: [{ text: 'There is a problem with your VAT number. Please check your answer and try again.' }]
+        })
+      }
+      next(err)
+    })
 }
 
 const postErrorResponse = (req, res, errors) => {

--- a/src/paths.js
+++ b/src/paths.js
@@ -197,7 +197,7 @@ module.exports = {
       },
       stripeDetails: {
         index: '/settings/stripe-details',
-        bankAccount: '/settings/stripe-details/bank-account',
+        bankDetails: '/settings/stripe-details/bank-details',
         responsiblePerson: {
           index: '/settings/stripe-details/responsible-person',
           homeAddress: '/settings/stripe-details/responsible-person/home-address',

--- a/src/services/stripe-details.service.js
+++ b/src/services/stripe-details.service.js
@@ -17,7 +17,7 @@ const connector = new ConnectorClient(process.env.CONNECTOR_URL)
  * @param {string} sortCode
  * @param {string} accountNumber
  */
-const updateStripeDetailsBankAccount = async (service, account, sortCode, accountNumber) => {
+const updateStripeDetailsBankDetails = async (service, account, sortCode, accountNumber) => {
   const stripeAccount = await connector.getStripeAccountByServiceIdAndAccountType(service.externalId, account.type)
   await updateBankAccount(stripeAccount.stripeAccountId, {
     bank_account_sort_code: sortCode,
@@ -218,7 +218,7 @@ const getStripeAccountOnboardingDetails = async (service, account) => {
 }
 
 module.exports = {
-  updateStripeDetailsBankAccount,
+  updateStripeDetailsBankDetails,
   updateStripeDetailsResponsiblePerson,
   updateStripeDetailsDirector,
   updateStripeDetailsCompanyNumber,

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -88,8 +88,8 @@ const stripeDetailsRouter = new Router({ mergeParams: true })
   .use(enforceLiveAccountOnly, enforcePaymentProviderType(STRIPE), permission('stripe-account-details:update'))
 stripeDetailsRouter.get(stripeDetailsPath.index, serviceSettingsController.stripeDetails.get)
 
-stripeDetailsRouter.get(stripeDetailsPath.bankAccount, serviceSettingsController.stripeDetails.bankAccount.get)
-stripeDetailsRouter.post(stripeDetailsPath.bankAccount, serviceSettingsController.stripeDetails.bankAccount.post)
+stripeDetailsRouter.get(stripeDetailsPath.bankDetails, serviceSettingsController.stripeDetails.bankDetails.get)
+stripeDetailsRouter.post(stripeDetailsPath.bankDetails, serviceSettingsController.stripeDetails.bankDetails.post)
 
 stripeDetailsRouter.get(stripeDetailsPath.companyNumber, serviceSettingsController.stripeDetails.companyNumber.get)
 stripeDetailsRouter.post(stripeDetailsPath.companyNumber, serviceSettingsController.stripeDetails.companyNumber.post)

--- a/src/utils/simplified-account/settings/stripe-details/tasks.js
+++ b/src/utils/simplified-account/settings/stripe-details/tasks.js
@@ -6,7 +6,7 @@ const stripeDetailsTasks = Object.freeze({
   bankAccount: {
     name: 'bankAccount',
     friendlyName: 'Organisation\'s bank details',
-    path: paths.simplifiedAccount.settings.stripeDetails.bankAccount
+    path: paths.simplifiedAccount.settings.stripeDetails.bankDetails
   },
   responsiblePerson: {
     name: 'responsiblePerson',

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/bank-details.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/bank-details.cy.js
@@ -51,7 +51,7 @@ describe('Stripe details settings', () => {
         setStubs({
           role: 'view-and-refund'
         })
-        cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/bank-account', { failOnStatusCode: false })
+        cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/bank-details', { failOnStatusCode: false })
       })
       it('should show not found page', () => {
         cy.title().should('eq', 'Page not found - GOV.UK Pay')
@@ -63,7 +63,7 @@ describe('Stripe details settings', () => {
         setStubs({
           paymentProvider: WORLDPAY
         })
-        cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/bank-account', { failOnStatusCode: false })
+        cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/bank-details', { failOnStatusCode: false })
       })
       it('should show not found page', () => {
         cy.title().should('eq', 'Page not found - GOV.UK Pay')
@@ -79,7 +79,7 @@ describe('Stripe details settings', () => {
             bankAccount: true
           })
         ])
-        cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/bank-account')
+        cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/bank-details')
       })
       it('should show the task already completed page', () => {
         cy.title().should('eq', 'An error occurred - GOV.UK Pay')
@@ -94,7 +94,7 @@ describe('Stripe details settings', () => {
             accountType: LIVE_ACCOUNT_TYPE
           })
         ])
-        cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/bank-account')
+        cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/bank-details')
       })
       describe('The settings navigation', () => {
         it('should show stripe details', () => {
@@ -124,7 +124,7 @@ describe('Stripe details settings', () => {
               accountType: LIVE_ACCOUNT_TYPE
             })
           ])
-          cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/bank-account')
+          cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/bank-details')
         })
 
         it('should format sort code with dashes when javascript is enabled', () => {
@@ -216,7 +216,7 @@ describe('Stripe details settings', () => {
               bankAccount: true
             })
           ])
-          cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/bank-account')
+          cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/bank-details')
         })
 
         it('should redirect to the task summary page on success', () => {
@@ -231,7 +231,7 @@ describe('Stripe details settings', () => {
           cy.get('#bank-account-submit').click()
           cy.title().should('eq', 'Settings - Stripe details - GOV.UK Pay')
           cy.get('h1').should('contain', 'Stripe details')
-          cy.location('pathname').should('not.contain', '/bank-account')
+          cy.location('pathname').should('not.contain', '/bank-details')
           cy.get('.govuk-task-list__item')
             .contains('Organisation\'s bank details')
             .parent()

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/director.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/director.cy.js
@@ -182,6 +182,13 @@ describe('Stripe details settings', () => {
                 stripeAccountId: STRIPE_ACCOUNT_ID
               }
             ),
+            stripePspStubs.listPersons({
+              stripeAccountId: STRIPE_ACCOUNT_ID
+            }),
+            stripePspStubs.createPerson({
+              stripeAccountId: STRIPE_ACCOUNT_ID,
+              director: true
+            }),
             stripePspStubs.updateAccount({
               stripeAccountId: STRIPE_ACCOUNT_ID
             }),

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/responsible-person.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/responsible-person.cy.js
@@ -242,8 +242,9 @@ describe('Stripe details settings', () => {
             stripePspStubs.listPersons({
               stripeAccountId: STRIPE_ACCOUNT_ID
             }),
-            stripePspStubs.createOrUpdatePerson({
-              stripeAccountId: STRIPE_ACCOUNT_ID
+            stripePspStubs.createPerson({
+              stripeAccountId: STRIPE_ACCOUNT_ID,
+              representative: true
             }),
             stripePspStubs.updateAccount({
               stripeAccountId: STRIPE_ACCOUNT_ID

--- a/test/cypress/stubs/stripe-psp-stubs.js
+++ b/test/cypress/stubs/stripe-psp-stubs.js
@@ -56,8 +56,17 @@ function updateListPerson (opts) {
   })
 }
 
+// TODO: bin me once simplified accounts are live
 function createOrUpdatePerson (opts) {
   const path = `/v1/accounts/${opts.stripeAccountId}/persons/person_1234`
+  const fixtureOpts = parseStripePersonOptions(opts)
+  return stubBuilder('POST', path, 200, {
+    response: stripePspFixtures.validStripePerson(fixtureOpts)
+  })
+}
+
+function createPerson (opts) {
+  const path = `/v1/accounts/${opts.stripeAccountId}/persons`
   const fixtureOpts = parseStripePersonOptions(opts)
   return stubBuilder('POST', path, 200, {
     response: stripePspFixtures.validStripePerson(fixtureOpts)
@@ -110,6 +119,7 @@ module.exports = {
   retrieveAccountDetails,
   updateListPerson,
   createOrUpdatePerson,
+  createPerson,
   updateCompany,
   updateAccount,
   uploadFile


### PR DESCRIPTION
### WHAT

- rename `/bank-account` path to `/bank-details` in stripe details settings
- prevent unhandled errors in stripe details controllers from being swallowed
- update cypress tests to account for additional stubbing