### PR TITLE
PP-13629 Correct select permission error link

### DIFF
--- a/src/controllers/simplified-account/settings/team-members/invite/invite.controller.js
+++ b/src/controllers/simplified-account/settings/team-members/invite/invite.controller.js
@@ -38,10 +38,10 @@ async function post (req, res, next) {
   }
 
   const validations = [
-    body('invitedUserRole')
-      .not().isEmpty().withMessage('Select a permission level'),
     body('invitedUserEmail')
-      .isEmail().withMessage('Enter a valid email address')
+      .isEmail().withMessage('Enter a valid email address'),
+    body('invitedUserRole')
+      .not().isEmpty().withMessage('Select a permission level')
   ]
   await Promise.all(validations.map(validation => validation.run(req)))
   const validationErrors = validationResult(req)

--- a/src/views/simplified-account/settings/team-members/invite.njk
+++ b/src/views/simplified-account/settings/team-members/invite.njk
@@ -25,7 +25,6 @@
     {% for role in availableRoles %}
       {% set roleItem = {
         value: role.name,
-        id: "role-" + role.name + "-input",
         text: role.description,
         label: { classes: "govuk-!-font-weight-bold" },
         hint: { html: "<div>" + role.explanation + "</div>" },


### PR DESCRIPTION
- remove ids from radio buttons for setting permission on the invite team member page so that the ids are generated automatically, which ensures that the validation error link points to the first radio button.
- fix order of validation error messages to match the order the elements appear in the form


https://github.com/user-attachments/assets/285f59c3-7731-49de-ba11-43aad9a3dcd9

