### PR TITLE
PP-14158 - Updating the Cypress tests to test rebranding.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -379,24 +379,6 @@
         "line_number": 12
       }
     ],
-    "test/cypress/integration/demo-payment/demo-payment.cy.js": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "test/cypress/integration/demo-payment/demo-payment.cy.js",
-        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
-        "is_verified": false,
-        "line_number": 5
-      }
-    ],
-    "test/cypress/integration/demo-payment/mock-cards.cy.js": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "test/cypress/integration/demo-payment/mock-cards.cy.js",
-        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
-        "is_verified": false,
-        "line_number": 6
-      }
-    ],
     "test/cypress/integration/index/index.cy.js": [
       {
         "type": "Hex High Entropy String",
@@ -413,6 +395,15 @@
         "hashed_secret": "3d2093e48d6aae02ea34492b56a980e47adc8b5c",
         "is_verified": false,
         "line_number": 12
+      }
+    ],
+    "test/cypress/integration/rebrand/rebrand-header-footer.cy.rebrand.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/rebrand/rebrand-header-footer.cy.rebrand.js",
+        "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
+        "is_verified": false,
+        "line_number": 6
       }
     ],
     "test/cypress/integration/registration/complete-registration.cy.js": [
@@ -768,5 +759,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-10T16:30:43Z"
+  "generated_at": "2025-06-20T13:43:27Z"
 }

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -60,7 +60,10 @@ module.exports = defineConfig({
     },
 
     baseUrl: 'http://127.0.0.1:3000',
-    specPattern: './test/cypress/integration/**/*.cy.{js,ts}',
+    specPattern: [
+      './test/cypress/integration/**/*.cy.{js,ts}',
+      './test/cypress/integration/**/*.rebrand.{js,ts}',
+    ],
     supportFile: './test/cypress/support'
   }
 })

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
     "test:pact": "rm -rf ./pacts && NODE_ENV=test mocha **/*.pact.test.js",
     "cypress:server": "run-amock --port=8000 | node -r dotenv/config dist/application.js dotenv_config_path=test/cypress/test.env",
     "cypress:dev-server": "run-amock --port=8000 | NODE_ENV=test node dev-server.mjs",
-    "cypress:test": "cypress run",
+    "cypress:test": "cypress run --spec './test/cypress/integration/**/*.cy.js'",
     "cypress:test-headed": "cypress open",
+    "cypress:server-rebrand": "run-amock --port=8000 | ENABLE_REBRAND=true node -r dotenv/config dist/application.js dotenv_config_path=test/cypress/test.env",
+    "cypress:test-rebrand": "cypress run --spec './test/cypress/integration/rebrand/rebrand-header-footer.cy.rebrand.js'",
     "publish-pacts": "./bin/publish-pacts.js"
   },
   "lint-staged": {

--- a/test/cypress/integration/rebrand/rebrand-header-footer.cy.rebrand.js
+++ b/test/cypress/integration/rebrand/rebrand-header-footer.cy.rebrand.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const userStubs = require('../../stubs/user-stubs')
+const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
+
+const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
+const gatewayAccountId = '42'
+
+describe('New branding', () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(userExternalId)
+
+    cy.task('setupStubs', [
+      userStubs.getUserSuccess({ userExternalId, gatewayAccountId }),
+      gatewayAccountStubs.getGatewayAccountsSuccess({ gatewayAccountId })
+    ])
+  })
+
+  it('should display the header and footer with the new brand', () => {
+    cy.visit('/')
+
+    cy.log('Should display the header with new branding')
+
+    cy.get('[data-cy=header]').should('have.css', 'background-color', 'rgb(29, 112, 184)')
+    cy.get('[data-cy=header]').should('have.css', 'color', 'rgb(255, 255, 255)')
+    cy.get('[data-cy=header]')
+      .find('.govuk-header__container')
+      .should('have.css', 'border-bottom-color', 'rgb(255, 255, 255)')
+
+    cy.log('Should display the footer with new branding')
+
+    cy.get('[data-cy=footer]')
+      .should('have.css', 'background-color', 'rgb(244, 248, 251)')
+      .should('have.css', 'border-top-color', 'rgb(29, 112, 184)')
+  })
+})


### PR DESCRIPTION
- Updating the Cypress tests to handle rebranding.
- This approach is taken from `pay-frontend` where it is already working.
- We now need 2 Cypress test suites temporarily until the new branding is live
  - Main test suite
    - Rebranding flag ENABLE_REBRAND is undefined.
    - Standard Cypress tests with the current branding.
    - Custom branding tests.
    - These are run with
      - `npm run cypress:server`
      - `npm run cypress:test`
  - Rebranding test suite
    - Rebranding flag ENABLE_REBRAND = true
    - Want to run the test to check the rebranding
    - I.e. Check that the header and footer has the new CSS styling.
    - This is a new test that is only run when ENABLE_FLAG=true.
    - Custom branding tests
      - These tests should work whether the ENABLE_REBRAND is true or false/undefined.
    - These are run with - `npm run cypress:server-rebrand` - `npm run cypress:test-rebrand`
- To stop the rebranding test running during the main test suite, it has a different file extension - cy.rebrand.js
- We use this file extension to exclude this test when the main test suite is run.
- Cypress config had to be updated to recognise this file extension.
- Once the new branding is LIVE, we can update the existing tests and go to just needing the main test suite.
- CICD will be updated to run both test suites in a future PR.

## What

PP-**[ADD TICKET NUMBER]**

_A brief description of the pull request_

### How
_Steps to test or reproduce_

### Accessibility (views have been added/changed)

> [!IMPORTANT]
> Complete this checklist when adding/modifying nunjucks templates

<details>
<summary>checklist</summary>

- [ ] keyboard navigation is validated (can navigate all interactive elements with a keyboard)
- [ ] skip to main content takes you to the main content (not a nav link e.g. back link)
- [ ] cypress tests include the `cy.checkAccessibility` command for each unique view
- [ ] the page title is unique
- [ ] all page content fits within desktop and mobile view ports (unless specified in the designs)
- [ ] links clearly explain where the link will take the user
- [ ] ‘change’ links have visually hidden text providing additional screen reader context
</details>

### Screenshots (views have been added/changed)

> [!NOTE]
> Include mobile and desktop variants, **highlight**(`#ff0000`) changes to existing views to help reviewers