### PR TITLE
PP-13136 Correct max webhook description length to 50 chars

### DIFF
--- a/src/utils/simplified-account/validation/webhook.schema.js
+++ b/src/utils/simplified-account/validation/webhook.schema.js
@@ -1,6 +1,6 @@
 const { body } = require('express-validator')
 
-const WEBHOOK_DESCRIPTION_MAX_LENGTH = 40
+const WEBHOOK_DESCRIPTION_MAX_LENGTH = 50
 
 const webhookSchema = {
   callbackUrl: {

--- a/src/utils/simplified-account/validation/webhook.schema.test.js
+++ b/src/utils/simplified-account/validation/webhook.schema.test.js
@@ -65,11 +65,11 @@ describe('Webhook Validation', () => {
 
     it('should fail when description is too long', async () => {
       const invalidReq = {
-        body: Object.assign({}, VALID_REQUEST.body, { description: 'This 41 character description is too long' })
+        body: Object.assign({}, VALID_REQUEST.body, { description: 'This description has 51 characters which is too big' })
       }
       await webhookSchema.description.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
-      expect(errors.array()[0].msg).to.equal('Description must be 40 characters or fewer')
+      expect(errors.array()[0].msg).to.equal('Description must be 50 characters or fewer')
     })
   })
 

--- a/src/views/simplified-account/settings/webhooks/create.njk
+++ b/src/views/simplified-account/settings/webhooks/create.njk
@@ -40,7 +40,7 @@
       name: "description",
       value: form.description,
       attributes: {
-        maxlength: "40"
+        maxlength: "50"
       },
       spellcheck: true,
       errorMessage: { text: errors.formErrors['description'] } if errors.formErrors['description'] else false


### PR DESCRIPTION
Max length for webhook description was incorrectly set to 40 characters.
- Correct max webhook description length to 50 characters in template and schema. 