### PR TITLE
PP-13612 Add visually hidden text to links

### DIFF
--- a/src/views/simplified-account/settings/team-members/index.njk
+++ b/src/views/simplified-account/settings/team-members/index.njk
@@ -42,8 +42,8 @@
           {% else %}
             {% if isServiceAdmin %}
               {% set actionItems = [
-                { href: member.changePermissionLink, text: "Change", classes: "govuk-link--no-visited-state" },
-                { href: member.removeLink, text: "Remove", classes: "govuk-link--no-visited-state" }
+                { href: member.changePermissionLink, text: "Change", visuallyHiddenText: member.email, classes: "govuk-link--no-visited-state" },
+                { href: member.removeLink, text: "Remove", visuallyHiddenText: member.email, classes: "govuk-link--no-visited-state" }
               ] %}
             {% endif %}
           {% endif %}


### PR DESCRIPTION
Accessibility testing identified that we aren't providing sufficient context to screenreader users to indicate the function of the 'change' and 'remove' links on the team members settings pages.

- Add the email address of the relevant team member as visually hidden text to these links so it's clear which team member the link relates to

![Screenshot 2025-03-06 at 13 24 29](https://github.com/user-attachments/assets/ade5f30f-af5d-401d-8e99-148bff906f78)
