### PR TITLE
PP-12427 switching credential logic

### DIFF
--- a/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.js
+++ b/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.js
@@ -17,9 +17,13 @@ async function getAccountDetails (req, res) {
 
 async function get (req, res) {
   const javascriptUnavailable = req.query.noscript === 'true'
+  /** @type {GatewayAccount} */
   const account = req.account
+  /** @type {GOVUKPayService} */
   const service = req.service
-  const stripeDetailsTasks = friendlyStripeTasks(account, service)
+  /** @type {StripeAccountSetup} */
+  const gatewayAccountStripeProgress = req.gatewayAccountStripeProgress
+  const stripeDetailsTasks = friendlyStripeTasks(gatewayAccountStripeProgress, account.type, service.externalId)
   const incompleteTasks = Object.values(stripeDetailsTasks).some(task => task.complete === false)
   let answers = {}
   // load account onboarding details synchronously if javascript is unavailable

--- a/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.test.js
@@ -48,12 +48,10 @@ describe('Controller: settings/stripe-details', () => {
     describe('when there are outstanding tasks', () => {
       before(() => {
         nextRequest({
-          account: {
-            connectorGatewayAccountStripeProgress: {
-              bankAccount: true,
-              vatNumber: false,
-              governmentEntityDocument: false
-            }
+          gatewayAccountStripeProgress: {
+            bankAccount: true,
+            vatNumber: false,
+            governmentEntityDocument: false
           }
         })
         call('get')
@@ -64,7 +62,7 @@ describe('Controller: settings/stripe-details', () => {
       })
 
       it('should pass req, res and template path to the response method', () => {
-        expect(mockResponse.args[0][0].account.connectorGatewayAccountStripeProgress).to.deep.equal({
+        expect(mockResponse.args[0][0].gatewayAccountStripeProgress).to.deep.equal({
           bankAccount: true,
           vatNumber: false,
           governmentEntityDocument: false

--- a/src/controllers/switch-psp/switch-tasks.service.js
+++ b/src/controllers/switch-psp/switch-tasks.service.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { CREDENTIAL_STATE } = require('../../utils/credentials')
+const CREDENTIAL_STATE = require('@models/credential-state')
 const lodash = require('lodash')
 
 function linkCredentialsComplete (targetCredential) {

--- a/src/controllers/switch-psp/verify-psp-integration.controller.js
+++ b/src/controllers/switch-psp/verify-psp-integration.controller.js
@@ -5,7 +5,7 @@ const { response } = require('../../utils/response')
 const { ConnectorClient } = require('../../services/clients/connector.client')
 const { getSwitchingCredential } = require('../../utils/credentials')
 const formatAccountPathsFor = require('../../utils/format-account-paths-for')
-const { CREDENTIAL_STATE } = require('../../utils/credentials')
+const CREDENTIAL_STATE = require('@models/credential-state')
 const {
   VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY,
   filterNextUrl

--- a/src/middleware/error-handler.js
+++ b/src/middleware/error-handler.js
@@ -77,7 +77,7 @@ module.exports = function errorHandler (err, req, res, next) {
   }
 
   if (err instanceof InvalidConfigurationError) {
-    logger.info(`InvalidConigurationError handled: ${err.message}. Rendering error page`)
+    logger.info(`InvalidConfigurationError handled: ${err.message}. Rendering error page`)
     return renderErrorView(req, res, 'This account is not configured to perform this action. Please contact the support team.', 400)
   }
 

--- a/src/middleware/simplified-account/check-task-completion.middleware.js
+++ b/src/middleware/simplified-account/check-task-completion.middleware.js
@@ -6,7 +6,7 @@ const {
 
 module.exports = function checkTaskCompletion (task) {
   return function (req, res, next) {
-    const stripeTaskProgress = req.account.connectorGatewayAccountStripeProgress
+    const stripeTaskProgress = req.gatewayAccountStripeProgress
     if (stripeTaskProgress[task]) {
       next(new TaskAlreadyCompletedError(`Attempted to access task page after completion [task: ${task}, serviceExternalId: ${req.service.externalId}]`))
     }

--- a/src/middleware/simplified-account/index.js
+++ b/src/middleware/simplified-account/index.js
@@ -1,6 +1,7 @@
 module.exports.enforceLiveAccountOnly = require('./enforce-live-account-only.middleware')
 module.exports.simplifiedAccountOptIn = require('./simplified-account-opt-in.middleware')
 module.exports.simplifiedAccountStrategy = require('./simplified-account-strategy.middleware')
+module.exports.stripeAccountSetupStrategy = require('./settings/stripe-account-setup-strategy.middleware')
 module.exports.enforcePaymentProviderType = require('./enforce-payment-provider-type.middleware')
 module.exports.enforceEmailCollectionModeNotOff = require('./enforce-email-collection-mode-not-off.middleware')
 module.exports.checkTaskCompletion = require('./check-task-completion.middleware')

--- a/src/middleware/simplified-account/settings/stripe-account-setup-strategy.middleware.js
+++ b/src/middleware/simplified-account/settings/stripe-account-setup-strategy.middleware.js
@@ -1,0 +1,14 @@
+const { getConnectorStripeAccountSetup } = require('@services/stripe-details.service')
+
+module.exports = async function (req, res, next) {
+  /** @type {GatewayAccount} */
+  const account = req.account
+  /** @type {GOVUKPayService} */
+  const service = req.service
+  return getConnectorStripeAccountSetup(service.externalId, account.type)
+    .then((data) => {
+      req.gatewayAccountStripeProgress = data
+      next()
+    })
+    .catch(err => next(err))
+}

--- a/src/middleware/simplified-account/settings/stripe-account-setup-strategy.middleware.test.js
+++ b/src/middleware/simplified-account/settings/stripe-account-setup-strategy.middleware.test.js
@@ -1,0 +1,52 @@
+const sinon = require('sinon')
+const { expect } = require('chai')
+const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
+const { RESTClientError } = require('@govuk-pay/pay-js-commons/lib/utils/axios-base-client/errors')
+
+const ACCOUNT_TYPE = 'live'
+const SERVICE_EXTERNAL_ID = 'service-id-123abc'
+
+const mockStripeDetailsService = {
+  getConnectorStripeAccountSetup: sinon.stub().resolves({
+    foo: 'bar'
+  })
+}
+
+const {
+  next,
+  call
+} = new ControllerTestBuilder('@middleware/simplified-account/settings/stripe-account-setup-strategy.middleware')
+  .withServiceExternalId(SERVICE_EXTERNAL_ID)
+  .withAccountType(ACCOUNT_TYPE)
+  .withStubs({
+    '@services/stripe-details.service': mockStripeDetailsService
+  })
+  .build()
+
+describe('Middleware: stripeAccountSetupStrategy', () => {
+  describe('when stripe account setup progress resolution succeeds', () => {
+    it('should set request key and call next', async () => {
+      const { req } = await call()
+      sinon.assert.calledOnce(next)
+      expect(req).to.have.property('gatewayAccountStripeProgress')
+      expect(req.gatewayAccountStripeProgress).to.deep.equal({
+        foo: 'bar'
+      })
+    })
+  })
+
+  describe('when stripe account setup progress resolution fails', () => {
+    before(() => {
+      const error = new RESTClientError('whoops')
+      mockStripeDetailsService.getConnectorStripeAccountSetup.rejects(error)
+    })
+
+    it('should call next with error', async () => {
+      await call()
+      const expectedError = sinon.match.instanceOf(RESTClientError)
+        .and(sinon.match.has('message', 'whoops'))
+      sinon.assert.calledOnce(next)
+      sinon.assert.calledWith(next, expectedError)
+    })
+  })
+})

--- a/src/middleware/simplified-account/simplified-account-strategy.middleware.test.js
+++ b/src/middleware/simplified-account/simplified-account-strategy.middleware.test.js
@@ -109,6 +109,7 @@ describe('Middleware: getSimplifiedAccount', () => {
 
     const expectedError = sinon.match.instanceOf(NotFoundError)
       .and(sinon.match.has('message', 'Could not resolve service external ID or gateway account type from request params'))
+    sinon.assert.calledOnce(next)
     sinon.assert.calledWith(next, expectedError)
   })
   it('should error if gateway account lookup fails for account type', async () => {
@@ -122,6 +123,7 @@ describe('Middleware: getSimplifiedAccount', () => {
 
     const expectedError = sinon.match.instanceOf(NotFoundError)
       .and(sinon.match.has('message', 'Could not retrieve gateway account with provided parameters'))
+    sinon.assert.calledOnce(next)
     sinon.assert.calledWith(next, expectedError)
   })
   describe('extend gateway account data with disableToggle3ds field', () => {
@@ -176,34 +178,6 @@ describe('Middleware: getSimplifiedAccount', () => {
       await simplifiedAccountStrategy(req, res, next)
       expect(req.account.supports3ds).to.equal(false)
       expect(req.account.externalId).to.equal(A_GATEWAY_EXTERNAL_ID)
-    })
-  })
-  describe('extend gateway account data stripe setup', () => {
-    ['worldpay', 'sandbox'].forEach(function (paymentProvider) {
-      it('should not extend the account data with stripe setup if payment provider is ' + paymentProvider, async () => {
-        const { simplifiedAccountStrategy } = setupSimplifiedAccountStrategyTest({
-          gatewayAccountID: '1',
-          gatewayAccountExternalId: A_GATEWAY_EXTERNAL_ID,
-          paymentProvider,
-          serviceExternalId: A_SERVICE_EXTERNAL_ID,
-          accountType: 'test'
-        })
-        await simplifiedAccountStrategy(req, res, next)
-        expect(req.account.externalId).to.equal(A_GATEWAY_EXTERNAL_ID)
-        expect(req.account).to.not.have.property('connectorGatewayAccountStripeProgress')
-      })
-    })
-    it('should extend the account data with supports3ds set to false if payment provider is stripe', async () => {
-      const { simplifiedAccountStrategy } = setupSimplifiedAccountStrategyTest({
-        gatewayAccountID: '1',
-        gatewayAccountExternalId: A_GATEWAY_EXTERNAL_ID,
-        paymentProvider: 'stripe',
-        serviceExternalId: A_SERVICE_EXTERNAL_ID,
-        accountType: 'test'
-      })
-      await simplifiedAccountStrategy(req, res, next)
-      expect(req.account.externalId).to.equal(A_GATEWAY_EXTERNAL_ID)
-      expect(req.account).to.have.property('connectorGatewayAccountStripeProgress')
     })
   })
 })

--- a/src/models/GatewayAccount.class.test.js
+++ b/src/models/GatewayAccount.class.test.js
@@ -1,0 +1,60 @@
+const GatewayAccount = require('@models/GatewayAccount.class')
+const { WORLDPAY } = require('@models/payment-providers')
+const { expect } = require('chai')
+const { InvalidConfigurationError } = require('@root/errors')
+
+const gatewayAccountCredentials = [
+  {
+    external_id: '64adb8fcef44416a81d9571685a3f25c',
+    payment_provider: 'stripe',
+    state: 'ACTIVE',
+    gateway_account_id: 12
+  }
+]
+
+describe('GatewayAccount', () => {
+  describe('getSwitchingCredentialIfPresent', () => {
+    it('should return a credential if one exists', () => {
+      const gatewayAccountData = {
+        gateway_account_credentials: [
+          ...gatewayAccountCredentials,
+          {
+            external_id: '9bda702de8a44b99901236d1fdd438da',
+            payment_provider: 'worldpay',
+            state: 'CREATED',
+            gateway_account_id: 12
+          }
+        ]
+      }
+      const gatewayAccount = new GatewayAccount(gatewayAccountData)
+      const switchingCredential = gatewayAccount.getSwitchingCredentialIfPresent()
+      expect(switchingCredential.paymentProvider).to.equal(WORLDPAY)
+    })
+
+    it('should throw invalid configuration error if more than one pending credential is found', () => {
+      const gatewayAccountData = {
+        gateway_account_id: 12,
+        gateway_account_credentials: [
+          ...gatewayAccountCredentials,
+          ...Array(2).fill({
+            external_id: '9bda702de8a44b99901236d1fdd438da',
+            payment_provider: 'worldpay',
+            state: 'CREATED',
+            gateway_account_id: 12
+          })
+        ]
+      }
+      const gatewayAccount = new GatewayAccount(gatewayAccountData)
+      expect(() => gatewayAccount.getSwitchingCredentialIfPresent()).to.throw(InvalidConfigurationError, 'Unexpected number of credentials in a pending state for gateway account [gateway_account_id: 12]')
+    })
+
+    it('should return null if no switching credential is found', () => {
+      const gatewayAccountData = {
+        gateway_account_credentials: gatewayAccountCredentials
+      }
+      const gatewayAccount = new GatewayAccount(gatewayAccountData)
+      const switchingCredential = gatewayAccount.getSwitchingCredentialIfPresent()
+      expect(switchingCredential).to.be.null //eslint-disable-line
+    })
+  })
+})

--- a/src/models/GatewayAccount.class.test.js
+++ b/src/models/GatewayAccount.class.test.js
@@ -33,7 +33,6 @@ describe('GatewayAccount', () => {
 
     it('should throw invalid configuration error if more than one pending credential is found', () => {
       const gatewayAccountData = {
-        gateway_account_id: 12,
         gateway_account_credentials: [
           ...gatewayAccountCredentials,
           ...Array(2).fill({
@@ -45,7 +44,7 @@ describe('GatewayAccount', () => {
         ]
       }
       const gatewayAccount = new GatewayAccount(gatewayAccountData)
-      expect(() => gatewayAccount.getSwitchingCredentialIfPresent()).to.throw(InvalidConfigurationError, 'Unexpected number of credentials in a pending state for gateway account [gateway_account_id: 12]')
+      expect(() => gatewayAccount.getSwitchingCredentialIfPresent()).to.throw(InvalidConfigurationError, 'Unexpected number of credentials in a pending state for gateway account [found 2]')
     })
 
     it('should return null if no switching credential is found', () => {

--- a/src/models/StripeAccountSetup.class.js
+++ b/src/models/StripeAccountSetup.class.js
@@ -1,5 +1,13 @@
-'use strict'
-
+/**
+ * @class StripeAccountSetup
+ * @property {boolean} bankAccount
+ * @property {boolean} responsiblePerson
+ * @property {boolean} vatNumber
+ * @property {boolean} companyNumber
+ * @property {boolean} director
+ * @property {boolean} governmentEntityDocument
+ * @property {boolean} organisationDetails
+ */
 class StripeAccountSetup {
   constructor (opts) {
     this.bankAccount = opts.bank_account

--- a/src/models/credential-state.js
+++ b/src/models/credential-state.js
@@ -1,0 +1,11 @@
+/**
+ * @readonly
+ * @enum {String}
+ */
+module.exports = {
+  CREATED: 'CREATED',
+  ENTERED: 'ENTERED',
+  VERIFIED: 'VERIFIED_WITH_LIVE_PAYMENT',
+  ACTIVE: 'ACTIVE',
+  RETIRED: 'RETIRED'
+}

--- a/src/models/gateway-account-credential/GatewayAccountCredential.class.js
+++ b/src/models/gateway-account-credential/GatewayAccountCredential.class.js
@@ -1,13 +1,5 @@
 const Credential = require('./Credential.class')
 
-const CREDENTIAL_STATE = {
-  CREATED: 'CREATED',
-  ENTERED: 'ENTERED',
-  VERIFIED: 'VERIFIED_WITH_LIVE_PAYMENT',
-  ACTIVE: 'ACTIVE',
-  RETIRED: 'RETIRED'
-}
-
 class GatewayAccountCredential {
   withExternalId (externalId) {
     this.externalId = externalId
@@ -71,4 +63,3 @@ class GatewayAccountCredential {
 
 module.exports.GatewayAccountCredential = GatewayAccountCredential
 module.exports.Credential = Credential
-module.exports.CREDENTIAL_STATE = CREDENTIAL_STATE

--- a/src/services/stripe-details.service.js
+++ b/src/services/stripe-details.service.js
@@ -11,6 +11,15 @@ const logger = require('@utils/logger')(__filename)
 const connector = new ConnectorClient(process.env.CONNECTOR_URL)
 
 /**
+ * @param {string} serviceExternalId
+ * @param {string} accountType
+ * @returns {Promise<StripeAccountSetup>}
+ */
+const getConnectorStripeAccountSetup = async (serviceExternalId, accountType) => {
+  return connector.getStripeAccountSetupByServiceExternalIdAndAccountType(serviceExternalId, accountType)
+}
+
+/**
  * Updates Stripe account bank details for the given service and account type
  * @param {GatewayAccount} account
  * @param {GOVUKPayService} service
@@ -237,5 +246,6 @@ module.exports = {
   updateStripeDetailsUploadEntityDocument,
   updateStripeDetailsOrganisationNameAndAddress,
   updateConnectorStripeProgress,
-  getStripeAccountOnboardingDetails
+  getStripeAccountOnboardingDetails,
+  getConnectorStripeAccountSetup
 }

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -3,6 +3,7 @@ const { Router } = require('express')
 const {
   simplifiedAccountStrategy,
   simplifiedAccountOptIn,
+  stripeAccountSetupStrategy,
   enforceEmailCollectionModeNotOff,
   enforceLiveAccountOnly,
   enforcePaymentProviderType,
@@ -104,7 +105,7 @@ simplifiedAccount.get(paths.simplifiedAccount.settings.switchPsp.switchToWorldpa
 // stripe details
 const stripeDetailsPath = paths.simplifiedAccount.settings.stripeDetails
 const stripeDetailsRouter = new Router({ mergeParams: true })
-  .use(enforceLiveAccountOnly, enforcePaymentProviderType(STRIPE), permission('stripe-account-details:update'))
+  .use(enforceLiveAccountOnly, enforcePaymentProviderType(STRIPE), permission('stripe-account-details:update'), stripeAccountSetupStrategy)
 stripeDetailsRouter.get(stripeDetailsPath.index, serviceSettingsController.stripeDetails.get)
 stripeDetailsRouter.get(stripeDetailsPath.accountDetails, serviceSettingsController.stripeDetails.getAccountDetails)
 

--- a/src/utils/credentials.js
+++ b/src/utils/credentials.js
@@ -2,14 +2,7 @@
 
 const paths = require('../paths')
 const { InvalidConfigurationError, NotFoundError } = require('../errors')
-
-const CREDENTIAL_STATE = {
-  CREATED: 'CREATED',
-  ENTERED: 'ENTERED',
-  VERIFIED: 'VERIFIED_WITH_LIVE_PAYMENT',
-  ACTIVE: 'ACTIVE',
-  RETIRED: 'RETIRED'
-}
+const CREDENTIAL_STATE = require('@models/credential-state')
 
 const pendingCredentialStates = [CREDENTIAL_STATE.CREATED, CREDENTIAL_STATE.ENTERED, CREDENTIAL_STATE.VERIFIED]
 

--- a/src/utils/nav-builder.js
+++ b/src/utils/nav-builder.js
@@ -8,7 +8,8 @@ const formatSimplifiedAccountPathsFor = require('./simplified-account/format/for
 const formatFutureStrategyAccountPathsFor = require('./format-future-strategy-account-paths-for')
 const pathLookup = require('./path-lookup')
 const formatPSPname = require('./format-PSP-name')
-const { getPSPPageLinks, CREDENTIAL_STATE } = require('./credentials')
+const { getPSPPageLinks } = require('./credentials')
+const CREDENTIAL_STATE = require('@models/credential-state')
 const flattenNestedValues = require('./flatten-nested-values')
 
 const mainSettingsPaths = [

--- a/src/utils/simplified-account/settings/stripe-details/tasks.js
+++ b/src/utils/simplified-account/settings/stripe-details/tasks.js
@@ -80,19 +80,20 @@ const getStripeTaskStatus = (task, complete, govEntityDocTaskUnavailable) => {
 
 /**
  * Transforms connectorGatewayAccountStripeProgress into 'render-able' stripe tasks
- * @param account {GatewayAccount}
- * @param service {GOVUKPayService}
+ * @param stripeAccountSetup {StripeAccountSetup}
+ * @param accountType {string}
+ * @param serviceExternalId {string}
  * @returns {[StripeTask]|[]}
  */
-const friendlyStripeTasks = (account, service) => {
-  if (account.connectorGatewayAccountStripeProgress) {
-    const progress = orderTasks(account.connectorGatewayAccountStripeProgress)
+const friendlyStripeTasks = (stripeAccountSetup, accountType, serviceExternalId) => {
+  if (stripeAccountSetup) {
+    const progress = orderTasks(stripeAccountSetup)
     const govEntityDocTaskUnavailable = Object.entries(progress)
       .some(([task, completed]) => task !== stripeDetailsTasks.governmentEntityDocument.name && completed === false)
 
     return Object.entries(progress).reduce((acc, [task, complete]) => {
       const linkText = stripeDetailsTasks[task].friendlyName
-      const href = formatSimplifiedAccountPathsFor(stripeDetailsTasks[task].path, service.externalId, account.type)
+      const href = formatSimplifiedAccountPathsFor(stripeDetailsTasks[task].path, serviceExternalId, accountType)
       acc.push({
         linkText,
         href,
@@ -102,7 +103,7 @@ const friendlyStripeTasks = (account, service) => {
       return acc
     }, [])
   } else {
-    logger.error(`Expected Stripe account progress for gateway account but none was found [gateway_account_id: ${account.id}]`)
+    logger.error(`Expected Stripe account progress for gateway account but none was found [service_external_id: ${serviceExternalId}, account_type: ${accountType}]`)
     return []
   }
 }

--- a/src/utils/simplified-account/settings/stripe-details/tasks.test.js
+++ b/src/utils/simplified-account/settings/stripe-details/tasks.test.js
@@ -43,7 +43,7 @@ describe('friendlyStripeTasks', () => {
   })
 
   it('should set task order according to stripeDetailsTasks key order', () => {
-    const accountWithMixedProgress = {
+    const setupObjectWithMixedProgress = {
       governmentEntityDocument: false,
       responsiblePerson: true,
       organisationDetails: false,
@@ -53,7 +53,7 @@ describe('friendlyStripeTasks', () => {
       vatNumber: true
     }
 
-    const result = friendlyStripeTasks(accountWithMixedProgress, account.type, service.externalId)
+    const result = friendlyStripeTasks(setupObjectWithMixedProgress, account.type, service.externalId)
     expect(result[0]).to.deep.include({
       linkText: 'Organisation\'s bank details', // bankAccount should be the first task
       complete: true,
@@ -67,23 +67,23 @@ describe('friendlyStripeTasks', () => {
   })
 
   it('should format paths correctly for task', () => {
-    const accountWithSingleTask = {
+    const setupObjectWithSingleTask = {
       director: true
     }
 
-    const result = friendlyStripeTasks(accountWithSingleTask, account.type, service.externalId)
+    const result = friendlyStripeTasks(setupObjectWithSingleTask, account.type, service.externalId)
 
     expect(result[0].href).to.equal(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.director, SERVICE_EXTERNAL_ID, ACCOUNT_TYPE))
   })
 
   it('should handle status values correctly', () => {
-    const accountWithMixedStatus = {
+    const setupObjectWithMixedStatus = {
       vatNumber: true,
       companyNumber: false,
       governmentEntityDocument: false
     }
 
-    const result = friendlyStripeTasks(accountWithMixedStatus, account.type, service.externalId)
+    const result = friendlyStripeTasks(setupObjectWithMixedStatus, account.type, service.externalId)
 
     expect(result[0].status).to.equal(COMPLETED_CANNOT_START) // eslint-disable-line
     expect(result[1].status).to.equal(NOT_STARTED) // eslint-disable-line
@@ -91,9 +91,9 @@ describe('friendlyStripeTasks', () => {
   })
 
   it('should handle empty progress object', () => {
-    const accountWithEmptyProgress = {}
+    const emptySetupObject = {}
 
-    const result = friendlyStripeTasks(accountWithEmptyProgress, account.type, service.externalId)
+    const result = friendlyStripeTasks(emptySetupObject, account.type, service.externalId)
     expect(result).to.be.an('array')
     expect(result).to.be.empty // eslint-disable-line
   })

--- a/src/utils/simplified-account/settings/stripe-details/tasks.test.js
+++ b/src/utils/simplified-account/settings/stripe-details/tasks.test.js
@@ -15,27 +15,24 @@ describe('friendlyStripeTasks', () => {
     externalId: SERVICE_EXTERNAL_ID
   }
 
-  it('should return empty array when connectorGatewayAccountStripeProgress is not present', () => {
-    const result = friendlyStripeTasks(account, service)
+  it('should return empty array when stripeAccountSetup is not present', () => {
+    const result = friendlyStripeTasks(null, account.type, service.externalId)
     expect(result).to.be.an('array')
     expect(result).to.be.empty // eslint-disable-line
   })
 
   it('should transform stripe tasks with all tasks completed', () => {
-    const accountWithProgress = {
-      ...account,
-      connectorGatewayAccountStripeProgress: {
-        bankAccount: true,
-        responsiblePerson: true,
-        director: true,
-        vatNumber: true,
-        companyNumber: true,
-        organisationDetails: true,
-        governmentEntityDocument: true
-      }
+    const stripeAccountSetup = {
+      bankAccount: true,
+      responsiblePerson: true,
+      director: true,
+      vatNumber: true,
+      companyNumber: true,
+      organisationDetails: true,
+      governmentEntityDocument: true
     }
 
-    const result = friendlyStripeTasks(accountWithProgress, service)
+    const result = friendlyStripeTasks(stripeAccountSetup, account.type, service.externalId)
 
     expect(result).to.be.an('array')
     expect(result).to.have.lengthOf(7)
@@ -47,19 +44,16 @@ describe('friendlyStripeTasks', () => {
 
   it('should set task order according to stripeDetailsTasks key order', () => {
     const accountWithMixedProgress = {
-      ...account,
-      connectorGatewayAccountStripeProgress: {
-        governmentEntityDocument: false,
-        responsiblePerson: true,
-        organisationDetails: false,
-        director: false,
-        companyNumber: false,
-        bankAccount: true,
-        vatNumber: true
-      }
+      governmentEntityDocument: false,
+      responsiblePerson: true,
+      organisationDetails: false,
+      director: false,
+      companyNumber: false,
+      bankAccount: true,
+      vatNumber: true
     }
 
-    const result = friendlyStripeTasks(accountWithMixedProgress, service)
+    const result = friendlyStripeTasks(accountWithMixedProgress, account.type, service.externalId)
     expect(result[0]).to.deep.include({
       linkText: 'Organisation\'s bank details', // bankAccount should be the first task
       complete: true,
@@ -74,28 +68,22 @@ describe('friendlyStripeTasks', () => {
 
   it('should format paths correctly for task', () => {
     const accountWithSingleTask = {
-      ...account,
-      connectorGatewayAccountStripeProgress: {
-        director: true
-      }
+      director: true
     }
 
-    const result = friendlyStripeTasks(accountWithSingleTask, service)
+    const result = friendlyStripeTasks(accountWithSingleTask, account.type, service.externalId)
 
     expect(result[0].href).to.equal(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.director, SERVICE_EXTERNAL_ID, ACCOUNT_TYPE))
   })
 
   it('should handle status values correctly', () => {
     const accountWithMixedStatus = {
-      ...account,
-      connectorGatewayAccountStripeProgress: {
-        vatNumber: true,
-        companyNumber: false,
-        governmentEntityDocument: false
-      }
+      vatNumber: true,
+      companyNumber: false,
+      governmentEntityDocument: false
     }
 
-    const result = friendlyStripeTasks(accountWithMixedStatus, service)
+    const result = friendlyStripeTasks(accountWithMixedStatus, account.type, service.externalId)
 
     expect(result[0].status).to.equal(COMPLETED_CANNOT_START) // eslint-disable-line
     expect(result[1].status).to.equal(NOT_STARTED) // eslint-disable-line
@@ -103,12 +91,9 @@ describe('friendlyStripeTasks', () => {
   })
 
   it('should handle empty progress object', () => {
-    const accountWithEmptyProgress = {
-      ...account,
-      connectorGatewayAccountStripeProgress: {}
-    }
+    const accountWithEmptyProgress = {}
 
-    const result = friendlyStripeTasks(accountWithEmptyProgress, service)
+    const result = friendlyStripeTasks(accountWithEmptyProgress, account.type, service.externalId)
     expect(result).to.be.an('array')
     expect(result).to.be.empty // eslint-disable-line
   })

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/bank-details.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/bank-details.cy.js
@@ -53,9 +53,10 @@ describe('Stripe details settings', () => {
         })
         cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/bank-details', { failOnStatusCode: false })
       })
-      it('should show not found page', () => {
-        cy.title().should('eq', 'Page not found - GOV.UK Pay')
-        cy.get('h1').should('contain.text', 'Page not found')
+      it('should show admin only error', () => {
+        cy.title().should('eq', 'An error occurred - GOV.UK Pay')
+        cy.get('h1').should('contain.text', 'An error occurred')
+        cy.get('#errorMsg').should('contain.text', 'You do not have the administrator rights to perform this operation.')
       })
     })
     describe('For a non-stripe service', () => {

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/company-number.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/company-number.cy.js
@@ -53,9 +53,10 @@ describe('Stripe details settings', () => {
         })
         cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/company-number', { failOnStatusCode: false })
       })
-      it('should show not found page', () => {
-        cy.title().should('eq', 'Page not found - GOV.UK Pay')
-        cy.get('h1').should('contain.text', 'Page not found')
+      it('should show admin only error', () => {
+        cy.title().should('eq', 'An error occurred - GOV.UK Pay')
+        cy.get('h1').should('contain.text', 'An error occurred')
+        cy.get('#errorMsg').should('contain.text', 'You do not have the administrator rights to perform this operation.')
       })
     })
     describe('For a non-stripe service', () => {

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/confirm-org-details.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/confirm-org-details.cy.js
@@ -54,9 +54,10 @@ describe('Stripe details settings', () => {
         })
         cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/organisation-details/index', { failOnStatusCode: false })
       })
-      it('should show not found page', () => {
-        cy.title().should('eq', 'Page not found - GOV.UK Pay')
-        cy.get('h1').should('contain.text', 'Page not found')
+      it('should show admin only error', () => {
+        cy.title().should('eq', 'An error occurred - GOV.UK Pay')
+        cy.get('h1').should('contain.text', 'An error occurred')
+        cy.get('#errorMsg').should('contain.text', 'You do not have the administrator rights to perform this operation.')
       })
     })
     describe('For a non-stripe service', () => {

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/director.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/director.cy.js
@@ -53,9 +53,10 @@ describe('Stripe details settings', () => {
         })
         cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/director', { failOnStatusCode: false })
       })
-      it('should show not found page', () => {
-        cy.title().should('eq', 'Page not found - GOV.UK Pay')
-        cy.get('h1').should('contain.text', 'Page not found')
+      it('should show admin only error', () => {
+        cy.title().should('eq', 'An error occurred - GOV.UK Pay')
+        cy.get('h1').should('contain.text', 'An error occurred')
+        cy.get('#errorMsg').should('contain.text', 'You do not have the administrator rights to perform this operation.')
       })
     })
     describe('For a non-stripe service', () => {

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/government-entity-document.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/government-entity-document.cy.js
@@ -53,9 +53,10 @@ describe('Stripe details settings', () => {
         })
         cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/government-entity-document', { failOnStatusCode: false })
       })
-      it('should show not found page', () => {
-        cy.title().should('eq', 'Page not found - GOV.UK Pay')
-        cy.get('h1').should('contain.text', 'Page not found')
+      it('should show admin only error', () => {
+        cy.title().should('eq', 'An error occurred - GOV.UK Pay')
+        cy.get('h1').should('contain.text', 'An error occurred')
+        cy.get('#errorMsg').should('contain.text', 'You do not have the administrator rights to perform this operation.')
       })
     })
     describe('For a non-stripe service', () => {

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/responsible-person.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/responsible-person.cy.js
@@ -53,9 +53,10 @@ describe('Stripe details settings', () => {
         })
         cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/responsible-person', { failOnStatusCode: false })
       })
-      it('should show not found page', () => {
-        cy.title().should('eq', 'Page not found - GOV.UK Pay')
-        cy.get('h1').should('contain.text', 'Page not found')
+      it('should show admin only error', () => {
+        cy.title().should('eq', 'An error occurred - GOV.UK Pay')
+        cy.get('h1').should('contain.text', 'An error occurred')
+        cy.get('#errorMsg').should('contain.text', 'You do not have the administrator rights to perform this operation.')
       })
     })
     describe('For a non-stripe service', () => {

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/task-summary.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/task-summary.cy.js
@@ -90,12 +90,18 @@ describe('Stripe details settings', () => {
         }
         setStubs({
           role
-        })
+        }, [
+          stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
+            serviceExternalId: SERVICE_EXTERNAL_ID,
+            accountType: LIVE_ACCOUNT_TYPE
+          })
+        ])
         cy.visit(SERVICE_SETTINGS_URL + '/stripe-details', { failOnStatusCode: false })
       })
-      it('should show 404 page', () => {
-        cy.title().should('eq', 'Page not found - GOV.UK Pay')
-        cy.get('h1').should('contain.text', 'Page not found')
+      it('should show admin only error', () => {
+        cy.title().should('eq', 'An error occurred - GOV.UK Pay')
+        cy.get('h1').should('contain.text', 'An error occurred')
+        cy.get('#errorMsg').should('contain.text', 'You do not have the administrator rights to perform this operation.')
       })
     })
     describe('For non-stripe service', () => {

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/vat-number.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/vat-number.cy.js
@@ -53,9 +53,10 @@ describe('Stripe details settings', () => {
         })
         cy.visit(STRIPE_DETAILS_SETTINGS_URL + '/vat-number', { failOnStatusCode: false })
       })
-      it('should show not found page', () => {
-        cy.title().should('eq', 'Page not found - GOV.UK Pay')
-        cy.get('h1').should('contain.text', 'Page not found')
+      it('should show admin only error', () => {
+        cy.title().should('eq', 'An error occurred - GOV.UK Pay')
+        cy.get('h1').should('contain.text', 'An error occurred')
+        cy.get('#errorMsg').should('contain.text', 'You do not have the administrator rights to perform this operation.')
       })
     })
     describe('For a non-stripe service', () => {


### PR DESCRIPTION
### WHAT

- new 'enum' of credential states
- new connector stripe account setup strategy middleware
- remove call to connector from account strategy middleware for stripe account setup
- add stripe account strategy middleware to stripe details router
- stop mutating the gateway account model with stripe account setup progress
  - move stripe account setup progress to a specific key on the request
- update gateway account model with class method for identifying a switching credential