### PR TITLE
PP-13821: Fix wide pre/code display issues

### DIFF
--- a/src/assets/sass/components/service-settings.scss
+++ b/src/assets/sass/components/service-settings.scss
@@ -104,3 +104,7 @@
     margin-top: 0.3em;
   }
 }
+
+.json-block {
+  overflow: scroll
+}

--- a/src/views/simplified-account/settings/webhooks/event.njk
+++ b/src/views/simplified-account/settings/webhooks/event.njk
@@ -46,7 +46,7 @@
 
   {{ govukDetails({
     summaryText: title + " event body",
-    html: '<pre><code>' + event.resource | dump(4) + '</code></pre>'
+    html: '<pre class="json-block"><code>' + event.resource | dump(4) + '</code></pre>'
   }) }}
 
   <h2 class="govuk-heading-m">Delivery Attempts</h2>


### PR DESCRIPTION
### WHAT

When showing the JSON dump of a webhook event the `<pre><code>` block can distort the usual layout because it is too wide.

This has been resolved by adding using css `overflow: scroll`

### SCREENS

#### BEFORE
<img width="562" alt="Screenshot 2025-03-26 at 09 25 44" src="https://github.com/user-attachments/assets/dc4e94d1-6106-4de1-9152-73a244295530" />

#### AFTER
<img width="562" alt="Screenshot 2025-03-26 at 09 25 05" src="https://github.com/user-attachments/assets/8e8ba8d0-2939-4522-a2d1-9bfa64d381a2" />
