### PR TITLE
PP-14401 Enable testing of *.ts test files, fix failing Typescript tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint",
     "lint-fix": "eslint --fix",
     "lint-sass": "stylelint 'src/assets/sass/**/*.scss'",
-    "test": "rm -rf ./pacts && NODE_ENV=test mocha '!(node_modules)/**/*.test'.js",
+    "test": "rm -rf ./pacts && NODE_ENV=test mocha '!(node_modules)/**/*.test'.[jt]s",
     "test:no-pact": "rm -rf ./pacts && NODE_ENV=test mocha --exclude **/*.pact.test.js '!(node_modules)/**/*.test'.js",
     "test:pact": "rm -rf ./pacts && NODE_ENV=test mocha **/*.pact.test.js",
     "cypress:server": "run-amock --port=8000 | node -r dotenv/config dist/application.js dotenv_config_path=test/cypress/test.env",

--- a/src/controllers/create-service/create-service.controller.js
+++ b/src/controllers/create-service/create-service.controller.js
@@ -6,7 +6,6 @@ const { response } = require('../../utils/response')
 const paths = require('../../paths')
 const serviceService = require('../../services/service.service')
 const userService = require('../../services/user.service')
-const formatAccountPathsFor = require('../../utils/format-account-paths-for')
 const formatServiceAndAccountPathsFor = require('@utils/simplified-account/format/format-service-and-account-paths-for')
 
 function get (req, res) {

--- a/src/controllers/create-service/get.controller.test.js
+++ b/src/controllers/create-service/get.controller.test.js
@@ -14,7 +14,7 @@ const getController = function (mockResponses) {
 
 describe('Controller: createService, Method: get', () => {
   describe('when there is no pre-existing pageData', () => {
-    before(() => {
+    beforeEach(() => {
       mockResponses.response = sinon.spy()
       const createServiceCtrl = getController(mockResponses)
       res = {}
@@ -43,7 +43,7 @@ describe('Controller: createService, Method: get', () => {
   })
 
   describe('when there is pre-existing pageData', () => {
-    before(() => {
+    beforeEach(() => {
       mockResponses.response = sinon.spy()
       const createServiceCtrl = getController(mockResponses)
       res = {}

--- a/src/controllers/create-service/post.controller.test.js
+++ b/src/controllers/create-service/post.controller.test.js
@@ -40,7 +40,7 @@ describe('Controller: createService, Method: post', () => {
     })
     mockUserService.assignServiceRole = sinon.stub().resolves()
 
-    before(async () => {
+    beforeEach(async () => {
       const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)
       req = {
         user: { externalId: '38475y38q4758ow4' },
@@ -72,7 +72,7 @@ describe('Controller: createService, Method: post', () => {
   })
 
   describe('when organisation type is provided, but create service fails', () => {
-    before(async () => {
+    beforeEach(async () => {
       mockServiceService.createService = sinon.stub().rejects(new Error('something went wrong'))
       const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)
       req = {
@@ -100,7 +100,7 @@ describe('Controller: createService, Method: post', () => {
   })
 
   describe('when organisation type is provided, and the create service succeeds, but the assign service role call fails', () => {
-    before(async () => {
+    beforeEach(async () => {
       mockServiceService.createService = sinon.stub().resolves({
         service: {
           externalId: 'def456'
@@ -134,7 +134,7 @@ describe('Controller: createService, Method: post', () => {
   })
 
   describe('when organisation type is not provided', () => {
-    before(async () => {
+    beforeEach(async () => {
       mockServiceService.createService = sinon.stub()
       mockUserService.assignServiceRole = sinon.stub()
       const addServiceCtrl = getController(mockResponses, mockServiceService, mockUserService)

--- a/src/controllers/create-service/select-organisation-type/select-organisation-type.test.js
+++ b/src/controllers/create-service/select-organisation-type/select-organisation-type.test.js
@@ -30,7 +30,7 @@ describe('Controller: selectOrganisationType, Method: get', () => {
   })
 
   describe('when there is pre-existing pageData', () => {
-    before(() => {
+    beforeEach(() => {
       mockResponse.response = sinon.spy()
       const selectOrganisationTypeController = controller(mockResponse)
       res = {
@@ -72,7 +72,7 @@ describe('Controller: selectOrganisationType, Method: get', () => {
 
 describe('Controller: selectOrganisationType, Method: post', () => {
   describe('when request passes validation', () => {
-    before(async () => {
+    beforeEach(async () => {
       mockResponse.response = sinon.spy()
       const selectOrganisationTypeController = controller(mockResponse)
       res = {}
@@ -98,7 +98,7 @@ describe('Controller: selectOrganisationType, Method: post', () => {
     })
   })
   describe('when request fails validation', () => {
-    before(async () => {
+    beforeEach(async () => {
       mockResponse.response = sinon.spy()
       const selectOrganisationTypeController = controller(mockResponse)
       res = {

--- a/src/controllers/edit-service-name/get.controller.test.js
+++ b/src/controllers/edit-service-name/get.controller.test.js
@@ -14,7 +14,7 @@ let req, res
 
 describe('Controller: editServiceName, Method: get', () => {
   describe('when there is no pre-existing pageData, but the service has an existing name', () => {
-    before(() => {
+    beforeEach(() => {
       mockResponses.response = sinon.spy()
       res = {}
       req = {
@@ -48,7 +48,7 @@ describe('Controller: editServiceName, Method: get', () => {
   })
 
   describe('when there is no pre-existing pageData, but the service has no existing name', () => {
-    before(() => {
+    beforeEach(() => {
       mockResponses.response = sinon.spy()
       res = {}
       req = {
@@ -67,7 +67,7 @@ describe('Controller: editServiceName, Method: get', () => {
   })
 
   describe('when there is pre-existing pageData', () => {
-    before(() => {
+    beforeEach(() => {
       mockResponses.response = sinon.spy()
       res = {}
       req = {

--- a/src/controllers/edit-service-name/post.controller.test.js
+++ b/src/controllers/edit-service-name/post.controller.test.js
@@ -16,7 +16,7 @@ let req, res, next
 
 describe('Controller: editServiceName, Method: get', () => {
   describe('when the service name is not empty', () => {
-    before(async function () {
+    beforeEach(async function () {
       mockServiceService.updateServiceName = sinon.stub().resolves()
       mockResponses.response = sinon.spy()
       req = {
@@ -40,7 +40,7 @@ describe('Controller: editServiceName, Method: get', () => {
   })
 
   describe('when the service name is not empty, but the update call fails', () => {
-    before(async function () {
+    beforeEach(async function () {
       mockServiceService.updateServiceName = sinon.stub().rejects(new Error('something went wrong'))
       mockResponses.renderErrorView = sinon.spy()
       req = {
@@ -64,7 +64,7 @@ describe('Controller: editServiceName, Method: get', () => {
   })
 
   describe('when the service name is empty', () => {
-    before(async function () {
+    beforeEach(async function () {
       mockServiceService.updateServiceName = sinon.stub().resolves()
       mockResponses.response = sinon.spy()
       req = {
@@ -93,7 +93,7 @@ describe('Controller: editServiceName, Method: get', () => {
   })
 
   describe('when the service name is too long', () => {
-    before(async function () {
+    beforeEach(async function () {
       mockServiceService.updateServiceName = sinon.stub().resolves()
       mockResponses.response = sinon.spy()
       req = {

--- a/src/controllers/request-to-go-live/organisation-address/get.controller.test.js
+++ b/src/controllers/request-to-go-live/organisation-address/get.controller.test.js
@@ -8,7 +8,7 @@ const goLiveStage = require('@models/constants/go-live-stage')
 const Service = require('@models/service/Service.class')
 const serviceFixtures = require('../../../../test/fixtures/service.fixtures')
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 
 const getController = function getController () {
   return proxyquire('./get.controller', {

--- a/src/controllers/request-to-go-live/organisation-address/post.controller.test.js
+++ b/src/controllers/request-to-go-live/organisation-address/post.controller.test.js
@@ -9,7 +9,7 @@ const Service = require('@models/service/Service.class')
 const serviceFixtures = require('../../../../test/fixtures/service.fixtures')
 const gatewayAccountFixture = require('../../../../test/fixtures/gateway-account.fixtures')
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 
 const loggerInfoMock = sinon.spy()
 const stripeAccountId = 'acct_123example123'

--- a/src/controllers/simplified-account/services/agreements/agreements.controller.test.ts
+++ b/src/controllers/simplified-account/services/agreements/agreements.controller.test.ts
@@ -7,7 +7,7 @@ import GatewayAccountType from '@models/gateway-account/gateway-account-type'
 const SERVICE_EXTERNAL_ID = 'service123abc'
 const AGREEMENT_EXTERNAL_ID = 'agreement123abc'
 const GATEWAY_ACCOUNT_ID = 117
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockAgreementsService = {
   searchAgreements: sinon.stub().resolves({
     total: 1,
@@ -38,13 +38,14 @@ const { nextRequest, call } = new ControllerTestBuilder(
     id: GATEWAY_ACCOUNT_ID,
     type: GatewayAccountType.TEST
   })
+  .withUrl(`https://wwww.compuglobalhypermeganet.example.com/service/${SERVICE_EXTERNAL_ID}/account/${GatewayAccountType.TEST}/agreements`)
   .build()
 
 
 describe('controller: services/agreements', () => {
   describe('get', () => {
     describe('agreements exist for service, no filters', () => {
-      before(async () => {
+      beforeEach(async () => {
         await call('get')
       })
 

--- a/src/controllers/simplified-account/services/agreements/cancel/cancel-agreement.controller.test.ts
+++ b/src/controllers/simplified-account/services/agreements/cancel/cancel-agreement.controller.test.ts
@@ -10,7 +10,7 @@ const GATEWAY_ACCOUNT_EXTERNAL_ID = 'account123abc'
 const USER_EXTERNAL_ID = 'user123def'
 const USER_EMAIL = 'scrooge.mcduck@pay.gov.uk'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 
 const mockAgreement = {
   externalId: AGREEMENT_EXTERNAL_ID,
@@ -52,7 +52,7 @@ const { nextRequest, call, res } = new ControllerTestBuilder(
 describe('controller: services/agreements/cancel', () => {
   describe('get', () => {
     describe('successful cancel agreement request', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           params: { agreementExternalId: AGREEMENT_EXTERNAL_ID },
         })
@@ -92,7 +92,7 @@ describe('controller: services/agreements/cancel', () => {
 
   describe('post', () => {
     describe('with valid yes answer', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           params: { agreementExternalId: AGREEMENT_EXTERNAL_ID },
           body: { cancelAgreement: 'yes' },
@@ -121,7 +121,7 @@ describe('controller: services/agreements/cancel', () => {
     })
 
     describe('with valid no answer', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockAgreementsService.cancelAgreement.resetHistory()
         res.redirect.resetHistory()
         nextRequest({
@@ -142,7 +142,7 @@ describe('controller: services/agreements/cancel', () => {
     })
 
     describe('with validation errors', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockResponse.resetHistory()
         res.redirect.resetHistory()
         nextRequest({

--- a/src/controllers/simplified-account/services/agreements/detail/agreement-detail.controller.test.ts
+++ b/src/controllers/simplified-account/services/agreements/detail/agreement-detail.controller.test.ts
@@ -9,7 +9,7 @@ const AGREEMENT_EXTERNAL_ID = 'agreement123abc'
 const GATEWAY_ACCOUNT_ID = 117
 const GATEWAY_ACCOUNT_EXTERNAL_ID = 'account123external'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 
 const mockAgreement = {
   externalId: AGREEMENT_EXTERNAL_ID,
@@ -61,7 +61,7 @@ const { nextRequest, call } = new ControllerTestBuilder(
 describe('controller: services/agreements/detail', () => {
   describe('get', () => {
     describe('successful agreement detail request', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           params: { agreementExternalId: AGREEMENT_EXTERNAL_ID },
           session: {},
@@ -134,7 +134,7 @@ describe('controller: services/agreements/detail', () => {
     })
 
     describe('with agreements filter in session', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           params: { agreementExternalId: AGREEMENT_EXTERNAL_ID },
           session: { agreementsFilter: 'status=ACTIVE&reference=test' },
@@ -149,7 +149,7 @@ describe('controller: services/agreements/detail', () => {
     })
 
     describe('without agreements filter in session', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           params: { agreementExternalId: AGREEMENT_EXTERNAL_ID },
           session: {},
@@ -167,7 +167,7 @@ describe('controller: services/agreements/detail', () => {
 
     describe('showCancelAgreementFunctionality conditions', () => {
       describe('when user lacks permission', () => {
-        before(async () => {
+        beforeEach(async () => {
           mockResponse.resetHistory()
           nextRequest({
             params: { agreementExternalId: AGREEMENT_EXTERNAL_ID },
@@ -186,7 +186,7 @@ describe('controller: services/agreements/detail', () => {
       })
 
       describe('when agreement is not active', () => {
-        before(async () => {
+        beforeEach(async () => {
           mockResponse.resetHistory()
           const inactiveAgreement = {
             ...mockAgreement,
@@ -214,7 +214,7 @@ describe('controller: services/agreements/detail', () => {
       })
 
       describe('when user lacks permission and agreement is not active', () => {
-        before(async () => {
+        beforeEach(async () => {
           mockResponse.resetHistory()
           const inactiveAgreement = {
             ...mockAgreement,

--- a/src/controllers/simplified-account/services/dashboard/dashboard-activity.controller.test.ts
+++ b/src/controllers/simplified-account/services/dashboard/dashboard-activity.controller.test.ts
@@ -103,7 +103,7 @@ const DEFAULT_PRODUCTS_RESPONSE = [
   }
 ]
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 
 const mockLedgerService = {
   dashboardTransactionSummary: sinon.stub().resolves(DEFAULT_DASHBOARD_TX_SUMMARY_RESPONSE),
@@ -149,7 +149,7 @@ const { nextRequest, call } = new ControllerTestBuilder(
 describe('controller: services/dashboard', () => {
   describe('get', () => {
     describe('sandbox test account, service is not live', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           service: SERVICE(GoLiveStage.NOT_STARTED),
           account: ACCOUNT(ACCOUNT_TYPE.TEST, PaymentProviders.SANDBOX, CredentialState.ACTIVE),
@@ -204,7 +204,7 @@ describe('controller: services/dashboard', () => {
     })
 
     describe('sandbox test account, service is live', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           service: SERVICE(GoLiveStage.LIVE),
           account: ACCOUNT(ACCOUNT_TYPE.TEST, PaymentProviders.SANDBOX, CredentialState.ACTIVE),
@@ -238,7 +238,7 @@ describe('controller: services/dashboard', () => {
 
     describe('worldpay test service', () => {
       describe('credential configured', () => {
-        before(async () => {
+        beforeEach(async () => {
           nextRequest({
             service: SERVICE(GoLiveStage.NOT_STARTED),
             account: ACCOUNT(ACCOUNT_TYPE.TEST, PaymentProviders.WORLDPAY, CredentialState.ACTIVE, WORLDPAY_CREDENTIAL),
@@ -277,7 +277,7 @@ describe('controller: services/dashboard', () => {
       })
 
       describe('credential not configured', () => {
-        before(async () => {
+        beforeEach(async () => {
           nextRequest({
             service: SERVICE(GoLiveStage.NOT_STARTED),
             account: ACCOUNT(ACCOUNT_TYPE.TEST, PaymentProviders.WORLDPAY, CredentialState.CREATED),
@@ -310,7 +310,7 @@ describe('controller: services/dashboard', () => {
     })
 
     describe('stripe test account, service is not live', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           service: SERVICE(GoLiveStage.NOT_STARTED),
           account: ACCOUNT(ACCOUNT_TYPE.TEST, PaymentProviders.STRIPE, CredentialState.ACTIVE, STRIPE_CREDENTIAL),
@@ -352,7 +352,7 @@ describe('controller: services/dashboard', () => {
     })
 
     describe('stripe test account, service is live', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           service: SERVICE(GoLiveStage.LIVE),
           account: ACCOUNT(ACCOUNT_TYPE.TEST, PaymentProviders.STRIPE, CredentialState.ACTIVE, STRIPE_CREDENTIAL),
@@ -389,7 +389,7 @@ describe('controller: services/dashboard', () => {
 
     describe('stripe live account', () => {
       describe('onboarding completed', () => {
-        before(async () => {
+        beforeEach(async () => {
           nextRequest({
             service: SERVICE(GoLiveStage.LIVE),
             account: ACCOUNT(ACCOUNT_TYPE.LIVE, PaymentProviders.STRIPE, CredentialState.ACTIVE, STRIPE_CREDENTIAL),
@@ -425,7 +425,7 @@ describe('controller: services/dashboard', () => {
       })
 
       describe('onboarding incomplete', () => {
-        before(async () => {
+        beforeEach(async () => {
           mockStripeDetailsService.getConnectorStripeAccountSetup.resolves(
             new StripeAccountSetup(buildGetStripeAccountSetupResponse())
           )
@@ -488,7 +488,7 @@ describe('controller: services/dashboard', () => {
 
     describe('worldpay live account', () => {
       describe('credential configured', () => {
-        before(async () => {
+        beforeEach(async () => {
           nextRequest({
             service: SERVICE(GoLiveStage.LIVE),
             account: ACCOUNT(ACCOUNT_TYPE.LIVE, PaymentProviders.WORLDPAY, CredentialState.ACTIVE, WORLDPAY_CREDENTIAL),
@@ -526,7 +526,7 @@ describe('controller: services/dashboard', () => {
         })
       })
       describe('credential not configured', () => {
-        before(async () => {
+        beforeEach(async () => {
           nextRequest({
             service: SERVICE(GoLiveStage.LIVE),
             account: ACCOUNT(ACCOUNT_TYPE.LIVE, PaymentProviders.WORLDPAY, CredentialState.CREATED),
@@ -579,7 +579,7 @@ describe('controller: services/dashboard', () => {
     })
 
     describe('stripe live account switching to worldpay', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           service: SERVICE(GoLiveStage.LIVE),
           account: new GatewayAccount(
@@ -644,7 +644,7 @@ describe('controller: services/dashboard', () => {
     })
 
     describe('worldpay live account with agent initiated moto enabled', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           service: new Service(
             validServiceResponse({
@@ -677,7 +677,7 @@ describe('controller: services/dashboard', () => {
 
     describe('edge cases', () => {
       describe('ledger unavailable', () => {
-        before(async () => {
+        beforeEach(async () => {
           mockLedgerService.dashboardTransactionSummary.rejects()
           nextRequest({
             service: SERVICE(GoLiveStage.NOT_STARTED),
@@ -705,7 +705,7 @@ describe('controller: services/dashboard', () => {
       })
 
       describe('connector unavailable', () => {
-        before(async () => {
+        beforeEach(async () => {
           mockStripeDetailsService.getConnectorStripeAccountSetup.rejects()
           nextRequest({
             service: SERVICE(GoLiveStage.LIVE),
@@ -733,7 +733,7 @@ describe('controller: services/dashboard', () => {
       })
 
       describe('stripe unavailable', () => {
-        before(async () => {
+        beforeEach(async () => {
           mockStripeDetailsService.getStripeAccountCapabilities.rejects()
           nextRequest({
             service: SERVICE(GoLiveStage.LIVE),

--- a/src/controllers/simplified-account/services/my-services.controller.test.js
+++ b/src/controllers/simplified-account/services/my-services.controller.test.js
@@ -14,7 +14,7 @@ const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/f
 const SERVICE_NAME = 'Rare coin authentication service'
 const SERVICE_EXTERNAL_ID = 'service-123-def'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockGatewayAccountService = {
   getGatewayAccountsByIds: sinon.stub().resolves({
     32: new GatewayAccount(validGatewayAccount({
@@ -102,14 +102,14 @@ const {
 describe('Controller: services/my-services.controller', () => {
   describe('get', () => {
     describe('for a service with two sandbox test accounts and a live account', () => {
-      before(() => {
+      beforeEach(async () => {
         userServiceRoles[0].service.gatewayAccountIds = ['35', '36', '37']
         nextRequest({
           user: {
             serviceRoles: userServiceRoles
           }
         })
-        call('get')
+        await call('get')
       })
 
       it('should call the response method with expected parameters', () => {
@@ -174,14 +174,14 @@ describe('Controller: services/my-services.controller', () => {
       })
     })
     describe('for a service with a test sandbox account, a test stripe account and no live account', () => {
-      before(() => {
+      beforeEach(async () => {
         userServiceRoles[0].service.gatewayAccountIds = ['34', '36']
         nextRequest({
           user: {
             serviceRoles: userServiceRoles
           }
         })
-        call('get')
+        await call('get')
       })
 
       it('should reformat links for test', () => {
@@ -228,14 +228,14 @@ describe('Controller: services/my-services.controller', () => {
       })
     })
     describe('for a service with an unsupported test account and a live account', () => {
-      before(() => {
+      beforeEach(async () => {
         userServiceRoles[0].service.gatewayAccountIds = ['33', '37']
         nextRequest({
           user: {
             serviceRoles: userServiceRoles
           }
         })
-        call('get')
+        await call('get')
       })
 
       it('should filter the unsupported test gateway account', () => {
@@ -260,14 +260,14 @@ describe('Controller: services/my-services.controller', () => {
       })
     })
     describe('for a service with disabled test gateway accounts', () => {
-      before(() => {
+      beforeEach(async () => {
         userServiceRoles[0].service.gatewayAccountIds = ['32', '38', '39']
         nextRequest({
           user: {
             serviceRoles: userServiceRoles
           }
         })
-        call('get')
+        await call('get')
       })
 
       it('should filter out the disabled test gateway accounts', () => {

--- a/src/controllers/simplified-account/services/payment-links/create/payment-link-amount.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/create/payment-link-amount.controller.test.ts
@@ -30,7 +30,7 @@ const { nextRequest, call, res } = new ControllerTestBuilder(
 describe('controller: services/payment-links/create/payment-link-amount', () => {
   describe('get', () => {
     describe('with existing session data', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockResponse.resetHistory()
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
@@ -91,7 +91,7 @@ describe('controller: services/payment-links/create/payment-link-amount', () => 
     })
 
     describe('with Welsh session data', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockResponse.resetHistory()
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Welsh Payment Link',
@@ -129,7 +129,7 @@ describe('controller: services/payment-links/create/payment-link-amount', () => 
 
 
     describe('with empty session data', () => {
-      before(async () => {
+      beforeEach(async () => {
         res.redirect.resetHistory()
 
         nextRequest({
@@ -149,7 +149,7 @@ describe('controller: services/payment-links/create/payment-link-amount', () => 
 
   describe('post', () => {
     describe('with fixed amount type', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           language: 'en',
@@ -183,7 +183,7 @@ describe('controller: services/payment-links/create/payment-link-amount', () => 
     })
 
     describe('with variable amount type', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           language: 'en',
@@ -235,7 +235,7 @@ describe('controller: services/payment-links/create/payment-link-amount', () => 
     })
 
     describe('with validation errors - no amount type selected', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           language: 'en',
@@ -283,7 +283,7 @@ describe('controller: services/payment-links/create/payment-link-amount', () => 
     })
 
     describe('with validation errors - fixed type but empty amount', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           language: 'en',
@@ -325,7 +325,7 @@ describe('controller: services/payment-links/create/payment-link-amount', () => 
     })
 
     describe('with validation errors - fixed type amount too low', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           language: 'en',
@@ -368,7 +368,7 @@ describe('controller: services/payment-links/create/payment-link-amount', () => 
     })
 
     describe('with validation errors - fixed type amount too high', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           language: 'en',
@@ -411,7 +411,7 @@ describe('controller: services/payment-links/create/payment-link-amount', () => 
     })
 
     describe('with validation errors - fixed type text amount', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           language: 'en',
@@ -453,7 +453,7 @@ describe('controller: services/payment-links/create/payment-link-amount', () => 
     })
 
     describe('with validation errors - variable type with hint too long', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           language: 'en',

--- a/src/controllers/simplified-account/services/payment-links/create/payment-link-information.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/create/payment-link-information.controller.test.ts
@@ -7,7 +7,7 @@ const SERVICE_EXTERNAL_ID = 'service123abc'
 const GATEWAY_ACCOUNT_ID = 117
 const GATEWAY_ACCOUNT_EXTERNAL_ID = 'account123abc'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 
 const { nextRequest, call, res } = new ControllerTestBuilder(
   '@controllers/simplified-account/services/payment-links/create/payment-link-information.controller'
@@ -30,7 +30,7 @@ const { nextRequest, call, res } = new ControllerTestBuilder(
 describe('controller: services/payment-links/create/payment-link-information', () => {
   describe('get', () => {
     describe('with no existing session data', () => {
-      before(async () => {
+      beforeEach(async () => {
         await call('get')
       })
 
@@ -73,7 +73,7 @@ describe('controller: services/payment-links/create/payment-link-information', (
     })
 
     describe('with existing session data', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockResponse.resetHistory()
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Existing Title',
@@ -103,7 +103,7 @@ describe('controller: services/payment-links/create/payment-link-information', (
     })
 
     describe('with Welsh language selected in session', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockResponse.resetHistory()
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Welsh Title',
@@ -131,7 +131,7 @@ describe('controller: services/payment-links/create/payment-link-information', (
     })
 
     describe('with Welsh language query parameter', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockResponse.resetHistory()
         nextRequest({
           query: { language: 'cy' },
@@ -148,7 +148,7 @@ describe('controller: services/payment-links/create/payment-link-information', (
     })
 
     describe('with Welsh language in session but no Welsh service name', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockResponse.resetHistory()
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Welsh Title',
@@ -181,7 +181,7 @@ describe('controller: services/payment-links/create/payment-link-information', (
 
   describe('post', () => {
     describe('with valid form data', () => {
-      before(async () => {
+      beforeEach(async () => {
         res.redirect.resetHistory()
 
         nextRequest({
@@ -201,7 +201,7 @@ describe('controller: services/payment-links/create/payment-link-information', (
     })
 
     describe('with Welsh language parameter', () => {
-      before(async () => {
+      beforeEach(async () => {
         res.redirect.resetHistory()
 
         nextRequest({
@@ -224,7 +224,7 @@ describe('controller: services/payment-links/create/payment-link-information', (
     describe('with Welsh language already saved in the session (user came back with Back link)', () => {
       let sessionLanguage: string
 
-      before(async () => {
+      beforeEach(async () => {
         res.redirect.resetHistory()
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Previous Title',
@@ -259,7 +259,7 @@ describe('controller: services/payment-links/create/payment-link-information', (
   })
 
     describe('when the user is coming back from the review page (FROM_REVIEW_QUERY_PARAM set to true)', () => {
-      before(async () => {
+      beforeEach(async () => {
         res.redirect.resetHistory()
 
         nextRequest({
@@ -280,7 +280,7 @@ describe('controller: services/payment-links/create/payment-link-information', (
     })
 
     describe('with validation errors - empty title', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockResponse.resetHistory()
         res.redirect.resetHistory()
 
@@ -329,7 +329,7 @@ describe('controller: services/payment-links/create/payment-link-information', (
     })
 
     describe('with validation errors - title too long', () => {
-      before(async () => {
+      beforeEach(async () => {
         const longTitle = 'a'.repeat(231)
         mockResponse.resetHistory()
         res.redirect.resetHistory()
@@ -355,7 +355,7 @@ describe('controller: services/payment-links/create/payment-link-information', (
     })
 
     describe('with validation errors - description with invalid characters', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockResponse.resetHistory()
         res.redirect.resetHistory()
 
@@ -380,7 +380,7 @@ describe('controller: services/payment-links/create/payment-link-information', (
     })
 
     describe('with validation errors - description too long', () => {
-      before(async () => {
+      beforeEach(async () => {
         const longDescription = 'a'.repeat(5001)
         mockResponse.resetHistory()
         res.redirect.resetHistory()

--- a/src/controllers/simplified-account/services/payment-links/create/payment-link-reference.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/create/payment-link-reference.controller.test.ts
@@ -7,7 +7,7 @@ const SERVICE_EXTERNAL_ID = 'service123abc'
 const GATEWAY_ACCOUNT_ID = 117
 const GATEWAY_ACCOUNT_EXTERNAL_ID = 'account123abc'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 
 const { nextRequest, call, res } = new ControllerTestBuilder(
   '@controllers/simplified-account/services/payment-links/create/payment-link-reference.controller'
@@ -30,7 +30,7 @@ const { nextRequest, call, res } = new ControllerTestBuilder(
 describe('controller: services/payment-links/create/payment-link-reference', () => {
   describe('get', () => {
     describe('with valid session data', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           paymentLinkDescription: 'Test Description',
@@ -92,7 +92,7 @@ describe('controller: services/payment-links/create/payment-link-reference', () 
     })
 
     describe('with Welsh session data', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockResponse.resetHistory()
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Welsh Payment Link',
@@ -129,7 +129,7 @@ describe('controller: services/payment-links/create/payment-link-reference', () 
     })
 
     describe('with empty session data', () => {
-      before(async () => {
+      beforeEach(async () => {
         res.redirect.resetHistory()
 
         nextRequest({
@@ -148,7 +148,7 @@ describe('controller: services/payment-links/create/payment-link-reference', () 
 
   describe('post', () => {
     describe('with valid standard reference type', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           language: 'en',
@@ -181,7 +181,7 @@ describe('controller: services/payment-links/create/payment-link-reference', () 
     })
 
     describe('with valid custom reference type', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           language: 'en',
@@ -216,7 +216,7 @@ describe('controller: services/payment-links/create/payment-link-reference', () 
     })
 
     describe('when the user is coming back from the review page (FROM_REVIEW_QUERY_PARAM set to true)', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           language: 'en',
@@ -251,7 +251,7 @@ describe('controller: services/payment-links/create/payment-link-reference', () 
     })
 
     describe('with empty session data', () => {
-      before(async () => {
+      beforeEach(async () => {
         res.redirect.resetHistory()
 
         nextRequest({
@@ -271,7 +271,7 @@ describe('controller: services/payment-links/create/payment-link-reference', () 
     })
 
     describe('with validation errors - no reference type selected', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           language: 'en',
@@ -321,7 +321,7 @@ describe('controller: services/payment-links/create/payment-link-reference', () 
     })
 
     describe('with validation errors - custom type but empty label', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           language: 'en',
@@ -364,7 +364,7 @@ describe('controller: services/payment-links/create/payment-link-reference', () 
     })
 
     describe('with validation errors - custom type with label too long', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           language: 'en',
@@ -403,7 +403,7 @@ describe('controller: services/payment-links/create/payment-link-reference', () 
     })
 
     describe('with validation errors - custom type with hint too long', () => {
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           language: 'en',

--- a/src/controllers/simplified-account/services/payment-links/create/payment-link-review.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/create/payment-link-review.controller.test.ts
@@ -9,7 +9,7 @@ const SERVICE_EXTERNAL_ID = 'service123abc'
 const GATEWAY_ACCOUNT_ID = 117
 const GATEWAY_ACCOUNT_EXTERNAL_ID = 'account123abc'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockCreatePaymentLinkToken = sinon.stub()
 const mockCreateProduct = sinon.stub()
 
@@ -38,7 +38,7 @@ describe('controller: services/payment-links/create/payment-link-review', () => 
     describe('with valid session data', () => {
       const expectedQueryStringForChangeLinks = FROM_REVIEW_QUERY_PARAM + '=true'
 
-      before(async () => {
+      beforeEach(async () => {
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Test Payment Link',
           paymentLinkDescription: 'Test Description',
@@ -119,7 +119,7 @@ describe('controller: services/payment-links/create/payment-link-review', () => 
     })
 
     describe('with Welsh session data', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockResponse.resetHistory()
         const sessionData: Partial<PaymentLinkCreationSession> = {
           paymentLinkTitle: 'Welsh Payment Link',
@@ -148,7 +148,7 @@ describe('controller: services/payment-links/create/payment-link-review', () => 
     })
 
     describe('with empty session data', () => {
-      before(async () => {
+      beforeEach(async () => {
         res.redirect.resetHistory()
 
         nextRequest({
@@ -167,7 +167,7 @@ describe('controller: services/payment-links/create/payment-link-review', () => 
 
   describe('post', () => {
     describe('with empty session data', () => {
-      before(async () => {
+      beforeEach(async () => {
         res.redirect.resetHistory()
 
         nextRequest({
@@ -196,7 +196,7 @@ describe('controller: services/payment-links/create/payment-link-review', () => 
         }
       }
 
-      before(async () => {
+      beforeEach(async () => {
         req.flash.resetHistory()
         res.redirect.resetHistory()
         mockCreateProduct.resetHistory()

--- a/src/controllers/simplified-account/services/payment-links/delete/delete-payment-link.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/delete/delete-payment-link.controller.test.ts
@@ -42,7 +42,7 @@ const MOCK_PRODUCT_NO_PRICE = new Product(
   }) as ProductData
 )
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockProductsService = {
   getProductByExternalId: sinon.stub().resolves(MOCK_PRODUCT),
   deleteProduct: sinon.stub().resolves(),

--- a/src/controllers/simplified-account/services/payment-links/delete/delete-payment-link.controller.ts
+++ b/src/controllers/simplified-account/services/payment-links/delete/delete-payment-link.controller.ts
@@ -25,8 +25,6 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   )
 
   return response(req, res, 'simplified-account/services/payment-links/delete/index', {
-    service,
-    account,
     backLink: backLinkUrl,
     paymentLink: {
       externalId: paymentLink.externalId,

--- a/src/controllers/simplified-account/services/payment-links/edit/amount/edit-link-amount.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/edit/amount/edit-link-amount.controller.test.ts
@@ -11,7 +11,7 @@ const GATEWAY_ACCOUNT_ID = 117
 const GATEWAY_ACCOUNT_EXTERNAL_ID = 'account123abc'
 const PRODUCT_EXTERNAL_ID = 'product123abc'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockGetProductByGatewayAccountIdAndExternalId = sinon.stub()
 const mockUpdateProduct = sinon.stub()
 
@@ -51,7 +51,7 @@ const mockProduct = {
 describe('controller: services/payment-links/edit/amount/edit-link-amount', () => {
   describe('get', () => {
     describe('with fixed amount product', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         nextRequest({
           params: { productExternalId: PRODUCT_EXTERNAL_ID },
@@ -105,7 +105,7 @@ describe('controller: services/payment-links/edit/amount/edit-link-amount', () =
     })
 
     describe('with variable amount product', () => {
-      before(async () => {
+      beforeEach(async () => {
         const variableProduct = {
           ...mockProduct,
           price: 0,
@@ -129,7 +129,7 @@ describe('controller: services/payment-links/edit/amount/edit-link-amount', () =
     })
 
     describe('with Welsh product', () => {
-      before(async () => {
+      beforeEach(async () => {
         const welshProduct = {
           ...mockProduct,
           language: 'cy',
@@ -152,7 +152,7 @@ describe('controller: services/payment-links/edit/amount/edit-link-amount', () =
 
   describe('post', () => {
     describe('with valid fixed amount data', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockUpdateProduct.resolves()
         res.redirect.resetHistory()
@@ -197,7 +197,7 @@ describe('controller: services/payment-links/edit/amount/edit-link-amount', () =
     })
 
     describe('with valid variable amount data', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockUpdateProduct.resolves()
         res.redirect.resetHistory()
@@ -239,7 +239,7 @@ describe('controller: services/payment-links/edit/amount/edit-link-amount', () =
     })
 
     describe('with validation errors - no amount type selected', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()
@@ -279,7 +279,7 @@ describe('controller: services/payment-links/edit/amount/edit-link-amount', () =
     })
 
     describe('with validation errors - fixed amount but no price', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()
@@ -311,7 +311,7 @@ describe('controller: services/payment-links/edit/amount/edit-link-amount', () =
     })
 
     describe('with validation errors - invalid amount format', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()

--- a/src/controllers/simplified-account/services/payment-links/edit/edit-payment-link.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/edit/edit-payment-link.controller.test.ts
@@ -10,7 +10,7 @@ const GATEWAY_ACCOUNT_ID = 117
 const GATEWAY_ACCOUNT_EXTERNAL_ID = 'account123abc'
 const PRODUCT_EXTERNAL_ID = 'product123abc'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockGetProductByGatewayAccountIdAndExternalId = sinon.stub()
 
 const { nextRequest, call } = new ControllerTestBuilder(
@@ -57,7 +57,7 @@ const mockProduct = {
 describe('controller: services/payment-links/edit/edit-payment-link', () => {
   describe('get', () => {
     describe('with valid product', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         nextRequest({
           params: { productExternalId: PRODUCT_EXTERNAL_ID },
@@ -160,7 +160,7 @@ describe('controller: services/payment-links/edit/edit-payment-link', () => {
     })
 
     describe('with product without description', () => {
-      before(async () => {
+      beforeEach(async () => {
         const productWithoutDescription = {
           ...mockProduct,
           description: undefined
@@ -182,7 +182,7 @@ describe('controller: services/payment-links/edit/edit-payment-link', () => {
     })
 
     describe('with variable amount product', () => {
-      before(async () => {
+      beforeEach(async () => {
         const variableAmountProduct = {
           ...mockProduct,
           price: 0
@@ -204,7 +204,7 @@ describe('controller: services/payment-links/edit/edit-payment-link', () => {
     })
 
     describe('with product without reference label', () => {
-      before(async () => {
+      beforeEach(async () => {
         const productWithoutReference = {
           ...mockProduct,
           referenceLabel: undefined
@@ -226,7 +226,7 @@ describe('controller: services/payment-links/edit/edit-payment-link', () => {
     })
 
     describe('with product without metadata', () => {
-      before(async () => {
+      beforeEach(async () => {
         const productWithoutMetadata = {
           ...mockProduct,
           metadata: undefined

--- a/src/controllers/simplified-account/services/payment-links/edit/info/edit-link-info.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/edit/info/edit-link-info.controller.test.ts
@@ -11,7 +11,7 @@ const GATEWAY_ACCOUNT_ID = 117
 const GATEWAY_ACCOUNT_EXTERNAL_ID = 'account123abc'
 const PRODUCT_EXTERNAL_ID = 'product123abc'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockGetProductByGatewayAccountIdAndExternalId = sinon.stub()
 const mockUpdateProduct = sinon.stub()
 
@@ -49,7 +49,7 @@ const mockProduct = {
 describe('controller: services/payment-links/edit/info/edit-link-info', () => {
   describe('get', () => {
     describe('with valid product', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         nextRequest({
           params: { productExternalId: PRODUCT_EXTERNAL_ID },
@@ -103,7 +103,7 @@ describe('controller: services/payment-links/edit/info/edit-link-info', () => {
     })
 
     describe('with Welsh product', () => {
-      before(async () => {
+      beforeEach(async () => {
         const welshProduct = {
           ...mockProduct,
           language: 'cy',
@@ -126,7 +126,7 @@ describe('controller: services/payment-links/edit/info/edit-link-info', () => {
 
   describe('post', () => {
     describe('with valid data', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockUpdateProduct.resolves()
         res.redirect.resetHistory()
@@ -171,7 +171,7 @@ describe('controller: services/payment-links/edit/info/edit-link-info', () => {
     })
 
     describe('with validation errors - empty name', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()
@@ -217,7 +217,7 @@ describe('controller: services/payment-links/edit/info/edit-link-info', () => {
     })
 
     describe('with validation errors - name too long', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()
@@ -251,12 +251,12 @@ describe('controller: services/payment-links/edit/info/edit-link-info', () => {
     })
 
     describe('with validation errors - description too long', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()
 
-        const longDescription = 'a'.repeat(256)
+        const longDescription = 'a'.repeat(5001)
         nextRequest({
           params: { productExternalId: PRODUCT_EXTERNAL_ID },
           body: {
@@ -278,7 +278,7 @@ describe('controller: services/payment-links/edit/info/edit-link-info', () => {
     })
 
     describe('with empty description', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockUpdateProduct.resolves()
         res.redirect.resetHistory()

--- a/src/controllers/simplified-account/services/payment-links/edit/metadata/add-link-metadata.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/edit/metadata/add-link-metadata.controller.test.ts
@@ -11,7 +11,7 @@ const GATEWAY_ACCOUNT_ID = 117
 const GATEWAY_ACCOUNT_EXTERNAL_ID = 'account123abc'
 const PRODUCT_EXTERNAL_ID = 'product123abc'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockGetProductByGatewayAccountIdAndExternalId = sinon.stub()
 const mockUpdateProduct = sinon.stub()
 
@@ -52,7 +52,7 @@ const mockProduct = {
 describe('controller: services/payment-links/edit/metadata/add-link-metadata', () => {
   describe('get', () => {
     describe('with valid product', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         nextRequest({
           params: { productExternalId: PRODUCT_EXTERNAL_ID },
@@ -108,7 +108,7 @@ describe('controller: services/payment-links/edit/metadata/add-link-metadata', (
     })
 
     describe('with Welsh product', () => {
-      before(async () => {
+      beforeEach(async () => {
         const welshProduct = {
           ...mockProduct,
           language: 'cy',
@@ -131,7 +131,7 @@ describe('controller: services/payment-links/edit/metadata/add-link-metadata', (
 
   describe('post', () => {
     describe('with valid data', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockUpdateProduct.resolves()
         res.redirect.resetHistory()
@@ -196,7 +196,7 @@ describe('controller: services/payment-links/edit/metadata/add-link-metadata', (
         language: 'en',
       } as Product
 
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(productWithoutMetadata)
         mockUpdateProduct.resolves()
         res.redirect.resetHistory()
@@ -253,7 +253,7 @@ describe('controller: services/payment-links/edit/metadata/add-link-metadata', (
     })
 
     describe('with validation errors - empty reporting column', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()
@@ -304,7 +304,7 @@ describe('controller: services/payment-links/edit/metadata/add-link-metadata', (
     })
 
     describe('with validation errors - empty cell content', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()
@@ -337,7 +337,7 @@ describe('controller: services/payment-links/edit/metadata/add-link-metadata', (
     })
 
     describe('with validation errors - duplicate reporting column', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()
@@ -363,7 +363,7 @@ describe('controller: services/payment-links/edit/metadata/add-link-metadata', (
     })
 
     describe('with validation errors - column name too long', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()

--- a/src/controllers/simplified-account/services/payment-links/edit/metadata/edit-link-metadata.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/edit/metadata/edit-link-metadata.controller.test.ts
@@ -12,7 +12,7 @@ const GATEWAY_ACCOUNT_EXTERNAL_ID = 'account123abc'
 const PRODUCT_EXTERNAL_ID = 'product123abc'
 const METADATA_KEY = 'existing_column'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockGetProductByGatewayAccountIdAndExternalId = sinon.stub()
 const mockUpdateProduct = sinon.stub()
 
@@ -55,7 +55,7 @@ const mockProduct = {
 describe('controller: services/payment-links/edit/metadata/edit-link-metadata', () => {
   describe('get', () => {
     describe('with valid metadata key', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         nextRequest({
           params: {
@@ -116,7 +116,7 @@ describe('controller: services/payment-links/edit/metadata/edit-link-metadata', 
     })
 
     describe('with invalid metadata key', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         next.resetHistory()
 
@@ -136,7 +136,7 @@ describe('controller: services/payment-links/edit/metadata/edit-link-metadata', 
     })
 
     describe('with Welsh product', () => {
-      before(async () => {
+      beforeEach(async () => {
         const welshProduct = {
           ...mockProduct,
           language: 'cy',
@@ -162,7 +162,7 @@ describe('controller: services/payment-links/edit/metadata/edit-link-metadata', 
 
   describe('post', () => {
     describe('with valid edit action', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockUpdateProduct.resolves()
         res.redirect.resetHistory()
@@ -224,7 +224,7 @@ describe('controller: services/payment-links/edit/metadata/edit-link-metadata', 
     })
 
     describe('with valid delete action', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockUpdateProduct.resolves()
         res.redirect.resetHistory()
@@ -282,7 +282,7 @@ describe('controller: services/payment-links/edit/metadata/edit-link-metadata', 
     })
 
     describe('with invalid metadata key', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         next.resetHistory()
 
@@ -307,7 +307,7 @@ describe('controller: services/payment-links/edit/metadata/edit-link-metadata', 
     })
 
     describe('with validation errors - edit action with empty column name', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()
@@ -355,7 +355,7 @@ describe('controller: services/payment-links/edit/metadata/edit-link-metadata', 
     })
 
     describe('with validation errors - edit action with empty cell content', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()
@@ -392,7 +392,7 @@ describe('controller: services/payment-links/edit/metadata/edit-link-metadata', 
     })
 
     describe('with validation errors - duplicate column name', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()

--- a/src/controllers/simplified-account/services/payment-links/edit/reference/edit-link-reference.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/edit/reference/edit-link-reference.controller.test.ts
@@ -11,7 +11,7 @@ const GATEWAY_ACCOUNT_ID = 117
 const GATEWAY_ACCOUNT_EXTERNAL_ID = 'account123abc'
 const PRODUCT_EXTERNAL_ID = 'product123abc'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockGetProductByGatewayAccountIdAndExternalId = sinon.stub()
 const mockUpdateProduct = sinon.stub()
 
@@ -52,7 +52,7 @@ const mockProduct = {
 describe('controller: services/payment-links/edit/reference/edit-link-reference', () => {
   describe('get', () => {
     describe('with custom reference product', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         nextRequest({
           params: { productExternalId: PRODUCT_EXTERNAL_ID },
@@ -111,7 +111,7 @@ describe('controller: services/payment-links/edit/reference/edit-link-reference'
     })
 
     describe('with standard reference product', () => {
-      before(async () => {
+      beforeEach(async () => {
         const standardReferenceProduct = {
           ...mockProduct,
           referenceEnabled: false,
@@ -137,7 +137,7 @@ describe('controller: services/payment-links/edit/reference/edit-link-reference'
     })
 
     describe('with Welsh product', () => {
-      before(async () => {
+      beforeEach(async () => {
         const welshProduct = {
           ...mockProduct,
           language: 'cy',
@@ -160,7 +160,7 @@ describe('controller: services/payment-links/edit/reference/edit-link-reference'
 
   describe('post', () => {
     describe('with valid standard reference type', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockUpdateProduct.resolves()
         res.redirect.resetHistory()
@@ -204,7 +204,7 @@ describe('controller: services/payment-links/edit/reference/edit-link-reference'
     })
 
     describe('with valid custom reference type', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockUpdateProduct.resolves()
         res.redirect.resetHistory()
@@ -250,7 +250,7 @@ describe('controller: services/payment-links/edit/reference/edit-link-reference'
     })
 
     describe('with validation errors - no reference type selected', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()
@@ -290,7 +290,7 @@ describe('controller: services/payment-links/edit/reference/edit-link-reference'
     })
 
     describe('with validation errors - custom type but empty label', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()
@@ -329,7 +329,7 @@ describe('controller: services/payment-links/edit/reference/edit-link-reference'
     })
 
     describe('with validation errors - custom type with label too long', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()
@@ -357,7 +357,7 @@ describe('controller: services/payment-links/edit/reference/edit-link-reference'
     })
 
     describe('with validation errors - custom type with hint too long', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockGetProductByGatewayAccountIdAndExternalId.resolves(mockProduct)
         mockResponse.resetHistory()
         res.redirect.resetHistory()

--- a/src/controllers/simplified-account/services/payment-links/payment-links.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/payment-links.controller.test.ts
@@ -81,6 +81,7 @@ describe('controller: services/payment-links', () => {
             createLink: '/service/service123abc/account/test/payment-links/create',
             products: [
               {
+                language: 'en',
                 name: 'Designer monocles',
                 href: 'http://products-ui.url/redirect/mcduck-enterprises/designer-monocles',
                 reference: 'Invoice number',
@@ -126,6 +127,7 @@ describe('controller: services/payment-links', () => {
             createLink: '/service/service123abc/account/live/payment-links/create',
             products: [
               {
+                language: 'en',
                 name: 'Designer monocles',
                 href: 'http://products-ui.url/redirect/mcduck-enterprises/designer-monocles',
                 reference: 'Created by GOV.UK Pay',

--- a/src/controllers/simplified-account/services/payment-links/payment-links.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/payment-links.controller.test.ts
@@ -34,7 +34,7 @@ const PRODUCT_REF_AMOUNT_DETAIL = new Product(
   }) as ProductData
 )
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockProductsService = {
   getProducts: sinon.stub().resolves([]),
 }

--- a/src/controllers/simplified-account/settings/api-keys/api-keys.controller.test.js
+++ b/src/controllers/simplified-account/settings/api-keys/api-keys.controller.test.js
@@ -6,7 +6,7 @@ const ACCOUNT_TYPE = 'live'
 const ACCOUNT_ID = '1337'
 const SERVICE_EXTERNAL_ID = 'service123abc'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const apiKeys = [{
   description: 'my token',
   createdBy: 'system generated',
@@ -36,8 +36,8 @@ const {
 
 describe('Controller: settings/api-keys', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
+    beforeEach(async () => {
+      await call('get')
     })
 
     it('should call apiKeysService', () => {

--- a/src/controllers/simplified-account/settings/api-keys/create/create-key.controller.test.js
+++ b/src/controllers/simplified-account/settings/api-keys/create/create-key.controller.test.js
@@ -13,7 +13,7 @@ const GATEWAY_ACCOUNT = {
 }
 const SERVICE_EXTERNAL_ID = 'service123abc'
 const NEW_API_KEY = 'api_live_123' // pragma: allowlist secret
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockApiKeysService = {
   createKey: sinon.stub().resolves(NEW_API_KEY),
   TOKEN_SOURCE
@@ -38,8 +38,8 @@ const {
 
 describe('Controller: settings/api-keys/create', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
+    beforeEach(async () => {
+      await call('get')
     })
 
     it('should call the response method with context', () => {
@@ -57,7 +57,7 @@ describe('Controller: settings/api-keys/create', () => {
   describe('post', () => {
     describe('a valid key name', () => {
       let thisCall
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             keyName: 'a test api key'
@@ -107,13 +107,13 @@ describe('Controller: settings/api-keys/create', () => {
         }
       ].forEach(({ testDescription, keyNameInput, expectedError }) => {
         describe(testDescription, () => {
-          before(() => {
+          beforeEach(async () => {
             nextRequest({
               body: {
                 keyName: keyNameInput
               }
             })
-            call('post')
+            await call('post')
           })
 
           it('should not call createKey', () => {

--- a/src/controllers/simplified-account/settings/api-keys/create/new-key-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/api-keys/create/new-key-details.controller.test.js
@@ -7,7 +7,7 @@ const paths = require('@root/paths')
 const SERVICE_EXTERNAL_ID = 'service123abc'
 const ACCOUNT_TYPE = 'live'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 
 const {
   res,
@@ -25,7 +25,7 @@ describe('Controller: settings/api-keys//create/new-key-details', () => {
   describe('get', () => {
     describe('key details present on session', () => {
       let thisCall
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           session: {
             formState: {
@@ -61,8 +61,8 @@ describe('Controller: settings/api-keys//create/new-key-details', () => {
       })
     })
     describe('key details not present on session', () => {
-      before(() => {
-        call('get')
+      beforeEach(async () => {
+        await call('get')
       })
 
       it('should not call the response method', () => {

--- a/src/controllers/simplified-account/settings/api-keys/edit/change-name.controller.test.js
+++ b/src/controllers/simplified-account/settings/api-keys/edit/change-name.controller.test.js
@@ -8,7 +8,7 @@ const ACCOUNT_TYPE = 'live'
 const SERVICE_EXTERNAL_ID = 'service123abc'
 const TOKEN_LINK = 'token456def'
 const TOKEN_DESC = 'S MCDUCK API DEV'
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockApiKeysService = {
   changeKeyName: sinon.stub().resolves(),
   getKeyByTokenLink: sinon.stub().resolves(new Token()
@@ -31,8 +31,8 @@ const {
 
 describe('Controller: settings/api-keys/change-name', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
+    beforeEach(async () => {
+      await call('get')
     })
 
     it('should call the response method with context', () => {
@@ -50,7 +50,7 @@ describe('Controller: settings/api-keys/change-name', () => {
 
   describe('post', () => {
     describe('a valid key name', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             keyName: 'S MCDUCK API PROD'
@@ -59,7 +59,7 @@ describe('Controller: settings/api-keys/change-name', () => {
             tokenLink: TOKEN_LINK
           }
         })
-        call('post')
+        await call('post')
       })
 
       it('should call changeKeyName with args', () => {
@@ -77,7 +77,7 @@ describe('Controller: settings/api-keys/change-name', () => {
     })
 
     describe('an invalid key name', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             keyName: ''
@@ -86,7 +86,7 @@ describe('Controller: settings/api-keys/change-name', () => {
             tokenLink: TOKEN_LINK
           }
         })
-        call('post')
+        await call('post')
       })
 
       it('should not call changeKeyName', () => {

--- a/src/controllers/simplified-account/settings/api-keys/revoke/revoke.controller.test.js
+++ b/src/controllers/simplified-account/settings/api-keys/revoke/revoke.controller.test.js
@@ -9,7 +9,7 @@ const SERVICE_EXTERNAL_ID = 'service123abc'
 const TOKEN_LINK = 'token456def'
 const TOKEN_DESC = 'S MCDUCK API DEV'
 const GATEWAY_ACCOUNT_ID = '1337'
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockApiKeysService = {
   getKeyByTokenLink: sinon.stub().resolves(new Token()
     .withDescription(TOKEN_DESC)
@@ -39,8 +39,8 @@ const {
 
 describe('Controller: settings/api-keys/revoke', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
+    beforeEach(async () => {
+      await call('get')
     })
 
     it('should call getKeyByTokenLink', () => {
@@ -60,11 +60,11 @@ describe('Controller: settings/api-keys/revoke', () => {
 
   describe('post', () => {
     describe('when nothing is selected', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {}
         })
-        call('post')
+        await call('post')
       })
 
       it('should not call revokeKey', () => {
@@ -99,13 +99,13 @@ describe('Controller: settings/api-keys/revoke', () => {
     })
 
     describe('when "No" is selected', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             revokeKey: 'no' // pragma: allowlist secret
           }
         })
-        call('post')
+        await call('post')
       })
 
       it('should not call revokeKey', () => {
@@ -121,13 +121,13 @@ describe('Controller: settings/api-keys/revoke', () => {
     })
 
     describe('when "Yes" is selected', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             revokeKey: 'yes' // pragma: allowlist secret
           }
         })
-        call('post')
+        await call('post')
       })
 
       it('should call revokeKey with args', () => {

--- a/src/controllers/simplified-account/settings/api-keys/revoke/revoked-keys.controller.test.js
+++ b/src/controllers/simplified-account/settings/api-keys/revoke/revoked-keys.controller.test.js
@@ -8,7 +8,7 @@ const ACCOUNT_TYPE = 'live'
 const SERVICE_EXTERNAL_ID = 'service123abc'
 const GATEWAY_ACCOUNT_ID = '1337'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockApiKeysService = {
   getRevokedKeys: sinon.stub().resolves([])
 }
@@ -43,9 +43,9 @@ describe('Controller: settings/api-keys/revoked-keys', () => {
         }
       ]
 
-      before(() => {
+      beforeEach(async () => {
         mockApiKeysService.getRevokedKeys.resolves(revokedKeys)
-        call('get')
+        await call('get')
       })
 
       it('should call getRevokedKeys with args', () => {
@@ -67,9 +67,9 @@ describe('Controller: settings/api-keys/revoked-keys', () => {
       })
     })
     describe('when revoked keys are not present', () => {
-      before(() => {
+      beforeEach(async () => {
         mockApiKeysService.getRevokedKeys.resolves([])
-        call('get')
+        await call('get')
       })
 
       it('should call getRevokedKeys with args', () => {

--- a/src/controllers/simplified-account/settings/card-payments/apple-pay.controller.test.js
+++ b/src/controllers/simplified-account/settings/card-payments/apple-pay.controller.test.js
@@ -8,7 +8,7 @@ const SERVICE_EXTERNAL_ID = 'service-id-123abc'
 
 const GATEWAY_ACCOUNT_ID = '123'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockUpdateApplePay = sinon.spy()
 
 const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/card-payments/apple-pay.controller')
@@ -26,8 +26,8 @@ const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/
 
 describe('Controller: settings/card-payments/apple-pay', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
+    beforeEach(async () => {
+      await call('get')
     })
     it('should call the response method', () => {
       expect(mockResponse.calledOnce).to.be.true
@@ -45,11 +45,11 @@ describe('Controller: settings/card-payments/apple-pay', () => {
     })
   })
   describe('post', () => {
-    before(() => {
+    beforeEach(async () => {
       nextRequest({
         body: { applePay: 'on' }
       })
-      call('post')
+      await call('post')
     })
 
     it('should update allow Apple Pay enabled', () => {

--- a/src/controllers/simplified-account/settings/card-payments/card-payments.controller.test.js
+++ b/src/controllers/simplified-account/settings/card-payments/card-payments.controller.test.js
@@ -13,7 +13,7 @@ const SERVICE_EXTERNAL_ID = 'service-id-123abc'
 const GATEWAY_ACCOUNT_ID = '123'
 const BASE_URL = `/service/${SERVICE_EXTERNAL_ID}/account/test/settings/card-payments/`
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 
 const adminUser = new User(userFixtures.validUserResponse({
   external_id: 'user-id-for-admin-user',
@@ -59,7 +59,7 @@ describe('Controller: settings/card-payments', () => {
   describe('get', () => {
     describe('for admin user', () => {
       describe('for non-moto gateway account', () => {
-        before(() => {
+        beforeEach(async () => {
           nextRequest({
             user: adminUser,
             service: {
@@ -72,7 +72,7 @@ describe('Controller: settings/card-payments', () => {
               getActiveCredential: () => true
             }
           })
-          call('get')
+          await call('get')
         })
         it('should call the response method', () => {
           expect(mockResponse).to.have.been.calledOnce
@@ -101,7 +101,7 @@ describe('Controller: settings/card-payments', () => {
         })
       })
       describe('for moto gateway account', () => {
-        before(() => {
+        beforeEach(async () => {
           nextRequest({
             user: adminUser,
             account: {
@@ -112,7 +112,7 @@ describe('Controller: settings/card-payments', () => {
               getActiveCredential: () => null
             }
           })
-          call('get')
+          await call('get')
         })
 
         it('should pass additional context data to the response method', () => {
@@ -126,7 +126,7 @@ describe('Controller: settings/card-payments', () => {
         })
       })
       describe('for worldpay gateway account with no active credential', () => {
-        before(() => {
+        beforeEach(async () => {
           nextRequest({
             user: adminUser,
             account: {
@@ -134,7 +134,7 @@ describe('Controller: settings/card-payments', () => {
               getActiveCredential: () => undefined
             }
           })
-          call('get')
+          await call('get')
         })
 
         it('should not enable edit of google pay setting', () => {
@@ -143,7 +143,7 @@ describe('Controller: settings/card-payments', () => {
         })
       })
       describe('for stripe gateway account with no active credential', () => {
-        before(() => {
+        beforeEach(async () => {
           nextRequest({
             user: adminUser,
             account: {
@@ -151,7 +151,7 @@ describe('Controller: settings/card-payments', () => {
               getActiveCredential: () => null
             }
           })
-          call('get')
+          await call('get')
         })
 
         it('should enable edit of google pay setting', () => {
@@ -160,7 +160,7 @@ describe('Controller: settings/card-payments', () => {
         })
       })
       describe('for worldpay gateway account with active credential', () => {
-        before(() => {
+        beforeEach(async () => {
           nextRequest({
             user: adminUser,
             account: {
@@ -168,7 +168,7 @@ describe('Controller: settings/card-payments', () => {
               getActiveCredential: () => true
             }
           })
-          call('get')
+          await call('get')
         })
 
         it('should enable edit of google pay setting', () => {
@@ -179,7 +179,7 @@ describe('Controller: settings/card-payments', () => {
     })
     describe('for non-admin user', () => {
       describe('for non-moto gateway account', () => {
-        before(() => {
+        beforeEach(async () => {
           nextRequest({
             user: viewOnlyUser,
             service: {
@@ -191,7 +191,7 @@ describe('Controller: settings/card-payments', () => {
               getActiveCredential: () => true
             }
           })
-          call('get')
+          await call('get')
         })
         it('should call the response method', () => {
           expect(mockResponse).to.have.been.calledOnce
@@ -213,7 +213,7 @@ describe('Controller: settings/card-payments', () => {
         })
       })
       describe('for moto gateway account', () => {
-        before(() => {
+        beforeEach(async () => {
           nextRequest({
             user: viewOnlyUser,
             account: {
@@ -223,7 +223,7 @@ describe('Controller: settings/card-payments', () => {
               getActiveCredential: () => null
             }
           })
-          call('get')
+          await call('get')
         })
 
         it('should pass additional context data to the response method', () => {

--- a/src/controllers/simplified-account/settings/card-payments/collect-billing-address.controller.test.js
+++ b/src/controllers/simplified-account/settings/card-payments/collect-billing-address.controller.test.js
@@ -8,7 +8,7 @@ const SERVICE_EXTERNAL_ID = 'service-id-123abc'
 
 const GATEWAY_ACCOUNT_ID = '123'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockUpdateCollectBillingAddress = sinon.spy()
 
 const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/card-payments/collect-billing-address.controller')
@@ -28,8 +28,8 @@ const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/
 
 describe('Controller: settings/card-payments/collect-billing-address', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
+    beforeEach(async () => {
+      await call('get')
     })
     it('should call the response method', () => {
       expect(mockResponse).to.have.been.calledOnce
@@ -47,11 +47,11 @@ describe('Controller: settings/card-payments/collect-billing-address', () => {
     })
   })
   describe('post', () => {
-    before(() => {
+    beforeEach(async () => {
       nextRequest({
         body: { collectBillingAddress: 'on' }
       })
-      call('post')
+      await call('post')
     })
 
     it('should update allow Collect billing address enabled', () => {

--- a/src/controllers/simplified-account/settings/card-payments/default-billing-address-country.controller.test.js
+++ b/src/controllers/simplified-account/settings/card-payments/default-billing-address-country.controller.test.js
@@ -8,7 +8,7 @@ const SERVICE_EXTERNAL_ID = 'service-id-123abc'
 
 const GATEWAY_ACCOUNT_ID = '123'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockUpdateDefaultBillingAddressCountry = sinon.spy()
 
 const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/card-payments/default-billing-address-country.controller')
@@ -28,8 +28,8 @@ const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/
 
 describe('Controller: settings/card-payments/default-billing-address', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
+    beforeEach(async () => {
+      await call('get')
     })
     it('should call the response method', () => {
       expect(mockResponse).to.have.been.calledOnce
@@ -47,11 +47,11 @@ describe('Controller: settings/card-payments/default-billing-address', () => {
     })
   })
   describe('post', () => {
-    before(() => {
+    beforeEach(async () => {
       nextRequest({
         body: { defaultBillingAddress: 'on' }
       })
-      call('post')
+      await call('post')
     })
 
     it('should update default billing address enabled', () => {

--- a/src/controllers/simplified-account/settings/card-payments/google-pay.controller.test.js
+++ b/src/controllers/simplified-account/settings/card-payments/google-pay.controller.test.js
@@ -8,7 +8,7 @@ const { formatSimplifiedAccountPathsFor } = require('@utils/simplified-account/f
 const ACCOUNT_TYPE = 'test'
 const SERVICE_EXTERNAL_ID = 'service-id-123abc'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockUpdateGooglePay = sinon.spy()
 const mockUpdateGooglePayMerchantId = sinon.spy()
 
@@ -34,8 +34,8 @@ const {
 describe('Controller: settings/card-payments/google-pay', () => {
   describe('get', () => {
     describe('a non-worldpay account', () => {
-      before(() => {
-        call('get', 1)
+      beforeEach(async () => {
+        await call('get', 1)
       })
       it('should call the response method', () => {
         expect(mockResponse).to.have.been.calledOnce
@@ -55,7 +55,7 @@ describe('Controller: settings/card-payments/google-pay', () => {
     })
 
     describe('a worldpay account', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           account: {
             paymentProvider: WORLDPAY,
@@ -68,7 +68,7 @@ describe('Controller: settings/card-payments/google-pay', () => {
             }
           }
         })
-        call('get', 1)
+        await call('get', 1)
       })
 
       it('should include google pay merchant id in the context', () => {
@@ -79,11 +79,11 @@ describe('Controller: settings/card-payments/google-pay', () => {
   })
   describe('post', () => {
     describe('a non-worldpay account', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: { googlePay: 'on' }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should not update Google Pay merchant id', () => {
@@ -103,7 +103,7 @@ describe('Controller: settings/card-payments/google-pay', () => {
     })
 
     describe('a worldpay account', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             googlePay: 'on',
@@ -121,7 +121,7 @@ describe('Controller: settings/card-payments/google-pay', () => {
             }
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should update Google Pay merchant id', () => {

--- a/src/controllers/simplified-account/settings/card-payments/moto-security/hide-card-number.controller.test.js
+++ b/src/controllers/simplified-account/settings/card-payments/moto-security/hide-card-number.controller.test.js
@@ -6,7 +6,7 @@ const paths = require('@root/paths')
 const ACCOUNT_TYPE = 'live'
 const SERVICE_EXTERNAL_ID = 'service-id-123abc'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockUpdateMotoMaskCardNumber = sinon.spy()
 
 const {
@@ -29,8 +29,8 @@ const {
 
 describe('Controller: settings/card-payments/moto-security/hide-card-number', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
+    beforeEach(async () => {
+      await call('get')
     })
     it('should call the response method with context', () => {
       sinon.assert.calledOnceWithExactly(mockResponse,
@@ -47,13 +47,13 @@ describe('Controller: settings/card-payments/moto-security/hide-card-number', ()
 
   describe('post', () => {
     describe('valid submission', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             hideCardNumber: 'on'
           }
         })
-        call('post')
+        await call('post')
       })
 
       it('should call updateMotoMaskCardNumber', () => {
@@ -71,13 +71,13 @@ describe('Controller: settings/card-payments/moto-security/hide-card-number', ()
       })
     })
     describe('invalid submission', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             NOTHideCardNumber: 'blah'
           }
         })
-        call('post')
+        await call('post')
       })
 
       it('should not call updateMotoMaskCardNumber', () => {

--- a/src/controllers/simplified-account/settings/card-payments/moto-security/hide-card-security-code.controller.test.js
+++ b/src/controllers/simplified-account/settings/card-payments/moto-security/hide-card-security-code.controller.test.js
@@ -6,7 +6,7 @@ const paths = require('@root/paths')
 const ACCOUNT_TYPE = 'live'
 const SERVICE_EXTERNAL_ID = 'service-id-123abc'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockUpdateMotoMaskSecurityCode = sinon.spy()
 
 const {
@@ -29,8 +29,8 @@ const {
 
 describe('Controller: settings/card-payments/moto-security/hide-card-security-code', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
+    beforeEach(async () => {
+      await call('get')
     })
     it('should call the response method with context', () => {
       sinon.assert.calledOnceWithExactly(mockResponse,
@@ -47,13 +47,13 @@ describe('Controller: settings/card-payments/moto-security/hide-card-security-co
 
   describe('post', () => {
     describe('valid submission', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             hideCardSecurityCode: 'off'
           }
         })
-        call('post')
+        await call('post')
       })
 
       it('should call updateMotoMaskSecurityCode', () => {
@@ -71,13 +71,13 @@ describe('Controller: settings/card-payments/moto-security/hide-card-security-co
       })
     })
     describe('invalid submission', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             // empty form submission
           }
         })
-        call('post')
+        await call('post')
       })
 
       it('should not call updateMotoMaskSecurityCode', () => {

--- a/src/controllers/simplified-account/settings/card-types/card-types.controller.test.js
+++ b/src/controllers/simplified-account/settings/card-types/card-types.controller.test.js
@@ -53,7 +53,7 @@ const allCardTypes = [{
 }]
 const acceptedCardTypes = [allCardTypes[0]]
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockGetAllCardTypes = sinon.stub().resolves({ card_types: allCardTypes })
 const mockGetAcceptedCardTypesForServiceAndAccountType = sinon.stub().resolves({ card_types: acceptedCardTypes })
 const mockPostAcceptedCardsForServiceAndAccountType = sinon.stub().resolves({})
@@ -73,11 +73,11 @@ const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/
 
 describe('Controller: settings/card-types', () => {
   describe('get for admin user', () => {
-    before(() => {
+    beforeEach(async () => {
       nextRequest({
         user: adminUser
       })
-      call('get')
+      await call('get')
     })
 
     it('should call the response method', () => {
@@ -102,11 +102,11 @@ describe('Controller: settings/card-types', () => {
   })
 
   describe('get for non-admin user', () => {
-    before(() => {
+    beforeEach(async () => {
       nextRequest({
         user: viewOnlyUser
       })
-      call('get')
+      await call('get')
     })
 
     it('should call the response method', () => {
@@ -131,12 +131,12 @@ describe('Controller: settings/card-types', () => {
   })
 
   describe('post to enable an additional card type', () => {
-    before(() => {
+    beforeEach(async () => {
       nextRequest({
         user: adminUser,
         body: { currentAcceptedCardTypeIds: 'id-001', debit: 'id-001', credit: ['id-002', 'id-003'] }
       })
-      call('post')
+      await call('post')
     })
 
     it('should call adminusers to update accepted card types', () => {
@@ -155,12 +155,12 @@ describe('Controller: settings/card-types', () => {
   })
 
   describe('post an unchanged set of card types', () => {
-    before(() => {
+    beforeEach(async () => {
       nextRequest({
         user: adminUser,
         body: { currentAcceptedCardTypeIds: 'id-001', debit: 'id-001' }
       })
-      call('post')
+      await call('post')
     })
 
     it('should not call adminusers', () => {
@@ -175,12 +175,12 @@ describe('Controller: settings/card-types', () => {
   })
 
   describe('post with no card types selected', () => {
-    before(() => {
+    beforeEach(async () => {
       nextRequest({
         user: adminUser,
         body: { currentAcceptedCardTypeIds: 'id-001' }
       })
-      call('post')
+      await call('post')
     })
 
     it('should not call adminusers', () => {

--- a/src/controllers/simplified-account/settings/email-notifications/email-collection-mode/email-collection-mode.controller.test.js
+++ b/src/controllers/simplified-account/settings/email-notifications/email-collection-mode/email-collection-mode.controller.test.js
@@ -3,7 +3,7 @@ const paths = require('@root/paths')
 const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
 const sinon = require('sinon')
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockEmailService = {
   setEmailCollectionModeByServiceIdAndAccountType: sinon.stub().resolves()
 }
@@ -30,7 +30,7 @@ const {
 
 describe('Controller: settings/email-notifications/email-collection-mode', () => {
   describe('get', () => {
-    before(() => {
+    beforeEach(async () => {
       call('get')
     })
 
@@ -57,7 +57,7 @@ describe('Controller: settings/email-notifications/email-collection-mode', () =>
   })
 
   describe('post', () => {
-    before(() => {
+    beforeEach(async () => {
       nextRequest({
         body: {
           emailCollectionMode: 'OPTIONAL'

--- a/src/controllers/simplified-account/settings/email-notifications/email-notifications.controller.test.js
+++ b/src/controllers/simplified-account/settings/email-notifications/email-notifications.controller.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const sinon = require('sinon')
 const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const ACCOUNT_TYPE = 'test'
 const SERVICE_ID = 'service-id-123abc'
 
@@ -28,7 +28,7 @@ const {
 
 describe('Controller: settings/email-notifications', () => {
   describe('get', () => {
-    before(() => {
+    beforeEach(async () => {
       call('get')
     })
 

--- a/src/controllers/simplified-account/settings/email-notifications/payment-confirmation-emails/payment-confirmation-emails.controller.test.js
+++ b/src/controllers/simplified-account/settings/email-notifications/payment-confirmation-emails/payment-confirmation-emails.controller.test.js
@@ -58,7 +58,7 @@ const setupTest = (additionalReqProps = {}) => {
 
 describe('Controller: settings/email-notifications/payment-confirmation-emails', () => {
   describe('get', () => {
-    before(() => {
+    beforeEach(async () => {
       setupTest()
       paymentConfirmationEmailsController.get(req, res)
     })
@@ -81,7 +81,7 @@ describe('Controller: settings/email-notifications/payment-confirmation-emails',
   })
 
   describe('post', () => {
-    before(() => {
+    beforeEach(async () => {
       setupTest({
         body: {
           paymentConfirmationEmailToggle: 'true'

--- a/src/controllers/simplified-account/settings/email-notifications/refund-emails/refund-emails.controller.test.js
+++ b/src/controllers/simplified-account/settings/email-notifications/refund-emails/refund-emails.controller.test.js
@@ -62,7 +62,7 @@ const setupTest = (additionalReqProps = {}) => {
 
 describe('Controller: settings/email-notifications/refund-emails', () => {
   describe('get', () => {
-    before(() => {
+    beforeEach(async () => {
       setupTest()
       refundEmailsController.get(req, res)
     })
@@ -85,7 +85,7 @@ describe('Controller: settings/email-notifications/refund-emails', () => {
   })
 
   describe('post', () => {
-    before(() => {
+    beforeEach(async () => {
       setupTest({
         body: {
           refundEmailToggle: 'false'

--- a/src/controllers/simplified-account/settings/email-notifications/templates/custom-paragraph.controller.test.js
+++ b/src/controllers/simplified-account/settings/email-notifications/templates/custom-paragraph.controller.test.js
@@ -66,9 +66,9 @@ const setupTest = (body = {}) => {
 
 describe('Controller: settings/email-notifications/templates/custom-paragraph', () => {
   describe('get', () => {
-    before(() => {
+    beforeEach(async () => {
       setupTest()
-      customParagraphController.get(req, res)
+      await customParagraphController.get(req, res)
     })
 
     it('should call the response method', () => {
@@ -89,10 +89,10 @@ describe('Controller: settings/email-notifications/templates/custom-paragraph', 
   })
 
   describe('postRemoveCustomParagraph', () => {
-    before(() => {
+    beforeEach(async () => {
       const body = { customParagraph: 'a test custom paragraph' }
       setupTest(body)
-      customParagraphController.postRemoveCustomParagraph(req, res)
+      await customParagraphController.postRemoveCustomParagraph(req, res)
     })
 
     it('should update the confirmation template', () => {
@@ -108,10 +108,10 @@ describe('Controller: settings/email-notifications/templates/custom-paragraph', 
 
   describe('postEditCustomParagraph', () => {
     describe('with empty body', () => {
-      before(() => {
+      beforeEach(async () => {
         const body = { customParagraph: '' }
         setupTest(body)
-        customParagraphController.postEditCustomParagraph(req, res)
+        await customParagraphController.postEditCustomParagraph(req, res)
       })
       it('should update the confirmation template', () => {
         expect(updateCustomParagraphByServiceIdAndAccountTypeStub.calledOnce).to.be.true
@@ -128,10 +128,10 @@ describe('Controller: settings/email-notifications/templates/custom-paragraph', 
       })
     })
     describe('without validation error', () => {
-      before(() => {
+      beforeEach(async () => {
         const body = { customParagraph: 'a test custom paragraph' }
         setupTest(body)
-        customParagraphController.postEditCustomParagraph(req, res)
+        await customParagraphController.postEditCustomParagraph(req, res)
       })
       it('should update the confirmation template', () => {
         expect(updateCustomParagraphByServiceIdAndAccountTypeStub.calledOnce).to.be.true
@@ -156,10 +156,10 @@ describe('Controller: settings/email-notifications/templates/custom-paragraph', 
 
     describe('with validation error', () => {
       const invalidText = 'hi'.repeat(5000)
-      before(() => {
+      beforeEach(async () => {
         const body = { customParagraph: invalidText }
         setupTest(body)
-        customParagraphController.postEditCustomParagraph(req, res)
+        await customParagraphController.postEditCustomParagraph(req, res)
       })
 
       it('should call the response method', () => {

--- a/src/controllers/simplified-account/settings/email-notifications/templates/templates.controller.test.js
+++ b/src/controllers/simplified-account/settings/email-notifications/templates/templates.controller.test.js
@@ -62,7 +62,7 @@ const setupTest = () => {
 
 describe('Controller: settings/email-notifications/templates', () => {
   describe('get', () => {
-    before(() => {
+    beforeEach(async () => {
       setupTest()
       templatesController.get(req, res)
     })

--- a/src/controllers/simplified-account/settings/organisation-details/edit-organisation-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/organisation-details/edit-organisation-details.controller.test.js
@@ -5,7 +5,7 @@ const ControllerTestBuilder = require('@test/test-helpers/simplified-account/con
 const chai = require('chai')
 const expect = chai.expect
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const updateServiceSpy = sinon.spy()
 
 const ACCOUNT_TYPE = 'live'
@@ -35,7 +35,7 @@ const { req, res, call, nextRequest } = new ControllerTestBuilder('@controllers/
 
 describe('Controller: settings/organisation-details', () => {
   describe('get', () => {
-    before(() => {
+    beforeEach(async () => {
       call('get')
     })
 
@@ -68,7 +68,7 @@ describe('Controller: settings/organisation-details', () => {
   })
 
   describe('post', () => {
-    before(() => {
+    beforeEach(async () => {
       nextRequest({
         body: {
           organisationName: 'Flancrest Enterprises',

--- a/src/controllers/simplified-account/settings/organisation-details/organisation-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/organisation-details/organisation-details.controller.test.js
@@ -5,7 +5,7 @@ const ControllerTestBuilder = require('@test/test-helpers/simplified-account/con
 const chai = require('chai')
 const expect = chai.expect
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 
 const ACCOUNT_TYPE = 'live'
 const SERVICE_EXTERNAL_ID = 'service-id-123abc'
@@ -25,7 +25,7 @@ describe('Controller: settings/organisation-details', () => {
   describe('get', () => {
     describe('where organisation details have been set', () => {
       let thisCall
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           service: {
             merchantDetails: {
@@ -66,7 +66,7 @@ describe('Controller: settings/organisation-details', () => {
     })
 
     describe('where organisation details have not been set', () => {
-      before(() => {
+      beforeEach(async () => {
         call('get')
       })
 

--- a/src/controllers/simplified-account/settings/service-name/edit/edit-service-name.controller.test.js
+++ b/src/controllers/simplified-account/settings/service-name/edit/edit-service-name.controller.test.js
@@ -31,7 +31,7 @@ const { req, res, call, nextRequest } = new ControllerTestBuilder('@controllers/
 describe('Controller: edit service name', () => {
   describe('get', () => {
     describe('when editing English service name', () => {
-      before(async () => {
+      beforeEach(async () => {
         await call('get')
       })
 
@@ -56,7 +56,7 @@ describe('Controller: edit service name', () => {
 
     describe('when editing Welsh service name', () => {
       let callContext
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           query: {
             cy: 'true'
@@ -87,7 +87,7 @@ describe('Controller: edit service name', () => {
 
   describe('post', () => {
     describe('when entering a valid English service name', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             serviceName: 'New English Name',
@@ -108,7 +108,7 @@ describe('Controller: edit service name', () => {
       })
     })
     describe('when entering a valid Welsh service name', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             serviceName: 'New Welsh Name',
@@ -131,7 +131,7 @@ describe('Controller: edit service name', () => {
 
     describe('when submitting an invalid service name', () => {
       let callContext
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             serviceName: 'this is a really really really long service name that is longer than fifty characters',

--- a/src/controllers/simplified-account/settings/service-name/remove-cy/remove-welsh-service-name.controller.test.js
+++ b/src/controllers/simplified-account/settings/service-name/remove-cy/remove-welsh-service-name.controller.test.js
@@ -29,7 +29,7 @@ const { req, res, call } = new ControllerTestBuilder('@controllers/simplified-ac
   .build()
 
 describe('Controller: remove welsh service name', () => {
-  before(async () => {
+  beforeEach(async () => {
     await call('post')
   })
 

--- a/src/controllers/simplified-account/settings/service-name/service-name.controller.test.js
+++ b/src/controllers/simplified-account/settings/service-name/service-name.controller.test.js
@@ -28,7 +28,7 @@ const { req, res, call, nextResponse } = new ControllerTestBuilder('@controllers
 describe('Controller: service name index', () => {
   describe('get', () => {
     describe('when there are no messages', () => {
-      before(async () => {
+      beforeEach(async () => {
         await call('get')
       })
 
@@ -52,7 +52,7 @@ describe('Controller: service name index', () => {
     })
 
     describe('when there are messages', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextResponse({
           locals: {
             flash: {

--- a/src/controllers/simplified-account/settings/stripe-details/bank-details/bank-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/bank-details/bank-details.controller.test.js
@@ -21,7 +21,7 @@ const getController = (stubs = {}) => {
   })
 }
 
-const setupTest = (method, additionalStubs = {}, additionalResProps = {}, additionalReqProps = {}) => {
+const setupTest = async (method, additionalStubs = {}, additionalResProps = {}, additionalReqProps = {}) => {
   responseStub = sinon.spy()
   updateStripeDetailsBankDetailsStub = sinon.stub().resolves()
   bankDetailsController = getController({
@@ -43,12 +43,12 @@ const setupTest = (method, additionalStubs = {}, additionalResProps = {}, additi
     ...additionalReqProps
   }
   next = sinon.spy()
-  bankDetailsController[method][1](req, res, next)
+  await bankDetailsController[method][1](req, res, next)
 }
 
 describe('Controller: settings/stripe-details/bank-details', () => {
   describe('get', () => {
-    before(() => setupTest('get'))
+    beforeEach(async () => await setupTest('get'))
 
     it('should call the response method', () => {
       expect(responseStub.called).to.be.true
@@ -70,7 +70,7 @@ describe('Controller: settings/stripe-details/bank-details', () => {
     const VALID_SORT_CODE = '309430'
     const VALID_ACCOUNT_NUMBER = '00733445'
     describe('when submitting valid bank details', () => {
-      before(() => setupTest('post', {}, {}, {
+      beforeEach(async () => await setupTest('post', {}, {}, {
         body: {
           sortCode: VALID_SORT_CODE,
           accountNumber: VALID_ACCOUNT_NUMBER
@@ -89,8 +89,8 @@ describe('Controller: settings/stripe-details/bank-details', () => {
 
     describe('when validation fails', () => {
       describe('for empty fields', () => {
-        before(() => {
-          setupTest('post',
+        beforeEach(async () => {
+          await setupTest('post',
             {},
             {},
             { body: { sortCodeInput: '', accountNumberInput: '' } }
@@ -123,8 +123,8 @@ describe('Controller: settings/stripe-details/bank-details', () => {
       })
 
       describe('for invalid sort code format', () => {
-        before(() => {
-          setupTest('post',
+        beforeEach(async () => {
+          await setupTest('post',
             {},
             {},
             { body: { sortCode: 'not-a-valid-sort-code', accountNumber: VALID_ACCOUNT_NUMBER } }
@@ -150,8 +150,8 @@ describe('Controller: settings/stripe-details/bank-details', () => {
       })
 
       describe('for invalid account number format', () => {
-        before(() => {
-          setupTest('post',
+        beforeEach(async () => {
+          await setupTest('post',
             {},
             {},
             { body: { sortCode: VALID_SORT_CODE, accountNumber: 'not-a-valid-account-number' } }
@@ -179,8 +179,8 @@ describe('Controller: settings/stripe-details/bank-details', () => {
 
     describe('when Stripe API returns errors', () => {
       describe('for unusable bank account', () => {
-        before(() => {
-          setupTest('post',
+        beforeEach(async () => {
+          await setupTest('post',
             { updateStripeDetailsBankDetails: sinon.stub().rejects({ code: 'bank_account_unusable' }) },
             {},
             { body: { sortCode: VALID_SORT_CODE, accountNumber: VALID_ACCOUNT_NUMBER } }
@@ -197,8 +197,8 @@ describe('Controller: settings/stripe-details/bank-details', () => {
       })
 
       describe('for invalid sort code', () => {
-        before(() => {
-          setupTest('post',
+        beforeEach(async () => {
+          await setupTest('post',
             { updateStripeDetailsBankDetails: sinon.stub().rejects({ code: 'routing_number_invalid' }) },
             {},
             { body: { sortCode: VALID_SORT_CODE, accountNumber: VALID_ACCOUNT_NUMBER } }
@@ -216,8 +216,8 @@ describe('Controller: settings/stripe-details/bank-details', () => {
       })
 
       describe('for invalid account number', () => {
-        before(() => {
-          setupTest('post',
+        beforeEach(async () => {
+          await setupTest('post',
             { updateStripeDetailsBankDetails: sinon.stub().rejects({ code: 'account_number_invalid' }) },
             {},
             { body: { sortCode: VALID_SORT_CODE, accountNumber: VALID_ACCOUNT_NUMBER } }
@@ -235,8 +235,8 @@ describe('Controller: settings/stripe-details/bank-details', () => {
       })
 
       describe('for unhandled errors with codes', () => {
-        before(() => {
-          setupTest('post',
+        beforeEach(async () => {
+          await setupTest('post',
             { updateStripeDetailsBankDetails: sinon.stub().rejects({ code: 'unhandled_error' }) },
             {},
             { body: { sortCode: VALID_SORT_CODE, accountNumber: VALID_ACCOUNT_NUMBER } }
@@ -250,8 +250,8 @@ describe('Controller: settings/stripe-details/bank-details', () => {
       })
 
       describe('for any other errors', () => {
-        before(() => {
-          setupTest('post',
+        beforeEach(async () => {
+          await setupTest('post',
             { updateStripeDetailsBankDetails: sinon.stub().rejects({ foo: 'bar' }) },
             {},
             { body: { sortCode: VALID_SORT_CODE, accountNumber: VALID_ACCOUNT_NUMBER } }

--- a/src/controllers/simplified-account/settings/stripe-details/company-number/company-number.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/company-number/company-number.controller.test.js
@@ -4,7 +4,7 @@ const paths = require('@root/paths')
 const sinon = require('sinon')
 const { expect } = require('chai')
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockStripeDetailsService = {
   updateStripeDetailsCompanyNumber: sinon.stub().resolves()
 }
@@ -30,8 +30,8 @@ const {
 
 describe('Controller: settings/stripe-details/company-number', () => {
   describe('get', () => {
-    before(() => {
-      call('get', 1)
+    beforeEach(async () => {
+      await call('get', 1)
     })
 
     it('should call the response method', () => {
@@ -95,14 +95,14 @@ describe('Controller: settings/stripe-details/company-number', () => {
 
     validCompanyNumbers.forEach(({ companyNumber, description }) => {
       describe(`when a valid ${description} is submitted`, () => {
-        before(() => {
+        beforeEach(async () => {
           nextRequest({
             body: {
               companyNumberDeclaration: 'yes',
               companyNumber
             }
           })
-          call('post', 1)
+          await call('post', 1)
         })
 
         it('should submit company number to the stripe details service', () => {
@@ -120,13 +120,13 @@ describe('Controller: settings/stripe-details/company-number', () => {
     })
 
     describe('when company number declaration is no', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             companyNumberDeclaration: 'no'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should not submit company number to the stripe details service', () => {
@@ -143,7 +143,7 @@ describe('Controller: settings/stripe-details/company-number', () => {
     })
 
     describe('when the Stripe API returns an error', () => {
-      before(() => {
+      beforeEach(async () => {
         nextStubs({
           '@services/stripe-details.service': {
             updateStripeDetailsCompanyNumber: sinon.stub().rejects({ type: 'StripeInvalidRequestError' })
@@ -155,7 +155,7 @@ describe('Controller: settings/stripe-details/company-number', () => {
             companyNumber: '01234567'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should render the form with appropriate error response', () => {
@@ -164,14 +164,14 @@ describe('Controller: settings/stripe-details/company-number', () => {
     })
 
     describe('when company number validation fails', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             companyNumberDeclaration: 'yes',
             companyNumber: 'what'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should not call the stripe details service', () => {
@@ -198,14 +198,14 @@ describe('Controller: settings/stripe-details/company-number', () => {
     })
 
     describe('when a limited company number is entered without a leading zero', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             companyNumberDeclaration: 'yes',
             companyNumber: '1234567'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should render the form with validation errors', () => {
@@ -217,11 +217,11 @@ describe('Controller: settings/stripe-details/company-number', () => {
     })
 
     describe('when no option is selected', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {}
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should render the form with validation errors', () => {

--- a/src/controllers/simplified-account/settings/stripe-details/director/director.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/director/director.controller.test.js
@@ -4,7 +4,7 @@ const paths = require('@root/paths')
 const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
 const { expect } = require('chai')
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockStripeDetailsService = {
   updateStripeDetailsDirector: sinon.stub().resolves()
 }
@@ -30,8 +30,8 @@ const {
 
 describe('Controller: settings/stripe-details/director', () => {
   describe('get', () => {
-    before(() => {
-      call('get', 1)
+    beforeEach(async () => {
+      await call('get', 1)
     })
 
     it('should call the response method', () => {
@@ -51,7 +51,7 @@ describe('Controller: settings/stripe-details/director', () => {
 
   describe('post', () => {
     describe('when submitting valid data', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             firstName: 'Scrooge',
@@ -62,7 +62,7 @@ describe('Controller: settings/stripe-details/director', () => {
             workEmail: 'scrooge.mcduck@pay.gov.uk'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
       it('should submit director details to the stripe details service', () => {
         expect(mockStripeDetailsService.updateStripeDetailsDirector).to.have.been.calledWith(
@@ -85,7 +85,7 @@ describe('Controller: settings/stripe-details/director', () => {
     })
 
     describe('when submitting invalid data', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             firstName: '',
@@ -96,7 +96,7 @@ describe('Controller: settings/stripe-details/director', () => {
             workEmail: 'scrooge.mcduck'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should not submit director details to the stripe details service', () => {
@@ -132,7 +132,7 @@ describe('Controller: settings/stripe-details/director', () => {
       })
     })
     describe('when the Stripe API returns an error', () => {
-      before(() => {
+      beforeEach(async () => {
         nextStubs({
           '@services/stripe-details.service': {
             updateStripeDetailsDirector: sinon.stub().rejects({ type: 'StripeInvalidRequestError' })
@@ -148,7 +148,7 @@ describe('Controller: settings/stripe-details/director', () => {
             workEmail: 'scrooge.mcduck@pay.gov.uk'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should render the form with appropriate error response', () => {

--- a/src/controllers/simplified-account/settings/stripe-details/government-entity-document/government-entity-document.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/government-entity-document/government-entity-document.controller.test.js
@@ -5,7 +5,7 @@ const ControllerTestBuilder = require('@test/test-helpers/simplified-account/con
 const { expect } = require('chai')
 const paths = require('@root/paths')
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockStripeDetailsService = {
   updateStripeDetailsUploadEntityDocument: sinon.stub().resolves()
 }
@@ -31,8 +31,8 @@ const {
 
 describe('Controller: settings/stripe-details/government-entity-document', () => {
   describe('get', () => {
-    before(() => {
-      call('get', 1)
+    beforeEach(async () => {
+      await call('get', 1)
     })
 
     it('should call the response method', () => {
@@ -52,14 +52,14 @@ describe('Controller: settings/stripe-details/government-entity-document', () =>
   })
   describe('post', () => {
     describe('when uploading a valid file', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           file: {
             size: 10 * 1024 * 1024,
             mimetype: 'image/jpeg'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should submit the file to the stripe details service', () => {
@@ -84,14 +84,14 @@ describe('Controller: settings/stripe-details/government-entity-document', () =>
 
     describe('when submitting invalid data', () => {
       describe('file is too large', () => {
-        before(() => {
+        beforeEach(async () => {
           nextRequest({
             file: {
               size: 11 * 1024 * 1024,
               mimetype: 'image/jpeg'
             }
           })
-          call('post', 1)
+          await call('post', 1)
         })
 
         it('should not submit the file to the stripe details service', () => {
@@ -128,14 +128,14 @@ describe('Controller: settings/stripe-details/government-entity-document', () =>
       })
 
       describe('mimetype is incorrect', () => {
-        before(() => {
+        beforeEach(async () => {
           nextRequest({
             file: {
               size: 10 * 1024 * 1024,
               mimetype: 'application/json'
             }
           })
-          call('post', 1)
+          await call('post', 1)
         })
 
         it('should not submit the file to the stripe details service', () => {
@@ -171,10 +171,10 @@ describe('Controller: settings/stripe-details/government-entity-document', () =>
         })
       })
       describe('file is missing', () => {
-        before(() => {
+        beforeEach(async () => {
           nextRequest({
           })
-          call('post', 1)
+          await call('post', 1)
         })
 
         it('should not submit the file to the stripe details service', () => {
@@ -212,7 +212,7 @@ describe('Controller: settings/stripe-details/government-entity-document', () =>
     })
 
     describe('when the Stripe API returns an error', () => {
-      before(() => {
+      beforeEach(async () => {
         nextStubs({
           '@services/stripe-details.service': {
             updateStripeDetailsUploadEntityDocument: sinon.stub().rejects({ type: 'StripeInvalidRequestError', param: 'file' })
@@ -224,7 +224,7 @@ describe('Controller: settings/stripe-details/government-entity-document', () =>
             mimetype: 'image/jpeg'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should not set message', () => {

--- a/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller.test.js
@@ -4,7 +4,7 @@ const formatSimplifiedAccountPathsFor = require('../../../../../utils/simplified
 const paths = require('@root/paths')
 const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockStripeDetailsService = {
   updateStripeDetailsOrganisationNameAndAddress: sinon.stub().resolves()
 }
@@ -45,8 +45,8 @@ const {
 
 describe('Controller: settings/stripe-details/organisation-details-update', () => {
   describe('get', () => {
-    before(() => {
-      call('get', 1)
+    beforeEach(async () => {
+      await call('get', 1)
     })
 
     it('should call the response method with correct arguments', () => {
@@ -70,7 +70,7 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
 
   describe('post', () => {
     describe('when submitting valid details', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             organisationName: 'Glomgold Industries',
@@ -80,7 +80,7 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             addressCountry: 'CS'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should submit organisation details to the stripe details service', () => {
@@ -103,7 +103,7 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
     })
 
     describe('when submitting invalid details', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             organisationName: '',
@@ -113,7 +113,7 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             addressCountry: 'CS'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should not submit organisation details to the stripe details service', () => {
@@ -160,7 +160,7 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
     })
 
     describe('when address line 2 is present', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             organisationName: 'McDuck Enterprises',
@@ -171,7 +171,7 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             addressCountry: 'CS'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should include additional details when submitting data to stripe details service', () => {

--- a/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details.controller.test.js
@@ -4,7 +4,7 @@ const ControllerTestBuilder = require('@test/test-helpers/simplified-account/con
 const sinon = require('sinon')
 const { expect } = require('chai')
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockStripeDetailsService = {
   updateConnectorStripeProgress: sinon.stub().resolves()
 }
@@ -32,8 +32,8 @@ const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/
 
 describe('Controller: settings/stripe-details/organisation-details', () => {
   describe('get', () => {
-    before(() => {
-      call('get', 1)
+    beforeEach(async () => {
+      await call('get', 1)
     })
 
     it('should call the response method', () => {
@@ -55,13 +55,13 @@ describe('Controller: settings/stripe-details/organisation-details', () => {
 
   describe('post', () => {
     describe('when user selects yes', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             confirmOrgDetails: 'true'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should update progress in connector database', () => {
@@ -78,13 +78,13 @@ describe('Controller: settings/stripe-details/organisation-details', () => {
     })
 
     describe('when user selects no', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             confirmOrgDetails: 'false'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should not update progress in connector database', () => {
@@ -100,13 +100,13 @@ describe('Controller: settings/stripe-details/organisation-details', () => {
     })
 
     describe('when user does not select an option', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             confirmOrgDetails: undefined
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should not redirect', () => {

--- a/src/controllers/simplified-account/settings/stripe-details/responsible-person/responsible-person-check-answers.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/responsible-person/responsible-person-check-answers.controller.test.js
@@ -24,7 +24,7 @@ const getController = (stubs = {}) => {
   })
 }
 
-const setupTest = (method, additionalStubs = {}, additionalResProps = {}, additionalReqProps = {}) => {
+const setupTest = async (method, additionalStubs = {}, additionalResProps = {}, additionalReqProps = {}) => {
   responseStub = sinon.spy()
   updateStripeDetailsResponsiblePersonStub = sinon.stub().resolves()
   responsiblePersonCheckAnswersController = getController({
@@ -47,13 +47,13 @@ const setupTest = (method, additionalStubs = {}, additionalResProps = {}, additi
     ...additionalReqProps
   }
   next = sinon.spy()
-  responsiblePersonCheckAnswersController[method][1](req, res, next)
+  await responsiblePersonCheckAnswersController[method][1](req, res, next)
 }
 
 describe('Controller: settings/stripe-details/responsible-person/responsible-person-check-answers', () => {
   describe('get', () => {
     describe('no existing form state', () => {
-      before(() => setupTest('get'))
+      beforeEach(async () => await setupTest('get'))
 
       it('should redirect the user to the start of the journey', () => {
         expect(res.redirect.calledOnce).to.be.true
@@ -80,7 +80,7 @@ describe('Controller: settings/stripe-details/responsible-person/responsible-per
         workTelephoneNumber: '01611234567',
         workEmail: 'scrooge.mcduck@pay.gov.uk'
       }
-      before(() => setupTest('get', {}, {}, {
+      beforeEach(async () => await setupTest('get', {}, {}, {
         session: {
           formState: {
             responsiblePerson: {
@@ -145,7 +145,7 @@ describe('Controller: settings/stripe-details/responsible-person/responsible-per
     }
 
     describe('when submitting a valid responsible person', () => {
-      before(() => setupTest('post', {}, {}, {
+      beforeEach(async () => await setupTest('post', {}, {}, {
         session: {
           formState: {
             responsiblePerson: validResponsiblePerson
@@ -187,8 +187,8 @@ describe('Controller: settings/stripe-details/responsible-person/responsible-per
 
     describe('when Stripe API returns errors', () => {
       describe('for invalid phone number', () => {
-        before(() => {
-          setupTest('post',
+        beforeEach(async () => {
+          await setupTest('post',
             {
               updateStripeDetailsResponsiblePerson: sinon.stub().rejects({
                 type: 'StripeInvalidRequestError',
@@ -216,8 +216,8 @@ describe('Controller: settings/stripe-details/responsible-person/responsible-per
       })
 
       describe('for unhandled invalid request errors', () => {
-        before(() => {
-          setupTest('post',
+        beforeEach(async () => {
+          await setupTest('post',
             {
               updateStripeDetailsResponsiblePerson: sinon.stub().rejects({
                 type: 'StripeInvalidRequestError',
@@ -245,8 +245,8 @@ describe('Controller: settings/stripe-details/responsible-person/responsible-per
       })
 
       describe('for any other errors', () => {
-        before(() => {
-          setupTest('post',
+        beforeEach(async () => {
+          await setupTest('post',
             {
               updateStripeDetailsResponsiblePerson: sinon.stub().rejects({
                 foo: 'bar'

--- a/src/controllers/simplified-account/settings/stripe-details/responsible-person/responsible-person-contact-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/responsible-person/responsible-person-contact-details.controller.test.js
@@ -20,7 +20,7 @@ const getController = (stubs = {}) => {
   })
 }
 
-const setupTest = (method, additionalStubs = {}, additionalResProps = {}, additionalReqProps = {}) => {
+const setupTest = async (method, additionalStubs = {}, additionalResProps = {}, additionalReqProps = {}) => {
   responseStub = sinon.spy()
   responsiblePersonContactDetailsController = getController({
     response: responseStub,
@@ -41,13 +41,13 @@ const setupTest = (method, additionalStubs = {}, additionalResProps = {}, additi
     ...additionalReqProps
   }
   next = sinon.spy()
-  responsiblePersonContactDetailsController[method][1](req, res, next)
+  await responsiblePersonContactDetailsController[method][1](req, res, next)
 }
 
 describe('Controller: settings/stripe-details/responsible-person-contact-details', () => {
   describe('get', () => {
     describe('no existing form state', () => {
-      before(() => setupTest('get'))
+      beforeEach(async () => setupTest('get'))
 
       it('should call the response method', () => {
         expect(responseStub.called).to.be.true
@@ -65,7 +65,7 @@ describe('Controller: settings/stripe-details/responsible-person-contact-details
       })
     })
     describe('existing form state', () => {
-      before(() => setupTest('get', {}, {}, {
+      beforeEach(async () => setupTest('get', {}, {}, {
         session: {
           formState: {
             responsiblePerson: {
@@ -95,7 +95,7 @@ describe('Controller: settings/stripe-details/responsible-person-contact-details
         workEmail: 'scrooge.mcduck@pay.gov.uk'
       }
 
-      before(() => setupTest('post', {}, {}, {
+      beforeEach(async () => setupTest('post', {}, {}, {
         body: validBody,
         session: {}
       }))
@@ -122,7 +122,7 @@ describe('Controller: settings/stripe-details/responsible-person-contact-details
         workEmail: 'not an email address'
       }
 
-      before(() => setupTest('post', {}, {}, {
+      beforeEach(async () => setupTest('post', {}, {}, {
         body: invalidBody,
         session: {}
       }))
@@ -165,7 +165,7 @@ describe('Controller: settings/stripe-details/responsible-person-contact-details
         }
       }
 
-      before(() => setupTest('post', {}, {}, {
+      beforeEach(async () => setupTest('post', {}, {}, {
         body: validBody,
         session: {
           formState: {

--- a/src/controllers/simplified-account/settings/stripe-details/responsible-person/responsible-person-home-address.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/responsible-person/responsible-person-home-address.controller.test.js
@@ -20,7 +20,7 @@ const getController = (stubs = {}) => {
   })
 }
 
-const setupTest = (method, additionalStubs = {}, additionalResProps = {}, additionalReqProps = {}) => {
+const setupTest = async (method, additionalStubs = {}, additionalResProps = {}, additionalReqProps = {}) => {
   responseStub = sinon.spy()
   responsiblePersonHomeAddressController = getController({
     response: responseStub,
@@ -41,13 +41,13 @@ const setupTest = (method, additionalStubs = {}, additionalResProps = {}, additi
     ...additionalReqProps
   }
   next = sinon.spy()
-  responsiblePersonHomeAddressController[method][1](req, res, next)
+  await responsiblePersonHomeAddressController[method][1](req, res, next)
 }
 
 describe('Controller: settings/stripe-details/responsible-person-home-address', () => {
   describe('get', () => {
     describe('no existing form state', () => {
-      before(() => setupTest('get'))
+      beforeEach(async () => setupTest('get'))
 
       it('should call the response method', () => {
         expect(responseStub.called).to.be.true
@@ -65,7 +65,7 @@ describe('Controller: settings/stripe-details/responsible-person-home-address', 
       })
     })
     describe('existing form state', () => {
-      before(() => setupTest('get', {}, {}, {
+      beforeEach(async () => setupTest('get', {}, {}, {
         session: {
           formState: {
             responsiblePerson: {
@@ -101,7 +101,7 @@ describe('Controller: settings/stripe-details/responsible-person-home-address', 
         homeAddressPostcode: 'SW1A 1AA'
       }
 
-      before(() => setupTest('post', {}, {}, {
+      beforeEach(async () => setupTest('post', {}, {}, {
         body: validBody,
         session: {}
       }))
@@ -132,7 +132,7 @@ describe('Controller: settings/stripe-details/responsible-person-home-address', 
         homeAddressPostcode: 'S123 LOL'
       }
 
-      before(() => setupTest('post', {}, {}, {
+      beforeEach(async () => setupTest('post', {}, {}, {
         body: invalidBody,
         session: {}
       }))
@@ -177,7 +177,7 @@ describe('Controller: settings/stripe-details/responsible-person-home-address', 
         }
       }
 
-      before(() => setupTest('post', {}, {}, {
+      beforeEach(async () => setupTest('post', {}, {}, {
         body: validBody,
         session: {
           formState: {

--- a/src/controllers/simplified-account/settings/stripe-details/responsible-person/responsible-person.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/responsible-person/responsible-person.controller.test.js
@@ -20,7 +20,7 @@ const getController = (stubs = {}) => {
   })
 }
 
-const setupTest = (method, additionalStubs = {}, additionalResProps = {}, additionalReqProps = {}) => {
+const setupTest = async (method, additionalStubs = {}, additionalResProps = {}, additionalReqProps = {}) => {
   responseStub = sinon.spy()
   responsiblePersonController = getController({
     response: responseStub,
@@ -41,13 +41,13 @@ const setupTest = (method, additionalStubs = {}, additionalResProps = {}, additi
     ...additionalReqProps
   }
   next = sinon.spy()
-  responsiblePersonController[method][1](req, res, next)
+  await responsiblePersonController[method][1](req, res, next)
 }
 
 describe('Controller: settings/stripe-details/responsible-person', () => {
   describe('get', () => {
     describe('no existing form state', () => {
-      before(() => setupTest('get'))
+      beforeEach(async () => setupTest('get'))
 
       it('should call the response method', () => {
         expect(responseStub.called).to.be.true
@@ -75,7 +75,7 @@ describe('Controller: settings/stripe-details/responsible-person', () => {
         dobMonth: '09',
         dobYear: '1940'
       }
-      before(() => setupTest('get', {}, {}, {
+      beforeEach(async () => setupTest('get', {}, {}, {
         session: {
           formState: {
             responsiblePerson: {
@@ -111,7 +111,7 @@ describe('Controller: settings/stripe-details/responsible-person', () => {
         dobYear: '1940'
       }
 
-      before(() => setupTest('post', {}, {}, {
+      beforeEach(async () => setupTest('post', {}, {}, {
         body: validBody,
         session: {}
       }))
@@ -146,7 +146,7 @@ describe('Controller: settings/stripe-details/responsible-person', () => {
         dobYear: ''
       }
 
-      before(() => setupTest('post', {}, {}, {
+      beforeEach(async () => setupTest('post', {}, {}, {
         body: invalidBody,
         session: {}
       }))
@@ -200,7 +200,7 @@ describe('Controller: settings/stripe-details/responsible-person', () => {
         }
       }
 
-      before(() => setupTest('post', {}, {}, {
+      beforeEach(async () => setupTest('post', {}, {}, {
         body: validBody,
         session: {
           formState: {

--- a/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.test.js
@@ -10,7 +10,7 @@ const CredentialState = require('@models/constants/credential-state')
 const ACCOUNT_TYPE = 'test'
 const SERVICE_ID = 'service-id-123abc'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockStripeDetailsService = {
   getStripeAccountOnboardingDetails: sinon.stub().resolves({
     foo: 'bar',
@@ -35,8 +35,8 @@ const {
 describe('Controller: settings/stripe-details', () => {
   describe('getAccountDetails', () => {
     describe('when requesting account details', () => {
-      before(() => {
-        call('getAccountDetails')
+      beforeEach(async () => {
+        await call('getAccountDetails')
       })
       it('should return a json object', () => {
         sinon.assert.calledOnce(mockStripeDetailsService.getStripeAccountOnboardingDetails)
@@ -50,7 +50,7 @@ describe('Controller: settings/stripe-details', () => {
 
   describe('get', () => {
     describe('when there are outstanding tasks', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           gatewayAccountStripeProgress: new StripeAccountSetup(
             buildGetStripeAccountSetupResponse({
@@ -58,7 +58,7 @@ describe('Controller: settings/stripe-details', () => {
             })
           )
         })
-        call('get')
+        await call('get')
       })
 
       it('should call the response method', () => {
@@ -102,7 +102,7 @@ describe('Controller: settings/stripe-details', () => {
     })
 
     describe('when messages are available', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           gatewayAccountStripeProgress: new StripeAccountSetup(
             buildGetStripeAccountSetupResponse()
@@ -115,7 +115,7 @@ describe('Controller: settings/stripe-details', () => {
             }
           }
         })
-        call('get')
+        await call('get')
       })
 
       it('should pass messages to the response method', () => {
@@ -124,7 +124,7 @@ describe('Controller: settings/stripe-details', () => {
     })
 
     describe('when all tasks are complete', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           gatewayAccountStripeProgress: new StripeAccountSetup(
             buildGetStripeAccountSetupResponse({
@@ -141,7 +141,7 @@ describe('Controller: settings/stripe-details', () => {
             noscript: 'true'
           }
         })
-        call('get')
+        await call('get')
       })
       it('should set incompleteTasks to false', () => {
         expect(mockResponse.args[0][3]).to.have.property('incompleteTasks').to.equal(false)
@@ -158,7 +158,7 @@ describe('Controller: settings/stripe-details', () => {
       })
     })
     describe('when account is switching providers', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           gatewayAccountStripeProgress: new StripeAccountSetup(
             buildGetStripeAccountSetupResponse({
@@ -177,7 +177,7 @@ describe('Controller: settings/stripe-details', () => {
               .withState(CredentialState.CREATED)
           }
         })
-        call('get')
+        await call('get')
       })
 
       it('should render response with answers', () => {

--- a/src/controllers/simplified-account/settings/stripe-details/vat-number/vat-number.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/vat-number/vat-number.controller.test.js
@@ -4,7 +4,7 @@ const paths = require('@root/paths')
 const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
 const { expect } = require('chai')
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockStripeDetailsService = {
   updateStripeDetailsVatNumber: sinon.stub().resolves()
 }
@@ -24,21 +24,20 @@ const { req, res, nextRequest, nextStubs, call } = new ControllerTestBuilder('@c
 
 describe('Controller: settings/stripe-details/vat-number', () => {
   describe('get', () => {
-    before(() => {
-      call('get', 1)
-    })
-
-    it('should call the response method', () => {
+    it('should call the response method',  async () => {
+      await call('get', 1)
       expect(mockResponse.called).to.be.true
     })
 
-    it('should pass req, res and template path to the response method', () => {
+    it('should pass req, res and template path to the response method', async () => {
+      await call('get', 1)
       expect(mockResponse.args[0][0]).to.deep.equal(req)
       expect(mockResponse.args[0][1]).to.deep.equal(res)
       expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/stripe-details/vat-number/index')
     })
 
-    it('should pass context data to the response method', () => {
+    it('should pass context data to the response method', async () => {
+      await call('get', 1)
       expect(mockResponse.args[0][3]).to.have.property('backLink').to.equal(STRIPE_DETAILS_INDEX_PATH)
     })
   })
@@ -69,14 +68,14 @@ describe('Controller: settings/stripe-details/vat-number', () => {
 
     validVATNumbers.forEach(({ vatNumber, description }) => {
       describe(`when a valid ${description} is submitted`, () => {
-        before(() => {
+        beforeEach(async () => {
           nextRequest({
             body: {
               vatNumberDeclaration: 'yes',
               vatNumber
             }
           })
-          call('post', 1)
+          await call('post', 1)
         })
 
         it('should submit vat number to the stripe details service', () => {
@@ -92,14 +91,15 @@ describe('Controller: settings/stripe-details/vat-number', () => {
         })
       })
     })
+
     describe('when VAT number declaration is no', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             vatNumberDeclaration: 'no'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should not submit VAT number to the stripe details service', () => {
@@ -116,7 +116,7 @@ describe('Controller: settings/stripe-details/vat-number', () => {
     })
 
     describe('when the Stripe API returns an error', () => {
-      before(() => {
+      beforeEach(async () => {
         nextStubs({
           '@services/stripe-details.service': {
             updateStripeDetailsVatNumber: sinon.stub().rejects({ type: 'StripeInvalidRequestError' })
@@ -128,7 +128,7 @@ describe('Controller: settings/stripe-details/vat-number', () => {
             vatNumber: 'GB123456789'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should render the form with appropriate error response', () => {
@@ -137,14 +137,14 @@ describe('Controller: settings/stripe-details/vat-number', () => {
     })
 
     describe('when VAT number validation fails', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             vatNumberDeclaration: 'yes',
             vatNumber: 'what'
           }
         })
-        call('post', 1)
+        await call('post', 1)
       })
 
       it('should not call the stripe details service', () => {

--- a/src/controllers/simplified-account/settings/switch-psp/make-test-payment/make-test-payment.controller.test.js
+++ b/src/controllers/simplified-account/settings/switch-psp/make-test-payment/make-test-payment.controller.test.js
@@ -21,7 +21,7 @@ const CHARGE_EXTERNAL_ID = 'charge-id-123abc'
 const CHARGE_URL = 'https://payment.gov.uk/blahblahblah'
 const USER_EXTERNAL_ID = 'user-id-123abc'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockChargeService = {
   createCharge: sinon.stub().resolves(
     new Charge(
@@ -79,8 +79,8 @@ const { req, res, next, nextRequest, call } = new ControllerTestBuilder(
 
 describe('Controller: settings/switch-psp/switch-to-worldpay/make-a-test-payment', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
+    beforeEach(async () => {
+      await call('get')
     })
 
     it('should call the response method', () => {
@@ -105,13 +105,13 @@ describe('Controller: settings/switch-psp/switch-to-worldpay/make-a-test-payment
 
   describe('getInbound', () => {
     describe('when payment is successful', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           session: {
             [VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY]: CHARGE_EXTERNAL_ID,
           },
         })
-        call('getInbound')
+        await call('getInbound')
       })
 
       it('should update the credential state', () => {
@@ -139,7 +139,7 @@ describe('Controller: settings/switch-psp/switch-to-worldpay/make-a-test-payment
       })
     })
     describe('when payment is not successful', () => {
-      before(() => {
+      beforeEach(async () => {
         mockChargeService.getCharge.resolves({
           state: {
             status: 'error',
@@ -150,7 +150,7 @@ describe('Controller: settings/switch-psp/switch-to-worldpay/make-a-test-payment
             [VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY]: CHARGE_EXTERNAL_ID,
           },
         })
-        call('getInbound')
+        await call('getInbound')
       })
 
       it('should set error message', () => {
@@ -172,7 +172,7 @@ describe('Controller: settings/switch-psp/switch-to-worldpay/make-a-test-payment
       })
     })
     describe('when there is a problem retrieving the charge', () => {
-      before(() => {
+      beforeEach(async () => {
         const error = new RESTClientError('whoops')
         mockChargeService.getCharge.rejects(error)
         nextRequest({
@@ -180,7 +180,7 @@ describe('Controller: settings/switch-psp/switch-to-worldpay/make-a-test-payment
             [VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY]: CHARGE_EXTERNAL_ID,
           },
         })
-        call('getInbound')
+        await call('getInbound')
       })
       it('should call next with error', () => {
         sinon.assert.notCalled(res.redirect)
@@ -191,7 +191,7 @@ describe('Controller: settings/switch-psp/switch-to-worldpay/make-a-test-payment
       })
     })
     describe('when there is a problem updating the credential', () => {
-      before(() => {
+      beforeEach(async () => {
         const error = new RESTClientError('whoops')
         mockWorldpayDetailsService.updateCredentialState.rejects(error)
         nextRequest({
@@ -199,7 +199,7 @@ describe('Controller: settings/switch-psp/switch-to-worldpay/make-a-test-payment
             [VERIFY_PSP_INTEGRATION_CHARGE_EXTERNAL_ID_KEY]: CHARGE_EXTERNAL_ID,
           },
         })
-        call('getInbound')
+        await call('getInbound')
       })
       it('should call next with error', () => {
         sinon.assert.notCalled(res.redirect)
@@ -212,8 +212,8 @@ describe('Controller: settings/switch-psp/switch-to-worldpay/make-a-test-payment
   })
 
   describe('post', () => {
-    before(() => {
-      call('post')
+    beforeEach(async () => {
+      await call('post')
     })
 
     it('should create a charge via the charge service', () => {
@@ -245,10 +245,10 @@ describe('Controller: settings/switch-psp/switch-to-worldpay/make-a-test-payment
     })
 
     describe('when there is a problem creating the charge', () => {
-      before(() => {
+      beforeEach(async () => {
         const error = new RESTClientError('whoops')
         mockChargeService.createCharge.rejects(error)
-        call('post')
+        await call('post')
       })
 
       it('should call next with error', () => {

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-stripe/switch-to-stripe.controller.test.ts
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-stripe/switch-to-stripe.controller.test.ts
@@ -29,7 +29,7 @@ const ALL_TASKS_COMPLETED_RESPONSE = buildGetStripeAccountSetupResponse({
   organisation_details: true
 })
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockStripeDetailsService = {
   getConnectorStripeAccountSetup: sinon.stub().resolves(new StripeAccountSetup(buildGetStripeAccountSetupResponse())),
 }
@@ -65,19 +65,18 @@ const { req, res, next, nextRequest, nextResponse, call } = new ControllerTestBu
 
 describe('Controller: settings/switch-psp/switch-to-stripe', () => {
   describe('get', () => {
-    before(async () => {
+    it('should call the response method', async () => {
       await call('get')
-    })
-
-    it('should call the response method', () => {
       sinon.assert.calledOnce(mockResponse)
     })
 
-    it('should pass req, res and template path to the response method', () => {
+    it('should pass req, res and template path to the response method', async () => {
+      await call('get')
       sinon.assert.calledWith(mockResponse, req, res, 'simplified-account/settings/switch-psp/switch-to-stripe/index')
     })
 
-    it('should pass the context data to the response method', () => {
+    it('should pass the context data to the response method', async () => {
+      await call('get')
       const context = mockResponse.args[0][3] as object
 
       sinon.assert.match(context, {
@@ -109,7 +108,7 @@ describe('Controller: settings/switch-psp/switch-to-stripe', () => {
     })
 
     describe('when stripe verification is pending', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockStripeDetailsService.getConnectorStripeAccountSetup.resolves(
           new StripeAccountSetup(ALL_TASKS_COMPLETED_RESPONSE)
         )
@@ -151,7 +150,7 @@ describe('Controller: settings/switch-psp/switch-to-stripe', () => {
     })
 
     describe('when stripe verification is successful', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockStripeDetailsService.getConnectorStripeAccountSetup.resolves(
           new StripeAccountSetup(ALL_TASKS_COMPLETED_RESPONSE)
         )
@@ -187,7 +186,7 @@ describe('Controller: settings/switch-psp/switch-to-stripe', () => {
     })
 
     describe('when all tasks are complete', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockStripeDetailsService.getConnectorStripeAccountSetup.resolves(
           new StripeAccountSetup(ALL_TASKS_COMPLETED_RESPONSE)
         )
@@ -215,7 +214,7 @@ describe('Controller: settings/switch-psp/switch-to-stripe', () => {
     })
 
     describe('when messages are available', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextResponse({
           locals: {
             flash: {
@@ -234,7 +233,7 @@ describe('Controller: settings/switch-psp/switch-to-stripe', () => {
 
   describe('post', () => {
     describe('when all tasks are complete', () => {
-      before(async () => {
+      beforeEach(async () => {
         mockStripeDetailsService.getConnectorStripeAccountSetup.resolves(
           new StripeAccountSetup(ALL_TASKS_COMPLETED_RESPONSE)
         )
@@ -281,7 +280,7 @@ describe('Controller: settings/switch-psp/switch-to-stripe', () => {
     })
 
     describe('when all tasks are not complete', () => {
-      before(async () => {
+      beforeEach(async () => {
         await call('post')
       })
 
@@ -303,7 +302,7 @@ describe('Controller: settings/switch-psp/switch-to-stripe', () => {
     })
 
     describe('when there is a problem talking to connector', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           account: {
             getSwitchingCredential: () => {

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/switch-to-worldpay.controller.test.js
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-worldpay/switch-to-worldpay.controller.test.js
@@ -16,7 +16,7 @@ const GenericTaskIdentifiers = require('@models/task-workflows/task-identifiers/
 const TaskStatus = require('@models/constants/task-status')
 const GatewayAccountType = require('@models/gateway-account/gateway-account-type')
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 
 const mockGatewayAccountsService = {
   completePaymentServiceProviderSwitch: sinon.stub().resolves()
@@ -65,15 +65,13 @@ const {
 
 describe('Controller: settings/switch-psp/switch-to-worldpay', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
-    })
-
-    it('should call the response method', () => {
+    it('should call the response method', async () => {
+      await call('get')
       sinon.assert.calledOnce(mockResponse)
     })
 
-    it('should pass req, res and template path to the response method', () => {
+    it('should pass req, res and template path to the response method', async () => {
+      await call('get')
       sinon.assert.calledWith(mockResponse,
         req,
         res,
@@ -81,7 +79,8 @@ describe('Controller: settings/switch-psp/switch-to-worldpay', () => {
       )
     })
 
-    it('should pass the context data to the response method', () => {
+    it('should pass the context data to the response method', async () => {
+      await call('get')
       const context = mockResponse.args[0][3]
       sinon.assert.match(context, {
         messages: [],
@@ -107,7 +106,7 @@ describe('Controller: settings/switch-psp/switch-to-worldpay', () => {
     })
 
     describe('when messages are available', () => {
-      before(() => {
+      beforeEach(async () => {
         nextResponse({
           locals: {
             flash: {
@@ -115,7 +114,7 @@ describe('Controller: settings/switch-psp/switch-to-worldpay', () => {
             }
           }
         })
-        call('get')
+        await call('get')
       })
 
       it('should pass messages to the response method', () => {
@@ -126,7 +125,7 @@ describe('Controller: settings/switch-psp/switch-to-worldpay', () => {
 
   describe('post', () => {
     describe('when all tasks are complete', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           account: {
             getSwitchingCredential: () => {
@@ -139,7 +138,7 @@ describe('Controller: settings/switch-psp/switch-to-worldpay', () => {
             }
           }
         })
-        call('post')
+        await call('post')
       })
 
       it('should call completePspSwitch', () => {
@@ -172,8 +171,8 @@ describe('Controller: settings/switch-psp/switch-to-worldpay', () => {
     })
 
     describe('when all tasks are not complete', () => {
-      before(() => {
-        call('post')
+      beforeEach(async () => {
+        await call('post')
       })
 
       it('should set error message', () => {
@@ -194,7 +193,7 @@ describe('Controller: settings/switch-psp/switch-to-worldpay', () => {
     })
 
     describe('when there is a problem talking to connector', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           account: {
             getSwitchingCredential: () => {
@@ -209,7 +208,7 @@ describe('Controller: settings/switch-psp/switch-to-worldpay', () => {
         })
         const error = new RESTClientError('whoops')
         mockGatewayAccountsService.completePaymentServiceProviderSwitch.rejects(error)
-        call('post')
+        await call('post')
       })
 
       it('should call next with error', () => {

--- a/src/controllers/simplified-account/settings/team-members/change-permission/change-permission.controller.test.js
+++ b/src/controllers/simplified-account/settings/team-members/change-permission/change-permission.controller.test.js
@@ -32,7 +32,7 @@ const viewOnlyUser = new User(userFixtures.validUserResponse(
     }
   }))
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockRenderErrorView = sinon.spy()
 const mockFindByExternalId = sinon.stub()
 const mockUpdateServiceRole = sinon.stub().resolves({})
@@ -50,12 +50,12 @@ const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/
 describe('Controller: settings/team-members/change-permission', () => {
   describe('get', () => {
     describe('success', () => {
-      before(() => {
+      beforeEach(async () => {
         mockFindByExternalId.resolves(viewOnlyUser)
         nextRequest({
           params: { externalUserId: 'user-id-to-change-permission' }
         })
-        call('get')
+        await call('get')
       })
 
       it('should call the response method', () => {
@@ -77,12 +77,12 @@ describe('Controller: settings/team-members/change-permission', () => {
       })
     })
     describe('failure - admin attempts to change own permissions', () => {
-      before(() => {
+      beforeEach(async () => {
         mockFindByExternalId.resolves(adminUser)
         nextRequest({
           params: { externalUserId: 'user-id-for-admin-user' }
         })
-        call('get')
+        await call('get')
       })
 
       it('should call the renderErrorView method', () => {
@@ -93,13 +93,13 @@ describe('Controller: settings/team-members/change-permission', () => {
   })
   describe('post', () => {
     describe('admin user selects a new role for the user', () => {
-      before(() => {
+      beforeEach(async () => {
         mockFindByExternalId.resolves(viewOnlyUser)
         nextRequest({
           params: { externalUserId: 'user-id-to-change-permission' },
           body: { newRole: 'view-and-refund' }
         })
-        call('post')
+        await call('post')
       })
 
       it('should call the update service role method with the new role', () => {
@@ -117,13 +117,13 @@ describe('Controller: settings/team-members/change-permission', () => {
       })
     })
     describe('admin user selects users current role', () => {
-      before(() => {
+      beforeEach(async () => {
         mockFindByExternalId.resolves(viewOnlyUser)
         nextRequest({
           params: { externalUserId: 'user-id-to-change-permission' },
           body: { newRole: 'view-only' }
         })
-        call('post')
+        await call('post')
       })
 
       it('should not attempt to update and should redirect to the team members index page without a notification', () => {
@@ -134,13 +134,13 @@ describe('Controller: settings/team-members/change-permission', () => {
       })
     })
     describe('failure - admin attempts to change own permissions', () => {
-      before(() => {
+      beforeEach(async () => {
         mockFindByExternalId.resolves(adminUser)
         nextRequest({
           params: { externalUserId: 'user-id-for-admin-user' },
           body: { newRole: 'view-and-refund' }
         })
-        call('post')
+        await call('post')
       })
 
       it('should call the renderErrorView method', () => {

--- a/src/controllers/simplified-account/settings/team-members/invite/invite.controller.test.js
+++ b/src/controllers/simplified-account/settings/team-members/invite/invite.controller.test.js
@@ -20,7 +20,7 @@ const adminUser = new User(userFixtures.validUserResponse({
   }
 }))
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockCreateInviteToJoinService = sinon.stub()
 
 const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/team-members/invite/invite.controller')
@@ -35,8 +35,8 @@ const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/
 
 describe('Controller: settings/team-members/invite', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
+    beforeEach(async () => {
+      await call('get')
     })
 
     it('should call the response method', () => {
@@ -58,12 +58,12 @@ describe('Controller: settings/team-members/invite', () => {
 
 describe('post', () => {
   describe('success', () => {
-    before(() => {
+    beforeEach(async () => {
       nextRequest({
         body: { invitedUserEmail: 'user-to-invite@users.gov.uk', invitedUserRole: 'view-only' }
       })
       mockCreateInviteToJoinService.resolves()
-      call('post')
+      await call('post')
     })
 
     it('should call adminusers to send an invite', () => {
@@ -82,12 +82,12 @@ describe('post', () => {
   })
 
   describe('failure - user already in service', () => {
-    before(() => {
+    beforeEach(async () => {
       nextRequest({
         body: { invitedUserEmail: 'user-to-invite@users.gov.uk', invitedUserRole: 'view-only' }
       })
       mockCreateInviteToJoinService.rejects(new RESTClientError(null, 'adminusers', 412))
-      call('post')
+      await call('post')
     })
 
     it('should respond with error message', () => {

--- a/src/controllers/simplified-account/settings/team-members/remove-user/remove-user.controller.test.js
+++ b/src/controllers/simplified-account/settings/team-members/remove-user/remove-user.controller.test.js
@@ -32,7 +32,7 @@ const viewOnlyUser = new User(userFixtures.validUserResponse(
     }
   }))
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockRenderErrorView = sinon.spy()
 const mockFindByExternalId = sinon.stub()
 const mockDelete = sinon.stub().returns({ })
@@ -50,12 +50,12 @@ const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/
 describe('Controller: settings/team-members/remove-user', () => {
   describe('get', () => {
     describe('success', () => {
-      before(() => {
+      beforeEach(async () => {
         mockFindByExternalId.resolves(viewOnlyUser)
         nextRequest({
           params: { externalUserId: 'user-id-to-remove' }
         })
-        call('get')
+        await call('get')
       })
 
       it('should call the response method', () => {
@@ -76,12 +76,12 @@ describe('Controller: settings/team-members/remove-user', () => {
     })
 
     describe('failure - admin attempts to remove self', () => {
-      before(() => {
+      beforeEach(async () => {
         mockFindByExternalId.resolves(adminUser)
         nextRequest({
           params: { externalUserId: 'user-id-for-admin-user' }
         })
-        call('get')
+        await call('get')
       })
 
       it('should call the renderErrorView method', () => {
@@ -93,13 +93,13 @@ describe('Controller: settings/team-members/remove-user', () => {
 
   describe('post', () => {
     describe('admin user confirmed remove user', () => {
-      before(() => {
+      beforeEach(async () => {
         mockFindByExternalId.resolves(adminUser)
         nextRequest({
           params: { externalUserId: 'user-id-to-remove' },
           body: { email: 'user-to-remove@users.gov.uk', confirmRemoveUser: 'yes' }
         })
-        call('post')
+        await call('post')
       })
 
       it('should remove the user from the service', () => {
@@ -118,13 +118,13 @@ describe('Controller: settings/team-members/remove-user', () => {
     })
 
     describe('admin user selected not to remove user', () => {
-      before(() => {
+      beforeEach(async () => {
         mockFindByExternalId.resolves(viewOnlyUser)
         nextRequest({
           params: { externalUserId: 'user-id-to-remove' },
           body: { email: 'user-to-remove@users.gov.uk', confirmRemoveUser: 'no' }
         })
-        call('post')
+        await call('post')
       })
 
       it('should redirect to the team members page without deleting the user', () => {
@@ -135,13 +135,13 @@ describe('Controller: settings/team-members/remove-user', () => {
     })
 
     describe('admin user attempted to remove self', () => {
-      before(() => {
+      beforeEach(async () => {
         mockFindByExternalId.resolves(adminUser)
         nextRequest({
           params: { externalUserId: 'user-id-for-admin-user' },
           body: { email: 'admin-user@users.gov.uk', confirmRemoveUser: 'yes' }
         })
-        call('post')
+        await call('post')
       })
 
       it('should call the renderErrorView method', () => {

--- a/src/controllers/simplified-account/settings/team-members/team-members.controller.test.js
+++ b/src/controllers/simplified-account/settings/team-members/team-members.controller.test.js
@@ -33,7 +33,7 @@ const invitedUsers = [
   { email: 'invited-view-only-user@user.gov.uk', role: 'view-only' }
 ]
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockGetServiceUsers = sinon.stub().resolves(users)
 const mockGetInvitedUsers = sinon.stub().resolves(invitedUsers)
 
@@ -50,11 +50,11 @@ const { res, nextRequest, call } = new ControllerTestBuilder('@controllers/simpl
 
 describe('Controller: settings/team-members', () => {
   describe('get', () => {
-    before(() => {
+    beforeEach(async () => {
       nextRequest({
         user: adminUser
       })
-      call('get')
+      await call('get')
     })
 
     it('should call the response method', () => {
@@ -88,11 +88,11 @@ describe('Controller: settings/team-members', () => {
   })
 
   describe('get', () => {
-    before(() => {
+    beforeEach(async () => {
       nextRequest({
         user: adminUser
       })
-      call('get')
+      await call('get')
     })
 
     it('should call the response method', () => {

--- a/src/controllers/simplified-account/settings/webhooks/create/create.controller.test.js
+++ b/src/controllers/simplified-account/settings/webhooks/create/create.controller.test.js
@@ -7,7 +7,7 @@ const { RESTClientError } = require('@govuk-pay/pay-js-commons/lib/utils/axios-b
 const ACCOUNT_TYPE = 'test'
 const SERVICE_EXTERNAL_ID = 'service-id-123abc'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockCreateWebhook = sinon.stub().resolves({})
 const mockCreateWebhookDomainNotAllowed = sinon.stub().rejects(new RESTClientError(null, 'webhooks', 400, 'CALLBACK_URL_NOT_ON_ALLOW_LIST'))
 
@@ -23,8 +23,8 @@ const { req, res, call, nextRequest, nextStubs } = new ControllerTestBuilder('@c
 
 describe('Controller: settings/webhooks', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
+    beforeEach(async () => {
+      await call('get')
     })
 
     it('should call the response method', () => {
@@ -45,7 +45,7 @@ describe('Controller: settings/webhooks', () => {
 
   describe('post', () => {
     describe('success', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             callbackUrl: 'https://www.gov.uk',
@@ -53,7 +53,7 @@ describe('Controller: settings/webhooks', () => {
             subscriptions: 'card_payment_succeeded'
           }
         })
-        call('post')
+        await call('post')
       })
 
       it('should call webhooks to create a webhook', () => {
@@ -67,7 +67,7 @@ describe('Controller: settings/webhooks', () => {
     })
 
     describe('failure - domain not in allow list', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             callbackUrl: 'https://www.gov.uk',
@@ -79,7 +79,7 @@ describe('Controller: settings/webhooks', () => {
           '@utils/response': { response: mockResponse },
           '@services/webhooks.service': { createWebhook: mockCreateWebhookDomainNotAllowed }
         })
-        call('post')
+        await call('post')
       })
 
       it('should respond with error message', () => {

--- a/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.test.js
+++ b/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.test.js
@@ -32,7 +32,7 @@ const webhookMessages = {
     { resource_id: 'payment11' }
   ]
 }
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockGetWebhook = sinon.stub().resolves(webhook)
 const mockGetSigningSecret = sinon.stub().resolves(signingSecret)
 const mockGetWebhookMessages = sinon.stub().resolves(webhookMessages)
@@ -54,7 +54,7 @@ const {
 
 describe('Controller: settings/webhooks/detail', () => {
   describe('get', () => {
-    before(async () => {
+    beforeEach(async () => {
       nextRequest({
         params: { webhookExternalId: WEBHOOK_EXTERNAL_ID }
       })

--- a/src/controllers/simplified-account/settings/webhooks/event/event.controller.test.js
+++ b/src/controllers/simplified-account/settings/webhooks/event/event.controller.test.js
@@ -33,7 +33,7 @@ const attempts = [
     result: '403 Forbidden'
   }
 ]
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockGetWebhookMessage = sinon.stub().resolves(event)
 const mockGetWebhookMessageAttempts = sinon.stub().resolves(attempts)
 
@@ -50,14 +50,14 @@ const { res, nextRequest, call } = new ControllerTestBuilder('@controllers/simpl
 
 describe('Controller: settings/webhooks/event', () => {
   describe('get', () => {
-    before(() => {
+    beforeEach(async () => {
       nextRequest({
         params: { webhookExternalId: WEBHOOK_EXTERNAL_ID, eventId: WEBHOOK_EVENT_EXTERNAL_ID },
         account: {
           externalId: GATEWAY_ACCOUNT_EXTERNAL_ID
         }
       })
-      call('get')
+      await call('get')
     })
 
     it('should call the response method', () => {

--- a/src/controllers/simplified-account/settings/webhooks/toggle/toggle-webhook-status.controller.test.js
+++ b/src/controllers/simplified-account/settings/webhooks/toggle/toggle-webhook-status.controller.test.js
@@ -12,7 +12,7 @@ const testWebhook = new Webhook()
   .withCallbackUrl('https://www.globexcorporation.example.com')
   .withStatus(WebhookStatus.INACTIVE)
   .withDescription('My webhook')
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockToggleWebhookStatus = sinon.stub().resolves({})
 const mockGetWebhook = sinon.stub().resolves(testWebhook)
 
@@ -30,12 +30,12 @@ const { req, res, call, nextRequest } = new ControllerTestBuilder('@controllers/
   .build()
 
 describe('Controller: settings/webhooks/update', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     mockGetWebhook.returns(testWebhook)
   })
 
   describe('get', () => {
-    before(async () => {
+    beforeEach(async () => {
       await call('get')
     })
 
@@ -62,7 +62,7 @@ describe('Controller: settings/webhooks/update', () => {
 
   describe('post', () => {
     describe('when no option is selected', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             toggleActive: ''
@@ -87,7 +87,7 @@ describe('Controller: settings/webhooks/update', () => {
     })
 
     describe('when "yes" is selected', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             toggleActive: 'yes'
@@ -118,7 +118,7 @@ describe('Controller: settings/webhooks/update', () => {
     })
 
     describe('when "no" is selected', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             toggleActive: 'no'

--- a/src/controllers/simplified-account/settings/webhooks/update/update-webhook.controller.test.js
+++ b/src/controllers/simplified-account/settings/webhooks/update/update-webhook.controller.test.js
@@ -10,7 +10,7 @@ const GATEWAY_ACCOUNT_ID = '100'
 
 const testWebhook = new Webhook()
   .withCallbackUrl('https://www.globexcorporation.example.com')
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockUpdateWebhook = sinon.stub().resolves({})
 const mockGetWebhook = sinon.stub().resolves(testWebhook)
 const mockUpdateWebhookDomainNotAllowed = sinon.stub().rejects(new RESTClientError(null, 'webhooks', 400, 'CALLBACK_URL_NOT_ON_ALLOW_LIST'))
@@ -30,7 +30,7 @@ const { req, res, call, nextRequest, nextStubs } = new ControllerTestBuilder('@c
 
 describe('Controller: settings/webhooks/update', () => {
   describe('get', () => {
-    before(async () => {
+    beforeEach(async () => {
       await call('get')
     })
 
@@ -60,7 +60,7 @@ describe('Controller: settings/webhooks/update', () => {
 
   describe('post', () => {
     describe('when the updates are valid', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             callbackUrl: 'https://www.compuglobalhypermeganet.example.com',
@@ -82,7 +82,7 @@ describe('Controller: settings/webhooks/update', () => {
     })
 
     describe('when there are validation errors', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             callbackUrl: 'not-a-valid-url',
@@ -110,7 +110,7 @@ describe('Controller: settings/webhooks/update', () => {
     })
 
     describe('when the domain not in the allow list', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             callbackUrl: 'https://www.gov.uk',
@@ -136,7 +136,7 @@ describe('Controller: settings/webhooks/update', () => {
     })
 
     describe('when the callback URL is not https', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             callbackUrl: 'http://www.gov.uk',

--- a/src/controllers/simplified-account/settings/webhooks/webhooks.controller.test.js
+++ b/src/controllers/simplified-account/settings/webhooks/webhooks.controller.test.js
@@ -13,7 +13,7 @@ const webhook = new Webhook()
   .withDescription('This is a description of the webhook')
   .withStatus(WebhookStatus.ACTIVE)
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const mockListWebhooks = sinon.stub().resolves([webhook])
 
 const { req, res, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/webhooks/webhooks.controller')
@@ -29,8 +29,8 @@ const { req, res, call } = new ControllerTestBuilder('@controllers/simplified-ac
 
 describe('Controller: settings/webhooks', () => {
   describe('get', () => {
-    before(() => {
-      call('get')
+    beforeEach(async () => {
+      await call('get')
     })
 
     it('should call the response method', () => {

--- a/src/controllers/simplified-account/settings/worldpay-details/credentials/one-off-customer-initiated.controller.test.ts
+++ b/src/controllers/simplified-account/settings/worldpay-details/credentials/one-off-customer-initiated.controller.test.ts
@@ -23,7 +23,7 @@ const ACCOUNT_CREDENTIAL = {
   },
 }
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 const findCredentialByExternalIdStub = sinon.stub()
 findCredentialByExternalIdStub.returns(ACCOUNT_CREDENTIAL)
 
@@ -53,7 +53,7 @@ const { req, res, nextRequest, call } = new ControllerTestBuilder(
 describe('Controller: settings/worldpay-details/credentials/one-off-customer-initiated', () => {
   describe('get', () => {
     describe('worldpay details journey', () => {
-      before(async () => {
+      beforeEach(async () => {
         await call('get')
       })
 
@@ -90,7 +90,7 @@ describe('Controller: settings/worldpay-details/credentials/one-off-customer-ini
     })
 
     describe('switch psp journey', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           url: `/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/switch-psp/one-off-customer-initiated/${CREDENTIAL_EXTERNAL_ID}`,
         })

--- a/src/controllers/simplified-account/settings/worldpay-details/flex-credentials/worldpay-flex-credentials.controller.test.js
+++ b/src/controllers/simplified-account/settings/worldpay-details/flex-credentials/worldpay-flex-credentials.controller.test.js
@@ -15,7 +15,7 @@ const ACCOUNT_TYPE = 'live'
 const SERVICE_EXTERNAL_ID = 'service123abc'
 const CREDENTIAL_EXTERNAL_ID = 'credential456def'
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 
 const worldpayDetailsServiceStubs = {
   check3dsFlexCredential: sinon.stub().returns(true),
@@ -55,7 +55,7 @@ const { req, res, nextRequest, nextStubs, call } = new ControllerTestBuilder('@c
 describe('Controller: settings/worldpay-details/flex-credentials', () => {
   describe('get', () => {
     describe('switch psp journey', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           url: `/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/switch-psp/flex-credentials`,
         })
@@ -100,7 +100,7 @@ describe('Controller: settings/worldpay-details/flex-credentials', () => {
     })
 
     describe('when credentials have already been set', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         nextRequest({
           account: {
             worldpay3dsFlex: {
@@ -231,7 +231,7 @@ describe('Controller: settings/worldpay-details/flex-credentials', () => {
       })
 
       describe('when submitting valid data', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
           nextRequest({
             body: {
               organisationalUnitId: '5bd9b55e4444761ac0af1c80', // pragma: allowlist secret
@@ -241,7 +241,7 @@ describe('Controller: settings/worldpay-details/flex-credentials', () => {
           })
         })
         describe('when the worldpay credential check fails', () => {
-          beforeEach(() => {
+          beforeEach(async () => {
             nextStubs({
               '@services/worldpay-details.service': {
                 check3dsFlexCredential: sinon.stub().returns(false),
@@ -276,7 +276,7 @@ describe('Controller: settings/worldpay-details/flex-credentials', () => {
         })
 
         describe('when the worldpay credential check passes', () => {
-          beforeEach(() => {
+          beforeEach(async () => {
             nextStubs({
               '@services/worldpay-details.service': worldpayDetailsServiceStubs
             })

--- a/src/controllers/simplified-account/settings/worldpay-details/recurring-customer-initiated-credentials/recurring-customer-initiated-credentials.controller.test.js
+++ b/src/controllers/simplified-account/settings/worldpay-details/recurring-customer-initiated-credentials/recurring-customer-initiated-credentials.controller.test.js
@@ -9,7 +9,7 @@ const paths = require('@root/paths')
 const WorldpayCredential = require('@models/gateway-account-credential/WorldpayCredential.class')
 const GatewayAccountType = require('@models/gateway-account/gateway-account-type')
 const formatServiceAndAccountPathsFor = require('@utils/simplified-account/format/format-service-and-account-paths-for')
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 
 const USERNAME = 'a-username'
 const PASSWORD = 'a-password' // pragma: allowlist secret
@@ -64,7 +64,7 @@ describe('Controller: settings/worldpay-details/recurring-customer-initiated-cre
     describe('when credentials do not exist', () => {
       let thisCall
 
-      before(async () => {
+      beforeEach(async () => {
         thisCall = await call('get')
       })
 
@@ -93,7 +93,7 @@ describe('Controller: settings/worldpay-details/recurring-customer-initiated-cre
     })
     describe('when credentials exist', () => {
       let thisCall
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           account: {
             gatewayAccountCredentials: [
@@ -138,7 +138,7 @@ describe('Controller: settings/worldpay-details/recurring-customer-initiated-cre
     })
 
     describe('switch psp journey', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           url: `/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/switch-psp/recurring-customer-initiated/${CREDENTIAL_EXTERNAL_ID}`,
         })
@@ -197,7 +197,7 @@ describe('Controller: settings/worldpay-details/recurring-customer-initiated-cre
     })
 
     describe('add details journey', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             merchantCode: MERCHANT_CODE,

--- a/src/controllers/simplified-account/settings/worldpay-details/recurring-merchant-initiated-credentials/recurring-merchant-initiated-credentials.controller.test.js
+++ b/src/controllers/simplified-account/settings/worldpay-details/recurring-merchant-initiated-credentials/recurring-merchant-initiated-credentials.controller.test.js
@@ -9,7 +9,7 @@ const PaymentProviders = require('@models/constants/payment-providers')
 const CredentialState = require('@models/constants/credential-state')
 const GatewayAccountType = require('@models/gateway-account/gateway-account-type')
 const formatServiceAndAccountPathsFor = require('@utils/simplified-account/format/format-service-and-account-paths-for')
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 
 const USERNAME = 'a-username'
 const PASSWORD = 'a-password' // pragma: allowlist secret
@@ -61,7 +61,7 @@ describe('Controller: settings/worldpay-details/recurring-merchant-initiated-cre
   describe('get', () => {
     describe('when credentials do not exist', () => {
       let thisCall
-      before(async () => {
+      beforeEach(async () => {
         thisCall = await call('get')
       })
 
@@ -90,7 +90,7 @@ describe('Controller: settings/worldpay-details/recurring-merchant-initiated-cre
     })
     describe('when credentials exist', () => {
       let thisCall
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           account: {
             gatewayAccountCredentials: [
@@ -107,6 +107,7 @@ describe('Controller: settings/worldpay-details/recurring-merchant-initiated-cre
         })
         thisCall = await call('get')
       })
+
       it('should call the response method', () => {
         expect(mockResponse.called).to.be.true
       })
@@ -135,7 +136,7 @@ describe('Controller: settings/worldpay-details/recurring-merchant-initiated-cre
     })
 
     describe('switch psp journey', () => {
-      before(async () => {
+      beforeEach(async () => {
         nextRequest({
           url: `/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/switch-psp/recurring-merchant-initiated/${CREDENTIAL_EXTERNAL_ID}`,
         })
@@ -195,7 +196,7 @@ describe('Controller: settings/worldpay-details/recurring-merchant-initiated-cre
 
 
     describe('add details journey', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         nextRequest({
           body: {
             merchantCode: MERCHANT_CODE,

--- a/src/controllers/simplified-account/settings/worldpay-details/worldpay-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/worldpay-details/worldpay-details.controller.test.js
@@ -10,7 +10,7 @@ const WorldpayTaskIdentifiers = require('@models/task-workflows/task-identifiers
 const TaskStatus = require('@models/constants/task-status')
 const GatewayAccountType = require('@models/gateway-account/gateway-account-type')
 
-const mockResponse = sinon.spy()
+const mockResponse = sinon.stub()
 
 const ACCOUNT_TYPE = GatewayAccountType.LIVE
 const SERVICE_EXTERNAL_ID = 'service123abc'
@@ -37,23 +37,23 @@ const { req, res, call, nextRequest } = new ControllerTestBuilder('@controllers/
   .build()
 
 describe('Controller: settings/worldpay-details', () => {
-  before(async () => {
-    await call('get')
-  })
 
   describe('get', () => {
     describe('for one-off card payments gateway account', () => {
-      it('should call the response method', () => {
+      it('should call the response method', async () => {
+        await call('get')
         expect(mockResponse.called).to.be.true
       })
 
-      it('should pass req, res and template path to the response method', () => {
+      it('should pass req, res and template path to the response method', async () => {
+        await call('get')
         expect(mockResponse.args[0][0]).to.deep.equal(req)
         expect(mockResponse.args[0][1]).to.deep.equal(res)
         expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/worldpay-details/index')
       })
 
-      it('should pass context data to the response method', () => {
+      it('should pass context data to the response method', async () => {
+        await call('get')
         const tasks = [{
           href: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.oneOffCustomerInitiated,
             SERVICE_EXTERNAL_ID, ACCOUNT_TYPE, CREDENTIAL_EXTERNAL_ID),
@@ -73,25 +73,27 @@ describe('Controller: settings/worldpay-details', () => {
     })
 
     describe('for a moto-enabled gateway account', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           account: {
             allowMoto: true
           }
         })
-        call('get')
       })
-      it('should call the response method', () => {
+      it('should call the response method', async () => {
+        await call('get')
         expect(mockResponse.called).to.be.true
       })
 
-      it('should pass req, res and template path to the response method', () => {
+      it('should pass req, res and template path to the response method', async () => {
+        await call('get')
         expect(mockResponse.args[0][0]).to.deep.equal(req)
         expect(mockResponse.args[0][1]).to.deep.equal(res)
         expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/worldpay-details/index')
       })
 
-      it('should pass context data to the response method', () => {
+      it('should pass context data to the response method', async () => {
+        await call('get')
         const tasks = [{
           href: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.oneOffCustomerInitiated,
             SERVICE_EXTERNAL_ID, ACCOUNT_TYPE, CREDENTIAL_EXTERNAL_ID),
@@ -105,26 +107,28 @@ describe('Controller: settings/worldpay-details', () => {
     })
 
     describe('for a recurring card payments gateway account', () => {
-      before(() => {
+      beforeEach(async () => {
         nextRequest({
           account: {
             recurringEnabled: true,
             allowMoto: false
           }
         })
-        call('get')
       })
-      it('should call the response method', () => {
+      it('should call the response method', async () => {
+        await call('get')
         expect(mockResponse.called).to.be.true
       })
 
-      it('should pass req, res and template path to the response method', () => {
+      it('should pass req, res and template path to the response method', async () => {
+        await call('get')
         expect(mockResponse.args[0][0]).to.deep.equal(req)
         expect(mockResponse.args[0][1]).to.deep.equal(res)
         expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/worldpay-details/index')
       })
 
-      it('should pass context data to the response method', () => {
+      it('should pass context data to the response method', async () => {
+        await call('get')
         const tasks = [{
           href: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.worldpayDetails.recurringCustomerInitiated,
             SERVICE_EXTERNAL_ID, ACCOUNT_TYPE, CREDENTIAL_EXTERNAL_ID),

--- a/src/middleware/restrict-to-sandbox-or-stripe-test-account.test.js
+++ b/src/middleware/restrict-to-sandbox-or-stripe-test-account.test.js
@@ -10,7 +10,7 @@ const GatewayAccountType = require('@models/gateway-account/gateway-account-type
 describe('restrict-to-sandbox middleware', () => {
   describe('when a user is using a sandbox account', () => {
     let req, res, next
-    before(done => {
+    beforeEach(done => {
       req = {
         account: {
           paymentProvider: PaymentProviders.SANDBOX,
@@ -31,7 +31,7 @@ describe('restrict-to-sandbox middleware', () => {
 
   describe('when a user is using a Stripe test account', () => {
     let req, res, next
-    before(done => {
+    beforeEach(done => {
       req = {
         account: {
           paymentProvider: PaymentProviders.STRIPE,
@@ -51,7 +51,7 @@ describe('restrict-to-sandbox middleware', () => {
 
   describe('when a user is using a Stripe live account', () => {
     let req, res, next
-    before(() => {
+    beforeEach(() => {
       req = {
         account: {
           paymentProvider: PaymentProviders.WORLDPAY,
@@ -72,7 +72,7 @@ describe('restrict-to-sandbox middleware', () => {
 
   describe('when a user is not using a sandbox account or a Stripe test account', () => {
     let req, res, next
-    before(() => {
+    beforeEach(() => {
       req = {
         account: {
           paymentProvider: PaymentProviders.WORLDPAY,

--- a/src/middleware/restrict-to-switching-account.test.ts
+++ b/src/middleware/restrict-to-switching-account.test.ts
@@ -30,10 +30,6 @@ describe('restrictToSwitchingAccount middleware', () => {
     next = sinon.spy()
   })
 
-  afterEach(() => {
-    sinon.restore()
-  })
-
   describe('when account is switching to stripe', () => {
     it('should call next() without error when switching credential provider is stripe', () => {
       const middleware = restrictToSwitchingAccount(PaymentProviders.STRIPE)

--- a/src/middleware/simplified-account/settings/stripe-account-setup-strategy.middleware.test.js
+++ b/src/middleware/simplified-account/settings/stripe-account-setup-strategy.middleware.test.js
@@ -36,7 +36,7 @@ describe('Middleware: stripeAccountSetupStrategy', () => {
   })
 
   describe('when stripe account setup progress resolution fails', () => {
-    before(() => {
+    beforeEach(() => {
       const error = new RESTClientError('whoops')
       mockStripeDetailsService.getConnectorStripeAccountSetup.rejects(error)
     })

--- a/src/models/user/User.class.test.js
+++ b/src/models/user/User.class.test.js
@@ -8,7 +8,7 @@ const userFixtures = require('@test/fixtures/user.fixtures')
 let user, service, result, permission, role
 
 describe('Class: User', () => {
-  before(() => {
+  beforeEach(() => {
     user = new User(userFixtures.validUserResponse())
     service = user.serviceRoles[0].service
     permission = user.serviceRoles[0].role.permissions[0].name

--- a/test/integration/error-handler.ft.test.js
+++ b/test/integration/error-handler.ft.test.js
@@ -9,7 +9,7 @@ describe('express unhandled error handler', () => {
     const testPath = '/test-error'
     let response, $
 
-    before(done => {
+    beforeEach(done => {
       const { getApp } = proxyquire('@root/server', {
         '@root/routes': {
           bind: (app) => {

--- a/test/integration/feedback/get-index.controller.ft.test.js
+++ b/test/integration/feedback/get-index.controller.ft.test.js
@@ -10,7 +10,7 @@ const paths = require('@root/paths')
 
 describe('Feedback page GET', () => {
   let result, $, session
-  before(done => {
+  beforeEach(done => {
     const user = getUser({
       permissions: [{ name: 'transactions:read' }]
     })

--- a/test/integration/feedback/post-index.controller.ft.test.js
+++ b/test/integration/feedback/post-index.controller.ft.test.js
@@ -16,7 +16,7 @@ const VALID_USER = getUser({
 
 describe('Feedback page POST', () => {
   let result, session, app
-  before('Arrange', () => {
+  beforeEach('Arrange', () => {
     session = getMockSession(VALID_USER)
     app = createAppWithSession(getApp(), session)
 
@@ -25,7 +25,7 @@ describe('Feedback page POST', () => {
       .reply(200)
   })
 
-  before('Act', done => {
+  beforeEach('Act', done => {
     supertest(app)
       .post(paths.feedback)
       .send({

--- a/test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class.js
+++ b/test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class.js
@@ -5,7 +5,7 @@ const proxyquire = require('proxyquire')
 module.exports = class ControllerTestBuilder {
   constructor (controllerPath) {
     this.controllerPath = controllerPath
-    this.next = sinon.spy()
+    this.next = sinon.stub()
     this.req = {
       service: {},
       account: {},
@@ -92,7 +92,6 @@ module.exports = class ControllerTestBuilder {
       nextResponse: this.nextResponse.bind(this),
       nextStubs: this.nextStubs.bind(this),
       call: async (method, index) => {
-        sinon.resetHistory() // ensure fresh mock data for each call
         if (this.nextStubsData) {
           Object.assign(this.stubs, this.nextStubsData) // copy by ref
           controller = Object.assign({}, controller, proxyquire(this.controllerPath, {

--- a/test/test-helpers/test-env.js
+++ b/test/test-helpers/test-env.js
@@ -5,10 +5,12 @@ const sinonChai = require('sinon-chai')
 const chaiAsPromised = require('chai-as-promised')
 const chai = require('chai')
 const nock = require('nock')
+const sinon = require('sinon')
 chai.should()
 chai.use(sinonChai)
 chai.use(chaiAsPromised)
 
 afterEach(() => {
+  sinon.resetHistory()
   nock.cleanAll()
 })


### PR DESCRIPTION
## What

PP-14401

- typescript tests weren't being run by `npm test`. this fixes that
- this also adds a call to `sinon.resetHistory()` after each test. stubs are therefore reset between tests, meaning `beforeEach` must be used in place of `before` in any test setup that affects stubs
- this also requires the use of `sinon` stubs over spies for any mocking which is used in multiple tests (without additional manual cleanup), as `sinon.resetHistory` only resets stubs