### PR TITLE
BAU add cypress dev server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ npm run cypress:test
 npm run cypress:test-headed
 ```
 
+#### Debugging Cypress tests
+
+You can start the Cypress server with in-line source maps and auto reload enabled by running `npm run cypress:dev-server`. 
+This will allow you to set breakpoints and step through the source when running a spec.
+
 ## Key environment variables
 
 | Variable               | required |  default value  | Description                                                                                                                                           |

--- a/dev-server.mjs
+++ b/dev-server.mjs
@@ -55,14 +55,20 @@ async function startDevServer() {
 
 await rm('dist', { recursive: true, force: true }, async () => {
   console.log('✅ [dist] cleared')
-  await access('/.dockerenv', constants.R_OK, (err) => {
-    if (err) {
-      console.log('🔩 using local .env')
-      args.unshift('-r', 'dotenv/config')
-    } else {
-      console.log('🐳 using docker env')
-    }
-  })
+  if (process.env.NODE_ENV === 'test') {
+    console.log('🧪 [cypress/test.env] loaded environment')
+    args.unshift('-r', 'dotenv/config')
+    args.push('dotenv_config_path=test/cypress/test.env')
+  } else {
+    await access('/.dockerenv', constants.R_OK, (err) => {
+      if (err) {
+        console.log('🔩 [.env] loaded environment')
+        args.unshift('-r', 'dotenv/config')
+      } else {
+        console.log('🐳 docker environment')
+      }
+    })
+  }
   startDevServer().then(() => {
     console.log('⚡️ dev server going up')
   }).catch(err => {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "test": "rm -rf ./pacts && NODE_ENV=test mocha '!(node_modules)/**/*.test'.js",
     "test:no-pact": "rm -rf ./pacts && NODE_ENV=test mocha --exclude **/*.pact.test.js '!(node_modules)/**/*.test'.js",
     "test:pact": "rm -rf ./pacts && NODE_ENV=test mocha **/*.pact.test.js",
-    "cypress:server": "run-amock --port=8000 | node --inspect -r dotenv/config dist/application.js dotenv_config_path=test/cypress/test.env",
+    "cypress:server": "run-amock --port=8000 | node -r dotenv/config dist/application.js dotenv_config_path=test/cypress/test.env",
+    "cypress:dev-server": "run-amock --port=8000 | NODE_ENV=test node dev-server.mjs",
     "cypress:test": "cypress run",
     "cypress:test-headed": "cypress open",
     "publish-pacts": "./bin/publish-pacts.js"


### PR DESCRIPTION
### WHAT

- add npm run command to start cypress server with inline source maps and hot reload enabled
- update `dev-server.mjs` to load cypress test .env
- update README with usage instructions
