### PR TITLE
PP-13356 use design system service nav

### DIFF
--- a/src/assets/sass/components/navigation.scss
+++ b/src/assets/sass/components/navigation.scss
@@ -22,74 +22,32 @@
   }
 }
 
-.service-navigation {
-  margin: 0;
-
-  @include govuk-media-query(tablet) {
-    margin: 0;
-  }
-
-  &--old {
-    @include govuk-media-query(tablet) {
-      float: right;
-    }
-  }
-
-  &--list {
-    margin: 0;
-    padding: 0;
-    list-style-type: none;
-  }
-
-  &--list-item {
-    margin-top: govuk-spacing(2);
-
-    @include govuk-font($size: 16);
-    @include govuk-media-query(tablet) {
-      display: inline-block;
-      margin: 0 govuk-spacing(6) 0 0;
-      border-bottom: 5px solid transparent;
-      border-left: 0;
-    }
-
-    &--old {
-      @include govuk-media-query(tablet) {
-        margin: 0 0 0 govuk-spacing(6);
-      }
-    }
-
-    a:link,
-    a:visited {
-      display: inline-block;
-      color: $govuk-link-colour;
-      text-decoration: none;
-      @include govuk-media-query(tablet) {
-        padding: govuk-spacing(2) 0;
-      }
-    }
-
-    a:focus {
-      color: $govuk-text-colour;
-      background-color: $govuk-focus-colour;
-      outline: 3px solid $govuk-focus-colour;
-    }
-
-    &-active {
-      padding-left: govuk-spacing(1);
-      border-left: 5px solid $govuk-text-colour;
-
-      @include govuk-media-query(tablet) {
-        padding-left: 0;
-        border-left: 0;
-        border-color: $govuk-text-colour;
-      }
-    }
-  }
-}
-
 @include govuk-media-query(tablet) {
   .navigation--pad-bottom {
     margin-bottom: govuk-spacing(9);
     padding-bottom: govuk-spacing(9);
+  }
+}
+
+.service-sub-nav {
+  .govuk-service-navigation {
+    background-color: #fff;
+    .govuk-width-container {
+      margin: 0;
+    }
+  }
+  ul.govuk-service-navigation__list {
+    @include govuk-font($size: 16);
+    @include govuk-media-query($until: tablet) {
+      li.govuk-service-navigation__item {
+        margin-top: 0;
+        margin-bottom: govuk-spacing(1);
+        padding-top: govuk-spacing(1);
+        padding-bottom: govuk-spacing(1);
+      }
+    }
+    li.govuk-service-navigation__item--active {
+      @include govuk-typography-weight-bold();
+    }
   }
 }

--- a/src/assets/sass/components/service-settings.scss
+++ b/src/assets/sass/components/service-settings.scss
@@ -18,15 +18,27 @@
   padding-top: govuk-spacing(1);
   padding-bottom: govuk-spacing(1);
   @include govuk-font(16);
+  a {
+    &:hover {
+      color: govuk-colour("dark-blue");
+      text-decoration: underline;
+      text-decoration-thickness: max(3px, .1875rem, .12em);
+      text-decoration-skip-ink: none;
+      text-decoration-skip: none;
+    }
+    &:focus {
+      text-decoration: none;
+    }
+  }
 }
 
 .service-settings-nav__li--active:before {
   content: '';
   position: absolute;
-  left: -14px;
+  left: -15px;
   top: 0;
   height: 100%;
-  width: 4px;
+  width: 5px;
   background-color: $govuk-brand-colour;
 }
 

--- a/src/views/includes/phase-banner.njk
+++ b/src/views/includes/phase-banner.njk
@@ -1,4 +1,5 @@
 {% from "../macro/breadcrumbs.njk" import breadcrumbs %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
 {% set accountLabelWithTag %}
   <strong>{{ currentService.name }}</strong>
   {% if currentGatewayAccount %}
@@ -52,18 +53,21 @@
 {{ breadcrumbs(breadcrumbItems) }}
 
 {% if not hideServiceNav and not hideServiceHeader %}
-  <div class="govuk-phase-banner govuk-clearfix pay-top-navigation" data-cy="service-nav">
-    <nav role="navigation" class="service-navigation" data-cy="account-sub-nav">
-      <ul class="service-navigation--list">
-        {% for item in serviceNavigationItems %}
-          {% if item.permissions %}
-            <li
-              class="service-navigation--list-item {% if item.current %} service-navigation--list-item-active {% endif %}">
-              <a id="{{ item.id }}" href="{{ item.url }}">{{ item.name }}</a>
-            </li>
-          {% endif %}
-        {% endfor %}
-      </ul>
-    </nav>
-  </div>
+  <nav role="navigation" class="service-sub-nav" data-cy="account-sub-nav">
+    {% set navItems = [] %}
+    {% for item in serviceNavigationItems %}
+      {% if item.permissions %}
+        {% set navItems = (navItems.push({
+          href: item.url,
+          text: item.name,
+          active: item.current
+        }), navItems) %}
+      {% endif %}
+    {% endfor %}
+    {{ govukServiceNavigation({
+      navigation: navItems,
+      navigationId: "service-nav",
+      menuButtonText: "Service menu"
+    }) }}
+  </nav>
 {% endif %}

--- a/src/views/simplified-account/settings/card-payments/index.njk
+++ b/src/views/simplified-account/settings/card-payments/index.njk
@@ -102,7 +102,7 @@
   }) }}
 
   {% if isMoto %}
-    <h3 class="govuk-heading-m">MOTO Security</h3>
+    <h3 class="govuk-heading-m">MOTO security</h3>
     <p class="govuk-body">Hide sensitive details being viewed on a call agent’s screen.</p>
 
     {{ govukSummaryList({

--- a/src/views/simplified-account/settings/organisation-details/index.njk
+++ b/src/views/simplified-account/settings/organisation-details/index.njk
@@ -18,7 +18,8 @@
         items: [
           {
             href: editOrganisationDetailsHref,
-            text: "Change"
+            text: "Change",
+            classes: "govuk-link--no-visited-state"
           }
         ]
       }

--- a/test/cypress/integration/agreements/agreements.cy.js
+++ b/test/cypress/integration/agreements/agreements.cy.js
@@ -72,8 +72,7 @@ describe('Agreements', () => {
 
     cy.visit('/test/service/service-id/account/gateway-account-id/agreements')
 
-    cy.get('#navigation-menu-agreements').should('have.length', 1)
-
+    cy.contains('.govuk-service-navigation__item--active', 'Agreements')
     cy.get('h1').contains('Agreements')
 
     cy.get('[data-cy=filter-container]').should('exist')

--- a/test/cypress/integration/settings/allow-apple-pay.cy.js
+++ b/test/cypress/integration/settings/allow-apple-pay.cy.js
@@ -33,7 +33,7 @@ describe('Apple Pay', () => {
     cy.get('input[type="radio"]').should('have.length', 2)
     cy.get('input[value="on"]').should('not.be.checked')
     cy.get('input[value="off"]').should('be.checked')
-    cy.get('#navigation-menu-settings').click()
+    cy.contains('.govuk-service-navigation__item--active', 'Settings').click()
     cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
   })
 
@@ -46,7 +46,7 @@ describe('Apple Pay', () => {
     cy.get('input[type="radio"]').should('have.length', 2)
     cy.get('input[value="on"]').should('be.checked')
     cy.get('input[value="off"]').should('not.be.checked')
-    cy.get('#navigation-menu-settings').click()
+    cy.contains('.govuk-service-navigation__item--active', 'Settings').click()
     cy.get('.govuk-summary-list__value').first().should('contain', 'On')
   })
 

--- a/test/cypress/integration/webhooks/webhooks.cy.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.js
@@ -49,7 +49,7 @@ describe('Webhooks', () => {
     cy.get('h1').should('have.text', 'Webhooks')
 
     // navigation menus are correctly integrated
-    cy.get('#navigation-menu-settings').parent().should('have.class', 'service-navigation--list-item-active')
+    cy.contains('.govuk-service-navigation__item--active', 'Settings')
     cy.get('#navigation-menu-webhooks').parent().should('have.class', 'govuk-!-margin-bottom-2')
 
     cy.get('[data-webhook-entry]').should('have.length', 3)

--- a/test/ui/navigation.ui.test.js
+++ b/test/ui/navigation.ui.test.js
@@ -25,8 +25,7 @@ describe('navigation menu', function () {
     }
 
     const body = render('dashboard/index', templateData)
-
-    body.should.containSelector('.service-navigation--list-item:nth-child(1)').withExactText('Dashboard')
+    body.should.containSelector('.govuk-service-navigation__item:nth-child(1)').withExactText('Dashboard')
   })
 
   it('should render Transactions navigation link when user have transactions read permission and payment type is card', function () {
@@ -49,29 +48,7 @@ describe('navigation menu', function () {
     }
 
     const body = render('dashboard/index', templateData)
-
-    body.should.containSelector('#navigation-menu-transactions').withExactText('Transactions')
-  })
-
-  it('should render Transactions navigation link when user have transactions read permission and payment type is direct debit', function () {
-    const testPermissions = {
-      transactions_read: true
-    }
-    const templateData = {
-      currentGatewayAccount: {
-        full_type: 'test'
-      },
-      currentService: { name: 'Service Name' },
-      permissions: testPermissions,
-      hideServiceNav: false,
-      serviceNavigationItems: serviceNavigationItems('/', testPermissions, 'direct debit'),
-      links: [],
-      linksToDisplay: []
-    }
-
-    const body = render('dashboard/index', templateData)
-
-    body.should.containNoSelector('#navigation-menu-transactions')
+    body.should.containSelector('.govuk-service-navigation__item:nth-child(2)').withExactText('Transactions')
   })
 
   it('should render API keys navigation link when user have tokens read permission', function () {


### PR DESCRIPTION
### WHAT

- update the service navigation to use the design system `service navigation` component
- tidy up the service settings navigation menu to better align with the design system
  - a11y: improve hover and focus states of links
- correct typos and link states

### SCREENS

#### BEFORE

Screenshot of Simplified Account Settings:
- Simplified Account Settings is the active service navigation element
- Service name is the active service settings navigation element
- Organisation details is being `hovered` over

<img width="1458" alt="Screenshot 2025-03-13 at 16 11 50" src="https://github.com/user-attachments/assets/2e6f750e-9036-4a68-a456-f281af3c3544" />

#### AFTER

Screenshot of Simplified Account Settings:
- Simplified Account Settings is the active service navigation element
  - Active text is now bold
  - Active indicator is now blue
  - Nav target sizes increased 
- Service name is the active service settings navigation element
  - Active indicator is slightly thicker to match service navigation 
- Organisation details is being `hovered` over
  - hover and focus states more obvious now 

<img width="1458" alt="Screenshot 2025-03-13 at 16 08 26" src="https://github.com/user-attachments/assets/757a9cd7-c743-4bbc-83c1-b63f1fea337b" />

