### PR TITLE
PP-12416: Add billing address sub heading

### DIFF
--- a/src/views/simplified-account/settings/card-payments/index.njk
+++ b/src/views/simplified-account/settings/card-payments/index.njk
@@ -10,6 +10,8 @@
   <p class="govuk-body">GOV.UK Pay uses 3D Secure for all card payments. 3D Secure (3DS) adds an extra layer of
     authentication to user payments.</p>
 
+  <h3 class="govuk-heading-m">Billing address</h3>
+  <p class="govuk-body">Payment Service Providers (PSPs) use the billing address to carry out fraud checks.</p>
 
 {{ govukSummaryList({
   classes: "govuk-!-margin-bottom-9",


### PR DESCRIPTION
### WHAT
Add a sub heading and paragraph for the billing address section of the card payments settings page to match design specification.

#### BEFORE

<img width="1182" alt="Screenshot 2025-03-04 at 10 22 50" src="https://github.com/user-attachments/assets/ce68e5ac-7a10-4073-a4c4-c8e302fac60a" />


#### AFTER
<img width="1182" alt="Screenshot 2025-03-04 at 10 23 20" src="https://github.com/user-attachments/assets/0cda50b3-d1b8-4ef1-ba55-3c86dd5b2a2f" />
