### PR TITLE
BAU Fix text overflow in payment link card title

### DIFF
--- a/src/views/simplified-account/services/payment-links/partials/_index-admin.njk
+++ b/src/views/simplified-account/services/payment-links/partials/_index-admin.njk
@@ -1,62 +1,74 @@
-<h1 class="govuk-heading-l page-title">
-  {{ servicePageTitle }}
-</h1>
+<h1 class="govuk-heading-l page-title">{{ servicePageTitle }}</h1>
 
 {% if products.length > 0 and serviceMode === 'test' %}
-  {{ govukWarningText({
-    text: "Test payment links will not work for paying users. Do not send them to users as they will be unable to pay for your service.",
-    iconFallbackText: "Warning"
-  }) }}
+  {{
+    govukWarningText({
+      text: "Test payment links will not work for paying users. Do not send them to users as they will be unable to pay for your service.",
+      iconFallbackText: "Warning"
+    })
+  }}
 {% endif %}
 
 {% if serviceMode === 'test' %}
-  <p class="govuk-body">You can create test payment links to see how your service will work. You can use
-    {{ "mock card numbers" | docsLink("testing_govuk_pay/#mock-card-numbers-and-email-addresses") | safe }}
-    to test payment links.</p>
+  <p class="govuk-body">
+    You can create test payment links to see how your service will work. You can use
+    {{ "mock card numbers" | docsLink("testing_govuk_pay/#mock-card-numbers-and-email-addresses") | safe }} to test
+    payment links.
+  </p>
   <h2 class="govuk-heading-m">Prefill payment link fields</h2>
-  <p class="govuk-body">You can test prefilling the amount, reference or both for users. Learn
-    {{ "how to create prefilled links" | docsLink("prefill_payment_links") | safe }}.</p>
+  <p class="govuk-body">
+    You can test prefilling the amount, reference or both for users. Learn
+    {{ "how to create prefilled links" | docsLink("prefill_payment_links") | safe }}.
+  </p>
 
   <h2 class="govuk-heading-m">Add metadata for reconciliation and reporting</h2>
-  <p class="govuk-body">You can test adding metadata like cost centre codes or business area to your test payment
-    links.</p>
-
+  <p class="govuk-body">
+    You can test adding metadata like cost centre codes or business area to your test payment links.
+  </p>
 {% else %}
-  <p class="govuk-body">You can create payment links and send them to your users so they can pay you. The
-    same payment link can be used by all users of your service. You can create payment links without any technical
-    knowledge.</p>
+  <p class="govuk-body">
+    You can create payment links and send them to your users so they can pay you. The same payment link can be used by
+    all users of your service. You can create payment links without any technical knowledge.
+  </p>
   <h2 class="govuk-heading-m">Prefill payment link fields</h2>
-  <p class="govuk-body">You can prefill the amount, reference or both for users. Learn
-    {{ "how to create prefilled links" | docsLink("prefill_payment_links") | safe }}.</p>
+  <p class="govuk-body">
+    You can prefill the amount, reference or both for users. Learn
+    {{ "how to create prefilled links" | docsLink("prefill_payment_links") | safe }}.
+  </p>
 
   <h2 class="govuk-heading-m">Add metadata for reconciliation and reporting</h2>
   <p class="govuk-body">You can add metadata like cost centre codes or business area to your payment links.</p>
 {% endif %}
 
-{{ govukAccordion({
-  id: "accordion-default",
-  classes: "disable-accordion-controls",
-  rememberExpanded: false,
-  items: [
-    {
-      heading: {
-      text: "See an example payment link"
-    },
-      content: {
-      html: examplePaymentLink
-    }
-    }
-  ]
-}) }}
+{{
+  govukAccordion({
+    id: "accordion-default",
+    classes: "disable-accordion-controls",
+    rememberExpanded: false,
+    items: [
+      {
+        heading: {
+        text: "See an example payment link"
+      },
+        content: {
+        html: examplePaymentLink
+      }
+      }
+    ]
+  })
+}}
 
 <div class="govuk-button-group">
-  {{ govukButton({
-    text: "Create a " + serviceMode + " payment link",
-    href: createLink
-  }) }}
+  {{
+    govukButton({
+      text: "Create a " + serviceMode + " payment link",
+      href: createLink
+    })
+  }}
 
-  <a class="govuk-link govuk-link--no-visited-state" href="{{ createLink }}?language=cy">Create a {{ serviceMode }}
-    payment link in Welsh</a>
+  <a class="govuk-link govuk-link--no-visited-state" href="{{ createLink }}?language=cy"
+    >Create a {{ serviceMode }} payment link in Welsh</a
+  >
 </div>
 
 {% if products.length > 0 %}
@@ -64,67 +76,69 @@
   {% for product in products %}
     {% set productTitle %}
       {{ product.name }}
-      {% if product.language === 'cy' %}<br><span class="govuk-!-font-weight-regular">(Welsh)</span>{% endif %}
+      {% if product.language === 'cy' %}<br /><span class="govuk-!-font-weight-regular">(Welsh)</span>{% endif %}
     {% endset %}
 
-    {{ govukSummaryList({
-      card: {
-        title: {
-          html: productTitle,
-          headingLevel: 3,
-          classes: "multiline-title"
+    {{
+      govukSummaryList({
+        card: {
+          title: {
+            html: productTitle,
+            headingLevel: 3,
+            classes: "multiline-title break-all"
+          },
+          actions: {
+            items: [
+              {
+                href: product.editLink,
+                text: 'Edit',
+                visuallyHiddenText: 'payment link',
+                classes: "govuk-link govuk-link--no-visited-state"
+              },
+              {
+                href: product.deleteLink,
+                text: 'Delete',
+                visuallyHiddenText: 'payment link',
+                classes: "govuk-link govuk-link--no-visited-state"
+              }
+            ]
+          }
         },
-        actions: {
-          items: [
-            {
-              href: product.editLink,
-              text: 'Edit',
-              visuallyHiddenText: 'payment link',
-              classes: "govuk-link govuk-link--no-visited-state"
-            },
-            {
-              href: product.deleteLink,
-              text: 'Delete',
-              visuallyHiddenText: 'payment link',
-              classes: "govuk-link govuk-link--no-visited-state"
-            }
-          ]
-        }
-      },
-      rows: [
-        {
-          key: {
-          text: 'Web address'
-        },
-          value: {
-          html: '<a href="' + product.href + '" class="govuk-link govuk-link--no-visited-state">' + product.href + '</a>'
-        }
-        },
-        {
-          key: {
-          text: 'Details'
-        },
-          value: {
-          html: product.details
-        }
-        } if product.details,
-        {
-          key: {
-          text: 'Payment reference'
-        },
-          value: {
-          text: product.reference
-        }
-        },
-        {
-          key: {
-          text: 'Payment amount'
-        },
-          value: {
-          text: product.amount
-        }
-        }
-      ]
-    }) }}
+        rows: [
+          {
+            key: {
+            text: 'Web address'
+          },
+            value: {
+            html: '<a href="' + product.href + '" class="govuk-link govuk-link--no-visited-state">' + product.href + '</a>'
+          }
+          },
+          {
+            key: {
+            text: 'Details'
+          },
+            value: {
+            html: product.details
+          }
+          } if product.details,
+          {
+            key: {
+            text: 'Payment reference'
+          },
+            value: {
+            text: product.reference
+          }
+          },
+          {
+            key: {
+            text: 'Payment amount'
+          },
+            value: {
+            text: product.amount
+          }
+          }
+        ]
+      })
+    }}
   {% endfor %}
 {% endif %}


### PR DESCRIPTION
## What

 - fix text overflow in payment link card titke

before:
<img width="1101" height="614" alt="Screenshot 2025-09-25 at 11 21 23" src="https://github.com/user-attachments/assets/9c286f9e-daf3-49cf-9a49-5ca7292b5cd1" />

after:
<img width="670" height="660" alt="Screenshot 2025-09-25 at 12 30 35" src="https://github.com/user-attachments/assets/39d891fa-ba4e-4386-a234-fc77eaed359b" />
