### PR TITLE
BAU fix issue in settings navigation where two links could be 'active'

### DIFF
--- a/src/utils/simplified-account/settings/SettingsBuilder.class.js
+++ b/src/utils/simplified-account/settings/SettingsBuilder.class.js
@@ -21,10 +21,9 @@ module.exports = class SettingsBuilder {
     if (!this.currentCategory) {
       throw new Error('Cannot add setting without category, use .category(name) first.')
     }
-
-    const urlParts = ['simplified', 'settings', `/${id}`]
+    const urlParts = ['simplified', Array.isArray(id) ? `settings/${id.join('/')}` : `settings/${id}`]
     const setting = {
-      id,
+      id: Array.isArray(id) ? id[id.length - 1] : id,
       name,
       url: this.pathFormatter(
         path,

--- a/src/utils/simplified-account/settings/service-settings.js
+++ b/src/utils/simplified-account/settings/service-settings.js
@@ -52,7 +52,7 @@ module.exports = (account, service, currentUrl, permissions) => {
       permission: account.paymentProvider === 'worldpay' && 'gateway_credentials_read'
     })
     .add({
-      id: 'switch-to-worldpay',
+      id: ['switch-psp', 'switch-to-worldpay'], // sits under settings/switch-psp/switch-to-worldpay
       name: 'switch to Worldpay',
       path: paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index,
       permission: account.paymentProvider === 'stripe' && account.providerSwitchEnabled && 'gateway_credentials_update'


### PR DESCRIPTION
### WHAT

- tighten up validation on 'current' key in the SettingsBuilder

### SCREENS
_Screenshots if view has been modified:_

#### BEFORE

<img width="1247" alt="Screenshot 2025-02-06 at 17 22 39" src="https://github.com/user-attachments/assets/dfaadca6-c12c-4681-b4fe-716276abeeae" />

#### AFTER

<img width="1247" alt="Screenshot 2025-02-06 at 17 22 09" src="https://github.com/user-attachments/assets/7cf57945-eb2c-4ddd-b223-6dd08fc74211" />
