### PR TITLE
PP-13984 Upgrade pay-selfservice with newest pay-js-commons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@aws-sdk/client-s3": "3.693.0",
         "@aws-sdk/s3-request-presigner": "3.693.0",
-        "@govuk-pay/pay-js-commons": "^6.0.36",
-        "@govuk-pay/pay-js-metrics": "^1.0.6",
+        "@govuk-pay/pay-js-commons": "^7.0.1",
+        "@govuk-pay/pay-js-metrics": "^1.0.13",
         "@sentry/node": "6.12.0",
         "accessible-autocomplete": "2.0.4",
         "axios": "^1.8.2",
@@ -3479,9 +3479,9 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "6.0.36",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.36.tgz",
-      "integrity": "sha512-1OpCMjm+kCW6mJbvIN6NF++HiYiO4cQEn+zrOfe/3beOjBqDmT4//YkGuzKGoJ0UU5F7olKo803Cwexectlhxg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-7.0.2.tgz",
+      "integrity": "sha512-V6rZJhdvhH5QdAYdJrB6eRrcRhSix8/omBkZuYwohlmG3pAHsUveGwEcezN3HtzTQpk8IpE0Xh6xPuAXbNhQGg==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.5",
@@ -3493,7 +3493,7 @@
         "winston": "3.9.0"
       },
       "engines": {
-        "node": "^18.17.1"
+        "node": "^22.15.0"
       }
     },
     "node_modules/@govuk-pay/pay-js-commons/node_modules/readable-stream": {
@@ -3533,9 +3533,9 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-metrics": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-1.0.12.tgz",
-      "integrity": "sha512-elEA/UPb6dsRGGRT+n7hLugFXM/sVoqglxwq3cokPKBXEe94JYxcJyb355NishlluwfXMEUIsJ30OyNZM41oLw==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-1.0.13.tgz",
+      "integrity": "sha512-RonGgB/AZU9Qj+fthUZmN+TpVNgenSMRFk4lO57VqYESLe4ukQBagVMaFPCn2bJFat1QEyb519IASOSiTXSaWg==",
       "license": "MIT",
       "dependencies": {
         "on-finished": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
   "dependencies": {
     "@aws-sdk/client-s3": "3.693.0",
     "@aws-sdk/s3-request-presigner": "3.693.0",
-    "@govuk-pay/pay-js-commons": "^6.0.36",
-    "@govuk-pay/pay-js-metrics": "^1.0.6",
+    "@govuk-pay/pay-js-commons": "^7.0.1",
+    "@govuk-pay/pay-js-metrics": "^1.0.13",
     "@sentry/node": "6.12.0",
     "accessible-autocomplete": "2.0.4",
     "axios": "^1.8.2",


### PR DESCRIPTION
## WHAT

With this change, we are updating pay-selfservice to use the new pay-js-commons.

We are also updating the version for pay-js-metrics.
