### PR TITLE
PP-13521 tidy up detail controller and template and update unit test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "3.693.0",
         "@aws-sdk/s3-request-presigner": "3.693.0",
-        "@govuk-pay/pay-js-commons": "^6.0.22",
+        "@govuk-pay/pay-js-commons": "^6.0.27",
         "@govuk-pay/pay-js-metrics": "^1.0.6",
         "@sentry/node": "6.12.0",
         "accessible-autocomplete": "2.0.4",
@@ -3831,9 +3831,9 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "6.0.22",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.22.tgz",
-      "integrity": "sha512-b9Vt14mr/G+uSXK/1uWUQg73wrghRYA7vtNlpvW5WaMpippyI3a7osVLmRsKUphNC30YyPGXBXtfuwvOerYngA==",
+      "version": "6.0.27",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.27.tgz",
+      "integrity": "sha512-8AVu4JkfZVV0C6zRxRtFEZzw8MAcuat/Fww/veyJ+PKv78J6ViQHL5aMBFh3aGx7z485eguQUZU+PsXEZLYheQ==",
       "dependencies": {
         "axios": "^1.6.5",
         "csrf": "^3.1.0",
@@ -21761,9 +21761,9 @@
       "dev": true
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "6.0.22",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.22.tgz",
-      "integrity": "sha512-b9Vt14mr/G+uSXK/1uWUQg73wrghRYA7vtNlpvW5WaMpippyI3a7osVLmRsKUphNC30YyPGXBXtfuwvOerYngA==",
+      "version": "6.0.27",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.27.tgz",
+      "integrity": "sha512-8AVu4JkfZVV0C6zRxRtFEZzw8MAcuat/Fww/veyJ+PKv78J6ViQHL5aMBFh3aGx7z485eguQUZU+PsXEZLYheQ==",
       "requires": {
         "axios": "^1.6.5",
         "csrf": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "3.693.0",
     "@aws-sdk/s3-request-presigner": "3.693.0",
-    "@govuk-pay/pay-js-commons": "^6.0.22",
+    "@govuk-pay/pay-js-commons": "^6.0.27",
     "@govuk-pay/pay-js-metrics": "^1.0.6",
     "@sentry/node": "6.12.0",
     "accessible-autocomplete": "2.0.4",

--- a/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
@@ -5,50 +5,46 @@ const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/forma
 const { constants } = require('@govuk-pay/pay-js-commons')
 
 async function get (req, res) {
-  const status = (req.query.deliveryStatus === 'successful' || req.query.deliveryStatus === 'failed')
-    ? req.query.deliveryStatus
-    : undefined
-  const page = parseInt(req.query.page || 1)
   const baseUrl = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.detail, req.service.externalId, req.account.type, req.params.webhookId)
+  const page = parseInt(req.query.page || 1)
   if (Number.isNaN(page) || page < 1) {
     res.redirect(baseUrl)
   }
 
+  const deliveryStatus = (req.query.deliveryStatus === 'successful' || req.query.deliveryStatus === 'failed') ? req.query.deliveryStatus : 'all'
   const webhook = await webhooksService.getWebhook(req.params.webhookId, req.service.externalId, req.account.id)
-  const messages = await webhooksService.getWebhookMessages(req.params.webhookId, { page, ...status && { status } })
-  const totalPages = Math.ceil(messages.total / 10)
+  const signingSecret = await webhooksService.getSigningSecret(req.params.webhookId, req.service.externalId, req.account.id)
+  const webhookMessages = await webhooksService.getWebhookMessages(req.params.webhookId, { page, ...deliveryStatus && { status: deliveryStatus } })
+  const totalPages = Math.ceil(webhookMessages.total / 10)
   if (totalPages > 0 && page > totalPages) {
     res.redirect(baseUrl)
   }
 
-  const webhookEvents = messages.results.map(result => ({
+  const webhookEvents = webhookMessages.results.map(result => ({
     resourceId: result.resource_id,
     eventType: result.event_type,
     lastDeliveryStatus: result.last_delivery_status,
     eventDate: result.event_date,
     eventDetailUrl: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.event, req.service.externalId, req.account.type, webhook.external_id, result.external_id)
   }))
-
-  const signingSecret = await webhooksService.getSigningSecret(req.params.webhookId, req.service.externalId, req.account.id)
-  const deliveryStatus = status || 'all'
-  const paginationDetails = getPaginationDetails(page, messages.total, baseUrl, deliveryStatus)
+  const paginationDetails = getPaginationDetails(page, webhookMessages.total, baseUrl, deliveryStatus)
 
   response(req, res, 'simplified-account/settings/webhooks/detail', {
     webhook,
     signingSecret,
     deliveryStatus,
-    eventTypes: constants.webhooks.humanReadableSubscriptions,
-    backToWebhooksLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type),
     webhookEvents,
-    paginationDetails
+    paginationDetails,
+    eventTypes: constants.webhooks.humanReadableSubscriptions,
+    backToWebhooksLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type)
   })
 }
 
-function getPaginationDetails (currentPage, total, baseUrl, deliveryStatus) {
-  if (total <= 10) {
+function getPaginationDetails (currentPage, totalWebhookEvents, baseUrl, deliveryStatus) {
+  if (totalWebhookEvents <= 10) {
     return {}
   }
-  const totalPages = Math.ceil(total / 10)
+  const totalPages = Math.ceil(totalWebhookEvents / 10)
   const result = { items: [] }
   if (currentPage !== 1) {
     result.previous = { href: `${baseUrl}?deliveryStatus=${deliveryStatus}&page=${currentPage - 1}` }

--- a/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.test.js
+++ b/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.test.js
@@ -14,11 +14,29 @@ const webhook = {
   status: 'ACTIVE'
 }
 const signingSecret = { signing_key: '123-signing-key-456'}
+const webhookMessages = {
+  count: 10,
+  page: 1,
+  total: 11,
+  results: [
+    { resource_id: 'payment_id-1' },
+    { resource_id: 'payment_id-2' },
+    { resource_id: 'payment_id-3' },
+    { resource_id: 'payment_id-4' },
+    { resource_id: 'payment_id-5' },
+    { resource_id: 'payment_id-6' },
+    { resource_id: 'payment_id-7' },
+    { resource_id: 'payment_id-8' },
+    { resource_id: 'payment_id-9' },
+    { resource_id: 'payment_id-10' },
+    { resource_id: 'payment_id-11' }
+  ]
+}
 
 const mockResponse = sinon.spy()
 const mockGetWebhook = sinon.stub().resolves(webhook)
 const mockGetSigningSecret = sinon.stub().resolves(signingSecret)
-const mockGetWebhookMessages = sinon.stub().resolves({ results: [] })
+const mockGetWebhookMessages = sinon.stub().resolves(webhookMessages)
 
 const { res, nextRequest, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/webhooks/detail/detail.controller')
   .withServiceExternalId(SERVICE_ID)
@@ -56,6 +74,25 @@ describe('Controller: settings/webhooks/detail', () => {
     it('should pass context data to the response method', () => {
       expect(mockResponse.args[0][3]).to.have.property('webhook').to.deep.equal(webhook)
       expect(mockResponse.args[0][3]).to.have.property('signingSecret').to.deep.equal(signingSecret)
+      expect(mockResponse.args[0][3]).to.have.property('deliveryStatus').to.equal('all')
+      expect(mockResponse.args[0][3]).to.have.property('webhookEvents').to.have.length(11)
+      expect(mockResponse.args[0][3].webhookEvents[0]).to.have.property('resourceId').to.equal('payment_id-1')
+      expect(mockResponse.args[0][3]).to.have.property('paginationDetails').to.deep.equal({
+        items: [
+          {
+            number: 1,
+            href: '/simplified/service/service-id-123abc/account/test/settings/webhooks/my-webhook-id-789?deliveryStatus=all&page=1',
+            current: true
+          },
+          {
+            number: 2,
+            href: '/simplified/service/service-id-123abc/account/test/settings/webhooks/my-webhook-id-789?deliveryStatus=all&page=2'
+          }
+        ],
+        next: {
+          href: '/simplified/service/service-id-123abc/account/test/settings/webhooks/my-webhook-id-789?deliveryStatus=all&page=2'
+        }
+      })
       expect(mockResponse.args[0][3]).to.have.property('eventTypes').to.have.property('CARD_PAYMENT_SUCCEEDED').to.equal('Payment succeeded')
       expect(mockResponse.args[0][3]).to.have.property('backToWebhooksLink')
         .to.equal('/simplified/service/service-id-123abc/account/test/settings/webhooks')

--- a/src/services/clients/webhooks.client.js
+++ b/src/services/clients/webhooks.client.js
@@ -77,7 +77,7 @@ async function messages (id, options = {}) {
   const baseUrl = options.baseUrl ? options.baseUrl : defaultRequestOptions.baseUrl
   const url = urlJoin(baseUrl, '/v1/webhook', id, 'message')
   let fullUrl = `${url}?page=${options.page}`
-  if (options.status) {
+  if (options.status && options.status !== 'all') {
     fullUrl = `${fullUrl}&status=${options.status.toUpperCase()}`
   }
   configureClient(client, fullUrl)

--- a/src/views/simplified-account/settings/webhooks/detail.njk
+++ b/src/views/simplified-account/settings/webhooks/detail.njk
@@ -101,44 +101,43 @@
   <h2 class="govuk-heading-m">Events</h2>
   <p class="govuk-body">Events sent to your webhook are stored for 7 days.</p>
   <form>
-  {{ govukSelect({
-    id: "filter-events",
-    name: "deliveryStatus",
-    label: {
-      text: "Filter Events",
-      classes: "govuk-label--s"
-    },
-    value: deliveryStatus,
-    items: [
-      {
-        value: "all",
-        text: "All"
+    {{ govukSelect({
+      id: "filter-events",
+      name: "deliveryStatus",
+      label: {
+        text: "Filter Events",
+        classes: "govuk-label--s"
       },
-      {
-        value: "successful",
-        text: "Successful"
-      },
-      {
-        value: "failed",
-        text: "Failed"
+      value: deliveryStatus,
+      items: [
+        {
+          value: "all",
+          text: "All"
+        },
+        {
+          value: "successful",
+          text: "Successful"
+        },
+        {
+          value: "failed",
+          text: "Failed"
+        }
+      ],
+      formGroup: {
+        afterInput: {
+            html: '<button type="submit" class="govuk-button govuk-button" data-module="govuk-button" data-govuk-button-init="">Update</button>'
+        }
       }
-    ],
-    formGroup: {
-      afterInput: {
-          html: '<button type="submit" class="govuk-button govuk-button" data-module="govuk-button" data-govuk-button-init="">Update</button>'
-      }
-    }
-  }) }}
+    }) }}
   </form>
 
   {% set eventRows = [] %}
   {% for event in webhookEvents %}
-    {% set eventTypeX = event.eventType | upper %}
     {% set eventRow = [
-      {text: event.resourceId},
-      {html: eventTypes[event.eventType | upper] + '<br><a href="'+event.eventDetailUrl+'">View details<a/>'},
-      {html: messageStatusTag(event.lastDeliveryStatus)},
-      {text: event.eventDate | datetime('datelong')}
+      { text: event.resourceId },
+      { html: eventTypes[event.eventType | upper] + '<br><a href="'+event.eventDetailUrl+'">View details<a/>' },
+      { html: messageStatusTag(event.lastDeliveryStatus) },
+      { text: event.eventDate | datetime('datetime') }
     ] %}
     {% set eventRows = (eventRows.push(eventRow), eventRows) %}
   {% endfor %}


### PR DESCRIPTION
Worked on with @kerrr, now that the page is mostly complete we are submitting for peer review.

This PR contains these changes:
- Refactor webhook detail controller to improve readability
- Fix webhook event date formatting
- Update controller unit test

Still to do:
- The page does not perfectly match the design. The design indicates a different colour coding for the delivery status tags than what services are currently seeing in the old settings; the design also shows a wider table than will currently fit in the standardised simplified settings layout. These issues require some discussion then can be resolved in a subsequent PR.
- Cypress tests will be done in a subsequent PR
- The event detail page has not yet been created so the 'view details' links for each of the webhook events don't currently go anywhere. Event detail page will be in a subsequent PR.

**Screenshots**
___
**Screenshot 1 - Top half of webhook details page showing the webhook summary card and signing secret**
![Screenshot 2025-02-26 at 12 56 22](https://github.com/user-attachments/assets/c3fff00e-6893-416d-9620-36f04b49e989)
___
**Screenshot 2 - Bottom half of webhook details page showing event details table with 'all' events shown (see comment above about the table width and status tags)**
![Screenshot 2025-02-26 at 12 56 40](https://github.com/user-attachments/assets/6adaa23c-84a1-44a7-a64b-8c7282835aa3)
___
**Screenshot 3 - Pagination at the bottom of the events table**
![Screenshot 2025-02-26 at 12 56 45](https://github.com/user-attachments/assets/6072dadf-536c-4244-aa19-692a52879ad5)
___
**Screenshot 4 - The events table with 'successful' webhook events shown**
![Screenshot 2025-02-26 at 12 56 54](https://github.com/user-attachments/assets/4fcfeb90-4238-479a-ae97-41212af29304)
___
**Screenshot 5 - The events table with 'failed' webhook events shown**
![Screenshot 2025-02-26 at 12 57 03](https://github.com/user-attachments/assets/853e9991-c91b-4e57-a63f-49f498859d42)
___



