### PR TITLE
PP-14158 Add and refactor Cypress tests

### DIFF
--- a/src/views/includes/footer.njk
+++ b/src/views/includes/footer.njk
@@ -98,5 +98,8 @@
       }
     ],
     html: 'Built by the <a class="govuk-footer__link" href="#">Government Digital Service</a>'
+  },
+  attributes : {
+      'data-cy': 'footer'
   }
 }) }}

--- a/src/views/includes/header.njk
+++ b/src/views/includes/header.njk
@@ -62,6 +62,8 @@ govuk-width-container govuk-header__container--{{accountType}}
     containerClasses: payHeaderClasses,
     productName: "Pay",
     navigation: payHeaderNavigation,
-    useTudorCrown: true
+    attributes : {
+      'data-cy': 'header'
+    }
   })
 }}

--- a/test/cypress/integration/index/index.cy.js
+++ b/test/cypress/integration/index/index.cy.js
@@ -24,29 +24,49 @@ describe('The index page', () => {
     })
   })
 
-  describe('footer content when logged in', () => {
-    beforeEach(() => {
+  describe('Header and footer', () => {
+    it('should display the header and footer correctly when logged in', () => {
       cy.visit('/')
-    })
 
-    it('should display the About section with 6 links', () => {
-      cy.get('footer .govuk-footer__section')
+      cy.log('should display the GOV.UK header correctly')
+
+      cy.get('[data-cy=header]').should('have.css', 'background-color', 'rgb(11, 12, 12)')
+      cy.get('[data-cy=header]').should('have.css', 'color', 'rgb(255, 255, 255)')
+      cy.get('[data-cy=header]')
+        .find('.govuk-header__container')
+        .should('have.css', 'border-bottom-color', 'rgb(29, 112, 184)')
+      cy.get('[data-cy=header]')
+        .find('.govuk-header__product-name')
+        .should('contain', 'Pay')
+
+      cy.log('should display the GOV.UK footer correctly')
+       
+      cy.get('[data-cy=footer]')
+        .should('have.css', 'background-color', 'rgb(243, 242, 241)')
+        .should('have.css', 'border-top-color', 'rgb(29, 112, 184)')
+
+      cy.log('footer - should display the About section with 6 links')
+
+      cy.get('[data-cy=footer]')
+        .find('.govuk-footer__section')
         .contains('About')
         .parent()
         .find('a')
         .should('have.length', 6)
-    })
 
-    it('should display the Support section with 4 links', () => {
-      cy.get('footer .govuk-footer__section')
+      cy.log('footer - should display the Support section with 4 links')
+
+      cy.get('[data-cy=footer]')
+        .find('.govuk-footer__section')
         .contains('Support')
         .parent()
         .find('a')
         .should('have.length', 4)
-    })
+    
+      cy.log('should display the Legal Terms section with 5 links when logged in')
 
-    it('should display the Legal Terms section with 5 links when logged in', () => {
-      cy.get('footer .govuk-footer__section')
+      cy.get('[data-cy=footer]')
+        .find('.govuk-footer__section')
         .contains('Legal Terms')
         .parent()
         .find('a')

--- a/test/cypress/integration/user/login.cy.js
+++ b/test/cypress/integration/user/login.cy.js
@@ -33,14 +33,43 @@ describe('Login Page', () => {
     it('should have the page title \'Sign in to GOV.UK Pay\'', () => {
       cy.title().should('eq', 'Sign in to GOV.UK Pay')
     })
+
     it('should redirect to the login page', () => {
       cy.url().should('include', '/login')
     })
+
     it('should have a link to the register page', () => {
       cy.contains('create one now').should('have.attr', 'href', '/register/email-address')
     })
+
     it('should have a link to the forgotten password page', () => {
       cy.contains('Forgot your password?').should('have.attr', 'href', '/reset-password')
+    })
+
+    it('should display the footer correctly when logged out', () => {
+      cy.log('should display the About section with 6 links')
+
+      cy.get('[data-cy=footer]')
+        .find('.govuk-footer__section')
+        .contains('About')
+        .parent()
+        .find('a')
+        .should('have.length', 6)
+
+      cy.log('should display the Support section with 4 links')
+
+      cy.get('[data-cy=footer]')
+        .find('.govuk-footer__section')
+        .contains('Support')
+        .parent()
+        .find('a')
+        .should('have.length', 4)
+    
+      cy.log('should not display Legal terms when logged out')
+      
+      cy.get('[data-cy=footer]')
+        .find('.govuk-footer__section')
+        .should('not.contain', 'Legal Terms')
     })
   })
 
@@ -136,30 +165,6 @@ describe('Login Page', () => {
       // should redirect to account dashboard page
       cy.location('pathname').should('eq', `/service/${serviceExternalId}/account/${accountType}/dashboard`)
       cy.title().should('eq', 'Dashboard - service-name - GOV.UK Pay')
-    })
-  })
-  describe('footer when logged out', () => {
-    beforeEach(() => {
-      cy.visit(`/account/${gatewayAccountExternalId}/dashboard`)
-    })
-    it('should display the About section with 6 links', () => {
-      cy.get('footer .govuk-footer__section')
-        .contains('About')
-        .parent()
-        .find('a')
-        .should('have.length', 6)
-    })
-
-    it('should display the Support section with 4 links', () => {
-      cy.get('footer .govuk-footer__section')
-        .contains('Support')
-        .parent()
-        .find('a')
-        .should('have.length', 4)
-    })
-    it('should not display Legal terms when logged out', () => {
-      cy.get('footer .govuk-footer__section')
-        .should('not.contain', 'Legal Terms')
     })
   })
 })


### PR DESCRIPTION
## What

PP-14158 - Add and refactor Cypress tests, getting ready for the rebrand changes

- Add tests to check current brand styling for the header and footer.
- Refactor existing footer tests:
  - To use a `data-cy` - which is best practise.
  - Make the tests not have to reload the page multiple times.