### PR TITLE
PP-14264 Update favicon to show new brand colours

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -55,7 +55,7 @@ const clientBuild = {
       resolveFrom: 'cwd',
       assets: [
         {
-          from: ['node_modules/govuk-frontend/dist/govuk/assets/**/*'],
+          from: ['node_modules/govuk-frontend/dist/govuk/assets/rebrand/**/*'],
           to: ['dist/govuk-frontend-assets']
         },
         {


### PR DESCRIPTION
## What
- Update the favicon to show the new branding
- It was showing the old branding colours (black and white) and now it shows the new one(blue and white)

# Screenshotts:
 Before:
<img width="699" alt="Screenshot 2025-07-09 at 14 26 13" src="https://github.com/user-attachments/assets/e8a089b0-77be-46d2-b8c6-b9d95a0bb6f2" />

After:
<img width="699" alt="Screenshot 2025-07-09 at 14 26 55" src="https://github.com/user-attachments/assets/d69dcafa-e313-4c49-b149-a1bc325c1156" />
