### PR TITLE
PP-13856 Ensure link to agreements is shown when viewing simplified settings

### DIFF
--- a/src/utils/nav-builder.js
+++ b/src/utils/nav-builder.js
@@ -50,7 +50,7 @@ const serviceNavigationItems = (currentPath, permissions, type, isDegatewayed, c
     name: 'Agreements',
     url: formatFutureStrategyAccountPathsFor(paths.futureAccountStrategy.agreements.index, account.type, serviceExternalId, gatewayAccountExternalId),
     current: pathLookup(currentPath, paths.futureAccountStrategy.agreements.index),
-    permissions: permissions.agreements_read && account.recurring_enabled
+    permissions: permissions.agreements_read && (account.recurring_enabled ?? account.recurringEnabled)
   })
   if (type === 'card') {
     navigationItems.push({


### PR DESCRIPTION
### What
 - there was a bug where the "agreements" tab in the nav bar would not show when viewing simplified settings
 - this fixes the bug

before (link showing on agreements page):
![Screenshot 2025-03-24 at 16-26-17 Agreements - GOV UK Pay](https://github.com/user-attachments/assets/84621154-7db4-41c7-bd10-8e8c1f0bdcea)

before (link not showing on simplified settings):
![Screenshot 2025-03-24 at 16-26-30 Email notifications - Settings - GOV UK Pay LIVE (Stripe) - GOV UK Pay](https://github.com/user-attachments/assets/ff8bb4dc-b693-4b32-b7f7-a52dfd62def1)

after (link showing on simplified settings page):
![Screenshot 2025-03-24 at 17-05-46 Service name - Settings - select a service - GOV UK Pay](https://github.com/user-attachments/assets/2fe50b66-87c9-4bdd-ad89-592ef36fee5e)
