### PR TITLE
PP-12416: Card payment non-MOTO

### DIFF
--- a/src/controllers/simplified-account/settings/card-payments/apple-pay.controller.js
+++ b/src/controllers/simplified-account/settings/card-payments/apple-pay.controller.js
@@ -1,0 +1,30 @@
+const { response } = require('@utils/response')
+const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/format')
+const { ConnectorClient } = require('@services/clients/connector.client')
+const { onOrOffToBool } = require('@utils/on-or-off')
+const paths = require('@root/paths')
+
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+
+function get (req, res) {
+  const url = req.originalUrl.split('?')[0]
+  const applePay = req.account?.allowApplePay
+  response(req, res, 'simplified-account/settings/card-payments/apple-pay', {
+    formAction: url,
+    currentState: applePay ? 'on' : 'off'
+  })
+}
+
+async function post (req, res) {
+  const userPreference = onOrOffToBool(req.body.applePay)
+  const serviceExternalId = req.service.externalId
+  const gatewayAccountId = req.account.id
+  await connector.toggleApplePay(gatewayAccountId, userPreference)
+  req.flash('update', `Apple Pay successfully ${userPreference ? 'enabled' : 'disabled'}`)
+  res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.cardPayments.index, serviceExternalId, req.account.type))
+}
+
+module.exports = {
+  get,
+  post
+}

--- a/src/controllers/simplified-account/settings/card-payments/card-payments.controller.js
+++ b/src/controllers/simplified-account/settings/card-payments/card-payments.controller.js
@@ -1,8 +1,12 @@
 const { response } = require('@utils/response')
 const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
 const paths = require('@root/paths')
+const collectBillingAddress = require('./collect-billing-address.controller')
+const defaultBillingAddressCountry = require('./default-billing-address-country.controller')
+const applePay = require('./apple-pay.controller')
+const googlePay = require('./google-pay.controller')
 
-const GB_COUNTRY_CODE = 'GB'
+const GB_COUNTRY_CODE = defaultBillingAddressCountry.GB_COUNTRY_CODE
 
 function get (req, res) {
   const serviceExternalId = req.service.externalId
@@ -10,10 +14,10 @@ function get (req, res) {
   const cardPaymentsPaths = paths.simplifiedAccount.settings.cardPayments
 
   const billing = req.service.collectBillingAddress
-  const country = req.service.defaultBillingAddressCountry === GB_COUNTRY_CODE ? 'United Kingdom' : req.service.defaultBillingAddressCountry
-  const raw = req.account?.rawResponse
-  const applePay = raw?.allow_apple_pay
-  const googlePay = raw?.allow_google_pay
+  const country = req.service.defaultBillingAddressCountry === GB_COUNTRY_CODE ? 'United Kingdom' : 'None'
+  const account = req.account
+  const applePay = account?.allowApplePay
+  const googlePay = account?.allowGooglePay
 
   response(req, res, 'simplified-account/settings/card-payments/index', {
     collectBillingAddressEnabled: billing,
@@ -28,5 +32,9 @@ function get (req, res) {
 }
 
 module.exports = {
-  get
+  get,
+  collectBillingAddress,
+  defaultBillingAddressCountry,
+  applePay,
+  googlePay
 }

--- a/src/controllers/simplified-account/settings/card-payments/card-payments.controller.js
+++ b/src/controllers/simplified-account/settings/card-payments/card-payments.controller.js
@@ -14,6 +14,7 @@ function get (req, res) {
   const cardPaymentsPaths = paths.simplifiedAccount.settings.cardPayments
 
   const billing = req.service.collectBillingAddress
+  console.log("defaultBillingAddressCountry ", req.service.defaultBillingAddressCountry)
   const country = req.service.defaultBillingAddressCountry === GB_COUNTRY_CODE ? 'United Kingdom' : 'None'
   const account = req.account
   const applePay = account?.allowApplePay

--- a/src/controllers/simplified-account/settings/card-payments/card-payments.controller.js
+++ b/src/controllers/simplified-account/settings/card-payments/card-payments.controller.js
@@ -14,11 +14,12 @@ function get (req, res) {
   const cardPaymentsPaths = paths.simplifiedAccount.settings.cardPayments
 
   const billing = req.service.collectBillingAddress
-  console.log("defaultBillingAddressCountry ", req.service.defaultBillingAddressCountry)
   const country = req.service.defaultBillingAddressCountry === GB_COUNTRY_CODE ? 'United Kingdom' : 'None'
   const account = req.account
   const applePay = account?.allowApplePay
   const googlePay = account?.allowGooglePay
+
+  const userCanUpdatePaymentTypes = req.user.hasPermission(serviceExternalId, 'payment-types:update')
 
   response(req, res, 'simplified-account/settings/card-payments/index', {
     collectBillingAddressEnabled: billing,
@@ -28,7 +29,8 @@ function get (req, res) {
     applePayEnabled: applePay,
     applePayAddressLink: formatSimplifiedAccountPathsFor(cardPaymentsPaths.applePay, serviceExternalId, accountType),
     googlePayEnabled: googlePay,
-    googlePayAddressLink: formatSimplifiedAccountPathsFor(cardPaymentsPaths.googlePay, serviceExternalId, accountType)
+    googlePayAddressLink: formatSimplifiedAccountPathsFor(cardPaymentsPaths.googlePay, serviceExternalId, accountType),
+    userCanUpdatePaymentTypes
   })
 }
 

--- a/src/controllers/simplified-account/settings/card-payments/collect-billing-address.controller.js
+++ b/src/controllers/simplified-account/settings/card-payments/collect-billing-address.controller.js
@@ -1,0 +1,26 @@
+const { response } = require('@utils/response')
+const { toggleCollectBillingAddress } = require('@services/service.service')
+const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/format')
+const { onOrOffToBool } = require('@utils/on-or-off')
+const paths = require('@root/paths')
+
+function get (req, res) {
+  const url = req.originalUrl.split('?')[0]
+  response(req, res, 'simplified-account/settings/card-payments/collect-billing-address', {
+    formAction: url,
+    currentState: req.service.collectBillingAddress ? 'on' : 'off'
+  })
+}
+
+async function post (req, res) {
+  const userPreference = onOrOffToBool(req.body.collectBillingAddress)
+  const serviceExternalId = req.service.externalId
+  await toggleCollectBillingAddress(serviceExternalId, userPreference)
+  req.flash('update', `Collect billing address successfully ${userPreference ? 'enabled' : 'disabled'}`)
+  res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.cardPayments.index, serviceExternalId, req.account.type))
+}
+
+module.exports = {
+  get,
+  post
+}

--- a/src/controllers/simplified-account/settings/card-payments/default-billing-address-country.controller.js
+++ b/src/controllers/simplified-account/settings/card-payments/default-billing-address-country.controller.js
@@ -15,7 +15,7 @@ function get (req, res) {
 }
 
 async function post (req, res) {
-  const userPreference = onOrOffToBool(req.body.collectBillingAddress)
+  const userPreference = onOrOffToBool(req.body.defaultBillingAddress)
   const serviceExternalId = req.service.externalId
   await adminUsersClient.updateDefaultBillingAddressCountry(serviceExternalId, userPreference ? 'GB' : null)
   req.flash('update', `Default billing address country successfully ${userPreference ? 'enabled' : 'disabled'}`)

--- a/src/controllers/simplified-account/settings/card-payments/default-billing-address-country.controller.js
+++ b/src/controllers/simplified-account/settings/card-payments/default-billing-address-country.controller.js
@@ -1,0 +1,29 @@
+const { response } = require('@utils/response')
+const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/format')
+const { onOrOffToBool } = require('@utils/on-or-off')
+const paths = require('@root/paths')
+const getAdminUsersClient = require('@root/services/clients/adminusers.client')
+const adminUsersClient = getAdminUsersClient()
+const GB_COUNTRY_CODE = 'GB'
+
+function get (req, res) {
+  const url = req.originalUrl.split('?')[0]
+  response(req, res, 'simplified-account/settings/card-payments/default-billing-address-country', {
+    formAction: url,
+    currentState: req.service.defaultBillingAddressCountry === GB_COUNTRY_CODE ? 'on' : 'off'
+  })
+}
+
+async function post (req, res) {
+  const userPreference = onOrOffToBool(req.body.collectBillingAddress)
+  const serviceExternalId = req.service.externalId
+  await adminUsersClient.updateDefaultBillingAddressCountry(serviceExternalId, userPreference ? 'GB' : null)
+  req.flash('update', `Default billing address country successfully ${userPreference ? 'enabled' : 'disabled'}`)
+  res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.cardPayments.index, serviceExternalId, req.account.type))
+}
+
+module.exports = {
+  get,
+  post,
+  GB_COUNTRY_CODE
+}

--- a/src/controllers/simplified-account/settings/card-payments/google-pay.controller.js
+++ b/src/controllers/simplified-account/settings/card-payments/google-pay.controller.js
@@ -1,0 +1,30 @@
+const { response } = require('@utils/response')
+const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/format')
+const { ConnectorClient } = require('@services/clients/connector.client')
+const { onOrOffToBool } = require('@utils/on-or-off')
+const paths = require('@root/paths')
+
+const connector = new ConnectorClient(process.env.CONNECTOR_URL)
+
+function get (req, res) {
+  const url = req.originalUrl.split('?')[0]
+  const googlePay = req.account?.allowGooglePay
+  response(req, res, 'simplified-account/settings/card-payments/google-pay', {
+    formAction: url,
+    currentState: googlePay ? 'on' : 'off'
+  })
+}
+
+async function post (req, res) {
+  const userPreference = onOrOffToBool(req.body.googlePay)
+  const serviceExternalId = req.service.externalId
+  const gatewayAccountId = req.account.id
+  await connector.toggleGooglePay(gatewayAccountId, userPreference)
+  req.flash('update', `Google Pay successfully ${userPreference ? 'enabled' : 'disabled'}`)
+  res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.cardPayments.index, serviceExternalId, req.account.type))
+}
+
+module.exports = {
+  get,
+  post
+}

--- a/src/models/GatewayAccount.class.js
+++ b/src/models/GatewayAccount.class.js
@@ -11,6 +11,8 @@ const { GatewayAccountCredential, CREDENTIAL_STATE } = require('@models/gateway-
  * @property {boolean} toggle3ds - whether 3DS is enabled or not on this gateway account
  * @property {[GatewayAccountCredential]} gatewayAccountCredentials - available credentials for gateway account
  * @property {GatewayAccountCredential} [activeCredential] - the active credential for the gateway account
+ * @property {bool} allowApplePay - whether the gateway has Apple Pay enabled or not
+ * @property {bool} allowGooglePay - whether the gateway has Google Pay enabled or not
  * @property {Object} rawResponse - raw 'gateway account' object
  */
 class GatewayAccount {
@@ -49,6 +51,8 @@ class GatewayAccount {
     this.supports3ds = ['worldpay', 'stripe'].includes(gatewayAccountData.payment_provider)
     this.disableToggle3ds = gatewayAccountData.payment_provider === 'stripe'
     this.requires3ds = gatewayAccountData.requires3ds
+    this.allowGooglePay = gatewayAccountData.allow_google_pay
+    this.allowApplePay = gatewayAccountData.allow_apple_pay
     /** @deprecated this is a temporary compatability fix! If you find yourself using this for new code
      * you should instead add any rawResponse data as part of the constructor */
     this.rawResponse = gatewayAccountData

--- a/src/models/Service.class.js
+++ b/src/models/Service.class.js
@@ -12,6 +12,7 @@
  */
 class Service {
   constructor (serviceData) {
+    console.log('Service data', serviceData)
     this.id = serviceData.id
     this.externalId = serviceData.external_id
     this.name = serviceData.name

--- a/src/models/Service.class.js
+++ b/src/models/Service.class.js
@@ -12,7 +12,6 @@
  */
 class Service {
   constructor (serviceData) {
-    console.log('Service data', serviceData)
     this.id = serviceData.id
     this.externalId = serviceData.external_id
     this.name = serviceData.name

--- a/src/server.js
+++ b/src/server.js
@@ -26,7 +26,7 @@ const formatFutureStrategyAccountPathsFor = require('@utils/format-future-strate
 const formatServicePathsFor = require('@utils/format-service-paths-for')
 const healthcheckController = require('@controllers/healthcheck.controller')
 const { healthcheck } = require('@root/paths.js')
-const { boolToText, boolToOnOrOff } = require('@utils/bool-to-text')
+const { boolToText, boolToOnOrOff } = require('@utils/on-or-off')
 // Global constants
 const bindHost = (process.env.BIND_HOST || '127.0.0.1')
 const port = (process.env.PORT || 3000)

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -64,14 +64,14 @@ simplifiedAccount.post(paths.simplifiedAccount.settings.cardTypes.index, permiss
 
 // card payments
 simplifiedAccount.get(paths.simplifiedAccount.settings.cardPayments.index, permission('payment-types:read'), serviceSettingsController.cardPayments.get)
-simplifiedAccount.get(paths.simplifiedAccount.settings.cardPayments.collectBillingAddress, permission('payment-types:read'), serviceSettingsController.cardPayments.collectBillingAddress.get)
+simplifiedAccount.get(paths.simplifiedAccount.settings.cardPayments.collectBillingAddress, permission('payment-types:update'), serviceSettingsController.cardPayments.collectBillingAddress.get)
 simplifiedAccount.post(paths.simplifiedAccount.settings.cardPayments.collectBillingAddress, permission('payment-types:update'), serviceSettingsController.cardPayments.collectBillingAddress.post)
-simplifiedAccount.get(paths.simplifiedAccount.settings.cardPayments.defaultBillingAddressCountry, permission('payment-types:read'), serviceSettingsController.cardPayments.defaultBillingAddressCountry.get)
+simplifiedAccount.get(paths.simplifiedAccount.settings.cardPayments.defaultBillingAddressCountry, permission('payment-types:update'), serviceSettingsController.cardPayments.defaultBillingAddressCountry.get)
 simplifiedAccount.post(paths.simplifiedAccount.settings.cardPayments.defaultBillingAddressCountry, permission('payment-types:update'), serviceSettingsController.cardPayments.defaultBillingAddressCountry.post)
-simplifiedAccount.get(paths.simplifiedAccount.settings.cardPayments.applePay, permission('payment-types:read'), serviceSettingsController.cardPayments.applePay.get)
-simplifiedAccount.post(paths.simplifiedAccount.settings.cardPayments.applePay, permission('payment-types:read'), serviceSettingsController.cardPayments.applePay.post)
-simplifiedAccount.get(paths.simplifiedAccount.settings.cardPayments.googlePay, permission('payment-types:read'), serviceSettingsController.cardPayments.googlePay.get)
-simplifiedAccount.post(paths.simplifiedAccount.settings.cardPayments.googlePay, permission('payment-types:read'), serviceSettingsController.cardPayments.googlePay.post)
+simplifiedAccount.get(paths.simplifiedAccount.settings.cardPayments.applePay, permission('payment-types:update'), serviceSettingsController.cardPayments.applePay.get)
+simplifiedAccount.post(paths.simplifiedAccount.settings.cardPayments.applePay, permission('payment-types:update'), serviceSettingsController.cardPayments.applePay.post)
+simplifiedAccount.get(paths.simplifiedAccount.settings.cardPayments.googlePay, permission('payment-types:update'), serviceSettingsController.cardPayments.googlePay.get)
+simplifiedAccount.post(paths.simplifiedAccount.settings.cardPayments.googlePay, permission('payment-types:update'), serviceSettingsController.cardPayments.googlePay.post)
 
 // worldpay details
 simplifiedAccount.get(paths.simplifiedAccount.settings.worldpayDetails.index, enforcePaymentProviderType(WORLDPAY), permission('gateway-credentials:read'), serviceSettingsController.worldpayDetails.get)

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -64,6 +64,14 @@ simplifiedAccount.post(paths.simplifiedAccount.settings.cardTypes.index, permiss
 
 // card payments
 simplifiedAccount.get(paths.simplifiedAccount.settings.cardPayments.index, permission('payment-types:read'), serviceSettingsController.cardPayments.get)
+simplifiedAccount.get(paths.simplifiedAccount.settings.cardPayments.collectBillingAddress, permission('payment-types:read'), serviceSettingsController.cardPayments.collectBillingAddress.get)
+simplifiedAccount.post(paths.simplifiedAccount.settings.cardPayments.collectBillingAddress, permission('payment-types:update'), serviceSettingsController.cardPayments.collectBillingAddress.post)
+simplifiedAccount.get(paths.simplifiedAccount.settings.cardPayments.defaultBillingAddressCountry, permission('payment-types:read'), serviceSettingsController.cardPayments.defaultBillingAddressCountry.get)
+simplifiedAccount.post(paths.simplifiedAccount.settings.cardPayments.defaultBillingAddressCountry, permission('payment-types:update'), serviceSettingsController.cardPayments.defaultBillingAddressCountry.post)
+simplifiedAccount.get(paths.simplifiedAccount.settings.cardPayments.applePay, permission('payment-types:read'), serviceSettingsController.cardPayments.applePay.get)
+simplifiedAccount.post(paths.simplifiedAccount.settings.cardPayments.applePay, permission('payment-types:read'), serviceSettingsController.cardPayments.applePay.post)
+simplifiedAccount.get(paths.simplifiedAccount.settings.cardPayments.googlePay, permission('payment-types:read'), serviceSettingsController.cardPayments.googlePay.get)
+simplifiedAccount.post(paths.simplifiedAccount.settings.cardPayments.googlePay, permission('payment-types:read'), serviceSettingsController.cardPayments.googlePay.post)
 
 // worldpay details
 simplifiedAccount.get(paths.simplifiedAccount.settings.worldpayDetails.index, enforcePaymentProviderType(WORLDPAY), permission('gateway-credentials:read'), serviceSettingsController.worldpayDetails.get)

--- a/src/utils/bool-to-text.js
+++ b/src/utils/bool-to-text.js
@@ -1,8 +1,0 @@
-const boolToText = (input, trueText, falseText) => {
-  return input === true ? trueText : falseText
-}
-
-module.exports = {
-  boolToText,
-  boolToOnOrOff: (input) => boolToText(input, 'On', 'Off')
-}

--- a/src/utils/on-or-off.js
+++ b/src/utils/on-or-off.js
@@ -1,0 +1,21 @@
+const boolToText = (input, trueText, falseText) => {
+  return input === true ? trueText : falseText
+}
+
+const boolToOnOrOff = (input) => boolToText(input, 'On', 'Off')
+
+const onOrOffToBool = (userInput) => {
+  if (userInput === 'on') {
+    return true
+  }
+  if (userInput === 'off') {
+    return false
+  }
+  throw new Error('Value other than "on" or "off" used for boolean input.')
+}
+
+module.exports = {
+  boolToText,
+  boolToOnOrOff,
+  onOrOffToBool
+}

--- a/src/views/simplified-account/settings/card-payments/apple-pay.njk
+++ b/src/views/simplified-account/settings/card-payments/apple-pay.njk
@@ -27,11 +27,13 @@
       items: [
         {
           value: "on",
-          text: "On"
+          text: "On",
+          id: "apple-pay-on"
         },
         {
           value: "off",
-          text: "Off"
+          text: "Off",
+          id: "apple-pay-off"
         }
       ]
     }) }}

--- a/src/views/simplified-account/settings/card-payments/apple-pay.njk
+++ b/src/views/simplified-account/settings/card-payments/apple-pay.njk
@@ -5,6 +5,9 @@
 {% endblock %}
 
 {% block settingsContent %}
+  {% if isReadOnly %}
+    {% include "includes/settings-read-only.njk" %}
+  {% endif %}
   <h1 class="govuk-heading-l">Apple Pay</h1>
   <h2 class="govuk-heading-s">
     If you turn on Apple Pay:

--- a/src/views/simplified-account/settings/card-payments/apple-pay.njk
+++ b/src/views/simplified-account/settings/card-payments/apple-pay.njk
@@ -1,0 +1,44 @@
+{% extends "../settings-layout.njk" %}
+
+{% block settingsPageTitle %}
+  Card payments
+{% endblock %}
+
+{% block settingsContent %}
+  <h1 class="govuk-heading-l">Apple Pay</h1>
+  <h2 class="govuk-heading-s">
+    If you turn on Apple Pay:
+  </h2>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>corporate card fees cannot be applied to payments made with Apple Pay.</li>
+  </ul>
+
+  <form action="{{ formAction }}" method="post">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    {{ govukRadios({
+      name: "applePay",
+      fieldset: {
+        legend: {
+          text: "Apple Pay",
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      value: currentState,
+      items: [
+        {
+          value: "on",
+          text: "On"
+        },
+        {
+          value: "off",
+          text: "Off"
+        }
+      ]
+    }) }}
+
+    {{ govukButton({
+      text: "Save changes"
+    }) }}
+  </form>
+
+{% endblock %}

--- a/src/views/simplified-account/settings/card-payments/collect-billing-address.njk
+++ b/src/views/simplified-account/settings/card-payments/collect-billing-address.njk
@@ -5,6 +5,9 @@
 {% endblock %}
 
 {% block settingsContent %}
+  {% if isReadOnly %}
+    {% include "includes/settings-read-only.njk" %}
+  {% endif %}
   <h1 class="govuk-heading-l">Billing address</h1>
   <p class="govuk-body">Payment service providers (PSPs) use the billing address to carry out fraud checks.</p>
   <p class="govuk-body">If you turn off the billing address:</p>

--- a/src/views/simplified-account/settings/card-payments/collect-billing-address.njk
+++ b/src/views/simplified-account/settings/card-payments/collect-billing-address.njk
@@ -1,0 +1,44 @@
+{% extends "../settings-layout.njk" %}
+
+{% block settingsPageTitle %}
+  Card payments
+{% endblock %}
+
+{% block settingsContent %}
+  <h1 class="govuk-heading-l">Billing address</h1>
+  <p class="govuk-body">Payment service providers (PSPs) use the billing address to carry out fraud checks.</p>
+  <p class="govuk-body">If you turn off the billing address:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>your payment service provider (PSP) or your users’ banks may decline more payments — if you’re unsure, check with your PSP</li>
+    <li>your GOV.UK Pay integration may stop working correctly — if you’re unsure, check with your technical team</li>
+  </ul>
+
+  <form action="{{ formAction }}" method="post">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    {{ govukRadios({
+      name: "collectBillingAddress",
+      fieldset: {
+        legend: {
+          text: "Billing address",
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      value: currentState,
+      items: [
+        {
+          value: "on",
+          text: "On"
+        },
+        {
+          value: "off",
+          text: "Off"
+        }
+      ]
+    }) }}
+
+    {{ govukButton({
+      text: "Save changes"
+    }) }}
+  </form>
+
+{% endblock %}

--- a/src/views/simplified-account/settings/card-payments/collect-billing-address.njk
+++ b/src/views/simplified-account/settings/card-payments/collect-billing-address.njk
@@ -27,11 +27,13 @@
       items: [
         {
           value: "on",
-          text: "On"
+          text: "On",
+          id: "collect-billing-address-on"
         },
         {
           value: "off",
-          text: "Off"
+          text: "Off",
+          id: "collect-billing-address-off"
         }
       ]
     }) }}

--- a/src/views/simplified-account/settings/card-payments/default-billing-address-country.njk
+++ b/src/views/simplified-account/settings/card-payments/default-billing-address-country.njk
@@ -12,7 +12,7 @@
   <form action="{{ formAction }}" method="post">
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
     {{ govukRadios({
-      name: "collectBillingAddress",
+      name: "defaultBillingAddress",
       value: currentState,
       items: [
         {

--- a/src/views/simplified-account/settings/card-payments/default-billing-address-country.njk
+++ b/src/views/simplified-account/settings/card-payments/default-billing-address-country.njk
@@ -17,11 +17,13 @@
       items: [
         {
           value: "on",
-          text: "On"
+          text: "On",
+          id: "default-billing-address-on"
         },
         {
           value: "off",
-          text: "Off"
+          text: "Off",
+          id: "default-billing-address-off"
         }
       ]
     }) }}

--- a/src/views/simplified-account/settings/card-payments/default-billing-address-country.njk
+++ b/src/views/simplified-account/settings/card-payments/default-billing-address-country.njk
@@ -1,0 +1,34 @@
+{% extends "../settings-layout.njk" %}
+
+{% block settingsPageTitle %}
+  Card payments
+{% endblock %}
+
+{% block settingsContent %}
+  <h1 class="govuk-heading-l">Set United Kingdom as the default billing address country</h1>
+  <p class="govuk-body">By default, the country field in the user's billing address will be automatically populated
+    with United Kingdom. If your service frequently takes payments from overseas users, you can turn this off.</p>
+
+  <form action="{{ formAction }}" method="post">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    {{ govukRadios({
+      name: "collectBillingAddress",
+      value: currentState,
+      items: [
+        {
+          value: "on",
+          text: "On"
+        },
+        {
+          value: "off",
+          text: "Off"
+        }
+      ]
+    }) }}
+
+    {{ govukButton({
+      text: "Save changes"
+    }) }}
+  </form>
+
+{% endblock %}

--- a/src/views/simplified-account/settings/card-payments/default-billing-address-country.njk
+++ b/src/views/simplified-account/settings/card-payments/default-billing-address-country.njk
@@ -5,6 +5,9 @@
 {% endblock %}
 
 {% block settingsContent %}
+  {% if isReadOnly %}
+    {% include "includes/settings-read-only.njk" %}
+  {% endif %}
   <h1 class="govuk-heading-l">Set United Kingdom as the default billing address country</h1>
   <p class="govuk-body">By default, the country field in the user's billing address will be automatically populated
     with United Kingdom. If your service frequently takes payments from overseas users, you can turn this off.</p>

--- a/src/views/simplified-account/settings/card-payments/google-pay.njk
+++ b/src/views/simplified-account/settings/card-payments/google-pay.njk
@@ -5,6 +5,9 @@
 {% endblock %}
 
 {% block settingsContent %}
+  {% if isReadOnly %}
+    {% include "includes/settings-read-only.njk" %}
+  {% endif %}
   <h1 class="govuk-heading-l">Google Pay</h1>
   <h2 class="govuk-heading-s">
     If you turn on Google Pay:

--- a/src/views/simplified-account/settings/card-payments/google-pay.njk
+++ b/src/views/simplified-account/settings/card-payments/google-pay.njk
@@ -28,11 +28,13 @@
       items: [
         {
           value: "on",
-          text: "On"
+          text: "On",
+          id: "google-pay-on"
         },
         {
           value: "off",
-          text: "Off"
+          text: "Off",
+          id: "google-pay-off"
         }
       ]
     }) }}

--- a/src/views/simplified-account/settings/card-payments/google-pay.njk
+++ b/src/views/simplified-account/settings/card-payments/google-pay.njk
@@ -1,0 +1,45 @@
+{% extends "../settings-layout.njk" %}
+
+{% block settingsPageTitle %}
+  Card payments
+{% endblock %}
+
+{% block settingsContent %}
+  <h1 class="govuk-heading-l">Google Pay</h1>
+  <h2 class="govuk-heading-s">
+    If you turn on Google Pay:
+  </h2>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>your service will accept both credit and debit cards</li>
+    <li>corporate card fees cannot be applied to payments made with Google Pay</li>
+  </ul>
+
+  <form action="{{ formAction }}" method="post">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+    {{ govukRadios({
+      name: "googlePay",
+      fieldset: {
+        legend: {
+          text: "Google Pay",
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      value: currentState,
+      items: [
+        {
+          value: "on",
+          text: "On"
+        },
+        {
+          value: "off",
+          text: "Off"
+        }
+      ]
+    }) }}
+
+    {{ govukButton({
+      text: "Save changes"
+    }) }}
+  </form>
+
+{% endblock %}

--- a/src/views/simplified-account/settings/card-payments/index.njk
+++ b/src/views/simplified-account/settings/card-payments/index.njk
@@ -7,7 +7,9 @@
 {% endblock %}
 
 {% block settingsContent %}
-
+  {% if not userCanUpdatePaymentTypes %}
+    {% include "simplified-account/settings/partials/read-only-message.njk" %}
+  {% endif %}
   {% if flash.update %}
     {% set html %}
       <h3 class="govuk-notification-banner__heading">
@@ -44,7 +46,7 @@
             visuallyHiddenText: "collect billing address"
           }
         ]
-      }
+      } if userCanUpdatePaymentTypes
     },
     {
       key: {
@@ -62,7 +64,7 @@
             visuallyHiddenText: "default billing address country"
           }
         ]
-      }
+      } if userCanUpdatePaymentTypes
     }
   ]
 }) }}
@@ -89,7 +91,7 @@
             visuallyHiddenText: "Apple Pay"
           }
         ]
-      }
+      } if userCanUpdatePaymentTypes
     },
     {
       key: {
@@ -107,7 +109,7 @@
             visuallyHiddenText: "Google Pay"
           }
         ]
-      }
+      } if userCanUpdatePaymentTypes
     }
   ]
 }) }}

--- a/src/views/simplified-account/settings/card-payments/index.njk
+++ b/src/views/simplified-account/settings/card-payments/index.njk
@@ -1,10 +1,25 @@
 {% extends "../settings-layout.njk" %}
 
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
 {% block settingsPageTitle %}
   Card payments
 {% endblock %}
 
 {% block settingsContent %}
+
+  {% if flash.update %}
+    {% set html %}
+      <h3 class="govuk-notification-banner__heading">
+        {{ flash.update }}
+      </h3>
+    {% endset %}
+
+    {{ govukNotificationBanner({
+      html: html,
+      type: "success"
+    }) }}
+  {% endif %}
   <h1 class="govuk-heading-l">Card payments</h1>
   <p class="govuk-body">GOV.UK Pay uses 3D Secure for all card payments. 3D Secure (3DS) adds an extra layer of
     authentication to user payments.</p>

--- a/src/views/simplified-account/settings/card-types/index.njk
+++ b/src/views/simplified-account/settings/card-types/index.njk
@@ -6,11 +6,7 @@
 
 {% block settingsContent %}
   {% if not isAdminUser %}
-    {{ govukInsetText({
-      text: "You don’t have permission to manage settings. Contact your service admin if you would like to manage 3D Secure,
-          accepted card types, email notifications, billing address or mask card numbers or security codes for MOTO services.",
-      classes: "service-settings-inset-text--grey"
-    }) }}
+    {% include "simplified-account/settings/partials/read-only-message.njk" %}
   {% endif %}
 
   <h1 class="govuk-heading-l">Card types</h1>

--- a/src/views/simplified-account/settings/email-notifications/index.njk
+++ b/src/views/simplified-account/settings/email-notifications/index.njk
@@ -6,11 +6,7 @@
 
 {% block settingsContent %}
   {% if not isAdminUser %}
-    {{ govukInsetText({
-      text: "You don’t have permission to manage settings. Contact your service admin if you would like to manage 3D Secure,
-        accepted card types, email notifications, billing address or mask card numbers or security codes for MOTO services.",
-      classes: "service-settings-inset-text--grey"
-    }) }}
+    {% include "simplified-account/settings/partials/read-only-message.njk" %}
   {% endif %}
 
   <h1 class="govuk-heading-l">Email notifications</h1>

--- a/src/views/simplified-account/settings/partials/read-only-message.njk
+++ b/src/views/simplified-account/settings/partials/read-only-message.njk
@@ -1,0 +1,5 @@
+{{ govukInsetText({
+  text: "You don’t have permission to manage settings. Contact your service admin if you would like to manage 3D Secure,
+          accepted card types, email notifications, billing address or mask card numbers or security codes for MOTO services.",
+  classes: "service-settings-inset-text--grey"
+}) }}

--- a/test/cypress/integration/simplified-account/service-settings/card-payments/index.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/card-payments/index.cy.js
@@ -1,40 +1,11 @@
-const userStubs = require('@test/cypress/stubs/user-stubs')
-const gatewayAccountStubs = require('@test/cypress/stubs/gateway-account-stubs')
-const ROLES = require('@test/fixtures/roles.fixtures')
-
-const USER_EXTERNAL_ID = 'user-123-abc'
-const SERVICE_EXTERNAL_ID = 'service-456-def'
-const GATEWAY_ACCOUNT_ID = 11
-const ACCOUNT_TYPE = 'test'
+const {
+  setupStubs,
+  USER_EXTERNAL_ID,
+  SERVICE_EXTERNAL_ID,
+  ACCOUNT_TYPE
+} = require('@test/cypress/integration/simplified-account/service-settings/card-payments/util')
 
 const pageUrl = `/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/card-payments`
-
-const setupStubs = ({
-  role,
-  collectBillingAddress,
-  defaultBillingAddressCountry,
-  allowApplePay,
-  allowGooglePay,
-  serviceName
-} = {}) => {
-  cy.task('setupStubs', [
-    userStubs.getUserSuccess({
-      userExternalId: USER_EXTERNAL_ID,
-      gatewayAccountId: GATEWAY_ACCOUNT_ID,
-      serviceName: { en: serviceName ?? 'My card payment service' },
-      serviceExternalId: SERVICE_EXTERNAL_ID,
-      role: ROLES[role ?? 'admin'],
-      collectBillingAddress: collectBillingAddress ?? true,
-      defaultBillingAddressCountry: defaultBillingAddressCountry ?? 'GB',
-      features: 'degatewayaccountification' // TODO remove features once simplified accounts are live
-    }),
-    gatewayAccountStubs.getAccountByServiceIdAndAccountType(SERVICE_EXTERNAL_ID, ACCOUNT_TYPE, {
-      gateway_account_id: GATEWAY_ACCOUNT_ID,
-      allow_apple_pay: allowApplePay ?? true,
-      allow_google_pay: allowGooglePay ?? true
-    })
-  ])
-}
 
 describe('Card payments page', () => {
   beforeEach(() => {
@@ -55,7 +26,7 @@ describe('Card payments page', () => {
       it('should display the provided card payment details (version 1 - everything on)', () => {
         setupStubs({
           collectBillingAddress: true,
-          defaultBillingAddressCountry: 'GB',
+          isDefaultBillingAddressCountryUK: true,
           allowApplePay: true,
           allowGooglePay: true,
           serviceName: 'version 1'
@@ -86,7 +57,7 @@ describe('Card payments page', () => {
       it('should display the provided card payment details (version 2 - everything off)', () => {
         setupStubs({
           collectBillingAddress: false,
-          defaultBillingAddressCountry: 'IE',
+          isDefaultBillingAddressCountryUK: false,
           allowApplePay: false,
           allowGooglePay: false,
           serviceName: 'version 2'
@@ -100,7 +71,7 @@ describe('Card payments page', () => {
           })
           cy.get('.govuk-summary-list__row').eq(1).within(() => {
             cy.get('.govuk-summary-list__key').should('contain', 'Default billing address country')
-            cy.get('.govuk-summary-list__value').should('contain', 'IE')
+            cy.get('.govuk-summary-list__value').should('contain', 'None')
           })
         })
         cy.get('.govuk-summary-list').eq(1).within(() => {

--- a/test/cypress/integration/simplified-account/service-settings/card-payments/index.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/card-payments/index.cy.js
@@ -25,6 +25,7 @@ describe('Card payments page', () => {
 
       it('should display the provided card payment details (version 1 - everything on)', () => {
         setupStubs({
+          role: 'admin',
           collectBillingAddress: true,
           isDefaultBillingAddressCountryUK: true,
           allowApplePay: true,
@@ -32,6 +33,80 @@ describe('Card payments page', () => {
           serviceName: 'version 1'
         })
         cy.visit(pageUrl)
+        cy.get('.govuk-summary-list').eq(0).within(() => {
+          cy.get('.govuk-summary-list__row').eq(0).within(() => {
+            cy.get('.govuk-summary-list__key').should('contain', 'Collect billing address')
+            cy.get('.govuk-summary-list__value').should('contain', 'On')
+            cy.get('.govuk-summary-list__actions').should('contain', 'Change')
+          })
+          cy.get('.govuk-summary-list__row').eq(1).within(() => {
+            cy.get('.govuk-summary-list__key').should('contain', 'Default billing address country')
+            cy.get('.govuk-summary-list__value').should('contain', 'United Kingdom')
+            cy.get('.govuk-summary-list__actions').should('contain', 'Change')
+          })
+        })
+        cy.get('.govuk-summary-list').eq(1).within(() => {
+          cy.get('.govuk-summary-list__row').eq(0).within(() => {
+            cy.get('.govuk-summary-list__key').should('contain', 'Apple Pay')
+            cy.get('.govuk-summary-list__value').should('contain', 'On')
+            cy.get('.govuk-summary-list__actions').should('contain', 'Change')
+          })
+          cy.get('.govuk-summary-list__row').eq(1).within(() => {
+            cy.get('.govuk-summary-list__key').should('contain', 'Google Pay')
+            cy.get('.govuk-summary-list__value').should('contain', 'On')
+            cy.get('.govuk-summary-list__actions').should('contain', 'Change')
+          })
+        })
+      })
+
+      it('should display the provided card payment details (version 2 - everything off)', () => {
+        setupStubs({
+          role: 'admin',
+          collectBillingAddress: false,
+          isDefaultBillingAddressCountryUK: false,
+          allowApplePay: false,
+          allowGooglePay: false,
+          serviceName: 'version 2'
+        })
+
+        cy.visit(pageUrl)
+        cy.get('.govuk-summary-list').eq(0).within(() => {
+          cy.get('.govuk-summary-list__row').eq(0).within(() => {
+            cy.get('.govuk-summary-list__key').should('contain', 'Collect billing address')
+            cy.get('.govuk-summary-list__value').should('contain', 'Off')
+            cy.get('.govuk-summary-list__actions').should('contain', 'Change')
+          })
+          cy.get('.govuk-summary-list__row').eq(1).within(() => {
+            cy.get('.govuk-summary-list__key').should('contain', 'Default billing address country')
+            cy.get('.govuk-summary-list__value').should('contain', 'None')
+            cy.get('.govuk-summary-list__actions').should('contain', 'Change')
+          })
+        })
+        cy.get('.govuk-summary-list').eq(1).within(() => {
+          cy.get('.govuk-summary-list__row').eq(0).within(() => {
+            cy.get('.govuk-summary-list__key').should('contain', 'Apple Pay')
+            cy.get('.govuk-summary-list__value').should('contain', 'Off')
+            cy.get('.govuk-summary-list__actions').should('contain', 'Change')
+          })
+          cy.get('.govuk-summary-list__row').eq(1).within(() => {
+            cy.get('.govuk-summary-list__key').should('contain', 'Google Pay')
+            cy.get('.govuk-summary-list__value').should('contain', 'Off')
+            cy.get('.govuk-summary-list__actions').should('contain', 'Change')
+          })
+        })
+      })
+
+      it('should handle view only users', () => {
+        setupStubs({
+          role: 'view-only',
+          collectBillingAddress: true,
+          isDefaultBillingAddressCountryUK: true,
+          allowApplePay: true,
+          allowGooglePay: true,
+          serviceName: 'version 1'
+        })
+        cy.visit(pageUrl)
+        cy.get('.govuk-summary-list__actions').should('not.exist')
         cy.get('.govuk-summary-list').eq(0).within(() => {
           cy.get('.govuk-summary-list__row').eq(0).within(() => {
             cy.get('.govuk-summary-list__key').should('contain', 'Collect billing address')
@@ -54,37 +129,6 @@ describe('Card payments page', () => {
         })
       })
 
-      it('should display the provided card payment details (version 2 - everything off)', () => {
-        setupStubs({
-          collectBillingAddress: false,
-          isDefaultBillingAddressCountryUK: false,
-          allowApplePay: false,
-          allowGooglePay: false,
-          serviceName: 'version 2'
-        })
-
-        cy.visit(pageUrl)
-        cy.get('.govuk-summary-list').eq(0).within(() => {
-          cy.get('.govuk-summary-list__row').eq(0).within(() => {
-            cy.get('.govuk-summary-list__key').should('contain', 'Collect billing address')
-            cy.get('.govuk-summary-list__value').should('contain', 'Off')
-          })
-          cy.get('.govuk-summary-list__row').eq(1).within(() => {
-            cy.get('.govuk-summary-list__key').should('contain', 'Default billing address country')
-            cy.get('.govuk-summary-list__value').should('contain', 'None')
-          })
-        })
-        cy.get('.govuk-summary-list').eq(1).within(() => {
-          cy.get('.govuk-summary-list__row').eq(0).within(() => {
-            cy.get('.govuk-summary-list__key').should('contain', 'Apple Pay')
-            cy.get('.govuk-summary-list__value').should('contain', 'Off')
-          })
-          cy.get('.govuk-summary-list__row').eq(1).within(() => {
-            cy.get('.govuk-summary-list__key').should('contain', 'Google Pay')
-            cy.get('.govuk-summary-list__value').should('contain', 'Off')
-          })
-        })
-      })
     })
   })
 })

--- a/test/cypress/integration/simplified-account/service-settings/card-payments/updates.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/card-payments/updates.cy.js
@@ -1,0 +1,21 @@
+const {
+  setupStubs,
+  USER_EXTERNAL_ID,
+  SERVICE_EXTERNAL_ID,
+  ACCOUNT_TYPE
+} = require('@test/cypress/integration/simplified-account/service-settings/card-payments/util')
+
+const baseUrl = `/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/card-payments`
+
+describe('Card payment updates', () => {
+  beforeEach(() => {
+    cy.task('clearStubs')
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
+  })
+
+  it('should allow update of Collect billing address', () => {
+    setupStubs()
+    cy.visit(baseUrl + '/collect-billing-address')
+    cy.get('h1').should('contain.text', 'Billing address')
+  })
+})

--- a/test/cypress/integration/simplified-account/service-settings/card-payments/updates.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/card-payments/updates.cy.js
@@ -1,9 +1,11 @@
 const {
   setupStubs,
   USER_EXTERNAL_ID,
+  GATEWAY_ACCOUNT_ID,
   SERVICE_EXTERNAL_ID,
   ACCOUNT_TYPE
 } = require('@test/cypress/integration/simplified-account/service-settings/card-payments/util')
+const { patchUpdateDefaultBillingAddressCountrySuccess, patchUpdateCollectBillingAddressSuccess } = require('@test/cypress/stubs/service-stubs')
 
 const baseUrl = `/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/card-payments`
 
@@ -15,7 +17,57 @@ describe('Card payment updates', () => {
 
   it('should allow update of Collect billing address', () => {
     setupStubs()
+    cy.task('setupStubs', [
+      patchUpdateCollectBillingAddressSuccess({
+        gatewayAccountId: GATEWAY_ACCOUNT_ID,
+        serviceExternalId: SERVICE_EXTERNAL_ID,
+        collectBillingAddress: false
+      })
+    ])
     cy.visit(baseUrl + '/collect-billing-address')
     cy.get('h1').should('contain.text', 'Billing address')
+    cy.get('input#collectBillingAddress-2').click()
+    cy.contains('button', 'Save changes').click()
+    cy.get('#govuk-notification-banner-title').should('contain.text', 'Success')
   })
+
+  it('should allow update of Default billing address country', () => {
+    setupStubs({
+      isDefaultBillingAddressCountryUK: false
+    })
+    cy.task('setupStubs', [
+      patchUpdateDefaultBillingAddressCountrySuccess({
+        gatewayAccountId: GATEWAY_ACCOUNT_ID,
+        serviceExternalId: SERVICE_EXTERNAL_ID,
+        country: 'GB'
+      })
+    ])
+    cy.visit(baseUrl + '/default-billing-address-country')
+    cy.get('h1').should('contain.text', 'Set United Kingdom as the default billing address country')
+    cy.get('input#defaultBillingAddress').click()
+    cy.contains('button', 'Save changes').click()
+    cy.get('#govuk-notification-banner-title').should('contain.text', 'Success')
+  })
+
+  // it('should allow update of Apple Pay', () => {
+  //   setupStubs()
+  //   cy.visit(baseUrl + '/apple-pay')
+  //   cy.get('h1').should('contain.text', 'Apple Pay')
+  // })
+  //
+  // it('should allow update of Google Pay', () => {
+  //   setupStubs()
+  //   cy.visit(baseUrl + '/google-pay')
+  //   cy.get('h1').should('contain.text', 'Google Pay')
+  // })
 })
+
+function setupServicePatchStub () {
+  cy.task('setupStubs', [
+    patchUpdateDefaultBillingAddressCountrySuccess({
+      gatewayAccountId: GATEWAY_ACCOUNT_ID,
+      serviceExternalId: SERVICE_EXTERNAL_ID,
+      country: 'GB'
+    })
+  ])
+}

--- a/test/cypress/integration/simplified-account/service-settings/card-payments/updates.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/card-payments/updates.cy.js
@@ -5,7 +5,11 @@ const {
   SERVICE_EXTERNAL_ID,
   ACCOUNT_TYPE
 } = require('@test/cypress/integration/simplified-account/service-settings/card-payments/util')
-const { patchUpdateDefaultBillingAddressCountrySuccess, patchUpdateCollectBillingAddressSuccess } = require('@test/cypress/stubs/service-stubs')
+const {
+  patchUpdateDefaultBillingAddressCountrySuccess,
+  patchUpdateCollectBillingAddressSuccess
+} = require('@test/cypress/stubs/service-stubs')
+const { patchAccountUpdateApplePaySuccess, patchAccountUpdateGooglePaySuccess } = require('@test/cypress/stubs/gateway-account-stubs')
 
 const baseUrl = `/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/card-payments`
 
@@ -16,7 +20,9 @@ describe('Card payment updates', () => {
   })
 
   it('should allow update of Collect billing address', () => {
-    setupStubs()
+    setupStubs({
+      collectBillingAddress: true
+    })
     cy.task('setupStubs', [
       patchUpdateCollectBillingAddressSuccess({
         gatewayAccountId: GATEWAY_ACCOUNT_ID,
@@ -26,7 +32,7 @@ describe('Card payment updates', () => {
     ])
     cy.visit(baseUrl + '/collect-billing-address')
     cy.get('h1').should('contain.text', 'Billing address')
-    cy.get('input#collectBillingAddress-2').click()
+    cy.get('input#collect-billing-address-off').click()
     cy.contains('button', 'Save changes').click()
     cy.get('#govuk-notification-banner-title').should('contain.text', 'Success')
   })
@@ -44,30 +50,36 @@ describe('Card payment updates', () => {
     ])
     cy.visit(baseUrl + '/default-billing-address-country')
     cy.get('h1').should('contain.text', 'Set United Kingdom as the default billing address country')
-    cy.get('input#defaultBillingAddress').click()
+    cy.get('input#default-billing-address-on').click()
     cy.contains('button', 'Save changes').click()
     cy.get('#govuk-notification-banner-title').should('contain.text', 'Success')
   })
 
-  // it('should allow update of Apple Pay', () => {
-  //   setupStubs()
-  //   cy.visit(baseUrl + '/apple-pay')
-  //   cy.get('h1').should('contain.text', 'Apple Pay')
-  // })
-  //
-  // it('should allow update of Google Pay', () => {
-  //   setupStubs()
-  //   cy.visit(baseUrl + '/google-pay')
-  //   cy.get('h1').should('contain.text', 'Google Pay')
-  // })
-})
-
-function setupServicePatchStub () {
-  cy.task('setupStubs', [
-    patchUpdateDefaultBillingAddressCountrySuccess({
-      gatewayAccountId: GATEWAY_ACCOUNT_ID,
-      serviceExternalId: SERVICE_EXTERNAL_ID,
-      country: 'GB'
+  it('should allow update of Apple Pay', () => {
+    setupStubs({
+      allowApplePay: false
     })
-  ])
-}
+    cy.task('setupStubs', [
+      patchAccountUpdateApplePaySuccess(GATEWAY_ACCOUNT_ID, true)
+    ])
+    cy.visit(baseUrl + '/apple-pay')
+    cy.get('h1').should('contain.text', 'Apple Pay')
+    cy.get('input#apple-pay-on').click()
+    cy.contains('button', 'Save changes').click()
+    cy.get('#govuk-notification-banner-title').should('contain.text', 'Success')
+  })
+
+  it('should allow update of Google Pay', () => {
+    setupStubs({
+      allowGooglePay: false
+    })
+    cy.task('setupStubs', [
+      patchAccountUpdateGooglePaySuccess(GATEWAY_ACCOUNT_ID, true)
+    ])
+    cy.visit(baseUrl + '/google-pay')
+    cy.get('h1').should('contain.text', 'Google Pay')
+    cy.get('input#google-pay-on').click()
+    cy.contains('button', 'Save changes').click()
+    cy.get('#govuk-notification-banner-title').should('contain.text', 'Success')
+  })
+})

--- a/test/cypress/integration/simplified-account/service-settings/card-payments/util.js
+++ b/test/cypress/integration/simplified-account/service-settings/card-payments/util.js
@@ -1,0 +1,53 @@
+const userStubs = require('@test/cypress/stubs/user-stubs')
+const ROLES = require('@test/fixtures/roles.fixtures')
+const gatewayAccountStubs = require('@test/cypress/stubs/gateway-account-stubs')
+
+const USER_EXTERNAL_ID = 'user-123-abc'
+const SERVICE_EXTERNAL_ID = 'service-456-def'
+const GATEWAY_ACCOUNT_ID = 11
+const ACCOUNT_TYPE = 'test'
+
+const setupStubs = ({
+  role,
+  collectBillingAddress,
+  isDefaultBillingAddressCountryUK,
+  allowApplePay,
+  allowGooglePay,
+  serviceName
+} = {}) => {
+  cy.task('setupStubs', [
+    userStubs.getUserSuccess({
+      userExternalId: USER_EXTERNAL_ID,
+      gatewayAccountId: GATEWAY_ACCOUNT_ID,
+      serviceName: { en: serviceName ?? 'My card payment service' },
+      serviceExternalId: SERVICE_EXTERNAL_ID,
+      role: ROLES[role ?? 'admin'],
+      collectBillingAddress: collectBillingAddress ?? true,
+      defaultBillingAddressCountry: getDefaultBillingAddressCountry(isDefaultBillingAddressCountryUK),
+      features: 'degatewayaccountification' // TODO remove features once simplified accounts are live
+    }),
+    gatewayAccountStubs.getAccountByServiceIdAndAccountType(SERVICE_EXTERNAL_ID, ACCOUNT_TYPE, {
+      gateway_account_id: GATEWAY_ACCOUNT_ID,
+      allow_apple_pay: allowApplePay ?? true,
+      allow_google_pay: allowGooglePay ?? true
+    })
+  ])
+}
+
+function getDefaultBillingAddressCountry (isDefaultBillingAddressCountryUK) {
+  if (isDefaultBillingAddressCountryUK === undefined) {
+    return 'GB'
+  }
+  if (isDefaultBillingAddressCountryUK === false) {
+    return null
+  }
+  return 'GB'
+}
+
+module.exports = {
+  setupStubs,
+  USER_EXTERNAL_ID,
+  SERVICE_EXTERNAL_ID,
+  GATEWAY_ACCOUNT_ID,
+  ACCOUNT_TYPE
+}

--- a/test/cypress/stubs/service-stubs.js
+++ b/test/cypress/stubs/service-stubs.js
@@ -115,6 +115,18 @@ function patchUpdateServiceGatewayAccounts (opts) {
   })
 }
 
+function patchUpdateCollectBillingAddressSuccess (opts) {
+  const path = `/v1/api/services/${opts.serviceExternalId}`
+  return stubBuilder('PATCH', path, 200, {
+    request: serviceFixtures.validCollectBillingAddressToggleRequest({ enabled: opts.collectBillingAddress }),
+    response: serviceFixtures.validServiceResponse({
+      external_id: opts.serviceExternalId,
+      gateway_account_ids: [opts.gatewayAccountId],
+      collect_billing_address: opts.collectBillingAddress
+    })
+  })
+}
+
 function patchUpdateDefaultBillingAddressCountrySuccess (opts) {
   const path = `/v1/api/services/${opts.serviceExternalId}`
   return stubBuilder('PATCH', path, 200, {
@@ -136,5 +148,6 @@ module.exports = {
   patchGoLiveStageFailure,
   patchUpdateServicePspTestAccountStage,
   patchUpdateServiceGatewayAccounts,
+  patchUpdateCollectBillingAddressSuccess,
   patchUpdateDefaultBillingAddressCountrySuccess
 }

--- a/test/cypress/stubs/user-stubs.js
+++ b/test/cypress/stubs/user-stubs.js
@@ -233,9 +233,7 @@ function getUserSuccessRespondDifferentlySecondTime (userExternalId, firstRespon
 }
 
 function buildServiceRoleOpts (opts) {
-  const service = {
-    default_billing_address_country: opts.defaultBillingAddressCountry
-  }
+  const service = {}
 
   if (opts.gatewayAccountId) {
     service.gateway_account_ids = [String(opts.gatewayAccountId)]
@@ -268,7 +266,7 @@ function buildServiceRoleOpts (opts) {
   if (opts.collectBillingAddress) {
     service.collect_billing_address = opts.collectBillingAddress
   }
-  if (opts.defaultBillingAddressCountry) {
+  if (Object.hasOwnProperty.apply(opts, ['defaultBillingAddressCountry'])) {
     service.default_billing_address_country = opts.defaultBillingAddressCountry
   }
 

--- a/test/fixtures/service.fixtures.js
+++ b/test/fixtures/service.fixtures.js
@@ -154,7 +154,7 @@ module.exports = {
 
     if (opts.default_billing_address_country !== null) {
       service.default_billing_address_country = opts.default_billing_address_country === undefined
-        ? 'GB'
+        ? 'GB2 - ' + JSON.stringify(opts.default_billing_address_country)
         : opts.default_billing_address_country
     }
 


### PR DESCRIPTION
(draft while waiting for a content review)

### WHAT
Adding card payments pages for simplified accounts

### HOW 
Added using the standard approach, also introduced a partial for the read only message

### SCREENS

![Screenshot 2025-01-24 at 17 18 37](https://github.com/user-attachments/assets/d4f55c02-f128-4758-9351-c4c8f40d0fc5)
![Screenshot 2025-01-24 at 17 18 26](https://github.com/user-attachments/assets/f0bde554-bade-4574-8a37-e49516925492)
![Screenshot 2025-01-24 at 17 18 10](https://github.com/user-attachments/assets/70873e57-232c-453b-8792-5658c48e36ed)
![Screenshot 2025-01-24 at 17 17 58](https://github.com/user-attachments/assets/43b9cf1e-d005-4219-8675-0f78877f6871)
![Screenshot 2025-01-24 at 17 17 24](https://github.com/user-attachments/assets/b39abd69-1314-45e5-bd2d-8ba3db8c4d8c)

Paired with @kerrr 
