### PR TITLE
BAU webhooks card and heading layout tweaks

### DIFF
--- a/src/assets/sass/components/service-settings.scss
+++ b/src/assets/sass/components/service-settings.scss
@@ -18,6 +18,7 @@
   padding-top: govuk-spacing(1);
   padding-bottom: govuk-spacing(1);
   @include govuk-font(16);
+
   a {
     &:hover {
       color: govuk-colour("dark-blue");
@@ -26,6 +27,7 @@
       text-decoration-skip-ink: none;
       text-decoration-skip: none;
     }
+
     &:focus {
       text-decoration: none;
     }
@@ -48,6 +50,7 @@
 
 .service-settings-pane {
   max-width: 630px;
+
   h1, .govuk-error-summary, .govuk-error-message {
     overflow-wrap: anywhere
   }
@@ -67,12 +70,15 @@
   .govuk-task-list__name-and-hint {
     width: 70% !important;
   }
+
   a:visited, a:link {
     color: govuk-colour("blue");
   }
+
   a:hover {
     color: govuk-colour("dark-blue");
   }
+
   a:active, a:focus {
     color: govuk-colour("black");
   }
@@ -86,12 +92,6 @@
 
   .govuk-summary-list__row:first-of-type {
     border-top: 1px solid govuk-colour("mid-grey");
-  }
-}
-
-.webhooks-summary-card {
-  .govuk-summary-list__key {
-    width: 180px;
   }
 }
 
@@ -129,29 +129,55 @@
   }
 }
 
-.header-with-tag {
+.text-with-tag {
   display: flex;
   align-items: flex-start;
-  > h1 {
-    margin-top: govuk-spacing(2);
-    margin-right: govuk-spacing(2);
-  }
-  > div {
-    white-space: nowrap;
-    margin-top: govuk-spacing(2);
-  }
+  gap: govuk-spacing(2);
 }
 
-.card-title-with-tag {
-  display: inline-flex;
-  flex-wrap: wrap;
-  > div {
-    margin-right: govuk-spacing(1);
-    &:first-child {
-      margin-bottom: govuk-spacing(1);
+.flex-align-items-centre {
+  align-items: center;
+}
+
+.text-with-tag__text {
+  flex: 1;
+  min-width: 0;
+}
+
+.text-with-tag__tag {
+  flex-shrink: 0;
+}
+
+.card-with-tag {
+  .govuk-summary-card__title-wrapper {
+    flex-wrap: wrap;
+
+    .govuk-summary-card__title {
+      flex-basis: 100%;
+      min-width: 100%;
+      margin: govuk-spacing(1) 0;
+    }
+
+    .govuk-summary-card__actions {
+      flex-basis: 100%;
     }
   }
+
+  .govuk-summary-card__content {
+    .govuk-summary-list__key {
+      width: 180px;
+      @include govuk-media-query($until: tablet) {
+        width: 100%;
+      }
+    }
+  }
+
 }
+
+.responsive-margin-bottom-l {
+  @include govuk-responsive-margin(6, "bottom");
+}
+
 
 .json-block {
   overflow: scroll

--- a/src/views/simplified-account/settings/webhooks/detail.njk
+++ b/src/views/simplified-account/settings/webhooks/detail.njk
@@ -7,9 +7,11 @@
 {% set settingsPageTitle = webhook.description %}
 
 {% block settingsContent %}
-  <div class="header-with-tag">
-    <h1 class="govuk-heading-l">{{ webhook.description }}</h1>
-    <div>
+  <div class="text-with-tag flex-align-items-centre responsive-margin-bottom-l">
+    <div class="text-with-tag__text">
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-0">{{ webhook.description }}</h1>
+    </div>
+    <div class="text-with-tag__tag">
       {{ webhookStatus(webhook.status) }}
     </div>
   </div>
@@ -65,7 +67,8 @@
   </div>
 
   <h2 class="govuk-heading-m">Signing Secret</h2>
-  <p class="govuk-body">Webhook messages sent by GOV.UK Pay will include a signature. Only your application should store this secret to verify messages are from GOV.UK Pay.</p>
+  <p class="govuk-body">Webhook messages sent by GOV.UK Pay will include a signature. Only your application should store
+    this secret to verify messages are from GOV.UK Pay.</p>
   <h3 class="govuk-visually-hidden" id="app-subnav-heading">{{ webhook.description }} signing secret </h3>
   <div>
     <span id="signing-secret" class="code copy-target">{{ signingSecret.signing_key }}</span>

--- a/src/views/simplified-account/settings/webhooks/index.njk
+++ b/src/views/simplified-account/settings/webhooks/index.njk
@@ -13,9 +13,9 @@
 {% endmacro %}
 
 {% macro webhookDescriptionWithTag(webhook) %}
-  <div class="card-title-with-tag">
-    <div>{{ webhook.description }}</div>
-    <div>{{ webhookStatus(webhook.status) }}</div>
+  <div class="text-with-tag">
+    <div class="text-with-tag__text">{{ webhook.description }}</div>
+    <div class="text-with-tag__tag">{{ webhookStatus(webhook.status) }}</div>
   </div>
 {% endmacro %}
 
@@ -42,8 +42,8 @@
       {% for webhook in activeWebhooks %}
         {% set webhookSubscriptionsList = webhookSubscriptions(webhook) %}
         {{ govukSummaryList({
-          classes: "webhooks-summary-card",
           card: {
+            classes: 'card-with-tag',
             title: {
               html: webhookDescriptionWithTag(webhook)
             },
@@ -90,8 +90,8 @@
       {% for webhook in deactivatedWebhooks %}
         {% set webhookSubscriptionsList = webhookSubscriptions(webhook) %}
         {{ govukSummaryList({
-          classes: "webhooks-summary-card",
           card: {
+            classes: 'card-with-tag',
             title: {
               html: webhookDescriptionWithTag(webhook)
             },

--- a/test/cypress/integration/simplified-account/service-settings/webhooks/webhook-detail.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/webhooks/webhook-detail.cy.js
@@ -106,8 +106,8 @@ describe('for an admin', () => {
 
   it('should show title and heading', () => {
     cy.title().should('eq', 'My first webhook - Settings - McDuck Enterprises - GOV.UK Pay')
-    cy.get('div.header-with-tag').find('h1').should('have.text', 'My first webhook')
-    cy.get('div.header-with-tag').find('.govuk-tag--blue').should('have.text', 'Active')
+    cy.get('div.text-with-tag').find('h1').should('have.text', 'My first webhook')
+    cy.get('div.text-with-tag').find('.govuk-tag--blue').should('have.text', 'Active')
   })
 
   it('should show summary list, update button and deactivate button', () => {


### PR DESCRIPTION
### WHAT

- css override classes for handling summary cards with tags

### SCREENS
_Screenshots if view has been modified:_

<img width="1259" alt="Screenshot 2025-03-28 at 16 47 23" src="https://github.com/user-attachments/assets/215c68c0-d57e-412c-870c-98016d913504" />
<img width="421" alt="Screenshot 2025-03-28 at 16 47 34" src="https://github.com/user-attachments/assets/66b5a93e-0d68-491b-ad38-02eb31f57be8" />
<img width="1272" alt="Screenshot 2025-03-28 at 16 48 02" src="https://github.com/user-attachments/assets/101fa4eb-7d03-4c00-9ecb-4d2b114d01d6" />
<img width="423" alt="Screenshot 2025-03-28 at 16 48 27" src="https://github.com/user-attachments/assets/25c21147-17e4-43b9-85b5-5cdd113ce749" />
