### PR TITLE
PP-14193 Use service layout for test-with-your-users index and payment links pages

### DIFF
--- a/src/controllers/simplified-account/services/test-with-your-users/index.controller.ts
+++ b/src/controllers/simplified-account/services/test-with-your-users/index.controller.ts
@@ -12,7 +12,7 @@ function get (req: ServiceRequest, res: ServiceResponse) {
     backLink: formatServiceAndAccountPathsFor(paths.simplifiedAccount.dashboard.index, req.service.externalId, req.account.type)
   }
 
-  return response(req, res, 'dashboard/demo-service/index', context)
+  return response(req, res, 'simplified-account/services/test-with-your-users/index', context)
 }
 
 export {

--- a/src/controllers/simplified-account/services/test-with-your-users/links.controller.ts
+++ b/src/controllers/simplified-account/services/test-with-your-users/links.controller.ts
@@ -18,7 +18,7 @@ async function get (req: ServiceRequest, res: ServiceResponse) {
     products: prototypeProducts
   }
 
-  return response(req, res, 'dashboard/demo-service/index', context)
+  return response(req, res, 'simplified-account/services/test-with-your-users/index', context)
 }
 
 export {

--- a/src/views/simplified-account/services/service-layout.njk
+++ b/src/views/simplified-account/services/service-layout.njk
@@ -25,7 +25,7 @@
     <div class="service-pane {% if fullWidth %}service-pane--full-width{% endif %}">
       {% if backLink %}
         {{ govukBackLink({
-          text: "Back",
+          text: backLinkText or "Back",
           href: backLink
         }) }}
       {% endif %}

--- a/src/views/simplified-account/services/test-with-your-users/index.njk
+++ b/src/views/simplified-account/services/test-with-your-users/index.njk
@@ -1,0 +1,47 @@
+{% extends "simplified-account/services/service-layout.njk" %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
+
+{% set servicePageTitle = "Test with your users" %}
+{% set backLinkText = "Back to dashboard" %}
+
+{% block serviceContent %}
+  <h1 class="govuk-heading-l page-title">
+    {{ servicePageTitle }}
+  </h1>
+
+  <p class="govuk-body">Create a reusable link to integrate your service prototype with GOV.UK Pay and test with users.</p>
+
+  {{
+    govukButton({
+      text: "Create prototype link",
+      href: createLink,
+      attributes: {
+        id: "prototyping__links-button-create"
+      }
+    })
+  }}
+
+  <div class="govuk-tabs">
+    <ul class="govuk-tabs__list">
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab {% if not productsTab %}
+govuk-tabs__tab--selected{% endif %}" href="{{ indexLink }}">
+          Mock card numbers
+        </a>
+      </li>
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab {% if productsTab %}
+govuk-tabs__tab--selected{% endif %}" href="{{ prototypesLink }}">
+          Prototype links
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  {% if productsTab %}
+    {% include './partials/_payment-links-list.njk' %}
+  {% else %}
+    {% include './partials/_mock-card-numbers.njk' %}
+  {% endif %}
+
+{% endblock %}

--- a/src/views/simplified-account/services/test-with-your-users/partials/_mock-card-numbers.njk
+++ b/src/views/simplified-account/services/test-with-your-users/partials/_mock-card-numbers.njk
@@ -1,0 +1,10 @@
+<p class="govuk-body">Use this card number to test a successful payment. Don’t use real card numbers.</p>
+{{
+govukInsetText({
+  html: '<p class="govuk-!-font-size-24 govuk-!-font-weight-bold">4000<span class="govuk-!-padding-left-3 govuk-!-padding-right-3">0566</span><span class="govuk-!-padding-right-3">5566</span>5556</p>'
+})
+}}
+<p class="govuk-body">
+  You can enter any valid value for the other details. For example, it doesn’t matter what expiry date you enter, but it must be in the future.
+</p>
+<p class="govuk-body">You can also use other card types and see errors. <a class="govuk-link" href="https://docs.payments.service.gov.uk/testing_govuk_pay/#mock-card-numbers-for-testing-purposes">See more card types in our documentation</a>.</p>

--- a/src/views/simplified-account/services/test-with-your-users/partials/_payment-links-list.njk
+++ b/src/views/simplified-account/services/test-with-your-users/partials/_payment-links-list.njk
@@ -1,0 +1,41 @@
+<h2 id="prototyping__links-header" class="govuk-heading-m">
+  {% if productsLength === 1 %}
+    There is 1 prototype link
+    {% elif productsLength > 1 %}
+    There are {{productsLength}} prototype links
+  {% else %}
+    There are no prototype links
+  {% endif %}
+</h2>
+<div class="key-list">
+  {% for product in products %}
+    <div class="key-list-item prototyping__links-list-item">
+      <h3 class="govuk-heading-s"><a class="govuk-link" href="{{ product.links.pay.href }}">{{ product.links.pay.href }}</a></h3>
+      <dl class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-0">
+        <dt class="govuk-!-display-inline-block">
+          Payment description:
+        </dt>
+        <dd class="govuk-!-display-inline-block govuk-!-font-weight-bold govuk-!-margin-left-0 prototyping__links-list-item-description">
+          {{ product.name }}
+        </dd>
+      </dl>
+      <dl class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-0">
+        <dt class="govuk-!-display-inline-block">
+          Payment amount:
+        </dt>
+        <dd class="govuk-!-display-inline-block govuk-!-font-weight-bold govuk-!-margin-left-0 prototyping__links-list-item-amount">
+          {{ product.price | penceToPoundsWithCurrency }}
+        </dd>
+      </dl>
+      <dl class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-0">
+        <dt class="govuk-!-display-inline-block">
+          Success page:
+        </dt>
+        <dd class="govuk-!-display-inline-block govuk-!-font-weight-bold govuk-!-margin-left-0 prototyping__links-list-item-success-page">
+          {{ product.returnUrl }}
+        </dd>
+      </dl>
+      <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-top-3"><a class="govuk-link govuk-link--no-visited-state prototyping__links-list-item-delete-link" href="links/disable/{{ product.externalId }}">Delete prototype link</a></p>
+    </div>
+  {% endfor %}
+</div>


### PR DESCRIPTION
## What

PP-14193
 - migrate index + payment links pages in `test-with-your-users` journey to new service layout
 
<img width="1247" height="832" alt="Screenshot 2025-07-22 at 11 35 37" src="https://github.com/user-attachments/assets/273a2086-c574-4df9-8e27-69d1255b0f99" />


<img width="1245" height="788" alt="Screenshot 2025-07-22 at 11 35 43" src="https://github.com/user-attachments/assets/b91f55e2-5a56-4563-913d-756285d68b39" />