### PR TITLE
PP-15031 Express 5 prep - update (live|test) routes

### DIFF
--- a/src/middleware/validate-status-filter.test.ts
+++ b/src/middleware/validate-status-filter.test.ts
@@ -1,0 +1,33 @@
+import sinon from 'sinon'
+import { ServiceRequest, ServiceResponse } from '@utils/types/express'
+import validateStatusFilter from './validate-status-filter'
+
+describe('validate status filter middleware', () => {
+  let req: Partial<ServiceRequest>
+  let res: Partial<ServiceResponse>
+  let next: sinon.SinonSpy
+
+  beforeEach(() => {
+    req = {} as Partial<ServiceRequest>
+    res = {} as Partial<ServiceResponse>
+    next = sinon.spy()
+  })
+
+  it('should call next() when status filter is TEST', () => {
+    req.params = { statusFilter: 'test' }
+    validateStatusFilter(req as ServiceRequest, res as ServiceResponse, next)
+    sinon.assert.calledWithExactly(next)
+  })
+
+  it('should call next() when status filter is LIVE', () => {
+    req.params = { statusFilter: 'live' }
+    validateStatusFilter(req as ServiceRequest, res as ServiceResponse, next)
+    sinon.assert.calledWithExactly(next)
+  })
+
+  it('should call next(route) when status filter is NOT live/test', () => {
+    req.params = { statusFilter: 'invalid-status' }
+    validateStatusFilter(req as ServiceRequest, res as ServiceResponse, next)
+    sinon.assert.calledWith(next, 'route')
+  })
+})

--- a/src/middleware/validate-status-filter.ts
+++ b/src/middleware/validate-status-filter.ts
@@ -1,0 +1,11 @@
+import { ServiceRequest, ServiceResponse } from '@utils/types/express'
+import { NextFunction } from 'express'
+
+function validateStatusFilter(req: ServiceRequest, _: ServiceResponse, next: NextFunction) {
+  if (!['test', 'live'].includes(req.params.statusFilter)) {
+    return next('route')
+  }
+  next()
+}
+
+export = validateStatusFilter

--- a/src/paths.js
+++ b/src/paths.js
@@ -338,16 +338,16 @@ module.exports = {
   index: '/',
   allServiceTransactions: {
     index: '/all-service-transactions',
-    indexStatusFilter: '/all-service-transactions/:statusFilter(test|live)',
-    indexStatusFilterWithoutSearch: '/all-service-transactions/nosearch/:statusFilter(test|live)',
+    indexStatusFilter: '/all-service-transactions/:statusFilter',
+    indexStatusFilterWithoutSearch: '/all-service-transactions/nosearch/:statusFilter',
     download: '/all-service-transactions/download',
-    downloadStatusFilter: '/all-service-transactions/download/:statusFilter(test|live)',
+    downloadStatusFilter: '/all-service-transactions/download/:statusFilter',
     redirectDetail: '/redirect/transactions/:chargeId',
     simplifiedAccount: {
       index: '/transactions/:modeFilter?',
       nosearch: '/transactions/nosearch',
       download: '/transaction/download/:modeFilter?',
-      filter: '/transactions/:statusFilter(test|live)',
+      filter: '/transactions/:statusFilter',
       detail: '/transactions/:transactionId',
       refund: '/transaction/:transactionId/refund',
     },
@@ -401,7 +401,7 @@ module.exports = {
   policyPage: '/policy/:key',
   payouts: {
     list: '/payments-to-your-bank-account',
-    listStatusFilter: '/payments-to-your-bank-account/:statusFilter(test|live)',
+    listStatusFilter: '/payments-to-your-bank-account/:statusFilter',
   },
   privacy: '/privacy',
   demoPaymentFwd: {

--- a/src/routes.js
+++ b/src/routes.js
@@ -21,6 +21,7 @@ const { enforceUserFirstFactor, redirectLoggedInUser } = require('./services/aut
 const trimUsername = require('./middleware/trim-username')
 const permission = require('./middleware/permission')
 const inviteCookieIsPresent = require('./middleware/invite-cookie-is-present')
+const validateStatusFilter = require('./middleware/validate-status-filter')
 
 // Controllers
 const staticController = require('./controllers/static.controller')
@@ -170,14 +171,25 @@ module.exports.bind = function (app) {
 
   // All service transactions
   app.get(allServiceTransactions.index, userIsAuthorised, allTransactionsController.getController)
-  app.get(allServiceTransactions.indexStatusFilter, userIsAuthorised, allTransactionsController.getController)
+  app.get(
+    allServiceTransactions.indexStatusFilter,
+    validateStatusFilter,
+    userIsAuthorised,
+    allTransactionsController.getController
+  )
   app.get(
     allServiceTransactions.indexStatusFilterWithoutSearch,
+    validateStatusFilter,
     userIsAuthorised,
     allTransactionsController.noAutosearchTransactions
   )
   app.get(allServiceTransactions.download, userIsAuthorised, allTransactionsController.downloadTransactions)
-  app.get(allServiceTransactions.downloadStatusFilter, userIsAuthorised, allTransactionsController.downloadTransactions)
+  app.get(
+    allServiceTransactions.downloadStatusFilter,
+    validateStatusFilter,
+    userIsAuthorised,
+    allTransactionsController.downloadTransactions
+  )
   app.get(allServiceTransactions.redirectDetail, userIsAuthorised, transactionDetailRedirectController)
 
   // all service transactions - simplified account
@@ -200,7 +212,7 @@ module.exports.bind = function (app) {
 
   // Payouts
   app.get(payouts.list, userIsAuthorised, payoutsController.listAllServicesPayouts)
-  app.get(payouts.listStatusFilter, userIsAuthorised, payoutsController.listAllServicesPayouts)
+  app.get(payouts.listStatusFilter, validateStatusFilter, userIsAuthorised, payoutsController.listAllServicesPayouts)
 
   // Stripe terms and conditions
   app.get(stripeTermsAndConditions, userIsAuthorised, stripeTermsAndConditionsController.get)


### PR DESCRIPTION
## What

PP-**15031**

- Express 5 does not allow paths such as: `/all-service-transactions/:statusFilter(test|live)`
  - Created a new middleware instead to restrict values to test or live.
  - Update paths to remove the (test|live) as this will be handled by the middleware instead

### How
- Check that pages with  the sub domain `/all-service-transactions` continue to work.
  - Check for both test and live transactions.

### Accessibility (views have been added/changed)

N/A

### Screenshots (views have been added/changed)

N/A