### PR TITLE
PP-13625 Correct Digital Wallets heading to h2

### DIFF
--- a/src/views/simplified-account/settings/card-payments/index.njk
+++ b/src/views/simplified-account/settings/card-payments/index.njk
@@ -56,7 +56,7 @@
     ]
   }) }}
 
-  <h3 class="govuk-heading-m">Digital wallets</h3>
+  <h2 class="govuk-heading-m">Digital wallets</h2>
   <p class="govuk-body">Let users pay with Apple Pay and Google Pay.</p>
 
   {{ govukSummaryList({


### PR DESCRIPTION
On the ‘Card payments' screen heading level 2 (H2) is skipped. ‘Card payments’ is h1 and then ‘Digital wallets’ is h2.
- correct 'Digital wallets' heading to h2
