### PR TITLE
PP-13612 Change h3 to h2

### DIFF
--- a/src/views/simplified-account/settings/team-members/index.njk
+++ b/src/views/simplified-account/settings/team-members/index.njk
@@ -28,10 +28,10 @@
   {% for role, roleDetails in roles %}
     {% if teamMembers[role].length %}
       <div class="team-member-email-list" id="team-members-{{ role }}-list">
-        <h3 id="{{ role }}-role-header" class="govuk-heading-m">
+        <h2 id="{{ role }}-role-header" class="govuk-heading-m">
           {{ roleDetails.description }} <span
             class="govuk-!-font-weight-regular pay-text-grey">({{ teamMembers[role].length }})</span>
-        </h3>
+        </h2>
 
         {% set teamMembersListedForRole = [] %}
         {% for member in teamMembers[role] %}


### PR DESCRIPTION
- correct role headings on team members page from h3 to h2 to avoid skipping heading levels which can cause confusion for some users.
