### PR TITLE
PP-15350 validate input for payment_link fields

### DIFF
--- a/src/utils/simplified-account/validation/payment-link.schema.test.ts
+++ b/src/utils/simplified-account/validation/payment-link.schema.test.ts
@@ -12,8 +12,8 @@ describe('Payment Link Schema Validation', () => {
         description: 'A valid payment link description',
         referenceTypeGroup: 'custom',
         referenceLabel: 'Order Number',
-        referenceHint: 'Enter your order number'
-      }
+        referenceHint: 'Enter your order number',
+      },
     }
   })
 
@@ -25,7 +25,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when title is empty', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, name: '' }
+        body: { ...BASE_REQ.body, name: '' },
       }
       await paymentLinkSchema.info.name.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -34,7 +34,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when title is only whitespace', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, name: '   ' }
+        body: { ...BASE_REQ.body, name: '   ' },
       }
       await paymentLinkSchema.info.name.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -43,7 +43,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when title exceeds 230 characters', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, name: 'a'.repeat(231) }
+        body: { ...BASE_REQ.body, name: 'a'.repeat(231) },
       }
       await paymentLinkSchema.info.name.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -52,7 +52,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should pass with title at exactly 230 characters', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, name: 'a'.repeat(230) }
+        body: { ...BASE_REQ.body, name: 'a'.repeat(230) },
       }
       await paymentLinkSchema.info.name.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -60,10 +60,28 @@ describe('Payment Link Schema Validation', () => {
 
     it('should trim whitespace from title', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, name: '  Valid Title  ' }
+        body: { ...BASE_REQ.body, name: '  Valid Title  ' },
       }
       await paymentLinkSchema.info.name.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
+    })
+
+    it('should fail with invalid characters - less than', async () => {
+      const invalidReq = {
+        body: { ...BASE_REQ.body, name: 'Title with < character' },
+      }
+      await paymentLinkSchema.info.name.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the Title')
+    })
+
+    it('should fail with invalid encoded characters - less than', async () => {
+      const invalidReq = {
+        body: { ...BASE_REQ.body, name: 'Title with &lt; character' },
+      }
+      await paymentLinkSchema.info.name.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the Title')
     })
   })
 
@@ -75,7 +93,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should pass with empty description', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, description: '' }
+        body: { ...BASE_REQ.body, description: '' },
       }
       await paymentLinkSchema.info.description.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -83,7 +101,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should pass with undefined description', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body }
+        body: { ...BASE_REQ.body },
       }
       delete validReq.body.description
       await paymentLinkSchema.info.description.validate.run(validReq)
@@ -92,7 +110,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when description exceeds 5000 characters', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, description: 'a'.repeat(5001) }
+        body: { ...BASE_REQ.body, description: 'a'.repeat(5001) },
       }
       await paymentLinkSchema.info.description.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -101,7 +119,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should pass with description at exactly 5000 characters', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, description: 'a'.repeat(5000) }
+        body: { ...BASE_REQ.body, description: 'a'.repeat(5000) },
       }
       await paymentLinkSchema.info.description.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -109,34 +127,43 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail with invalid characters - less than', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, description: 'Description with < character' }
+        body: { ...BASE_REQ.body, description: 'Description with < character' },
       }
       await paymentLinkSchema.info.description.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
-      expect(errors.array()[0].msg).to.equal('Details contains invalid characters')
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the Details')
     })
 
     it('should fail with invalid characters - greater than', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, description: 'Description with > character' }
+        body: { ...BASE_REQ.body, description: 'Description with > character' },
       }
       await paymentLinkSchema.info.description.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
-      expect(errors.array()[0].msg).to.equal('Details contains invalid characters')
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the Details')
     })
 
     it('should fail with invalid characters - pipe', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, description: 'Description with | character' }
+        body: { ...BASE_REQ.body, description: 'Description with | character' },
       }
       await paymentLinkSchema.info.description.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
-      expect(errors.array()[0].msg).to.equal('Details contains invalid characters')
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the Details')
+    })
+
+    it('should fail with invalid encoded characters - less than', async () => {
+      const invalidReq = {
+        body: { ...BASE_REQ.body, description: 'Description with &lt; character' },
+      }
+      await paymentLinkSchema.info.description.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the Details')
     })
 
     it('should pass with valid special characters', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, description: 'Description with £$%^&*()_-+={}[]@#~:;"/.,? and more!' }
+        body: { ...BASE_REQ.body, description: 'Description with £$%^&*()_-+={}[]@#~:;"/.,? and more!' },
       }
       await paymentLinkSchema.info.description.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -144,7 +171,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should trim whitespace from description', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, description: '  Valid description  ' }
+        body: { ...BASE_REQ.body, description: '  Valid description  ' },
       }
       await paymentLinkSchema.info.description.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -154,7 +181,7 @@ describe('Payment Link Schema Validation', () => {
   describe('Reference Type Validation', () => {
     it('should pass with custom reference type', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, referenceTypeGroup: 'custom' }
+        body: { ...BASE_REQ.body, referenceTypeGroup: 'custom' },
       }
       await paymentLinkSchema.reference.type.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -162,7 +189,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should pass with standard reference type', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, referenceTypeGroup: 'standard' }
+        body: { ...BASE_REQ.body, referenceTypeGroup: 'standard' },
       }
       await paymentLinkSchema.reference.type.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -170,7 +197,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when reference type is empty', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, referenceTypeGroup: '' }
+        body: { ...BASE_REQ.body, referenceTypeGroup: '' },
       }
       await paymentLinkSchema.reference.type.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -179,7 +206,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail with invalid reference type', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, referenceTypeGroup: 'invalid' }
+        body: { ...BASE_REQ.body, referenceTypeGroup: 'invalid' },
       }
       await paymentLinkSchema.reference.type.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -188,7 +215,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when reference type is only whitespace', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, referenceTypeGroup: '   ' }
+        body: { ...BASE_REQ.body, referenceTypeGroup: '   ' },
       }
       await paymentLinkSchema.reference.type.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -197,7 +224,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should trim whitespace from reference type', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, referenceTypeGroup: '  custom  ' }
+        body: { ...BASE_REQ.body, referenceTypeGroup: '  custom  ' },
       }
       await paymentLinkSchema.reference.type.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -212,7 +239,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when reference label is empty', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, referenceLabel: '' }
+        body: { ...BASE_REQ.body, referenceLabel: '' },
       }
       await paymentLinkSchema.reference.label.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -221,7 +248,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when reference label is only whitespace', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, referenceLabel: '   ' }
+        body: { ...BASE_REQ.body, referenceLabel: '   ' },
       }
       await paymentLinkSchema.reference.label.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -230,7 +257,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when reference label exceeds 50 characters', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, referenceLabel: 'a'.repeat(51) }
+        body: { ...BASE_REQ.body, referenceLabel: 'a'.repeat(51) },
       }
       await paymentLinkSchema.reference.label.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -239,7 +266,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should pass with reference label at exactly 50 characters', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, referenceLabel: 'a'.repeat(50) }
+        body: { ...BASE_REQ.body, referenceLabel: 'a'.repeat(50) },
       }
       await paymentLinkSchema.reference.label.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -247,10 +274,28 @@ describe('Payment Link Schema Validation', () => {
 
     it('should trim whitespace from reference label', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, referenceLabel: '  Valid Label  ' }
+        body: { ...BASE_REQ.body, referenceLabel: '  Valid Label  ' },
       }
       await paymentLinkSchema.reference.label.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
+    })
+
+    it('should fail with invalid characters - less than', async () => {
+      const invalidReq = {
+        body: { ...BASE_REQ.body, referenceLabel: 'Reference with < character' },
+      }
+      await paymentLinkSchema.reference.label.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the Reference')
+    })
+
+    it('should fail with invalid encoded characters - less than', async () => {
+      const invalidReq = {
+        body: { ...BASE_REQ.body, referenceLabel: 'Reference with &lt; character' },
+      }
+      await paymentLinkSchema.reference.label.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the Reference')
     })
   })
 
@@ -262,7 +307,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should pass with empty hint', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, referenceHint: '' }
+        body: { ...BASE_REQ.body, referenceHint: '' },
       }
       await paymentLinkSchema.reference.hint.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -270,7 +315,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should pass with undefined hint', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body }
+        body: { ...BASE_REQ.body },
       }
       delete validReq.body.referenceHint
       await paymentLinkSchema.reference.hint.validate.run(validReq)
@@ -279,7 +324,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when hint exceeds 255 characters', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, referenceHint: 'a'.repeat(256) }
+        body: { ...BASE_REQ.body, referenceHint: 'a'.repeat(256) },
       }
       await paymentLinkSchema.reference.hint.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -288,7 +333,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should pass with hint at exactly 255 characters', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, referenceHint: 'a'.repeat(255) }
+        body: { ...BASE_REQ.body, referenceHint: 'a'.repeat(255) },
       }
       await paymentLinkSchema.reference.hint.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -296,17 +341,39 @@ describe('Payment Link Schema Validation', () => {
 
     it('should trim whitespace from hint', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, referenceHint: '  Valid hint text  ' }
+        body: { ...BASE_REQ.body, referenceHint: '  Valid hint text  ' },
       }
       await paymentLinkSchema.reference.hint.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
+    })
+
+    it('should fail with invalid characters - less than', async () => {
+      const invalidReq = {
+        body: { ...BASE_REQ.body, referenceHint: 'Reference hint with < character' },
+      }
+      await paymentLinkSchema.reference.hint.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal(
+        'You cannot use any of the following characters < > | in the Reference Hint'
+      )
+    })
+
+    it('should fail with invalid encoded characters - less than', async () => {
+      const invalidReq = {
+        body: { ...BASE_REQ.body, referenceHint: 'Reference hint with &lt; character' },
+      }
+      await paymentLinkSchema.reference.hint.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal(
+        'You cannot use any of the following characters < > | in the Reference Hint'
+      )
     })
   })
 
   describe('Amount Type Validation', () => {
     it('should pass with fixed amount type', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, amountTypeGroup: 'fixed' }
+        body: { ...BASE_REQ.body, amountTypeGroup: 'fixed' },
       }
       await paymentLinkSchema.amount.type.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -314,7 +381,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should pass with variable amount type', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, amountTypeGroup: 'variable' }
+        body: { ...BASE_REQ.body, amountTypeGroup: 'variable' },
       }
       await paymentLinkSchema.amount.type.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -322,7 +389,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when amount type is empty', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, amountTypeGroup: '' }
+        body: { ...BASE_REQ.body, amountTypeGroup: '' },
       }
       await paymentLinkSchema.amount.type.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -331,7 +398,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail with invalid amount type', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, amountTypeGroup: 'invalid' }
+        body: { ...BASE_REQ.body, amountTypeGroup: 'invalid' },
       }
       await paymentLinkSchema.amount.type.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -340,7 +407,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when amount type is only whitespace', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, amountTypeGroup: '   ' }
+        body: { ...BASE_REQ.body, amountTypeGroup: '   ' },
       }
       await paymentLinkSchema.amount.type.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -349,7 +416,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should trim whitespace from amount type', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, amountTypeGroup: '  fixed  ' }
+        body: { ...BASE_REQ.body, amountTypeGroup: '  fixed  ' },
       }
       await paymentLinkSchema.amount.type.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -359,7 +426,7 @@ describe('Payment Link Schema Validation', () => {
   describe('Amount Hint Validation', () => {
     it('should pass with a valid amount hint', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, amountHint: 'Enter your amount' }
+        body: { ...BASE_REQ.body, amountHint: 'Enter your amount' },
       }
       await paymentLinkSchema.amount.hint.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -367,7 +434,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should pass with empty amount hint', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, amountHint: '' }
+        body: { ...BASE_REQ.body, amountHint: '' },
       }
       await paymentLinkSchema.amount.hint.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -375,7 +442,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should pass with undefined amount hint', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body }
+        body: { ...BASE_REQ.body },
       }
       delete validReq.body.amountHint
       await paymentLinkSchema.amount.hint.validate.run(validReq)
@@ -384,7 +451,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when amount hint exceeds 255 characters', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, amountHint: 'a'.repeat(256) }
+        body: { ...BASE_REQ.body, amountHint: 'a'.repeat(256) },
       }
       await paymentLinkSchema.amount.hint.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -393,7 +460,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should pass with amount hint at exactly 255 characters', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, amountHint: 'a'.repeat(255) }
+        body: { ...BASE_REQ.body, amountHint: 'a'.repeat(255) },
       }
       await paymentLinkSchema.amount.hint.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -401,23 +468,41 @@ describe('Payment Link Schema Validation', () => {
 
     it('should trim whitespace from amount hint', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, amountHint: '  Valid amount hint  ' }
+        body: { ...BASE_REQ.body, amountHint: '  Valid amount hint  ' },
       }
       await paymentLinkSchema.amount.hint.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
+    })
+
+    it('should fail with invalid characters - less than', async () => {
+      const invalidReq = {
+        body: { ...BASE_REQ.body, amountHint: 'Amount hint with < character' },
+      }
+      await paymentLinkSchema.amount.hint.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the Amount Hint')
+    })
+
+    it('should fail with invalid encoded characters - less than', async () => {
+      const invalidReq = {
+        body: { ...BASE_REQ.body, amountHint: 'Amount hint with &lt; character' },
+      }
+      await paymentLinkSchema.amount.hint.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the Amount Hint')
     })
   })
 
   describe('Metadata Column Header Validation', () => {
     const existingMetadata = {
-      'existing_column': 'existing_value',
-      'another_column': 'another_value'
+      existing_column: 'existing_value',
+      another_column: 'another_value',
     }
 
     describe('Adding new column', () => {
       it('should pass with valid new column header', async () => {
         const validReq = {
-          body: { ...BASE_REQ.body, reportingColumn: 'new_column' }
+          body: { ...BASE_REQ.body, reportingColumn: 'new_column' },
         }
         await paymentLinkSchema.metadata.columnHeader.add.validate(existingMetadata).run(validReq)
         expect(validationResult(validReq).isEmpty()).to.be.true
@@ -425,7 +510,7 @@ describe('Payment Link Schema Validation', () => {
 
       it('should fail when column header is empty', async () => {
         const invalidReq = {
-          body: { ...BASE_REQ.body, reportingColumn: '' }
+          body: { ...BASE_REQ.body, reportingColumn: '' },
         }
         await paymentLinkSchema.metadata.columnHeader.add.validate(existingMetadata).run(invalidReq)
         const errors = validationResult(invalidReq)
@@ -434,7 +519,7 @@ describe('Payment Link Schema Validation', () => {
 
       it('should fail when column header is only whitespace', async () => {
         const invalidReq = {
-          body: { ...BASE_REQ.body, reportingColumn: '   ' }
+          body: { ...BASE_REQ.body, reportingColumn: '   ' },
         }
         await paymentLinkSchema.metadata.columnHeader.add.validate(existingMetadata).run(invalidReq)
         const errors = validationResult(invalidReq)
@@ -443,7 +528,7 @@ describe('Payment Link Schema Validation', () => {
 
       it('should fail when column header exceeds 30 characters', async () => {
         const invalidReq = {
-          body: { ...BASE_REQ.body, reportingColumn: 'a'.repeat(31) }
+          body: { ...BASE_REQ.body, reportingColumn: 'a'.repeat(31) },
         }
         await paymentLinkSchema.metadata.columnHeader.add.validate(existingMetadata).run(invalidReq)
         const errors = validationResult(invalidReq)
@@ -452,7 +537,7 @@ describe('Payment Link Schema Validation', () => {
 
       it('should pass with column header at exactly 30 characters', async () => {
         const validReq = {
-          body: { ...BASE_REQ.body, reportingColumn: 'a'.repeat(30) }
+          body: { ...BASE_REQ.body, reportingColumn: 'a'.repeat(30) },
         }
         await paymentLinkSchema.metadata.columnHeader.add.validate(existingMetadata).run(validReq)
         expect(validationResult(validReq).isEmpty()).to.be.true
@@ -460,7 +545,7 @@ describe('Payment Link Schema Validation', () => {
 
       it('should fail when column header already exists', async () => {
         const invalidReq = {
-          body: { ...BASE_REQ.body, reportingColumn: 'existing_column' }
+          body: { ...BASE_REQ.body, reportingColumn: 'existing_column' },
         }
         await paymentLinkSchema.metadata.columnHeader.add.validate(existingMetadata).run(invalidReq)
         const errors = validationResult(invalidReq)
@@ -468,20 +553,24 @@ describe('Payment Link Schema Validation', () => {
       })
 
       it('should fail when trying to add more than 15 columns', async () => {
-        const maxMetadata = Array.from({ length: 15 }, (_, i) => [`column_${i}`, `value_${i}`])
-          .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {})
-        
+        const maxMetadata = Array.from({ length: 15 }, (_, i) => [`column_${i}`, `value_${i}`]).reduce(
+          (acc, [key, value]) => ({ ...acc, [key]: value }),
+          {}
+        )
+
         const invalidReq = {
-          body: { ...BASE_REQ.body, reportingColumn: 'new_column' }
+          body: { ...BASE_REQ.body, reportingColumn: 'new_column' },
         }
         await paymentLinkSchema.metadata.columnHeader.add.validate(maxMetadata).run(invalidReq)
         const errors = validationResult(invalidReq)
-        expect(errors.array()[0].msg).to.equal('You have already set 15 reporting columns for this payment link, remove one to set another')
+        expect(errors.array()[0].msg).to.equal(
+          'You have already set 15 reporting columns for this payment link, remove one to set another'
+        )
       })
 
       it('should trim whitespace from column header', async () => {
         const validReq = {
-          body: { ...BASE_REQ.body, reportingColumn: '  new_column  ' }
+          body: { ...BASE_REQ.body, reportingColumn: '  new_column  ' },
         }
         await paymentLinkSchema.metadata.columnHeader.add.validate(existingMetadata).run(validReq)
         expect(validationResult(validReq).isEmpty()).to.be.true
@@ -491,7 +580,7 @@ describe('Payment Link Schema Validation', () => {
     describe('Editing existing column', () => {
       it('should pass when editing column header to same value', async () => {
         const validReq = {
-          body: { ...BASE_REQ.body, reportingColumn: 'existing_column' }
+          body: { ...BASE_REQ.body, reportingColumn: 'existing_column' },
         }
         await paymentLinkSchema.metadata.columnHeader.edit.validate(existingMetadata, 'existing_column').run(validReq)
         expect(validationResult(validReq).isEmpty()).to.be.true
@@ -499,7 +588,7 @@ describe('Payment Link Schema Validation', () => {
 
       it('should pass when editing column header to new value', async () => {
         const validReq = {
-          body: { ...BASE_REQ.body, reportingColumn: 'updated_column' }
+          body: { ...BASE_REQ.body, reportingColumn: 'updated_column' },
         }
         await paymentLinkSchema.metadata.columnHeader.edit.validate(existingMetadata, 'existing_column').run(validReq)
         expect(validationResult(validReq).isEmpty()).to.be.true
@@ -507,7 +596,7 @@ describe('Payment Link Schema Validation', () => {
 
       it('should fail when editing column header to duplicate existing value', async () => {
         const invalidReq = {
-          body: { ...BASE_REQ.body, reportingColumn: 'another_column' }
+          body: { ...BASE_REQ.body, reportingColumn: 'another_column' },
         }
         await paymentLinkSchema.metadata.columnHeader.edit.validate(existingMetadata, 'existing_column').run(invalidReq)
         const errors = validationResult(invalidReq)
@@ -516,7 +605,7 @@ describe('Payment Link Schema Validation', () => {
 
       it('should fail when editing column header is empty', async () => {
         const invalidReq = {
-          body: { ...BASE_REQ.body, reportingColumn: '' }
+          body: { ...BASE_REQ.body, reportingColumn: '' },
         }
         await paymentLinkSchema.metadata.columnHeader.edit.validate(existingMetadata, 'existing_column').run(invalidReq)
         const errors = validationResult(invalidReq)
@@ -525,7 +614,7 @@ describe('Payment Link Schema Validation', () => {
 
       it('should fail when editing column header exceeds 30 characters', async () => {
         const invalidReq = {
-          body: { ...BASE_REQ.body, reportingColumn: 'a'.repeat(31) }
+          body: { ...BASE_REQ.body, reportingColumn: 'a'.repeat(31) },
         }
         await paymentLinkSchema.metadata.columnHeader.edit.validate(existingMetadata, 'existing_column').run(invalidReq)
         const errors = validationResult(invalidReq)
@@ -537,7 +626,7 @@ describe('Payment Link Schema Validation', () => {
   describe('Metadata Cell Content Validation', () => {
     it('should pass with valid cell content', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, cellContent: 'Valid cell content' }
+        body: { ...BASE_REQ.body, cellContent: 'Valid cell content' },
       }
       await paymentLinkSchema.metadata.cellContent.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -545,7 +634,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when cell content is empty', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, cellContent: '' }
+        body: { ...BASE_REQ.body, cellContent: '' },
       }
       await paymentLinkSchema.metadata.cellContent.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -554,7 +643,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when cell content is only whitespace', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, cellContent: '   ' }
+        body: { ...BASE_REQ.body, cellContent: '   ' },
       }
       await paymentLinkSchema.metadata.cellContent.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -563,7 +652,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should fail when cell content exceeds 100 characters', async () => {
       const invalidReq = {
-        body: { ...BASE_REQ.body, cellContent: 'a'.repeat(101) }
+        body: { ...BASE_REQ.body, cellContent: 'a'.repeat(101) },
       }
       await paymentLinkSchema.metadata.cellContent.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -572,7 +661,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should pass with cell content at exactly 100 characters', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, cellContent: 'a'.repeat(100) }
+        body: { ...BASE_REQ.body, cellContent: 'a'.repeat(100) },
       }
       await paymentLinkSchema.metadata.cellContent.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -580,7 +669,7 @@ describe('Payment Link Schema Validation', () => {
 
     it('should trim whitespace from cell content', async () => {
       const validReq = {
-        body: { ...BASE_REQ.body, cellContent: '  Valid content  ' }
+        body: { ...BASE_REQ.body, cellContent: '  Valid content  ' },
       }
       await paymentLinkSchema.metadata.cellContent.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true

--- a/src/utils/simplified-account/validation/payment-link.schema.ts
+++ b/src/utils/simplified-account/validation/payment-link.schema.ts
@@ -14,7 +14,12 @@ const paymentLinkSchema = {
         .withMessage('Enter a title')
         .bail()
         .isLength({ max: 230 })
-        .withMessage('Title must be 230 characters or fewer'),
+        .withMessage('Title must be 230 characters or fewer')
+        .bail()
+        .unescape()
+        .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
+        .withMessage('You cannot use any of the following characters < > | in the Title')
+        .bail(),
     },
     description: {
       validate: body('description')
@@ -22,8 +27,11 @@ const paymentLinkSchema = {
         .trim()
         .isLength({ min: 0, max: 5000 })
         .withMessage('Details must be less than 5000 characters')
+        .bail()
+        .unescape()
         .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
-        .withMessage('Details contains invalid characters'),
+        .withMessage('You cannot use any of the following characters < > | in the Details')
+        .bail(),
     },
   },
   existing: {
@@ -35,6 +43,7 @@ const paymentLinkSchema = {
         .bail()
         .isLength({ max: 230 })
         .withMessage('a payment link address must be 230 characters or fewer')
+        .bail()
         .custom(async (value: string, { req }) => {
           const currentSession = PaymentLinkCreationSession.extract(req as ServiceRequest)
           if (!currentSession.serviceNamePath || !value) {
@@ -46,7 +55,8 @@ const paymentLinkSchema = {
           ).catch(() => undefined)
           return paymentLink ? Promise.reject(new Error()) : Promise.resolve()
         })
-        .withMessage('The website address is already taken'),
+        .withMessage('The website address is already taken')
+        .bail(),
     },
   },
   reference: {
@@ -57,22 +67,34 @@ const paymentLinkSchema = {
         .withMessage('Please select an option')
         .bail()
         .isIn(['custom', 'standard'])
-        .withMessage('Please select an option'),
+        .withMessage('Please select an option')
+        .bail(),
     },
     label: {
       validate: body('referenceLabel')
         .trim()
         .notEmpty()
         .withMessage('Please enter a reference')
+        .bail()
         .isLength({ max: 50 })
-        .withMessage('Reference must be be 50 characters or fewer'),
+        .withMessage('Reference must be be 50 characters or fewer')
+        .bail()
+        .unescape()
+        .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
+        .withMessage('You cannot use any of the following characters < > | in the Reference')
+        .bail(),
     },
     hint: {
       validate: body('referenceHint')
         .optional({ values: 'falsy' })
         .trim()
         .isLength({ max: 255 })
-        .withMessage('Hint text must be be 255 characters or fewer'),
+        .withMessage('Hint text must be be 255 characters or fewer')
+        .bail()
+        .unescape()
+        .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
+        .withMessage('You cannot use any of the following characters < > | in the Reference Hint')
+        .bail(),
     },
   },
   amount: {
@@ -83,7 +105,8 @@ const paymentLinkSchema = {
         .withMessage('Please select an option')
         .bail()
         .isIn(['fixed', 'variable'])
-        .withMessage('Please select an option'),
+        .withMessage('Please select an option')
+        .bail(),
     },
     price: {
       validate: demoPaymentSchema.paymentAmount.validate,
@@ -93,7 +116,12 @@ const paymentLinkSchema = {
         .optional({ values: 'falsy' })
         .trim()
         .isLength({ max: 255 })
-        .withMessage('Hint text must be be 255 characters or fewer'),
+        .withMessage('Hint text must be be 255 characters or fewer')
+        .bail()
+        .unescape()
+        .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
+        .withMessage('You cannot use any of the following characters < > | in the Amount Hint')
+        .bail(),
     },
   },
   metadata: {
@@ -113,7 +141,8 @@ const paymentLinkSchema = {
         .withMessage('Enter the cell content')
         .bail()
         .isLength({ min: 1, max: 100 })
-        .withMessage('Cell content must be 100 characters or fewer'),
+        .withMessage('Cell content must be 100 characters or fewer')
+        .bail(),
     },
   },
 }


### PR DESCRIPTION
## What

Add extra validation, deny <, >, and | characters to be used for different text. This is to sanitise HTML tags.
