### PR TITLE
PP-13521: Initial setup of webhooks detail view

### DIFF
--- a/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
@@ -1,0 +1,14 @@
+const paths = require('@root/paths')
+const { response } = require('@utils/response')
+const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
+
+async function get (req, res) {
+  response(req, res, 'simplified-account/settings/webhooks/detail', {
+    description: 'Description from the webhook',
+    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type)
+  })
+}
+
+module.exports = {
+  get
+}

--- a/src/controllers/simplified-account/settings/webhooks/webhooks.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/webhooks.controller.js
@@ -15,11 +15,13 @@ async function get (req, res) {
     activeWebhooks,
     deactivatedWebhooks,
     eventTypes: constants.webhooks.humanReadableSubscriptions,
-    createWebhookLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.create, req.service.externalId, req.account.type)
+    createWebhookLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.create, req.service.externalId, req.account.type),
+    detailWebhookBaseUrl: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type) + '/'
   })
 }
 
 module.exports = {
   get,
-  create: require('./create/create.controller')
+  create: require('./create/create.controller'),
+  detail: require('./detail/detail.controller')
 }

--- a/src/paths.js
+++ b/src/paths.js
@@ -238,7 +238,8 @@ module.exports = {
       },
       webhooks: {
         index: '/settings/webhooks',
-        create: '/settings/webhooks/create'
+        create: '/settings/webhooks/create',
+        detail: '/settings/webhooks/:webhookId'
       },
       switchPsp: {
         switchToWorldpay: {

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -97,6 +97,7 @@ simplifiedAccount.get(paths.simplifiedAccount.settings.apiKeys.revokedKeys, perm
 simplifiedAccount.get(paths.simplifiedAccount.settings.webhooks.index, permission('webhooks:read'), serviceSettingsController.webhooks.get)
 simplifiedAccount.get(paths.simplifiedAccount.settings.webhooks.create, permission('webhooks:read'), serviceSettingsController.webhooks.create.get)
 simplifiedAccount.post(paths.simplifiedAccount.settings.webhooks.create, permission('webhooks:update'), serviceSettingsController.webhooks.create.post)
+simplifiedAccount.get(paths.simplifiedAccount.settings.webhooks.detail, permission('webhooks:read'), serviceSettingsController.webhooks.detail.get)
 
 // switch psp
 simplifiedAccount.get(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index, permission('gateway-credentials:update'), serviceSettingsController.switchPsp.switchToWorldpay.get)

--- a/src/views/simplified-account/settings/webhooks/detail.njk
+++ b/src/views/simplified-account/settings/webhooks/detail.njk
@@ -1,0 +1,7 @@
+{% extends "../settings-layout.njk" %}
+
+{% set settingsPageTitle = description %}
+
+{% block settingsContent %}
+  <h1 class="govuk-heading-l">{{ description }}</h1>
+{% endblock %}

--- a/src/views/simplified-account/settings/webhooks/index.njk
+++ b/src/views/simplified-account/settings/webhooks/index.njk
@@ -35,6 +35,7 @@
       {% for webhook in activeWebhooks %}
         {% set webhookDescriptionWithTag = webhook.description + '&nbsp&nbsp&nbsp' + webhookStatusTag(webhook.status) %}
         {% set webhookSubscriptionsList = webhookSubscriptions(webhook) %}
+        {% set webhookDetailUrl = detailWebhookBaseUrl + webhook.external_id %}
         {{ govukSummaryList({
           classes: "webhooks-summary-card",
           card: {
@@ -44,7 +45,7 @@
             actions: {
               items: [
                 {
-                  href: '',
+                  href: webhookDetailUrl,
                   text: 'View',
                   classes: "govuk-link govuk-link--no-visited-state"
                 },


### PR DESCRIPTION
### WHAT

Set up initial outline for webhooks details view. This commit just sets up the basic view template and controller, and links them from the webhooks ndex page.

* Create detail controller
* Create detail view template
* Update paths
* Add route
* Update webhooks controller to link webhook summary to webhook detail.

