### PR TITLE
[DO NOT MERGE] PP-15031 Upgrade to Express 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "common-password": "0.1.2",
         "connect-flash": "0.1.1",
         "cookie-parser": "1.4.x",
-        "express": "4.21.2",
+        "express": "^5.2.1",
         "express-validator": "^7.3.0",
         "google-libphonenumber": "3.2.33",
         "govuk-frontend": "^5.11.1",
@@ -9292,6 +9292,20 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@pact-foundation/pact/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/@pact-foundation/pact/node_modules/agent-base": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -9300,6 +9314,127 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@pact-foundation/pact/node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@pact-foundation/pact/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@pact-foundation/pact/node_modules/https-proxy-agent": {
@@ -9314,6 +9449,91 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@pact-foundation/pact/node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@pact-foundation/pact/node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -13349,16 +13569,41 @@
       }
     },
     "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
       "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/accessible-autocomplete": {
@@ -13605,6 +13850,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/array-union": {
@@ -15112,6 +15358,7 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -16711,45 +16958,42 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 18"
       },
       "funding": {
         "type": "opencollective",
@@ -16787,43 +17031,222 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/express/node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+    "node_modules/express/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
-    "node_modules/express/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/express/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.6"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">=0.6"
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/express/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/ext": {
@@ -17091,37 +17514,25 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/finalhandler/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/finalhandler/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -19792,6 +20203,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -19818,6 +20230,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -20271,9 +20684,9 @@
       }
     },
     "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -20681,7 +21094,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -21102,10 +21514,14 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT"
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -22544,6 +22960,28 @@
       "integrity": "sha512-fJhQQI5tLrQvYIYFpOnFinzv9dwmR7hRnUz1XqP3OJ1jIweTNOd6aTO4jwQSgcBSFUB+/KHJxuGneime+FdzOw==",
       "license": "MIT"
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
@@ -22589,6 +23027,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -23287,18 +23726,128 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.19.0"
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/serve-static/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve-static/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-static/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/set-blocking": {
@@ -25575,7 +26124,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "common-password": "0.1.2",
     "connect-flash": "0.1.1",
     "cookie-parser": "1.4.x",
-    "express": "4.21.2",
+    "express": "^5.2.1",
     "express-validator": "^7.3.0",
     "google-libphonenumber": "3.2.33",
     "govuk-frontend": "^5.11.1",

--- a/src/controllers/simplified-account/services/agreements/agreements.controller.ts
+++ b/src/controllers/simplified-account/services/agreements/agreements.controller.ts
@@ -3,7 +3,7 @@ import * as cancel from './cancel/cancel-agreement.controller'
 import { response } from '@utils/response'
 import { ServiceRequest, ServiceResponse } from '@utils/types/express'
 import { searchAgreements } from '@services/agreements.service'
-import { query, validationResult } from 'express-validator'
+import { query, validationResult, matchedData } from 'express-validator'
 import { ACTIVE, INACTIVE, CANCELLED, CREATED } from '@models/agreements/agreement-status'
 import getPagination from '@utils/simplified-account/pagination'
 import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
@@ -40,15 +40,17 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   await Promise.all(validations.map(async (validation) => validation.run(req)))
 
   const errors = validationResult(req)
+  const { page } = matchedData(req)
 
   if (!errors.isEmpty()) {
     const formattedErrors = formatValidationErrors(errors)
+
     return response(req, res, 'simplified-account/services/agreements/index', {
       errors: {
         summary: formattedErrors.errorSummary,
         formErrors: formattedErrors.formErrors,
       },
-      ...(await loadAgreements(req.service.externalId, req.account.id, req.account.type, Number(req.query.page))),
+      ...(await loadAgreements(req.service.externalId, req.account.id, req.account.type, Number(page))),
     })
   }
 
@@ -61,13 +63,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   req.session.agreementsFilter = req.url.split('?')[1] || ''
 
   return response(req, res, 'simplified-account/services/agreements/index', {
-    ...(await loadAgreements(
-      req.service.externalId,
-      req.account.id,
-      req.account.type,
-      Number(req.query.page),
-      filters
-    )),
+    ...(await loadAgreements(req.service.externalId, req.account.id, req.account.type, Number(page), filters)),
   })
 }
 

--- a/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
@@ -54,8 +54,6 @@ async function get(req, res) {
     req.account.id
   )
 
-  console.log('!! 6 - after signing')
-
   const webhookMessages = await webhooksService.getWebhookMessages(req.params.webhookExternalId, {
     page: currentPage,
     ...(deliveryStatus && { status: deliveryStatus }),

--- a/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
@@ -13,48 +13,84 @@ const PAGE_SIZE = 10
  * @param {import('@utils/types/settings/settings-request').SettingsRequest} req
  * @param {import('express').Response} res
  */
-async function get (req, res) {
-  const webhooksDetailUrl = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.detail, req.service.externalId, req.account.type, req.params.webhookExternalId)
+async function get(req, res) {
+  console.log('!! - 3 - detail controller')
+  const webhooksDetailUrl = formatSimplifiedAccountPathsFor(
+    paths.simplifiedAccount.settings.webhooks.detail,
+    req.service.externalId,
+    req.account.type,
+    req.params.webhookExternalId
+  )
+  console.log('!! - 4 - detail controller - webhooksDetailUrl: ', webhooksDetailUrl)
   const validations = [
-    query('page')
-      .customSanitizer((value) => {
-        const pageNumber = Number(value)
-        if (isNaN(pageNumber)) {
-          return 1
-        }
-        return pageNumber
-      }),
-    query('deliveryStatus')
-      .customSanitizer((value) => {
-        const validValues = [ALL, SUCCESSFUL, FAILED, PENDING, WILL_NOT_SEND]
-        if (!validValues.includes(value)) {
-          return ALL
-        }
-        return value
-      })
+    query('page').customSanitizer((value) => {
+      const pageNumber = Number(value)
+      console.log('!! 1 pageNumber: ', pageNumber)
+      if (isNaN(pageNumber)) {
+        console.log('!! 1b - returning 1')
+        return 1
+      }
+      return pageNumber
+    }),
+    query('deliveryStatus').customSanitizer((value) => {
+      const validValues = [ALL, SUCCESSFUL, FAILED, PENDING, WILL_NOT_SEND]
+      if (!validValues.includes(value)) {
+        return ALL
+      }
+      return value
+    }),
   ]
 
-  await Promise.all(validations.map(async validation => validation.run(req)))
+  await Promise.all(validations.map(async (validation) => validation.run(req)))
+  console.log('!! - req.query: ', JSON.stringify(req.query))
+  console.log('!! - req.query.page: ', req.query.page)
   let currentPage = Number(req.query.page)
   const deliveryStatus = req.query.deliveryStatus
 
   const webhook = await webhooksService.getWebhook(req.params.webhookExternalId, req.service.externalId, req.account.id)
-  const signingSecret = await webhooksService.getSigningSecret(req.params.webhookExternalId, req.service.externalId, req.account.id)
-  const webhookMessages = await webhooksService.getWebhookMessages(req.params.webhookExternalId, { page: currentPage, ...deliveryStatus && { status: deliveryStatus } })
+  console.log('!! 5 - validation')
+  const signingSecret = await webhooksService.getSigningSecret(
+    req.params.webhookExternalId,
+    req.service.externalId,
+    req.account.id
+  )
+
+  console.log('!! 6 - after signing')
+
+  const webhookMessages = await webhooksService.getWebhookMessages(req.params.webhookExternalId, {
+    page: currentPage,
+    ...(deliveryStatus && { status: deliveryStatus }),
+  })
+
+  console.log('!! 7 - after getWebhookMessages')
+
   const totalPages = Math.ceil(webhookMessages.total / PAGE_SIZE)
   if (totalPages > 0 && currentPage > totalPages) {
     currentPage = totalPages
   }
 
-  const webhookEvents = webhookMessages.results.map(result => ({
+  const webhookEvents = webhookMessages.results.map((result) => ({
     resourceId: result.resource_id,
     eventType: result.event_type,
     lastDeliveryStatus: result.last_delivery_status,
     eventDate: result.event_date,
-    eventDetailUrl: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.event, req.service.externalId, req.account.type, webhook.externalId, result.external_id)
+    eventDetailUrl: formatSimplifiedAccountPathsFor(
+      paths.simplifiedAccount.settings.webhooks.event,
+      req.service.externalId,
+      req.account.type,
+      webhook.externalId,
+      result.external_id
+    ),
   }))
 
-  const pagination = getPagination(currentPage, PAGE_SIZE, webhookMessages.total, (pageNumber) => `${webhooksDetailUrl}?deliveryStatus=${deliveryStatus}&page=${pageNumber}#events`)
+  const pagination = getPagination(
+    currentPage,
+    PAGE_SIZE,
+    webhookMessages.total,
+    (pageNumber) => `${webhooksDetailUrl}?deliveryStatus=${deliveryStatus}&page=${pageNumber}#events`
+  )
+
+  console.log('!! 6')
 
   const messages = res.locals?.flash?.messages ?? []
   response(req, res, 'simplified-account/settings/webhooks/detail', {
@@ -65,12 +101,26 @@ async function get (req, res) {
     webhookEvents,
     pagination,
     eventTypes: constants.webhooks.humanReadableSubscriptions,
-    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type),
-    updateWebhookLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.update, req.service.externalId, req.account.type, req.params.webhookExternalId),
-    toggleWebhookStatusLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.toggle, req.service.externalId, req.account.type, req.params.webhookExternalId)
+    backLink: formatSimplifiedAccountPathsFor(
+      paths.simplifiedAccount.settings.webhooks.index,
+      req.service.externalId,
+      req.account.type
+    ),
+    updateWebhookLink: formatSimplifiedAccountPathsFor(
+      paths.simplifiedAccount.settings.webhooks.update,
+      req.service.externalId,
+      req.account.type,
+      req.params.webhookExternalId
+    ),
+    toggleWebhookStatusLink: formatSimplifiedAccountPathsFor(
+      paths.simplifiedAccount.settings.webhooks.toggle,
+      req.service.externalId,
+      req.account.type,
+      req.params.webhookExternalId
+    ),
   })
 }
 
 module.exports = {
-  get
+  get,
 }

--- a/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
@@ -4,7 +4,7 @@ const getPagination = require('@utils/simplified-account/pagination')
 const webhooksService = require('@services/webhooks.service')
 const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
 const { constants } = require('@govuk-pay/pay-js-commons')
-const { query } = require('express-validator')
+const { query, matchedData } = require('express-validator')
 const { ALL, SUCCESSFUL, FAILED, PENDING, WILL_NOT_SEND } = require('@models/constants/webhook-delivery-status')
 
 const PAGE_SIZE = 10
@@ -42,10 +42,9 @@ async function get(req, res) {
   ]
 
   await Promise.all(validations.map(async (validation) => validation.run(req)))
-  console.log('!! - req.query: ', JSON.stringify(req.query))
-  console.log('!! - req.query.page: ', req.query.page)
-  let currentPage = Number(req.query.page)
-  const deliveryStatus = req.query.deliveryStatus
+
+  const { page, deliveryStatus } = matchedData(req)
+  let currentPage = Number(page)
 
   const webhook = await webhooksService.getWebhook(req.params.webhookExternalId, req.service.externalId, req.account.id)
   console.log('!! 5 - validation')

--- a/src/controllers/simplified-account/settings/webhooks/update/update-webhook.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/update/update-webhook.controller.js
@@ -3,7 +3,10 @@ const paths = require('@root/paths')
 const { response } = require('@utils/response')
 const { constants } = require('@govuk-pay/pay-js-commons')
 const webhooksService = require('@services/webhooks.service')
-const { webhookErrorIdentifiers, CREATE_AND_UPDATE_WEBHOOK_VALIDATIONS } = require('@utils/simplified-account/validation/webhook.schema')
+const {
+  webhookErrorIdentifiers,
+  CREATE_AND_UPDATE_WEBHOOK_VALIDATIONS,
+} = require('@utils/simplified-account/validation/webhook.schema')
 const { validationResult } = require('express-validator')
 const formatValidationErrors = require('@utils/simplified-account/format/format-validation-errors')
 const { responseWithErrors } = require('@controllers/simplified-account/settings/webhooks/create/create.controller')
@@ -15,16 +18,22 @@ const WebhookUpdateRequest = require('@models/webhooks/WebhookUpdateRequest.clas
  * @param res
  * @returns {Promise<void>}
  */
-async function get (req, res) {
+async function get(req, res) {
   console.log('!! 2 - inside controller')
   const webhook = await webhooksService.getWebhook(req.params.webhookExternalId, req.service.externalId, req.account.id)
 
   response(req, res, 'simplified-account/settings/webhooks/edit', {
     form: {
-      callbackUrl: webhook.callbackUrl, description: webhook.description, subscriptions: webhook.subscriptions
+      callbackUrl: webhook.callbackUrl,
+      description: webhook.description,
+      subscriptions: webhook.subscriptions,
     },
     eventTypes: constants.webhooks.humanReadableSubscriptions,
-    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type)
+    backLink: formatSimplifiedAccountPathsFor(
+      paths.simplifiedAccount.settings.webhooks.index,
+      req.service.externalId,
+      req.account.type
+    ),
   })
 }
 
@@ -35,8 +44,8 @@ async function get (req, res) {
  * @param next {function}
  * @returns {Promise<void>}
  */
-async function post (req, res, next) {
-  await Promise.all(CREATE_AND_UPDATE_WEBHOOK_VALIDATIONS.map(validation => validation.run(req)))
+async function post(req, res, next) {
+  await Promise.all(CREATE_AND_UPDATE_WEBHOOK_VALIDATIONS.map((validation) => validation.run(req)))
   const validationErrors = validationResult(req)
   if (!validationErrors.isEmpty()) {
     const formattedValidationErrors = formatValidationErrors(validationErrors)
@@ -44,18 +53,26 @@ async function post (req, res, next) {
   }
 
   const webhookUpdateRequest = new WebhookUpdateRequest()
-    .replace().description(req.body.description)
-    .replace().callbackUrl(req.body.callbackUrl)
-    .replace().subscriptions(typeof (req.body.subscriptions) === 'string' ? [req.body.subscriptions] : req.body.subscriptions)
+    .replace()
+    .description(req.body.description)
+    .replace()
+    .callbackUrl(req.body.callbackUrl)
+    .replace()
+    .subscriptions(typeof req.body.subscriptions === 'string' ? [req.body.subscriptions] : req.body.subscriptions)
 
   try {
-    await webhooksService.updateWebhook(req.params.webhookExternalId, req.service.externalId, req.account.id, webhookUpdateRequest)
+    await webhooksService.updateWebhook(
+      req.params.webhookExternalId,
+      req.service.externalId,
+      req.account.id,
+      webhookUpdateRequest
+    )
   } catch (updateWebhookError) {
     if (updateWebhookError.errorIdentifier in webhookErrorIdentifiers) {
       const callbackErrorMessage = webhookErrorIdentifiers[updateWebhookError.errorIdentifier]
       const callbackUrlError = {
         errorSummary: [{ text: callbackErrorMessage, href: '#callback-url' }],
-        formErrors: { callbackUrl: callbackErrorMessage }
+        formErrors: { callbackUrl: callbackErrorMessage },
       }
       return responseWithErrors(req, res, callbackUrlError)
     } else {
@@ -63,10 +80,17 @@ async function post (req, res, next) {
     }
   }
 
-  return res.redirect(formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.detail, req.service.externalId, req.account.type, req.params.webhookExternalId))
+  return res.redirect(
+    formatSimplifiedAccountPathsFor(
+      paths.simplifiedAccount.settings.webhooks.detail,
+      req.service.externalId,
+      req.account.type,
+      req.params.webhookExternalId
+    )
+  )
 }
 
 module.exports = {
   get,
-  post
+  post,
 }

--- a/src/controllers/simplified-account/settings/webhooks/update/update-webhook.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/update/update-webhook.controller.js
@@ -16,6 +16,7 @@ const WebhookUpdateRequest = require('@models/webhooks/WebhookUpdateRequest.clas
  * @returns {Promise<void>}
  */
 async function get (req, res) {
+  console.log('!! 2 - inside controller')
   const webhook = await webhooksService.getWebhook(req.params.webhookExternalId, req.service.externalId, req.account.id)
 
   response(req, res, 'simplified-account/settings/webhooks/edit', {

--- a/src/controllers/simplified-account/settings/webhooks/webhooks.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/webhooks.controller.js
@@ -5,22 +5,42 @@ const webhooksService = require('@services/webhooks.service')
 const { constants } = require('@govuk-pay/pay-js-commons')
 const { WebhookStatus } = require('@models/webhooks/Webhook.class')
 
-async function get (req, res) {
+async function get(req, res) {
+  console.log('!! 1 - inside controller')
   const accountIsLive = req.account.type === 'live'
   const messages = res.locals?.flash?.messages ?? []
-  const webhooks = await webhooksService.listWebhooks(req.service.externalId, req.account.id, accountIsLive)
-    .then(webhooks => webhooks.map(webhook => Object.assign(webhook, {
-      detailUrl: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.detail, req.service.externalId, req.account.type, webhook.externalId),
-      updateUrl: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.update, req.service.externalId, req.account.type, webhook.externalId)
-    })))
-  const activeWebhooks = webhooks.filter(webhook => webhook.status === WebhookStatus.ACTIVE)
-  const deactivatedWebhooks = webhooks.filter(webhook => webhook.status === WebhookStatus.INACTIVE)
+  const webhooks = await webhooksService
+    .listWebhooks(req.service.externalId, req.account.id, accountIsLive)
+    .then((webhooks) =>
+      webhooks.map((webhook) =>
+        Object.assign(webhook, {
+          detailUrl: formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.webhooks.detail,
+            req.service.externalId,
+            req.account.type,
+            webhook.externalId
+          ),
+          updateUrl: formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.webhooks.update,
+            req.service.externalId,
+            req.account.type,
+            webhook.externalId
+          ),
+        })
+      )
+    )
+  const activeWebhooks = webhooks.filter((webhook) => webhook.status === WebhookStatus.ACTIVE)
+  const deactivatedWebhooks = webhooks.filter((webhook) => webhook.status === WebhookStatus.INACTIVE)
   response(req, res, 'simplified-account/settings/webhooks/index', {
     messages,
     activeWebhooks,
     deactivatedWebhooks,
     eventTypes: constants.webhooks.humanReadableSubscriptions,
-    createWebhookLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.create, req.service.externalId, req.account.type)
+    createWebhookLink: formatSimplifiedAccountPathsFor(
+      paths.simplifiedAccount.settings.webhooks.create,
+      req.service.externalId,
+      req.account.type
+    ),
   })
 }
 
@@ -30,5 +50,5 @@ module.exports = {
   detail: require('./detail/detail.controller'),
   event: require('./event/event.controller'),
   update: require('./update/update-webhook.controller'),
-  toggle: require('./toggle/toggle-webhook-status.controller')
+  toggle: require('./toggle/toggle-webhook-status.controller'),
 }

--- a/src/middleware/validate-status-filter.test.ts
+++ b/src/middleware/validate-status-filter.test.ts
@@ -1,0 +1,33 @@
+import sinon from 'sinon'
+import { ServiceRequest, ServiceResponse } from '@utils/types/express'
+import validateStatusFilter from './validate-status-filter'
+
+describe('validate status filter middleware', () => {
+  let req: Partial<ServiceRequest>
+  let res: Partial<ServiceResponse>
+  let next: sinon.SinonSpy
+
+  beforeEach(() => {
+    req = {} as Partial<ServiceRequest>
+    res = {} as Partial<ServiceResponse>
+    next = sinon.spy()
+  })
+
+  it('should call next() when status filter is TEST', () => {
+    req.params = { statusFilter: 'test' }
+    validateStatusFilter(req as ServiceRequest, res as ServiceResponse, next)
+    sinon.assert.calledWithExactly(next)
+  })
+
+  it('should call next() when status filter is LIVE', () => {
+    req.params = { statusFilter: 'live' }
+    validateStatusFilter(req as ServiceRequest, res as ServiceResponse, next)
+    sinon.assert.calledWithExactly(next)
+  })
+
+  it('should call next(route) when status filter is NOT live/test', () => {
+    req.params = { statusFilter: 'invalid-status' }
+    validateStatusFilter(req as ServiceRequest, res as ServiceResponse, next)
+    sinon.assert.calledWith(next, 'route')
+  })
+})

--- a/src/middleware/validate-status-filter.ts
+++ b/src/middleware/validate-status-filter.ts
@@ -1,0 +1,11 @@
+import { ServiceRequest, ServiceResponse } from '@utils/types/express'
+import { NextFunction } from 'express'
+
+function validateStatusFilter(req: ServiceRequest, _: ServiceResponse, next: NextFunction) {
+  if (!['test', 'live'].includes(req.params.statusFilter)) {
+    return next('route')
+  }
+  next()
+}
+
+export = validateStatusFilter

--- a/src/paths.js
+++ b/src/paths.js
@@ -338,16 +338,16 @@ module.exports = {
   index: '/',
   allServiceTransactions: {
     index: '/all-service-transactions',
-    indexStatusFilter: '/all-service-transactions/:statusFilter(test|live)',
-    indexStatusFilterWithoutSearch: '/all-service-transactions/nosearch/:statusFilter(test|live)',
+    indexStatusFilter: '/all-service-transactions/:statusFilter',
+    indexStatusFilterWithoutSearch: '/all-service-transactions/nosearch/:statusFilter',
     download: '/all-service-transactions/download',
-    downloadStatusFilter: '/all-service-transactions/download/:statusFilter(test|live)',
+    downloadStatusFilter: '/all-service-transactions/download/:statusFilter',
     redirectDetail: '/redirect/transactions/:chargeId',
     simplifiedAccount: {
-      index: '/transactions/:modeFilter?',
+      index: '/transactions{/:modeFilter}',
       nosearch: '/transactions/nosearch',
-      download: '/transaction/download/:modeFilter?',
-      filter: '/transactions/:statusFilter(test|live)',
+      download: '/transaction/download{/:modeFilter}',
+      filter: '/transactions/:statusFilter',
       detail: '/transactions/:transactionId',
       refund: '/transaction/:transactionId/refund',
     },
@@ -401,7 +401,7 @@ module.exports = {
   policyPage: '/policy/:key',
   payouts: {
     list: '/payments-to-your-bank-account',
-    listStatusFilter: '/payments-to-your-bank-account/:statusFilter(test|live)',
+    listStatusFilter: '/payments-to-your-bank-account/:statusFilter',
   },
   privacy: '/privacy',
   demoPaymentFwd: {

--- a/src/routes.js
+++ b/src/routes.js
@@ -195,7 +195,6 @@ module.exports.bind = function (app) {
   // all service transactions - simplified account
   app.get(
     allServiceTransactions.simplifiedAccount.index,
-    validateStatusFilter,
     experimentalFeature(Features.TRANSACTIONS),
     userIsAuthorised,
     homeController.allServiceTransactions.list.get

--- a/src/routes.js
+++ b/src/routes.js
@@ -21,6 +21,7 @@ const { enforceUserFirstFactor, redirectLoggedInUser } = require('./services/aut
 const trimUsername = require('./middleware/trim-username')
 const permission = require('./middleware/permission')
 const inviteCookieIsPresent = require('./middleware/invite-cookie-is-present')
+const validateStatusFilter = require('./middleware/validate-status-filter')
 
 // Controllers
 const staticController = require('./controllers/static.controller')
@@ -170,19 +171,31 @@ module.exports.bind = function (app) {
 
   // All service transactions
   app.get(allServiceTransactions.index, userIsAuthorised, allTransactionsController.getController)
-  app.get(allServiceTransactions.indexStatusFilter, userIsAuthorised, allTransactionsController.getController)
+  app.get(
+    allServiceTransactions.indexStatusFilter,
+    validateStatusFilter,
+    userIsAuthorised,
+    allTransactionsController.getController
+  )
   app.get(
     allServiceTransactions.indexStatusFilterWithoutSearch,
+    validateStatusFilter,
     userIsAuthorised,
     allTransactionsController.noAutosearchTransactions
   )
   app.get(allServiceTransactions.download, userIsAuthorised, allTransactionsController.downloadTransactions)
-  app.get(allServiceTransactions.downloadStatusFilter, userIsAuthorised, allTransactionsController.downloadTransactions)
+  app.get(
+    allServiceTransactions.downloadStatusFilter,
+    validateStatusFilter,
+    userIsAuthorised,
+    allTransactionsController.downloadTransactions
+  )
   app.get(allServiceTransactions.redirectDetail, userIsAuthorised, transactionDetailRedirectController)
 
   // all service transactions - simplified account
   app.get(
     allServiceTransactions.simplifiedAccount.index,
+    validateStatusFilter,
     experimentalFeature(Features.TRANSACTIONS),
     userIsAuthorised,
     homeController.allServiceTransactions.list.get
@@ -200,7 +213,7 @@ module.exports.bind = function (app) {
 
   // Payouts
   app.get(payouts.list, userIsAuthorised, payoutsController.listAllServicesPayouts)
-  app.get(payouts.listStatusFilter, userIsAuthorised, payoutsController.listAllServicesPayouts)
+  app.get(payouts.listStatusFilter, validateStatusFilter, userIsAuthorised, payoutsController.listAllServicesPayouts)
 
   // Stripe terms and conditions
   app.get(stripeTermsAndConditions, userIsAuthorised, stripeTermsAndConditionsController.get)
@@ -321,7 +334,7 @@ module.exports.bind = function (app) {
   app.get('/.well-known/security.txt', (req, res) => res.redirect(securitytxt))
   app.get('/security.txt', (req, res) => res.redirect(securitytxt))
 
-  app.all('*', (req, res, next) => {
+  app.all('*splat', (req, res, next) => {
     if (accountUrls.isLegacyAccountsUrl(req.url)) {
       logger.info('Accounts URL utility forwarding a legacy account URL', {
         url: req.originalUrl,

--- a/src/services/clients/webhooks.client.js
+++ b/src/services/clients/webhooks.client.js
@@ -8,7 +8,7 @@ const { Webhook } = require('@models/webhooks/Webhook.class')
 const defaultRequestOptions = {
   baseUrl: process.env.WEBHOOKS_URL,
   json: true,
-  service: 'webhooks'
+  service: 'webhooks',
 }
 
 const client = new Client(defaultRequestOptions.service)
@@ -21,17 +21,17 @@ const client = new Client(defaultRequestOptions.service)
  * @param options {{ baseUrl: String }}
  * @returns {Promise<Webhook>}
  */
-async function webhook (webhookExternalId, serviceExternalId, gatewayAccountId, options = {}) {
+async function webhook(webhookExternalId, serviceExternalId, gatewayAccountId, options = {}) {
   const baseUrl = options.baseUrl ? options.baseUrl : defaultRequestOptions.baseUrl
   const url = urlJoin(baseUrl, '/v1/webhook', webhookExternalId)
   const fullUrl = `${url}?service_id=${serviceExternalId}&gateway_account_id=${gatewayAccountId}`
   configureClient(client, fullUrl)
-  console.log('!! - webhook client');
+  console.log('!! - webhook client')
   const response = await client.get(fullUrl, 'Get one webhook')
   return Webhook.fromJson(response.data)
 }
 
-async function signingSecret (webhookId, serviceId, gatewayAccountId, options = {}) {
+async function signingSecret(webhookId, serviceId, gatewayAccountId, options = {}) {
   const baseUrl = options.baseUrl ? options.baseUrl : defaultRequestOptions.baseUrl
   const url = urlJoin(baseUrl, '/v1/webhook/', webhookId, '/signing-key')
   const fullUrl = `${url}?service_id=${serviceId}&gateway_account_id=${gatewayAccountId}`
@@ -40,7 +40,7 @@ async function signingSecret (webhookId, serviceId, gatewayAccountId, options = 
   return response.data
 }
 
-async function resetSigningSecret (webhookId, serviceId, gatewayAccountId, options = {}) {
+async function resetSigningSecret(webhookId, serviceId, gatewayAccountId, options = {}) {
   const baseUrl = options.baseUrl ? options.baseUrl : defaultRequestOptions.baseUrl
   const url = urlJoin(baseUrl, '/v1/webhook/', webhookId, '/signing-key')
   const fullUrl = `${url}?service_id=${serviceId}&gateway_account_id=${gatewayAccountId}`
@@ -57,16 +57,16 @@ async function resetSigningSecret (webhookId, serviceId, gatewayAccountId, optio
  * @param options {{ baseUrl: String }}
  * @returns {Promise<[Webhook]>}
  */
-async function webhooks (serviceExternalId, gatewayAccountId, isLive, options = {}) {
+async function webhooks(serviceExternalId, gatewayAccountId, isLive, options = {}) {
   const baseUrl = options.baseUrl ? options.baseUrl : defaultRequestOptions.baseUrl
   const url = urlJoin(baseUrl, '/v1/webhook')
   const fullUrl = `${url}?service_id=${serviceExternalId}&gateway_account_id=${gatewayAccountId}&live=${isLive}`
   configureClient(client, fullUrl)
   const response = await client.get(fullUrl, 'List webhooks for service')
-  return response.data.map(webhookData => Webhook.fromJson(webhookData))
+  return response.data.map((webhookData) => Webhook.fromJson(webhookData))
 }
 
-async function message (id, webhookId, options = {}) {
+async function message(id, webhookId, options = {}) {
   const baseUrl = options.baseUrl ? options.baseUrl : defaultRequestOptions.baseUrl
   const url = urlJoin(baseUrl, '/v1/webhook', webhookId, 'message', id)
   configureClient(client, url)
@@ -74,7 +74,7 @@ async function message (id, webhookId, options = {}) {
   return response.data
 }
 
-async function attempts (messageId, webhookId, options = {}) {
+async function attempts(messageId, webhookId, options = {}) {
   const baseUrl = options.baseUrl ? options.baseUrl : defaultRequestOptions.baseUrl
   const url = urlJoin(baseUrl, '/v1/webhook', webhookId, 'message', messageId, 'attempt')
   configureClient(client, url)
@@ -82,7 +82,7 @@ async function attempts (messageId, webhookId, options = {}) {
   return response.data
 }
 
-async function messages (id, options = {}) {
+async function messages(id, options = {}) {
   const baseUrl = options.baseUrl ? options.baseUrl : defaultRequestOptions.baseUrl
   const url = urlJoin(baseUrl, '/v1/webhook', id, 'message')
   let fullUrl = `${url}?page=${options.page}`
@@ -95,14 +95,14 @@ async function messages (id, options = {}) {
 }
 
 // TODO refactor to explicitly pass all params in the method once old webhooks controller code is deleted
-async function createWebhook (serviceId, gatewayAccountId, isLive, options = {}) {
+async function createWebhook(serviceId, gatewayAccountId, isLive, options = {}) {
   const body = {
     service_id: serviceId,
     gateway_account_id: gatewayAccountId,
     live: isLive,
     callback_url: options.callbackUrl || options.callback_url,
     subscriptions: options.subscriptions,
-    description: options.description
+    description: options.description,
   }
   const baseUrl = options.baseUrl ? options.baseUrl : defaultRequestOptions.baseUrl
   const url = urlJoin(baseUrl, '/v1/webhook')
@@ -120,19 +120,18 @@ async function createWebhook (serviceId, gatewayAccountId, isLive, options = {})
  * @param options {{ baseUrl: String }}
  * @returns {Promise<*>}
  */
-async function updateWebhook (webhookExternalId, serviceExternalId, gatewayAccountId, patchRequest, options = {}) {
+async function updateWebhook(webhookExternalId, serviceExternalId, gatewayAccountId, patchRequest, options = {}) {
   const baseUrl = options.baseUrl ? options.baseUrl : defaultRequestOptions.baseUrl
   const url = urlJoin(baseUrl, '/v1/webhook', webhookExternalId)
   const fullUrl = `${url}?service_id=${serviceExternalId}&gateway_account_id=${gatewayAccountId}`
   configureClient(client, fullUrl)
-  const response = await client.patch(fullUrl, patchRequest.toJson(), 'Update webhook')
-    .catch(e => {
-      throw e
-    })
+  const response = await client.patch(fullUrl, patchRequest.toJson(), 'Update webhook').catch((e) => {
+    throw e
+  })
   return response.data
 }
 
-async function resendWebhookMessage (webhookId, messageId, options = {}) {
+async function resendWebhookMessage(webhookId, messageId, options = {}) {
   const baseUrl = options.baseUrl ? options.baseUrl : defaultRequestOptions.baseUrl
   const url = urlJoin(baseUrl, '/v1/webhook', webhookId, 'message', messageId, 'resend')
   configureClient(client, url)
@@ -150,5 +149,5 @@ module.exports = {
   messages,
   message,
   attempts,
-  resendWebhookMessage
+  resendWebhookMessage,
 }

--- a/src/services/clients/webhooks.client.js
+++ b/src/services/clients/webhooks.client.js
@@ -26,6 +26,7 @@ async function webhook (webhookExternalId, serviceExternalId, gatewayAccountId, 
   const url = urlJoin(baseUrl, '/v1/webhook', webhookExternalId)
   const fullUrl = `${url}?service_id=${serviceExternalId}&gateway_account_id=${gatewayAccountId}`
   configureClient(client, fullUrl)
+  console.log('!! - webhook client');
   const response = await client.get(fullUrl, 'Get one webhook')
   return Webhook.fromJson(response.data)
 }

--- a/src/services/webhooks.service.js
+++ b/src/services/webhooks.service.js
@@ -8,18 +8,18 @@ const { NotFoundError } = require('@root/errors')
 
 const PAGE_SIZE = 10
 
-function sortByActiveStatus (a, b) {
+function sortByActiveStatus(a, b) {
   return Number(b.status === 'ACTIVE') - Number(a.status === 'ACTIVE')
 }
 
-function formatPages (searchResponse) {
+function formatPages(searchResponse) {
   const { page, count } = searchResponse
   const paginator = new Paginator(null, PAGE_SIZE, page)
-  const hasMultiplePages = (count >= PAGE_SIZE) || (page > 1)
+  const hasMultiplePages = count >= PAGE_SIZE || page > 1
   const links = hasMultiplePages && paginator.buildNavigation(count)
   return {
     ...searchResponse,
-    links
+    links,
   }
 }
 
@@ -30,13 +30,13 @@ function formatPages (searchResponse) {
  * @param isLive {boolean}
  * @returns {Promise<Webhook[]>}
  */
-async function listWebhooks (serviceExternalId, gatewayAccountId, isLive) {
-  console.log('!!-list Webhooks');
+async function listWebhooks(serviceExternalId, gatewayAccountId, isLive) {
+  console.log('!!-list Webhooks')
   const webhooks = await webhooksClient.webhooks(serviceExternalId, gatewayAccountId, isLive)
   return webhooks.sort(sortByActiveStatus)
 }
 
-function createWebhook (serviceId, gatewayAccountId, isLive, options = {}) {
+function createWebhook(serviceId, gatewayAccountId, isLive, options = {}) {
   options.subscriptions = typeof options.subscriptions === 'string' ? [options.subscriptions] : options.subscriptions
   return webhooksClient.createWebhook(serviceId, gatewayAccountId, isLive, options)
 }
@@ -49,7 +49,7 @@ function createWebhook (serviceId, gatewayAccountId, isLive, options = {}) {
  * @param patchRequest {WebhookUpdateRequest}
  * @returns {Promise<*>}
  */
-function updateWebhook (webhookExternalId, serviceExternalId, gatewayAccountId, patchRequest) {
+function updateWebhook(webhookExternalId, serviceExternalId, gatewayAccountId, patchRequest) {
   return webhooksClient.updateWebhook(webhookExternalId, serviceExternalId, gatewayAccountId, patchRequest)
 }
 
@@ -60,36 +60,37 @@ function updateWebhook (webhookExternalId, serviceExternalId, gatewayAccountId, 
  * @param gatewayAccountId {String}
  * @returns {Promise<Webhook>}
  */
-function getWebhook (webhookExternalId, serviceExternalId, gatewayAccountId) {
-  return webhooksClient.webhook(webhookExternalId, serviceExternalId, gatewayAccountId)
-    .catch(e => {
-      if (e.errorCode === 404) {
-        throw new NotFoundError(`Webhook with external ID <${webhookExternalId}> not found for service <${serviceExternalId}>, account <${gatewayAccountId}>`)
-      } else {
-        throw e
-      }
-    })
+function getWebhook(webhookExternalId, serviceExternalId, gatewayAccountId) {
+  return webhooksClient.webhook(webhookExternalId, serviceExternalId, gatewayAccountId).catch((e) => {
+    if (e.errorCode === 404) {
+      throw new NotFoundError(
+        `Webhook with external ID <${webhookExternalId}> not found for service <${serviceExternalId}>, account <${gatewayAccountId}>`
+      )
+    } else {
+      throw e
+    }
+  })
 }
 
-function getWebhookMessage (id, webhookId) {
+function getWebhookMessage(id, webhookId) {
   return webhooksClient.message(id, webhookId)
 }
 
-function getWebhookMessageAttempts (messageId, webhookId) {
+function getWebhookMessageAttempts(messageId, webhookId) {
   return webhooksClient.attempts(messageId, webhookId)
 }
 
-async function getWebhookMessages (id, options = {}) {
+async function getWebhookMessages(id, options = {}) {
   console.log('!! - options: ', options)
   const searchResponse = await webhooksClient.messages(id, options)
   return formatPages(searchResponse)
 }
 
-function getSigningSecret (webhookId, serviceId, gatewayAccountId) {
+function getSigningSecret(webhookId, serviceId, gatewayAccountId) {
   return webhooksClient.signingSecret(webhookId, serviceId, gatewayAccountId)
 }
 
-function resetSigningSecret (webhookId, serviceId, gatewayAccountId) {
+function resetSigningSecret(webhookId, serviceId, gatewayAccountId) {
   return webhooksClient.resetSigningSecret(webhookId, serviceId, gatewayAccountId)
 }
 
@@ -101,14 +102,13 @@ function resetSigningSecret (webhookId, serviceId, gatewayAccountId) {
  * @param currentStatus {WebhookStatus}
  * @returns {Promise<*>}
  */
-function toggleStatus (webhookExternalId, serviceId, gatewayAccountId, currentStatus) {
+function toggleStatus(webhookExternalId, serviceId, gatewayAccountId, currentStatus) {
   const status = currentStatus === WebhookStatus.ACTIVE ? WebhookStatus.INACTIVE : WebhookStatus.ACTIVE
-  const webhookUpdateRequest = new WebhookUpdateRequest()
-    .replace().status(status)
+  const webhookUpdateRequest = new WebhookUpdateRequest().replace().status(status)
   return webhooksClient.updateWebhook(webhookExternalId, serviceId, gatewayAccountId, webhookUpdateRequest)
 }
 
-function resendWebhookMessage (webhookId, messageId) {
+function resendWebhookMessage(webhookId, messageId) {
   return webhooksClient.resendWebhookMessage(webhookId, messageId)
 }
 
@@ -123,5 +123,5 @@ module.exports = {
   getWebhookMessages,
   getWebhookMessage,
   getWebhookMessageAttempts,
-  resendWebhookMessage
+  resendWebhookMessage,
 }

--- a/src/services/webhooks.service.js
+++ b/src/services/webhooks.service.js
@@ -31,6 +31,7 @@ function formatPages (searchResponse) {
  * @returns {Promise<Webhook[]>}
  */
 async function listWebhooks (serviceExternalId, gatewayAccountId, isLive) {
+  console.log('!!-list Webhooks');
   const webhooks = await webhooksClient.webhooks(serviceExternalId, gatewayAccountId, isLive)
   return webhooks.sort(sortByActiveStatus)
 }
@@ -79,6 +80,7 @@ function getWebhookMessageAttempts (messageId, webhookId) {
 }
 
 async function getWebhookMessages (id, options = {}) {
+  console.log('!! - options: ', options)
   const searchResponse = await webhooksClient.messages(id, options)
   return formatPages(searchResponse)
 }

--- a/src/utils/replace-params-in-path.test.js
+++ b/src/utils/replace-params-in-path.test.js
@@ -1,14 +1,16 @@
 const { expect } = require('chai')
 const formattedPathFor = require('./replace-params-in-path')
 
-describe.only('1 formattedPathFor', () => {
+describe('formattedPathFor', () => {
   describe('with a required parameter', () => {
     it('should replace a single param', () => {
       expect(formattedPathFor('/service/:serviceId', 'abc123')).to.equal('/service/abc123')
     })
 
     it('should replace multiple params', () => {
-      expect(formattedPathFor('/service/:serviceId/account/:accountId', 'abc123', 'def456')).to.equal('/service/abc123/account/def456')
+      expect(formattedPathFor('/service/:serviceId/account/:accountId', 'abc123', 'def456')).to.equal(
+        '/service/abc123/account/def456'
+      )
     })
 
     it('should encode special characters in params', () => {

--- a/src/utils/replace-params-in-path.ts
+++ b/src/utils/replace-params-in-path.ts
@@ -1,11 +1,25 @@
 const formatPathFor = (path: string, ...pathParams: string[]): string => {
-  const paramNames = path.split('/').filter((segment) => segment.startsWith(':'))
-  paramNames.forEach((paramName, index) => {
-    if (pathParams[index]) {
-      path = path.replace(paramName, encodeURIComponent(pathParams[index]))
+  let paramIndex = 0
+
+  // Unwrap optional segments: {/:param} -> /:param and :param? -> :param
+  const unwrapped = path.replace('{/', '/').replace('}', '')
+
+  const segments = unwrapped.split('/')
+  const result: string[] = []
+
+  segments.forEach((segment) => {
+    if (segment.startsWith(':')) {
+      const value = pathParams[paramIndex]
+      paramIndex++
+      if (value) {
+        result.push(encodeURIComponent(value))
+      }
+    } else {
+      result.push(segment)
     }
   })
-  return path
+
+  return result.join('/')
 }
 
 export = formatPathFor

--- a/src/utils/simplified-account/format/format-paths-for.test.js
+++ b/src/utils/simplified-account/format/format-paths-for.test.js
@@ -1,14 +1,16 @@
 const { expect } = require('chai')
 const formattedPathFor = require('@utils/simplified-account/format/format-paths-for')
 
-describe.only('1 formattedPathFor', () => {
+describe('formattedPathFor', () => {
   describe('with a required parameter', () => {
     it('should replace a single param', () => {
       expect(formattedPathFor('/service/:serviceId', 'abc123')).to.equal('/service/abc123')
     })
 
     it('should replace multiple params', () => {
-      expect(formattedPathFor('/service/:serviceId/account/:accountId', 'abc123', 'def456')).to.equal('/service/abc123/account/def456')
+      expect(formattedPathFor('/service/:serviceId/account/:accountId', 'abc123', 'def456')).to.equal(
+        '/service/abc123/account/def456'
+      )
     })
 
     it('should encode special characters in params', () => {

--- a/src/utils/simplified-account/format/format-paths-for.test.js
+++ b/src/utils/simplified-account/format/format-paths-for.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai')
-const formattedPathFor = require('./replace-params-in-path')
+const formattedPathFor = require('@utils/simplified-account/format/format-paths-for')
 
 describe.only('1 formattedPathFor', () => {
   describe('with a required parameter', () => {

--- a/src/utils/simplified-account/format/format-paths-for.ts
+++ b/src/utils/simplified-account/format/format-paths-for.ts
@@ -1,11 +1,25 @@
-const formattedPathFor = (path: string, ...pathParams: string[]) => {
-  const paramNames = path.split('/').filter((segment) => segment.startsWith(':'))
-  paramNames.forEach((paramName, index) => {
-    if (pathParams[index]) {
-      path = path.replace(paramName, encodeURIComponent(pathParams[index]))
+const formattedPathFor = (path: string, ...pathParams: string[]): string => {
+  let paramIndex = 0
+
+  // Unwrap optional segments: {/:param} -> /:param and :param? -> :param
+  const unwrapped = path.replace('{/', '/').replace('}', '')
+
+  const segments = unwrapped.split('/')
+  const result: string[] = []
+
+  segments.forEach((segment) => {
+    if (segment.startsWith(':')) {
+      const value = pathParams[paramIndex]
+      paramIndex++
+      if (value) {
+        result.push(encodeURIComponent(value))
+      }
+    } else {
+      result.push(segment)
     }
   })
-  return path
+
+  return result.join('/')
 }
 
 export = formattedPathFor

--- a/test/cypress/integration/simplified-account/service-settings/webhooks/toggle-webhook-status.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/webhooks/toggle-webhook-status.cy.js
@@ -76,7 +76,7 @@ describe('webhook settings - toggle webhook status', () => {
           })
         })
 
-        it.only('should be accessible from the webhook detail page', () => {
+        it('should be accessible from the webhook detail page', () => {
           cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/webhooks/${WEBHOOK_EXTERNAL_ID}`)
 
           cy.get('a').contains('Deactivate webhook').click()

--- a/test/cypress/integration/simplified-account/service-settings/webhooks/toggle-webhook-status.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/webhooks/toggle-webhook-status.cy.js
@@ -76,7 +76,7 @@ describe('webhook settings - toggle webhook status', () => {
           })
         })
 
-        it('should be accessible from the webhook detail page', () => {
+        it.only('should be accessible from the webhook detail page', () => {
           cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/${ACCOUNT_TYPE}/settings/webhooks/${WEBHOOK_EXTERNAL_ID}`)
 
           cy.get('a').contains('Deactivate webhook').click()

--- a/test/test-helpers/mock-session.js
+++ b/test/test-helpers/mock-session.js
@@ -13,7 +13,7 @@ const getUser = (opts) => {
 
 const createAppWithSession = function (app, sessionData, registerInviteData) {
   const proxyApp = express()
-  proxyApp.all('*', function (req, res, next) {
+  proxyApp.all('*splat', function (req, res, next) {
     sessionData.destroy = sinon.stub()
     req.session = req.session || sessionData || {}
     req.register_invite = registerInviteData || {}
@@ -55,11 +55,11 @@ const getMockSession = function (user) {
     csrfSecret: '123',
     12345: { refunded_amount: 5 },
     passport: {
-      user
+      user,
     },
     secondFactor: 'totp',
     last_url: 'last_url',
-    version: user.sessionVersion
+    version: user.sessionVersion,
   })
 }
 
@@ -71,5 +71,5 @@ module.exports = {
   getUser,
   getAppWithSessionWithoutSecondFactor,
   getAppWithRegisterInvitesCookie,
-  getAppWithLoggedOutSession
+  getAppWithLoggedOutSession,
 }


### PR DESCRIPTION
## What

This is a draft PR and will be split up into smaller PRs.

Keep it open in draft for reference.

PP-15031

- Update paths as cannot use regex in paths anymore
- Created a new middleware to set the status filter on routes that use
  a regex to set the status filter.
- Update the catch all from '*' to '*splat' - which is the common used
  convention in Express 5.

### How
- Check a few pages and make sure app is still running.
- In particular, check the `payouts` and `all services transactions` page.

### Accessibility (views have been added/changed)
N/A

### Screenshots (views have been added/changed)
N/A