### PR TITLE
PP-13521 Update webhook validation error messages

### DIFF
--- a/src/controllers/simplified-account/settings/webhooks/toggle/toggle-webhook-status.controller.test.js
+++ b/src/controllers/simplified-account/settings/webhooks/toggle/toggle-webhook-status.controller.test.js
@@ -76,9 +76,9 @@ describe('Controller: settings/webhooks/update', () => {
         mockResponse.should.have.been.calledWith(sinon.match.any, sinon.match.any, sinon.match.any, {
           errors: {
             summary: [
-              { text: 'Confirm if you want to activate https://www.globexcorporation.example.com', href: '#toggle-active' }
+              { text: 'Confirm if you want to activate My webhook', href: '#toggle-active' }
             ],
-            formErrors: { toggleActive: 'Confirm if you want to activate https://www.globexcorporation.example.com' }
+            formErrors: { toggleActive: 'Confirm if you want to activate My webhook' }
           },
           webhook: testWebhook,
           backLink: '/service/service-id-123abc/account/test/settings/webhooks/webhook-external-id'

--- a/src/utils/simplified-account/validation/webhook.schema.js
+++ b/src/utils/simplified-account/validation/webhook.schema.js
@@ -35,7 +35,7 @@ const webhookSchema = {
     validate: (webhook) => body('toggleActive')
       .toLowerCase()
       .isIn(['yes', 'no'])
-      .withMessage(`Confirm if you want to ${webhook.status === WebhookStatus.INACTIVE ? 'activate' : 'deactivate'} ${webhook.callbackUrl}`)
+      .withMessage(`Confirm if you want to ${webhook.status === WebhookStatus.INACTIVE ? 'activate' : 'deactivate'} ${webhook.description}`)
   }
 }
 

--- a/test/cypress/integration/simplified-account/service-settings/webhooks/toggle-webhook-status.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/webhooks/toggle-webhook-status.cy.js
@@ -138,9 +138,9 @@ describe('webhook settings - toggle webhook status', () => {
 
             cy.get('.govuk-error-summary')
               .should('exist')
-              .should('contain.text', 'Confirm if you want to deactivate https://www.compuglobalhypermeganet.example.com')
+              .should('contain.text', 'Confirm if you want to deactivate a really awesome webhook')
 
-            cy.get('#toggle-active-error').should('contain.text', 'Confirm if you want to deactivate https://www.compuglobalhypermeganet.example.com')
+            cy.get('#toggle-active-error').should('contain.text', 'Confirm if you want to deactivate a really awesome webhook')
           })
         })
 
@@ -200,9 +200,9 @@ describe('webhook settings - toggle webhook status', () => {
 
             cy.get('.govuk-error-summary')
               .should('exist')
-              .should('contain.text', 'Confirm if you want to activate https://www.compuglobalhypermeganet.example.com')
+              .should('contain.text', 'Confirm if you want to activate a really awesome webhook')
 
-            cy.get('#toggle-active-error').should('contain.text', 'Confirm if you want to activate https://www.compuglobalhypermeganet.example.com')
+            cy.get('#toggle-active-error').should('contain.text', 'Confirm if you want to activate a really awesome webhook')
           })
         })
 


### PR DESCRIPTION
- Update validation error messages for the toggle webhook active status page to refer to webhook description, not webhook callback url.

Before (error message refers to callback url)
<img width="508" alt="Screenshot 2025-03-28 at 14 16 45" src="https://github.com/user-attachments/assets/96b2505a-5ef8-4ffa-a39a-36099359fb01" />

----
After

<img width="336" alt="Screenshot 2025-03-28 at 14 07 30" src="https://github.com/user-attachments/assets/9f016fae-27a4-4c8a-af10-390fe90050c7" />

---

<img width="344" alt="Screenshot 2025-03-28 at 14 08 15" src="https://github.com/user-attachments/assets/6bf014af-09b2-425f-8ac6-33563249f85b" />
