### PR TITLE
PP-14331 Restyle web address widget for new payment link

### DIFF
--- a/src/assets/sass/application.scss
+++ b/src/assets/sass/application.scss
@@ -61,3 +61,4 @@ $govuk-assets-path: "/govuk-frontend-assets/";
 @import "components/fieldset-legend-width";
 @import "components/lists";
 @import "components/overrides";
+@import "components/url-preview.scss"

--- a/src/assets/sass/components/url-preview.scss
+++ b/src/assets/sass/components/url-preview.scss
@@ -1,0 +1,5 @@
+.url-preview {
+  border: 1px solid #B1B4B6;
+  background-color: #EEEFEF;
+  padding: 5px;
+}

--- a/src/client-side/input-confirm.js
+++ b/src/client-side/input-confirm.js
@@ -11,9 +11,9 @@ const confirmInput = (e) => {
   if (!confirmation) {
     confirmation = document.createElement('div')
     confirmation.innerHTML = `
-      <div id="${confirmationId}" class="govuk-inset-text input-confirm">
-        <h3 class="govuk-heading-s govuk-!-margin-bottom-2">${input.dataset.confirmationTitle}</h3>
-        <p class="govuk-body">
+      <div id="${confirmationId}" class="input-confirm">
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-2">${input.dataset.confirmationTitle}</h3>
+        <p class="govuk-body url-preview">
           ${input.dataset.confirmationLabel}<span class="input-confirmation"></span>
         </p>
       </div>`

--- a/src/views/simplified-account/services/payment-links/create/index.njk
+++ b/src/views/simplified-account/services/payment-links/create/index.njk
@@ -32,7 +32,7 @@
     Give your users more information{% if isWelsh %} in Welsh{% endif %}. For example, you could tell them how long it takes for their application to be processed.
   {% endset %}
 
-  {% set confirmationLabel %}{{friendlyURL}}/{{serviceName | removeIndefiniteArticles | slugify}}/{% endset %}
+  {% set confirmationLabel %} https://www.gov.uk/payments{{friendlyURL}}/{{serviceName | removeIndefiniteArticles | slugify}}/{% endset %}
 
   <form method="post" novalidate>
     <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>


### PR DESCRIPTION
## What

[PP-14331](https://payments-platform.atlassian.net/browse/PP-14331)

- update web address preview as per new design, when creating payment links
- long text wraps to new line

### How
- navigate to create a (test) payment link in new service navigation

### Screenshots (views have been added/changed)

 
><img width="661" height="332" alt="Screenshot 2025-08-13 at 11 37 30" src="https://github.com/user-attachments/assets/e7b78194-4a6d-4503-af28-970d0a060d2c" />
------------
><img width="667" height="191" alt="Screenshot 2025-08-13 at 11 37 59" src="https://github.com/user-attachments/assets/f09b88d4-8fdd-4ef8-8c93-fddc39676628" />



[PP-14331]: https://payments-platform.atlassian.net/browse/PP-14331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ