### PR TITLE
PP-13690 Correct heading tag to h2

### DIFF
--- a/src/views/simplified-account/settings/stripe-details/index.njk
+++ b/src/views/simplified-account/settings/stripe-details/index.njk
@@ -14,7 +14,7 @@
   {% endif %}
   <h1 class="govuk-heading-l">{{ settingsPageTitle }}</h1>
   {% if incompleteTasks %}
-    <p class="govuk-body govuk-!-font-weight-bold">Add your organisation's details</p>
+    <h2 class="govuk-heading-s">Add your organisation's details</h2>
     {{ taskList({
       tasks: tasks,
       idPrefix: 'stripe-details'


### PR DESCRIPTION
‘Add your organisation's details' on 'Stripe details’ tasklist is styled as an heading but coded as body text. 

- Use h2 instead of body text for this heading.