### PR TITLE
PP-13525 Fix my services view to not show disabled gateway accounts

### DIFF
--- a/src/controllers/simplified-account/services/my-services.controller.js
+++ b/src/controllers/simplified-account/services/my-services.controller.js
@@ -56,6 +56,7 @@ const mergeServicesWithGatewayAccounts = (services, gatewayAccounts, flags) => {
     const mappedGatewayAccounts = service.gatewayAccountIds
       .map(id => gatewayAccounts[id])
       .filter(account => account !== undefined)
+      .filter(account => !account.disabled)
 
     const mappedLiveGatewayAccounts = mappedGatewayAccounts
       .filter(account => account.type === 'live')

--- a/src/controllers/simplified-account/services/my-services.controller.test.js
+++ b/src/controllers/simplified-account/services/my-services.controller.test.js
@@ -53,6 +53,20 @@ const mockGatewayAccountService = {
       service_name: SERVICE_NAME,
       type: 'live',
       payment_provider: WORLDPAY
+    })),
+    38: new GatewayAccount(validGatewayAccount({
+      gateway_account_id: 38,
+      service_name: SERVICE_NAME,
+      type: 'test',
+      payment_provider: SANDBOX,
+      disabled: true
+    })),
+    39: new GatewayAccount(validGatewayAccount({
+      gateway_account_id: 39,
+      service_name: SERVICE_NAME,
+      type: 'test',
+      payment_provider: SANDBOX,
+      disabled: true
     }))
   })
 }
@@ -398,6 +412,39 @@ describe('Controller: services/my-services.controller', () => {
                   gatewayAccounts: sinon.match(accounts => {
                     expect(accounts.length).to.equal(1)
                     expect(accounts[0].type).to.equal('live')
+                    expect(accounts[0].paymentProvider).to.equal(WORLDPAY)
+                    return true
+                  })
+                })
+              ]
+            })
+          )
+        })
+      })
+      describe('for a service with disabled test gateway accounts', () => {
+        before(() => {
+          userServiceRoles[0].service.gatewayAccountIds = ['32', '38', '39']
+          nextRequest({
+            user: {
+              isDegatewayed: () => true,
+              serviceRoles: userServiceRoles
+            }
+          })
+          call('get')
+        })
+
+        it('should filter out the disabled test gateway accounts', () => {
+          sinon.assert.calledWithMatch(mockResponse,
+            sinon.match.any,
+            sinon.match.any,
+            sinon.match.any,
+            sinon.match({
+              services: [
+                sinon.match({
+                  name: SERVICE_NAME,
+                  gatewayAccounts: sinon.match(accounts => {
+                    expect(accounts.length).to.equal(1)
+                    expect(accounts[0].type).to.equal('test')
                     expect(accounts[0].paymentProvider).to.equal(WORLDPAY)
                     return true
                   })

--- a/src/models/GatewayAccount.class.js
+++ b/src/models/GatewayAccount.class.js
@@ -30,6 +30,7 @@ const pendingCredentialStates = [CREDENTIAL_STATE.CREATED, CREDENTIAL_STATE.ENTE
  * @property {boolean} toggle3ds whether 3DS is enabled or not on this gateway account
  * @property {Worldpay3dsFlexCredential} worldpay3dsFlex available credentials for gateway account
  * @property {Object} rawResponse raw 'gateway account' object
+ * @property {boolean} disabled whether the gateway account is disabled
  */
 class GatewayAccount {
   constructor (gatewayAccountData) {
@@ -59,6 +60,7 @@ class GatewayAccount {
     if (gatewayAccountData?.worldpay_3ds_flex) {
       this.worldpay3dsFlex = Worldpay3dsFlexCredential.fromJson(gatewayAccountData.worldpay_3ds_flex)
     }
+    this.disabled = gatewayAccountData.disabled
     /** @deprecated this is a temporary compatability fix! If you find yourself using this for new code
      * you should instead add any rawResponse data as part of the constructor */
     this.rawResponse = gatewayAccountData


### PR DESCRIPTION
### WHAT
 - this fixes a bug in the my services view where services can still be linked to disabled gateway accounts, however these will not be returned by Connector when querying by service external ID & account type, and so should not be viewable
