### PR TITLE
PP-12427 switch to worldpay (MOTO service) impl

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,16 +1,37 @@
 {
   "compilerOptions": {
+    "checkJs": true,
+    "module": "commonjs",
     "baseUrl": ".",
     "paths": {
-      "@root/*": ["src/*"],
-      "@controllers/*": ["src/controllers/*"],
-      "@middleware/*": ["src/middleware/*"],
-      "@models/*": ["src/models/*"],
-      "@services/*": ["src/services/*"],
-      "@utils/*": ["src/utils/*"],
-      "@views/*": ["src/views/*"],
-      "@test/*": ["test/*"]
+      "@controllers/*": [
+        "src/controllers/*"
+      ],
+      "@middleware/*": [
+        "src/middleware/*"
+      ],
+      "@models/*": [
+        "src/models/*"
+      ],
+      "@services/*": [
+        "src/services/*"
+      ],
+      "@utils/*": [
+        "src/utils/*"
+      ],
+      "@views/*": [
+        "src/views/*"
+      ],
+      "@root/*": [
+        "src/*"
+      ],
+      "@test/*": [
+        "test/*"
+      ]
     }
   },
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.js
+++ b/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.js
@@ -17,11 +17,8 @@ async function getAccountDetails (req, res) {
 
 async function get (req, res) {
   const javascriptUnavailable = req.query.noscript === 'true'
-  /** @type {GatewayAccount} */
   const account = req.account
-  /** @type {GOVUKPayService} */
   const service = req.service
-  /** @type {StripeAccountSetup} */
   const gatewayAccountStripeProgress = req.gatewayAccountStripeProgress
   const stripeDetailsTasks = friendlyStripeTasks(gatewayAccountStripeProgress, account.type, service.externalId)
   const incompleteTasks = Object.values(stripeDetailsTasks).some(task => task.complete === false)

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/add-flex-credentials.controller.js
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/add-flex-credentials.controller.js
@@ -1,0 +1,8 @@
+// TODO PP-13353
+function get (re, res) {
+  res.status(501).json({ error: 'not implemented' })
+}
+
+module.exports = {
+  get
+}

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/add-worldpay-credentials.controller.js
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/add-worldpay-credentials.controller.js
@@ -8,9 +8,7 @@ const worldpayDetailsService = require('@services/worldpay-details.service')
 const { oneOffCustomerInitiatedSchema } = require('@utils/simplified-account/validation/worldpay/one-off-customer-initiated.schema')
 
 function get(req, res) {
-  /** @type {GatewayAccount} */
   const account = req.account
-  /** @type {GOVUKPayService} */
   const service = req.service
   const existingCredentials = account.getSwitchingCredential().credentials?.oneOffCustomerInitiated || {}
   const context = {
@@ -22,9 +20,7 @@ function get(req, res) {
 }
 
 async function post(req, res, next) {
-  /** @type {GatewayAccount} */
   const account = req.account
-  /** @type {GOVUKPayService} */
   const service = req.service
   const validations = [
     oneOffCustomerInitiatedSchema.merchantCode.validate,
@@ -73,9 +69,7 @@ async function post(req, res, next) {
 }
 
 const postErrorResponse = (req, res, errors) => {
-  /** @type {GatewayAccount} */
   const account = req.account
-  /** @type {GOVUKPayService} */
   const service = req.service
   return response(req, res, 'simplified-account/settings/switch-psp/switch-to-worldpay/add-worldpay-credentials', {
     errors,

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/add-worldpay-credentials.controller.js
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/add-worldpay-credentials.controller.js
@@ -1,0 +1,95 @@
+const { response } = require('@utils/response')
+const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
+const paths = require('@root/paths')
+const { validationResult } = require('express-validator')
+const formatValidationErrors = require('@utils/simplified-account/format/format-validation-errors')
+const WorldpayCredential = require('@models/gateway-account-credential/WorldpayCredential.class')
+const worldpayDetailsService = require('@services/worldpay-details.service')
+const { oneOffCustomerInitiatedSchema } = require('@utils/simplified-account/validation/worldpay/one-off-customer-initiated.schema')
+
+function get(req, res) {
+  /** @type {GatewayAccount} */
+  const account = req.account
+  /** @type {GOVUKPayService} */
+  const service = req.service
+  const existingCredentials = account.getSwitchingCredential().credentials?.oneOffCustomerInitiated || {}
+  const context = {
+    credentials: existingCredentials,
+    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index,
+      service.externalId, account.type)
+  }
+  return response(req, res, 'simplified-account/settings/switch-psp/switch-to-worldpay/add-worldpay-credentials', context)
+}
+
+async function post(req, res, next) {
+  /** @type {GatewayAccount} */
+  const account = req.account
+  /** @type {GOVUKPayService} */
+  const service = req.service
+  const validations = [
+    oneOffCustomerInitiatedSchema.merchantCode.validate,
+    oneOffCustomerInitiatedSchema.username.validate,
+    oneOffCustomerInitiatedSchema.password.validate
+  ]
+
+  await Promise.all(validations.map(validation => validation.run(req)))
+  const validationErrors = validationResult(req)
+  if (!validationErrors.isEmpty()) {
+    const formattedErrors = formatValidationErrors(validationErrors)
+    return postErrorResponse(req, res, {
+      summary: formattedErrors.errorSummary,
+      formErrors: formattedErrors.formErrors
+    })
+  }
+
+  const credential = new WorldpayCredential()
+    .withMerchantCode(req.body.merchantCode)
+    .withUsername(req.body.username)
+    .withPassword(req.body.password)
+
+  const isValid = await worldpayDetailsService.checkCredential(req.service.externalId, req.account.type, credential)
+  if (!isValid) {
+    return postErrorResponse(req, res, {
+      summary: [
+        {
+          text: 'Check your Worldpay credentials, failed to link your account to Worldpay with credentials provided',
+          href: '#merchant-code'
+        }
+      ]
+    })
+  }
+
+  const switchingCredential = account.getSwitchingCredential()
+
+  worldpayDetailsService.updateOneOffCustomerInitiatedCredentials(
+    service.externalId,
+    account.type,
+    switchingCredential.externalId,
+    req.user.externalId,
+    credential
+  ).then(() => {
+    res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index, service.externalId, account.type))
+  }).catch((err) => next(err))
+}
+
+const postErrorResponse = (req, res, errors) => {
+  /** @type {GatewayAccount} */
+  const account = req.account
+  /** @type {GOVUKPayService} */
+  const service = req.service
+  return response(req, res, 'simplified-account/settings/switch-psp/switch-to-worldpay/add-worldpay-credentials', {
+    errors,
+    credentials: {
+      merchantCode: req.body.merchantCode,
+      username: req.body.username,
+      password: req.body.password
+    },
+    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index,
+      service.externalId, account.type)
+  })
+}
+
+module.exports = {
+  get,
+  post
+}

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/make-test-payment.controller.js
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/make-test-payment.controller.js
@@ -1,0 +1,81 @@
+const { response } = require('@utils/response')
+const { VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY, filterNextUrl } = require('@utils/verify-psp-integration')
+const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
+const formatPSPName = require('@utils/format-PSP-name')
+const paths = require('@root/paths')
+const chargeService = require('@services/charge.service')
+const ChargeRequest = require('@models/ChargeRequest.class')
+const urljoin = require('url-join')
+const CREDENTIAL_STATE = require('@models/constants/credential-state')
+const worldpayDetailsService = require('@services/worldpay-details.service')
+const SELFSERVICE_URL = process.env.SELFSERVICE_URL
+
+function get (req, res) {
+  /** @type {GatewayAccount} */
+  const account = req.account
+  /** @type {GOVUKPayService} */
+  const service = req.service
+  const context = {
+    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index,
+      service.externalId, account.type)
+  }
+  return response(req, res, 'simplified-account/settings/switch-psp/switch-to-worldpay/make-a-test-payment', context)
+}
+
+async function post (req, res, next) {
+  /** @type {GatewayAccount} */
+  const account = req.account
+  /** @type {GOVUKPayService} */
+  const service = req.service
+  const targetCredential = account.getSwitchingCredential()
+  const chargeRequest = new ChargeRequest()
+    .withAmount(200)
+    .withDescription('Live payment to verify Worldpay integration')
+    .withReference('VERIFY_PSP_INTEGRATION')
+    .withReturnUrl(urljoin(SELFSERVICE_URL, formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.makeTestPayment.inbound,
+      service.externalId, account.type)))
+    .withCredentialId(targetCredential.externalId)
+    .withMoto(account.allowMoto)
+
+  chargeService.createCharge(service.externalId, account.type, chargeRequest)
+    .then((response) => {
+      req.session[VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY] = response.charge_id
+      res.redirect(filterNextUrl(response))
+    })
+    .catch((error) => {
+      next(error)
+    })
+}
+
+async function getInbound (req, res, next) {
+  /** @type {GatewayAccount} */
+  const account = req.account
+  /** @type {GOVUKPayService} */
+  const service = req.service
+  /** @type {User} */
+  const user = req.user
+  const chargeExternalId = req.session[VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY]
+  delete req.session[VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY]
+  const targetCredential = account.getSwitchingCredential()
+  if (!chargeExternalId) {
+    throw new Error('No charge found on session')
+  }
+  chargeService.getCharge(service.externalId, account.type, chargeExternalId)
+    .then(async (charge) => {
+      if (charge.state.status === 'success') {
+        await worldpayDetailsService.updateCredentialState(service.externalId, account.type, targetCredential.externalId, user.externalId, CREDENTIAL_STATE.VERIFIED)
+        req.flash('messages', { state: 'success', icon: '&check;', heading: 'Payment verified', body: `This service is ready to switch to ${formatPSPName(targetCredential.paymentProvider)}` })
+      } else {
+        req.flash('messages', { state: 'error', heading: 'There is a problem', body: 'The payment has failed. Check your Worldpay credentials and try again. If you need help, contact govuk-pay-support@digital.cabinet-office.gov.uk' })
+      }
+      res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index,
+        service.externalId, account.type))
+    })
+    .catch(err => next(err))
+}
+
+module.exports = {
+  get,
+  getInbound,
+  post
+}

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/make-test-payment.controller.js
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/make-test-payment.controller.js
@@ -11,9 +11,7 @@ const worldpayDetailsService = require('@services/worldpay-details.service')
 const SELFSERVICE_URL = process.env.SELFSERVICE_URL
 
 function get (req, res) {
-  /** @type {GatewayAccount} */
   const account = req.account
-  /** @type {GOVUKPayService} */
   const service = req.service
   const context = {
     backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index,
@@ -23,9 +21,7 @@ function get (req, res) {
 }
 
 async function post (req, res, next) {
-  /** @type {GatewayAccount} */
   const account = req.account
-  /** @type {GOVUKPayService} */
   const service = req.service
   const targetCredential = account.getSwitchingCredential()
   const chargeRequest = new ChargeRequest()
@@ -48,11 +44,8 @@ async function post (req, res, next) {
 }
 
 async function getInbound (req, res, next) {
-  /** @type {GatewayAccount} */
   const account = req.account
-  /** @type {GOVUKPayService} */
   const service = req.service
-  /** @type {User} */
   const user = req.user
   const chargeExternalId = req.session[VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY]
   delete req.session[VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY]

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/switch-to-worldpay.controller.js
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/switch-to-worldpay.controller.js
@@ -1,10 +1,61 @@
 const { response } = require('@utils/response')
+const { WorldpayTasks } = require('@models/WorldpayTasks.class')
+const GatewayAccountSwitchPaymentProviderRequest = require('@models/gateway-account/GatewayAccountSwitchPaymentProviderRequest.class')
+const formatAccountPathsFor = require('@utils/format-account-paths-for')
+const paths = require('@root/paths')
+const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/format')
+const formatPSPName = require('@utils/format-PSP-name')
+const gatewayAccountsService = require('@services/gateway-accounts.service')
 
 function get (req, res, next) {
-  const context = {}
+  /** @type {GatewayAccount} */
+  const account = req.account
+  /** @type {GOVUKPayService} */
+  const service = req.service
+  const worldpayTasks = new WorldpayTasks(account, service.externalId, true)
+
+  const context = {
+    messages: res.locals?.flash?.messages ?? [],
+    isMoto: account.allowMoto,
+    currentPsp: account.paymentProvider,
+    incompleteTasks: worldpayTasks.incompleteTasks,
+    tasks: worldpayTasks.tasks,
+    transactionsUrl: formatAccountPathsFor(paths.account.transactions.index, account.externalId)
+  }
   return response(req, res, 'simplified-account/settings/switch-psp/switch-to-worldpay/index', context)
 }
 
+function post (req, res, next) {
+  /** @type {GatewayAccount} */
+  const account = req.account
+  /** @type {GOVUKPayService} */
+  const service = req.service
+  /** @type {User} */
+  const user = req.user
+  const targetCredential = account.getSwitchingCredential()
+  const worldpayTasks = new WorldpayTasks(account, service.externalId, true)
+
+  if (worldpayTasks.incompleteTasks) {
+    req.flash('messages', { state: 'error', heading: 'There is a problem', body: 'You cannot switch providers until all required tasks are completed' })
+    res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index, service.externalId, account.type))
+  }
+
+  const switchProviderRequest = new GatewayAccountSwitchPaymentProviderRequest()
+    .withUserExternalId(user.externalId)
+    .withGatewayAccountCredentialExternalId(targetCredential.externalId)
+
+  gatewayAccountsService.postSwitchPSP(service.externalId, account.type, switchProviderRequest)
+    .then(() => {
+      req.flash('messages', { state: 'success', icon: '&check;', heading: `Service connected to ${formatPSPName(targetCredential.paymentProvider)}`, body: 'This service can now take payments' })
+      res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.index, service.externalId, account.type))
+    })
+    .catch(err => next(err))
+}
+
 module.exports = {
-  get
+  get,
+  post,
+  oneOffCustomerInitiated: require('./add-worldpay-credentials.controller'),
+  flexCredentials: require('./add-flex-credentials.controller'),
+  makeTestPayment: require('./make-test-payment.controller')
 }

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/switch-to-worldpay.controller.js
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/switch-to-worldpay.controller.js
@@ -8,9 +8,7 @@ const formatPSPName = require('@utils/format-PSP-name')
 const gatewayAccountsService = require('@services/gateway-accounts.service')
 
 function get (req, res, next) {
-  /** @type {GatewayAccount} */
   const account = req.account
-  /** @type {GOVUKPayService} */
   const service = req.service
   const worldpayTasks = new WorldpayTasks(account, service.externalId, true)
 
@@ -26,11 +24,8 @@ function get (req, res, next) {
 }
 
 function post (req, res, next) {
-  /** @type {GatewayAccount} */
   const account = req.account
-  /** @type {GOVUKPayService} */
   const service = req.service
-  /** @type {User} */
   const user = req.user
   const targetCredential = account.getSwitchingCredential()
   const worldpayTasks = new WorldpayTasks(account, service.externalId, true)

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/switch-to-worldpay.controller.js
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/switch-to-worldpay.controller.js
@@ -32,7 +32,7 @@ function post (req, res, next) {
 
   if (worldpayTasks.incompleteTasks) {
     req.flash('messages', { state: 'error', heading: 'There is a problem', body: 'You cannot switch providers until all required tasks are completed' })
-    res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index, service.externalId, account.type))
+    return res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index, service.externalId, account.type))
   }
 
   const switchProviderRequest = new GatewayAccountSwitchPaymentProviderRequest()

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/switch-to-worldpay.controller.test.js
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/switch-to-worldpay.controller.test.js
@@ -1,9 +1,17 @@
 const sinon = require('sinon')
 const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
 const { expect } = require('chai')
+const { STRIPE } = require('@models/constants/payment-providers')
+const formatAccountPathsFor = require('@utils/format-account-paths-for')
+const paths = require('@root/paths')
 
 const mockResponse = sinon.spy()
+const mockWorldpayTasks = {
+  tasks: ['foo', 'bar', 'baz'],
+  incompleteTasks: true
+}
 const ACCOUNT_TYPE = 'live'
+const ACCOUNT_EXTERNAL_ID = 'account-id-123abc'
 const SERVICE_ID = 'service-id-123abc'
 
 const {
@@ -12,9 +20,16 @@ const {
   call
 } = new ControllerTestBuilder('@controllers/simplified-account/settings/switch-psp/switch-to-worldpay/switch-to-worldpay.controller')
   .withServiceExternalId(SERVICE_ID)
-  .withAccountType(ACCOUNT_TYPE)
+  .withAccount({
+    externalId: ACCOUNT_EXTERNAL_ID,
+    type: ACCOUNT_TYPE,
+    providerSwitchEnabled: true,
+    paymentProvider: STRIPE,
+    allowMoto: true
+  })
   .withStubs({
-    '@utils/response': { response: mockResponse }
+    '@utils/response': { response: mockResponse },
+    '@models/WorldpayTasks.class': { WorldpayTasks: sinon.stub().returns(mockWorldpayTasks) }
   })
   .build()
 
@@ -32,6 +47,15 @@ describe('Controller: settings/switch-psp/switch-to-worldpay', () => {
       expect(mockResponse.args[0][0]).to.deep.equal(req)
       expect(mockResponse.args[0][1]).to.deep.equal(res)
       expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/switch-psp/switch-to-worldpay/index')
+    })
+
+    it('should pass the context data to the response method', () => {
+      const context = mockResponse.args[0][3]
+      expect(context.isMoto).to.equal(true)
+      expect(context.currentPsp).to.equal(STRIPE)
+      expect(context.incompleteTasks).to.equal(true)
+      expect(context.tasks).to.deep.equal(['foo', 'bar', 'baz'])
+      expect(context.transactionsUrl).to.equal(formatAccountPathsFor(paths.account.transactions.index, ACCOUNT_EXTERNAL_ID))
     })
   })
 })

--- a/src/controllers/simplified-account/settings/worldpay-details/credentials/worldpay-credentials.controller.js
+++ b/src/controllers/simplified-account/settings/worldpay-details/credentials/worldpay-credentials.controller.js
@@ -1,11 +1,12 @@
 const { response } = require('@utils/response')
 const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
 const paths = require('@root/paths')
-const { body, validationResult } = require('express-validator')
+const { validationResult } = require('express-validator')
 const formatValidationErrors = require('@utils/simplified-account/format/format-validation-errors')
 const worldpayDetailsService = require('@services/worldpay-details.service')
 const WorldpayCredential = require('@models/gateway-account-credential/WorldpayCredential.class')
 const { WorldpayTasks } = require('@models/WorldpayTasks.class')
+const { oneOffCustomerInitiatedSchema } = require('@utils/simplified-account/validation/worldpay/one-off-customer-initiated.schema')
 
 function get (req, res) {
   const existingCredentials = req.account.getCurrentCredential().credentials?.oneOffCustomerInitiated || {}
@@ -18,15 +19,9 @@ function get (req, res) {
 }
 
 const worldpayCredentialsValidations = [
-  body('merchantCode').not().isEmpty().withMessage('Enter your merchant code').bail()
-    .custom((value, { req }) => {
-      if (req.account.allowMoto && !value.endsWith('MOTO') && !value.endsWith('MOTOGBP')) {
-        throw new Error('Enter a MOTO merchant code. MOTO payments are enabled for this account')
-      }
-      return true
-    }),
-  body('username').not().isEmpty().withMessage('Enter your username'),
-  body('password').not().isEmpty().withMessage('Enter your password')
+  oneOffCustomerInitiatedSchema.merchantCode.validate,
+  oneOffCustomerInitiatedSchema.username.validate,
+  oneOffCustomerInitiatedSchema.password.validate
 ]
 
 async function post (req, res) {

--- a/src/middleware/restrict-to-switching-account.js
+++ b/src/middleware/restrict-to-switching-account.js
@@ -3,7 +3,7 @@
 const { NotFoundError } = require('../errors')
 
 module.exports = (req, res, next) => {
-  if (req.account.provider_switch_enabled) {
+  if (req.account.provider_switch_enabled || req.account.providerSwitchEnabled) {
     next()
   } else {
     next(new NotFoundError('This page is only available for accounts flagged for switching provider'))

--- a/src/middleware/simplified-account/settings/stripe-account-setup-strategy.middleware.js
+++ b/src/middleware/simplified-account/settings/stripe-account-setup-strategy.middleware.js
@@ -1,9 +1,7 @@
 const { getConnectorStripeAccountSetup } = require('@services/stripe-details.service')
 
 module.exports = async function (req, res, next) {
-  /** @type {GatewayAccount} */
   const account = req.account
-  /** @type {GOVUKPayService} */
   const service = req.service
   return getConnectorStripeAccountSetup(service.externalId, account.type)
     .then((data) => {

--- a/src/models/ChargeRequest.class.js
+++ b/src/models/ChargeRequest.class.js
@@ -1,0 +1,65 @@
+class ChargeRequest {
+  /**
+   * @param {number} amount
+   */
+  withAmount (amount) {
+    this.amount = amount
+    return this
+  }
+
+  /**
+   * @param {string} description
+   */
+  withDescription (description) {
+    this.description = description
+    return this
+  }
+
+  /**
+   * @param {string} reference
+   */
+  withReference (reference) {
+    this.reference = reference
+    return this
+  }
+
+  /**
+   * @param {string} returnUrl
+   */
+  withReturnUrl (returnUrl) {
+    this.returnUrl = returnUrl
+    return this
+  }
+
+  /**
+   * @param {string} credentialId
+   */
+  withCredentialId (credentialId) {
+    this.credentialId = credentialId
+    return this
+  }
+
+  /**
+   * @param {boolean} moto
+   */
+  withMoto (moto) {
+    this.moto = moto
+    return this
+  }
+
+  /**
+   * @returns {Object}
+   */
+  toPayload () {
+    return {
+      amount: this.amount,
+      description: this.description,
+      reference: this.reference,
+      return_url: this.returnUrl,
+      credential_id: this.credentialId,
+      moto: this.moto
+    }
+  }
+}
+
+module.exports = ChargeRequest

--- a/src/models/GatewayAccount.class.js
+++ b/src/models/GatewayAccount.class.js
@@ -2,43 +2,33 @@ const { GatewayAccountCredential } = require('@models/gateway-account-credential
 const CREDENTIAL_STATE = require('@models/constants/credential-state')
 const Worldpay3dsFlexCredential = require('@models/gateway-account-credential/Worldpay3dsFlexCredential.class')
 const { InvalidConfigurationError } = require('@root/errors')
+const logger = require('@utils/logger')(__filename)
 const pendingCredentialStates = [CREDENTIAL_STATE.CREATED, CREDENTIAL_STATE.ENTERED, CREDENTIAL_STATE.VERIFIED]
 
 /**
  * @class GatewayAccount
- * @property {string} name - The name of the gateway account
- * @property {string} id - The id of the gateway account
- * @property {string} type - The type of the gateway account (e.g. test/live)
- * @property {string} paymentProvider - The payment provider for the gateway account (e.g. stripe/worldpay)
- * @property {string} description - The description of the gateway account
- * @property {boolean} allowMoto - whether MOTO payments are enabled on the gateway account
- * @property {string} analyticsId - Google analyticsId of the gateway account
- * @property {boolean} toggle3ds - whether 3DS is enabled or not on this gateway account
- * @property {[GatewayAccountCredential]} gatewayAccountCredentials - available credentials for gateway account
- * @property {bool} allowApplePay - whether the gateway has Apple Pay enabled or not
- * @property {bool} allowGooglePay - whether the gateway has Google Pay enabled or not
- * @property {Object} rawResponse - raw 'gateway account' object
+ * Represents a gateway account
+ * @property {string} id The id of the gateway account
+ * @property {string} externalId The external id of the gateway account
+ * @property {string} name The name of the gateway account
+ * @property {string} type The type of the gateway account (e.g. test/live)
+ * @property {string} paymentProvider The payment provider for the gateway account (e.g. stripe/worldpay)
+ * @property {string} description The description of the gateway account
+ * @property {boolean} allowMoto whether MOTO payments are enabled on the gateway account
+ * @property {string} analyticsId Google analyticsId of the gateway account
+ * @property {boolean} toggle3ds whether 3DS is enabled or not on this gateway account
+ * @property {boolean} providerSwitchEnabled whether provider switching is enabled on this gateway account
+ * @property {boolean} recurringEnabled whether recurring payments are enabled on this gateway account
+ * @property {GatewayAccountCredential[]} gatewayAccountCredentials available credentials for gateway account
+ * @property {Worldpay3dsFlexCredential} worldpay3dsFlex available credentials for gateway account
+ * @property {boolean} supports3ds
+ * @property {boolean} disableToggle3ds
+ * @property {boolean} requires3ds
+ * @property {boolean} allowApplePay whether the gateway has Apple Pay enabled or not
+ * @property {boolean} allowGooglePay whether the gateway has Google Pay enabled or not
+ * @property {Object} rawResponse raw 'gateway account' object
  */
 class GatewayAccount {
-  /**
-   * Create an instance of GatewayAccount
-   * @param {Object} gatewayAccountData - raw 'gateway account' object from server
-   * @param {string} gatewayAccountData.gateway_account_id - The ID of the gateway account
-   * @param {string} gatewayAccountData.external_id - The external ID of the gateway account
-   * @param {string} gatewayAccountData.service_name - The name of the gateway account
-   * @param {string} gatewayAccountData.type - The type of the gateway account
-   * @param {string} gatewayAccountData.payment_provider - The payment provider of the gateway account
-   * @param {string} gatewayAccountData.description - The description of the gateway account
-   * @param {boolean} gatewayAccountData.allow_moto - whether MOTO payments are enabled on the gateway account
-   * @param {string} gatewayAccountData.analytics_id - Google analytics_id of the gateway account
-   * @param {boolean} gatewayAccountData.toggle_3ds - whether 3DS is enabled or not on this gateway account
-   * @param {boolean} gatewayAccountData.provider_switch_enabled - indicates that the gateway is transitioning psp
-   * @param {boolean} gatewayAccountData.recurring_enabled - whether recurring card payments are enabled on this account
-   * @param {[{Object}]} gatewayAccountData.gateway_account_credentials - credentials present for the gateway account
-   * @param {boolean} gatewayAccountData.allow_google_pay - whether google pay is enabled on this account
-   * @param {boolean} gatewayAccountData.allow_apple_pay - whether apple pay is enabled on this account
-   * @param {Object} [gatewayAccountData.worldpay_3ds_flex] - 3ds flex credentials and metadata for Worldpay
-   **/
   constructor (gatewayAccountData) {
     this.id = gatewayAccountData.gateway_account_id
     this.externalId = gatewayAccountData.external_id
@@ -68,8 +58,7 @@ class GatewayAccount {
   }
 
   /**
-   *
-   * @returns {GatewayAccountCredential}
+   * @returns {GatewayAccountCredential} The current credential
    */
   getCurrentCredential () {
     if (this.gatewayAccountCredentials.length === 1) {
@@ -88,27 +77,30 @@ class GatewayAccount {
   }
 
   /**
-   * @returns {GatewayAccountCredential}
+   * Returns exactly one credential in a pending state
+   * @returns {GatewayAccountCredential} The switching credential
+   * @throws {InvalidConfigurationError} When there isn't exactly one pending credential
    */
-  getSwitchingCredentialIfPresent () {
-    // service must have an active credential to be 'switching' from
-    if (this.getActiveCredential()) {
-      const pendingCredentials = this.gatewayAccountCredentials
-        .filter((credential) => pendingCredentialStates.includes(credential.state))
-      // service must have exactly one credential in a pending state
-      if (pendingCredentials.length > 1) {
-        throw new InvalidConfigurationError(`Unexpected number of credentials in a pending state for gateway account [found ${pendingCredentials.length}]`)
-      }
-      if (pendingCredentials.length === 1) {
-        return pendingCredentials[0]
-      }
+  getSwitchingCredential () {
+    if (!this.providerSwitchEnabled || !this.getActiveCredential()) {
+      logger.warn(`Requested switching credential from incompatible gateway account [gateway_account_id: ${this.id}]`)
       return null
     }
-    return null
+
+    const pendingCredentials = this.gatewayAccountCredentials
+      .filter(credential => pendingCredentialStates.includes(credential.state))
+
+    if (pendingCredentials.length !== 1) {
+      throw new InvalidConfigurationError(
+        `Unexpected number of credentials in a pending state for gateway account [found: ${pendingCredentials.length}, gateway_account_id: ${this.id}]`
+      )
+    }
+
+    return pendingCredentials[0]
   }
 
   /**
-   * @method toJson
+   * Returns a minimal representation of the gateway account
    * @returns {Object} A minimal representation of the gateway account
    */
   toMinimalJson () {

--- a/src/models/GatewayAccount.class.js
+++ b/src/models/GatewayAccount.class.js
@@ -2,7 +2,6 @@ const { GatewayAccountCredential } = require('@models/gateway-account-credential
 const CREDENTIAL_STATE = require('@models/constants/credential-state')
 const Worldpay3dsFlexCredential = require('@models/gateway-account-credential/Worldpay3dsFlexCredential.class')
 const { InvalidConfigurationError } = require('@root/errors')
-const logger = require('@utils/logger')(__filename)
 const pendingCredentialStates = [CREDENTIAL_STATE.CREATED, CREDENTIAL_STATE.ENTERED, CREDENTIAL_STATE.VERIFIED]
 
 /**
@@ -83,8 +82,9 @@ class GatewayAccount {
    */
   getSwitchingCredential () {
     if (!this.providerSwitchEnabled || !this.getActiveCredential()) {
-      logger.warn(`Requested switching credential from incompatible gateway account [gateway_account_id: ${this.id}]`)
-      return null
+      throw new InvalidConfigurationError(
+        `Requested switching credential from incompatible gateway account [gateway_account_id: ${this.id}]`
+      )
     }
 
     const pendingCredentials = this.gatewayAccountCredentials

--- a/src/models/GatewayAccount.class.test.js
+++ b/src/models/GatewayAccount.class.test.js
@@ -64,7 +64,7 @@ describe('GatewayAccount', () => {
         .to.throw(InvalidConfigurationError)
     })
 
-    it('should return null if no active credential found for gateway account', () => {
+    it('should throw invalid configuration error if no active credential found for gateway account', () => {
       const gatewayAccount = new GatewayAccount({
         gateway_account_id: 12,
         provider_switch_enabled: true,
@@ -77,18 +77,18 @@ describe('GatewayAccount', () => {
           }
         ]
       })
-      const switchingCredential = gatewayAccount.getSwitchingCredential()
-      expect(switchingCredential).to.be.null //eslint-disable-line
+      expect(() => gatewayAccount.getSwitchingCredential())
+        .to.throw(InvalidConfigurationError)
     })
 
-    it('should return null if provider switching is not enabled', () => {
+    it('should throw invalid configuration error if provider switching is not enabled', () => {
       const gatewayAccount = new GatewayAccount({
         gateway_account_id: 12,
         provider_switch_enabled: false,
         gateway_account_credentials: gatewayAccountCredentials
       })
-      const switchingCredential = gatewayAccount.getSwitchingCredential()
-      expect(switchingCredential).to.be.null //eslint-disable-line
+      expect(() => gatewayAccount.getSwitchingCredential())
+        .to.throw(InvalidConfigurationError)
     })
   })
 })

--- a/src/models/GatewayAccount.class.test.js
+++ b/src/models/GatewayAccount.class.test.js
@@ -2,6 +2,7 @@ const GatewayAccount = require('@models/GatewayAccount.class')
 const { WORLDPAY } = require('@models/constants/payment-providers')
 const { expect } = require('chai')
 const { InvalidConfigurationError } = require('@root/errors')
+const { CREDENTIAL_STATE } = require('@utils/credentials')
 
 const gatewayAccountCredentials = [
   {
@@ -13,9 +14,11 @@ const gatewayAccountCredentials = [
 ]
 
 describe('GatewayAccount', () => {
-  describe('getSwitchingCredentialIfPresent', () => {
+  describe('getSwitchingCredential', () => {
     it('should return a credential if one exists', () => {
       const gatewayAccountData = {
+        gateway_account_id: 12,
+        provider_switch_enabled: true,
         gateway_account_credentials: [
           ...gatewayAccountCredentials,
           {
@@ -27,12 +30,14 @@ describe('GatewayAccount', () => {
         ]
       }
       const gatewayAccount = new GatewayAccount(gatewayAccountData)
-      const switchingCredential = gatewayAccount.getSwitchingCredentialIfPresent()
+      const switchingCredential = gatewayAccount.getSwitchingCredential()
       expect(switchingCredential.paymentProvider).to.equal(WORLDPAY)
     })
 
     it('should throw invalid configuration error if more than one pending credential is found', () => {
       const gatewayAccountData = {
+        gateway_account_id: 12,
+        provider_switch_enabled: true,
         gateway_account_credentials: [
           ...gatewayAccountCredentials,
           ...Array(2).fill({
@@ -44,15 +49,45 @@ describe('GatewayAccount', () => {
         ]
       }
       const gatewayAccount = new GatewayAccount(gatewayAccountData)
-      expect(() => gatewayAccount.getSwitchingCredentialIfPresent()).to.throw(InvalidConfigurationError, 'Unexpected number of credentials in a pending state for gateway account [found 2]')
+      expect(() => gatewayAccount.getSwitchingCredential())
+        .to.throw(InvalidConfigurationError, 'Unexpected number of credentials in a pending state for gateway account [found: 2, gateway_account_id: 12]')
     })
 
-    it('should return null if no switching credential is found', () => {
+    it('should throw invalid configuration error if no switching credential is found', () => {
       const gatewayAccountData = {
+        gateway_account_id: 12,
+        provider_switch_enabled: true,
         gateway_account_credentials: gatewayAccountCredentials
       }
       const gatewayAccount = new GatewayAccount(gatewayAccountData)
-      const switchingCredential = gatewayAccount.getSwitchingCredentialIfPresent()
+      expect(() => gatewayAccount.getSwitchingCredential())
+        .to.throw(InvalidConfigurationError)
+    })
+
+    it('should return null if no active credential found for gateway account', () => {
+      const gatewayAccount = new GatewayAccount({
+        gateway_account_id: 12,
+        provider_switch_enabled: true,
+        gateway_account_credentials: [
+          {
+            external_id: '64adb8fcef44416a81d9571685a3f25c',
+            payment_provider: 'stripe',
+            state: CREDENTIAL_STATE.RETIRED,
+            gateway_account_id: 12
+          }
+        ]
+      })
+      const switchingCredential = gatewayAccount.getSwitchingCredential()
+      expect(switchingCredential).to.be.null //eslint-disable-line
+    })
+
+    it('should return null if provider switching is not enabled', () => {
+      const gatewayAccount = new GatewayAccount({
+        gateway_account_id: 12,
+        provider_switch_enabled: false,
+        gateway_account_credentials: gatewayAccountCredentials
+      })
+      const switchingCredential = gatewayAccount.getSwitchingCredential()
       expect(switchingCredential).to.be.null //eslint-disable-line
     })
   })

--- a/src/models/Service.class.js
+++ b/src/models/Service.class.js
@@ -1,10 +1,8 @@
-'use strict'
-
 /**
  * @class GOVUKPayService
- * @property externalId {string} - The external id of the service
- * @property currentGoLiveStage {string} - Live stage of the service
- * @property name {string} - English name of service
+ * @property {string} externalId  - The external id of the service
+ * @property {string} currentGoLiveStage  - Live stage of the service
+ * @property {string} name  - English name of service
  * @property {{
  *   en: string,
  *   cy: string

--- a/src/models/gateway-account-credential/GatewayAccountCredentialUpdateRequest.class.js
+++ b/src/models/gateway-account-credential/GatewayAccountCredentialUpdateRequest.class.js
@@ -34,6 +34,10 @@ const safeOperation = (op, request) => {
           return request
         }
       }
+    },
+    state: (value) => {
+      request.updates.push({ op, path: 'state', value })
+      return request
     }
   }
 }

--- a/src/models/gateway-account/GatewayAccountSwitchPaymentProviderRequest.class.js
+++ b/src/models/gateway-account/GatewayAccountSwitchPaymentProviderRequest.class.js
@@ -1,0 +1,29 @@
+class GatewayAccountSwitchPaymentProviderRequest {
+  /**
+   * @param {String} userExternalId
+   */
+  withUserExternalId (userExternalId) {
+    this.userExternalId = userExternalId
+    return this
+  }
+
+  /**
+   * @param {String} gatewayAccountCredentialExternalId
+   */
+  withGatewayAccountCredentialExternalId (gatewayAccountCredentialExternalId) {
+    this.gatewayAccountCredentialExternalId = gatewayAccountCredentialExternalId
+    return this
+  }
+
+  /**
+   * @returns {Object}
+   */
+  toPayload () {
+    return {
+      user_external_id: this.userExternalId,
+      gateway_account_credential_external_id: this.gatewayAccountCredentialExternalId
+    }
+  }
+}
+
+module.exports = GatewayAccountSwitchPaymentProviderRequest

--- a/src/paths.js
+++ b/src/paths.js
@@ -246,8 +246,12 @@ module.exports = {
       switchPsp: {
         switchToWorldpay: {
           index: '/settings/switch-psp/switch-to-worldpay',
-          linkCredentials: '/settings/switch-psp/switch-to-worldpay/worldpay-details/one-off-customer-initiated',
-          makeTestPayment: '/settings/switch-psp/switch-to-worldpay/worldpay-details/test-payment'
+          oneOffCustomerInitiated: '/settings/switch-psp/switch-to-worldpay/worldpay-details/one-off-customer-initiated',
+          flexCredentials: '/settings/switch-psp/switch-to-worldpay/worldpay-details/flex-credentials',
+          makeTestPayment: {
+            outbound: '/settings/switch-psp/switch-to-worldpay/worldpay-details/make-a-payment',
+            inbound: '/settings/switch-psp/switch-to-worldpay/worldpay-details/make-a-payment/verify'
+          }
         }
       }
     }

--- a/src/services/charge.service.js
+++ b/src/services/charge.service.js
@@ -1,0 +1,7 @@
+const { ConnectorClient } = require('@services/clients/connector.client')
+const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
+
+module.exports = {
+  createCharge: connectorClient.postChargeRequestByServiceExternalIdAndAccountType.bind(connectorClient),
+  getCharge: connectorClient.getChargeByServiceExternalIdAndAccountType.bind(connectorClient)
+}

--- a/src/services/clients/connector.client.js
+++ b/src/services/clients/connector.client.js
@@ -31,7 +31,7 @@ ConnectorClient.prototype = {
       .replace('{serviceExternalId}', encodeURIComponent(params.serviceExternalId))
       .replace('{accountType}', encodeURIComponent(params.accountType))
     configureClient(client, url)
-    const response = await client.get(url, 'get gateway account by service Id and account type')
+    const response = await client.get(url, 'get gateway account by service external id and account type')
     return new GatewayAccount(response.data)
   },
 
@@ -632,7 +632,7 @@ ConnectorClient.prototype = {
   /**
    * @param serviceExternalId {string}
    * @param accountType {string}
-   * @returns {StripeAccountSetup}
+   * @returns {Promise<StripeAccountSetup>}
    */
   getStripeAccountSetupByServiceExternalIdAndAccountType: async function (serviceExternalId, accountType) {
     const url = `${this.connectorUrl}/v1/api/service/{serviceExternalId}/account/{accountType}/stripe-setup`
@@ -692,7 +692,7 @@ ConnectorClient.prototype = {
    * Get Stripe account for the given service and account type
    * @param serviceExternalId {string}
    * @param accountType {string}
-   * @returns {StripeAccount}
+   * @returns {Promise<StripeAccount>}
    */
   getStripeAccountByServiceIdAndAccountType: async function (serviceExternalId, accountType) {
     const url = `${this.connectorUrl}/v1/api/service/{serviceExternalId}/account/{accountType}/stripe-account`
@@ -724,6 +724,37 @@ ConnectorClient.prototype = {
     return response.data
   },
 
+  /**
+   * @param {String} serviceExternalId
+   * @param {String} accountType
+   * @param {ChargeRequest} chargeRequest
+   * @returns {Promise<{Object}>}
+   */
+  postChargeRequestByServiceExternalIdAndAccountType: async function (serviceExternalId, accountType, chargeRequest) {
+    const url = `${this.connectorUrl}/v1/api/service/{serviceExternalId}/account/{accountType}/charges`
+      .replace('{serviceExternalId}', encodeURIComponent(serviceExternalId))
+      .replace('{accountType}', encodeURIComponent(accountType))
+    configureClient(client, url)
+    const response = await client.post(url, chargeRequest.toPayload(), 'create a charge')
+    return response.data
+  },
+
+  /**
+   * @param {String} serviceExternalId
+   * @param {String} accountType
+   * @param {String} chargeExternalId
+   * @returns {Promise<{Object}>}
+   */
+  getChargeByServiceExternalIdAndAccountType: async function (serviceExternalId, accountType, chargeExternalId) {
+    const url = `${this.connectorUrl}/v1/api/service/{serviceExternalId}/account/{accountType}/charges/{chargeExternalId}`
+      .replace('{serviceExternalId}', encodeURIComponent(serviceExternalId))
+      .replace('{accountType}', encodeURIComponent(accountType))
+      .replace('{chargeExternalId}', encodeURIComponent(chargeExternalId))
+    configureClient(client, url)
+    const response = await client.get(url, 'get a charge')
+    return response.data
+  },
+
   getCharge: async function (gatewayAccountId, chargeExternalId) {
     const url = `${this.connectorUrl}/v1/api/accounts/{accountId}/charges/{chargeId}`
       .replace('{accountId}', encodeURIComponent(gatewayAccountId))
@@ -739,6 +770,20 @@ ConnectorClient.prototype = {
     configureClient(client, url)
     const response = await client.post(url, payload, 'switch account payment service provider')
     return response.data
+  },
+
+  /**
+   * @param {String} serviceExternalId
+   * @param {String} accountType
+   * @param {GatewayAccountSwitchPaymentProviderRequest} gatewayAccountSwitchProviderRequest
+   * @returns {Promise<{Object}>}
+   */
+  postSwitchPSPBByServiceExternalIdAndAccountType: async function (serviceExternalId, accountType, gatewayAccountSwitchProviderRequest) {
+    const url = `${this.connectorUrl}/v1/api/service/{serviceExternalId}/account/{accountType}/switch-psp`
+      .replace('{serviceExternalId}', encodeURIComponent(serviceExternalId))
+      .replace('{accountType}', encodeURIComponent(accountType))
+    configureClient(client, url)
+    return client.post(url, gatewayAccountSwitchProviderRequest.toPayload(), 'switch account payment service provider')
   }
 }
 

--- a/src/services/clients/connector.client.js
+++ b/src/services/clients/connector.client.js
@@ -776,14 +776,13 @@ ConnectorClient.prototype = {
    * @param {String} serviceExternalId
    * @param {String} accountType
    * @param {GatewayAccountSwitchPaymentProviderRequest} gatewayAccountSwitchProviderRequest
-   * @returns {Promise<{Object}>}
    */
-  postSwitchPSPBByServiceExternalIdAndAccountType: async function (serviceExternalId, accountType, gatewayAccountSwitchProviderRequest) {
+  postSwitchPSPByServiceExternalIdAndAccountType: async function (serviceExternalId, accountType, gatewayAccountSwitchProviderRequest) {
     const url = `${this.connectorUrl}/v1/api/service/{serviceExternalId}/account/{accountType}/switch-psp`
       .replace('{serviceExternalId}', encodeURIComponent(serviceExternalId))
       .replace('{accountType}', encodeURIComponent(accountType))
     configureClient(client, url)
-    return client.post(url, gatewayAccountSwitchProviderRequest.toPayload(), 'switch account payment service provider')
+    await client.post(url, gatewayAccountSwitchProviderRequest.toPayload(), 'switch account payment service provider')
   }
 }
 

--- a/src/services/gateway-accounts.service.js
+++ b/src/services/gateway-accounts.service.js
@@ -1,0 +1,6 @@
+const { ConnectorClient } = require('@services/clients/connector.client')
+const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
+
+module.exports = {
+  postSwitchPSP: connectorClient.postSwitchPSPBByServiceExternalIdAndAccountType.bind(connectorClient)
+}

--- a/src/services/gateway-accounts.service.js
+++ b/src/services/gateway-accounts.service.js
@@ -2,5 +2,5 @@ const { ConnectorClient } = require('@services/clients/connector.client')
 const connectorClient = new ConnectorClient(process.env.CONNECTOR_URL)
 
 module.exports = {
-  postSwitchPSP: connectorClient.postSwitchPSPBByServiceExternalIdAndAccountType.bind(connectorClient)
+  postSwitchPSP: connectorClient.postSwitchPSPByServiceExternalIdAndAccountType.bind(connectorClient)
 }

--- a/src/services/worldpay-details.service.js
+++ b/src/services/worldpay-details.service.js
@@ -50,7 +50,6 @@ async function check3dsFlexCredential (serviceExternalId, accountType, flexCrede
 }
 
 /**
- *
  * @param {String} serviceExternalId
  * @param {String} accountType
  * @param {String} credentialId
@@ -62,6 +61,20 @@ async function updateOneOffCustomerInitiatedCredentials (serviceExternalId, acco
   const patchRequest = new GatewayAccountCredentialUpdateRequest(userExternalId)
     .replace().credentials().oneOffCustomerInitiated(credential.toJson())
   return connectorClient.patchGatewayAccountCredentialsByServiceExternalIdAndAccountType(serviceExternalId, accountType, credentialId, patchRequest)
+}
+
+/**
+ * @param {String} serviceExternalId
+ * @param {String} accountType
+ * @param {String} credentialExternalId
+ * @param {String} userExternalId
+ * @param {String} credentialState
+ * @returns {Promise<GatewayAccountCredential>}
+ */
+async function updateCredentialState (serviceExternalId, accountType, credentialExternalId, userExternalId, credentialState) {
+  const patchRequest = new GatewayAccountCredentialUpdateRequest(userExternalId)
+    .replace().state(credentialState)
+  return connectorClient.patchGatewayAccountCredentialsByServiceExternalIdAndAccountType(serviceExternalId, accountType, credentialExternalId, patchRequest)
 }
 
 /**
@@ -106,6 +119,7 @@ async function updateIntegrationVersion3ds (serviceExternalId, accountType, inte
 module.exports = {
   checkCredential,
   updateOneOffCustomerInitiatedCredentials,
+  updateCredentialState,
   check3dsFlexCredential,
   update3dsFlexCredentials,
   updateIntegrationVersion3ds,

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -9,6 +9,7 @@ const {
   enforcePaymentProviderType,
   defaultViewDecider
 } = require('@middleware/simplified-account')
+const restrictToSwitchingAccount = require('@middleware/restrict-to-switching-account')
 const userIsAuthorised = require('@middleware/user-is-authorised')
 const permission = require('@middleware/permission')
 const paths = require('./paths')
@@ -103,7 +104,14 @@ simplifiedAccount.post(paths.simplifiedAccount.settings.webhooks.create, permiss
 simplifiedAccount.get(paths.simplifiedAccount.settings.webhooks.detail, permission('webhooks:read'), serviceSettingsController.webhooks.detail.get)
 
 // switch psp
-simplifiedAccount.get(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index, permission('gateway-credentials:update'), serviceSettingsController.switchPsp.switchToWorldpay.get)
+simplifiedAccount.get(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index, restrictToSwitchingAccount, permission('gateway-credentials:update'), serviceSettingsController.switchPsp.switchToWorldpay.get)
+simplifiedAccount.post(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index, restrictToSwitchingAccount, permission('gateway-credentials:update'), serviceSettingsController.switchPsp.switchToWorldpay.post)
+simplifiedAccount.get(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.oneOffCustomerInitiated, restrictToSwitchingAccount, permission('gateway-credentials:update'), serviceSettingsController.switchPsp.switchToWorldpay.oneOffCustomerInitiated.get)
+simplifiedAccount.post(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.oneOffCustomerInitiated, restrictToSwitchingAccount, permission('gateway-credentials:update'), serviceSettingsController.switchPsp.switchToWorldpay.oneOffCustomerInitiated.post)
+simplifiedAccount.get(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.flexCredentials, restrictToSwitchingAccount, permission('gateway-credentials:update'), serviceSettingsController.switchPsp.switchToWorldpay.flexCredentials.get)
+simplifiedAccount.get(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.makeTestPayment.outbound, restrictToSwitchingAccount, permission('gateway-credentials:update'), serviceSettingsController.switchPsp.switchToWorldpay.makeTestPayment.get)
+simplifiedAccount.post(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.makeTestPayment.outbound, restrictToSwitchingAccount, permission('gateway-credentials:update'), serviceSettingsController.switchPsp.switchToWorldpay.makeTestPayment.post)
+simplifiedAccount.get(paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.makeTestPayment.inbound, restrictToSwitchingAccount, permission('gateway-credentials:update'), serviceSettingsController.switchPsp.switchToWorldpay.makeTestPayment.getInbound)
 
 // stripe details
 const stripeDetailsPath = paths.simplifiedAccount.settings.stripeDetails

--- a/src/utils/simplified-account/validation/worldpay/one-off-customer-initiated.schema.js
+++ b/src/utils/simplified-account/validation/worldpay/one-off-customer-initiated.schema.js
@@ -1,0 +1,33 @@
+const { body } = require('express-validator')
+
+const oneOffCustomerInitiatedSchema = {
+  merchantCode: {
+    validate: body('merchantCode')
+      .not()
+      .isEmpty()
+      .withMessage('Enter your merchant code')
+      .bail()
+      .custom((value, { req }) => {
+        if (req.account.allowMoto && !value.endsWith('MOTO') && !value.endsWith('MOTOGBP')) {
+          throw new Error('Enter a MOTO merchant code. MOTO payments are enabled for this account')
+        }
+        return true
+      })
+  },
+  username: {
+    validate: body('username')
+      .not()
+      .isEmpty()
+      .withMessage('Enter your username')
+  },
+  password: {
+    validate: body('password')
+      .not()
+      .isEmpty()
+      .withMessage('Enter your password')
+  }
+}
+
+module.exports = {
+  oneOffCustomerInitiatedSchema
+}

--- a/src/utils/verify-psp-integration.js
+++ b/src/utils/verify-psp-integration.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY = 'verify_psp_integration_charge_external_id'
 
 function filterNextUrl (charge = {}) {

--- a/src/views/simplified-account/settings/switch-psp/switch-to-worldpay/add-worldpay-credentials.njk
+++ b/src/views/simplified-account/settings/switch-psp/switch-to-worldpay/add-worldpay-credentials.njk
@@ -5,5 +5,5 @@
 {% block settingsContent %}
   <h1 class="govuk-heading-l">{{ settingsPageTitle }}</h1>
 
-  {% include "../../worldpay-details/includes/_worldpay-credentials-input.njk" %}
+  {% include "simplified-account/settings/worldpay-details/includes/_worldpay-credentials-input.njk" %}
 {% endblock %}

--- a/src/views/simplified-account/settings/switch-psp/switch-to-worldpay/index.njk
+++ b/src/views/simplified-account/settings/switch-psp/switch-to-worldpay/index.njk
@@ -1,7 +1,50 @@
-{% extends "../../settings-layout.njk" %}
+{% extends "simplified-account/settings/settings-layout.njk" %}
+{% from "macro/task-list.njk" import taskList %}
 
 {% set settingsPageTitle = "Switch to Worldpay" %}
 
 {% block settingsContent %}
-  <h1 class="govuk-heading-l">Switch to Worldpay</h1>
+  <h1 class="govuk-heading-l">{{ settingsPageTitle }}</h1>
+
+  {% if incompleteTasks %}
+
+    <p class="govuk-body">
+      This service is taking payments with {{ currentPsp | smartCaps }}.
+    </p>
+
+    <p class="govuk-body">To prepare for the switch, you need:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>your Worldpay account credentials: Merchant code, username and password</li>
+      {% if isMoto == false %}
+        <li>your Worldpay 3DS Flex account credentials: Organisational unit ID, issuer and JWT MAC key</li>
+      {% endif %}
+      <li>a debit or credit card to make a nominal live payment (refundable)</li>
+    </ul>
+
+    <h3 class="govuk-heading-s">Get ready to switch PSP to Worldpay</h3>
+
+    {{ taskList({
+      tasks: tasks,
+      idPrefix: 'worldpay-tasks'
+    }) }}
+
+  {% else %}
+
+    <p class="govuk-body">Your payment was successful. The connection between Worldpay and GOV.UK Pay is working. You
+      can check the payment in <a class="govuk-link govuk-link--no-visited-state" href="{{ transactionsUrl }}">Transactions</a>
+      and refund the payment.</p>
+
+    {{ govukWarningText({
+      text: "Once you switch, Worldpay will immediately start taking payments. You can refund previous payments through GOV.UK Pay.",
+      iconFallbackText: "Warning"
+    }) }}
+
+    <form id="switch-psp" method="post">
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+      {{ govukButton({
+        text: "Switch to Worldpay"
+      }) }}
+    </form>
+  {% endif %}
 {% endblock %}

--- a/src/views/simplified-account/settings/switch-psp/switch-to-worldpay/make-a-test-payment.njk
+++ b/src/views/simplified-account/settings/switch-psp/switch-to-worldpay/make-a-test-payment.njk
@@ -1,0 +1,15 @@
+{% extends "simplified-account/settings/settings-layout.njk" %}
+
+{% set settingsPageTitle = "Test the connection between Worldpay and GOV.UK Pay" %}
+
+{% block settingsContent %}
+  <h1 class="govuk-heading-l">{{ settingsPageTitle }}</h1>
+  <p class="govuk-body">Make a live payment of £2 with a debit or credit card to check that the connection with Worldpay
+    is working. You can refund the payment anytime.</p>
+  <form id="make-a-payment" method="post">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+    {{ govukButton({
+      text: "Continue to live payment"
+    }) }}
+  </form>
+{% endblock %}

--- a/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-worldpay/switch-to-worldpay.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-worldpay/switch-to-worldpay.cy.js
@@ -27,7 +27,21 @@ const setStubs = (opts = {}, additionalStubs = []) => {
       gateway_account_id: GATEWAY_ACCOUNT_ID,
       type: LIVE_ACCOUNT_TYPE,
       payment_provider: STRIPE,
-      provider_switch_enabled: true
+      provider_switch_enabled: true,
+      allow_moto: true,
+      gateway_account_credentials: [
+        {
+          state: 'ACTIVE',
+          payment_provider: 'stripe',
+          credentials: {
+            stripe_account_id: 'acct_blahblahblah'
+          }
+        },
+        {
+          state: 'CREATED',
+          payment_provider: 'worldpay'
+        }
+      ]
     }),
     stripeAccountSetupStubs.getStripeSetupProgressByServiceExternalIdAndAccountType({
       serviceExternalId: SERVICE_EXTERNAL_ID,


### PR DESCRIPTION
### WHAT

- new views and controllers for handling switch to worldpay tasks for a moto service
- new `ChargeRequest` class
- new `GatewayAccountSwitchPaymentProviderRequest` class
- extend `WorldpayTasks`: add `makeALivePayment` (verify that worldpay credentials are working)
- update `GatewayAccountCredentialUpdateRequest`, enable credential state change
- extract one off customer initiated credentials validation into reusable schema

### HOW 

this PR requires a [corresponding change in connector](https://github.com/alphagov/pay-connector/pull/5722) in order to behave correctly

additionally, our stubbing mechanism for worldpay orders does not account for how we currently handle moto services. 

in production a gateway account will have a MOTO specific merchant code that worldpay will recognise and determine not to request a 3DS check. 

our stubbing mechanism is not that smart (because connector still includes the flag to request 3DS regardless of MOTO status). you will need to manually change the gateway account `requires3ds` flag to false in order to test locally if using stubs to mock out worldpay responses

### SCREENS

<img width="1247" alt="Screenshot 2025-02-17 at 23 24 05" src="https://github.com/user-attachments/assets/4616981d-0369-4f98-b27e-e85d3c764067" />

<img width="1247" alt="Screenshot 2025-02-17 at 23 21 31" src="https://github.com/user-attachments/assets/ca117ef7-96eb-4910-8709-0609d3b2d9bf" />

<img width="1247" alt="Screenshot 2025-02-17 at 23 21 38" src="https://github.com/user-attachments/assets/db3468b7-326d-4a29-b62a-0951abfe6958" />

<img width="1247" alt="Screenshot 2025-02-17 at 23 21 43" src="https://github.com/user-attachments/assets/3ee74352-d9a5-4be2-b39a-441dce78d8bc" />

<img width="1247" alt="Screenshot 2025-02-17 at 23 22 22" src="https://github.com/user-attachments/assets/75cb0ec1-9b44-41b5-a54a-e209f3b28aa2" />

<img width="1247" alt="Screenshot 2025-02-17 at 23 23 01" src="https://github.com/user-attachments/assets/4b207073-26fa-49d3-a7d2-9ee070e1af7d" />

<img width="1247" alt="Screenshot 2025-02-17 at 23 23 16" src="https://github.com/user-attachments/assets/02faa1f8-79f8-4740-a511-61306c9b0159" />

<img width="1247" alt="Screenshot 2025-02-17 at 23 23 20" src="https://github.com/user-attachments/assets/2a92438e-5b01-44e1-9f98-a0962a703a41" />

<img width="1247" alt="Screenshot 2025-02-17 at 23 23 23" src="https://github.com/user-attachments/assets/225bf46e-be87-4ee7-b7a1-56ac619e7947" />

<img width="1247" alt="Screenshot 2025-02-17 at 23 23 33" src="https://github.com/user-attachments/assets/52383994-c863-479b-b8c9-363211c0d6ff" />

<img width="1247" alt="Screenshot 2025-02-17 at 23 23 40" src="https://github.com/user-attachments/assets/f21f040f-556f-44cc-b04a-2f1da2f30322" />

<img width="1247" alt="Screenshot 2025-02-17 at 23 24 16" src="https://github.com/user-attachments/assets/46f33ba5-1341-4978-ae25-c9a404e24803" />

<img width="1247" alt="Screenshot 2025-02-17 at 23 24 24" src="https://github.com/user-attachments/assets/fa8d3b51-8419-4bcd-b72e-8ee649da3e45" />
