### PR TITLE
PP-13624 Prepopulate api key name field

### DIFF
--- a/src/controllers/simplified-account/settings/api-keys/change-name/change-name.controller.js
+++ b/src/controllers/simplified-account/settings/api-keys/change-name/change-name.controller.js
@@ -3,11 +3,13 @@ const { validationResult } = require('express-validator')
 const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
 const formatValidationErrors = require('@utils/simplified-account/format/format-validation-errors')
 const { response } = require('@utils/response')
-const { changeApiKeyName } = require('@services/api-keys.service')
+const { getKeyByTokenLink, changeApiKeyName } = require('@services/api-keys.service')
 const DESCRIPTION_VALIDATION = require('@controllers/simplified-account/settings/api-keys/validations')
 
-function get (req, res) {
+async function get (req, res) {
+  const { description } = await getKeyByTokenLink(req.account.id, req.params.tokenLink)
   return response(req, res, 'simplified-account/settings/api-keys/api-key-name', {
+    description,
     backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.apiKeys.index, req.service.externalId, req.account.type)
   })
 }

--- a/src/controllers/simplified-account/settings/api-keys/change-name/change-name.controller.test.js
+++ b/src/controllers/simplified-account/settings/api-keys/change-name/change-name.controller.test.js
@@ -3,11 +3,15 @@ const sinon = require('sinon')
 const { expect } = require('chai')
 const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
 const paths = require('@root/paths')
+const GatewayAccount = require('@models/GatewayAccount.class')
 
 const ACCOUNT_TYPE = 'live'
 const SERVICE_ID = 'service-id-123abc'
+const GATEWAY_ACCOUNT_ID = 1
 const mockResponse = sinon.spy()
+const DESCRIPTION = 'My API key description'
 const apiKeysService = {
+  getKeyByTokenLink: sinon.stub().resolves({ description: DESCRIPTION }),
   changeApiKeyName: sinon.stub().resolves()
 }
 const {
@@ -17,11 +21,15 @@ const {
   call
 } = new ControllerTestBuilder('@controllers/simplified-account/settings/api-keys/change-name/change-name.controller')
   .withServiceExternalId(SERVICE_ID)
-  .withAccountType(ACCOUNT_TYPE)
+  .withAccount(new GatewayAccount({
+    type: ACCOUNT_TYPE,
+    gateway_account_id: GATEWAY_ACCOUNT_ID
+  }))
   .withStubs({
     '@utils/response': { response: mockResponse },
     '@services/api-keys.service': apiKeysService
   })
+  .withParams({ tokenLink: '123-456-abc' })
   .build()
 
 describe('Controller: settings/api-keys/change-name', () => {
@@ -30,13 +38,17 @@ describe('Controller: settings/api-keys/change-name', () => {
       call('get')
     })
 
-    it('should call the response method', () => {
+    it('should get api key and call the response method', () => {
+      expect(apiKeysService.getKeyByTokenLink).to.have.been.calledWith(1, '123-456-abc')
       expect(mockResponse).to.have.been.calledOnce // eslint-disable-line
     })
 
     it('should pass req, res, template path and context to the response method', () => {
       expect(mockResponse).to.have.been.calledWith(req, res, 'simplified-account/settings/api-keys/api-key-name',
-        { backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.apiKeys.index, SERVICE_ID, ACCOUNT_TYPE) })
+        {
+          description: DESCRIPTION,
+          backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.apiKeys.index, SERVICE_ID, ACCOUNT_TYPE)
+        })
     })
   })
 
@@ -46,9 +58,6 @@ describe('Controller: settings/api-keys/change-name', () => {
         nextRequest({
           body: {
             description: 'a test api key'
-          },
-          params: {
-            tokenLink: '123-456-abc'
           }
         })
         call('post')
@@ -71,9 +80,6 @@ describe('Controller: settings/api-keys/change-name', () => {
         nextRequest({
           body: {
             description: ''
-          },
-          params: {
-            tokenLink: '123-456-abc'
           }
         })
         call('post')

--- a/src/views/simplified-account/settings/api-keys/api-key-name.njk
+++ b/src/views/simplified-account/settings/api-keys/api-key-name.njk
@@ -13,6 +13,7 @@
       id: "description",
       name: "description",
       type: "text",
+      value: description,
       attributes: {
         maxlength: "50"
       },

--- a/test/cypress/integration/simplified-account/service-settings/api-keys/api-keys.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/api-keys/api-keys.cy.js
@@ -321,6 +321,7 @@ describe('Settings - API keys', () => {
       beforeEach(() => {
         setupStubs('admin', apiKeys)
         cy.task('setupStubs', [
+          apiKeysStubs.getKeyByTokenLink(GATEWAY_ACCOUNT_ID, TOKEN_LINK, 'mathematical clothes'),
           apiKeysStubs.changeApiKeyName(TOKEN_LINK, NEW_API_KEY_NAME)
         ])
         cy.visit(`/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/api-keys`)
@@ -339,7 +340,8 @@ describe('Settings - API keys', () => {
           cy.contains('h2', 'mathematical clothes').should('exist')
           cy.contains('a', 'Change name').click()
         })
-        cy.get('input[id="description"]').type(NEW_API_KEY_NAME)
+        cy.get('input[id="description"]').should('have.value', 'mathematical clothes')
+        cy.get('input[id="description"]').clear().type(NEW_API_KEY_NAME)
         cy.contains('button', 'Continue').click()
         cy.url().should('include', `/simplified/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/api-keys`)
         cy.contains('h1', 'Test API keys').should('exist')


### PR DESCRIPTION
The ‘API key name’ field is not populated with the previous saved name when the user selects ‘Change name' from the 'API keys’ page. 

- prepopulate the api key name field with the saved value
 
In the screenshots below the original value is 'my original name' and this is shown when the user clicks on 'Change name'.


![Screenshot 2025-03-19 at 15 29 46](https://github.com/user-attachments/assets/e5b3e222-bda3-4e62-8e44-ee57341c9b47)

![Screenshot 2025-03-19 at 15 29 53](https://github.com/user-attachments/assets/c7b52488-40c9-4c75-91d8-c3db658fc5fe)

![Screenshot 2025-03-19 at 15 30 02](https://github.com/user-attachments/assets/c953b3de-8c8d-4697-8f78-27737e5baa9c)

![Screenshot 2025-03-19 at 15 30 08](https://github.com/user-attachments/assets/84497262-3704-492b-9342-9a285c08e5c0)

