### PR TITLE
PP-13557: Specifying that it the stub should only match when there is no query string.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
       },
       "devDependencies": {
         "@cypress/webpack-preprocessor": "^6.0.2",
-        "@govuk-pay/run-amock": "0.0.8",
+        "@govuk-pay/run-amock": "0.0.9",
         "@pact-foundation/pact": "^12.1.1",
         "@pact-foundation/pact-core": "^14.0.5",
         "@types/jquery": "^3.5.32",
@@ -3866,9 +3866,9 @@
       }
     },
     "node_modules/@govuk-pay/run-amock": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.8.tgz",
-      "integrity": "sha512-Jmk/gae8CE1V+9fY67aamwunSzcqmv85zWtIO00vDYqm/yl8bjvLwkMUws22DDm98Y6F0KTgLsk5XxJOjn2zYg==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.9.tgz",
+      "integrity": "sha512-5XJybR2TBjENM1Lji5KqozDH9zPyBhmZbFK60vMIzzbuq12dcrx+NGQ3TIM77tAOZfsr/GL5vyMv9O98a45tcg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -21788,9 +21788,9 @@
       }
     },
     "@govuk-pay/run-amock": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.8.tgz",
-      "integrity": "sha512-Jmk/gae8CE1V+9fY67aamwunSzcqmv85zWtIO00vDYqm/yl8bjvLwkMUws22DDm98Y6F0KTgLsk5XxJOjn2zYg==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.9.tgz",
+      "integrity": "sha512-5XJybR2TBjENM1Lji5KqozDH9zPyBhmZbFK60vMIzzbuq12dcrx+NGQ3TIM77tAOZfsr/GL5vyMv9O98a45tcg==",
       "dev": true
     },
     "@hapi/hoek": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^6.0.2",
-    "@govuk-pay/run-amock": "0.0.8",
+    "@govuk-pay/run-amock": "0.0.9",
     "@pact-foundation/pact": "^12.1.1",
     "@pact-foundation/pact-core": "^14.0.5",
     "@types/jquery": "^3.5.32",

--- a/test/cypress/stubs/api-keys-stubs.js
+++ b/test/cypress/stubs/api-keys-stubs.js
@@ -9,7 +9,8 @@ function getActiveApiKeysForGatewayAccount (gatewayAccountId, tokens = []) {
   return stubBuilder('GET', path, 200, {
     response: {
       tokens: tokens.map(t => t.toJson())
-    }
+    },
+    query: {}
   })
 }
 


### PR DESCRIPTION
### WHAT
There was a breaking change to Run Amock which was intended to make this test work.  The desired behaviour for this test is "it should only match when no query string is present", that lead to a change where all query strings, headers and request bodies were treated in a stricter way than Mountebank (which Run Amock is based on) handles them.

As we're reverting that change this breaking change, this test needs to specify that it should only match when there is no query string, that's done by specifying `query: {}`.

Note - there was a bug in Run Amock which meant that this approach did not work, this is resolved in PR https://github.com/alphagov/pay-run-amock/pull/16

Related PRs:

The change in Run Amock: https://github.com/alphagov/pay-run-amock/pull/16

Updates to other projects:
https://github.com/alphagov/pay-products-ui/pull/2742
https://github.com/alphagov/pay-frontend/pull/3950