### PR TITLE
PP-13822 API key name page heading as form label

### DIFF
--- a/src/views/simplified-account/settings/api-keys/api-key-name.njk
+++ b/src/views/simplified-account/settings/api-keys/api-key-name.njk
@@ -4,12 +4,15 @@
 
 {% block settingsContent %}
 
-  <h1 class="govuk-heading-l page-title">{{ settingsPageTitle }}</h1>
-
   <form id="api-key-name" method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
     {{ govukInput({
+      label: {
+        text: "API key name",
+        classes: "govuk-label--l",
+        isPageHeading: true
+      },
       id: "description",
       name: "description",
       type: "text",


### PR DESCRIPTION
Accessibility - On the ‘'API key name’ screen there isn't a form label associated with the text input. 
- add a label to the api key name field
- make this label the page heading

![Screenshot 2025-03-19 at 17 12 22](https://github.com/user-attachments/assets/007ee045-2dd7-4029-bb40-43e81f64aae8)
