### PR TITLE
PP-13622 Fix incorrect negation of value in the admin tool search when a dispute is won

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -650,7 +650,7 @@
         "filename": "test/cypress/integration/transactions/transaction-search.cy.js",
         "hashed_secret": "13f4f9188f0777d4d93a6ed585ee67fdacb47397",
         "is_verified": false,
-        "line_number": 184
+        "line_number": 220
       }
     ],
     "test/cypress/integration/user/change-sign-in-method.cy.js": [
@@ -899,5 +899,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-27T16:13:03Z"
+  "generated_at": "2025-04-09T13:58:48Z"
 }

--- a/src/utils/transaction-view.js
+++ b/src/utils/transaction-view.js
@@ -109,9 +109,10 @@ module.exports = {
       }
 
       const transactionType = element.transaction_type && element.transaction_type.toLowerCase()
-      if (transactionType === 'refund' || transactionType === 'dispute') {
+      if (transactionType === 'refund' || (transactionType === 'dispute' && element.state.status !== 'won')) {
         element.amount = `–${element.amount}`
       }
+
       delete element.created_date
     })
 


### PR DESCRIPTION
With this change, we are fixing a bug for which disputed amounts are shown in the admin tool always as negative numbers.

The logic will now consider also the state of the dispute and present the value as positive when the dispute has been won by the service.

Further information in Jira.

https://payments-platform.atlassian.net/browse/PP-13622


### Screenshot from the cypress tests

![Won disputes are positive values](https://github.com/user-attachments/assets/d5a1cb94-6f21-477d-be4a-39757976668e)


