### PR TITLE
PP-14438 Improve payment link creation success banner

### DIFF
--- a/src/controllers/simplified-account/services/payment-links/create/payment-link-review.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/create/payment-link-review.controller.test.ts
@@ -1,6 +1,8 @@
 import ControllerTestBuilder from '@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class'
 import sinon from 'sinon'
 import GatewayAccountType from '@models/gateway-account/gateway-account-type'
+import GatewayAccount from '@models/gateway-account/GatewayAccount.class'
+import { validGatewayAccount } from '@test/fixtures/gateway-account.fixtures'
 import { FROM_REVIEW_QUERY_PARAM, PaymentLinkCreationSession } from './constants'
 import { CreateProductRequest } from '@models/products/CreateProductRequest.class'
 import productTypes from '@utils/product-types'
@@ -242,7 +244,19 @@ describe('controller: services/payment-links/create/payment-link-review', () => 
           flash: req.flash,
           user: {
             email: 'test@example.com'
-          }
+          },
+          service: {
+            name: 'McDuck Enterprises',
+            serviceName: { en: 'McDuck Enterprises', cy: 'Mentrau McDuck' },
+            externalId: SERVICE_EXTERNAL_ID
+          },
+          account: new GatewayAccount(
+            validGatewayAccount({
+              gateway_account_id: GATEWAY_ACCOUNT_ID,
+              external_id: SERVICE_EXTERNAL_ID,
+              type: GatewayAccountType.TEST
+              })
+            )
         })
 
         await call('post')
@@ -281,21 +295,93 @@ describe('controller: services/payment-links/create/payment-link-review', () => 
         sinon.assert.calledWith(mockCreateProduct, expectedCreateProductRequest)
       })
 
-      it('should set success flash message', () => {
+      it('should redirect to payment links index after successful creation', () => {
+        sinon.assert.calledOnce(res.redirect)
+        sinon.assert.calledWith(res.redirect, sinon.match(/payment-links/))
+      })
+
+      it('should set success message informing the user about testing the payment link (test service or live service in Sandbox mode)', () => {
         sinon.assert.calledWith(
           req.flash,
           'messages',
           sinon.match({
             state: 'success',
             icon: '&check;',
-            heading: 'Test Payment Link has been created'
+            heading: 'Test Payment Link has been created',
+            body: sinon.match("test your payment link")
           })
         )
       })
+    })
 
-      it('should redirect to payment links index after successful creation', () => {
-        sinon.assert.calledOnce(res.redirect)
-        sinon.assert.calledWith(res.redirect, sinon.match(/payment-links/))
+    describe('when the user confirms the creation of the payment link for a live service in normal mode', () => {
+      const mockPaymentLink = {
+        name: 'Test Payment Link',
+        links: {
+          pay: {
+            href: 'https://pay-test-link.gov.uk'
+          }
+        }
+      }
+
+      beforeEach(async () => {
+        req.flash.resetHistory()
+        res.redirect.resetHistory()
+        mockCreateProduct.resetHistory()
+        mockCreateProduct.resolves(mockPaymentLink)
+        mockCreatePaymentLinkToken.resetHistory()
+        mockCreatePaymentLinkToken.resolves('big-beautiful-token')
+
+        const sessionData: Partial<PaymentLinkCreationSession> = {
+          paymentLinkTitle: 'Test Payment Link',
+          paymentLinkDescription: 'Test Description',
+          language: 'en',
+          serviceNamePath: 'test-service',
+          productNamePath: 'test-payment-link',
+          paymentReferenceType: 'custom',
+          paymentReferenceLabel: 'Order Number',
+          paymentReferenceHint: 'Enter your order number',
+          paymentLinkAmount: 1500
+        }
+
+        nextRequest({
+          session: {
+            pageData: {
+              createPaymentLink: sessionData,
+            },
+          },
+          flash: req.flash,
+          user: {
+            email: 'test@example.com'
+          },
+          service: {
+            name: 'McDuck Enterprises',
+            serviceName: { en: 'McDuck Enterprises', cy: 'Mentrau McDuck' },
+            externalId: SERVICE_EXTERNAL_ID
+          },
+          account: new GatewayAccount(
+            validGatewayAccount({
+              gateway_account_id: GATEWAY_ACCOUNT_ID,
+              external_id: SERVICE_EXTERNAL_ID,
+              type: GatewayAccountType.LIVE
+              })
+            )
+        })
+
+        await call('post')
+      })
+
+      it('should set success flash message with empty body (live service in normal mode)', () => {
+        sinon.assert.calledWith(
+          req.flash,
+          'messages',
+          sinon.match({
+            state: 'success',
+            icon: '&check;',
+            heading: 'Test Payment Link has been created',
+            body: ''
+          })
+        )
       })
     })
   })

--- a/src/controllers/simplified-account/services/payment-links/create/payment-link-review.controller.ts
+++ b/src/controllers/simplified-account/services/payment-links/create/payment-link-review.controller.ts
@@ -1,6 +1,7 @@
 import { ServiceRequest, ServiceResponse } from '@utils/types/express'
 import { response } from '@utils/response'
 import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
+import GatewayAccountType from '@models/gateway-account/gateway-account-type'
 import paths from '@root/paths'
 import { CREATE_SESSION_KEY, FROM_REVIEW_QUERY_PARAM, PaymentLinkCreationSession } from './constants'
 const PRODUCTS_FRIENDLY_BASE_URI = process.env.PRODUCTS_FRIENDLY_BASE_URI!
@@ -9,7 +10,6 @@ import { createProduct } from '@services/products.service'
 import { CreateProductRequest } from '@models/products/CreateProductRequest.class'
 import { createPaymentLinkToken } from '@services/tokens.service'
 import productTypes from '@utils/product-types'
-import formatServicePathsFor from '@utils/format-service-paths-for'
 
 function get(req: ServiceRequest, res: ServiceResponse) {
   const { service, account } = req
@@ -112,11 +112,10 @@ async function post(req: ServiceRequest, res: ServiceResponse) {
     .withMetadata(pageData.metadata) 
     
   const paymentLink = await createProduct(createProductRequest)
-  const goLiveLink = formatServicePathsFor(paths.service.requestToGoLive.index, req.service.externalId) as string
-  const successBannerBody = `You can <a href="${paymentLink.links.pay.href}/"
-    class="govuk-link govuk-link--no-visited-state" target="_blank">test your payment link</a>.
-    You'll need to create it again if you want to use it when you <a href="${goLiveLink}"
-    class="govuk-link govuk-link--no-visited-state" target="_blank">go live</a>.`
+  const successBannerBody = account.type === GatewayAccountType.TEST ?
+    `You can <a href="${paymentLink.links.pay.href}/"
+        class="govuk-link govuk-link--no-visited-state" target="_blank">test your payment link</a>.`
+      : ''
   req.flash('messages', {
     state: 'success',
     icon: '&check;',


### PR DESCRIPTION
## What

PP-**[14438](https://payments-platform.atlassian.net/browse/PP-14438)**

With this change, we are improving the success banner at payment link
creation, so that it displays an additional message with a link to test the
newly created payment link if the payment link has been created in a test
service or for a live service in sandbox mode.

No message aside from the banner title will be displayed if the service is
live and in normal mode.

Further information in Jira.

https://payments-platform.atlassian.net/browse/PP-14438

### How

- start a payment link creation journey
- get to the review page
- confirm the creation of the payment link
- check that the success banner is appropriate for the type and mode of the account as follows
  - for a test account: "You can test your payment link."
  - for a live account in sandbox mode:  "You can test your payment link."
  - for a live account in normal mode: no message


### Accessibility (views have been added/changed)

Minor change: copy only.

### Test account OR Live account in Sandbox mode
 
<img width="1001" height="525" alt="Sandbox" src="https://github.com/user-attachments/assets/579836f9-79c8-4f43-98e9-df109a50618c" />

### Live account / Normal mode

<img width="646" height="219" alt="Screenshot 2025-09-03 at 14 26 08" src="https://github.com/user-attachments/assets/dc1833d6-db59-4dc6-83bf-d19cb443bef7" />

## Corresponding test cases

<img width="935" height="141" alt="test cases" src="https://github.com/user-attachments/assets/5619e43e-4a08-4cf9-804c-3e8653577629" />




