### PR TITLE
PP-15348 4.2.1

### DIFF
--- a/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller.test.js
@@ -6,40 +6,48 @@ const ControllerTestBuilder = require('@test/test-helpers/simplified-account/con
 
 const mockResponse = sinon.stub()
 const mockStripeDetailsService = {
-  updateStripeDetailsOrganisationNameAndAddress: sinon.stub().resolves()
+  updateStripeDetailsOrganisationNameAndAddress: sinon.stub().resolves(),
 }
 const mockCommonsUtils = {
   countries: {
-    govukFrontendFormatted: sinon.stub().returns([{
-      value: 'CS',
-      text: 'Calisota'
-    }])
-  }
+    govukFrontendFormatted: sinon.stub().returns([
+      {
+        value: 'CS',
+        text: 'Calisota',
+      },
+    ]),
+  },
 }
 
 const ACCOUNT_TYPE = 'live'
 const SERVICE_ID = 'service-id-123abc'
-const STRIPE_DETAILS_INDEX_PATH = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.index, SERVICE_ID, ACCOUNT_TYPE)
-const STRIPE_DETAILS_ORG_DETAILS_INDEX_PATH = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.organisationDetails.index, SERVICE_ID, ACCOUNT_TYPE)
+const STRIPE_DETAILS_INDEX_PATH = formatSimplifiedAccountPathsFor(
+  paths.simplifiedAccount.settings.stripeDetails.index,
+  SERVICE_ID,
+  ACCOUNT_TYPE
+)
+const STRIPE_DETAILS_ORG_DETAILS_INDEX_PATH = formatSimplifiedAccountPathsFor(
+  paths.simplifiedAccount.settings.stripeDetails.organisationDetails.index,
+  SERVICE_ID,
+  ACCOUNT_TYPE
+)
 
-const {
-  res,
-  nextRequest,
-  call
-} = new ControllerTestBuilder('@controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller')
+const { res, nextRequest, call } = new ControllerTestBuilder(
+  '@controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller'
+)
   .withService({
     externalId: SERVICE_ID,
     merchantDetails: {
       name: 'McDuck Enterprises',
       addressLine1: 'McDuck Manor',
-      addressCity: 'Duckburg'
-    }
+      addressCity: 'Duckburg',
+    },
   })
   .withAccount({ type: ACCOUNT_TYPE })
   .withStubs({
     '@utils/response': { response: mockResponse },
     '@services/stripe-details.service': mockStripeDetailsService,
-    '@govuk-pay/pay-js-commons': { utils: mockCommonsUtils }
+    '@govuk-pay/pay-js-commons': { utils: mockCommonsUtils },
   })
   .build()
 
@@ -53,7 +61,8 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
       expect(mockResponse).to.have.been.calledWith(
         sinon.match.any,
         sinon.match.any,
-        'simplified-account/settings/stripe-details/organisation-details/update-organisation-details', {
+        'simplified-account/settings/stripe-details/organisation-details/update-organisation-details',
+        {
           backLink: STRIPE_DETAILS_ORG_DETAILS_INDEX_PATH,
           countries: [{ value: 'CS', text: 'Calisota' }],
           organisationDetails: {
@@ -62,9 +71,10 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             addressLine2: undefined,
             addressCity: 'Duckburg',
             addressPostcode: undefined,
-            addressCountry: undefined
-          }
-        })
+            addressCountry: undefined,
+          },
+        }
+      )
     })
   })
 
@@ -77,8 +87,8 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             addressLine1: 'McDuck Manor',
             addressCity: 'Duckburg',
             addressPostcode: 'SW1A 1AA',
-            addressCountry: 'CS'
-          }
+            addressCountry: 'CS',
+          },
         })
         await call('post', 1)
       })
@@ -92,8 +102,9 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             address_line1: 'McDuck Manor',
             address_city: 'Duckburg',
             address_postcode: 'SW1A 1AA',
-            address_country: 'CS'
-          })
+            address_country: 'CS',
+          }
+        )
       })
 
       it('should redirect to the stripe details index page', () => {
@@ -102,16 +113,16 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
       })
     })
 
-    describe('when submitting invalid details', () => {
+    describe('when submitting invalid details - empty organisation name', () => {
       beforeEach(async () => {
         nextRequest({
           body: {
             organisationName: '',
             addressLine1: 'McDuck Manor',
             addressCity: 'Duckburg',
-            addressPostcode: '',
-            addressCountry: 'CS'
-          }
+            addressPostcode: 'E96FB',
+            addressCountry: 'CS',
+          },
         })
         await call('post', 1)
       })
@@ -128,22 +139,18 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
         expect(mockResponse).to.have.been.calledWith(
           sinon.match.any,
           sinon.match.any,
-          'simplified-account/settings/stripe-details/organisation-details/update-organisation-details', {
+          'simplified-account/settings/stripe-details/organisation-details/update-organisation-details',
+          {
             errors: {
               summary: [
                 {
                   text: 'Enter an organisation name',
-                  href: '#organisation-name'
+                  href: '#organisation-name',
                 },
-                {
-                  text: 'Enter a postcode',
-                  href: '#address-postcode'
-                }
               ],
               formErrors: {
                 organisationName: 'Enter an organisation name',
-                addressPostcode: 'Enter a postcode'
-              }
+              },
             },
             backLink: STRIPE_DETAILS_ORG_DETAILS_INDEX_PATH,
             organisationDetails: {
@@ -151,11 +158,66 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
               addressLine1: 'McDuck Manor',
               addressLine2: '',
               addressCity: 'Duckburg',
-              addressPostcode: '',
-              addressCountry: 'CS'
+              addressPostcode: 'E96FB',
+              addressCountry: 'CS',
             },
-            countries: [{ value: 'CS', text: 'Calisota' }]
-          })
+            countries: [{ value: 'CS', text: 'Calisota' }],
+          }
+        )
+      })
+    })
+
+    describe('when submitting invalid details - empty postcode', () => {
+      beforeEach(async () => {
+        nextRequest({
+          body: {
+            organisationName: 'McDuck Manor',
+            addressLine1: 'McDuck Manor',
+            addressCity: 'Duckburg',
+            addressPostcode: '',
+            addressCountry: 'CS',
+          },
+        })
+        await call('post', 1)
+      })
+
+      it('should not submit organisation details to the stripe details service', () => {
+        expect(mockStripeDetailsService.updateStripeDetailsOrganisationNameAndAddress).to.not.have.been.called
+      })
+
+      it('should not redirect', () => {
+        expect(res.redirect).to.not.have.been.called
+      })
+
+      it('should pass context data to the response method with errors', () => {
+        expect(mockResponse).to.have.been.calledWith(
+          sinon.match.any,
+          sinon.match.any,
+          'simplified-account/settings/stripe-details/organisation-details/update-organisation-details',
+          {
+            errors: {
+              summary: [
+                {
+                  text: 'Enter a postcode',
+                  href: '#address-postcode',
+                },
+              ],
+              formErrors: {
+                addressPostcode: 'Enter a postcode',
+              },
+            },
+            backLink: STRIPE_DETAILS_ORG_DETAILS_INDEX_PATH,
+            organisationDetails: {
+              organisationName: 'McDuck Manor',
+              addressLine1: 'McDuck Manor',
+              addressLine2: '',
+              addressCity: 'Duckburg',
+              addressPostcode: '',
+              addressCountry: 'CS',
+            },
+            countries: [{ value: 'CS', text: 'Calisota' }],
+          }
+        )
       })
     })
 
@@ -168,8 +230,8 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             addressLine2: 'The Money Bin',
             addressCity: 'Duckburg',
             addressPostcode: 'SW1A 1AA',
-            addressCountry: 'CS'
-          }
+            addressCountry: 'CS',
+          },
         })
         await call('post', 1)
       })
@@ -184,8 +246,9 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             address_line2: 'The Money Bin',
             address_city: 'Duckburg',
             address_postcode: 'SW1A 1AA',
-            address_country: 'CS'
-          })
+            address_country: 'CS',
+          }
+        )
       })
     })
   })

--- a/src/utils/simplified-account/validation/organisation-details.schema.test.js
+++ b/src/utils/simplified-account/validation/organisation-details.schema.test.js
@@ -14,9 +14,46 @@ describe('Organisation details Validation', () => {
         addressCountry: 'GB',
         addressPostcode: 'NT1 1AA',
         telephoneNumber: '01611234567',
-        organisationUrl: 'https://www.compuglobalhypermeganet.example.com'
-      }
+        organisationUrl: 'https://www.compuglobalhypermeganet.example.com',
+      },
     }
+  })
+
+  describe('XSS sanitisation', () => {
+    const xssPayload = '<script>alert("Stored Cross-Site Scripting")</script>'
+    const escaped = '&lt;script&gt;alert(&quot;Stored Cross-Site Scripting&quot;)&lt;&#x2F;script&gt;'
+
+    it('should escape XSS in organisationName', async () => {
+      const req = {
+        body: { ...BASE_REQ.body, organisationName: xssPayload },
+      }
+      await organisationDetailsSchema.organisationName.validate.run(req)
+      expect(req.body.organisationName).to.equal(escaped)
+    })
+
+    it('should escape XSS in addressLine1', async () => {
+      const req = {
+        body: { ...BASE_REQ.body, addressLine1: xssPayload },
+      }
+      await organisationDetailsSchema.organisationAddress.line1.validate.run(req)
+      expect(req.body.addressLine1).to.equal(escaped)
+    })
+
+    it('should escape XSS in addressLine2', async () => {
+      const req = {
+        body: { ...BASE_REQ.body, addressLine2: xssPayload },
+      }
+      await organisationDetailsSchema.organisationAddress.line2.validate.run(req)
+      expect(req.body.addressLine2).to.equal(escaped)
+    })
+
+    it('should escape XSS in addressCity', async () => {
+      const req = {
+        body: { ...BASE_REQ.body, addressCity: xssPayload },
+      }
+      await organisationDetailsSchema.organisationAddress.city.validate.run(req)
+      expect(req.body.addressCity).to.equal(escaped)
+    })
   })
 
   describe('Organisation name Validation', () => {
@@ -27,7 +64,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when first name is empty', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { organisationName: '' })
+        body: Object.assign({}, BASE_REQ.body, { organisationName: '' }),
       }
       await organisationDetailsSchema.organisationName.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -36,7 +73,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when organisation name exceeds 100 characters', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { organisationName: 'a'.repeat(101) })
+        body: Object.assign({}, BASE_REQ.body, { organisationName: 'a'.repeat(101) }),
       }
       await organisationDetailsSchema.organisationName.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -56,7 +93,7 @@ describe('Organisation details Validation', () => {
 
     it('should pass with empty address line 2', async () => {
       const validReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressLine2: '' })
+        body: Object.assign({}, BASE_REQ.body, { addressLine2: '' }),
       }
       await organisationDetailsSchema.organisationAddress.line2.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -64,7 +101,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when city is empty', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressCity: '' })
+        body: Object.assign({}, BASE_REQ.body, { addressCity: '' }),
       }
       await organisationDetailsSchema.organisationAddress.city.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -73,7 +110,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when city exceeds 255 characters', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressCity: 'a'.repeat(256) })
+        body: Object.assign({}, BASE_REQ.body, { addressCity: 'a'.repeat(256) }),
       }
       await organisationDetailsSchema.organisationAddress.city.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -82,7 +119,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when postcode is empty', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressPostcode: '' })
+        body: Object.assign({}, BASE_REQ.body, { addressPostcode: '' }),
       }
       await organisationDetailsSchema.organisationAddress.postcode.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -91,7 +128,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail with invalid postcode', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressPostcode: 'not a postcode' })
+        body: Object.assign({}, BASE_REQ.body, { addressPostcode: 'not a postcode' }),
       }
       await organisationDetailsSchema.organisationAddress.postcode.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -100,7 +137,7 @@ describe('Organisation details Validation', () => {
 
     it('should pass with invalid postcode if country code is not GB', async () => {
       const validReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressPostcode: 'not a postcode', addressCountry: 'US' })
+        body: Object.assign({}, BASE_REQ.body, { addressPostcode: 'not a postcode', addressCountry: 'US' }),
       }
       await organisationDetailsSchema.organisationAddress.postcode.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -109,34 +146,34 @@ describe('Organisation details Validation', () => {
     const validPostcodes = [
       {
         postcode: 'SW1A 1AA',
-        description: 'standard London postcode'
+        description: 'standard London postcode',
       },
       {
         postcode: 'SW1A1AA',
-        description: 'standard London postcode no space'
+        description: 'standard London postcode no space',
       },
       {
         postcode: 'M2 3AA',
-        description: 'short-form postcode'
+        description: 'short-form postcode',
       },
       {
         postcode: 'SK4 4PB',
-        description: '6 character postcode'
+        description: '6 character postcode',
       },
       {
         postcode: 'W1A 0AX',
-        description: 'special case postcode'
+        description: 'special case postcode',
       },
       {
         postcode: 'GIR 0AA',
-        description: 'special case postcode'
-      }
+        description: 'special case postcode',
+      },
     ]
 
     validPostcodes.forEach(({ postcode, description }) => {
       it(`should validate ${description}: ${postcode}`, async () => {
         const validReq = {
-          body: Object.assign({}, BASE_REQ.body, { addressPostcode: postcode })
+          body: Object.assign({}, BASE_REQ.body, { addressPostcode: postcode }),
         }
         await organisationDetailsSchema.organisationAddress.postcode.validate.run(validReq)
         expect(validationResult(validReq).isEmpty()).to.be.true
@@ -146,27 +183,27 @@ describe('Organisation details Validation', () => {
     const invalidPostcodes = [
       {
         postcode: 'INVALID',
-        description: 'completely invalid format'
+        description: 'completely invalid format',
       },
       {
         postcode: '123 456',
-        description: 'numeric only'
+        description: 'numeric only',
       },
       {
         postcode: 'ABC DEF',
-        description: 'letters only'
+        description: 'letters only',
       },
 
       {
         postcode: 'SW1A 1AAA',
-        description: 'too many characters'
-      }
+        description: 'too many characters',
+      },
     ]
 
     invalidPostcodes.forEach(({ postcode, description }) => {
       it(`should reject invalid ${description}: ${postcode}`, async () => {
         const invalidReq = {
-          body: Object.assign({}, BASE_REQ.body, { addressPostcode: postcode })
+          body: Object.assign({}, BASE_REQ.body, { addressPostcode: postcode }),
         }
         await organisationDetailsSchema.organisationAddress.postcode.validate.run(invalidReq)
         const errors = validationResult(invalidReq)
@@ -177,7 +214,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when country is empty', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressCountry: '' })
+        body: Object.assign({}, BASE_REQ.body, { addressCountry: '' }),
       }
       await organisationDetailsSchema.organisationAddress.country.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -186,7 +223,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when country is shorter than 2 characters', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressCountry: 'A' })
+        body: Object.assign({}, BASE_REQ.body, { addressCountry: 'A' }),
       }
       await organisationDetailsSchema.organisationAddress.country.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -195,7 +232,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when country is longer than 2 characters', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressCountry: 'AAA' })
+        body: Object.assign({}, BASE_REQ.body, { addressCountry: 'AAA' }),
       }
       await organisationDetailsSchema.organisationAddress.country.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -211,7 +248,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail with empty telephone number', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { telephoneNumber: '' })
+        body: Object.assign({}, BASE_REQ.body, { telephoneNumber: '' }),
       }
       await organisationDetailsSchema.telephoneNumber.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -220,11 +257,13 @@ describe('Organisation details Validation', () => {
 
     it('should fail with invalid telephone number', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { telephoneNumber: 'not a phone number' })
+        body: Object.assign({}, BASE_REQ.body, { telephoneNumber: 'not a phone number' }),
       }
       await organisationDetailsSchema.telephoneNumber.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
-      expect(errors.array()[0].msg).to.equal('Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
+      expect(errors.array()[0].msg).to.equal(
+        'Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192'
+      )
     })
   })
 
@@ -236,7 +275,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail with an empty url', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { organisationUrl: '' })
+        body: Object.assign({}, BASE_REQ.body, { organisationUrl: '' }),
       }
       await organisationDetailsSchema.organisationUrl.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -245,7 +284,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail with an invalid url', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { organisationUrl: 'not-a-valid-url' })
+        body: Object.assign({}, BASE_REQ.body, { organisationUrl: 'not-a-valid-url' }),
       }
       await organisationDetailsSchema.organisationUrl.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -254,7 +293,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail with when missing a url protocol', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { organisationUrl: 'nohttp.exmaple.com' })
+        body: Object.assign({}, BASE_REQ.body, { organisationUrl: 'nohttp.exmaple.com' }),
       }
       await organisationDetailsSchema.organisationUrl.validate.run(invalidReq)
       const errors = validationResult(invalidReq)

--- a/src/utils/simplified-account/validation/organisation-details.schema.ts
+++ b/src/utils/simplified-account/validation/organisation-details.schema.ts
@@ -19,6 +19,7 @@ const organisationDetailsSchema = {
       .notEmpty()
       .withMessage('Enter an organisation name')
       .bail()
+      .escape()
       .isLength({ max: ORGANISATION_NAME_MAX_LENGTH })
       .withMessage(`Organisation name must be ${ORGANISATION_NAME_MAX_LENGTH} characters or fewer`),
   },
@@ -29,12 +30,14 @@ const organisationDetailsSchema = {
         .notEmpty()
         .withMessage('Enter a building and street')
         .bail()
+        .escape()
         .isLength({ max: ADDRESS_FIELD_MAX_LENGTH })
         .withMessage(`Building and street must be ${ADDRESS_FIELD_MAX_LENGTH} characters or fewer`),
     },
     line2: {
       validate: body('addressLine2')
         .trim()
+        .escape()
         .isLength({ max: ADDRESS_FIELD_MAX_LENGTH })
         .withMessage(`Building and street must be ${ADDRESS_FIELD_MAX_LENGTH} characters or fewer`),
     },
@@ -44,6 +47,7 @@ const organisationDetailsSchema = {
         .notEmpty()
         .withMessage('Enter a town or city')
         .bail()
+        .escape()
         .isLength({ max: ADDRESS_FIELD_MAX_LENGTH })
         .withMessage(`Town or city must be ${ADDRESS_FIELD_MAX_LENGTH} characters or fewer`),
     },


### PR DESCRIPTION


Further information in the Jira ticket.

https://payments-platform.atlassian.net/browse/PP-15348

### How to reproduce

- Log on as a service admin
- Visit http://127.0.0.1:3000/service/{SERVICE-ID}/account/test/settings/organisation-details
- Enter or update the organisation addressLine1 with <script>alert('hello')</script>
- Save
- When the page loads after the update you should not get an alert 
- and the text <script>alert('hello')</script> should be displayed

Previously the text would not be displayed and the alert would be executed and shown on the webpage.


### Accessibility (views have been added/changed)

n/a

### Screenshots (views have been added/changed)
<img width="542" height="204" alt="alert" src="https://github.com/user-attachments/assets/f9044ec8-e6af-466f-9c73-3b69901776a5" />
