### PR TITLE
PP-13825 Admin tool timezone notification banner

### DIFF
--- a/src/views/transaction-detail/index.njk
+++ b/src/views/transaction-detail/index.njk
@@ -65,6 +65,7 @@
     {% endif %}
 
     <h1 class="govuk-heading-l">Transaction details</h1>
+    {% include "transactions/timezone-banner.njk" %}
     {% include "./_details.njk" %}
 
     {% if dispute %}

--- a/src/views/transactions/index.njk
+++ b/src/views/transactions/index.njk
@@ -66,6 +66,7 @@
        Transactions
     {% endif %}
   </h1>
+  {% include "transactions/timezone-banner.njk" %}
 
   {% if allServiceTransactions %}
     {% if filterLiveAccounts %}

--- a/src/views/transactions/timezone-banner.njk
+++ b/src/views/transactions/timezone-banner.njk
@@ -1,0 +1,18 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% set html %}
+  <h3 class="govuk-notification-banner__heading">
+    BST has started and it could affect your reporting.
+  </h3>
+  <p class="govuk-body">
+    Clocks in the UK went forward 1 hour on 30 March 2025 for British Summer Time (BST). During BST,
+    times in the GOV.UK Pay admin tool are 1 hour ahead of downloaded CSV files.<br>You can read more
+    about <a class="govuk-notification-banner__link" href="https://docs.payments.service.gov.uk/reporting/#timezones-in-gov-uk-pay">
+      how timezones work in GOV.UK Pay in our documentation</a>.
+  </p>
+{% endset %}
+
+{{ govukNotificationBanner({
+  html: html,
+  classes: "govuk-!-margin-bottom-4 govuk-!-margin-top-0"
+}) }}

--- a/test/cypress/integration/all-service-transactions/all-service-transactions.cy.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions.cy.js
@@ -77,6 +77,38 @@ describe('All service transactions', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
+  it('should display timezone notification banner with correct content and link in live mode', () => {
+    cy.task('setupStubs', [
+      userStub,
+      gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccountStripe, gatewayAccount2, gatewayAccount3]),
+      transactionStubs.getLedgerTransactionsSuccess({
+        gatewayAccountIds: [gatewayAccountStripe.gatewayAccountId, gatewayAccount2.gatewayAccountId],
+        transactions: liveTransactions
+      }),
+      transactionStubs.getLedgerTransactionsSuccess({
+        gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
+        transactions: testTransactions
+      }),
+      gatewayAccountStubs.getCardTypesSuccess()
+    ])
+
+    cy.visit(transactionsUrl)
+
+    cy.get('.govuk-notification-banner').should('exist').within(() => {
+      cy.get('.govuk-notification-banner__heading')
+        .should('contain', 'BST has started and it could affect your reporting.')
+
+      cy.get('.govuk-body')
+        .should('contain', 'Clocks in the UK went forward 1 hour on 30 March 2025 for British Summer Time (BST)')
+        .and('contain', 'times in the GOV.UK Pay admin tool are 1 hour ahead of downloaded CSV files.')
+        .and('contain', 'how timezones work in GOV.UK Pay in our documentation')
+
+      cy.get('a.govuk-notification-banner__link')
+        .should('have.attr', 'href')
+        .and('include', 'https://docs.payments.service.gov.uk/reporting/#timezones-in-gov-uk-pay')
+    })
+  })
+
   it('should display All Service Transactions list page with live transactions and ability to view test transactions', () => {
     cy.task('setupStubs', [
       userStub,

--- a/test/cypress/integration/transactions/transaction-details.cy.js
+++ b/test/cypress/integration/transactions/transaction-details.cy.js
@@ -548,5 +548,29 @@ describe('Transaction details page', () => {
         cy.get('[data-cy=dispute-evidence-due-date]').contains(utcToDisplay('2022-08-04T13:59:59.000Z')).should('exist')
       })
     })
+
+    it('should display timezone notification banner', () => {
+      const disputedPaymentDetails = defaultTransactionDetails()
+      disputedPaymentDetails.disputed = true
+      disputedPaymentDetails.refund_summary_status = 'unavailable'
+      const disputeTransactionDetails = defaultDisputeDetails()
+
+      cy.task('setupStubs', getStubs(disputedPaymentDetails, {}, disputeTransactionDetails))
+      cy.visit(`${transactionsUrl}/${disputedPaymentDetails.transaction_id}`)
+
+      cy.get('.govuk-notification-banner').should('exist').within(() => {
+        cy.get('.govuk-notification-banner__heading')
+          .should('contain', 'BST has started and it could affect your reporting.')
+
+        cy.get('.govuk-body')
+          .should('contain', 'Clocks in the UK went forward 1 hour on 30 March 2025 for British Summer Time (BST)')
+          .and('contain', 'times in the GOV.UK Pay admin tool are 1 hour ahead of downloaded CSV files.')
+          .and('contain', 'how timezones work in GOV.UK Pay in our documentation')
+
+        cy.get('a.govuk-notification-banner__link')
+          .should('have.attr', 'href')
+          .and('include', 'https://docs.payments.service.gov.uk/reporting/#timezones-in-gov-uk-pay')
+      })
+    })
   })
 })

--- a/test/cypress/integration/transactions/transaction-list-pagination.cy.js
+++ b/test/cypress/integration/transactions/transaction-list-pagination.cy.js
@@ -276,5 +276,34 @@ describe('Transactions list pagination', () => {
         cy.get('button.pay-button--as-link.displaySize').should('contain', '100')
       })
     })
+
+    it('should display timezone notification banner on the Transaction List page', () => {
+      const opts = transactionSearchResultOpts(
+        150,
+        500,
+        1,
+        {},
+        {
+          self: {
+            href: '/v1/transactions?&page=1&display_size=500&state='
+          }
+        }
+      )
+      cy.task('setupStubs', getStubs(opts))
+      cy.visit(transactionsUrl + '?pageSize=500&page=1')
+      cy.get('.govuk-notification-banner').should('exist').within(() => {
+        cy.get('.govuk-notification-banner__heading')
+          .should('contain', 'BST has started and it could affect your reporting.')
+
+        cy.get('.govuk-body')
+          .should('contain', 'Clocks in the UK went forward 1 hour on 30 March 2025 for British Summer Time (BST)')
+          .and('contain', 'times in the GOV.UK Pay admin tool are 1 hour ahead of downloaded CSV files.')
+          .and('contain', 'how timezones work in GOV.UK Pay in our documentation')
+
+        cy.get('a.govuk-notification-banner__link')
+          .should('have.attr', 'href')
+          .and('include', 'https://docs.payments.service.gov.uk/reporting/#timezones-in-gov-uk-pay')
+      })
+    })
   })
 })


### PR DESCRIPTION
### WHAT
- add timezone notification banner for timezone guidance to transactions list page, transactions for all services and transaction details page

#### Screenshots:

![Transactions](https://github.com/user-attachments/assets/8afa531f-cd40-4dc1-b780-48bf61f4864b)

![transaction-details](https://github.com/user-attachments/assets/2739a7f7-0922-4d4a-badb-eaa8cd908275)

![transaction-for-all-services](https://github.com/user-attachments/assets/7cf6472a-2ab9-4997-86b4-8f9053e3b849)




