### PR TITLE
PP-14277 Update privacy page to reference DSIT

### DIFF
--- a/src/views/privacy/privacy.njk
+++ b/src/views/privacy/privacy.njk
@@ -6,8 +6,13 @@
 
 {% block mainContent %}
   <div class="govuk-grid-column-one-third sub-navigation-container">
-    <nav class="sub-navigation" data-click-events data-click-category="Content" data-click-action="Link clicked"
-         data-cy="sub-navigation">
+    <nav
+      class="sub-navigation"
+      data-click-events
+      data-click-category="Content"
+      data-click-action="Link clicked"
+      data-cy="sub-navigation"
+    >
       <ol itemscope itemtype="http://schema.org/ItemList">
         <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
           <a class="govuk-link" itemprop="item" href="#who-we-are">
@@ -71,19 +76,18 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Privacy notice</h1>
 
-    <p class="govuk-body-l">Last updated: 7 April 2025</p>
+    <p class="govuk-body-l">Last updated: 20 April 2026</p>
 
     <h2 class="govuk-heading-m" id="who-we-are">Who we are</h2>
 
     <p class="govuk-body">
-      GOV.UK Pay is a payments service that’s built and maintained by the
-      Government Digital Service, which is part of the Cabinet Office
-      (“GDS”, “we”, “us”, “our”).
+      GOV.UK Pay is a payments service that’s built and maintained by the Government Digital Service, which is part of
+      the Department for Science, Innovation and Technology (“GDS”, “we”, “us”, “our”).
     </p>
 
     <p class="govuk-body">
-      Public sector organisations use GOV.UK Pay to take payments online and over the phone. To do
-      that, we collect, process and store certain data about paying users and public sector users.
+      Public sector organisations use GOV.UK Pay to take payments online and over the phone. To do that, we collect,
+      process and store certain data about paying users and public sector users.
     </p>
 
     <p class="govuk-body">
@@ -92,8 +96,8 @@
     </p>
 
     <p class="govuk-body">
-      If you’re an employee or contractor for a public sector organisation using GOV.UK
-      Pay as part of your role this privacy notice explains:
+      If you’re an employee or contractor for a public sector organisation using GOV.UK Pay as part of your role this
+      privacy notice explains:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
@@ -105,8 +109,8 @@
 
     <p class="govuk-body">
       Read the
-      <a class="govuk-link" href="https://ico.org.uk/ESDWebPages/Entry/Z7414053">
-        Cabinet Office’s entry in the Data Protection Public Register
+      <a class="govuk-link" href="https://ico.org.uk/ESDWebPages/Entry/ZB546218">
+        Department for Science, Innovation and Technology’s entry in the Data Protection Public Register
       </a>
       for more information.
     </p>
@@ -114,14 +118,14 @@
     <h2 class="govuk-heading-m" id="why-we-need-your-data">Why we need your data</h2>
 
     <p class="govuk-body">
-      When a public sector organisation wants to use GOV.UK Pay, you, as the employee will need to
-      create an account on GOV.UK Pay. We collect and process data about you, your colleagues and
-      your organisation in order to facilitate the set up of payment services and the taking and
-      managing of payments from your users.
+      When a public sector organisation wants to use GOV.UK Pay, you, as the employee will need to create an account on
+      GOV.UK Pay. We collect and process data about you, your colleagues and your organisation in order to facilitate
+      the set up of payment services and the taking and managing of payments from your users.
     </p>
 
-    <h2 class="govuk-heading-m" id="what-data-we-need-from-public-sector-employees">What data we need from public sector
-      employees</h2>
+    <h2 class="govuk-heading-m" id="what-data-we-need-from-public-sector-employees"
+      >What data we need from public sector employees</h2
+    >
 
     <p class="govuk-body">
       When
@@ -140,10 +144,9 @@
     </ul>
 
     <p class="govuk-body">
-      We also record a user’s permission level which determines the activity and
-      data any invited user has access to. When you request to make your payment
-      service live on GOV.UK Pay, with our payment provider Stripe, we require
-      the following additional information:
+      We also record a user’s permission level which determines the activity and data any invited user has access to.
+      When you request to make your payment service live on GOV.UK Pay, with our payment provider Stripe, we require the
+      following additional information:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
@@ -153,9 +156,8 @@
     </ul>
 
     <p class="govuk-body">
-      If you are an individual who holds a director and/or responsible person
-      role we will also collect the following personal data about you to enable
-      integration with our payment provider Stripe:
+      If you are an individual who holds a director and/or responsible person role we will also collect the following
+      personal data about you to enable integration with our payment provider Stripe:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
@@ -167,15 +169,15 @@
     </ul>
 
     <p class="govuk-body">
-      The legal basis for processing this data is ‘public task’ – allowing
-      you to access GOV.UK Pay to take and manage payments from users of your public service.
+      The legal basis for processing this data is ‘public task’ – allowing you to access GOV.UK Pay to take and manage
+      payments from users of your public service.
     </p>
 
     <h2 class="govuk-heading-m" id="what-we-do-with-your-data">What we do with your data</h2>
 
     <p class="govuk-body">
-      To carry out our responsibilities to the public sector organisation that uses GOV.UK Pay, we will need
-      to process data. This will allow us to:
+      To carry out our responsibilities to the public sector organisation that uses GOV.UK Pay, we will need to process
+      data. This will allow us to:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
@@ -185,8 +187,8 @@
       <li>allow you and other employees to log in and administer payments and refunds</li>
       <li>respond to any queries raised by the organisation or the payment provider in respect of the service</li>
       <li>
-        contact employees who are responsible for managing and operating the service about any changes or
-        issues and which may require action from them
+        contact employees who are responsible for managing and operating the service about any changes or issues and
+        which may require action from them
       </li>
       <li>inform users about changes and new features in GOV.UK Pay</li>
       <li>ask you to share your views and experiences of using GOV.UK Pay - for example, by responding to a survey</li>
@@ -194,14 +196,11 @@
 
     <p class="govuk-body">
       Where you provide your consent, we use
-      <a class="govuk-link" href="https://support.google.com/analytics/topic/2919631">
-        Google Analytics
-      </a> cookies to collect information about how you use GOV.UK Pay.
+      <a class="govuk-link" href="https://support.google.com/analytics/topic/2919631"> Google Analytics </a> cookies to
+      collect information about how you use GOV.UK Pay.
     </p>
 
-    <p class="govuk-body">
-      Google Analytics processes information about:
-    </p>
+    <p class="govuk-body"> Google Analytics processes information about: </p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>the pages you visit on GOV.UK Pay and when logged into the Pay admin tool</li>
@@ -210,9 +209,7 @@
       <li>what you click on while you’re visiting the site</li>
     </ul>
 
-    <p class="govuk-body">
-      We also receive the same information from other government digital services and GOV.UK.
-    </p>
+    <p class="govuk-body"> We also receive the same information from other government digital services and GOV.UK. </p>
 
     <p class="govuk-body">
       We make sure you cannot be directly identified by Google Analytics data. We do this by using Google Analytics
@@ -222,9 +219,7 @@
 
     <h2 class="govuk-heading-m" id="how-long-we-keep-your-data">How long we keep your data</h2>
 
-    <p class="govuk-body">
-      We will retain your personal data for as long as:
-    </p>
+    <p class="govuk-body"> We will retain your personal data for as long as: </p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>you operate and have access to a service on Pay</li>
@@ -237,41 +232,38 @@
     </h2>
 
     <p class="govuk-body">
-      We design, build and run our systems to make sure that your data is as safe as possible at any stage, both
-      while it’s processed and when it’s stored. We are committed to doing all that we can to keep your data secure.
-      We set up systems and processes to prevent unauthorised access or disclosure of the data we collect about
-      you – for example, we protect your data using varying levels of encryption. All third parties who process
-      personal data for GDS are required to keep that data secure. From time to time we will test the system
-      for security vulnerabilities.
+      We design, build and run our systems to make sure that your data is as safe as possible at any stage, both while
+      it’s processed and when it’s stored. We are committed to doing all that we can to keep your data secure. We set up
+      systems and processes to prevent unauthorised access or disclosure of the data we collect about you – for example,
+      we protect your data using varying levels of encryption. All third parties who process personal data for GDS are
+      required to keep that data secure. From time to time we will test the system for security vulnerabilities.
     </p>
 
     <p class="govuk-body">
-      Your personal data may, throughout the course of its processing at GDS, be transferred outside the UK. Where
-      this is the case all appropriate technical and legal safeguards will be put in place to make sure that you are
-      afforded the same level of protection as within the UK. We will only transfer your data to another country if
-      we are sure that there is enough protection in place to make sure that your data is secure.
+      Your personal data may, throughout the course of its processing at GDS, be transferred outside the UK. Where this
+      is the case all appropriate technical and legal safeguards will be put in place to make sure that you are afforded
+      the same level of protection as within the UK. We will only transfer your data to another country if we are sure
+      that there is enough protection in place to make sure that your data is secure.
     </p>
 
     <h2 class="govuk-heading-m" id="who-your-data-might-be-shared-with">Who your data might be shared with</h2>
 
-    <p class="govuk-body">
-      There are times when we need to share your data.
-    </p>
+    <p class="govuk-body"> There are times when we need to share your data. </p>
 
     <h3 class="govuk-heading-s">Payment providers</h3>
 
     <p class="govuk-body">
       Our contracted payment provider is Stripe Payments Europe Limited. If you make use of this contract we will pass
-      data to them to onboard your service and to comply with know your customer (KYC), anti-money laundering, and
-      other legal and compliance requirements. Read
+      data to them to onboard your service and to comply with know your customer (KYC), anti-money laundering, and other
+      legal and compliance requirements. Read
       <a class="govuk-link" href="https://stripe.com/gb/privacy">Stripe’s privacy policy</a>
       for more information.
     </p>
 
     <p class="govuk-body">
-      We also work with Government Banking Service and their contracted payment provider is Worldpay. If you make use
-      of this contract we may share data with them on their or your request to facilitate onboarding, operations,
-      support and troubleshooting issues. Read
+      We also work with Government Banking Service and their contracted payment provider is Worldpay. If you make use of
+      this contract we may share data with them on their or your request to facilitate onboarding, operations, support
+      and troubleshooting issues. Read
       <a class="govuk-link" href="https://privacy.worldpay.com/policies/en/">Worldpay’s privacy policy</a>
       for more information.
     </p>
@@ -279,13 +271,11 @@
     <h3 class="govuk-heading-s">Legal and regulatory entities</h3>
 
     <p class="govuk-body">
-      We may have to share your personal data with law enforcement agencies or regulatory
-      bodies if we have to comply with any legal obligation or court order.
+      We may have to share your personal data with law enforcement agencies or regulatory bodies if we have to comply
+      with any legal obligation or court order.
     </p>
 
-    <p class="govuk-body">
-      We will not:
-    </p>
+    <p class="govuk-body"> We will not: </p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>sell or rent your data to third parties</li>
@@ -296,15 +286,13 @@
 
     <p class="govuk-body">
       Our services are not designed for, or intentionally targeted at, children 13 years of age or younger. It is not
-      our policy to intentionally collect or maintain data about anyone under the age of 13.  User’s can only create
-      an account on Pay if they hold and have access to a public sector email address.
+      our policy to intentionally collect or maintain data about anyone under the age of 13. User’s can only create an
+      account on Pay if they hold and have access to a public sector email address.
     </p>
 
     <h2 class="govuk-heading-m" id="what-are-your-rights">What are your rights</h2>
 
-    <p class="govuk-body">
-      You have the right to request:
-    </p>
+    <p class="govuk-body"> You have the right to request: </p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>information about how your personal data is processed</li>
@@ -312,9 +300,7 @@
       <li>that anything inaccurate in your personal data is corrected immediately</li>
     </ul>
 
-    <p class="govuk-body">
-      You can also:
-    </p>
+    <p class="govuk-body"> You can also: </p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>raise an objection about how your personal data is processed</li>
@@ -339,9 +325,7 @@
 
     <p class="govuk-body">
       Contact
-      <a class="govuk-link" href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk">
-        gds-privacy-office@digital.cabinet-office.gov.uk
-      </a>
+      <a class="govuk-link" href="mailto:gds.data.protection@dsit.gov.uk"> gds.data.protection@dsit.gov.uk </a>
       if you either:
     </p>
 
@@ -351,28 +335,29 @@
     </ul>
 
     <p class="govuk-body">
-      You can also contact the Cabinet Office Data Protection Officer.
+      You can also contact the Department for Science, Innovation and Technology Data Protection Officer.
     </p>
 
-    <p class="govuk-body">Data Protection Officer<br/>
-      <a class="govuk-link" href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a><br/>
-      Cabinet Office<br/>
-      70 Whitehall<br/>
-      London SW1A 2AS
+    <p class="govuk-body"
+      >Data Protection Officer<br />
+      <a class="govuk-link" href="mailto:dataprotection@dsit.gov.uk">dataprotection@dsit.gov.uk</a><br />
+      Department for Science, Innovation and Technology<br />
+      22-26 Whitehall<br />
+      London SW1A 2EG
     </p>
 
     <p class="govuk-body">
       If you have a complaint, you can also contact the
-      <a class="govuk-link" href="https://ico.org.uk/">Information Commissioner</a>,
-      who is an independent regulator set up to uphold information rights.
+      <a class="govuk-link" href="https://ico.org.uk/">Information Commissioner</a>, who is an independent regulator set
+      up to uphold information rights.
     </p>
 
     <p class="govuk-body">
-      <a class="govuk-link" href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br/>
-      0303 123 1113<br/>
-      Wycliffe House<br/>
-      Water Lane<br/>
-      Wilmslow<br/>
+      <a class="govuk-link" href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br />
+      0303 123 1113<br />
+      Wycliffe House<br />
+      Water Lane<br />
+      Wilmslow<br />
       Cheshire SK9 5AF
     </p>
   </div>


### PR DESCRIPTION
## What

PP-**14277**

Update privacy page content to reference DSIT instead of cabinet office.

### How
1. Go to the [privacy page](https://selfservice.payments.service.gov.uk/privacy)
2. The content should be referencing DSIT instead of cabinet office.

### Accessibility (views have been added/changed)
N/A

