### PR TITLE
PP-13354 unit test moto security controllers

### DIFF
--- a/src/controllers/simplified-account/settings/card-payments/card-payments.controller.test.js
+++ b/src/controllers/simplified-account/settings/card-payments/card-payments.controller.test.js
@@ -3,6 +3,8 @@ const { expect } = require('chai')
 const sinon = require('sinon')
 const User = require('@models/User.class')
 const userFixtures = require('@test/fixtures/user.fixtures')
+const formatSimplifiedAccountPathsFor = require('../../../../utils/simplified-account/format/format-simplified-account-paths-for')
+const paths = require('@root/paths')
 
 const ACCOUNT_TYPE = 'test'
 const SERVICE_EXTERNAL_ID = 'service-id-123abc'
@@ -37,90 +39,150 @@ const viewOnlyUser = new User(userFixtures.validUserResponse(
     }
   }))
 
-const { res, nextRequest, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/card-payments/card-payments.controller')
+const {
+  res,
+  nextRequest,
+  call
+} = new ControllerTestBuilder('@controllers/simplified-account/settings/card-payments/card-payments.controller')
+  .withServiceExternalId(SERVICE_EXTERNAL_ID)
+  .withAccount({
+    type: ACCOUNT_TYPE,
+    id: GATEWAY_ACCOUNT_ID
+  })
   .withStubs({
     '@utils/response': { response: mockResponse }
   })
   .build()
 
 describe('Controller: settings/card-payments', () => {
-  describe('get for admin user', () => {
-    before(() => {
-      nextRequest({
-        user: adminUser,
-        service: {
-          externalId: SERVICE_EXTERNAL_ID,
-          collectBillingAddress: false,
-          defaultBillingAddressCountry: 'GB'
-        },
-        account: {
-          type: ACCOUNT_TYPE,
-          id: GATEWAY_ACCOUNT_ID,
-          allowApplePay: false,
-          allowGooglePay: false,
-          getActiveCredential: () => true
-        }
+  describe('get', () => {
+    describe('for admin user', () => {
+      describe('for non-moto gateway account', () => {
+        before(() => {
+          nextRequest({
+            user: adminUser,
+            service: {
+              collectBillingAddress: false,
+              defaultBillingAddressCountry: 'GB'
+            },
+            account: {
+              allowApplePay: false,
+              allowGooglePay: false,
+              getActiveCredential: () => true
+            }
+          })
+          call('get')
+        })
+        it('should call the response method', () => {
+          expect(mockResponse).to.have.been.calledOnce  // eslint-disable-line
+        })
+
+        it('should pass req, res and template path to the response method', () => {
+          expect(mockResponse.args[0][0].user).to.deep.equal(adminUser)
+          expect(mockResponse.args[0][1]).to.deep.equal(res)
+          expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/card-payments/index')
+        })
+
+        it('should pass context data to the response method', () => {
+          const context = mockResponse.args[0][3]
+          expect(context).to.have.property('collectBillingAddressEnabled').to.equal(false)
+          expect(context).to.have.property('collectBillingAddressLink').to.equal(BASE_URL + 'collect-billing-address')
+          expect(context).to.have.property('defaultBillingAddressCountry').to.equal('United Kingdom')
+          expect(context).to.have.property('defaultBillingAddressCountryLink').to.equal(BASE_URL + 'default-billing-address-country')
+          expect(context).to.have.property('applePayEnabled').to.equal(false)
+          expect(context).to.have.property('applePayLink').to.equal(BASE_URL + 'apple-pay')
+          expect(context).to.have.property('googlePayEnabled').to.equal(false)
+          expect(context).to.have.property('googlePayLink').to.equal(BASE_URL + 'google-pay')
+          expect(context).to.have.property('googlePayEditable').to.equal(true)
+          expect(context).to.have.property('userCanUpdatePaymentTypes').to.equal(true)
+          expect(context).to.not.have.property('isMoto')
+          expect(context).to.not.have.property('hideCardSecurityCodeEnabled')
+        })
       })
-      call('get')
-    })
-    it('should call the response method', () => {
-      expect(mockResponse).to.have.been.calledOnce  // eslint-disable-line
-    })
+      describe('for moto gateway account', () => {
+        before(() => {
+          nextRequest({
+            user: adminUser,
+            account: {
+              allowMoto: true,
+              motoMaskCardNumber: false,
+              motoMaskCardSecurityCode: true,
+              getActiveCredential: () => null
+            }
+          })
+          call('get')
+        })
 
-    it('should pass req, res and template path to the response method', () => {
-      expect(mockResponse.args[0][0].user).to.deep.equal(adminUser)
-      expect(mockResponse.args[0][1]).to.deep.equal(res)
-      expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/card-payments/index')
-    })
-
-    it('should pass context data to the response method', () => {
-      const context = mockResponse.args[0][3]
-      expect(context).to.have.property('collectBillingAddressEnabled').to.equal(false)
-      expect(context).to.have.property('collectBillingAddressLink').to.equal(BASE_URL + 'collect-billing-address')
-      expect(context).to.have.property('defaultBillingAddressCountry').to.equal('United Kingdom')
-      expect(context).to.have.property('defaultBillingAddressCountryLink').to.equal(BASE_URL + 'default-billing-address-country')
-      expect(context).to.have.property('applePayEnabled').to.equal(false)
-      expect(context).to.have.property('applePayLink').to.equal(BASE_URL + 'apple-pay')
-      expect(context).to.have.property('googlePayEnabled').to.equal(false)
-      expect(context).to.have.property('googlePayLink').to.equal(BASE_URL + 'google-pay')
-      expect(context).to.have.property('userCanUpdatePaymentTypes').to.equal(true)
-    })
-  })
-  describe('get for non-admin user', () => {
-    before(() => {
-      nextRequest({
-        user: viewOnlyUser,
-        service: {
-          externalId: SERVICE_EXTERNAL_ID,
-          collectBillingAddress: true
-        },
-        account: {
-          type: ACCOUNT_TYPE,
-          id: GATEWAY_ACCOUNT_ID,
-          allowApplePay: true,
-          allowGooglePay: true,
-          getActiveCredential: () => true
-        }
+        it('should pass additional context data to the response method', () => {
+          const context = mockResponse.args[0][3]
+          expect(context).to.have.property('googlePayEditable').to.equal(false)
+          expect(context).to.have.property('isMoto').to.equal(true)
+          expect(context).to.have.property('hideCardNumberEnabled').to.equal(false)
+          expect(context).to.have.property('hideCardNumberLink').to.equal(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.cardPayments.motoSecurity.hideCardNumber, SERVICE_EXTERNAL_ID, ACCOUNT_TYPE))
+          expect(context).to.have.property('hideCardSecurityCodeEnabled').to.equal(true)
+          expect(context).to.have.property('hideCardSecurityCodeLink').to.equal(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.cardPayments.motoSecurity.hideCardSecurityCode, SERVICE_EXTERNAL_ID, ACCOUNT_TYPE))
+        })
       })
-      call('get')
     })
-    it('should call the response method', () => {
-      expect(mockResponse).to.have.been.calledOnce  // eslint-disable-line
-    })
+    describe('for non-admin user', () => {
+      describe('for non-moto gateway account', () => {
+        before(() => {
+          nextRequest({
+            user: viewOnlyUser,
+            service: {
+              collectBillingAddress: true
+            },
+            account: {
+              allowApplePay: true,
+              allowGooglePay: true,
+              getActiveCredential: () => true
+            }
+          })
+          call('get')
+        })
+        it('should call the response method', () => {
+          expect(mockResponse).to.have.been.calledOnce  // eslint-disable-line
+        })
 
-    it('should pass req, res and template path to the response method', () => {
-      expect(mockResponse.args[0][0].user).to.deep.equal(viewOnlyUser)
-      expect(mockResponse.args[0][1]).to.deep.equal(res)
-      expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/card-payments/index')
-    })
+        it('should pass req, res and template path to the response method', () => {
+          expect(mockResponse.args[0][0].user).to.deep.equal(viewOnlyUser)
+          expect(mockResponse.args[0][1]).to.deep.equal(res)
+          expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/card-payments/index')
+        })
 
-    it('should pass context data to the response method', () => {
-      const context = mockResponse.args[0][3]
-      expect(context).to.have.property('collectBillingAddressEnabled').to.equal(true)
-      expect(context).to.have.property('defaultBillingAddressCountry').to.equal('None')
-      expect(context).to.have.property('applePayEnabled').to.equal(true)
-      expect(context).to.have.property('googlePayEnabled').to.equal(true)
-      expect(context).to.have.property('userCanUpdatePaymentTypes').to.equal(false)
+        it('should pass context data to the response method', () => {
+          const context = mockResponse.args[0][3]
+          expect(context).to.have.property('collectBillingAddressEnabled').to.equal(true)
+          expect(context).to.have.property('defaultBillingAddressCountry').to.equal('None')
+          expect(context).to.have.property('applePayEnabled').to.equal(true)
+          expect(context).to.have.property('googlePayEnabled').to.equal(true)
+          expect(context).to.have.property('userCanUpdatePaymentTypes').to.equal(false)
+        })
+      })
+      describe('for moto gateway account', () => {
+        before(() => {
+          nextRequest({
+            user: viewOnlyUser,
+            account: {
+              allowMoto: true,
+              motoMaskCardNumber: false,
+              motoMaskCardSecurityCode: true,
+              getActiveCredential: () => null
+            }
+          })
+          call('get')
+        })
+
+        it('should pass additional context data to the response method', () => {
+          const context = mockResponse.args[0][3]
+          expect(context).to.have.property('userCanUpdatePaymentTypes').to.equal(false)
+          expect(context).to.have.property('isMoto').to.equal(true)
+          expect(context).to.have.property('hideCardNumberEnabled').to.equal(false)
+          expect(context).to.have.property('hideCardNumberLink').to.equal(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.cardPayments.motoSecurity.hideCardNumber, SERVICE_EXTERNAL_ID, ACCOUNT_TYPE))
+          expect(context).to.have.property('hideCardSecurityCodeEnabled').to.equal(true)
+          expect(context).to.have.property('hideCardSecurityCodeLink').to.equal(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.cardPayments.motoSecurity.hideCardSecurityCode, SERVICE_EXTERNAL_ID, ACCOUNT_TYPE))
+        })
+      })
     })
   })
 })

--- a/src/controllers/simplified-account/settings/card-payments/card-payments.controller.test.js
+++ b/src/controllers/simplified-account/settings/card-payments/card-payments.controller.test.js
@@ -3,7 +3,7 @@ const { expect } = require('chai')
 const sinon = require('sinon')
 const User = require('@models/User.class')
 const userFixtures = require('@test/fixtures/user.fixtures')
-const formatSimplifiedAccountPathsFor = require('../../../../utils/simplified-account/format/format-simplified-account-paths-for')
+const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
 const paths = require('@root/paths')
 
 const ACCOUNT_TYPE = 'test'

--- a/src/controllers/simplified-account/settings/card-payments/google-pay.controller.js
+++ b/src/controllers/simplified-account/settings/card-payments/google-pay.controller.js
@@ -5,7 +5,11 @@ const { updateAllowGooglePay } = require('@services/card-payments.service')
 const { validationResult } = require('express-validator')
 const { WORLDPAY } = require('@models/constants/payment-providers')
 const { updateGooglePayMerchantId } = require('@services/worldpay-details.service')
-const { googlePaySchema, GOOGLE_PAY_TOGGLE_FIELD, GOOGLE_PAY_MERCHANT_ID_FIELD } = require('@utils/simplified-account/validation/google-pay.schema')
+const {
+  googlePaySchema,
+  GOOGLE_PAY_TOGGLE_FIELD,
+  GOOGLE_PAY_MERCHANT_ID_FIELD
+} = require('@utils/simplified-account/validation/google-pay.schema')
 
 /**
  * @param {import('@utils/types/settings/settings-request').SettingsRequest} req

--- a/src/controllers/simplified-account/settings/card-payments/google-pay.controller.test.js
+++ b/src/controllers/simplified-account/settings/card-payments/google-pay.controller.test.js
@@ -2,64 +2,148 @@ const ControllerTestBuilder = require('@test/test-helpers/simplified-account/con
 const { expect } = require('chai')
 const sinon = require('sinon')
 const paths = require('@root/paths')
+const { WORLDPAY, STRIPE } = require('@models/constants/payment-providers')
+const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/format')
 
 const ACCOUNT_TYPE = 'test'
 const SERVICE_EXTERNAL_ID = 'service-id-123abc'
 
-const GATEWAY_ACCOUNT_ID = '123'
-
 const mockResponse = sinon.spy()
 const mockUpdateGooglePay = sinon.spy()
+const mockUpdateGooglePayMerchantId = sinon.spy()
 
-const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/card-payments/google-pay.controller')
+const {
+  req,
+  res,
+  nextRequest,
+  call
+} = new ControllerTestBuilder('@controllers/simplified-account/settings/card-payments/google-pay.controller')
   .withAccount({
     type: ACCOUNT_TYPE,
-    id: GATEWAY_ACCOUNT_ID,
-    allowGooglePay: false
+    allowGooglePay: false,
+    paymentProvider: STRIPE
   })
   .withServiceExternalId(SERVICE_EXTERNAL_ID)
   .withStubs({
     '@utils/response': { response: mockResponse },
-    '@services/card-payments.service': { updateAllowGooglePay: mockUpdateGooglePay }
+    '@services/card-payments.service': { updateAllowGooglePay: mockUpdateGooglePay },
+    '@services/worldpay-details.service': { updateGooglePayMerchantId: mockUpdateGooglePayMerchantId }
   })
   .build()
 
 describe('Controller: settings/card-payments/google-pay', () => {
   describe('get', () => {
-    before(() => {
-      call('get', 1)
-    })
-    it('should call the response method', () => {
-      expect(mockResponse).to.have.been.calledOnce  // eslint-disable-line
-    })
-    it('should pass req, res and template path to the response method', () => {
-      expect(mockResponse.args[0][0]).to.deep.equal(req)
-      expect(mockResponse.args[0][1]).to.deep.equal(res)
-      expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/card-payments/google-pay')
+    describe('a non-worldpay account', () => {
+      before(() => {
+        call('get', 1)
+      })
+      it('should call the response method', () => {
+        expect(mockResponse).to.have.been.calledOnce  // eslint-disable-line
+      })
+      it('should pass req, res and template path to the response method', () => {
+        expect(mockResponse.args[0][0]).to.deep.equal(req)
+        expect(mockResponse.args[0][1]).to.deep.equal(res)
+        expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/card-payments/google-pay')
+      })
+
+      it('should pass context data to the response method', () => {
+        const context = mockResponse.args[0][3]
+        expect(context).to.not.have.property('currentGooglePayMerchantId')
+        expect(context).to.have.property('currentState').to.equal('off')
+        expect(context).to.have.property('backLink').to.equal(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/test/settings/card-payments`)
+      })
     })
 
-    it('should pass context data to the response method', () => {
-      const context = mockResponse.args[0][3]
-      expect(context).to.have.property('currentState').to.equal('off')
-      expect(context).to.have.property('backLink').to.equal(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/test/settings/card-payments`)
+    describe('a worldpay account', () => {
+      before(() => {
+        nextRequest({
+          account: {
+            paymentProvider: WORLDPAY,
+            getCurrentCredential: () => {
+              return {
+                credentials: {
+                  googlePayMerchantId: 'blah'
+                }
+              }
+            }
+          }
+        })
+        call('get', 1)
+      })
+
+      it('should include google pay merchant id in the context', () => {
+        const context = mockResponse.args[0][3]
+        expect(context).to.have.property('currentGooglePayMerchantId').to.equal('blah')
+      })
     })
   })
   describe('post', () => {
-    before(() => {
-      nextRequest({
-        body: { googlePay: 'on' }
+    describe('a non-worldpay account', () => {
+      before(() => {
+        nextRequest({
+          body: { googlePay: 'on' }
+        })
+        call('post', 1)
       })
-      call('post', 1)
+
+      it('should not update Google Pay merchant id', () => {
+        sinon.assert.notCalled(mockUpdateGooglePayMerchantId)
+      })
+
+      it('should update allow Google Pay enabled', () => {
+        expect(mockUpdateGooglePay.calledOnce).to.be.true // eslint-disable-line
+        sinon.assert.calledWith(mockUpdateGooglePay, SERVICE_EXTERNAL_ID, ACCOUNT_TYPE, true)
+      })
+
+      it('should redirect to the card payments index page', () => {
+        sinon.assert.calledOnceWithExactly(res.redirect,
+          formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.cardPayments.index, SERVICE_EXTERNAL_ID, ACCOUNT_TYPE)
+        )
+      })
     })
 
-    it('should update allow Google Pay enabled', () => {
-      expect(mockUpdateGooglePay.calledOnce).to.be.true // eslint-disable-line
-      expect(mockUpdateGooglePay.calledWith(SERVICE_EXTERNAL_ID, ACCOUNT_TYPE, true)).to.be.true // eslint-disable-line
-    })
+    describe('a worldpay account', () => {
+      before(() => {
+        nextRequest({
+          body: {
+            googlePay: 'on',
+            googlePayMerchantId: '0123456789abcde'
+          },
+          user: {
+            externalId: 'user-123-abc'
+          },
+          account: {
+            paymentProvider: WORLDPAY,
+            getCurrentCredential: () => {
+              return {
+                externalId: 'credential-123-abc'
+              }
+            }
+          }
+        })
+        call('post', 1)
+      })
 
-    it('should redirect to the card payments index page', () => {
-      expect(res.redirect.calledOnce).to.be.true // eslint-disable-line
-      expect(res.redirect.args[0][0]).to.include(paths.simplifiedAccount.settings.cardPayments.index)
+      it('should update Google Pay merchant id', () => {
+        sinon.assert.calledOnceWithExactly(mockUpdateGooglePayMerchantId,
+          SERVICE_EXTERNAL_ID,
+          ACCOUNT_TYPE,
+          'credential-123-abc',
+          'user-123-abc',
+          '0123456789abcde'
+        )
+      })
+
+      it('should update allow Google Pay enabled', () => {
+        expect(mockUpdateGooglePay.calledOnce).to.be.true // eslint-disable-line
+        sinon.assert.calledWith(mockUpdateGooglePay, SERVICE_EXTERNAL_ID, ACCOUNT_TYPE, true)
+      })
+
+      it('should redirect to the card payments index page', () => {
+        sinon.assert.calledOnceWithExactly(res.redirect,
+          formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.cardPayments.index, SERVICE_EXTERNAL_ID, ACCOUNT_TYPE)
+        )
+      })
     })
   })
 })

--- a/src/controllers/simplified-account/settings/card-payments/moto-security/hide-card-number.controller.test.js
+++ b/src/controllers/simplified-account/settings/card-payments/moto-security/hide-card-number.controller.test.js
@@ -1,0 +1,111 @@
+const sinon = require('sinon')
+const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
+const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/format')
+const paths = require('@root/paths')
+
+const ACCOUNT_TYPE = 'live'
+const SERVICE_EXTERNAL_ID = 'service-id-123abc'
+
+const mockResponse = sinon.spy()
+const mockUpdateMotoMaskCardNumber = sinon.spy()
+
+const {
+  req,
+  res,
+  nextRequest,
+  call
+} = new ControllerTestBuilder('@controllers/simplified-account/settings/card-payments/moto-security/hide-card-number.controller')
+  .withAccount({
+    type: ACCOUNT_TYPE,
+    allowMoto: true,
+    motoMaskCardNumber: false
+  })
+  .withServiceExternalId(SERVICE_EXTERNAL_ID)
+  .withStubs({
+    '@utils/response': { response: mockResponse },
+    '@services/card-payments.service': { updateMotoMaskCardNumber: mockUpdateMotoMaskCardNumber }
+  })
+  .build()
+
+describe('Controller: settings/card-payments/moto-security/hide-card-number', () => {
+  describe('get', () => {
+    before(() => {
+      call('get')
+    })
+    it('should call the response method with context', () => {
+      sinon.assert.calledOnceWithExactly(mockResponse,
+        req,
+        res,
+        'simplified-account/settings/card-payments/moto-security/hide-card-number',
+        {
+          backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.cardPayments.index, SERVICE_EXTERNAL_ID, ACCOUNT_TYPE),
+          currentState: 'off'
+        }
+      )
+    })
+  })
+
+  describe('post', () => {
+    describe('valid submission', () => {
+      before(() => {
+        nextRequest({
+          body: {
+            hideCardNumber: 'on'
+          }
+        })
+        call('post')
+      })
+
+      it('should call updateMotoMaskCardNumber', () => {
+        sinon.assert.calledOnceWithExactly(mockUpdateMotoMaskCardNumber,
+          SERVICE_EXTERNAL_ID,
+          ACCOUNT_TYPE,
+          true
+        )
+      })
+
+      it('should redirect the user on success', () => {
+        sinon.assert.calledOnceWithExactly(res.redirect,
+          formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.cardPayments.index, SERVICE_EXTERNAL_ID, ACCOUNT_TYPE)
+        )
+      })
+    })
+    describe('invalid submission', () => {
+      before(() => {
+        nextRequest({
+          body: {
+            NOTHideCardNumber: 'blah'
+          }
+        })
+        call('post')
+      })
+
+      it('should not call updateMotoMaskCardNumber', () => {
+        sinon.assert.notCalled(mockUpdateMotoMaskCardNumber)
+      })
+
+      it('should not redirect the user', () => {
+        sinon.assert.notCalled(res.redirect)
+      })
+
+      it('should call the response method with errors', () => {
+        sinon.assert.calledWithMatch(mockResponse,
+          sinon.match.any,
+          sinon.match.any,
+          sinon.match.any,
+          {
+            errors: {
+              formErrors: {
+                hideCardNumber: 'Select an option'
+              },
+              summary: [{
+                text: 'Select an option',
+                href: '#hide-card-number'
+              }]
+            }
+          }
+        )
+      })
+    })
+  })
+})

--- a/src/controllers/simplified-account/settings/card-payments/moto-security/hide-card-security-code.controller.test.js
+++ b/src/controllers/simplified-account/settings/card-payments/moto-security/hide-card-security-code.controller.test.js
@@ -1,0 +1,111 @@
+const sinon = require('sinon')
+const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
+const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/format')
+const paths = require('@root/paths')
+
+const ACCOUNT_TYPE = 'live'
+const SERVICE_EXTERNAL_ID = 'service-id-123abc'
+
+const mockResponse = sinon.spy()
+const mockUpdateMotoMaskSecurityCode = sinon.spy()
+
+const {
+  req,
+  res,
+  nextRequest,
+  call
+} = new ControllerTestBuilder('@controllers/simplified-account/settings/card-payments/moto-security/hide-card-security-code.controller')
+  .withAccount({
+    type: ACCOUNT_TYPE,
+    allowMoto: true,
+    motoMaskCardSecurityCode: true
+  })
+  .withServiceExternalId(SERVICE_EXTERNAL_ID)
+  .withStubs({
+    '@utils/response': { response: mockResponse },
+    '@services/card-payments.service': { updateMotoMaskSecurityCode: mockUpdateMotoMaskSecurityCode }
+  })
+  .build()
+
+describe('Controller: settings/card-payments/moto-security/hide-card-security-code', () => {
+  describe('get', () => {
+    before(() => {
+      call('get')
+    })
+    it('should call the response method with context', () => {
+      sinon.assert.calledOnceWithExactly(mockResponse,
+        req,
+        res,
+        'simplified-account/settings/card-payments/moto-security/hide-card-security-code',
+        {
+          backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.cardPayments.index, SERVICE_EXTERNAL_ID, ACCOUNT_TYPE),
+          currentState: 'on'
+        }
+      )
+    })
+  })
+
+  describe('post', () => {
+    describe('valid submission', () => {
+      before(() => {
+        nextRequest({
+          body: {
+            hideCardSecurityCode: 'off'
+          }
+        })
+        call('post')
+      })
+
+      it('should call updateMotoMaskSecurityCode', () => {
+        sinon.assert.calledOnceWithExactly(mockUpdateMotoMaskSecurityCode,
+          SERVICE_EXTERNAL_ID,
+          ACCOUNT_TYPE,
+          false
+        )
+      })
+
+      it('should redirect the user on success', () => {
+        sinon.assert.calledOnceWithExactly(res.redirect,
+          formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.cardPayments.index, SERVICE_EXTERNAL_ID, ACCOUNT_TYPE)
+        )
+      })
+    })
+    describe('invalid submission', () => {
+      before(() => {
+        nextRequest({
+          body: {
+            // empty form submission
+          }
+        })
+        call('post')
+      })
+
+      it('should not call updateMotoMaskSecurityCode', () => {
+        sinon.assert.notCalled(mockUpdateMotoMaskSecurityCode)
+      })
+
+      it('should not redirect the user', () => {
+        sinon.assert.notCalled(res.redirect)
+      })
+
+      it('should call the response method with errors', () => {
+        sinon.assert.calledWithMatch(mockResponse,
+          sinon.match.any,
+          sinon.match.any,
+          sinon.match.any,
+          {
+            errors: {
+              formErrors: {
+                hideCardSecurityCode: 'Select an option'
+              },
+              summary: [{
+                text: 'Select an option',
+                href: '#hide-card-security-code'
+              }]
+            }
+          }
+        )
+      })
+    })
+  })
+})

--- a/src/views/simplified-account/services/my-services/_service-section.njk
+++ b/src/views/simplified-account/services/my-services/_service-section.njk
@@ -34,9 +34,6 @@
             {% if account.providerSwitchEnabled and service.userIsAdminForService %}
               <strong class="govuk-tag govuk-tag--blue service-info--tag">Switch PSP</strong>
             {% endif %}
-            {% if flags.userIsDegatewayed and account.allowMoto %}
-              <strong class="govuk-tag govuk-tag--turquoise service-info--tag">MOTO</strong>
-            {% endif %}
           </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
### WHAT

- add unit tests for mask card number and security code settings controllers
- update google pay controller test to include worldpay specific google pay merchant id logic
- remove MOTO UI flag from my services view