### PR TITLE
PP-13261: Show recurring payment credentials tasks

### DIFF
--- a/src/models/gateway-account-credential/Credential.class.js
+++ b/src/models/gateway-account-credential/Credential.class.js
@@ -21,6 +21,26 @@ class Credential {
     return this
   }
 
+  /**
+   *
+   * @param {WorldpayCredential} recurringCustomerInitated
+   * @returns {Credential}
+   */
+  withRecurringCustomerInitiated (recurringCustomerInitated) {
+    this.recurringCustomerInitated = recurringCustomerInitated
+    return this
+  }
+
+  /**
+   *
+   * @param {WorldpayCredential} recurringMerchantInitated
+   * @returns {Credential}
+   */
+  withRecurringMerchantInitiated (recurringMerchantInitated) {
+    this.recurringMerchantInitated = recurringMerchantInitated
+    return this
+  }
+
   /** @deprecated this is a temporary compatability fix! If you find yourself using this for new code
    * you should instead add any rawResponse data as part of the constructor */
   withRawResponse (data) {
@@ -45,6 +65,12 @@ class Credential {
     }
     if (data?.one_off_customer_initiated) {
       credential.withOneOffCustomerInitiated(WorldpayCredential.fromJson(data.one_off_customer_initiated))
+    }
+    if (data?.recurring_customer_initiated) {
+      credential.withRecurringCustomerInitiated(WorldpayCredential.fromJson(data.recurring_customer_initiated))
+    }
+    if (data?.recurring_merchant_initiated) {
+      credential.withRecurringMerchantInitiated(WorldpayCredential.fromJson(data.recurring_customer_initiated))
     }
     return credential
   }

--- a/src/paths.js
+++ b/src/paths.js
@@ -216,8 +216,10 @@ module.exports = {
       },
       worldpayDetails: {
         index: '/settings/worldpay-details',
+        flexCredentials: '/settings/worldpay-details/flex-credentials',
         oneOffCustomerInitiated: '/settings/worldpay-details/one-off-customer-initiated',
-        flexCredentials: '/settings/worldpay-details/flex-credentials'
+        recurringCustomerInitiated: '/settings/worldpay-details/recurring-customer-initiated',
+        recurringMerchantInitiated: '/settings/worldpay-details/recurring-merchant-initiated'
       },
       cardPayments: {
         index: '/settings/card-payments',


### PR DESCRIPTION
This PR displays outstanding recurring payment credentials tasks on the Worldpay details page. The links don't link to anywhere valid yet.

Tasks shown where recurring payments are enabled:

<img width="947" alt="Screenshot 2025-02-10 at 17 58 12" src="https://github.com/user-attachments/assets/1ee124e0-4d58-43a6-a8d3-4630ba3a4c8f" />
