### PR TITLE
PP-13521: Show webhook event resource

### DIFF
--- a/src/views/simplified-account/settings/webhooks/event.njk
+++ b/src/views/simplified-account/settings/webhooks/event.njk
@@ -9,8 +9,6 @@
 
 {% block settingsContent %}
 
-
-
   <h1 class="govuk-heading-l">{{ title }}</h1>
 
   {% set resourceLink %}
@@ -44,6 +42,11 @@
         }
       }
     ]
+  }) }}
+
+  {{ govukDetails({
+    summaryText: title + " event body",
+    html: '<pre><code>' + event.resource | dump(4) + '</code></pre>'
   }) }}
 
   <h2 class="govuk-heading-m">Delivery Attempts</h2>

--- a/src/views/simplified-account/settings/webhooks/event.njk
+++ b/src/views/simplified-account/settings/webhooks/event.njk
@@ -50,13 +50,12 @@
   }) }}
 
   <h2 class="govuk-heading-m">Delivery Attempts</h2>
-
   {% set attemptRows = [] %}
   {% for attempt in attempts %}
     {% set attemptRow = [
       { text: attempt.send_at | datetime("datetime") },
       { html: messageStatusTag(attempt.status) },
-      { html: attempt.status_code },
+      { text: (attempt.status_code if attempt.status_code else 'None') },
       { text: attempt.result }
     ] %}
     {% set attemptRows = (attemptRows.push(attemptRow), attemptRows) %}

--- a/test/cypress/integration/simplified-account/service-settings/webhooks/webhook-event.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/webhooks/webhook-event.cy.js
@@ -4,6 +4,7 @@ const gatewayAccountStubs = require('@test/cypress/stubs/gateway-account-stubs')
 const webhooksStubs = require('@test/cypress/stubs/webhooks-stubs')
 const moment = require('moment-timezone')
 const checkSettingsNavigation = require('@test/cypress/integration/simplified-account/service-settings/helpers/check-settings-nav')
+const transactionFixtures = require('@test/fixtures/ledger-transaction.fixtures')
 
 const USER_EXTERNAL_ID = 'user-123-abc'
 const SERVICE_EXTERNAL_ID = 'service-456-def'
@@ -25,6 +26,8 @@ const WEBHOOK_BASE_URL = `/simplified/service/${SERVICE_EXTERNAL_ID}/account/${L
 const WEBHOOK_DETAILS_URL = `${WEBHOOK_BASE_URL}/${WEBHOOK_ID}`
 const WEBHOOK_EVENT_URL = `${WEBHOOK_DETAILS_URL}/event/${webhookEvent.external_id}`
 const WEBHOOK_EVENT_RESOURCE_URL = `/account/a-valid-external-id/transactions/${webhookEvent.resource_id}`
+
+const WEBHOOK_EVENT_RESOURCE = transactionFixtures.validTransactionDetailsResponse({ transaction_id: 'an-external-id' })
 
 const attempts = [
   {
@@ -104,6 +107,11 @@ describe('for an admin', () => {
   it('should show title and heading', () => {
     cy.title().should('eq', 'Payment captured - Settings - McDuck Enterprises - GOV.UK Pay')
     cy.get('h1.govuk-heading-l').should('have.text', 'Payment captured')
+  })
+
+  it('should show event body in detail component', () => {
+    cy.get('.govuk-details summary').should('contain.text', 'Payment captured event body').click()
+    cy.get('.govuk-details div.govuk-details__text pre code').should('contain.text', JSON.stringify(WEBHOOK_EVENT_RESOURCE, null, 4))
   })
 
   it('should show active "Webhooks" link', () => {


### PR DESCRIPTION
### WHAT

Update the webhook event detail page to show a json representation of the resource from the event, in a design system detail component. This is to match the UI  design.
    
Update the Cypress test for webhook events details page to check for the event body detail.

Update the table showing delivery attempts for webhook events, so that when there is no status code we do not leave a blank cell. This is to improve accessability.

### SCREENS

#### AFTER

<img width="677" alt="Screenshot 2025-03-18 at 10 07 12" src="https://github.com/user-attachments/assets/5205eb2a-fe60-440c-b1d5-26dcca27a9af" />

<img width="821" alt="Screenshot 2025-03-18 at 10 07 45" src="https://github.com/user-attachments/assets/ecbae355-18e7-4c0d-bcfc-4f5dfeb035d3" />
