### PR TITLE
PP-14395 Restrict Welsh service name detour to live accounts only

### DIFF
--- a/src/controllers/simplified-account/services/payment-links/create/payment-link-information.controller.ts
+++ b/src/controllers/simplified-account/services/payment-links/create/payment-link-information.controller.ts
@@ -8,6 +8,7 @@ import { PaymentLinkCreationSession, CREATE_SESSION_KEY, FROM_REVIEW_QUERY_PARAM
 import lodash from 'lodash'
 import slugifyString from '@utils/simplified-account/format/slugify-string'
 import { paymentLinkSchema } from '@utils/simplified-account/validation/payment-link.schema'
+import GatewayAccountType from '@models/gateway-account/gateway-account-type'
 
 const PRODUCTS_FRIENDLY_BASE_URI = process.env.PRODUCTS_FRIENDLY_BASE_URI!
 
@@ -18,7 +19,7 @@ function get(req: ServiceRequest, res: ServiceResponse) {
   const isUsingEnglishServiceName = currentSession.useEnglishServiceName === 'true' || (req.query.useEnglishServiceName as string) === 'true'
 
   // handle case where welsh payment link is selected but no welsh service name is set
-  if (isWelsh && !service.serviceName.cy && !isUsingEnglishServiceName) {
+  if (isWelsh && !service.serviceName.cy && !isUsingEnglishServiceName && account.type !== GatewayAccountType.TEST) {
     return res.redirect(
       formatServiceAndAccountPathsFor(
         paths.simplifiedAccount.paymentLinks.addWelshServiceName,


### PR DESCRIPTION
## What

[PP-**14395**](https://payments-platform.atlassian.net/browse/PP-14395)

With this change, we are completing the work to prevent the creation of
payment links in Welsh for a service whose name has not been set in Welsh
yet.

With a first PR[1], we have introduced a detour when a service admin starts
the payment link creation journey in Welsh, so that they are directed to the
update service name page for the Welsh option before continuing the payment
link creation.

With this commit, we are now activating this feature only for a LIVE service
account in normal mode.

Further information in Jira[2].

[1]
https://github.com/alphagov/pay-selfservice/pull/4718

[2]
https://payments-platform.atlassian.net/browse/PP-14395

### Accessibility (views have been added/changed)

No changes