### PR TITLE
PP-14458 Add Stripe account ID to stripe-details page

### DIFF
--- a/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.test.js
@@ -15,6 +15,7 @@ const mockStripeDetailsService = {
   getStripeAccountOnboardingDetails: sinon.stub().resolves({
     foo: 'bar',
   }),
+  getStripeAccountIdForGatewayAccount: sinon.stub().returns('accnt_1234'),
 }
 
 const { req, res, nextRequest, nextResponse, call } = new ControllerTestBuilder(
@@ -75,6 +76,10 @@ describe('Controller: settings/stripe-details', () => {
       it('should pass context data to the response method', () => {
         expect(mockResponse.args[0][3]).to.have.property('incompleteTasks').to.equal(true)
         expect(mockResponse.args[0][3]).to.have.property('serviceExternalId').to.equal(SERVICE_ID)
+      })
+
+      it('should pass stripe account ID to the response method', () => {
+        expect(mockResponse.args[0][3]).to.have.property('stripeAccountId').to.equal('accnt_1234')
       })
 
       it('should pass Stripe details tasks to the response method', () => {

--- a/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.ts
+++ b/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.ts
@@ -7,7 +7,10 @@ import * as responsiblePerson from './responsible-person/responsible-person.cont
 import * as vatNumber from './vat-number/vat-number.controller'
 import { ServiceRequest, ServiceResponse } from '@utils/types/express'
 import { response } from '@utils/response'
-import { getStripeAccountOnboardingDetails, getStripeAccountIdForGatewayAccount } from '@services/stripe-details.service'
+import {
+  getStripeAccountOnboardingDetails,
+  getStripeAccountIdForGatewayAccount,
+} from '@services/stripe-details.service'
 import paths from '@root/paths'
 import StripeTasks from '@models/task-workflows/StripeTasks.class'
 import PaymentProviders from '@models/constants/payment-providers'

--- a/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.ts
+++ b/src/controllers/simplified-account/settings/stripe-details/stripe-details.controller.ts
@@ -7,7 +7,7 @@ import * as responsiblePerson from './responsible-person/responsible-person.cont
 import * as vatNumber from './vat-number/vat-number.controller'
 import { ServiceRequest, ServiceResponse } from '@utils/types/express'
 import { response } from '@utils/response'
-import { getStripeAccountOnboardingDetails } from '@services/stripe-details.service'
+import { getStripeAccountOnboardingDetails, getStripeAccountIdForGatewayAccount } from '@services/stripe-details.service'
 import paths from '@root/paths'
 import StripeTasks from '@models/task-workflows/StripeTasks.class'
 import PaymentProviders from '@models/constants/payment-providers'
@@ -34,6 +34,7 @@ async function get(
   const account = req.account
   const service = req.service
   const credentialIsActive = account.getActiveCredential() !== undefined
+  const stripeAccountId = getStripeAccountIdForGatewayAccount(account)
   const stripeTasks = new StripeTasks(req.gatewayAccountStripeProgress, account, service.externalId)
   let answers = {}
   // load account onboarding details synchronously if javascript is unavailable
@@ -67,6 +68,7 @@ async function get(
     serviceExternalId: service.externalId,
     answers,
     currentPsp: req.account.paymentProvider,
+    stripeAccountId,
     providerSwitchEnabled: account.providerSwitchEnabled,
     ...(req.account.providerSwitchEnabled && {
       switchingPsp: PaymentProviders.WORLDPAY, // Stripe can only switch to Worldpay (currently)

--- a/src/services/stripe-details.service.ts
+++ b/src/services/stripe-details.service.ts
@@ -15,7 +15,10 @@ const logger = createLogger(__filename)
 const connectorClient = new ConnectorClient()
 
 const getConnectorStripeAccountSetup = async (serviceExternalId: string, accountType: string) => {
-  return connectorClient.gatewayAccounts.getStripeAccountSetupByServiceExternalIdAndAccountType(serviceExternalId, accountType)
+  return connectorClient.gatewayAccounts.getStripeAccountSetupByServiceExternalIdAndAccountType(
+    serviceExternalId,
+    accountType
+  )
 }
 
 const updateConnectorStripeProgress = async (service: Service, gatewayAccount: GatewayAccount, step: string) => {

--- a/src/services/stripe-details.service.ts
+++ b/src/services/stripe-details.service.ts
@@ -254,5 +254,6 @@ export {
   updateConnectorStripeProgress,
   getStripeAccountOnboardingDetails,
   getStripeAccountCapabilities,
+  getStripeAccountIdForGatewayAccount,
   getConnectorStripeAccountSetup,
 }

--- a/src/views/simplified-account/settings/stripe-details/index.njk
+++ b/src/views/simplified-account/settings/stripe-details/index.njk
@@ -8,77 +8,93 @@
 {% block settingsContent %}
   {% if providerSwitchEnabled %}
     {% set switchMessage %}
-      Your service is ready to switch PSP from {{ currentPsp | smartCaps }} to {{ switchingPsp | smartCaps }}.<br>
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ switchPspLink }}">Switch to {{ switchingPsp | smartCaps }}.</a>
+      Your service is ready to switch PSP from {{ currentPsp | smartCaps }} to {{ switchingPsp | smartCaps }}.<br />
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ switchPspLink }}"
+        >Switch to {{ switchingPsp | smartCaps }}.</a
+      >
     {% endset %}
 
-    {{ govukInsetText({
-      html: switchMessage,
-      classes: "service-settings-inset-text--grey"
-    }) }}
+    {{
+      govukInsetText({
+        html: switchMessage,
+        classes: "service-settings-inset-text--grey"
+      })
+    }}
   {% endif %}
   <h1 class="govuk-heading-l">{{ settingsPageTitle }}</h1>
   {% if incompleteTasks %}
     <p class="govuk-body">This information will be sent to Stripe so that your service can take payments.</p>
     <h2 class="govuk-heading-s">Stripe Account ID</h2>
-    <p class="govuk-body" data-cy="stripe-account-id">{{stripeAccountId}}</p>
+    <p class="govuk-body" data-cy="stripe-account-id">{{ stripeAccountId }}</p>
     <h3 class="govuk-heading-s">Add your organisation's details</h3>
-    {{ taskList({
-      tasks: tasks,
-      idPrefix: 'stripe-details'
-    }) }}
+    {{
+      taskList({
+        tasks: tasks,
+        idPrefix: 'stripe-details'
+      })
+    }}
   {% else %}
-    <p class="govuk-body">This information has been sent to Stripe so that your service can take payments. For
-      security
-      reasons we cannot show all the information submitted to Stripe.</p>
+    <p class="govuk-body">
+      This information has been sent to Stripe so that your service can take payments. For security reasons we cannot
+      show all the information submitted to Stripe.
+    </p>
 
-    <p class="govuk-body">If you need to change the details below or upload another Government Entity document, <a
+    <p class="govuk-body">
+      If you need to change the details below or upload another Government Entity document,
+      <a
         class="govuk-link govuk-link--no-visited-state"
-        href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk?subject=Change request - Stripe details [service external id: {{ serviceExternalId }}]">contact
-        GOV.UK Pay</a>
+        href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk?subject=Change request - Stripe details [service external id: {{ serviceExternalId }}]"
+        >contact GOV.UK Pay</a
+      >
     </p>
 
     <h2 class="govuk-heading-s">Stripe Account ID</h2>
-    <p class="govuk-body" data-cy="stripe-account-id">{{stripeAccountId}}</p>
+    <p class="govuk-body" data-cy="stripe-account-id">{{ stripeAccountId }}</p>
 
     {% if javascriptUnavailable %}
       {% for section, content in answers %}
         {% set rows = [] %}
         {% for key, value in content.rows %}
-          {% set rows = (rows.push({
-            key: {
-              text: key
-            },
-            value: {
-              text: value
-            }
-          }), rows) %}
+          {%
+            set rows = (rows.push({
+              key: {
+                text: key
+              },
+              value: {
+                text: value
+              }
+            }), rows)
+          %}
         {% endfor %}
-        {{ govukSummaryList({
-          card: {
-            title: {
-              text: content.title
-            }
-          },
-          rows: rows
-        }) }}
+        {{
+          govukSummaryList({
+            card: {
+              title: {
+                text: content.title
+              }
+            },
+            rows: rows
+          })
+        }}
       {% endfor %}
     {% else %}
       <noscript>
-        <meta http-equiv="refresh" content="0; url=?noscript=true">
-        <p class="govuk-body">You are being redirected, please wait...
-          If you are not redirected, <a class="govuk-body govuk-link--no-visited-state" href="?noscript=true">click
-            here</a>.</p>
+        <meta http-equiv="refresh" content="0; url=?noscript=true" />
+        <p class="govuk-body">
+          You are being redirected, please wait... If you are not redirected,
+          <a class="govuk-body govuk-link--no-visited-state" href="?noscript=true">click here</a>.
+        </p>
       </noscript>
 
       <div id="spinner-container">
-        {{ spinner({
-          text: "Loading account details..."
-        }) }}
+        {{
+          spinner({
+            text: "Loading account details..."
+          })
+        }}
       </div>
 
-      <div id="loaded-content-container" style="display: none;">
-      </div>
+      <div id="loaded-content-container" style="display: none;"></div>
 
       <script>
         document.addEventListener('DOMContentLoaded', async () => {
@@ -98,12 +114,16 @@
                 </div>
                 <div class="govuk-summary-card__content">
                   <dl class="govuk-summary-list">
-                    ${Object.entries(content.rows).map(([key, value]) => `
+                    ${Object.entries(content.rows)
+                      .map(
+                        ([key, value]) => `
                       <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">${key}</dt>
                         <dd class="govuk-summary-list__value">${value}</dd>
                       </div>
-                    `).join('')}
+                    `
+                      )
+                      .join('')}
                   </dl>
                 </div>
               </div>

--- a/src/views/simplified-account/settings/stripe-details/index.njk
+++ b/src/views/simplified-account/settings/stripe-details/index.njk
@@ -19,7 +19,10 @@
   {% endif %}
   <h1 class="govuk-heading-l">{{ settingsPageTitle }}</h1>
   {% if incompleteTasks %}
-    <h2 class="govuk-heading-s">Add your organisation's details</h2>
+    <p class="govuk-body">This information will be sent to Stripe so that your service can take payments.</p>
+    <h2 class="govuk-heading-s">Stripe Account ID</h2>
+    <p class="govuk-body" data-cy="stripe-account-id">{{stripeAccountId}}</p>
+    <h3 class="govuk-heading-s">Add your organisation's details</h3>
     {{ taskList({
       tasks: tasks,
       idPrefix: 'stripe-details'
@@ -34,6 +37,9 @@
         href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk?subject=Change request - Stripe details [service external id: {{ serviceExternalId }}]">contact
         GOV.UK Pay</a>
     </p>
+
+    <h2 class="govuk-heading-s">Stripe Account ID</h2>
+    <p class="govuk-body" data-cy="stripe-account-id">{{stripeAccountId}}</p>
 
     {% if javascriptUnavailable %}
       {% for section, content in answers %}

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/task-summary.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/task-summary.cy.js
@@ -74,7 +74,10 @@ describe('Stripe details settings', () => {
       })
       it('should show stripe account ID', () => {
         cy.get('h2').should('contain', 'Stripe Account ID')
-        cy.get('[data-cy="stripe-account-id"]').should('contain', STRIPE_CREDENTIAL_IN_ACTIVE_STATE.credentials.stripe_account_id)
+        cy.get('[data-cy="stripe-account-id"]').should(
+          'contain',
+          STRIPE_CREDENTIAL_IN_ACTIVE_STATE.credentials.stripe_account_id
+        )
       })
       describe('The settings navigation', () => {
         it('should show active "Stripe details" link in the setting navigation', () => {
@@ -170,7 +173,10 @@ describe('Stripe details settings', () => {
       })
 
       it('should show stripe details', () => {
-        cy.get('[data-cy="stripe-account-id"]').should('contain', STRIPE_CREDENTIAL_IN_ACTIVE_STATE.credentials.stripe_account_id)
+        cy.get('[data-cy="stripe-account-id"]').should(
+          'contain',
+          STRIPE_CREDENTIAL_IN_ACTIVE_STATE.credentials.stripe_account_id
+        )
         cy.get('.govuk-summary-card').should('have.length', 3)
         cy.get('.govuk-summary-card').eq(0).should('contain', 'Sort code').should('contain', '10-88-00')
         cy.get('.govuk-summary-card').eq(1).should('contain', 'Service director').should('contain', 'Scrooge McDuck')

--- a/test/cypress/integration/simplified-account/service-settings/stripe-details/task-summary.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/stripe-details/task-summary.cy.js
@@ -72,6 +72,10 @@ describe('Stripe details settings', () => {
       it('should show the correct heading', () => {
         cy.get('h1').should('contain', 'Stripe details')
       })
+      it('should show stripe account ID', () => {
+        cy.get('h2').should('contain', 'Stripe Account ID')
+        cy.get('[data-cy="stripe-account-id"]').should('contain', STRIPE_CREDENTIAL_IN_ACTIVE_STATE.credentials.stripe_account_id)
+      })
       describe('The settings navigation', () => {
         it('should show active "Stripe details" link in the setting navigation', () => {
           checkSettingsNavigation('Stripe details', SERVICE_SETTINGS_URL + '/stripe-details')
@@ -166,6 +170,7 @@ describe('Stripe details settings', () => {
       })
 
       it('should show stripe details', () => {
+        cy.get('[data-cy="stripe-account-id"]').should('contain', STRIPE_CREDENTIAL_IN_ACTIVE_STATE.credentials.stripe_account_id)
         cy.get('.govuk-summary-card').should('have.length', 3)
         cy.get('.govuk-summary-card').eq(0).should('contain', 'Sort code').should('contain', '10-88-00')
         cy.get('.govuk-summary-card').eq(1).should('contain', 'Service director').should('contain', 'Scrooge McDuck')


### PR DESCRIPTION
## What
- Displays `Stripe Account ID` on Stripe details page

#### 1. During onboarding

_**current:**_
<img width="530" height="312" alt="image" src="https://github.com/user-attachments/assets/2f8dd016-0f66-4519-a8ec-1ce2d7eb112a" />


 _**new:**_
<img width="530" height="486" alt="image" src="https://github.com/user-attachments/assets/23d941b1-dc83-4fa8-9932-b64a9d9599c2" />

##
#### 2. After all tasks are completed

**current:**
<img width="525" height="286" alt="image" src="https://github.com/user-attachments/assets/c2c0896e-f028-475d-bd3c-b4244d3e964c" />

**new:**
<img width="519" height="353" alt="image" src="https://github.com/user-attachments/assets/cf71974a-5bc3-4e01-8374-40f37ddb1b81" />
