### PR TITLE
PP-15348 - 4.2.1-A

### DIFF
--- a/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller.test.js
@@ -6,40 +6,48 @@ const ControllerTestBuilder = require('@test/test-helpers/simplified-account/con
 
 const mockResponse = sinon.stub()
 const mockStripeDetailsService = {
-  updateStripeDetailsOrganisationNameAndAddress: sinon.stub().resolves()
+  updateStripeDetailsOrganisationNameAndAddress: sinon.stub().resolves(),
 }
 const mockCommonsUtils = {
   countries: {
-    govukFrontendFormatted: sinon.stub().returns([{
-      value: 'CS',
-      text: 'Calisota'
-    }])
-  }
+    govukFrontendFormatted: sinon.stub().returns([
+      {
+        value: 'CS',
+        text: 'Calisota',
+      },
+    ]),
+  },
 }
 
 const ACCOUNT_TYPE = 'live'
 const SERVICE_ID = 'service-id-123abc'
-const STRIPE_DETAILS_INDEX_PATH = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.index, SERVICE_ID, ACCOUNT_TYPE)
-const STRIPE_DETAILS_ORG_DETAILS_INDEX_PATH = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.stripeDetails.organisationDetails.index, SERVICE_ID, ACCOUNT_TYPE)
+const STRIPE_DETAILS_INDEX_PATH = formatSimplifiedAccountPathsFor(
+  paths.simplifiedAccount.settings.stripeDetails.index,
+  SERVICE_ID,
+  ACCOUNT_TYPE
+)
+const STRIPE_DETAILS_ORG_DETAILS_INDEX_PATH = formatSimplifiedAccountPathsFor(
+  paths.simplifiedAccount.settings.stripeDetails.organisationDetails.index,
+  SERVICE_ID,
+  ACCOUNT_TYPE
+)
 
-const {
-  res,
-  nextRequest,
-  call
-} = new ControllerTestBuilder('@controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller')
+const { res, nextRequest, call } = new ControllerTestBuilder(
+  '@controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller'
+)
   .withService({
     externalId: SERVICE_ID,
     merchantDetails: {
       name: 'McDuck Enterprises',
       addressLine1: 'McDuck Manor',
-      addressCity: 'Duckburg'
-    }
+      addressCity: 'Duckburg',
+    },
   })
   .withAccount({ type: ACCOUNT_TYPE })
   .withStubs({
     '@utils/response': { response: mockResponse },
     '@services/stripe-details.service': mockStripeDetailsService,
-    '@govuk-pay/pay-js-commons': { utils: mockCommonsUtils }
+    '@govuk-pay/pay-js-commons': { utils: mockCommonsUtils },
   })
   .build()
 
@@ -53,7 +61,8 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
       expect(mockResponse).to.have.been.calledWith(
         sinon.match.any,
         sinon.match.any,
-        'simplified-account/settings/stripe-details/organisation-details/update-organisation-details', {
+        'simplified-account/settings/stripe-details/organisation-details/update-organisation-details',
+        {
           backLink: STRIPE_DETAILS_ORG_DETAILS_INDEX_PATH,
           countries: [{ value: 'CS', text: 'Calisota' }],
           organisationDetails: {
@@ -62,9 +71,10 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             addressLine2: undefined,
             addressCity: 'Duckburg',
             addressPostcode: undefined,
-            addressCountry: undefined
-          }
-        })
+            addressCountry: undefined,
+          },
+        }
+      )
     })
   })
 
@@ -77,8 +87,8 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             addressLine1: 'McDuck Manor',
             addressCity: 'Duckburg',
             addressPostcode: 'SW1A 1AA',
-            addressCountry: 'CS'
-          }
+            addressCountry: 'CS',
+          },
         })
         await call('post', 1)
       })
@@ -92,8 +102,9 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             address_line1: 'McDuck Manor',
             address_city: 'Duckburg',
             address_postcode: 'SW1A 1AA',
-            address_country: 'CS'
-          })
+            address_country: 'CS',
+          }
+        )
       })
 
       it('should redirect to the stripe details index page', () => {
@@ -110,8 +121,8 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             addressLine1: 'McDuck Manor',
             addressCity: 'Duckburg',
             addressPostcode: '',
-            addressCountry: 'CS'
-          }
+            addressCountry: 'CS',
+          },
         })
         await call('post', 1)
       })
@@ -128,22 +139,23 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
         expect(mockResponse).to.have.been.calledWith(
           sinon.match.any,
           sinon.match.any,
-          'simplified-account/settings/stripe-details/organisation-details/update-organisation-details', {
+          'simplified-account/settings/stripe-details/organisation-details/update-organisation-details',
+          {
             errors: {
               summary: [
                 {
                   text: 'Enter an organisation name',
-                  href: '#organisation-name'
+                  href: '#organisation-name',
                 },
                 {
                   text: 'Enter a postcode',
-                  href: '#address-postcode'
-                }
+                  href: '#address-postcode',
+                },
               ],
               formErrors: {
                 organisationName: 'Enter an organisation name',
-                addressPostcode: 'Enter a postcode'
-              }
+                addressPostcode: 'Enter a postcode',
+              },
             },
             backLink: STRIPE_DETAILS_ORG_DETAILS_INDEX_PATH,
             organisationDetails: {
@@ -152,10 +164,11 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
               addressLine2: undefined,
               addressCity: 'Duckburg',
               addressPostcode: '',
-              addressCountry: 'CS'
+              addressCountry: 'CS',
             },
-            countries: [{ value: 'CS', text: 'Calisota' }]
-          })
+            countries: [{ value: 'CS', text: 'Calisota' }],
+          }
+        )
       })
     })
 
@@ -168,8 +181,8 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             addressLine2: 'The Money Bin',
             addressCity: 'Duckburg',
             addressPostcode: 'SW1A 1AA',
-            addressCountry: 'CS'
-          }
+            addressCountry: 'CS',
+          },
         })
         await call('post', 1)
       })
@@ -184,8 +197,9 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             address_line2: 'The Money Bin',
             address_city: 'Duckburg',
             address_postcode: 'SW1A 1AA',
-            address_country: 'CS'
-          })
+            address_country: 'CS',
+          }
+        )
       })
     })
   })

--- a/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller.test.js
@@ -113,11 +113,11 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
       })
     })
 
-    describe('when submitting invalid details', () => {
+    describe('when submitting invalid details - missing postcode', () => {
       beforeEach(async () => {
         nextRequest({
           body: {
-            organisationName: '',
+            organisationName: 'McDuck Institute',
             addressLine1: 'McDuck Manor',
             addressCity: 'Duckburg',
             addressPostcode: '',
@@ -144,17 +144,66 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             errors: {
               summary: [
                 {
-                  text: 'Enter an organisation name',
-                  href: '#organisation-name',
-                },
-                {
                   text: 'Enter a postcode',
                   href: '#address-postcode',
                 },
               ],
               formErrors: {
-                organisationName: 'Enter an organisation name',
                 addressPostcode: 'Enter a postcode',
+              },
+            },
+            backLink: STRIPE_DETAILS_ORG_DETAILS_INDEX_PATH,
+            organisationDetails: {
+              organisationName: 'McDuck Institute',
+              addressLine1: 'McDuck Manor',
+              addressLine2: undefined,
+              addressCity: 'Duckburg',
+              addressPostcode: '',
+              addressCountry: 'CS',
+            },
+            countries: [{ value: 'CS', text: 'Calisota' }],
+          }
+        )
+      })
+    })
+
+    describe('when submitting invalid details - missing organisation name', () => {
+      beforeEach(async () => {
+        nextRequest({
+          body: {
+            organisationName: '',
+            addressLine1: 'McDuck Manor',
+            addressCity: 'Duckburg',
+            addressPostcode: 'E9 6FB',
+            addressCountry: 'CS',
+          },
+        })
+        await call('post', 1)
+      })
+
+      it('should not submit organisation details to the stripe details service', () => {
+        expect(mockStripeDetailsService.updateStripeDetailsOrganisationNameAndAddress).to.not.have.been.called
+      })
+
+      it('should not redirect', () => {
+        expect(res.redirect).to.not.have.been.called
+      })
+
+      it('should pass context data to the response method with errors', () => {
+        expect(mockResponse).to.have.been.calledWith(
+          sinon.match.any,
+          sinon.match.any,
+          'simplified-account/settings/stripe-details/organisation-details/update-organisation-details',
+          {
+            errors: {
+              summary: [
+                {
+                  text: 'Enter an organisation name',
+                  href: '#organisation-name',
+                },
+              ],
+              formErrors: {
+                organisationName: 'Enter an organisation name',
               },
             },
             backLink: STRIPE_DETAILS_ORG_DETAILS_INDEX_PATH,
@@ -163,7 +212,61 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
               addressLine1: 'McDuck Manor',
               addressLine2: undefined,
               addressCity: 'Duckburg',
-              addressPostcode: '',
+              addressPostcode: 'E9 6FB',
+              addressCountry: 'CS',
+            },
+            countries: [{ value: 'CS', text: 'Calisota' }],
+          }
+        )
+      })
+    })
+
+    describe('when submitting invalid details - invalid characters in organisation name', () => {
+      beforeEach(async () => {
+        nextRequest({
+          body: {
+            organisationName: 'McDuck Institute <script>alert("xss!")</script>',
+            addressLine1: 'McDuck Manor',
+            addressCity: 'Duckburg',
+            addressPostcode: 'E9 6FB',
+            addressCountry: 'CS',
+          },
+        })
+        await call('post', 1)
+      })
+
+      it('should not submit organisation details to the stripe details service', () => {
+        expect(mockStripeDetailsService.updateStripeDetailsOrganisationNameAndAddress).to.not.have.been.called
+      })
+
+      it('should not redirect', () => {
+        expect(res.redirect).to.not.have.been.called
+      })
+
+      it('should pass context data to the response method with errors', () => {
+        expect(mockResponse).to.have.been.calledWith(
+          sinon.match.any,
+          sinon.match.any,
+          'simplified-account/settings/stripe-details/organisation-details/update-organisation-details',
+          {
+            errors: {
+              summary: [
+                {
+                  text: 'You cannot use any of the following characters < > | in the organisation name',
+                  href: '#organisation-name',
+                },
+              ],
+              formErrors: {
+                organisationName: 'You cannot use any of the following characters < > | in the organisation name',
+              },
+            },
+            backLink: STRIPE_DETAILS_ORG_DETAILS_INDEX_PATH,
+            organisationDetails: {
+              organisationName: 'McDuck Institute <script>alert("xss!")</script>',
+              addressLine1: 'McDuck Manor',
+              addressLine2: undefined,
+              addressCity: 'Duckburg',
+              addressPostcode: 'E9 6FB',
               addressCountry: 'CS',
             },
             countries: [{ value: 'CS', text: 'Calisota' }],

--- a/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller.test.js
+++ b/src/controllers/simplified-account/settings/stripe-details/organisation-details/organisation-details-update.controller.test.js
@@ -149,7 +149,7 @@ describe('Controller: settings/stripe-details/organisation-details-update', () =
             organisationDetails: {
               organisationName: '',
               addressLine1: 'McDuck Manor',
-              addressLine2: '',
+              addressLine2: undefined,
               addressCity: 'Duckburg',
               addressPostcode: '',
               addressCountry: 'CS'

--- a/src/utils/simplified-account/validation/organisation-details.schema.test.js
+++ b/src/utils/simplified-account/validation/organisation-details.schema.test.js
@@ -115,9 +115,7 @@ describe('Organisation details Validation', () => {
       }
       await organisationDetailsSchema.organisationAddress.line1.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
-      expect(errors.array()[0].msg).to.equal(
-        'You cannot use any of the following characters < > | in the address line 1'
-      )
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in address line 1')
     })
 
     it('should pass with empty address line 2', async () => {
@@ -134,9 +132,7 @@ describe('Organisation details Validation', () => {
       }
       await organisationDetailsSchema.organisationAddress.line2.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
-      expect(errors.array()[0].msg).to.equal(
-        'You cannot use any of the following characters < > | in the address line 2'
-      )
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in address line 2')
     })
 
     it('should fail when city is empty', async () => {

--- a/src/utils/simplified-account/validation/organisation-details.schema.test.js
+++ b/src/utils/simplified-account/validation/organisation-details.schema.test.js
@@ -115,7 +115,9 @@ describe('Organisation details Validation', () => {
       }
       await organisationDetailsSchema.organisationAddress.line1.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
-      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the address line 1')
+      expect(errors.array()[0].msg).to.equal(
+        'You cannot use any of the following characters < > | in the address line 1'
+      )
     })
 
     it('should pass with empty address line 2', async () => {
@@ -132,7 +134,9 @@ describe('Organisation details Validation', () => {
       }
       await organisationDetailsSchema.organisationAddress.line2.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
-      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the address line 2')
+      expect(errors.array()[0].msg).to.equal(
+        'You cannot use any of the following characters < > | in the address line 2'
+      )
     })
 
     it('should fail when city is empty', async () => {

--- a/src/utils/simplified-account/validation/organisation-details.schema.test.js
+++ b/src/utils/simplified-account/validation/organisation-details.schema.test.js
@@ -109,12 +109,30 @@ describe('Organisation details Validation', () => {
       expect(validationResult(BASE_REQ).isEmpty()).to.be.true
     })
 
+    it('should fail when address line 1 contains forbidden characters', async () => {
+      const invalidReq = {
+        body: Object.assign({}, BASE_REQ.body, { addressLine1: '<script>alert("XSS!");</script>' }),
+      }
+      await organisationDetailsSchema.organisationAddress.line1.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the address line 1')
+    })
+
     it('should pass with empty address line 2', async () => {
       const validReq = {
         body: Object.assign({}, BASE_REQ.body, { addressLine2: '' }),
       }
       await organisationDetailsSchema.organisationAddress.line2.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
+    })
+
+    it('should fail when address line 2 contains forbidden characters', async () => {
+      const invalidReq = {
+        body: Object.assign({}, BASE_REQ.body, { addressLine2: '<script>alert("XSS!");</script>' }),
+      }
+      await organisationDetailsSchema.organisationAddress.line2.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the address line 2')
     })
 
     it('should fail when city is empty', async () => {
@@ -133,6 +151,15 @@ describe('Organisation details Validation', () => {
       await organisationDetailsSchema.organisationAddress.city.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
       expect(errors.array()[0].msg).to.equal('Town or city must be 255 characters or fewer')
+    })
+
+    it('should fail when city contains forbidden characters', async () => {
+      const invalidReq = {
+        body: Object.assign({}, BASE_REQ.body, { addressCity: '<script>alert("XSS!");</script>' }),
+      }
+      await organisationDetailsSchema.organisationAddress.city.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the town or city')
     })
 
     it('should fail when postcode is empty', async () => {

--- a/src/utils/simplified-account/validation/organisation-details.schema.test.js
+++ b/src/utils/simplified-account/validation/organisation-details.schema.test.js
@@ -25,7 +25,7 @@ describe('Organisation details Validation', () => {
       expect(validationResult(BASE_REQ).isEmpty()).to.be.true
     })
 
-    it('should fail when first name is empty', async () => {
+    it('should fail when organisation name is empty', async () => {
       const invalidReq = {
         body: Object.assign({}, BASE_REQ.body, { organisationName: '' })
       }
@@ -41,6 +41,51 @@ describe('Organisation details Validation', () => {
       await organisationDetailsSchema.organisationName.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
       expect(errors.array()[0].msg).to.equal('Organisation name must be 100 characters or fewer')
+    })
+
+    it('should fail with invalid characters - less than', async () => {
+      const invalidReq = {
+        body: Object.assign({}, BASE_REQ.body, { organisationName: 'Name with < character'  })
+      }
+      await organisationDetailsSchema.organisationName.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the organisation name')
+    })
+
+    it('should fail with invalid encoded characters - less than', async () => {
+      const invalidReq = {
+        body: Object.assign({}, BASE_REQ.body, { organisationName: 'Name with &lt;  character'  })
+      }
+      await organisationDetailsSchema.organisationName.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the organisation name')
+    })
+
+    it('should fail with invalid characters - greater than', async () => {
+      const invalidReq = {
+        body: Object.assign({}, BASE_REQ.body, { organisationName: 'Name with > character'  })
+      }
+      await organisationDetailsSchema.organisationName.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the organisation name')
+    })
+
+    it('should fail with invalid encoded characters - greater than', async () => {
+      const invalidReq = {
+        body: Object.assign({}, BASE_REQ.body, { organisationName: 'Name with &gt; character'  })
+      }
+      await organisationDetailsSchema.organisationName.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the organisation name')
+    })
+
+    it('should fail with invalid characters - pipe', async () => {
+      const invalidReq = {
+        body: Object.assign({}, BASE_REQ.body, { organisationName: 'Name with | character' })
+      }
+      await organisationDetailsSchema.organisationName.validate.run(invalidReq)
+      const errors = validationResult(invalidReq)
+      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the organisation name')
     })
   })
 

--- a/src/utils/simplified-account/validation/organisation-details.schema.test.js
+++ b/src/utils/simplified-account/validation/organisation-details.schema.test.js
@@ -14,8 +14,8 @@ describe('Organisation details Validation', () => {
         addressCountry: 'GB',
         addressPostcode: 'NT1 1AA',
         telephoneNumber: '01611234567',
-        organisationUrl: 'https://www.compuglobalhypermeganet.example.com'
-      }
+        organisationUrl: 'https://www.compuglobalhypermeganet.example.com',
+      },
     }
   })
 
@@ -27,7 +27,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when organisation name is empty', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { organisationName: '' })
+        body: Object.assign({}, BASE_REQ.body, { organisationName: '' }),
       }
       await organisationDetailsSchema.organisationName.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -36,7 +36,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when organisation name exceeds 100 characters', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { organisationName: 'a'.repeat(101) })
+        body: Object.assign({}, BASE_REQ.body, { organisationName: 'a'.repeat(101) }),
       }
       await organisationDetailsSchema.organisationName.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -45,47 +45,57 @@ describe('Organisation details Validation', () => {
 
     it('should fail with invalid characters - less than', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { organisationName: 'Name with < character'  })
+        body: Object.assign({}, BASE_REQ.body, { organisationName: 'Name with < character' }),
       }
       await organisationDetailsSchema.organisationName.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
-      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the organisation name')
+      expect(errors.array()[0].msg).to.equal(
+        'You cannot use any of the following characters < > | in the organisation name'
+      )
     })
 
     it('should fail with invalid encoded characters - less than', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { organisationName: 'Name with &lt;  character'  })
+        body: Object.assign({}, BASE_REQ.body, { organisationName: 'Name with &lt;  character' }),
       }
       await organisationDetailsSchema.organisationName.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
-      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the organisation name')
+      expect(errors.array()[0].msg).to.equal(
+        'You cannot use any of the following characters < > | in the organisation name'
+      )
     })
 
     it('should fail with invalid characters - greater than', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { organisationName: 'Name with > character'  })
+        body: Object.assign({}, BASE_REQ.body, { organisationName: 'Name with > character' }),
       }
       await organisationDetailsSchema.organisationName.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
-      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the organisation name')
+      expect(errors.array()[0].msg).to.equal(
+        'You cannot use any of the following characters < > | in the organisation name'
+      )
     })
 
     it('should fail with invalid encoded characters - greater than', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { organisationName: 'Name with &gt; character'  })
+        body: Object.assign({}, BASE_REQ.body, { organisationName: 'Name with &gt; character' }),
       }
       await organisationDetailsSchema.organisationName.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
-      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the organisation name')
+      expect(errors.array()[0].msg).to.equal(
+        'You cannot use any of the following characters < > | in the organisation name'
+      )
     })
 
     it('should fail with invalid characters - pipe', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { organisationName: 'Name with | character' })
+        body: Object.assign({}, BASE_REQ.body, { organisationName: 'Name with | character' }),
       }
       await organisationDetailsSchema.organisationName.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
-      expect(errors.array()[0].msg).to.equal('You cannot use any of the following characters < > | in the organisation name')
+      expect(errors.array()[0].msg).to.equal(
+        'You cannot use any of the following characters < > | in the organisation name'
+      )
     })
   })
 
@@ -101,7 +111,7 @@ describe('Organisation details Validation', () => {
 
     it('should pass with empty address line 2', async () => {
       const validReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressLine2: '' })
+        body: Object.assign({}, BASE_REQ.body, { addressLine2: '' }),
       }
       await organisationDetailsSchema.organisationAddress.line2.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -109,7 +119,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when city is empty', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressCity: '' })
+        body: Object.assign({}, BASE_REQ.body, { addressCity: '' }),
       }
       await organisationDetailsSchema.organisationAddress.city.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -118,7 +128,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when city exceeds 255 characters', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressCity: 'a'.repeat(256) })
+        body: Object.assign({}, BASE_REQ.body, { addressCity: 'a'.repeat(256) }),
       }
       await organisationDetailsSchema.organisationAddress.city.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -127,7 +137,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when postcode is empty', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressPostcode: '' })
+        body: Object.assign({}, BASE_REQ.body, { addressPostcode: '' }),
       }
       await organisationDetailsSchema.organisationAddress.postcode.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -136,7 +146,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail with invalid postcode', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressPostcode: 'not a postcode' })
+        body: Object.assign({}, BASE_REQ.body, { addressPostcode: 'not a postcode' }),
       }
       await organisationDetailsSchema.organisationAddress.postcode.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -145,7 +155,7 @@ describe('Organisation details Validation', () => {
 
     it('should pass with invalid postcode if country code is not GB', async () => {
       const validReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressPostcode: 'not a postcode', addressCountry: 'US' })
+        body: Object.assign({}, BASE_REQ.body, { addressPostcode: 'not a postcode', addressCountry: 'US' }),
       }
       await organisationDetailsSchema.organisationAddress.postcode.validate.run(validReq)
       expect(validationResult(validReq).isEmpty()).to.be.true
@@ -154,34 +164,34 @@ describe('Organisation details Validation', () => {
     const validPostcodes = [
       {
         postcode: 'SW1A 1AA',
-        description: 'standard London postcode'
+        description: 'standard London postcode',
       },
       {
         postcode: 'SW1A1AA',
-        description: 'standard London postcode no space'
+        description: 'standard London postcode no space',
       },
       {
         postcode: 'M2 3AA',
-        description: 'short-form postcode'
+        description: 'short-form postcode',
       },
       {
         postcode: 'SK4 4PB',
-        description: '6 character postcode'
+        description: '6 character postcode',
       },
       {
         postcode: 'W1A 0AX',
-        description: 'special case postcode'
+        description: 'special case postcode',
       },
       {
         postcode: 'GIR 0AA',
-        description: 'special case postcode'
-      }
+        description: 'special case postcode',
+      },
     ]
 
     validPostcodes.forEach(({ postcode, description }) => {
       it(`should validate ${description}: ${postcode}`, async () => {
         const validReq = {
-          body: Object.assign({}, BASE_REQ.body, { addressPostcode: postcode })
+          body: Object.assign({}, BASE_REQ.body, { addressPostcode: postcode }),
         }
         await organisationDetailsSchema.organisationAddress.postcode.validate.run(validReq)
         expect(validationResult(validReq).isEmpty()).to.be.true
@@ -191,27 +201,27 @@ describe('Organisation details Validation', () => {
     const invalidPostcodes = [
       {
         postcode: 'INVALID',
-        description: 'completely invalid format'
+        description: 'completely invalid format',
       },
       {
         postcode: '123 456',
-        description: 'numeric only'
+        description: 'numeric only',
       },
       {
         postcode: 'ABC DEF',
-        description: 'letters only'
+        description: 'letters only',
       },
 
       {
         postcode: 'SW1A 1AAA',
-        description: 'too many characters'
-      }
+        description: 'too many characters',
+      },
     ]
 
     invalidPostcodes.forEach(({ postcode, description }) => {
       it(`should reject invalid ${description}: ${postcode}`, async () => {
         const invalidReq = {
-          body: Object.assign({}, BASE_REQ.body, { addressPostcode: postcode })
+          body: Object.assign({}, BASE_REQ.body, { addressPostcode: postcode }),
         }
         await organisationDetailsSchema.organisationAddress.postcode.validate.run(invalidReq)
         const errors = validationResult(invalidReq)
@@ -222,7 +232,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when country is empty', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressCountry: '' })
+        body: Object.assign({}, BASE_REQ.body, { addressCountry: '' }),
       }
       await organisationDetailsSchema.organisationAddress.country.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -231,7 +241,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when country is shorter than 2 characters', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressCountry: 'A' })
+        body: Object.assign({}, BASE_REQ.body, { addressCountry: 'A' }),
       }
       await organisationDetailsSchema.organisationAddress.country.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -240,7 +250,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail when country is longer than 2 characters', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { addressCountry: 'AAA' })
+        body: Object.assign({}, BASE_REQ.body, { addressCountry: 'AAA' }),
       }
       await organisationDetailsSchema.organisationAddress.country.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -256,7 +266,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail with empty telephone number', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { telephoneNumber: '' })
+        body: Object.assign({}, BASE_REQ.body, { telephoneNumber: '' }),
       }
       await organisationDetailsSchema.telephoneNumber.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -265,11 +275,13 @@ describe('Organisation details Validation', () => {
 
     it('should fail with invalid telephone number', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { telephoneNumber: 'not a phone number' })
+        body: Object.assign({}, BASE_REQ.body, { telephoneNumber: 'not a phone number' }),
       }
       await organisationDetailsSchema.telephoneNumber.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
-      expect(errors.array()[0].msg).to.equal('Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
+      expect(errors.array()[0].msg).to.equal(
+        'Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192'
+      )
     })
   })
 
@@ -281,7 +293,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail with an empty url', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { organisationUrl: '' })
+        body: Object.assign({}, BASE_REQ.body, { organisationUrl: '' }),
       }
       await organisationDetailsSchema.organisationUrl.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -290,7 +302,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail with an invalid url', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { organisationUrl: 'not-a-valid-url' })
+        body: Object.assign({}, BASE_REQ.body, { organisationUrl: 'not-a-valid-url' }),
       }
       await organisationDetailsSchema.organisationUrl.validate.run(invalidReq)
       const errors = validationResult(invalidReq)
@@ -299,7 +311,7 @@ describe('Organisation details Validation', () => {
 
     it('should fail with when missing a url protocol', async () => {
       const invalidReq = {
-        body: Object.assign({}, BASE_REQ.body, { organisationUrl: 'nohttp.exmaple.com' })
+        body: Object.assign({}, BASE_REQ.body, { organisationUrl: 'nohttp.exmaple.com' }),
       }
       await organisationDetailsSchema.organisationUrl.validate.run(invalidReq)
       const errors = validationResult(invalidReq)

--- a/src/utils/simplified-account/validation/organisation-details.schema.ts
+++ b/src/utils/simplified-account/validation/organisation-details.schema.ts
@@ -20,7 +20,11 @@ const organisationDetailsSchema = {
       .withMessage('Enter an organisation name')
       .bail()
       .isLength({ max: ORGANISATION_NAME_MAX_LENGTH })
-      .withMessage(`Organisation name must be ${ORGANISATION_NAME_MAX_LENGTH} characters or fewer`),
+      .withMessage(`Organisation name must be ${ORGANISATION_NAME_MAX_LENGTH} characters or fewer`)
+      .bail()
+      .unescape()
+      .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
+      .withMessage('You cannot use any of the following characters < > | in the organisation name'),
   },
   organisationAddress: {
     line1: {
@@ -30,13 +34,21 @@ const organisationDetailsSchema = {
         .withMessage('Enter a building and street')
         .bail()
         .isLength({ max: ADDRESS_FIELD_MAX_LENGTH })
-        .withMessage(`Building and street must be ${ADDRESS_FIELD_MAX_LENGTH} characters or fewer`),
+        .withMessage(`Building and street must be ${ADDRESS_FIELD_MAX_LENGTH} characters or fewer`)
+        .bail()
+        .unescape()
+        .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
+        .withMessage('You cannot use any of the following characters < > | in the address line 1'),
     },
     line2: {
       validate: body('addressLine2')
-        .trim()
+        .trim().optional({ values: 'falsy' })
         .isLength({ max: ADDRESS_FIELD_MAX_LENGTH })
-        .withMessage(`Building and street must be ${ADDRESS_FIELD_MAX_LENGTH} characters or fewer`),
+        .withMessage(`Building and street must be ${ADDRESS_FIELD_MAX_LENGTH} characters or fewer`)
+        .bail()
+        .unescape()
+        .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
+        .withMessage('You cannot use any of the following characters < > | in the address line 2'),
     },
     city: {
       validate: body('addressCity')
@@ -45,7 +57,11 @@ const organisationDetailsSchema = {
         .withMessage('Enter a town or city')
         .bail()
         .isLength({ max: ADDRESS_FIELD_MAX_LENGTH })
-        .withMessage(`Town or city must be ${ADDRESS_FIELD_MAX_LENGTH} characters or fewer`),
+        .withMessage(`Town or city must be ${ADDRESS_FIELD_MAX_LENGTH} characters or fewer`)
+        .bail()
+        .unescape()
+        .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
+        .withMessage('You cannot use any of the following characters < > | in the town or city'),
     },
     postcode: {
       validate: body('addressPostcode')

--- a/src/utils/simplified-account/validation/organisation-details.schema.ts
+++ b/src/utils/simplified-account/validation/organisation-details.schema.ts
@@ -42,7 +42,8 @@ const organisationDetailsSchema = {
     },
     line2: {
       validate: body('addressLine2')
-        .trim().optional({ values: 'falsy' })
+        .trim()
+        .optional({ values: 'falsy' })
         .isLength({ max: ADDRESS_FIELD_MAX_LENGTH })
         .withMessage(`Building and street must be ${ADDRESS_FIELD_MAX_LENGTH} characters or fewer`)
         .bail()

--- a/src/utils/simplified-account/validation/organisation-details.schema.ts
+++ b/src/utils/simplified-account/validation/organisation-details.schema.ts
@@ -38,7 +38,7 @@ const organisationDetailsSchema = {
         .bail()
         .unescape()
         .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
-        .withMessage('You cannot use any of the following characters < > | in the address line 1'),
+        .withMessage('You cannot use any of the following characters < > | in address line 1'),
     },
     line2: {
       validate: body('addressLine2')
@@ -49,7 +49,7 @@ const organisationDetailsSchema = {
         .bail()
         .unescape()
         .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
-        .withMessage('You cannot use any of the following characters < > | in the address line 2'),
+        .withMessage('You cannot use any of the following characters < > | in address line 2'),
     },
     city: {
       validate: body('addressCity')


### PR DESCRIPTION

Further information in the Jira ticket.

https://payments-platform.atlassian.net/browse/PP-15348

### How to reproduce

- Log on as a service admin
- Visit http://127.0.0.1:3000/service/{SERVICE-ID}/account/test/settings/organisation-details
- Enter or update the organisation address fields with <script>alert('hello')</script>
- You should get an error message stating: You cannot use any of the following characters < > | in the {FIELD_NAME}

Previously the input would be saved, on refresh it would not be displayed and the alert would be executed and shown on the webpage.


### Accessibility (views have been added/changed)

n/a

### BEFORE
<img width="542" height="204" alt="alert" src="https://github.com/user-attachments/assets/f9044ec8-e6af-466f-9c73-3b69901776a5" />

### AFTER
<img width="1015" height="885" alt="AFTER" src="https://github.com/user-attachments/assets/05a973a7-183d-4423-a178-14a94db2716a" />

