### PR TITLE
PP-14384 fix bug with language selection

### DIFF
--- a/src/controllers/simplified-account/services/payment-links/create/payment-link-information.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/create/payment-link-information.controller.test.ts
@@ -216,6 +216,43 @@ describe('controller: services/payment-links/create/payment-link-information', (
       })
     })
 
+    describe('with Welsh language already saved in the session (user came back with Back link)', () => {
+      let sessionLanguage: string
+
+      before(async () => {
+        res.redirect.resetHistory()
+        const sessionData: Partial<PaymentLinkCreationSession> = {
+          paymentLinkTitle: 'Previous Title',
+          language: 'cy',
+          serviceNamePath: 'test-service',
+          productNamePath: 'previous-title',
+      }
+
+      nextRequest({
+        session: {
+          pageData: {
+            createPaymentLink: sessionData,
+          },
+        },
+        body: {
+          name: 'Welsh Payment Link',
+          description: 'Welsh Description',
+        },
+      })
+
+      const result = await call('post')
+      const thisRequest = result.req as Record<string, unknown>
+      const session = thisRequest.session as { pageData: { createPaymentLink: { language: string } } }
+      sessionLanguage = session.pageData.createPaymentLink.language
+    })
+
+    it('should retain Welsh language from session and redirect', () => {
+      sinon.assert.calledOnce(res.redirect)
+      sinon.assert.calledWith(res.redirect, sinon.match(/payment-links.*reference/))
+      sinon.assert.match(sessionLanguage, 'cy')
+    })
+  })
+
     describe('with validation errors - empty title', () => {
       before(async () => {
         mockResponse.resetHistory()

--- a/src/controllers/simplified-account/services/payment-links/create/payment-link-information.controller.ts
+++ b/src/controllers/simplified-account/services/payment-links/create/payment-link-information.controller.ts
@@ -46,7 +46,8 @@ interface CreateLinkInformationBody {
 
 async function post(req: ServiceRequest<CreateLinkInformationBody>, res: ServiceResponse) {
   const { account, service } = req
-  const isWelsh = (req.query.language as string) === 'cy'
+  const currentSession = lodash.get(req, CREATE_SESSION_KEY, {} as PaymentLinkCreationSession)
+  const isWelsh = currentSession.language === 'cy' || (req.query.language as string) === 'cy'
   const serviceName = isWelsh ? (service.serviceName.cy ?? service.name) : service.name
 
   const validations = [


### PR DESCRIPTION
## What

PP-**[14384]**

Bug fix for language selection during payment link creation journey.
If the user starts the creation of a payment link in Welsh, then going back to 
the information page should not drop that selection.

### Steps to test or reproduce

- Update the service in the settings so that there is a Welsh version for the service name (optional: see notes below)
- Create a payment link in Welsh
   - note that the information page does not show a screenshot at the bottom of the page
- Enter a title for the payment link
   - note that the web address widget is using a URL containing the Welsh version of the service name
- Continue to the reference page
   - no need to add anything here
- Click Back (at the top left) to go back to the information page
   - you are back on the information page
   - the language setting is still right (note the web address and the absence of the image)
- Continue to the reference page
   - note that we have now lost the language setting  
   - note the image at the bottom
    - if you click ‘Back’ again, you will see that the information page now shows: 
      - the web address with the English version of the service name
      - the image at the bottom of the page

**Notes**

When the language is set to Welsh:

- there should be no example images at the bottom of the pages
- the web address indicated in the information page should contain the welsh version of the service name



