### PR TITLE
PP-13521: Update webhook event page title

### DIFF
--- a/src/views/simplified-account/settings/webhooks/event.njk
+++ b/src/views/simplified-account/settings/webhooks/event.njk
@@ -5,7 +5,7 @@
 {% set settingsPageTitle = webhook.description %}
 
 {% set title = eventTypes[event.event_type | upper] %}
-{% set settingsPageTitle = title %}
+{% set settingsPageTitle = title + " event details" %}
 
 {% block settingsContent %}
 

--- a/test/cypress/integration/simplified-account/service-settings/webhooks/webhook-event.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/webhooks/webhook-event.cy.js
@@ -105,7 +105,7 @@ describe('for an admin', () => {
   })
 
   it('should show title and heading', () => {
-    cy.title().should('eq', 'Payment captured - Settings - McDuck Enterprises - GOV.UK Pay')
+    cy.title().should('eq', 'Payment captured event details - Settings - McDuck Enterprises - GOV.UK Pay')
     cy.get('h1.govuk-heading-l').should('have.text', 'Payment captured')
   })
 


### PR DESCRIPTION
### WHAT

Minor update to Webhook event page title to match design.

While most pages insert the same value as the H1 heading into the start of the standardized title, this page should be:
```
[Event name] event details - Settings - [Service name] - GOV.UK Pay
```