### PR TITLE
PP-14222 scaffold new payment links pages

### DIFF
--- a/src/controllers/simplified-account/services/index.ts
+++ b/src/controllers/simplified-account/services/index.ts
@@ -1,9 +1,11 @@
 import * as dashboard from './dashboard/dashboard.controller'
 import * as myServices from './my-services.controller'
 import * as demoPayment from './make-a-demo-payment/make-a-demo-payment.controller'
+import * as paymentLinks from './payment-links/payment-links.controller'
 
 export = {
   myServices,
   dashboard,
-  demoPayment
+  demoPayment,
+  paymentLinks
 }

--- a/src/controllers/simplified-account/services/payment-links/create/create-payment-link.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/create/create-payment-link.controller.test.ts
@@ -1,0 +1,27 @@
+import ControllerTestBuilder from '@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class'
+import sinon from 'sinon'
+
+const mockResponse = sinon.spy()
+
+const { call, nextRequest } = new ControllerTestBuilder(
+  '@controllers/simplified-account/services/payment-links/create/create-payment-link.controller',
+)
+  .withStubs({
+    '@utils/response': { response: mockResponse },
+  })
+  .build()
+
+describe('controller: services/payment-links/create', () => {
+  describe('get', () => {
+    beforeEach(async () => {
+      nextRequest({
+        // modify the request
+      })
+      await call('get')
+    })
+
+    it('should call the response method', () => {
+      sinon.assert.calledOnce(mockResponse)
+    })
+  })
+})

--- a/src/controllers/simplified-account/services/payment-links/create/create-payment-link.controller.ts
+++ b/src/controllers/simplified-account/services/payment-links/create/create-payment-link.controller.ts
@@ -1,0 +1,17 @@
+import { response } from '@utils/response'
+import { ServiceRequest, ServiceResponse } from '@utils/types/express'
+
+function get (req: ServiceRequest, res: ServiceResponse) {
+  return response(req, res, 'simplified-account/services/payment-links/create/index', {})
+}
+
+function post (req: ServiceRequest, res: ServiceResponse) {
+  return res.status(501).json({
+    message: 'not implemented'
+  })
+}
+
+export {
+  get,
+  post
+}

--- a/src/controllers/simplified-account/services/payment-links/delete/delete-payment-link.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/delete/delete-payment-link.controller.test.ts
@@ -1,0 +1,27 @@
+import ControllerTestBuilder from '@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class'
+import sinon from 'sinon'
+
+const mockResponse = sinon.spy()
+
+const { call, nextRequest } = new ControllerTestBuilder(
+  '@controllers/simplified-account/services/payment-links/delete/delete-payment-link.controller',
+)
+  .withStubs({
+    '@utils/response': { response: mockResponse },
+  })
+  .build()
+
+describe('controller: services/payment-links/delete', () => {
+  describe('get', () => {
+    beforeEach(async () => {
+      nextRequest({
+        // modify the request
+      })
+      await call('get')
+    })
+
+    it('should call the response method', () => {
+      sinon.assert.calledOnce(mockResponse)
+    })
+  })
+})

--- a/src/controllers/simplified-account/services/payment-links/delete/delete-payment-link.controller.ts
+++ b/src/controllers/simplified-account/services/payment-links/delete/delete-payment-link.controller.ts
@@ -1,0 +1,16 @@
+import { ServiceRequest, ServiceResponse } from '@utils/types/express'
+import { response } from '@utils/response'
+
+function get (req: ServiceRequest, res: ServiceResponse) {
+  return response(req, res, 'simplified-account/services/payment-links/delete/index', {})
+}
+
+function post (req: ServiceRequest, res: ServiceResponse) {
+  return res.status(501).json({
+    message: 'not implemented'
+  })}
+
+export {
+  get,
+  post
+}

--- a/src/controllers/simplified-account/services/payment-links/edit/edit-payment-link.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/edit/edit-payment-link.controller.test.ts
@@ -1,0 +1,27 @@
+import ControllerTestBuilder from '@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class'
+import sinon from 'sinon'
+
+const mockResponse = sinon.spy()
+
+const { call, nextRequest } = new ControllerTestBuilder(
+  '@controllers/simplified-account/services/payment-links/edit/edit-payment-link.controller',
+)
+  .withStubs({
+    '@utils/response': { response: mockResponse },
+  })
+  .build()
+
+describe('controller: services/payment-links/edit', () => {
+  describe('get', () => {
+    beforeEach(async () => {
+      nextRequest({
+        // modify the request
+      })
+      await call('get')
+    })
+
+    it('should call the response method', () => {
+      sinon.assert.calledOnce(mockResponse)
+    })
+  })
+})

--- a/src/controllers/simplified-account/services/payment-links/edit/edit-payment-link.controller.ts
+++ b/src/controllers/simplified-account/services/payment-links/edit/edit-payment-link.controller.ts
@@ -1,0 +1,17 @@
+import { ServiceRequest, ServiceResponse } from '@utils/types/express'
+import { response } from '@utils/response'
+
+function get (req: ServiceRequest, res: ServiceResponse) {
+  return response(req, res, 'simplified-account/services/payment-links/edit/index', {})
+}
+
+function post (req: ServiceRequest, res: ServiceResponse) {
+  return res.status(501).json({
+    message: 'not implemented'
+  })
+}
+
+export {
+  get,
+  post
+}

--- a/src/controllers/simplified-account/services/payment-links/payment-links.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/payment-links.controller.test.ts
@@ -1,0 +1,27 @@
+import ControllerTestBuilder from '@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class'
+import sinon from 'sinon'
+
+const mockResponse = sinon.spy()
+
+const { call, nextRequest } = new ControllerTestBuilder(
+  '@controllers/simplified-account/services/payment-links/payment-links.controller',
+)
+  .withStubs({
+    '@utils/response': { response: mockResponse },
+  })
+  .build()
+
+describe('controller: services/payment-links', () => {
+  describe('get', () => {
+    beforeEach(async () => {
+      nextRequest({
+        // modify the request
+      })
+      await call('get')
+    })
+
+    it('should call the response method', () => {
+      sinon.assert.calledOnce(mockResponse)
+    })
+  })
+})

--- a/src/controllers/simplified-account/services/payment-links/payment-links.controller.ts
+++ b/src/controllers/simplified-account/services/payment-links/payment-links.controller.ts
@@ -1,0 +1,23 @@
+import * as create from './create/create-payment-link.controller'
+import * as edit from './edit/edit-payment-link.controller'
+import * as remove from './delete/delete-payment-link.controller'
+import { ServiceRequest, ServiceResponse } from '@utils/types/express'
+import { response } from '@utils/response'
+
+function get (req: ServiceRequest, res: ServiceResponse) {
+  return response(req, res, 'simplified-account/services/payment-links/index', {})
+}
+
+function post (req: ServiceRequest, res: ServiceResponse) {
+  return res.status(501).json({
+    message: 'not implemented'
+  })
+}
+
+export {
+  get,
+  post,
+  create,
+  edit,
+  remove
+}

--- a/src/middleware/simplified-account/expermimental-feature.middleware.ts
+++ b/src/middleware/simplified-account/expermimental-feature.middleware.ts
@@ -1,0 +1,13 @@
+import express from 'express'
+import { NotFoundError } from '@root/errors'
+
+const experimentalFeature = (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  const experimentFeaturesEnabledForEnvironment = process.env.EXPERIMENTAL_FEATURES_FLAG === 'true'
+  if (!experimentFeaturesEnabledForEnvironment) {
+    return next(new NotFoundError('Experimental features not enabled in this environment'))
+  }
+  next()
+}
+
+export = experimentalFeature
+

--- a/src/middleware/simplified-account/index.js
+++ b/src/middleware/simplified-account/index.js
@@ -9,3 +9,4 @@ module.exports.defaultViewDecider = require('./settings/default-view-decider.mid
 module.exports.defaultViewDecider = require('./settings/default-view-decider.middleware')
 module.exports.canStartPspPaymentVerificationTask = require('./settings/psp-switch-payment-verification.middleware')
 module.exports.pspSwitchRedirect = require('./settings/psp-switch-redirect.middleware')
+module.exports.experimentalFeature = require('./expermimental-feature.middleware')

--- a/src/paths.js
+++ b/src/paths.js
@@ -155,6 +155,12 @@ module.exports = {
       edit: '/demo-payment/edit',
       mockCard: '/demo-payment/mock-card-number',
     },
+    paymentLinks: {
+      index: '/payment-links',
+      create: '/payment-links/create',
+      edit: '/payment-links/:productExternalId/edit',
+      delete: '/payment-links/:productExternalId/delete',
+    },
     settings: {
       index: '/settings',
       serviceName: {

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -10,6 +10,7 @@ const {
   defaultViewDecider,
   pspSwitchRedirect,
   canStartPspPaymentVerificationTask,
+  experimentalFeature
 } = require('@middleware/simplified-account')
 const restrictToSwitchingAccount = require('@middleware/restrict-to-switching-account')
 const restrictToSandboxOrStripeTestAccount = require('@middleware/restrict-to-sandbox-or-stripe-test-account')
@@ -38,6 +39,12 @@ simplifiedAccount.post(paths.simplifiedAccount.demoPayment.edit, restrictToSandb
 simplifiedAccount.get(paths.simplifiedAccount.demoPayment.mockCard, restrictToSandboxOrStripeTestAccount, servicesController.demoPayment.mockCardNumber.get)
 simplifiedAccount.post(paths.simplifiedAccount.demoPayment.mockCard, restrictToSandboxOrStripeTestAccount, servicesController.demoPayment.post)
 
+// payment links
+
+simplifiedAccount.get(paths.simplifiedAccount.paymentLinks.index, experimentalFeature, servicesController.paymentLinks.get)
+simplifiedAccount.get(paths.simplifiedAccount.paymentLinks.create, experimentalFeature, servicesController.paymentLinks.create.get)
+simplifiedAccount.get(paths.simplifiedAccount.paymentLinks.edit, experimentalFeature, servicesController.paymentLinks.edit.get)
+simplifiedAccount.get(paths.simplifiedAccount.paymentLinks.delete, experimentalFeature, servicesController.paymentLinks.remove.get)
 
 // settings index
 simplifiedAccount.get(paths.simplifiedAccount.settings.index, defaultViewDecider)

--- a/src/utils/display-converter.js
+++ b/src/utils/display-converter.js
@@ -161,7 +161,7 @@ module.exports = function (req, data, template) {
       account
     )
     if (currentUrl.match(/service\/\w+\/account\/(test|live)\//)) {
-      convertedData.NEW_SERVICE_NAV = process.env.NEW_SERVICE_NAV_FLAG === 'true'
+      convertedData.NEW_SERVICE_NAV = process.env.EXPERIMENTAL_FEATURES_FLAG === 'true'
       convertedData.serviceNavigation = serviceNavigation(account, service, currentUrl, permissions)
       convertedData.serviceSettings = serviceSettingsNavigation(account, service, currentUrl, permissions)
     }

--- a/src/utils/simplified-account/navigation/service-navigation.ts
+++ b/src/utils/simplified-account/navigation/service-navigation.ts
@@ -19,7 +19,16 @@ export = (account: GatewayAccount, service: Service, currentUrl: string, permiss
       ),
       hasPermission: UserPermissions.any,
     })
-
+    .add({
+      id: 'payment-links',
+      name: 'payment links',
+      path: formatServiceAndAccountPathsFor(
+        paths.simplifiedAccount.paymentLinks.index,
+        service.externalId,
+        account.type
+      ),
+      hasPermission: UserPermissions.any,
+    })
     .build()
   return getViewableNav(serviceNavigation)
 }

--- a/src/utils/types/express/ServiceRequest.ts
+++ b/src/utils/types/express/ServiceRequest.ts
@@ -1,7 +1,7 @@
+import express from 'express'
 import type User from '@models/user/User.class'
 import type Service from '@models/service/Service.class'
 import type GatewayAccount from '@models/gateway-account/GatewayAccount.class'
-import type { Request } from 'express'
 import type StripeAccountSetup from '@models/StripeAccountSetup.class'
 import ClientSessionsCookie from '@utils/types/client-sessions/ClientSessionsCookie'
 
@@ -15,7 +15,7 @@ interface Message {
   body?: string
 }
 
-export default interface ServiceRequest<T = never> extends Request {
+export default interface ServiceRequest<T = never> extends express.Request {
   user: User
   service: Service
   account: GatewayAccount

--- a/src/utils/types/express/ServiceResponse.ts
+++ b/src/utils/types/express/ServiceResponse.ts
@@ -1,7 +1,7 @@
-import type { Response } from 'express'
+import express from 'express'
 
-export default interface ServiceResponse extends Response {
-  locals: Response['locals'] & {
+export default interface ServiceResponse extends express.Response {
+  locals: express.Response['locals'] & {
     flash?: {
       messages?: { type: string; message: string }[]
     }

--- a/src/views/simplified-account/services/payment-links/create/index.njk
+++ b/src/views/simplified-account/services/payment-links/create/index.njk
@@ -1,0 +1,9 @@
+{% extends "simplified-account/services/service-layout.njk" %}
+
+{% set servicePageTitle = "Create payment link" %}
+
+{% block serviceContent %}
+  <h1 class="govuk-heading-l page-title">
+    {{ servicePageTitle }}
+  </h1>
+{% endblock %}

--- a/src/views/simplified-account/services/payment-links/delete/index.njk
+++ b/src/views/simplified-account/services/payment-links/delete/index.njk
@@ -1,0 +1,9 @@
+{% extends "simplified-account/services/service-layout.njk" %}
+
+{% set servicePageTitle = "Delete payment link" %}
+
+{% block serviceContent %}
+  <h1 class="govuk-heading-l page-title">
+    {{ servicePageTitle }}
+  </h1>
+{% endblock %}

--- a/src/views/simplified-account/services/payment-links/edit/index.njk
+++ b/src/views/simplified-account/services/payment-links/edit/index.njk
@@ -1,0 +1,9 @@
+{% extends "simplified-account/services/service-layout.njk" %}
+
+{% set servicePageTitle = "Edit payment link" %}
+
+{% block serviceContent %}
+  <h1 class="govuk-heading-l page-title">
+    {{ servicePageTitle }}
+  </h1>
+{% endblock %}

--- a/src/views/simplified-account/services/payment-links/index.njk
+++ b/src/views/simplified-account/services/payment-links/index.njk
@@ -1,0 +1,9 @@
+{% extends "simplified-account/services/service-layout.njk" %}
+
+{% set servicePageTitle = "Payment links" %}
+
+{% block serviceContent %}
+  <h1 class="govuk-heading-l page-title">
+    {{ servicePageTitle }}
+  </h1>
+{% endblock %}


### PR DESCRIPTION
## What

PP-14222

- add empty views and controllers for new payment links pages
- add new experimental features middleware
  - this middleware function checks for the presence of `EXPERIMENTAL_FEATURES_FLAG` in the environment, returning a 404 if the flag is not set or is false
- update display converter to use the `EXPERIMENTAL_FEATURES_FLAG` environment value when evaluating whether to render the new service navigation
