### PR TITLE
PP-12440 Display saved 3DS flex credentials in settings

### DIFF
--- a/src/controllers/simplified-account/settings/worldpay-details/flex-credentials/worldpay-flex-credentials.controller.js
+++ b/src/controllers/simplified-account/settings/worldpay-details/flex-credentials/worldpay-flex-credentials.controller.js
@@ -10,6 +10,10 @@ const INTEGRATION_VERSION_3DS = 2
 
 function get (req, res) {
   return response(req, res, 'simplified-account/settings/worldpay-details/flex-credentials', {
+    credentials: {
+      organisationalUnitId: req.account?.worldpay3dsFlex?.organisationalUnitId,
+      issuer: req.account?.worldpay3dsFlex?.issuer
+    },
     backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.index,
       req.service.externalId, req.account.type)
   })

--- a/src/controllers/simplified-account/settings/worldpay-details/flex-credentials/worldpay-flex-credentials.controller.test.js
+++ b/src/controllers/simplified-account/settings/worldpay-details/flex-credentials/worldpay-flex-credentials.controller.test.js
@@ -48,25 +48,51 @@ const { req, res, nextRequest, nextStubs, call } = new ControllerTestBuilder('@c
 
 describe('Controller: settings/worldpay-details/flex-credentials', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
+    describe('when no credentials have yet been set', () => {
+      beforeEach(() => {
+        call('get')
+      })
+
+      it('should call the response method', () => {
+        expect(mockResponse.called).to.be.true // eslint-disable-line
+      })
+
+      it('should pass req, res and template path to the response method', () => {
+        mockResponse.should.have.been.calledWith(req, res, 'simplified-account/settings/worldpay-details/flex-credentials')
+      })
+
+      it('should pass context data with no credentials to the response method', () => {
+        mockResponse.should.have.been.calledWith(sinon.match.any, sinon.match.any, sinon.match.any, {
+          credentials: {
+            organisationalUnitId: undefined,
+            issuer: undefined
+          },
+          backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.index, SERVICE_ID, ACCOUNT_TYPE)
+        })
+      })
     })
 
-    it('should call the response method', () => {
-      expect(mockResponse.called).to.be.true // eslint-disable-line
-    })
+    describe('when credentials have already been set', () => {
+      beforeEach(() => {
+        nextRequest({
+          account: {
+            worldpay3dsFlex: {
+              organisationalUnitId: '5bd9b55e4444761ac0af1c80', // pragma: allowlist secret
+              issuer: '5bd9e0e4444dce15fed8c940' // pragma: allowlist secret
+            }
+          }
+        })
+        call('get')
+      })
 
-    it('should pass req, res and template path to the response method', () => {
-      mockResponse.should.have.been.calledWith(req, res, 'simplified-account/settings/worldpay-details/flex-credentials')
-    })
-
-    it('should pass context data to the response method', () => {
-      mockResponse.should.have.been.calledWith(sinon.match.any, sinon.match.any, sinon.match.any, {
-        credentials: {
-          organisationalUnitId: undefined,
-          issuer: undefined
-        },
-        backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.index, SERVICE_ID, ACCOUNT_TYPE)
+      it('should pass context data with credentials to the response method', () => {
+        mockResponse.should.have.been.calledWith(sinon.match.any, sinon.match.any, sinon.match.any, {
+          credentials: {
+            organisationalUnitId: '5bd9b55e4444761ac0af1c80', // pragma: allowlist secret
+            issuer: '5bd9e0e4444dce15fed8c940' // pragma: allowlist secret
+          },
+          backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.index, SERVICE_ID, ACCOUNT_TYPE)
+        })
       })
     })
   })

--- a/src/controllers/simplified-account/settings/worldpay-details/flex-credentials/worldpay-flex-credentials.controller.test.js
+++ b/src/controllers/simplified-account/settings/worldpay-details/flex-credentials/worldpay-flex-credentials.controller.test.js
@@ -62,6 +62,10 @@ describe('Controller: settings/worldpay-details/flex-credentials', () => {
 
     it('should pass context data to the response method', () => {
       mockResponse.should.have.been.calledWith(sinon.match.any, sinon.match.any, sinon.match.any, {
+        credentials: {
+          organisationalUnitId: undefined,
+          issuer: undefined
+        },
         backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.index, SERVICE_ID, ACCOUNT_TYPE)
       })
     })

--- a/src/controllers/simplified-account/settings/worldpay-details/worldpay-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/worldpay-details/worldpay-details.controller.test.js
@@ -55,7 +55,7 @@ describe('Controller: settings/worldpay-details', () => {
           SERVICE_ID, ACCOUNT_TYPE),
         id: 'worldpay-credentials',
         linkText: 'Link your Worldpay account with GOV.UK Pay',
-        complete: false
+        status: 'NOT_STARTED'
       }]
       expect(mockResponse.args[0][3]).to.have.property('tasks').to.deep.equal(tasks)
       expect(mockResponse.args[0][3]).to.have.property('incompleteTasks').to.equal(true)

--- a/src/models/GatewayAccount.class.js
+++ b/src/models/GatewayAccount.class.js
@@ -1,4 +1,5 @@
 const { GatewayAccountCredential, CREDENTIAL_STATE } = require('@models/gateway-account-credential/GatewayAccountCredential.class')
+const Worldpay3dsFlexCredential = require('@models/gateway-account-credential/Worldpay3dsFlexCredential.class')
 
 /**
  * @class GatewayAccount
@@ -29,6 +30,7 @@ class GatewayAccount {
    * @param {boolean} gatewayAccountData.provider_switch_enabled - indicates that the gateway is transitioning psp
    * @param {boolean} gatewayAccountData.recurring_enabled - whether recurring card payments are enabled on this account
    * @param {[{Object}]} gatewayAccountData.gateway_account_credentials - whether recurring card payments are enabled on this account
+   * @param {Object} [gatewayAccountData.worldpay_3ds_flex] - 3ds flex credentials and metadata for Worldpay
    **/
   constructor (gatewayAccountData) {
     this.id = gatewayAccountData.gateway_account_id
@@ -45,6 +47,9 @@ class GatewayAccount {
     if (gatewayAccountData?.gateway_account_credentials) {
       this.gatewayAccountCredentials = gatewayAccountData?.gateway_account_credentials
         .map(credentialData => GatewayAccountCredential.fromJson(credentialData))
+    }
+    if (gatewayAccountData?.worldpay_3ds_flex) {
+      this.worldpay3dsFlex = Worldpay3dsFlexCredential.fromJson(gatewayAccountData.worldpay_3ds_flex)
     }
     this.supports3ds = ['worldpay', 'stripe'].includes(gatewayAccountData.payment_provider)
     this.disableToggle3ds = gatewayAccountData.payment_provider === 'stripe'

--- a/src/models/WorldpayTasks.class.js
+++ b/src/models/WorldpayTasks.class.js
@@ -33,7 +33,7 @@ class WorldpayTasks {
       this.tasks.push(WorldpayTask.flexCredentialsTask(serviceExternalId, gatewayAccount.type, gatewayAccount.worldpay3dsFlex, this.tasks.filter(t => t.id === 'worldpay-credentials')[0]?.status === TASK_STATUS.COMPLETED))
     }
 
-    this.incompleteTasks = this.tasks.filter(t => t.complete !== true).length > 0
+    this.incompleteTasks = this.tasks.filter(t => t.status !== TASK_STATUS.COMPLETED).length > 0
   }
 
   static async recalculate (serviceExternalId, accountType) {

--- a/src/models/gateway-account-credential/Worldpay3dsFlexCredential.class.js
+++ b/src/models/gateway-account-credential/Worldpay3dsFlexCredential.class.js
@@ -38,8 +38,8 @@ class Worldpay3dsFlexCredential {
     return new Worldpay3dsFlexCredential()
       .withOrganisationalUnitId(data?.organisational_unit_id)
       .withIssuer(data?.issuer)
-      .withExemptionEngineEnabled(data?.exemption_engine_enabled)
-      .withCorporateExemptionsEnabled(data?.corporate_exemptions_enabled)
+      .withExemptionEngineEnabled(data?.exemption_engine_enabled ?? false)
+      .withCorporateExemptionsEnabled(data?.corporate_exemptions_enabled ?? false)
   }
 }
 

--- a/src/models/gateway-account-credential/Worldpay3dsFlexCredential.class.js
+++ b/src/models/gateway-account-credential/Worldpay3dsFlexCredential.class.js
@@ -14,6 +14,18 @@ class Worldpay3dsFlexCredential {
     return this
   }
 
+  // additional metadata returned by Connector - not included in POST body to update credentials
+  withExemptionEngineEnabled (exemptionEngineEnabled) {
+    this.exemptionEngineEnabled = exemptionEngineEnabled
+    return this
+  }
+
+  // additional metadata returned by Connector - not included in POST body to update credentials
+  withCorporateExemptionsEnabled (corporateExemptionsEnabled) {
+    this.corporateExemptionsEnabled = corporateExemptionsEnabled
+    return this
+  }
+
   toJson () {
     return {
       organisational_unit_id: this.organisationalUnitId,
@@ -26,7 +38,8 @@ class Worldpay3dsFlexCredential {
     return new Worldpay3dsFlexCredential()
       .withOrganisationalUnitId(data?.organisational_unit_id)
       .withIssuer(data?.issuer)
-      .withJwtMacKey(data?.jwt_mac_key)
+      .withExemptionEngineEnabled(data?.exemption_engine_enabled)
+      .withCorporateExemptionsEnabled(data?.corporate_exemptions_enabled)
   }
 }
 

--- a/src/views/simplified-account/settings/worldpay-details/flex-credentials.njk
+++ b/src/views/simplified-account/settings/worldpay-details/flex-credentials.njk
@@ -59,7 +59,6 @@
         classes: "govuk-input--width-20",
         type: 'password',
         autocomplete: 'off',
-        value: credentials.jwtMacKey,
         errorMessage: errors.formErrors.jwtMacKey and {
           text: errors.formErrors.jwtMacKey
         }

--- a/src/views/simplified-account/settings/worldpay-details/index.njk
+++ b/src/views/simplified-account/settings/worldpay-details/index.njk
@@ -12,24 +12,32 @@
 
     {% set taskList = [] %}
     {% for task in tasks %}
-      {% set taskList = (taskList.push({
-        title: {
-          text: task.linkText
-        },
-        href: task.href,
-        status: {
+      {% if task.status == 'CANNOT_START' %}
+        {% set taskStatusTag = {
+          tag: {
+            text: "Cannot start yet",
+            classes: "govuk-tag--grey"
+          }
+        } %}
+      {% elseif task.status == 'COMPLETED' %}
+        {% set taskStatusTag = {
+          text: "Completed"
+        } %}
+      {% else %}
+        {% set taskStatusTag = {
           tag: {
             text: "Not yet started",
             classes: "govuk-tag--blue"
           }
-        } if not (task.complete == true) else (
-          {
-            tag: {
-              text: "Completed",
-              classes: "govuk-tag--grey"
-            }
-          }
-        )
+        } %}
+      {% endif %}
+
+      {% set taskList = (taskList.push({
+        title: {
+          text: task.linkText
+        },
+        href: task.href if task.status != 'CANNOT_START',
+        status: taskStatusTag
       }), taskList) %}
     {% endfor %}
 


### PR DESCRIPTION
### WHAT
 - Display saved 3DS Flex credentials in completed task card & edit credentials form
 - this omits the JWT Mac Key for security purposes
 - updates Flex credentials task to show as "Cannot start yet" if Worldpay details are not set

![Screenshot 2025-02-03 at 17-52-45 Worldpay details - Settings - Test Worldpay Service - GOV UK Pay](https://github.com/user-attachments/assets/4a842a2b-ad6f-400c-84b3-99f54c28eb9c)

