### PR TITLE
PP-13521: Implement pagination for webhook detail messages

### DIFF
--- a/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
@@ -8,9 +8,19 @@ async function get (req, res) {
   const status = (req.query.deliveryStatus === 'successful' || req.query.deliveryStatus === 'failed')
     ? req.query.deliveryStatus
     : undefined
-  const page = req.query.page || 1
+  const page = parseInt(req.query.page || 1)
+  const baseUrl = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.detail, req.service.externalId, req.account.type, req.params.webhookId)
+  if (Number.isNaN(page) || page < 1) {
+    res.redirect(baseUrl)
+  }
+
   const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId, req.account.id)
   const messages = await webhooksService.getWebhookMessages(req.params.webhookId, { page, ...status && { status } })
+  const totalPages = Math.ceil(messages.total / 10)
+  if (totalPages > 0 && page > totalPages) {
+    res.redirect(baseUrl)
+  }
+
   const webhookEvents = messages.results.map(result => ({
     resourceId: result.resource_id,
     eventType: result.event_type,
@@ -20,14 +30,39 @@ async function get (req, res) {
   }))
 
   const signingSecret = await webhooksService.getSigningSecret(req.params.webhookId, req.service.externalId, req.account.id)
+  const deliveryStatus = status || 'all'
+  const paginationDetails = getPaginationDetails(page, messages.total, baseUrl, deliveryStatus)
+
   response(req, res, 'simplified-account/settings/webhooks/detail', {
     webhook,
     signingSecret,
-    deliveryStatus: status || 'all',
+    deliveryStatus,
     eventTypes: constants.webhooks.humanReadableSubscriptions,
     backToWebhooksLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type),
-    webhookEvents
+    webhookEvents,
+    paginationDetails
   })
+}
+
+function getPaginationDetails (currentPage, total, baseUrl, deliveryStatus) {
+  if (total <= 10) {
+    return {}
+  }
+  const totalPages = Math.ceil(total / 10)
+  const result = { items: [] }
+  if (currentPage !== 1) {
+    result.previous = { href: `${baseUrl}?deliveryStatus=${deliveryStatus}&page=${currentPage - 1}` }
+  }
+  if (currentPage !== totalPages) {
+    result.next = { href: `${baseUrl}?deliveryStatus=${deliveryStatus}&page=${currentPage + 1}` }
+  }
+  for (let i = 0; i < totalPages; i++) {
+    result.items[i] = { number: i + 1, href: `${baseUrl}?deliveryStatus=${deliveryStatus}&page=${i + 1}` }
+    if (currentPage === i + 1) {
+      result.items[i].current = true
+    }
+  }
+  return result
 }
 
 module.exports = {

--- a/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
@@ -5,7 +5,9 @@ const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/forma
 const { constants } = require('@govuk-pay/pay-js-commons')
 
 async function get (req, res) {
-  const status = req.query.status
+  const status = (req.query.deliveryStatus === 'successful' || req.query.deliveryStatus === 'failed')
+    ? req.query.deliveryStatus
+    : undefined
   const page = req.query.page || 1
   const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId, req.account.id)
   const messages = await webhooksService.getWebhookMessages(req.params.webhookId, { page, ...status && { status } })
@@ -21,6 +23,7 @@ async function get (req, res) {
   response(req, res, 'simplified-account/settings/webhooks/detail', {
     webhook,
     signingSecret,
+    deliveryStatus: status || 'all',
     eventTypes: constants.webhooks.humanReadableSubscriptions,
     backToWebhooksLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type),
     webhookEvents

--- a/src/views/simplified-account/settings/webhooks/detail.njk
+++ b/src/views/simplified-account/settings/webhooks/detail.njk
@@ -100,14 +100,15 @@
 
   <h2 class="govuk-heading-m">Events</h2>
   <p class="govuk-body">Events sent to your webhook are stored for 7 days.</p>
-
+  <form>
   {{ govukSelect({
     id: "filter-events",
-    name: "Filter events",
+    name: "deliveryStatus",
     label: {
-      text: "Filter events",
+      text: "Filter Events",
       classes: "govuk-label--s"
     },
+    value: deliveryStatus,
     items: [
       {
         value: "all",
@@ -128,6 +129,7 @@
       }
     }
   }) }}
+  </form>
 
   {% set eventRows = [] %}
   {% for event in webhookEvents %}
@@ -159,6 +161,32 @@
     ],
     rows: eventRows
 
+  }) }}
+
+  {% from "govuk/components/pagination/macro.njk" import govukPagination %}
+
+  {{ govukPagination({
+    previous: {
+      href: "#"
+    },
+    next: {
+      href: "#"
+    },
+    items: [
+      {
+        number: 1,
+        href: "#"
+      },
+      {
+        number: 2,
+        current: true,
+        href: "#"
+      },
+      {
+        number: 3,
+        href: "#"
+      }
+    ]
   }) }}
 
 {% endblock %}

--- a/src/views/simplified-account/settings/webhooks/detail.njk
+++ b/src/views/simplified-account/settings/webhooks/detail.njk
@@ -165,28 +165,6 @@
 
   {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
-  {{ govukPagination({
-    previous: {
-      href: "#"
-    },
-    next: {
-      href: "#"
-    },
-    items: [
-      {
-        number: 1,
-        href: "#"
-      },
-      {
-        number: 2,
-        current: true,
-        href: "#"
-      },
-      {
-        number: 3,
-        href: "#"
-      }
-    ]
-  }) }}
+  {{ govukPagination( paginationDetails ) }}
 
 {% endblock %}


### PR DESCRIPTION
### WHAT

Implement pagination control to the webhook detail view.

We have done this by building the pagination object in the controller and passing that the nunjucks view. 

Manipulating the page query parameters to invalid values is handled by redirecting to the default base url for the webhook detail view.

### SCREENS
<img width="1183" alt="Screenshot 2025-02-25 at 15 30 30" src="https://github.com/user-attachments/assets/60186b7a-af3b-494b-b73e-fa5a97493a85" />

<img width="1183" alt="Screenshot 2025-02-25 at 15 30 59" src="https://github.com/user-attachments/assets/8a73cc73-b108-42a7-932d-88396705cc3c" />


