### PR TITLE
PP-114193 Migrate test-with-your-users create & confirm views to service layout

### DIFF
--- a/src/controllers/simplified-account/services/test-with-your-users/create.controller.ts
+++ b/src/controllers/simplified-account/services/test-with-your-users/create.controller.ts
@@ -11,7 +11,7 @@ function get (req: ServiceRequest, res: ServiceResponse) {
     ...lodash.get(req, 'session.pageData.createPrototypeLink', {})
   }
 
-  return response(req, res, 'dashboard/demo-service/create', context)
+  return response(req, res, 'simplified-account/services/test-with-your-users/create', context)
 }
 
 export {

--- a/src/controllers/simplified-account/services/test-with-your-users/submit.controller.js
+++ b/src/controllers/simplified-account/services/test-with-your-users/submit.controller.js
@@ -64,7 +64,7 @@ module.exports = async (req, res) => {
       prototypesLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.testWithYourUsers.links,  req.service.externalId, req.account.type),
     }
 
-    return response(req, res, 'dashboard/demo-service/confirm', context)
+    return response(req, res, 'simplified-account/services/test-with-your-users/confirm', context)
   } catch (err) {
     logger.error(`Create product failed - ${err.message}`)
     req.flash('genericError', 'Something went wrong. Please try again or contact support.')

--- a/src/views/simplified-account/services/test-with-your-users/confirm.njk
+++ b/src/views/simplified-account/services/test-with-your-users/confirm.njk
@@ -1,0 +1,34 @@
+{% extends "simplified-account/services/service-layout.njk" %}
+
+{% set servicePageTitle = "Your prototype link" %}
+{% set backLinkText = "Back to prototype links" %}
+
+{% block serviceContent %}
+  <h1 class="govuk-heading-l page-title">
+    {{ servicePageTitle }}
+  </h1>
+
+  <p class="govuk-body">This link will send the user to our payment pages. Use it in a “pay now” button, for example, to integrate it with your prototype.</p>
+
+  {% set prototypeLink %}
+    <p class="govuk-body govuk-!-font-weight-bold"><a class="pay-protototype-link govuk-link" id="prototyping__links-link-create-payment" href="{{prototypeLink}}">{{prototypeLink}}</a></p>
+  {% endset %}
+
+  {{
+  govukInsetText({
+    html: prototypeLink
+  })
+  }}
+
+  <p class="govuk-body">Links will be saved for as long as you need them in the prototype links tab.</p>
+
+  {{
+  govukButton({
+    text: "See prototype links",
+    href: prototypesLink,
+    attributes: {
+      id: "see-prototype-links"
+    }
+  })
+  }}
+{% endblock %}

--- a/src/views/simplified-account/services/test-with-your-users/create.njk
+++ b/src/views/simplified-account/services/test-with-your-users/create.njk
@@ -1,0 +1,83 @@
+{% extends "simplified-account/services/service-layout.njk" %}
+
+{% set servicePageTitle = "Create a prototype link" %}
+{% set backLinkText = "Back to prototype links" %}
+
+
+{% block serviceContent %}
+  <h1 class="govuk-heading-l page-title">
+    {{ servicePageTitle }}
+  </h1>
+
+  <form method="post" action="{{ confirmLink }}" novalidate>
+    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+
+    {{
+    govukInput({
+      name: "payment-description",
+      id: "prototyping__links-input-description",
+      label: {
+        text: "Payment description",
+        classes: "govuk-label--s"
+      },
+      hint: {
+        text: "Tell users what they are paying for"
+      },
+      value: paymentDescription,
+      spellcheck: true
+    })
+    }}
+
+    <div class="currency-input govuk-form-group">
+      <label class="govuk-label govuk-label--s" for="payment-amount">
+        Payment amount
+        <span class="govuk-visually-hidden">in &pound;</span>
+      </label>
+      <div class="currency-input__inner">
+        <span class="currency-input__inner__unit">&pound;</span>
+        <input
+          class="govuk-input govuk-input--width-10"
+          aria-label="Enter amount in pounds"
+          name="payment-amount"
+          data-non-numeric
+          type="text"
+          spellcheck="false"
+          id="prototyping__links-input-amount"
+          {% if paymentAmount %}
+            value="{{ paymentAmount | penceToPounds }}"
+          {% endif %}
+          data-trim
+        />
+      </div>
+    </div>
+
+    {{
+    govukInput({
+      name: "confirmation-page",
+      id: "prototyping__links-input-confirmation-page",
+      label: {
+        text: "Confirmation page",
+        classes: "govuk-label--s"
+      },
+      hint: {
+        text: "Enter the secure URL users will go to after they have completed the test payment"
+      },
+      type: "url",
+      spellcheck: false,
+      value: confirmationPage,
+      attributes: {
+        "data-trim": true
+      }
+    })
+    }}
+
+    {{
+    govukButton({
+      text: "Create prototype link",
+      attributes: {
+        id: "prototyping__links-button-create-prototype-link"
+      }
+    })
+    }}
+  </form>
+{% endblock %}

--- a/src/views/simplified-account/services/test-with-your-users/index.njk
+++ b/src/views/simplified-account/services/test-with-your-users/index.njk
@@ -1,5 +1,4 @@
 {% extends "simplified-account/services/service-layout.njk" %}
-{% from "govuk/components/tabs/macro.njk" import govukTabs %}
 
 {% set servicePageTitle = "Test with your users" %}
 {% set backLinkText = "Back to dashboard" %}


### PR DESCRIPTION
## What

PP-14193
 - migrate `create` and `confirm` pages in `test-with-your-users` journey to new service layout
 
<img width="1284" height="757" alt="Screenshot 2025-07-22 at 12 49 59" src="https://github.com/user-attachments/assets/846d28ec-9d1f-4af9-9a46-36de74a35afe" />

 
<img width="1260" height="576" alt="Screenshot 2025-07-22 at 12 50 08" src="https://github.com/user-attachments/assets/71174da6-313f-44b8-aa55-c73aa55cf6b3" />
