### PR TITLE
PP-13817: Place span tag within the anchor tag

### DIFF
--- a/src/views/simplified-account/settings/webhooks/event.njk
+++ b/src/views/simplified-account/settings/webhooks/event.njk
@@ -12,7 +12,7 @@
   <h1 class="govuk-heading-l">{{ title }}</h1>
 
   {% set resourceLink %}
-    <span class="govuk-visually-hidden">GOV.UK Payment ID </span><a class="govuk-link" href="{{ resourceLink }}">{{ event.resource_id }}</a>
+    <a class="govuk-link" href="{{ resourceLink }}"><span class="govuk-visually-hidden">GOV.UK Payment ID </span>{{ event.resource_id }}</a>
   {% endset %}
   {{ govukSummaryList({
     classes: "webhooks-summary-card",

--- a/test/cypress/integration/simplified-account/service-settings/webhooks/webhook-event.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/webhooks/webhook-event.cy.js
@@ -123,27 +123,12 @@ describe('for an admin', () => {
     cy.get('.govuk-summary-list').should('have.length', 1)
     cy.get('.govuk-summary-list__row:eq(0) > dt').should('contain.text', 'GOV.UK Payment ID')
     cy.get('.govuk-summary-list__row:eq(0) > dd').within(() => {
-      cy.get('a').then(($span) => {
-        cy.get('span')
-          .should('have.attr', 'class', 'govuk-visually-hidden')
-          .should('contain.text', 'GOV.UK Payment ID')
-        cy.get('a')
-          .should('have.attr', 'href', WEBHOOK_EVENT_RESOURCE_URL)
-          .should('contain.text', webhookEvent.resource_id)
-        cy.get('span').then(($span) => {
-          cy.get('a').then(($a) => {
-            /* Ensure the <span> comes before the <a> in the DOM
-             Attempted to use Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0) which works as it is a built-in
-             part of the browser's JavaScript API, but this fails the build with:
-
-             standard: Use JavaScript Standard Style (https://standardjs.com); 'Node' is not defined. (no-undef)
-
-             Instead of using Node.DOCUMENT_POSITION_FOLLOWING, its numeric value, which is 4 can be used.
-             */
-            expect($span[0].compareDocumentPosition($a[0]) & 4).to.be.greaterThan(0)
-          })
-        })
-      })
+      cy.get('span')
+        .should('have.attr', 'class', 'govuk-visually-hidden')
+        .should('contain.text', 'GOV.UK Payment ID')
+      cy.get('a')
+        .should('have.attr', 'href', WEBHOOK_EVENT_RESOURCE_URL)
+        .should('contain.text', webhookEvent.resource_id)
     })
     cy.get('.govuk-summary-list__row:eq(1) > dt').should('contain.text', 'Event date')
     cy.get('.govuk-summary-list__row:eq(1) > dd').should('contain.text', '25 February 2025')


### PR DESCRIPTION
The screenreader won't read out the text within the span tag if it's outside the anchor tag.

See [jira comment](https://payments-platform.atlassian.net/browse/PP-13817?focusedCommentId=61862).