### PR TITLE
PP-14352 Improve UI for payment link creation journey - Remove character count

### DIFF
--- a/src/views/simplified-account/services/payment-links/partials/forms/_payment-link-amount.njk
+++ b/src/views/simplified-account/services/payment-links/partials/forms/_payment-link-amount.njk
@@ -28,7 +28,7 @@
   {% endif %}
 
   {% set userProvidedAmountHTML %}
-    {{ govukCharacterCount({
+    {{ govukTextarea({
       id: "amount-hint",
       name: "amountHint",
       value: formValues.amountHint,

--- a/src/views/simplified-account/services/payment-links/partials/forms/_payment-link-reference.njk
+++ b/src/views/simplified-account/services/payment-links/partials/forms/_payment-link-reference.njk
@@ -27,7 +27,7 @@
     }
   }) }}
 
-  {{ govukCharacterCount({
+  {{ govukTextarea({
     id: "reference-hint",
     name: "referenceHint",
     value: formValues.referenceHint,


### PR DESCRIPTION
## What

[PP-**14352**](https://payments-platform.atlassian.net/browse/PP-14352)

With this change, we are changing a couple of components from govukCharacterCount to the simpler govukInput so that we stop showing the number of characters remaining when the user is typing the reference name or the hint for the payment amount.

Further information in Jira.

https://payments-platform.atlassian.net/browse/PP-14352

### How
* start the payment link creation journey
* enter a title
* continue to the reference page
* check the radios items

### Accessibility (views have been added/changed)
<details>
<summary>checklist</summary>
- no changes
</details>

### Before

<img width="1029" height="867" alt="BEFORE-" src="https://github.com/user-attachments/assets/32f0fed0-a4af-4252-9a16-75c2f06e3053" />

### After

<img width="1039" height="872" alt="AFTER -" src="https://github.com/user-attachments/assets/bd435598-699c-4c75-bef4-3dbb37322907" />

