### PR TITLE
PP-13616: Add ARIA labels for settings navigation

### DIFF
--- a/src/views/simplified-account/settings/_settings-navigation.njk
+++ b/src/views/simplified-account/settings/_settings-navigation.njk
@@ -1,12 +1,13 @@
 <div class="govuk-grid-column-one-quarter service-settings-nav">
-  <nav role="navigation">
+  <nav role="navigation" aria-labelledby="app-subnav-heading">
+    <h2 class="govuk-visually-hidden" id="app-subnav-heading">Service settings</h2>
       {% for key, array in serviceSettings %}
         {% if array and array.length > 0 %}
-        <h2 class="service-settings-nav__h3">{{ key | smartCaps }}</h2>
+        <h3 class="service-settings-nav__h3">{{ key | smartCaps }}</h3>
         <ul class="govuk-list">
           {% for setting in array %}
             <li class="service-settings-nav__li{% if setting.current %} service-settings-nav__li--active{% endif %}">
-              <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" id="{{setting.id}}" href="{{setting.url}}">{{setting.name | smartCaps}}</a>
+              <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" id="{{setting.id}}" href="{{setting.url}}" {% if setting.current %}aria-current="page"{% endif %}>{{setting.name | smartCaps}}</a>
             </li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
### WHAT

Add aria labels for navigation:
* add aria-current page to the `<a>` tag for the active page.
* add aria-labelledby to the `<nav>` tag, linking to a new `<h2>` hidden navigation heading.
* demoted the previous `<h2>` section headings to `<h3>`
