### PR TITLE
PP-13989 Add classes & IDs for end to end test compatibility

### DIFF
--- a/src/views/simplified-account/settings/_settings-navigation.njk
+++ b/src/views/simplified-account/settings/_settings-navigation.njk
@@ -7,7 +7,7 @@
         <ul class="govuk-list">
           {% for setting in array %}
             <li class="service-settings-nav__li{% if setting.current %} service-settings-nav__li--active{% endif %}">
-              <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" id="{{setting.id}}" href="{{setting.url}}" {% if setting.current %}aria-current="page"{% endif %}>{{setting.name | smartCaps}}</a>
+              <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" id="settings-navigation-{{setting.id}}" href="{{setting.url}}" {% if setting.current %}aria-current="page"{% endif %}>{{setting.name | smartCaps}}</a>
             </li>
           {% endfor %}
         </ul>

--- a/src/views/simplified-account/settings/api-keys/index.njk
+++ b/src/views/simplified-account/settings/api-keys/index.njk
@@ -27,7 +27,10 @@
   {{ govukButton({
     href: createKeyLink,
     text: 'Create a new API key',
-    classes: 'govuk-!-margin-top-2'
+    classes: 'govuk-!-margin-top-2',
+    attributes: {
+      id: "create-api-key"
+    }
   }) }}
 
   {% if activeKeys.length == 0 %}
@@ -93,7 +96,10 @@
     {{ govukButton({
       href: revokedKeysLink,
       text: 'Show revoked API keys',
-      classes: 'govuk-!-margin-top-2 govuk-button--secondary'
+      classes: 'govuk-!-margin-top-2 govuk-button--secondary',
+      attributes: {
+        id: "revoked-keys-link"
+      }
     }) }}
   {% endif %}
 {% endblock %}

--- a/src/views/simplified-account/settings/api-keys/partials/_api_key_name_form.njk
+++ b/src/views/simplified-account/settings/api-keys/partials/_api_key_name_form.njk
@@ -22,6 +22,9 @@
   }) }}
 
   {{ govukButton({
-    text: "Continue"
+    text: "Continue",
+    attributes: {
+      id: "continue-button"
+    }
   }) }}
 </form>

--- a/src/views/simplified-account/settings/api-keys/revoke/index.njk
+++ b/src/views/simplified-account/settings/api-keys/revoke/index.njk
@@ -22,16 +22,21 @@
       items: [
         {
           text: 'Yes',
-          value: 'yes'
+          value: 'yes',
+          id: 'yes-radio'
         },
         {
           text: 'No',
-          value: 'no'
+          value: 'no',
+          id: 'no-radio'
         }
       ]
     }) }}
     {{ govukButton({
-      text: 'Save changes'
+      text: 'Save changes',
+      attributes: {
+        id: "revoke-button"
+      }
     }) }}
   </form>
 {% endblock %}

--- a/test/cypress/integration/simplified-account/service-settings/api-keys/api-keys.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/api-keys/api-keys.cy.js
@@ -125,7 +125,7 @@ describe('Settings - API keys', () => {
         cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/api-keys`)
       })
       it('should show appropriate buttons and text', () => {
-        cy.get('#api-keys').should('have.text', 'API keys')
+        cy.get('#settings-navigation-api-keys').should('have.text', 'API keys')
         cy.get('.service-settings-pane')
           .find('a')
           .contains('Create a new API key')
@@ -151,7 +151,7 @@ describe('Settings - API keys', () => {
       })
 
       it('should show appropriate buttons and text', () => {
-        cy.get('#api-keys').should('have.text', 'API keys')
+        cy.get('#settings-navigation-api-keys').should('have.text', 'API keys')
         cy.get('.service-settings-pane')
           .find('a')
           .contains('Create a new API key')
@@ -367,7 +367,7 @@ describe('Settings - API keys', () => {
 
     it('should not show API keys link in the navigation panel', () => {
       cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings`)
-      cy.get('#api-keys').should('not.exist')
+      cy.get('#settings-navigation-api-keys').should('not.exist')
     })
 
     it('should return forbidden when visiting the create api key url directly', () => {

--- a/test/cypress/integration/simplified-account/service-settings/card-payments/index.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/card-payments/index.cy.js
@@ -59,7 +59,7 @@ describe('Card payments page', () => {
         setupStubs()
         cy.visit(pageUrl)
         cy.get('.service-settings-nav__li--active').within(() => {
-          cy.get('#card-payments').should('contain.text', 'Card payments')
+          cy.get('#settings-navigation-card-payments').should('contain.text', 'Card payments')
         })
       })
 
@@ -164,7 +164,7 @@ describe('Card payments page', () => {
         setupStubs()
         cy.visit(pageUrl)
         cy.get('.service-settings-nav__li--active').within(() => {
-          cy.get('#card-payments').should('contain.text', 'Card payments')
+          cy.get('#settings-navigation-card-payments').should('contain.text', 'Card payments')
         })
       })
 

--- a/test/cypress/integration/simplified-account/service-settings/card-payments/updates.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/card-payments/updates.cy.js
@@ -82,7 +82,7 @@ describe('Card payment updates', () => {
     cy.visit(baseUrl + '/default-billing-address-country')
     cy.get('h1').should('contain.text', 'Default billing address country')
     cy.get('.service-settings-nav__li--active').within(() => {
-      cy.get('#card-payments').should('contain.text', 'Card payments')
+      cy.get('#settings-navigation-card-payments').should('contain.text', 'Card payments')
     })
     cy.get('input#default-billing-address-on').click()
     cy.contains('button', 'Save changes').click()


### PR DESCRIPTION
## What

PP-13989
 - add classes & IDs to elements on the API keys settings so these can be used in end to end tests
