### PR TITLE
Pp 13521: Update Webhooks details page

### DIFF
--- a/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
@@ -5,14 +5,25 @@ const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/forma
 const { constants } = require('@govuk-pay/pay-js-commons')
 
 async function get (req, res) {
+  const status = req.query.status
+  const page = req.query.page || 1
   const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId, req.account.id)
+  const messages = await webhooksService.getWebhookMessages(req.params.webhookId, { page, ...status && { status } })
+  const webhookEvents = messages.results.map(result => ({
+    resourceId: result.resource_id,
+    eventType: result.event_type,
+    lastDeliveryStatus: result.last_delivery_status,
+    eventDate: result.event_date,
+    eventDetailUrl: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.event, req.service.externalId, req.account.type, webhook.external_id, result.external_id)
+  }))
+
   const signingSecret = await webhooksService.getSigningSecret(req.params.webhookId, req.service.externalId, req.account.id)
-  // TODO get webhook messages and pass them into the template
   response(req, res, 'simplified-account/settings/webhooks/detail', {
     webhook,
     signingSecret,
     eventTypes: constants.webhooks.humanReadableSubscriptions,
-    backToWebhooksLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type)
+    backToWebhooksLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type),
+    webhookEvents
   })
 }
 

--- a/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.test.js
+++ b/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.test.js
@@ -18,6 +18,7 @@ const signingSecret = { signing_key: '123-signing-key-456'}
 const mockResponse = sinon.spy()
 const mockGetWebhook = sinon.stub().resolves(webhook)
 const mockGetSigningSecret = sinon.stub().resolves(signingSecret)
+const mockGetWebhookMessages = sinon.stub().resolves({ results: [] })
 
 const { res, nextRequest, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/webhooks/detail/detail.controller')
   .withServiceExternalId(SERVICE_ID)
@@ -26,7 +27,7 @@ const { res, nextRequest, call } = new ControllerTestBuilder('@controllers/simpl
   .withStubs({
     '@utils/response': { response: mockResponse },
     '@services/webhooks.service':
-      { getWebhook: mockGetWebhook, getSigningSecret: mockGetSigningSecret }
+      { getWebhook: mockGetWebhook, getSigningSecret: mockGetSigningSecret, getWebhookMessages: mockGetWebhookMessages }
   })
   .build()
 
@@ -41,6 +42,7 @@ describe('Controller: settings/webhooks/detail', () => {
 
     it('should call the response method', () => {
       expect(mockGetWebhook.calledWith(WEBHOOK_ID, SERVICE_ID, GATEWAY_ACCOUNT_ID)).to.be.true // eslint-disable-line
+      expect(mockGetWebhookMessages.calledWith(WEBHOOK_ID)).to.be.true // eslint-disable-line
       expect(mockGetSigningSecret.calledWith(WEBHOOK_ID, SERVICE_ID, GATEWAY_ACCOUNT_ID)).to.be.true // eslint-disable-line
       expect(mockResponse.called).to.be.true // eslint-disable-line
     })

--- a/src/paths.js
+++ b/src/paths.js
@@ -242,7 +242,8 @@ module.exports = {
         index: '/settings/webhooks',
         create: '/settings/webhooks/create',
         detail: '/settings/webhooks/:webhookId',
-        update: '/settings/webhooks/:webhookId/update'
+        update: '/settings/webhooks/:webhookId/update',
+        event: '/settings/webhooks/:webhookId/event/:eventId'
       },
       switchPsp: {
         switchToWorldpay: {

--- a/src/views/simplified-account/settings/webhooks/_message_status.njk
+++ b/src/views/simplified-account/settings/webhooks/_message_status.njk
@@ -1,0 +1,16 @@
+{% set statusStyleMap = {
+"PENDING": "govuk-tag--grey",
+"SUCCESSFUL": "govuk-tag--green",
+"FAILED": "govuk-tag--red",
+"WILL_NOT_SEND": "govuk-tag--yellow"
+} %}
+{% set statusTextMap = {
+"PENDING": "Pending Retry",
+"SUCCESSFUL": "Successful",
+"FAILED": "Failed",
+"WILL_NOT_SEND": "Will not send"
+} %}
+
+{% macro messageStatusTag(status) %}
+<strong class="govuk-tag {{ statusStyleMap[status] }}">{{ statusTextMap[status] }}</strong>
+{% endmacro %}

--- a/src/views/simplified-account/settings/webhooks/detail.njk
+++ b/src/views/simplified-account/settings/webhooks/detail.njk
@@ -1,4 +1,5 @@
 {% from "./_webhook_status.njk" import webhookStatusTag %}
+{% from "./_message_status.njk" import messageStatusTag %}
 {% extends "../settings-layout.njk" %}
 
 {% macro webhookSubscriptions(webhook) %}
@@ -9,7 +10,6 @@
     {% endfor %}
   </ul>
 {% endmacro %}
-
 
 {% set settingsPageTitle = webhook.description %}
 
@@ -121,14 +121,44 @@
         value: "failed",
         text: "Failed"
       }
-    ]
+    ],
+    formGroup: {
+      afterInput: {
+          html: '<button type="submit" class="govuk-button govuk-button" data-module="govuk-button" data-govuk-button-init="">Update</button>'
+      }
+    }
   }) }}
 
-  {{
-  govukButton({
-    text: "Update",
-    classes: "govuk-button"
-  })
-  }}
+  {% set eventRows = [] %}
+  {% for event in webhookEvents %}
+    {% set eventTypeX = event.eventType | upper %}
+    {% set eventRow = [
+      {text: event.resourceId},
+      {html: eventTypes[event.eventType | upper] + '<br><a href="'+event.eventDetailUrl+'">View details<a/>'},
+      {html: messageStatusTag(event.lastDeliveryStatus)},
+      {text: event.eventDate | datetime('datelong')}
+    ] %}
+    {% set eventRows = (eventRows.push(eventRow), eventRows) %}
+  {% endfor %}
+
+  {{ govukTable({
+    firstCellIsHeader: false,
+    head: [
+      {
+        text: "GOV.UK payment ID"
+      },
+      {
+        text: "Event name"
+      },
+      {
+        text: "Delivery status"
+      },
+      {
+        text: "Event date"
+      }
+    ],
+    rows: eventRows
+
+  }) }}
 
 {% endblock %}

--- a/src/views/simplified-account/settings/webhooks/detail.njk
+++ b/src/views/simplified-account/settings/webhooks/detail.njk
@@ -64,32 +64,25 @@
   }) }}
 
   {% if webhook.status == 'ACTIVE' %}
-
     {{ govukButton({
       href: deactivateWebhookLink,
       text: 'Deactivate webhook',
       classes: 'govuk-!-margin-top-2 govuk-button--secondary'
     }) }}
-
   {% else %}
-
     {{ govukButton({
       href: activateWebhookLink,
       text: 'Activate webhook',
       classes: 'govuk-!-margin-top-2 govuk-button--secondary'
     }) }}
-
   {% endif %}
 
 
   <h2 class="govuk-heading-m">Signing Secret</h2>
-
   <p class="govuk-body">Webhook messages sent by GOV.UK Pay will include a signature. Only your application should store this secret to verify messages are from GOV.UK Pay.</p>
-
   <div>
     <span id="signing-secret" class="code copy-target">{{ signingSecret.signing_key }}</span>
   </div>
-
   {{
   govukButton({
     text: "Copy signing secret to clipboard",
@@ -103,7 +96,39 @@
     }
   })
   }}
-
   <div class="copy-notification govuk-visually-hidden" aria-live="assertive"></div>
+
+  <h2 class="govuk-heading-m">Events</h2>
+  <p class="govuk-body">Events sent to your webhook are stored for 7 days.</p>
+
+  {{ govukSelect({
+    id: "filter-events",
+    name: "Filter events",
+    label: {
+      text: "Filter events",
+      classes: "govuk-label--s"
+    },
+    items: [
+      {
+        value: "all",
+        text: "All"
+      },
+      {
+        value: "successful",
+        text: "Successful"
+      },
+      {
+        value: "failed",
+        text: "Failed"
+      }
+    ]
+  }) }}
+
+  {{
+  govukButton({
+    text: "Update",
+    classes: "govuk-button"
+  })
+  }}
 
 {% endblock %}

--- a/test/cypress/integration/simplified-account/service-settings/webhooks/webhook-detail.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/webhooks/webhook-detail.cy.js
@@ -43,6 +43,9 @@ const setStubs = (opts = {}, additionalStubs = []) => {
       external_id: WEBHOOK_ID,
       signing_key: '123-signing-secret-456'
     }),
+    webhooksStubs.getWebhookMessagesListSuccess({
+      external_id: WEBHOOK_ID
+    }),
     ...additionalStubs])
 }
 


### PR DESCRIPTION
### WHAT

Update Webhook details page:
- Add Webhook summary card
- Add Webhook secret
- Add events to the webhooks details page.

The correct information is displayed, including links to the event details page, however the exact formation will require more work.
Pagination, filtering and test are not part of this PR.

### SCREENS
![Screenshot 2025-02-24 at 11 28 37](https://github.com/user-attachments/assets/a05daa0f-3c1f-45b2-9fc5-3fd60b2d042b)

