### PR TITLE
PP-13136 Create webhook page

### DIFF
--- a/src/controllers/simplified-account/settings/team-members/team-members.controller.test.js
+++ b/src/controllers/simplified-account/settings/team-members/team-members.controller.test.js
@@ -60,7 +60,6 @@ describe('Controller: settings/team-members', () => {
     it('should call the response method', () => {
       expect(mockGetServiceUsers.called).to.be.true // eslint-disable-line
       expect(mockResponse.called).to.be.true // eslint-disable-line
-      expect(mockResponse.called).to.be.true // eslint-disable-line
     })
 
     it('should pass req, res and template path to the response method', () => {

--- a/src/controllers/simplified-account/settings/webhooks/create/create.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/create/create.controller.js
@@ -1,9 +1,22 @@
 const { response } = require('@utils/response')
+const { constants } = require('@govuk-pay/pay-js-commons')
+const formatSimplifiedAccountPathsFor = require('../../../../../utils/simplified-account/format/format-simplified-account-paths-for')
+const paths = require('@root/paths')
 
 async function get (req, res) {
-  response(req, res, 'simplified-account/settings/webhooks/create', {})
+  response(req, res, 'simplified-account/settings/webhooks/create', {
+    eventTypes: constants.webhooks.humanReadableSubscriptions,
+    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type)
+  })
+}
+
+async function post (req, res) {
+  // TODO: implement post controller
+  res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type)
+  )
 }
 
 module.exports = {
-  get
+  get,
+  post
 }

--- a/src/controllers/simplified-account/settings/webhooks/create/create.controller.test.js
+++ b/src/controllers/simplified-account/settings/webhooks/create/create.controller.test.js
@@ -1,0 +1,39 @@
+const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
+const { expect } = require('chai')
+const sinon = require('sinon')
+
+const ACCOUNT_TYPE = 'test'
+const SERVICE_ID = 'service-id-123abc'
+
+const mockResponse = sinon.spy()
+
+const { req, res, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/webhooks/create/create.controller')
+  .withServiceExternalId(SERVICE_ID)
+  .withAccountType(ACCOUNT_TYPE)
+  .withStubs({
+    '@utils/response': { response: mockResponse }
+  })
+  .build()
+
+describe('Controller: settings/webhooks', () => {
+  describe('get', () => {
+    before(() => {
+      call('get')
+    })
+
+    it('should call the response method', () => {
+      expect(mockResponse.called).to.be.true // eslint-disable-line
+    })
+
+    it('should pass req, res and template path to the response method', () => {
+      expect(mockResponse.args[0]).to.include(req)
+      expect(mockResponse.args[0]).to.include(res)
+      expect(mockResponse.args[0]).to.include('simplified-account/settings/webhooks/create')
+    })
+
+    it('should pass context data to the response method', () => {
+      expect(mockResponse.args[0][3]).to.have.property('eventTypes').to.have.property('CARD_PAYMENT_SUCCEEDED').to.equal('Payment succeeded')
+      expect(mockResponse.args[0][3]).to.have.property('backLink').to.equal('/simplified/service/service-id-123abc/account/test/settings/webhooks')
+    })
+  })
+})

--- a/src/controllers/simplified-account/settings/webhooks/webhooks.controller.test.js
+++ b/src/controllers/simplified-account/settings/webhooks/webhooks.controller.test.js
@@ -37,7 +37,6 @@ describe('Controller: settings/webhooks', () => {
     it('should call the response method', () => {
       expect(mockListWebhooks.calledWith(SERVICE_ID, GATEWAY_ACCOUNT_ID, false)).to.be.true // eslint-disable-line
       expect(mockResponse.called).to.be.true // eslint-disable-line
-      expect(mockResponse.called).to.be.true // eslint-disable-line
     })
 
     it('should pass req, res and template path to the response method', () => {

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -87,6 +87,7 @@ simplifiedAccount.get(paths.simplifiedAccount.settings.apiKeys.revokedKeys, perm
 // webhooks
 simplifiedAccount.get(paths.simplifiedAccount.settings.webhooks.index, permission('webhooks:read'), serviceSettingsController.webhooks.get)
 simplifiedAccount.get(paths.simplifiedAccount.settings.webhooks.create, permission('webhooks:read'), serviceSettingsController.webhooks.create.get)
+simplifiedAccount.post(paths.simplifiedAccount.settings.webhooks.create, permission('webhooks:update'), serviceSettingsController.webhooks.create.post)
 
 // stripe details
 const stripeDetailsPath = paths.simplifiedAccount.settings.stripeDetails

--- a/src/views/simplified-account/settings/webhooks/create.njk
+++ b/src/views/simplified-account/settings/webhooks/create.njk
@@ -1,10 +1,68 @@
 {% extends "../settings-layout.njk" %}
 
-{% block settingsPageTitle %}
-  Create a webhook
-{% endblock %}
+{% set settingsPageTitle = "Webhook details" %}
 
 {% block settingsContent %}
-  <h1 class="govuk-heading-l">Webhook details</h1>
+  <h1 class="govuk-heading-l">{{ settingsPageTitle }}</h1>
+  <form method="post" novalidate>
+    <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
+    {% set subscriptionItems = [] %}
+    {% for key, name in eventTypes %}
+      {% set normalisedKey = key | lower %}
+      {% set subscriptionItems = (subscriptionItems.push({ value: normalisedKey, text: name }), subscriptionItems) %}
+    {% endfor %}
+
+    {{ govukInput({
+      label: {
+        text: "Callback URL",
+        classes: "govuk-label--s"
+      },
+      hint: { text: "The HTTPS URL GOV.UK Pay will send webhook messages to" },
+      id: "callback_url",
+      name: "callback_url",
+      value: form.values.callback_url,
+      type: "url",
+      spellcheck: false,
+      errorMessage: form.errors.callback_url and {
+        text: form.errors.callback_url
+      }
+    }) }}
+
+    {{ govukInput({
+      label: {
+        text: "Description",
+        classes: "govuk-label--s"
+      },
+      hint: { text: "Short summary of what this webhook will be used for" },
+      id: "description",
+      name: "description",
+      value: form.values.description,
+      spellcheck: true,
+      errorMessage: form.errors.description and {
+        text: form.errors.description
+      }
+    }) }}
+
+    {{ govukCheckboxes({
+      idPrefix: "subscriptions",
+      name: "subscriptions",
+      fieldset: {
+        legend: {
+          text: "Which payment events should we send?",
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: subscriptionItems,
+      errorMessage: form.errors.subscriptions and {
+        text: form.errors.subscriptions
+      }
+    }) }}
+
+    {{ govukButton({
+      text: "Save",
+      type: "submit"
+    }) }}
+
+  </form>
 {% endblock %}

--- a/src/views/simplified-account/settings/webhooks/create.njk
+++ b/src/views/simplified-account/settings/webhooks/create.njk
@@ -20,13 +20,9 @@
       },
       hint: { text: "The HTTPS URL GOV.UK Pay will send webhook messages to" },
       id: "callback_url",
-      name: "callback_url",
-      value: form.values.callback_url,
+      name: "callbackUrl",
       type: "url",
-      spellcheck: false,
-      errorMessage: form.errors.callback_url and {
-        text: form.errors.callback_url
-      }
+      spellcheck: false
     }) }}
 
     {{ govukInput({
@@ -37,11 +33,7 @@
       hint: { text: "Short summary of what this webhook will be used for" },
       id: "description",
       name: "description",
-      value: form.values.description,
-      spellcheck: true,
-      errorMessage: form.errors.description and {
-        text: form.errors.description
-      }
+      spellcheck: true
     }) }}
 
     {{ govukCheckboxes({
@@ -53,10 +45,7 @@
           classes: "govuk-fieldset__legend--m"
         }
       },
-      items: subscriptionItems,
-      errorMessage: form.errors.subscriptions and {
-        text: form.errors.subscriptions
-      }
+      items: subscriptionItems
     }) }}
 
     {{ govukButton({


### PR DESCRIPTION
- Update the create webhook page to match design
- Remove some duplicate lines that were spotted in other simplified settings tests.
- NB: This step is just to present the form as it appears on the design. Functionality to be implemented later. This page will also be used for updating existing webhooks, but this responsibility isn't implemented either.

For subsequent PRs:
- logic to handle form submission, including validation and saving the webhook.
- using this page for updating existing webhooks.
- Cypress tests

<img width="812" alt="Screenshot 2025-01-29 at 13 10 41" src="https://github.com/user-attachments/assets/25bb85f2-e41b-4fd6-8ec3-637ff580125c" />
