### PR TITLE
PP-14549 - Add Website address is already taken screen

### DIFF
--- a/src/controllers/simplified-account/services/payment-links/create/constants.ts
+++ b/src/controllers/simplified-account/services/payment-links/create/constants.ts
@@ -1,3 +1,6 @@
+import { ServiceRequest } from '@utils/types/express'
+import lodash from 'lodash'
+
 export interface PaymentLinkCreationSession {
   paymentLinkTitle: string
   paymentLinkDescription?: string
@@ -18,3 +21,16 @@ export interface PaymentLinkCreationSession {
 
 export const CREATE_SESSION_KEY = 'session.pageData.createPaymentLink'
 export const FROM_REVIEW_QUERY_PARAM = 'fromReview'
+
+export function getSession<T>(
+  req: ServiceRequest<T>,
+  defaultValue: PaymentLinkCreationSession
+): PaymentLinkCreationSession
+export function getSession<T>(req: ServiceRequest<T>): PaymentLinkCreationSession
+
+export function getSession<T>(
+  req: ServiceRequest<T>,
+  defaultValue?: PaymentLinkCreationSession
+): PaymentLinkCreationSession {
+  return lodash.get(req, CREATE_SESSION_KEY, defaultValue ?? ({} as PaymentLinkCreationSession))
+}

--- a/src/controllers/simplified-account/services/payment-links/create/index.ts
+++ b/src/controllers/simplified-account/services/payment-links/create/index.ts
@@ -1,15 +1,9 @@
 import * as information from './payment-link-information.controller'
+import * as existingPaymentLink from '../existing/check-payment-link-exists.controller'
 import * as addWelshServiceName from './payment-link-add-welsh-service-name.controller'
 import * as reference from './payment-link-reference.controller'
 import * as amount from './payment-link-amount.controller'
 import * as review from './payment-link-review.controller'
 import * as metadata from './metadata'
 
-export {
-  information,
-  reference,
-  amount,
-  review,
-  addWelshServiceName,
-  metadata
-}
+export { information, reference, amount, review, addWelshServiceName, existingPaymentLink, metadata }

--- a/src/controllers/simplified-account/services/payment-links/existing/check-payment-link-exists.controller.test.ts
+++ b/src/controllers/simplified-account/services/payment-links/existing/check-payment-link-exists.controller.test.ts
@@ -1,0 +1,354 @@
+import ControllerTestBuilder from '@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class'
+import sinon from 'sinon'
+import GatewayAccountType from '@models/gateway-account/gateway-account-type'
+import { PaymentLinkCreationSession } from '@controllers/simplified-account/services/payment-links/create/constants'
+
+const SERVICE_EXTERNAL_ID = 'service123abc'
+const GATEWAY_ACCOUNT_ID = 117
+const GATEWAY_ACCOUNT_EXTERNAL_ID = 'account123abc'
+
+const mockResponse = sinon.stub()
+
+const { nextRequest, call, res } = new ControllerTestBuilder(
+  '@controllers/simplified-account/services/payment-links/existing/check-payment-link-exists.controller'
+)
+  .withStubs({
+    '@utils/response': { response: mockResponse },
+  })
+  .withAccount({
+    id: GATEWAY_ACCOUNT_ID,
+    externalId: GATEWAY_ACCOUNT_EXTERNAL_ID,
+    type: GatewayAccountType.TEST,
+  })
+  .withService({
+    name: 'McDuck Enterprises',
+    serviceName: { en: 'McDuck Enterprises', cy: 'Mentrau McDuck' },
+    externalId: SERVICE_EXTERNAL_ID,
+  })
+  .build()
+
+describe('controller: services/payment-links/existing/check-payment-link-exists', () => {
+  describe('get', () => {
+    describe('with valid session data', () => {
+      beforeEach(async () => {
+        mockResponse.resetHistory()
+        const sessionData: Partial<PaymentLinkCreationSession> = {
+          paymentLinkTitle: 'My Link',
+          productNamePath: 'my-link',
+        }
+        nextRequest({
+          session: {
+            pageData: {
+              createPaymentLink: sessionData,
+            },
+          },
+        })
+        await call('get')
+      })
+
+      it('should call the response method', () => {
+        sinon.assert.calledOnce(mockResponse)
+      })
+
+      it('should pass correct template path', () => {
+        sinon.assert.calledWith(
+          mockResponse,
+          sinon.match.any,
+          sinon.match.any,
+          'simplified-account/services/payment-links/create/check-payment-link'
+        )
+      })
+
+      it('should set form values from session', () => {
+        const context = mockResponse.args[0][3] as Record<string, unknown>
+        const formValues = context.formValues as { link: string }
+        sinon.assert.match(formValues, { paymentLink: 'My Link' })
+      })
+    })
+
+    describe('with service missing name', () => {
+      beforeEach(async () => {
+        mockResponse.resetHistory()
+        nextRequest({
+          service: {
+            externalId: SERVICE_EXTERNAL_ID,
+            gatewayAccountIds: ['acc1'],
+            serviceName: { cy: 'Mentrau McDuck' },
+          },
+          session: {
+            pageData: {
+              createPaymentLink: {
+                paymentLinkTitle: 'No Name Link',
+                productNamePath: 'no-name-link',
+              },
+            },
+          },
+        })
+        await call('get')
+      })
+
+      it('should render with a fallback service name', () => {
+        const context = mockResponse.args[0][3] as Record<string, unknown>
+        sinon.assert.match(context.service, 'McDuck Enterprises')
+      })
+    })
+
+    describe('with Welsh language selected', () => {
+      beforeEach(async () => {
+        mockResponse.resetHistory()
+        const sessionData: Partial<PaymentLinkCreationSession> = {
+          paymentLinkTitle: 'Welsh Link',
+          productNamePath: 'welsh-link',
+        }
+        nextRequest({
+          session: {
+            pageData: {
+              createPaymentLink: sessionData,
+            },
+          },
+          query: { language: 'cy' },
+        })
+        await call('get')
+      })
+
+      it('should set isWelsh to true and use Welsh service name', () => {
+        const context = mockResponse.args[0][3] as Record<string, unknown>
+        sinon.assert.match(context.isWelsh, true)
+        sinon.assert.match(context.service, 'Mentrau McDuck')
+      })
+    })
+
+    describe('with missing session data', () => {
+      beforeEach(async () => {
+        mockResponse.resetHistory()
+        nextRequest({
+          session: {},
+        })
+        await call('get')
+      })
+
+      it('should redirect to index', () => {
+        sinon.assert.calledOnce(res.redirect)
+        sinon.assert.calledWith(res.redirect, sinon.match(/payment-links/))
+      })
+    })
+    describe('with unexpected account type', () => {
+      beforeEach(async () => {
+        mockResponse.resetHistory()
+        nextRequest({
+          account: {
+            id: GATEWAY_ACCOUNT_ID,
+            externalId: GATEWAY_ACCOUNT_EXTERNAL_ID,
+            type: 'UNKNOWN_TYPE',
+          },
+          session: {
+            pageData: {
+              createPaymentLink: {
+                paymentLinkTitle: 'Edge Link',
+                productNamePath: 'edge-link',
+              },
+            },
+          },
+        })
+        await call('get')
+      })
+
+      it('should not throw and render the page', () => {
+        sinon.assert.calledOnce(mockResponse)
+        sinon.assert.calledWith(
+          mockResponse,
+          sinon.match.any,
+          sinon.match.any,
+          'simplified-account/services/payment-links/create/check-payment-link'
+        )
+      })
+    })
+
+    describe('with malformed session data', () => {
+      beforeEach(async () => {
+        mockResponse.resetHistory()
+        nextRequest({
+          session: {
+            pageData: {
+              // createPaymentLink is missing required fields
+              createPaymentLink: {},
+            },
+          },
+        })
+        await call('get')
+      })
+
+      it('should redirect to index', () => {
+        sinon.assert.calledOnce(res.redirect)
+        sinon.assert.calledWith(res.redirect, sinon.match(/payment-links/))
+      })
+    })
+  })
+
+  describe('post', () => {
+    describe('with valid form data', () => {
+      beforeEach(async () => {
+        res.redirect.resetHistory()
+        const sessionData: Partial<PaymentLinkCreationSession> = {
+          paymentLinkTitle: 'Valid Link',
+          productNamePath: 'valid-link',
+          serviceNamePath: 'Valid Service Link',
+        }
+        nextRequest({
+          session: {
+            pageData: {
+              createPaymentLink: sessionData,
+            },
+          },
+          body: {
+            paymentLink: 'Valid Link',
+          },
+        })
+        await call('post')
+      })
+
+      it('should redirect to reference page', () => {
+        sinon.assert.calledOnce(res.redirect)
+        sinon.assert.calledWith(res.redirect, sinon.match(/payment-links.*reference/))
+      })
+    })
+
+    describe('with validation errors (empty link)', () => {
+      beforeEach(async () => {
+        mockResponse.resetHistory()
+        res.redirect.resetHistory()
+        const sessionData: Partial<PaymentLinkCreationSession> = {
+          paymentLinkTitle: '',
+          productNamePath: '',
+        }
+        nextRequest({
+          session: {
+            pageData: {
+              createPaymentLink: sessionData,
+            },
+          },
+          body: {
+            paymentLink: '',
+          },
+        })
+        await call('post')
+      })
+
+      it('should render the form with errors', () => {
+        sinon.assert.calledOnce(mockResponse)
+        sinon.assert.calledWith(
+          mockResponse,
+          sinon.match.any,
+          sinon.match.any,
+          'simplified-account/services/payment-links/create/check-payment-link'
+        )
+      })
+
+      it('should not redirect', () => {
+        sinon.assert.notCalled(res.redirect)
+      })
+    })
+
+    describe('with missing session data', () => {
+      beforeEach(async () => {
+        res.redirect.resetHistory()
+        nextRequest({
+          session: {},
+          body: {
+            paymentLink: 'Any Link',
+          },
+        })
+        await call('post')
+      })
+
+      it('should redirect to index', () => {
+        sinon.assert.calledOnce(res.redirect)
+        sinon.assert.calledWith(res.redirect, sinon.match(/payment-links/))
+      })
+    })
+    describe('with unexpected account type', () => {
+      beforeEach(async () => {
+        res.redirect.resetHistory()
+        nextRequest({
+          account: {
+            id: GATEWAY_ACCOUNT_ID,
+            externalId: GATEWAY_ACCOUNT_EXTERNAL_ID,
+            type: 'UNKNOWN_TYPE',
+          },
+          session: {
+            pageData: {
+              createPaymentLink: {
+                paymentLinkTitle: 'Edge Link',
+                productNamePath: 'edge-link',
+              },
+            },
+          },
+          body: {
+            paymentLink: 'Edge Link',
+          },
+        })
+        await call('post')
+      })
+
+      it('should not throw and redirect to reference page', () => {
+        sinon.assert.calledOnce(res.redirect)
+        sinon.assert.calledWith(res.redirect, sinon.match(/payment-links.*reference/))
+      })
+    })
+
+    describe('with malformed session data', () => {
+      beforeEach(async () => {
+        res.redirect.resetHistory()
+        nextRequest({
+          session: {
+            pageData: {
+              // createPaymentLink is missing required fields
+              createPaymentLink: {},
+            },
+          },
+          body: {
+            paymentLink: 'Malformed Link',
+          },
+        })
+        await call('post')
+      })
+
+      it('should redirect to index', () => {
+        sinon.assert.calledOnce(res.redirect)
+        sinon.assert.calledWith(res.redirect, sinon.match(/payment-links/))
+      })
+    })
+
+    describe('with PRODUCTS_FRIENDLY_BASE_URI unset', () => {
+      let originalEnv: string | undefined
+      beforeEach(async () => {
+        res.redirect.resetHistory()
+        originalEnv = process.env.PRODUCTS_FRIENDLY_BASE_URI
+        delete process.env.PRODUCTS_FRIENDLY_BASE_URI
+        const sessionData: Partial<PaymentLinkCreationSession> = {
+          paymentLinkTitle: 'No Env Link',
+          productNamePath: 'no-env-link',
+        }
+        nextRequest({
+          session: {
+            pageData: {
+              createPaymentLink: sessionData,
+            },
+          },
+          body: {
+            paymentLink: 'No Env Link',
+          },
+        })
+        await call('post')
+      })
+      afterEach(() => {
+        process.env.PRODUCTS_FRIENDLY_BASE_URI = originalEnv
+      })
+
+      it('should not throw and redirect to reference page', () => {
+        sinon.assert.calledOnce(res.redirect)
+        sinon.assert.calledWith(res.redirect, sinon.match(/payment-links.*reference/))
+      })
+    })
+  })
+})

--- a/src/controllers/simplified-account/services/payment-links/existing/check-payment-link-exists.controller.ts
+++ b/src/controllers/simplified-account/services/payment-links/existing/check-payment-link-exists.controller.ts
@@ -1,0 +1,134 @@
+import { ServiceRequest, ServiceResponse } from '@utils/types/express'
+import { response } from '@utils/response'
+import lodash from 'lodash'
+import paths from '@root/paths'
+import slugifyString from '@utils/simplified-account/format/slugify-string'
+import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
+import { ValidationChain, validationResult } from 'express-validator'
+import formatValidationErrors from '../../../../../utils/simplified-account/format/format-validation-errors'
+import { paymentLinkSchema } from '@utils/simplified-account/validation/payment-link.schema'
+import {
+  CREATE_SESSION_KEY,
+  getSession,
+  PaymentLinkCreationSession,
+} from '@controllers/simplified-account/services/payment-links/create/constants'
+import { isWelshSelected } from '@utils/simplified-account/is-welsh'
+import type Service from '@models/service/Service.class'
+import type GatewayAccount from '@models/gateway-account/GatewayAccount.class'
+
+const FRIENDLY_URL = String(process.env.PRODUCTS_FRIENDLY_BASE_URI)
+
+function get(req: ServiceRequest, res: ServiceResponse) {
+  const sessionInfo = extractSessionInfo(req, res)
+  if (!sessionInfo) return
+  const { service, account, session } = sessionInfo
+  const isWelsh = isWelshSelected(req)
+
+  renderPage(req, res, getRenderOptions(service, account, session, isWelsh))
+}
+
+async function post(req: ServiceRequest, res: ServiceResponse) {
+  const sessionInfo = extractSessionInfo(req, res)
+  if (!sessionInfo) return
+  const { service, account, session } = sessionInfo
+  const isWelsh = isWelshSelected(req)
+  const Validation = paymentLinkSchema.existing.paymentLink.validate
+
+  const hasErrors = await validateAndRenderErrors(
+    req,
+    res,
+    Validation,
+    getRenderOptions(service, account, session, isWelsh)
+  )
+  if (hasErrors) return
+
+  lodash.set(req, CREATE_SESSION_KEY, {
+    ...session,
+    productNamePath: slugifyString(session.productNamePath),
+    friendlyURL: FRIENDLY_URL,
+    serviceNamePath: slugifyString(service.name),
+  } as PaymentLinkCreationSession)
+
+  res.redirect(
+    formatServiceAndAccountPathsFor(paths.simplifiedAccount.paymentLinks.reference, service.externalId, account.type)
+  )
+}
+
+// Interfaces
+interface RenderOptions {
+  backLink: string
+  serviceMode: string
+  formValues: { paymentLink: string }
+  service: string
+  friendlyURL: string
+  productNamePath: string
+  isWelsh: boolean
+  errors?: object
+}
+
+// Support functions
+function redirectToIndex(res: ServiceResponse, serviceId: string, accountType: string) {
+  res.redirect(formatServiceAndAccountPathsFor(paths.simplifiedAccount.paymentLinks.index, serviceId, accountType))
+}
+
+function extractSessionInfo<T>(req: ServiceRequest<T>, res: ServiceResponse) {
+  const service = req.service
+  const account = req.account
+  const session = getSession(req)
+  if (lodash.isEmpty(session)) {
+    redirectToIndex(res, service.externalId, account.type)
+    return
+  }
+  return { service, account, session }
+}
+
+function getRenderOptions(
+  service: Service,
+  account: GatewayAccount,
+  session: PaymentLinkCreationSession,
+  isWelsh: boolean
+) {
+  const serviceName = isWelsh && service.serviceName?.cy ? service.serviceName.cy : service.name
+  return {
+    backLink: formatServiceAndAccountPathsFor(
+      paths.simplifiedAccount.paymentLinks.create,
+      service.externalId,
+      account.type
+    ),
+    serviceMode: account.type,
+    formValues: { paymentLink: session.paymentLinkTitle },
+    service: serviceName,
+    friendlyURL: FRIENDLY_URL,
+    productNamePath: session.productNamePath,
+    isWelsh,
+  }
+}
+
+function renderPage(req: ServiceRequest, res: ServiceResponse, renderOptions: RenderOptions) {
+  response(req, res, 'simplified-account/services/payment-links/create/check-payment-link', renderOptions)
+}
+
+async function validateAndRenderErrors(
+  req: ServiceRequest,
+  res: ServiceResponse,
+  validate: ValidationChain,
+  renderOptions: RenderOptions
+): Promise<boolean> {
+  await validate.run(req)
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    const formatted = formatValidationErrors(errors)
+    renderPage(req, res, {
+      ...renderOptions,
+      errors: {
+        summary: formatted.errorSummary,
+        formErrors: formatted.formErrors,
+      },
+      formValues: req.body,
+    })
+    return true
+  }
+  return false
+}
+
+export { get, post }

--- a/src/paths.js
+++ b/src/paths.js
@@ -163,10 +163,11 @@ module.exports = {
         metadata: {
           add: '/payment-links/:productExternalId/add/reporting-column',
           update: '/payment-links/:productExternalId/edit/reporting-column/:metadataKey',
-        }
+        },
       },
       review: '/payment-links/review',
       delete: '/payment-links/:productExternalId/delete',
+      existingPaymentLink: '/payment-links/existing',
     },
     testWithYourUsers: {
       index: '/test-with-your-users',

--- a/src/services/clients/pay/ProductsClient.class.ts
+++ b/src/services/clients/pay/ProductsClient.class.ts
@@ -56,6 +56,14 @@ class ProductsClient extends BaseClient {
         return new Product(response.data)
       },
 
+      getByServiceAndProductPath: async (serviceNamePath: string, productNamePath: string) => {
+        const path = '/v1/api/products?serviceNamePath={serviceNamePath}&productNamePath={productNamePath}'
+          .replace('{serviceNamePath}', encodeURIComponent(serviceNamePath))
+          .replace('{productNamePath}', encodeURIComponent(productNamePath))
+        const response = await this.get<ProductData>(path, 'find a product by its product path')
+        return new Product(response.data)
+      },
+
       create: async (createProductRequest: CreateProductRequest) => {
         const path = '/v1/api/products'
         const response = await this.post<CreateProductRequestData, ProductData>(

--- a/src/services/products.service.ts
+++ b/src/services/products.service.ts
@@ -8,6 +8,9 @@ const productsClient = new ProductsClient()
 const getProducts = (gatewayAccountId: number, productType: ProductType) =>
   productsClient.products.getByGatewayAccountIdAndProductType(gatewayAccountId, productType)
 
+const getProductByServiceAndProductPath = (serviceNamePath: string, productNamePath: string) =>
+  productsClient.products.getByServiceAndProductPath(serviceNamePath, productNamePath)
+
 const getProductByExternalId = (productExternalId: string) => productsClient.products.getByExternalId(productExternalId)
 
 const getProductByGatewayAccountIdAndExternalId = (gatewayAccountId: number, productExternalId: string) =>
@@ -46,6 +49,7 @@ export {
   getProducts,
   getProductByExternalId,
   getProductByGatewayAccountIdAndExternalId,
+  getProductByServiceAndProductPath,
   deleteProduct,
   updateProduct,
   createDemoProduct,

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -81,6 +81,18 @@ simplifiedAccount.post(
   servicesController.paymentLinks.create.information.post
 )
 simplifiedAccount.get(
+  paths.simplifiedAccount.paymentLinks.existingPaymentLink,
+  experimentalFeature,
+  permission('tokens:create'),
+  servicesController.paymentLinks.create.existingPaymentLink.get
+)
+simplifiedAccount.post(
+  paths.simplifiedAccount.paymentLinks.existingPaymentLink,
+  experimentalFeature,
+  permission('tokens:create'),
+  servicesController.paymentLinks.create.existingPaymentLink.post
+)
+simplifiedAccount.get(
   paths.simplifiedAccount.paymentLinks.addWelshServiceName,
   experimentalFeature,
   permission('tokens:create'),
@@ -246,12 +258,43 @@ simplifiedAccount.post(
 )
 
 // test with your users
-simplifiedAccount.get(paths.simplifiedAccount.testWithYourUsers.index, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.index.get)
-simplifiedAccount.get(paths.simplifiedAccount.testWithYourUsers.links, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.links.get)
-simplifiedAccount.get(paths.simplifiedAccount.testWithYourUsers.create, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.create.get)
-simplifiedAccount.post(paths.simplifiedAccount.testWithYourUsers.create, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.create.postValidation, testWithYourUsersController.create.post)
-simplifiedAccount.get(paths.simplifiedAccount.testWithYourUsers.confirm, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.confirm.get)
-simplifiedAccount.get(paths.simplifiedAccount.testWithYourUsers.disable, permission('transactions:read'), restrictToSandboxOrStripeTestAccount, testWithYourUsersController.disable.post)
+simplifiedAccount.get(
+  paths.simplifiedAccount.testWithYourUsers.index,
+  permission('transactions:read'),
+  restrictToSandboxOrStripeTestAccount,
+  testWithYourUsersController.index.get
+)
+simplifiedAccount.get(
+  paths.simplifiedAccount.testWithYourUsers.links,
+  permission('transactions:read'),
+  restrictToSandboxOrStripeTestAccount,
+  testWithYourUsersController.links.get
+)
+simplifiedAccount.get(
+  paths.simplifiedAccount.testWithYourUsers.create,
+  permission('transactions:read'),
+  restrictToSandboxOrStripeTestAccount,
+  testWithYourUsersController.create.get
+)
+simplifiedAccount.post(
+  paths.simplifiedAccount.testWithYourUsers.create,
+  permission('transactions:read'),
+  restrictToSandboxOrStripeTestAccount,
+  testWithYourUsersController.create.postValidation,
+  testWithYourUsersController.create.post
+)
+simplifiedAccount.get(
+  paths.simplifiedAccount.testWithYourUsers.confirm,
+  permission('transactions:read'),
+  restrictToSandboxOrStripeTestAccount,
+  testWithYourUsersController.confirm.get
+)
+simplifiedAccount.get(
+  paths.simplifiedAccount.testWithYourUsers.disable,
+  permission('transactions:read'),
+  restrictToSandboxOrStripeTestAccount,
+  testWithYourUsersController.disable.post
+)
 
 // agreements
 simplifiedAccount.get(
@@ -768,7 +811,6 @@ simplifiedAccount.get(
 
 // stripe details
 const stripeDetailsPath = paths.simplifiedAccount.settings.stripeDetails
-const switchToStripePath = paths.simplifiedAccount.settings.switchPsp.switchToStripe
 const stripeDetailsRouter = new Router({ mergeParams: true }).use(
   enforceLiveAccountOnly,
   enforcePaymentProviderType(STRIPE),

--- a/src/utils/simplified-account/is-welsh.ts
+++ b/src/utils/simplified-account/is-welsh.ts
@@ -1,0 +1,11 @@
+import { ServiceRequest } from '@utils/types/express'
+import {
+  PaymentLinkCreationSession,
+  CREATE_SESSION_KEY,
+} from '@controllers/simplified-account/services/payment-links/create/constants'
+import lodash from 'lodash'
+
+export function isWelshSelected(req: ServiceRequest): boolean {
+  const currentSession = lodash.get(req, CREATE_SESSION_KEY, {} as PaymentLinkCreationSession)
+  return currentSession.language === 'cy' || (req.query.language as string) === 'cy'
+}

--- a/src/views/simplified-account/services/payment-links/create/check-payment-link.njk
+++ b/src/views/simplified-account/services/payment-links/create/check-payment-link.njk
@@ -1,0 +1,66 @@
+{% extends "simplified-account/services/service-layout.njk" %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+
+{% set servicePageTitle %}
+  Change the unique part of the website address - Payment links - {{ serviceName }} - GOV.UK Pay
+{% endset %}
+
+{% block serviceContent %}
+  <span class="govuk-caption-l">Create {{ serviceMode }} payment link {% if isWelsh %}(Welsh){% endif %}</span>
+  <h1 class="govuk-heading-l">Change the unique part of the website address</h1>
+
+  <form method="post">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}" />
+
+    <div class="govuk-form-group {% if flash.genericError %}govuk-form-group--error{% endif %}">
+      <div id="payment-name-path-hint" class="govuk-hint">
+        The website address we automatically generated for this payment link is already taken. You need to choose a new
+        one. It is currently <b>/{{ productNamePath | removeIndefiniteArticles | slugify }}</b>. This will not change
+        the payment link title.
+      </div>
+      <br />
+      <span
+        class="govuk-hint pay-text-black"
+        style="background-color: #f3f3f3; border: 1px solid #b1b4b6; padding: 5px; display: inline-block; word-break: break-all;"
+      >
+        {{ friendlyURL }}/{{ currentService.name | removeIndefiniteArticles | slugify }}/
+      </span>
+
+      {{
+        govukInput({
+         id: "payment-link",
+         name: "paymentLink",
+          value: formValues.paymentLink,
+          errorMessage: { text: errors.formErrors['paymentLink'] } if errors.formErrors['paymentLink'] else false,
+          classes: "govuk-!-width-one-half",
+          spellcheck: false,
+          type: "text",
+          attributes: {
+          "autocapitalize": "none",
+          "autofocus": "true",
+          "data-confirmation-filter": "slugify",
+          "aria-describedby": "payment-name-path-hint"
+          }
+        })
+      }}
+    </div>
+
+    {{
+      govukButton({
+        text: 'Continue',
+        classes: 'button'
+      })
+    }}
+    &nbsp;
+    {{
+      govukButton({
+        text: "Change The Title Instead",
+        classes: "govuk-button--secondary",
+        href: "/service/" + currentService.externalId + "/account/" + accountType + "/payment-links/create"
+      })
+    }}
+  </form>
+{% endblock %}


### PR DESCRIPTION
This is an existing screen in the payment link creation journey. It is seen if the user enters a payment link title and the website address generated already exists. The user has to chance to edit the website address without change the payment link title. 

## What

PP-**PP-14549**
Write the existing screen in the payment link creation journey in TS in simplified accounts. It is seen if the user enters a payment link title and the website address generated already exists. The user has to chance to edit the website address without change the payment link title. 

Validation was added
removed unused var 
refactored isWelsh out into a reusable component  


### How
1) Go to the payment link page
2) Create a new payment line using an existing payment link 
3) you should see this page
<img width="1336" height="1010" alt="image" src="https://github.com/user-attachments/assets/f9487e3b-1e3b-4fed-a5ab-5f819e27acaa" />
4) remove the text and try submit "continue" button, it should throw an error
5) type a payment link that exists and try submit "continue" button it will throw an error
6) if you click "Change The Title Instead" it should take you back to the "Enter payment link details" page "payment-links/create" link
7) if you type a unique link, it should continue to the next page "reference"

### Accessibility (views have been added/changed)

> [!IMPORTANT]
> Complete this checklist when adding/modifying nunjucks templates

<details>
<summary>checklist</summary>

- [✅] keyboard navigation is validated (can navigate all interactive elements with a keyboard)
- [ ] skip to main content takes you to the main content (not a nav link e.g. back link)
- [ ] cypress tests include the `cy.checkAccessibility` command for each unique view
- [✅] the page title is unique
- [✅] all page content fits within desktop and mobile view ports (unless specified in the designs)
- [ ] links clearly explain where the link will take the user
- [ ] ‘change’ links have visually hidden text providing additional screen reader context
</details>

### Screenshots (views have been added/changed)......whole new page 
Desktop:
<img width="1336" height="1010" alt="image" src="https://github.com/user-attachments/assets/f9487e3b-1e3b-4fed-a5ab-5f819e27acaa" />

mobile: 
<img width="990" height="1500" alt="image" src="https://github.com/user-attachments/assets/48bd27d2-e5bf-40f3-b93b-cfc6cfb0b37d" />


> [!NOTE]
> Include mobile and desktop variants, **highlight**(`#ff0000`) changes to existing views to help reviewers