### PR TITLE
PP-14193 Move prototypes to service routes

### DIFF
--- a/src/controllers/simplified-account/services/dashboard/dashboard.controller.ts
+++ b/src/controllers/simplified-account/services/dashboard/dashboard.controller.ts
@@ -67,7 +67,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
           paths.simplifiedAccount.testWithYourUsers.index,
           req.service.externalId,
           req.account.type
-        ) as string,
+        ),
         createPaymentLink: formatAccountPathsFor(paths.account.paymentLinks.start, req.account.externalId) as string,
         managePaymentLinks: formatAccountPathsFor(
           paths.account.paymentLinks.manage.index,

--- a/src/controllers/simplified-account/services/dashboard/dashboard.controller.ts
+++ b/src/controllers/simplified-account/services/dashboard/dashboard.controller.ts
@@ -63,9 +63,10 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
           req.service.externalId,
           req.account.type
         ),
-        demoPaymentLink: formatAccountPathsFor(
-          paths.account.prototyping.demoService.index,
-          req.account.externalId
+        demoPaymentLink: formatServiceAndAccountPathsFor(
+          paths.simplifiedAccount.testWithYourUsers.index,
+          req.service.externalId,
+          req.account.type
         ) as string,
         createPaymentLink: formatAccountPathsFor(paths.account.paymentLinks.start, req.account.externalId) as string,
         managePaymentLinks: formatAccountPathsFor(

--- a/src/controllers/test-with-your-users/create.controller.js
+++ b/src/controllers/test-with-your-users/create.controller.js
@@ -3,8 +3,14 @@
 const lodash = require('lodash')
 
 const { response } = require('../../utils/response.js')
+const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/format')
+const paths = require('@root/paths')
 
 module.exports = (req, res) => {
-  const pageData = lodash.get(req, 'session.pageData.createPrototypeLink', {})
-  response(req, res, 'dashboard/demo-service/create', pageData)
+  const context = {
+    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.links,  req.service.externalId, req.account.type),
+    confirmLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.confirm,  req.service.externalId, req.account.type),
+    ...lodash.get(req, 'session.pageData.createPrototypeLink', {})
+  }
+  response(req, res, 'dashboard/demo-service/create', context)
 }

--- a/src/controllers/test-with-your-users/disable.controller.js
+++ b/src/controllers/test-with-your-users/disable.controller.js
@@ -3,18 +3,17 @@
 const logger = require('../../utils/logger')(__filename)
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
-const formatAccountPathsFor = require('../../utils/format-account-paths-for')
+const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/format')
 
 module.exports = (req, res) => {
-  const gatewayAccountId = req.account.gateway_account_id
-  productsClient.product.disable(gatewayAccountId, req.params.productExternalId)
+  productsClient.product.disable(req.account.id, req.params.productExternalId)
     .then(() => {
       req.flash('generic', 'Prototype link deleted')
-      res.redirect(formatAccountPathsFor(paths.account.prototyping.demoService.links, req.account.external_id))
+      res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.links,  req.service.externalId, req.account.type))
     })
     .catch((err) => {
       logger.error(`Disable product failed - ${err.message}`)
       req.flash('genericError', 'Something went wrong when deleting the prototype link. Please try again or contact support.')
-      res.redirect(formatAccountPathsFor(paths.account.prototyping.demoService.links, req.account.external_id))
+      res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.links,  req.service.externalId, req.account.type))
     })
 }

--- a/src/controllers/test-with-your-users/index.controller.js
+++ b/src/controllers/test-with-your-users/index.controller.js
@@ -1,9 +1,17 @@
 'use strict'
 
 const { response } = require('../../utils/response.js')
+const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/format')
+const paths= require('@root/paths')
 
-const PAGE_PARAMS = {
-  productsTab: false
+
+module.exports = (req, res) => {
+  const context = {
+    productsTab: false,
+    createLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.create, req.service.externalId, req.account.type),
+    prototypesLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.links,  req.service.externalId, req.account.type),
+    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.dashboard.index, req.service.externalId, req.account.type)
+  }
+
+  return response(req, res, 'dashboard/demo-service/index', context)
 }
-
-module.exports = (req, res) => response(req, res, 'dashboard/demo-service/index', PAGE_PARAMS)

--- a/src/controllers/test-with-your-users/links.controller.js
+++ b/src/controllers/test-with-your-users/links.controller.js
@@ -3,18 +3,18 @@
 const { response } = require('../../utils/response.js')
 const paths = require('../../paths')
 const productsClient = require('../../services/clients/products.client.js')
-const formatAccountPathsFor = require('../../utils/format-account-paths-for')
+const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/format')
 
 module.exports = async function getIndex (req, res, next) {
   const params = {
     productsTab: true,
-    createPage: formatAccountPathsFor(paths.account.prototyping.demoService.create, req.account.external_id),
-    indexPage: formatAccountPathsFor(paths.account.prototyping.demoService.index, req.account.external_id),
-    linksPage: formatAccountPathsFor(paths.account.prototyping.demoService.links, req.account.external_id)
+    createPage: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.create, req.service.externalId, req.account.type),
+    indexPage: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.index, req.service.externalId, req.account.type),
+    linksPage: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.links, req.service.externalId, req.account.type)
   }
 
   try {
-    const prototypeProducts = await productsClient.product.getByGatewayAccountIdAndType(req.account.gateway_account_id, 'PROTOTYPE')
+    const prototypeProducts = await productsClient.product.getByGatewayAccountIdAndType(req.account.id, 'PROTOTYPE')
     params.productsLength = prototypeProducts.length
     params.products = prototypeProducts
     return response(req, res, 'dashboard/demo-service/index', params)

--- a/src/controllers/test-with-your-users/links.controller.js
+++ b/src/controllers/test-with-your-users/links.controller.js
@@ -8,9 +8,10 @@ const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/f
 module.exports = async function getIndex (req, res, next) {
   const params = {
     productsTab: true,
-    createPage: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.create, req.service.externalId, req.account.type),
-    indexPage: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.index, req.service.externalId, req.account.type),
-    linksPage: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.links, req.service.externalId, req.account.type)
+    createLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.create, req.service.externalId, req.account.type),
+    indexLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.index, req.service.externalId, req.account.type),
+    prototypesLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.links, req.service.externalId, req.account.type),
+    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.index, req.service.externalId, req.account.type)
   }
 
   try {

--- a/src/controllers/test-with-your-users/submit.controller.js
+++ b/src/controllers/test-with-your-users/submit.controller.js
@@ -10,10 +10,10 @@ const productTypes = require('../../utils/product-types')
 const publicAuthClient = require('../../services/clients/public-auth.client')
 const { isCurrency, isHttps, isAboveMaxAmount } = require('../../utils/validation/field-validation-checks')
 const { penceToPounds, safeConvertPoundsStringToPence } = require('../../utils/currency-formatter')
-const formatAccountPathsFor = require('../../utils/format-account-paths-for')
+const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/format')
 
 module.exports = async (req, res) => {
-  const gatewayAccountId = req.account.gateway_account_id
+  const gatewayAccountId = req.account.id
   const confirmationPage = req.body['confirmation-page']
   const paymentDescription = req.body['payment-description']
   const paymentAmountInPence = safeConvertPoundsStringToPence(req.body['payment-amount'], true)
@@ -30,7 +30,7 @@ module.exports = async (req, res) => {
   }
 
   if (lodash.get(req, 'session.flash.genericError.length')) {
-    return res.redirect(formatAccountPathsFor(paths.account.prototyping.demoService.create, req.account.external_id))
+    return res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.create, req.service.externalId, req.account.type))
   }
 
   try {
@@ -57,10 +57,17 @@ module.exports = async (req, res) => {
 
     const prototypeLink = lodash.get(product, 'links.pay.href')
     lodash.set(req, 'session.pageData.createPrototypeLink', {})
-    return response(req, res, 'dashboard/demo-service/confirm', { prototypeLink })
+
+    const context = {
+      prototypeLink,
+      backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.links, req.service.externalId, req.account.type),
+      prototypesLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.links,  req.service.externalId, req.account.type),
+    }
+
+    return response(req, res, 'dashboard/demo-service/confirm', context)
   } catch (err) {
     logger.error(`Create product failed - ${err.message}`)
     req.flash('genericError', 'Something went wrong. Please try again or contact support.')
-    return res.redirect(formatAccountPathsFor(paths.account.prototyping.demoService.create, req.account.external_id))
+    return res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.create, req.service.externalId, req.account.type))
   }
 }

--- a/src/paths.js
+++ b/src/paths.js
@@ -161,6 +161,13 @@ module.exports = {
       edit: '/payment-links/:productExternalId/edit',
       delete: '/payment-links/:productExternalId/delete',
     },
+    testWithYourUsers: {
+      index: '/test-with-your-users',
+      links: '/test-with-your-users/links',
+      create: '/test-with-your-users/create',
+      confirm: '/test-with-your-users/confirm',
+      disable: '/test-with-your-users/links/disable/:productExternalId',
+    },
     settings: {
       index: '/settings',
       serviceName: {

--- a/src/routes.js
+++ b/src/routes.js
@@ -258,13 +258,6 @@ module.exports.bind = function (app) {
   // Settings
   app.use(paths.simplifiedAccount.root, simplifiedAccountRoutes)
 
-  // Prototype links
-  account.get(prototyping.demoService.index, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.index)
-  account.get(prototyping.demoService.links, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.links)
-  account.get(prototyping.demoService.create, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.create)
-  account.post(prototyping.demoService.confirm, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.submit)
-  account.get(prototyping.demoService.disable, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.disable)
-
   // Create payment link
   account.get(paymentLinks.start, permission('tokens:create'), paymentLinksController.getStart)
   account.get(paymentLinks.information, permission('tokens:create'), paymentLinksController.getInformation)

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -24,6 +24,7 @@ const {
   GOV_ENTITY_DOC_FORM_FIELD_NAME,
 } = require('@controllers/simplified-account/settings/stripe-details/government-entity-document/constants')
 const formatServiceAndAccountPathsFor = require('@utils/simplified-account/format/format-service-and-account-paths-for')
+const testWithYourUsersController = require('@controllers/test-with-your-users')
 
 const upload = multer({ storage: multer.memoryStorage() })
 const simplifiedAccount = new Router({ mergeParams: true })
@@ -60,7 +61,6 @@ simplifiedAccount.post(
 )
 
 // payment links
-
 simplifiedAccount.get(
   paths.simplifiedAccount.paymentLinks.index,
   experimentalFeature,
@@ -90,6 +90,13 @@ simplifiedAccount.post(
   permission('tokens:create'),
   servicesController.paymentLinks.remove.post
 )
+
+// test with your users
+simplifiedAccount.get(paths.simplifiedAccount.testWithYourUsers.index, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.index)
+simplifiedAccount.get(paths.simplifiedAccount.testWithYourUsers.links, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.links)
+simplifiedAccount.get(paths.simplifiedAccount.testWithYourUsers.create, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.create)
+simplifiedAccount.post(paths.simplifiedAccount.testWithYourUsers.confirm, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.submit)
+simplifiedAccount.get(paths.simplifiedAccount.testWithYourUsers.disable, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.disable)
 
 // settings index
 simplifiedAccount.get(paths.simplifiedAccount.settings.index, defaultViewDecider)

--- a/src/views/dashboard/demo-service/confirm.njk
+++ b/src/views/dashboard/demo-service/confirm.njk
@@ -9,7 +9,7 @@
   {{
     govukBackLink({
       text: "Back to prototype links",
-      href: formatAccountPathsFor(routes.account.prototyping.demoService.links,  currentGatewayAccount.external_id),
+      href: backLink,
       attributes: {
         id: "prototyping__links-link-back"
       }
@@ -37,7 +37,7 @@
   {{
     govukButton({
       text: "See prototype links",
-      href: formatAccountPathsFor(routes.account.prototyping.demoService.links,  currentGatewayAccount.external_id),
+      href: prototypesLink,
       attributes: {
         id: "see-prototype-links"
       }

--- a/src/views/dashboard/demo-service/create.njk
+++ b/src/views/dashboard/demo-service/create.njk
@@ -9,7 +9,7 @@
   {{
     govukBackLink({
       text: "Back to prototype links",
-      href: formatAccountPathsFor(routes.account.prototyping.demoService.links,  currentGatewayAccount.external_id)
+      href: backLink
     })
   }}
 {% endblock %}
@@ -17,7 +17,7 @@
 {% block mainContent %}
 <div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">Create a prototype link</h1>
-  <form method="post" action="{{formatAccountPathsFor(routes.account.prototyping.demoService.confirm,  currentGatewayAccount.external_id)}}" novalidate>
+  <form method="post" action="{{ confirmLink }}" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
 
     {{

--- a/src/views/dashboard/demo-service/index.njk
+++ b/src/views/dashboard/demo-service/index.njk
@@ -33,7 +33,7 @@
     <ul class="govuk-tabs__list">
       <li class="govuk-tabs__list-item">
         <a class="govuk-tabs__tab {% if not productsTab %}
-govuk-tabs__tab--selected{% endif %}" href="{{ prototypesLink }}">
+govuk-tabs__tab--selected{% endif %}" href="{{ indexLink }}">
           Mock card numbers
         </a>
       </li>

--- a/src/views/dashboard/demo-service/index.njk
+++ b/src/views/dashboard/demo-service/index.njk
@@ -9,7 +9,7 @@
   {{
     govukBackLink({
       text: "Back to dashboard",
-      href: formatAccountPathsFor(routes.account.dashboard.index,  currentGatewayAccount.external_id)
+      href: backLink
     })
   }}
 {% endblock %}
@@ -22,7 +22,7 @@
   {{
     govukButton({
       text: "Create prototype link",
-      href: formatAccountPathsFor(routes.account.prototyping.demoService.create,  currentGatewayAccount.external_id),
+      href: createLink,
       attributes: {
         id: "prototyping__links-button-create"
       }
@@ -33,13 +33,13 @@
     <ul class="govuk-tabs__list">
       <li class="govuk-tabs__list-item">
         <a class="govuk-tabs__tab {% if not productsTab %}
-govuk-tabs__tab--selected{% endif %}" href="{{formatAccountPathsFor(routes.account.prototyping.demoService.index,  currentGatewayAccount.external_id)}}">
+govuk-tabs__tab--selected{% endif %}" href="{{ prototypesLink }}">
           Mock card numbers
         </a>
       </li>
       <li class="govuk-tabs__list-item">
         <a class="govuk-tabs__tab {% if productsTab %}
-govuk-tabs__tab--selected{% endif %}" href="{{formatAccountPathsFor(routes.account.prototyping.demoService.links,  currentGatewayAccount.external_id)}}">
+govuk-tabs__tab--selected{% endif %}" href="{{ prototypesLink }}">
           Prototype links
         </a>
       </li>

--- a/test/cypress/integration/test-with-your-users/create-prototype-link.cy.js
+++ b/test/cypress/integration/test-with-your-users/create-prototype-link.cy.js
@@ -35,11 +35,17 @@ const setupStubs = (options = {}) => {
       vatNumber: false,
       companyNumber: false
     }),
+    gatewayAccountStubs.getAccountByServiceIdAndAccountType(SERVICE_EXTERNAL_ID, options.type || 'test', {
+      gateway_account_id: GATEWAY_ACCOUNT_ID,
+      external_id: GATEWAY_ACCOUNT_EXTERNAL_ID,
+      payment_provider: options.paymentProvider || 'sandbox',
+      type: options.type || 'test'
+    }),
     // create api key
     apiKeysStubs.createApiKey(GATEWAY_ACCOUNT_ID, USER_EMAIL, `Token for Prototype: Test prototype link description`, API_KEY_TOKEN, {
       type: 'PRODUCTS',
       serviceExternalId: SERVICE_EXTERNAL_ID,
-      serviceMode: 'test'
+      serviceMode: options.type || 'test'
     }),
     // create product
     productsStubs.postCreateProductSuccess(),
@@ -61,9 +67,9 @@ describe('create prototype links page', () => {
       })
 
       it('should be possible to access the "Create prototype link" page', () => {
-        cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`)
+        cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`)
         cy.contains('a', 'Create prototype link').should('exist').click()
-        cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+        cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
       })
     })
 
@@ -75,9 +81,9 @@ describe('create prototype links page', () => {
       })
 
       it('should be possible to access the "Create prototype link" page', () => {
-        cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`)
+        cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`)
         cy.contains('a', 'Create prototype link').should('exist').click()
-        cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+        cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
       })
     })
 
@@ -91,9 +97,9 @@ describe('create prototype links page', () => {
       })
 
       it('should be possible to access the "Create prototype link" page', () => {
-        cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`)
+        cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`)
         cy.contains('a', 'Create prototype link').should('exist').click()
-        cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+        cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
       })
     })
 
@@ -107,9 +113,9 @@ describe('create prototype links page', () => {
       })
 
       it('should be possible to access the "Create prototype link" page', () => {
-        cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`)
+        cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`)
         cy.contains('a', 'Create prototype link').should('exist').click()
-        cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+        cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
       })
     })
 
@@ -124,7 +130,7 @@ describe('create prototype links page', () => {
 
       it('should not be possible to access the "Create prototype link" page', () => {
         cy.request({
-          url: `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`,
+          url: `/service/${SERVICE_EXTERNAL_ID}/account/live/test-with-your-users/create`,
           failOnStatusCode: false,
         }).then((response) => expect(response.status).to.eq(404))
       })
@@ -141,7 +147,7 @@ describe('create prototype links page', () => {
 
       it('should not be possible to access the "Create prototype link" page', () => {
         cy.request({
-          url: `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`,
+          url: `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`,
           failOnStatusCode: false,
         }).then((response) => expect(response.status).to.eq(404))
       })
@@ -154,58 +160,58 @@ describe('create prototype links page', () => {
     })
 
     it('should return an error if no description is entered', () => {
-      cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+      cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
 
       cy.contains('button', 'Create prototype link').click()
-      cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+      cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
 
       cy.get('.flash-container>.generic-error')
         .should('contain.text', 'Enter a description')
     })
 
     it('should return an error if no amount is entered', () => {
-      cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+      cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
       cy.get('input#prototyping__links-input-description').type('Test prototype link description', { delay: 0 })
 
       cy.contains('button', 'Create prototype link').click()
-      cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+      cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
 
       cy.get('.flash-container>.generic-error')
         .should('contain.text', 'Enter an amount in pounds and pence using digits and a decimal point. For example “10.50”')
     })
 
     it('should return an error if the amount is too high', () => {
-      cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+      cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
       cy.get('input#prototyping__links-input-description').type('Test prototype link description', { delay: 0 })
       cy.get('input#prototyping__links-input-amount').type('100000.01', { delay: 0 })
 
       cy.contains('button', 'Create prototype link').click()
-      cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+      cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
 
       cy.get('.flash-container>.generic-error')
         .should('contain.text', 'Enter an amount under £100,000')
     })
 
     it('should return an error if no confirmation page URL is entered', () => {
-      cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+      cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
       cy.get('input#prototyping__links-input-description').type('Test prototype link description', { delay: 0 })
       cy.get('input#prototyping__links-input-amount').type('100.00', { delay: 0 })
 
       cy.contains('button', 'Create prototype link').click()
-      cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+      cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
 
       cy.get('.flash-container>.generic-error')
         .should('contain.text', 'URL must begin with https://')
     })
 
     it('should return an error if the confirmation page URL is not https', () => {
-      cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+      cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
       cy.get('input#prototyping__links-input-description').type('Test prototype link description', { delay: 0 })
       cy.get('input#prototyping__links-input-amount').type('100.00', { delay: 0 })
       cy.get('input#prototyping__links-input-confirmation-page').type('http://www.gov.uk', { delay: 0 })
 
       cy.contains('button', 'Create prototype link').click()
-      cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+      cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
 
       cy.get('.flash-container>.generic-error')
         .should('contain.text', 'URL must begin with https://')
@@ -218,20 +224,20 @@ describe('create prototype links page', () => {
     })
 
     it('should redirect to the "Your prototype link" page', () => {
-      cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+      cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
       cy.get('input#prototyping__links-input-description').type('Test prototype link description', { delay: 0 })
       cy.get('input#prototyping__links-input-amount').type('100.00', { delay: 0 })
       cy.get('input#prototyping__links-input-confirmation-page').type('https://www.gov.uk', { delay: 0 })
 
       cy.contains('button', 'Create prototype link').click()
-      cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/confirm`)
+      cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/confirm`)
 
       cy.contains('a', 'http://products-ui.url/pay/cf3hp2')
         .should('have.attr', 'href', 'http://products-ui.url/pay/cf3hp2')
 
       cy.contains('a', 'See prototype links').click()
 
-      cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/links`)
+      cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/links`)
     })
   })
 })

--- a/test/cypress/integration/test-with-your-users/prototype-links.cy.js
+++ b/test/cypress/integration/test-with-your-users/prototype-links.cy.js
@@ -24,6 +24,12 @@ const setupStubs = (options = {}) => {
       paymentProvider: options.paymentProvider || 'sandbox',
       type: options.type || 'test'
     }),
+    gatewayAccountStubs.getAccountByServiceIdAndAccountType(SERVICE_EXTERNAL_ID, options.type || 'test', {
+      gateway_account_id: GATEWAY_ACCOUNT_ID,
+      external_id: GATEWAY_ACCOUNT_EXTERNAL_ID,
+      payment_provider: options.paymentProvider || 'sandbox',
+      type: options.type || 'test'
+    }),
     stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({
       gatewayAccountId: GATEWAY_ACCOUNT_ID,
       responsiblePerson: false,
@@ -51,9 +57,9 @@ describe('prototype links page', () => {
       })
 
       it('should be possible to access the prototype links page', () => {
-        cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`)
+        cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`)
         cy.contains('a', 'Prototype links').should('exist').click()
-        cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/links`)
+        cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/links`)
       })
     })
 
@@ -65,9 +71,9 @@ describe('prototype links page', () => {
       })
 
       it('should be possible to access the prototype links page', () => {
-        cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`)
+        cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`)
         cy.contains('a', 'Prototype links').should('exist').click()
-        cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/links`)
+        cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/links`)
       })
     })
 
@@ -81,9 +87,9 @@ describe('prototype links page', () => {
       })
 
       it('should be possible to access the prototype links page', () => {
-        cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`)
+        cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`)
         cy.contains('a', 'Prototype links').should('exist').click()
-        cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/links`)
+        cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/links`)
       })
     })
 
@@ -97,9 +103,9 @@ describe('prototype links page', () => {
       })
 
       it('should be possible to access the prototype links page', () => {
-        cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`)
+        cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`)
         cy.contains('a', 'Prototype links').should('exist').click()
-        cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/links`)
+        cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/links`)
       })
     })
 
@@ -114,7 +120,7 @@ describe('prototype links page', () => {
 
       it('should not be possible to access the prototype links page', () => {
         cy.request({
-          url: `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/links`,
+          url: `/service/${SERVICE_EXTERNAL_ID}/account/live/test-with-your-users/links`,
           failOnStatusCode: false,
         }).then((response) => expect(response.status).to.eq(404))
       })
@@ -131,7 +137,7 @@ describe('prototype links page', () => {
 
       it('should not be possible to access the prototype links page', () => {
         cy.request({
-          url: `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/links`,
+          url: `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/links`,
           failOnStatusCode: false,
         }).then((response) => expect(response.status).to.eq(404))
       })
@@ -159,7 +165,7 @@ describe('prototype links page', () => {
     })
 
     it('should show the list of prototype links', () => {
-      cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/links`)
+      cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/links`)
 
       cy.get('#prototyping__links-header').should('contain.text', 'There are 2 prototype links')
 
@@ -194,7 +200,7 @@ describe('prototype links page', () => {
     })
 
     it('should allow disabling a prototype link', () => {
-      cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/links`)
+      cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/links`)
 
       cy.get('.key-list').within(() => {
         cy.get('.key-list-item').eq(0).within(() => {
@@ -202,7 +208,7 @@ describe('prototype links page', () => {
         })
       })
 
-      cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/links`)
+      cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/links`)
 
       cy.get('.govuk-notification-banner')
         .should('contain.text', 'Prototype link deleted')
@@ -217,7 +223,7 @@ describe('prototype links page', () => {
     })
 
     it('should show there are no prototype links', () => {
-      cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/links`)
+      cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/links`)
 
       cy.get('#prototyping__links-header').should('contain.text', 'There are no prototype links')
     })

--- a/test/cypress/integration/test-with-your-users/test-with-your-users.cy.js
+++ b/test/cypress/integration/test-with-your-users/test-with-your-users.cy.js
@@ -64,7 +64,7 @@ describe('test with your users', () => {
       it('should be possible to access the "Test with you users" page', () => {
         cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/dashboard`)
         cy.contains('a', 'Test with your users').click()
-        cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`)
+        cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`)
       })
     })
 
@@ -78,7 +78,7 @@ describe('test with your users', () => {
       it('should be possible to access the "Test with you users" page', () => {
         cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/dashboard`)
         cy.contains('a', 'Test with your users').click()
-        cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`)
+        cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`)
       })
     })
 
@@ -94,7 +94,7 @@ describe('test with your users', () => {
       it('should be possible to access the "Test with you users" page', () => {
         cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/dashboard`)
         cy.contains('a', 'Test with your users').click()
-        cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`)
+        cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`)
       })
     })
 
@@ -110,7 +110,7 @@ describe('test with your users', () => {
       it('should be possible to access the "Test with you users" page', () => {
         cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/dashboard`)
         cy.contains('a', 'Test with your users').click()
-        cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`)
+        cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`)
       })
     })
 
@@ -128,7 +128,7 @@ describe('test with your users', () => {
         cy.contains('a', 'Test with your users').should('not.exist')
 
         cy.request({
-          url: `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`,
+          url: `/service/${SERVICE_EXTERNAL_ID}/account/live/test-with-your-users`,
           failOnStatusCode: false,
         }).then((response) => expect(response.status).to.eq(404))    })
     })
@@ -147,7 +147,7 @@ describe('test with your users', () => {
       cy.get('a').contains( 'Test with your users').should('not.exist')
 
       cy.request({
-        url: `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`,
+        url: `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`,
         failOnStatusCode: false,
       }).then((response) => expect(response.status).to.eq(404))
     })
@@ -161,25 +161,25 @@ describe('test with your users', () => {
     })
 
     it('should show the mock card number by default', () => {
-      cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`)
+      cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`)
 
       cy.contains('div', '4000056655665556').should('exist')
     })
 
     it('should link to the existing prototype links page', () => {
-      cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`)
+      cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`)
 
       cy.contains('a', 'Prototype links').should('exist').click()
 
-      cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/links`)
+      cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/links`)
     })
 
     it('should link to the "create prototype links" page', () => {
-      cy.visit(`/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users`)
+      cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users`)
 
       cy.contains('a.govuk-button', 'Create prototype link').click()
 
-      cy.location('pathname').should('eq', `/account/${GATEWAY_ACCOUNT_EXTERNAL_ID}/test-with-your-users/create`)
+      cy.location('pathname').should('eq', `/service/${SERVICE_EXTERNAL_ID}/account/test/test-with-your-users/create`)
     })
   })
 


### PR DESCRIPTION
## What

PP-14193
- move `test-with-your-users` pages to service-level routes
- update associated controllers to use the service model

Controllers will be re-written in typescript in later PRs, this allows them to be re-written one by one on the new routes 

### Accessibility (views have been added/changed)
N/A - views should not have changed

Redo of #4630 