### PR TITLE
PP-12440 Worldpay Details Settings - one off card payments & 3ds flex credentials skeleton

### DIFF
--- a/src/controllers/simplified-account/settings/worldpay-details/flex-credentials/worldpay-flex-credentials.controller.js
+++ b/src/controllers/simplified-account/settings/worldpay-details/flex-credentials/worldpay-flex-credentials.controller.js
@@ -1,0 +1,14 @@
+const { response } = require('@utils/response')
+const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
+const paths = require('@root/paths')
+
+function get (req, res) {
+  return response(req, res, 'simplified-account/settings/worldpay-details/flex-credentials', {
+    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.index,
+      req.service.externalId, req.account.type)
+  })
+}
+
+module.exports = {
+  get
+}

--- a/src/controllers/simplified-account/settings/worldpay-details/worldpay-details.controller.js
+++ b/src/controllers/simplified-account/settings/worldpay-details/worldpay-details.controller.js
@@ -12,5 +12,8 @@ function get (req, res) {
   return response(req, res, 'simplified-account/settings/worldpay-details/index', context)
 }
 
-module.exports.get = get
-module.exports.worldpayCredentials = require('./credentials/worldpay-credentials.controller')
+module.exports = {
+  get,
+  oneOffCustomerInitiatedCredentials: require('./credentials/worldpay-credentials.controller'),
+  flexCredentials: require('./flex-credentials/worldpay-flex-credentials.controller')
+}

--- a/src/models/WorldpayTasks.class.js
+++ b/src/models/WorldpayTasks.class.js
@@ -22,7 +22,7 @@ class WorldpayTasks {
       this.tasks.push(WorldpayTask.flexCredentialsTask(serviceExternalId, gatewayAccount.type))
     }
 
-    this.incompleteTasks = this.tasks.filter(t => !(t.complete === true)).length > 0
+    this.incompleteTasks = this.tasks.filter(t => t.complete !== true).length > 0
   }
 
   static async recalculate (serviceExternalId, accountType) {

--- a/src/models/WorldpayTasks.class.js
+++ b/src/models/WorldpayTasks.class.js
@@ -8,7 +8,7 @@ const connectorClient = new Connector(process.env.CONNECTOR_URL)
 class WorldpayTasks {
   /**
    * @param {GatewayAccount} gatewayAccount
-   * @param {Service} service
+   * @param {String} serviceExternalId
    */
   constructor (gatewayAccount, serviceExternalId) {
     this.tasks = []
@@ -16,41 +16,85 @@ class WorldpayTasks {
 
     const credential = gatewayAccount.getCurrentCredential()
 
-    if (gatewayAccount.allowMoto) {
-      const worldpayCredentials = {
-        href: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.oneOffCustomerInitiated,
-          serviceExternalId, gatewayAccount.type),
-        id: 'worldpay-credentials',
-        linkText: 'Link your Worldpay account with GOV.UK Pay'
+    this.tasks.push(WorldpayTask.oneOffCustomerInitiatedCredentialsTask(serviceExternalId, gatewayAccount.type, credential))
 
-      }
-      if (!credential || !credential.credentials.oneOffCustomerInitiated) {
-        worldpayCredentials.complete = false
-      } else {
-        worldpayCredentials.complete = true
-        worldpayCredentials.completedCard = {
-          title: 'Account credentials',
-          rows: [{
-            keyText: 'Merchant code',
-            valueText: credential.credentials?.oneOffCustomerInitiated?.merchantCode
-          }, {
-            keyText: 'Username',
-            valueText: credential.credentials?.oneOffCustomerInitiated?.username
-          }, {
-            keyText: 'Password',
-            valueText: '●●●●●●●●'
-          }]
-        }
-      }
-      this.tasks.push(worldpayCredentials)
+    if (!gatewayAccount.allowMoto) {
+      this.tasks.push(WorldpayTask.flexCredentialsTask(serviceExternalId, gatewayAccount.type))
     }
 
-    this.incompleteTasks = this.tasks.filter(t => t.complete === false).length > 0
+    this.incompleteTasks = this.tasks.filter(t => !(t.complete === true)).length > 0
   }
 
   static async recalculate (serviceExternalId, accountType) {
     const gatewayAccount = await connectorClient.getAccountByServiceExternalIdAndAccountType({ serviceExternalId, accountType })
     return new WorldpayTasks(gatewayAccount, serviceExternalId)
+  }
+}
+
+class WorldpayTask {
+  constructor (href, id, linkText) {
+    this.href = href
+    this.id = id
+    this.linkText = linkText
+    this.complete = false
+  }
+
+  setComplete (isComplete) {
+    this.complete = isComplete
+  }
+
+  setCompletedCard (card) {
+    this.completedCard = card
+  }
+
+  /**
+   * @param {String} serviceExternalId
+   * @param {String} accountType
+   * @returns {WorldpayTask}
+   */
+  static flexCredentialsTask (serviceExternalId, accountType) {
+    const task = new WorldpayTask(
+      formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.flexCredentials,
+        serviceExternalId, accountType),
+      '3ds-flex-credentials',
+      'Configure 3DS'
+    )
+    return task
+  }
+
+  /**
+   * @param {String} serviceExternalId
+   * @param {String} accountType
+   * @param {GatewayAccountCredential} credential
+   * @returns {WorldpayTask}
+   */
+  static oneOffCustomerInitiatedCredentialsTask (serviceExternalId, accountType, credential) {
+    const task = new WorldpayTask(
+      formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.oneOffCustomerInitiated,
+        serviceExternalId, accountType),
+      'worldpay-credentials',
+      'Link your Worldpay account with GOV.UK Pay'
+    )
+    if (!credential || !credential.credentials.oneOffCustomerInitiated) {
+      task.setComplete(false)
+    } else {
+      task.setComplete(true)
+      task.setCompletedCard({
+        title: 'Account credentials',
+        rows: [{
+          keyText: 'Merchant code',
+          valueText: credential.credentials?.oneOffCustomerInitiated?.merchantCode
+        }, {
+          keyText: 'Username',
+          valueText: credential.credentials?.oneOffCustomerInitiated?.username
+        }, {
+          keyText: 'Password',
+          valueText: '●●●●●●●●'
+        }]
+      })
+    }
+
+    return task
   }
 }
 

--- a/src/paths.js
+++ b/src/paths.js
@@ -215,7 +215,8 @@ module.exports = {
       },
       worldpayDetails: {
         index: '/settings/worldpay-details',
-        oneOffCustomerInitiated: '/settings/worldpay-details/one-off-customer-initiated'
+        oneOffCustomerInitiated: '/settings/worldpay-details/one-off-customer-initiated',
+        flexCredentials: '/settings/worldpay-details/flex-credentials'
       },
       cardPayments: {
         index: '/settings/card-payments',

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -67,8 +67,9 @@ simplifiedAccount.get(paths.simplifiedAccount.settings.cardPayments.index, permi
 
 // worldpay details
 simplifiedAccount.get(paths.simplifiedAccount.settings.worldpayDetails.index, enforcePaymentProviderType(WORLDPAY), permission('gateway-credentials:read'), serviceSettingsController.worldpayDetails.get)
-simplifiedAccount.get(paths.simplifiedAccount.settings.worldpayDetails.oneOffCustomerInitiated, enforcePaymentProviderType(WORLDPAY), permission('gateway-credentials:update'), serviceSettingsController.worldpayDetails.worldpayCredentials.get)
-simplifiedAccount.post(paths.simplifiedAccount.settings.worldpayDetails.oneOffCustomerInitiated, enforcePaymentProviderType(WORLDPAY), permission('gateway-credentials:update'), serviceSettingsController.worldpayDetails.worldpayCredentials.post)
+simplifiedAccount.get(paths.simplifiedAccount.settings.worldpayDetails.oneOffCustomerInitiated, enforcePaymentProviderType(WORLDPAY), permission('gateway-credentials:update'), serviceSettingsController.worldpayDetails.oneOffCustomerInitiatedCredentials.get)
+simplifiedAccount.post(paths.simplifiedAccount.settings.worldpayDetails.oneOffCustomerInitiated, enforcePaymentProviderType(WORLDPAY), permission('gateway-credentials:update'), serviceSettingsController.worldpayDetails.oneOffCustomerInitiatedCredentials.post)
+simplifiedAccount.get(paths.simplifiedAccount.settings.worldpayDetails.flexCredentials, enforcePaymentProviderType(WORLDPAY), permission('gateway-credentials:update'), serviceSettingsController.worldpayDetails.flexCredentials.get)
 
 // card types
 simplifiedAccount.get(paths.simplifiedAccount.settings.cardTypes.index, permission('transactions:read'), serviceSettingsController.cardTypes.get)

--- a/src/views/simplified-account/settings/worldpay-details/flex-credentials.njk
+++ b/src/views/simplified-account/settings/worldpay-details/flex-credentials.njk
@@ -1,12 +1,11 @@
 {% extends "../settings-layout.njk" %}
 
 {% block settingsPageTitle %}
-  Worldpay details
+  Your Worldpay 3ds Flex credentials
 {% endblock %}
 
 {% block settingsContent %}
   <h1 class="govuk-heading-l">Your Worldpay 3ds Flex credentials</h1>
-
 
   <form id="credentials-form" method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
@@ -32,7 +31,7 @@
           text: 'Issuer (API ID)'
         },
         hint: {
-          text: 'Provided to you by Worldpay. For example, ‘5bd9e0e4444dce153428c940’.'
+          text: 'Provided to you by Worldpay. For example, ‘5bd9e0e4444dce15fed8c940’.'
         },
         id: 'issuer',
         name: 'issuer',

--- a/src/views/simplified-account/settings/worldpay-details/flex-credentials.njk
+++ b/src/views/simplified-account/settings/worldpay-details/flex-credentials.njk
@@ -1,0 +1,69 @@
+{% extends "../settings-layout.njk" %}
+
+{% block settingsPageTitle %}
+  Worldpay details
+{% endblock %}
+
+{% block settingsContent %}
+  <h1 class="govuk-heading-l">Your Worldpay 3ds Flex credentials</h1>
+
+
+  <form id="credentials-form" method="post" novalidate>
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
+
+    {{
+      govukInput({
+        label: {
+          text: 'Organisational Unit ID'
+        },
+        hint: {
+          text: 'Provided to you by Worldpay. For example, ‘5bd9b55e4444761ac0af1c80’.'
+        },
+        id: 'organisational-unit-id',
+        name: 'organisationalUnitId',
+        classes: 'govuk-input--width-20',
+        type: 'text'
+      })
+    }}
+
+    {{
+      govukInput({
+        label: {
+          text: 'Issuer (API ID)'
+        },
+        hint: {
+          text: 'Provided to you by Worldpay. For example, ‘5bd9e0e4444dce153428c940’.'
+        },
+        id: 'issuer',
+        name: 'issuer',
+        classes: 'govuk-input--width-20',
+        type: 'text'
+      })
+    }}
+
+    {{
+      govukInput({
+        label: {
+          text: 'JWT MAC key (API key)'
+        },
+        hint: {
+          text: 'Provided to you by Worldpay. For example, ‘fa2daee2-1fbb-45ff-4444-52805d5cd9e0’.'
+        },
+        id: 'jwt-mac-key',
+        name: 'jwtMacKey',
+        classes: "govuk-input--width-20",
+        type: 'password',
+        autocomplete: 'off'
+      })
+    }}
+
+    {{
+    govukButton({
+      text: 'Save credentials',
+      attributes: {
+        id: 'submitCredentials'
+      }
+    })
+    }}
+  </form>
+{% endblock %}

--- a/src/views/simplified-account/settings/worldpay-details/flex-credentials.njk
+++ b/src/views/simplified-account/settings/worldpay-details/flex-credentials.njk
@@ -1,11 +1,11 @@
 {% extends "../settings-layout.njk" %}
 
 {% block settingsPageTitle %}
-  Your Worldpay 3ds Flex credentials
+  Your Worldpay 3DS Flex credentials
 {% endblock %}
 
 {% block settingsContent %}
-  <h1 class="govuk-heading-l">Your Worldpay 3ds Flex credentials</h1>
+  <h1 class="govuk-heading-l">Your Worldpay 3DS Flex credentials</h1>
 
   <form id="credentials-form" method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />

--- a/src/views/simplified-account/settings/worldpay-details/index.njk
+++ b/src/views/simplified-account/settings/worldpay-details/index.njk
@@ -24,7 +24,7 @@
             text: "Not yet started",
             classes: "govuk-tag--blue"
           }
-        } if task.complete == false else (
+        } if not (task.complete == true) else (
           {
             tag: {
               text: "Completed",


### PR DESCRIPTION
### WHAT
 - Update one-off customer initiated credentials task to show for all Worldpay accounts
 - add skeleton for 3ds flex credentials task for non-MOTO accounts
   - currently has a basic task object, basic controller with GET endpoint, and nunjucks template for flex credentials form

Tasks for non-MOTO service:

![Screenshot 2025-01-27 at 14-48-34 Settings - Worldpay details - GOV UK Pay](https://github.com/user-attachments/assets/8e8aae01-c813-4029-b312-2f7462c09714)

3ds Flex Credentials form:

![Screenshot 2025-01-27 at 16-20-09 Settings - Your Worldpay 3ds Flex credentials - GOV UK Pay](https://github.com/user-attachments/assets/a5228f01-c094-43d1-b8cd-1f4d5f41ff71)
