### PR TITLE
BAU — Remove section-* tokens from autocomplete attributes

### DIFF
--- a/src/views/simplified-account/settings/organisation-details/_edit-organisation-details-address.njk
+++ b/src/views/simplified-account/settings/organisation-details/_edit-organisation-details-address.njk
@@ -16,7 +16,7 @@
     classes: "govuk-!-width-three-quarters",
     id: "address-line1",
     name: "addressLine1",
-    autocomplete: "section-address address-line1",
+    autocomplete: "address-line1",
     errorMessage: { text: errors.formErrors['addressLine1'] } if errors.formErrors['addressLine1'] else false,
     value: organisationDetails.addressLine1
   }) }}
@@ -28,7 +28,7 @@
     classes: "govuk-!-width-three-quarters",
     id: "address-line2",
     name: "addressLine2",
-    autocomplete: "section-address address-line2",
+    autocomplete: "address-line2",
     errorMessage: { text: errors.formErrors['addressLine2'] } if errors.formErrors['addressLine2'] else false,
     value: organisationDetails.addressLine2
   }) }}
@@ -40,7 +40,7 @@
     classes: "govuk-!-width-two-thirds",
     id: "address-city",
     name: "addressCity",
-    autocomplete: "section-address address-level2",
+    autocomplete: "address-level2",
     errorMessage: { text: errors.formErrors['addressCity'] } if errors.formErrors['addressCity'] else false,
     value: organisationDetails.addressCity
   }) }}
@@ -63,7 +63,7 @@
     classes: "govuk-!-width-one-quarter",
     id: "address-postcode",
     name: "addressPostcode",
-    autocomplete: "section-address postal-code",
+    autocomplete: "postal-code",
     errorMessage: { text: errors.formErrors['addressPostcode'] } if errors.formErrors['addressPostcode'] else false,
     value: organisationDetails.addressPostcode
   }) }}

--- a/src/views/simplified-account/settings/organisation-details/_edit-organisation-details-name.njk
+++ b/src/views/simplified-account/settings/organisation-details/_edit-organisation-details-name.njk
@@ -17,5 +17,6 @@
     html: organisationNameHint
   },
   classes: "govuk-!-width-three-quarters",
+  autocomplete: organization,
   value: organisationDetails.organisationName
 }) }}

--- a/src/views/simplified-account/settings/stripe-details/partials/_stripe_person_dob.njk
+++ b/src/views/simplified-account/settings/stripe-details/partials/_stripe_person_dob.njk
@@ -19,7 +19,7 @@
       name: "dobDay",
       id: "dob-day",
       classes: "govuk-input--width-2 govuk-input--error" if (errors.formErrors['dob'] or errors.formErrors['dobDay']) else "govuk-input--width-2",
-      autocomplete: "section-person bday-day"
+      autocomplete: "bday-day"
     },
     {
       label: "Month",
@@ -27,7 +27,7 @@
       name: "dobMonth",
       id: "dob-month",
       classes: "govuk-input--width-2 govuk-input--error" if (errors.formErrors['dob'] or errors.formErrors['dobMonth']) else "govuk-input--width-2",
-      autocomplete: "section-person bday-month"
+      autocomplete: "bday-month"
     },
     {
       label: "Year",
@@ -35,7 +35,7 @@
       name: "dobYear",
       id: "dob-year",
       classes: "govuk-input--width-4 govuk-input--error" if (errors.formErrors['dob'] or errors.formErrors['dobYear']) else "govuk-input--width-4",
-      autocomplete: "section-person bday-year"
+      autocomplete: "bday-year"
     }
   ]
 }) }}

--- a/src/views/simplified-account/settings/stripe-details/responsible-person/contact-details.njk
+++ b/src/views/simplified-account/settings/stripe-details/responsible-person/contact-details.njk
@@ -20,7 +20,7 @@
       name: "workTelephoneNumber",
       value: contact.workTelephoneNumber,
       type: "tel",
-      autocomplete: "section-contact work tel",
+      autocomplete: "work tel",
       errorMessage: { text: errors.formErrors['workTelephoneNumber'] } if errors.formErrors['workTelephoneNumber'] else false,
       classes: "govuk-!-full-width"
     }) }}
@@ -34,7 +34,7 @@
       name: "workEmail",
       value: contact.workEmail,
       type: "email",
-      autocomplete: "section-contact work email",
+      autocomplete: "work email",
       spellcheck: false,
       errorMessage: { text: errors.formErrors['workEmail'] } if errors.formErrors['workEmail'] else false,
       classes: "govuk-!-full-width"

--- a/src/views/simplified-account/settings/stripe-details/responsible-person/home-address.njk
+++ b/src/views/simplified-account/settings/stripe-details/responsible-person/home-address.njk
@@ -17,7 +17,7 @@
         name: "homeAddressLine1",
         value: address.homeAddressLine1,
         type: "text",
-        autocomplete: "section-address address-line1",
+        autocomplete: "address-line1",
         errorMessage: { text: errors.formErrors['homeAddressLine1'] } if errors.formErrors['homeAddressLine1'] else false,
         classes: "govuk-!-width-three-quarters"
       }) }}
@@ -29,7 +29,7 @@
         name: "homeAddressLine2",
         value: address.homeAddressLine2,
         type: "text",
-        autocomplete: "section-address address-line2",
+        autocomplete: "address-line2",
         errorMessage: { text: errors.formErrors['homeAddressLine2'] } if errors.formErrors['homeAddressLine2'] else false,
         attributes: {
           "aria-label": "Enter address line 2"
@@ -44,7 +44,7 @@
         name: "homeAddressCity",
         value: address.homeAddressCity,
         type: "text",
-        autocomplete: "section-address address-level2",
+        autocomplete: "address-level2",
         errorMessage: { text: errors.formErrors['homeAddressCity'] } if errors.formErrors['homeAddressCity'] else false,
         classes: "govuk-!-width-one-half"
       }) }}
@@ -56,7 +56,7 @@
         name: "homeAddressPostcode",
         value: address.homeAddressPostcode,
         type: "text",
-        autocomplete: "section-address postal-code",
+        autocomplete: "postal-code",
         classes: "govuk-!-width-one-third",
         errorMessage: { text: errors.formErrors['homeAddressPostcode'] } if errors.formErrors['homeAddressPostcode'] else false
       }) }}

--- a/src/views/simplified-account/settings/stripe-details/responsible-person/index.njk
+++ b/src/views/simplified-account/settings/stripe-details/responsible-person/index.njk
@@ -35,7 +35,7 @@
         name: "firstName",
         value: name.firstName,
         type: "text",
-        autocomplete: "section-person given-name",
+        autocomplete: "given-name",
         spellcheck: false,
         errorMessage: { text: errors.formErrors['firstName'] } if errors.formErrors['firstName'] else false,
         classes: "govuk-!-width-three-quarters"
@@ -49,7 +49,7 @@
         name: "lastName",
         value: name.lastName,
         type: "text",
-        autocomplete: "section-person family-name",
+        autocomplete: "family-name",
         spellcheck: false,
         errorMessage: { text: errors.formErrors['lastName'] } if errors.formErrors['lastName'] else false,
         classes: "govuk-!-width-three-quarters"


### PR DESCRIPTION
In some cases, particularly when we make use of partials to put together a complete form, we mix `autocomplete` attributes that do not have a `section-*` token with attributes that do have a `section-*` token. This places them in different autofill scopes, indicating they do not refer to the same subject, which may hinder browsers from filling in complete and consistent information.

Remove all the `section-*` tokens. They are only useful when there’s a form that asks for information about two different subjects (for example, two different people) and we do not seem to do that.

Also add a missing `autocomplete="organization"` attribute.