### PR TITLE
PP-13985: Bump pay-js-metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-s3": "3.693.0",
         "@aws-sdk/s3-request-presigner": "3.693.0",
         "@govuk-pay/pay-js-commons": "^7.0.2",
-        "@govuk-pay/pay-js-metrics": "^1.0.6",
+        "@govuk-pay/pay-js-metrics": "^1.0.13",
         "@sentry/node": "6.12.0",
         "accessible-autocomplete": "2.0.4",
         "axios": "^1.8.2",
@@ -3533,9 +3533,9 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-metrics": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-1.0.12.tgz",
-      "integrity": "sha512-elEA/UPb6dsRGGRT+n7hLugFXM/sVoqglxwq3cokPKBXEe94JYxcJyb355NishlluwfXMEUIsJ30OyNZM41oLw==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-1.0.13.tgz",
+      "integrity": "sha512-RonGgB/AZU9Qj+fthUZmN+TpVNgenSMRFk4lO57VqYESLe4ukQBagVMaFPCn2bJFat1QEyb519IASOSiTXSaWg==",
       "license": "MIT",
       "dependencies": {
         "on-finished": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@aws-sdk/client-s3": "3.693.0",
     "@aws-sdk/s3-request-presigner": "3.693.0",
     "@govuk-pay/pay-js-commons": "^7.0.2",
-    "@govuk-pay/pay-js-metrics": "^1.0.6",
+    "@govuk-pay/pay-js-metrics": "^1.0.13",
     "@sentry/node": "6.12.0",
     "accessible-autocomplete": "2.0.4",
     "axios": "^1.8.2",


### PR DESCRIPTION
## What

New version of pay-js-metrics, using Node 22. Bumping self-service so it doesn't get left behind.