### PR TITLE
PP-TBA Allow Dependabot PRs for pay-js-commons and metrics

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,14 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 10
   labels:
   - dependencies
   - govuk-pay
   - javascript
+  allow:
+  - dependency-name: "@govuk-pay/pay-js-commons"
+  - dependency-name: "@govuk-pay/pay-js-metrics"
   ignore:
   - dependency-name: change-case
     versions:


### PR DESCRIPTION
## What

Some time ago we stopped Dependabot PRs for the npm ecosystem[1].

With this change, we are tweaking the setting to allow PRs from Dependabot for pay-js-commons and pay-js-metrics.

[1]
https://payments-platform.atlassian.net/browse/PP-11138


