### PR TITLE
PP-15163 Add contents:read permission to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   security-events: write
+  contents: read
 
 jobs:
   analyze:


### PR DESCRIPTION
## What
- CodeQL action needs `contents: read` permission as per https://github.com/github/codeql-action?tab=readme-ov-file#workflow-permissions

