### PR TITLE
BAU always show worldpay details

### DIFF
--- a/src/utils/simplified-account/settings/service-settings.js
+++ b/src/utils/simplified-account/settings/service-settings.js
@@ -50,7 +50,8 @@ module.exports = (account, service, currentUrl, permissions) => {
       id: 'worldpay-details',
       name: 'worldpay details',
       path: paths.simplifiedAccount.settings.worldpayDetails.index,
-      permission: account.paymentProvider === 'worldpay' && 'gateway_credentials_read'
+      permission: account.paymentProvider === 'worldpay' && 'gateway_credentials_read',
+      alwaysViewable: true // worldpay test accounts are user configurable so details should always be visible
     })
     .add({
       id: ['switch-psp', 'switch-to-worldpay'], // sits under settings/switch-psp/switch-to-worldpay


### PR DESCRIPTION
### WHAT

In the case of a service that has a live worldpay gateway and a test worldpay gateway and NO sandbox account (not a configuration we expect), worldpay details are not accessible for the test gateway. 

worldpay details should always be accessible, regardless of test or live mode.
