### PR TITLE
Pp 13521 webhook details page

### DIFF
--- a/src/assets/sass/components/service-settings.scss
+++ b/src/assets/sass/components/service-settings.scss
@@ -79,3 +79,13 @@
     width: 180px;
   }
 }
+
+.webhook-header-with-tag {
+  display: flex;
+  align-items: flex-start;
+  .webhook-tag {
+    white-space: nowrap;
+    padding: 4px 12px;
+    margin-top: 0.3em;
+  }
+}

--- a/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
@@ -1,11 +1,16 @@
 const paths = require('@root/paths')
 const { response } = require('@utils/response')
+const webhooksService = require('@services/webhooks.service')
 const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
+const { constants } = require('@govuk-pay/pay-js-commons')
 
 async function get (req, res) {
+  const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId, req.account.id)
+  console.log('webhook: ------ ' + JSON.stringify(webhook))
   response(req, res, 'simplified-account/settings/webhooks/detail', {
-    description: 'Description from the webhook',
-    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type)
+    webhook,
+    eventTypes: constants.webhooks.humanReadableSubscriptions,
+    backToWebhooksLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type)
   })
 }
 

--- a/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
@@ -6,9 +6,11 @@ const { constants } = require('@govuk-pay/pay-js-commons')
 
 async function get (req, res) {
   const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId, req.account.id)
-  console.log('webhook: ------ ' + JSON.stringify(webhook))
+  const signingSecret = await webhooksService.getSigningSecret(req.params.webhookId, req.service.externalId, req.account.id)
+  // TODO get webhook messages and pass them into the template
   response(req, res, 'simplified-account/settings/webhooks/detail', {
     webhook,
+    signingSecret,
     eventTypes: constants.webhooks.humanReadableSubscriptions,
     backToWebhooksLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type)
   })

--- a/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.test.js
+++ b/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.test.js
@@ -1,0 +1,62 @@
+const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
+const { expect } = require('chai')
+const sinon = require('sinon')
+
+const ACCOUNT_TYPE = 'test'
+const SERVICE_ID = 'service-id-123abc'
+const GATEWAY_ACCOUNT_ID = '123'
+const WEBHOOK_ID = 'my-webhook-id-789'
+
+const webhook = {
+  id: WEBHOOK_ID,
+  callback_url: 'https://www.callback-url.gov.uk',
+  description: 'This is a description of the webhook',
+  status: 'ACTIVE'
+}
+const signingSecret = { signing_key: '123-signing-key-456'}
+
+const mockResponse = sinon.spy()
+const mockGetWebhook = sinon.stub().resolves(webhook)
+const mockGetSigningSecret = sinon.stub().resolves(signingSecret)
+
+const { res, nextRequest, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/webhooks/detail/detail.controller')
+  .withServiceExternalId(SERVICE_ID)
+  .withAccountType(ACCOUNT_TYPE)
+  .withAccount({ type: ACCOUNT_TYPE, id: GATEWAY_ACCOUNT_ID })
+  .withStubs({
+    '@utils/response': { response: mockResponse },
+    '@services/webhooks.service':
+      { getWebhook: mockGetWebhook, getSigningSecret: mockGetSigningSecret }
+  })
+  .build()
+
+describe('Controller: settings/webhooks/detail', () => {
+  describe('get', () => {
+    before(() => {
+      nextRequest({
+        params: { webhookId: WEBHOOK_ID }
+      })
+      call('get')
+    })
+
+    it('should call the response method', () => {
+      expect(mockGetWebhook.calledWith(WEBHOOK_ID, SERVICE_ID, GATEWAY_ACCOUNT_ID)).to.be.true // eslint-disable-line
+      expect(mockGetSigningSecret.calledWith(WEBHOOK_ID, SERVICE_ID, GATEWAY_ACCOUNT_ID)).to.be.true // eslint-disable-line
+      expect(mockResponse.called).to.be.true // eslint-disable-line
+    })
+
+    it('should pass req, res and template path to the response method', () => {
+      expect(mockResponse.args[0][0].params).to.deep.equal({ webhookId: WEBHOOK_ID })
+      expect(mockResponse.args[0]).to.include(res)
+      expect(mockResponse.args[0]).to.include('simplified-account/settings/webhooks/detail')
+    })
+
+    it('should pass context data to the response method', () => {
+      expect(mockResponse.args[0][3]).to.have.property('webhook').to.deep.equal(webhook)
+      expect(mockResponse.args[0][3]).to.have.property('signingSecret').to.deep.equal(signingSecret)
+      expect(mockResponse.args[0][3]).to.have.property('eventTypes').to.have.property('CARD_PAYMENT_SUCCEEDED').to.equal('Payment succeeded')
+      expect(mockResponse.args[0][3]).to.have.property('backToWebhooksLink')
+        .to.equal('/simplified/service/service-id-123abc/account/test/settings/webhooks')
+    })
+  })
+})

--- a/src/controllers/simplified-account/settings/webhooks/webhooks.controller.test.js
+++ b/src/controllers/simplified-account/settings/webhooks/webhooks.controller.test.js
@@ -52,6 +52,8 @@ describe('Controller: settings/webhooks', () => {
       expect(mockResponse.args[0][3]).to.have.property('eventTypes').to.have.property('CARD_PAYMENT_SUCCEEDED').to.equal('Payment succeeded')
       expect(mockResponse.args[0][3]).to.have.property('createWebhookLink')
         .to.equal('/simplified/service/service-id-123abc/account/test/settings/webhooks/create')
+      expect(mockResponse.args[0][3]).to.have.property('detailWebhookBaseUrl')
+        .to.equal('/simplified/service/service-id-123abc/account/test/settings/webhooks/')
     })
   })
 })

--- a/src/views/simplified-account/settings/webhooks/detail.njk
+++ b/src/views/simplified-account/settings/webhooks/detail.njk
@@ -1,7 +1,106 @@
+{% from "./_webhook_status.njk" import webhookStatusTag %}
 {% extends "../settings-layout.njk" %}
+
+{% macro webhookSubscriptions(webhook) %}
+  <ul class="govuk-list">
+    {% for subscription in webhook.subscriptions | sort %}
+      {% set key = subscription | upper %}
+      <li>{{ eventTypes[key] }}</li>
+    {% endfor %}
+  </ul>
+{% endmacro %}
+
 
 {% set settingsPageTitle = description %}
 
 {% block settingsContent %}
-  <h1 class="govuk-heading-l">{{ description }}</h1>
+
+  {{ govukBackLink({
+    text: "Back to webhooks",
+    href: backToWebhooksLink
+  }) }}
+
+  <h1 class="govuk-heading-l">{{ webhook.description }} {{ webhookStatusTag(webhook.status) }}</h1>
+
+  {% set webhookSubscriptionsList = webhookSubscriptions(webhook) %}
+
+  {{ govukSummaryList({
+    classes: "webhooks-summary-card",
+    rows: [
+      {
+        key: {
+          text: 'Callback URL'
+        },
+        value: {
+          text: webhook.callback_url
+        }
+      },
+      {
+        key: {
+          text: 'Payment events sent by this webhook'
+        },
+        value: {
+          html: webhookSubscriptionsList
+        }
+      },
+      {
+        key: {
+          text: 'Date created'
+        },
+        value: {
+          html: webhook.created_date | datetime('datelong')
+        }
+      }
+    ]
+  }) }}
+
+  {{ govukButton({
+    href: updateWebhookLink,
+    text: 'Update webhook',
+    classes: 'govuk-!-margin-top-2 govuk-button--secondary'
+  }) }}
+
+  {% if webhook.status == 'ACTIVE' %}
+
+    {{ govukButton({
+      href: deactivateWebhookLink,
+      text: 'Deactivate webhook',
+      classes: 'govuk-!-margin-top-2 govuk-button--secondary'
+    }) }}
+
+  {% else %}
+
+    {{ govukButton({
+      href: activateWebhookLink,
+      text: 'Activate webhook',
+      classes: 'govuk-!-margin-top-2 govuk-button--secondary'
+    }) }}
+
+  {% endif %}
+
+
+  <h2 class="govuk-heading-m">Signing Secret</h2>
+
+  <p class="govuk-body">Webhook messages sent by GOV.UK Pay will include a signature. Only your application should store this secret to verify messages are from GOV.UK Pay.</p>
+
+  <div>
+    <span id="secret" class="code copy-target">this-is-a-placeholder--{{ signingSecret.signing_key }}</span>
+  </div>
+
+  {{
+  govukButton({
+    text: "Copy signing secret to clipboard",
+    classes: "govuk-button--secondary govuk-!-margin-top-4",
+    attributes: {
+      id: "copy-signing-secret",
+      "data-copy-text": true,
+      "data-target": "copy-target",
+      "data-success": "Webhook signing secret has been copied",
+      "data-notification-target": "copy-notification"
+    }
+  })
+  }}
+
+  <div class="copy-notification govuk-visually-hidden" aria-live="assertive"></div>
+
 {% endblock %}

--- a/src/views/simplified-account/settings/webhooks/detail.njk
+++ b/src/views/simplified-account/settings/webhooks/detail.njk
@@ -20,7 +20,10 @@
     href: backToWebhooksLink
   }) }}
 
-  <h1 class="govuk-heading-l">{{ webhook.description }} {{ webhookStatusTag(webhook.status) }}</h1>
+  <div class="webhook-header-with-tag">
+    <h1 class="govuk-heading-l">{{ webhook.description }} </h1>
+    <span class="webhook-tag">{{ webhookStatusTag(webhook.status) }}</span>
+  </div>
 
   {% set webhookSubscriptionsList = webhookSubscriptions(webhook) %}
 
@@ -84,7 +87,7 @@
   <p class="govuk-body">Webhook messages sent by GOV.UK Pay will include a signature. Only your application should store this secret to verify messages are from GOV.UK Pay.</p>
 
   <div>
-    <span id="secret" class="code copy-target">this-is-a-placeholder--{{ signingSecret.signing_key }}</span>
+    <span id="signing-secret" class="code copy-target">{{ signingSecret.signing_key }}</span>
   </div>
 
   {{
@@ -95,7 +98,7 @@
       id: "copy-signing-secret",
       "data-copy-text": true,
       "data-target": "copy-target",
-      "data-success": "Webhook signing secret has been copied",
+      "data-success": "Signing secret copied",
       "data-notification-target": "copy-notification"
     }
   })

--- a/src/views/simplified-account/settings/webhooks/index.njk
+++ b/src/views/simplified-account/settings/webhooks/index.njk
@@ -85,6 +85,7 @@
       {% for webhook in deactivatedWebhooks %}
         {% set webhookDescriptionWithTag = webhook.description + '&nbsp&nbsp&nbsp' + webhookStatusTag(webhook.status) %}
         {% set webhookSubscriptionsList = webhookSubscriptions(webhook) %}
+        {% set webhookDetailUrl = detailWebhookBaseUrl + webhook.external_id %}
         {{ govukSummaryList({
           classes: "webhooks-summary-card",
           card: {
@@ -94,12 +95,14 @@
             actions: {
               items: [
                 {
-                  href: '',
-                  text: 'View'
+                  href: webhookDetailUrl,
+                  text: 'View',
+                  classes: "govuk-link govuk-link--no-visited-state"
                 },
                 {
                   href: '',
-                  text: 'Update'
+                  text: 'Update',
+                  classes: "govuk-link govuk-link--no-visited-state"
                 }
               ]
             }


### PR DESCRIPTION
- Webhook detail controller: Get the webhook and signing secret and pass to the template
- Webhook detail template: Display the webhook details and signing secret as per design
- Add some scss to position the status tag correctly next to the webhook detail heading
- Unit test the detail controller

To do in subsequent PRs:
- Add the 'Events' table which shows the events that have been sent as webhook messages. The design for this is being reviewed so this section will be implemented later, with corresponding updates to the unit tests.
- Cypress tests

![Screenshot 2025-02-13 at 14 12 40](https://github.com/user-attachments/assets/aed4cec8-2408-4b1e-9f75-4320fd546a88)
