### PR TITLE
PP-14457 Fix headings for accessibility

### DIFF
--- a/src/views/simplified-account/home/my-services/_services.njk
+++ b/src/views/simplified-account/home/my-services/_services.njk
@@ -8,11 +8,11 @@
     {% for service in services %}
       <div class="service-link" data-name="{{ service.name }}">
         <div class="service-link__name">
-          <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-0">
+          <h2 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-0">
             <a href="{{ service.href }}" class="service-link__overlay-link govuk-link govuk-link--no-visited-state"
               >{{ service.name }}</a
             >
-          </p>
+          </h2>
           <div class="service-link__status">
             {% if service.status.tag %}
               {{

--- a/src/views/simplified-account/home/my-services/_side-bar-links.njk
+++ b/src/views/simplified-account/home/my-services/_side-bar-links.njk
@@ -1,15 +1,15 @@
 {% if services.length %}
-  <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-2">
+  <h3 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-2">
     <a href="{{ allServiceTransactionsPath }}" class="govuk-link govuk-link--no-visited-state"
       >Transactions for all services</a
     >
-  </p>
+  </h3>
   <p class="govuk-body">View transactions for all of your services</p>
 
   {% if flags.hasAccountWithPayouts %}
-    <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-2">
+    <h3 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-2">
       <a href="{{ payoutsPath }}" class="govuk-link govuk-link--no-visited-state">Payments to your bank account</a>
-    </p>
+    </h3>
     <p class="govuk-body">Download CSV reports to see what payments have gone into your bank account</p>
   {% endif %}
 {% endif %}


### PR DESCRIPTION
## What

PP-**[14457](https://payments-platform.atlassian.net/browse/PP-14457)**

With this change, we are fixing the names of services listed in the new My services page as well as links to reach the page for All transactions so that they are set as headings, in line with the WCAG review performed by our designer.

### How

- log on to Selfservice
- visit /my-services
- inspect the rendered HTML code for the service names and the links in the right hand side
- check that they are rendered as headings, H2 and H3, respectively

### Screenshots

#### Rendered page

<img width="941" height="367" alt="rendered page" src="https://github.com/user-attachments/assets/8a06da4c-3394-4f3f-ab7f-d76df1c36f66" />

#### Services names

<img width="588" height="144" alt="service names" src="https://github.com/user-attachments/assets/143c326f-9d41-4549-9d46-dcb43815de75" />

#### Links

<img width="628" height="127" alt="links" src="https://github.com/user-attachments/assets/cfa84229-b195-4bf9-af68-f29f60b08d9b" />





