### PR TITLE
PP-14067 Show 'Add phone number' if phone number is placeholder string

### DIFF
--- a/src/views/team-members/edit-phone-number.njk
+++ b/src/views/team-members/edit-phone-number.njk
@@ -42,7 +42,7 @@
         name: "phone",
         type: "tel",
         autocomplete: "mobile tel",
-        value: telephoneNumber,
+        value: telephoneNumber if telephone_number != ' ',
         classes: "govuk-!-width-one-half",
         label: {
           text: "Phone number"

--- a/src/views/team-members/team-member-profile.njk
+++ b/src/views/team-members/team-member-profile.njk
@@ -44,7 +44,7 @@ My profile - GOV.UK Pay
         Mobile number
       </dt>
       <dd class="profile-settings__value govuk-table__cell" id="telephone-number">
-        {% if telephone_number %}
+        {% if telephone_number and telephone_number != ' ' %}
           {{ telephone_number}}
           <span class="profile-settings__change-link">
             <a class="govuk-link govuk-link--no-visited-state" href="{{routes.user.profile.phoneNumber }}" id="change-phone-link">Change <span class="govuk-visually-hidden">mobile number</span></a>


### PR DESCRIPTION
## What

PP-14067
 - show the "Add phone number" message added in #4611 if phone number is set to a placeholder string of `' '`
 - `null` phone numbers were set to this placeholder in https://github.com/alphagov/pay-scripts/pull/1569 as a workaround to allow phone numbers to be added before #4611