### PR TITLE
PP-12395: Show revoked API keys page

### DIFF
--- a/src/controllers/simplified-account/settings/api-keys/api-keys.controller.js
+++ b/src/controllers/simplified-account/settings/api-keys/api-keys.controller.js
@@ -5,6 +5,7 @@ const paths = require('@root/paths')
 
 async function get (req, res) {
   const activeKeys = await apiKeysService.getActiveKeys(req.account.id)
+  const revokedKeys = await apiKeysService.getRevokedKeys(req.account.id)
   const messages = res.locals?.flash?.messages ?? []
   return response(req, res, 'simplified-account/settings/api-keys/index', {
     messages,
@@ -20,7 +21,9 @@ async function get (req, res) {
     }),
     createApiKeyLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.apiKeys.create,
       req.service.externalId, req.account.type),
-    showRevokedKeysLink: '#'
+    revokedKeysLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.apiKeys.revokedKeys,
+      req.service.externalId, req.account.type),
+    showRevokedKeysLink: revokedKeys.length > 0
   })
 }
 
@@ -28,3 +31,4 @@ module.exports = { get }
 module.exports.createApiKey = require('./create/create-api-key.controller')
 module.exports.changeName = require('./change-name/change-name.controller')
 module.exports.revoke = require('./revoke/revoke.controller')
+module.exports.revokedKeys = require('./revoked-keys/revoked-keys.controller')

--- a/src/controllers/simplified-account/settings/api-keys/api-keys.controller.test.js
+++ b/src/controllers/simplified-account/settings/api-keys/api-keys.controller.test.js
@@ -7,7 +7,8 @@ const SERVICE_ID = 'service-id-123abc'
 const mockResponse = sinon.spy()
 const apiKeys = [{ description: 'my token', createdBy: 'system generated', issuedDate: '12 Dec 2024', tokenLink: '123-345' }]
 const apiKeysService = {
-  getActiveKeys: sinon.stub().resolves(apiKeys)
+  getActiveKeys: sinon.stub().resolves(apiKeys),
+  getRevokedKeys: sinon.stub().resolves([])
 }
 
 const {
@@ -47,6 +48,13 @@ describe('Controller: settings/api-keys', () => {
             revokeKeyLink: `/simplified/service/${SERVICE_ID}/account/${ACCOUNT_TYPE}/settings/api-keys/revoke/${apiKeys[0].tokenLink}`
           }
         }))
+      expect(mockResponse.args[0][3]).to.have.property('createApiKeyLink').to.equal(
+        `/simplified/service/${SERVICE_ID}/account/${ACCOUNT_TYPE}/settings/api-keys/create`
+      )
+      expect(mockResponse.args[0][3]).to.have.property('revokedKeysLink').to.equal(
+        `/simplified/service/${SERVICE_ID}/account/${ACCOUNT_TYPE}/settings/api-keys/revoked`
+      )
+      expect(mockResponse.args[0][3]).to.have.property('showRevokedKeysLink').to.equal(false)
     })
   })
 })

--- a/src/controllers/simplified-account/settings/api-keys/revoked-keys/revoked-keys.controller.js
+++ b/src/controllers/simplified-account/settings/api-keys/revoked-keys/revoked-keys.controller.js
@@ -1,0 +1,14 @@
+const { response } = require('@utils/response')
+const { getRevokedKeys } = require('@services/api-keys.service')
+const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
+const paths = require('@root/paths')
+
+async function get (req, res) {
+  const revokedKeys = await getRevokedKeys(req.account.id)
+  return response(req, res, 'simplified-account/settings/api-keys/revoked-keys', {
+    tokens: revokedKeys,
+    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.apiKeys.index, req.service.externalId, req.account.type)
+  })
+}
+
+module.exports = { get }

--- a/src/controllers/simplified-account/settings/api-keys/revoked-keys/revoked-keys.controller.test.js
+++ b/src/controllers/simplified-account/settings/api-keys/revoked-keys/revoked-keys.controller.test.js
@@ -1,0 +1,64 @@
+const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
+const sinon = require('sinon')
+const { expect } = require('chai')
+const formatSimplifiedAccountPathsFor = require('../../../../../utils/simplified-account/format/format-simplified-account-paths-for')
+const paths = require('@root/paths')
+const GatewayAccount = require('@models/GatewayAccount.class')
+
+const ACCOUNT_TYPE = 'live'
+const SERVICE_ID = 'service-id-123abc'
+const GATEWAY_ACCOUNT_ID = '1'
+const mockResponse = sinon.spy()
+const revokedKeys = [
+  {
+    description: 'my token',
+    createdBy: 'system generated',
+    issuedDate: '12 Dec 2024',
+    tokenLink: '123-345',
+    revokedDate: '14 Jan 2025'
+  }]
+const apiKeysService = {
+  getRevokedKeys: sinon.stub().resolves(revokedKeys)
+}
+
+const {
+  req,
+  res,
+  call
+} = new ControllerTestBuilder('@controllers/simplified-account/settings/api-keys/revoked-keys/revoked-keys.controller')
+  .withServiceExternalId(SERVICE_ID)
+  .withAccount(new GatewayAccount({
+    type: ACCOUNT_TYPE,
+    gateway_account_id: GATEWAY_ACCOUNT_ID
+  }))
+  .withStubs({
+    '@utils/response': { response: mockResponse },
+    '@services/api-keys.service': apiKeysService
+  })
+  .build()
+
+describe('Controller: settings/api-keys/revoked-keys', () => {
+  describe('get', () => {
+    before(() => {
+      call('get')
+    })
+    it('should call apiKeysService.getRevokedKeys', () => {
+      expect(apiKeysService.getRevokedKeys).to.have.been.calledWith(GATEWAY_ACCOUNT_ID)
+    })
+
+    it('should call the response method', () => {
+      expect(mockResponse).to.have.been.calledOnce // eslint-disable-line
+    })
+
+    it('should pass req, res, template path and context to the response method', () => {
+      expect(mockResponse).to.have.been.calledWith(
+        req,
+        res,
+        'simplified-account/settings/api-keys/revoked-keys',
+        {
+          tokens: revokedKeys,
+          backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.apiKeys.index, SERVICE_ID, ACCOUNT_TYPE)
+        })
+    })
+  })
+})

--- a/src/models/Token.class.js
+++ b/src/models/Token.class.js
@@ -24,12 +24,18 @@ class Token {
     return this
   }
 
+  withRevokedDate (revokedDate) {
+    this.revokedDate = revokedDate
+    return this
+  }
+
   toJson () {
     return {
       ...this.description && { description: this.description },
       ...this.createdBy && { created_by: this.createdBy },
       ...this.issuedDate && { issued_date: this.issuedDate },
       ...this.tokenLink && { token_link: this.tokenLink },
+      ...this.revokedDate && { revoked: this.revokedDate },
       ...this.lastUsed && { last_used: this.lastUsed }
     }
   }
@@ -44,6 +50,7 @@ class Token {
       .withIssuedDate(data?.issued_date)
       .withLastUsed(data?.last_used)
       .withTokenLink(data?.token_link)
+      .withRevokedDate(data?.revoked)
   }
 }
 

--- a/src/paths.js
+++ b/src/paths.js
@@ -231,7 +231,8 @@ module.exports = {
         index: '/settings/api-keys',
         create: '/settings/api-keys/create',
         changeName: '/settings/api-keys/change-name/:tokenLink',
-        revoke: '/settings/api-keys/revoke/:tokenLink'
+        revoke: '/settings/api-keys/revoke/:tokenLink',
+        revokedKeys: '/settings/api-keys/revoked'
       },
       webhooks: {
         index: '/settings/webhooks'

--- a/src/services/api-keys.service.js
+++ b/src/services/api-keys.service.js
@@ -27,15 +27,26 @@ const createApiKey = async (gatewayAccount, description, email, tokenSource) => 
 }
 
 /**
+ * Gets the list of revoked api keys for a gateway account
+ * @param {string} gatewayAccountId
+ * @returns {[Token]}
+ */
+const getRevokedKeys = async (gatewayAccountId) => {
+  const response = await publicAuthClient.getRevokedTokensForAccount({ accountId: gatewayAccountId })
+  const revokedTokens = response.tokens || []
+  return revokedTokens.map(tokenData => Token.fromJson(tokenData))
+}
+
+/**
  * Gets the list of active api keys for a gateway account
  * @param {string} gatewayAccountId
  * @returns {[Token]}
  */
 const getActiveKeys = async (gatewayAccountId) => {
-  const publicAuthData = await publicAuthClient.getActiveTokensForAccount({
+  const response = await publicAuthClient.getActiveTokensForAccount({
     accountId: gatewayAccountId
   })
-  return publicAuthData.tokens.map(tokenData => Token.fromJson(tokenData))
+  return response.tokens.map(tokenData => Token.fromJson(tokenData))
 }
 
 /**
@@ -73,6 +84,7 @@ module.exports = {
   createApiKey,
   getActiveKeys,
   getKeyByTokenLink,
+  getRevokedKeys,
   revokeKey,
   TOKEN_SOURCE
 }

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -81,6 +81,7 @@ simplifiedAccount.get(paths.simplifiedAccount.settings.apiKeys.changeName, permi
 simplifiedAccount.post(paths.simplifiedAccount.settings.apiKeys.changeName, permission('tokens:update'), serviceSettingsController.apiKeys.changeName.post)
 simplifiedAccount.get(paths.simplifiedAccount.settings.apiKeys.revoke, permission('tokens:delete'), serviceSettingsController.apiKeys.revoke.get)
 simplifiedAccount.post(paths.simplifiedAccount.settings.apiKeys.revoke, permission('tokens:delete'), serviceSettingsController.apiKeys.revoke.post)
+simplifiedAccount.get(paths.simplifiedAccount.settings.apiKeys.revokedKeys, permission('tokens:delete'), serviceSettingsController.apiKeys.revokedKeys.get)
 
 // stripe details
 const stripeDetailsPath = paths.simplifiedAccount.settings.stripeDetails

--- a/src/views/simplified-account/settings/api-keys/index.njk
+++ b/src/views/simplified-account/settings/api-keys/index.njk
@@ -89,9 +89,11 @@
     {% endfor %}
   {% endif %}
 
-  {{ govukButton({
-    href: showRevokedKeysLink,
-    text: 'Show revoked API keys',
-    classes: 'govuk-!-margin-top-2 govuk-button--secondary'
-  }) }}
+  {% if showRevokedKeysLink %}
+    {{ govukButton({
+      href: revokedKeysLink,
+      text: 'Show revoked API keys',
+      classes: 'govuk-!-margin-top-2 govuk-button--secondary'
+    }) }}
+  {% endif %}
 {% endblock %}

--- a/src/views/simplified-account/settings/api-keys/revoked-keys.njk
+++ b/src/views/simplified-account/settings/api-keys/revoked-keys.njk
@@ -1,0 +1,56 @@
+{% extends "../settings-layout.njk" %}
+
+{% block settingsPageTitle %}
+  Revoked API keys
+{% endblock %}
+
+{% block settingsContent %}
+
+  <h1 class="govuk-heading-l page-title">
+    Revoked API keys ({{ tokens.length }})
+  </h1>
+
+  {% for key in tokens %}
+    {{ govukSummaryList({
+      card: {
+        title: {
+          text: key.description
+        }
+      },
+      rows: [
+        {
+          key: {
+            text: 'Created by'
+          },
+          value: {
+            text: key.createdBy
+          }
+        },
+        {
+          key: {
+            text: 'Date created'
+          },
+          value: {
+            text: key.issuedDate
+          }
+        },
+        {
+          key: {
+            text: 'Last used'
+          },
+          value: {
+            text: key.lastUsed
+          }
+        },
+        {
+          key: {
+            text: 'Date revoked'
+          },
+          value: {
+            text: key.revokedDate
+          }
+        }
+      ]
+    }) }}
+  {% endfor %}
+{% endblock %}

--- a/test/cypress/integration/simplified-account/service-settings/api-keys/api-keys.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/api-keys/api-keys.cy.js
@@ -48,10 +48,11 @@ describe('Settings - API keys', () => {
           .find('h2')
           .contains('There are no active test API keys')
           .should('exist')
-        cy.get('.service-settings-pane')
-          .find('a')
-          .contains('Show revoked API keys')
-          .should('exist')
+        // TODO move the below to a separate test
+        // cy.get('.service-settings-pane')
+        //   .find('a')
+        //   .contains('Show revoked API keys')
+        //   .should('exist')
       })
     })
 


### PR DESCRIPTION
If there revoked keys, show the "Show revoked API keys" button on the API keys landing page. If there no revoked keys, this button should not be shown.

Not covered in this PR:
* Cypress tests
* Returning a 404 if navigating directly to /simplified/service/{serviceId}/account/{type}/settings/api-keys/revoked when there are no revoked keys

### SCREENS

If there no revoked keys, this "Show revoked API keys" button  should not be shown:
<img width="621" alt="Screenshot 2025-01-15 at 17 04 02" src="https://github.com/user-attachments/assets/c842a1b3-2605-4358-aa7a-8eff466aa7cf" />

The "Revoked API keys" page:
<img width="658" alt="Screenshot 2025-01-15 at 16 45 41" src="https://github.com/user-attachments/assets/f91132ac-4081-4848-813f-f23732ef37bd" />
