### PR TITLE
PP-14158 Add rebrand flag to Nunjucks global variable

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -10,6 +10,7 @@ const staticify = require('staticify')(__dirname)
 const router = require('@root/routes')
 const cookieUtil = require('@utils/cookie')
 const noCache = require('@utils/no-cache')
+const addRebrandFlagToNunjucks = require('@utils/add-rebrand-flag-to-nunjucks')
 const auth = require('@services/auth.service')
 const middlewareUtils = require('@utils/middleware')
 const errorHandler = require('@middleware/error-handler')
@@ -105,6 +106,8 @@ function initialiseTemplateEngine(app) {
   // if it's not production we want to re-evaluate the assets on each file change
   nunjucksEnvironment.addGlobal('css_path', staticify.getVersionedPath('/assets/stylesheets/application.css'))
   nunjucksEnvironment.addGlobal('js_path', staticify.getVersionedPath('/assets/js/client.js'))
+
+  addRebrandFlagToNunjucks(nunjucksEnvironment)
 
   // Load custom Nunjucks filters
   for (const name in nunjucksFilters) {

--- a/src/utils/add-rebrand-flag-to-nunjucks.js
+++ b/src/utils/add-rebrand-flag-to-nunjucks.js
@@ -1,0 +1,5 @@
+module.exports = function (nunjucksEnvironment) {
+  if (process.env.ENABLE_REBRAND === 'true') {
+    nunjucksEnvironment.addGlobal('govukRebrand', true)
+  }
+}

--- a/src/utils/add-rebrand-flag-to-nunjucks.test.js
+++ b/src/utils/add-rebrand-flag-to-nunjucks.test.js
@@ -1,0 +1,32 @@
+const { expect } = require('chai')
+const sinon = require('sinon')
+
+const addRebrandFlagToNunjucks = require('./add-rebrand-flag-to-nunjucks.js')
+
+const nunjucksEnvironment = {
+  addGlobal: sinon.spy()
+}
+
+describe('Add rebrand flag to Nunjucks environment', function () {
+  beforeEach(function () {
+    process.env.ENABLE_REBRAND = undefined
+    nunjucksEnvironment.addGlobal.resetHistory()
+  })
+
+  it('should NOT set the Nunjucks rebrand global variable when process.env.ENABLE_REBRAND = undefined', function () {
+    addRebrandFlagToNunjucks(nunjucksEnvironment)
+    expect(nunjucksEnvironment.addGlobal.called).to.equal(false)
+  })
+
+  it('should set the Nunjucks rebrand global variable when process.env.ENABLE_REBRAND = true', function () {
+    process.env.ENABLE_REBRAND = 'true'
+    addRebrandFlagToNunjucks(nunjucksEnvironment)
+    expect(nunjucksEnvironment.addGlobal.calledWithExactly('govukRebrand', true)).to.equal(true)
+  })
+
+  it('should NOT set the Nunjucks rebrand global variable when process.env.ENABLE_REBRAND = false', function () {
+    process.env.ENABLE_REBRAND = 'false'
+    addRebrandFlagToNunjucks(nunjucksEnvironment)
+    expect(nunjucksEnvironment.addGlobal.called).to.equal(false)
+  })
+})


### PR DESCRIPTION
## What

PP-14158

- This code is setting up the app to use the rebrand.
- At the moment the current branding is being used.
- A Nunjucks global variable will be added if ENABLE_REBRAND=true.
  - This variable is used by govuk-frontend to determine if the new branding should be shown.
- The ENABLE_REBRAND is currently not being used.  This will be used in the future.