### PR TITLE
PP-13261: Recurring creds on the worldpay details page

### DIFF
--- a/src/controllers/simplified-account/settings/worldpay-details/worldpay-details.controller.js
+++ b/src/controllers/simplified-account/settings/worldpay-details/worldpay-details.controller.js
@@ -14,18 +14,35 @@ function get (req, res) {
 
   if (!worldpayTasks.incompleteTasks) {
     context.answers = {
-      oneOffCustomerInitiated: {
-        href: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.oneOffCustomerInitiated,
-          req.service.externalId, req.account.type),
-        merchantCode: req.account.getCurrentCredential().credentials.oneOffCustomerInitiated.merchantCode,
-        username: req.account.getCurrentCredential().credentials.oneOffCustomerInitiated.username
-      },
       worldpay3dsFlex: worldpayTasks.findTask('3ds-flex-credentials') && {
         href: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.flexCredentials,
           req.service.externalId, req.account.type),
         organisationalUnitId: req.account.worldpay3dsFlex.organisationalUnitId,
         issuer: req.account.worldpay3dsFlex.issuer
       }
+    }
+    if (worldpayTasks.hasRecurringTasks()) {
+      context.answers.tasksWithMerchantCodeAndUsername = [{
+        title: 'Recurring customer initiated transaction (CIT) credentials',
+        href: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.recurringCustomerInitiated,
+          req.service.externalId, req.account.type),
+        merchantCode: req.account.getCurrentCredential().credentials.recurringCustomerInitiated.merchantCode,
+        username: req.account.getCurrentCredential().credentials.recurringCustomerInitiated.username
+      }, {
+        title: 'Recurring merchant initiated transaction (MIT) credentials',
+        href: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.recurringMerchantInitiated,
+          req.service.externalId, req.account.type),
+        merchantCode: req.account.getCurrentCredential().credentials.recurringMerchantInitiated.merchantCode,
+        username: req.account.getCurrentCredential().credentials.recurringMerchantInitiated.username
+      }]
+    } else {
+      context.answers.tasksWithMerchantCodeAndUsername = [{
+        title: 'Account credentials',
+        href: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.oneOffCustomerInitiated,
+          req.service.externalId, req.account.type),
+        merchantCode: req.account.getCurrentCredential().credentials.oneOffCustomerInitiated.merchantCode,
+        username: req.account.getCurrentCredential().credentials.oneOffCustomerInitiated.username
+      }]
     }
   }
 

--- a/src/controllers/simplified-account/settings/worldpay-details/worldpay-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/worldpay-details/worldpay-details.controller.test.js
@@ -125,13 +125,13 @@ describe('Controller: settings/worldpay-details', () => {
         const tasks = [{
           href: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.recurringCustomerInitiated,
             SERVICE_ID, ACCOUNT_TYPE),
-          id: null,
+          id: 'cit-credentials',
           linkText: 'Recurring customer initiated transaction (CIT) credentials',
           status: 'NOT_STARTED'
         }, {
           href: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.recurringMerchantInitiated,
             SERVICE_ID, ACCOUNT_TYPE),
-          id: null,
+          id: 'mit-credentials',
           linkText: 'Recurring merchant initiated transaction (MIT) credentials',
           status: 'NOT_STARTED'
         }, {

--- a/src/models/WorldpayTasks.class.js
+++ b/src/models/WorldpayTasks.class.js
@@ -38,6 +38,10 @@ class WorldpayTasks {
       task.status !== TASK_STATUS.COMPLETED).length > 0
   }
 
+  hasRecurringTasks () {
+    return this.tasks.find(t => t.id === 'cit-credentials') && this.tasks.find(t => t.id === 'mit-credentials')
+  }
+
   /**
    *
    * @param {String} taskId
@@ -109,7 +113,7 @@ class WorldpayTask {
     const task = new WorldpayTask(
       formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.recurringCustomerInitiated,
         serviceExternalId, accountType),
-      null,
+      'cit-credentials',
       'Recurring customer initiated transaction (CIT) credentials'
     )
     if (!credential || !credential.credentials.recurringCustomerInitiated) {
@@ -131,10 +135,10 @@ class WorldpayTask {
     const task = new WorldpayTask(
       formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.recurringMerchantInitiated,
         serviceExternalId, accountType),
-      null,
+      'mit-credentials',
       'Recurring merchant initiated transaction (MIT) credentials'
     )
-    if (!credential || !credential.credentials.recurringMerchantInitated) {
+    if (!credential || !credential.credentials.recurringMerchantInitiated) {
       task.setStatus(TASK_STATUS.NOT_STARTED)
     } else {
       task.setStatus(TASK_STATUS.COMPLETED)

--- a/src/models/gateway-account-credential/Credential.class.js
+++ b/src/models/gateway-account-credential/Credential.class.js
@@ -33,11 +33,11 @@ class Credential {
 
   /**
    *
-   * @param {WorldpayCredential} recurringMerchantInitated
+   * @param {WorldpayCredential} recurringMerchantInitiated
    * @returns {Credential}
    */
-  withRecurringMerchantInitiated (recurringMerchantInitated) {
-    this.recurringMerchantInitated = recurringMerchantInitated
+  withRecurringMerchantInitiated (recurringMerchantInitiated) {
+    this.recurringMerchantInitiated = recurringMerchantInitiated
     return this
   }
 

--- a/src/views/simplified-account/settings/worldpay-details/index.njk
+++ b/src/views/simplified-account/settings/worldpay-details/index.njk
@@ -16,14 +16,16 @@
     }) }}
   {% else %}
 
+    {% for task in answers.tasksWithMerchantCodeAndUsername %}
+
       {{ govukSummaryList({
         card: {
           title: {
-            text: 'Account credentials'
+            text: task.title
           },
           actions: {
             items: [{
-              href: answers.oneOffCustomerInitiated.href,
+              href: task.href,
               text: 'Change',
               classes: 'govuk-link--no-visited-state'
             }]
@@ -31,15 +33,17 @@
         },
         rows: [{
           key: { text: 'Merchant code' },
-          value: { text: answers.oneOffCustomerInitiated.merchantCode }
+          value: { text: task.merchantCode }
         }, {
           key: { text: 'Username' },
-          value: { text: answers.oneOffCustomerInitiated.username }
+          value: { text: task.username }
         }, {
           key: { text: 'Password' },
           value: { text: '●●●●●●●●' }
         }]
       }) }}
+
+    {% endfor %}
 
     {% if answers.worldpay3dsFlex %}
 


### PR DESCRIPTION
Enable the worldpay details page controller and view show the one-off and recurring credentials correctly.

### SCREENS

Screenshot of notification banner when either CIT or MIT creds were the last task to complete:
![Screenshot 2025-02-18 at 17 56 35](https://github.com/user-attachments/assets/693464c4-0ce5-4f8d-9dfa-04a2d8a52e2c)

Screenshot when re-visiting Worldpay details page:
![Screenshot 2025-02-18 at 17 52 09](https://github.com/user-attachments/assets/78cb442d-1bf9-4268-ac17-f3bb26409874)

I've also verified that one-off card payments creds still work as expected:
<img width="913" alt="Screenshot 2025-02-19 at 09 51 49" src="https://github.com/user-attachments/assets/aca9d174-be15-47a5-ba57-048508db6cf6" />


