### PR TITLE
PP-14622 Display mode links conditionally

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -278,42 +278,42 @@
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "8a764e7de8baf91c09a0141c9d0653d6c62300fa",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 107
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "c15bfbed4cf339878d4c69339491df034b592627",
         "is_verified": false,
-        "line_number": 109
+        "line_number": 113
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "09ea33e2341efbf111c4eb12a709ae94c96a7e51",
         "is_verified": false,
-        "line_number": 117
+        "line_number": 121
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "d9d993cc5556aa0fa6e18b26fdfd4fa8527db044",
         "is_verified": false,
-        "line_number": 122
+        "line_number": 126
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "ce50854e96f8dd430451450f2e7334e4b48db7f0",
         "is_verified": false,
-        "line_number": 127
+        "line_number": 131
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "34f47d2f3c482850fd7f6de8564a8aa73afe87bc",
         "is_verified": false,
-        "line_number": 132
+        "line_number": 136
       }
     ],
     "src/views/simplified-account/transactions/index.njk": [
@@ -838,5 +838,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-23T16:52:41Z"
+  "generated_at": "2026-03-25T13:16:43Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -278,42 +278,42 @@
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "8a764e7de8baf91c09a0141c9d0653d6c62300fa",
         "is_verified": false,
-        "line_number": 107
+        "line_number": 110
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "c15bfbed4cf339878d4c69339491df034b592627",
         "is_verified": false,
-        "line_number": 113
+        "line_number": 116
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "09ea33e2341efbf111c4eb12a709ae94c96a7e51",
         "is_verified": false,
-        "line_number": 121
+        "line_number": 124
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "d9d993cc5556aa0fa6e18b26fdfd4fa8527db044",
         "is_verified": false,
-        "line_number": 126
+        "line_number": 129
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "ce50854e96f8dd430451450f2e7334e4b48db7f0",
         "is_verified": false,
-        "line_number": 131
+        "line_number": 134
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "34f47d2f3c482850fd7f6de8564a8aa73afe87bc",
         "is_verified": false,
-        "line_number": 136
+        "line_number": 139
       }
     ],
     "src/views/simplified-account/transactions/index.njk": [
@@ -838,5 +838,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-25T13:16:43Z"
+  "generated_at": "2026-04-07T14:20:26Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -278,42 +278,42 @@
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "8a764e7de8baf91c09a0141c9d0653d6c62300fa",
         "is_verified": false,
-        "line_number": 110
+        "line_number": 109
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "c15bfbed4cf339878d4c69339491df034b592627",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 115
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "09ea33e2341efbf111c4eb12a709ae94c96a7e51",
         "is_verified": false,
-        "line_number": 124
+        "line_number": 123
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "d9d993cc5556aa0fa6e18b26fdfd4fa8527db044",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 128
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "ce50854e96f8dd430451450f2e7334e4b48db7f0",
         "is_verified": false,
-        "line_number": 134
+        "line_number": 133
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "34f47d2f3c482850fd7f6de8564a8aa73afe87bc",
         "is_verified": false,
-        "line_number": 139
+        "line_number": 138
       }
     ],
     "src/views/simplified-account/transactions/index.njk": [
@@ -838,5 +838,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-07T14:20:26Z"
+  "generated_at": "2026-04-08T10:37:40Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -278,42 +278,42 @@
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "8a764e7de8baf91c09a0141c9d0653d6c62300fa",
         "is_verified": false,
-        "line_number": 100
+        "line_number": 103
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "c15bfbed4cf339878d4c69339491df034b592627",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 109
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "09ea33e2341efbf111c4eb12a709ae94c96a7e51",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 117
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "d9d993cc5556aa0fa6e18b26fdfd4fa8527db044",
         "is_verified": false,
-        "line_number": 119
+        "line_number": 122
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "ce50854e96f8dd430451450f2e7334e4b48db7f0",
         "is_verified": false,
-        "line_number": 124
+        "line_number": 127
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "34f47d2f3c482850fd7f6de8564a8aa73afe87bc",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 132
       }
     ],
     "src/views/simplified-account/transactions/index.njk": [
@@ -838,5 +838,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-20T10:31:33Z"
+  "generated_at": "2026-03-23T16:52:41Z"
 }

--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -39,8 +39,9 @@ async function get(
 
   const allGatewayAccounts = await findGatewayAccountsByService(userServiceExternalIds)
   const gatewayAccountsByMode = allGatewayAccounts.filter((gatewayAccount) => gatewayAccount.type === modeFilter)
-
   const gatewayAccountIds = gatewayAccountsByMode.map((gatewayAccountData) => gatewayAccountData.id)
+  const showOppositeModeLink = allGatewayAccounts.length > gatewayAccountsByMode.length
+
   if (!gatewayAccountIds.length && !req.params.modeFilter) {
     // no live gateway accounts
     return res.redirect(formattedPathFor(paths.allServiceTransactions.simplifiedAccount.index, 'test'))
@@ -50,7 +51,6 @@ async function get(
     throw new NotFoundError(`Could not retrieve any gateway accounts with provided parameters`)
   }
 
-  const showOppositeModeLink = allGatewayAccounts.length > gatewayAccountsByMode.length
   const isStripe = gatewayAccountsByMode.some(
     (gatewayAccount) => gatewayAccount.paymentProvider === PaymentProviders.STRIPE
   )

--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -5,7 +5,7 @@ import { AuthenticatedRequest } from '@utils/types/express'
 import { findGatewayAccountsByService } from '@services/gateway-accounts.service'
 import { getAllCardTypes } from '@services/card-types.service'
 import { searchTransactions } from '@services/transactions.service'
-import { NoServicesWithPermissionError } from '@root/errors'
+import { NoServicesWithPermissionError, NotFoundError } from '@root/errors'
 import { isBritishSummerTime } from '@utils/dates'
 import paths from '@root/paths'
 import {
@@ -44,6 +44,10 @@ async function get(
   if (!gatewayAccountIds.length && !req.params.modeFilter) {
     // no live gateway accounts
     return res.redirect(formattedPathFor(paths.allServiceTransactions.simplifiedAccount.index, 'test'))
+  }
+
+  if (!gatewayAccountsByMode.length) {
+    throw new NotFoundError(`Could not retrieve any gateway accounts with provided parameters`)
   }
 
   const showOppositeModeLink = allGatewayAccounts.length > gatewayAccountsByMode.length

--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -41,7 +41,7 @@ async function get(
     // no live gateway accounts
     return res.redirect(formattedPathFor(paths.allServiceTransactions.simplifiedAccount.index, 'test'))
   }
-
+  const showOppositeModeLink = true
   const isStripe = gatewayAccounts.some((gatewayAccount) => gatewayAccount.paymentProvider === PaymentProviders.STRIPE)
 
   const PAGE_SIZE = 20
@@ -93,6 +93,7 @@ async function get(
     statuses: eventStates,
     downloadLink,
     showCsvDownload,
+    showOppositeModeLink,
     oppositeModeLink,
   })
 }

--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -72,6 +72,8 @@ async function get(
   const totalPages = Math.ceil(results.total / PAGE_SIZE)
   const currentPage = Math.min(transactionSearchParams.page!, totalPages)
   const transactionsUrl = formattedPathFor(paths.allServiceTransactions.simplifiedAccount.index, modeFilter)
+  const oppositeMode = modeFilter === 'test' ? 'live' : 'test'
+  const oppositeModeLink = formattedPathFor(paths.allServiceTransactions.simplifiedAccount.index, oppositeMode)
   const { path } = getUrlGenerator(req.query as Record<string, string>, transactionsUrl)
   const pagination = getPagination(currentPage, PAGE_SIZE, results.total, path)
 
@@ -80,6 +82,7 @@ async function get(
 
   return response(req, res, 'simplified-account/home/all-service-transactions/index', {
     modeFilter,
+    oppositeMode,
     results,
     isBST: isBritishSummerTime(),
     pagination,
@@ -90,6 +93,7 @@ async function get(
     statuses: eventStates,
     downloadLink,
     showCsvDownload,
+    oppositeModeLink
   })
 }
 

--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -38,17 +38,17 @@ async function get(
     )
   }
 
-  const gatewayAccounts = await findGatewayAccountsByService(userServiceExternalIds, modeFilter)
   const allGatewayAccounts = await findGatewayAccountsByService(userServiceExternalIds)
-  const gatewayAccountIds = gatewayAccounts.map((gatewayAccountData) => gatewayAccountData.id)
+  const gatewayAccountsByMode = allGatewayAccounts.filter((gatewayAccount) => gatewayAccount.type === modeFilter)
+
+  const gatewayAccountIds = gatewayAccountsByMode.map((gatewayAccountData) => gatewayAccountData.id)
   if (!gatewayAccountIds.length && !req.params.modeFilter) {
     // no live gateway accounts
     return res.redirect(formattedPathFor(paths.allServiceTransactions.simplifiedAccount.index, 'test'))
   }
-  const showOppositeModeLink = allGatewayAccounts.some(
-    (gatewayAccount) => gatewayAccount.type === GatewayAccountType.LIVE
-  )
-  const isStripe = gatewayAccounts.some((gatewayAccount) => gatewayAccount.paymentProvider === PaymentProviders.STRIPE)
+
+  const showOppositeModeLink = allGatewayAccounts.length > gatewayAccountsByMode.length
+  const isStripe = gatewayAccountsByMode.some((gatewayAccount) => gatewayAccount.paymentProvider === PaymentProviders.STRIPE)
 
   const PAGE_SIZE = 20
   const transactionSearchParams = TransactionSearchParams.fromSearchQuery(gatewayAccountIds, req.query, true, PAGE_SIZE)

--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -93,7 +93,7 @@ async function get(
     statuses: eventStates,
     downloadLink,
     showCsvDownload,
-    oppositeModeLink
+    oppositeModeLink,
   })
 }
 

--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -16,6 +16,7 @@ import lodash from 'lodash'
 import PaymentProviders from '@models/constants/payment-providers'
 import formattedPathFor from '@utils/simplified-account/format/format-paths-for'
 import getPagination from '@utils/simplified-account/pagination'
+import GatewayAccountType from '@models/gateway-account/gateway-account-type'
 
 const LEDGER_TRANSACTION_COUNT_LIMIT = 5000
 
@@ -38,12 +39,15 @@ async function get(
   }
 
   const gatewayAccounts = await findGatewayAccountsByService(userServiceExternalIds, modeFilter)
+  const allGatewayAccounts = await findGatewayAccountsByService(userServiceExternalIds)
   const gatewayAccountIds = gatewayAccounts.map((gatewayAccountData) => gatewayAccountData.id)
   if (!gatewayAccountIds.length && !req.params.modeFilter) {
     // no live gateway accounts
     return res.redirect(formattedPathFor(paths.allServiceTransactions.simplifiedAccount.index, 'test'))
   }
-  const showOppositeModeLink = true
+  const showOppositeModeLink = allGatewayAccounts.some(
+    (gatewayAccount) => gatewayAccount.type === GatewayAccountType.LIVE
+  )
   const isStripe = gatewayAccounts.some((gatewayAccount) => gatewayAccount.paymentProvider === PaymentProviders.STRIPE)
 
   const PAGE_SIZE = 20

--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -16,7 +16,6 @@ import lodash from 'lodash'
 import PaymentProviders from '@models/constants/payment-providers'
 import formattedPathFor from '@utils/simplified-account/format/format-paths-for'
 import getPagination from '@utils/simplified-account/pagination'
-import GatewayAccountType from '@models/gateway-account/gateway-account-type'
 
 const LEDGER_TRANSACTION_COUNT_LIMIT = 5000
 
@@ -48,7 +47,9 @@ async function get(
   }
 
   const showOppositeModeLink = allGatewayAccounts.length > gatewayAccountsByMode.length
-  const isStripe = gatewayAccountsByMode.some((gatewayAccount) => gatewayAccount.paymentProvider === PaymentProviders.STRIPE)
+  const isStripe = gatewayAccountsByMode.some(
+    (gatewayAccount) => gatewayAccount.paymentProvider === PaymentProviders.STRIPE
+  )
 
   const PAGE_SIZE = 20
   const transactionSearchParams = TransactionSearchParams.fromSearchQuery(gatewayAccountIds, req.query, true, PAGE_SIZE)

--- a/src/views/simplified-account/home/all-service-transactions/index.njk
+++ b/src/views/simplified-account/home/all-service-transactions/index.njk
@@ -9,8 +9,11 @@
 
 {% block mainContent %}
   <div class="govuk-grid-column-three-quarters" style="padding: 0">
-    <h1 class="govuk-heading-l">{{ modeFilter | capitalize }} transactions: all services</h1>
-
+    <div class="govuk-button-group" style="display: flex; align-items: center;">
+      <h1 class="govuk-heading-l" style="margin-right: 20px" >{{ modeFilter | capitalize }}  transactions: all services</h1>
+      <a class="govuk-link govuk-link--no-visited-state" style="margin-top: -10px" href="{{ oppositeModeLink }}">View {{ oppositeMode }} transactions</a>
+    </div>
+    
     <form method="GET" novalidate autocomplete="off">
       {% include "simplified-account/transactions/filter.njk" %}
 

--- a/src/views/simplified-account/home/all-service-transactions/index.njk
+++ b/src/views/simplified-account/home/all-service-transactions/index.njk
@@ -13,12 +13,11 @@
       <h1 class="govuk-heading-l" style="margin-right: 20px"
         >{{ modeFilter | capitalize }} transactions: all services</h1
       >
-          {% if (showOppositeModeLink) %}
-           <a class="govuk-link govuk-link--no-visited-state" style="margin-top: -10px" href="{{ oppositeModeLink }}"
-        >View {{ oppositeMode }} transactions</a
-      >
-    {% endif %}
-
+      {% if (showOppositeModeLink) %}
+        <a class="govuk-link govuk-link--no-visited-state" style="margin-top: -10px" href="{{ oppositeModeLink }}"
+          >View {{ oppositeMode }} transactions</a
+        >
+      {% endif %}
     </div>
 
     <form method="GET" novalidate autocomplete="off">

--- a/src/views/simplified-account/home/all-service-transactions/index.njk
+++ b/src/views/simplified-account/home/all-service-transactions/index.njk
@@ -13,9 +13,12 @@
       <h1 class="govuk-heading-l" style="margin-right: 20px"
         >{{ modeFilter | capitalize }} transactions: all services</h1
       >
-      <a class="govuk-link govuk-link--no-visited-state" style="margin-top: -10px" href="{{ oppositeModeLink }}"
+          {% if (showOppositeModeLink) %}
+           <a class="govuk-link govuk-link--no-visited-state" style="margin-top: -10px" href="{{ oppositeModeLink }}"
         >View {{ oppositeMode }} transactions</a
       >
+    {% endif %}
+
     </div>
 
     <form method="GET" novalidate autocomplete="off">

--- a/src/views/simplified-account/home/all-service-transactions/index.njk
+++ b/src/views/simplified-account/home/all-service-transactions/index.njk
@@ -10,10 +10,14 @@
 {% block mainContent %}
   <div class="govuk-grid-column-three-quarters" style="padding: 0">
     <div class="govuk-button-group" style="display: flex; align-items: center;">
-      <h1 class="govuk-heading-l" style="margin-right: 20px" >{{ modeFilter | capitalize }}  transactions: all services</h1>
-      <a class="govuk-link govuk-link--no-visited-state" style="margin-top: -10px" href="{{ oppositeModeLink }}">View {{ oppositeMode }} transactions</a>
+      <h1 class="govuk-heading-l" style="margin-right: 20px"
+        >{{ modeFilter | capitalize }} transactions: all services</h1
+      >
+      <a class="govuk-link govuk-link--no-visited-state" style="margin-top: -10px" href="{{ oppositeModeLink }}"
+        >View {{ oppositeMode }} transactions</a
+      >
     </div>
-    
+
     <form method="GET" novalidate autocomplete="off">
       {% include "simplified-account/transactions/filter.njk" %}
 

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
@@ -68,7 +68,7 @@ describe('All service transactions index', () => {
       cy.a11yCheck()
     })
 
-    it('should display correct heading', () => {
+    it('should display correct page title and heading', () => {
       const heading = `Live ${HEADING_SUFFIX}`
 
       cy.title().should('eq', `${heading} - GOV.UK Pay`)
@@ -91,7 +91,7 @@ describe('All service transactions index', () => {
       cy.a11yCheck()
     })
 
-    it('should display correct heading', () => {
+    it('should display correct page title and headings', () => {
       const heading = `Test ${HEADING_SUFFIX}`
 
       cy.title().should('eq', `${heading} - GOV.UK Pay`)

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
@@ -1,0 +1,127 @@
+import userStubs from '@test/cypress/stubs/user-stubs'
+import gatewayAccountStubs, { getCardTypesSuccess } from '@test/cypress/stubs/gateway-account-stubs'
+import { TransactionFixture } from '@test/fixtures/transaction/transaction.fixture'
+import { LIVE, TEST } from '@models/gateway-account/gateway-account-type'
+import { last12MonthsStartDate } from '@utils/simplified-account/services/dashboard/datetime-utils'
+import { getTransactionEvents, getTransactionForGatewayAccount } from '@test/cypress/stubs/simplified-account/transaction-stubs'
+import ROLES from '@test/fixtures/roles.fixtures'
+import { TransactionEventFixture } from '@test/fixtures/transaction/transaction-event.fixture'
+import transactionStubs from '@test/cypress/stubs/transaction-stubs'
+
+const TRANSACTION = new TransactionFixture()
+const TRANSACTION_CREATED_TIMESTAMP = TRANSACTION.createdDate
+
+const TRANSACTION_EVENTS = [
+  new TransactionEventFixture({
+    amount: 1250,
+    state: {
+      finished: false,
+      status: 'CREATED',
+    },
+    resourceType: 'PAYMENT',
+    eventType: 'PAYMENT_CREATED',
+    timestamp: TRANSACTION_CREATED_TIMESTAMP,
+  }),
+]
+
+const USER_EXTERNAL_ID = 'user123abc'
+const SERVICE_EXTERNAL_ID = 'service456def'
+const GATEWAY_ACCOUNT_ID = '1'
+const SERVICE_NAME = {
+  en: 'McDuck Enterprises',
+  cy: 'Mentrau McDuck',
+}
+const USER_EMAIL = 's.mcduck@example.com'
+
+const TEST_TRANSACTIONS_LIST_URL = `/transactions/${TEST}`
+const LIVE_TRANSACTIONS_LIST_URL = `/transactions/${LIVE}`
+
+const HEADING_SUFFIX = 'transactions: all services'
+
+const userAndGatewayAccountStubs = [
+  userStubs.getUserSuccess({
+    userExternalId: USER_EXTERNAL_ID,
+    email: USER_EMAIL,
+    serviceExternalId: SERVICE_EXTERNAL_ID,
+    gatewayAccountId: GATEWAY_ACCOUNT_ID,
+    serviceName: SERVICE_NAME,
+    role: ROLES['view-and-refund'],
+  }),
+]
+
+describe('All service transactions index', () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs,
+      getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION),
+      getTransactionEvents(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION_EVENTS),
+      getCardTypesSuccess(),
+      transactionStubs.getLedgerTransactionsSuccess({
+        gatewayAccountId: GATEWAY_ACCOUNT_ID,
+        transactions: [TRANSACTION],
+        filters: { from_date: last12MonthsStartDate },
+        displaySize: 20,
+        transactionLength: 1,
+      }),
+
+      gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
+        serviceExternalId: SERVICE_EXTERNAL_ID,
+        type: 'test',
+        gatewayAccountId: GATEWAY_ACCOUNT_ID,
+      }),
+      gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
+        serviceExternalId: SERVICE_EXTERNAL_ID,
+        type: 'live',
+        gatewayAccountId: GATEWAY_ACCOUNT_ID,
+      }),
+
+    ])
+  })
+
+  describe('Live page content', () => {
+    beforeEach(() => {
+      cy.visit(LIVE_TRANSACTIONS_LIST_URL)
+    })
+
+    it('accessibility check', () => {
+      cy.a11yCheck()
+    })
+
+    it('should display correct heading', () => {
+      const heading = `Live ${HEADING_SUFFIX}`
+
+      cy.title().should('eq', `${heading} - GOV.UK Pay`)
+      cy.get('h1').should('contain.text', heading)
+    })
+
+    it('should navigate to test transactions', () => {
+      cy.contains('a.govuk-link', 'View test transactions').should('be.visible').click()
+      cy.get('h1').should('contain.text', 'Test transactions: all services')
+      cy.url().should('include', TEST_TRANSACTIONS_LIST_URL)
+    })
+  })
+
+  describe('Test page content', () => {
+    beforeEach(() => {
+      cy.visit(TEST_TRANSACTIONS_LIST_URL)
+    })
+
+    it('accessibility check', () => {
+      cy.a11yCheck()
+    })
+
+    it('should display correct heading', () => {
+      const heading = `Test ${HEADING_SUFFIX}`
+
+      cy.title().should('eq', `${heading} - GOV.UK Pay`)
+      cy.get('h1').should('contain.text', heading)
+    })
+
+    it('should navigate to live transactions', () => {
+      cy.contains('a.govuk-link', 'View live transactions').should('be.visible').click()
+      cy.get('h1').should('contain.text', 'Live transactions: all services')
+      cy.url().should('include', LIVE_TRANSACTIONS_LIST_URL)
+    })
+  })
+})

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
@@ -3,29 +3,10 @@ import gatewayAccountStubs, { getCardTypesSuccess } from '@test/cypress/stubs/ga
 import { TransactionFixture } from '@test/fixtures/transaction/transaction.fixture'
 import { LIVE, TEST } from '@models/gateway-account/gateway-account-type'
 import { last12MonthsStartDate } from '@utils/simplified-account/services/dashboard/datetime-utils'
-import {
-  getTransactionEvents,
-  getTransactionForGatewayAccount,
-} from '@test/cypress/stubs/simplified-account/transaction-stubs'
-import ROLES from '@test/fixtures/roles.fixtures'
-import { TransactionEventFixture } from '@test/fixtures/transaction/transaction-event.fixture'
+import { getTransactionForGatewayAccount } from '@test/cypress/stubs/simplified-account/transaction-stubs'
 import transactionStubs from '@test/cypress/stubs/transaction-stubs'
 
 const TRANSACTION = new TransactionFixture()
-const TRANSACTION_CREATED_TIMESTAMP = TRANSACTION.createdDate
-
-const TRANSACTION_EVENTS = [
-  new TransactionEventFixture({
-    amount: 1250,
-    state: {
-      finished: false,
-      status: 'CREATED',
-    },
-    resourceType: 'PAYMENT',
-    eventType: 'PAYMENT_CREATED',
-    timestamp: TRANSACTION_CREATED_TIMESTAMP,
-  }),
-]
 
 const USER_EXTERNAL_ID = 'user123abc'
 const SERVICE_EXTERNAL_ID = 'service456def'
@@ -48,7 +29,6 @@ const userAndGatewayAccountStubs = [
     serviceExternalId: SERVICE_EXTERNAL_ID,
     gatewayAccountId: GATEWAY_ACCOUNT_ID,
     serviceName: SERVICE_NAME,
-    role: ROLES['view-and-refund'],
   }),
 ]
 
@@ -58,7 +38,6 @@ describe('All service transactions index', () => {
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION),
-      getTransactionEvents(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION_EVENTS),
       getCardTypesSuccess(),
       transactionStubs.getLedgerTransactionsSuccess({
         gatewayAccountId: GATEWAY_ACCOUNT_ID,
@@ -67,7 +46,6 @@ describe('All service transactions index', () => {
         displaySize: 20,
         transactionLength: 1,
       }),
-
       gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
         serviceExternalId: SERVICE_EXTERNAL_ID,
         type: 'test',
@@ -99,7 +77,7 @@ describe('All service transactions index', () => {
 
     it('should navigate to test transactions', () => {
       cy.contains('a.govuk-link', 'View test transactions').should('be.visible').click()
-      cy.get('h1').should('contain.text', 'Test transactions: all services')
+      cy.get('h1').should('contain.text', `Test ${HEADING_SUFFIX}`)
       cy.url().should('include', TEST_TRANSACTIONS_LIST_URL)
     })
   })
@@ -122,7 +100,7 @@ describe('All service transactions index', () => {
 
     it('should navigate to live transactions', () => {
       cy.contains('a.govuk-link', 'View live transactions').should('be.visible').click()
-      cy.get('h1').should('contain.text', 'Live transactions: all services')
+      cy.get('h1').should('contain.text', `Live ${HEADING_SUFFIX}`)
       cy.url().should('include', LIVE_TRANSACTIONS_LIST_URL)
     })
   })

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
@@ -3,7 +3,10 @@ import gatewayAccountStubs, { getCardTypesSuccess } from '@test/cypress/stubs/ga
 import { TransactionFixture } from '@test/fixtures/transaction/transaction.fixture'
 import { LIVE, TEST } from '@models/gateway-account/gateway-account-type'
 import { last12MonthsStartDate } from '@utils/simplified-account/services/dashboard/datetime-utils'
-import { getTransactionEvents, getTransactionForGatewayAccount } from '@test/cypress/stubs/simplified-account/transaction-stubs'
+import {
+  getTransactionEvents,
+  getTransactionForGatewayAccount,
+} from '@test/cypress/stubs/simplified-account/transaction-stubs'
 import ROLES from '@test/fixtures/roles.fixtures'
 import { TransactionEventFixture } from '@test/fixtures/transaction/transaction-event.fixture'
 import transactionStubs from '@test/cypress/stubs/transaction-stubs'
@@ -75,7 +78,6 @@ describe('All service transactions index', () => {
         type: 'live',
         gatewayAccountId: GATEWAY_ACCOUNT_ID,
       }),
-
     ])
   })
 

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
@@ -10,7 +10,8 @@ const TRANSACTION = new TransactionFixture()
 
 const USER_EXTERNAL_ID = 'user123abc'
 const SERVICE_EXTERNAL_ID = 'service456def'
-const GATEWAY_ACCOUNT_ID = '1'
+const LIVE_GATEWAY_ACCOUNT_ID = '1'
+const TEST_GATEWAY_ACCOUNT_ID = '2'
 const SERVICE_NAME = {
   en: 'McDuck Enterprises',
   cy: 'Mentrau McDuck',
@@ -27,7 +28,7 @@ const userAndGatewayAccountStubs = [
     userExternalId: USER_EXTERNAL_ID,
     email: USER_EMAIL,
     serviceExternalId: SERVICE_EXTERNAL_ID,
-    gatewayAccountId: GATEWAY_ACCOUNT_ID,
+    gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
     serviceName: SERVICE_NAME,
   }),
 ]
@@ -36,46 +37,65 @@ describe('All service transactions index', () => {
   beforeEach(() => {
     cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
-      ...userAndGatewayAccountStubs,
-      getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION),
+      getTransactionForGatewayAccount(LIVE_GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION),
       getCardTypesSuccess(),
-      transactionStubs.getLedgerTransactionsSuccess({
-        gatewayAccountId: GATEWAY_ACCOUNT_ID,
-        transactions: [TRANSACTION],
-        filters: { from_date: last12MonthsStartDate },
-        displaySize: 20,
-        transactionLength: 1,
-      }),
-      gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
-        serviceExternalId: SERVICE_EXTERNAL_ID,
-        type: 'test',
-        gatewayAccountId: GATEWAY_ACCOUNT_ID,
-      }),
-      gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
-        serviceExternalId: SERVICE_EXTERNAL_ID,
-        type: 'live',
-        gatewayAccountId: GATEWAY_ACCOUNT_ID,
-      }),
     ])
   })
 
   describe('Live page content', () => {
     beforeEach(() => {
+      cy.task('setupStubs', [
+        ...userAndGatewayAccountStubs,
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
+          transactions: [TRANSACTION],
+          filters: { from_date: last12MonthsStartDate },
+          displaySize: 20,
+          transactionLength: 1,
+        }),
+        gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          type: 'test',
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+        }),
+        gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          type: 'live',
+          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
+        }),
+      ])
       cy.visit(LIVE_TRANSACTIONS_LIST_URL)
     })
 
-    it('accessibility check', () => {
-      cy.a11yCheck()
-    })
+    // it('accessibility check', () => {
+    //   cy.a11yCheck()
+    // })
 
-    it('should display correct page title and heading', () => {
-      const heading = `Live ${HEADING_SUFFIX}`
+    // it('should display correct page title and heading', () => {
+    //   const heading = `Live ${HEADING_SUFFIX}`
 
-      cy.title().should('eq', `${heading} - GOV.UK Pay`)
-      cy.get('h1').should('contain.text', heading)
-    })
+    //   cy.title().should('eq', `${heading} - GOV.UK Pay`)
+    //   cy.get('h1').should('contain.text', heading)
+    // })
 
     it('should navigate to test transactions', () => {
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({
+          userExternalId: USER_EXTERNAL_ID,
+          email: USER_EMAIL,
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+          serviceName: SERVICE_NAME,
+        }),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+          transactions: [TRANSACTION],
+          filters: { from_date: last12MonthsStartDate },
+          displaySize: 20,
+          transactionLength: 1,
+        }),
+      ])
+
       cy.contains('a.govuk-link', 'View test transactions').should('be.visible').click()
       cy.get('h1').should('contain.text', `Test ${HEADING_SUFFIX}`)
       cy.url().should('include', TEST_TRANSACTIONS_LIST_URL)
@@ -83,15 +103,57 @@ describe('All service transactions index', () => {
   })
 
   describe('Test page content', () => {
-    beforeEach(() => {
-      cy.visit(TEST_TRANSACTIONS_LIST_URL)
-    })
-
     it('accessibility check', () => {
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({
+          userExternalId: USER_EXTERNAL_ID,
+          email: USER_EMAIL,
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+          serviceName: SERVICE_NAME,
+        }),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+          transactions: [TRANSACTION],
+          filters: { from_date: last12MonthsStartDate },
+          displaySize: 20,
+          transactionLength: 1,
+        }),
+        gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          type: 'test',
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+        }),
+      ])
+      cy.visit(TEST_TRANSACTIONS_LIST_URL)
       cy.a11yCheck()
     })
 
     it('should display correct page title and headings', () => {
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({
+          userExternalId: USER_EXTERNAL_ID,
+          email: USER_EMAIL,
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+          serviceName: SERVICE_NAME,
+        }),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+          transactions: [TRANSACTION],
+          filters: { from_date: last12MonthsStartDate },
+          displaySize: 20,
+          transactionLength: 1,
+        }),
+        gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          type: 'test',
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+        }),
+      ])
+
+      cy.visit(TEST_TRANSACTIONS_LIST_URL)
+
       const heading = `Test ${HEADING_SUFFIX}`
 
       cy.title().should('eq', `${heading} - GOV.UK Pay`)
@@ -99,6 +161,48 @@ describe('All service transactions index', () => {
     })
 
     it('should navigate to live transactions', () => {
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({
+          userExternalId: USER_EXTERNAL_ID,
+          email: USER_EMAIL,
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+          serviceName: SERVICE_NAME,
+        }),
+        userStubs.getUserSuccess({
+          userExternalId: USER_EXTERNAL_ID,
+          email: USER_EMAIL,
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
+          serviceName: SERVICE_NAME,
+        }),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+          transactions: [TRANSACTION],
+          filters: { from_date: last12MonthsStartDate },
+          displaySize: 20,
+          transactionLength: 1,
+        }),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
+          transactions: [TRANSACTION],
+          filters: { from_date: last12MonthsStartDate },
+          displaySize: 20,
+          transactionLength: 1,
+        }),
+        gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          type: 'test',
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+        }),
+        gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          type: 'live',
+          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
+        }),
+      ])
+      cy.visit(TEST_TRANSACTIONS_LIST_URL)
+
       cy.contains('a.govuk-link', 'View live transactions').should('be.visible').click()
       cy.get('h1').should('contain.text', `Live ${HEADING_SUFFIX}`)
       cy.url().should('include', LIVE_TRANSACTIONS_LIST_URL)

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
@@ -23,34 +23,37 @@ const LIVE_TRANSACTIONS_LIST_URL = `/transactions/${LIVE}`
 
 const HEADING_SUFFIX = 'transactions: all services'
 
-const userAndGatewayAccountStubs = [
-  userStubs.getUserSuccess({
-    userExternalId: USER_EXTERNAL_ID,
-    email: USER_EMAIL,
-    serviceExternalId: SERVICE_EXTERNAL_ID,
-    gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
-    serviceName: SERVICE_NAME,
-  }),
-  gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
-    serviceExternalId: SERVICE_EXTERNAL_ID,
-    type: 'live',
-    gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
-  }),
-]
-
 describe('All service transactions index', () => {
   beforeEach(() => {
     cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       getTransactionForGatewayAccount(LIVE_GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION),
       getCardTypesSuccess(),
+      userStubs.getUserSuccess({
+        userExternalId: USER_EXTERNAL_ID,
+        email: USER_EMAIL,
+        serviceExternalId: SERVICE_EXTERNAL_ID,
+        gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
+        serviceName: SERVICE_NAME,
+      }),
     ])
   })
 
   describe('Live page content', () => {
     beforeEach(() => {
       cy.task('setupStubs', [
-        ...userAndGatewayAccountStubs,
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
+          transactions: [TRANSACTION],
+          filters: { from_date: last12MonthsStartDate },
+          displaySize: 20,
+          transactionLength: 1,
+        }),
+      ])
+    })
+
+    it('accessibility check', () => {
+      cy.task('setupStubs', [
         transactionStubs.getLedgerTransactionsSuccess({
           gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
@@ -61,31 +64,58 @@ describe('All service transactions index', () => {
         gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE],
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID]
         }),
       ])
       cy.visit(LIVE_TRANSACTIONS_LIST_URL)
-    })
-
-    it('accessibility check', () => {
       cy.a11yCheck()
     })
 
     it('should display correct page title and heading', () => {
+      cy.task('setupStubs', [
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
+          transactions: [TRANSACTION],
+          filters: { from_date: last12MonthsStartDate },
+          displaySize: 20,
+          transactionLength: 1,
+        }),
+        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [LIVE],
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID]
+        }),
+      ])
+      cy.visit(LIVE_TRANSACTIONS_LIST_URL)
+
       const heading = `Live ${HEADING_SUFFIX}`
 
       cy.title().should('eq', `${heading} - GOV.UK Pay`)
       cy.get('h1').should('contain.text', heading)
     })
 
+    it('should not show link to test mode if no test accounts exist', () => {
+      cy.task('setupStubs', [
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
+          transactions: [TRANSACTION],
+          filters: { from_date: last12MonthsStartDate },
+          displaySize: 20,
+          transactionLength: 1,
+        }),
+        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [LIVE],
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID]
+        }),
+      ])
+      cy.visit(LIVE_TRANSACTIONS_LIST_URL)
+
+      cy.contains('a.govuk-link', 'View test transactions').should('not.exist')
+    })
+
     it('should navigate to test transactions', () => {
       cy.task('setupStubs', [
-        userStubs.getUserSuccess({
-          userExternalId: USER_EXTERNAL_ID,
-          email: USER_EMAIL,
-          serviceExternalId: SERVICE_EXTERNAL_ID,
-          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
-          serviceName: SERVICE_NAME,
-        }),
         transactionStubs.getLedgerTransactionsSuccess({
           gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
@@ -101,8 +131,10 @@ describe('All service transactions index', () => {
         gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE, TEST],
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID, TEST_GATEWAY_ACCOUNT_ID]
         }),
       ])
+      cy.visit(LIVE_TRANSACTIONS_LIST_URL)
 
       cy.contains('a.govuk-link', 'View test transactions').should('be.visible').click()
       cy.get('h1').should('contain.text', `Test ${HEADING_SUFFIX}`)
@@ -140,6 +172,7 @@ describe('All service transactions index', () => {
         gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [TEST],
+          gatewayAccountIds: [TEST_GATEWAY_ACCOUNT_ID]
         }),
       ])
       cy.visit(TEST_TRANSACTIONS_LIST_URL)
@@ -151,6 +184,7 @@ describe('All service transactions index', () => {
         gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [TEST],
+          gatewayAccountIds: [TEST_GATEWAY_ACCOUNT_ID]
         }),
       ])
       cy.visit(TEST_TRANSACTIONS_LIST_URL)
@@ -158,6 +192,20 @@ describe('All service transactions index', () => {
 
       cy.title().should('eq', `${heading} - GOV.UK Pay`)
       cy.get('h1').should('contain.text', heading)
+    })
+
+    it('should not show link to live mode if no live accounts exist', () => {
+      cy.task('setupStubs', [
+        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [TEST],
+          gatewayAccountIds: [TEST_GATEWAY_ACCOUNT_ID]
+        }),
+      ])
+      cy.visit(TEST_TRANSACTIONS_LIST_URL)
+
+      cy.contains('a.govuk-link', 'View live transactions').should('not.exist')
+      cy.url().should('include', TEST_TRANSACTIONS_LIST_URL)
     })
 
     it('should navigate to live transactions', () => {
@@ -172,6 +220,7 @@ describe('All service transactions index', () => {
         gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE, TEST],
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID, TEST_GATEWAY_ACCOUNT_ID]
         }),
         gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
@@ -184,19 +233,6 @@ describe('All service transactions index', () => {
       cy.contains('a.govuk-link', 'View live transactions').should('be.visible').click()
       cy.get('h1').should('contain.text', `Live ${HEADING_SUFFIX}`)
       cy.url().should('include', LIVE_TRANSACTIONS_LIST_URL)
-    })
-
-    it('should not show link to live mode if no live accounts exist', () => {
-      cy.task('setupStubs', [
-        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
-          serviceExternalId: SERVICE_EXTERNAL_ID,
-          types: [TEST],
-        }),
-      ])
-      cy.visit(TEST_TRANSACTIONS_LIST_URL)
-
-      cy.contains('a.govuk-link', 'View live transactions').should('not.exist')
-      cy.url().should('include', TEST_TRANSACTIONS_LIST_URL)
     })
   })
 })

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
@@ -61,7 +61,7 @@ describe('All service transactions index', () => {
           displaySize: 20,
           transactionLength: 1,
         }),
-        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE],
           gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID],
@@ -80,7 +80,7 @@ describe('All service transactions index', () => {
           displaySize: 20,
           transactionLength: 1,
         }),
-        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE],
           gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID],
@@ -103,7 +103,7 @@ describe('All service transactions index', () => {
           displaySize: 20,
           transactionLength: 1,
         }),
-        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE],
           gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID],
@@ -128,7 +128,7 @@ describe('All service transactions index', () => {
           type: TEST,
           gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
         }),
-        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE, TEST],
           gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID, TEST_GATEWAY_ACCOUNT_ID],
@@ -169,7 +169,7 @@ describe('All service transactions index', () => {
 
     it('accessibility check', () => {
       cy.task('setupStubs', [
-        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [TEST],
           gatewayAccountIds: [TEST_GATEWAY_ACCOUNT_ID],
@@ -181,7 +181,7 @@ describe('All service transactions index', () => {
 
     it('should display correct page title and headings', () => {
       cy.task('setupStubs', [
-        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [TEST],
           gatewayAccountIds: [TEST_GATEWAY_ACCOUNT_ID],
@@ -196,7 +196,7 @@ describe('All service transactions index', () => {
 
     it('should not show link to live mode if no live accounts exist', () => {
       cy.task('setupStubs', [
-        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [TEST],
           gatewayAccountIds: [TEST_GATEWAY_ACCOUNT_ID],
@@ -217,7 +217,7 @@ describe('All service transactions index', () => {
           displaySize: 20,
           transactionLength: 1,
         }),
-        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE, TEST],
           gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID, TEST_GATEWAY_ACCOUNT_ID],

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
@@ -31,6 +31,11 @@ const userAndGatewayAccountStubs = [
     gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
     serviceName: SERVICE_NAME,
   }),
+  gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
+    serviceExternalId: SERVICE_EXTERNAL_ID,
+    type: 'live',
+    gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
+  }),
 ]
 
 describe('All service transactions index', () => {
@@ -53,30 +58,20 @@ describe('All service transactions index', () => {
           displaySize: 20,
           transactionLength: 1,
         }),
-        gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
-          serviceExternalId: SERVICE_EXTERNAL_ID,
-          type: 'test',
-          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
-        }),
-        gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
-          serviceExternalId: SERVICE_EXTERNAL_ID,
-          type: 'live',
-          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
-        }),
       ])
       cy.visit(LIVE_TRANSACTIONS_LIST_URL)
     })
 
-    // it('accessibility check', () => {
-    //   cy.a11yCheck()
-    // })
+    it('accessibility check', () => {
+      cy.a11yCheck()
+    })
 
-    // it('should display correct page title and heading', () => {
-    //   const heading = `Live ${HEADING_SUFFIX}`
+    it('should display correct page title and heading', () => {
+      const heading = `Live ${HEADING_SUFFIX}`
 
-    //   cy.title().should('eq', `${heading} - GOV.UK Pay`)
-    //   cy.get('h1').should('contain.text', heading)
-    // })
+      cy.title().should('eq', `${heading} - GOV.UK Pay`)
+      cy.get('h1').should('contain.text', heading)
+    })
 
     it('should navigate to test transactions', () => {
       cy.task('setupStubs', [
@@ -93,6 +88,11 @@ describe('All service transactions index', () => {
           filters: { from_date: last12MonthsStartDate },
           displaySize: 20,
           transactionLength: 1,
+        }),
+        gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          type: 'test',
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
         }),
       ])
 
@@ -162,18 +162,12 @@ describe('All service transactions index', () => {
 
     it('should navigate to live transactions', () => {
       cy.task('setupStubs', [
+        ...userAndGatewayAccountStubs,
         userStubs.getUserSuccess({
           userExternalId: USER_EXTERNAL_ID,
           email: USER_EMAIL,
           serviceExternalId: SERVICE_EXTERNAL_ID,
           gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
-          serviceName: SERVICE_NAME,
-        }),
-        userStubs.getUserSuccess({
-          userExternalId: USER_EXTERNAL_ID,
-          email: USER_EMAIL,
-          serviceExternalId: SERVICE_EXTERNAL_ID,
-          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
           serviceName: SERVICE_NAME,
         }),
         transactionStubs.getLedgerTransactionsSuccess({
@@ -194,11 +188,6 @@ describe('All service transactions index', () => {
           serviceExternalId: SERVICE_EXTERNAL_ID,
           type: 'test',
           gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
-        }),
-        gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
-          serviceExternalId: SERVICE_EXTERNAL_ID,
-          type: 'live',
-          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
         }),
       ])
       cy.visit(TEST_TRANSACTIONS_LIST_URL)

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
@@ -58,6 +58,10 @@ describe('All service transactions index', () => {
           displaySize: 20,
           transactionLength: 1,
         }),
+        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [LIVE],
+        }),
       ])
       cy.visit(LIVE_TRANSACTIONS_LIST_URL)
     })
@@ -91,8 +95,12 @@ describe('All service transactions index', () => {
         }),
         gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
-          type: 'test',
+          type: TEST,
           gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+        }),
+        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [LIVE, TEST],
         }),
       ])
 
@@ -103,7 +111,7 @@ describe('All service transactions index', () => {
   })
 
   describe('Test page content', () => {
-    it('accessibility check', () => {
+    beforeEach(() => {
       cy.task('setupStubs', [
         userStubs.getUserSuccess({
           userExternalId: USER_EXTERNAL_ID,
@@ -121,8 +129,17 @@ describe('All service transactions index', () => {
         }),
         gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
-          type: 'test',
+          type: TEST,
           gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+        }),
+      ])
+    })
+
+    it('accessibility check', () => {
+      cy.task('setupStubs', [
+        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [TEST],
         }),
       ])
       cy.visit(TEST_TRANSACTIONS_LIST_URL)
@@ -131,29 +148,12 @@ describe('All service transactions index', () => {
 
     it('should display correct page title and headings', () => {
       cy.task('setupStubs', [
-        userStubs.getUserSuccess({
-          userExternalId: USER_EXTERNAL_ID,
-          email: USER_EMAIL,
+        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
-          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
-          serviceName: SERVICE_NAME,
-        }),
-        transactionStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
-          transactions: [TRANSACTION],
-          filters: { from_date: last12MonthsStartDate },
-          displaySize: 20,
-          transactionLength: 1,
-        }),
-        gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
-          serviceExternalId: SERVICE_EXTERNAL_ID,
-          type: 'test',
-          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+          types: [TEST],
         }),
       ])
-
       cy.visit(TEST_TRANSACTIONS_LIST_URL)
-
       const heading = `Test ${HEADING_SUFFIX}`
 
       cy.title().should('eq', `${heading} - GOV.UK Pay`)
@@ -162,21 +162,6 @@ describe('All service transactions index', () => {
 
     it('should navigate to live transactions', () => {
       cy.task('setupStubs', [
-        ...userAndGatewayAccountStubs,
-        userStubs.getUserSuccess({
-          userExternalId: USER_EXTERNAL_ID,
-          email: USER_EMAIL,
-          serviceExternalId: SERVICE_EXTERNAL_ID,
-          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
-          serviceName: SERVICE_NAME,
-        }),
-        transactionStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
-          transactions: [TRANSACTION],
-          filters: { from_date: last12MonthsStartDate },
-          displaySize: 20,
-          transactionLength: 1,
-        }),
         transactionStubs.getLedgerTransactionsSuccess({
           gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
@@ -184,10 +169,14 @@ describe('All service transactions index', () => {
           displaySize: 20,
           transactionLength: 1,
         }),
+        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [LIVE, TEST],
+        }),
         gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
-          type: 'test',
-          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+          type: LIVE,
+          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
         }),
       ])
       cy.visit(TEST_TRANSACTIONS_LIST_URL)
@@ -195,6 +184,19 @@ describe('All service transactions index', () => {
       cy.contains('a.govuk-link', 'View live transactions').should('be.visible').click()
       cy.get('h1').should('contain.text', `Live ${HEADING_SUFFIX}`)
       cy.url().should('include', LIVE_TRANSACTIONS_LIST_URL)
+    })
+
+    it('should not show link to live mode if no live accounts exist', () => {
+      cy.task('setupStubs', [
+        gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [TEST],
+        }),
+      ])
+      cy.visit(TEST_TRANSACTIONS_LIST_URL)
+
+      cy.contains('a.govuk-link', 'View live transactions').should('not.exist')
+      cy.url().should('include', TEST_TRANSACTIONS_LIST_URL)
     })
   })
 })

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
@@ -64,7 +64,7 @@ describe('All service transactions index', () => {
         gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE],
-          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID]
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID],
         }),
       ])
       cy.visit(LIVE_TRANSACTIONS_LIST_URL)
@@ -83,7 +83,7 @@ describe('All service transactions index', () => {
         gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE],
-          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID]
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID],
         }),
       ])
       cy.visit(LIVE_TRANSACTIONS_LIST_URL)
@@ -106,7 +106,7 @@ describe('All service transactions index', () => {
         gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE],
-          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID]
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID],
         }),
       ])
       cy.visit(LIVE_TRANSACTIONS_LIST_URL)
@@ -131,7 +131,7 @@ describe('All service transactions index', () => {
         gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE, TEST],
-          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID, TEST_GATEWAY_ACCOUNT_ID]
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID, TEST_GATEWAY_ACCOUNT_ID],
         }),
       ])
       cy.visit(LIVE_TRANSACTIONS_LIST_URL)
@@ -172,7 +172,7 @@ describe('All service transactions index', () => {
         gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [TEST],
-          gatewayAccountIds: [TEST_GATEWAY_ACCOUNT_ID]
+          gatewayAccountIds: [TEST_GATEWAY_ACCOUNT_ID],
         }),
       ])
       cy.visit(TEST_TRANSACTIONS_LIST_URL)
@@ -184,7 +184,7 @@ describe('All service transactions index', () => {
         gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [TEST],
-          gatewayAccountIds: [TEST_GATEWAY_ACCOUNT_ID]
+          gatewayAccountIds: [TEST_GATEWAY_ACCOUNT_ID],
         }),
       ])
       cy.visit(TEST_TRANSACTIONS_LIST_URL)
@@ -199,7 +199,7 @@ describe('All service transactions index', () => {
         gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [TEST],
-          gatewayAccountIds: [TEST_GATEWAY_ACCOUNT_ID]
+          gatewayAccountIds: [TEST_GATEWAY_ACCOUNT_ID],
         }),
       ])
       cy.visit(TEST_TRANSACTIONS_LIST_URL)
@@ -220,7 +220,7 @@ describe('All service transactions index', () => {
         gatewayAccountStubs.getMultipleGatewayAccountsByServiceIdSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE, TEST],
-          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID, TEST_GATEWAY_ACCOUNT_ID]
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID, TEST_GATEWAY_ACCOUNT_ID],
         }),
         gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -147,15 +147,15 @@ function getMultipleGatewayAccountsByServiceIdSuccess(opts) {
 
   const accounts = opts.gatewayAccountIds.map((id, index) => ({
     gateway_account_id: id,
-    type: opts.types[index]
-  }));
+    type: opts.types[index],
+  }))
 
   return stubBuilder('GET', path, 200, {
     query: {
       serviceIds: opts.serviceExternalId,
     },
     response: gatewayAccountFixtures.validGatewayAccountsResponse({
-      accounts
+      accounts,
     }),
   })
 }
@@ -645,5 +645,5 @@ module.exports = {
   setRefundEmailEnabledByServiceIdAndAccountType,
   getAcceptedCardTypesByServiceExternalIdAndAccountType,
   postAcceptedCardTypesByServiceExternalIdAndAccountType,
-  getMultipleGatewayAccountsByServiceIdSuccess
+  getMultipleGatewayAccountsByServiceIdSuccess,
 }

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -142,7 +142,7 @@ function getGatewayAccountByServiceIdsSuccess(opts) {
   })
 }
 
-function getMultipleGatewayAccountsByServiceIdSuccess(opts) {
+function getGatewayAccountsByServiceIdAndTypeSuccess(opts) {
   const path = '/v1/api/accounts'
 
   const accounts = opts.gatewayAccountIds.map((id, index) => ({
@@ -645,5 +645,5 @@ module.exports = {
   setRefundEmailEnabledByServiceIdAndAccountType,
   getAcceptedCardTypesByServiceExternalIdAndAccountType,
   postAcceptedCardTypesByServiceExternalIdAndAccountType,
-  getMultipleGatewayAccountsByServiceIdSuccess,
+  getGatewayAccountsByServiceIdAndTypeSuccess,
 }

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -142,6 +142,23 @@ function getGatewayAccountByServiceIdsSuccess(opts) {
   })
 }
 
+function getMultipleGatewayAccountsByServiceIdSuccess(opts) {
+  const path = '/v1/api/accounts'
+  const accounts = opts.types.map(accountType => ({
+    gateway_account_id: opts.gatewayAccountId,
+    type: accountType
+  }));
+
+  return stubBuilder('GET', path, 200, {
+    query: {
+      serviceIds: opts.serviceExternalId,
+    },
+    response: gatewayAccountFixtures.validGatewayAccountsResponse({
+      accounts
+    }),
+  })
+}
+
 function getGatewayAccountsSuccessForMultipleAccounts(accountsOpts) {
   const path = '/v1/api/accounts'
   return stubBuilder('GET', path, 200, {
@@ -627,4 +644,5 @@ module.exports = {
   setRefundEmailEnabledByServiceIdAndAccountType,
   getAcceptedCardTypesByServiceExternalIdAndAccountType,
   postAcceptedCardTypesByServiceExternalIdAndAccountType,
+  getMultipleGatewayAccountsByServiceIdSuccess
 }

--- a/test/cypress/stubs/gateway-account-stubs.js
+++ b/test/cypress/stubs/gateway-account-stubs.js
@@ -144,9 +144,10 @@ function getGatewayAccountByServiceIdsSuccess(opts) {
 
 function getMultipleGatewayAccountsByServiceIdSuccess(opts) {
   const path = '/v1/api/accounts'
-  const accounts = opts.types.map(accountType => ({
-    gateway_account_id: opts.gatewayAccountId,
-    type: accountType
+
+  const accounts = opts.gatewayAccountIds.map((id, index) => ({
+    gateway_account_id: id,
+    type: opts.types[index]
   }));
 
   return stubBuilder('GET', path, 200, {


### PR DESCRIPTION
## What

PP-14622

- Add logic to conditionally display the "opposite mode link" only when live accounts exist
- Add Cypress tests
- Add not found error if navigating to mode with no gateway accounts
