### PR TITLE
PP-14241 Remove superfluous fieldset on transactions page

### DIFF
--- a/src/views/transactions/filter.njk
+++ b/src/views/transactions/filter.njk
@@ -110,7 +110,8 @@
           <legend class="govuk-visually-hidden">
               Card brand
           </legend>
-          <fieldset class="govuk-fieldset">
+          {# When JavaScript enhances the select to a multi-select, the label element’s for attribute will reference a button element #}
+          {# WAVE complains about this but it is valid according to the HTML standard and the label will activate the button #}
           {{
             govukSelect({
               id: "card-brand",
@@ -130,7 +131,6 @@
               items: cardBrands
             })
           }}
-          </fieldset>
         </fieldset>
       </div>
       <div class="govuk-grid-column-one-quarter">
@@ -138,6 +138,8 @@
           <legend class="govuk-visually-hidden">
               Payment status
           </legend>
+          {# When JavaScript enhances the select to a multi-select, the label element’s for attribute will reference a button element #}
+          {# WAVE complains about this but it is valid according to the HTML standard and the label will activate the button #}
           {{
             govukSelect({
               id: "state",


### PR DESCRIPTION
Remove superfluous and `legend`-less `fieldset` for card brand form controls on transactions page.

On the same page, WAVE complains that the ‘Card brand’ and ‘Payment status’ `label` elements are orphans because they reference `button` elements after the JavaScript enhances the select to a multi-select. However, the HTML standard says it is valid for a `label` element to reference a `button` element. Add Nunjucks comments clarifying this.