### PR TITLE
PP-15166 Parse Luxon DateTimes as Europe/London Timezone

### DIFF
--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.test.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.test.ts
@@ -158,10 +158,13 @@ describe('controller: services/ledger', () => {
 
         mockLedgerService.searchTransactions.should.have.been.calledOnce
 
-        const searchParams = mockLedgerService.searchTransactions.firstCall.args[0] as Record<string, object>
+        const searchParams = mockLedgerService.searchTransactions.firstCall.args[0] as {
+          fromDate: DateTime<true>
+          toDate: DateTime<true>
+        } & Record<string, object>
         searchParams.dateFilter.should.eql('yesterday')
-        searchParams.fromDate.should.eql('2025-11-01T00:00:00.000+00:00')
-        searchParams.toDate.should.eql('2025-11-01T23:59:59.999+00:00')
+        searchParams.fromDate.toUTC().toISO().should.eql('2025-11-01T00:00:00.000Z')
+        searchParams.toDate.toUTC().toISO().should.eql('2025-11-01T23:59:59.999Z')
       })
 
       it('should include filters in context', async () => {
@@ -171,10 +174,12 @@ describe('controller: services/ledger', () => {
 
         await call('get')
 
-        const context = mockResponse.args[0][3] as { filters: Record<string, object> }
+        const context = mockResponse.args[0][3] as {
+          filters: { fromDate: DateTime<true>; toDate: DateTime<true> } & Record<string, object>
+        }
         context.filters.dateFilter.should.eql('yesterday')
-        context.filters.fromDate.should.eql('2025-11-01T00:00:00.000+00:00')
-        context.filters.toDate.should.eql('2025-11-01T23:59:59.999+00:00')
+        context.filters.fromDate.toUTC().toISO().should.eql('2025-11-01T00:00:00.000Z')
+        context.filters.toDate.toUTC().toISO().should.eql('2025-11-01T23:59:59.999Z')
       })
     })
 
@@ -188,10 +193,13 @@ describe('controller: services/ledger', () => {
 
         mockLedgerService.searchTransactions.should.have.been.calledOnce
 
-        const searchParams = mockLedgerService.searchTransactions.firstCall.args[0] as Record<string, object>
+        const searchParams = mockLedgerService.searchTransactions.firstCall.args[0] as {
+          fromDate: DateTime<true>
+          toDate: DateTime<true>
+        } & Record<string, object>
         searchParams.dateFilter.should.eql('custom-range')
-        searchParams.fromDate.should.eql('2025-11-01T00:00:00.000+00:00')
-        searchParams.toDate.should.eql('2025-11-30T23:59:59.999+00:00')
+        searchParams.fromDate.toUTC().toISO().should.eql('2025-11-01T00:00:00.000Z')
+        searchParams.toDate.toUTC().toISO().should.eql('2025-11-30T23:59:59.999Z')
       })
 
       it('should include the filters in the context', async () => {
@@ -201,10 +209,15 @@ describe('controller: services/ledger', () => {
 
         await call('get')
 
-        const context = mockResponse.args[0][3] as { filters: Record<string, object> }
+        const context = mockResponse.args[0][3] as {
+          filters: {
+            fromDate: DateTime<true>
+            toDate: DateTime<true>
+          } & Record<string, object>
+        }
         context.filters.dateFilter.should.eql('custom-range')
-        context.filters.fromDate.should.eql('2025-11-01T00:00:00.000+00:00')
-        context.filters.toDate.should.eql('2025-11-30T23:59:59.999+00:00')
+        context.filters.fromDate.toUTC().toISO().should.eql('2025-11-01T00:00:00.000Z')
+        context.filters.toDate.toUTC().toISO().should.eql('2025-11-30T23:59:59.999Z')
       })
     })
 
@@ -225,9 +238,12 @@ describe('controller: services/ledger', () => {
 
         mockLedgerService.searchTransactions.should.have.been.calledOnce
 
-        const searchParams = mockLedgerService.searchTransactions.firstCall.args[0] as Record<string, object>
-        searchParams.fromDate.should.eql('2025-11-01T09:30:00.000+00:00')
-        searchParams.toDate.should.eql('2025-11-30T17:45:00.000+00:00')
+        const searchParams = mockLedgerService.searchTransactions.firstCall.args[0] as {
+          fromDate: DateTime<true>
+          toDate: DateTime<true>
+        } & Record<string, object>
+        searchParams.fromDate.toUTC().toISO().should.eql('2025-11-01T09:30:00.000Z')
+        searchParams.toDate.toUTC().toISO().should.eql('2025-11-30T17:45:00.000Z')
       })
 
       it('should include the filters in the context', async () => {
@@ -246,10 +262,13 @@ describe('controller: services/ledger', () => {
 
         mockLedgerService.searchTransactions.should.have.been.calledOnce
 
-        const searchParams = mockLedgerService.searchTransactions.firstCall.args[0] as Record<string, object>
+        const searchParams = mockLedgerService.searchTransactions.firstCall.args[0] as {
+          fromDate: DateTime<true>
+          toDate: DateTime<true>
+        } & Record<string, object>
         searchParams.includeTime.should.eql(true)
-        searchParams.fromDate.should.eql('2025-11-01T09:30:00.000+00:00')
-        searchParams.toDate.should.eql('2025-11-30T17:45:00.000+00:00')
+        searchParams.fromDate.toUTC().toISO().should.eql('2025-11-01T09:30:00.000Z')
+        searchParams.toDate.toUTC().toISO().should.eql('2025-11-30T17:45:00.000Z')
       })
     })
 

--- a/src/models/transaction/Event.class.ts
+++ b/src/models/transaction/Event.class.ts
@@ -19,7 +19,7 @@ class Event {
     this.amount = data.amount
     this.resourceType = data.resource_type
     this.eventType = data.event_type
-    this.timestamp = DateTime.fromISO(data.timestamp)
+    this.timestamp = DateTime.fromISO(data.timestamp, { zone: 'Europe/London' })
     this.state = new State(data.state)
     this.metadata = data.data
 

--- a/src/models/transaction/Transaction.class.ts
+++ b/src/models/transaction/Transaction.class.ts
@@ -61,7 +61,7 @@ class Transaction {
     this.netAmount = data.net_amount
     this.totalAmount = data.total_amount
     this.fee = data.fee
-    this.createdDate = DateTime.fromISO(data.created_date)
+    this.createdDate = DateTime.fromISO(data.created_date, { zone: 'Europe/London' })
     this.description = data.description
     this.paymentProvider = data.payment_provider
     this.walletType = data.wallet_type
@@ -73,7 +73,9 @@ class Transaction {
     this.cardDetails = data.card_details && new CardDetails(data.card_details)
     this.transactionType = data.transaction_type
     this.reason = data.reason ? parseReason(data.reason) : undefined
-    this.evidenceDueDate = data.evidence_due_date ? DateTime.fromISO(data.evidence_due_date) : undefined
+    this.evidenceDueDate = data.evidence_due_date
+      ? DateTime.fromISO(data.evidence_due_date, { zone: 'Europe/London' })
+      : undefined
     this.data = data
     this.paymentDetails = data.payment_details && new PaymentDetails(data.payment_details)
     this.parentTransactionExternalId = data.parent_transaction_id

--- a/src/models/transaction/TransactionSearchParams.class.ts
+++ b/src/models/transaction/TransactionSearchParams.class.ts
@@ -6,6 +6,7 @@ import {
   PaymentStatusFilterMapping,
   RefundStatusFilterMapping,
 } from '@utils/simplified-account/services/transactions/status-filters'
+import { parseDateTime } from '@utils/time/parse-date-time'
 import { DateTime } from 'luxon'
 
 interface TransactionSearchQuery {
@@ -41,8 +42,8 @@ export class TransactionSearchParams {
   email?: string
   type?: string
   dateFilter?: string
-  fromDate?: string
-  toDate?: string
+  fromDate?: DateTime
+  toDate?: DateTime
   state?: string[]
   paymentStates?: string[]
   refundStates?: string[]
@@ -129,11 +130,11 @@ export class TransactionSearchParams {
         queryParams.fromDate!,
         queryParams.fromTime!,
         queryParams.includeTime === 'include'
-      ).toISO()!
+      )
 
       // parse end date/time, clamp to end of day if not including time
       const toDate = parseDateTime(queryParams.toDate!, queryParams.toTime!, queryParams.includeTime === 'include')
-      searchParams.toDate = queryParams.includeTime === 'include' ? toDate.toISO()! : toDate.endOf('day').toISO()!
+      searchParams.toDate = queryParams.includeTime === 'include' ? toDate : toDate.endOf('day')
 
       searchParams.dateFilter = queryParams.dateFilter
       searchParams.includeTime = queryParams.includeTime === 'include'
@@ -141,8 +142,8 @@ export class TransactionSearchParams {
       const dateRange = getPeriodUKDateTimeRange(queryParams.dateFilter as Period)
 
       searchParams.dateFilter = queryParams.dateFilter
-      searchParams.fromDate = dateRange.start.toISO()!
-      searchParams.toDate = dateRange.end.toISO()!
+      searchParams.fromDate = dateRange.start
+      searchParams.toDate = dateRange.end
       searchParams.includeTime = false
     }
 
@@ -161,14 +162,6 @@ export class TransactionSearchParams {
 
     return searchParams
   }
-}
-
-function parseDateTime(date: string, time: string, includeTime: boolean): DateTime {
-  if (includeTime && time !== '') {
-    const dateTime = `${date} ${time}`
-    return DateTime.fromFormat(dateTime, 'dd/LL/yyyy H:mm:ss')
-  }
-  return DateTime.fromFormat(date, 'dd/LL/yyyy')
 }
 
 function convertStateFilter(stateFilters: string | string[]): ConnectorStates {

--- a/src/models/transaction/TransactionSearchParams.class.ts
+++ b/src/models/transaction/TransactionSearchParams.class.ts
@@ -7,7 +7,7 @@ import {
   RefundStatusFilterMapping,
 } from '@utils/simplified-account/services/transactions/status-filters'
 import { parseDateTime } from '@utils/time/parse-date-time'
-import { DateTime } from 'luxon'
+import type { DateTime } from 'luxon'
 
 interface TransactionSearchQuery {
   cardholderName?: string

--- a/src/models/transaction/dto/TransactionSearchParams.dto.ts
+++ b/src/models/transaction/dto/TransactionSearchParams.dto.ts
@@ -1,6 +1,7 @@
 import { TransactionSearchParams } from '@models/transaction/TransactionSearchParams.class'
 import { toLower } from 'lodash'
 import { TimeConstants } from '@utils/time/time-constants'
+import { DateTime } from 'luxon'
 
 export class TransactionSearchParamsData {
   readonly account_id: string
@@ -37,10 +38,10 @@ export class TransactionSearchParamsData {
     this.transaction_type = params.type ?? undefined
     this.reference = params.reference ?? undefined
     this.email = params.email ?? undefined
-    this.from_date = params.fromDate
+    this.from_date = params.fromDate?.isValid
       ? params.fromDate.toUTC().toISO()!
       : TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO()
-    this.to_date = params.toDate ? params.toDate.toUTC().toISO()! : undefined
+    this.to_date = params.toDate?.isValid ? params.toDate.toUTC().toISO()! : undefined
     this.payment_states = params.paymentStates?.map(toLower).join(',')
     this.refund_states = params.refundStates?.map(toLower).join(',')
     this.dispute_states = params.disputeStates?.map(toLower).join(',')

--- a/src/models/transaction/dto/TransactionSearchParams.dto.ts
+++ b/src/models/transaction/dto/TransactionSearchParams.dto.ts
@@ -1,6 +1,6 @@
-import { last12MonthsStartDate } from '@utils/simplified-account/services/dashboard/datetime-utils'
 import { TransactionSearchParams } from '@models/transaction/TransactionSearchParams.class'
 import { toLower } from 'lodash'
+import { TimeConstants } from '@utils/time/time-constants'
 
 export class TransactionSearchParamsData {
   readonly account_id: string
@@ -37,8 +37,10 @@ export class TransactionSearchParamsData {
     this.transaction_type = params.type ?? undefined
     this.reference = params.reference ?? undefined
     this.email = params.email ?? undefined
-    this.from_date = params.fromDate ?? last12MonthsStartDate.toISO()!
-    this.to_date = params.toDate ?? undefined
+    this.from_date = params.fromDate
+      ? params.fromDate.toUTC().toISO()!
+      : TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO()
+    this.to_date = params.toDate ? params.toDate.toUTC().toISO()! : undefined
     this.payment_states = params.paymentStates?.map(toLower).join(',')
     this.refund_states = params.refundStates?.map(toLower).join(',')
     this.dispute_states = params.disputeStates?.map(toLower).join(',')

--- a/src/models/transaction/dto/TransactionSearchParams.dto.ts
+++ b/src/models/transaction/dto/TransactionSearchParams.dto.ts
@@ -1,7 +1,6 @@
 import { TransactionSearchParams } from '@models/transaction/TransactionSearchParams.class'
 import { toLower } from 'lodash'
 import { TimeConstants } from '@utils/time/time-constants'
-import { DateTime } from 'luxon'
 
 export class TransactionSearchParamsData {
   readonly account_id: string

--- a/src/utils/simplified-account/services/dashboard/datetime-utils.test.ts
+++ b/src/utils/simplified-account/services/dashboard/datetime-utils.test.ts
@@ -27,7 +27,7 @@ describe('DateTime Utility', () => {
         minute: '2-digit',
         second: undefined,
         timeZoneName: 'short',
-        hour12: true
+        hour12: true,
       })
     })
   })
@@ -106,6 +106,46 @@ describe('DateTime Utility', () => {
       })
     })
 
+    describe('when period is "last-12-months"', () => {
+      it('should return range for 12 months ending now', () => {
+        const result = getPeriodUKDateTimeRange('last-12-months')
+
+        const expectedStart = DateTime.fromISO('2024-01-15T00:00:00.000', { zone: 'Europe/London' })
+        const expectedEnd = DateTime.fromISO('2025-01-15T14:30:00.000Z', { zone: 'Europe/London' })
+
+        expect(result.start.toISO()).to.equal(expectedStart.toISO())
+        expect(result.end.toISO()).to.equal(expectedEnd.toISO())
+      })
+
+      it('should span exactly 12 months', () => {
+        const result = getPeriodUKDateTimeRange('last-12-months')
+        const daysDiff = result.end.diff(result.start, 'months').months
+
+        expect(Math.floor(daysDiff)).to.equal(12)
+        expect(daysDiff).to.be.greaterThan(11.9)
+      })
+    })
+
+    describe('when period is "all-time"', () => {
+      it('should return range for 7 years ending now', () => {
+        const result = getPeriodUKDateTimeRange('all-time')
+
+        const expectedStart = DateTime.fromISO('2018-01-15T00:00:00.000', { zone: 'Europe/London' })
+        const expectedEnd = DateTime.fromISO('2025-01-15T14:30:00.000Z', { zone: 'Europe/London' })
+
+        expect(result.start.toISO()).to.equal(expectedStart.toISO())
+        expect(result.end.toISO()).to.equal(expectedEnd.toISO())
+      })
+
+      it('should span exactly 12 months', () => {
+        const result = getPeriodUKDateTimeRange('all-time')
+        const daysDiff = result.end.diff(result.start, 'years').years
+
+        expect(Math.floor(daysDiff)).to.equal(7)
+        expect(daysDiff).to.be.greaterThan(6.9)
+      })
+    })
+
     describe('edge cases', () => {
       it('should handle leap year correctly for period', () => {
         clock.restore()
@@ -143,7 +183,7 @@ describe('DateTime Utility', () => {
       it('should ensure start is always before or equal to end', () => {
         const periods: Period[] = ['today', 'yesterday', 'previous-seven-days', 'previous-thirty-days']
 
-        periods.forEach(period => {
+        periods.forEach((period) => {
           const result = getPeriodUKDateTimeRange(period)
           expect(result.start.toMillis()).to.be.lessThan(result.end.toMillis())
         })

--- a/src/utils/simplified-account/services/dashboard/datetime-utils.ts
+++ b/src/utils/simplified-account/services/dashboard/datetime-utils.ts
@@ -1,4 +1,5 @@
 import { DateTime, DateTimeFormatOptions } from 'luxon'
+import { TimeConstants } from '@utils/time/time-constants'
 
 export type Period =
   | 'today'
@@ -27,45 +28,43 @@ export const DT_FULL = {
 
 export function getPeriodUKDateTimeRange(period: Period): DateTimeRange {
   const now = DateTime.now().setLocale('en-GB').setZone('Europe/London')
-  const yesterday = now.minus({ days: 1 })
 
   switch (period) {
     case 'yesterday':
       return {
-        start: yesterday.startOf('day'),
-        end: yesterday.endOf('day'),
+        start: TimeConstants.YESTERDAY,
+        end: TimeConstants.YESTERDAY.endOf('day'),
       }
 
     case 'previous-seven-days':
       return {
-        start: yesterday.minus({ days: 6 }).startOf('day'),
-        end: yesterday.endOf('day'),
+        start: TimeConstants.SEVEN_DAYS_AGO,
+        end: TimeConstants.END_OF_YESTERDAY,
       }
 
     case 'previous-thirty-days':
       return {
-        start: yesterday.minus({ days: 29 }).startOf('day'),
-        end: yesterday.endOf('day'),
+        start: TimeConstants.THIRTY_DAYS_AGO,
+        end: TimeConstants.END_OF_YESTERDAY,
       }
 
     case 'previous-month': {
-      const lastMonth = now.minus({ months: 1 })
       return {
-        start: lastMonth.startOf('month'),
-        end: lastMonth.endOf('month'),
+        start: TimeConstants.START_OF_LAST_MONTH,
+        end: TimeConstants.END_OF_LAST_MONTH,
       }
     }
 
     case 'last-12-months': {
       return {
-        start: now.startOf('day').minus({ years: 1 }),
+        start: TimeConstants.TWELVE_MONTHS_AGO,
         end: now,
       }
     }
 
     case 'all-time': {
       return {
-        start: now.startOf('day').minus({ years: 7 }),
+        start: TimeConstants.SEVEN_YEARS_AGO,
         end: now,
       }
     }
@@ -78,9 +77,3 @@ export function getPeriodUKDateTimeRange(period: Period): DateTimeRange {
       }
   }
 }
-
-export const last12MonthsStartDate = DateTime.now()
-  .setLocale('en-GB')
-  .setZone('Europe/London')
-  .startOf('day')
-  .minus({ years: 1 })

--- a/src/utils/simplified-account/services/dashboard/datetime-utils.ts
+++ b/src/utils/simplified-account/services/dashboard/datetime-utils.ts
@@ -11,8 +11,8 @@ export type Period =
   | 'all-time'
 
 interface DateTimeRange {
-  start: DateTime
-  end: DateTime
+  start: DateTime<true>
+  end: DateTime<true>
 }
 
 export const DT_FULL = {
@@ -27,7 +27,7 @@ export const DT_FULL = {
 } as DateTimeFormatOptions
 
 export function getPeriodUKDateTimeRange(period: Period): DateTimeRange {
-  const now = DateTime.now().setLocale('en-GB').setZone('Europe/London')
+  const now = DateTime.now().setLocale('en-GB').setZone('Europe/London') as DateTime<true>
 
   switch (period) {
     case 'yesterday':

--- a/src/utils/time/global-time-defaults.ts
+++ b/src/utils/time/global-time-defaults.ts
@@ -1,0 +1,15 @@
+import { Settings } from 'luxon'
+
+interface GlobalTimeOptions {
+  defaultLocale?: string
+  defaultZone?: string
+}
+
+// Sets the luxon DateTime to be in GB/London time
+// All times should be displayed in UK time (GMT or BST)
+function setGlobalTimeDefaults(options: GlobalTimeOptions = {}) {
+  Settings.defaultLocale = options.defaultLocale ?? 'en-GB'
+  Settings.defaultZone = options.defaultZone ?? 'Europe/London'
+}
+
+export { setGlobalTimeDefaults }

--- a/src/utils/time/parse-date-time.test.ts
+++ b/src/utils/time/parse-date-time.test.ts
@@ -1,4 +1,5 @@
 import { parseDateTime } from '@utils/time/parse-date-time'
+import { expect } from 'chai'
 
 const JANUARY_FIRST_2027 = '2027-01-01T00:00:00.000Z'
 const JANUARY_FIRST_2027_NINE_SEVENTEEN_AM = '2027-01-01T09:17:00.000Z'
@@ -26,19 +27,41 @@ describe('date and time parsing tests', () => {
     })
   })
 
-  describe('Parsing dates with GMT times', () => {
-    it('should correctly parse a date with time during GMT', () => {
-      const parsed = parseDateTime('01/01/2027', '9:17:00', true)
-      parsed.should.not.be.null
-      parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027_NINE_SEVENTEEN_AM)
+  describe('parsing dates with times', () => {
+    describe('Parsing dates with GMT times', () => {
+      it('should correctly parse a date with time during GMT', () => {
+        const parsed = parseDateTime('01/01/2027', '9:17:00', true)
+        parsed.should.not.be.null
+        parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027_NINE_SEVENTEEN_AM)
+      })
+    })
+
+    describe('Parsing dates with BST times', () => {
+      it('should correctly parse a date with time during BST', () => {
+        const parsed = parseDateTime('01/06/2027', '13:42:00', true)
+        parsed.should.not.be.null
+        parsed.toUTC().toISO()!.should.eq(JUNE_FIRST_2027_ONE_FORTY_TWO_PM)
+      })
     })
   })
 
-  describe('Parsing dates with BST times', () => {
-    it('should correctly parse a date with time during BST', () => {
-      const parsed = parseDateTime('01/06/2027', '13:42:00', true)
-      parsed.should.not.be.null
-      parsed.toUTC().toISO()!.should.eq(JUNE_FIRST_2027_ONE_FORTY_TWO_PM)
+  describe('parsing invalid dates and times', () => {
+    describe('for an invalid date', () => {
+      it('should return a DateTime with isValid false', () => {
+        const parsed = parseDateTime('notadate', '13:42:00', false)
+        parsed.should.not.be.null
+        parsed.isValid.should.be.false
+        expect(parsed.toISO()).to.be.null
+      })
+    })
+
+    describe('for an invalid time', () => {
+      it('should return a DateTime with isValid false', () => {
+        const parsed = parseDateTime('01/06/2027', 'notatime', true)
+        parsed.should.not.be.null
+        parsed.isValid.should.be.false
+        expect(parsed.toISO()).to.be.null
+      })
     })
   })
 })

--- a/src/utils/time/parse-date-time.test.ts
+++ b/src/utils/time/parse-date-time.test.ts
@@ -1,0 +1,44 @@
+import { parseDateTime } from '@utils/time/parse-date-time'
+
+const JANUARY_FIRST_2027 = '2027-01-01T00:00:00.000Z'
+const JANUARY_FIRST_2027_NINE_SEVENTEEN_AM = '2027-01-01T09:17:00.000Z'
+
+const JUNE_FIRST_2027_ONE_FORTY_TWO_PM = '2027-06-01T12:42:00.000Z' // during BST, so UTC is one hour behind
+
+describe('date and time parsing tests', () => {
+  describe('Parsing Dates only', () => {
+    it('should correctly parse a date if a time is not provided includeTime is false', () => {
+      const parsed = parseDateTime('01/01/2027', '', false)
+      parsed.should.not.be.null
+      parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027)
+    })
+
+    it('should correctly parse a date if a time is not provided and includeTime is true', () => {
+      const parsed = parseDateTime('01/01/2027', '', true)
+      parsed.should.not.be.null
+      parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027)
+    })
+
+    it('should correctly parse a date if a time is provided and includeTime is false', () => {
+      const parsed = parseDateTime('01/01/2027', '09:17:00', false)
+      parsed.should.not.be.null
+      parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027)
+    })
+  })
+
+  describe('Parsing dates with GMT times', () => {
+    it('should correctly parse a date with time during GMT', () => {
+      const parsed = parseDateTime('01/01/2027', '9:17:00', true)
+      parsed.should.not.be.null
+      parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027_NINE_SEVENTEEN_AM)
+    })
+  })
+
+  describe('Parsing dates with BST times', () => {
+    it('should correctly parse a date with time during BST', () => {
+      const parsed = parseDateTime('01/06/2027', '13:42:00', true)
+      parsed.should.not.be.null
+      parsed.toUTC().toISO()!.should.eq(JUNE_FIRST_2027_ONE_FORTY_TWO_PM)
+    })
+  })
+})

--- a/src/utils/time/parse-date-time.ts
+++ b/src/utils/time/parse-date-time.ts
@@ -1,0 +1,9 @@
+import { DateTime } from 'luxon'
+
+export function parseDateTime(date: string, time: string, includeTime: boolean): DateTime {
+  if (includeTime && time !== '') {
+    const dateTime = `${date} ${time}`
+    return DateTime.fromFormat(dateTime, 'dd/LL/yyyy H:mm:ss', { zone: 'Europe/London' })
+  }
+  return DateTime.fromFormat(date, 'dd/LL/yyyy', { zone: 'Europe/London' })
+}

--- a/src/utils/time/time-constants.ts
+++ b/src/utils/time/time-constants.ts
@@ -1,0 +1,63 @@
+import { DateTime } from 'luxon'
+
+export class TimeConstants {
+  static get TWELVE_MONTHS_AGO(): DateTime<true> {
+    return DateTime.now()
+      .setLocale('en-GB')
+      .setZone('Europe/London')
+      .startOf('day')
+      .minus({ years: 1 }) as DateTime<true>
+  }
+
+  static get YESTERDAY(): DateTime<true> {
+    return DateTime.now()
+      .setLocale('en-GB')
+      .setZone('Europe/London')
+      .startOf('day')
+      .minus({ days: 1 }) as DateTime<true>
+  }
+
+  static get END_OF_YESTERDAY(): DateTime<true> {
+    return DateTime.now().setLocale('en-GB').setZone('Europe/London').minus({ days: 1 }).endOf('day') as DateTime<true>
+  }
+
+  static get SEVEN_DAYS_AGO(): DateTime<true> {
+    return DateTime.now()
+      .setLocale('en-GB')
+      .setZone('Europe/London')
+      .startOf('day')
+      .minus({ days: 7 }) as DateTime<true>
+  }
+
+  static get THIRTY_DAYS_AGO(): DateTime<true> {
+    return DateTime.now()
+      .setLocale('en-GB')
+      .setZone('Europe/London')
+      .startOf('day')
+      .minus({ days: 30 }) as DateTime<true>
+  }
+
+  static get START_OF_LAST_MONTH(): DateTime<true> {
+    return DateTime.now()
+      .setLocale('en-GB')
+      .setZone('Europe/London')
+      .minus({ months: 1 })
+      .startOf('month') as DateTime<true>
+  }
+
+  static get END_OF_LAST_MONTH(): DateTime<true> {
+    return DateTime.now()
+      .setLocale('en-GB')
+      .setZone('Europe/London')
+      .minus({ months: 1 })
+      .endOf('month') as DateTime<true>
+  }
+
+  static get SEVEN_YEARS_AGO(): DateTime<true> {
+    return DateTime.now()
+      .setLocale('en-GB')
+      .setZone('Europe/London')
+      .minus({ years: 1 })
+      .startOf('day') as DateTime<true>
+  }
+}

--- a/src/utils/time/time-constants.ts
+++ b/src/utils/time/time-constants.ts
@@ -57,7 +57,7 @@ export class TimeConstants {
     return DateTime.now()
       .setLocale('en-GB')
       .setZone('Europe/London')
-      .minus({ years: 1 })
+      .minus({ years: 7 })
       .startOf('day') as DateTime<true>
   }
 }

--- a/test/cypress/integration/make-a-demo-payment/go-to-transactions.cy.js
+++ b/test/cypress/integration/make-a-demo-payment/go-to-transactions.cy.js
@@ -1,5 +1,5 @@
 import GatewayAccountType from '@models/gateway-account/gateway-account-type'
-import { last12MonthsStartDate } from '@utils/simplified-account/services/dashboard/datetime-utils'
+import { TimeConstants } from '@utils/time/time-constants'
 
 const userStubs = require('@test/cypress/stubs/user-stubs')
 const ROLES = require('@test/fixtures/roles.fixtures')
@@ -42,7 +42,7 @@ const setupStubs = (options = {}) => {
     transactionStubs.getLedgerTransactionsSuccess({
       gatewayAccountId: GATEWAY_ACCOUNT_ID,
       displaySize: 20,
-      filters: { from_date: last12MonthsStartDate },
+      filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
       transactionLength: 1,
     }),
     gatewayAccountStubs.getCardTypesSuccess(),

--- a/test/cypress/integration/simplified-account/agreements/agreements.cy.ts
+++ b/test/cypress/integration/simplified-account/agreements/agreements.cy.ts
@@ -7,7 +7,7 @@ import {
   checkServiceNavigation,
   checkTitleAndHeading,
 } from '@test/cypress/integration/simplified-account/common/assertions'
-import { last12MonthsStartDate } from '@utils/simplified-account/services/dashboard/datetime-utils'
+import { TimeConstants } from '@utils/time/time-constants'
 
 const USER_EXTERNAL_ID = 'user456def'
 const USER_EMAIL = 's.mcduck@pay.gov.uk'
@@ -170,7 +170,7 @@ describe('Agreements', () => {
         filters: {
           agreement_id: 'a-valid-agreement-id',
           display_size: 5,
-          from_date: last12MonthsStartDate.toISO(),
+          from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
         },
       }),
     ])
@@ -289,7 +289,7 @@ describe('Agreements', () => {
         filters: {
           agreement_id: 'agreement123abc',
           display_size: 5,
-          from_date: last12MonthsStartDate.toISO(),
+          from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
         },
       }),
       agreementStubs.postCancelAgreementByServiceExternalIdAndAccountType({

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transaction-refund.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transaction-refund.cy.ts
@@ -6,11 +6,13 @@ import {
   getTransactionEvents,
   getTransactionForGatewayAccount,
 } from '@test/cypress/stubs/simplified-account/transaction-stubs'
-import { TITLE_FRIENDLY_DATE_TIME } from '@models/constants/time-formats'
 import { TransactionEventFixture } from '@test/fixtures/transaction/transaction-event.fixture'
 import ROLES from '@test/fixtures/roles.fixtures'
+import { DateTime } from 'luxon'
 
-const TRANSACTION = new TransactionFixture()
+const TRANSACTION_CREATED_TIMESTAMP = DateTime.fromISO('2025-07-22T03:14:15.926+01:00')
+const TRANSACTION = new TransactionFixture({ createdDate: TRANSACTION_CREATED_TIMESTAMP })
+
 const USER_EXTERNAL_ID = 'user456def'
 const USER_EMAIL = 's.mcduck@example.com'
 const GATEWAY_ACCOUNT_ID = TRANSACTION.gatewayAccountId
@@ -66,14 +68,9 @@ describe('All services refund page', () => {
   })
 
   it('should display correct page title and headings', () => {
-    const title = 'Refund'
-
     cy.visit(TRANSACTION_REFUND_URL)
-    cy.title().should(
-      'eq',
-      `${title} - ${TRANSACTION.createdDate.toFormat(TITLE_FRIENDLY_DATE_TIME)} - ${TRANSACTION.reference} - GOV.UK Pay`
-    )
-    cy.get('h1').should('contain.text', title)
+    cy.title().should('eq', `Refund - 22 Jul 2025 03:14:15 - ${TRANSACTION.reference} - GOV.UK Pay`)
+    cy.get('h1').should('contain.text', 'Refund')
   })
 
   it('should navigate to transaction detail page when back link is clicked', () => {

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-detail.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-detail.cy.ts
@@ -8,12 +8,12 @@ import {
   getTransactionForGatewayAccount,
 } from '@test/cypress/stubs/simplified-account/transaction-stubs'
 import { TransactionEventFixture } from '@test/fixtures/transaction/transaction-event.fixture'
-import { TITLE_FRIENDLY_DATE_TIME } from '@models/constants/time-formats'
-import { last12MonthsStartDate } from '@utils/simplified-account/services/dashboard/datetime-utils'
 import ROLES from '@test/fixtures/roles.fixtures'
+import { DateTime } from 'luxon'
+import { TimeConstants } from '@utils/time/time-constants'
 
-const TRANSACTION = new TransactionFixture()
-const TRANSACTION_CREATED_TIMESTAMP = TRANSACTION.createdDate
+const TRANSACTION_CREATED_TIMESTAMP = DateTime.fromISO('2025-07-22T03:14:15.926+01:00')
+const TRANSACTION = new TransactionFixture({ createdDate: TRANSACTION_CREATED_TIMESTAMP })
 
 const TRANSACTION_EVENTS = [
   new TransactionEventFixture({
@@ -66,7 +66,7 @@ describe('All services transaction details page', () => {
       transactionStubs.getLedgerTransactionsSuccess({
         gatewayAccountId: GATEWAY_ACCOUNT_ID,
         transactions: [TRANSACTION],
-        filters: { from_date: last12MonthsStartDate },
+        filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
         displaySize: 20,
         transactionLength: 1,
       }),
@@ -79,15 +79,10 @@ describe('All services transaction details page', () => {
   })
 
   it('should display correct page title and headings', () => {
-    const title = 'Transaction details'
-
     cy.visit(ALL_SERVICES_TRANSACTION_URL)
 
-    cy.title().should(
-      'eq',
-      `${title} - ${TRANSACTION.createdDate.toFormat(TITLE_FRIENDLY_DATE_TIME)} - ${TRANSACTION.reference} - GOV.UK Pay`
-    )
-    cy.get('h1').should('contain.text', title)
+    cy.title().should('eq', `Transaction details - 22 Jul 2025 03:14:15 - ${TRANSACTION.reference} - GOV.UK Pay`)
+    cy.get('h1').should('contain.text', 'Transaction details')
   })
 
   it('should navigate to transactions list page when back link is clicked', () => {

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
@@ -2,11 +2,13 @@ import userStubs from '@test/cypress/stubs/user-stubs'
 import gatewayAccountStubs, { getCardTypesSuccess } from '@test/cypress/stubs/gateway-account-stubs'
 import { TransactionFixture } from '@test/fixtures/transaction/transaction.fixture'
 import { LIVE, TEST } from '@models/gateway-account/gateway-account-type'
-import { last12MonthsStartDate } from '@utils/simplified-account/services/dashboard/datetime-utils'
 import { getTransactionForGatewayAccount } from '@test/cypress/stubs/simplified-account/transaction-stubs'
 import transactionStubs from '@test/cypress/stubs/transaction-stubs'
+import { DateTime } from 'luxon'
+import { TimeConstants } from '@utils/time/time-constants'
 
-const TRANSACTION = new TransactionFixture()
+const TRANSACTION_CREATED_TIMESTAMP = DateTime.fromISO('2025-07-22T03:14:15.926+01:00')
+const TRANSACTION = new TransactionFixture({ createdDate: TRANSACTION_CREATED_TIMESTAMP })
 
 const USER_EXTERNAL_ID = 'user123abc'
 const SERVICE_EXTERNAL_ID = 'service456def'
@@ -45,7 +47,7 @@ describe('All service transactions index', () => {
         transactionStubs.getLedgerTransactionsSuccess({
           gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: last12MonthsStartDate },
+          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
           displaySize: 20,
           transactionLength: 1,
         }),
@@ -57,7 +59,7 @@ describe('All service transactions index', () => {
         transactionStubs.getLedgerTransactionsSuccess({
           gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: last12MonthsStartDate },
+          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
           displaySize: 20,
           transactionLength: 1,
         }),
@@ -76,7 +78,7 @@ describe('All service transactions index', () => {
         transactionStubs.getLedgerTransactionsSuccess({
           gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: last12MonthsStartDate },
+          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
           displaySize: 20,
           transactionLength: 1,
         }),
@@ -99,7 +101,7 @@ describe('All service transactions index', () => {
         transactionStubs.getLedgerTransactionsSuccess({
           gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: last12MonthsStartDate },
+          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
           displaySize: 20,
           transactionLength: 1,
         }),
@@ -119,7 +121,7 @@ describe('All service transactions index', () => {
         transactionStubs.getLedgerTransactionsSuccess({
           gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: last12MonthsStartDate },
+          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
           displaySize: 20,
           transactionLength: 1,
         }),
@@ -155,7 +157,7 @@ describe('All service transactions index', () => {
         transactionStubs.getLedgerTransactionsSuccess({
           gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: last12MonthsStartDate },
+          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
           displaySize: 20,
           transactionLength: 1,
         }),
@@ -213,7 +215,7 @@ describe('All service transactions index', () => {
         transactionStubs.getLedgerTransactionsSuccess({
           gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: last12MonthsStartDate },
+          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
           displaySize: 20,
           transactionLength: 1,
         }),

--- a/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
+++ b/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
@@ -279,7 +279,10 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           displaySize: 20,
-          filters: { from_date: yesterday.startOf('day').toISO(), to_date: yesterday.endOf('day').toISO() },
+          filters: {
+            from_date: yesterday.startOf('day').toUTC().toISO(),
+            to_date: yesterday.endOf('day').toUTC().toISO(),
+          },
           transactions: [transactionFromYesterday],
           transactionLength: 1,
         }),
@@ -764,7 +767,7 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO },
+          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
           displaySize: 20,
           transactionLength: 10,
           page: 1,

--- a/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
+++ b/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
@@ -3,7 +3,6 @@ import gatewayAccountStubs from '@test/cypress/stubs/gateway-account-stubs'
 import { TransactionFixture } from '@test/fixtures/transaction/transaction.fixture'
 import { checkServiceNavigation, checkTitleAndHeading } from '../common/assertions'
 import { TEST } from '@models/gateway-account/gateway-account-type'
-import { last12MonthsStartDate } from '@utils/simplified-account/services/dashboard/datetime-utils'
 import { penceToPoundsWithCurrency } from '@utils/currency-formatter'
 import { TransactionData } from '@models/transaction/dto/Transaction.dto'
 import { Status } from '@models/transaction/types/status'
@@ -13,6 +12,7 @@ import { TransactionStateFixture } from '@test/fixtures/transaction/transaction-
 import { getTransactionsForGatewayAccount } from '@test/cypress/stubs/simplified-account/transaction-stubs'
 import { PaymentDetailsFixture } from '@test/fixtures/transaction/payment-details.fixture'
 import { getLedgerTransactionsFailure, getLedgerTransactionsSuccess } from '@test/cypress/stubs/transaction-stubs'
+import { TimeConstants } from '@utils/time/time-constants'
 
 const TRANSACTION = new TransactionFixture().toTransactionData()
 
@@ -129,7 +129,7 @@ describe('Transactions index', () => {
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
           transactionLength: 6000,
-          filters: { from_date: last12MonthsStartDate },
+          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
           displaySize: 20,
         }),
       ])
@@ -145,7 +145,7 @@ describe('Transactions index', () => {
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
           transactionLength: 6000,
-          filters: { reference: 'unfiltered', from_date: last12MonthsStartDate },
+          filters: { reference: 'unfiltered', from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
           displaySize: 20,
         }),
       ])
@@ -265,7 +265,7 @@ describe('Transactions index', () => {
       cy.get('#toDate').should('be.empty')
     })
 
-    it.skip('should be able to filter using date ranges', () => {
+    it('should be able to filter using date ranges', () => {
       const now = DateTime.now().setLocale('en-GB').setZone('Europe/London')
       const yesterday = now.minus({ days: 1 })
 
@@ -279,7 +279,7 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           displaySize: 20,
-          filters: { from_date: yesterday.startOf('day'), to_date: yesterday.endOf('day') },
+          filters: { from_date: yesterday.startOf('day').toISO(), to_date: yesterday.endOf('day').toISO() },
           transactions: [transactionFromYesterday],
           transactionLength: 1,
         }),
@@ -585,7 +585,7 @@ describe('Transactions index', () => {
             gatewayAccountId: GATEWAY_ACCOUNT_ID,
             transactions: [TRANSACTION],
             filters: {
-              from_date: last12MonthsStartDate,
+              from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
             },
             displaySize: 20,
             transactionLength: 1,
@@ -615,7 +615,7 @@ describe('Transactions index', () => {
             gatewayAccountId: GATEWAY_ACCOUNT_ID,
             transactions: [TRANSACTION],
             filters: {
-              from_date: last12MonthsStartDate,
+              from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
             },
             displaySize: 20,
             transactionLength: 1,
@@ -644,7 +644,7 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: last12MonthsStartDate },
+          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
           displaySize: 20,
           transactionLength: 50,
         }),
@@ -695,7 +695,7 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: last12MonthsStartDate },
+          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
           displaySize: 20,
           transactionLength: 100,
           page: 3,
@@ -734,7 +734,7 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: last12MonthsStartDate },
+          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
           displaySize: 20,
           transactionLength: 100,
           page: 5,
@@ -764,7 +764,7 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: last12MonthsStartDate },
+          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO },
           displaySize: 20,
           transactionLength: 10,
           page: 1,
@@ -792,7 +792,7 @@ describe('Transactions index', () => {
         gatewayAccountId: GATEWAY_ACCOUNT_ID,
         transactions: [TRANSACTION],
         filters: {
-          from_date: last12MonthsStartDate,
+          from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
           reference,
           email,
           cardholder_name: cardholderNameSearchParam,

--- a/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
+++ b/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
@@ -18,13 +18,17 @@ import {
 import { TransactionEventFixture } from '@test/fixtures/transaction/transaction-event.fixture'
 import { LedgerRefundSummaryFixture } from '@test/fixtures/transaction/ledger-refund-summary.fixture'
 import { RefundSummaryStatus } from '@models/common/refund-summary/RefundSummaryStatus'
-import { DATE_TIME, TITLE_FRIENDLY_DATE_TIME } from '@models/constants/time-formats'
-import { last12MonthsStartDate } from '@utils/simplified-account/services/dashboard/datetime-utils'
+import { DATE_TIME } from '@models/constants/time-formats'
 import { checkServiceNavigation } from '../common/assertions'
 import ROLES from '@test/fixtures/roles.fixtures'
+import { DateTime } from 'luxon'
+import { TimeConstants } from '@utils/time/time-constants'
+import { setGlobalTimeDefaults } from '@utils/time/global-time-defaults'
+setGlobalTimeDefaults()
 
-const TRANSACTION = new TransactionFixture()
-const TRANSACTION_CREATED_TIMESTAMP = TRANSACTION.createdDate
+const TRANSACTION_CREATED_TIMESTAMP = DateTime.fromISO('2025-07-22T03:14:15.926+01:00')
+const TRANSACTION = new TransactionFixture({ createdDate: TRANSACTION_CREATED_TIMESTAMP })
+
 const CARD_DETAILS = TRANSACTION.cardDetails!
 
 const TRANSACTION_EVENTS = [
@@ -94,7 +98,7 @@ describe('Transaction details page', () => {
 
     cy.title().should(
       'eq',
-      `Transaction details - ${TRANSACTION.createdDate.toFormat(TITLE_FRIENDLY_DATE_TIME)} - ${TRANSACTION.reference} - ${SERVICE_NAME.en} - GOV.UK Pay`
+      `Transaction details - 22 Jul 2025 03:14:15 - ${TRANSACTION.reference} - ${SERVICE_NAME.en} - GOV.UK Pay`
     )
     cy.get('h1').should('contain.text', 'Transaction details')
     cy.get('h2').should('contain.text', 'Amount')
@@ -111,7 +115,7 @@ describe('Transaction details page', () => {
       transactionStubs.getLedgerTransactionsSuccess({
         gatewayAccountId: GATEWAY_ACCOUNT_ID,
         transactions: [TRANSACTION],
-        filters: { from_date: last12MonthsStartDate },
+        filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
         displaySize: 20,
         transactionLength: 1,
       }),
@@ -157,10 +161,7 @@ describe('Transaction details page', () => {
       .eq(3)
       .within(() => {
         cy.get('.govuk-summary-list__key').should('contain.text', 'Date created')
-        cy.get('.govuk-summary-list__value').should(
-          'contain.text',
-          `${TRANSACTION.createdDate.toFormat(DATE_TIME)} (BST)`
-        )
+        cy.get('.govuk-summary-list__value').should('contain.text', `22 Jul 25 - 03:14:15 (BST)`)
       })
 
     cy.get('.govuk-summary-list__row')
@@ -557,10 +558,7 @@ describe('Transaction details page', () => {
       .within(() => {
         cy.get('.govuk-table__cell:eq(0)').should('contain.text', 'Declined')
         cy.get('.govuk-table__cell:eq(1)').should('contain.text', formattedAmount)
-        cy.get('.govuk-table__cell:eq(2)').should(
-          'contain.text',
-          `${transactionDeclinedTimestamp.toFormat(DATE_TIME)} (GMT)`
-        )
+        cy.get('.govuk-table__cell:eq(2)').should('contain.text', `22 Nov 25 - 03:14:15 (GMT)`)
       })
 
     cy.get('.govuk-table__row')
@@ -568,10 +566,7 @@ describe('Transaction details page', () => {
       .within(() => {
         cy.get('.govuk-table__cell:eq(0)').should('contain.text', 'Started')
         cy.get('.govuk-table__cell:eq(1)').should('contain.text', formattedAmount)
-        cy.get('.govuk-table__cell:eq(2)').should(
-          'contain.text',
-          `${transactionStartedTimestamp.toFormat(DATE_TIME)} (BST)`
-        )
+        cy.get('.govuk-table__cell:eq(2)').should('contain.text', `22 Jul 25 - 03:15:15 (BST)`)
       })
 
     cy.get('.govuk-table__row')
@@ -579,10 +574,7 @@ describe('Transaction details page', () => {
       .within(() => {
         cy.get('.govuk-table__cell:eq(0)').should('contain.text', 'Created')
         cy.get('.govuk-table__cell:eq(1)').should('contain.text', formattedAmount)
-        cy.get('.govuk-table__cell:eq(2)').should(
-          'contain.text',
-          `${TRANSACTION_CREATED_TIMESTAMP.toFormat(DATE_TIME)} (BST)`
-        )
+        cy.get('.govuk-table__cell:eq(2)').should('contain.text', `22 Jul 25 - 03:14:15 (BST)`)
       })
   })
 

--- a/test/cypress/integration/simplified-account/transactions/transaction-refund.cy.ts
+++ b/test/cypress/integration/simplified-account/transactions/transaction-refund.cy.ts
@@ -7,14 +7,15 @@ import {
   getTransactionForGatewayAccount,
   postRefund,
 } from '@test/cypress/stubs/simplified-account/transaction-stubs'
-import { TITLE_FRIENDLY_DATE_TIME } from '@models/constants/time-formats'
 import { penceToPoundsWithCurrency } from '@utils/currency-formatter'
 import { LedgerRefundSummaryFixture } from '@test/fixtures/transaction/ledger-refund-summary.fixture'
 import { TransactionEventFixture } from '@test/fixtures/transaction/transaction-event.fixture'
 import { checkServiceNavigation } from '../common/assertions'
 import ROLES from '@test/fixtures/roles.fixtures'
+import { DateTime } from 'luxon'
 
-const TRANSACTION = new TransactionFixture()
+const TRANSACTION_CREATED_TIMESTAMP = DateTime.fromISO('2025-07-22T03:14:15.926+01:00')
+const TRANSACTION = new TransactionFixture({ createdDate: TRANSACTION_CREATED_TIMESTAMP })
 const USER_EXTERNAL_ID = 'user456def'
 const USER_EMAIL = 's.mcduck@example.com'
 const GATEWAY_ACCOUNT_ID = TRANSACTION.gatewayAccountId
@@ -82,7 +83,7 @@ describe('Refund page', () => {
     checkServiceNavigation('Transactions', transactionListUrl)
     cy.title().should(
       'eq',
-      `Refund - ${TRANSACTION.createdDate.toFormat(TITLE_FRIENDLY_DATE_TIME)} - ${TRANSACTION.reference} - ${SERVICE_NAME.en} - GOV.UK Pay`
+      `Refund - 22 Jul 2025 03:14:15 - ${TRANSACTION.reference} - ${SERVICE_NAME.en} - GOV.UK Pay`
     )
     cy.get('h1').should('contain.text', 'Refund')
   })

--- a/test/cypress/stubs/simplified-account/transaction-stubs.ts
+++ b/test/cypress/stubs/simplified-account/transaction-stubs.ts
@@ -3,8 +3,8 @@ import ledgerTransactionFixtures from '@test/fixtures/ledger-transaction.fixture
 import { TransactionFixture } from '@test/fixtures/transaction/transaction.fixture'
 import { TransactionEventFixture } from '@test/fixtures/transaction/transaction-event.fixture'
 import refundFixtures from '@test/fixtures/refund.fixtures'
-import { last12MonthsStartDate } from '@utils/simplified-account/services/dashboard/datetime-utils'
 import { TransactionData } from '@models/transaction/dto/Transaction.dto'
+import { TimeConstants } from '@utils/time/time-constants'
 
 function getTransaction(transactionExternalId: string) {
   const path = `/v1/transaction/${transactionExternalId}`
@@ -54,7 +54,7 @@ function getTransactionsForGatewayAccount(gatewayAccountId: string) {
           display_size: 20,
           limit_total: true,
           limit_total_size: 5001,
-          from_date: last12MonthsStartDate,
+          from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
         },
       })
     },

--- a/test/fixtures/transaction/transaction-event.fixture.ts
+++ b/test/fixtures/transaction/transaction-event.fixture.ts
@@ -18,7 +18,7 @@ export class TransactionEventFixture {
     this.amount = 1000
     this.resourceType = ResourceType.PAYMENT
     this.eventType = EventType.PAYMENT_CREATED
-    this.timestamp = DateTime.fromISO('2025-07-22T03:14:15.926Z')
+    this.timestamp = DateTime.fromISO('2025-07-22T03:14:15.926+01:00')
     this.state = new TransactionStateFixture()
 
     if (options) {

--- a/test/fixtures/transaction/transaction.fixture.ts
+++ b/test/fixtures/transaction/transaction.fixture.ts
@@ -57,7 +57,7 @@ export class TransactionFixture {
     this.reference = 'transaction-reference'
     this.state = new TransactionStateFixture()
     this.amount = 1000
-    this.createdDate = DateTime.fromISO('2025-07-22T03:14:15.926Z')
+    this.createdDate = DateTime.fromISO('2025-07-22T03:14:15.926+01:00')
     this.description = 'a test transaction'
     this.paymentProvider = 'sandbox'
     this.email = 'test2@example.org'


### PR DESCRIPTION
## What

PP-15166
- parse `luxon` DateTimes as `Europe/London` times to ensure BST is handled correctly
  - this fixes a bug with a skipped Cypress test failing in CI due to Github actions runtime defaulting to UTC
- send times to Ledger as times in UTC rather than with offsets to match Ledger spec
- add `TimeConstants` class with useful times for fixed points in the past
  - class getters ensure time constants are calculated at (and therefore relative to) the time they are called, rather than at app startup time
- hardcode some times in cypress tests to ensure dates are displayed correctly
