### PR TITLE
PP-13760 Fix headers and error messages not wrapping when screen resized

### DIFF
--- a/src/assets/sass/components/service-settings.scss
+++ b/src/assets/sass/components/service-settings.scss
@@ -49,7 +49,7 @@
 .service-settings-pane {
   max-width: 630px;
   h1, .service-settings-break-word  {
-    word-break: break-word;
+    overflow-wrap: anywhere;
   }
 }
 

--- a/src/assets/sass/components/service-settings.scss
+++ b/src/assets/sass/components/service-settings.scss
@@ -48,7 +48,9 @@
 
 .service-settings-pane {
   max-width: 630px;
-  word-break: break-word;
+  h1, .service-settings-break-word  {
+    word-break: break-word;
+  }
 }
 
 .service-settings-inset-text--grey {

--- a/src/assets/sass/components/service-settings.scss
+++ b/src/assets/sass/components/service-settings.scss
@@ -48,8 +48,8 @@
 
 .service-settings-pane {
   max-width: 630px;
-  h1, .service-settings-break-word  {
-    overflow-wrap: anywhere;
+  h1, .govuk-error-summary, .govuk-error-message {
+    overflow-wrap: anywhere
   }
 }
 

--- a/src/assets/sass/components/service-settings.scss
+++ b/src/assets/sass/components/service-settings.scss
@@ -48,6 +48,7 @@
 
 .service-settings-pane {
   max-width: 630px;
+  word-break: break-word;
 }
 
 .service-settings-inset-text--grey {

--- a/src/views/simplified-account/settings/settings-layout.njk
+++ b/src/views/simplified-account/settings/settings-layout.njk
@@ -33,7 +33,8 @@
       {% if errors %}
         {{ govukErrorSummary({
           titleText: "There is a problem",
-          errorList: errors.summary
+          errorList: errors.summary,
+          classes: "service-settings-break-word"
         }) }}
       {% endif %}
       <div id="service-settings-content">

--- a/src/views/simplified-account/settings/settings-layout.njk
+++ b/src/views/simplified-account/settings/settings-layout.njk
@@ -33,8 +33,7 @@
       {% if errors %}
         {{ govukErrorSummary({
           titleText: "There is a problem",
-          errorList: errors.summary,
-          classes: "service-settings-break-word"
+          errorList: errors.summary
         }) }}
       {% endif %}
       <div id="service-settings-content">


### PR DESCRIPTION
Context: H1 'Change permission for [email address]' does not adjust to screen size so some of the characters cannot be seen without horizontal scrolling. The same applies to the remove user page. Additionally, the validation error summary (and form error message will also extend outside of the boundary of the error box when the screen is resized. This problem also applies to webhooks where a 50-character webhook description may be used in the heading.
- apply `word break: break-word;` across the simplified settings pane

**change permissions before**
-----

<img width="948" alt="Screenshot 2025-03-21 at 14 47 57" src="https://github.com/user-attachments/assets/3b8a171b-1cbb-4523-a29d-ae1c6f2cd313" />

-----
**change permissions after**
-----

<img width="830" alt="Screenshot 2025-03-21 at 15 06 38" src="https://github.com/user-attachments/assets/0288da8a-5ff9-4545-86ba-77742b30747c" />

-----
**remove user after**
-----
<img width="808" alt="Screenshot 2025-03-21 at 14 49 26" src="https://github.com/user-attachments/assets/de110905-d7ff-4435-8ac8-14ab587efc3e" />
