### PR TITLE
PP-14067 Add link to set mobile number if no number is set

### DIFF
--- a/src/assets/sass/components/my-profile.scss
+++ b/src/assets/sass/components/my-profile.scss
@@ -16,4 +16,8 @@
   &__change-link{
     float: right;
   }
+
+  dd {
+    overflow-wrap: anywhere
+  }
 }

--- a/src/views/team-members/team-member-profile.njk
+++ b/src/views/team-members/team-member-profile.njk
@@ -39,19 +39,21 @@ My profile - GOV.UK Pay
         {{email}}
       </dd>
     </div>
-    {% if telephone_number %}
     <div class="profile-settings__row" data-cy="telephone-number-row">
       <dt class="profile-settings__setting govuk-table__cell govuk-heading-s">
         Mobile number
       </dt>
       <dd class="profile-settings__value govuk-table__cell" id="telephone-number">
-        {{telephone_number}}
-        <span class="profile-settings__change-link">
-          <a class="govuk-link govuk-link--no-visited-state" href="{{routes.user.profile.phoneNumber }}" id="change-phone-link">Change <span class="govuk-visually-hidden">mobile number</span></a>
-        </span>
+        {% if telephone_number %}
+          {{ telephone_number}}
+          <span class="profile-settings__change-link">
+            <a class="govuk-link govuk-link--no-visited-state" href="{{routes.user.profile.phoneNumber }}" id="change-phone-link">Change <span class="govuk-visually-hidden">mobile number</span></a>
+          </span>
+        {% else %}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{routes.user.profile.phoneNumber }}" id="change-phone-link">Add mobile number</a>
+        {% endif %}
       </dd>
     </div>
-    {% endif %}
     <div class="profile-settings__row">
       <dt class="profile-settings__setting govuk-table__cell govuk-heading-s">
         Sign-in method

--- a/test/cypress/integration/user/my-profile.cy.js
+++ b/test/cypress/integration/user/my-profile.cy.js
@@ -12,9 +12,16 @@ describe('My profile page', () => {
       ])
     })
 
-    it('should not show telephone number row', () => {
+    it('should show telephone number row link to add number', () => {
       cy.visit('/my-profile')
-      cy.get('[data-cy=telephone-number-row]').should('not.exist')
+
+      cy.get('[data-cy=telephone-number-row]').should('exist')
+      cy.get('[data-cy=telephone-number-row]>dd').within(() => {
+        cy.get('a')
+          .should('contain', 'Add mobile number')
+          .click()
+      })
+      cy.location('pathname').should('eq', '/my-profile/phone-number')
     })
   })
 
@@ -28,8 +35,20 @@ describe('My profile page', () => {
 
     it('should show telephone number row', () => {
       cy.visit('/my-profile')
+
       cy.get('[data-cy=telephone-number-row]').should('exist')
       cy.get('[data-cy=telephone-number-row]>dd').should('contain', testPhoneNumber)
+    })
+
+    it('should have link to change phone number', () => {
+      cy.visit('/my-profile')
+
+      cy.get('[data-cy=telephone-number-row]>dd').within(() => {
+        cy.get('a')
+          .should('contain', 'Change')
+          .click()
+      })
+      cy.location('pathname').should('eq', '/my-profile/phone-number')
     })
   })
 })

--- a/test/cypress/integration/user/my-profile.cy.js
+++ b/test/cypress/integration/user/my-profile.cy.js
@@ -4,6 +4,20 @@ describe('My profile page', () => {
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
   const testPhoneNumber = '+441234567890'
 
+  describe('accessibility check', () => {
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId)
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({ userExternalId, telephoneNumber: null })
+      ])
+    })
+
+    it('should check accessibility of the page', { defaultCommandTimeout: 15000 }, () => {
+      cy.visit('/my-profile')
+      cy.a11yCheck()
+    })
+  })
+
   describe('User does not have telephone number', () => {
     beforeEach(() => {
       cy.setEncryptedCookies(userExternalId)

--- a/test/cypress/integration/user/my-profile.cy.js
+++ b/test/cypress/integration/user/my-profile.cy.js
@@ -26,7 +26,7 @@ describe('My profile page', () => {
       ])
     })
 
-    it('should show telephone number row link to add number', () => {
+    it('should show telephone number row with link to add number', () => {
       cy.visit('/my-profile')
 
       cy.get('[data-cy=telephone-number-row]').should('exist')


### PR DESCRIPTION
## What

PP-14067

 - show link to add a mobile number in `/my-profile` if no mobile number is set

### Accessibility (views have been added/changed)

<details>
<summary>checklist</summary>

- [x] keyboard navigation is validated (can navigate all interactive elements with a keyboard)
- [x] skip to main content takes you to the main content (not a nav link e.g. back link)
- [x] cypress tests include the `cy.checkAccessibility` command for each unique view
- [x] the page title is unique
- [x] all page content fits within desktop and mobile view ports (unless specified in the designs)
- [x] links clearly explain where the link will take the user
- [x] ‘change’ links have visually hidden text providing additional screen reader context
</details>

### Screenshots (views have been added/changed)
<img width="834" alt="Screenshot 2025-05-14 at 12 16 00" src="https://github.com/user-attachments/assets/391277de-b39e-4b91-a572-a2eca6d0607b" />

![Screenshot 2025-05-16 at 09-41-32 My profile - GOV UK Pay](https://github.com/user-attachments/assets/9db50b5f-a800-4261-b819-1a05003233c6)


> [!NOTE]
> Include mobile and desktop variants, **highlight**(`#ff0000`) changes to existing views to help reviewers