### PR TITLE
BAU Update stubs in Cypress tests to be more robust

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -454,7 +454,7 @@
         "filename": "test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.js",
         "hashed_secret": "631e4be72b31b1013671549f5f5daf2140c52293",
         "is_verified": false,
-        "line_number": 9
+        "line_number": 10
       }
     ],
     "test/cypress/integration/request-to-go-live/index.cy.js": [
@@ -908,5 +908,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-13T19:08:27Z"
+  "generated_at": "2025-01-20T13:08:00Z"
 }

--- a/src/services/clients/adminusers.client.js
+++ b/src/services/clients/adminusers.client.js
@@ -250,14 +250,14 @@ module.exports = function (clientOptions = {}) {
   async function sendOtp (inviteCode) {
     const url = `${baseUrl}/v1/api/invites/${inviteCode}/send-otp`
     configureClient(client, url)
-    const response = await client.post(url, 'send OTP code')
+    const response = await client.post(url, undefined, 'send OTP code')
     return response.data
   }
 
   async function reprovisionOtp (inviteCode) {
     const url = `${baseUrl}/v1/api/invites/${inviteCode}/reprovision-otp`
     configureClient(client, url)
-    const response = await client.post(url, 're-provision OTP key')
+    const response = await client.post(url, undefined, 're-provision OTP key')
     return response.data
   }
 

--- a/src/services/clients/adminusers.client.js
+++ b/src/services/clients/adminusers.client.js
@@ -436,7 +436,7 @@ module.exports = function (clientOptions = {}) {
   async function provisionNewOtpKey (externalId) {
     const url = `${baseUrl}${userResource}/${externalId}/second-factor/provision`
     configureClient(client, url)
-    const response = await client.post(url, 'create a new 2FA provisional OTP key')
+    const response = await client.post(url, undefined, 'create a new 2FA provisional OTP key')
     return responseBodyToUserTransformer(response.data)
   }
 

--- a/src/services/clients/connector.client.js
+++ b/src/services/clients/connector.client.js
@@ -85,8 +85,9 @@ ConnectorClient.prototype = {
    * @param type
    * @param serviceName
    * @param analyticsId
+   * @param serviceId
    *
-   * @returns {Promise}
+   * @returns {Promise<GatewayAccount>}
    */
   createGatewayAccount: async function (paymentProvider, type, serviceName, analyticsId, serviceId) {
     const payload = {
@@ -108,7 +109,7 @@ ConnectorClient.prototype = {
     const url = `${this.connectorUrl}/v1/api/accounts`
     configureClient(client, url)
     const response = await client.post(url, payload, 'create a gateway account')
-    return response.data
+    return new GatewayAccount(response.data)
   },
 
   patchAccountGatewayAccountCredentials: async function (params) {

--- a/src/services/clients/ledger.client.js
+++ b/src/services/clients/ledger.client.js
@@ -80,15 +80,14 @@ const transactions = async function transactions (gatewayAccountIds = [], filter
     url,
     'List transactions for a given gateway account ID',
     {
-      data: {
+      loggingMetadata: {
         gateway_account_ids: gatewayAccountIds,
         multiple_accounts: gatewayAccountIds.length > 1,
         filters: Object.keys(filters).sort().join(', ')
       }
     }
   )
-  const body = legacyConnectorTransactionsParity(response.data)
-  return body
+  return legacyConnectorTransactionsParity(response.data)
 }
 
 const transactionSummary = async function transactionSummary (gatewayAccountId, fromDate, toDate, options = {}) {

--- a/src/services/service.create-service.test.js
+++ b/src/services/service.create-service.test.js
@@ -27,8 +27,8 @@ describe('service service', function () {
     }
 
     const createGatewayAccount = sinon.stub().resolves({
-      gateway_account_id: '1',
-      external_id: 'sandbox-external-id'
+      id: '1',
+      externalId: 'sandbox-external-id'
     })
     const requestStripeTestAccount = sinon.stub().resolves({
       gateway_account_id: '2',

--- a/src/services/service.service.js
+++ b/src/services/service.service.js
@@ -66,7 +66,7 @@ async function createService (serviceName, serviceNameCy, serviceOrgType = 'cent
   // @TODO(sfount) PP-8438 support existing method of associating services with internal card accounts, this should be
   //               removed once connector integration indexed by services have been migrated
 
-  const actualAccountId = stripeTestGatewayAccount ? stripeTestGatewayAccount.gateway_account_id : sandboxGatewayAccount.gateway_account_id
+  const actualAccountId = stripeTestGatewayAccount ? stripeTestGatewayAccount.gateway_account_id : sandboxGatewayAccount.id
   await adminUsersClient.addGatewayAccountsToService(service.externalId, [actualAccountId])
   if (stripeTestGatewayAccount) {
     await adminUsersClient.updatePspTestAccountStage(service.externalId, CREATED)
@@ -75,7 +75,7 @@ async function createService (serviceName, serviceNameCy, serviceOrgType = 'cent
 
   return {
     service,
-    externalAccountId: stripeTestGatewayAccount ? stripeTestGatewayAccount.gateway_account_external_id : sandboxGatewayAccount.external_id
+    externalAccountId: stripeTestGatewayAccount ? stripeTestGatewayAccount.gateway_account_external_id : sandboxGatewayAccount.externalId
   }
 }
 

--- a/test/cypress/integration/agreements/agreement.cy.js
+++ b/test/cypress/integration/agreements/agreement.cy.js
@@ -4,6 +4,7 @@ const agreementStubs = require('../../stubs/agreement-stubs')
 const transactionStubs = require('../../stubs/transaction-stubs')
 
 const userExternalId = 'some-user-id'
+const userEmail = 'some-user-email@example.com'
 const gatewayAccountId = 10
 const gatewayAccountExternalId = 'gateway-account-id'
 const serviceExternalId = 'service-id'
@@ -14,7 +15,8 @@ const userAndGatewayAccountStubs = function (role) {
       userExternalId,
       serviceExternalId,
       gatewayAccountId,
-      role
+      role,
+      email: userEmail
     }),
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
       gatewayAccountId,
@@ -129,9 +131,11 @@ describe('Agreement detail page', () => {
 
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs(),
-      agreementStubs.postConectorCancelAgreementSuccess({
+      agreementStubs.postConnectorCancelAgreementSuccess({
         gatewayAccountId,
-        external_id: 'a-valid-agreement-id'
+        external_id: 'a-valid-agreement-id',
+        user_email: userEmail,
+        user_external_id: userExternalId
       }),
       agreementStubs.getLedgerAgreementSuccess({
         service_id: serviceExternalId,
@@ -175,7 +179,7 @@ describe('Agreement detail page', () => {
 
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs(),
-      agreementStubs.postConectorCancelAgreementFailure({
+      agreementStubs.postConnectorCancelAgreementFailure({
         gatewayAccountId,
         external_id: 'a-valid-agreement-id'
       })

--- a/test/cypress/integration/all-service-transactions/all-service-transactions.cy.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions.cy.js
@@ -136,11 +136,11 @@ describe('All service transactions', () => {
         }
       }),
       gatewayAccountStubs.getCardTypesSuccess(),
-      transactionStubs.getLedgerTransactionSuccess({ transactionDetails: testTransactions[0], gateway_account_id: gatewayAccount3.gatewayAccountId }),
+      transactionStubs.getLedgerTransactionSuccess({ transactionDetails: testTransactions[0], gatewayAccountId: gatewayAccount3.gatewayAccountId }),
       transactionStubs.getLedgerTransactionSuccess({ transactionDetails: testTransactions[0] }),
       gatewayAccountStubs.getGatewayAccountSuccess(gatewayAccount3),
       gatewayAccountStubs.getGatewayAccountByExternalIdSuccess(gatewayAccount3),
-      transactionStubs.getLedgerEventsSuccess({ transactionId: 'transaction-id-3', gateway_account_id: gatewayAccount3.gatewayAccountId })
+      transactionStubs.getLedgerEventsSuccess({ transactionId: 'transaction-id-3', gatewayAccountId: gatewayAccount3.gatewayAccountId })
     ])
 
     cy.visit('/all-service-transactions/test')

--- a/test/cypress/integration/all-service-transactions/all-service-transactions.cy.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions.cy.js
@@ -120,7 +120,7 @@ describe('All service transactions', () => {
     cy.get('#charge-id-transaction-id-4').should('exist')
   })
 
-  it('should have links back to all service transactions when navigating to transaction detail page', () => {
+  it.only('should have links back to all service transactions when navigating to transaction detail page', () => {
     cy.task('setupStubs', [
       userStub,
       gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccountStripe, gatewayAccount2, gatewayAccount3]),
@@ -136,10 +136,11 @@ describe('All service transactions', () => {
         }
       }),
       gatewayAccountStubs.getCardTypesSuccess(),
+      transactionStubs.getLedgerTransactionSuccess({ transactionDetails: testTransactions[0], gateway_account_id: gatewayAccount3.gatewayAccountId }),
       transactionStubs.getLedgerTransactionSuccess({ transactionDetails: testTransactions[0] }),
       gatewayAccountStubs.getGatewayAccountSuccess(gatewayAccount3),
       gatewayAccountStubs.getGatewayAccountByExternalIdSuccess(gatewayAccount3),
-      transactionStubs.getLedgerEventsSuccess({ transactionId: 'transaction-id-3' })
+      transactionStubs.getLedgerEventsSuccess({ transactionId: 'transaction-id-3', gateway_account_id: gatewayAccount3.gatewayAccountId })
     ])
 
     cy.visit('/all-service-transactions/test')

--- a/test/cypress/integration/all-service-transactions/all-service-transactions.cy.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions.cy.js
@@ -120,7 +120,7 @@ describe('All service transactions', () => {
     cy.get('#charge-id-transaction-id-4').should('exist')
   })
 
-  it.only('should have links back to all service transactions when navigating to transaction detail page', () => {
+  it('should have links back to all service transactions when navigating to transaction detail page', () => {
     cy.task('setupStubs', [
       userStub,
       gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccountStripe, gatewayAccount2, gatewayAccount3]),

--- a/test/cypress/integration/invite/complete-invite-for-existing-user.cy.js
+++ b/test/cypress/integration/invite/complete-invite-for-existing-user.cy.js
@@ -17,7 +17,7 @@ describe('Complete an invite for an existing user', () => {
         is_invite_to_join_service: true,
         email
       }),
-      inviteStubs.completeInviteToServiceSuccess(inviteCode, userExternalId, serviceExternalId),
+      inviteStubs.completeInviteToServiceSuccess(inviteCode, userExternalId, serviceExternalId, 'SMS'),
       userStubs.getUserSuccess({
         userExternalId,
         email,

--- a/test/cypress/integration/my-services/add-new-service.cy.js
+++ b/test/cypress/integration/my-services/add-new-service.cy.js
@@ -25,7 +25,7 @@ const assignUserRoleStub =
 
 describe('Add a new service', () => {
   describe('Add a new service without a Welsh name', () => {
-    it.only('should display the service dashboard', () => {
+    it('should display the service dashboard', () => {
       cy.task('setupStubs', [
         userStubs.getUserSuccess({ userExternalId: authenticatedUserId, gatewayAccountId: '1' }),
         gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId: '1' }),
@@ -106,7 +106,7 @@ describe('Add a new service', () => {
           gatewayAccountId: newGatewayAccountId,
           serviceName: { en: newServiceName, cy: newServiceWelshName }
         }),
-        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId }),
+        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId, gatewayAccountIds: [newGatewayAccountId] }),
         gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
           gatewayAccountExternalId: 'a-valid-external-id',
           gatewayAccountId: '1'

--- a/test/cypress/integration/my-services/add-new-service.cy.js
+++ b/test/cypress/integration/my-services/add-new-service.cy.js
@@ -17,7 +17,7 @@ const createGatewayAccountStub =
     serviceId: newServiceId,
     paymentProvider: 'sandbox',
     type: 'test',
-    gatewayAccountId: newGatewayAccountId
+    gatewayAccountId: `${newGatewayAccountId}`
   })
 
 const assignUserRoleStub =
@@ -33,7 +33,7 @@ describe('Add a new service', () => {
         assignUserRoleStub,
         serviceStubs.postCreateServiceSuccess({
           serviceExternalId: newServiceId,
-          gatewayAccountId: newGatewayAccountId,
+          gatewayAccountId: `${newGatewayAccountId}`,
           serviceName: { en: newServiceName }
         }),
         serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId, gatewayAccountIds: [newGatewayAccountId] }),

--- a/test/cypress/integration/my-services/add-new-service.cy.js
+++ b/test/cypress/integration/my-services/add-new-service.cy.js
@@ -25,7 +25,7 @@ const assignUserRoleStub =
 
 describe('Add a new service', () => {
   describe('Add a new service without a Welsh name', () => {
-    it('should display the service dashboard', () => {
+    it.only('should display the service dashboard', () => {
       cy.task('setupStubs', [
         userStubs.getUserSuccess({ userExternalId: authenticatedUserId, gatewayAccountId: '1' }),
         gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId: '1' }),
@@ -36,7 +36,7 @@ describe('Add a new service', () => {
           gatewayAccountId: newGatewayAccountId,
           serviceName: { en: newServiceName }
         }),
-        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId }),
+        serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId: newServiceId, gatewayAccountIds: [newGatewayAccountId] }),
         gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
           gatewayAccountExternalId: 'a-valid-external-id',
           gatewayAccountId: '1'

--- a/test/cypress/integration/payment-links/create-payment-link.cy.js
+++ b/test/cypress/integration/payment-links/create-payment-link.cy.js
@@ -78,7 +78,7 @@ describe('The create payment link flow', () => {
     const referenceHint = 'Found in the email'
     const amount = 10
 
-    it('Should allow creating an english payment link', () => {
+    it.only('Should allow creating an english payment link', () => {
       cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/create-payment-link`)
 

--- a/test/cypress/integration/payment-links/create-payment-link.cy.js
+++ b/test/cypress/integration/payment-links/create-payment-link.cy.js
@@ -78,7 +78,7 @@ describe('The create payment link flow', () => {
     const referenceHint = 'Found in the email'
     const amount = 10
 
-    it.only('Should allow creating an english payment link', () => {
+    it('Should allow creating an english payment link', () => {
       cy.setEncryptedCookies(userExternalId)
       cy.visit(`/account/${gatewayAccountExternalId}/create-payment-link`)
 

--- a/test/cypress/integration/registration/complete-registration.cy.js
+++ b/test/cypress/integration/registration/complete-registration.cy.js
@@ -27,7 +27,7 @@ describe('Complete registration after following link in invite email', () => {
         }),
         inviteStubs.postSendOtpSuccess(inviteCode),
         inviteStubs.postValidateOtpSuccess(inviteCode, validOtpCode),
-        inviteStubs.completeInviteSuccess(inviteCode, createdUserExternalId),
+        inviteStubs.completeInviteSuccess(inviteCode, createdUserExternalId, 'SMS'),
         userStubs.getUserSuccess({ userExternalId: createdUserExternalId, gatewayAccountId: '1' }),
         gatewayAccountStubs.getGatewayAccountsSuccess({
           gatewayAccountId: '1'
@@ -204,7 +204,7 @@ describe('Complete registration after following link in invite email', () => {
           otp_key: otpKey
         }),
         inviteStubs.postValidateOtpSuccess(inviteCode, validOtpCode),
-        inviteStubs.completeInviteSuccess(inviteCode, createdUserExternalId),
+        inviteStubs.completeInviteSuccess(inviteCode, createdUserExternalId, 'APP'),
         userStubs.getUserSuccess({ userExternalId: createdUserExternalId, gatewayAccountId: '1' }),
         gatewayAccountStubs.getGatewayAccountsSuccess({
           gatewayAccountId: '1'

--- a/test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.js
+++ b/test/cypress/integration/request-psp-test-account/submit-request-for-psp-test-account.cy.js
@@ -6,6 +6,7 @@ const tokenStubs = require('../../stubs/token-stubs')
 describe('Request PSP test account: submit request', () => {
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
   const sandboxGatewayAccountId = 42
+  const stripeGatewayAccountId = 43
   const serviceExternalId = 'afe452323dd04d1898672bfaba25e3a6'
   const requestStripeTestAccountUrl = `/service/${serviceExternalId}/request-stripe-test-account`
   const stripeGatewayAccountExternalId = 'a-stripe-gw-external-id'
@@ -14,20 +15,21 @@ describe('Request PSP test account: submit request', () => {
     cy.task('setupStubs', [
       userStubs.getUserSuccessRespondDifferentlySecondTime(userExternalId,
         {
-          gatewayAccountId: sandboxGatewayAccountId,
+          gatewayAccountId: `${sandboxGatewayAccountId}`,
           serviceExternalId,
           pspTestAccountStage: pspTestAccountStageFirstResponse
         },
         {
-          gatewayAccountId: sandboxGatewayAccountId,
+          gatewayAccountId: `${sandboxGatewayAccountId}`,
           serviceExternalId,
           pspTestAccountStage: pspTestAccountStageSecondResponse
         }
       ),
-      gatewayAccountStubs.getAccountByServiceIdAndAccountType(serviceExternalId, 'test', { gateway_account_id: sandboxGatewayAccountId }),
-      gatewayAccountStubs.requestStripeTestAccount(serviceExternalId, { gateway_account_external_id: stripeGatewayAccountExternalId }),
+      gatewayAccountStubs.getAccountByServiceIdAndAccountType(serviceExternalId, 'test', { gateway_account_id: `${sandboxGatewayAccountId}` }),
+      gatewayAccountStubs.requestStripeTestAccount(serviceExternalId, { gateway_account_id: `${stripeGatewayAccountId}`, gateway_account_external_id: stripeGatewayAccountExternalId }),
       gatewayAccountStubs.addGatewayAccountsToService(serviceExternalId),
-      serviceStubs.patchUpdateServicePspTestAccountStage({ serviceExternalId, gatewayAccountId: sandboxGatewayAccountId, pspTestAccountStage: 'REQUEST_SUBMITTED' }),
+      serviceStubs.patchUpdateServiceGatewayAccounts({ serviceExternalId, gatewayAccountIds: [stripeGatewayAccountId] }),
+      serviceStubs.patchUpdateServicePspTestAccountStage({ serviceExternalId, gatewayAccountId: `${sandboxGatewayAccountId}`, pspTestAccountStage: 'CREATED' }),
       tokenStubs.revokeTokensForAccount(sandboxGatewayAccountId)
     ])
   }

--- a/test/cypress/integration/request-to-go-live/agreement.cy.js
+++ b/test/cypress/integration/request-to-go-live/agreement.cy.js
@@ -98,7 +98,7 @@ describe('Request to go live: agreement', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', [
         ...getStubsForPageSubmission('CHOSEN_PSP_STRIPE', 'TERMS_AGREED_STRIPE'),
-        goLiveRequestStubs.postStripeAgreementIpAddress(serviceExternalId)
+        goLiveRequestStubs.postStripeAgreementIpAddress(serviceExternalId, '127.0.0.1')
       ])
 
       cy.get('#agreement').check()

--- a/test/cypress/integration/settings/allow-google-pay.cy.js
+++ b/test/cypress/integration/settings/allow-google-pay.cy.js
@@ -31,10 +31,9 @@ describe('Google Pay', () => {
   it('should allow us to enable and requires a gateway merchant ID for a Worldpay account', () => {
     cy.task('setupStubs', [
       ...getUserAndAccountStubs(false),
-      gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, credentialId, {
+      gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, credentialId, userExternalId, {
         path: 'credentials/gateway_merchant_id',
-        value: '111111111111111',
-        userExternalId
+        value: '111111111111111'
       }),
       gatewayAccountStubs.patchAccountUpdateGooglePaySuccess(gatewayAccountId, true)
     ])

--- a/test/cypress/integration/settings/allow-google-pay.cy.js
+++ b/test/cypress/integration/settings/allow-google-pay.cy.js
@@ -31,7 +31,11 @@ describe('Google Pay', () => {
   it('should allow us to enable and requires a gateway merchant ID for a Worldpay account', () => {
     cy.task('setupStubs', [
       ...getUserAndAccountStubs(false),
-      gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, credentialId),
+      gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, credentialId, {
+        path: 'credentials/gateway_merchant_id',
+        value: '111111111111111',
+        userExternalId
+      }),
       gatewayAccountStubs.patchAccountUpdateGooglePaySuccess(gatewayAccountId, true)
     ])
 

--- a/test/cypress/integration/settings/switch-psp.cy.js
+++ b/test/cypress/integration/settings/switch-psp.cy.js
@@ -131,7 +131,15 @@ describe('Switch PSP settings page', () => {
               username,
               password
             }),
-            gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, switchingToCredentialId),
+            gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, switchingToCredentialId, {
+              path: 'credentials/worldpay/one_off_customer_initiated',
+              value: {
+                merchant_code: merchantId,
+                username,
+                password
+              },
+              userExternalId
+            }),
             gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, 1)
           ])
 
@@ -373,7 +381,11 @@ describe('Switch PSP settings page', () => {
               status: 'success',
               next_url: '/should_follow_to_payment_page'
             }),
-            gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, switchingToCredentialId)
+            gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, switchingToCredentialId, {
+              path: 'state',
+              value: 'VERIFIED_WITH_LIVE_PAYMENT',
+              userExternalId
+            })
           ])
 
           cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
@@ -405,7 +417,10 @@ describe('Switch PSP settings page', () => {
           2)
           cy.task('setupStubs', [
             ...userAndAccountStubs,
-            gatewayAccountStubs.postSwitchPspSuccess(gatewayAccountId)
+            gatewayAccountStubs.postSwitchPspSuccess(gatewayAccountId, {
+              userExternalId,
+              credentialExternalId: switchingToCredentialExternalId
+            })
           ])
         })
 

--- a/test/cypress/integration/settings/switch-psp.cy.js
+++ b/test/cypress/integration/settings/switch-psp.cy.js
@@ -131,16 +131,14 @@ describe('Switch PSP settings page', () => {
               username,
               password
             }),
-            gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, switchingToCredentialId, {
+            gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, switchingToCredentialId, userExternalId, {
               path: 'credentials/worldpay/one_off_customer_initiated',
               value: {
                 merchant_code: merchantId,
                 username,
                 password
-              },
-              userExternalId
-            }),
-            gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, 1)
+              }
+            })
           ])
 
           cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
@@ -381,10 +379,9 @@ describe('Switch PSP settings page', () => {
               status: 'success',
               next_url: '/should_follow_to_payment_page'
             }),
-            gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, switchingToCredentialId, {
+            gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, switchingToCredentialId, userExternalId, {
               path: 'state',
-              value: 'VERIFIED_WITH_LIVE_PAYMENT',
-              userExternalId
+              value: 'VERIFIED_WITH_LIVE_PAYMENT'
             })
           ])
 

--- a/test/cypress/integration/settings/your-psp-stripe-tasklist.cy.js
+++ b/test/cypress/integration/settings/your-psp-stripe-tasklist.cy.js
@@ -25,7 +25,7 @@ const typedHomeAddress = '64 Zoo Lane Road'
 const typedPostcode = 'W89 1FZ'
 const typedPhoneNumber = '+44 0808 157 0192'
 
-function setupYourPspStubs (opts = {}) {
+function setupYourPspStubs (opts = {}, patchOpts) {
   const user = userStubs.getUserSuccess({ userExternalId, gatewayAccountId, serviceName })
 
   const gatewayAccountByExternalId = gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
@@ -51,7 +51,7 @@ function setupYourPspStubs (opts = {}) {
     governmentEntityDocument: opts.governmentEntityDocument
   })
 
-  const updateStripeAccountSetupStub = stripeAccountSetupStubs.patchUpdateStripeSetupSuccess(gatewayAccountId)
+  const updateStripeAccountSetupStub = stripeAccountSetupStubs.patchUpdateStripeSetupSuccess(gatewayAccountId, patchOpts)
   const getStripeAccountStub = getStripeAccountSuccess(gatewayAccountId, stripeAccountId)
   const updateStripeAccountStub = updateAccount({ stripeAccountId })
   const getListPersonStub = listPersons({ stripeAccountId })
@@ -155,7 +155,7 @@ describe('Your PSP Stripe page', () => {
       cy.get('strong[id="task-government-entity-document-status"]').should('contain', 'Complete')
     })
 
-    it('should autamatically show government document as cannot start yet and the rest of the tasks as not started', () => {
+    it('should automatically show government document as cannot start yet and the rest of the tasks as not started', () => {
       setupYourPspStubs()
       cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
 
@@ -171,7 +171,7 @@ describe('Your PSP Stripe page', () => {
 
   describe('Bank details task', () => {
     it('should click bank details task and redirect to task list when valid bank details is submitted', () => {
-      setupYourPspStubs()
+      setupYourPspStubs({}, { path: 'bank_account', value: true })
 
       cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
 
@@ -196,7 +196,7 @@ describe('Your PSP Stripe page', () => {
 
   describe('VAT task', () => {
     it('should click VAT number task and redirect back to tasklist when valid VAT number is submitted', () => {
-      setupYourPspStubs()
+      setupYourPspStubs({}, { path: 'vat_number', value: true })
 
       cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
       cy.get('[data-cy="task-vatNumber"]').contains('VAT registration number').click()
@@ -220,7 +220,7 @@ describe('Your PSP Stripe page', () => {
 
   describe('Company number task', () => {
     it('should click company registration task and redirect back to tasklist when valid company number is submitted', () => {
-      setupYourPspStubs()
+      setupYourPspStubs({}, { path: 'company_number', value: true })
 
       cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
       cy.get('[data-cy="task-Company-number"]').contains('Company registration number').click()
@@ -244,7 +244,7 @@ describe('Your PSP Stripe page', () => {
 
   describe('Service director task', () => {
     it('should click on service director task and redirect back to tasklist when valid service director information is submitted', () => {
-      setupYourPspStubs()
+      setupYourPspStubs({}, { path: 'director', value: true })
 
       cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
       cy.get('[data-cy="task-director"]').contains('Service director').click()
@@ -272,7 +272,7 @@ describe('Your PSP Stripe page', () => {
 
   describe('Responsible person task', () => {
     it('should click Responsible task and redirect back to tasklist when valid responsible information is submitted', () => {
-      setupYourPspStubs()
+      setupYourPspStubs({}, { path: 'responsible_person', value: true })
 
       cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
       cy.get('[data-cy="task-sro"]').contains('Responsible person').click()
@@ -304,7 +304,7 @@ describe('Your PSP Stripe page', () => {
 
   describe('Confirm Organisation details task', () => {
     it('should click on Confirm organisation details task and redirect to tasklist page when organisation details are correct', () => {
-      setupYourPspStubs()
+      setupYourPspStubs({}, { path: 'organisation_details', value: true })
 
       cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
       cy.get('[data-cy="task-checkorganisation-details"]').contains('Confirm your organisation’s name and address match your government entity document').click()

--- a/test/cypress/integration/simplified-account/service-settings/email-notifications/email-notifications.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/email-notifications/email-notifications.cy.js
@@ -306,6 +306,7 @@ describe('Email notifications settings', () => {
 
     describe('for a non-admin user', () => {
       beforeEach(() => {
+        O
         setupStubs(NON_ADMIN_ROLE)
       })
       it('should show relevant tabs only', () => {

--- a/test/cypress/integration/simplified-account/service-settings/email-notifications/email-notifications.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/email-notifications/email-notifications.cy.js
@@ -306,7 +306,6 @@ describe('Email notifications settings', () => {
 
     describe('for a non-admin user', () => {
       beforeEach(() => {
-        O
         setupStubs(NON_ADMIN_ROLE)
       })
       it('should show relevant tabs only', () => {

--- a/test/cypress/integration/simplified-account/service-settings/service-name/service-name.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/service-name/service-name.cy.js
@@ -260,7 +260,7 @@ describe('Service name settings', () => {
         cy.get('.govuk-button').should('contain.text', 'Save changes')
         cy.get('.govuk-button').should('not.contain.text', 'Remove Welsh service name')
       })
-      it('should submit form', () => {
+      it.only('should submit form', () => {
         cy.get('input[name="serviceName"]').clear({ force: true }).type('My New Service Name')
           .should('have.value', 'My New Service Name')
         cy.get('button[form="edit-service-name"]').click()

--- a/test/cypress/integration/simplified-account/service-settings/service-name/service-name.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/service-name/service-name.cy.js
@@ -260,7 +260,7 @@ describe('Service name settings', () => {
         cy.get('.govuk-button').should('contain.text', 'Save changes')
         cy.get('.govuk-button').should('not.contain.text', 'Remove Welsh service name')
       })
-      it.only('should submit form', () => {
+      it('should submit form', () => {
         cy.get('input[name="serviceName"]').clear({ force: true }).type('My New Service Name')
           .should('have.value', 'My New Service Name')
         cy.get('button[form="edit-service-name"]').click()

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/bank-details.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/bank-details.cy.js
@@ -208,7 +208,9 @@ describe('Stripe details settings', () => {
             }),
             stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE
+              accountType: LIVE_ACCOUNT_TYPE,
+              path: 'bank_account',
+              value: true
             }),
             stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/bank-details.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/bank-details.cy.js
@@ -206,12 +206,11 @@ describe('Stripe details settings', () => {
             stripePspStubs.updateAccount({
               stripeAccountId: STRIPE_ACCOUNT_ID
             }),
-            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
-              serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE,
-              path: 'bank_account',
-              value: true
-            }),
+            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE,
+              {
+                path: 'bank_account',
+                value: true
+              }),
             stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
               accountType: LIVE_ACCOUNT_TYPE,

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/company-number.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/company-number.cy.js
@@ -174,7 +174,9 @@ describe('Stripe details settings', () => {
             }),
             stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE
+              accountType: LIVE_ACCOUNT_TYPE,
+              path: 'company_number',
+              value: true
             }),
             stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
@@ -219,7 +221,9 @@ describe('Stripe details settings', () => {
             ),
             stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE
+              accountType: LIVE_ACCOUNT_TYPE,
+              path: 'company_number',
+              value: true
             }),
             stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/company-number.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/company-number.cy.js
@@ -172,12 +172,11 @@ describe('Stripe details settings', () => {
             stripePspStubs.updateAccount({
               stripeAccountId: STRIPE_ACCOUNT_ID
             }),
-            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
-              serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE,
-              path: 'company_number',
-              value: true
-            }),
+            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE,
+              {
+                path: 'company_number',
+                value: true
+              }),
             stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
               accountType: LIVE_ACCOUNT_TYPE,
@@ -219,12 +218,11 @@ describe('Stripe details settings', () => {
                 stripeAccountId: STRIPE_ACCOUNT_ID
               }
             ),
-            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
-              serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE,
-              path: 'company_number',
-              value: true
-            }),
+            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE,
+              {
+                path: 'company_number',
+                value: true
+              }),
             stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
               accountType: LIVE_ACCOUNT_TYPE,

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/confirm-org-details.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/confirm-org-details.cy.js
@@ -134,12 +134,11 @@ describe('Stripe details settings', () => {
             stripePspStubs.updateAccount({
               stripeAccountId: STRIPE_ACCOUNT_ID
             }),
-            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
-              serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE,
-              path: 'organisation_details',
-              value: true
-            }),
+            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE,
+              {
+                path: 'organisation_details',
+                value: true
+              }),
             stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
               accountType: LIVE_ACCOUNT_TYPE,
@@ -199,12 +198,11 @@ describe('Stripe details settings', () => {
               stripePspStubs.updateAccount({
                 stripeAccountId: STRIPE_ACCOUNT_ID
               }),
-              stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
-                serviceExternalId: SERVICE_EXTERNAL_ID,
-                accountType: LIVE_ACCOUNT_TYPE,
-                path: 'organisation_details',
-                value: true
-              }),
+              stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE,
+                {
+                  path: 'organisation_details',
+                  value: true
+                }),
               serviceStubs.patchUpdateMerchantDetailsSuccess({
                 serviceExternalId: SERVICE_EXTERNAL_ID,
                 merchantDetails: {

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/confirm-org-details.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/confirm-org-details.cy.js
@@ -136,7 +136,9 @@ describe('Stripe details settings', () => {
             }),
             stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE
+              accountType: LIVE_ACCOUNT_TYPE,
+              path: 'organisation_details',
+              value: true
             }),
             stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
@@ -199,10 +201,20 @@ describe('Stripe details settings', () => {
               }),
               stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
                 serviceExternalId: SERVICE_EXTERNAL_ID,
-                accountType: LIVE_ACCOUNT_TYPE
+                accountType: LIVE_ACCOUNT_TYPE,
+                path: 'organisation_details',
+                value: true
               }),
-              serviceStubs.patchUpdateServiceGatewayAccounts({
-                serviceExternalId: SERVICE_EXTERNAL_ID
+              serviceStubs.patchUpdateMerchantDetailsSuccess({
+                serviceExternalId: SERVICE_EXTERNAL_ID,
+                merchantDetails: {
+                  name: 'Glomgold Industries',
+                  address_line1: 'McDuck Manor',
+                  address_line2: '',
+                  address_city: 'Duckburg',
+                  address_postcode: 'SW1A 1AA',
+                  address_country: 'GB'
+                }
               }),
               stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
                 serviceExternalId: SERVICE_EXTERNAL_ID,
@@ -213,7 +225,7 @@ describe('Stripe details settings', () => {
             cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/organisation-details/index')
           })
 
-          it('should redirect to the task summary page on success', () => {
+          it.only('should redirect to the task summary page on success', () => {
             cy.get('input[type="radio"]')
               .siblings('label')
               .contains('No, these organisation details do not match')

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/confirm-org-details.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/confirm-org-details.cy.js
@@ -225,7 +225,7 @@ describe('Stripe details settings', () => {
             cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/organisation-details/index')
           })
 
-          it.only('should redirect to the task summary page on success', () => {
+          it('should redirect to the task summary page on success', () => {
             cy.get('input[type="radio"]')
               .siblings('label')
               .contains('No, these organisation details do not match')

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/director.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/director.cy.js
@@ -194,7 +194,9 @@ describe('Stripe details settings', () => {
             }),
             stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE
+              accountType: LIVE_ACCOUNT_TYPE,
+              path: 'director',
+              value: true
             }),
             stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/director.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/director.cy.js
@@ -192,12 +192,11 @@ describe('Stripe details settings', () => {
             stripePspStubs.updateAccount({
               stripeAccountId: STRIPE_ACCOUNT_ID
             }),
-            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
-              serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE,
-              path: 'director',
-              value: true
-            }),
+            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE,
+              {
+                path: 'director',
+                value: true
+              }),
             stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
               accountType: LIVE_ACCOUNT_TYPE,

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/government-entity-document.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/government-entity-document.cy.js
@@ -229,12 +229,11 @@ describe('Stripe details settings', () => {
             stripePspStubs.updateAccount({
               stripeAccountId: STRIPE_ACCOUNT_ID
             }),
-            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
-              serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE,
-              path: 'government_entity_document',
-              value: true
-            }),
+            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE,
+              {
+                path: 'government_entity_document',
+                value: true
+              }),
             stripePspStubs.retrieveAccountDetails({
               stripeAccountId: STRIPE_ACCOUNT_ID
             }),

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/government-entity-document.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/government-entity-document.cy.js
@@ -231,7 +231,9 @@ describe('Stripe details settings', () => {
             }),
             stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE
+              accountType: LIVE_ACCOUNT_TYPE,
+              path: 'government_entity_document',
+              value: true
             }),
             stripePspStubs.retrieveAccountDetails({
               stripeAccountId: STRIPE_ACCOUNT_ID

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/responsible-person.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/responsible-person.cy.js
@@ -249,12 +249,11 @@ describe('Stripe details settings', () => {
             stripePspStubs.updateAccount({
               stripeAccountId: STRIPE_ACCOUNT_ID
             }),
-            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
-              serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE,
-              path: 'responsible_person',
-              value: true
-            })
+            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE,
+              {
+                path: 'responsible_person',
+                value: true
+              })
           ])
           cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/responsible-person')
         })

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/responsible-person.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/responsible-person.cy.js
@@ -251,7 +251,9 @@ describe('Stripe details settings', () => {
             }),
             stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE
+              accountType: LIVE_ACCOUNT_TYPE,
+              path: 'responsible_person',
+              value: true
             })
           ])
           cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/responsible-person')

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/vat-number.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/vat-number.cy.js
@@ -174,7 +174,9 @@ describe('Stripe details settings', () => {
             }),
             stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE
+              accountType: LIVE_ACCOUNT_TYPE,
+              path: 'vat_number',
+              value: true
             }),
             stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
@@ -219,7 +221,9 @@ describe('Stripe details settings', () => {
             ),
             stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE
+              accountType: LIVE_ACCOUNT_TYPE,
+              path: 'vat_number',
+              value: true
             }),
             stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/vat-number.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/vat-number.cy.js
@@ -172,12 +172,11 @@ describe('Stripe details settings', () => {
             stripePspStubs.updateAccount({
               stripeAccountId: STRIPE_ACCOUNT_ID
             }),
-            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
-              serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE,
-              path: 'vat_number',
-              value: true
-            }),
+            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE,
+              {
+                path: 'vat_number',
+                value: true
+              }),
             stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
               accountType: LIVE_ACCOUNT_TYPE,
@@ -219,12 +218,11 @@ describe('Stripe details settings', () => {
                 stripeAccountId: STRIPE_ACCOUNT_ID
               }
             ),
-            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType({
-              serviceExternalId: SERVICE_EXTERNAL_ID,
-              accountType: LIVE_ACCOUNT_TYPE,
-              path: 'vat_number',
-              value: true
-            }),
+            stripeAccountSetupStubs.patchStripeProgressByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE,
+              {
+                path: 'vat_number',
+                value: true
+              }),
             stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
               serviceExternalId: SERVICE_EXTERNAL_ID,
               accountType: LIVE_ACCOUNT_TYPE,

--- a/test/cypress/integration/stripe-setup/update-org-details.cy.js
+++ b/test/cypress/integration/stripe-setup/update-org-details.cy.js
@@ -51,7 +51,7 @@ function setupStubs (stripeSetupOptions, type = 'live', paymentProvider = 'strip
     }),
     stripeSetupStub,
     stripeAccountStubs.getStripeAccountSuccess(gatewayAccountId, 'acct_123example123'),
-    stripeAccountSetupStubs.patchUpdateStripeSetupSuccess(gatewayAccountId),
+    stripeAccountSetupStubs.patchUpdateStripeSetupSuccess(gatewayAccountId, { path: 'organisation_details', value: true }),
     stripeUpdateCompanyStub,
     transactionSummaryStubs.getDashboardStatistics()
   ])

--- a/test/cypress/integration/stripe-setup/vat-number.cy.js
+++ b/test/cypress/integration/stripe-setup/vat-number.cy.js
@@ -37,7 +37,7 @@ function setupStubs (vatNumber, type = 'live', paymentProvider = 'stripe') {
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type, paymentProvider, gatewayAccountCredentials }),
     stripeSetupStub,
     stripeAccountStubs.getStripeAccountSuccess(gatewayAccountId, 'acct_123example123'),
-    stripeAccountSetupStubs.patchUpdateStripeSetupSuccess(gatewayAccountId),
+    stripeAccountSetupStubs.patchUpdateStripeSetupSuccess(gatewayAccountId, { path: 'vat_number', value: true }),
     transactionSummaryStubs.getDashboardStatistics()
   ])
 }

--- a/test/cypress/integration/transactions/transaction-details.cy.js
+++ b/test/cypress/integration/transactions/transaction-details.cy.js
@@ -113,8 +113,8 @@ describe('Transaction details page', () => {
         paymentProvider: transactionDetails.payment_provider,
         allowMoto: additionalGatewayAccountOpts.allow_moto
       }),
-      transactionStubs.getLedgerTransactionSuccess({ transactionDetails }),
-      transactionStubs.getLedgerEventsSuccess({ transactionId, events: transactionDetails.events }),
+      transactionStubs.getLedgerTransactionSuccess({ transactionDetails, gatewayAccountId }),
+      transactionStubs.getLedgerEventsSuccess({ transactionId, events: transactionDetails.events, gatewayAccountId }),
       stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
         gatewayAccountId,
         bankAccount: true,

--- a/test/cypress/integration/user/change-sign-in-method.cy.js
+++ b/test/cypress/integration/user/change-sign-in-method.cy.js
@@ -67,8 +67,8 @@ describe('Change sign in method', () => {
             }),
             userStubs.postProvisionSecondFactorSuccess(userExternalId),
             userStubs.patchUpdateUserPhoneNumberSuccess(userExternalId, validPhoneNumber),
-            userStubs.postSecondFactorSuccess(userExternalId),
-            userStubs.postActivateSecondFactorSuccess(userExternalId)
+            userStubs.postSecondFactorSuccess(userExternalId, true),
+            userStubs.postActivateSecondFactorSuccess(userExternalId, { code: '123456', secondFactor: 'SMS' })
           ])
 
           cy.get('button').contains('Continue').click()
@@ -177,7 +177,7 @@ describe('Change sign in method', () => {
         cy.task('setupStubs', [
           userStubs.getUserSuccess({ userExternalId, telephoneNumber: null, secondFactor: 'SMS', provisionalOtpKey }),
           userStubs.postProvisionSecondFactorSuccess(userExternalId),
-          userStubs.postActivateSecondFactorSuccess(userExternalId)
+          userStubs.postActivateSecondFactorSuccess(userExternalId, { secondFactor: 'APP', code: '123456' })
         ])
 
         cy.visit('/my-profile/two-factor-auth')

--- a/test/cypress/integration/webhooks/webhooks.cy.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.js
@@ -126,7 +126,20 @@ describe('Webhooks', () => {
   it('should update a webhook with valid properties', () => {
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
-      webhooksStubs.patchUpdateWebhookSuccess(webhookExternalId)
+      webhooksStubs.patchBatchUpdateWebhookSuccess(gatewayAccountId, serviceExternalId, webhookExternalId, [{
+        path: 'callback_url',
+        value: 'https://some-callback-url.test'
+      }, {
+        path: 'description',
+        value: 'a valid webhook description'
+      }, {
+        path: 'subscriptions',
+        value: [
+          'card_payment_succeeded',
+          'card_payment_captured',
+          'card_payment_refunded'
+        ]
+      }])
     ])
     cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
 
@@ -141,6 +154,8 @@ describe('Webhooks', () => {
     cy.get('[value=card_payment_captured]').should('be.checked')
 
     cy.get('button').contains('Update webhook').click()
+
+    cy.location('pathname').should('eq', `/test/service/service-id/account/gateway-account-id/webhooks/${webhookExternalId}`)
   })
 
   it('should show a webhook signing secret', () => {
@@ -159,7 +174,7 @@ describe('Webhooks', () => {
   it('should toggle a webhook status', () => {
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
-      webhooksStubs.patchUpdateWebhookSuccess(webhookExternalId, { path: 'status', value: 'INACTIVE', serviceExternalId, gatewayAccountId })
+      webhooksStubs.patchUpdateWebhookSuccess(gatewayAccountId, serviceExternalId, webhookExternalId, { path: 'status', value: 'INACTIVE' })
     ])
     cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
     cy.get('[data-action=update]').then((links) => links[0].click())
@@ -169,6 +184,8 @@ describe('Webhooks', () => {
 
     cy.get('#toggle-active-webhook').click()
     cy.get('.govuk-notification-banner__heading').contains('Webhook status updated')
+
+    cy.location('pathname').should('eq', `/test/service/service-id/account/gateway-account-id/webhooks/${webhookExternalId}`)
   })
 
   it('should browse to event detail page', () => {

--- a/test/cypress/integration/webhooks/webhooks.cy.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.js
@@ -159,7 +159,7 @@ describe('Webhooks', () => {
   it('should toggle a webhook status', () => {
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
-      webhooksStubs.patchUpdateWebhookSuccess(webhookExternalId)
+      webhooksStubs.patchUpdateWebhookSuccess(webhookExternalId, { path: 'status', value: 'INACTIVE', serviceExternalId, gatewayAccountId })
     ])
     cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
     cy.get('[data-action=update]').then((links) => links[0].click())

--- a/test/cypress/stubs/agreement-stubs.js
+++ b/test/cypress/stubs/agreement-stubs.js
@@ -28,12 +28,17 @@ function getLedgerAgreementSuccess (opts = {}) {
   })
 }
 
-function postConectorCancelAgreementSuccess (opts = {}) {
+function postConnectorCancelAgreementSuccess (opts = {}) {
   const path = `/v1/api/accounts/${opts.gatewayAccountId}/agreements/${opts.external_id}/cancel`
-  return stubBuilder('POST', path, 200)
+  return stubBuilder('POST', path, 200, {
+    request: {
+      user_email: opts.user_email,
+      user_external_id: opts.user_external_id
+    }
+  })
 }
 
-function postConectorCancelAgreementFailure (opts = {}) {
+function postConnectorCancelAgreementFailure (opts = {}) {
   const path = `/v1/api/accounts/${opts.gatewayAccountId}/agreements/${opts.external_id}/cancel`
   return stubBuilder('POST', path, 500)
 }
@@ -41,6 +46,6 @@ function postConectorCancelAgreementFailure (opts = {}) {
 module.exports = {
   getLedgerAgreementsSuccess,
   getLedgerAgreementSuccess,
-  postConectorCancelAgreementSuccess,
-  postConectorCancelAgreementFailure
+  postConnectorCancelAgreementSuccess,
+  postConnectorCancelAgreementFailure
 }

--- a/test/cypress/stubs/connector-charge-stubs.js
+++ b/test/cypress/stubs/connector-charge-stubs.js
@@ -4,7 +4,8 @@ const { stubBuilder } = require('./stub-builder')
 function postCreateChargeSuccess (opts) {
   const path = `/v1/api/accounts/${opts.gateway_account_id}/charges`
   return stubBuilder('POST', path, 200, {
-    response: connectorChargeFixtures.validChargeResponse(opts)
+    response: connectorChargeFixtures.validChargeResponse(opts),
+    deepMatchRequest: false
   })
 }
 

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -196,15 +196,17 @@ function patchAccountEmailCollectionModeSuccess (opts) {
 function patchAccountEmailCollectionModeSuccessByServiceIdAndAccountType (serviceId, accountType, emailCollectionMode = 'MANDATORY') {
   const path = `/v1/api/service/${serviceId}/account/${accountType}`
   return stubBuilder('PATCH', path, 200,
-    { op: 'replace', path: 'email_collection_mode', value: emailCollectionMode })
+    { request: { op: 'replace', path: 'email_collection_mode', value: emailCollectionMode } })
 }
 
 function setRefundEmailEnabledByServiceIdAndAccountType (serviceId, accountType, enabled) {
   const path = `/v1/api/service/${serviceId}/account/${accountType}/email-notification`
   const payload = {
-    op: 'replace',
-    path: '/refund_issued/enabled',
-    value: enabled
+    request: {
+      op: 'replace',
+      path: '/refund_issued/enabled',
+      value: enabled
+    }
   }
   return stubBuilder('PATCH', path, 200, payload)
 }
@@ -212,9 +214,11 @@ function setRefundEmailEnabledByServiceIdAndAccountType (serviceId, accountType,
 function patchCustomParagraphByServiceIdAndAccountType (serviceId, accountType, text) {
   const path = `/v1/api/service/${serviceId}/account/${accountType}/email-notification`
   const payload = {
-    op: 'replace',
-    path: '/payment_confirmed/template_body',
-    value: text
+    request: {
+      op: 'replace',
+      path: '/payment_confirmed/template_body',
+      value: text
+    }
   }
   return stubBuilder('PATCH', path, 200, payload)
 }
@@ -222,9 +226,11 @@ function patchCustomParagraphByServiceIdAndAccountType (serviceId, accountType, 
 function setPaymentConfirmationEmailEnabledByServiceIdAndAccountType (serviceId, accountType, enabled) {
   const path = `/v1/api/service/${serviceId}/account/${accountType}/email-notification`
   const payload = {
-    op: 'replace',
-    path: '/payment_confirmed/enabled',
-    value: enabled
+    request: {
+      op: 'replace',
+      path: '/payment_confirmed/enabled',
+      value: enabled
+    }
   }
   return stubBuilder('PATCH', path, 200, payload)
 }
@@ -246,7 +252,8 @@ function patchAccountUpdateGooglePaySuccess (gatewayAccountId, allowGooglePay) {
 function patchUpdateServiceNameSuccess (gatewayAccountId, serviceName) {
   const path = `/v1/frontend/accounts/${gatewayAccountId}/servicename`
   return stubBuilder('PATCH', path, 200, {
-    request: gatewayAccountFixtures.validPatchServiceNameRequest(serviceName)
+    request: gatewayAccountFixtures.validPatchServiceNameRequest(serviceName),
+    deepMatchRequest: true
   })
 }
 
@@ -312,7 +319,8 @@ function patchUpdateCredentialsSuccess (gatewayAccountId, credentialId) {
 function patchUpdateWorldpayOneOffCredentialsSuccess (opts = {}) {
   const path = `/v1/api/accounts/${opts.gatewayAccountId}/credentials/${opts.credentialId}`
   return stubBuilder('PATCH', path, 200, {
-    request: gatewayAccountFixtures.validUpdateGatewayAccountCredentialsRequest(opts)
+    request: gatewayAccountFixtures.validUpdateGatewayAccountCredentialsRequest(opts),
+    deepMatchRequest: true
   })
 }
 

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -169,7 +169,9 @@ function getCardTypesSuccess () {
 
 function postUpdateCardTypesSuccess (gatewayAccountId) {
   const path = `/v1/frontend/accounts/${gatewayAccountId}/card-types`
-  return stubBuilder('POST', path, 200)
+  return stubBuilder('POST', path, 200, {
+    deepMatchRequest: false
+  })
 }
 
 function patchConfirmationEmailToggleSuccess (opts) {
@@ -311,22 +313,36 @@ function postUpdateWorldpay3dsFlexCredentials (opts) {
   })
 }
 
-function patchUpdateCredentialsSuccess (gatewayAccountId, credentialId) {
+function patchUpdateCredentialsSuccess (gatewayAccountId, credentialId, patchOpts = {}) {
   const path = `/v1/api/accounts/${gatewayAccountId}/credentials/${credentialId}`
-  return stubBuilder('PATCH', path, 200)
+  return stubBuilder('PATCH', path, 200, {
+    request: [{
+      op: 'replace',
+      path: patchOpts.path,
+      value: patchOpts.value
+    }, {
+      op: 'replace',
+      path: 'last_updated_by_user_external_id',
+      value: patchOpts.userExternalId
+    }]
+  })
 }
 
 function patchUpdateWorldpayOneOffCredentialsSuccess (opts = {}) {
   const path = `/v1/api/accounts/${opts.gatewayAccountId}/credentials/${opts.credentialId}`
   return stubBuilder('PATCH', path, 200, {
-    request: gatewayAccountFixtures.validUpdateGatewayAccountCredentialsRequest(opts),
-    deepMatchRequest: true
+    request: gatewayAccountFixtures.validUpdateGatewayAccountCredentialsRequest(opts)
   })
 }
 
-function postSwitchPspSuccess (gatewayAccountId) {
+function postSwitchPspSuccess (gatewayAccountId, opts) {
   const path = `/v1/api/accounts/${gatewayAccountId}/switch-psp`
-  return stubBuilder('POST', path, 200)
+  return stubBuilder('POST', path, 200, {
+    request: {
+      user_external_id: opts.userExternalId,
+      gateway_account_credential_external_id: opts.credentialExternalId
+    }
+  })
 }
 
 function getAccountByServiceIdAndAccountType (serviceExternalId, accountType = 'test', opts = {}) {

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -313,7 +313,15 @@ function postUpdateWorldpay3dsFlexCredentials (opts) {
   })
 }
 
-function patchUpdateCredentialsSuccess (gatewayAccountId, credentialId, patchOpts = {}) {
+/**
+ *
+ * @param {Number | String} gatewayAccountId
+ * @param {Number | String} credentialId
+ * @param {String} updatedByUserExternalId
+ * @param {{ path: String, value: String }} patchOpts
+ * @returns {{predicates: [{deepEquals: {path, method}}|{equals: {path, method}}], name: string, responses: [{is: {headers, statusCode: *}}]}}
+ */
+function patchUpdateCredentialsSuccess (gatewayAccountId, credentialId, updatedByUserExternalId, patchOpts) {
   const path = `/v1/api/accounts/${gatewayAccountId}/credentials/${credentialId}`
   return stubBuilder('PATCH', path, 200, {
     request: [{
@@ -323,7 +331,7 @@ function patchUpdateCredentialsSuccess (gatewayAccountId, credentialId, patchOpt
     }, {
       op: 'replace',
       path: 'last_updated_by_user_external_id',
-      value: patchOpts.userExternalId
+      value: updatedByUserExternalId
     }]
   })
 }

--- a/test/cypress/stubs/go-live-request-stubs.js
+++ b/test/cypress/stubs/go-live-request-stubs.js
@@ -16,9 +16,13 @@ function postGovUkPayAgreement (opts) {
   })
 }
 
-function postStripeAgreementIpAddress (serviceExternalId) {
+function postStripeAgreementIpAddress (serviceExternalId, ipAddress) {
   const path = `/v1/api/services/${serviceExternalId}/stripe-agreement`
-  return stubBuilder('POST', path, 201)
+  return stubBuilder('POST', path, 201, {
+    request: {
+      ip_address: ipAddress
+    }
+  })
 }
 
 module.exports = {

--- a/test/cypress/stubs/invite-stubs.js
+++ b/test/cypress/stubs/invite-stubs.js
@@ -51,16 +51,22 @@ function getInviteSuccess (opts) {
   })
 }
 
-function completeInviteSuccess (inviteCode, userExternalId) {
+function completeInviteSuccess (inviteCode, userExternalId, secondFactor) {
   const path = `/v1/api/invites/${inviteCode}/complete`
   return stubBuilder('POST', path, 200, {
+    request: {
+      second_factor: secondFactor
+    },
     response: inviteFixtures.validInviteCompleteResponse({ user_external_id: userExternalId })
   })
 }
 
-function completeInviteToServiceSuccess (inviteCode, userExternalId, serviceExternalId) {
+function completeInviteToServiceSuccess (inviteCode, userExternalId, serviceExternalId, secondFactor) {
   const path = `/v1/api/invites/${inviteCode}/complete`
   return stubBuilder('POST', path, 200, {
+    request: {
+      second_factor: secondFactor
+    },
     response: inviteFixtures.validInviteCompleteResponse({
       user_external_id: userExternalId,
       service_external_id: serviceExternalId
@@ -82,7 +88,12 @@ function postSendOtpSuccess (inviteCode) {
 
 function postValidateOtpSuccess (inviteCode, otpCode) {
   const path = '/v2/api/invites/otp/validate'
-  return stubBuilder('POST', path, 200)
+  return stubBuilder('POST', path, 200, {
+    request: {
+      code: inviteCode,
+      otp: otpCode
+    }
+  })
 }
 
 function patchUpdateInvitePasswordSuccess (inviteCode, password) {

--- a/test/cypress/stubs/invite-stubs.js
+++ b/test/cypress/stubs/invite-stubs.js
@@ -88,14 +88,16 @@ function postValidateOtpSuccess (inviteCode, otpCode) {
 function patchUpdateInvitePasswordSuccess (inviteCode, password) {
   const path = `/v1/api/invites/${inviteCode}`
   return stubBuilder('PATCH', path, 200, {
-    request: inviteFixtures.validUpdateInvitePasswordRequest(password)
+    request: inviteFixtures.validUpdateInvitePasswordRequest(password),
+    deepMatchRequest: true
   })
 }
 
 function patchUpdateInvitePhoneNumberSuccess (inviteCode, phoneNumber) {
   const path = `/v1/api/invites/${inviteCode}`
   return stubBuilder('PATCH', path, 200, {
-    request: inviteFixtures.validUpdateInvitePhoneNumberRequest(phoneNumber)
+    request: inviteFixtures.validUpdateInvitePhoneNumberRequest(phoneNumber),
+    deepMatchRequest: true
   })
 }
 

--- a/test/cypress/stubs/products-stubs.js
+++ b/test/cypress/stubs/products-stubs.js
@@ -35,9 +35,10 @@ function getProductsByGatewayAccountIdAndTypeFailure (gatewayAccountId, productT
   })
 }
 
-function postCreateProductSuccess () {
+function postCreateProductSuccess (opts = {}) {
   const path = '/v1/api/products'
   return stubBuilder('POST', path, 200, {
+    deepMatchRequest: false,
     response: productFixtures.validAdhocProductResponse()
   })
 }

--- a/test/cypress/stubs/products-stubs.js
+++ b/test/cypress/stubs/products-stubs.js
@@ -35,7 +35,7 @@ function getProductsByGatewayAccountIdAndTypeFailure (gatewayAccountId, productT
   })
 }
 
-function postCreateProductSuccess (opts = {}) {
+function postCreateProductSuccess () {
   const path = '/v1/api/products'
   return stubBuilder('POST', path, 200, {
     deepMatchRequest: false,

--- a/test/cypress/stubs/service-stubs.js
+++ b/test/cypress/stubs/service-stubs.js
@@ -19,7 +19,8 @@ function postCreateServiceSuccess (opts) {
   const path = '/v1/api/services'
   return stubBuilder('POST', path, 200, {
     request: serviceFixtures.validCreateServiceRequest(fixtureOpts),
-    response: serviceFixtures.validServiceResponse(fixtureOpts)
+    response: serviceFixtures.validServiceResponse(fixtureOpts),
+    deepMatchRequest: true
   })
 }
 
@@ -33,7 +34,8 @@ function patchUpdateServiceNameSuccess (opts) {
     response: serviceFixtures.validServiceResponse({
       external_id: opts.serviceExternalId,
       gateway_account_ids: [opts.gatewayAccountId]
-    })
+    }),
+    deepMatchRequest: true
   })
 }
 function patchUpdateServiceGoLiveStageSuccess (opts) {
@@ -77,7 +79,8 @@ function patchUpdateMerchantDetailsSuccess (opts) {
       gateway_account_ids: [opts.gatewayAccountId],
       current_go_live_stage: opts.currentGoLiveStage,
       merchant_details: merchantDetails
-    })
+    }),
+    deepMatchRequest: true
   })
 }
 
@@ -105,7 +108,9 @@ function patchGoLiveStageFailure (opts) {
 function patchUpdateServiceGatewayAccounts (opts) {
   const path = `/v1/api/services/${opts.serviceExternalId}`
   return stubBuilder('PATCH', path, 200, {
-    response: serviceFixtures.validServiceResponse()
+    request: serviceFixtures.addGatewayAccountsRequest(opts.gatewayAccountIds),
+    response: serviceFixtures.validServiceResponse(),
+    deepMatchRequest: true
   })
 }
 

--- a/test/cypress/stubs/service-stubs.js
+++ b/test/cypress/stubs/service-stubs.js
@@ -91,7 +91,8 @@ function patchUpdateServiceSuccessCatchAll (opts) {
       external_id: opts.serviceExternalId,
       current_go_live_stage: opts.currentGoLiveStage,
       takes_payments_over_phone: opts.takesPaymentsOverPhone
-    })
+    }),
+    deepMatchRequest: false
   })
 }
 

--- a/test/cypress/stubs/stripe-account-setup-stub.js
+++ b/test/cypress/stubs/stripe-account-setup-stub.js
@@ -143,9 +143,15 @@ function getGatewayAccountStripeSetupFlagForMultipleCalls (opts) {
   }
 }
 
-function patchUpdateStripeSetupSuccess (gatewayAccountId) {
+function patchUpdateStripeSetupSuccess (gatewayAccountId, opts = {}) {
   const path = `/v1/api/accounts/${gatewayAccountId}/stripe-setup`
-  return stubBuilder('PATCH', path, 200)
+  return stubBuilder('PATCH', path, 200, {
+    request: opts.patches || [{
+      op: 'replace',
+      path: opts.path,
+      value: opts.value
+    }]
+  })
 }
 
 function patchStripeProgressByServiceExternalIdAndAccountType (opts) {

--- a/test/cypress/stubs/stripe-account-setup-stub.js
+++ b/test/cypress/stubs/stripe-account-setup-stub.js
@@ -150,7 +150,13 @@ function patchUpdateStripeSetupSuccess (gatewayAccountId) {
 
 function patchStripeProgressByServiceExternalIdAndAccountType (opts) {
   const path = `/v1/api/service/${opts.serviceExternalId}/account/${opts.accountType}/stripe-setup`
-  return stubBuilder('PATCH', path, 200)
+  return stubBuilder('PATCH', path, 200, {
+    request: opts.patches || [{
+      op: 'replace',
+      path: opts.path,
+      value: opts.value
+    }]
+  })
 }
 
 module.exports = {

--- a/test/cypress/stubs/stripe-account-setup-stub.js
+++ b/test/cypress/stubs/stripe-account-setup-stub.js
@@ -143,24 +143,37 @@ function getGatewayAccountStripeSetupFlagForMultipleCalls (opts) {
   }
 }
 
-function patchUpdateStripeSetupSuccess (gatewayAccountId, opts = {}) {
+/**
+ *
+ * @param {String | Number} gatewayAccountId
+ * @param {{ path: String, value: boolean }} patchOpts
+ * @returns {{predicates: ({deepEquals: {path, method}}|{equals: {path, method}})[], name: string, responses: {is: {headers: (*|{'Content-Type': string}), statusCode}}[]}}
+ */
+function patchUpdateStripeSetupSuccess (gatewayAccountId, patchOpts = {}) {
   const path = `/v1/api/accounts/${gatewayAccountId}/stripe-setup`
   return stubBuilder('PATCH', path, 200, {
-    request: opts.patches || [{
+    request: [{
       op: 'replace',
-      path: opts.path,
-      value: opts.value
+      path: patchOpts.path,
+      value: patchOpts.value
     }]
   })
 }
 
-function patchStripeProgressByServiceExternalIdAndAccountType (opts) {
-  const path = `/v1/api/service/${opts.serviceExternalId}/account/${opts.accountType}/stripe-setup`
+/**
+ *
+ * @param {String} serviceExternalId
+ * @param {String} accountType
+ * @param {{ path: String, value: boolean }} patchOpts
+ * @returns {{predicates: ({deepEquals: {path, method}}|{equals: {path, method}})[], name: string, responses: {is: {headers: (*|{'Content-Type': string}), statusCode}}[]}}
+ */
+function patchStripeProgressByServiceExternalIdAndAccountType (serviceExternalId, accountType, patchOpts) {
+  const path = `/v1/api/service/${serviceExternalId}/account/${accountType}/stripe-setup`
   return stubBuilder('PATCH', path, 200, {
-    request: opts.patches || [{
+    request: [{
       op: 'replace',
-      path: opts.path,
-      value: opts.value
+      path: patchOpts.path,
+      value: patchOpts.value
     }]
   })
 }

--- a/test/cypress/stubs/stripe-psp-stubs.js
+++ b/test/cypress/stubs/stripe-psp-stubs.js
@@ -36,7 +36,11 @@ function listPersons (opts) {
 function listBankAccount (opts) {
   const path = `/v1/accounts/${opts.stripeAccountId}/external_accounts`
   return stubBuilder('GET', path, 200, {
-    response: stripePspFixtures.validBankAccount(opts)
+    response: stripePspFixtures.validBankAccount(opts),
+    query: {
+      object: 'bank_account',
+      limit: 1
+    }
   })
 }
 
@@ -61,7 +65,8 @@ function createOrUpdatePerson (opts) {
   const path = `/v1/accounts/${opts.stripeAccountId}/persons/person_1234`
   const fixtureOpts = parseStripePersonOptions(opts)
   return stubBuilder('POST', path, 200, {
-    response: stripePspFixtures.validStripePerson(fixtureOpts)
+    response: stripePspFixtures.validStripePerson(fixtureOpts),
+    deepMatchRequest: false
   })
 }
 
@@ -69,7 +74,8 @@ function createPerson (opts) {
   const path = `/v1/accounts/${opts.stripeAccountId}/persons`
   const fixtureOpts = parseStripePersonOptions(opts)
   return stubBuilder('POST', path, 200, {
-    response: stripePspFixtures.validStripePerson(fixtureOpts)
+    response: stripePspFixtures.validStripePerson(fixtureOpts),
+    deepMatchRequest: false
   })
 }
 
@@ -77,7 +83,8 @@ function updateCompany (opts) {
   const path = `/v1/accounts/${opts.stripeAccountId}`
   const fixtureOpts = parseStripeAccountOptions(opts)
   return stubBuilder('POST', path, 200, {
-    response: stripePspFixtures.validRetrieveStripeAccountDetails(fixtureOpts)
+    response: stripePspFixtures.validRetrieveStripeAccountDetails(fixtureOpts),
+    deepMatchRequest: false
   })
 }
 
@@ -85,7 +92,8 @@ function updateAccount (opts) {
   const path = `/v1/accounts/${opts.stripeAccountId}`
   const fixtureOpts = parseStripeAccountOptions(opts)
   return stubBuilder('POST', path, 200, {
-    response: stripePspFixtures.validRetrieveStripeAccountDetails(fixtureOpts)
+    response: stripePspFixtures.validRetrieveStripeAccountDetails(fixtureOpts),
+    deepMatchRequest: false
   })
 }
 
@@ -109,7 +117,8 @@ function uploadFile () {
       title: null,
       type: 'png',
       url: null
-    }
+    },
+    deepMatchRequest: false
   })
 }
 

--- a/test/cypress/stubs/stripe-psp-stubs.js
+++ b/test/cypress/stubs/stripe-psp-stubs.js
@@ -56,7 +56,8 @@ function updateListPerson (opts) {
   const path = `/v1/accounts/${opts.stripeAccountId}/persons`
   const fixtureOpts = parseStripePersonOptions(opts)
   return stubBuilder('POST', path, 200, {
-    response: stripePspFixtures.validStripePerson(fixtureOpts)
+    response: stripePspFixtures.validStripePerson(fixtureOpts),
+    deepMatchRequest: false
   })
 }
 

--- a/test/cypress/stubs/stub-builder.js
+++ b/test/cypress/stubs/stub-builder.js
@@ -1,5 +1,13 @@
 'use strict'
 
+/**
+ *
+ * @param {String} method
+ * @param {String} path
+ * @param {Number} responseCode
+ * @param additionalParams
+ * @returns {{predicates: ({deepEquals: {path, method}}|{equals: {path, method}})[], name: string, responses: [{is: {headers: (*|{'Content-Type': string}), statusCode}}]}}
+ */
 function stubBuilder (method, path, responseCode, additionalParams = {}) {
   const request = {
     method,
@@ -21,7 +29,6 @@ function stubBuilder (method, path, responseCode, additionalParams = {}) {
   }
 
   let predicate
-  // cy.log(additionalParams?.deepMatchRequest)
   if (additionalParams?.deepMatchRequest === false) { // eslint-disable-line no-prototype-builtins
     predicate = { equals: request }
   } else {

--- a/test/cypress/stubs/stub-builder.js
+++ b/test/cypress/stubs/stub-builder.js
@@ -21,10 +21,11 @@ function stubBuilder (method, path, responseCode, additionalParams = {}) {
   }
 
   let predicate
-  if (!additionalParams.hasOwnProperty('deepMatchRequest') || additionalParams.deepMatchRequest) { // eslint-disable-line no-prototype-builtins
-    predicate = { deepEquals: request }
-  } else {
+  // cy.log(additionalParams?.deepMatchRequest)
+  if (additionalParams?.deepMatchRequest === false) { // eslint-disable-line no-prototype-builtins
     predicate = { equals: request }
+  } else {
+    predicate = { deepEquals: request }
   }
 
   const stub = {

--- a/test/cypress/stubs/token-stubs.js
+++ b/test/cypress/stubs/token-stubs.js
@@ -6,6 +6,7 @@ const { stubBuilder } = require('./stub-builder')
 function postCreateTokenForAccountSuccess (opts) {
   const path = '/v1/frontend/auth'
   return stubBuilder('POST', path, 200, {
+    deepMatchRequest: false,
     response: tokenFixtures.validCreateTokenForGatewayAccountResponse(opts)
   })
 }

--- a/test/cypress/stubs/transaction-stubs.js
+++ b/test/cypress/stubs/transaction-stubs.js
@@ -6,19 +6,13 @@ const ledgerTransactionFixtures = require('../../fixtures/ledger-transaction.fix
 const refundFixtures = require('../../fixtures/refund.fixtures')
 const { stubBuilder } = require('./stub-builder')
 
-const filterNames = {
-  agreement_id: 'agreementId',
-  display_size: 'pageSize',
-  reference: 'reference'
-}
-
 function getLedgerTransactionSuccess (opts) {
   const path = `/v1/transaction/${opts.transactionDetails.transaction_id}`
   return stubBuilder('GET', path, 200, {
     response: ledgerTransactionFixtures.validTransactionDetailsResponse(opts.transactionDetails),
     query: {
-      ...opts.gateway_account_id && { account_id: opts.gateway_account_id },
-      ...!opts.gateway_account_id && { override_account_id_restriction: true }
+      ...opts.gatewayAccountId && { account_id: opts.gatewayAccountId },
+      ...!opts.gatewayAccountId && { override_account_id_restriction: true }
     }
   })
 }
@@ -42,7 +36,7 @@ function getLedgerEventsSuccess (opts) {
       payment_states: opts.events
     }),
     query: {
-      gateway_account_id: opts.gateway_account_id
+      gateway_account_id: opts.gatewayAccountId
     }
   })
 }
@@ -57,11 +51,6 @@ function getLedgerTransactionsSuccess (opts) {
       limit_total: true,
       limit_total_size: 5001
     }),
-    request: {
-      gateway_account_ids: opts.gatewayAccountIds ? opts.gatewayAccountIds : [opts.gatewayAccountId],
-      multiple_accounts: opts.gatewayAccountIds ? opts.gatewayAccountIds.length > 1 : false,
-      filters: Object.keys(opts.filters || {}).map(filter => filterNames[filter]).join(', ')
-    },
     response: ledgerTransactionFixtures.validTransactionSearchResponse({
       page: opts.page || 1,
       display_size: opts.displaySize,
@@ -105,7 +94,8 @@ function postRefundAmountNotAvailable (opts) {
 function getTransactionsSummarySuccess (opts) {
   const path = '/v1/report/transactions-summary'
   return stubBuilder('GET', path, 200, {
-    response: ledgerTransactionFixtures.validTransactionSummaryDetails(opts)
+    response: ledgerTransactionFixtures.validTransactionSummaryDetails(opts),
+    deepMatchRequest: false
   })
 }
 

--- a/test/cypress/stubs/transaction-summary-stubs.js
+++ b/test/cypress/stubs/transaction-summary-stubs.js
@@ -6,7 +6,8 @@ const { stubBuilder } = require('./stub-builder')
 function getDashboardStatistics (opts = {}) {
   const path = '/v1/report/transactions-summary'
   return stubBuilder('GET', path, 200, {
-    response: ledgerFixture.validTransactionSummaryDetails(opts)
+    response: ledgerFixture.validTransactionSummaryDetails(opts),
+    deepMatchRequest: false
   })
 }
 

--- a/test/cypress/stubs/user-stubs.js
+++ b/test/cypress/stubs/user-stubs.js
@@ -86,14 +86,23 @@ function postUserAuthenticateInvalidPassword (username, password) {
   })
 }
 
-function postSecondFactorSuccess (userExternalId) {
+function postSecondFactorSuccess (userExternalId, provisional = false) {
   const path = `/v1/api/users/${userExternalId}/second-factor`
-  return stubBuilder('POST', path, 200)
+  return stubBuilder('POST', path, 200, {
+    request: {
+      provisional
+    }
+  })
 }
 
-function postActivateSecondFactorSuccess (userExternalId) {
+function postActivateSecondFactorSuccess (userExternalId, opts = {}) {
   const path = `/v1/api/users/${userExternalId}/second-factor/activate`
-  return stubBuilder('POST', path, 200)
+  return stubBuilder('POST', path, 200, {
+    request: {
+      code: opts.code,
+      second_factor: opts.secondFactor
+    }
+  })
 }
 
 function postAuthenticateSecondFactorSuccess (userExternalId, code) {

--- a/test/cypress/stubs/webhooks-stubs.js
+++ b/test/cypress/stubs/webhooks-stubs.js
@@ -68,7 +68,7 @@ function getWebhookMessageAttempts (opts = {}) {
 
 function postCreateWebhookSuccess () {
   const path = '/v1/webhook'
-  return stubBuilder('POST', path, 200)
+  return stubBuilder('POST', path, 200, { deepMatchRequest: false })
 }
 
 function createWebhookViolatesBackend (opts = {}) {
@@ -77,13 +77,24 @@ function createWebhookViolatesBackend (opts = {}) {
     response: {
       error_identifier: 'CALLBACK_URL_NOT_ON_ALLOW_LIST',
       message: 'Callback url violated security constraints'
-    }
+    },
+    deepMatchRequest: false
   })
 }
 
-function patchUpdateWebhookSuccess (webhookExternalId) {
+function patchUpdateWebhookSuccess (webhookExternalId, opts = {}) {
   const path = `/v1/webhook/${webhookExternalId}`
-  return stubBuilder('PATCH', path, 200)
+  return stubBuilder('PATCH', path, 200, {
+    request: [{
+      op: 'replace',
+      path: opts.path,
+      value: opts.value
+    }],
+    query: {
+      service_id: opts.serviceExternalId,
+      gateway_account_id: opts.gatewayAccountId
+    }
+  })
 }
 
 module.exports = {

--- a/test/cypress/stubs/webhooks-stubs.js
+++ b/test/cypress/stubs/webhooks-stubs.js
@@ -82,17 +82,50 @@ function createWebhookViolatesBackend (opts = {}) {
   })
 }
 
-function patchUpdateWebhookSuccess (webhookExternalId, opts = {}) {
+/**
+ *
+ * @param {Number | String} gatewayAccountId
+ * @param {String} serviceExternalId
+ * @param {String} webhookExternalId
+ * @param {{ path: String, value: String }} patchOpts
+ * @returns {{predicates: [{deepEquals: {path, method}}|{equals: {path, method}}], name: string, responses: [{is: {headers, statusCode: *}}]}}
+ */
+function patchUpdateWebhookSuccess (gatewayAccountId, serviceExternalId, webhookExternalId, patchOpts) {
   const path = `/v1/webhook/${webhookExternalId}`
   return stubBuilder('PATCH', path, 200, {
     request: [{
       op: 'replace',
-      path: opts.path,
-      value: opts.value
+      path: patchOpts.path,
+      value: patchOpts.value
     }],
     query: {
-      service_id: opts.serviceExternalId,
-      gateway_account_id: opts.gatewayAccountId
+      service_id: serviceExternalId,
+      gateway_account_id: gatewayAccountId
+    }
+  })
+}
+
+/**
+ *
+ * @param {Number | String} gatewayAccountId
+ * @param {String} serviceExternalId
+ * @param {String} webhookExternalId
+ * @param {[{ path: String, value: String | Array }]} patches
+ * @returns {{predicates: [{deepEquals: {path, method}}|{equals: {path, method}}], name: string, responses: [{is: {headers, statusCode: *}}]}}
+ */
+function patchBatchUpdateWebhookSuccess (gatewayAccountId, serviceExternalId, webhookExternalId, patches) {
+  const path = `/v1/webhook/${webhookExternalId}`
+  return stubBuilder('PATCH', path, 200, {
+    request: patches.map(patch => {
+      return {
+        op: 'replace',
+        path: patch.path,
+        value: patch.value
+      }
+    }),
+    query: {
+      service_id: serviceExternalId,
+      gateway_account_id: gatewayAccountId
     }
   })
 }
@@ -106,5 +139,6 @@ module.exports = {
   getWebhookMessageAttempts,
   postCreateWebhookSuccess,
   createWebhookViolatesBackend,
-  patchUpdateWebhookSuccess
+  patchUpdateWebhookSuccess,
+  patchBatchUpdateWebhookSuccess
 }

--- a/test/cypress/stubs/zendesk-stubs.js
+++ b/test/cypress/stubs/zendesk-stubs.js
@@ -3,7 +3,9 @@
 const { stubBuilder } = require('./stub-builder')
 
 function createTicketSuccess () {
-  return stubBuilder('POST', '/zendesk/tickets', 200)
+  return stubBuilder('POST', '/zendesk/tickets', 200, {
+    deepMatchRequest: false
+  })
 }
 
 module.exports = {

--- a/test/fixtures/gateway-account.fixtures.js
+++ b/test/fixtures/gateway-account.fixtures.js
@@ -395,7 +395,7 @@ function validPostAccountSwitchPSPRequest (opts = {}) {
 function requestStripeTestAccountResponse (opts = {}) {
   return {
     stripe_connect_account_id: 'acct_1234',
-    gateway_account_id: '2',
+    gateway_account_id: opts.gateway_account_id || '2',
     gateway_account_external_id: opts.gateway_account_external_id || 'a-gateway-account-external-id'
   }
 }

--- a/test/fixtures/service.fixtures.js
+++ b/test/fixtures/service.fixtures.js
@@ -50,7 +50,7 @@ module.exports = {
     return {
       op: 'add',
       path: 'gateway_account_ids',
-      value: gatewayAccountIds
+      value: gatewayAccountIds.map(id => `${id}`)
     }
   },
 


### PR DESCRIPTION
### What
- Update stubs in Cypress tests to use full queries & request bodies where possible, use `deepMatchRequest: false` where not possible
- Fix a few bugs in Axios clients with logging metadata incorrectly being sent in requests