### PR TITLE
PP-15031 - Express 5 prep - use matchedData()

### DIFF
--- a/src/controllers/simplified-account/services/agreements/agreements.controller.ts
+++ b/src/controllers/simplified-account/services/agreements/agreements.controller.ts
@@ -3,7 +3,7 @@ import * as cancel from './cancel/cancel-agreement.controller'
 import { response } from '@utils/response'
 import { ServiceRequest, ServiceResponse } from '@utils/types/express'
 import { searchAgreements } from '@services/agreements.service'
-import { query, validationResult } from 'express-validator'
+import { query, validationResult, matchedData } from 'express-validator'
 import { ACTIVE, INACTIVE, CANCELLED, CREATED } from '@models/agreements/agreement-status'
 import getPagination from '@utils/simplified-account/pagination'
 import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
@@ -40,6 +40,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   await Promise.all(validations.map(async (validation) => validation.run(req)))
 
   const errors = validationResult(req)
+  const { page } = matchedData(req)
 
   if (!errors.isEmpty()) {
     const formattedErrors = formatValidationErrors(errors)
@@ -48,7 +49,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
         summary: formattedErrors.errorSummary,
         formErrors: formattedErrors.formErrors,
       },
-      ...(await loadAgreements(req.service.externalId, req.account.id, req.account.type, Number(req.query.page))),
+      ...(await loadAgreements(req.service.externalId, req.account.id, req.account.type, Number(page))),
     })
   }
 
@@ -61,13 +62,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   req.session.agreementsFilter = req.url.split('?')[1] || ''
 
   return response(req, res, 'simplified-account/services/agreements/index', {
-    ...(await loadAgreements(
-      req.service.externalId,
-      req.account.id,
-      req.account.type,
-      Number(req.query.page),
-      filters
-    )),
+    ...(await loadAgreements(req.service.externalId, req.account.id, req.account.type, Number(page), filters)),
   })
 }
 

--- a/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
+++ b/src/controllers/simplified-account/settings/webhooks/detail/detail.controller.js
@@ -4,7 +4,7 @@ const getPagination = require('@utils/simplified-account/pagination')
 const webhooksService = require('@services/webhooks.service')
 const formatSimplifiedAccountPathsFor = require('@utils/simplified-account/format/format-simplified-account-paths-for')
 const { constants } = require('@govuk-pay/pay-js-commons')
-const { query } = require('express-validator')
+const { query, matchedData } = require('express-validator')
 const { ALL, SUCCESSFUL, FAILED, PENDING, WILL_NOT_SEND } = require('@models/constants/webhook-delivery-status')
 
 const PAGE_SIZE = 10
@@ -13,48 +13,70 @@ const PAGE_SIZE = 10
  * @param {import('@utils/types/settings/settings-request').SettingsRequest} req
  * @param {import('express').Response} res
  */
-async function get (req, res) {
-  const webhooksDetailUrl = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.detail, req.service.externalId, req.account.type, req.params.webhookExternalId)
+async function get(req, res) {
+  const webhooksDetailUrl = formatSimplifiedAccountPathsFor(
+    paths.simplifiedAccount.settings.webhooks.detail,
+    req.service.externalId,
+    req.account.type,
+    req.params.webhookExternalId
+  )
   const validations = [
-    query('page')
-      .customSanitizer((value) => {
-        const pageNumber = Number(value)
-        if (isNaN(pageNumber)) {
-          return 1
-        }
-        return pageNumber
-      }),
-    query('deliveryStatus')
-      .customSanitizer((value) => {
-        const validValues = [ALL, SUCCESSFUL, FAILED, PENDING, WILL_NOT_SEND]
-        if (!validValues.includes(value)) {
-          return ALL
-        }
-        return value
-      })
+    query('page').customSanitizer((value) => {
+      const pageNumber = Number(value)
+      if (isNaN(pageNumber)) {
+        return 1
+      }
+      return pageNumber
+    }),
+    query('deliveryStatus').customSanitizer((value) => {
+      const validValues = [ALL, SUCCESSFUL, FAILED, PENDING, WILL_NOT_SEND]
+      if (!validValues.includes(value)) {
+        return ALL
+      }
+      return value
+    }),
   ]
 
-  await Promise.all(validations.map(async validation => validation.run(req)))
-  let currentPage = Number(req.query.page)
-  const deliveryStatus = req.query.deliveryStatus
+  await Promise.all(validations.map(async (validation) => validation.run(req)))
+
+  const { page, deliveryStatus } = matchedData(req)
+  let currentPage = Number(page)
 
   const webhook = await webhooksService.getWebhook(req.params.webhookExternalId, req.service.externalId, req.account.id)
-  const signingSecret = await webhooksService.getSigningSecret(req.params.webhookExternalId, req.service.externalId, req.account.id)
-  const webhookMessages = await webhooksService.getWebhookMessages(req.params.webhookExternalId, { page: currentPage, ...deliveryStatus && { status: deliveryStatus } })
+  const signingSecret = await webhooksService.getSigningSecret(
+    req.params.webhookExternalId,
+    req.service.externalId,
+    req.account.id
+  )
+  const webhookMessages = await webhooksService.getWebhookMessages(req.params.webhookExternalId, {
+    page: currentPage,
+    ...(deliveryStatus && { status: deliveryStatus }),
+  })
   const totalPages = Math.ceil(webhookMessages.total / PAGE_SIZE)
   if (totalPages > 0 && currentPage > totalPages) {
     currentPage = totalPages
   }
 
-  const webhookEvents = webhookMessages.results.map(result => ({
+  const webhookEvents = webhookMessages.results.map((result) => ({
     resourceId: result.resource_id,
     eventType: result.event_type,
     lastDeliveryStatus: result.last_delivery_status,
     eventDate: result.event_date,
-    eventDetailUrl: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.event, req.service.externalId, req.account.type, webhook.externalId, result.external_id)
+    eventDetailUrl: formatSimplifiedAccountPathsFor(
+      paths.simplifiedAccount.settings.webhooks.event,
+      req.service.externalId,
+      req.account.type,
+      webhook.externalId,
+      result.external_id
+    ),
   }))
 
-  const pagination = getPagination(currentPage, PAGE_SIZE, webhookMessages.total, (pageNumber) => `${webhooksDetailUrl}?deliveryStatus=${deliveryStatus}&page=${pageNumber}#events`)
+  const pagination = getPagination(
+    currentPage,
+    PAGE_SIZE,
+    webhookMessages.total,
+    (pageNumber) => `${webhooksDetailUrl}?deliveryStatus=${deliveryStatus}&page=${pageNumber}#events`
+  )
 
   const messages = res.locals?.flash?.messages ?? []
   response(req, res, 'simplified-account/settings/webhooks/detail', {
@@ -65,12 +87,26 @@ async function get (req, res) {
     webhookEvents,
     pagination,
     eventTypes: constants.webhooks.humanReadableSubscriptions,
-    backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.index, req.service.externalId, req.account.type),
-    updateWebhookLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.update, req.service.externalId, req.account.type, req.params.webhookExternalId),
-    toggleWebhookStatusLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.webhooks.toggle, req.service.externalId, req.account.type, req.params.webhookExternalId)
+    backLink: formatSimplifiedAccountPathsFor(
+      paths.simplifiedAccount.settings.webhooks.index,
+      req.service.externalId,
+      req.account.type
+    ),
+    updateWebhookLink: formatSimplifiedAccountPathsFor(
+      paths.simplifiedAccount.settings.webhooks.update,
+      req.service.externalId,
+      req.account.type,
+      req.params.webhookExternalId
+    ),
+    toggleWebhookStatusLink: formatSimplifiedAccountPathsFor(
+      paths.simplifiedAccount.settings.webhooks.toggle,
+      req.service.externalId,
+      req.account.type,
+      req.params.webhookExternalId
+    ),
   })
 }
 
 module.exports = {
-  get
+  get,
 }


### PR DESCRIPTION


## What

PP-**15031**

- Getting things ready for the Express 5 upgrade.
- Update to use the express-validator > matchedData() function
  - Instead of reading the updated req.query object
  - As Express 5 has made req.query read only.

### How
Check the following pages are still working:
- Agreements list page
- Webhooks detail page

### Accessibility (views have been added/changed)

N/A

### Screenshots (views have been added/changed)

N/A