### PR TITLE
PP-14193 Fix text overflow for long descriptions & URLs

### DIFF
--- a/src/views/simplified-account/services/test-with-your-users/confirm.njk
+++ b/src/views/simplified-account/services/test-with-your-users/confirm.njk
@@ -3,14 +3,19 @@
 {% set servicePageTitle = "Your prototype link" %}
 
 {% block serviceContent %}
-  <h1 class="govuk-heading-l page-title">
-    {{ servicePageTitle }}
-  </h1>
+  <h1 class="govuk-heading-l page-title">{{ servicePageTitle }}</h1>
 
-  <p class="govuk-body">This link will send the user to our payment pages. Use it in a “pay now” button, for example, to integrate it with your prototype.</p>
+  <p class="govuk-body">
+    This link will send the user to our payment pages. Use it in a “pay now” button, for example, to integrate it with
+    your prototype.
+  </p>
 
   {% set prototypeLink %}
-    <p class="govuk-body govuk-!-font-weight-bold"><a class="pay-protototype-link govuk-link" id="prototyping__links-link-create-payment" href="{{prototypeLink}}">{{prototypeLink}}</a></p>
+    <p class="govuk-body govuk-!-font-weight-bold">
+      <a class="pay-protototype-link govuk-link" id="prototyping__links-link-create-payment" href="{{ prototypeLink }}"
+        >{{ prototypeLink }}</a
+      >
+    </p>
   {% endset %}
 
   {{
@@ -22,12 +27,12 @@
   <p class="govuk-body">Links will be saved for as long as you need them in the prototype links tab.</p>
 
   {{
-  govukButton({
-    text: "See prototype links",
-    href: prototypesLink,
-    attributes: {
-      id: "see-prototype-links"
-    }
-  })
+    govukButton({
+      text: "See prototype links",
+      href: prototypesLink,
+      attributes: {
+        id: "see-prototype-links"
+      }
+    })
   }}
 {% endblock %}

--- a/src/views/simplified-account/services/test-with-your-users/create.njk
+++ b/src/views/simplified-account/services/test-with-your-users/create.njk
@@ -3,75 +3,77 @@
 {% set servicePageTitle = "Create a prototype link" %}
 
 {% block serviceContent %}
-  <h1 class="govuk-heading-l page-title">
-    {{ servicePageTitle }}
-  </h1>
+  <h1 class="govuk-heading-l page-title">{{ servicePageTitle }}</h1>
 
   <form method="post" novalidate>
-    <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
-
-    {{ govukInput({
-      name: "description",
-      id: "description",
-      label: {
-        text: "Payment description",
-        classes: "govuk-label--s"
-      },
-      hint: {
-        text: "Tell users what they are paying for"
-      },
-      value: prototypeLinkData.description,
-      spellcheck: true,
-      errorMessage: { text: errors.formErrors['description'] } if errors.formErrors['description'] else false
-    }) }}
-
-    {{ govukInput({
-      name: "paymentAmount",
-      id: "payment-amount",
-      label: {
-        html: "Payment amount <span class='govuk-visually-hidden'>in &pound;</span>",
-        classes: "govuk-label--s"
-      },
-      prefix: {
-        text: "£"
-      },
-      classes: "govuk-input--width-10",
-      attributes: {
-        'data-trim': true,
-        spellcheck: false
-      },
-      value: prototypeLinkData.paymentAmount,
-      errorMessage: { text: errors.formErrors['paymentAmount'] } if errors.formErrors['paymentAmount'] else false
-    }) }}
+    <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}" />
 
     {{
-    govukInput({
-      name: "confirmationPage",
-      id: "confirmation-page",
-      label: {
-        text: "Confirmation page",
-        classes: "govuk-label--s"
-      },
-      hint: {
-        text: "Enter the secure URL users will go to after they have completed the test payment"
-      },
-      type: "url",
-      spellcheck: false,
-      value: prototypeLinkData.confirmationPage,
-      attributes: {
-        "data-trim": true
-      },
-      errorMessage: { text: errors.formErrors['confirmationPage'] } if errors.formErrors['confirmationPage'] else false
-    })
+      govukInput({
+        name: "description",
+        id: "description",
+        label: {
+          text: "Payment description",
+          classes: "govuk-label--s"
+        },
+        hint: {
+          text: "Tell users what they are paying for"
+        },
+        value: prototypeLinkData.description,
+        spellcheck: true,
+        errorMessage: { text: errors.formErrors['description'] } if errors.formErrors['description'] else false
+      })
     }}
 
     {{
-    govukButton({
-      text: "Create prototype link",
-      attributes: {
-        id: "prototyping__links-button-create-prototype-link"
-      }
-    })
+      govukInput({
+        name: "paymentAmount",
+        id: "payment-amount",
+        label: {
+          html: "Payment amount <span class='govuk-visually-hidden'>in &pound;</span>",
+          classes: "govuk-label--s"
+        },
+        prefix: {
+          text: "£"
+        },
+        classes: "govuk-input--width-10",
+        attributes: {
+          'data-trim': true,
+          spellcheck: false
+        },
+        value: prototypeLinkData.paymentAmount,
+        errorMessage: { text: errors.formErrors['paymentAmount'] } if errors.formErrors['paymentAmount'] else false
+      })
+    }}
+
+    {{
+      govukInput({
+        name: "confirmationPage",
+        id: "confirmation-page",
+        label: {
+          text: "Confirmation page",
+          classes: "govuk-label--s"
+        },
+        hint: {
+          text: "Enter the secure URL users will go to after they have completed the test payment"
+        },
+        type: "url",
+        spellcheck: false,
+        value: prototypeLinkData.confirmationPage,
+        attributes: {
+          "data-trim": true
+        },
+        errorMessage: { text: errors.formErrors['confirmationPage'] } if errors.formErrors['confirmationPage'] else false
+      })
+    }}
+
+    {{
+      govukButton({
+        text: "Create prototype link",
+        attributes: {
+          id: "prototyping__links-button-create-prototype-link"
+        }
+      })
     }}
   </form>
 {% endblock %}

--- a/src/views/simplified-account/services/test-with-your-users/index.njk
+++ b/src/views/simplified-account/services/test-with-your-users/index.njk
@@ -1,13 +1,14 @@
 {% extends "simplified-account/services/service-layout.njk" %}
+{% extends "simplified-account/services/service-layout.njk" %}
 
 {% set servicePageTitle = "Test with your users" %}
 
 {% block serviceContent %}
-  <h1 class="govuk-heading-l page-title">
-    {{ servicePageTitle }}
-  </h1>
+  <h1 class="govuk-heading-l page-title">{{ servicePageTitle }}</h1>
 
-  <p class="govuk-body">Create a reusable link to integrate your service prototype with GOV.UK Pay and test with users.</p>
+  <p class="govuk-body">
+    Create a reusable link to integrate your service prototype with GOV.UK Pay and test with users.
+  </p>
 
   {{
     govukButton({
@@ -22,27 +23,30 @@
   <div class="govuk-tabs">
     <ul class="govuk-tabs__list">
       <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-        <a class="govuk-tabs__tab" href="{{ indexLink }}">
-          Mock card numbers
-        </a>
+        <a class="govuk-tabs__tab" href="{{ indexLink }}"> Mock card numbers </a>
       </li>
       <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="{{ prototypesLink }}">
-          Prototype links
-        </a>
+        <a class="govuk-tabs__tab" href="{{ prototypesLink }}"> Prototype links </a>
       </li>
     </ul>
   </div>
 
   <p class="govuk-body">Use this card number to test a successful payment. Don’t use real card numbers.</p>
-    {{
-      govukInsetText({
-        html: '<p class="govuk-!-font-size-24 govuk-!-font-weight-bold">4000<span class="govuk-!-padding-left-3 govuk-!-padding-right-3">0566</span><span class="govuk-!-padding-right-3">5566</span>5556</p>'
-      })
-    }}
+  {{
+    govukInsetText({
+      html: '<p class="govuk-!-font-size-24 govuk-!-font-weight-bold">4000<span class="govuk-!-padding-left-3 govuk-!-padding-right-3">0566</span><span class="govuk-!-padding-right-3">5566</span>5556</p>'
+    })
+  }}
   <p class="govuk-body">
-    You can enter any valid value for the other details. For example, it doesn’t matter what expiry date you enter, but it must be in the future.
+    You can enter any valid value for the other details. For example, it doesn’t matter what expiry date you enter, but
+    it must be in the future.
   </p>
-  <p class="govuk-body">You can also use other card types and see errors. <a class="govuk-link" href="https://docs.payments.service.gov.uk/testing_govuk_pay/#mock-card-numbers-for-testing-purposes">See more card types in our documentation</a>.</p>
-
+  <p class="govuk-body">
+    You can also use other card types and see errors.
+    <a
+      class="govuk-link"
+      href="https://docs.payments.service.gov.uk/testing_govuk_pay/#mock-card-numbers-for-testing-purposes"
+      >See more card types in our documentation</a
+    >.
+  </p>
 {% endblock %}

--- a/src/views/simplified-account/services/test-with-your-users/links.njk
+++ b/src/views/simplified-account/services/test-with-your-users/links.njk
@@ -3,11 +3,11 @@
 {% set servicePageTitle = "Test with your users" %}
 
 {% block serviceContent %}
-  <h1 class="govuk-heading-l page-title">
-    {{ servicePageTitle }}
-  </h1>
+  <h1 class="govuk-heading-l page-title">{{ servicePageTitle }}</h1>
 
-  <p class="govuk-body">Create a reusable link to integrate your service prototype with GOV.UK Pay and test with users.</p>
+  <p class="govuk-body">
+    Create a reusable link to integrate your service prototype with GOV.UK Pay and test with users.
+  </p>
 
   {{
     govukButton({
@@ -22,14 +22,10 @@
   <div class="govuk-tabs">
     <ul class="govuk-tabs__list">
       <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="{{ indexLink }}">
-          Mock card numbers
-        </a>
+        <a class="govuk-tabs__tab" href="{{ indexLink }}"> Mock card numbers </a>
       </li>
       <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-        <a class="govuk-tabs__tab">
-          Prototype links
-        </a>
+        <a class="govuk-tabs__tab"> Prototype links </a>
       </li>
     </ul>
   </div>
@@ -37,7 +33,7 @@
   <h2 id="prototyping__links-header" class="govuk-heading-m">
     {% if products | length === 1 %}
       There is 1 prototype link
-      {% elif products | length > 1 %}
+    {% elif products | length > 1 %}
       There are {{ products | length }} prototype links
     {% else %}
       There are no prototype links
@@ -45,35 +41,42 @@
   </h2>
   <div class="key-list">
     {% for product in products %}
-      <div class="key-list-item prototyping__links-list-item">
-        <h3 class="govuk-heading-s"><a class="govuk-link" href="{{ product.links.pay.href }}">{{ product.links.pay.href }}</a></h3>
+      <div class="key-list-item prototyping__links-list-item break-all">
+        <h3 class="govuk-heading-s">
+          <a class="govuk-link" href="{{ product.links.pay.href }}">{{ product.links.pay.href }}</a>
+        </h3>
         <dl class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-0">
-          <dt class="govuk-!-display-inline-block">
-            Payment description:
-          </dt>
-          <dd class="govuk-!-display-inline-block govuk-!-font-weight-bold govuk-!-margin-left-0 prototyping__links-list-item-description">
+          <dt class="govuk-!-display-inline-block">Payment description:</dt>
+          <dd
+            class="govuk-!-display-inline-block govuk-!-font-weight-bold govuk-!-margin-left-0 prototyping__links-list-item-description"
+          >
             {{ product.name }}
           </dd>
         </dl>
         <dl class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-0">
-          <dt class="govuk-!-display-inline-block">
-            Payment amount:
-          </dt>
-          <dd class="govuk-!-display-inline-block govuk-!-font-weight-bold govuk-!-margin-left-0 prototyping__links-list-item-amount">
+          <dt class="govuk-!-display-inline-block">Payment amount:</dt>
+          <dd
+            class="govuk-!-display-inline-block govuk-!-font-weight-bold govuk-!-margin-left-0 prototyping__links-list-item-amount"
+          >
             {{ product.price | penceToPoundsWithCurrency }}
           </dd>
         </dl>
         <dl class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-0">
-          <dt class="govuk-!-display-inline-block">
-            Success page:
-          </dt>
-          <dd class="govuk-!-display-inline-block govuk-!-font-weight-bold govuk-!-margin-left-0 prototyping__links-list-item-success-page">
+          <dt class="govuk-!-display-inline-block">Success page:</dt>
+          <dd
+            class="govuk-!-display-inline-block govuk-!-font-weight-bold govuk-!-margin-left-0 prototyping__links-list-item-success-page"
+          >
             {{ product.returnUrl }}
           </dd>
         </dl>
-        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-top-3"><a class="govuk-link govuk-link--no-visited-state prototyping__links-list-item-delete-link" href="links/disable/{{ product.externalId }}">Delete prototype link</a></p>
+        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-top-3">
+          <a
+            class="govuk-link govuk-link--no-visited-state prototyping__links-list-item-delete-link"
+            href="links/disable/{{ product.externalId }}"
+            >Delete prototype link</a
+          >
+        </p>
       </div>
     {% endfor %}
   </div>
-
 {% endblock %}


### PR DESCRIPTION
## What

PP-14193

 - fix layout for long payment link descriptions & URLs
 - format nunjucks files with prettier

### Screenshots (views have been added/changed)
<img width="1175" height="1068" alt="Screenshot 2025-09-24 at 14 56 44" src="https://github.com/user-attachments/assets/898cb084-8685-4de3-8564-a5f9e9c55d39" />
