### PR TITLE
PP-13779 - Correct h3 to h2 on card payments page

### DIFF
--- a/src/views/simplified-account/settings/card-payments/index.njk
+++ b/src/views/simplified-account/settings/card-payments/index.njk
@@ -11,7 +11,7 @@
   <p class="govuk-body">GOV.UK Pay uses 3D Secure for all card payments. 3D Secure (3DS) adds an extra layer of
     authentication to user payments.</p>
 
-  <h3 class="govuk-heading-m">Billing address</h3>
+  <h2 class="govuk-heading-m">Billing address</h2>
   <p class="govuk-body">Payment Service Providers (PSPs) use the billing address to carry out fraud checks.</p>
 
   {{ govukSummaryList({


### PR DESCRIPTION
On the ‘Card payments' screen heading level 2 (H2) is skipped. ‘Card payments’ is h1 and then ‘Billing address’ is h3.

- change h3 to h2 for Billing address heading.

![Screenshot 2025-03-13 at 17 36 33](https://github.com/user-attachments/assets/19e6fb9b-b763-442e-a098-457919cc747a)
