### PR TITLE
ZD-6128034 Update merchant code validation

### DIFF
--- a/src/utils/simplified-account/validation/worldpay/validations.schema.js
+++ b/src/utils/simplified-account/validation/worldpay/validations.schema.js
@@ -8,41 +8,56 @@ const ONE_OFF_CUSTOMER_INITIATED_SCHEMA = {
       .withMessage('Enter your merchant code')
       .bail()
       .custom((value, { req }) => {
-        if (req.account.allowMoto && !value.endsWith('MOTO') && !value.endsWith('MOTOGBP')) {
+        if (
+          req.account.allowMoto &&
+          !value.endsWith('MOTO') &&
+          !value.endsWith('MOTOGBP') &&
+          !value.endsWith('MOTONI')
+        ) {
           throw new Error('Enter a MOTO merchant code. MOTO payments are enabled for this account')
         }
         return true
-      })
+      }),
   },
   username: {
-    validate: body('username')
-      .not()
-      .isEmpty()
-      .withMessage('Enter your username')
+    validate: body('username').not().isEmpty().withMessage('Enter your username'),
   },
   password: {
-    validate: body('password')
-      .not()
-      .isEmpty()
-      .withMessage('Enter your password')
-  }
+    validate: body('password').not().isEmpty().withMessage('Enter your password'),
+  },
 }
 
 const THREE_DS_FLEX_VALIDATION = [
   body('organisationalUnitId')
-    .notEmpty().withMessage('Enter your organisational unit ID').bail()
-    .isHexadecimal().withMessage('Enter your organisational unit ID in the format you received it').bail()
-    .isLength({ min: 24, max: 24 }).withMessage('Enter your organisational unit ID in the format you received it').bail(),
+    .notEmpty()
+    .withMessage('Enter your organisational unit ID')
+    .bail()
+    .isHexadecimal()
+    .withMessage('Enter your organisational unit ID in the format you received it')
+    .bail()
+    .isLength({ min: 24, max: 24 })
+    .withMessage('Enter your organisational unit ID in the format you received it')
+    .bail(),
   body('issuer')
-    .notEmpty().withMessage('Enter your issuer').bail()
-    .isHexadecimal().withMessage('Enter your issuer in the format you received it').bail()
-    .isLength({ min: 24, max: 24 }).withMessage('Enter your issuer in the format you received it').bail(),
+    .notEmpty()
+    .withMessage('Enter your issuer')
+    .bail()
+    .isHexadecimal()
+    .withMessage('Enter your issuer in the format you received it')
+    .bail()
+    .isLength({ min: 24, max: 24 })
+    .withMessage('Enter your issuer in the format you received it')
+    .bail(),
   body('jwtMacKey')
-    .notEmpty().withMessage('Enter your JWT MAC key').bail()
-    .isUUID().withMessage('Enter your JWT MAC key in the format you received it').bail()
+    .notEmpty()
+    .withMessage('Enter your JWT MAC key')
+    .bail()
+    .isUUID()
+    .withMessage('Enter your JWT MAC key in the format you received it')
+    .bail(),
 ]
 
 module.exports = {
   ONE_OFF_CUSTOMER_INITIATED_SCHEMA,
-  THREE_DS_FLEX_VALIDATION
+  THREE_DS_FLEX_VALIDATION,
 }

--- a/src/utils/simplified-account/validation/worldpay/validations.schema.test.js
+++ b/src/utils/simplified-account/validation/worldpay/validations.schema.test.js
@@ -9,9 +9,9 @@ describe('One Off Customer Initiated Credentials Validation', () => {
     beforeEach(() => {
       req = {
         account: {
-          allowMoto: false
+          allowMoto: false,
         },
-        body: {}
+        body: {},
       }
     })
 
@@ -33,15 +33,16 @@ describe('One Off Customer Initiated Credentials Validation', () => {
     beforeEach(() => {
       req = {
         account: {
-          allowMoto: true
+          allowMoto: true,
         },
-        body: {}
+        body: {},
       }
     })
 
     const validTestCases = [
       { merchantCode: 'helloMOTO', desc: 'MOTO merchant code' },
-      { merchantCode: 'helloMOTOGBP', desc: 'MOTOGBP merchant code' }
+      { merchantCode: 'helloMOTOGBP', desc: 'MOTOGBP merchant code' },
+      { merchantCode: 'helloMOTONI', desc: 'MOTONI merchant code' },
     ]
 
     validTestCases.forEach(({ merchantCode, desc }) => {
@@ -52,7 +53,7 @@ describe('One Off Customer Initiated Credentials Validation', () => {
       })
     })
 
-    it('should fail when merchant code does not end with MOTO|MOTOGBP', async () => {
+    it('should fail when merchant code does not end with MOTO|MOTOGBP|MOTONI', async () => {
       req.body.merchantCode = 'hello'
       await ONE_OFF_CUSTOMER_INITIATED_SCHEMA.merchantCode.validate.run(req)
       const errors = validationResult(req)
@@ -71,9 +72,9 @@ describe('One Off Customer Initiated Credentials Validation', () => {
     beforeEach(() => {
       req = {
         account: {
-          allowMoto: false
+          allowMoto: false,
         },
-        body: {}
+        body: {},
       }
     })
 
@@ -95,9 +96,9 @@ describe('One Off Customer Initiated Credentials Validation', () => {
     beforeEach(() => {
       req = {
         account: {
-          allowMoto: false
+          allowMoto: false,
         },
-        body: {}
+        body: {},
       }
     })
 


### PR DESCRIPTION
With this change, we are updating the merchant code validation 
in order to allow merchant codes ending with MOTONI.

https://govuk.zendesk.com/agent/tickets/6128034

Note that I have included changes introduced by `npx prettier` 
which are just style related changes and can be ignored. 

I have commented in the code the changes that matter for this PR.

Next time, I will split the change in two commits or two PRs.

