### PR TITLE
PP-13829 Redirect to simplified settings index page from old settings

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -600,7 +600,7 @@
         "filename": "test/cypress/integration/settings/your-psp.cy.js",
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_verified": false,
-        "line_number": 486
+        "line_number": 487
       }
     ],
     "test/cypress/integration/switch-psp/organisation-url.cy.js": [
@@ -609,7 +609,7 @@
         "filename": "test/cypress/integration/switch-psp/organisation-url.cy.js",
         "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
         "is_verified": false,
-        "line_number": 9
+        "line_number": 10
       }
     ],
     "test/cypress/integration/transactions/transaction-details.cy.js": [
@@ -899,5 +899,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-21T11:50:40Z"
+  "generated_at": "2025-03-27T16:09:13Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -609,7 +609,7 @@
         "filename": "test/cypress/integration/switch-psp/organisation-url.cy.js",
         "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
         "is_verified": false,
-        "line_number": 10
+        "line_number": 9
       }
     ],
     "test/cypress/integration/transactions/transaction-details.cy.js": [
@@ -899,5 +899,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-27T16:09:13Z"
+  "generated_at": "2025-03-27T16:13:03Z"
 }

--- a/src/middleware/simplified-account/simplified-settings-redirect.middleware.js
+++ b/src/middleware/simplified-account/simplified-settings-redirect.middleware.js
@@ -1,7 +1,7 @@
 const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/format')
 const paths = require('@root/paths')
 const gatewayAccountsService = require('@services/gateway-accounts.service')
-const logger = require('@utils/logger')(__filename)
+const logger = require('@utils/logger')('simplified-settings-redirect.middleware.js')
 
 module.exports = async (req, res, next) => {
   if (!req.user?.isDegatewayed()) {
@@ -14,12 +14,19 @@ module.exports = async (req, res, next) => {
   }
 
   if (req.account) {
+    logger.info('Redirecting to simplified settings using account specified in URL')
     return res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.index, req.service.externalId, req.account.type))
   }
 
   const liveAccountExists = await (gatewayAccountsService.getGatewayAccountByServiceExternalIdAndType(req.service.externalId, 'live')
     .then(() => true)
     .catch(() => false))
+
+  if (liveAccountExists) {
+    logger.info('Live account exists for service. Redirecting to simplified settings for "live" account type')
+  } else {
+    logger.info('No ive account exists for service. Redirecting to simplified settings for "test" account type')
+  }
 
   return res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.index, req.service.externalId, liveAccountExists ? 'live' : 'test'))
 }

--- a/src/middleware/simplified-account/simplified-settings-redirect.middleware.js
+++ b/src/middleware/simplified-account/simplified-settings-redirect.middleware.js
@@ -1,0 +1,25 @@
+const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/format')
+const paths = require('@root/paths')
+const gatewayAccountsService = require('@services/gateway-accounts.service')
+const logger = require('@utils/logger')(__filename)
+
+module.exports = async (req, res, next) => {
+  if (!req.user?.isDegatewayed()) {
+    return next()
+  }
+
+  if (!req.service) {
+    logger.warn('Simplified settings redirect middleware used on route with no service. Skipping redirect')
+    return next()
+  }
+
+  if (req.account) {
+    return res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.index, req.service.externalId, req.account.type))
+  }
+
+  const liveAccountExists = await (gatewayAccountsService.getGatewayAccountByServiceExternalIdAndType(req.service.externalId, 'live')
+    .then(() => true)
+    .catch(() => false))
+
+  return res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.index, req.service.externalId, liveAccountExists ? 'live' : 'test'))
+}

--- a/src/middleware/simplified-account/simplified-settings-redirect.middleware.js
+++ b/src/middleware/simplified-account/simplified-settings-redirect.middleware.js
@@ -25,7 +25,7 @@ module.exports = async (req, res, next) => {
   if (liveAccountExists) {
     logger.info('Live account exists for service. Redirecting to simplified settings for "live" account type')
   } else {
-    logger.info('No ive account exists for service. Redirecting to simplified settings for "test" account type')
+    logger.info('No live account exists for service. Redirecting to simplified settings for "test" account type')
   }
 
   return res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.index, req.service.externalId, liveAccountExists ? 'live' : 'test'))

--- a/src/routes.js
+++ b/src/routes.js
@@ -22,6 +22,7 @@ const restrictToStripeAccountContext = require('./middleware/stripe-setup/restri
 const restrictToSwitchingAccount = require('./middleware/restrict-to-switching-account')
 const uploadGovernmentEntityDocument = require('./middleware/multer-middleware')
 const inviteCookieIsPresent = require('./middleware/invite-cookie-is-present')
+const simplifiedSettingsRedirect = require('./middleware/simplified-account/simplified-settings-redirect.middleware')
 
 // Controllers
 const staticController = require('./controllers/static.controller')
@@ -277,24 +278,24 @@ module.exports.bind = function (app) {
   // --------------------
 
   // Edit service name
-  service.get(editServiceName.index, permission('service-name:update'), editServiceNameController.get)
-  service.post(editServiceName.update, permission('service-name:update'), editServiceNameController.post)
+  service.get(editServiceName.index, simplifiedSettingsRedirect, permission('service-name:update'), editServiceNameController.get)
+  service.post(editServiceName.update, simplifiedSettingsRedirect, permission('service-name:update'), editServiceNameController.post)
 
   // Team members
-  service.get(teamMembers.index, serviceUsersController.index)
-  service.get(teamMembers.show, permission('users-service:read'), serviceUsersController.show)
-  service.get(teamMembers.permissions, permission('users-service:create'), serviceRolesUpdateController.index)
-  service.post(teamMembers.permissions, permission('users-service:create'), serviceRolesUpdateController.update)
-  service.post(teamMembers.delete, permission('users-service:delete'), serviceUsersController.remove)
+  service.get(teamMembers.index, simplifiedSettingsRedirect, serviceUsersController.index)
+  service.get(teamMembers.show, simplifiedSettingsRedirect, permission('users-service:read'), serviceUsersController.show)
+  service.get(teamMembers.permissions, simplifiedSettingsRedirect, permission('users-service:create'), serviceRolesUpdateController.index)
+  service.post(teamMembers.permissions, simplifiedSettingsRedirect, permission('users-service:create'), serviceRolesUpdateController.update)
+  service.post(teamMembers.delete, simplifiedSettingsRedirect, permission('users-service:delete'), serviceUsersController.remove)
 
   // Invite team member
-  service.get(teamMembers.invite, permission('users-service:create'), inviteUserController.index)
-  service.post(teamMembers.invite, permission('users-service:create'), inviteUserController.invite)
+  service.get(teamMembers.invite, simplifiedSettingsRedirect, permission('users-service:create'), inviteUserController.index)
+  service.post(teamMembers.invite, simplifiedSettingsRedirect, permission('users-service:create'), inviteUserController.invite)
 
   // Merchant details
-  service.get(organisationDetails.index, permission('merchant-details:read'), organisationDetailsController.showOrganisationDetails)
-  service.get(organisationDetails.edit, permission('merchant-details:update'), requestToGoLiveOrganisationAddressController.get)
-  service.post(organisationDetails.edit, permission('merchant-details:update'), requestToGoLiveOrganisationAddressController.post)
+  service.get(organisationDetails.index, simplifiedSettingsRedirect, permission('merchant-details:read'), organisationDetailsController.showOrganisationDetails)
+  service.get(organisationDetails.edit, simplifiedSettingsRedirect, permission('merchant-details:update'), requestToGoLiveOrganisationAddressController.get)
+  service.post(organisationDetails.edit, simplifiedSettingsRedirect, permission('merchant-details:update'), requestToGoLiveOrganisationAddressController.post)
 
   // Request to go live
   service.get(requestToGoLive.index, permission('go-live-stage:read'), requestToGoLiveIndexController.get)
@@ -331,73 +332,73 @@ module.exports.bind = function (app) {
   account.post(transactions.refund, permission('refunds:create'), transactionRefundController)
 
   // Settings
-  account.get(settings.index, permission('transactions-details:read'), settingsController.index)
+  account.get(settings.index, simplifiedSettingsRedirect, permission('transactions-details:read'), settingsController.index)
 
   // Your PSP
-  account.get(yourPsp.index, permission('gateway-credentials:read'), yourPspController.getIndex)
-  account.get([yourPsp.flex, switchPSP.flex], permission('gateway-credentials:update'), yourPspController.getFlex)
-  account.post([yourPsp.flex, switchPSP.flex], permission('gateway-credentials:update'), yourPspController.postFlex)
+  account.get(yourPsp.index, simplifiedSettingsRedirect, permission('gateway-credentials:read'), yourPspController.getIndex)
+  account.get([yourPsp.flex, switchPSP.flex], simplifiedSettingsRedirect, permission('gateway-credentials:update'), yourPspController.getFlex)
+  account.post([yourPsp.flex, switchPSP.flex], simplifiedSettingsRedirect, permission('gateway-credentials:update'), yourPspController.postFlex)
 
-  account.get(switchPSP.index, restrictToSwitchingAccount, permission('gateway-credentials:update'), switchPSPController.switchPSPPage)
-  account.post(switchPSP.index, restrictToSwitchingAccount, permission('gateway-credentials:update'), switchPSPController.submitSwitchPSP)
-  account.get(switchPSP.verifyPSPIntegrationPayment, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.verifyPSPIntegrationPaymentPage)
-  account.post(switchPSP.verifyPSPIntegrationPayment, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.startPaymentJourney)
-  account.get(switchPSP.receiveVerifyPSPIntegrationPayment, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.completePaymentJourney)
+  account.get(switchPSP.index, restrictToSwitchingAccount, simplifiedSettingsRedirect, permission('gateway-credentials:update'), switchPSPController.switchPSPPage)
+  account.post(switchPSP.index, restrictToSwitchingAccount, simplifiedSettingsRedirect, permission('gateway-credentials:update'), switchPSPController.submitSwitchPSP)
+  account.get(switchPSP.verifyPSPIntegrationPayment, simplifiedSettingsRedirect, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.verifyPSPIntegrationPaymentPage)
+  account.post(switchPSP.verifyPSPIntegrationPayment, simplifiedSettingsRedirect, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.startPaymentJourney)
+  account.get(switchPSP.receiveVerifyPSPIntegrationPayment, simplifiedSettingsRedirect, restrictToSwitchingAccount, permission('gateway-credentials:update'), verifyPSPIntegrationController.completePaymentJourney)
 
   // Credentials
-  account.get(yourPsp.worldpayCredentialsWithGatewayCheck, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)
-  account.post(yourPsp.worldpayCredentialsWithGatewayCheck, permission('gateway-credentials:read'), worldpayCredentialsController.updateWorldpayCredentials)
-  account.get(switchPSP.credentialsWithGatewayCheck, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)
-  account.post(switchPSP.credentialsWithGatewayCheck, permission('gateway-credentials:read'), worldpayCredentialsController.updateWorldpayCredentials)
+  account.get(yourPsp.worldpayCredentialsWithGatewayCheck, simplifiedSettingsRedirect, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)
+  account.post(yourPsp.worldpayCredentialsWithGatewayCheck, simplifiedSettingsRedirect, permission('gateway-credentials:read'), worldpayCredentialsController.updateWorldpayCredentials)
+  account.get(switchPSP.credentialsWithGatewayCheck, simplifiedSettingsRedirect, permission('gateway-credentials:read'), worldpayCredentialsController.showWorldpayCredentialsPage)
+  account.post(switchPSP.credentialsWithGatewayCheck, simplifiedSettingsRedirect, permission('gateway-credentials:read'), worldpayCredentialsController.updateWorldpayCredentials)
 
-  account.get(credentials.edit, permission('gateway-credentials:update'), credentialsController.editCredentials)
-  account.post(credentials.index, permission('gateway-credentials:update'), credentialsController.update)
-  account.get(notificationCredentials.edit, permission('gateway-credentials:update'), credentialsController.editNotificationCredentials)
-  account.post(notificationCredentials.update, permission('gateway-credentials:update'), credentialsController.updateNotificationCredentials)
+  account.get(credentials.edit, simplifiedSettingsRedirect, permission('gateway-credentials:update'), credentialsController.editCredentials)
+  account.post(credentials.index, simplifiedSettingsRedirect, permission('gateway-credentials:update'), credentialsController.update)
+  account.get(notificationCredentials.edit, simplifiedSettingsRedirect, permission('gateway-credentials:update'), credentialsController.editNotificationCredentials)
+  account.post(notificationCredentials.update, simplifiedSettingsRedirect, permission('gateway-credentials:update'), credentialsController.updateNotificationCredentials)
 
   // API keys
-  account.get(apiKeys.index, permission('tokens-active:read'), apiKeysController.getIndex)
-  account.get(apiKeys.revoked, permission('tokens-revoked:read'), apiKeysController.getRevoked)
-  account.get(apiKeys.create, permission('tokens:create'), apiKeysController.getCreate)
-  account.post(apiKeys.create, permission('tokens:create'), apiKeysController.postCreate)
-  account.post(apiKeys.revoke, permission('tokens:delete'), apiKeysController.postRevoke)
-  account.post(apiKeys.update, permission('tokens:update'), apiKeysController.postUpdate)
+  account.get(apiKeys.index, simplifiedSettingsRedirect, permission('tokens-active:read'), apiKeysController.getIndex)
+  account.get(apiKeys.revoked, simplifiedSettingsRedirect, permission('tokens-revoked:read'), apiKeysController.getRevoked)
+  account.get(apiKeys.create, simplifiedSettingsRedirect, permission('tokens:create'), apiKeysController.getCreate)
+  account.post(apiKeys.create, simplifiedSettingsRedirect, permission('tokens:create'), apiKeysController.postCreate)
+  account.post(apiKeys.revoke, simplifiedSettingsRedirect, permission('tokens:delete'), apiKeysController.postRevoke)
+  account.post(apiKeys.update, simplifiedSettingsRedirect, permission('tokens:update'), apiKeysController.postUpdate)
 
   // Payment types
-  account.get(paymentTypes.index, permission('payment-types:read'), paymentTypesController.getIndex)
-  account.post(paymentTypes.index, permission('payment-types:update'), paymentTypesController.postIndex)
+  account.get(paymentTypes.index, simplifiedSettingsRedirect, permission('payment-types:read'), paymentTypesController.getIndex)
+  account.post(paymentTypes.index, simplifiedSettingsRedirect, permission('payment-types:update'), paymentTypesController.postIndex)
 
   // Digital wallet
-  account.get(digitalWallet.applePay, permission('payment-types:update'), digitalWalletController.getApplePay)
-  account.post(digitalWallet.applePay, permission('payment-types:update'), digitalWalletController.postApplePay)
-  account.get(digitalWallet.googlePay, permission('payment-types:update'), digitalWalletController.getGooglePay)
-  account.post(digitalWallet.googlePay, permission('payment-types:update'), digitalWalletController.postGooglePay)
+  account.get(digitalWallet.applePay, simplifiedSettingsRedirect, permission('payment-types:update'), digitalWalletController.getApplePay)
+  account.post(digitalWallet.applePay, simplifiedSettingsRedirect, permission('payment-types:update'), digitalWalletController.postApplePay)
+  account.get(digitalWallet.googlePay, simplifiedSettingsRedirect, permission('payment-types:update'), digitalWalletController.getGooglePay)
+  account.post(digitalWallet.googlePay, simplifiedSettingsRedirect, permission('payment-types:update'), digitalWalletController.postGooglePay)
 
   // Email notifications
-  account.get(emailNotifications.index, permission('email-notification-template:read'), emailNotificationsController.showConfirmationEmailTemplate)
-  account.get(emailNotifications.indexRefundTabEnabled, permission('email-notification-template:read'), emailNotificationsController.showRefundEmailTemplate)
-  account.get(emailNotifications.edit, permission('email-notification-paragraph:update'), emailNotificationsController.editCustomParagraph)
-  account.post(emailNotifications.confirm, permission('email-notification-paragraph:update'), emailNotificationsController.confirmCustomParagraph)
-  account.post(emailNotifications.update, permission('email-notification-paragraph:update'), emailNotificationsController.updateCustomParagraph)
-  account.get(emailNotifications.collection, permission('email-notification-template:read'), emailNotificationsController.collectionEmailIndex)
-  account.post(emailNotifications.collection, permission('email-notification-toggle:update'), emailNotificationsController.collectionEmailUpdate)
-  account.get(emailNotifications.confirmation, permission('email-notification-template:read'), emailNotificationsController.confirmationEmailIndex)
-  account.post(emailNotifications.confirmation, permission('email-notification-toggle:update'), emailNotificationsController.confirmationEmailUpdate)
-  account.post(emailNotifications.off, permission('email-notification-toggle:update'), emailNotificationsController.confirmationEmailOff)
-  account.get(emailNotifications.refund, permission('email-notification-template:read'), emailNotificationsController.refundEmailIndex)
-  account.post(emailNotifications.refund, permission('email-notification-toggle:update'), emailNotificationsController.refundEmailUpdate)
+  account.get(emailNotifications.index, simplifiedSettingsRedirect, permission('email-notification-template:read'), emailNotificationsController.showConfirmationEmailTemplate)
+  account.get(emailNotifications.indexRefundTabEnabled, simplifiedSettingsRedirect, permission('email-notification-template:read'), emailNotificationsController.showRefundEmailTemplate)
+  account.get(emailNotifications.edit, simplifiedSettingsRedirect, permission('email-notification-paragraph:update'), emailNotificationsController.editCustomParagraph)
+  account.post(emailNotifications.confirm, simplifiedSettingsRedirect, permission('email-notification-paragraph:update'), emailNotificationsController.confirmCustomParagraph)
+  account.post(emailNotifications.update, simplifiedSettingsRedirect, permission('email-notification-paragraph:update'), emailNotificationsController.updateCustomParagraph)
+  account.get(emailNotifications.collection, simplifiedSettingsRedirect, permission('email-notification-template:read'), emailNotificationsController.collectionEmailIndex)
+  account.post(emailNotifications.collection, simplifiedSettingsRedirect, permission('email-notification-toggle:update'), emailNotificationsController.collectionEmailUpdate)
+  account.get(emailNotifications.confirmation, simplifiedSettingsRedirect, permission('email-notification-template:read'), emailNotificationsController.confirmationEmailIndex)
+  account.post(emailNotifications.confirmation, simplifiedSettingsRedirect, permission('email-notification-toggle:update'), emailNotificationsController.confirmationEmailUpdate)
+  account.post(emailNotifications.off, simplifiedSettingsRedirect, permission('email-notification-toggle:update'), emailNotificationsController.confirmationEmailOff)
+  account.get(emailNotifications.refund, simplifiedSettingsRedirect, permission('email-notification-template:read'), emailNotificationsController.refundEmailIndex)
+  account.post(emailNotifications.refund, simplifiedSettingsRedirect, permission('email-notification-toggle:update'), emailNotificationsController.refundEmailUpdate)
 
   // MOTO mask card number & security code
-  account.get(toggleMotoMaskCardNumberAndSecurityCode.cardNumber, permission('moto-mask-input:read'), toggleMotoMaskCardNumber.get)
-  account.post(toggleMotoMaskCardNumberAndSecurityCode.cardNumber, permission('moto-mask-input:update'), toggleMotoMaskCardNumber.post)
-  account.get(toggleMotoMaskCardNumberAndSecurityCode.securityCode, permission('moto-mask-input:read'), toggleMotoMaskSecurityCode.get)
-  account.post(toggleMotoMaskCardNumberAndSecurityCode.securityCode, permission('moto-mask-input:update'), toggleMotoMaskSecurityCode.post)
+  account.get(toggleMotoMaskCardNumberAndSecurityCode.cardNumber, simplifiedSettingsRedirect, permission('moto-mask-input:read'), toggleMotoMaskCardNumber.get)
+  account.post(toggleMotoMaskCardNumberAndSecurityCode.cardNumber, simplifiedSettingsRedirect, permission('moto-mask-input:update'), toggleMotoMaskCardNumber.post)
+  account.get(toggleMotoMaskCardNumberAndSecurityCode.securityCode, simplifiedSettingsRedirect, permission('moto-mask-input:read'), toggleMotoMaskSecurityCode.get)
+  account.post(toggleMotoMaskCardNumberAndSecurityCode.securityCode, simplifiedSettingsRedirect, permission('moto-mask-input:update'), toggleMotoMaskSecurityCode.post)
 
-  account.get(toggleBillingAddress.index, permission('toggle-billing-address:read'), toggleBillingAddressController.getIndex)
-  account.post(toggleBillingAddress.index, permission('toggle-billing-address:update'), toggleBillingAddressController.postIndex)
+  account.get(toggleBillingAddress.index, simplifiedSettingsRedirect, permission('toggle-billing-address:read'), toggleBillingAddressController.getIndex)
+  account.post(toggleBillingAddress.index, simplifiedSettingsRedirect, permission('toggle-billing-address:update'), toggleBillingAddressController.postIndex)
 
-  account.get(defaultBillingAddressCountry.index, permission('toggle-billing-address:read'), defaultBillingAddressCountryController.showDefaultBillingAddressCountry)
-  account.post(defaultBillingAddressCountry.index, permission('toggle-billing-address:update'), defaultBillingAddressCountryController.updateDefaultBillingAddressCountry)
+  account.get(defaultBillingAddressCountry.index, simplifiedSettingsRedirect, permission('toggle-billing-address:read'), defaultBillingAddressCountryController.showDefaultBillingAddressCountry)
+  account.post(defaultBillingAddressCountry.index, simplifiedSettingsRedirect, permission('toggle-billing-address:update'), defaultBillingAddressCountryController.updateDefaultBillingAddressCountry)
 
   // Prototype links
   account.get(prototyping.demoService.index, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.index)
@@ -454,22 +455,22 @@ module.exports.bind = function (app) {
   account.post(switchPSP.organisationUrl, permission('merchant-details:update'), restrictToStripeAccountContext, organisationUrlController.post)
 
   // Stripe setup
-  account.get([yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails], permission('stripe-bank-details:update'), restrictToStripeAccountContext, stripeSetupBankDetailsController.get)
-  account.post([yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails], permission('stripe-bank-details:update'), restrictToStripeAccountContext, stripeSetupBankDetailsController.post)
-  account.get([yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson], permission('stripe-responsible-person:update'), restrictToStripeAccountContext, stripeSetupResponsiblePersonController.get)
-  account.post([yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson], permission('stripe-responsible-person:update'), restrictToStripeAccountContext, stripeSetupResponsiblePersonController.post)
-  account.get([yourPsp.stripeSetup.director, switchPSP.stripeSetup.director], permission('stripe-director:update'), restrictToStripeAccountContext, stripeSetupDirectorController.get)
-  account.post([yourPsp.stripeSetup.director, switchPSP.stripeSetup.director], permission('stripe-director:update'), restrictToStripeAccountContext, stripeSetupDirectorController.post)
-  account.get([yourPsp.stripeSetup.vatNumber, switchPSP.stripeSetup.vatNumber], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupVatNumberController.get)
-  account.post([yourPsp.stripeSetup.vatNumber, switchPSP.stripeSetup.vatNumber], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupVatNumberController.post)
-  account.get([yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.get)
-  account.post([yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber], permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.post)
-  account.get([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument], permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, stripeSetupGovernmentEntityDocument.get)
-  account.post([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument], permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, uploadGovernmentEntityDocument, stripeSetupGovernmentEntityDocument.post)
-  account.get([yourPsp.stripeSetup.checkOrgDetails, switchPSP.stripeSetup.checkOrgDetails], permission('stripe-organisation-details:update'), restrictToStripeAccountContext, stripeSetupCheckOrgDetailsController.get)
-  account.post([yourPsp.stripeSetup.checkOrgDetails, switchPSP.stripeSetup.checkOrgDetails], permission('stripe-organisation-details:update'), restrictToStripeAccountContext, stripeSetupCheckOrgDetailsController.post)
-  account.get([yourPsp.stripeSetup.updateOrgDetails, switchPSP.stripeSetup.updateOrgDetails], permission('stripe-organisation-details:update'), restrictToStripeAccountContext, requestToGoLiveOrganisationAddressController.get)
-  account.post([yourPsp.stripeSetup.updateOrgDetails, switchPSP.stripeSetup.updateOrgDetails], permission('stripe-organisation-details:update'), restrictToStripeAccountContext, requestToGoLiveOrganisationAddressController.post)
+  account.get([yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails], simplifiedSettingsRedirect, permission('stripe-bank-details:update'), restrictToStripeAccountContext, stripeSetupBankDetailsController.get)
+  account.post([yourPsp.stripeSetup.bankDetails, switchPSP.stripeSetup.bankDetails], simplifiedSettingsRedirect, permission('stripe-bank-details:update'), restrictToStripeAccountContext, stripeSetupBankDetailsController.post)
+  account.get([yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson], simplifiedSettingsRedirect, permission('stripe-responsible-person:update'), restrictToStripeAccountContext, stripeSetupResponsiblePersonController.get)
+  account.post([yourPsp.stripeSetup.responsiblePerson, switchPSP.stripeSetup.responsiblePerson], simplifiedSettingsRedirect, permission('stripe-responsible-person:update'), restrictToStripeAccountContext, stripeSetupResponsiblePersonController.post)
+  account.get([yourPsp.stripeSetup.director, switchPSP.stripeSetup.director], simplifiedSettingsRedirect, permission('stripe-director:update'), restrictToStripeAccountContext, stripeSetupDirectorController.get)
+  account.post([yourPsp.stripeSetup.director, switchPSP.stripeSetup.director], simplifiedSettingsRedirect, permission('stripe-director:update'), restrictToStripeAccountContext, stripeSetupDirectorController.post)
+  account.get([yourPsp.stripeSetup.vatNumber, switchPSP.stripeSetup.vatNumber], simplifiedSettingsRedirect, permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupVatNumberController.get)
+  account.post([yourPsp.stripeSetup.vatNumber, switchPSP.stripeSetup.vatNumber], simplifiedSettingsRedirect, permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupVatNumberController.post)
+  account.get([yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber], simplifiedSettingsRedirect, permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.get)
+  account.post([yourPsp.stripeSetup.companyNumber, switchPSP.stripeSetup.companyNumber], simplifiedSettingsRedirect, permission('stripe-vat-number-company-number:update'), restrictToStripeAccountContext, stripeSetupCompanyNumberController.post)
+  account.get([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument], simplifiedSettingsRedirect, permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, stripeSetupGovernmentEntityDocument.get)
+  account.post([yourPsp.stripeSetup.governmentEntityDocument, switchPSP.stripeSetup.governmentEntityDocument], simplifiedSettingsRedirect, permission('stripe-government-entity-document:update'), restrictToStripeAccountContext, uploadGovernmentEntityDocument, stripeSetupGovernmentEntityDocument.post)
+  account.get([yourPsp.stripeSetup.checkOrgDetails, switchPSP.stripeSetup.checkOrgDetails], simplifiedSettingsRedirect, permission('stripe-organisation-details:update'), restrictToStripeAccountContext, stripeSetupCheckOrgDetailsController.get)
+  account.post([yourPsp.stripeSetup.checkOrgDetails, switchPSP.stripeSetup.checkOrgDetails], simplifiedSettingsRedirect, permission('stripe-organisation-details:update'), restrictToStripeAccountContext, stripeSetupCheckOrgDetailsController.post)
+  account.get([yourPsp.stripeSetup.updateOrgDetails, switchPSP.stripeSetup.updateOrgDetails], simplifiedSettingsRedirect, permission('stripe-organisation-details:update'), restrictToStripeAccountContext, requestToGoLiveOrganisationAddressController.get)
+  account.post([yourPsp.stripeSetup.updateOrgDetails, switchPSP.stripeSetup.updateOrgDetails], simplifiedSettingsRedirect, permission('stripe-organisation-details:update'), restrictToStripeAccountContext, requestToGoLiveOrganisationAddressController.post)
 
   account.get(stripe.addPspAccountDetails, permission('stripe-account-details:update'), restrictToStripeAccountContext, stripeSetupAddPspAccountDetailsController.get)
 
@@ -478,17 +479,17 @@ module.exports.bind = function (app) {
   futureAccountStrategy.post(agreements.cancel, permission('agreements:update'), agreementsController.cancelAgreement)
 
   // Webhook settings
-  futureAccountStrategy.get(webhooks.index, permission('webhooks:read'), webhooksController.listWebhooksPage)
-  futureAccountStrategy.get(webhooks.create, permission('webhooks:update'), webhooksController.createWebhookPage)
-  futureAccountStrategy.post(webhooks.create, permission('webhooks:update'), webhooksController.createWebhook)
-  futureAccountStrategy.get(webhooks.update, permission('webhooks:update'), webhooksController.updateWebhookPage)
-  futureAccountStrategy.post(webhooks.update, permission('webhooks:update'), webhooksController.updateWebhook)
-  futureAccountStrategy.get(webhooks.detail, permission('webhooks:read'), webhooksController.webhookDetailPage)
-  futureAccountStrategy.get(webhooks.message, permission('webhooks:read'), webhooksController.webhookMessageDetailPage)
-  futureAccountStrategy.post(webhooks.resendMessage, permission('webhooks:update'), webhooksController.resendWebhookMessage)
-  futureAccountStrategy.get(webhooks.signingSecret, permission('webhooks:update'), webhooksController.signingSecretPage)
-  futureAccountStrategy.get(webhooks.toggleActive, permission('webhooks:update'), webhooksController.toggleActivePage)
-  futureAccountStrategy.post(webhooks.toggleActive, permission('webhooks:update'), webhooksController.toggleActiveWebhook)
+  futureAccountStrategy.get(webhooks.index, simplifiedSettingsRedirect, permission('webhooks:read'), webhooksController.listWebhooksPage)
+  futureAccountStrategy.get(webhooks.create, simplifiedSettingsRedirect, permission('webhooks:update'), webhooksController.createWebhookPage)
+  futureAccountStrategy.post(webhooks.create, simplifiedSettingsRedirect, permission('webhooks:update'), webhooksController.createWebhook)
+  futureAccountStrategy.get(webhooks.update, simplifiedSettingsRedirect, permission('webhooks:update'), webhooksController.updateWebhookPage)
+  futureAccountStrategy.post(webhooks.update, simplifiedSettingsRedirect, permission('webhooks:update'), webhooksController.updateWebhook)
+  futureAccountStrategy.get(webhooks.detail, simplifiedSettingsRedirect, permission('webhooks:read'), webhooksController.webhookDetailPage)
+  futureAccountStrategy.get(webhooks.message, simplifiedSettingsRedirect, permission('webhooks:read'), webhooksController.webhookMessageDetailPage)
+  futureAccountStrategy.post(webhooks.resendMessage, simplifiedSettingsRedirect, permission('webhooks:update'), webhooksController.resendWebhookMessage)
+  futureAccountStrategy.get(webhooks.signingSecret, simplifiedSettingsRedirect, permission('webhooks:update'), webhooksController.signingSecretPage)
+  futureAccountStrategy.get(webhooks.toggleActive, simplifiedSettingsRedirect, permission('webhooks:update'), webhooksController.toggleActivePage)
+  futureAccountStrategy.post(webhooks.toggleActive, simplifiedSettingsRedirect, permission('webhooks:update'), webhooksController.toggleActiveWebhook)
 
   app.use(paths.account.root, account)
   app.use(paths.service.root, service)

--- a/src/services/gateway-accounts.service.js
+++ b/src/services/gateway-accounts.service.js
@@ -14,7 +14,21 @@ async function getGatewayAccountsByIds (gatewayAccountIds) {
   }, {})
 }
 
+/**
+ *
+ * @param serviceExternalId
+ * @param accountType
+ * @returns {Promise<GatewayAccount>}
+ */
+async function getGatewayAccountByServiceExternalIdAndType (serviceExternalId, accountType) {
+  return connectorClient.getAccountByServiceExternalIdAndAccountType({
+    serviceExternalId,
+    accountType
+  })
+}
+
 module.exports = {
   getGatewayAccountsByIds,
+  getGatewayAccountByServiceExternalIdAndType,
   postSwitchPSP: connectorClient.postSwitchPSPByServiceExternalIdAndAccountType.bind(connectorClient)
 }

--- a/test/cypress/integration/demo-payment/mock-cards-stripe.cy.js
+++ b/test/cypress/integration/demo-payment/mock-cards-stripe.cy.js
@@ -38,15 +38,17 @@ describe('Show Mock cards screen for stripe accounts', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  it('should display stripe settings page correctly', () => {
-    setupYourPspStubs()
-    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-    cy.log('Continue to Make a demo payment page via Dashboard')
-    cy.get('a').contains('Dashboard').click()
-    cy.get('a').contains('Make a demo payment').click()
-    cy.log('Continue to Mock Cards page')
-    cy.get('a').contains('Continue').click()
-    cy.get('h1').should('have.text', 'Mock card numbers')
-    cy.get('p').contains(/^4000058260000005/)
+  describe.skip('with simplified settings disabled', () => {
+    it('should display stripe settings page correctly', () => {
+      setupYourPspStubs()
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+      cy.log('Continue to Make a demo payment page via Dashboard')
+      cy.get('a').contains('Dashboard').click()
+      cy.get('a').contains('Make a demo payment').click()
+      cy.log('Continue to Mock Cards page')
+      cy.get('a').contains('Continue').click()
+      cy.get('h1').should('have.text', 'Mock card numbers')
+      cy.get('p').contains(/^4000058260000005/)
+    })
   })
 })

--- a/test/cypress/integration/manage-team-members/edit-permissions.cy.js
+++ b/test/cypress/integration/manage-team-members/edit-permissions.cy.js
@@ -21,41 +21,43 @@ const userWeAreEditingStubOpts = {
 }
 
 describe('Edit service user permissions', () => {
-  it('should be able to update a team members permissions', () => {
-    cy.task('setupStubs', [
-      userStubs.getUserSuccess(authenticatedUserStubOpts),
-      userStubs.getUserSuccess(userWeAreEditingStubOpts),
-      userStubs.getServiceUsersSuccess({
-        serviceExternalId: SERVICE_EXTERNAL_ID,
-        users: [authenticatedUserStubOpts, userWeAreEditingStubOpts]
-      }),
-      inviteStubs.getInvitedUsersSuccess({ serviceExternalId: SERVICE_EXTERNAL_ID, invites: [] }),
-      userStubs.putUpdateServiceRoleSuccess({
-        serviceExternalId: SERVICE_EXTERNAL_ID,
-        userExternalId: EDITING_USER_ID,
-        role: 'view-and-refund'
-      })
-    ])
+  describe.skip('with simplified settings disabled', () => {
+    it('should be able to update a team members permissions', () => {
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess(authenticatedUserStubOpts),
+        userStubs.getUserSuccess(userWeAreEditingStubOpts),
+        userStubs.getServiceUsersSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          users: [authenticatedUserStubOpts, userWeAreEditingStubOpts]
+        }),
+        inviteStubs.getInvitedUsersSuccess({ serviceExternalId: SERVICE_EXTERNAL_ID, invites: [] }),
+        userStubs.putUpdateServiceRoleSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          userExternalId: EDITING_USER_ID,
+          role: 'view-and-refund'
+        })
+      ])
 
-    cy.setEncryptedCookies(AUTHENTICATED_USER_ID)
+      cy.setEncryptedCookies(AUTHENTICATED_USER_ID)
 
-    cy.visit(`/service/${SERVICE_EXTERNAL_ID}/team-members`)
+      cy.visit(`/service/${SERVICE_EXTERNAL_ID}/team-members`)
 
-    cy.get('#team-members-admin-list').find('tr').first().find('td').first().find('a').contains('logged-in-user@example.com (you)')
-    cy.get('#team-members-admin-list').find('tr').eq(1).find('td').first().find('a').contains('other-user@example.com')
+      cy.get('#team-members-admin-list').find('tr').first().find('td').first().find('a').contains('logged-in-user@example.com (you)')
+      cy.get('#team-members-admin-list').find('tr').eq(1).find('td').first().find('a').contains('other-user@example.com')
 
-    cy.get('a').contains('other-user@example.com').click()
+      cy.get('a').contains('other-user@example.com').click()
 
-    cy.get('h1').contains('Details for other-user@example.com')
-    cy.get('table').find('tr').first().find('td').first().contains('other-user@example.com')
-    cy.get('table').find('tr').eq(1).find('td').first().contains('Administrator')
-    cy.get('table').find('tr').eq(1).find('td').eq(1).find('a').contains('Edit permissions')
+      cy.get('h1').contains('Details for other-user@example.com')
+      cy.get('table').find('tr').first().find('td').first().contains('other-user@example.com')
+      cy.get('table').find('tr').eq(1).find('td').first().contains('Administrator')
+      cy.get('table').find('tr').eq(1).find('td').eq(1).find('a').contains('Edit permissions')
 
-    cy.get('a').contains('Edit permissions').click()
-    cy.get('#role-admin-input').should('exist').should('have.attr', 'checked')
+      cy.get('a').contains('Edit permissions').click()
+      cy.get('#role-admin-input').should('exist').should('have.attr', 'checked')
 
-    cy.get('#role-view-and-refund-input').click()
-    cy.get('button').contains('Save changes').click()
-    cy.get('.govuk-notification-banner--success').contains('Permissions have been updated')
+      cy.get('#role-view-and-refund-input').click()
+      cy.get('button').contains('Save changes').click()
+      cy.get('.govuk-notification-banner--success').contains('Permissions have been updated')
+    })
   })
 })

--- a/test/cypress/integration/manage-team-members/manage-team-members.cy.js
+++ b/test/cypress/integration/manage-team-members/manage-team-members.cy.js
@@ -7,52 +7,54 @@ const SERVICE_EXTERNAL_ID = 'service_abc_123'
 const AUTHENTICATED_USER_ID = 'authenticated-user-id'
 
 describe('Manage team members page', () => {
-  beforeEach(() => {
-    const authenticatedUserStubOpts = getUserWithServiceRoleStubOpts(AUTHENTICATED_USER_ID, 'logged-in-user@example.com', SERVICE_EXTERNAL_ID, 'admin')
-    const adminUserStubOpts = getUserWithServiceRoleStubOpts('admin-user-id', 'admin-user@example.com', SERVICE_EXTERNAL_ID, 'admin')
-    const viewOnlyUserStubOpts = getUserWithServiceRoleStubOpts('view-only-user-id', 'view-only-user@example.com', SERVICE_EXTERNAL_ID, 'view-only')
-    const viewAndRefundUserStubOpts = getUserWithServiceRoleStubOpts('view-and-refund-user-id', 'view-and-refund-user@example.com', SERVICE_EXTERNAL_ID, 'view-and-refund')
+  describe.skip('with simplified settings disabled', () => {
+    beforeEach(() => {
+      const authenticatedUserStubOpts = getUserWithServiceRoleStubOpts(AUTHENTICATED_USER_ID, 'logged-in-user@example.com', SERVICE_EXTERNAL_ID, 'admin')
+      const adminUserStubOpts = getUserWithServiceRoleStubOpts('admin-user-id', 'admin-user@example.com', SERVICE_EXTERNAL_ID, 'admin')
+      const viewOnlyUserStubOpts = getUserWithServiceRoleStubOpts('view-only-user-id', 'view-only-user@example.com', SERVICE_EXTERNAL_ID, 'view-only')
+      const viewAndRefundUserStubOpts = getUserWithServiceRoleStubOpts('view-and-refund-user-id', 'view-and-refund-user@example.com', SERVICE_EXTERNAL_ID, 'view-and-refund')
 
-    const invites = [
-      {
-        email: 'invited-admin-user@example.com',
-        role: 'admin'
-      },
-      {
-        email: 'invited-view-only-user@example.com',
-        role: 'view-only'
-      },
-      {
-        email: 'invited-view-and-refund-user@example.com',
-        role: 'view-and-refund'
-      }
-    ]
+      const invites = [
+        {
+          email: 'invited-admin-user@example.com',
+          role: 'admin'
+        },
+        {
+          email: 'invited-view-only-user@example.com',
+          role: 'view-only'
+        },
+        {
+          email: 'invited-view-and-refund-user@example.com',
+          role: 'view-and-refund'
+        }
+      ]
 
-    cy.task('setupStubs', [
-      getUserSuccess(authenticatedUserStubOpts),
-      getServiceUsersSuccess({
-        serviceExternalId: SERVICE_EXTERNAL_ID,
-        users: [authenticatedUserStubOpts, adminUserStubOpts, viewOnlyUserStubOpts, viewAndRefundUserStubOpts]
-      }),
-      inviteStubs.getInvitedUsersSuccess({
-        serviceExternalId: SERVICE_EXTERNAL_ID,
-        invites
-      })
-    ])
-  })
+      cy.task('setupStubs', [
+        getUserSuccess(authenticatedUserStubOpts),
+        getServiceUsersSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          users: [authenticatedUserStubOpts, adminUserStubOpts, viewOnlyUserStubOpts, viewAndRefundUserStubOpts]
+        }),
+        inviteStubs.getInvitedUsersSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          invites
+        })
+      ])
+    })
 
-  it('should display the manage team members page with users in correct categories', () => {
-    cy.setEncryptedCookies(AUTHENTICATED_USER_ID)
+    it('should display the manage team members page with users in correct categories', () => {
+      cy.setEncryptedCookies(AUTHENTICATED_USER_ID)
 
-    cy.visit(`/service/${SERVICE_EXTERNAL_ID}/team-members`)
+      cy.visit(`/service/${SERVICE_EXTERNAL_ID}/team-members`)
 
-    cy.get('#team-members-admin-list').find('tr').first().find('td').first().find('a').contains('logged-in-user@example.com (you)')
-    cy.get('#team-members-admin-list').find('tr').eq(1).find('td').first().find('a').contains('admin-user@example.com')
-    cy.get('#team-members-view-and-refund-list').find('tr').first().find('td').first().find('a').contains('view-and-refund-user@example.com')
-    cy.get('#team-members-view-only-list').find('tr').first().find('td').first().find('a').contains('view-only-user@example.com')
+      cy.get('#team-members-admin-list').find('tr').first().find('td').first().find('a').contains('logged-in-user@example.com (you)')
+      cy.get('#team-members-admin-list').find('tr').eq(1).find('td').first().find('a').contains('admin-user@example.com')
+      cy.get('#team-members-view-and-refund-list').find('tr').first().find('td').first().find('a').contains('view-and-refund-user@example.com')
+      cy.get('#team-members-view-only-list').find('tr').first().find('td').first().find('a').contains('view-only-user@example.com')
 
-    cy.get('#invited-team-members-admin-list').find('tr').first().find('td').contains('invited-admin-user@example.com')
-    cy.get('#invited-team-members-view-and-refund-list').find('tr').first().find('td').contains('invited-view-and-refund-user@example.com')
-    cy.get('#invited-team-members-view-only-list').find('tr').first().find('td').contains('invited-view-only-user@example.com')
+      cy.get('#invited-team-members-admin-list').find('tr').first().find('td').contains('invited-admin-user@example.com')
+      cy.get('#invited-team-members-view-and-refund-list').find('tr').first().find('td').contains('invited-view-and-refund-user@example.com')
+      cy.get('#invited-team-members-view-only-list').find('tr').first().find('td').contains('invited-view-only-user@example.com')
+    })
   })
 })

--- a/test/cypress/integration/settings/allow-apple-pay.cy.js
+++ b/test/cypress/integration/settings/allow-apple-pay.cy.js
@@ -24,46 +24,48 @@ describe('Apple Pay', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  it.skip('should show it is disabled', () => {
-    setupStubs(false)
+  describe.skip('with simplified settings disabled', () => {
+    it.skip('should show it is disabled', () => {
+      setupStubs(false)
 
-    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-    cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
-    cy.get('a').contains('Change Apple Pay settings').click()
-    cy.get('input[type="radio"]').should('have.length', 2)
-    cy.get('input[value="on"]').should('not.be.checked')
-    cy.get('input[value="off"]').should('be.checked')
-    cy.contains('.govuk-service-navigation__item--active', 'Settings').click()
-    cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
-  })
-
-  it.skip('should show it is enabled', () => {
-    setupStubs(true)
-
-    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-    cy.get('.govuk-summary-list__value').first().should('contain', 'On')
-    cy.get('a').contains('Change Apple Pay settings').click()
-    cy.get('input[type="radio"]').should('have.length', 2)
-    cy.get('input[value="on"]').should('be.checked')
-    cy.get('input[value="off"]').should('not.be.checked')
-    cy.contains('.govuk-service-navigation__item--active', 'Settings').click()
-    cy.get('.govuk-summary-list__value').first().should('contain', 'On')
-  })
-
-  it('should allow us to enable', () => {
-    setupStubs(false)
-
-    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-    cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
-    cy.get('a').contains('Change Apple Pay settings').click()
-
-    cy.get('input[value="on"]').click()
-    cy.get('input[value="on"]').should('be.checked')
-    cy.get('.govuk-button').contains('Save changes').click()
-
-    cy.location().should((location) => {
-      expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+      cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
+      cy.get('a').contains('Change Apple Pay settings').click()
+      cy.get('input[type="radio"]').should('have.length', 2)
+      cy.get('input[value="on"]').should('not.be.checked')
+      cy.get('input[value="off"]').should('be.checked')
+      cy.contains('.govuk-service-navigation__item--active', 'Settings').click()
+      cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
     })
-    cy.get('.govuk-notification-banner--success').should('contain', 'Apple Pay successfully enabled')
+
+    it.skip('should show it is enabled', () => {
+      setupStubs(true)
+
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+      cy.get('.govuk-summary-list__value').first().should('contain', 'On')
+      cy.get('a').contains('Change Apple Pay settings').click()
+      cy.get('input[type="radio"]').should('have.length', 2)
+      cy.get('input[value="on"]').should('be.checked')
+      cy.get('input[value="off"]').should('not.be.checked')
+      cy.contains('.govuk-service-navigation__item--active', 'Settings').click()
+      cy.get('.govuk-summary-list__value').first().should('contain', 'On')
+    })
+
+    it('should allow us to enable', () => {
+      setupStubs(false)
+
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+      cy.get('.govuk-summary-list__value').first().should('contain', 'Off')
+      cy.get('a').contains('Change Apple Pay settings').click()
+
+      cy.get('input[value="on"]').click()
+      cy.get('input[value="on"]').should('be.checked')
+      cy.get('.govuk-button').contains('Save changes').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
+      })
+      cy.get('.govuk-notification-banner--success').should('contain', 'Apple Pay successfully enabled')
+    })
   })
 })

--- a/test/cypress/integration/settings/allow-google-pay.cy.js
+++ b/test/cypress/integration/settings/allow-google-pay.cy.js
@@ -28,107 +28,109 @@ describe('Google Pay', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  it('should allow us to enable and requires a gateway merchant ID for a Worldpay account', () => {
-    cy.task('setupStubs', [
-      ...getUserAndAccountStubs(false),
-      gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, credentialId, userExternalId, {
-        path: 'credentials/gateway_merchant_id',
-        value: '111111111111111'
-      }),
-      gatewayAccountStubs.patchAccountUpdateGooglePaySuccess(gatewayAccountId, true)
-    ])
+  describe.skip('with simplified settings disabled', () => {
+    it('should allow us to enable and requires a gateway merchant ID for a Worldpay account', () => {
+      cy.task('setupStubs', [
+        ...getUserAndAccountStubs(false),
+        gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, credentialId, userExternalId, {
+          path: 'credentials/gateway_merchant_id',
+          value: '111111111111111'
+        }),
+        gatewayAccountStubs.patchAccountUpdateGooglePaySuccess(gatewayAccountId, true)
+      ])
 
-    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-    cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
-    cy.get('a').contains('Change Google Pay settings').click()
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+      cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
+      cy.get('a').contains('Change Google Pay settings').click()
 
-    cy.get('input[type="radio"]').should('have.length', 2)
-    cy.get('input[value="on"]').should('not.be.checked')
-    cy.get('input[value="off"]').should('be.checked')
-    cy.get('#merchantId').should('not.be.visible')
+      cy.get('input[type="radio"]').should('have.length', 2)
+      cy.get('input[value="on"]').should('not.be.checked')
+      cy.get('input[value="off"]').should('be.checked')
+      cy.get('#merchantId').should('not.be.visible')
 
-    cy.get('p').contains('You’ll need a Google Pay merchant ID').should('exist')
+      cy.get('p').contains('You’ll need a Google Pay merchant ID').should('exist')
 
-    cy.get('input[value="on"]').click()
-    cy.get('input[value="on"]').should('be.checked')
+      cy.get('input[value="on"]').click()
+      cy.get('input[value="on"]').should('be.checked')
 
-    cy.log('Click save without entering a gateway merchant ID')
-    cy.get('.govuk-button').contains('Save changes').click()
+      cy.log('Click save without entering a gateway merchant ID')
+      cy.get('.govuk-button').contains('Save changes').click()
 
-    cy.log('Should show an with error message')
-    cy.get('[data-cy=error-summary]').find('a').should('have.length', 1)
-    cy.get('[data-cy=error-summary]').should('exist').within(() => {
-      cy.get('a[href="#merchantId"]').should('contain', 'Enter a valid Merchant ID')
+      cy.log('Should show an with error message')
+      cy.get('[data-cy=error-summary]').find('a').should('have.length', 1)
+      cy.get('[data-cy=error-summary]').should('exist').within(() => {
+        cy.get('a[href="#merchantId"]').should('contain', 'Enter a valid Merchant ID')
+      })
+
+      cy.get('input[value="on"]').should('be.checked')
+      cy.get('#merchantId').parent().should('exist').within(() => {
+        cy.get('.govuk-error-message').should('contain', 'Enter a valid Merchant ID')
+      })
+
+      cy.log('Enter a valid merchant ID and submit')
+      cy.get('#merchantId').type('111111111111111')
+      cy.get('.govuk-button').contains('Save changes').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
+      })
+      cy.get('.govuk-notification-banner--success').should('contain', 'Google Pay successfully enabled')
     })
 
-    cy.get('input[value="on"]').should('be.checked')
-    cy.get('#merchantId').parent().should('exist').within(() => {
-      cy.get('.govuk-error-message').should('contain', 'Enter a valid Merchant ID')
+    it('should allow us to enable and does not require a gateway merchant ID for a Stripe account', () => {
+      cy.task('setupStubs', [
+        ...getUserAndAccountStubs(false, 'stripe'),
+        stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId }),
+        gatewayAccountStubs.patchAccountUpdateGooglePaySuccess(gatewayAccountId, true)
+      ])
+
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+      cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
+      cy.get('a').contains('Change Google Pay settings').click()
+
+      cy.get('input[type="radio"]').should('have.length', 2)
+      cy.get('input[value="on"]').should('not.be.checked')
+      cy.get('input[value="off"]').should('be.checked')
+      cy.get('#merchantId').should('not.exist')
+
+      cy.get('p').contains('You’ll need a Google Pay merchant ID').should('not.exist')
+
+      cy.get('input[value="on"]').click()
+      cy.get('input[value="on"]').should('be.checked')
+
+      cy.get('.govuk-button').contains('Save changes').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
+      })
+      cy.get('.govuk-notification-banner--success').should('contain', 'Google Pay successfully enabled')
     })
 
-    cy.log('Enter a valid merchant ID and submit')
-    cy.get('#merchantId').type('111111111111111')
-    cy.get('.govuk-button').contains('Save changes').click()
+    it('should allow us to disable', () => {
+      cy.task('setupStubs', [
+        ...getUserAndAccountStubs(true),
+        gatewayAccountStubs.patchAccountUpdateGooglePaySuccess(gatewayAccountId, false)
+      ])
 
-    cy.location().should((location) => {
-      expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+      cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On')
+      cy.get('a').contains('Change Google Pay settings').click()
+
+      cy.get('input[type="radio"]').should('have.length', 2)
+      cy.get('input[value="on"]').should('be.checked')
+      cy.get('input[value="off"]').should('not.be.checked')
+      cy.get('#merchantId').should('be.visible')
+
+      cy.get('input[value="off"]').click()
+      cy.get('input[value="off"]').should('be.checked')
+      cy.get('#merchantId').should('not.be.visible')
+
+      cy.get('.govuk-button').contains('Save changes').click()
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
+      })
+      cy.get('.govuk-notification-banner--success').should('contain', 'Google Pay successfully disabled')
     })
-    cy.get('.govuk-notification-banner--success').should('contain', 'Google Pay successfully enabled')
-  })
-
-  it('should allow us to enable and does not require a gateway merchant ID for a Stripe account', () => {
-    cy.task('setupStubs', [
-      ...getUserAndAccountStubs(false, 'stripe'),
-      stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId }),
-      gatewayAccountStubs.patchAccountUpdateGooglePaySuccess(gatewayAccountId, true)
-    ])
-
-    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-    cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
-    cy.get('a').contains('Change Google Pay settings').click()
-
-    cy.get('input[type="radio"]').should('have.length', 2)
-    cy.get('input[value="on"]').should('not.be.checked')
-    cy.get('input[value="off"]').should('be.checked')
-    cy.get('#merchantId').should('not.exist')
-
-    cy.get('p').contains('You’ll need a Google Pay merchant ID').should('not.exist')
-
-    cy.get('input[value="on"]').click()
-    cy.get('input[value="on"]').should('be.checked')
-
-    cy.get('.govuk-button').contains('Save changes').click()
-
-    cy.location().should((location) => {
-      expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
-    })
-    cy.get('.govuk-notification-banner--success').should('contain', 'Google Pay successfully enabled')
-  })
-
-  it('should allow us to disable', () => {
-    cy.task('setupStubs', [
-      ...getUserAndAccountStubs(true),
-      gatewayAccountStubs.patchAccountUpdateGooglePaySuccess(gatewayAccountId, false)
-    ])
-
-    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-    cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On')
-    cy.get('a').contains('Change Google Pay settings').click()
-
-    cy.get('input[type="radio"]').should('have.length', 2)
-    cy.get('input[value="on"]').should('be.checked')
-    cy.get('input[value="off"]').should('not.be.checked')
-    cy.get('#merchantId').should('be.visible')
-
-    cy.get('input[value="off"]').click()
-    cy.get('input[value="off"]').should('be.checked')
-    cy.get('#merchantId').should('not.be.visible')
-
-    cy.get('.govuk-button').contains('Save changes').click()
-
-    cy.location().should((location) => {
-      expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
-    })
-    cy.get('.govuk-notification-banner--success').should('contain', 'Google Pay successfully disabled')
   })
 })

--- a/test/cypress/integration/settings/api-keys.cy.js
+++ b/test/cypress/integration/settings/api-keys.cy.js
@@ -25,23 +25,25 @@ describe('API keys', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  it('should show API keys link for an account that is not disabled', () => {
-    setupStubs(false)
-    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-    cy.location('pathname').should('eq', `/account/${gatewayAccountExternalId}/settings`)
-    cy.get('#navigation-menu-api-keys').should('contain', 'API keys').click()
-    cy.location('pathname').should('eq', `/account/${gatewayAccountExternalId}/api-keys`)
-    cy.get('.govuk-heading-l').should('have.text', 'API Keys')
-    cy.get('#active-tokens').should('contain.text', 'There is 1 active API key')
-    cy.get('#create-api-key').should('exist')
-    cy.get('.key-list').within(() => {
-      cy.get('.govuk-heading-s').should('have.text', 'my-token-description')
+  describe.skip('with simplified settings disabled', () => {
+    it('should show API keys link for an account that is not disabled', () => {
+      setupStubs(false)
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+      cy.location('pathname').should('eq', `/account/${gatewayAccountExternalId}/settings`)
+      cy.get('#navigation-menu-api-keys').should('contain', 'API keys').click()
+      cy.location('pathname').should('eq', `/account/${gatewayAccountExternalId}/api-keys`)
+      cy.get('.govuk-heading-l').should('have.text', 'API Keys')
+      cy.get('#active-tokens').should('contain.text', 'There is 1 active API key')
+      cy.get('#create-api-key').should('exist')
+      cy.get('.key-list').within(() => {
+        cy.get('.govuk-heading-s').should('have.text', 'my-token-description')
+      })
     })
-  })
 
-  it('should not show API keys link for an account that is disabled', () => {
-    setupStubs(true)
-    cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-    cy.get('#navigation-menu-api-keys').should('not.exist')
+    it('should not show API keys link for an account that is disabled', () => {
+      setupStubs(true)
+      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+      cy.get('#navigation-menu-api-keys').should('not.exist')
+    })
   })
 })

--- a/test/cypress/integration/settings/default-billing-address-country.cy.js
+++ b/test/cypress/integration/settings/default-billing-address-country.cy.js
@@ -24,73 +24,75 @@ describe('Default billing address country', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  describe('User is an admin', () => {
-    it('should show default country as None and allow updating', () => {
-      cy.task('setupStubs', [
-        ...getUserAndGatewayAccountStubs(null),
-        serviceStubs.patchUpdateDefaultBillingAddressCountrySuccess({
-          serviceExternalId,
-          gatewayAccountId,
-          country: 'GB'
-        })
-      ])
-
-      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-
-      cy.get('[data-cy=billing-address-settings]').within(() => {
-        cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Default billing address country')
-        cy.get('.govuk-summary-list__value').eq(1).should('contain', 'None')
-        cy.get('.govuk-summary-list__actions').eq(1).contains('Change').click()
-      })
-
-      cy.get('input[type="radio"]').should('have.length', 2)
-      cy.get('input[value="on"]').should('not.be.checked')
-      cy.get('input[value="off"]').should('be.checked')
-
-      cy.get('input[value="on"]').click()
-      cy.get('.govuk-button').contains('Save changes').click()
-
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
-      })
-
-      it('should show default billing address country as "United Kingdom"', () => {
+  describe.skip('with simplified settings disabled', () => {
+    describe('User is an admin', () => {
+      it('should show default country as None and allow updating', () => {
         cy.task('setupStubs', [
-          ...getUserAndGatewayAccountStubs('GB')
+          ...getUserAndGatewayAccountStubs(null),
+          serviceStubs.patchUpdateDefaultBillingAddressCountrySuccess({
+            serviceExternalId,
+            gatewayAccountId,
+            country: 'GB'
+          })
         ])
 
         cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-        cy.get('.govuk-notification-banner--success').should('contain', 'United Kingdom as the default billing address: On')
 
-        cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Default billing address country')
-        cy.get('.govuk-summary-list__value').eq(1).should('contain', 'United Kingdom')
+        cy.get('[data-cy=billing-address-settings]').within(() => {
+          cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Default billing address country')
+          cy.get('.govuk-summary-list__value').eq(1).should('contain', 'None')
+          cy.get('.govuk-summary-list__actions').eq(1).contains('Change').click()
+        })
+
+        cy.get('input[type="radio"]').should('have.length', 2)
+        cy.get('input[value="on"]').should('not.be.checked')
+        cy.get('input[value="off"]').should('be.checked')
+
+        cy.get('input[value="on"]').click()
+        cy.get('.govuk-button').contains('Save changes').click()
+
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
+        })
+
+        it('should show default billing address country as "United Kingdom"', () => {
+          cy.task('setupStubs', [
+            ...getUserAndGatewayAccountStubs('GB')
+          ])
+
+          cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+          cy.get('.govuk-notification-banner--success').should('contain', 'United Kingdom as the default billing address: On')
+
+          cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Default billing address country')
+          cy.get('.govuk-summary-list__value').eq(1).should('contain', 'United Kingdom')
+        })
       })
     })
-  })
 
-  describe('User is view only', () => {
-    it('should have settings page disabled', () => {
-      cy.task('setupStubs', [
-        userStubs.getUserSuccess({
-          userExternalId,
-          gatewayAccountId,
-          role: {
-            permissions: [
-              { name: 'transactions-details:read' },
-              { name: 'toggle-billing-address:read' }
-            ]
-          }
-        }),
-        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId })
-      ])
+    describe('User is view only', () => {
+      it('should have settings page disabled', () => {
+        cy.task('setupStubs', [
+          userStubs.getUserSuccess({
+            userExternalId,
+            gatewayAccountId,
+            role: {
+              permissions: [
+                { name: 'transactions-details:read' },
+                { name: 'toggle-billing-address:read' }
+              ]
+            }
+          }),
+          gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId })
+        ])
 
-      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
 
-      cy.get('[data-cy=billing-address-settings]').contains('View').click()
-      cy.get('.pay-info-warning-box').contains('You don’t have permission')
-      cy.get('input[value="on"]').should('be.disabled')
-      cy.get('input[value="off"]').should('be.disabled')
-      cy.get('.govuk-button').should('be.disabled')
+        cy.get('[data-cy=billing-address-settings]').contains('View').click()
+        cy.get('.pay-info-warning-box').contains('You don’t have permission')
+        cy.get('input[value="on"]').should('be.disabled')
+        cy.get('input[value="off"]').should('be.disabled')
+        cy.get('.govuk-button').should('be.disabled')
+      })
     })
   })
 })

--- a/test/cypress/integration/settings/email-notifications.cy.js
+++ b/test/cypress/integration/settings/email-notifications.cy.js
@@ -19,210 +19,212 @@ function setupStubs (role) {
 }
 
 describe('Settings', () => {
-  describe('For an admin user', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
-      setupStubs()
+  describe.skip('with simplified settings disabled', () => {
+    describe('For an admin user', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
+        setupStubs()
 
-      cy.visit(settingsUrl)
-    })
+        cy.visit(settingsUrl)
+      })
 
-    describe('Settings default page', () => {
-      it(`should have the page title 'Settings - ${serviceName} - GOV.UK Pay'`, () => {
-        cy.get('[data-cy=email-notification-settings]').within(() => {
-          cy.get('.govuk-summary-list__key').eq(0).should('contain', 'Enter an email address')
-          cy.get('.govuk-summary-list__value').eq(0).should('contain', 'On (mandatory)')
-          cy.get('.govuk-summary-list__actions a').eq(0).contains('Change enter an email address settings')
-          cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Payment confirmation emails')
-          cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On')
-          cy.get('.govuk-summary-list__actions a').eq(1).contains('Change payment confirmation emails settings')
-          cy.get('.govuk-summary-list__key').eq(2).should('contain', 'Refund emails')
-          cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
-          cy.get('.govuk-summary-list__actions a').eq(2).contains('Change refund emails settings')
+      describe('Settings default page', () => {
+        it(`should have the page title 'Settings - ${serviceName} - GOV.UK Pay'`, () => {
+          cy.get('[data-cy=email-notification-settings]').within(() => {
+            cy.get('.govuk-summary-list__key').eq(0).should('contain', 'Enter an email address')
+            cy.get('.govuk-summary-list__value').eq(0).should('contain', 'On (mandatory)')
+            cy.get('.govuk-summary-list__actions a').eq(0).contains('Change enter an email address settings')
+            cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Payment confirmation emails')
+            cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On')
+            cy.get('.govuk-summary-list__actions a').eq(1).contains('Change payment confirmation emails settings')
+            cy.get('.govuk-summary-list__key').eq(2).should('contain', 'Refund emails')
+            cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
+            cy.get('.govuk-summary-list__actions a').eq(2).contains('Change refund emails settings')
+          })
+        })
+      })
+
+      describe('Email notifications home page', () => {
+        it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
+          cy.get('#templates-link').click()
+          cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
+          cy.get('#confirmation-email-template').should('contain', 'Confirmation email template')
+
+          // Click the 'Refund email' tab
+          cy.get('#refund-tab').click()
+          cy.url().should('include', '/email-notifications-refund')
+          cy.get('#refund-email-template').should('contain', 'Refund email template')
+        })
+      })
+
+      describe('Email collection mode page', () => {
+        it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
+          // Access the collection mode page
+          cy.get('[data-cy=email-notification-settings]').within(() => {
+            cy.get('.govuk-summary-list__key').eq(0).should('contain', 'Enter an email address')
+            cy.get('.govuk-summary-list__value').eq(0).should('contain', 'On (mandatory)')
+            cy.get('.email-notifications-toggle-collection').contains('Change enter an email address settings').click()
+          })
+          cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
+          cy.url().should('include', '/email-settings-collection')
+
+          cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to ask users for an email address on the card payment page?')
+
+          // Test the save button
+          cy.contains('Save changes').click()
+          cy.url().should('include', settingsUrl)
+          cy.get('.govuk-notification-banner--success').should('contain', 'Email address collection is set to on (mandatory)')
+
+          // Access the collection mode page again
+          cy.get('.email-notifications-toggle-collection').click()
+          // Test the cancel button
+          cy.contains('Cancel').click()
+          cy.url().should('include', settingsUrl)
+        })
+      })
+
+      describe('Confirmation email toggle page', () => {
+        it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
+          // Access the confirmation toggle page
+          cy.get('[data-cy=email-notification-settings]').within(() => {
+            cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Payment confirmation emails')
+            cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On')
+            cy.get('.email-notifications-toggle-confirmation').contains('Change payment confirmation emails settings').click()
+          })
+          cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
+
+          cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to send payment confirmation emails?')
+
+          cy.contains('Save changes').click()
+          cy.url().should('include', settingsUrl)
+          cy.get('.govuk-notification-banner--success').should('contain', 'Payment confirmation emails are turned on')
+
+          // Access the confirmation toggle page again
+          cy.get('.email-notifications-toggle-confirmation').click()
+          // Test the cancel button
+          cy.contains('Cancel').click()
+          cy.url().should('include', settingsUrl)
+        })
+      })
+
+      describe('Refund email toggle page', () => {
+        it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
+          // Access the refund toggle page
+          cy.get('[data-cy=email-notification-settings]').within(() => {
+            cy.get('.govuk-summary-list__key').eq(2).should('contain', 'Refund emails')
+            cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
+            cy.get('.email-notifications-toggle-refund').contains('Change refund emails settings').click()
+          })
+          cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
+
+          cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to send refund emails?')
+
+          cy.contains('Save changes').click()
+          cy.url().should('include', settingsUrl)
+          cy.get('.govuk-notification-banner--success').should('contain', 'Refund emails are turned on')
+
+          // Access the refund toggle page again
+          cy.get('.email-notifications-toggle-refund').click()
+          // Test the cancel button
+          cy.contains('Cancel').click()
+          cy.url().should('include', settingsUrl)
         })
       })
     })
 
-    describe('Email notifications home page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
-        cy.get('#templates-link').click()
-        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
-        cy.get('#confirmation-email-template').should('contain', 'Confirmation email template')
+    describe('For a read-only user', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
+        const role = {
+          permissions: [
+            {
+              name: 'email-notification-template:read',
+              description: 'Viewemailnotificationstemplate'
+            },
+            {
+              name: 'transactions-details:read',
+              description: 'Viewtransactionsdetailsonly'
+            }
+          ]
+        }
+        setupStubs(role)
 
-        // Click the 'Refund email' tab
-        cy.get('#refund-tab').click()
-        cy.url().should('include', '/email-notifications-refund')
-        cy.get('#refund-email-template').should('contain', 'Refund email template')
+        cy.visit(settingsUrl)
       })
-    })
 
-    describe('Email collection mode page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
-        // Access the collection mode page
-        cy.get('[data-cy=email-notification-settings]').within(() => {
-          cy.get('.govuk-summary-list__key').eq(0).should('contain', 'Enter an email address')
-          cy.get('.govuk-summary-list__value').eq(0).should('contain', 'On (mandatory)')
-          cy.get('.email-notifications-toggle-collection').contains('Change enter an email address settings').click()
+      describe('Email notifications home page', () => {
+        it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
+          // Default notifications page and confirmation email tab contents
+          cy.get('#templates-link').click()
+          cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
+          cy.get('#confirmation-email-template').should('contain', 'Confirmation email template')
+
+          // Click the 'Refund email' tab
+          cy.get('#refund-tab').click()
+          cy.url().should('include', '/email-notifications-refund')
+          cy.get('#refund-email-template').should('contain', 'Refund email template')
         })
-        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
-        cy.url().should('include', '/email-settings-collection')
-
-        cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to ask users for an email address on the card payment page?')
-
-        // Test the save button
-        cy.contains('Save changes').click()
-        cy.url().should('include', settingsUrl)
-        cy.get('.govuk-notification-banner--success').should('contain', 'Email address collection is set to on (mandatory)')
-
-        // Access the collection mode page again
-        cy.get('.email-notifications-toggle-collection').click()
-        // Test the cancel button
-        cy.contains('Cancel').click()
-        cy.url().should('include', settingsUrl)
       })
-    })
 
-    describe('Confirmation email toggle page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
-        // Access the confirmation toggle page
-        cy.get('[data-cy=email-notification-settings]').within(() => {
-          cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Payment confirmation emails')
-          cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On')
-          cy.get('.email-notifications-toggle-confirmation').contains('Change payment confirmation emails settings').click()
+      describe('Email collection mode page', () => {
+        it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
+          // Access the collection mode page
+          cy.get('[data-cy=email-notification-settings]').within(() => {
+            cy.get('.govuk-summary-list__key').eq(0).should('contain', 'Enter an email address')
+            cy.get('.govuk-summary-list__value').eq(0).should('contain', 'On (mandatory)')
+            cy.get('.email-notifications-toggle-collection').contains('View enter an email address settings').click()
+          })
+          cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
+          cy.url().should('include', '/email-settings-collection')
+
+          cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to ask users for an email address on the card payment page?')
+
+          // Test it’s read-only
+          cy.get('input[disabled]').should('have.length', 3)
+          // Test the back button
+          cy.contains('Go back').click()
+          cy.url().should('include', settingsUrl)
         })
-        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
-
-        cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to send payment confirmation emails?')
-
-        cy.contains('Save changes').click()
-        cy.url().should('include', settingsUrl)
-        cy.get('.govuk-notification-banner--success').should('contain', 'Payment confirmation emails are turned on')
-
-        // Access the confirmation toggle page again
-        cy.get('.email-notifications-toggle-confirmation').click()
-        // Test the cancel button
-        cy.contains('Cancel').click()
-        cy.url().should('include', settingsUrl)
       })
-    })
 
-    describe('Refund email toggle page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
-        // Access the refund toggle page
-        cy.get('[data-cy=email-notification-settings]').within(() => {
-          cy.get('.govuk-summary-list__key').eq(2).should('contain', 'Refund emails')
-          cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
-          cy.get('.email-notifications-toggle-refund').contains('Change refund emails settings').click()
+      describe('Confirmation email toggle page', () => {
+        it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
+          // Access the confirmation toggle page
+          cy.get('[data-cy=email-notification-settings]').within(() => {
+            cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Payment confirmation emails')
+            cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On')
+            cy.get('.email-notifications-toggle-confirmation').contains('View payment confirmation emails settings').click()
+          })
+          cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
+
+          cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to send payment confirmation emails?')
+
+          // Test it’s read-only
+          cy.get('input[disabled]').should('have.length', 2)
+          // Test the back button
+          cy.contains('Go back').click()
+          cy.url().should('include', settingsUrl)
         })
-        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
-
-        cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to send refund emails?')
-
-        cy.contains('Save changes').click()
-        cy.url().should('include', settingsUrl)
-        cy.get('.govuk-notification-banner--success').should('contain', 'Refund emails are turned on')
-
-        // Access the refund toggle page again
-        cy.get('.email-notifications-toggle-refund').click()
-        // Test the cancel button
-        cy.contains('Cancel').click()
-        cy.url().should('include', settingsUrl)
       })
-    })
-  })
 
-  describe('For a read-only user', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
-      const role = {
-        permissions: [
-          {
-            name: 'email-notification-template:read',
-            description: 'Viewemailnotificationstemplate'
-          },
-          {
-            name: 'transactions-details:read',
-            description: 'Viewtransactionsdetailsonly'
-          }
-        ]
-      }
-      setupStubs(role)
+      describe('Refund email toggle page', () => {
+        it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
+          // Access the refund toggle page
+          cy.get('[data-cy=email-notification-settings]').within(() => {
+            cy.get('.govuk-summary-list__key').eq(2).should('contain', 'Refund emails')
+            cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
+            cy.get('.email-notifications-toggle-refund').contains('View refund emails settings').click()
+          })
+          cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
 
-      cy.visit(settingsUrl)
-    })
+          cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to send refund emails?')
 
-    describe('Email notifications home page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
-        // Default notifications page and confirmation email tab contents
-        cy.get('#templates-link').click()
-        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
-        cy.get('#confirmation-email-template').should('contain', 'Confirmation email template')
-
-        // Click the 'Refund email' tab
-        cy.get('#refund-tab').click()
-        cy.url().should('include', '/email-notifications-refund')
-        cy.get('#refund-email-template').should('contain', 'Refund email template')
-      })
-    })
-
-    describe('Email collection mode page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
-        // Access the collection mode page
-        cy.get('[data-cy=email-notification-settings]').within(() => {
-          cy.get('.govuk-summary-list__key').eq(0).should('contain', 'Enter an email address')
-          cy.get('.govuk-summary-list__value').eq(0).should('contain', 'On (mandatory)')
-          cy.get('.email-notifications-toggle-collection').contains('View enter an email address settings').click()
+          // Test it’s read-only
+          cy.get('input[disabled]').should('have.length', 2)
+          // Test the cancel button
+          cy.contains('Go back').click()
+          cy.url().should('include', settingsUrl)
         })
-        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
-        cy.url().should('include', '/email-settings-collection')
-
-        cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to ask users for an email address on the card payment page?')
-
-        // Test it’s read-only
-        cy.get('input[disabled]').should('have.length', 3)
-        // Test the back button
-        cy.contains('Go back').click()
-        cy.url().should('include', settingsUrl)
-      })
-    })
-
-    describe('Confirmation email toggle page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
-        // Access the confirmation toggle page
-        cy.get('[data-cy=email-notification-settings]').within(() => {
-          cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Payment confirmation emails')
-          cy.get('.govuk-summary-list__value').eq(1).should('contain', 'On')
-          cy.get('.email-notifications-toggle-confirmation').contains('View payment confirmation emails settings').click()
-        })
-        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
-
-        cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to send payment confirmation emails?')
-
-        // Test it’s read-only
-        cy.get('input[disabled]').should('have.length', 2)
-        // Test the back button
-        cy.contains('Go back').click()
-        cy.url().should('include', settingsUrl)
-      })
-    })
-
-    describe('Refund email toggle page', () => {
-      it(`should have the page title 'Email notifications - ${serviceName} Sandbox test - GOV.UK Pay'`, () => {
-        // Access the refund toggle page
-        cy.get('[data-cy=email-notification-settings]').within(() => {
-          cy.get('.govuk-summary-list__key').eq(2).should('contain', 'Refund emails')
-          cy.get('.govuk-summary-list__value').eq(2).should('contain', 'On')
-          cy.get('.email-notifications-toggle-refund').contains('View refund emails settings').click()
-        })
-        cy.title().should('eq', `Email notifications - ${serviceName} Sandbox test - GOV.UK Pay`)
-
-        cy.get('.govuk-fieldset__heading').first().should('contain', 'Do you want to send refund emails?')
-
-        // Test it’s read-only
-        cy.get('input[disabled]').should('have.length', 2)
-        // Test the cancel button
-        cy.contains('Go back').click()
-        cy.url().should('include', settingsUrl)
       })
     })
   })

--- a/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.js
+++ b/test/cypress/integration/settings/mask-moto-card-number-and-security-code.cy.js
@@ -58,105 +58,107 @@ describe('MOTO mask security section', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  describe('When accessing MOTO mask settings', () => {
-    describe('when gateway account has allowMoto=false', () => {
-      it('should not show mask security section', () => {
-        setupMotoStubs({ allowMoto: false })
+  describe.skip('with simplified settings disabled', () => {
+    describe('When accessing MOTO mask settings', () => {
+      describe('when gateway account has allowMoto=false', () => {
+        it('should not show mask security section', () => {
+          setupMotoStubs({ allowMoto: false })
 
-        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-        cy.get('#moto-mask-security-settings-heading').should('not.exist')
+          cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+          cy.get('#moto-mask-security-settings-heading').should('not.exist')
+        })
       })
-    })
 
-    describe('mask card number - when user has read permission and card number mask disabled', () => {
-      it('should show radios as disabled and card number mask disabled', () => {
-        setupMotoStubs({ readonly: true, allowMoto: true, motoMaskCardNumber: false })
+      describe('mask card number - when user has read permission and card number mask disabled', () => {
+        it('should show radios as disabled and card number mask disabled', () => {
+          setupMotoStubs({ readonly: true, allowMoto: true, motoMaskCardNumber: false })
 
-        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-        cy.get('[data-cy=moto-security-settings]').within(() => {
-          cy.get('.govuk-summary-list__key').eq(0).should('contain', 'Hide card numbers')
-          cy.get('.govuk-summary-list__value').eq(0).should('contain', 'Off')
-          cy.get('.govuk-summary-list__actions a').eq(0).contains('View')
-          cy.get('.govuk-summary-list__actions a').eq(0).click()
+          cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+          cy.get('[data-cy=moto-security-settings]').within(() => {
+            cy.get('.govuk-summary-list__key').eq(0).should('contain', 'Hide card numbers')
+            cy.get('.govuk-summary-list__value').eq(0).should('contain', 'Off')
+            cy.get('.govuk-summary-list__actions a').eq(0).contains('View')
+            cy.get('.govuk-summary-list__actions a').eq(0).click()
+          })
+          cy.title().should('eq', `MOTO - hide card numbers for ${serviceName} - GOV.UK Pay`)
+          cy.get('.pay-info-warning-box').should('exist')
+          cy.get('input[value="on"]').should('be.disabled')
+          cy.get('input[value="off"]').should('be.disabled')
+          cy.get('input[value="on"]').should('not.be.checked')
+          cy.get('input[value="off"]').should('be.checked')
         })
-        cy.title().should('eq', `MOTO - hide card numbers for ${serviceName} - GOV.UK Pay`)
-        cy.get('.pay-info-warning-box').should('exist')
-        cy.get('input[value="on"]').should('be.disabled')
-        cy.get('input[value="off"]').should('be.disabled')
-        cy.get('input[value="on"]').should('not.be.checked')
-        cy.get('input[value="off"]').should('be.checked')
       })
-    })
 
-    describe('mask card number - when user has update permission and card number mask disabled', () => {
-      it('should show radios as enabled and card number mask disabled and allow updating', () => {
-        setupMotoStubs({ readonly: false, allowMoto: true, motoMaskCardNumber: false })
+      describe('mask card number - when user has update permission and card number mask disabled', () => {
+        it('should show radios as enabled and card number mask disabled and allow updating', () => {
+          setupMotoStubs({ readonly: false, allowMoto: true, motoMaskCardNumber: false })
 
-        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-        cy.get('[data-cy=moto-security-settings]').within(() => {
-          cy.get('.govuk-summary-list__key').eq(0).should('contain', 'Hide card numbers')
-          cy.get('.govuk-summary-list__value').eq(0).should('contain', 'Off')
-          cy.get('.govuk-summary-list__actions a').eq(0).contains('Change')
-          cy.get('.govuk-summary-list__actions a').eq(0).click()
+          cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+          cy.get('[data-cy=moto-security-settings]').within(() => {
+            cy.get('.govuk-summary-list__key').eq(0).should('contain', 'Hide card numbers')
+            cy.get('.govuk-summary-list__value').eq(0).should('contain', 'Off')
+            cy.get('.govuk-summary-list__actions a').eq(0).contains('Change')
+            cy.get('.govuk-summary-list__actions a').eq(0).click()
+          })
+          cy.title().should('eq', `MOTO - hide card numbers for ${serviceName} - GOV.UK Pay`)
+          cy.get('input[value="on"]').should('not.be.disabled')
+          cy.get('input[value="off"]').should('not.be.disabled')
+          cy.get('input[value="on"]').should('not.be.checked')
+          cy.get('input[value="off"]').should('be.checked')
+
+          cy.get('input[value="on"]').click()
+          cy.get('#save-moto-mask-changes').click()
+          cy.location().should((location) => {
+            expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
+          })
+          cy.get('.govuk-notification-banner--success').contains('Your changes have saved')
         })
-        cy.title().should('eq', `MOTO - hide card numbers for ${serviceName} - GOV.UK Pay`)
-        cy.get('input[value="on"]').should('not.be.disabled')
-        cy.get('input[value="off"]').should('not.be.disabled')
-        cy.get('input[value="on"]').should('not.be.checked')
-        cy.get('input[value="off"]').should('be.checked')
-
-        cy.get('input[value="on"]').click()
-        cy.get('#save-moto-mask-changes').click()
-        cy.location().should((location) => {
-          expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
-        })
-        cy.get('.govuk-notification-banner--success').contains('Your changes have saved')
       })
-    })
 
-    describe('mask security code - when user has read permission and security code mask disabled', () => {
-      it('should show radios as disabled and card number mask disabled', () => {
-        setupMotoStubs({ readonly: true, allowMoto: true, motoMaskSecurityCode: false })
+      describe('mask security code - when user has read permission and security code mask disabled', () => {
+        it('should show radios as disabled and card number mask disabled', () => {
+          setupMotoStubs({ readonly: true, allowMoto: true, motoMaskSecurityCode: false })
 
-        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-        cy.get('[data-cy=moto-security-settings]').within(() => {
-          cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Hide card security codes')
-          cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
-          cy.get('.govuk-summary-list__actions a').eq(1).contains('View')
-          cy.get('.govuk-summary-list__actions a').eq(1).click()
+          cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+          cy.get('[data-cy=moto-security-settings]').within(() => {
+            cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Hide card security codes')
+            cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
+            cy.get('.govuk-summary-list__actions a').eq(1).contains('View')
+            cy.get('.govuk-summary-list__actions a').eq(1).click()
+          })
+          cy.title().should('eq', `MOTO - hide security codes for ${serviceName} - GOV.UK Pay`)
+          cy.get('.pay-info-warning-box').should('exist')
+          cy.get('input[value="on"]').should('be.disabled')
+          cy.get('input[value="off"]').should('be.disabled')
+          cy.get('input[value="on"]').should('not.be.checked')
+          cy.get('input[value="off"]').should('be.checked')
         })
-        cy.title().should('eq', `MOTO - hide security codes for ${serviceName} - GOV.UK Pay`)
-        cy.get('.pay-info-warning-box').should('exist')
-        cy.get('input[value="on"]').should('be.disabled')
-        cy.get('input[value="off"]').should('be.disabled')
-        cy.get('input[value="on"]').should('not.be.checked')
-        cy.get('input[value="off"]').should('be.checked')
       })
-    })
 
-    describe('mask security code - when user has update permission and security code mask disabled', () => {
-      it('should show radios as enabled and no masking and allow updating', () => {
-        setupMotoStubs({ readonly: false, allowMoto: true, motoMaskSecurityCode: false })
+      describe('mask security code - when user has update permission and security code mask disabled', () => {
+        it('should show radios as enabled and no masking and allow updating', () => {
+          setupMotoStubs({ readonly: false, allowMoto: true, motoMaskSecurityCode: false })
 
-        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-        cy.get('[data-cy=moto-security-settings]').within(() => {
-          cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Hide card security codes')
-          cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
-          cy.get('.govuk-summary-list__actions a').eq(1).contains('Change')
-          cy.get('.govuk-summary-list__actions a').eq(1).click()
+          cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+          cy.get('[data-cy=moto-security-settings]').within(() => {
+            cy.get('.govuk-summary-list__key').eq(1).should('contain', 'Hide card security codes')
+            cy.get('.govuk-summary-list__value').eq(1).should('contain', 'Off')
+            cy.get('.govuk-summary-list__actions a').eq(1).contains('Change')
+            cy.get('.govuk-summary-list__actions a').eq(1).click()
+          })
+          cy.title().should('eq', `MOTO - hide security codes for ${serviceName} - GOV.UK Pay`)
+          cy.get('input[value="on"]').should('not.be.disabled')
+          cy.get('input[value="off"]').should('not.be.disabled')
+          cy.get('input[value="on"]').should('not.be.checked')
+          cy.get('input[value="off"]').should('be.checked')
+
+          cy.get('input[value="on"]').click()
+          cy.get('#save-moto-mask-changes').click()
+          cy.location().should((location) => {
+            expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
+          })
+          cy.get('.govuk-notification-banner--success').contains('Your changes have saved')
         })
-        cy.title().should('eq', `MOTO - hide security codes for ${serviceName} - GOV.UK Pay`)
-        cy.get('input[value="on"]').should('not.be.disabled')
-        cy.get('input[value="off"]').should('not.be.disabled')
-        cy.get('input[value="on"]').should('not.be.checked')
-        cy.get('input[value="off"]').should('be.checked')
-
-        cy.get('input[value="on"]').click()
-        cy.get('#save-moto-mask-changes').click()
-        cy.location().should((location) => {
-          expect(location.pathname).to.eq(`/account/${gatewayAccountExternalId}/settings`)
-        })
-        cy.get('.govuk-notification-banner--success').contains('Your changes have saved')
       })
     })
   })

--- a/test/cypress/integration/settings/payment-types.cy.js
+++ b/test/cypress/integration/settings/payment-types.cy.js
@@ -23,102 +23,87 @@ describe('Payment types', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  it('should display page and allow updating card types', () => {
-    setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName)
-    cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
-
-    cy.title().should('eq', `Manage payment types - ${serviceName} - GOV.UK Pay`)
-
-    cy.get('#debit').should('be.checked')
-    cy.get('#debit-2').should('be.checked')
-
-    cy.get('#debit-3').should('be.not.checked')
-    cy.get('#debit-3').should('be.disabled')
-    cy.get('#debit-3-item-hint').should('be.visible')
-
-    cy.get('#credit').should('be.checked')
-    cy.get('#credit-2').should('be.checked')
-    cy.get('#credit-3').should('be.checked')
-    cy.get('#credit-3-item-hint').should('be.visible')
-    cy.get('#credit-4').should('be.not.checked')
-    cy.get('#credit-5').should('be.not.checked')
-    cy.get('#credit-6').should('be.not.checked')
-    cy.get('#credit-7').should('be.not.checked')
-
-    cy.get('#credit-4').click()
-    cy.get('#credit-4').should('be.checked')
-    cy.get('#save-card-types').click()
-
-    cy.title().should('eq', `Manage payment types - ${serviceName} - GOV.UK Pay`)
-    cy.get('.govuk-notification-banner--success')
-      .should('exist')
-      .should('contain', 'Accepted card types have been updated')
-  })
-
-  context('when the account is a payment provider test account', () => {
-    context('when 3DS is not enabled', () => {
-      beforeEach(() => {
-        setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, 'test')
-        cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
-      })
-
-      it('should show debit cards that do not require 3DS as enabled and without hint', () => {
-        cy.get('#debit-2').should('be.checked')
-        cy.get('#debit-2-item-hint').should('not.exist')
-      })
-
-      it('should show debit cards requiring 3DS as disabled and with hint', () => {
-        cy.get('#debit-3').should('be.disabled')
-        cy.get('#debit-3-item-hint').should('be.visible')
-        cy.get('#debit-3-item-hint')
-          .invoke('text')
-          .should('include', 'cannot be used because 3D Secure is switched off for this service')
-      })
-    })
-
-    context('when 3DS is enabled', () => {
-      beforeEach(() => {
-        setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, 'test', true)
-        cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
-      })
-
-      it('should show debit cards that do not require 3DS as enabled and without hint', () => {
-        cy.get('#debit-2').should('be.checked')
-        cy.get('#debit-2-item-hint').should('not.exist')
-      })
-
-      it('should show debit cards requiring 3DS as enabled and without hint', () => {
-        cy.get('#debit-3').should('not.be.disabled')
-        cy.get('#debit-3-item-hint').should('not.exist')
-      })
-    })
-  })
-
-  context('when the account is a sandbox test account', () => {
-    beforeEach(() => {
-      setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, 'test', false, 'sandbox')
+  describe.skip('with simplified settings disabled', () => {
+    it('should display page and allow updating card types', () => {
+      setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName)
       cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
-    })
 
-    it('should show debit cards that do not require 3DS as enabled and without hint', () => {
+      cy.title().should('eq', `Manage payment types - ${serviceName} - GOV.UK Pay`)
+
+      cy.get('#debit').should('be.checked')
       cy.get('#debit-2').should('be.checked')
-      cy.get('#debit-2-item-hint').should('not.exist')
-    })
 
-    it('should show debit cards requiring 3DS as disabled and with hint', () => {
+      cy.get('#debit-3').should('be.not.checked')
       cy.get('#debit-3').should('be.disabled')
       cy.get('#debit-3-item-hint').should('be.visible')
-      cy.get('#debit-3-item-hint')
-        .invoke('text')
-        .should('include', 'is not available on sandbox test accounts')
-    })
-  })
 
-  context('when the account is live', () => {
-    context('when 3DS is not enabled', () => {
+      cy.get('#credit').should('be.checked')
+      cy.get('#credit-2').should('be.checked')
+      cy.get('#credit-3').should('be.checked')
+      cy.get('#credit-3-item-hint').should('be.visible')
+      cy.get('#credit-4').should('be.not.checked')
+      cy.get('#credit-5').should('be.not.checked')
+      cy.get('#credit-6').should('be.not.checked')
+      cy.get('#credit-7').should('be.not.checked')
+
+      cy.get('#credit-4').click()
+      cy.get('#credit-4').should('be.checked')
+      cy.get('#save-card-types').click()
+
+      cy.title().should('eq', `Manage payment types - ${serviceName} - GOV.UK Pay`)
+      cy.get('.govuk-notification-banner--success')
+        .should('exist')
+        .should('contain', 'Accepted card types have been updated')
+    })
+
+    context('when the account is a payment provider test account', () => {
+      context('when 3DS is not enabled', () => {
+        beforeEach(() => {
+          setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, 'test')
+          cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
+        })
+
+        it('should show debit cards that do not require 3DS as enabled and without hint', () => {
+          cy.get('#debit-2').should('be.checked')
+          cy.get('#debit-2-item-hint').should('not.exist')
+        })
+
+        it('should show debit cards requiring 3DS as disabled and with hint', () => {
+          cy.get('#debit-3').should('be.disabled')
+          cy.get('#debit-3-item-hint').should('be.visible')
+          cy.get('#debit-3-item-hint')
+            .invoke('text')
+            .should('include', 'cannot be used because 3D Secure is switched off for this service')
+        })
+      })
+
+      context('when 3DS is enabled', () => {
+        beforeEach(() => {
+          setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, 'test', true)
+          cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
+        })
+
+        it('should show debit cards that do not require 3DS as enabled and without hint', () => {
+          cy.get('#debit-2').should('be.checked')
+          cy.get('#debit-2-item-hint').should('not.exist')
+        })
+
+        it('should show debit cards requiring 3DS as enabled and without hint', () => {
+          cy.get('#debit-3').should('not.be.disabled')
+          cy.get('#debit-3-item-hint').should('not.exist')
+        })
+      })
+    })
+
+    context('when the account is a sandbox test account', () => {
       beforeEach(() => {
-        setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, 'live', false, 'stripe')
+        setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, 'test', false, 'sandbox')
         cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
+      })
+
+      it('should show debit cards that do not require 3DS as enabled and without hint', () => {
+        cy.get('#debit-2').should('be.checked')
+        cy.get('#debit-2-item-hint').should('not.exist')
       })
 
       it('should show debit cards requiring 3DS as disabled and with hint', () => {
@@ -126,43 +111,60 @@ describe('Payment types', () => {
         cy.get('#debit-3-item-hint').should('be.visible')
         cy.get('#debit-3-item-hint')
           .invoke('text')
-          .should('include', 'cannot be used because 3D Secure is switched off for this service')
-      })
-
-      it('should show debit cards that do not require 3DS as enabled and without hint', () => {
-        cy.get('#debit-2').should('be.checked')
-        cy.get('#debit-2-item-hint').should('not.exist')
+          .should('include', 'is not available on sandbox test accounts')
       })
     })
 
-    context('when 3DS is enabled', () => {
-      beforeEach(() => {
-        setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, 'live', true)
-        cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
+    context('when the account is live', () => {
+      context('when 3DS is not enabled', () => {
+        beforeEach(() => {
+          setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, 'live', false, 'stripe')
+          cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
+        })
+
+        it('should show debit cards requiring 3DS as disabled and with hint', () => {
+          cy.get('#debit-3').should('be.disabled')
+          cy.get('#debit-3-item-hint').should('be.visible')
+          cy.get('#debit-3-item-hint')
+            .invoke('text')
+            .should('include', 'cannot be used because 3D Secure is switched off for this service')
+        })
+
+        it('should show debit cards that do not require 3DS as enabled and without hint', () => {
+          cy.get('#debit-2').should('be.checked')
+          cy.get('#debit-2-item-hint').should('not.exist')
+        })
       })
 
-      it('should show debit cards that do not require 3DS as enabled and without hint', () => {
-        cy.get('#debit-2').should('be.checked')
-        cy.get('#debit-2-item-hint').should('not.exist')
-      })
+      context('when 3DS is enabled', () => {
+        beforeEach(() => {
+          setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName, 'live', true)
+          cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
+        })
 
-      it('should show debit cards requiring 3DS as enabled and without hint', () => {
-        cy.get('#debit-3').should('not.be.disabled')
-        cy.get('#debit-3-item-hint').should('not.exist')
+        it('should show debit cards that do not require 3DS as enabled and without hint', () => {
+          cy.get('#debit-2').should('be.checked')
+          cy.get('#debit-2-item-hint').should('not.exist')
+        })
+
+        it('should show debit cards requiring 3DS as enabled and without hint', () => {
+          cy.get('#debit-3').should('not.be.disabled')
+          cy.get('#debit-3-item-hint').should('not.exist')
+        })
       })
     })
-  })
 
-  it('should show error if user tries to disable all card types', () => {
-    setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName)
-    cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
+    it('should show error if user tries to disable all card types', () => {
+      setupStubs(userExternalId, gatewayAccountId, gatewayAccountExternalId, serviceName)
+      cy.visit(`/account/${gatewayAccountExternalId}/payment-types`)
 
-    cy.get('#debit').click()
-    cy.get('#debit-2').click()
-    cy.get('#credit').click()
-    cy.get('#credit-2').click()
-    cy.get('#credit-3').click()
-    cy.get('#save-card-types').click()
-    cy.get('.error-summary').should('be.visible')
+      cy.get('#debit').click()
+      cy.get('#debit-2').click()
+      cy.get('#credit').click()
+      cy.get('#credit-2').click()
+      cy.get('#credit-3').click()
+      cy.get('#save-card-types').click()
+      cy.get('.error-summary').should('be.visible')
+    })
   })
 })

--- a/test/cypress/integration/settings/switch-psp.cy.js
+++ b/test/cypress/integration/settings/switch-psp.cy.js
@@ -67,291 +67,336 @@ describe('Switch PSP settings page', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  describe('When using an account with switching flag disabled', () => {
-    it('should not show link to Switch PSP in the side navigation', () => {
-      cy.task('setupStubs', getUserAndAccountStubs('smartpay', false))
+  describe.skip('with simplified settings disabled', () => {
+    describe('When using an account with switching flag disabled', () => {
+      it('should not show link to Switch PSP in the side navigation', () => {
+        cy.task('setupStubs', getUserAndAccountStubs('smartpay', false))
 
-      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-      cy.get('.service-info--tag').should('not.contain', 'switching psp')
-      cy.get('#navigation-menu-switch-psp').should('have.length', 0)
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+        cy.get('.service-info--tag').should('not.contain', 'switching psp')
+        cy.get('#navigation-menu-switch-psp').should('have.length', 0)
+      })
     })
-  })
 
-  describe('When using an account with switching flag enabled', () => {
-    describe('When Worldpay non-MOTO account', () => {
-      describe('When switching is not started', () => {
-        it('should show dashboard message for switching psp', () => {
-          cy.task('setupStubs', [
-            ...getUserAndAccountStubsForSwitchingNotStarted(),
-            transactionStubs.getTransactionsSummarySuccess()
-          ])
-
-          cy.visit(`/account/${gatewayAccountExternalId}/dashboard`)
-          cy.get('.govuk-notification-banner__heading').should('contain', 'Switch your payment service provider (PSP) to Worldpay')
-        })
-
-        it('should show the switch message for current psp page', () => {
-          cy.task('setupStubs', getUserAndAccountStubsForSwitchingNotStarted())
-
-          cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-          cy.get('a').contains('Your PSP - Smartpay').click()
-          cy.get('#switched-psp-status').should('contain', 'Your service is ready to switch PSP from Smartpay to Worldpay.')
-        })
-
-        it('should show the switch PSP page for switching to Worldpay with tasks not started', () => {
-          cy.task('setupStubs', getUserAndAccountStubsForSwitchingNotStarted())
-
-          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
-          cy.get('.service-info--tag').should('contain', 'switch psp')
-          cy.get('#navigation-menu-switch-psp').should('have.length', 1)
-          cy.get('h1').should('contain', 'Switch payment service provider')
-          cy.get('li').contains('your Worldpay account credentials: Merchant code, username and password').should('exist')
-          cy.get('#switch-psp-action-step').should('contain', 'Switch PSP to Worldpay')
-          cy.get('.govuk-warning-text').should('contain', 'Once you switch, Worldpay will immediately start taking payments. You can refund previous payments through Smartpay.')
-
-          cy.get('.app-task-list>li').eq(0).should('contain', 'Get ready to switch PSP')
-            .within(() => {
-              cy.get('.app-task-list__item').should('have.length', 3)
-              cy.get('.app-task-list__item').eq(0).should('contain', 'Link your Worldpay account with GOV.UK Pay')
-                .find('.app-task-list__tag').should('have.text', 'Not started')
-              cy.get('.app-task-list__item').eq(1).should('contain', 'Provide your Worldpay 3DS Flex credentials')
-                .find('.app-task-list__tag').should('have.text', 'Not started')
-              cy.get('.app-task-list__item').eq(2).should('contain', 'Make a live payment to test your Worldpay PSP')
-                .find('.app-task-list__tag').should('have.text', 'Cannot start yet')
-            })
-          cy.get('button').contains('Switch to Worldpay').should('have.disabled')
-        })
-
-        it('should allow linking account', () => {
-          cy.task('setupStubs', [
-            ...getUserAndAccountStubsForSwitchingNotStarted(),
-            gatewayAccountStubs.postCheckWorldpayCredentials({
-              gatewayAccountId,
-              merchant_code: merchantId,
-              username,
-              password
-            }),
-            gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, switchingToCredentialId, userExternalId, {
-              path: 'credentials/worldpay/one_off_customer_initiated',
-              value: {
-                merchant_code: merchantId,
-                username,
-                password
-              }
-            })
-          ])
-
-          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
-
-          cy.get('.app-task-list__item').contains('Link your Worldpay account with GOV.UK Pay').click()
-          cy.get('h1').should('contain', 'Your Worldpay credentials')
-          cy.get('.govuk-back-link').should('contain', 'Back to Switching payment service provider (PSP)')
-
-          cy.get('#merchantId').type('abc')
-          cy.get('#username').type('me')
-          cy.get('#password').type('1')
-          cy.get('button').contains('Save credentials').click()
-
-          cy.get('h1').should('contain', 'Switch payment service provider')
-        })
-
-        it('should allow providing 3DS flex credentials', () => {
-          cy.task('setupStubs', [
-            ...getUserAndAccountStubsForSwitchingNotStarted(),
-            gatewayAccountStubs.postCheckWorldpay3dsFlexCredentials({
-              gatewayAccountId,
-              result: 'valid',
-              organisational_unit_id: organisationalUnitId,
-              issuer,
-              jwt_mac_key: jwtMacKey
-            }),
-            gatewayAccountStubs.postUpdateWorldpay3dsFlexCredentials({
-              gatewayAccountId,
-              organisational_unit_id: organisationalUnitId,
-              issuer,
-              jwt_mac_key: jwtMacKey
-            }),
-            gatewayAccountStubs.patchUpdate3dsVersionSuccess(gatewayAccountId, 2)
-          ])
-
-          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
-
-          cy.get('.app-task-list__item').contains('Provide your Worldpay 3DS Flex credentials').click()
-          cy.get('h1').should('contain', 'Your Worldpay 3DS Flex credentials')
-          cy.get('.govuk-back-link').should('contain', 'Back to Switching payment service provider (PSP)')
-
-          cy.get('#organisational-unit-id').type(organisationalUnitId)
-          cy.get('#issuer').type(issuer)
-          cy.get('#jwt-mac-key').type(jwtMacKey)
-          cy.get('button').contains('Save credentials').click()
-
-          cy.get('h1').should('contain', 'Switch payment service provider')
-        })
-      })
-
-      describe('When credentials steps are completed', () => {
-        it('should show steps as completed', () => {
-          cy.task('setupStubs', [
-            ...getUserAndAccountStubs('smartpay', true, [
-              {
-                payment_provider: 'smartpay',
-                state: 'ACTIVE',
-                id: currentCredentialId,
-                external_id: currentCredentialExternalId
-              },
-              {
-                payment_provider: 'worldpay',
-                state: 'ENTERED',
-                id: switchingToCredentialId,
-                external_id: switchingToCredentialExternalId
-              }
-            ],
-            null,
-            true,
-            2)
-          ])
-
-          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
-
-          cy.get('.app-task-list__item').eq(0).should('contain', 'Link your Worldpay account with GOV.UK Pay')
-            .find('.app-task-list__tag').should('have.text', 'Completed')
-          cy.get('.app-task-list__item').eq(1).should('contain', 'Provide your Worldpay 3DS Flex credentials')
-            .find('.app-task-list__tag').should('have.text', 'Completed')
-          cy.get('.app-task-list__item').eq(2).should('contain', 'Make a live payment to test your Worldpay PSP')
-            .find('.app-task-list__tag').should('have.text', 'Not started')
-        })
-      })
-
-      describe('When Worldpay MOTO account', () => {
+    describe('When using an account with switching flag enabled', () => {
+      describe('When Worldpay non-MOTO account', () => {
         describe('When switching is not started', () => {
-          beforeEach(() => {
-            cy.task('setupStubs', getUserAndAccountStubs('smartpay', true, [
-              { payment_provider: 'smartpay', state: 'ACTIVE' },
-              { payment_provider: 'worldpay', state: 'CREATED' }
-            ],
-            null,
-            null,
-            null,
-            true))
+          it('should show dashboard message for switching psp', () => {
+            cy.task('setupStubs', [
+              ...getUserAndAccountStubsForSwitchingNotStarted(),
+              transactionStubs.getTransactionsSummarySuccess()
+            ])
+
+            cy.visit(`/account/${gatewayAccountExternalId}/dashboard`)
+            cy.get('.govuk-notification-banner__heading').should('contain', 'Switch your payment service provider (PSP) to Worldpay')
           })
 
-          it('should have task list for Worldpay with correct tags', () => {
+          it('should show the switch message for current psp page', () => {
+            cy.task('setupStubs', getUserAndAccountStubsForSwitchingNotStarted())
+
+            cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+            cy.get('a').contains('Your PSP - Smartpay').click()
+            cy.get('#switched-psp-status').should('contain', 'Your service is ready to switch PSP from Smartpay to Worldpay.')
+          })
+
+          it('should show the switch PSP page for switching to Worldpay with tasks not started', () => {
+            cy.task('setupStubs', getUserAndAccountStubsForSwitchingNotStarted())
+
             cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
+            cy.get('.service-info--tag').should('contain', 'switch psp')
+            cy.get('#navigation-menu-switch-psp').should('have.length', 1)
+            cy.get('h1').should('contain', 'Switch payment service provider')
+            cy.get('li').contains('your Worldpay account credentials: Merchant code, username and password').should('exist')
+            cy.get('#switch-psp-action-step').should('contain', 'Switch PSP to Worldpay')
+            cy.get('.govuk-warning-text').should('contain', 'Once you switch, Worldpay will immediately start taking payments. You can refund previous payments through Smartpay.')
 
             cy.get('.app-task-list>li').eq(0).should('contain', 'Get ready to switch PSP')
               .within(() => {
-                cy.get('.app-task-list__item').should('have.length', 2)
+                cy.get('.app-task-list__item').should('have.length', 3)
                 cy.get('.app-task-list__item').eq(0).should('contain', 'Link your Worldpay account with GOV.UK Pay')
                   .find('.app-task-list__tag').should('have.text', 'Not started')
-                cy.get('.app-task-list__item').eq(1).should('contain', 'Make a live payment to test your Worldpay PSP')
+                cy.get('.app-task-list__item').eq(1).should('contain', 'Provide your Worldpay 3DS Flex credentials')
+                  .find('.app-task-list__tag').should('have.text', 'Not started')
+                cy.get('.app-task-list__item').eq(2).should('contain', 'Make a live payment to test your Worldpay PSP')
                   .find('.app-task-list__tag').should('have.text', 'Cannot start yet')
               })
             cy.get('button').contains('Switch to Worldpay').should('have.disabled')
           })
-        })
 
-        describe('When account is linked', () => {
-          beforeEach(() => {
+          it('should allow linking account', () => {
             cy.task('setupStubs', [
-              ...getUserAndAccountStubs(
-                'smartpay',
-                true,
-                [
-                  { payment_provider: 'smartpay', state: 'ACTIVE' },
-                  { payment_provider: 'worldpay', state: 'ENTERED' }
-                ],
-                null,
-                null,
-                null,
-                true
-              )
+              ...getUserAndAccountStubsForSwitchingNotStarted(),
+              gatewayAccountStubs.postCheckWorldpayCredentials({
+                gatewayAccountId,
+                merchant_code: merchantId,
+                username,
+                password
+              }),
+              gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, switchingToCredentialId, userExternalId, {
+                path: 'credentials/worldpay/one_off_customer_initiated',
+                value: {
+                  merchant_code: merchantId,
+                  username,
+                  password
+                }
+              })
             ])
+
+            cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
+
+            cy.get('.app-task-list__item').contains('Link your Worldpay account with GOV.UK Pay').click()
+            cy.get('h1').should('contain', 'Your Worldpay credentials')
+            cy.get('.govuk-back-link').should('contain', 'Back to Switching payment service provider (PSP)')
+
+            cy.get('#merchantId').type('abc')
+            cy.get('#username').type('me')
+            cy.get('#password').type('1')
+            cy.get('button').contains('Save credentials').click()
+
+            cy.get('h1').should('contain', 'Switch payment service provider')
           })
 
-          it('should should the task list with the link Worldpay account step complete', () => {
+          it('should allow providing 3DS flex credentials', () => {
+            cy.task('setupStubs', [
+              ...getUserAndAccountStubsForSwitchingNotStarted(),
+              gatewayAccountStubs.postCheckWorldpay3dsFlexCredentials({
+                gatewayAccountId,
+                result: 'valid',
+                organisational_unit_id: organisationalUnitId,
+                issuer,
+                jwt_mac_key: jwtMacKey
+              }),
+              gatewayAccountStubs.postUpdateWorldpay3dsFlexCredentials({
+                gatewayAccountId,
+                organisational_unit_id: organisationalUnitId,
+                issuer,
+                jwt_mac_key: jwtMacKey
+              }),
+              gatewayAccountStubs.patchUpdate3dsVersionSuccess(gatewayAccountId, 2)
+            ])
+
+            cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
+
+            cy.get('.app-task-list__item').contains('Provide your Worldpay 3DS Flex credentials').click()
+            cy.get('h1').should('contain', 'Your Worldpay 3DS Flex credentials')
+            cy.get('.govuk-back-link').should('contain', 'Back to Switching payment service provider (PSP)')
+
+            cy.get('#organisational-unit-id').type(organisationalUnitId)
+            cy.get('#issuer').type(issuer)
+            cy.get('#jwt-mac-key').type(jwtMacKey)
+            cy.get('button').contains('Save credentials').click()
+
+            cy.get('h1').should('contain', 'Switch payment service provider')
+          })
+        })
+
+        describe('When credentials steps are completed', () => {
+          it('should show steps as completed', () => {
+            cy.task('setupStubs', [
+              ...getUserAndAccountStubs('smartpay', true, [
+                {
+                  payment_provider: 'smartpay',
+                  state: 'ACTIVE',
+                  id: currentCredentialId,
+                  external_id: currentCredentialExternalId
+                },
+                {
+                  payment_provider: 'worldpay',
+                  state: 'ENTERED',
+                  id: switchingToCredentialId,
+                  external_id: switchingToCredentialExternalId
+                }
+              ],
+              null,
+              true,
+              2)
+            ])
+
             cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
 
             cy.get('.app-task-list__item').eq(0).should('contain', 'Link your Worldpay account with GOV.UK Pay')
               .find('.app-task-list__tag').should('have.text', 'Completed')
-            cy.get('.app-task-list__item').eq(1).should('contain', 'Make a live payment to test your Worldpay PSP')
+            cy.get('.app-task-list__item').eq(1).should('contain', 'Provide your Worldpay 3DS Flex credentials')
+              .find('.app-task-list__tag').should('have.text', 'Completed')
+            cy.get('.app-task-list__item').eq(2).should('contain', 'Make a live payment to test your Worldpay PSP')
               .find('.app-task-list__tag').should('have.text', 'Not started')
           })
         })
-      })
 
-      describe('PSP integration verified with live payment', () => {
-        it('should now be clickable and navigate to the verify PSP integration page', () => {
-          cy.task('setupStubs', [
-            ...getUserAndAccountStubs('smartpay', true, [
-              {
-                payment_provider: 'smartpay',
-                state: 'ACTIVE',
-                id: currentCredentialId,
-                external_id: currentCredentialExternalId
-              },
-              {
-                payment_provider: 'worldpay',
-                state: 'ENTERED',
-                id: switchingToCredentialId,
-                external_id: switchingToCredentialExternalId
-              }
-            ],
-            null,
-            true,
-            2),
-            connectorChargeStubs.postCreateChargeSuccess({
-              gateway_account_id: gatewayAccountId,
-              chargeExternalId: 'a-valid-charge-external-id',
-              nextUrl: '/should_follow_to_payment_page'
+        describe('When Worldpay MOTO account', () => {
+          describe('When switching is not started', () => {
+            beforeEach(() => {
+              cy.task('setupStubs', getUserAndAccountStubs('smartpay', true, [
+                { payment_provider: 'smartpay', state: 'ACTIVE' },
+                { payment_provider: 'worldpay', state: 'CREATED' }
+              ],
+              null,
+              null,
+              null,
+              true))
             })
-          ])
 
-          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
-          cy.get('.app-task-list__item').contains('Make a live payment to test your Worldpay PSP').click()
-          cy.get('h1').should('contain', 'Test the connection between Worldpay and GOV.UK Pay')
-          cy.get('.govuk-back-link').should('contain', 'Back to Switching payment service provider (PSP)')
+            it('should have task list for Worldpay with correct tags', () => {
+              cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
 
-          cy.get('button').contains('Continue to live payment').click()
-          cy.location().should((location) => {
-            expect(location.pathname).to.eq('/should_follow_to_payment_page')
+              cy.get('.app-task-list>li').eq(0).should('contain', 'Get ready to switch PSP')
+                .within(() => {
+                  cy.get('.app-task-list__item').should('have.length', 2)
+                  cy.get('.app-task-list__item').eq(0).should('contain', 'Link your Worldpay account with GOV.UK Pay')
+                    .find('.app-task-list__tag').should('have.text', 'Not started')
+                  cy.get('.app-task-list__item').eq(1).should('contain', 'Make a live payment to test your Worldpay PSP')
+                    .find('.app-task-list__tag').should('have.text', 'Cannot start yet')
+                })
+              cy.get('button').contains('Switch to Worldpay').should('have.disabled')
+            })
+          })
+
+          describe('When account is linked', () => {
+            beforeEach(() => {
+              cy.task('setupStubs', [
+                ...getUserAndAccountStubs(
+                  'smartpay',
+                  true,
+                  [
+                    { payment_provider: 'smartpay', state: 'ACTIVE' },
+                    { payment_provider: 'worldpay', state: 'ENTERED' }
+                  ],
+                  null,
+                  null,
+                  null,
+                  true
+                )
+              ])
+            })
+
+            it('should should the task list with the link Worldpay account step complete', () => {
+              cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
+
+              cy.get('.app-task-list__item').eq(0).should('contain', 'Link your Worldpay account with GOV.UK Pay')
+                .find('.app-task-list__tag').should('have.text', 'Completed')
+              cy.get('.app-task-list__item').eq(1).should('contain', 'Make a live payment to test your Worldpay PSP')
+                .find('.app-task-list__tag').should('have.text', 'Not started')
+            })
           })
         })
 
-        it('returning with a failed payment should present an error', () => {
-          cy.task('setupStubs', [
-            ...getUserAndAccountStubs('smartpay', true, [
-              {
-                payment_provider: 'smartpay',
-                state: 'ACTIVE',
-                id: currentCredentialId,
-                external_id: currentCredentialExternalId
-              },
-              {
-                payment_provider: 'worldpay',
-                state: 'ENTERED',
-                id: switchingToCredentialId,
-                external_id: switchingToCredentialExternalId
-              }
-            ],
-            null,
-            true,
-            2),
-            connectorChargeStubs.getChargeSuccess({
-              gateway_account_id: gatewayAccountId,
-              chargeExternalId: 'a-valid-charge-external-id',
-              status: 'cancelled',
-              nextUrl: '/should_follow_to_payment_page'
-            })
-          ])
-          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp/verify-psp-integration/callback`)
+        describe('PSP integration verified with live payment', () => {
+          it('should now be clickable and navigate to the verify PSP integration page', () => {
+            cy.task('setupStubs', [
+              ...getUserAndAccountStubs('smartpay', true, [
+                {
+                  payment_provider: 'smartpay',
+                  state: 'ACTIVE',
+                  id: currentCredentialId,
+                  external_id: currentCredentialExternalId
+                },
+                {
+                  payment_provider: 'worldpay',
+                  state: 'ENTERED',
+                  id: switchingToCredentialId,
+                  external_id: switchingToCredentialExternalId
+                }
+              ],
+              null,
+              true,
+              2),
+              connectorChargeStubs.postCreateChargeSuccess({
+                gateway_account_id: gatewayAccountId,
+                chargeExternalId: 'a-valid-charge-external-id',
+                nextUrl: '/should_follow_to_payment_page'
+              })
+            ])
 
-          cy.get('.govuk-error-summary__body').first().contains('Please check your Worldpay credentials and try making another payment.')
-          cy.get('.govuk-back-link').click()
+            cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
+            cy.get('.app-task-list__item').contains('Make a live payment to test your Worldpay PSP').click()
+            cy.get('h1').should('contain', 'Test the connection between Worldpay and GOV.UK Pay')
+            cy.get('.govuk-back-link').should('contain', 'Back to Switching payment service provider (PSP)')
+
+            cy.get('button').contains('Continue to live payment').click()
+            cy.location().should((location) => {
+              expect(location.pathname).to.eq('/should_follow_to_payment_page')
+            })
+          })
+
+          it('returning with a failed payment should present an error', () => {
+            cy.task('setupStubs', [
+              ...getUserAndAccountStubs('smartpay', true, [
+                {
+                  payment_provider: 'smartpay',
+                  state: 'ACTIVE',
+                  id: currentCredentialId,
+                  external_id: currentCredentialExternalId
+                },
+                {
+                  payment_provider: 'worldpay',
+                  state: 'ENTERED',
+                  id: switchingToCredentialId,
+                  external_id: switchingToCredentialExternalId
+                }
+              ],
+              null,
+              true,
+              2),
+              connectorChargeStubs.getChargeSuccess({
+                gateway_account_id: gatewayAccountId,
+                chargeExternalId: 'a-valid-charge-external-id',
+                status: 'cancelled',
+                nextUrl: '/should_follow_to_payment_page'
+              })
+            ])
+            cy.visit(`/account/${gatewayAccountExternalId}/switch-psp/verify-psp-integration/callback`)
+
+            cy.get('.govuk-error-summary__body').first().contains('Please check your Worldpay credentials and try making another payment.')
+            cy.get('.govuk-back-link').click()
+          })
+
+          it('returning with a successful payment should present completion message', () => {
+            cy.task('setupStubs', [
+              ...getUserAndAccountStubs('smartpay', true, [
+                {
+                  payment_provider: 'smartpay',
+                  state: 'ACTIVE',
+                  id: currentCredentialId,
+                  external_id: currentCredentialExternalId
+                },
+                {
+                  payment_provider: 'worldpay',
+                  state: 'VERIFIED_WITH_LIVE_PAYMENT',
+                  id: switchingToCredentialId,
+                  external_id: switchingToCredentialExternalId
+                }
+              ],
+              null,
+              true,
+              2),
+              connectorChargeStubs.postCreateChargeSuccess({
+                gateway_account_id: gatewayAccountId,
+                chargeExternalId: 'a-valid-charge-external-id',
+                nextUrl: '/should_follow_to_payment_page'
+              }),
+              connectorChargeStubs.getChargeSuccess({
+                gateway_account_id: gatewayAccountId,
+                chargeExternalId: 'a-valid-charge-external-id',
+                status: 'success',
+                nextUrl: '/should_follow_to_payment_page'
+              }),
+              gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, switchingToCredentialId, userExternalId, {
+                path: 'state',
+                value: 'VERIFIED_WITH_LIVE_PAYMENT'
+              })
+            ])
+
+            cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
+            cy.get('.app-task-list__item').contains('Make a live payment to test your Worldpay PSP').click()
+            cy.get('button').contains('Continue to live payment').click()
+            cy.visit(`/account/${gatewayAccountExternalId}/switch-psp/verify-psp-integration/callback`)
+            cy.get('.govuk-notification-banner__content').contains('Your live payment has succeeded')
+          })
         })
 
-        it('returning with a successful payment should present completion message', () => {
-          cy.task('setupStubs', [
-            ...getUserAndAccountStubs('smartpay', true, [
+        describe('Switch PSP', () => {
+          beforeEach(() => {
+            const userAndAccountStubs = getUserAndAccountStubs('smartpay', true, [
               {
                 payment_provider: 'smartpay',
                 state: 'ACTIVE',
@@ -367,224 +412,181 @@ describe('Switch PSP settings page', () => {
             ],
             null,
             true,
-            2),
-            connectorChargeStubs.postCreateChargeSuccess({
-              gateway_account_id: gatewayAccountId,
-              chargeExternalId: 'a-valid-charge-external-id',
-              nextUrl: '/should_follow_to_payment_page'
-            }),
-            connectorChargeStubs.getChargeSuccess({
-              gateway_account_id: gatewayAccountId,
-              chargeExternalId: 'a-valid-charge-external-id',
-              status: 'success',
-              nextUrl: '/should_follow_to_payment_page'
-            }),
-            gatewayAccountStubs.patchUpdateCredentialsSuccess(gatewayAccountId, switchingToCredentialId, userExternalId, {
-              path: 'state',
-              value: 'VERIFIED_WITH_LIVE_PAYMENT'
-            })
-          ])
+            2)
+            cy.task('setupStubs', [
+              ...userAndAccountStubs,
+              gatewayAccountStubs.postSwitchPspSuccess(gatewayAccountId, {
+                userExternalId,
+                credentialExternalId: switchingToCredentialExternalId
+              })
+            ])
+          })
 
-          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
-          cy.get('.app-task-list__item').contains('Make a live payment to test your Worldpay PSP').click()
-          cy.get('button').contains('Continue to live payment').click()
-          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp/verify-psp-integration/callback`)
-          cy.get('.govuk-notification-banner__content').contains('Your live payment has succeeded')
+          it('submits and navigates through to success page with appropriate message', () => {
+            cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
+            cy.get('button').contains('Switch to Worldpay').click()
+            cy.get('.govuk-notification-banner__heading').contains('You\'ve switched payment service provider')
+            cy.get('.govuk-notification-banner__content').contains('Your service is now taking payments through Worldpay. You can still process refunds of previous payments through Smartpay.')
+          })
+        })
+
+        describe('Switched PSP', () => {
+          beforeEach(() => {
+            cy.task('setupStubs', getUserAndAccountStubs('smartpay', true, [
+              {
+                payment_provider: 'smartpay',
+                state: 'ACTIVE',
+                external_id: 'a-valid-external-id-smartpay',
+                active_start_date: '2018-05-03T00:00:00.000Z'
+              },
+              {
+                payment_provider: 'worldpay',
+                state: 'RETIRED',
+                active_end_date: '2018-05-03T00:00:00.000Z',
+                external_id: 'a-valid-external-id-worldpay'
+              }
+            ],
+            null,
+            true,
+            2))
+          })
+
+          it('sets transitioned text on the old psp page', () => {
+            cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+            cy.get('a').contains('Old PSP - Worldpay').click()
+            cy.get('#switched-psp-status').should('contain', 'This service is taking payments with Smartpay. It switched from using Worldpay on 3 May 2018')
+          })
+
+          it('sets transitioned text on the your psp page for new provider', () => {
+            cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+            cy.get('a').contains('Your PSP - Smartpay').click()
+            cy.get('#switched-psp-status').should('contain', 'This service started taking payments with Smartpay on 3 May 2018.')
+          })
         })
       })
 
-      describe('Switch PSP', () => {
-        beforeEach(() => {
-          const userAndAccountStubs = getUserAndAccountStubs('smartpay', true, [
-            {
-              payment_provider: 'smartpay',
-              state: 'ACTIVE',
-              id: currentCredentialId,
-              external_id: currentCredentialExternalId
-            },
-            {
-              payment_provider: 'worldpay',
-              state: 'VERIFIED_WITH_LIVE_PAYMENT',
-              id: switchingToCredentialId,
-              external_id: switchingToCredentialExternalId
-            }
-          ],
-          null,
-          true,
-          2)
-          cy.task('setupStubs', [
-            ...userAndAccountStubs,
-            gatewayAccountStubs.postSwitchPspSuccess(gatewayAccountId, {
-              userExternalId,
-              credentialExternalId: switchingToCredentialExternalId
-            })
-          ])
-        })
-
-        it('submits and navigates through to success page with appropriate message', () => {
-          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
-          cy.get('button').contains('Switch to Worldpay').click()
-          cy.get('.govuk-notification-banner__heading').contains('You\'ve switched payment service provider')
-          cy.get('.govuk-notification-banner__content').contains('Your service is now taking payments through Worldpay. You can still process refunds of previous payments through Smartpay.')
-        })
-      })
-
-      describe('Switched PSP', () => {
-        beforeEach(() => {
-          cy.task('setupStubs', getUserAndAccountStubs('smartpay', true, [
-            {
-              payment_provider: 'smartpay',
-              state: 'ACTIVE',
-              external_id: 'a-valid-external-id-smartpay',
-              active_start_date: '2018-05-03T00:00:00.000Z'
-            },
-            {
-              payment_provider: 'worldpay',
-              state: 'RETIRED',
-              active_end_date: '2018-05-03T00:00:00.000Z',
-              external_id: 'a-valid-external-id-worldpay'
-            }
-          ],
-          null,
-          true,
-          2))
-        })
-
-        it('sets transitioned text on the old psp page', () => {
-          cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-          cy.get('a').contains('Old PSP - Worldpay').click()
-          cy.get('#switched-psp-status').should('contain', 'This service is taking payments with Smartpay. It switched from using Worldpay on 3 May 2018')
-        })
-
-        it('sets transitioned text on the your psp page for new provider', () => {
-          cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-          cy.get('a').contains('Your PSP - Smartpay').click()
-          cy.get('#switched-psp-status').should('contain', 'This service started taking payments with Smartpay on 3 May 2018.')
-        })
-      })
-    })
-
-    describe('When switching to Stripe', () => {
-      describe('Switching page', () => {
-        beforeEach(() => {
-          cy.task('setupStubs', [
-            ...getUserAndAccountStubs('smartpay', true, [
-              { payment_provider: 'smartpay', state: 'ACTIVE' },
-              { payment_provider: 'stripe', state: 'CREATED' }
-            ]),
-            stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
-              gatewayAccountId
-            })
-          ])
-        })
-
-        it('shows Stripe specific tasks', () => {
-          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
-          cy.get('.govuk-heading-l').should('contain', 'Switch payment service provider (PSP)')
-
-          cy.get('strong[id="Add organisation website address-status"]').should('contain', 'Not started')
-          cy.get('span').contains('Add organisation website address').should('exist')
-          cy.get('strong[id="Provide your bank details-status"]').should('contain', 'Not started')
-          cy.get('span').contains('Provide your bank details').should('exist')
-          cy.get('strong[id="Provide details about your responsible person-status"]').should('contain', 'Not started')
-          cy.get('span').contains('Provide details about your responsible person').should('exist')
-          cy.get('strong[id="Provide details about the director of your organisation-status"]').should('contain', 'Not started')
-          cy.get('span').contains('Provide details about the director of your organisation').should('exist')
-          cy.get('strong[id="Provide your organisation’s VAT number-status"]').should('contain', 'Not started')
-          cy.get('span').contains('Provide your organisation’s VAT number').should('exist')
-          cy.get('strong[id="Provide your Company registration number-status"]').should('contain', 'Not started')
-          cy.get('span').contains('Provide your Company registration number').should('exist')
-          cy.get('strong[id="Confirm your organisation details-status"]').should('contain', 'Not started')
-          cy.get('span').contains('Confirm your organisation details').should('exist')
-          cy.get('strong[id="Upload a government entity document-status"]').should('contain', 'Not started')
-          cy.get('span').contains('Upload a government entity document').should('exist')
-          cy.get('strong[id="Make a live payment to test your Stripe PSP-status"]').should('contain', 'Cannot start yet')
-          cy.get('span').contains('Make a live payment to test your Stripe PSP').should('exist')
-        })
-      })
-
-      describe('Stripe pages show contextually appropriate information for the switch flow', () => {
-        beforeEach(() => {
-          cy.task('setupStubs', [
-            ...getUserAndAccountStubs(
-              'smartpay',
-              true,
-              [
+      describe('When switching to Stripe', () => {
+        describe('Switching page', () => {
+          beforeEach(() => {
+            cy.task('setupStubs', [
+              ...getUserAndAccountStubs('smartpay', true, [
                 { payment_provider: 'smartpay', state: 'ACTIVE' },
-                {
-                  payment_provider: 'stripe',
-                  state: 'CREATED',
-                  credentials: { stripe_account_id: 'a-valid-stripe-account-id' }
-                }
-              ]
-            ),
-            stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
-              gatewayAccountId
-            })
-          ])
+                { payment_provider: 'stripe', state: 'CREATED' }
+              ]),
+              stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+                gatewayAccountId
+              })
+            ])
+          })
+
+          it('shows Stripe specific tasks', () => {
+            cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
+            cy.get('.govuk-heading-l').should('contain', 'Switch payment service provider (PSP)')
+
+            cy.get('strong[id="Add organisation website address-status"]').should('contain', 'Not started')
+            cy.get('span').contains('Add organisation website address').should('exist')
+            cy.get('strong[id="Provide your bank details-status"]').should('contain', 'Not started')
+            cy.get('span').contains('Provide your bank details').should('exist')
+            cy.get('strong[id="Provide details about your responsible person-status"]').should('contain', 'Not started')
+            cy.get('span').contains('Provide details about your responsible person').should('exist')
+            cy.get('strong[id="Provide details about the director of your organisation-status"]').should('contain', 'Not started')
+            cy.get('span').contains('Provide details about the director of your organisation').should('exist')
+            cy.get('strong[id="Provide your organisation’s VAT number-status"]').should('contain', 'Not started')
+            cy.get('span').contains('Provide your organisation’s VAT number').should('exist')
+            cy.get('strong[id="Provide your Company registration number-status"]').should('contain', 'Not started')
+            cy.get('span').contains('Provide your Company registration number').should('exist')
+            cy.get('strong[id="Confirm your organisation details-status"]').should('contain', 'Not started')
+            cy.get('span').contains('Confirm your organisation details').should('exist')
+            cy.get('strong[id="Upload a government entity document-status"]').should('contain', 'Not started')
+            cy.get('span').contains('Upload a government entity document').should('exist')
+            cy.get('strong[id="Make a live payment to test your Stripe PSP-status"]').should('contain', 'Cannot start yet')
+            cy.get('span').contains('Make a live payment to test your Stripe PSP').should('exist')
+          })
         })
 
-        it('loads the `VAT number` page', () => {
-          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
-          cy.get('a').contains('Provide your organisation’s VAT number').click()
-          cy.get('#navigation-menu-switch-psp').parent().should('have.class', 'govuk-!-font-weight-bold')
-          cy.get('a').contains('Back to Switching payment service provider (PSP)').should('exist')
+        describe('Stripe pages show contextually appropriate information for the switch flow', () => {
+          beforeEach(() => {
+            cy.task('setupStubs', [
+              ...getUserAndAccountStubs(
+                'smartpay',
+                true,
+                [
+                  { payment_provider: 'smartpay', state: 'ACTIVE' },
+                  {
+                    payment_provider: 'stripe',
+                    state: 'CREATED',
+                    credentials: { stripe_account_id: 'a-valid-stripe-account-id' }
+                  }
+                ]
+              ),
+              stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+                gatewayAccountId
+              })
+            ])
+          })
+
+          it('loads the `VAT number` page', () => {
+            cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
+            cy.get('a').contains('Provide your organisation’s VAT number').click()
+            cy.get('#navigation-menu-switch-psp').parent().should('have.class', 'govuk-!-font-weight-bold')
+            cy.get('a').contains('Back to Switching payment service provider (PSP)').should('exist')
+          })
+
+          it('loads the `check org details` page', () => {
+            cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
+            cy.get('a').contains('Confirm your organisation details').click()
+            cy.get('#navigation-menu-switch-psp').parent().should('have.class', 'govuk-!-font-weight-bold')
+            cy.get('a').contains('Back to Switching payment service provider (PSP)').should('exist')
+            cy.get('h1').contains('Check your organisation’s details')
+          })
         })
 
-        it('loads the `check org details` page', () => {
-          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
-          cy.get('a').contains('Confirm your organisation details').click()
-          cy.get('#navigation-menu-switch-psp').parent().should('have.class', 'govuk-!-font-weight-bold')
-          cy.get('a').contains('Back to Switching payment service provider (PSP)').should('exist')
-          cy.get('h1').contains('Check your organisation’s details')
-        })
-      })
+        describe('Switch page unlocks appropriately', () => {
+          beforeEach(() => {
+            const merchantDetails = {
+              url: 'https://www.valid-url.com'
+            }
+            cy.task('setupStubs', [
+              ...getUserAndAccountStubs(
+                'smartpay',
+                true,
+                [
+                  { payment_provider: 'smartpay', state: 'ACTIVE' },
+                  {
+                    payment_provider: 'stripe',
+                    state: 'VERIFIED_WITH_LIVE_PAYMENT',
+                    credentials: { stripe_account_id: 'a-valid-stripe-account-id' }
+                  }
+                ],
+                merchantDetails
+              ),
+              stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+                gatewayAccountId,
+                bankAccount: true,
+                vatNumber: true,
+                companyNumber: true,
+                responsiblePerson: true,
+                director: true,
+                organisationDetails: true,
+                governmentEntityDocument: true
+              })
+            ])
+          })
+          it('all steps are complete', () => {
+            cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
 
-      describe('Switch page unlocks appropriately', () => {
-        beforeEach(() => {
-          const merchantDetails = {
-            url: 'https://www.valid-url.com'
-          }
-          cy.task('setupStubs', [
-            ...getUserAndAccountStubs(
-              'smartpay',
-              true,
-              [
-                { payment_provider: 'smartpay', state: 'ACTIVE' },
-                {
-                  payment_provider: 'stripe',
-                  state: 'VERIFIED_WITH_LIVE_PAYMENT',
-                  credentials: { stripe_account_id: 'a-valid-stripe-account-id' }
-                }
-              ],
-              merchantDetails
-            ),
-            stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
-              gatewayAccountId,
-              bankAccount: true,
-              vatNumber: true,
-              companyNumber: true,
-              responsiblePerson: true,
-              director: true,
-              organisationDetails: true,
-              governmentEntityDocument: true
-            })
-          ])
-        })
-        it('all steps are complete', () => {
-          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
+            cy.get('strong[id="Add organisation website address-status"]').should('contain', 'Completed')
+            cy.get('strong[id="Provide your bank details-status"]').should('contain', 'Completed')
+            cy.get('strong[id="Provide details about your responsible person-status"]').should('contain', 'Completed')
+            cy.get('strong[id="Provide details about the director of your organisation-status"]').should('contain', 'Completed')
+            cy.get('strong[id="Provide your organisation’s VAT number-status"]').should('contain', 'Completed')
+            cy.get('strong[id="Provide your Company registration number-status"]').should('contain', 'Completed')
+            cy.get('strong[id="Confirm your organisation details-status"]').should('contain', 'Completed')
+            cy.get('strong[id="Upload a government entity document-status"]').should('contain', 'Completed')
+            cy.get('strong[id="Make a live payment to test your Stripe PSP-status"]').should('contain', 'Completed')
 
-          cy.get('strong[id="Add organisation website address-status"]').should('contain', 'Completed')
-          cy.get('strong[id="Provide your bank details-status"]').should('contain', 'Completed')
-          cy.get('strong[id="Provide details about your responsible person-status"]').should('contain', 'Completed')
-          cy.get('strong[id="Provide details about the director of your organisation-status"]').should('contain', 'Completed')
-          cy.get('strong[id="Provide your organisation’s VAT number-status"]').should('contain', 'Completed')
-          cy.get('strong[id="Provide your Company registration number-status"]').should('contain', 'Completed')
-          cy.get('strong[id="Confirm your organisation details-status"]').should('contain', 'Completed')
-          cy.get('strong[id="Upload a government entity document-status"]').should('contain', 'Completed')
-          cy.get('strong[id="Make a live payment to test your Stripe PSP-status"]').should('contain', 'Completed')
-
-          cy.get('button').contains('Switch to Stripe').should('not.be.disabled')
+            cy.get('button').contains('Switch to Stripe').should('not.be.disabled')
+          })
         })
       })
     })

--- a/test/cypress/integration/settings/verify-psp-integration.cy.js
+++ b/test/cypress/integration/settings/verify-psp-integration.cy.js
@@ -20,68 +20,70 @@ describe('Verify PSP Integration page', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  describe('When switching to Worldpay', () => {
-    beforeEach(() => {
-      cy.task('setupStubs', getUserAndAccountStubs('smartpay', true, [
-        { payment_provider: 'smartpay', state: 'ACTIVE' },
-        { payment_provider: 'worldpay', state: 'ENTERED' }
-      ]),
-      stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
-        gatewayAccountId
-      }))
-    })
-
-    it('should display enabled live payment button', () => {
-      cy.visit(`/account/${gatewayAccountExternalId}/switch-psp/verify-psp-integration`)
-      cy.get('h1').should('contain', 'Test the connection between Worldpay and GOV.UK Pay')
-      cy.get('p').contains('Make a live payment of £2 with a debit or credit card')
-      cy.get('button').should('exist')
-      cy.get('button').should('contain', 'Continue to live payment')
-      cy.get('button').should('be.not.disabled')
-    })
-  })
-
-  describe('When switching to Stripe and cannot make a test payment', () => {
-    beforeEach(() => {
-      cy.task('setupStubs', [
-        ...getUserAndAccountStubs('smartpay', true, [
+  describe.skip('with simplified settings disabled', () => {
+    describe('When switching to Worldpay', () => {
+      beforeEach(() => {
+        cy.task('setupStubs', getUserAndAccountStubs('smartpay', true, [
           { payment_provider: 'smartpay', state: 'ACTIVE' },
-          { payment_provider: 'stripe', state: 'CREATED' }
+          { payment_provider: 'worldpay', state: 'ENTERED' }
         ]),
         stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
           gatewayAccountId
-        })
-      ])
+        }))
+      })
+
+      it('should display enabled live payment button', () => {
+        cy.visit(`/account/${gatewayAccountExternalId}/switch-psp/verify-psp-integration`)
+        cy.get('h1').should('contain', 'Test the connection between Worldpay and GOV.UK Pay')
+        cy.get('p').contains('Make a live payment of £2 with a debit or credit card')
+        cy.get('button').should('exist')
+        cy.get('button').should('contain', 'Continue to live payment')
+        cy.get('button').should('be.not.disabled')
+      })
     })
 
-    it('should display disabled live payment button', () => {
-      cy.visit(`/account/${gatewayAccountExternalId}/switch-psp/verify-psp-integration`)
-      cy.get('h1').should('contain', 'Test the connection between Stripe and GOV.UK Pay')
-      cy.get('p').contains('Stripe is still verifying your details.')
-      cy.get('button').contains('Continue to live payment').should('not.exist')
-    })
-  })
+    describe('When switching to Stripe and cannot make a test payment', () => {
+      beforeEach(() => {
+        cy.task('setupStubs', [
+          ...getUserAndAccountStubs('smartpay', true, [
+            { payment_provider: 'smartpay', state: 'ACTIVE' },
+            { payment_provider: 'stripe', state: 'CREATED' }
+          ]),
+          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+            gatewayAccountId
+          })
+        ])
+      })
 
-  describe('When switching to Stripe and can make a test payment', () => {
-    beforeEach(() => {
-      cy.task('setupStubs', [
-        ...getUserAndAccountStubs('smartpay', true, [
-          { payment_provider: 'smartpay', state: 'ACTIVE' },
-          { payment_provider: 'stripe', state: 'ENTERED' }
-        ]),
-        stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
-          gatewayAccountId
-        })
-      ])
+      it('should display disabled live payment button', () => {
+        cy.visit(`/account/${gatewayAccountExternalId}/switch-psp/verify-psp-integration`)
+        cy.get('h1').should('contain', 'Test the connection between Stripe and GOV.UK Pay')
+        cy.get('p').contains('Stripe is still verifying your details.')
+        cy.get('button').contains('Continue to live payment').should('not.exist')
+      })
     })
 
-    it('should display enabled live payment button', () => {
-      cy.visit(`/account/${gatewayAccountExternalId}/switch-psp/verify-psp-integration`)
-      cy.get('h1').should('contain', 'Test the connection between Stripe and GOV.UK Pay')
-      cy.get('p').contains('Make a live payment of £2 with a debit or credit card')
-      cy.get('button').should('exist')
-      cy.get('button').should('contain', 'Continue to live payment')
-      cy.get('button').should('be.not.disabled')
+    describe('When switching to Stripe and can make a test payment', () => {
+      beforeEach(() => {
+        cy.task('setupStubs', [
+          ...getUserAndAccountStubs('smartpay', true, [
+            { payment_provider: 'smartpay', state: 'ACTIVE' },
+            { payment_provider: 'stripe', state: 'ENTERED' }
+          ]),
+          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+            gatewayAccountId
+          })
+        ])
+      })
+
+      it('should display enabled live payment button', () => {
+        cy.visit(`/account/${gatewayAccountExternalId}/switch-psp/verify-psp-integration`)
+        cy.get('h1').should('contain', 'Test the connection between Stripe and GOV.UK Pay')
+        cy.get('p').contains('Make a live payment of £2 with a debit or credit card')
+        cy.get('button').should('exist')
+        cy.get('button').should('contain', 'Continue to live payment')
+        cy.get('button').should('be.not.disabled')
+      })
     })
   })
 })

--- a/test/cypress/integration/settings/your-psp-stripe-tasklist.cy.js
+++ b/test/cypress/integration/settings/your-psp-stripe-tasklist.cy.js
@@ -66,281 +66,283 @@ describe('Your PSP Stripe page', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  describe('Should display the page correctly', () => {
-    it('should display Your PSP - Stripe page correctly', () => {
-      setupYourPspStubs()
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('h1').should('contain', 'Information for Stripe')
-      cy.get('#navigation-menu-your-psp')
-        .should('contain', 'Information for Stripe')
-        .parent().should('have.class', 'govuk-!-font-weight-bold')
+  describe.skip('with simplified settings disabled', () => {
+    describe('Should display the page correctly', () => {
+      it('should display Your PSP - Stripe page correctly', () => {
+        setupYourPspStubs()
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+        cy.get('h1').should('contain', 'Information for Stripe')
+        cy.get('#navigation-menu-your-psp')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
 
-      cy.get('[data-cy=warning-text]').should('contain', 'You need to submit additional information to Stripe.')
-      cy.get('h2').should('contain', 'Information incomplete')
-      cy.get('[data-cy="progress-indicator"]').should('contain', '0 out of 7 steps completed')
-      cy.get('h2').should('contain', 'Add your organisation’s details')
+        cy.get('[data-cy=warning-text]').should('contain', 'You need to submit additional information to Stripe.')
+        cy.get('h2').should('contain', 'Information incomplete')
+        cy.get('[data-cy="progress-indicator"]').should('contain', '0 out of 7 steps completed')
+        cy.get('h2').should('contain', 'Add your organisation’s details')
 
-      cy.get('[data-cy="task-bank-details"]').contains('Bank Details')
-        .should('exist')
-        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/bank-details`)
-      cy.get('[data-cy="task-sro"]').contains('Responsible person')
-        .should('exist')
-        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/responsible-person`)
-      cy.get('[data-cy="task-director"]').contains('Service director')
-        .should('exist')
-        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/director`)
-      cy.get('[data-cy="task-vatNumber"]').contains('VAT registration number')
-        .should('exist')
-        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/vat-number`)
-      cy.get('[data-cy="task-Company-number"]').contains('Company registration number')
-        .should('exist')
-        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/company-number`)
-      cy.get('[data-cy="task-checkorganisation-details"]').contains('Confirm your organisation’s name and address match your government entity document')
-        .should('exist')
-        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/check-organisation-details`)
-      cy.get('[data-cy="task-government-entity-document"]').contains('Government entity document')
-        .should('exist')
-        .should('not.have.attr', 'href')
-    })
-
-    it('should show progress indicator and warning text when some steps are not complete', () => {
-      setupYourPspStubs({
-        bankAccount: true,
-        responsiblePerson: true,
-        director: false,
-        vatNumber: false,
-        companyNumber: false,
-        organisationDetails: false,
-        governmentEntityDocument: false
+        cy.get('[data-cy="task-bank-details"]').contains('Bank Details')
+          .should('exist')
+          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/bank-details`)
+        cy.get('[data-cy="task-sro"]').contains('Responsible person')
+          .should('exist')
+          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/responsible-person`)
+        cy.get('[data-cy="task-director"]').contains('Service director')
+          .should('exist')
+          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/director`)
+        cy.get('[data-cy="task-vatNumber"]').contains('VAT registration number')
+          .should('exist')
+          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/vat-number`)
+        cy.get('[data-cy="task-Company-number"]').contains('Company registration number')
+          .should('exist')
+          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/company-number`)
+        cy.get('[data-cy="task-checkorganisation-details"]').contains('Confirm your organisation’s name and address match your government entity document')
+          .should('exist')
+          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/check-organisation-details`)
+        cy.get('[data-cy="task-government-entity-document"]').contains('Government entity document')
+          .should('exist')
+          .should('not.have.attr', 'href')
       })
 
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+      it('should show progress indicator and warning text when some steps are not complete', () => {
+        setupYourPspStubs({
+          bankAccount: true,
+          responsiblePerson: true,
+          director: false,
+          vatNumber: false,
+          companyNumber: false,
+          organisationDetails: false,
+          governmentEntityDocument: false
+        })
 
-      cy.get('[data-cy=warning-text]').should('contain', 'You need to submit additional information to Stripe.')
-      cy.get('h2').should('contain', 'Information incomplete')
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
 
-      cy.get('[data-cy="progress-indicator"]').should('contain', '2 out of 7 steps complete')
-      cy.get('strong[id="task-bank-details-status"]').should('contain', 'Complete')
-      cy.get('strong[id="task-sro-status"]').should('contain', 'Complete')
-      cy.get('strong[id="task-director-status"]').should('contain', 'Not started')
-      cy.get('strong[id="task-vatNumber-status"]').should('contain', 'Not started')
-      cy.get('strong[id="task-Company-number-status"]').should('contain', 'Not started')
-      cy.get('strong[id="task-checkorganisation-details-status"]').should('contain', 'Not started')
-      cy.get('strong[id="task-government-entity-document-status"]').should('contain', 'Cannot start yet')
-    })
+        cy.get('[data-cy=warning-text]').should('contain', 'You need to submit additional information to Stripe.')
+        cy.get('h2').should('contain', 'Information incomplete')
 
-    it('should show progress indicator and all completed tasks', () => {
-      setupYourPspStubs({
-        bankAccount: true,
-        director: true,
-        vatNumber: true,
-        companyNumber: true,
-        responsiblePerson: true,
-        organisationDetails: true,
-        governmentEntityDocument: true
+        cy.get('[data-cy="progress-indicator"]').should('contain', '2 out of 7 steps complete')
+        cy.get('strong[id="task-bank-details-status"]').should('contain', 'Complete')
+        cy.get('strong[id="task-sro-status"]').should('contain', 'Complete')
+        cy.get('strong[id="task-director-status"]').should('contain', 'Not started')
+        cy.get('strong[id="task-vatNumber-status"]').should('contain', 'Not started')
+        cy.get('strong[id="task-Company-number-status"]').should('contain', 'Not started')
+        cy.get('strong[id="task-checkorganisation-details-status"]').should('contain', 'Not started')
+        cy.get('strong[id="task-government-entity-document-status"]').should('contain', 'Cannot start yet')
       })
 
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+      it('should show progress indicator and all completed tasks', () => {
+        setupYourPspStubs({
+          bankAccount: true,
+          director: true,
+          vatNumber: true,
+          companyNumber: true,
+          responsiblePerson: true,
+          organisationDetails: true,
+          governmentEntityDocument: true
+        })
 
-      cy.get('[data-cy=warning-text]').should('not.exist')
-      cy.get('h2').should('contain', 'Information complete')
-      cy.get('[data-cy="progress-indicator"]').should('contain', '7 out of 7 steps complete')
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
 
-      cy.get('strong[id="task-bank-details-status"]').should('contain', 'Complete')
-      cy.get('strong[id="task-sro-status"]').should('contain', 'Complete')
-      cy.get('strong[id="task-director-status"]').should('contain', 'Complete')
-      cy.get('strong[id="task-vatNumber-status"]').should('contain', 'Complete')
-      cy.get('strong[id="task-Company-number-status"]').should('contain', 'Complete')
-      cy.get('strong[id="task-checkorganisation-details-status"]').should('contain', 'Complete')
-      cy.get('strong[id="task-government-entity-document-status"]').should('contain', 'Complete')
-    })
+        cy.get('[data-cy=warning-text]').should('not.exist')
+        cy.get('h2').should('contain', 'Information complete')
+        cy.get('[data-cy="progress-indicator"]').should('contain', '7 out of 7 steps complete')
 
-    it('should automatically show government document as cannot start yet and the rest of the tasks as not started', () => {
-      setupYourPspStubs()
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-
-      cy.get('strong[id="task-bank-details-status"]').should('contain', 'Not started')
-      cy.get('strong[id="task-sro-status"]').should('contain', 'Not started')
-      cy.get('strong[id="task-director-status"]').should('contain', 'Not started')
-      cy.get('strong[id="task-vatNumber-status"]').should('contain', 'Not started')
-      cy.get('strong[id="task-Company-number-status"]').should('contain', 'Not started')
-      cy.get('strong[id="task-checkorganisation-details-status"]').should('contain', 'Not started')
-      cy.get('strong[id="task-government-entity-document-status"]').should('contain', 'Cannot start yet')
-    })
-  })
-
-  describe('Bank details task', () => {
-    it('should click bank details task and redirect to task list when valid bank details is submitted', () => {
-      setupYourPspStubs({}, { path: 'bank_account', value: true })
-
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-
-      cy.get('[data-cy="task-bank-details"]').contains('Bank Details').click()
-      cy.get('h1').should('contain', 'Enter your organisation’s banking details')
-      cy.get('input#account-number[name="account-number"]').type(accountNumber)
-      cy.get('input#sort-code[name="sort-code"]').type(sortCode)
-      cy.get('#bank-details-form > button').click()
-      cy.get('h1').should('contain', 'Information for Stripe')
-    })
-
-    it('should have Bank details hyperlink removed when complete and status updated to "COMPLETE" ', () => {
-      setupYourPspStubs({
-        bankAccount: true
+        cy.get('strong[id="task-bank-details-status"]').should('contain', 'Complete')
+        cy.get('strong[id="task-sro-status"]').should('contain', 'Complete')
+        cy.get('strong[id="task-director-status"]').should('contain', 'Complete')
+        cy.get('strong[id="task-vatNumber-status"]').should('contain', 'Complete')
+        cy.get('strong[id="task-Company-number-status"]').should('contain', 'Complete')
+        cy.get('strong[id="task-checkorganisation-details-status"]').should('contain', 'Complete')
+        cy.get('strong[id="task-government-entity-document-status"]').should('contain', 'Complete')
       })
 
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('strong[id="task-bank-details-status"]').should('contain', 'Complete')
-      cy.get('[data-cy="task-bank-details"]').contains('Bank Details').should('not.have.attr', 'href')
-    })
-  })
+      it('should automatically show government document as cannot start yet and the rest of the tasks as not started', () => {
+        setupYourPspStubs()
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
 
-  describe('VAT task', () => {
-    it('should click VAT number task and redirect back to tasklist when valid VAT number is submitted', () => {
-      setupYourPspStubs({}, { path: 'vat_number', value: true })
-
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('[data-cy="task-vatNumber"]').contains('VAT registration number').click()
-      cy.get('h1').should('contain', 'VAT registration number')
-      cy.get('#have-vat-number').click()
-      cy.get('#vat-number').type(standardVatNumber)
-      cy.get('#vat-number-form > button').click()
-      cy.get('h1').should('contain', 'Information for Stripe')
+        cy.get('strong[id="task-bank-details-status"]').should('contain', 'Not started')
+        cy.get('strong[id="task-sro-status"]').should('contain', 'Not started')
+        cy.get('strong[id="task-director-status"]').should('contain', 'Not started')
+        cy.get('strong[id="task-vatNumber-status"]').should('contain', 'Not started')
+        cy.get('strong[id="task-Company-number-status"]').should('contain', 'Not started')
+        cy.get('strong[id="task-checkorganisation-details-status"]').should('contain', 'Not started')
+        cy.get('strong[id="task-government-entity-document-status"]').should('contain', 'Cannot start yet')
+      })
     })
 
-    it('should have VAT number task hyperlink removed when complete and status updated to "COMPLETE " ', () => {
-      setupYourPspStubs({
-        vatNumber: true
+    describe('Bank details task', () => {
+      it('should click bank details task and redirect to task list when valid bank details is submitted', () => {
+        setupYourPspStubs({}, { path: 'bank_account', value: true })
+
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+
+        cy.get('[data-cy="task-bank-details"]').contains('Bank Details').click()
+        cy.get('h1').should('contain', 'Enter your organisation’s banking details')
+        cy.get('input#account-number[name="account-number"]').type(accountNumber)
+        cy.get('input#sort-code[name="sort-code"]').type(sortCode)
+        cy.get('#bank-details-form > button').click()
+        cy.get('h1').should('contain', 'Information for Stripe')
       })
 
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('[data-cy="task-vatNumber"]').contains('VAT registration number').should('not.have.attr', 'href')
-      cy.get('strong[id="task-vatNumber-status"]').should('contain', 'Complete')
-    })
-  })
+      it('should have Bank details hyperlink removed when complete and status updated to "COMPLETE" ', () => {
+        setupYourPspStubs({
+          bankAccount: true
+        })
 
-  describe('Company number task', () => {
-    it('should click company registration task and redirect back to tasklist when valid company number is submitted', () => {
-      setupYourPspStubs({}, { path: 'company_number', value: true })
-
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('[data-cy="task-Company-number"]').contains('Company registration number').click()
-      cy.get('h1').should('contain', 'Company registration number')
-      cy.get('#company-number-declaration').click()
-      cy.get('#company-number').type(validCompanyNumber)
-      cy.get('#company-number-form > button').click()
-      cy.get('h1').should('contain', 'Information for Stripe')
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+        cy.get('strong[id="task-bank-details-status"]').should('contain', 'Complete')
+        cy.get('[data-cy="task-bank-details"]').contains('Bank Details').should('not.have.attr', 'href')
+      })
     })
 
-    it('should have Company registration number task hyperlink removed when complete and status updated to "COMPLETE " ', () => {
-      setupYourPspStubs({
-        companyNumber: true
+    describe('VAT task', () => {
+      it('should click VAT number task and redirect back to tasklist when valid VAT number is submitted', () => {
+        setupYourPspStubs({}, { path: 'vat_number', value: true })
+
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+        cy.get('[data-cy="task-vatNumber"]').contains('VAT registration number').click()
+        cy.get('h1').should('contain', 'VAT registration number')
+        cy.get('#have-vat-number').click()
+        cy.get('#vat-number').type(standardVatNumber)
+        cy.get('#vat-number-form > button').click()
+        cy.get('h1').should('contain', 'Information for Stripe')
       })
 
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('[data-cy="task-Company-number"]').contains('Company registration number').should('not.have.attr', 'href')
-      cy.get('strong[id="task-Company-number-status"]').should('contain', 'Complete')
-    })
-  })
+      it('should have VAT number task hyperlink removed when complete and status updated to "COMPLETE " ', () => {
+        setupYourPspStubs({
+          vatNumber: true
+        })
 
-  describe('Service director task', () => {
-    it('should click on service director task and redirect back to tasklist when valid service director information is submitted', () => {
-      setupYourPspStubs({}, { path: 'director', value: true })
-
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('[data-cy="task-director"]').contains('Service director').click()
-      cy.get('h1').should('contain', 'Enter a director’s details')
-      cy.get('#first-name').type(typedFirstName)
-      cy.get('#last-name').type(typedLastName)
-      cy.get('#dob-day').type(typedDobDay)
-      cy.get('#dob-month').type(typedDobMonth)
-      cy.get('#dob-year').type(typedDobYear)
-      cy.get('#email').type(typedEmail)
-      cy.get('#director-form > button').click()
-      cy.get('h1').should('contain', 'Information for Stripe')
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+        cy.get('[data-cy="task-vatNumber"]').contains('VAT registration number').should('not.have.attr', 'href')
+        cy.get('strong[id="task-vatNumber-status"]').should('contain', 'Complete')
+      })
     })
 
-    it('should have Service director task hyperlink removed when complete and status updated to "COMPLETE"', () => {
-      setupYourPspStubs({
-        director: true
+    describe('Company number task', () => {
+      it('should click company registration task and redirect back to tasklist when valid company number is submitted', () => {
+        setupYourPspStubs({}, { path: 'company_number', value: true })
+
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+        cy.get('[data-cy="task-Company-number"]').contains('Company registration number').click()
+        cy.get('h1').should('contain', 'Company registration number')
+        cy.get('#company-number-declaration').click()
+        cy.get('#company-number').type(validCompanyNumber)
+        cy.get('#company-number-form > button').click()
+        cy.get('h1').should('contain', 'Information for Stripe')
       })
 
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('strong[id="task-director-status"]').should('contain', 'Complete')
-      cy.get('[data-cy="task-director"]').contains('Service director').should('not.have.attr', 'href')
-    })
-  })
+      it('should have Company registration number task hyperlink removed when complete and status updated to "COMPLETE " ', () => {
+        setupYourPspStubs({
+          companyNumber: true
+        })
 
-  describe('Responsible person task', () => {
-    it('should click Responsible task and redirect back to tasklist when valid responsible information is submitted', () => {
-      setupYourPspStubs({}, { path: 'responsible_person', value: true })
-
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('[data-cy="task-sro"]').contains('Responsible person').click()
-      cy.get('h1').should('contain', 'Enter responsible person details')
-      cy.get('#first-name').type(typedFirstName)
-      cy.get('#last-name').type(typedLastName)
-      cy.get('#dob-day').type(typedDobDay)
-      cy.get('#dob-month').type(typedDobMonth)
-      cy.get('#dob-year').type(typedDobYear)
-      cy.get('#email').type(typedEmail)
-      cy.get('#home-address-line-1').type(typedHomeAddress)
-      cy.get('#home-address-city').type('London')
-      cy.get('#home-address-postcode').type(typedPostcode)
-      cy.get('#telephone-number').type(typedPhoneNumber)
-      cy.get('#responsible-person-form > button').click()
-      cy.get('h1').should('contain', 'Information for Stripe')
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+        cy.get('[data-cy="task-Company-number"]').contains('Company registration number').should('not.have.attr', 'href')
+        cy.get('strong[id="task-Company-number-status"]').should('contain', 'Complete')
+      })
     })
 
-    it('should have Responsible person task hyperlink removed when complete and status updated to "COMPLETE" ', () => {
-      setupYourPspStubs({
-        responsiblePerson: true
+    describe('Service director task', () => {
+      it('should click on service director task and redirect back to tasklist when valid service director information is submitted', () => {
+        setupYourPspStubs({}, { path: 'director', value: true })
+
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+        cy.get('[data-cy="task-director"]').contains('Service director').click()
+        cy.get('h1').should('contain', 'Enter a director’s details')
+        cy.get('#first-name').type(typedFirstName)
+        cy.get('#last-name').type(typedLastName)
+        cy.get('#dob-day').type(typedDobDay)
+        cy.get('#dob-month').type(typedDobMonth)
+        cy.get('#dob-year').type(typedDobYear)
+        cy.get('#email').type(typedEmail)
+        cy.get('#director-form > button').click()
+        cy.get('h1').should('contain', 'Information for Stripe')
       })
 
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('[data-cy="task-sro"]').contains('Responsible person').should('not.have.attr', 'href')
-      cy.get('strong[id="task-sro-status"]').should('contain', 'Complete')
-    })
-  })
+      it('should have Service director task hyperlink removed when complete and status updated to "COMPLETE"', () => {
+        setupYourPspStubs({
+          director: true
+        })
 
-  describe('Confirm Organisation details task', () => {
-    it('should click on Confirm organisation details task and redirect to tasklist page when organisation details are correct', () => {
-      setupYourPspStubs({}, { path: 'organisation_details', value: true })
-
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('[data-cy="task-checkorganisation-details"]').contains('Confirm your organisation’s name and address match your government entity document').click()
-      cy.get('h1').contains('Check your organisation’s details')
-      cy.get('[data-cy="yes-radio"]').click()
-      cy.get('[data-cy="continue-button"]').click()
-      cy.get('h1').should('contain', 'Information for Stripe')
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+        cy.get('strong[id="task-director-status"]').should('contain', 'Complete')
+        cy.get('[data-cy="task-director"]').contains('Service director').should('not.have.attr', 'href')
+      })
     })
 
-    it('should have Confirm Organisation details task hyperlink removed when complete and status updated to "COMPLETE" ', () => {
-      setupYourPspStubs({
-        organisationDetails: true
+    describe('Responsible person task', () => {
+      it('should click Responsible task and redirect back to tasklist when valid responsible information is submitted', () => {
+        setupYourPspStubs({}, { path: 'responsible_person', value: true })
+
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+        cy.get('[data-cy="task-sro"]').contains('Responsible person').click()
+        cy.get('h1').should('contain', 'Enter responsible person details')
+        cy.get('#first-name').type(typedFirstName)
+        cy.get('#last-name').type(typedLastName)
+        cy.get('#dob-day').type(typedDobDay)
+        cy.get('#dob-month').type(typedDobMonth)
+        cy.get('#dob-year').type(typedDobYear)
+        cy.get('#email').type(typedEmail)
+        cy.get('#home-address-line-1').type(typedHomeAddress)
+        cy.get('#home-address-city').type('London')
+        cy.get('#home-address-postcode').type(typedPostcode)
+        cy.get('#telephone-number').type(typedPhoneNumber)
+        cy.get('#responsible-person-form > button').click()
+        cy.get('h1').should('contain', 'Information for Stripe')
       })
 
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('[data-cy="task-checkorganisation-details"]').contains('Confirm your organisation’s name and address match your government entity document').should('not.have.attr', 'href')
-      cy.get('strong[id="task-checkorganisation-details-status"]').should('contain', 'Complete')
-    })
-  })
+      it('should have Responsible person task hyperlink removed when complete and status updated to "COMPLETE" ', () => {
+        setupYourPspStubs({
+          responsiblePerson: true
+        })
 
-  describe('Government entity task', () => {
-    it('should have Government entity document hyperlinked  when all other tasks are complete and should click Government entity task and display the correct page', () => {
-      setupYourPspStubs({
-        bankAccount: true,
-        director: true,
-        vatNumber: true,
-        companyNumber: true,
-        responsiblePerson: true,
-        organisationDetails: true,
-        governmentEntityDocument: false
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+        cy.get('[data-cy="task-sro"]').contains('Responsible person').should('not.have.attr', 'href')
+        cy.get('strong[id="task-sro-status"]').should('contain', 'Complete')
+      })
+    })
+
+    describe('Confirm Organisation details task', () => {
+      it('should click on Confirm organisation details task and redirect to tasklist page when organisation details are correct', () => {
+        setupYourPspStubs({}, { path: 'organisation_details', value: true })
+
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+        cy.get('[data-cy="task-checkorganisation-details"]').contains('Confirm your organisation’s name and address match your government entity document').click()
+        cy.get('h1').contains('Check your organisation’s details')
+        cy.get('[data-cy="yes-radio"]').click()
+        cy.get('[data-cy="continue-button"]').click()
+        cy.get('h1').should('contain', 'Information for Stripe')
       })
 
-      cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
-      cy.get('[data-cy="task-government-entity-document"]').contains('Government entity document').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/government-entity-document`)
-      cy.get('[data-cy="task-government-entity-document"]').contains('Government entity document').click()
-      cy.get('h1').contains('Upload a government entity document')
+      it('should have Confirm Organisation details task hyperlink removed when complete and status updated to "COMPLETE" ', () => {
+        setupYourPspStubs({
+          organisationDetails: true
+        })
+
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+        cy.get('[data-cy="task-checkorganisation-details"]').contains('Confirm your organisation’s name and address match your government entity document').should('not.have.attr', 'href')
+        cy.get('strong[id="task-checkorganisation-details-status"]').should('contain', 'Complete')
+      })
+    })
+
+    describe('Government entity task', () => {
+      it('should have Government entity document hyperlinked  when all other tasks are complete and should click Government entity task and display the correct page', () => {
+        setupYourPspStubs({
+          bankAccount: true,
+          director: true,
+          vatNumber: true,
+          companyNumber: true,
+          responsiblePerson: true,
+          organisationDetails: true,
+          governmentEntityDocument: false
+        })
+
+        cy.visit(`/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}`)
+        cy.get('[data-cy="task-government-entity-document"]').contains('Government entity document').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${credentialExternalId}/government-entity-document`)
+        cy.get('[data-cy="task-government-entity-document"]').contains('Government entity document').click()
+        cy.get('h1').contains('Upload a government entity document')
+      })
     })
   })
 })

--- a/test/cypress/integration/settings/your-psp.cy.js
+++ b/test/cypress/integration/settings/your-psp.cy.js
@@ -108,386 +108,329 @@ describe('Your PSP settings page', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  describe('When using a sandbox account', () => {
-    it('should not show link to Your PSP in the side navigation', () => {
-      cy.task('setupStubs', getUserAndGatewayAccountStubs())
-      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-      cy.get('#navigation-menu-your-psp').should('have.length', 0)
-    })
-  })
-
-  describe('When using a Worldpay account', () => {
-    const gatewayAccountOpts = {
-      gateway: 'worldpay',
-      emptyCredentials: true,
-      gatewayAccountCredentials: [{
-        payment_provider: 'worldpay',
-        external_id: credentialExternalId,
-        id: credentialsId,
-        state: 'CREATED',
-        credentials: {}
-      }]
-    }
-
-    it('should show link to "Your PSP - Worldpay" in the side navigation and render page when clicked', () => {
-      cy.task('setupStubs', getUserAndGatewayAccountStubs(gatewayAccountOpts))
-      cy.visit(`/account/${gatewayAccountExternalId}/settings`)
-      cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Worldpay')
-      cy.get('#navigation-menu-your-psp').click()
-
-      cy.get('.value-merchant-id').should('contain', 'Not configured')
-      cy.get('.value-username').should('contain', 'Not configured')
-      cy.get('.value-password').should('contain', 'Not configured')
-      cy.get('.value-organisational-unit-id').should('contain', 'Not configured')
-      cy.get('.value-issuer').should('contain', 'Not configured')
-      cy.get('.value-jwt-mac-key').should('contain', 'Not configured')
-    })
-
-    it('should allow account credentials to be configured and all values must be set', () => {
-      cy.task('setupStubs', [
-        ...getUserAndGatewayAccountStubs(gatewayAccountOpts),
-        gatewayAccountStubs.postCheckWorldpayCredentials({ ...testCredentials, gatewayAccountId }),
-        gatewayAccountStubs.patchUpdateWorldpayOneOffCredentialsSuccess({
-          gatewayAccountId,
-          credentialId: credentialsId,
-          userExternalId,
-          credentials: testCredentials
-        })
-      ])
-      cy.visit(`${yourPspPath}/${credentialExternalId}`)
-      cy.get('#credentials-change-link').click()
-      cy.get('#merchantId').type(testCredentials.merchant_code)
-      cy.get('#username').type(testCredentials.username)
-      cy.get('#submitCredentials').click()
-      cy.get('.govuk-error-summary').should('have.length', 1)
-      cy.get('#password').type(testCredentials.password)
-      cy.get('#submitCredentials').click()
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}`)
+  describe.skip('with simplified settings disabled', () => {
+    describe('When using a sandbox account', () => {
+      it('should not show link to Your PSP in the side navigation', () => {
+        cy.task('setupStubs', getUserAndGatewayAccountStubs())
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+        cy.get('#navigation-menu-your-psp').should('have.length', 0)
       })
     })
 
-    it('should not allow MOTO merchant account code', () => {
-      cy.task('setupStubs', getUserAndGatewayAccountStubs(gatewayAccountOpts))
-      cy.visit(`${yourPspPath}/${credentialExternalId}`)
-      cy.get('#credentials-change-link').click()
-      cy.get('#merchantId').type('merchant-account-code-ending-with-MOTO')
-      cy.get('#username').type(testCredentials.username)
-      cy.get('#password').type(testCredentials.password)
-      cy.get('#submitCredentials').click()
-      cy.get('.govuk-error-summary').should('have.length', 1)
-      cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'MOTO merchant code not allowed. Please contact support if you would like MOTO payments enabled')
-    })
-
-    it('should allow 3DS Flex credentials to be configured (trimming leading and trailing space) and all values must be valid and set', () => {
-      cy.task('setupStubs', [
-        ...getUserAndGatewayAccountStubs(gatewayAccountOpts),
-        gatewayAccountStubs.postCheckWorldpay3dsFlexCredentials({ gatewayAccountId, result: 'valid' }),
-        gatewayAccountStubs.postUpdateWorldpay3dsFlexCredentials({ gatewayAccountId, ...testFlexCredentials }),
-        gatewayAccountStubs.patchUpdate3dsVersionSuccess(gatewayAccountId, 2)
-      ])
-      cy.visit(`${yourPspPath}/${credentialExternalId}`)
-
-      cy.get('#flex-credentials-change-link').click()
-      cy.get('#removeFlexCredentials').should('not.exist')
-      cy.get('#organisational-unit-id').type('Invalid organisational unit ID')
-      cy.get('#issuer').type('Invalid issuer')
-      cy.get('#jwt-mac-key').type('Invalid JWT MAC key')
-      cy.get('#submitFlexCredentials').click()
-      cy.get('.govuk-error-summary').should('have.length', 1)
-      cy.get('#organisational-unit-id').should('have.value', 'Invalid organisational unit ID')
-      cy.get('#issuer').should('have.value', 'Invalid issuer')
-      cy.get('#jwt-mac-key').should('have.value', '')
-      cy.get('#organisational-unit-id').clear().type(' ' + testFlexCredentials.organisational_unit_id + ' ')
-      cy.get('#issuer').clear().type(' ' + testFlexCredentials.issuer + ' ')
-      cy.get('#jwt-mac-key').type(' ' + testFlexCredentials.jwt_mac_key + ' ')
-      cy.get('#submitFlexCredentials').click()
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}`)
-      })
-    })
-
-    it('should not allow invalid 3DS Flex credentials to be saved', () => {
-      cy.task('setupStubs', [
-        ...getUserAndGatewayAccountStubs(gatewayAccountOpts),
-        gatewayAccountStubs.postCheckWorldpay3dsFlexCredentials({
-          gatewayAccountId,
-          result: 'invalid',
-          organisational_unit_id: '5bd9b55e4444761ac0af1c81',
-          issuer: '5bd9e0e4444dce153428c941',
-          jwt_mac_key: 'ffffffff-aaaa-1111-1111-52805d5cd9e1'
-        })
-      ])
-      cy.visit(`${yourPspPath}/${credentialExternalId}`)
-      cy.get('#flex-credentials-change-link').click()
-      cy.get('#organisational-unit-id').type(testInvalidFlexCredentials.organisational_unit_id)
-      cy.get('#issuer').type(testInvalidFlexCredentials.issuer)
-      cy.get('#jwt-mac-key').type(testInvalidFlexCredentials.jwt_mac_key)
-      cy.get('#submitFlexCredentials').click()
-      cy.title().should('eq', 'Error: Your PSP - Purchase a positron projection permit Worldpay - GOV.UK Pay')
-      cy.get('.govuk-error-summary').contains('There is a problem')
-      cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'Organisational unit ID may not be correct')
-      cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#organisational-unit-id')
-      cy.get('ul.govuk-error-summary__list > li:nth-child(2) > a').should('contain', 'Issuer may not be correct')
-      cy.get('ul.govuk-error-summary__list > li:nth-child(2) > a').should('have.attr', 'href', '#issuer')
-      cy.get('ul.govuk-error-summary__list > li:nth-child(3) > a').should('contain', 'JWT MAC key may not be correct')
-      cy.get('ul.govuk-error-summary__list > li:nth-child(3) > a').should('have.attr', 'href', '#jwt-mac-key')
-      cy.get('input#organisational-unit-id').should('have.class', 'govuk-input--error')
-      cy.get('#organisational-unit-id-error').should('contain', 'Enter your organisational unit ID in the format you received it')
-      cy.get('input#issuer').should('have.class', 'govuk-input--error')
-      cy.get('#issuer-error').should('contain', 'Enter your issuer in the format you received it')
-      cy.get('input#jwt-mac-key').should('have.class', 'govuk-input--error')
-      cy.get('#jwt-mac-key-error').should('contain', 'Enter your JWT MAC key in the format you received it')
-      cy.get('#organisational-unit-id').should('have.value', testInvalidFlexCredentials.organisational_unit_id)
-      cy.get('#issuer').should('have.value', testInvalidFlexCredentials.issuer)
-      cy.get('#jwt-mac-key').should('have.value', '')
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}/flex`)
-      })
-    })
-
-    it('should display generic problem page when getting a bad result from connector', () => {
-      cy.task('setupStubs', [
-        ...getUserAndGatewayAccountStubs(gatewayAccountOpts),
-        gatewayAccountStubs.postCheckWorldpay3dsFlexCredentialsWithBadResult({
-          gatewayAccountId, ...testBadResultFlexCredentials
-        })
-      ])
-      cy.visit(`${yourPspPath}/${credentialExternalId}`)
-      cy.get('#flex-credentials-change-link').click()
-      cy.get('#organisational-unit-id').type(testBadResultFlexCredentials.organisational_unit_id)
-      cy.get('#issuer').type(testBadResultFlexCredentials.issuer)
-      cy.get('#jwt-mac-key').type(testBadResultFlexCredentials.jwt_mac_key)
-      cy.get('#submitFlexCredentials').click()
-      cy.get('h1').should('contain', 'An error occurred')
-      cy.get('#errorMsg').should('contain', 'Please try again or contact support team.')
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}/flex`)
-      })
-    })
-  })
-
-  describe('When using a Worldpay account with existing credentials', () => {
-    it('should show all credentials as configured', () => {
-      const merchantCode = 'a-merchant-code'
-      const username = 'a-username'
-      cy.task('setupStubs', getUserAndGatewayAccountStubs({
+    describe('When using a Worldpay account', () => {
+      const gatewayAccountOpts = {
         gateway: 'worldpay',
+        emptyCredentials: true,
         gatewayAccountCredentials: [{
           payment_provider: 'worldpay',
-          credentials: {
-            one_off_customer_initiated: {
-              merchant_code: merchantCode,
-              username
-            }
-          },
           external_id: credentialExternalId,
-          id: credentialsId
-        }],
-        requires3ds: true,
-        worldpay3dsFlex: testFlexCredentials
-      }))
+          id: credentialsId,
+          state: 'CREATED',
+          credentials: {}
+        }]
+      }
 
-      cy.visit(`${yourPspPath}/${credentialExternalId}`)
+      it('should show link to "Your PSP - Worldpay" in the side navigation and render page when clicked', () => {
+        cy.task('setupStubs', getUserAndGatewayAccountStubs(gatewayAccountOpts))
+        cy.visit(`/account/${gatewayAccountExternalId}/settings`)
+        cy.get('#navigation-menu-your-psp').should('contain', 'Your PSP - Worldpay')
+        cy.get('#navigation-menu-your-psp').click()
 
-      cy.get('.value-merchant-id').should('contain', merchantCode)
-      cy.get('.value-username').should('contain', username)
-      cy.get('.value-password').should('contain', '●●●●●●●●')
-      cy.get('.value-organisational-unit-id').should('contain', testFlexCredentials.organisational_unit_id)
-      cy.get('.value-issuer').should('contain', testFlexCredentials.issuer)
-      cy.get('.value-jwt-mac-key').should('contain', '●●●●●●●●')
-
-      cy.get('#flex-credentials-change-link').click()
-    })
-  })
-
-  describe('When using a Worldpay account with MOTO enabled', () => {
-    const gatewayAccountOpts = {
-      gateway: 'worldpay',
-      requires3ds: true,
-      allowMoto: true,
-      integrationVersion3ds: 1,
-      gatewayAccountCredentials: [{
-        payment_provider: 'worldpay',
-        credentials: {},
-        external_id: credentialExternalId,
-        id: credentialsId
-      }],
-      validateCredentials: testCredentialsMOTO
-    }
-
-    it('should not have 3DS flex section', () => {
-      cy.task('setupStubs', getUserAndGatewayAccountStubs(gatewayAccountOpts))
-      cy.visit(`${yourPspPath}/${credentialExternalId}`)
-      cy.get('h2').contains('3DS Flex').should('not.exist')
-      cy.get('#worldpay-3ds-flex-is-off').should('not.exist')
-      cy.get('#worldpay-3ds-flex-is-off').should('not.exist')
-      cy.get('#worldpay-3ds-flex-is-on').should('not.exist')
-    })
-
-    it('should not allow non-MOTO merchant account code', () => {
-      cy.task('setupStubs', getUserAndGatewayAccountStubs(gatewayAccountOpts))
-      cy.visit(`${yourPspPath}/${credentialExternalId}`)
-      cy.get('#credentials-change-link').click()
-      cy.get('#merchantId').clear()
-      cy.get('#merchantId').type('non-moto-merchant-code')
-      cy.get('#username').type(testCredentialsMOTO.username)
-      cy.get('#password').type(testCredentialsMOTO.password)
-      cy.get('#submitCredentials').click()
-      cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'Enter a MOTO merchant code. MOTO payments are enabled for the account')
-    })
-
-    it('should allow MOTO merchant account code', () => {
-      cy.task('setupStubs', [
-        ...getUserAndGatewayAccountStubs(gatewayAccountOpts),
-        gatewayAccountStubs.postCheckWorldpayCredentials({ ...testCredentialsMOTO, gatewayAccountId }),
-        gatewayAccountStubs.patchUpdateWorldpayOneOffCredentialsSuccess({
-          gatewayAccountId,
-          credentialId: credentialsId,
-          userExternalId,
-          credentials: testCredentialsMOTO
-        })
-      ])
-      cy.visit(`${yourPspPath}/${credentialExternalId}`)
-      cy.get('#credentials-change-link').click()
-      cy.get('#merchantId').clear()
-      cy.get('#merchantId').type(testCredentialsMOTO.merchant_code)
-      cy.get('#username').type(testCredentialsMOTO.username)
-      cy.get('#password').type(testCredentialsMOTO.password)
-      cy.get('#submitCredentials').click()
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}`)
+        cy.get('.value-merchant-id').should('contain', 'Not configured')
+        cy.get('.value-username').should('contain', 'Not configured')
+        cy.get('.value-password').should('contain', 'Not configured')
+        cy.get('.value-organisational-unit-id').should('contain', 'Not configured')
+        cy.get('.value-issuer').should('contain', 'Not configured')
+        cy.get('.value-jwt-mac-key').should('contain', 'Not configured')
       })
-      cy.get('h1').contains('Your payment service provider (PSP) - Worldpay').should('exist')
-    })
 
-    it('should allow MOTO merchant account code ending MOTOGBP', () => {
-      cy.task('setupStubs', [
-        ...getUserAndGatewayAccountStubs(gatewayAccountOpts),
-        gatewayAccountStubs.postCheckWorldpayCredentials({ ...testCredentialsMOTOGBP, gatewayAccountId }),
-        gatewayAccountStubs.patchUpdateWorldpayOneOffCredentialsSuccess({
-          gatewayAccountId,
-          credentialId: credentialsId,
-          userExternalId,
-          credentials: testCredentialsMOTOGBP
+      it('should allow account credentials to be configured and all values must be set', () => {
+        cy.task('setupStubs', [
+          ...getUserAndGatewayAccountStubs(gatewayAccountOpts),
+          gatewayAccountStubs.postCheckWorldpayCredentials({ ...testCredentials, gatewayAccountId }),
+          gatewayAccountStubs.patchUpdateWorldpayOneOffCredentialsSuccess({
+            gatewayAccountId,
+            credentialId: credentialsId,
+            userExternalId,
+            credentials: testCredentials
+          })
+        ])
+        cy.visit(`${yourPspPath}/${credentialExternalId}`)
+        cy.get('#credentials-change-link').click()
+        cy.get('#merchantId').type(testCredentials.merchant_code)
+        cy.get('#username').type(testCredentials.username)
+        cy.get('#submitCredentials').click()
+        cy.get('.govuk-error-summary').should('have.length', 1)
+        cy.get('#password').type(testCredentials.password)
+        cy.get('#submitCredentials').click()
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}`)
         })
-      ])
-      cy.visit(`${yourPspPath}/${credentialExternalId}`)
-      cy.get('#credentials-change-link').click()
-      cy.get('#merchantId').clear()
-      cy.get('#merchantId').type(testCredentialsMOTOGBP.merchant_code)
-      cy.get('#username').type(testCredentialsMOTOGBP.username)
-      cy.get('#password').type(testCredentialsMOTOGBP.password)
-      cy.get('#submitCredentials').click()
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}`)
       })
-      cy.get('h1').contains('Your payment service provider (PSP) - Worldpay').should('exist')
-    })
-  })
 
-  describe('When using a Worldpay account with recurring payments enabled', () => {
-    it('should render the page correctly when there are no existing credentials', () => {
-      cy.task('setupStubs', getUserAndGatewayAccountStubs({
+      it('should not allow MOTO merchant account code', () => {
+        cy.task('setupStubs', getUserAndGatewayAccountStubs(gatewayAccountOpts))
+        cy.visit(`${yourPspPath}/${credentialExternalId}`)
+        cy.get('#credentials-change-link').click()
+        cy.get('#merchantId').type('merchant-account-code-ending-with-MOTO')
+        cy.get('#username').type(testCredentials.username)
+        cy.get('#password').type(testCredentials.password)
+        cy.get('#submitCredentials').click()
+        cy.get('.govuk-error-summary').should('have.length', 1)
+        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'MOTO merchant code not allowed. Please contact support if you would like MOTO payments enabled')
+      })
+
+      it('should allow 3DS Flex credentials to be configured (trimming leading and trailing space) and all values must be valid and set', () => {
+        cy.task('setupStubs', [
+          ...getUserAndGatewayAccountStubs(gatewayAccountOpts),
+          gatewayAccountStubs.postCheckWorldpay3dsFlexCredentials({ gatewayAccountId, result: 'valid' }),
+          gatewayAccountStubs.postUpdateWorldpay3dsFlexCredentials({ gatewayAccountId, ...testFlexCredentials }),
+          gatewayAccountStubs.patchUpdate3dsVersionSuccess(gatewayAccountId, 2)
+        ])
+        cy.visit(`${yourPspPath}/${credentialExternalId}`)
+
+        cy.get('#flex-credentials-change-link').click()
+        cy.get('#removeFlexCredentials').should('not.exist')
+        cy.get('#organisational-unit-id').type('Invalid organisational unit ID')
+        cy.get('#issuer').type('Invalid issuer')
+        cy.get('#jwt-mac-key').type('Invalid JWT MAC key')
+        cy.get('#submitFlexCredentials').click()
+        cy.get('.govuk-error-summary').should('have.length', 1)
+        cy.get('#organisational-unit-id').should('have.value', 'Invalid organisational unit ID')
+        cy.get('#issuer').should('have.value', 'Invalid issuer')
+        cy.get('#jwt-mac-key').should('have.value', '')
+        cy.get('#organisational-unit-id').clear().type(' ' + testFlexCredentials.organisational_unit_id + ' ')
+        cy.get('#issuer').clear().type(' ' + testFlexCredentials.issuer + ' ')
+        cy.get('#jwt-mac-key').type(' ' + testFlexCredentials.jwt_mac_key + ' ')
+        cy.get('#submitFlexCredentials').click()
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}`)
+        })
+      })
+
+      it('should not allow invalid 3DS Flex credentials to be saved', () => {
+        cy.task('setupStubs', [
+          ...getUserAndGatewayAccountStubs(gatewayAccountOpts),
+          gatewayAccountStubs.postCheckWorldpay3dsFlexCredentials({
+            gatewayAccountId,
+            result: 'invalid',
+            organisational_unit_id: '5bd9b55e4444761ac0af1c81',
+            issuer: '5bd9e0e4444dce153428c941',
+            jwt_mac_key: 'ffffffff-aaaa-1111-1111-52805d5cd9e1'
+          })
+        ])
+        cy.visit(`${yourPspPath}/${credentialExternalId}`)
+        cy.get('#flex-credentials-change-link').click()
+        cy.get('#organisational-unit-id').type(testInvalidFlexCredentials.organisational_unit_id)
+        cy.get('#issuer').type(testInvalidFlexCredentials.issuer)
+        cy.get('#jwt-mac-key').type(testInvalidFlexCredentials.jwt_mac_key)
+        cy.get('#submitFlexCredentials').click()
+        cy.title().should('eq', 'Error: Your PSP - Purchase a positron projection permit Worldpay - GOV.UK Pay')
+        cy.get('.govuk-error-summary').contains('There is a problem')
+        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'Organisational unit ID may not be correct')
+        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#organisational-unit-id')
+        cy.get('ul.govuk-error-summary__list > li:nth-child(2) > a').should('contain', 'Issuer may not be correct')
+        cy.get('ul.govuk-error-summary__list > li:nth-child(2) > a').should('have.attr', 'href', '#issuer')
+        cy.get('ul.govuk-error-summary__list > li:nth-child(3) > a').should('contain', 'JWT MAC key may not be correct')
+        cy.get('ul.govuk-error-summary__list > li:nth-child(3) > a').should('have.attr', 'href', '#jwt-mac-key')
+        cy.get('input#organisational-unit-id').should('have.class', 'govuk-input--error')
+        cy.get('#organisational-unit-id-error').should('contain', 'Enter your organisational unit ID in the format you received it')
+        cy.get('input#issuer').should('have.class', 'govuk-input--error')
+        cy.get('#issuer-error').should('contain', 'Enter your issuer in the format you received it')
+        cy.get('input#jwt-mac-key').should('have.class', 'govuk-input--error')
+        cy.get('#jwt-mac-key-error').should('contain', 'Enter your JWT MAC key in the format you received it')
+        cy.get('#organisational-unit-id').should('have.value', testInvalidFlexCredentials.organisational_unit_id)
+        cy.get('#issuer').should('have.value', testInvalidFlexCredentials.issuer)
+        cy.get('#jwt-mac-key').should('have.value', '')
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}/flex`)
+        })
+      })
+
+      it('should display generic problem page when getting a bad result from connector', () => {
+        cy.task('setupStubs', [
+          ...getUserAndGatewayAccountStubs(gatewayAccountOpts),
+          gatewayAccountStubs.postCheckWorldpay3dsFlexCredentialsWithBadResult({
+            gatewayAccountId, ...testBadResultFlexCredentials
+          })
+        ])
+        cy.visit(`${yourPspPath}/${credentialExternalId}`)
+        cy.get('#flex-credentials-change-link').click()
+        cy.get('#organisational-unit-id').type(testBadResultFlexCredentials.organisational_unit_id)
+        cy.get('#issuer').type(testBadResultFlexCredentials.issuer)
+        cy.get('#jwt-mac-key').type(testBadResultFlexCredentials.jwt_mac_key)
+        cy.get('#submitFlexCredentials').click()
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#errorMsg').should('contain', 'Please try again or contact support team.')
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}/flex`)
+        })
+      })
+    })
+
+    describe('When using a Worldpay account with existing credentials', () => {
+      it('should show all credentials as configured', () => {
+        const merchantCode = 'a-merchant-code'
+        const username = 'a-username'
+        cy.task('setupStubs', getUserAndGatewayAccountStubs({
+          gateway: 'worldpay',
+          gatewayAccountCredentials: [{
+            payment_provider: 'worldpay',
+            credentials: {
+              one_off_customer_initiated: {
+                merchant_code: merchantCode,
+                username
+              }
+            },
+            external_id: credentialExternalId,
+            id: credentialsId
+          }],
+          requires3ds: true,
+          worldpay3dsFlex: testFlexCredentials
+        }))
+
+        cy.visit(`${yourPspPath}/${credentialExternalId}`)
+
+        cy.get('.value-merchant-id').should('contain', merchantCode)
+        cy.get('.value-username').should('contain', username)
+        cy.get('.value-password').should('contain', '●●●●●●●●')
+        cy.get('.value-organisational-unit-id').should('contain', testFlexCredentials.organisational_unit_id)
+        cy.get('.value-issuer').should('contain', testFlexCredentials.issuer)
+        cy.get('.value-jwt-mac-key').should('contain', '●●●●●●●●')
+
+        cy.get('#flex-credentials-change-link').click()
+      })
+    })
+
+    describe('When using a Worldpay account with MOTO enabled', () => {
+      const gatewayAccountOpts = {
         gateway: 'worldpay',
         requires3ds: true,
-        recurringEnabled: true,
+        allowMoto: true,
         integrationVersion3ds: 1,
         gatewayAccountCredentials: [{
           payment_provider: 'worldpay',
           credentials: {},
           external_id: credentialExternalId,
           id: credentialsId
-        }]
-      }))
-
-      cy.visit(`${yourPspPath}/${credentialExternalId}`)
-
-      cy.get('[data-cy=cit-credentials-summary-list]').within(() => {
-        cy.get('.value-merchant-id').should('contain', 'Not configured')
-        cy.get('.value-username').should('contain', 'Not configured')
-        cy.get('.value-password').should('contain', 'Not configured')
-      })
-
-      cy.get('[data-cy=mit-credentials-summary-list]').within(() => {
-        cy.get('.value-merchant-id').should('contain', 'Not configured')
-        cy.get('.value-username').should('contain', 'Not configured')
-        cy.get('.value-password').should('contain', 'Not configured')
-      })
-
-      cy.get('[data-cy=worldpay-flex-settings-summary-list]').within(() => {
-        cy.get('.value-organisational-unit-id').should('contain', 'Not configured')
-        cy.get('.value-issuer').should('contain', 'Not configured')
-        cy.get('.value-jwt-mac-key').should('contain', 'Not configured')
-      })
-    })
-
-    it('should render the page correctly when there are existing credentials', () => {
-      const citMerchantCode = 'a-cit-merchant-code'
-      const mitMerchantCode = 'a-mit-merchant-code'
-
-      const citUsername = 'a-cit-username'
-      const mitUsername = 'a-mit-username'
-
-      cy.task('setupStubs', getUserAndGatewayAccountStubs({
-        gateway: 'worldpay',
-        requires3ds: true,
-        recurringEnabled: true,
-        integrationVersion3ds: 1,
-        gatewayAccountCredentials: [{
-          payment_provider: 'worldpay',
-          credentials: {
-            recurring_customer_initiated: {
-              merchant_code: citMerchantCode,
-              username: citUsername
-            },
-            recurring_merchant_initiated: {
-              merchant_code: mitMerchantCode,
-              username: mitUsername
-            }
-          },
-          external_id: credentialExternalId,
-          id: credentialsId
         }],
-        worldpay3dsFlex: testFlexCredentials
-      }))
-
-      cy.visit(`${yourPspPath}/${credentialExternalId}`)
-
-      cy.get('[data-cy=cit-credentials-summary-list]').within(() => {
-        cy.get('.value-merchant-id').should('contain', citMerchantCode)
-        cy.get('.value-username').should('contain', citUsername)
-        cy.get('.value-password').should('contain', '●●●●●●●●')
-      })
-
-      cy.get('[data-cy=mit-credentials-summary-list]').within(() => {
-        cy.get('.value-merchant-id').should('contain', mitMerchantCode)
-        cy.get('.value-username').should('contain', mitUsername)
-        cy.get('.value-password').should('contain', '●●●●●●●●')
-      })
-
-      cy.get('[data-cy=worldpay-flex-settings-summary-list]').within(() => {
-        cy.get('.value-organisational-unit-id').should('contain', testFlexCredentials.organisational_unit_id)
-        cy.get('.value-issuer').should('contain', testFlexCredentials.issuer)
-        cy.get('.value-jwt-mac-key').should('contain', '●●●●●●●●')
-      })
-    })
-
-    it('should link to and appropriately pre-populate the pages for updating recurring merchant details', () => {
-      const citMerchantCode = 'a-cit-merchant-code'
-      const mitMerchantCode = 'a-mit-merchant-code'
-
-      const citUsername = 'a-cit-username'
-      const mitUsername = 'a-mit-username'
-
-      const validateCredentials = {
-        merchant_code: citMerchantCode,
-        username: citUsername,
-        password: 'a-password'
+        validateCredentials: testCredentialsMOTO
       }
 
-      cy.task('setupStubs', [
-        ...getUserAndGatewayAccountStubs({
+      it('should not have 3DS flex section', () => {
+        cy.task('setupStubs', getUserAndGatewayAccountStubs(gatewayAccountOpts))
+        cy.visit(`${yourPspPath}/${credentialExternalId}`)
+        cy.get('h2').contains('3DS Flex').should('not.exist')
+        cy.get('#worldpay-3ds-flex-is-off').should('not.exist')
+        cy.get('#worldpay-3ds-flex-is-off').should('not.exist')
+        cy.get('#worldpay-3ds-flex-is-on').should('not.exist')
+      })
+
+      it('should not allow non-MOTO merchant account code', () => {
+        cy.task('setupStubs', getUserAndGatewayAccountStubs(gatewayAccountOpts))
+        cy.visit(`${yourPspPath}/${credentialExternalId}`)
+        cy.get('#credentials-change-link').click()
+        cy.get('#merchantId').clear()
+        cy.get('#merchantId').type('non-moto-merchant-code')
+        cy.get('#username').type(testCredentialsMOTO.username)
+        cy.get('#password').type(testCredentialsMOTO.password)
+        cy.get('#submitCredentials').click()
+        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'Enter a MOTO merchant code. MOTO payments are enabled for the account')
+      })
+
+      it('should allow MOTO merchant account code', () => {
+        cy.task('setupStubs', [
+          ...getUserAndGatewayAccountStubs(gatewayAccountOpts),
+          gatewayAccountStubs.postCheckWorldpayCredentials({ ...testCredentialsMOTO, gatewayAccountId }),
+          gatewayAccountStubs.patchUpdateWorldpayOneOffCredentialsSuccess({
+            gatewayAccountId,
+            credentialId: credentialsId,
+            userExternalId,
+            credentials: testCredentialsMOTO
+          })
+        ])
+        cy.visit(`${yourPspPath}/${credentialExternalId}`)
+        cy.get('#credentials-change-link').click()
+        cy.get('#merchantId').clear()
+        cy.get('#merchantId').type(testCredentialsMOTO.merchant_code)
+        cy.get('#username').type(testCredentialsMOTO.username)
+        cy.get('#password').type(testCredentialsMOTO.password)
+        cy.get('#submitCredentials').click()
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}`)
+        })
+        cy.get('h1').contains('Your payment service provider (PSP) - Worldpay').should('exist')
+      })
+
+      it('should allow MOTO merchant account code ending MOTOGBP', () => {
+        cy.task('setupStubs', [
+          ...getUserAndGatewayAccountStubs(gatewayAccountOpts),
+          gatewayAccountStubs.postCheckWorldpayCredentials({ ...testCredentialsMOTOGBP, gatewayAccountId }),
+          gatewayAccountStubs.patchUpdateWorldpayOneOffCredentialsSuccess({
+            gatewayAccountId,
+            credentialId: credentialsId,
+            userExternalId,
+            credentials: testCredentialsMOTOGBP
+          })
+        ])
+        cy.visit(`${yourPspPath}/${credentialExternalId}`)
+        cy.get('#credentials-change-link').click()
+        cy.get('#merchantId').clear()
+        cy.get('#merchantId').type(testCredentialsMOTOGBP.merchant_code)
+        cy.get('#username').type(testCredentialsMOTOGBP.username)
+        cy.get('#password').type(testCredentialsMOTOGBP.password)
+        cy.get('#submitCredentials').click()
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}`)
+        })
+        cy.get('h1').contains('Your payment service provider (PSP) - Worldpay').should('exist')
+      })
+    })
+
+    describe('When using a Worldpay account with recurring payments enabled', () => {
+      it('should render the page correctly when there are no existing credentials', () => {
+        cy.task('setupStubs', getUserAndGatewayAccountStubs({
+          gateway: 'worldpay',
+          requires3ds: true,
+          recurringEnabled: true,
+          integrationVersion3ds: 1,
+          gatewayAccountCredentials: [{
+            payment_provider: 'worldpay',
+            credentials: {},
+            external_id: credentialExternalId,
+            id: credentialsId
+          }]
+        }))
+
+        cy.visit(`${yourPspPath}/${credentialExternalId}`)
+
+        cy.get('[data-cy=cit-credentials-summary-list]').within(() => {
+          cy.get('.value-merchant-id').should('contain', 'Not configured')
+          cy.get('.value-username').should('contain', 'Not configured')
+          cy.get('.value-password').should('contain', 'Not configured')
+        })
+
+        cy.get('[data-cy=mit-credentials-summary-list]').within(() => {
+          cy.get('.value-merchant-id').should('contain', 'Not configured')
+          cy.get('.value-username').should('contain', 'Not configured')
+          cy.get('.value-password').should('contain', 'Not configured')
+        })
+
+        cy.get('[data-cy=worldpay-flex-settings-summary-list]').within(() => {
+          cy.get('.value-organisational-unit-id').should('contain', 'Not configured')
+          cy.get('.value-issuer').should('contain', 'Not configured')
+          cy.get('.value-jwt-mac-key').should('contain', 'Not configured')
+        })
+      })
+
+      it('should render the page correctly when there are existing credentials', () => {
+        const citMerchantCode = 'a-cit-merchant-code'
+        const mitMerchantCode = 'a-mit-merchant-code'
+
+        const citUsername = 'a-cit-username'
+        const mitUsername = 'a-mit-username'
+
+        cy.task('setupStubs', getUserAndGatewayAccountStubs({
           gateway: 'worldpay',
           requires3ds: true,
           recurringEnabled: true,
@@ -507,41 +450,100 @@ describe('Your PSP settings page', () => {
             external_id: credentialExternalId,
             id: credentialsId
           }],
-          worldpay3dsFlex: testFlexCredentials,
-          validateCredentials
-        }),
-        gatewayAccountStubs.postCheckWorldpayCredentials({ ...validateCredentials, gatewayAccountId }),
-        gatewayAccountStubs.patchUpdateWorldpayOneOffCredentialsSuccess({
-          gatewayAccountId,
-          credentialId: credentialsId,
-          userExternalId,
-          path: 'credentials/worldpay/recurring_customer_initiated',
-          credentials: validateCredentials
+          worldpay3dsFlex: testFlexCredentials
+        }))
+
+        cy.visit(`${yourPspPath}/${credentialExternalId}`)
+
+        cy.get('[data-cy=cit-credentials-summary-list]').within(() => {
+          cy.get('.value-merchant-id').should('contain', citMerchantCode)
+          cy.get('.value-username').should('contain', citUsername)
+          cy.get('.value-password').should('contain', '●●●●●●●●')
         })
-      ])
 
-      cy.visit(`${yourPspPath}/${credentialExternalId}`)
+        cy.get('[data-cy=mit-credentials-summary-list]').within(() => {
+          cy.get('.value-merchant-id').should('contain', mitMerchantCode)
+          cy.get('.value-username').should('contain', mitUsername)
+          cy.get('.value-password').should('contain', '●●●●●●●●')
+        })
 
-      cy.get('#mit-credentials-change-link').click()
-
-      cy.get('h1').should('contain', 'Recurring merchant initiated transaction (MIT) credentials')
-      cy.get('#merchantId').should('have.value', mitMerchantCode)
-      cy.get('#username').should('have.value', mitUsername)
-
-      cy.get('.govuk-back-link').click()
-
-      cy.get('#cit-credentials-change-link').click()
-
-      cy.get('h1').should('contain', 'Recurring customer initiated transaction (CIT) credentials')
-      cy.get('#merchantId').should('have.value', citMerchantCode)
-      cy.get('#username').should('have.value', citUsername)
-
-      cy.get('#password').type('a-password')
-      cy.get('#submitCredentials').click()
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}`)
+        cy.get('[data-cy=worldpay-flex-settings-summary-list]').within(() => {
+          cy.get('.value-organisational-unit-id').should('contain', testFlexCredentials.organisational_unit_id)
+          cy.get('.value-issuer').should('contain', testFlexCredentials.issuer)
+          cy.get('.value-jwt-mac-key').should('contain', '●●●●●●●●')
+        })
       })
-      cy.get('h1').contains('Your payment service provider (PSP) - Worldpay').should('exist')
+
+      it('should link to and appropriately pre-populate the pages for updating recurring merchant details', () => {
+        const citMerchantCode = 'a-cit-merchant-code'
+        const mitMerchantCode = 'a-mit-merchant-code'
+
+        const citUsername = 'a-cit-username'
+        const mitUsername = 'a-mit-username'
+
+        const validateCredentials = {
+          merchant_code: citMerchantCode,
+          username: citUsername,
+          password: 'a-password'
+        }
+
+        cy.task('setupStubs', [
+          ...getUserAndGatewayAccountStubs({
+            gateway: 'worldpay',
+            requires3ds: true,
+            recurringEnabled: true,
+            integrationVersion3ds: 1,
+            gatewayAccountCredentials: [{
+              payment_provider: 'worldpay',
+              credentials: {
+                recurring_customer_initiated: {
+                  merchant_code: citMerchantCode,
+                  username: citUsername
+                },
+                recurring_merchant_initiated: {
+                  merchant_code: mitMerchantCode,
+                  username: mitUsername
+                }
+              },
+              external_id: credentialExternalId,
+              id: credentialsId
+            }],
+            worldpay3dsFlex: testFlexCredentials,
+            validateCredentials
+          }),
+          gatewayAccountStubs.postCheckWorldpayCredentials({ ...validateCredentials, gatewayAccountId }),
+          gatewayAccountStubs.patchUpdateWorldpayOneOffCredentialsSuccess({
+            gatewayAccountId,
+            credentialId: credentialsId,
+            userExternalId,
+            path: 'credentials/worldpay/recurring_customer_initiated',
+            credentials: validateCredentials
+          })
+        ])
+
+        cy.visit(`${yourPspPath}/${credentialExternalId}`)
+
+        cy.get('#mit-credentials-change-link').click()
+
+        cy.get('h1').should('contain', 'Recurring merchant initiated transaction (MIT) credentials')
+        cy.get('#merchantId').should('have.value', mitMerchantCode)
+        cy.get('#username').should('have.value', mitUsername)
+
+        cy.get('.govuk-back-link').click()
+
+        cy.get('#cit-credentials-change-link').click()
+
+        cy.get('h1').should('contain', 'Recurring customer initiated transaction (CIT) credentials')
+        cy.get('#merchantId').should('have.value', citMerchantCode)
+        cy.get('#username').should('have.value', citUsername)
+
+        cy.get('#password').type('a-password')
+        cy.get('#submitCredentials').click()
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq(`${yourPspPath}/${credentialExternalId}`)
+        })
+        cy.get('h1').contains('Your payment service provider (PSP) - Worldpay').should('exist')
+      })
     })
   })
 })

--- a/test/cypress/integration/stripe-setup/bank-details.cy.js
+++ b/test/cypress/integration/stripe-setup/bank-details.cy.js
@@ -43,130 +43,137 @@ function setupStubs (bankAccount, type = 'live', paymentProvider = 'stripe') {
 }
 
 describe('Stripe setup: bank details page', () => {
-  describe('Card gateway account', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
-    })
-
-    describe('Bank details page is shown', () => {
+  describe.skip('with simplified settings disabled', () => {
+    describe('Card gateway account', () => {
       beforeEach(() => {
-        setupStubs(false)
-        cy.visit(bankDetailsUrl)
+        cy.setEncryptedCookies(userExternalId)
       })
 
-      it('should display page correctly', () => {
-        cy.get('h1').should('contain', 'Enter your organisation’s banking details')
+      describe('Bank details page is shown', () => {
+        beforeEach(() => {
+          setupStubs(false)
+          cy.visit(bankDetailsUrl)
+        })
 
-        cy.get('#navigation-menu-your-psp')
-          .should('contain', 'Information for Stripe')
-          .parent().should('have.class', 'govuk-!-font-weight-bold')
+        it('should display page correctly', () => {
+          cy.get('h1').should('contain', 'Enter your organisation’s banking details')
 
-        cy.get('#bank-details-form').should('exist')
-          .within(() => {
-            cy.get('input#account-number').should('exist')
-            cy.get('input#sort-code').should('exist')
-            cy.get('button').should('exist')
-            cy.get('button').should('contain', 'Save and continue')
+          cy.get('#navigation-menu-your-psp')
+            .should('contain', 'Information for Stripe')
+            .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+          cy.get('#bank-details-form').should('exist')
+            .within(() => {
+              cy.get('input#account-number').should('exist')
+              cy.get('input#sort-code').should('exist')
+              cy.get('button').should('exist')
+              cy.get('button').should('contain', 'Save and continue')
+            })
+        })
+
+        it('should have a back link that redirects back to tasklist page', () => {
+          cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
+          cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+        })
+
+        it('should display an error when all fields are blank', () => {
+          cy.get('#bank-details-form > button').click()
+
+          cy.get('h2').should('contain', 'There is a problem')
+          cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'Enter a sort code')
+          cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#sort-code')
+          cy.get('ul.govuk-error-summary__list > li:nth-child(2) > a').should('contain', 'Enter an account number')
+          cy.get('ul.govuk-error-summary__list > li:nth-child(2) > a').should('have.attr', 'href', '#account-number')
+
+          cy.get('input#account-number').should('have.class', 'govuk-input--error')
+          cy.get('.govuk-form-group--error > input#account-number').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('contain', 'Enter an account number')
           })
+
+          cy.get('input#sort-code').should('have.class', 'govuk-input--error')
+          cy.get('.govuk-form-group--error > input#sort-code').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('contain', 'Enter a sort code')
+          })
+
+          cy.get('#navigation-menu-your-psp')
+            .should('contain', 'Information for Stripe')
+            .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+          cy.get('.govuk-back-link')
+            .should('contain', 'Back to information for Stripe')
+            .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+        })
       })
 
-      it('should have a back link that redirects back to tasklist page', () => {
-        cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
-        cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
-      })
+      describe('Bank account flag already true', () => {
+        it('should display an error when on Bank details page', () => {
+          setupStubs(true)
 
-      it('should display an error when all fields are blank', () => {
-        cy.get('#bank-details-form > button').click()
+          cy.visit(bankDetailsUrl)
 
-        cy.get('h2').should('contain', 'There is a problem')
-        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'Enter a sort code')
-        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#sort-code')
-        cy.get('ul.govuk-error-summary__list > li:nth-child(2) > a').should('contain', 'Enter an account number')
-        cy.get('ul.govuk-error-summary__list > li:nth-child(2) > a').should('have.attr', 'href', '#account-number')
-
-        cy.get('input#account-number').should('have.class', 'govuk-input--error')
-        cy.get('.govuk-form-group--error > input#account-number').parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('contain', 'Enter an account number')
+          cy.get('h1').should('contain', 'An error occurred')
+          cy.get('#back-link').should('contain', 'Back to dashboard')
+          cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+          cy.get('#error-message').should('contain', 'You’ve already provided your bank details. Contact GOV.UK Pay support if you need to update them.')
         })
 
-        cy.get('input#sort-code').should('have.class', 'govuk-input--error')
-        cy.get('.govuk-form-group--error > input#sort-code').parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('contain', 'Enter a sort code')
+        it('should display an error when submitting Bank details page', () => {
+          setupStubs([false, true], 'live', 'stripe')
+
+          cy.visit(bankDetailsUrl)
+
+          cy.get('input#account-number[name="account-number"]').type(accountNumber)
+          cy.get('input#sort-code[name="sort-code"]').type(sortCode)
+          cy.get('#bank-details-form > button').click()
+
+          cy.get('h1').should('contain', 'An error occurred')
+          cy.get('#back-link').should('contain', 'Back to dashboard')
+          cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+          cy.get('#error-message').should('contain', 'You’ve already provided your bank details. Contact GOV.UK Pay support if you need to update them.')
         })
-
-        cy.get('#navigation-menu-your-psp')
-          .should('contain', 'Information for Stripe')
-          .parent().should('have.class', 'govuk-!-font-weight-bold')
-
-        cy.get('.govuk-back-link')
-          .should('contain', 'Back to information for Stripe')
-          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
-      })
-    })
-
-    describe('Bank account flag already true', () => {
-      it('should display an error when on Bank details page', () => {
-        setupStubs(true)
-
-        cy.visit(bankDetailsUrl)
-
-        cy.get('h1').should('contain', 'An error occurred')
-        cy.get('#back-link').should('contain', 'Back to dashboard')
-        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
-        cy.get('#error-message').should('contain', 'You’ve already provided your bank details. Contact GOV.UK Pay support if you need to update them.')
       })
 
-      it('should display an error when submitting Bank details page', () => {
-        setupStubs([false, true], 'live', 'stripe')
+      describe('Not a Stripe gateway account', () => {
+        it('should show a 404 error when gateway account is not Stripe', () => {
+          setupStubs(true, 'live', 'sandbox')
 
-        cy.visit(bankDetailsUrl)
-
-        cy.get('input#account-number[name="account-number"]').type(accountNumber)
-        cy.get('input#sort-code[name="sort-code"]').type(sortCode)
-        cy.get('#bank-details-form > button').click()
-
-        cy.get('h1').should('contain', 'An error occurred')
-        cy.get('#back-link').should('contain', 'Back to dashboard')
-        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
-        cy.get('#error-message').should('contain', 'You’ve already provided your bank details. Contact GOV.UK Pay support if you need to update them.')
-      })
-    })
-
-    describe('Not a Stripe gateway account', () => {
-      it('should show a 404 error when gateway account is not Stripe', () => {
-        setupStubs(true, 'live', 'sandbox')
-
-        cy.visit(bankDetailsUrl, {
-          failOnStatusCode: false
+          cy.visit(bankDetailsUrl, {
+            failOnStatusCode: false
+          })
+          cy.get('h1').should('contain', 'Page not found')
         })
-        cy.get('h1').should('contain', 'Page not found')
       })
-    })
 
-    describe('Not a live gateway account', () => {
-      it('should show a 404 error when gateway account is not live', () => {
-        setupStubs(false, 'test', 'sandbox')
+      describe('Not a live gateway account', () => {
+        it('should show a 404 error when gateway account is not live', () => {
+          setupStubs(false, 'test', 'sandbox')
 
-        cy.visit(bankDetailsUrl, {
-          failOnStatusCode: false
+          cy.visit(bankDetailsUrl, {
+            failOnStatusCode: false
+          })
+          cy.get('h1').should('contain', 'Page not found')
         })
-        cy.get('h1').should('contain', 'Page not found')
       })
-    })
 
-    describe('User does not have the correct permissions', () => {
-      it('should show a permission error when the user does not have enough permissions', () => {
-        cy.task('setupStubs', [
-          userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
-          gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'live', paymentProvider: 'stripe' }),
-          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, bankAccount: false })
-        ])
+      describe('User does not have the correct permissions', () => {
+        it('should show a permission error when the user does not have enough permissions', () => {
+          cy.task('setupStubs', [
+            userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
+            gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+              gatewayAccountId,
+              gatewayAccountExternalId,
+              type: 'live',
+              paymentProvider: 'stripe'
+            }),
+            stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, bankAccount: false })
+          ])
 
-        cy.visit(bankDetailsUrl, {
-          failOnStatusCode: false
+          cy.visit(bankDetailsUrl, {
+            failOnStatusCode: false
+          })
+          cy.get('h1').should('contain', 'An error occurred')
+          cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
         })
-        cy.get('h1').should('contain', 'An error occurred')
-        cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
       })
     })
   })

--- a/test/cypress/integration/stripe-setup/check-org-details.cy.js
+++ b/test/cypress/integration/stripe-setup/check-org-details.cy.js
@@ -66,133 +66,135 @@ function setupStubs (organisationDetails, type = 'live', paymentProvider = 'stri
 }
 
 describe('Stripe setup: Check your organisation’s details', () => {
-  describe('when user is admin, account is Stripe and "organisation details" is not already submitted', () => {
-    beforeEach(() => {
-      setupStubs(false)
+  describe.skip('with simplified settings disabled', () => {
+    describe('when user is admin, account is Stripe and "organisation details" is not already submitted', () => {
+      beforeEach(() => {
+        setupStubs(false)
 
-      cy.setEncryptedCookies(userExternalId, {})
+        cy.setEncryptedCookies(userExternalId, {})
 
-      cy.visit(checkOrgDetailsUrl)
+        cy.visit(checkOrgDetailsUrl)
+      })
+
+      it('should display page correctly', () => {
+        cy.get('h1').should('contain', 'Check your organisation’s details')
+
+        cy.get('#navigation-menu-your-psp')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+        cy.get('[data-cy=org-details]').should('exist')
+        cy.get('[data-cy=org-details]').find('dd').eq(0).should('contain', 'HMRC')
+        cy.get('[data-cy=org-details]').find('dd').eq(1)
+          .should('contain', validLine1)
+          .should('contain', validLine2)
+          .should('contain', validCity)
+          .should('contain', validPostcodeGb)
+
+        cy.get('[data-cy=form]')
+          .within(() => {
+            cy.get('[data-cy=yes-radio]').should('exist')
+            cy.get('[data-cy=no-radio]').should('exist')
+          })
+      })
+
+      it('should have a back link that redirects back to tasklist page', () => {
+        cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
+        cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+      })
+
+      it('should display the account sub nav', () => {
+        cy.get('[data-cy=account-sub-nav]')
+          .should('exist')
+      })
+
+      it('should display an error when a radio button is not clicked', () => {
+        cy.get('[data-cy=continue-button]').click()
+
+        cy.get('[data-cy=error-summary] a')
+          .should('contain', 'Select yes if your organisation’s details match the details on your government entity document')
+          .should('have.attr', 'href', '#confirm-org-details')
+
+        cy.get('[data-cy=error-message]').should('contain', 'Select yes if your organisation’s details match the details on your government entity document')
+
+        cy.get('#navigation-menu-your-psp')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+        cy.get('.govuk-back-link')
+          .should('contain', 'Back to information for Stripe')
+          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+      })
     })
 
-    it('should display page correctly', () => {
-      cy.get('h1').should('contain', 'Check your organisation’s details')
+    describe('when user is admin, account is Stripe and "organisation details" is already submitted', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
+      })
 
-      cy.get('#navigation-menu-your-psp')
-        .should('contain', 'Information for Stripe')
-        .parent().should('have.class', 'govuk-!-font-weight-bold')
+      it('should display an error when displaying the page', () => {
+        setupStubs(true)
 
-      cy.get('[data-cy=org-details]').should('exist')
-      cy.get('[data-cy=org-details]').find('dd').eq(0).should('contain', 'HMRC')
-      cy.get('[data-cy=org-details]').find('dd').eq(1)
-        .should('contain', validLine1)
-        .should('contain', validLine2)
-        .should('contain', validCity)
-        .should('contain', validPostcodeGb)
+        cy.visit(checkOrgDetailsUrl)
 
-      cy.get('[data-cy=form]')
-        .within(() => {
-          cy.get('[data-cy=yes-radio]').should('exist')
-          cy.get('[data-cy=no-radio]').should('exist')
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#back-link').should('contain', 'Back to dashboard')
+        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+        cy.get('#error-message').should('contain', 'You’ve already submitted your organisation details. Contact GOV.UK Pay support if you need to update them.')
+      })
+    })
+
+    describe('when it is not a Stripe gateway account', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
+      })
+
+      it('should show a 404 error when gateway account is not Stripe', () => {
+        setupStubs(false, 'live', 'sandbox')
+
+        cy.visit(checkOrgDetailsUrl, {
+          failOnStatusCode: false
         })
-    })
-
-    it('should have a back link that redirects back to tasklist page', () => {
-      cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
-      cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
-    })
-
-    it('should display the account sub nav', () => {
-      cy.get('[data-cy=account-sub-nav]')
-        .should('exist')
-    })
-
-    it('should display an error when a radio button is not clicked', () => {
-      cy.get('[data-cy=continue-button]').click()
-
-      cy.get('[data-cy=error-summary] a')
-        .should('contain', 'Select yes if your organisation’s details match the details on your government entity document')
-        .should('have.attr', 'href', '#confirm-org-details')
-
-      cy.get('[data-cy=error-message]').should('contain', 'Select yes if your organisation’s details match the details on your government entity document')
-
-      cy.get('#navigation-menu-your-psp')
-        .should('contain', 'Information for Stripe')
-        .parent().should('have.class', 'govuk-!-font-weight-bold')
-
-      cy.get('.govuk-back-link')
-        .should('contain', 'Back to information for Stripe')
-        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
-    })
-  })
-
-  describe('when user is admin, account is Stripe and "organisation details" is already submitted', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
-    })
-
-    it('should display an error when displaying the page', () => {
-      setupStubs(true)
-
-      cy.visit(checkOrgDetailsUrl)
-
-      cy.get('h1').should('contain', 'An error occurred')
-      cy.get('#back-link').should('contain', 'Back to dashboard')
-      cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
-      cy.get('#error-message').should('contain', 'You’ve already submitted your organisation details. Contact GOV.UK Pay support if you need to update them.')
-    })
-  })
-
-  describe('when it is not a Stripe gateway account', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
-    })
-
-    it('should show a 404 error when gateway account is not Stripe', () => {
-      setupStubs(false, 'live', 'sandbox')
-
-      cy.visit(checkOrgDetailsUrl, {
-        failOnStatusCode: false
+        cy.get('h1').should('contain', 'Page not found')
       })
-      cy.get('h1').should('contain', 'Page not found')
-    })
-  })
-
-  describe('when it is not a live gateway account', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
     })
 
-    it('should show a 404 error when gateway account is not live', () => {
-      setupStubs(false, 'test', 'stripe')
-
-      cy.visit(checkOrgDetailsUrl, {
-        failOnStatusCode: false
+    describe('when it is not a live gateway account', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
       })
-      cy.get('h1').should('contain', 'Page not found')
+
+      it('should show a 404 error when gateway account is not live', () => {
+        setupStubs(false, 'test', 'stripe')
+
+        cy.visit(checkOrgDetailsUrl, {
+          failOnStatusCode: false
+        })
+        cy.get('h1').should('contain', 'Page not found')
+      })
     })
-  })
 
-  describe('when the user does not have the correct permissions', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
-    })
+    describe('when the user does not have the correct permissions', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
+      })
 
-    it('should show a permission error when the user does not have enough permissions', () => {
-      cy.task('setupStubs', [
-        userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
-        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
-          gatewayAccountId,
-          gatewayAccountExternalId,
-          type: 'live',
-          paymentProvider: 'stripe'
-        }),
-        stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, vatNumber: true })
-      ])
+      it('should show a permission error when the user does not have enough permissions', () => {
+        cy.task('setupStubs', [
+          userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
+          gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+            gatewayAccountId,
+            gatewayAccountExternalId,
+            type: 'live',
+            paymentProvider: 'stripe'
+          }),
+          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, vatNumber: true })
+        ])
 
-      cy.visit(checkOrgDetailsUrl, { failOnStatusCode: false })
-      cy.get('h1').should('contain', 'An error occurred')
-      cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+        cy.visit(checkOrgDetailsUrl, { failOnStatusCode: false })
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+      })
     })
   })
 })

--- a/test/cypress/integration/stripe-setup/company-number.cy.js
+++ b/test/cypress/integration/stripe-setup/company-number.cy.js
@@ -41,157 +41,164 @@ function setupStubs (companyNumber, type = 'live', paymentProvider = 'stripe') {
 }
 
 describe('Stripe setup: company number page', () => {
-  describe('Card gateway account', () => {
-    describe('when user is admin, account is Stripe and "company number" is not already submitted', () => {
-      beforeEach(() => {
-        setupStubs(false)
+  describe.skip('with simplified settings disabled', () => {
+    describe('Card gateway account', () => {
+      describe('when user is admin, account is Stripe and "company number" is not already submitted', () => {
+        beforeEach(() => {
+          setupStubs(false)
 
-        cy.setEncryptedCookies(userExternalId, {})
-        cy.visit(companyNumberUrl)
-      })
-
-      it('should display page correctly', () => {
-        cy.get('h1').should('contain', 'Company registration number')
-
-        cy.get('#navigation-menu-your-psp')
-          .should('contain', 'Information for Stripe')
-          .parent().should('have.class', 'govuk-!-font-weight-bold')
-
-        cy.get('#company-number-form').should('exist')
-          .within(() => {
-            cy.get('input#company-number-declaration[name="company-number-declaration"]').check()
-            cy.get('input#company-number[name="company-number"]').should('be.visible')
-
-            cy.get('input#company-number-declaration-2[name="company-number-declaration"]').check()
-            cy.get('input#company-number[name="company-number"]').should('not.be.visible')
-
-            cy.get('button').should('exist')
-            cy.get('button').should('contain', 'Save and continue')
-          })
-      })
-
-      it('should have a back link that redirects back to tasklist page', () => {
-        cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
-        cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
-      })
-
-      it('should display an error when no options are selected', () => {
-        cy.get('#company-number-form > button').click()
-
-        cy.get('h2').should('contain', 'There is a problem')
-        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'You must answer this question')
-        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#company-number-declaration')
-
-        cy.get('#company-number-declaration-error').should('contain', 'You must answer this question')
-
-        cy.get('#navigation-menu-your-psp')
-          .should('contain', 'Information for Stripe')
-          .parent().should('have.class', 'govuk-!-font-weight-bold')
-
-        cy.get('.govuk-back-link')
-          .should('contain', 'Back to information for Stripe')
-          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
-      })
-
-      it('should display an error when company number input is blank and "Yes" option is selected', () => {
-        cy.get('#company-number-form').should('exist')
-          .within(() => {
-            cy.get('input#company-number-declaration[name="company-number-declaration"]').check()
-            cy.get('input#company-number[name="company-number"]').type('        ')
-
-            cy.get('button').click()
-          })
-
-        cy.get('h2').should('contain', 'There is a problem')
-        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'Enter a Company registration number')
-        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#company-number')
-
-        cy.get('input#company-number[name="company-number"]').should('have.class', 'govuk-input--error')
-        cy.get('#company-number-error').should('contain', 'Enter a Company registration number')
-      })
-    })
-
-    describe('when user is admin, account is Stripe and "company number" is already submitted', () => {
-      beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId)
-      })
-
-      it('should display an error when displaying the page', () => {
-        setupStubs(true)
-
-        cy.visit(companyNumberUrl)
-
-        cy.get('h1').should('contain', 'An error occurred')
-        cy.get('#back-link').should('contain', 'Back to dashboard')
-        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
-        cy.get('#error-message').should('contain', 'You’ve already provided your Company registration number. Contact GOV.UK Pay support if you need to update it.')
-      })
-
-      it('should display an error when submitting the form', () => {
-        setupStubs([false, true])
-
-        cy.visit(companyNumberUrl)
-
-        cy.get('#company-number-form').should('exist')
-          .within(() => {
-            cy.get('input#company-number-declaration-2[name="company-number-declaration"]').check()
-            cy.get('input#company-number[name="company-number"]').should('not.be.visible')
-
-            cy.get('button').click()
-          })
-
-        cy.get('h1').should('contain', 'An error occurred')
-        cy.get('#back-link').should('contain', 'Back to dashboard')
-        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
-        cy.get('#error-message').should('contain', 'You’ve already provided your Company registration number. Contact GOV.UK Pay support if you need to update it.')
-      })
-    })
-
-    describe('when it is not a Stripe gateway account', () => {
-      beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId)
-      })
-
-      it('should show a 404 error when gateway account is not Stripe', () => {
-        setupStubs([false, true], 'live', 'sandbox')
-
-        cy.visit(companyNumberUrl, {
-          failOnStatusCode: false
+          cy.setEncryptedCookies(userExternalId, {})
+          cy.visit(companyNumberUrl)
         })
-        cy.get('h1').should('contain', 'Page not found')
-      })
-    })
 
-    describe('when it is not a live gateway account', () => {
-      beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId)
-      })
+        it('should display page correctly', () => {
+          cy.get('h1').should('contain', 'Company registration number')
 
-      it('should show a 404 error when gateway account is not live', () => {
-        setupStubs([false, true], 'test', 'stripe')
+          cy.get('#navigation-menu-your-psp')
+            .should('contain', 'Information for Stripe')
+            .parent().should('have.class', 'govuk-!-font-weight-bold')
 
-        cy.visit(companyNumberUrl, {
-          failOnStatusCode: false
+          cy.get('#company-number-form').should('exist')
+            .within(() => {
+              cy.get('input#company-number-declaration[name="company-number-declaration"]').check()
+              cy.get('input#company-number[name="company-number"]').should('be.visible')
+
+              cy.get('input#company-number-declaration-2[name="company-number-declaration"]').check()
+              cy.get('input#company-number[name="company-number"]').should('not.be.visible')
+
+              cy.get('button').should('exist')
+              cy.get('button').should('contain', 'Save and continue')
+            })
         })
-        cy.get('h1').should('contain', 'Page not found')
+
+        it('should have a back link that redirects back to tasklist page', () => {
+          cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
+          cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+        })
+
+        it('should display an error when no options are selected', () => {
+          cy.get('#company-number-form > button').click()
+
+          cy.get('h2').should('contain', 'There is a problem')
+          cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'You must answer this question')
+          cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#company-number-declaration')
+
+          cy.get('#company-number-declaration-error').should('contain', 'You must answer this question')
+
+          cy.get('#navigation-menu-your-psp')
+            .should('contain', 'Information for Stripe')
+            .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+          cy.get('.govuk-back-link')
+            .should('contain', 'Back to information for Stripe')
+            .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+        })
+
+        it('should display an error when company number input is blank and "Yes" option is selected', () => {
+          cy.get('#company-number-form').should('exist')
+            .within(() => {
+              cy.get('input#company-number-declaration[name="company-number-declaration"]').check()
+              cy.get('input#company-number[name="company-number"]').type('        ')
+
+              cy.get('button').click()
+            })
+
+          cy.get('h2').should('contain', 'There is a problem')
+          cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'Enter a Company registration number')
+          cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#company-number')
+
+          cy.get('input#company-number[name="company-number"]').should('have.class', 'govuk-input--error')
+          cy.get('#company-number-error').should('contain', 'Enter a Company registration number')
+        })
       })
-    })
 
-    describe('when the user does not have the correct permissions', () => {
-      beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId)
+      describe('when user is admin, account is Stripe and "company number" is already submitted', () => {
+        beforeEach(() => {
+          cy.setEncryptedCookies(userExternalId)
+        })
+
+        it('should display an error when displaying the page', () => {
+          setupStubs(true)
+
+          cy.visit(companyNumberUrl)
+
+          cy.get('h1').should('contain', 'An error occurred')
+          cy.get('#back-link').should('contain', 'Back to dashboard')
+          cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+          cy.get('#error-message').should('contain', 'You’ve already provided your Company registration number. Contact GOV.UK Pay support if you need to update it.')
+        })
+
+        it('should display an error when submitting the form', () => {
+          setupStubs([false, true])
+
+          cy.visit(companyNumberUrl)
+
+          cy.get('#company-number-form').should('exist')
+            .within(() => {
+              cy.get('input#company-number-declaration-2[name="company-number-declaration"]').check()
+              cy.get('input#company-number[name="company-number"]').should('not.be.visible')
+
+              cy.get('button').click()
+            })
+
+          cy.get('h1').should('contain', 'An error occurred')
+          cy.get('#back-link').should('contain', 'Back to dashboard')
+          cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+          cy.get('#error-message').should('contain', 'You’ve already provided your Company registration number. Contact GOV.UK Pay support if you need to update it.')
+        })
       })
 
-      it('should show a permission error when the user does not have enough permissions', () => {
-        cy.task('setupStubs', [
-          userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
-          gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'live', paymentProvider: 'stripe' }),
-          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, companyNumber: true })
-        ])
+      describe('when it is not a Stripe gateway account', () => {
+        beforeEach(() => {
+          cy.setEncryptedCookies(userExternalId)
+        })
 
-        cy.visit(companyNumberUrl, { failOnStatusCode: false })
-        cy.get('h1').should('contain', 'An error occurred')
-        cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+        it('should show a 404 error when gateway account is not Stripe', () => {
+          setupStubs([false, true], 'live', 'sandbox')
+
+          cy.visit(companyNumberUrl, {
+            failOnStatusCode: false
+          })
+          cy.get('h1').should('contain', 'Page not found')
+        })
+      })
+
+      describe('when it is not a live gateway account', () => {
+        beforeEach(() => {
+          cy.setEncryptedCookies(userExternalId)
+        })
+
+        it('should show a 404 error when gateway account is not live', () => {
+          setupStubs([false, true], 'test', 'stripe')
+
+          cy.visit(companyNumberUrl, {
+            failOnStatusCode: false
+          })
+          cy.get('h1').should('contain', 'Page not found')
+        })
+      })
+
+      describe('when the user does not have the correct permissions', () => {
+        beforeEach(() => {
+          cy.setEncryptedCookies(userExternalId)
+        })
+
+        it('should show a permission error when the user does not have enough permissions', () => {
+          cy.task('setupStubs', [
+            userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
+            gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+              gatewayAccountId,
+              gatewayAccountExternalId,
+              type: 'live',
+              paymentProvider: 'stripe'
+            }),
+            stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, companyNumber: true })
+          ])
+
+          cy.visit(companyNumberUrl, { failOnStatusCode: false })
+          cy.get('h1').should('contain', 'An error occurred')
+          cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+        })
       })
     })
   })

--- a/test/cypress/integration/stripe-setup/director.cy.js
+++ b/test/cypress/integration/stripe-setup/director.cy.js
@@ -83,154 +83,156 @@ describe('Stripe setup: director page', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  describe('when user is admin, account is Stripe and director details have not been entered', () => {
-    beforeEach(() => {
-      setupStubs(false)
+  describe.skip('with simplified settings disabled', () => {
+    describe('when user is admin, account is Stripe and director details have not been entered', () => {
+      beforeEach(() => {
+        setupStubs(false)
 
-      cy.visit(directorUrl)
-    })
+        cy.visit(directorUrl)
+      })
 
-    it('should display form with name, dob and email fields', () => {
-      cy.get('h1').should('contain', 'Enter a director’s details')
+      it('should display form with name, dob and email fields', () => {
+        cy.get('h1').should('contain', 'Enter a director’s details')
 
-      cy.get('#navigation-menu-your-psp')
-        .should('contain', 'Information for Stripe')
-        .parent().should('have.class', 'govuk-!-font-weight-bold')
+        cy.get('#navigation-menu-your-psp')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
 
-      cy.get('#director-form').should('exist')
-        .within(() => {
-          cy.get('label[for="first-name"]').should('exist')
-          cy.get('input#first-name[name="first-name"][autocomplete="given-name"]').should('exist')
+        cy.get('#director-form').should('exist')
+          .within(() => {
+            cy.get('label[for="first-name"]').should('exist')
+            cy.get('input#first-name[name="first-name"][autocomplete="given-name"]').should('exist')
 
-          cy.get('label[for="last-name"]').should('exist')
-          cy.get('input#last-name[name="last-name"][autocomplete="family-name"]').should('exist')
+            cy.get('label[for="last-name"]').should('exist')
+            cy.get('input#last-name[name="last-name"][autocomplete="family-name"]').should('exist')
 
-          cy.get('label[for="email"]').should('exist')
-          cy.get('input#email[name="email"][autocomplete="work email"]').should('exist')
+            cy.get('label[for="email"]').should('exist')
+            cy.get('input#email[name="email"][autocomplete="work email"]').should('exist')
 
-          cy.get('label[for="dob-day"]').should('exist')
-          cy.get('input#dob-day[name="dob-day"][autocomplete="bday-day"]').should('exist')
+            cy.get('label[for="dob-day"]').should('exist')
+            cy.get('input#dob-day[name="dob-day"][autocomplete="bday-day"]').should('exist')
 
-          cy.get('label[for="dob-month"]').should('exist')
-          cy.get('input#dob-month[name="dob-month"][autocomplete="bday-month"]').should('exist')
+            cy.get('label[for="dob-month"]').should('exist')
+            cy.get('input#dob-month[name="dob-month"][autocomplete="bday-month"]').should('exist')
 
-          cy.get('label[for="dob-year"]').should('exist')
-          cy.get('input#dob-year[name="dob-year"][autocomplete="bday-year"]').should('exist')
+            cy.get('label[for="dob-year"]').should('exist')
+            cy.get('input#dob-year[name="dob-year"][autocomplete="bday-year"]').should('exist')
+
+            cy.get('button').should('exist')
+          })
+      })
+
+      it('should have a back link that redirects back to tasklist page', () => {
+        cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
+        cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+      })
+
+      it('should show errors when validation fails', () => {
+        cy.get('#director-form').within(() => {
+          cy.get('#dob-day').type('29')
+          cy.get('#dob-month').type('2')
+          cy.get('#dob-year').type('2001')
+          cy.get('#email').type('a')
+          cy.get('button').click()
+        })
+
+        cy.get('.govuk-error-summary').should('exist').within(() => {
+          cy.get('a[href="#first-name"]').should('contain', 'Enter a first name')
+          cy.get('a[href="#last-name"]').should('contain', 'Enter a last name')
+          cy.get('a[href="#dob-day"]').should('contain', 'Enter a valid date')
+          cy.get('a[href="#email"]').should('contain', 'Enter a valid email address')
+        })
+
+        cy.get('#director-form').should('exist').within(() => {
+          cy.get('.govuk-form-group--error > input#first-name').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('exist')
+          })
+
+          cy.get('.govuk-form-group--error > input#last-name').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('exist')
+          })
+
+          cy.get('.govuk-form-group--error > input#email').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('exist')
+            cy.get('input#email').should('have.attr', 'value', 'a')
+          })
+
+          cy.get('.govuk-form-group--error > fieldset > #dob-error').parent().parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('exist')
+            cy.get('input#dob-day').should('have.attr', 'value', '29')
+            cy.get('input#dob-month').should('have.attr', 'value', '2')
+            cy.get('input#dob-year').should('have.attr', 'value', '2001')
+          })
 
           cy.get('button').should('exist')
         })
+
+        cy.get('#navigation-menu-your-psp')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+        cy.get('.govuk-back-link')
+          .should('contain', 'Back to information for Stripe')
+          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+      })
     })
 
-    it('should have a back link that redirects back to tasklist page', () => {
-      cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
-      cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
-    })
+    describe('trying to save details when director already nominated', function () {
+      beforeEach(() => {
+        setupStubs([false, true])
 
-    it('should show errors when validation fails', () => {
-      cy.get('#director-form').within(() => {
-        cy.get('#dob-day').type('29')
-        cy.get('#dob-month').type('2')
-        cy.get('#dob-year').type('2001')
-        cy.get('#email').type('a')
-        cy.get('button').click()
+        cy.visit(directorUrl)
       })
 
-      cy.get('.govuk-error-summary').should('exist').within(() => {
-        cy.get('a[href="#first-name"]').should('contain', 'Enter a first name')
-        cy.get('a[href="#last-name"]').should('contain', 'Enter a last name')
-        cy.get('a[href="#dob-day"]').should('contain', 'Enter a valid date')
-        cy.get('a[href="#email"]').should('contain', 'Enter a valid email address')
+      it('should display an error instead of saving details', () => {
+        cy.get('#director-form').within(() => {
+          cy.get('#first-name').type(typedFirstName)
+          cy.get('#last-name').type(typedLastName)
+          cy.get('#dob-day').type(typedDobDay)
+          cy.get('#dob-month').type(typedDobMonth)
+          cy.get('#dob-year').type(typedDobYear)
+          cy.get('button').click()
+        })
+
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#back-link').should('contain', 'Back to dashboard')
+        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+        cy.get('#error-message').should('contain', 'You’ve already provided director details.')
+      })
+    })
+
+    describe('when it’s not a Stripe gateway account', () => {
+      beforeEach(() => {
+        setupStubs(false, 'live', 'worldpay')
+
+        cy.visit(directorUrl, { failOnStatusCode: false })
       })
 
-      cy.get('#director-form').should('exist').within(() => {
-        cy.get('.govuk-form-group--error > input#first-name').parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('exist')
-        })
+      it('should return a 404', () => {
+        cy.get('h1').should('contain', 'Page not found')
+      })
+    })
 
-        cy.get('.govuk-form-group--error > input#last-name').parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('exist')
-        })
+    describe('when user has incorrect permissions', () => {
+      beforeEach(() => {
+        cy.task('setupStubs', [
+          userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
+          gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+            gatewayAccountId,
+            gatewayAccountExternalId,
+            type: 'live',
+            paymentProvider: 'stripe'
+          }),
+          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, responsiblePerson: true })
+        ])
 
-        cy.get('.govuk-form-group--error > input#email').parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('exist')
-          cy.get('input#email').should('have.attr', 'value', 'a')
-        })
-
-        cy.get('.govuk-form-group--error > fieldset > #dob-error').parent().parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('exist')
-          cy.get('input#dob-day').should('have.attr', 'value', '29')
-          cy.get('input#dob-month').should('have.attr', 'value', '2')
-          cy.get('input#dob-year').should('have.attr', 'value', '2001')
-        })
-
-        cy.get('button').should('exist')
+        cy.visit(directorUrl, { failOnStatusCode: false })
       })
 
-      cy.get('#navigation-menu-your-psp')
-        .should('contain', 'Information for Stripe')
-        .parent().should('have.class', 'govuk-!-font-weight-bold')
-
-      cy.get('.govuk-back-link')
-        .should('contain', 'Back to information for Stripe')
-        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
-    })
-  })
-
-  describe('trying to save details when director already nominated', function () {
-    beforeEach(() => {
-      setupStubs([false, true])
-
-      cy.visit(directorUrl)
-    })
-
-    it('should display an error instead of saving details', () => {
-      cy.get('#director-form').within(() => {
-        cy.get('#first-name').type(typedFirstName)
-        cy.get('#last-name').type(typedLastName)
-        cy.get('#dob-day').type(typedDobDay)
-        cy.get('#dob-month').type(typedDobMonth)
-        cy.get('#dob-year').type(typedDobYear)
-        cy.get('button').click()
+      it('should show a permission denied error', () => {
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#errorMsg').should('contain', 'not have the administrator rights')
       })
-
-      cy.get('h1').should('contain', 'An error occurred')
-      cy.get('#back-link').should('contain', 'Back to dashboard')
-      cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
-      cy.get('#error-message').should('contain', 'You’ve already provided director details.')
-    })
-  })
-
-  describe('when it’s not a Stripe gateway account', () => {
-    beforeEach(() => {
-      setupStubs(false, 'live', 'worldpay')
-
-      cy.visit(directorUrl, { failOnStatusCode: false })
-    })
-
-    it('should return a 404', () => {
-      cy.get('h1').should('contain', 'Page not found')
-    })
-  })
-
-  describe('when user has incorrect permissions', () => {
-    beforeEach(() => {
-      cy.task('setupStubs', [
-        userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
-        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
-          gatewayAccountId,
-          gatewayAccountExternalId,
-          type: 'live',
-          paymentProvider: 'stripe'
-        }),
-        stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, responsiblePerson: true })
-      ])
-
-      cy.visit(directorUrl, { failOnStatusCode: false })
-    })
-
-    it('should show a permission denied error', () => {
-      cy.get('h1').should('contain', 'An error occurred')
-      cy.get('#errorMsg').should('contain', 'not have the administrator rights')
     })
   })
 })

--- a/test/cypress/integration/stripe-setup/government-entity-document.cy.js
+++ b/test/cypress/integration/stripe-setup/government-entity-document.cy.js
@@ -50,126 +50,128 @@ function setupStubs (governmentEntityDocument, type = 'live', paymentProvider = 
 }
 
 describe('Stripe setup: Government entity document', () => {
-  describe('when user is admin, account is Stripe and "Government entity document" is not already submitted', () => {
-    beforeEach(() => {
-      setupStubs(false)
+  describe.skip('with simplified settings disabled', () => {
+    describe('when user is admin, account is Stripe and "Government entity document" is not already submitted', () => {
+      beforeEach(() => {
+        setupStubs(false)
 
-      cy.setEncryptedCookies(userExternalId, {})
+        cy.setEncryptedCookies(userExternalId, {})
 
-      cy.visit(governmentEntityDocumentUrl)
-    })
+        cy.visit(governmentEntityDocumentUrl)
+      })
 
-    it('should display page correctly', () => {
-      cy.get('h1').should('contain', 'Upload a government entity document')
+      it('should display page correctly', () => {
+        cy.get('h1').should('contain', 'Upload a government entity document')
 
-      cy.get('#navigation-menu-your-psp')
-        .should('contain', 'Information for Stripe')
-        .parent().should('have.class', 'govuk-!-font-weight-bold')
+        cy.get('#navigation-menu-your-psp')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
 
-      cy.get('#government-entity-document-form').should('exist')
-        .within(() => {
-          cy.get('input#government-entity-document').should('exist')
-          cy.get('button').should('exist')
-          cy.get('button').should('contain', 'Submit and continue')
+        cy.get('#government-entity-document-form').should('exist')
+          .within(() => {
+            cy.get('input#government-entity-document').should('exist')
+            cy.get('button').should('exist')
+            cy.get('button').should('contain', 'Submit and continue')
 
-          cy.get('#navigation-menu-switch-psp').should('not.exist')
+            cy.get('#navigation-menu-switch-psp').should('not.exist')
+          })
+      })
+
+      it('should have a back link that redirects back to tasklist page', () => {
+        cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
+        cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+      })
+
+      it('should display an error when file is not selected', () => {
+        cy.get('#government-entity-document-form > button').click()
+
+        cy.get('h2').should('contain', 'There is a problem')
+        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'Select a file to upload')
+        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#government-entity-document')
+
+        cy.get('.govuk-form-group--error > input#government-entity-document').parent().should('exist').within(() => {
+          cy.get('.govuk-error-message').should('exist')
+          cy.get('p.govuk-error-message').should('contain', 'Select a file to upload')
         })
+
+        cy.get('#navigation-menu-your-psp')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+        cy.get('.govuk-back-link')
+          .should('contain', 'Back to information for Stripe')
+          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+      })
     })
 
-    it('should have a back link that redirects back to tasklist page', () => {
-      cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
-      cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
-    })
-
-    it('should display an error when file is not selected', () => {
-      cy.get('#government-entity-document-form > button').click()
-
-      cy.get('h2').should('contain', 'There is a problem')
-      cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'Select a file to upload')
-      cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#government-entity-document')
-
-      cy.get('.govuk-form-group--error > input#government-entity-document').parent().should('exist').within(() => {
-        cy.get('.govuk-error-message').should('exist')
-        cy.get('p.govuk-error-message').should('contain', 'Select a file to upload')
+    describe('when user is admin, account is Stripe and "Government entity document" is already submitted', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
       })
 
-      cy.get('#navigation-menu-your-psp')
-        .should('contain', 'Information for Stripe')
-        .parent().should('have.class', 'govuk-!-font-weight-bold')
+      it('should display an error when displaying the page', () => {
+        setupStubs(true)
 
-      cy.get('.govuk-back-link')
-        .should('contain', 'Back to information for Stripe')
-        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
-    })
-  })
+        cy.visit(governmentEntityDocumentUrl)
 
-  describe('when user is admin, account is Stripe and "Government entity document" is already submitted', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
-    })
-
-    it('should display an error when displaying the page', () => {
-      setupStubs(true)
-
-      cy.visit(governmentEntityDocumentUrl)
-
-      cy.get('h1').should('contain', 'An error occurred')
-      cy.get('#back-link').should('contain', 'Back to dashboard')
-      cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
-      cy.get('#error-message').should('contain', 'You’ve already provided a government entity document. Contact GOV.UK Pay support if you need to update it.')
-    })
-  })
-
-  describe('when it is not a Stripe gateway account', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
-    })
-
-    it('should show a 404 error when gateway account is not Stripe', () => {
-      setupStubs(false, 'live', 'sandbox')
-
-      cy.visit(governmentEntityDocumentUrl, {
-        failOnStatusCode: false
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#back-link').should('contain', 'Back to dashboard')
+        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+        cy.get('#error-message').should('contain', 'You’ve already provided a government entity document. Contact GOV.UK Pay support if you need to update it.')
       })
-      cy.get('h1').should('contain', 'Page not found')
-    })
-  })
-
-  describe('when it is not a live gateway account', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
     })
 
-    it('should show a 404 error when gateway account is not live', () => {
-      setupStubs(false, 'test', 'stripe')
-
-      cy.visit(governmentEntityDocumentUrl, {
-        failOnStatusCode: false
+    describe('when it is not a Stripe gateway account', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
       })
-      cy.get('h1').should('contain', 'Page not found')
+
+      it('should show a 404 error when gateway account is not Stripe', () => {
+        setupStubs(false, 'live', 'sandbox')
+
+        cy.visit(governmentEntityDocumentUrl, {
+          failOnStatusCode: false
+        })
+        cy.get('h1').should('contain', 'Page not found')
+      })
     })
-  })
 
-  describe('when the user does not have the correct permissions', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
+    describe('when it is not a live gateway account', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
+      })
+
+      it('should show a 404 error when gateway account is not live', () => {
+        setupStubs(false, 'test', 'stripe')
+
+        cy.visit(governmentEntityDocumentUrl, {
+          failOnStatusCode: false
+        })
+        cy.get('h1').should('contain', 'Page not found')
+      })
     })
 
-    it('should show a permission error when the user does not have enough permissions', () => {
-      cy.task('setupStubs', [
-        userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
-        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
-          gatewayAccountId,
-          gatewayAccountExternalId,
-          type: 'live',
-          paymentProvider: 'stripe'
-        }),
-        stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, vatNumber: true })
-      ])
+    describe('when the user does not have the correct permissions', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
+      })
 
-      cy.visit(governmentEntityDocumentUrl, { failOnStatusCode: false })
-      cy.get('h1').should('contain', 'An error occurred')
-      cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+      it('should show a permission error when the user does not have enough permissions', () => {
+        cy.task('setupStubs', [
+          userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
+          gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+            gatewayAccountId,
+            gatewayAccountExternalId,
+            type: 'live',
+            paymentProvider: 'stripe'
+          }),
+          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, vatNumber: true })
+        ])
+
+        cy.visit(governmentEntityDocumentUrl, { failOnStatusCode: false })
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+      })
     })
   })
 })

--- a/test/cypress/integration/stripe-setup/responsible-person.cy.js
+++ b/test/cypress/integration/stripe-setup/responsible-person.cy.js
@@ -45,194 +45,201 @@ describe('Stripe setup: responsible person page', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  describe('when user is admin, account is Stripe and responsible person not already nominated', () => {
-    beforeEach(() => {
-      setupStubs(false)
+  describe.skip('with simplified settings disabled', () => {
+    describe('when user is admin, account is Stripe and responsible person not already nominated', () => {
+      beforeEach(() => {
+        setupStubs(false)
 
-      cy.visit(responsiblePersonUrl)
-    })
+        cy.visit(responsiblePersonUrl)
+      })
 
-    it('should display form', () => {
-      cy.get('h1').should('contain', 'Enter responsible person details')
+      it('should display form', () => {
+        cy.get('h1').should('contain', 'Enter responsible person details')
 
-      cy.get('#navigation-menu-your-psp')
-        .should('contain', 'Information for Stripe')
-        .parent().should('have.class', 'govuk-!-font-weight-bold')
+        cy.get('#navigation-menu-your-psp')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
 
-      cy.get('#responsible-person-form').should('exist')
-        .within(() => {
-          cy.get('label[for="first-name"]').should('exist')
-          cy.get('input#first-name[name="first-name"][autocomplete="given-name"]').should('exist')
+        cy.get('#responsible-person-form').should('exist')
+          .within(() => {
+            cy.get('label[for="first-name"]').should('exist')
+            cy.get('input#first-name[name="first-name"][autocomplete="given-name"]').should('exist')
 
-          cy.get('label[for="last-name"]').should('exist')
-          cy.get('input#last-name[name="last-name"][autocomplete="family-name"]').should('exist')
+            cy.get('label[for="last-name"]').should('exist')
+            cy.get('input#last-name[name="last-name"][autocomplete="family-name"]').should('exist')
 
-          cy.get('label[for="home-address-line-1"]').should('exist')
-          cy.get('input#home-address-line-1[name="home-address-line-1"][autocomplete="address-line1"]').should('exist')
-          cy.get('input#home-address-line-2[name="home-address-line-2"][autocomplete="address-line2"]').should('exist')
+            cy.get('label[for="home-address-line-1"]').should('exist')
+            cy.get('input#home-address-line-1[name="home-address-line-1"][autocomplete="address-line1"]').should('exist')
+            cy.get('input#home-address-line-2[name="home-address-line-2"][autocomplete="address-line2"]').should('exist')
 
-          cy.get('label[for="home-address-city"]').should('exist')
-          cy.get('input#home-address-city[name="home-address-city"][autocomplete="address-level2"]').should('exist')
+            cy.get('label[for="home-address-city"]').should('exist')
+            cy.get('input#home-address-city[name="home-address-city"][autocomplete="address-level2"]').should('exist')
 
-          cy.get('label[for="home-address-postcode"]').should('exist')
-          cy.get('input#home-address-postcode[name="home-address-postcode"][autocomplete="postal-code"]').should('exist')
+            cy.get('label[for="home-address-postcode"]').should('exist')
+            cy.get('input#home-address-postcode[name="home-address-postcode"][autocomplete="postal-code"]').should('exist')
 
-          cy.get('label[for="dob-day"]').should('exist')
-          cy.get('input#dob-day[name="dob-day"][autocomplete="bday-day"]').should('exist')
+            cy.get('label[for="dob-day"]').should('exist')
+            cy.get('input#dob-day[name="dob-day"][autocomplete="bday-day"]').should('exist')
 
-          cy.get('label[for="dob-month"]').should('exist')
-          cy.get('input#dob-month[name="dob-month"][autocomplete="bday-month"]').should('exist')
+            cy.get('label[for="dob-month"]').should('exist')
+            cy.get('input#dob-month[name="dob-month"][autocomplete="bday-month"]').should('exist')
 
-          cy.get('label[for="dob-year"]').should('exist')
-          cy.get('input#dob-year[name="dob-year"][autocomplete="bday-year"]').should('exist')
+            cy.get('label[for="dob-year"]').should('exist')
+            cy.get('input#dob-year[name="dob-year"][autocomplete="bday-year"]').should('exist')
 
-          cy.get('label[for="telephone-number"]').should('exist')
-          cy.get('input#telephone-number[name="telephone-number"][autocomplete="work tel"]').should('exist')
+            cy.get('label[for="telephone-number"]').should('exist')
+            cy.get('input#telephone-number[name="telephone-number"][autocomplete="work tel"]').should('exist')
 
-          cy.get('label[for="email"]').should('exist')
-          cy.get('input#email[name="email"][autocomplete="work email"]').should('exist')
+            cy.get('label[for="email"]').should('exist')
+            cy.get('input#email[name="email"][autocomplete="work email"]').should('exist')
+
+            cy.get('button').should('exist')
+          })
+      })
+
+      it('should have a back link that redirects back to tasklist page', () => {
+        cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
+        cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+      })
+
+      it('should show errors when validation fails', () => {
+        cy.get('#responsible-person-form').within(() => {
+          cy.get('#home-address-postcode').type('1')
+          cy.get('#dob-day').type('a')
+          cy.get('#dob-month').type('b')
+          cy.get('#dob-year').type('20')
+          cy.get('#telephone-number').type('123')
+          cy.get('#email').type('foo')
+          cy.get('button').click()
+        })
+
+        cy.get('.govuk-error-summary').should('exist').within(() => {
+          cy.get('a[href="#first-name"]').should('contain', 'Enter a first name')
+          cy.get('a[href="#last-name"]').should('contain', 'Enter a last name')
+          cy.get('a[href="#home-address-line-1"]').should('contain', 'Enter a building name, number and street')
+          cy.get('a[href="#home-address-city"]').should('contain', 'Enter a town or city')
+          cy.get('a[href="#home-address-postcode"]').should('contain', 'Enter a real postcode')
+          cy.get('a[href="#dob-day"]').should('contain', 'Enter a valid date')
+          cy.get('a[href="#telephone-number"]').should('contain', 'Enter a telephone number')
+          cy.get('a[href="#email"]').should('contain', 'Enter a valid email address')
+        })
+
+        cy.get('#responsible-person-form').should('exist').within(() => {
+          cy.get('.govuk-form-group--error > input#first-name').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('exist')
+            cy.get('input#first-name').should('exist')
+          })
+          cy.get('.govuk-form-group--error > input#last-name').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('exist')
+            cy.get('input#last-name').should('exist')
+          })
+          cy.get('.govuk-form-group--error > input#home-address-line-1').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('exist')
+          })
+          cy.get('.govuk-form-group--error > input#home-address-city').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('exist')
+          })
+          cy.get('.govuk-form-group--error > input#home-address-postcode').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('exist')
+            cy.get('input#home-address-postcode').should('have.attr', 'value', '1')
+          })
+
+          cy.get('.govuk-form-group--error > fieldset > #dob-error').parent().parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('exist')
+            cy.get('input#dob-day').should('have.attr', 'value', 'a')
+            cy.get('input#dob-month').should('have.attr', 'value', 'b')
+            cy.get('input#dob-year').should('have.attr', 'value', '20')
+          })
+
+          cy.get('.govuk-form-group--error > input#telephone-number').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('exist')
+            cy.get('input#telephone-number').should('have.attr', 'value', '123')
+          })
+
+          cy.get('.govuk-form-group--error > input#email').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('exist')
+            cy.get('input#email').should('have.attr', 'value', 'foo')
+          })
 
           cy.get('button').should('exist')
         })
+
+        cy.get('#navigation-menu-your-psp')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+        cy.get('.govuk-back-link')
+          .should('contain', 'Back to information for Stripe')
+          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+      })
     })
 
-    it('should have a back link that redirects back to tasklist page', () => {
-      cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
-      cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
-    })
+    describe('trying to view form when responsible person already nominated', () => {
+      beforeEach(() => {
+        setupStubs(true)
 
-    it('should show errors when validation fails', () => {
-      cy.get('#responsible-person-form').within(() => {
-        cy.get('#home-address-postcode').type('1')
-        cy.get('#dob-day').type('a')
-        cy.get('#dob-month').type('b')
-        cy.get('#dob-year').type('20')
-        cy.get('#telephone-number').type('123')
-        cy.get('#email').type('foo')
-        cy.get('button').click()
+        cy.visit(responsiblePersonUrl)
       })
 
-      cy.get('.govuk-error-summary').should('exist').within(() => {
-        cy.get('a[href="#first-name"]').should('contain', 'Enter a first name')
-        cy.get('a[href="#last-name"]').should('contain', 'Enter a last name')
-        cy.get('a[href="#home-address-line-1"]').should('contain', 'Enter a building name, number and street')
-        cy.get('a[href="#home-address-city"]').should('contain', 'Enter a town or city')
-        cy.get('a[href="#home-address-postcode"]').should('contain', 'Enter a real postcode')
-        cy.get('a[href="#dob-day"]').should('contain', 'Enter a valid date')
-        cy.get('a[href="#telephone-number"]').should('contain', 'Enter a telephone number')
-        cy.get('a[href="#email"]').should('contain', 'Enter a valid email address')
+      it('should display an error instead of showing form', () => {
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#back-link').should('contain', 'Back to dashboard')
+        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+        cy.get('#error-message').should('contain', 'You’ve already nominated your responsible person. Contact GOV.UK Pay support if you need to change them.')
+      })
+    })
+
+    describe('trying to save details when responsible person already nominated', function () {
+      beforeEach(() => {
+        setupStubs([false, true])
+
+        cy.visit(responsiblePersonUrl)
       })
 
-      cy.get('#responsible-person-form').should('exist').within(() => {
-        cy.get('.govuk-form-group--error > input#first-name').parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('exist')
-          cy.get('input#first-name').should('exist')
-        })
-        cy.get('.govuk-form-group--error > input#last-name').parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('exist')
-          cy.get('input#last-name').should('exist')
-        })
-        cy.get('.govuk-form-group--error > input#home-address-line-1').parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('exist')
-        })
-        cy.get('.govuk-form-group--error > input#home-address-city').parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('exist')
-        })
-        cy.get('.govuk-form-group--error > input#home-address-postcode').parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('exist')
-          cy.get('input#home-address-postcode').should('have.attr', 'value', '1')
+      it('should display an error instead of saving details', () => {
+        cy.get('#responsible-person-form').within(() => {
+          cy.get('button').click()
         })
 
-        cy.get('.govuk-form-group--error > fieldset > #dob-error').parent().parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('exist')
-          cy.get('input#dob-day').should('have.attr', 'value', 'a')
-          cy.get('input#dob-month').should('have.attr', 'value', 'b')
-          cy.get('input#dob-year').should('have.attr', 'value', '20')
-        })
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#back-link').should('contain', 'Back to dashboard')
+        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+        cy.get('#error-message').should('contain', 'You’ve already nominated your responsible person. Contact GOV.UK Pay support if you need to change them.')
+      })
+    })
 
-        cy.get('.govuk-form-group--error > input#telephone-number').parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('exist')
-          cy.get('input#telephone-number').should('have.attr', 'value', '123')
-        })
+    describe('when it’s not a Stripe gateway account', () => {
+      beforeEach(() => {
+        setupStubs(false, 'live', 'worldpay')
 
-        cy.get('.govuk-form-group--error > input#email').parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('exist')
-          cy.get('input#email').should('have.attr', 'value', 'foo')
-        })
-
-        cy.get('button').should('exist')
+        cy.visit(responsiblePersonUrl, { failOnStatusCode: false })
       })
 
-      cy.get('#navigation-menu-your-psp')
-        .should('contain', 'Information for Stripe')
-        .parent().should('have.class', 'govuk-!-font-weight-bold')
-
-      cy.get('.govuk-back-link')
-        .should('contain', 'Back to information for Stripe')
-        .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
-    })
-  })
-
-  describe('trying to view form when responsible person already nominated', () => {
-    beforeEach(() => {
-      setupStubs(true)
-
-      cy.visit(responsiblePersonUrl)
+      it('should return a 404', () => {
+        cy.get('h1').should('contain', 'Page not found')
+      })
     })
 
-    it('should display an error instead of showing form', () => {
-      cy.get('h1').should('contain', 'An error occurred')
-      cy.get('#back-link').should('contain', 'Back to dashboard')
-      cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
-      cy.get('#error-message').should('contain', 'You’ve already nominated your responsible person. Contact GOV.UK Pay support if you need to change them.')
-    })
-  })
+    describe('when user has incorrect permissions', () => {
+      beforeEach(() => {
+        cy.task('setupStubs', [
+          userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
+          gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+            gatewayAccountId,
+            gatewayAccountExternalId,
+            type: 'live',
+            paymentProvider: 'stripe'
+          }),
+          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, responsiblePerson: true })
+        ])
 
-  describe('trying to save details when responsible person already nominated', function () {
-    beforeEach(() => {
-      setupStubs([false, true])
-
-      cy.visit(responsiblePersonUrl)
-    })
-
-    it('should display an error instead of saving details', () => {
-      cy.get('#responsible-person-form').within(() => {
-        cy.get('button').click()
+        cy.visit(responsiblePersonUrl, { failOnStatusCode: false })
       })
 
-      cy.get('h1').should('contain', 'An error occurred')
-      cy.get('#back-link').should('contain', 'Back to dashboard')
-      cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
-      cy.get('#error-message').should('contain', 'You’ve already nominated your responsible person. Contact GOV.UK Pay support if you need to change them.')
-    })
-  })
-
-  describe('when it’s not a Stripe gateway account', () => {
-    beforeEach(() => {
-      setupStubs(false, 'live', 'worldpay')
-
-      cy.visit(responsiblePersonUrl, { failOnStatusCode: false })
-    })
-
-    it('should return a 404', () => {
-      cy.get('h1').should('contain', 'Page not found')
-    })
-  })
-
-  describe('when user has incorrect permissions', () => {
-    beforeEach(() => {
-      cy.task('setupStubs', [
-        userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
-        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'live', paymentProvider: 'stripe' }),
-        stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, responsiblePerson: true })
-      ])
-
-      cy.visit(responsiblePersonUrl, { failOnStatusCode: false })
-    })
-
-    it('should show a permission denied error', () => {
-      cy.get('h1').should('contain', 'An error occurred')
-      cy.get('#errorMsg').should('contain', 'not have the administrator rights')
+      it('should show a permission denied error', () => {
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#errorMsg').should('contain', 'not have the administrator rights')
+      })
     })
   })
 })

--- a/test/cypress/integration/stripe-setup/update-org-details.cy.js
+++ b/test/cypress/integration/stripe-setup/update-org-details.cy.js
@@ -65,176 +65,177 @@ describe('The organisation address page', () => {
   const countryGb = 'GB'
   const invalidPostcode = '123'
   const validPostcode = 'N1 1NN'
+  describe.skip('with simplified settings disabled', () => {
+    describe('Stripe setup after `go live` request and there are no existing merchant details', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
+      })
 
-  describe('Stripe setup after `go live` request and there are no existing merchant details', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
+      beforeEach(() => {
+        setupStubs(false)
+      })
+
+      it('should allow updating organisation details', () => {
+        cy.visit(pageUrl)
+
+        cy.get('h1').should('contain', 'What is the name and address of your organisation on your government entity document?')
+
+        cy.get('.govuk-back-link').should('contain', 'Back to check your organisation’s details')
+        cy.get('.govuk-back-link').should('have.attr', 'href', checkOrgDetailsUrl)
+
+        cy.get('#navigation-menu-your-psp')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+        cy.get('[data-cy=label-org-name]').should('exist')
+        cy.get('[data-cy=input-org-name]').should('exist')
+
+        cy.get('[data-cy=label-address-line-1]').should('exist')
+        cy.get('[data-cy=input-address-line-1]').should('exist')
+        cy.get('[data-cy=input-address-line-2]').should('exist')
+
+        cy.get('[data-cy=label-address-city]').should('exist')
+        cy.get('[data-cy=input-address-city]').should('exist')
+
+        cy.get('[data-cy=label-address-country]').should('exist')
+        cy.get('[data-cy=input-address-country]').should('exist')
+
+        cy.get('[data-cy=label-address-postcode]').should('exist')
+        cy.get('[data-cy=input-address-postcode]').should('exist')
+
+        cy.get('[data-cy=label-telephone-number]').should('not.exist')
+        cy.get('[data-cy=hint-telephone-number]').should('not.exist')
+        cy.get('[data-cy=input-telephone-number]').should('not.exist')
+
+        cy.get('[data-cy=label-url]').should('not.exist')
+        cy.get('[data-cy=hint-url]').should('not.exist')
+        cy.get('[data-cy=input-url]').should('not.exist')
+
+        cy.get('[data-cy=continue-button]').should('exist')
+        cy.get('[data-cy=save-button]').should('not.exist')
+
+        cy.get('[data-cy=account-sub-nav]')
+          .should('exist')
+
+        cy.log('Enter invalid values and check errors are displayed')
+        cy.get('[data-cy=input-address-postcode]').type(invalidPostcode)
+
+        cy.get('[data-cy=continue-button]').click()
+
+        cy.get('[data-cy=error-summary]').find('a').should('have.length', 4)
+        cy.get('[data-cy=error-summary]').should('exist').within(() => {
+          cy.get('a[href="#address-line1"]').should('contain', 'Enter a building and street')
+          cy.get('a[href="#address-city"]').should('contain', 'Enter a town or city')
+          cy.get('a[href="#address-postcode"]').should('contain', 'Enter a real postcode')
+        })
+
+        cy.get('[data-cy=input-address-line-1]').parent().should('exist').within(() => {
+          cy.get('.govuk-error-message').should('contain', 'Enter a building and street')
+        })
+        cy.get('[data-cy=input-address-city]').parent().should('exist').within(() => {
+          cy.get('.govuk-error-message').should('contain', 'Enter a town or city')
+        })
+        cy.get('[data-cy=input-address-postcode]').parent().should('exist').within(() => {
+          cy.get('.govuk-error-message').should('contain', 'Enter a real postcode')
+        })
+
+        cy.get('#navigation-menu-your-psp')
+          .should('contain', 'Information for Stripe')
+          .parent().should('have.class', 'govuk-!-font-weight-bold')
+
+        cy.get('.govuk-back-link')
+          .should('contain', 'Back to check your organisation’s details')
+          .should('have.attr', 'href', checkOrgDetailsUrl)
+
+        cy.log('Fill in details for all fields to check values are displayed back when form is re-rendered with validation errors')
+        cy.get('[data-cy=input-org-name]').type(validOrgName)
+        cy.get('[data-cy=input-address-line-1]').type(validLine1)
+        cy.get('[data-cy=input-address-line-2]').type(validLine2)
+        cy.get('[data-cy=input-address-city]').type(validCity)
+        cy.get('[data-cy=input-address-country]').select(countryGb)
+        cy.get('[data-cy=continue-button]').click()
+
+        cy.get('[data-cy=error-summary]').find('a').should('have.length', 1)
+        cy.get('[data-cy=error-summary]').should('exist').within(() => {
+          cy.get('a').should('contain', 'Enter a real postcode')
+        })
+
+        cy.get('#address-line1').should('have.value', validLine1)
+        cy.get('#address-line2').should('have.value', validLine2)
+        cy.get('#address-city').should('have.value', validCity)
+        cy.get('#address-country').should('have.value', countryGb)
+        cy.get('#address-postcode').should('have.value', invalidPostcode)
+
+        // Set up stubs that return a different result for the stripe setup the first time the account is retrieved.
+        // This is necessary as it is not possible to submit the form if the organisation details step has already been
+        // completed.
+        cy.task('clearStubs')
+        setupStubs({
+          organisationDetails: [false, true, true]
+        })
+
+        cy.log('Enter valid details and submit')
+        cy.get('#address-postcode').clear()
+        cy.get('#address-postcode').type(validPostcode)
+        cy.get('[data-cy=continue-button]').click()
+
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq('/account/a-valid-external-id/your-psp/a-valid-credential-external-id')
+        })
+      })
     })
 
-    beforeEach(() => {
-      setupStubs(false)
-    })
-
-    it('should allow updating organisation details', () => {
-      cy.visit(pageUrl)
-
-      cy.get('h1').should('contain', 'What is the name and address of your organisation on your government entity document?')
-
-      cy.get('.govuk-back-link').should('contain', 'Back to check your organisation’s details')
-      cy.get('.govuk-back-link').should('have.attr', 'href', checkOrgDetailsUrl)
-
-      cy.get('#navigation-menu-your-psp')
-        .should('contain', 'Information for Stripe')
-        .parent().should('have.class', 'govuk-!-font-weight-bold')
-
-      cy.get('[data-cy=label-org-name]').should('exist')
-      cy.get('[data-cy=input-org-name]').should('exist')
-
-      cy.get('[data-cy=label-address-line-1]').should('exist')
-      cy.get('[data-cy=input-address-line-1]').should('exist')
-      cy.get('[data-cy=input-address-line-2]').should('exist')
-
-      cy.get('[data-cy=label-address-city]').should('exist')
-      cy.get('[data-cy=input-address-city]').should('exist')
-
-      cy.get('[data-cy=label-address-country]').should('exist')
-      cy.get('[data-cy=input-address-country]').should('exist')
-
-      cy.get('[data-cy=label-address-postcode]').should('exist')
-      cy.get('[data-cy=input-address-postcode]').should('exist')
-
-      cy.get('[data-cy=label-telephone-number]').should('not.exist')
-      cy.get('[data-cy=hint-telephone-number]').should('not.exist')
-      cy.get('[data-cy=input-telephone-number]').should('not.exist')
-
-      cy.get('[data-cy=label-url]').should('not.exist')
-      cy.get('[data-cy=hint-url]').should('not.exist')
-      cy.get('[data-cy=input-url]').should('not.exist')
-
-      cy.get('[data-cy=continue-button]').should('exist')
-      cy.get('[data-cy=save-button]').should('not.exist')
-
-      cy.get('[data-cy=account-sub-nav]')
-        .should('exist')
-
-      cy.log('Enter invalid values and check errors are displayed')
-      cy.get('[data-cy=input-address-postcode]').type(invalidPostcode)
-
-      cy.get('[data-cy=continue-button]').click()
-
-      cy.get('[data-cy=error-summary]').find('a').should('have.length', 4)
-      cy.get('[data-cy=error-summary]').should('exist').within(() => {
-        cy.get('a[href="#address-line1"]').should('contain', 'Enter a building and street')
-        cy.get('a[href="#address-city"]').should('contain', 'Enter a town or city')
-        cy.get('a[href="#address-postcode"]').should('contain', 'Enter a real postcode')
+    describe('when it is not a Stripe gateway account', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
       })
 
-      cy.get('[data-cy=input-address-line-1]').parent().should('exist').within(() => {
-        cy.get('.govuk-error-message').should('contain', 'Enter a building and street')
-      })
-      cy.get('[data-cy=input-address-city]').parent().should('exist').within(() => {
-        cy.get('.govuk-error-message').should('contain', 'Enter a town or city')
-      })
-      cy.get('[data-cy=input-address-postcode]').parent().should('exist').within(() => {
-        cy.get('.govuk-error-message').should('contain', 'Enter a real postcode')
-      })
+      it('should show a 404 error when gateway account is not Stripe', () => {
+        setupStubs(false, 'live', 'sandbox')
 
-      cy.get('#navigation-menu-your-psp')
-        .should('contain', 'Information for Stripe')
-        .parent().should('have.class', 'govuk-!-font-weight-bold')
-
-      cy.get('.govuk-back-link')
-        .should('contain', 'Back to check your organisation’s details')
-        .should('have.attr', 'href', checkOrgDetailsUrl)
-
-      cy.log('Fill in details for all fields to check values are displayed back when form is re-rendered with validation errors')
-      cy.get('[data-cy=input-org-name]').type(validOrgName)
-      cy.get('[data-cy=input-address-line-1]').type(validLine1)
-      cy.get('[data-cy=input-address-line-2]').type(validLine2)
-      cy.get('[data-cy=input-address-city]').type(validCity)
-      cy.get('[data-cy=input-address-country]').select(countryGb)
-      cy.get('[data-cy=continue-button]').click()
-
-      cy.get('[data-cy=error-summary]').find('a').should('have.length', 1)
-      cy.get('[data-cy=error-summary]').should('exist').within(() => {
-        cy.get('a').should('contain', 'Enter a real postcode')
-      })
-
-      cy.get('#address-line1').should('have.value', validLine1)
-      cy.get('#address-line2').should('have.value', validLine2)
-      cy.get('#address-city').should('have.value', validCity)
-      cy.get('#address-country').should('have.value', countryGb)
-      cy.get('#address-postcode').should('have.value', invalidPostcode)
-
-      // Set up stubs that return a different result for the stripe setup the first time the account is retrieved.
-      // This is necessary as it is not possible to submit the form if the organisation details step has already been
-      // completed.
-      cy.task('clearStubs')
-      setupStubs({
-        organisationDetails: [false, true, true]
-      })
-
-      cy.log('Enter valid details and submit')
-      cy.get('#address-postcode').clear()
-      cy.get('#address-postcode').type(validPostcode)
-      cy.get('[data-cy=continue-button]').click()
-
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq('/account/a-valid-external-id/your-psp/a-valid-credential-external-id')
+        cy.visit(pageUrl, {
+          failOnStatusCode: false
+        })
+        cy.get('h1').should('contain', 'Page not found')
       })
     })
-  })
 
-  describe('when it is not a Stripe gateway account', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
-    })
-
-    it('should show a 404 error when gateway account is not Stripe', () => {
-      setupStubs(false, 'live', 'sandbox')
-
-      cy.visit(pageUrl, {
-        failOnStatusCode: false
+    describe('when it is not a live gateway account', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
       })
-      cy.get('h1').should('contain', 'Page not found')
-    })
-  })
 
-  describe('when it is not a live gateway account', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
-    })
+      it('should show a 404 error when gateway account is not live', () => {
+        setupStubs(false, 'test', 'stripe')
 
-    it('should show a 404 error when gateway account is not live', () => {
-      setupStubs(false, 'test', 'stripe')
-
-      cy.visit(checkOrgDetailsUrl, {
-        failOnStatusCode: false
+        cy.visit(checkOrgDetailsUrl, {
+          failOnStatusCode: false
+        })
+        cy.get('h1').should('contain', 'Page not found')
       })
-      cy.get('h1').should('contain', 'Page not found')
-    })
-  })
-
-  describe('when the user does not have the correct permissions', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
     })
 
-    it('should show a permission error when the user does not have enough permissions', () => {
-      cy.task('setupStubs', [
-        userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
-        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
-          gatewayAccountId,
-          gatewayAccountExternalId,
-          type: 'live',
-          paymentProvider: 'stripe'
-        }),
-        stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, vatNumber: true })
-      ])
+    describe('when the user does not have the correct permissions', () => {
+      beforeEach(() => {
+        cy.setEncryptedCookies(userExternalId)
+      })
 
-      cy.visit(checkOrgDetailsUrl, { failOnStatusCode: false })
-      cy.get('h1').should('contain', 'An error occurred')
-      cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+      it('should show a permission error when the user does not have enough permissions', () => {
+        cy.task('setupStubs', [
+          userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
+          gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+            gatewayAccountId,
+            gatewayAccountExternalId,
+            type: 'live',
+            paymentProvider: 'stripe'
+          }),
+          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, vatNumber: true })
+        ])
+
+        cy.visit(checkOrgDetailsUrl, { failOnStatusCode: false })
+        cy.get('h1').should('contain', 'An error occurred')
+        cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+      })
     })
   })
 })

--- a/test/cypress/integration/stripe-setup/vat-number.cy.js
+++ b/test/cypress/integration/stripe-setup/vat-number.cy.js
@@ -43,159 +43,161 @@ function setupStubs (vatNumber, type = 'live', paymentProvider = 'stripe') {
 }
 
 describe('Stripe setup: VAT number page', () => {
-  describe('Card gateway account', () => {
-    describe('when user is admin, account is Stripe and "VAT number" is not already submitted', () => {
-      beforeEach(() => {
-        setupStubs(false)
+  describe.skip('with simplified settings disabled', () => {
+    describe('Card gateway account', () => {
+      describe('when user is admin, account is Stripe and "VAT number" is not already submitted', () => {
+        beforeEach(() => {
+          setupStubs(false)
 
-        cy.setEncryptedCookies(userExternalId, {})
+          cy.setEncryptedCookies(userExternalId, {})
 
-        cy.visit(vatNumberUrl)
-      })
+          cy.visit(vatNumberUrl)
+        })
 
-      it('should display page correctly', () => {
-        cy.get('h1').should('contain', 'VAT registration number')
+        it('should display page correctly', () => {
+          cy.get('h1').should('contain', 'VAT registration number')
 
-        cy.get('#navigation-menu-your-psp')
-          .should('contain', 'Information for Stripe')
-          .parent().should('have.class', 'govuk-!-font-weight-bold')
+          cy.get('#navigation-menu-your-psp')
+            .should('contain', 'Information for Stripe')
+            .parent().should('have.class', 'govuk-!-font-weight-bold')
 
-        cy.get('#vat-number-form').should('exist')
-          .within(() => {
-            cy.get('input#have-vat-number').should('exist')
-            cy.get('input#not-have-vat-number').should('exist')
-            cy.get('input#vat-number[name="vat-number"]').should('exist')
-            cy.get('button').should('exist')
-            cy.get('button').should('contain', 'Save and continue')
+          cy.get('#vat-number-form').should('exist')
+            .within(() => {
+              cy.get('input#have-vat-number').should('exist')
+              cy.get('input#not-have-vat-number').should('exist')
+              cy.get('input#vat-number[name="vat-number"]').should('exist')
+              cy.get('button').should('exist')
+              cy.get('button').should('contain', 'Save and continue')
 
-            cy.get('#navigation-menu-switch-psp').should('not.exist')
+              cy.get('#navigation-menu-switch-psp').should('not.exist')
+            })
+        })
+
+        it('should have a back link that redirects back to tasklist page', () => {
+          cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
+          cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
+        })
+
+        it('should display an error when VAT number input is blank', () => {
+          cy.get('input#have-vat-number').click()
+          cy.get('#vat-number-form > button').click()
+
+          cy.get('h2').should('contain', 'There is a problem')
+          cy.get('input#have-vat-number').should('be.checked')
+          cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'Enter your VAT registration number')
+          cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#vat-number')
+
+          cy.get('.govuk-form-group--error > input#vat-number').parent().should('exist').within(() => {
+            cy.get('.govuk-error-message').should('exist')
+            cy.get('p.govuk-error-message').should('contain', 'Enter your VAT registration number')
           })
-      })
 
-      it('should have a back link that redirects back to tasklist page', () => {
-        cy.get('.govuk-back-link').should('contain', 'Back to information for Stripe')
-        cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
-      })
+          cy.get('#navigation-menu-your-psp')
+            .should('contain', 'Information for Stripe')
+            .parent().should('have.class', 'govuk-!-font-weight-bold')
 
-      it('should display an error when VAT number input is blank', () => {
-        cy.get('input#have-vat-number').click()
-        cy.get('#vat-number-form > button').click()
-
-        cy.get('h2').should('contain', 'There is a problem')
-        cy.get('input#have-vat-number').should('be.checked')
-        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'Enter your VAT registration number')
-        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#vat-number')
-
-        cy.get('.govuk-form-group--error > input#vat-number').parent().should('exist').within(() => {
-          cy.get('.govuk-error-message').should('exist')
-          cy.get('p.govuk-error-message').should('contain', 'Enter your VAT registration number')
+          cy.get('.govuk-back-link')
+            .should('contain', 'Back to information for Stripe')
+            .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
         })
 
-        cy.get('#navigation-menu-your-psp')
-          .should('contain', 'Information for Stripe')
-          .parent().should('have.class', 'govuk-!-font-weight-bold')
+        it('should redirect to tasklist page when "No" VAT number is chosen', () => {
+          cy.get('input#not-have-vat-number').click()
+          cy.get('#vat-number-form > button').click()
 
-        cy.get('.govuk-back-link')
-          .should('contain', 'Back to information for Stripe')
-          .should('have.attr', 'href', `/account/${gatewayAccountExternalId}/your-psp/${gatewayAccountCredentialExternalId}`)
-      })
+          cy.location().should((location) => {
+            expect(location.pathname).to.eq(taskListUrl)
+          })
+        })
 
-      it('should redirect to tasklist page when "No" VAT number is chosen', () => {
-        cy.get('input#not-have-vat-number').click()
-        cy.get('#vat-number-form > button').click()
+        it('should display an error when no option was chosen', () => {
+          cy.get('#vat-number-form > button').click()
 
-        cy.location().should((location) => {
-          expect(location.pathname).to.eq(taskListUrl)
+          cy.get('h2').should('contain', 'There is a problem')
+          cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'You must answer this question')
+          cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#have-vat-number')
         })
       })
 
-      it('should display an error when no option was chosen', () => {
-        cy.get('#vat-number-form > button').click()
-
-        cy.get('h2').should('contain', 'There is a problem')
-        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('contain', 'You must answer this question')
-        cy.get('ul.govuk-error-summary__list > li:nth-child(1) > a').should('have.attr', 'href', '#have-vat-number')
-      })
-    })
-
-    describe('when user is admin, account is Stripe and "VAT number" is already submitted', () => {
-      beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId)
-      })
-
-      it('should display an error when displaying the page', () => {
-        setupStubs(true)
-
-        cy.visit(vatNumberUrl)
-
-        cy.get('h1').should('contain', 'An error occurred')
-        cy.get('#back-link').should('contain', 'Back to dashboard')
-        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
-        cy.get('#error-message').should('contain', 'You’ve already provided your VAT number. Contact GOV.UK Pay support if you need to update it.')
-      })
-
-      it('should display an error when submitting the form', () => {
-        setupStubs([false, true])
-
-        cy.visit(vatNumberUrl)
-
-        cy.get('input#have-vat-number').click()
-        cy.get('input#vat-number[name="vat-number"]').type('GB999 9999 73')
-
-        cy.get('#vat-number-form > button').click()
-
-        cy.get('h1').should('contain', 'An error occurred')
-        cy.get('#back-link').should('contain', 'Back to dashboard')
-        cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
-        cy.get('#error-message').should('contain', 'You’ve already provided your VAT number. Contact GOV.UK Pay support if you need to update it.')
-      })
-    })
-
-    describe('when it is not a Stripe gateway account', () => {
-      beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId)
-      })
-
-      it('should show a 404 error when gateway account is not Stripe', () => {
-        setupStubs(false, 'live', 'sandbox')
-
-        cy.visit(vatNumberUrl, {
-          failOnStatusCode: false
+      describe('when user is admin, account is Stripe and "VAT number" is already submitted', () => {
+        beforeEach(() => {
+          cy.setEncryptedCookies(userExternalId)
         })
-        cy.get('h1').should('contain', 'Page not found')
-      })
-    })
 
-    describe('when it is not a live gateway account', () => {
-      beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId)
-      })
+        it('should display an error when displaying the page', () => {
+          setupStubs(true)
 
-      it('should show a 404 error when gateway account is not live', () => {
-        setupStubs(false, 'test', 'stripe')
+          cy.visit(vatNumberUrl)
 
-        cy.visit(vatNumberUrl, {
-          failOnStatusCode: false
+          cy.get('h1').should('contain', 'An error occurred')
+          cy.get('#back-link').should('contain', 'Back to dashboard')
+          cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+          cy.get('#error-message').should('contain', 'You’ve already provided your VAT number. Contact GOV.UK Pay support if you need to update it.')
         })
-        cy.get('h1').should('contain', 'Page not found')
+
+        it('should display an error when submitting the form', () => {
+          setupStubs([false, true])
+
+          cy.visit(vatNumberUrl)
+
+          cy.get('input#have-vat-number').click()
+          cy.get('input#vat-number[name="vat-number"]').type('GB999 9999 73')
+
+          cy.get('#vat-number-form > button').click()
+
+          cy.get('h1').should('contain', 'An error occurred')
+          cy.get('#back-link').should('contain', 'Back to dashboard')
+          cy.get('#back-link').should('have.attr', 'href', dashboardUrl)
+          cy.get('#error-message').should('contain', 'You’ve already provided your VAT number. Contact GOV.UK Pay support if you need to update it.')
+        })
       })
-    })
 
-    describe('when the user does not have the correct permissions', () => {
-      beforeEach(() => {
-        cy.setEncryptedCookies(userExternalId)
+      describe('when it is not a Stripe gateway account', () => {
+        beforeEach(() => {
+          cy.setEncryptedCookies(userExternalId)
+        })
+
+        it('should show a 404 error when gateway account is not Stripe', () => {
+          setupStubs(false, 'live', 'sandbox')
+
+          cy.visit(vatNumberUrl, {
+            failOnStatusCode: false
+          })
+          cy.get('h1').should('contain', 'Page not found')
+        })
       })
 
-      it('should show a permission error when the user does not have enough permissions', () => {
-        cy.task('setupStubs', [
-          userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
-          gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'live', paymentProvider: 'stripe' }),
-          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, vatNumber: true })
-        ])
+      describe('when it is not a live gateway account', () => {
+        beforeEach(() => {
+          cy.setEncryptedCookies(userExternalId)
+        })
 
-        cy.visit(vatNumberUrl, { failOnStatusCode: false })
-        cy.get('h1').should('contain', 'An error occurred')
-        cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+        it('should show a 404 error when gateway account is not live', () => {
+          setupStubs(false, 'test', 'stripe')
+
+          cy.visit(vatNumberUrl, {
+            failOnStatusCode: false
+          })
+          cy.get('h1').should('contain', 'Page not found')
+        })
+      })
+
+      describe('when the user does not have the correct permissions', () => {
+        beforeEach(() => {
+          cy.setEncryptedCookies(userExternalId)
+        })
+
+        it('should show a permission error when the user does not have enough permissions', () => {
+          cy.task('setupStubs', [
+            userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
+            gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, type: 'live', paymentProvider: 'stripe' }),
+            stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, vatNumber: true })
+          ])
+
+          cy.visit(vatNumberUrl, { failOnStatusCode: false })
+          cy.get('h1').should('contain', 'An error occurred')
+          cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
+        })
       })
     })
   })

--- a/test/cypress/integration/switch-psp/organisation-url.cy.js
+++ b/test/cypress/integration/switch-psp/organisation-url.cy.js
@@ -5,7 +5,6 @@ const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 const stripeAccountSetupStubs = require('../../stubs/stripe-account-setup-stub')
 const stripePspStubs = require('../../stubs/stripe-psp-stubs')
 const serviceStubs = require('../../stubs/service-stubs')
-const ROLES = require('@test/fixtures/roles.fixtures')
 
 const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
 const gatewayAccountId = '42'

--- a/test/cypress/integration/switch-psp/organisation-url.cy.js
+++ b/test/cypress/integration/switch-psp/organisation-url.cy.js
@@ -5,11 +5,12 @@ const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 const stripeAccountSetupStubs = require('../../stubs/stripe-account-setup-stub')
 const stripePspStubs = require('../../stubs/stripe-psp-stubs')
 const serviceStubs = require('../../stubs/service-stubs')
+const ROLES = require('@test/fixtures/roles.fixtures')
 
 const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
 const gatewayAccountId = '42'
 const gatewayAccountExternalId = 'a-valid-external-id'
-const serviceExternalId = 'a-service-external-id'
+const serviceExternalId = 'aserviceexternalid'
 
 function getUserAndAccountStubs (paymentProvider, providerSwitchEnabled, gatewayAccountCredentials, merchantDetails) {
   return [
@@ -30,107 +31,109 @@ describe('Switch PSP', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  describe('Organisation URL', () => {
-    const gatewayAccountCredentialExternalId = 'a-valid-credential-external-id'
-    const validUrl = 'https://www.valid-url.com'
+  describe.skip('with simplified settings disabled', () => {
+    describe('Organisation URL', () => {
+      const gatewayAccountCredentialExternalId = 'a-valid-credential-external-id'
+      const validUrl = 'https://www.valid-url.com'
 
-    describe('User is an admin user', () => {
-      beforeEach(() => {
-        const stripeUpdateAccountStub = stripePspStubs.updateAccount({
-          stripeAccountId: 'acct_123example123',
-          url: validUrl
-        })
-        const merchantDetails = {
-          url: validUrl
-        }
-
-        const servicePatch = serviceStubs.patchUpdateMerchantDetailsSuccess({
-          serviceExternalId, gatewayAccountId, merchantDetails
-        })
-
-        cy.task('setupStubs', [
-          ...getUserAndAccountStubs(
-            'smartpay',
-            true,
-            [
-              { payment_provider: 'smartpay', state: 'ACTIVE' },
-              {
-                external_id: gatewayAccountCredentialExternalId,
-                payment_provider: 'stripe',
-                state: 'VERIFIED_WITH_LIVE_PAYMENT',
-                credentials: { stripe_account_id: 'acct_123example123' }
-              }
-            ]
-          ),
-          stripeUpdateAccountStub,
-          servicePatch,
-          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
-            gatewayAccountId,
-            bankAccount: true,
-            vatNumber: true,
-            companyNumber: true,
-            responsiblePerson: true,
-            director: true
+      describe('User is an admin user', () => {
+        beforeEach(() => {
+          const stripeUpdateAccountStub = stripePspStubs.updateAccount({
+            stripeAccountId: 'acct_123example123',
+            url: validUrl
           })
-        ])
+          const merchantDetails = {
+            url: validUrl
+          }
 
-        cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
-      })
-
-      it('should display organisation URL page correctly when switching PSP', () => {
-        cy.get('a').contains('Add organisation website address').click()
-
-        cy.get('#organisation-url-form').should('exist')
-          .within(() => {
-            cy.get('input#organisation-url').should('exist')
+          const servicePatch = serviceStubs.patchUpdateMerchantDetailsSuccess({
+            serviceExternalId, gatewayAccountId, merchantDetails
           })
-        cy.get('.govuk-back-link').should('contain', 'Back to Switching payment service provider (PSP)')
-        cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/switch-psp`)
+
+          cy.task('setupStubs', [
+            ...getUserAndAccountStubs(
+              'smartpay',
+              true,
+              [
+                { payment_provider: 'smartpay', state: 'ACTIVE' },
+                {
+                  external_id: gatewayAccountCredentialExternalId,
+                  payment_provider: 'stripe',
+                  state: 'VERIFIED_WITH_LIVE_PAYMENT',
+                  credentials: { stripe_account_id: 'acct_123example123' }
+                }
+              ]
+            ),
+            stripeUpdateAccountStub,
+            servicePatch,
+            stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
+              gatewayAccountId,
+              bankAccount: true,
+              vatNumber: true,
+              companyNumber: true,
+              responsiblePerson: true,
+              director: true
+            })
+          ])
+
+          cy.visit(`/account/${gatewayAccountExternalId}/switch-psp`)
+        })
+
+        it('should display organisation URL page correctly when switching PSP', () => {
+          cy.get('a').contains('Add organisation website address').click()
+
+          cy.get('#organisation-url-form').should('exist')
+            .within(() => {
+              cy.get('input#organisation-url').should('exist')
+            })
+          cy.get('.govuk-back-link').should('contain', 'Back to Switching payment service provider (PSP)')
+          cy.get('.govuk-back-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/switch-psp`)
+        })
+
+        it('should submit organisation URL and redirect to switch PSP page', () => {
+          cy.get('a').contains('Add organisation website address').click()
+
+          cy.get('#organisation-url-form').within(() => {
+            cy.get('#organisation-url').type('https://www.valid-url.com')
+            cy.get('button').click()
+          })
+
+          cy.get('h1').should('contain', 'Switch payment service provider (PSP)')
+        })
+
+        it('should show an error if an invalid URL is submitted', () => {
+          cy.get('a').contains('Add organisation website address').click()
+          cy.get('#organisation-url-form').within(() => {
+            cy.get('#organisation-url').type('invalid-url.com')
+            cy.get('button').click()
+          })
+
+          cy.get('.govuk-error-summary').should('exist').within(() => {
+            cy.get('a[href="#organisation-url"]').should('contain', 'Enter a valid website address')
+          })
+        })
       })
 
-      it('should submit organisation URL and redirect to switch PSP page', () => {
-        cy.get('a').contains('Add organisation website address').click()
+      describe('User does not have the correct permissions', () => {
+        it('should show a permission error when the user does not have enough permissions', () => {
+          cy.task('setupStubs', [
+            userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
+            gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
+              gatewayAccountId,
+              gatewayAccountExternalId,
+              type: 'live',
+              paymentProvider: 'stripe'
+            }),
+            stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, bankAccount: false })
+          ])
 
-        cy.get('#organisation-url-form').within(() => {
-          cy.get('#organisation-url').type('https://www.valid-url.com')
-          cy.get('button').click()
+          const organisationUrl = `/account/${gatewayAccountExternalId}/switch-psp/${gatewayAccountCredentialExternalId}/organisation-url`
+          cy.visit(organisationUrl, {
+            failOnStatusCode: false
+          })
+          cy.get('h1').should('contain', 'An error occurred')
+          cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
         })
-
-        cy.get('h1').should('contain', 'Switch payment service provider (PSP)')
-      })
-
-      it('should show an error if an invalid URL is submitted', () => {
-        cy.get('a').contains('Add organisation website address').click()
-        cy.get('#organisation-url-form').within(() => {
-          cy.get('#organisation-url').type('invalid-url.com')
-          cy.get('button').click()
-        })
-
-        cy.get('.govuk-error-summary').should('exist').within(() => {
-          cy.get('a[href="#organisation-url"]').should('contain', 'Enter a valid website address')
-        })
-      })
-    })
-
-    describe('User does not have the correct permissions', () => {
-      it('should show a permission error when the user does not have enough permissions', () => {
-        cy.task('setupStubs', [
-          userStubs.getUserWithNoPermissions(userExternalId, gatewayAccountId),
-          gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
-            gatewayAccountId,
-            gatewayAccountExternalId,
-            type: 'live',
-            paymentProvider: 'stripe'
-          }),
-          stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId, bankAccount: false })
-        ])
-
-        const organisationUrl = `/account/${gatewayAccountExternalId}/switch-psp/${gatewayAccountCredentialExternalId}/organisation-url`
-        cy.visit(organisationUrl, {
-          failOnStatusCode: false
-        })
-        cy.get('h1').should('contain', 'An error occurred')
-        cy.get('#errorMsg').should('contain', 'You do not have the administrator rights to perform this operation.')
       })
     })
   })

--- a/test/cypress/integration/webhooks/webhooks.cy.js
+++ b/test/cypress/integration/webhooks/webhooks.cy.js
@@ -1,16 +1,17 @@
 const userStubs = require('../../stubs/user-stubs')
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 const webhooksStubs = require('../../stubs/webhooks-stubs')
+const ROLES = require('@test/fixtures/roles.fixtures')
 
 const userExternalId = 'some-user-id'
 const gatewayAccountId = 10
 const gatewayAccountExternalId = 'gateway-account-id'
-const serviceExternalId = 'service-id'
+const serviceExternalId = 'serviceid'
 const webhookExternalId = 'webhook-id'
 const messageExternalId = 'message-id'
 
 const userAndGatewayAccountStubs = [
-  userStubs.getUserSuccess({ userExternalId, serviceExternalId, gatewayAccountId }),
+  userStubs.getUserSuccess({ userExternalId, serviceExternalId, gatewayAccountId, role: ROLES.admin }),
   gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({ gatewayAccountId, gatewayAccountExternalId, serviceExternalId }),
   webhooksStubs.getWebhooksListSuccess({ service_id: serviceExternalId, gateway_account_id: gatewayAccountId, live: false, webhooks: [{ external_id: webhookExternalId }, { status: 'INACTIVE' }, { status: 'DISABLED' }] }),
   webhooksStubs.getWebhookSuccess({ service_id: serviceExternalId, gateway_account_id: gatewayAccountId, external_id: webhookExternalId, subscriptions: ['card_payment_captured', 'card_payment_succeeded', 'card_payment_refunded'] }),
@@ -34,7 +35,11 @@ const userAndGatewayAccountStubs = [
   }),
   webhooksStubs.getWebhookSigningSecret({ service_id: serviceExternalId, gateway_account_id: gatewayAccountId, external_id: webhookExternalId }),
   webhooksStubs.getWebhookMessage({ external_id: messageExternalId, webhook_id: webhookExternalId }),
-  webhooksStubs.getWebhookMessageAttempts({ message_id: messageExternalId, webhook_id: webhookExternalId, attempts: [{}] })
+  webhooksStubs.getWebhookMessageAttempts({ message_id: messageExternalId, webhook_id: webhookExternalId, attempts: [{}] }),
+  gatewayAccountStubs.getAccountByServiceIdAndAccountType(serviceExternalId, 'test', {
+    gateway_account_id: gatewayAccountId,
+    type: 'test'
+  })
 ]
 
 describe('Webhooks', () => {
@@ -42,163 +47,173 @@ describe('Webhooks', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  it.skip('should correctly list webhooks for a given service', () => {
-    cy.task('setupStubs', [...userAndGatewayAccountStubs])
-    cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
+  describe('with simplified settings enabled', () => {
+    it('should redirect to the settings index page', () => {
+      cy.task('setupStubs', [...userAndGatewayAccountStubs])
+      cy.visit('/test/service/serviceid/account/gateway-account-id/webhooks')
 
-    cy.get('h1').should('have.text', 'Webhooks')
-
-    // navigation menus are correctly integrated
-    cy.contains('.govuk-service-navigation__item--active', 'Settings')
-    cy.get('#navigation-menu-webhooks').parent().should('have.class', 'govuk-!-margin-bottom-2')
-
-    cy.get('[data-webhook-entry]').should('have.length', 3)
+      cy.location('pathname').should('eq', '/service/serviceid/account/test/settings')
+    })
   })
 
-  it('should correctly display simple data consistency properties when creating', () => {
-    cy.task('setupStubs', [
-      ...userAndGatewayAccountStubs
-    ])
+  describe.skip('with simplified settings disabled', () => {
+    it('should correctly list webhooks for a given service', () => {
+      cy.task('setupStubs', [...userAndGatewayAccountStubs])
+      cy.visit('/test/service/serviceid/account/gateway-account-id/webhooks')
 
-    cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
-    cy.get('[data-action=create').contains('Create a new webhook').click()
+      cy.get('h1').should('have.text', 'Webhooks')
 
-    // no data has been provided
-    cy.get('button').contains('Create webhook').click()
+      // navigation menus are correctly integrated
+      cy.contains('.govuk-service-navigation__item--active', 'Settings')
+      cy.get('#navigation-menu-webhooks').parent().should('have.class', 'govuk-!-margin-bottom-2')
 
-    cy.get('.govuk-error-summary').should('be.visible')
-    cy.get('.govuk-error-summary__list').children().should('have.length', 2)
-    cy.get('#callback_url-error').should('be.visible')
-    cy.get('#subscriptions-error').should('be.visible')
-  })
+      cy.get('[data-webhook-entry]').should('have.length', 3)
+    })
 
-  it('should correctly display backend validated error identifiers', () => {
-    cy.task('setupStubs', [
-      ...userAndGatewayAccountStubs,
-      webhooksStubs.createWebhookViolatesBackend()
-    ])
+    it('should correctly display simple data consistency properties when creating', () => {
+      cy.task('setupStubs', [
+        ...userAndGatewayAccountStubs
+      ])
 
-    const callbackUrl = 'https://some-valid-callback-url.test'
-    const description = 'A valid Webhook description'
+      cy.visit('/test/service/serviceid/account/gateway-account-id/webhooks')
+      cy.get('[data-action=create').contains('Create a new webhook').click()
 
-    cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
-    cy.get('[data-action=create').contains('Create a new webhook').click()
-    cy.get('#callback_url').type(callbackUrl)
-    cy.get('#description').type(description)
-    cy.get('[value=card_payment_captured]').click()
-    cy.get('button').contains('Create webhook').click()
+      // no data has been provided
+      cy.get('button').contains('Create webhook').click()
 
-    cy.get('.govuk-error-summary').should('be.visible')
-    cy.get('.govuk-error-summary__list').children().should('have.length', 1)
-    cy.get('#callback_url-error').should('be.visible')
-  })
+      cy.get('.govuk-error-summary').should('be.visible')
+      cy.get('.govuk-error-summary__list').children().should('have.length', 2)
+      cy.get('#callback_url-error').should('be.visible')
+      cy.get('#subscriptions-error').should('be.visible')
+    })
 
-  it('should create a webhook with valid properties', () => {
-    const callbackUrl = 'https://some-valid-callback-url.test'
-    const description = 'A valid Webhook description'
+    it('should correctly display backend validated error identifiers', () => {
+      cy.task('setupStubs', [
+        ...userAndGatewayAccountStubs,
+        webhooksStubs.createWebhookViolatesBackend()
+      ])
 
-    cy.task('setupStubs', [
-      ...userAndGatewayAccountStubs,
-      webhooksStubs.postCreateWebhookSuccess(),
-      webhooksStubs.getWebhookMessagesListSuccess({ service_id: serviceExternalId, external_id: webhookExternalId, messages: [{ status: 'FAILED' }], status: 'FAILED' })
-    ])
+      const callbackUrl = 'https://some-valid-callback-url.test'
+      const description = 'A valid Webhook description'
 
-    cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
-    cy.get('[data-action=create').contains('Create a new webhook').click()
-    cy.get('#callback_url').type(callbackUrl)
-    cy.get('#description').type(description)
-    cy.get('[value=card_payment_captured]').click()
-    cy.get('button').contains('Create webhook').click()
+      cy.visit('/test/service/serviceid/account/gateway-account-id/webhooks')
+      cy.get('[data-action=create').contains('Create a new webhook').click()
+      cy.get('#callback_url').type(callbackUrl)
+      cy.get('#description').type(description)
+      cy.get('[value=card_payment_captured]').click()
+      cy.get('button').contains('Create webhook').click()
 
-    cy.get('[data-action=update]').then((links) => links[0].click())
+      cy.get('.govuk-error-summary').should('be.visible')
+      cy.get('.govuk-error-summary__list').children().should('have.length', 1)
+      cy.get('#callback_url-error').should('be.visible')
+    })
 
-    cy.get('h1').contains('https://some-callback-url.test')
-    cy.get('.govuk-list.govuk-list--bullet > li').should('have.length', 3)
+    it('should create a webhook with valid properties', () => {
+      const callbackUrl = 'https://some-valid-callback-url.test'
+      const description = 'A valid Webhook description'
 
-    // based on number of rows stubbed and client pagination logic
-    cy.get('.govuk-table__body > .govuk-table__row').should('have.length', 11)
-    cy.get('.paginationForm').should('have.length', 2)
+      cy.task('setupStubs', [
+        ...userAndGatewayAccountStubs,
+        webhooksStubs.postCreateWebhookSuccess(),
+        webhooksStubs.getWebhookMessagesListSuccess({ service_id: serviceExternalId, external_id: webhookExternalId, messages: [{ status: 'FAILED' }], status: 'FAILED' })
+      ])
 
-    cy.get('a#filter-failed').click()
-    cy.get('a#filter-failed').should('have.class', 'govuk-!-font-weight-bold')
-  })
+      cy.visit('/test/service/serviceid/account/gateway-account-id/webhooks')
+      cy.get('[data-action=create').contains('Create a new webhook').click()
+      cy.get('#callback_url').type(callbackUrl)
+      cy.get('#description').type(description)
+      cy.get('[value=card_payment_captured]').click()
+      cy.get('button').contains('Create webhook').click()
 
-  it('should update a webhook with valid properties', () => {
-    cy.task('setupStubs', [
-      ...userAndGatewayAccountStubs,
-      webhooksStubs.patchBatchUpdateWebhookSuccess(gatewayAccountId, serviceExternalId, webhookExternalId, [{
-        path: 'callback_url',
-        value: 'https://some-callback-url.test'
-      }, {
-        path: 'description',
-        value: 'a valid webhook description'
-      }, {
-        path: 'subscriptions',
-        value: [
-          'card_payment_succeeded',
-          'card_payment_captured',
-          'card_payment_refunded'
-        ]
-      }])
-    ])
-    cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
+      cy.get('[data-action=update]').then((links) => links[0].click())
 
-    // link to detail page
-    cy.get('[data-action=update]').then((links) => links[0].click())
+      cy.get('h1').contains('https://some-callback-url.test')
+      cy.get('.govuk-list.govuk-list--bullet > li').should('have.length', 3)
 
-    // button through to update webhooks
-    cy.get('[data-action=update]').click()
+      // based on number of rows stubbed and client pagination logic
+      cy.get('.govuk-table__body > .govuk-table__row').should('have.length', 11)
+      cy.get('.paginationForm').should('have.length', 2)
 
-    cy.get('#callback_url').should('have.value', 'https://some-callback-url.test')
-    cy.get('#description').should('have.value', 'a valid webhook description')
-    cy.get('[value=card_payment_captured]').should('be.checked')
+      cy.get('a#filter-failed').click()
+      cy.get('a#filter-failed').should('have.class', 'govuk-!-font-weight-bold')
+    })
 
-    cy.get('button').contains('Update webhook').click()
+    it('should update a webhook with valid properties', () => {
+      cy.task('setupStubs', [
+        ...userAndGatewayAccountStubs,
+        webhooksStubs.patchBatchUpdateWebhookSuccess(gatewayAccountId, serviceExternalId, webhookExternalId, [{
+          path: 'callback_url',
+          value: 'https://some-callback-url.test'
+        }, {
+          path: 'description',
+          value: 'a valid webhook description'
+        }, {
+          path: 'subscriptions',
+          value: [
+            'card_payment_succeeded',
+            'card_payment_captured',
+            'card_payment_refunded'
+          ]
+        }])
+      ])
+      cy.visit('/test/service/serviceid/account/gateway-account-id/webhooks')
 
-    cy.location('pathname').should('eq', `/test/service/service-id/account/gateway-account-id/webhooks/${webhookExternalId}`)
-  })
+      // link to detail page
+      cy.get('[data-action=update]').then((links) => links[0].click())
 
-  it('should show a webhook signing secret', () => {
-    cy.task('setupStubs', [
-      ...userAndGatewayAccountStubs
-    ])
-    cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
-    cy.get('[data-action=update]').then((links) => links[0].click())
-    cy.get('#signing-secret').click()
+      // button through to update webhooks
+      cy.get('[data-action=update]').click()
 
-    cy.get('h1').contains('Manage signing secret')
+      cy.get('#callback_url').should('have.value', 'https://some-callback-url.test')
+      cy.get('#description').should('have.value', 'a valid webhook description')
+      cy.get('[value=card_payment_captured]').should('be.checked')
 
-    cy.get('#secret').contains('valid-signing-secret')
-  })
+      cy.get('button').contains('Update webhook').click()
 
-  it('should toggle a webhook status', () => {
-    cy.task('setupStubs', [
-      ...userAndGatewayAccountStubs,
-      webhooksStubs.patchUpdateWebhookSuccess(gatewayAccountId, serviceExternalId, webhookExternalId, { path: 'status', value: 'INACTIVE' })
-    ])
-    cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
-    cy.get('[data-action=update]').then((links) => links[0].click())
-    cy.get('#toggle-status').click()
+      cy.location('pathname').should('eq', `/test/service/serviceid/account/gateway-account-id/webhooks/${webhookExternalId}`)
+    })
 
-    cy.get('h1').contains('Deactivate webhook')
+    it('should show a webhook signing secret', () => {
+      cy.task('setupStubs', [
+        ...userAndGatewayAccountStubs
+      ])
+      cy.visit('/test/service/serviceid/account/gateway-account-id/webhooks')
+      cy.get('[data-action=update]').then((links) => links[0].click())
+      cy.get('#signing-secret').click()
 
-    cy.get('#toggle-active-webhook').click()
-    cy.get('.govuk-notification-banner__heading').contains('Webhook status updated')
+      cy.get('h1').contains('Manage signing secret')
 
-    cy.location('pathname').should('eq', `/test/service/service-id/account/gateway-account-id/webhooks/${webhookExternalId}`)
-  })
+      cy.get('#secret').contains('valid-signing-secret')
+    })
 
-  it('should browse to event detail page', () => {
-    cy.task('setupStubs', [
-      ...userAndGatewayAccountStubs
-    ])
-    cy.visit('/test/service/service-id/account/gateway-account-id/webhooks')
-    cy.get('[data-action=update]').then((links) => links[0].click())
-    cy.get('[data-action=detail]').then((links) => links[0].click())
-    cy.get('h1').contains('Payment captured')
-  })
+    it('should toggle a webhook status', () => {
+      cy.task('setupStubs', [
+        ...userAndGatewayAccountStubs,
+        webhooksStubs.patchUpdateWebhookSuccess(gatewayAccountId, serviceExternalId, webhookExternalId, { path: 'status', value: 'INACTIVE' })
+      ])
+      cy.visit('/test/service/serviceid/account/gateway-account-id/webhooks')
+      cy.get('[data-action=update]').then((links) => links[0].click())
+      cy.get('#toggle-status').click()
 
-  /* re-introduce when backend POST route enabled */
+      cy.get('h1').contains('Deactivate webhook')
+
+      cy.get('#toggle-active-webhook').click()
+      cy.get('.govuk-notification-banner__heading').contains('Webhook status updated')
+
+      cy.location('pathname').should('eq', `/test/service/serviceid/account/gateway-account-id/webhooks/${webhookExternalId}`)
+    })
+
+    it('should browse to event detail page', () => {
+      cy.task('setupStubs', [
+        ...userAndGatewayAccountStubs
+      ])
+      cy.visit('/test/service/serviceid/account/gateway-account-id/webhooks')
+      cy.get('[data-action=update]').then((links) => links[0].click())
+      cy.get('[data-action=detail]').then((links) => links[0].click())
+      cy.get('h1').contains('Payment captured')
+    })
+
+    /* re-introduce when backend POST route enabled */
   /* it('should schedule a webhook message for retry', () => {
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs
@@ -206,4 +221,5 @@ describe('Webhooks', () => {
     cy.get('[data-action=resend]').click()
     cy.get('.govuk-notification-banner__heading').contains('Webhook message scheduled for retry')
   }) */
+  })
 })


### PR DESCRIPTION
### WHAT
 - if a degatewayed user attempts to access an old settings route (e.g. in case of having them bookmarked) this will redirect them to the settings index page
 - attempts to redirect to the correct account type based on the accessed setting
 - for service level settings, redirect to live if a live account exists, otherwise redirect to test
 - logs redirects so we can easily determine if the old settings routes are still accessed
