### PR TITLE
PP-13613 move skip link target for settings pages

### DIFF
--- a/src/views/simplified-account/settings/settings-layout.njk
+++ b/src/views/simplified-account/settings/settings-layout.njk
@@ -1,9 +1,17 @@
 {% extends "layout.njk" %}
 {% from "macro/system-messages.njk" import systemMessages %}
 {% from "govuk/components/task-list/macro.njk" import govukTaskList %}
+{% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
 
 {% block pageTitle %}
-  {{ settingsPageTitle }} - Settings - {{  currentService.name }} - GOV.UK Pay
+  {{ settingsPageTitle }} - Settings - {{ currentService.name }} - GOV.UK Pay
+{% endblock %}
+
+{% block skipLink %}
+  {{ govukSkipLink({
+    text: "Skip to main content",
+    href: "#service-settings-content"
+  }) }}
 {% endblock %}
 
 {% block sideNavigation %}
@@ -28,7 +36,10 @@
           errorList: errors.summary
         }) }}
       {% endif %}
-      {% block settingsContent %}{% endblock %}
+      <div id="service-settings-content">
+        {% block settingsContent %}
+        {% endblock %}
+      </div>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
### WHAT

- adjust the skiplink component to target the main content of each settings page

#### BEFORE

skiplink targets left side nav

https://github.com/user-attachments/assets/1b13720d-ee3d-4256-a21a-184e5c78a687

#### AFTER

skiplink targets main settings content

https://github.com/user-attachments/assets/b1d53332-7cb8-420f-a822-d880fd3c2d74
