### PR TITLE
PP-14159 Add Cypress rebrand tests to Github actions

### DIFF
--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -43,6 +43,11 @@ jobs:
     uses: alphagov/pay-ci/.github/workflows/_run-node-cypress-tests.yml@master
     with:
       LIBGL_ALWAYS_SOFTWARE: "1"
+  
+  cypress-tests-rebrand:
+    name: "Cypress tests for rebranding"
+    needs: [ install-and-compile ]
+    uses: alphagov/pay-ci/.github/workflows/_run-node-cypress-tests-rebrand.yml@master
 
   pact-providers-contract-tests:
     name: "Provider tests"


### PR DESCRIPTION
## What

PP-14159

- Add the step to run the Cypress rebranding tests to GHA.