### PR TITLE
PP-13312 Fix bugs in card types

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -524,7 +524,7 @@
         "filename": "test/cypress/integration/settings/payment-types.cy.js",
         "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
         "is_verified": false,
-        "line_number": 15
+        "line_number": 17
       }
     ],
     "test/cypress/integration/settings/switch-psp.cy.js": [

--- a/src/controllers/payment-types/get-index.controller.js
+++ b/src/controllers/payment-types/get-index.controller.js
@@ -25,11 +25,10 @@ function formatCardsForTemplate (allCards, acceptedCards, account) {
     .map(card => {
       const formatted = formatCardInfoForNunjucks(card)
       const threeDSEnabled = account.requires3ds
-
       if (card.requires3ds && !threeDSEnabled) {
         formatted.disabled = true
         formatted.hint = {
-          html: account.type === 'sandbox' ? `${card.label} is not available on sandbox test accounts` : `${card.label} cannot be used because 3D Secure is not available. Please contact support`
+          html: account.payment_provider === 'sandbox' ? `${card.label} is not available on sandbox test accounts` : `${card.label} cannot be used because 3D Secure is not available. Please contact support`
         }
       }
       return formatted

--- a/src/controllers/payment-types/get-index.controller.js
+++ b/src/controllers/payment-types/get-index.controller.js
@@ -28,7 +28,7 @@ function formatCardsForTemplate (allCards, acceptedCards, account) {
       if (card.requires3ds && !threeDSEnabled) {
         formatted.disabled = true
         formatted.hint = {
-          html: account.payment_provider === 'sandbox' ? `${card.label} is not available on sandbox test accounts` : `${card.label} cannot be used because 3D Secure is not available. Please contact support`
+          html: account.payment_provider === 'sandbox' ? `${card.label} is not available on sandbox test accounts` : `${card.label} cannot be used because 3D Secure is switched off for this service`
         }
       }
       return formatted

--- a/src/models/GatewayAccount.class.js
+++ b/src/models/GatewayAccount.class.js
@@ -48,6 +48,7 @@ class GatewayAccount {
     }
     this.supports3ds = ['worldpay', 'stripe'].includes(gatewayAccountData.payment_provider)
     this.disableToggle3ds = gatewayAccountData.payment_provider === 'stripe'
+    this.requires3ds = gatewayAccountData.requires3ds
     /** @deprecated this is a temporary compatability fix! If you find yourself using this for new code
      * you should instead add any rawResponse data as part of the constructor */
     this.rawResponse = gatewayAccountData

--- a/src/utils/simplified-account/format/format-card-types.js
+++ b/src/utils/simplified-account/format/format-card-types.js
@@ -16,13 +16,13 @@ const createCardTypeChecklistItem = (card, acceptedCards) => {
   }
 }
 
-const disableCheckboxIf3dsRequiredButNotEnabled = (cardTypeChecklistItem, accountType, accountRequires3ds) => {
-  if (cardTypeChecklistItem.requires3ds && !accountRequires3ds) {
+const disableCheckboxIf3dsRequiredButNotEnabled = (cardTypeChecklistItem, account) => {
+  if (cardTypeChecklistItem.requires3ds && !account.requires3ds) {
     return {
       ...cardTypeChecklistItem,
       disabled: true,
       hint: {
-        html: accountType === 'test' ? `${cardTypeChecklistItem.text} is not available on test accounts` : `${cardTypeChecklistItem.text} cannot be used because 3D Secure is not available. Please contact support`
+        html: account.paymentProvider === 'sandbox' ? `${cardTypeChecklistItem.text} is not available on sandbox test accounts` : `${cardTypeChecklistItem.text} cannot be used because 3D Secure is not available. Please contact support`
       }
     }
   }
@@ -44,7 +44,7 @@ const addHintForAmexAndUnionpayIfWorldpay = (cardTypeChecklistItem, paymentProvi
 const formatCardTypesForAdminTemplate = (allCards, acceptedCards, account) => {
   const debitCardChecklistItems = allCards.filter(card => card.type === 'DEBIT')
     .map(card => createCardTypeChecklistItem(card, acceptedCards))
-    .map(cardTypeChecklistItem => disableCheckboxIf3dsRequiredButNotEnabled(cardTypeChecklistItem, account.type, account.requires3ds))
+    .map(cardTypeChecklistItem => disableCheckboxIf3dsRequiredButNotEnabled(cardTypeChecklistItem, account))
 
   const creditCardChecklistItems = allCards.filter(card => card.type === 'CREDIT')
     .map(card => createCardTypeChecklistItem(card, acceptedCards))

--- a/src/utils/simplified-account/format/format-card-types.js
+++ b/src/utils/simplified-account/format/format-card-types.js
@@ -22,7 +22,7 @@ const disableCheckboxIf3dsRequiredButNotEnabled = (cardTypeChecklistItem, accoun
       ...cardTypeChecklistItem,
       disabled: true,
       hint: {
-        html: account.paymentProvider === 'sandbox' ? `${cardTypeChecklistItem.text} is not available on sandbox test accounts` : `${cardTypeChecklistItem.text} cannot be used because 3D Secure is not available. Please contact support`
+        html: account.paymentProvider === 'sandbox' ? `${cardTypeChecklistItem.text} is not available on sandbox test accounts` : `${cardTypeChecklistItem.text} cannot be used because 3D Secure is switched off for this service`
       }
     }
   }

--- a/src/utils/simplified-account/format/format-card-types.test.js
+++ b/src/utils/simplified-account/format/format-card-types.test.js
@@ -90,7 +90,7 @@ describe('format-card-types for template', () => {
       const cards = formatCardTypesForTemplate(allCards, acceptedCards, account, true)
       expect(cards.debitCards.filter(card => card.text === 'Maestro')[0]).to.have.property('disabled').to.be.true // eslint-disable-line no-unused-expressions
       expect(cards.debitCards.filter(card => card.text === 'Maestro')[0]).to.have.property('hint')
-        .to.deep.equal({ html: 'Maestro cannot be used because 3D Secure is not available. Please contact support' })
+        .to.deep.equal({ html: 'Maestro cannot be used because 3D Secure is switched off for this service' })
     })
 
     it('should add hint to American Express if payment provider is Worldpay and account is live', () => {

--- a/src/utils/simplified-account/format/format-card-types.test.js
+++ b/src/utils/simplified-account/format/format-card-types.test.js
@@ -75,13 +75,13 @@ describe('format-card-types for template', () => {
       expect(cards.creditCards[2]).to.deep.include({ text: 'JCB', checked: true })
     })
 
-    it('should set checkbox to disabled for requires3ds card types if 3ds not enabled for test account', () => {
+    it('should set checkbox to disabled for requires3ds card types if 3ds not enabled for sandbox account', () => {
       const acceptedCards = [...allCards]
-      const account = { requires3ds: false, type: 'test' }
+      const account = { requires3ds: false, type: 'test', paymentProvider: 'sandbox' }
       const cards = formatCardTypesForTemplate(allCards, acceptedCards, account, true)
       expect(cards.debitCards.filter(card => card.text === 'Maestro')[0]).to.have.property('disabled').to.be.true // eslint-disable-line no-unused-expressions
       expect(cards.debitCards.filter(card => card.text === 'Maestro')[0]).to.have.property('hint')
-        .to.deep.equal({ html: 'Maestro is not available on test accounts' })
+        .to.deep.equal({ html: 'Maestro is not available on sandbox test accounts' })
     })
 
     it('should set checkbox to disabled for requires3ds card types if 3ds not enabled for live account', () => {

--- a/test/cypress/integration/settings/payment-types.cy.js
+++ b/test/cypress/integration/settings/payment-types.cy.js
@@ -72,7 +72,7 @@ describe('Payment types', () => {
         cy.get('#debit-3-item-hint').should('be.visible')
         cy.get('#debit-3-item-hint')
           .invoke('text')
-          .should('include', 'cannot be used because 3D Secure is not available. Please contact support')
+          .should('include', 'cannot be used because 3D Secure is switched off for this service')
       })
     })
 
@@ -126,7 +126,7 @@ describe('Payment types', () => {
         cy.get('#debit-3-item-hint').should('be.visible')
         cy.get('#debit-3-item-hint')
           .invoke('text')
-          .should('include', 'cannot be used because 3D Secure is not available. Please contact support')
+          .should('include', 'cannot be used because 3D Secure is switched off for this service')
       })
 
       it('should show debit cards that do not require 3DS as enabled and without hint', () => {

--- a/test/cypress/integration/settings/payment-types.cy.js
+++ b/test/cypress/integration/settings/payment-types.cy.js
@@ -1,13 +1,15 @@
 const userStubs = require('../../stubs/user-stubs')
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+const stripeSetupStubs = require('../../stubs/stripe-account-setup-stub')
 
-function setupStubs (userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, type = 'test', requires3ds = false) {
+function setupStubs (userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, type = 'test', requires3ds = false, paymentProvider = 'stripe') {
   cy.task('setupStubs', [
     userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName }),
-    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type, requires3ds }),
+    gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type, requires3ds, paymentProvider }),
     gatewayAccountStubs.getAcceptedCardTypesSuccess({ gatewayAccountId }),
     gatewayAccountStubs.getCardTypesSuccess(),
-    gatewayAccountStubs.postUpdateCardTypesSuccess(gatewayAccountId)
+    gatewayAccountStubs.postUpdateCardTypesSuccess(gatewayAccountId),
+    stripeSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId })
   ])
 }
 
@@ -53,7 +55,7 @@ describe('Payment types', () => {
       .should('contain', 'Accepted card types have been updated')
   })
 
-  context('when the account is test', () => {
+  context('when the account is a payment provider test account', () => {
     context('when 3DS is not enabled', () => {
       beforeEach(() => {
         setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, 'test')
@@ -92,9 +94,9 @@ describe('Payment types', () => {
     })
   })
 
-  context('when the account is sandbox', () => {
+  context('when the account is a sandbox test account', () => {
     beforeEach(() => {
-      setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, 'sandbox')
+      setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, 'test', false, 'sandbox')
       cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
     })
 
@@ -115,7 +117,7 @@ describe('Payment types', () => {
   context('when the account is live', () => {
     context('when 3DS is not enabled', () => {
       beforeEach(() => {
-        setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, 'live')
+        setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, 'live', false, 'stripe')
         cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
       })
 


### PR DESCRIPTION
There's a discrepancy in the card types pages for old settings and simplified settings in relation to the Maestro cards. Maestro cards require a 3ds check so are only available for accounts where `requires3ds` is set to `true`. Maestro is not available on sandbox.

- fix old settings code - check if the `paymentProvider` is `sandbox` (rather than the account `type` which can only be `test` or `live`) to determine what message to display if Maestro is disabled. Correct Cypress tests accordingly.
- fix simplified settings code - add `requires3ds` to the `GatewayAccount` class so that it is available as `req.account.requires3ds` (previously this was `undefined`, causing the Maestro card type checkbox to be disabled incorrectly).

A Cypress test will be added in a separate PR to cover the simplified settings card types page.


**1. Screenshots for Live account, stripe, requires3ds ON (so Maestro is enabled)**
---
<img width="606" alt="Screenshot 2025-01-17 at 12 02 05" src="https://github.com/user-attachments/assets/85aaebe0-bcc4-49d1-971b-7ed6d90d70f6" />
<img width="580" alt="Screenshot 2025-01-17 at 12 02 14" src="https://github.com/user-attachments/assets/0b2affee-baa2-4db5-bceb-a0758244ca32" />

**2. Screenshots for Live account, Worldpay, requires3ds OFF (so Maestro is disabled)**
---
![Screenshot 2025-01-20 at 11 05 01](https://github.com/user-attachments/assets/aa15eb91-8871-4d32-ba4d-06f221279c57)
![Screenshot 2025-01-20 at 11 05 07](https://github.com/user-attachments/assets/901bd566-34c6-48ef-b0dd-142c0958b2d9)


**3. Stripe test accounts, and Worldpay live and test accounts, are the same as the above, ie. enabled if requires3ds is ON but disabled if its OFF (trust me)**
---

**4. Screenshot for sandbox account (so Maestro is disabled)**
---
<img width="669" alt="Screenshot 2025-01-17 at 13 52 54" src="https://github.com/user-attachments/assets/b8c4aa3a-f7d9-4e85-9f52-8efbfe02ab07" />
<img width="661" alt="Screenshot 2025-01-17 at 13 53 01" src="https://github.com/user-attachments/assets/2d7b5d58-f725-4f82-af2c-3868adba6bde" />

