### PR TITLE
PP-13521: Add webhook event page

### DIFF
--- a/src/controllers/simplified-account/settings/webhooks/event/event.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/event/event.controller.js
@@ -1,0 +1,29 @@
+const paths = require('@root/paths')
+const { response } = require('@utils/response')
+const webhooksService = require('@services/webhooks.service')
+const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
+const formatAccountPathsFor = require('@utils/format-account-paths-for')
+const { constants } = require('@govuk-pay/pay-js-commons')
+
+/**
+ *
+ * @param req {SimplifiedAccountRequest}
+ * @param res
+ * @returns {Promise<void>}
+ */
+async function get (req, res) {
+  const event = await webhooksService.getWebhookMessage(req.params.eventId, req.params.webhookExternalId)
+  const attempts = await webhooksService.getWebhookMessageAttempts(req.params.eventId, req.params.webhookExternalId)
+
+  response(req, res, 'simplified-account/settings/webhooks/event', {
+    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.detail, req.service.externalId, req.account.type, req.params.webhookExternalId),
+    resourceLink: formatAccountPathsFor(paths.account.transactions.detail, req.account.externalId, event.resource_id),
+    eventTypes: constants.webhooks.humanReadableSubscriptions,
+    event,
+    attempts
+  })
+}
+
+module.exports = {
+  get
+}

--- a/src/controllers/simplified-account/settings/webhooks/webhooks.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/webhooks.controller.js
@@ -28,6 +28,7 @@ module.exports = {
   get,
   create: require('./create/create.controller'),
   detail: require('./detail/detail.controller'),
+  event: require('./event/event.controller'),
   update: require('./update/update-webhook.controller'),
   toggle: require('./toggle/toggle-webhook-status.controller')
 }

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -102,6 +102,7 @@ simplifiedAccount.get(paths.simplifiedAccount.settings.webhooks.index, permissio
 simplifiedAccount.get(paths.simplifiedAccount.settings.webhooks.create, permission('webhooks:update'), serviceSettingsController.webhooks.create.get)
 simplifiedAccount.post(paths.simplifiedAccount.settings.webhooks.create, permission('webhooks:update'), serviceSettingsController.webhooks.create.post)
 simplifiedAccount.get(paths.simplifiedAccount.settings.webhooks.detail, permission('webhooks:read'), serviceSettingsController.webhooks.detail.get)
+simplifiedAccount.get(paths.simplifiedAccount.settings.webhooks.event, permission('webhooks:read'), serviceSettingsController.webhooks.event.get)
 simplifiedAccount.get(paths.simplifiedAccount.settings.webhooks.update, permission('webhooks:update'), serviceSettingsController.webhooks.update.get)
 simplifiedAccount.post(paths.simplifiedAccount.settings.webhooks.update, permission('webhooks:update'), serviceSettingsController.webhooks.update.post)
 simplifiedAccount.get(paths.simplifiedAccount.settings.webhooks.toggle, permission('webhooks:update'), serviceSettingsController.webhooks.toggle.get)

--- a/src/views/simplified-account/settings/webhooks/event.njk
+++ b/src/views/simplified-account/settings/webhooks/event.njk
@@ -1,0 +1,78 @@
+{% from "./_webhook_status.njk" import webhookStatusTag %}
+{% from "./_message_status.njk" import messageStatusTag %}
+{% extends "../settings-layout.njk" %}
+
+{% set settingsPageTitle = webhook.description %}
+
+{% block settingsContent %}
+
+  <h1 class="govuk-heading-l">{{ eventTypes[event.event_type | upper] }}</h1>
+
+  {% set resourceLink %}
+    <a class="govuk-link" href="{{ resourceLink }}">{{ event.resource_id }}</a>
+  {% endset %}
+  {{ govukSummaryList({
+    classes: "webhooks-summary-card",
+    rows: [
+      {
+        key: {
+          text: 'GOV.UK Payment ID'
+        },
+        value: {
+          html: resourceLink
+        }
+      },
+      {
+        key: {
+          text: 'Event date'
+        },
+        value: {
+          html: event.event_date | datetime('datelong')
+        }
+      },
+      {
+        key: {
+          text: 'Status'
+        },
+        value: {
+          html: messageStatusTag(event.latest_attempt.status)
+        }
+      }
+    ]
+  }) }}
+
+  <h2 class="govuk-heading-m">Delivery Attempts</h2>
+
+  {% set attemptRows = [] %}
+  {% for attempt in attempts %}
+    {% set attemptRow = [
+      { text: attempt.send_at | datetime("datetime") },
+      { html: messageStatusTag(attempt.status) },
+      { html: attempt.status_code },
+      { text: attempt.result }
+    ] %}
+    {% set attemptRows = (attemptRows.push(attemptRow), attemptRows) %}
+  {% endfor %}
+
+
+  {{ govukTable({
+    firstCellIsHeader: false,
+    head: [
+      {
+        text: "Attempt date"
+      },
+      {
+        text: "Status"
+      },
+      {
+        text: "Status code"
+      },
+      {
+        text: "Result"
+      }
+    ],
+    rows: attemptRows
+
+  }) }}
+
+{% endblock %}


### PR DESCRIPTION
### WHAT
Add the page showing detail for an individual webhook event. This is linked from the webhooks detail page showing all events.

Tests are not included in this PR.

### SCREENS

<img width="1090" alt="Screenshot 2025-03-07 at 09 49 37" src="https://github.com/user-attachments/assets/2cc5a289-9d76-40c1-8560-d58300a3c96a" />
