### PR TITLE
PP-13619 Fix Worldpay privacy policy link

### DIFF
--- a/src/views/privacy/privacy.njk
+++ b/src/views/privacy/privacy.njk
@@ -71,7 +71,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Privacy notice</h1>
 
-    <p class="govuk-body-l">Last updated: 15 October 2024</p>
+    <p class="govuk-body-l">Last updated: 7 April 2025</p>
 
     <h2 class="govuk-heading-m" id="who-we-are">Who we are</h2>
 
@@ -272,7 +272,7 @@
       We also work with Government Banking Service and their contracted payment provider is Worldpay. If you make use
       of this contract we may share data with them on their or your request to facilitate onboarding, operations,
       support and troubleshooting issues. Read
-      <a class="govuk-link" href="https://online.worldpay.com/terms/privacy">WorldPay’s privacy policy</a>
+      <a class="govuk-link" href="https://privacy.worldpay.com/policies/en/">Worldpay’s privacy policy</a>
       for more information.
     </p>
 


### PR DESCRIPTION
In our privacy policy, update the link to Worldpay’s privacy policy from the current URL (which no longer exists) to the new [Worldpay Privacy Center](https://privacy.worldpay.com/policies/en).