### PR TITLE
PP-13136 Validate and create webhook

### DIFF
--- a/src/controllers/simplified-account/settings/webhooks/create/create.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/create/create.controller.js
@@ -29,7 +29,6 @@ async function post (req, res, next) {
   }
   try {
     await webhooksService.createWebhook(req.service.externalId, req.account.id, accountIsLive, req.body)
-    req.flash('messages', { state: 'success', icon: '&check;', heading: 'Successfully created webhook' })
     res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type))
   } catch (createWebhookError) {
     if (createWebhookError.errorIdentifier in webhookErrorIdentifiers) {

--- a/src/controllers/simplified-account/settings/webhooks/create/create.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/create/create.controller.js
@@ -1,7 +1,11 @@
+const paths = require('@root/paths')
 const { response } = require('@utils/response')
 const { constants } = require('@govuk-pay/pay-js-commons')
-const formatSimplifiedAccountPathsFor = require('../../../../../utils/simplified-account/format/format-simplified-account-paths-for')
-const paths = require('@root/paths')
+const { validationResult } = require('express-validator')
+const { webhookSchema, webhookErrorIdentifiers } = require('@utils/simplified-account/validation/webhook.schema')
+const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
+const formatValidationErrors = require('@utils/simplified-account/format/format-validation-errors')
+const webhooksService = require('@services/webhooks.service')
 
 async function get (req, res) {
   response(req, res, 'simplified-account/settings/webhooks/create', {
@@ -10,10 +14,48 @@ async function get (req, res) {
   })
 }
 
-async function post (req, res) {
-  // TODO: implement post controller
-  res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type)
-  )
+async function post (req, res, next) {
+  const accountIsLive = req.account.type === 'live'
+  const validations = [
+    webhookSchema.callbackUrl.validate,
+    webhookSchema.description.validate,
+    webhookSchema.subscriptions.validate
+  ]
+  await Promise.all(validations.map(validation => validation.run(req)))
+  const validationErrors = validationResult(req)
+  if (!validationErrors.isEmpty()) {
+    const formattedValidationErrors = formatValidationErrors(validationErrors)
+    return responseWithErrors(req, res, formattedValidationErrors)
+  }
+  try {
+    await webhooksService.createWebhook(req.service.externalId, req.account.id, accountIsLive, req.body)
+    req.flash('messages', { state: 'success', icon: '&check;', heading: 'Successfully created webhook' })
+    res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type))
+  } catch (createWebhookError) {
+    if (createWebhookError.errorIdentifier in webhookErrorIdentifiers) {
+      const callbackErrorMessage = webhookErrorIdentifiers[createWebhookError.errorIdentifier]
+      const callbackUrlError = {
+        errorSummary: [{ text: callbackErrorMessage, href: '#callback-url' }],
+        formErrors: { callbackUrl: callbackErrorMessage }
+      }
+      return responseWithErrors(req, res, callbackUrlError)
+    } else {
+      next(createWebhookError)
+    }
+  }
+}
+
+const responseWithErrors = (req, res, errors) => {
+  const subscriptions = typeof req.body.subscriptions === 'string' ? [req.body.subscriptions] : req.body.subscriptions
+  return response(req, res, 'simplified-account/settings/webhooks/create', {
+    form: { callbackUrl: req.body.callbackUrl, description: req.body.description, subscriptions },
+    errors: {
+      summary: errors.errorSummary,
+      formErrors: errors.formErrors
+    },
+    eventTypes: constants.webhooks.humanReadableSubscriptions,
+    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type)
+  })
 }
 
 module.exports = {

--- a/src/controllers/simplified-account/settings/webhooks/create/create.controller.test.js
+++ b/src/controllers/simplified-account/settings/webhooks/create/create.controller.test.js
@@ -1,17 +1,23 @@
 const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
 const { expect } = require('chai')
 const sinon = require('sinon')
+const paths = require('@root/paths')
+const { RESTClientError } = require('@govuk-pay/pay-js-commons/lib/utils/axios-base-client/errors')
 
 const ACCOUNT_TYPE = 'test'
 const SERVICE_ID = 'service-id-123abc'
 
 const mockResponse = sinon.spy()
+const mockCreateWebhook = sinon.stub().resolves({})
+const mockCreateWebhookDomainNotAllowed = sinon.stub().rejects(new RESTClientError(null, 'webhooks', 400, 'CALLBACK_URL_NOT_ON_ALLOW_LIST'))
 
-const { req, res, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/webhooks/create/create.controller')
+const { req, res, call, nextRequest, nextStubs } = new ControllerTestBuilder('@controllers/simplified-account/settings/webhooks/create/create.controller')
   .withServiceExternalId(SERVICE_ID)
   .withAccountType(ACCOUNT_TYPE)
   .withStubs({
-    '@utils/response': { response: mockResponse }
+    '@utils/response': { response: mockResponse },
+    '@services/webhooks.service': { createWebhook: mockCreateWebhook }
+
   })
   .build()
 
@@ -34,6 +40,62 @@ describe('Controller: settings/webhooks', () => {
     it('should pass context data to the response method', () => {
       expect(mockResponse.args[0][3]).to.have.property('eventTypes').to.have.property('CARD_PAYMENT_SUCCEEDED').to.equal('Payment succeeded')
       expect(mockResponse.args[0][3]).to.have.property('backLink').to.equal('/simplified/service/service-id-123abc/account/test/settings/webhooks')
+    })
+  })
+
+  describe('post', () => {
+    describe('success', () => {
+      before(() => {
+        nextRequest({
+          body: {
+            callbackUrl: 'https://www.gov.uk',
+            description: 'Webhook description',
+            subscriptions: 'Payment created'
+          }
+        })
+        call('post')
+      })
+
+      it('should call webhooks to create a webhook', () => {
+        expect(mockCreateWebhook.called).to.be.true // eslint-disable-line
+      })
+
+      it('should redirect to the webhooks index page', () => {
+        sinon.assert.calledWith(req.flash, 'messages', {
+          state: 'success',
+          icon: '&check;',
+          heading: 'Successfully created webhook'
+        })
+        expect(res.redirect.calledOnce).to.be.true // eslint-disable-line
+        expect(res.redirect.args[0][0]).to.include(paths.simplifiedAccount.settings.webhooks.index)
+      })
+    })
+
+    describe('failure - domain not in allow list', () => {
+      before(() => {
+        nextRequest({
+          body: {
+            callbackUrl: 'https://www.gov.uk',
+            description: 'Webhook description',
+            subscriptions: 'Payment created'
+          }
+        })
+        nextStubs({
+          '@utils/response': { response: mockResponse },
+          '@services/webhooks.service': { createWebhook: mockCreateWebhookDomainNotAllowed }
+        })
+        call('post')
+      })
+
+      it('should respond with error message', () => {
+        expect(mockCreateWebhookDomainNotAllowed.called).to.be.true // eslint-disable-line
+        expect(mockResponse.calledOnce).to.be.true // eslint-disable-line
+        expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/webhooks/create')
+        expect(mockResponse.args[0][3]).to.have.property('errors').to.deep.equal({
+          summary: [{ text: 'Callback URL must be approved. Please contact support', href: '#callback-url' }],
+          formErrors: { callbackUrl: 'Callback URL must be approved. Please contact support' }
+        })
+      })
     })
   })
 })

--- a/src/controllers/simplified-account/settings/webhooks/create/create.controller.test.js
+++ b/src/controllers/simplified-account/settings/webhooks/create/create.controller.test.js
@@ -61,11 +61,6 @@ describe('Controller: settings/webhooks', () => {
       })
 
       it('should redirect to the webhooks index page', () => {
-        sinon.assert.calledWith(req.flash, 'messages', {
-          state: 'success',
-          icon: '&check;',
-          heading: 'Successfully created webhook'
-        })
         expect(res.redirect.calledOnce).to.be.true // eslint-disable-line
         expect(res.redirect.args[0][0]).to.include(paths.simplifiedAccount.settings.webhooks.index)
       })

--- a/src/controllers/simplified-account/settings/webhooks/webhooks.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/webhooks.controller.js
@@ -6,10 +6,12 @@ const { constants } = require('@govuk-pay/pay-js-commons')
 
 async function get (req, res) {
   const accountIsLive = req.account.type === 'live'
+  const messages = res.locals?.flash?.messages ?? []
   const webhooks = await webhooksService.listWebhooks(req.service.externalId, req.account.id, accountIsLive)
   const activeWebhooks = webhooks.filter(webhook => webhook.status === 'ACTIVE')
   const deactivatedWebhooks = webhooks.filter(webhook => webhook.status === 'INACTIVE')
   response(req, res, 'simplified-account/settings/webhooks/index', {
+    messages,
     activeWebhooks,
     deactivatedWebhooks,
     eventTypes: constants.webhooks.humanReadableSubscriptions,

--- a/src/controllers/webhooks/webhooks.controller.js
+++ b/src/controllers/webhooks/webhooks.controller.js
@@ -102,7 +102,6 @@ async function createWebhook (req, res, next) {
       await webhooksService.createWebhook(req.service.externalId, req.account.gateway_account_id, req.isLive, req.body)
     } catch (createWebhookError) {
       form = webhooksFormSchema.parseResponse(createWebhookError, req.body)
-
       if (form.errorSummaryList.length) {
         response(req, res, 'webhooks/edit', { eventTypes: constants.webhooks.humanReadableSubscriptions, form })
       } else {

--- a/src/services/clients/webhooks.client.js
+++ b/src/services/clients/webhooks.client.js
@@ -81,7 +81,7 @@ async function createWebhook (serviceId, gatewayAccountId, isLive, options = {})
     service_id: serviceId,
     gateway_account_id: gatewayAccountId,
     live: isLive,
-    callback_url: options.callback_url,
+    callback_url: options.callbackUrl || options.callback_url,
     subscriptions: options.subscriptions,
     description: options.description
   }

--- a/src/services/clients/webhooks.client.js
+++ b/src/services/clients/webhooks.client.js
@@ -76,6 +76,7 @@ async function messages (id, options = {}) {
   return response.data
 }
 
+// TODO refactor to explicitly pass all params in the method once old webhooks controller code is deleted
 async function createWebhook (serviceId, gatewayAccountId, isLive, options = {}) {
   const body = {
     service_id: serviceId,

--- a/src/utils/simplified-account/validation/webhook.schema.js
+++ b/src/utils/simplified-account/validation/webhook.schema.js
@@ -1,0 +1,40 @@
+const { body } = require('express-validator')
+
+const WEBHOOK_DESCRIPTION_MAX_LENGTH = 40
+
+const webhookSchema = {
+  callbackUrl: {
+    validate: body('callbackUrl').trim()
+      .notEmpty()
+      .withMessage('Enter a callback url')
+      .bail()
+      .isURL({ protocols: ['https'], require_protocol: true, validate_length: true })
+      .withMessage('Enter a valid callback url beginning with https://')
+
+  },
+  description: {
+    validate: body('description').trim()
+      .notEmpty()
+      .withMessage('Enter a description')
+      .bail()
+      .isLength({ max: WEBHOOK_DESCRIPTION_MAX_LENGTH })
+      .withMessage(`Description must be ${WEBHOOK_DESCRIPTION_MAX_LENGTH} characters or fewer`)
+  },
+  subscriptions: {
+    validate: body('subscriptions')
+      .notEmpty()
+      .withMessage('Select at least one payment event')
+  }
+}
+
+// errors returned by pay-webhooks
+const webhookErrorIdentifiers = {
+  CALLBACK_URL_MALFORMED: 'Enter a valid callback URL',
+  CALLBACK_URL_PROTOCOL_NOT_SUPPORTED: 'Callback URL must begin with https://',
+  CALLBACK_URL_NOT_ON_ALLOW_LIST: 'Callback URL must be approved. Please contact support'
+}
+
+module.exports = {
+  webhookSchema,
+  webhookErrorIdentifiers
+}

--- a/src/utils/simplified-account/validation/webhook.schema.test.js
+++ b/src/utils/simplified-account/validation/webhook.schema.test.js
@@ -3,9 +3,9 @@ const { webhookSchema } = require('./webhook.schema')
 const { validationResult } = require('express-validator')
 
 describe('Webhook Validation', () => {
-  let BASE_REQ
+  let VALID_REQUEST
   beforeEach(() => {
-    BASE_REQ = {
+    VALID_REQUEST = {
       body: {
         callbackUrl: 'https://www.gov.uk',
         description: 'A valid webhook description',
@@ -16,13 +16,13 @@ describe('Webhook Validation', () => {
 
   describe('Callback url validation', () => {
     it('should pass with a valid callback url', async () => {
-      await webhookSchema.callbackUrl.validate.run(BASE_REQ)
-      expect(validationResult(BASE_REQ).isEmpty()).to.be.true // eslint-disable-line
+      await webhookSchema.callbackUrl.validate.run(VALID_REQUEST)
+      expect(validationResult(VALID_REQUEST).isEmpty()).to.be.true // eslint-disable-line
     })
 
     it('should fail when callback url is empty', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { callbackUrl: '' })
+        body: Object.assign({}, VALID_REQUEST.body, { callbackUrl: '' })
       }
       await webhookSchema.callbackUrl.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -31,7 +31,7 @@ describe('Webhook Validation', () => {
 
     it('should fail when callback url is http', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { callbackUrl: 'http://www.gov.uk' })
+        body: Object.assign({}, VALID_REQUEST.body, { callbackUrl: 'http://www.gov.uk' })
       }
       await webhookSchema.callbackUrl.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -40,7 +40,7 @@ describe('Webhook Validation', () => {
 
     it('should fail when callback url is malformed', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { callbackUrl: 'https://malformed-url' })
+        body: Object.assign({}, VALID_REQUEST.body, { callbackUrl: 'https://malformed-url' })
       }
       await webhookSchema.callbackUrl.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -50,13 +50,13 @@ describe('Webhook Validation', () => {
 
   describe('description validation', () => {
     it('should pass with a valid description', async () => {
-      await webhookSchema.description.validate.run(BASE_REQ)
-      expect(validationResult(BASE_REQ).isEmpty()).to.be.true // eslint-disable-line
+      await webhookSchema.description.validate.run(VALID_REQUEST)
+      expect(validationResult(VALID_REQUEST).isEmpty()).to.be.true // eslint-disable-line
     })
 
     it('should fail when description is empty', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { description: '' })
+        body: Object.assign({}, VALID_REQUEST.body, { description: '' })
       }
       await webhookSchema.description.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -65,7 +65,7 @@ describe('Webhook Validation', () => {
 
     it('should fail when description is too long', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { description: 'This 41 character description is too long' })
+        body: Object.assign({}, VALID_REQUEST.body, { description: 'This 41 character description is too long' })
       }
       await webhookSchema.description.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -75,16 +75,16 @@ describe('Webhook Validation', () => {
 
   describe('subscriptions validation', () => {
     it('should pass with more than one subscriptions', async () => {
-      await webhookSchema.subscriptions.validate.run(BASE_REQ)
-      expect(validationResult(BASE_REQ).isEmpty()).to.be.true // eslint-disable-line
+      await webhookSchema.subscriptions.validate.run(VALID_REQUEST)
+      expect(validationResult(VALID_REQUEST).isEmpty()).to.be.true // eslint-disable-line
     })
 
     it('should pass with one subscription', async () => {
-      const validReq = {
-        body: Object.assign({}, BASE_REQ.body, { subscriptions: 'card_payment_succeeded' })
+      const validRequestWithOneSubscription = {
+        body: Object.assign({}, VALID_REQUEST.body, { subscriptions: 'card_payment_succeeded' })
       }
-      await webhookSchema.subscriptions.validate.run(validReq)
-      expect(validationResult(BASE_REQ).isEmpty()).to.be.true // eslint-disable-line
+      await webhookSchema.subscriptions.validate.run(validRequestWithOneSubscription)
+      expect(validationResult(validRequestWithOneSubscription).isEmpty()).to.be.true // eslint-disable-line
     })
 
     it('should fail with no subscriptions', async () => {
@@ -99,5 +99,4 @@ describe('Webhook Validation', () => {
       expect(errors.array()[0].msg).to.equal('Select at least one payment event')
     })
   })
-
 })

--- a/src/utils/simplified-account/validation/webhook.schema.test.js
+++ b/src/utils/simplified-account/validation/webhook.schema.test.js
@@ -1,0 +1,103 @@
+const { expect } = require('chai')
+const { webhookSchema } = require('./webhook.schema')
+const { validationResult } = require('express-validator')
+
+describe('Webhook Validation', () => {
+  let BASE_REQ
+  beforeEach(() => {
+    BASE_REQ = {
+      body: {
+        callbackUrl: 'https://www.gov.uk',
+        description: 'A valid webhook description',
+        subscriptions: ['card_payment_succeeded', 'card_payment_failed']
+      }
+    }
+  })
+
+  describe('Callback url validation', () => {
+    it('should pass with a valid callback url', async () => {
+      await webhookSchema.callbackUrl.validate.run(BASE_REQ)
+      expect(validationResult(BASE_REQ).isEmpty()).to.be.true // eslint-disable-line
+    })
+
+    it('should fail when callback url is empty', async () => {
+      const invalidReq = {
+        body: Object.assign({}, BASE_REQ.body, { callbackUrl: '' })
+      }
+      await webhookSchema.callbackUrl.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('Enter a callback url')
+    })
+
+    it('should fail when callback url is http', async () => {
+      const invalidReq = {
+        body: Object.assign({}, BASE_REQ.body, { callbackUrl: 'http://www.gov.uk' })
+      }
+      await webhookSchema.callbackUrl.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('Enter a valid callback url beginning with https://')
+    })
+
+    it('should fail when callback url is malformed', async () => {
+      const invalidReq = {
+        body: Object.assign({}, BASE_REQ.body, { callbackUrl: 'https://malformed-url' })
+      }
+      await webhookSchema.callbackUrl.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('Enter a valid callback url beginning with https://')
+    })
+  })
+
+  describe('description validation', () => {
+    it('should pass with a valid description', async () => {
+      await webhookSchema.description.validate.run(BASE_REQ)
+      expect(validationResult(BASE_REQ).isEmpty()).to.be.true // eslint-disable-line
+    })
+
+    it('should fail when description is empty', async () => {
+      const invalidReq = {
+        body: Object.assign({}, BASE_REQ.body, { description: '' })
+      }
+      await webhookSchema.description.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('Enter a description')
+    })
+
+    it('should fail when description is too long', async () => {
+      const invalidReq = {
+        body: Object.assign({}, BASE_REQ.body, { description: 'This 41 character description is too long' })
+      }
+      await webhookSchema.description.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('Description must be 40 characters or fewer')
+    })
+  })
+
+  describe('subscriptions validation', () => {
+    it('should pass with more than one subscriptions', async () => {
+      await webhookSchema.subscriptions.validate.run(BASE_REQ)
+      expect(validationResult(BASE_REQ).isEmpty()).to.be.true // eslint-disable-line
+    })
+
+    it('should pass with one subscription', async () => {
+      const validReq = {
+        body: Object.assign({}, BASE_REQ.body, { subscriptions: 'card_payment_succeeded' })
+      }
+      await webhookSchema.subscriptions.validate.run(validReq)
+      expect(validationResult(BASE_REQ).isEmpty()).to.be.true // eslint-disable-line
+    })
+
+    it('should fail with no subscriptions', async () => {
+      const invalidReq = {
+        body: {
+          callbackUrl: 'https://www.gov.uk',
+          description: 'A valid webhook description'
+        }
+      }
+      await webhookSchema.subscriptions.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('Select at least one payment event')
+    })
+  })
+
+})

--- a/src/views/simplified-account/settings/webhooks/create.njk
+++ b/src/views/simplified-account/settings/webhooks/create.njk
@@ -26,7 +26,8 @@
       name: "callbackUrl",
       value: form.callbackUrl,
       type: "url",
-      spellcheck: false
+      spellcheck: false,
+      errorMessage: { text: errors.formErrors['callbackUrl'] } if errors.formErrors['callbackUrl'] else false
     }) }}
 
     {{ govukInput({
@@ -38,7 +39,8 @@
       id: "description",
       name: "description",
       value: form.description,
-      spellcheck: true
+      spellcheck: true,
+      errorMessage: { text: errors.formErrors['description'] } if errors.formErrors['description'] else false
     }) }}
 
     {{ govukCheckboxes({
@@ -50,7 +52,8 @@
           classes: "govuk-fieldset__legend--m"
         }
       },
-      items: subscriptionItems
+      items: subscriptionItems,
+      errorMessage: { text: errors.formErrors['subscriptions'] } if errors.formErrors['subscriptions'] else false
     }) }}
 
     {{ govukButton({

--- a/src/views/simplified-account/settings/webhooks/create.njk
+++ b/src/views/simplified-account/settings/webhooks/create.njk
@@ -40,7 +40,7 @@
       name: "description",
       value: form.description,
       attributes: {
-        maxlength: "50"
+        maxlength: "40"
       },
       spellcheck: true,
       errorMessage: { text: errors.formErrors['description'] } if errors.formErrors['description'] else false

--- a/src/views/simplified-account/settings/webhooks/create.njk
+++ b/src/views/simplified-account/settings/webhooks/create.njk
@@ -10,7 +10,10 @@
     {% set subscriptionItems = [] %}
     {% for key, name in eventTypes %}
       {% set normalisedKey = key | lower %}
-      {% set subscriptionItems = (subscriptionItems.push({ value: normalisedKey, text: name }), subscriptionItems) %}
+      {% if form.subscriptions %}
+        {% set checked = normalisedKey in form.subscriptions %}
+      {% endif %}
+      {% set subscriptionItems = (subscriptionItems.push({ value: normalisedKey, text: name, checked: checked}), subscriptionItems) %}
     {% endfor %}
 
     {{ govukInput({
@@ -21,6 +24,7 @@
       hint: { text: "The HTTPS URL GOV.UK Pay will send webhook messages to" },
       id: "callback_url",
       name: "callbackUrl",
+      value: form.callbackUrl,
       type: "url",
       spellcheck: false
     }) }}
@@ -33,6 +37,7 @@
       hint: { text: "Short summary of what this webhook will be used for" },
       id: "description",
       name: "description",
+      value: form.description,
       spellcheck: true
     }) }}
 

--- a/src/views/simplified-account/settings/webhooks/create.njk
+++ b/src/views/simplified-account/settings/webhooks/create.njk
@@ -39,6 +39,9 @@
       id: "description",
       name: "description",
       value: form.description,
+      attributes: {
+        maxlength: "50"
+      },
       spellcheck: true,
       errorMessage: { text: errors.formErrors['description'] } if errors.formErrors['description'] else false
     }) }}


### PR DESCRIPTION
- Validation for create webhook
- Call pay-webhooks to create the webhook
- Handle validation errors from pay-webhooks (pay-webhooks validation includes a check against an allow list of domains).
NB Currently following webhook creation there is a redirect to the main webhooks page. Discussing with designers whether this is the right approach, could potentially direct to the webhook details page (which hasn't yet been added).

For subsequent PRs
- Cypress tests for main webhook page and create webhook page.
- Other webhook settings pages are subject of separate JIRA tickets.


**Screenshot 1. Callback url empty**
![Screenshot 2025-01-31 at 13 01 26](https://github.com/user-attachments/assets/09b63a05-869d-4b36-8ae9-bbb5f5700c48)

---
**Screenshot 2. Callback url non-https**
![Screenshot 2025-01-31 at 13 02 07](https://github.com/user-attachments/assets/b4a77ba4-9ae1-493f-8d02-f62ce547b36d)

---
**Screenshot 3. Callback url has domain not in allow list (live accounts only)**
![Screenshot 2025-01-31 at 13 14 12](https://github.com/user-attachments/assets/dbcafbe9-3b8b-49cb-9632-51befae706a0)

---
**Screenshot 4. Description empty**
![Screenshot 2025-01-31 at 13 01 36](https://github.com/user-attachments/assets/38710eb4-885a-499b-8474-5bf5ce2bb889)

---
**Screenshot 5. Description too long**
![Screenshot 2025-01-31 at 13 17 14](https://github.com/user-attachments/assets/e2402995-a9f2-4cbc-a46f-b11534f7aebf)
---

**Screenshot 6. No payment events selected**
![Screenshot 2025-01-31 at 13 01 48](https://github.com/user-attachments/assets/c4934872-f254-433c-bb93-bf02fc87fe9a)

---



