### PR TITLE
PP-14220 Delete a payment link journey

### DIFF
--- a/src/controllers/simplified-account/services/payment-links/delete/delete-payment-link.controller.ts
+++ b/src/controllers/simplified-account/services/payment-links/delete/delete-payment-link.controller.ts
@@ -92,6 +92,11 @@ async function post(req: ServiceRequest<DeletePaymentLinkBody>, res: ServiceResp
   }
   deleteProduct(account.id, productExternalId)
     .then(() => {
+      req.flash('messages', {
+              state: 'success',
+              icon: '&check;',
+              heading: `Successfully deleted ` + paymentLink.name,
+            })
       res.redirect(
         formatServiceAndAccountPathsFor(paths.simplifiedAccount.paymentLinks.index, service.externalId, account.type)
       )


### PR DESCRIPTION
## What

[PP-14220](https://payments-platform.atlassian.net/browse/PP-14220?atlOrigin=eyJpIjoiYWY2MGNkOGRmZDJkNGI5ZWJmMTFiNGMzNGJlMWY5M2MiLCJwIjoiaiJ9)

- add success banner for payment link deletion

### How

- ensure you have one or more payment links created
- add EXPERIMENTAL_FEATURES=true to your `.env` file
- login to locally running self service
- navigate to payment links
- delete one of your payments links, and confirm when prompted

You should a success banner (as per below) that confirms deletion, and no error message

### Screenshots

> 
<img width="699" height="211" alt="Screenshot 2025-07-17 at 09 19 10" src="https://github.com/user-attachments/assets/4a83ec37-6e30-44e1-928a-06dad4d8b97d" />
