### PR TITLE
PP-13356 Use ControllerTestBuilder in remove user test

### DIFF
--- a/src/controllers/simplified-account/settings/team-members/invite/invite.controller.test.js
+++ b/src/controllers/simplified-account/settings/team-members/invite/invite.controller.test.js
@@ -21,8 +21,7 @@ const adminUser = new User(userFixtures.validUserResponse({
 }))
 
 const mockResponse = sinon.spy()
-const mockCreateInviteToJoinServiceSuccess = sinon.stub().resolves()
-const mockCreateInviteToJoinServiceRejects = sinon.stub().rejects(new RESTClientError(null, 'adminusers', 412))
+const mockCreateInviteToJoinService = sinon.stub()
 
 const { req, res, nextRequest, nextStubs, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/team-members/invite/invite.controller')
   .withServiceExternalId(SERVICE_ID)
@@ -64,13 +63,13 @@ describe('post', () => {
       })
       nextStubs({
         '@services/user.service':
-          { createInviteToJoinService: mockCreateInviteToJoinServiceSuccess }
+          { createInviteToJoinService: mockCreateInviteToJoinService.resolves() }
       })
       call('post')
     })
 
     it('should call adminusers to send an invite', () => {
-      expect(mockCreateInviteToJoinServiceSuccess.calledWith('user-to-invite@users.gov.uk', adminUser.externalId, SERVICE_ID, 'view-only')).to.be.true // eslint-disable-line
+      expect(mockCreateInviteToJoinService.calledWith('user-to-invite@users.gov.uk', adminUser.externalId, SERVICE_ID, 'view-only')).to.be.true // eslint-disable-line
     })
 
     it('should redirect to the team members index page', () => {
@@ -91,13 +90,13 @@ describe('post', () => {
       })
       nextStubs({
         '@services/user.service':
-          { createInviteToJoinService: mockCreateInviteToJoinServiceRejects }
+          { createInviteToJoinService: mockCreateInviteToJoinService.rejects(new RESTClientError(null, 'adminusers', 412)) }
       })
       call('post')
     })
 
     it('should respond with error message', () => {
-      expect(mockCreateInviteToJoinServiceRejects.calledWith('user-to-invite@users.gov.uk', adminUser.externalId, SERVICE_ID, 'view-only')).to.be.true // eslint-disable-line
+      expect(mockCreateInviteToJoinService.calledWith('user-to-invite@users.gov.uk', adminUser.externalId, SERVICE_ID, 'view-only')).to.be.true // eslint-disable-line
       expect(mockResponse.calledOnce).to.be.true // eslint-disable-line
       expect(mockResponse.args[0][1]).to.deep.equal(res)
       expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/team-members/invite')

--- a/src/controllers/simplified-account/settings/team-members/invite/invite.controller.test.js
+++ b/src/controllers/simplified-account/settings/team-members/invite/invite.controller.test.js
@@ -23,11 +23,12 @@ const adminUser = new User(userFixtures.validUserResponse({
 const mockResponse = sinon.spy()
 const mockCreateInviteToJoinService = sinon.stub()
 
-const { req, res, nextRequest, nextStubs, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/team-members/invite/invite.controller')
+const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/team-members/invite/invite.controller')
   .withServiceExternalId(SERVICE_ID)
   .withAccountType(ACCOUNT_TYPE)
   .withStubs({
-    '@utils/response': { response: mockResponse }
+    '@utils/response': { response: mockResponse },
+    '@services/user.service': { createInviteToJoinService: mockCreateInviteToJoinService }
   })
   .withUser(adminUser)
   .build()
@@ -61,10 +62,7 @@ describe('post', () => {
       nextRequest({
         body: { invitedUserEmail: 'user-to-invite@users.gov.uk', invitedUserRole: 'view-only' }
       })
-      nextStubs({
-        '@services/user.service':
-          { createInviteToJoinService: mockCreateInviteToJoinService.resolves() }
-      })
+      mockCreateInviteToJoinService.resolves()
       call('post')
     })
 
@@ -88,10 +86,7 @@ describe('post', () => {
       nextRequest({
         body: { invitedUserEmail: 'user-to-invite@users.gov.uk', invitedUserRole: 'view-only' }
       })
-      nextStubs({
-        '@services/user.service':
-          { createInviteToJoinService: mockCreateInviteToJoinService.rejects(new RESTClientError(null, 'adminusers', 412)) }
-      })
+      mockCreateInviteToJoinService.rejects(new RESTClientError(null, 'adminusers', 412))
       call('post')
     })
 

--- a/src/controllers/simplified-account/settings/team-members/remove-user/remove-user.controller.test.js
+++ b/src/controllers/simplified-account/settings/team-members/remove-user/remove-user.controller.test.js
@@ -37,11 +37,12 @@ const mockRenderErrorView = sinon.spy()
 const mockFindByExternalId = sinon.stub()
 const mockDelete = sinon.stub().returns({ })
 
-const { req, res, nextRequest, nextStubs, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/team-members/remove-user/remove-user.controller')
+const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/team-members/remove-user/remove-user.controller')
   .withServiceExternalId(SERVICE_ID)
   .withAccountType(ACCOUNT_TYPE)
   .withStubs({
-    '@utils/response': { response: mockResponse, renderErrorView: mockRenderErrorView }
+    '@utils/response': { response: mockResponse, renderErrorView: mockRenderErrorView },
+    '@services/user.service': { findByExternalId: mockFindByExternalId, delete: mockDelete }
   })
   .withUser(adminUser)
   .build()
@@ -50,10 +51,7 @@ describe('Controller: settings/team-members/remove-user', () => {
   describe('get', () => {
     describe('success', () => {
       before(() => {
-        nextStubs({
-          '@services/user.service':
-            { findByExternalId: mockFindByExternalId.resolves(viewOnlyUser) }
-        })
+        mockFindByExternalId.resolves(viewOnlyUser)
         nextRequest({
           params: { externalUserId: 'user-id-to-remove' }
         })
@@ -79,10 +77,7 @@ describe('Controller: settings/team-members/remove-user', () => {
 
     describe('failure - admin attempts to remove self', () => {
       before(() => {
-        nextStubs({
-          '@services/user.service':
-            { findByExternalId: mockFindByExternalId.resolves(adminUser) }
-        })
+        mockFindByExternalId.resolves(adminUser)
         nextRequest({
           params: { externalUserId: 'user-id-for-admin-user' }
         })
@@ -99,10 +94,7 @@ describe('Controller: settings/team-members/remove-user', () => {
   describe('post', () => {
     describe('admin user confirmed remove user', () => {
       before(() => {
-        nextStubs({
-          '@services/user.service':
-            { findByExternalId: mockFindByExternalId.resolves(adminUser), delete: mockDelete }
-        })
+        mockFindByExternalId.resolves(adminUser)
         nextRequest({
           params: { externalUserId: 'user-id-to-remove' },
           body: { email: 'user-to-remove@users.gov.uk', confirmRemoveUser: 'yes' }
@@ -127,10 +119,7 @@ describe('Controller: settings/team-members/remove-user', () => {
 
     describe('admin user selected not to remove user', () => {
       before(() => {
-        nextStubs({
-          '@services/user.service':
-            { findByExternalId: mockFindByExternalId.resolves(viewOnlyUser), delete: mockDelete }
-        })
+        mockFindByExternalId.resolves(viewOnlyUser)
         nextRequest({
           params: { externalUserId: 'user-id-to-remove' },
           body: { email: 'user-to-remove@users.gov.uk', confirmRemoveUser: 'no' }
@@ -147,10 +136,7 @@ describe('Controller: settings/team-members/remove-user', () => {
 
     describe('admin user attempted to remove self', () => {
       before(() => {
-        nextStubs({
-          '@services/user.service':
-            { findByExternalId: mockFindByExternalId.resolves(adminUser), delete: mockDelete }
-        })
+        mockFindByExternalId.resolves(adminUser)
         nextRequest({
           params: { externalUserId: 'user-id-for-admin-user' },
           body: { email: 'admin-user@users.gov.uk', confirmRemoveUser: 'yes' }

--- a/src/controllers/simplified-account/settings/team-members/remove-user/remove-user.controller.test.js
+++ b/src/controllers/simplified-account/settings/team-members/remove-user/remove-user.controller.test.js
@@ -34,8 +34,7 @@ const viewOnlyUser = new User(userFixtures.validUserResponse(
 
 const mockResponse = sinon.spy()
 const mockRenderErrorView = sinon.spy()
-const mockFindByExternalIdGetsAdminUser = sinon.stub().resolves(adminUser)
-const mockFindByExternalIdGetsViewOnlyUser = sinon.stub().resolves(viewOnlyUser)
+const mockFindByExternalId = sinon.stub()
 const mockDelete = sinon.stub().returns({ })
 
 const { req, res, nextRequest, nextStubs, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/team-members/remove-user/remove-user.controller')
@@ -53,7 +52,7 @@ describe('Controller: settings/team-members/remove-user', () => {
       before(() => {
         nextStubs({
           '@services/user.service':
-            { findByExternalId: mockFindByExternalIdGetsViewOnlyUser }
+            { findByExternalId: mockFindByExternalId.resolves(viewOnlyUser) }
         })
         nextRequest({
           params: { externalUserId: 'user-id-to-remove' }
@@ -62,7 +61,7 @@ describe('Controller: settings/team-members/remove-user', () => {
       })
 
       it('should call the response method', () => {
-        expect(mockFindByExternalIdGetsViewOnlyUser.called).to.be.true // eslint-disable-line
+        expect(mockFindByExternalId.called).to.be.true // eslint-disable-line
         expect(mockResponse.called).to.be.true // eslint-disable-line
       })
 
@@ -82,7 +81,7 @@ describe('Controller: settings/team-members/remove-user', () => {
       before(() => {
         nextStubs({
           '@services/user.service':
-            { findByExternalId: mockFindByExternalIdGetsAdminUser }
+            { findByExternalId: mockFindByExternalId.resolves(adminUser) }
         })
         nextRequest({
           params: { externalUserId: 'user-id-for-admin-user' }
@@ -102,7 +101,7 @@ describe('Controller: settings/team-members/remove-user', () => {
       before(() => {
         nextStubs({
           '@services/user.service':
-            { findByExternalId: mockFindByExternalIdGetsViewOnlyUser, delete: mockDelete }
+            { findByExternalId: mockFindByExternalId.resolves(adminUser), delete: mockDelete }
         })
         nextRequest({
           params: { externalUserId: 'user-id-to-remove' },
@@ -130,7 +129,7 @@ describe('Controller: settings/team-members/remove-user', () => {
       before(() => {
         nextStubs({
           '@services/user.service':
-            { findByExternalId: mockFindByExternalIdGetsViewOnlyUser, delete: mockDelete }
+            { findByExternalId: mockFindByExternalId.resolves(viewOnlyUser), delete: mockDelete }
         })
         nextRequest({
           params: { externalUserId: 'user-id-to-remove' },
@@ -150,7 +149,7 @@ describe('Controller: settings/team-members/remove-user', () => {
       before(() => {
         nextStubs({
           '@services/user.service':
-            { findByExternalId: mockFindByExternalIdGetsAdminUser, delete: mockDelete }
+            { findByExternalId: mockFindByExternalId.resolves(adminUser), delete: mockDelete }
         })
         nextRequest({
           params: { externalUserId: 'user-id-for-admin-user' },


### PR DESCRIPTION
- Refactor remove user controller test to use ControllerTestBuilder
- also: minor refactor to invite user controller test to avoid using multiple stubs for same method