### PR TITLE
PP-13924 update payer email setting page

### DIFF
--- a/src/views/simplified-account/settings/email-notifications/collect-email-page.njk
+++ b/src/views/simplified-account/settings/email-notifications/collect-email-page.njk
@@ -3,15 +3,19 @@
 {% set settingsPageTitle = "Ask users for their email address" %}
 
 {% block settingsContent %}
+  <h1 class="govuk-heading-l">Ask users for their email address on payment pages</h1>
+  <p class="govuk-body">Email addresses can be collected on payment pages or collected elsewhere in your service.
+    <a class="govuk-link" href="https://docs.payments.service.gov.uk/optional_features/prefill_user_details/">Read about how to prefill payment fields</a></p>
+  <p class="govuk-body">If you ask for email addresses, users are less likely to encounter a 3D Secure challenge.</p>
+
   <form id="email-collection-mode" method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
-
     {{ govukRadios({
       idPrefix: 'mode',
       name: 'emailCollectionMode',
       fieldset: {
         legend: {
-          text: 'Ask users for their email address',
+          text: '',
           isPageHeading: true,
           classes: 'govuk-fieldset__legend--l govuk-!-font-weight-bold'
         }

--- a/src/views/simplified-account/settings/email-notifications/index.njk
+++ b/src/views/simplified-account/settings/email-notifications/index.njk
@@ -1,6 +1,6 @@
 {% extends "../settings-layout.njk" %}
 
-{% set settingsPageTitle = "Email notifications" %}
+{% set settingsPageTitle = "Paying user email addresses" %}
 
 
 {% block settingsContent %}
@@ -9,6 +9,8 @@
   {% endif %}
 
   <h1 class="govuk-heading-l">{{ settingsPageTitle }}</h1>
+  <p class="govuk-body">You can ask users for their email address to send confirmation and refund emails, or you can
+    communicate with them separately. Email addresses are also used by Payment Service Providers (PSPs) to carry out fraud checks.</p>
 
   {{ govukSummaryList({
     rows: [

--- a/test/cypress/integration/simplified-account/service-settings/email-notifications/email-notifications.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/email-notifications/email-notifications.cy.js
@@ -37,8 +37,8 @@ describe('Email notifications settings', () => {
 
       it('should show the correct heading and title', () => {
         cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/test/settings/email-notifications`)
-        cy.get('h1').should('contain', 'Email notifications')
-        cy.title().should('eq', 'Email notifications - Settings - My cool service - GOV.UK Pay')
+        cy.get('h1').should('contain', 'Paying user email addresses')
+        cy.title().should('eq', 'Paying user email addresses - Settings - My cool service - GOV.UK Pay')
       })
 
       it('should show active "Email notifications" link in the setting navigation', () => {
@@ -145,7 +145,6 @@ describe('Email notifications settings', () => {
       it('should navigate to the email collection mode page', () => {
         cy.title().should('eq', 'Ask users for their email address - Settings - My cool service - GOV.UK Pay')
         cy.url().should('include', '/settings/email-notifications/email-collection-mode')
-        cy.get('.govuk-fieldset__heading').first().should('contain', 'Ask users for their email address')
         cy.get('.govuk-radios').within(() => {
           cy.get('.govuk-radios__item').eq(0).should('contain', 'On – as a mandatory field')
           cy.get('.govuk-radios__item').eq(1).should('contain', 'On – as an optional field')
@@ -156,14 +155,14 @@ describe('Email notifications settings', () => {
       it('should navigate to the email notifications landing page after "Save changes" is clicked', () => {
         cy.get('input[type="radio"][value="OFF"]').check()
         cy.get('.govuk-button').contains('Save changes').click()
-        cy.get('h1').should('contain', 'Email notifications')
-        cy.title().should('eq', 'Email notifications - Settings - My cool service - GOV.UK Pay')
+        cy.get('h1').should('contain', 'Paying user email addresses')
+        cy.title().should('eq', 'Paying user email addresses - Settings - My cool service - GOV.UK Pay')
       })
 
       it('should navigate to the email notifications landing page after "Back" is clicked', () => {
         cy.get('.govuk-back-link').click()
-        cy.get('h1').should('contain', 'Email notifications')
-        cy.title().should('eq', 'Email notifications - Settings - My cool service - GOV.UK Pay')
+        cy.get('h1').should('contain', 'Paying user email addresses')
+        cy.title().should('eq', 'Paying user email addresses - Settings - My cool service - GOV.UK Pay')
       })
     })
 
@@ -264,8 +263,8 @@ describe('Email notifications settings', () => {
             // navigate back to email notifications page
             cy.get('input[type="radio"][value="false"]').check()
             cy.get('.govuk-button').contains('Save changes').click()
-            cy.get('h1').should('contain', 'Email notifications')
-            cy.title().should('eq', 'Email notifications - Settings - My cool service - GOV.UK Pay')
+            cy.get('h1').should('contain', 'Paying user email addresses')
+            cy.title().should('eq', 'Paying user email addresses - Settings - My cool service - GOV.UK Pay')
           })
         })
       })
@@ -319,8 +318,8 @@ describe('Email notifications settings', () => {
             // navigate back to email notifications page
             cy.get('input[type="radio"][value="false"]').check()
             cy.get('.govuk-button').contains('Save changes').click()
-            cy.get('h1').should('contain', 'Email notifications')
-            cy.title().should('eq', 'Email notifications - Settings - My cool service - GOV.UK Pay')
+            cy.get('h1').should('contain', 'Paying user email addresses')
+            cy.title().should('eq', 'Paying user email addresses - Settings - My cool service - GOV.UK Pay')
           })
         })
       })

--- a/test/cypress/integration/simplified-account/service-settings/service-name/service-name.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/service-name/service-name.cy.js
@@ -39,7 +39,7 @@ describe('Service name settings', () => {
   beforeEach(() => {
     cy.setEncryptedCookies(USER_EXTERNAL_ID)
   })
-  describe('The default settings page', () => {
+  describe.only('The default settings page', () => {
     describe('For an admin user', () => {
       beforeEach(() => {
         setStubs()
@@ -80,10 +80,10 @@ describe('Service name settings', () => {
         cy.visit(SERVICE_SETTINGS_URL)
       })
       it('should be Email notifications', () => {
-        cy.title().should('eq', 'Email notifications - Settings - My Cool Service - GOV.UK Pay')
+        cy.title().should('eq', 'Paying user email addresses - Settings - My Cool Service - GOV.UK Pay')
       })
       it('should show the correct heading', () => {
-        cy.get('h1').should('contain', 'Email notifications')
+        cy.get('h1').should('contain', 'Paying user email addresses')
       })
       describe('The settings navigation', () => {
         it('should not show service name', () => {


### PR DESCRIPTION
## What

Update headers and body texts for `Email notifications` and `Ask users for their email address` pages.

**Email notifications changes**
<img width="433" height="260" alt="Screenshot 2025-07-30 at 14 51 36" src="https://github.com/user-attachments/assets/3a2e1308-7f40-41d5-9737-5262b19e62cb" />

**Ask users for their email address changes**
<img width="476" height="424" alt="Screenshot 2025-07-30 at 14 57 09" src="https://github.com/user-attachments/assets/472933a2-877e-41d9-8740-28e8242f10e0" />

