### PR TITLE
PP-14265 Add tests to error pages to check branding

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cypress:test": "cypress run --spec './test/cypress/integration/**/*.cy.js'",
     "cypress:test-headed": "cypress open",
     "cypress:server-rebrand": "run-amock --port=8000 | ENABLE_REBRAND=true node -r dotenv/config dist/application.js dotenv_config_path=test/cypress/test.env",
-    "cypress:test-rebrand": "cypress run --spec './test/cypress/integration/rebrand/rebrand-header-footer.cy.rebrand.js'",
+    "cypress:test-rebrand": "cypress run --spec './test/cypress/integration/rebrand/rebrand-header-footer.cy.rebrand.js,./test/cypress/integration/rebrand/errors.cy.rebrand.js'",
     "publish-pacts": "./bin/publish-pacts.js"
   },
   "lint-staged": {

--- a/test/cypress/integration/errors/errors.cy.js
+++ b/test/cypress/integration/errors/errors.cy.js
@@ -9,8 +9,26 @@ describe('Error pages', () => {
     beforeEach(() => {
       cy.clearCookies()
     })
-    it('should display logged out header on 404 page', () => {
+    it('should display logged out header on 404 page and display the header and footer with the correct branding', () => {
       cy.visit('/a-route-that-does-not-exist', { failOnStatusCode: false })
+
+      cy.log('should display the GOV.UK header correctly')
+
+      cy.get('[data-cy=header]').should('have.css', 'background-color', 'rgb(11, 12, 12)')
+      cy.get('[data-cy=header]').should('have.css', 'color', 'rgb(255, 255, 255)')
+      cy.get('[data-cy=header]')
+        .find('.govuk-header__container')
+        .should('have.css', 'border-bottom-color', 'rgb(29, 112, 184)')
+      cy.get('[data-cy=header]')
+        .find('.govuk-header__product-name')
+        .should('contain', 'Pay')
+
+      cy.log('should display the GOV.UK footer correctly')
+       
+      cy.get('[data-cy=footer]')
+        .should('have.css', 'background-color', 'rgb(243, 242, 241)')
+        .should('have.css', 'border-top-color', 'rgb(29, 112, 184)')
+
       cy.get('h1').should('have.text', 'Page not found')
       cy.get('nav').contains('Sign in')
       cy.get('.govuk-breadcrumbs').should('not.exist')

--- a/test/cypress/integration/rebrand/errors.cy.rebrand.js
+++ b/test/cypress/integration/rebrand/errors.cy.rebrand.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const userStubs = require('../../stubs/user-stubs')
+
+const userExternalId = 'authenticated-user-id'
+
+describe('Error pages', () => {
+  describe('User not logged in', () => {
+    beforeEach(() => {
+      cy.clearCookies()
+    })
+    it('should display logged out header on 404 page and display the header and footer with the new branding', () => {
+      cy.visit('/a-route-that-does-not-exist', { failOnStatusCode: false })
+
+      cy.log('Should display the header with new branding')
+
+      cy.get('[data-cy=header]').should('have.css', 'background-color', 'rgb(29, 112, 184)')
+      cy.get('[data-cy=header]').should('have.css', 'color', 'rgb(255, 255, 255)')
+      cy.get('[data-cy=header]')
+        .find('.govuk-header__container')
+        .should('have.css', 'border-bottom-color', 'rgb(255, 255, 255)')
+
+      cy.log('Should display the footer with new branding')
+
+      cy.get('[data-cy=footer]')
+        .should('have.css', 'background-color', 'rgb(244, 248, 251)')
+        .should('have.css', 'border-top-color', 'rgb(29, 112, 184)')
+
+      cy.get('h1').should('have.text', 'Page not found')
+      cy.get('nav').contains('Sign in')
+      cy.get('.govuk-breadcrumbs').should('not.exist')
+    })
+  })
+})


### PR DESCRIPTION
## What

PP-14265

- Create separate tests to check the branding for error pages depending on the ENABLE_REBRAND flag.
- Update the rebrand test suite to run the new branding test for error pages.