### PR TITLE
PP-14020 Fix feedback form so that email cannot be replaced

### DIFF
--- a/src/controllers/feedback/get-index.controller.js
+++ b/src/controllers/feedback/get-index.controller.js
@@ -6,7 +6,6 @@ const { response } = require('../../utils/response.js')
 
 module.exports = (req, res) => {
   const pageData = {
-    email: req.user.email
   }
 
   const sessionFeedback = lodash.get(req, 'session.pageData.feedback', {})

--- a/src/controllers/feedback/post-index.controller.js
+++ b/src/controllers/feedback/post-index.controller.js
@@ -10,8 +10,10 @@ module.exports = async function postZendeskFeedback (req, res) {
 ----
 ${req.body['feedback-suggestion']}`
 
+  const email = req.user.email
+
   const opts = {
-    email: req.body.email,
+    email: email,
     name: '(no name supplied)',
     type: 'question',
     subject: 'Feedback from service',

--- a/src/views/feedback/index.njk
+++ b/src/views/feedback/index.njk
@@ -10,7 +10,6 @@ Give feedback — GOV.UK Pay
 
   <form method="POST" action="{{routes.feedback}}" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-    <input id="email" name="email" type="hidden" value="{{email}}"/>
     <input id="service-name" name="service-name" type="hidden" value="{{currentService.name}}"/>
     <input id="service-external-id" name="service-external-id" type="hidden" value="{{currentService.externalId}}"/>
     <input id="gateway" name="service-gateway" type="hidden" value="{{currentGatewayAccount.payment_provider}} - {{currentGatewayAccount.type}}"/>


### PR DESCRIPTION
With this change, we are fixing a minor issue with an internal feedback form so that service admins cannot replace the email address when sending feedback.

Further information in Jira.

https://payments-platform.atlassian.net/browse/PP-14020


