### PR TITLE
BAU async stripe account data loading for simplified settings

### DIFF
--- a/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.test.js
@@ -28,6 +28,21 @@ const {
   .build()
 
 describe('Controller: settings/stripe-details', () => {
+  describe('getAccountDetails', () => {
+    describe('when requesting account details', () => {
+      before(() => {
+        call('getAccountDetails')
+      })
+      it('should return a json object', () => {
+        sinon.assert.calledOnce(mockStripeDetailsService.getStripeAccountOnboardingDetails)
+        sinon.assert.calledWith(mockStripeDetailsService.getStripeAccountOnboardingDetails, req.service)
+        sinon.assert.calledWith(res.json, {
+          foo: 'bar'
+        })
+      })
+    })
+  })
+
   describe('get', () => {
     describe('when there are outstanding tasks', () => {
       before(() => {
@@ -109,6 +124,9 @@ describe('Controller: settings/stripe-details', () => {
               vatNumber: true,
               governmentEntityDocument: true
             }
+          },
+          query: {
+            noscript: 'true'
           }
         })
         call('get')

--- a/src/paths.js
+++ b/src/paths.js
@@ -197,6 +197,7 @@ module.exports = {
       },
       stripeDetails: {
         index: '/settings/stripe-details',
+        accountDetails: '/settings/stripe-details/account',
         bankDetails: '/settings/stripe-details/bank-details',
         responsiblePerson: {
           index: '/settings/stripe-details/responsible-person',

--- a/src/services/stripe-details.service.js
+++ b/src/services/stripe-details.service.js
@@ -7,7 +7,7 @@ const {
 } = require('@services/clients/stripe/stripe.client')
 const { ServiceUpdateRequest } = require('@models/ServiceUpdateRequest.class')
 const { updateService } = require('@services/service.service')
-const logger = require('../utils/logger')(__filename)
+const logger = require('@utils/logger')(__filename)
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
 /**
@@ -197,19 +197,30 @@ const getStripeAccountOnboardingDetails = async (service, account) => {
     const director = persons.data.find(person => person.relationship?.director)
 
     return {
-      company: {
-        vatNumber: connectAccount.company?.vat_id_provided ? 'Provided' : 'Not provided',
-        companyNumber: connectAccount.company?.tax_id_provided ? 'Provided' : 'Not provided',
-        entityDocument: connectAccount.company?.verification?.document ? 'Provided' : 'Not provided'
-      },
       bankAccount: {
-        sortCode: bankAccount.data[0]?.routing_number,
-        accountNumber: bankAccount.data[0]?.last4
-          ? `●●●●${bankAccount.data[0].last4}`
-          : ''
+        title: 'Organisation bank details',
+        rows: {
+          'Sort code': bankAccount.data[0]?.routing_number,
+          'Account number': bankAccount.data[0]?.last4
+            ? `●●●●${bankAccount.data[0].last4}`
+            : ''
+        }
       },
-      responsiblePerson: responsiblePerson ? `${responsiblePerson.first_name} ${responsiblePerson.last_name}` : '',
-      director: director ? `${director.first_name} ${director.last_name}` : ''
+      contact: {
+        title: 'Organisation contact',
+        rows: {
+          'Responsible person': responsiblePerson ? `${responsiblePerson.first_name} ${responsiblePerson.last_name}` : '',
+          'Service director': director ? `${director.first_name} ${director.last_name}` : ''
+        }
+      },
+      company: {
+        title: 'Company registration details',
+        rows: {
+          'VAT registration number': connectAccount.company?.vat_id_provided ? 'Provided' : 'Not provided',
+          'Company registration number': connectAccount.company?.tax_id_provided ? 'Provided' : 'Not provided',
+          'Government entity document': connectAccount.company?.verification?.document ? 'Provided' : 'Not provided'
+        }
+      }
     }
   } catch (error) {
     logger.error(error.message)

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -95,6 +95,7 @@ const stripeDetailsPath = paths.simplifiedAccount.settings.stripeDetails
 const stripeDetailsRouter = new Router({ mergeParams: true })
   .use(enforceLiveAccountOnly, enforcePaymentProviderType(STRIPE), permission('stripe-account-details:update'))
 stripeDetailsRouter.get(stripeDetailsPath.index, serviceSettingsController.stripeDetails.get)
+stripeDetailsRouter.get(stripeDetailsPath.accountDetails, serviceSettingsController.stripeDetails.getAccountDetails)
 
 stripeDetailsRouter.get(stripeDetailsPath.bankDetails, serviceSettingsController.stripeDetails.bankDetails.get)
 stripeDetailsRouter.post(stripeDetailsPath.bankDetails, serviceSettingsController.stripeDetails.bankDetails.post)

--- a/src/views/simplified-account/settings/stripe-details/_task-list.njk
+++ b/src/views/simplified-account/settings/stripe-details/_task-list.njk
@@ -1,0 +1,30 @@
+{% set taskList = [] %}
+{% for key, value in stripeDetailsTasks %}
+  {% set taskList = (taskList.push({
+    title: {
+      text: value.friendlyName
+    },
+    href: value.href if value.status == false else undefined,
+    status: {
+      tag: {
+        text: "Not yet started",
+        classes: "govuk-tag--blue"
+      }
+    } if value.status == false else (
+      {
+        tag: {
+        text: "Cannot start yet",
+        classes: "govuk-tag--grey"
+      }
+      } if value.status == 'disabled' else {
+        text: "Completed"
+      }
+    )
+  }), taskList) %}
+{% endfor %}
+
+{{ govukTaskList({
+  idPrefix: "stripe-details",
+  items: taskList,
+  classes: "task-list"
+}) }}

--- a/src/views/simplified-account/settings/stripe-details/index.njk
+++ b/src/views/simplified-account/settings/stripe-details/index.njk
@@ -1,4 +1,6 @@
 {% extends "../settings-layout.njk" %}
+{% from "includes/spinner.njk" import spinner %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% set settingsPageTitle = "Stripe details" %}
 
@@ -12,37 +14,7 @@
   <h1 class="govuk-heading-l">{{ settingsPageTitle }}</h1>
   {% if incompleteTasks %}
     <p class="govuk-body govuk-!-font-weight-bold">Add your organisation's details</p>
-
-    {% set taskList = [] %}
-    {% for key, value in stripeDetailsTasks %}
-      {% set taskList = (taskList.push({
-        title: {
-          text: value.friendlyName
-        },
-        href: value.href if value.status == false else undefined,
-        status: {
-          tag: {
-            text: "Not yet started",
-            classes: "govuk-tag--blue"
-          }
-        } if value.status == false else (
-          {
-            tag: {
-              text: "Cannot start yet",
-              classes: "govuk-tag--grey"
-            }
-          } if value.status == 'disabled' else {
-            text: "Completed"
-          }
-        )
-      }), taskList) %}
-    {% endfor %}
-
-    {{ govukTaskList({
-      idPrefix: "stripe-details",
-      items: taskList,
-      classes: "task-list"
-    }) }}
+    {% include "./_task-list.njk" %}
   {% else %}
     <p class="govuk-body">This information has been sent to Stripe so that your service can take payments. For
       security
@@ -51,92 +23,93 @@
     <p class="govuk-body">If you need to change these details or upload another Government Entity document, <a
         class="govuk-link govuk-link--no-visited-state"
         href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk?subject=Change request - Stripe details [service external id: {{ serviceExternalId }}]">contact
-        GOV.UK Pay</a></p>
+        GOV.UK Pay</a>
+    </p>
 
-    {{ govukSummaryList({
-      card: {
-        title: {
-          text: "Organisation bank details"
-        }
-      },
-      rows: [
-        {
-          key: {
-          text: "Sort code"
-        },
-          value: {
-          text: answers.bankAccount.sortCode
-        }
-        },
-        {
-          key: {
-          text: "Account number"
-        },
-          value: {
-          text: answers.bankAccount.accountNumber
-        }
-        }
-      ]
-    }) }}
+    {% if javascriptUnavailable %}
+      {% for section, content in answers %}
+        {% set rows = [] %}
+        {% for key, value in content.rows %}
+          {% set rows = (rows.push({
+            key: {
+              text: key
+            },
+            value: {
+              text: value
+            }
+          }), rows) %}
+        {% endfor %}
+        {{ govukSummaryList({
+          card: {
+            title: {
+              text: content.title
+            }
+          },
+          rows: rows
+        }) }}
+      {% endfor %}
+    {% else %}
+      <noscript>
+        <meta http-equiv="refresh" content="0; url=?noscript=true">
+        <p class="govuk-body">You are being redirected, please wait...
+          If you are not redirected, <a class="govuk-body govuk-link--no-visited-state" href="?noscript=true">click
+            here</a>.</p>
+      </noscript>
 
-    {{ govukSummaryList({
-      card: {
-        title: {
-          text: "Organisation contact"
-        }
-      },
-      rows: [
-        {
-          key: {
-          text: "Responsible person"
-        },
-          value: {
-          text: answers.responsiblePerson
-        }
-        },
-        {
-          key: {
-          text: "Service director"
-        },
-          value: {
-          text: answers.director
-        }
-        }
-      ]
-    }) }}
+      <div id="spinner-container">
+        {{ spinner({
+          text: "Loading account details..."
+        }) }}
+      </div>
 
-    {{ govukSummaryList({
-      card: {
-        title: {
-          text: "Company registration details"
-        }
-      },
-      rows: [
-        {
-          key: {
-          text: "VAT registration number"
-        },
-          value: {
-          text: answers.company.vatNumber
-        }
-        },
-        {
-          key: {
-          text: "Company registration number"
-        },
-          value: {
-          text: answers.company.companyNumber
-        }
-        },
-        {
-          key: {
-          text: "Government entity document"
-        },
-          value: {
-          text: answers.company.entityDocument
-        }
-        }
-      ]
-    }) }}
+      <div id="loaded-content-container" style="display: none;">
+      </div>
+
+      <script>
+        document.addEventListener('DOMContentLoaded', async () => {
+          try {
+            const response = await fetch('{{ accountDetailsPath }}')
+            const data = await response.json()
+            document.getElementById('spinner-container').style.display = 'none'
+            const contentContainer = document.getElementById('loaded-content-container')
+
+            contentContainer.innerHTML = ''
+
+            for (const [_, content] of Object.entries(data)) {
+              const html = `
+              <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                  <h2 class="govuk-summary-card__title">${content.title}</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                  <dl class="govuk-summary-list">
+                    ${Object.entries(content.rows).map(([key, value]) => `
+                      <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">${key}</dt>
+                        <dd class="govuk-summary-list__value">${value}</dd>
+                      </div>
+                    `).join('')}
+                  </dl>
+                </div>
+              </div>
+              `
+              contentContainer.insertAdjacentHTML('beforeend', html)
+            }
+            contentContainer.style.display = 'block'
+          } catch (err) {
+            console.log(err)
+            document.getElementById('spinner-container').innerHTML = `
+            <div class="govuk-warning-text">
+              <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+              <strong class="govuk-warning-text__text">
+                <span class="govuk-visually-hidden">Warning</span>
+                There was a problem fetching data from Stripe, try again later.
+              </strong>
+            </div>
+          `
+          }
+        })
+      </script>
+    {% endif %}
   {% endif %}
 {% endblock %}

--- a/test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class.js
+++ b/test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class.js
@@ -9,10 +9,12 @@ module.exports = class ControllerTestBuilder {
     this.req = {
       service: {},
       account: {},
+      query: {},
       flash: sinon.spy()
     }
     this.res = {
-      redirect: sinon.spy()
+      redirect: sinon.spy(),
+      json: sinon.spy()
     }
     this.nextReq = null
     this.nextRes = null


### PR DESCRIPTION
### WHAT

- asynchronously retrieve stripe account data when clientside javascript is enabled, fall back to synchronous loading otherwise

### SCREENS
_Screenshots if view has been modified:_

#### BEFORE

Notice the delay when clicking `Stripe details` and how long the page takes to load

https://github.com/user-attachments/assets/1c3b1351-575e-47c8-b01b-2d9020d4564e

#### AFTER

Instant page load, additional data is loaded in when ready

https://github.com/user-attachments/assets/ec1fc4c8-99ef-4089-9419-3c1a56a1b3c1

Browser javascript disabled (page will auto refresh once spinner has loaded to request stripe data synchronously):

https://github.com/user-attachments/assets/45f72ef5-6e84-4d6e-8f97-ca0021276ff1

Error state when loading data async:

https://github.com/user-attachments/assets/c287beb2-a9f1-43f2-b048-3ff9ea7e77e1

