### PR TITLE
PP-13525 return a test account if only test accounts exist

### DIFF
--- a/src/assets/sass/components/my-services.scss
+++ b/src/assets/sass/components/my-services.scss
@@ -23,7 +23,7 @@
 
 .service-section__links {
   margin-bottom: govuk-spacing(4);
-  li:first-child {
+  li.live {
     margin-top: 0;
     margin-bottom: govuk-spacing(4);
   }

--- a/src/views/simplified-account/services/my-services/_service-section.njk
+++ b/src/views/simplified-account/services/my-services/_service-section.njk
@@ -22,7 +22,7 @@
     {% if service.gatewayAccounts.length %}
       <ul class="govuk-list service-section__links">
         {% for account in service.gatewayAccounts %}
-          <li>
+          <li class="{{ account.type }}">
             <a href="{{ account.links.dashboardLink }}" class="service-switcher govuk-link govuk-link--no-visited-state service-section__link service-section__link--{{ account.type }}">
               {{ account.type | title }}
               {% if account.type === 'live' %}


### PR DESCRIPTION
### WHAT

- in the case of a service with only test accounts without provider duplication, return one
- don't provide live gateway link formatting to test account links