### PR TITLE
PP-15348 Remediate 4.2.1-B

### DIFF
--- a/src/controllers/simplified-account/settings/service-name/edit/edit-service-name.controller.test.ts
+++ b/src/controllers/simplified-account/settings/service-name/edit/edit-service-name.controller.test.ts
@@ -179,7 +179,7 @@ describe('Controller: edit service name', () => {
       })
     })
 
-    describe('when submitting an invalid service name', () => {
+    describe('when submitting an invalid service name: length', () => {
       const longName =
           'this is a really really really long service name that is longer than fifty characters'
       beforeEach(async () => {
@@ -210,6 +210,112 @@ describe('Controller: edit service name', () => {
 
         sinon.assert.match(context.editCy, false)
         sinon.assert.match(context.serviceName, longName)
+
+        const errors = context.errors as Record<string, unknown>
+        sinon.assert.match(errors.summary, sinon.match.array)
+        sinon.assert.match(errors.formErrors, sinon.match.object)
+
+        sinon.assert.match(context.backLink, formatSimplifiedAccountPathsFor(
+          paths.simplifiedAccount.settings.serviceName.index,
+          SERVICE_EXTERNAL_ID,
+          ACCOUNT_TYPE
+        ))
+        sinon.assert.match(context.submitLink, formatSimplifiedAccountPathsFor(
+          paths.simplifiedAccount.settings.serviceName.edit,
+          SERVICE_EXTERNAL_ID,
+          ACCOUNT_TYPE
+        ))
+        sinon.assert.match(context.removeCyLink, formatSimplifiedAccountPathsFor(
+          paths.simplifiedAccount.settings.serviceName.removeCy,
+          SERVICE_EXTERNAL_ID,
+          ACCOUNT_TYPE
+        ))
+      })
+    })
+
+    describe('when submitting an invalid service name: special characters', () => {
+      const invalidName = '<script>alert("xss!")</script>'
+      beforeEach(async () => {
+        mockUpdateServiceName.resetHistory()
+        mockResponse.resetHistory()
+        nextRequest({
+          body: {
+            serviceName: invalidName,
+            cy: 'false'
+          }
+        })
+        await call('post')
+      })
+
+      it('should not update the service name', () => {
+        sinon.assert.notCalled(mockUpdateServiceName)
+      })
+
+      it('should render the edit page with errors', () => {
+        sinon.assert.calledOnce(mockResponse)
+
+        const templatePath = mockResponse.args[0][2] as string
+        sinon.assert.match(templatePath, 'simplified-account/settings/service-name/edit-service-name')
+      })
+
+      it('should set error context data', () => {
+        const context = mockResponse.args[0][3] as Record<string, unknown>
+
+        sinon.assert.match(context.editCy, false)
+        sinon.assert.match(context.serviceName, invalidName)
+
+        const errors = context.errors as Record<string, unknown>
+        sinon.assert.match(errors.summary, sinon.match.array)
+        sinon.assert.match(errors.formErrors, sinon.match.object)
+
+        sinon.assert.match(context.backLink, formatSimplifiedAccountPathsFor(
+          paths.simplifiedAccount.settings.serviceName.index,
+          SERVICE_EXTERNAL_ID,
+          ACCOUNT_TYPE
+        ))
+        sinon.assert.match(context.submitLink, formatSimplifiedAccountPathsFor(
+          paths.simplifiedAccount.settings.serviceName.edit,
+          SERVICE_EXTERNAL_ID,
+          ACCOUNT_TYPE
+        ))
+        sinon.assert.match(context.removeCyLink, formatSimplifiedAccountPathsFor(
+          paths.simplifiedAccount.settings.serviceName.removeCy,
+          SERVICE_EXTERNAL_ID,
+          ACCOUNT_TYPE
+        ))
+      })
+    })
+
+    describe('when submitting an invalid Welsh service name: special characters', () => {
+      const invalidName = '<script>alert("xss!")</script>'
+      beforeEach(async () => {
+        mockUpdateServiceName.resetHistory()
+        mockResponse.resetHistory()
+        nextRequest({
+          body: {
+            serviceName: invalidName,
+            cy: 'true'
+          }
+        })
+        await call('post')
+      })
+
+      it('should not update the service name', () => {
+        sinon.assert.notCalled(mockUpdateServiceName)
+      })
+
+      it('should render the edit page with errors', () => {
+        sinon.assert.calledOnce(mockResponse)
+
+        const templatePath = mockResponse.args[0][2] as string
+        sinon.assert.match(templatePath, 'simplified-account/settings/service-name/edit-service-name')
+      })
+
+      it('should set error context data', () => {
+        const context = mockResponse.args[0][3] as Record<string, unknown>
+
+        sinon.assert.match(context.editCy, true)
+        sinon.assert.match(context.serviceName, invalidName)
 
         const errors = context.errors as Record<string, unknown>
         sinon.assert.match(errors.summary, sinon.match.array)

--- a/src/controllers/simplified-account/settings/service-name/edit/edit-service-name.controller.test.ts
+++ b/src/controllers/simplified-account/settings/service-name/edit/edit-service-name.controller.test.ts
@@ -12,12 +12,7 @@ const CY_SERVICE_NAME = 'Fy Ngwasanaeth Cwl'
 const mockResponse = sinon.stub()
 const mockUpdateServiceName = sinon.stub()
 
-const {
-  req,
-  res,
-  call,
-  nextRequest
-} = new ControllerTestBuilder(
+const { req, res, call, nextRequest } = new ControllerTestBuilder(
   '@controllers/simplified-account/settings/service-name/edit/edit-service-name.controller'
 )
   .withService({
@@ -25,13 +20,13 @@ const {
     externalId: SERVICE_EXTERNAL_ID,
     serviceName: {
       en: EN_SERVICE_NAME,
-      cy: CY_SERVICE_NAME
-    }
+      cy: CY_SERVICE_NAME,
+    },
   })
   .withAccountType(ACCOUNT_TYPE)
   .withStubs({
     '@utils/response': { response: mockResponse },
-    '@services/service.service': { updateServiceName: mockUpdateServiceName }
+    '@services/service.service': { updateServiceName: mockUpdateServiceName },
   })
   .build()
 
@@ -48,28 +43,29 @@ describe('Controller: edit service name', () => {
       })
 
       it('should pass req, res and template path to the response method', () => {
-        sinon.assert.calledWith(
-          mockResponse,
-          req,
-          res,
-          'simplified-account/settings/service-name/edit-service-name'
-        )
+        sinon.assert.calledWith(mockResponse, req, res, 'simplified-account/settings/service-name/edit-service-name')
       })
 
       it('should set context data', () => {
         const context = mockResponse.args[0][3] as Record<string, unknown>
         sinon.assert.match(context.editCy, false)
         sinon.assert.match(context.serviceName, EN_SERVICE_NAME)
-        sinon.assert.match(context.backLink, formatSimplifiedAccountPathsFor(
-          paths.simplifiedAccount.settings.serviceName.index,
-          SERVICE_EXTERNAL_ID,
-          ACCOUNT_TYPE
-        ))
-        sinon.assert.match(context.submitLink, formatSimplifiedAccountPathsFor(
-          paths.simplifiedAccount.settings.serviceName.edit,
-          SERVICE_EXTERNAL_ID,
-          ACCOUNT_TYPE
-        ))
+        sinon.assert.match(
+          context.backLink,
+          formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.serviceName.index,
+            SERVICE_EXTERNAL_ID,
+            ACCOUNT_TYPE
+          )
+        )
+        sinon.assert.match(
+          context.submitLink,
+          formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.serviceName.edit,
+            SERVICE_EXTERNAL_ID,
+            ACCOUNT_TYPE
+          )
+        )
       })
     })
 
@@ -93,21 +89,30 @@ describe('Controller: edit service name', () => {
         const context = mockResponse.args[0][3] as Record<string, unknown>
         sinon.assert.match(context.editCy, true)
         sinon.assert.match(context.serviceName, CY_SERVICE_NAME)
-        sinon.assert.match(context.backLink, formatSimplifiedAccountPathsFor(
-          paths.simplifiedAccount.settings.serviceName.index,
-          SERVICE_EXTERNAL_ID,
-          ACCOUNT_TYPE
-        ))
-        sinon.assert.match(context.submitLink, formatSimplifiedAccountPathsFor(
-          paths.simplifiedAccount.settings.serviceName.edit,
-          SERVICE_EXTERNAL_ID,
-          ACCOUNT_TYPE
-        ))
-        sinon.assert.match(context.removeCyLink, formatSimplifiedAccountPathsFor(
-          paths.simplifiedAccount.settings.serviceName.removeCy,
-          SERVICE_EXTERNAL_ID,
-          ACCOUNT_TYPE
-        ))
+        sinon.assert.match(
+          context.backLink,
+          formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.serviceName.index,
+            SERVICE_EXTERNAL_ID,
+            ACCOUNT_TYPE
+          )
+        )
+        sinon.assert.match(
+          context.submitLink,
+          formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.serviceName.edit,
+            SERVICE_EXTERNAL_ID,
+            ACCOUNT_TYPE
+          )
+        )
+        sinon.assert.match(
+          context.removeCyLink,
+          formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.serviceName.removeCy,
+            SERVICE_EXTERNAL_ID,
+            ACCOUNT_TYPE
+          )
+        )
       })
     })
   })
@@ -118,19 +123,14 @@ describe('Controller: edit service name', () => {
         mockUpdateServiceName.resetHistory()
         res.redirect.resetHistory?.()
         nextRequest({
-          body: { serviceName: 'New English Name', cy: 'false' }
+          body: { serviceName: 'New English Name', cy: 'false' },
         })
         await call('post')
       })
 
       it('should update the service name', () => {
         sinon.assert.calledOnce(mockUpdateServiceName)
-        sinon.assert.calledWith(
-          mockUpdateServiceName,
-          SERVICE_EXTERNAL_ID,
-          'New English Name',
-          CY_SERVICE_NAME
-        )
+        sinon.assert.calledWith(mockUpdateServiceName, SERVICE_EXTERNAL_ID, 'New English Name', CY_SERVICE_NAME)
       })
 
       it('should redirect to the service name index page', () => {
@@ -151,19 +151,14 @@ describe('Controller: edit service name', () => {
         mockUpdateServiceName.resetHistory()
         res.redirect.resetHistory?.()
         nextRequest({
-          body: { serviceName: 'New Welsh Name', cy: 'true' }
+          body: { serviceName: 'New Welsh Name', cy: 'true' },
         })
         await call('post')
       })
 
       it('should update the service name', () => {
         sinon.assert.calledOnce(mockUpdateServiceName)
-        sinon.assert.calledWith(
-          mockUpdateServiceName,
-          SERVICE_EXTERNAL_ID,
-          EN_SERVICE_NAME,
-          'New Welsh Name'
-        )
+        sinon.assert.calledWith(mockUpdateServiceName, SERVICE_EXTERNAL_ID, EN_SERVICE_NAME, 'New Welsh Name')
       })
 
       it('should redirect to the service name index page', () => {
@@ -180,16 +175,15 @@ describe('Controller: edit service name', () => {
     })
 
     describe('when submitting an invalid service name: length', () => {
-      const longName =
-          'this is a really really really long service name that is longer than fifty characters'
+      const longName = 'this is a really really really long service name that is longer than fifty characters'
       beforeEach(async () => {
         mockUpdateServiceName.resetHistory()
         mockResponse.resetHistory()
         nextRequest({
           body: {
             serviceName: longName,
-            cy: 'false'
-          }
+            cy: 'false',
+          },
         })
         await call('post')
       })
@@ -215,21 +209,30 @@ describe('Controller: edit service name', () => {
         sinon.assert.match(errors.summary, sinon.match.array)
         sinon.assert.match(errors.formErrors, sinon.match.object)
 
-        sinon.assert.match(context.backLink, formatSimplifiedAccountPathsFor(
-          paths.simplifiedAccount.settings.serviceName.index,
-          SERVICE_EXTERNAL_ID,
-          ACCOUNT_TYPE
-        ))
-        sinon.assert.match(context.submitLink, formatSimplifiedAccountPathsFor(
-          paths.simplifiedAccount.settings.serviceName.edit,
-          SERVICE_EXTERNAL_ID,
-          ACCOUNT_TYPE
-        ))
-        sinon.assert.match(context.removeCyLink, formatSimplifiedAccountPathsFor(
-          paths.simplifiedAccount.settings.serviceName.removeCy,
-          SERVICE_EXTERNAL_ID,
-          ACCOUNT_TYPE
-        ))
+        sinon.assert.match(
+          context.backLink,
+          formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.serviceName.index,
+            SERVICE_EXTERNAL_ID,
+            ACCOUNT_TYPE
+          )
+        )
+        sinon.assert.match(
+          context.submitLink,
+          formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.serviceName.edit,
+            SERVICE_EXTERNAL_ID,
+            ACCOUNT_TYPE
+          )
+        )
+        sinon.assert.match(
+          context.removeCyLink,
+          formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.serviceName.removeCy,
+            SERVICE_EXTERNAL_ID,
+            ACCOUNT_TYPE
+          )
+        )
       })
     })
 
@@ -241,8 +244,8 @@ describe('Controller: edit service name', () => {
         nextRequest({
           body: {
             serviceName: invalidName,
-            cy: 'false'
-          }
+            cy: 'false',
+          },
         })
         await call('post')
       })
@@ -268,21 +271,30 @@ describe('Controller: edit service name', () => {
         sinon.assert.match(errors.summary, sinon.match.array)
         sinon.assert.match(errors.formErrors, sinon.match.object)
 
-        sinon.assert.match(context.backLink, formatSimplifiedAccountPathsFor(
-          paths.simplifiedAccount.settings.serviceName.index,
-          SERVICE_EXTERNAL_ID,
-          ACCOUNT_TYPE
-        ))
-        sinon.assert.match(context.submitLink, formatSimplifiedAccountPathsFor(
-          paths.simplifiedAccount.settings.serviceName.edit,
-          SERVICE_EXTERNAL_ID,
-          ACCOUNT_TYPE
-        ))
-        sinon.assert.match(context.removeCyLink, formatSimplifiedAccountPathsFor(
-          paths.simplifiedAccount.settings.serviceName.removeCy,
-          SERVICE_EXTERNAL_ID,
-          ACCOUNT_TYPE
-        ))
+        sinon.assert.match(
+          context.backLink,
+          formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.serviceName.index,
+            SERVICE_EXTERNAL_ID,
+            ACCOUNT_TYPE
+          )
+        )
+        sinon.assert.match(
+          context.submitLink,
+          formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.serviceName.edit,
+            SERVICE_EXTERNAL_ID,
+            ACCOUNT_TYPE
+          )
+        )
+        sinon.assert.match(
+          context.removeCyLink,
+          formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.serviceName.removeCy,
+            SERVICE_EXTERNAL_ID,
+            ACCOUNT_TYPE
+          )
+        )
       })
     })
 
@@ -294,8 +306,8 @@ describe('Controller: edit service name', () => {
         nextRequest({
           body: {
             serviceName: invalidName,
-            cy: 'true'
-          }
+            cy: 'true',
+          },
         })
         await call('post')
       })
@@ -321,21 +333,30 @@ describe('Controller: edit service name', () => {
         sinon.assert.match(errors.summary, sinon.match.array)
         sinon.assert.match(errors.formErrors, sinon.match.object)
 
-        sinon.assert.match(context.backLink, formatSimplifiedAccountPathsFor(
-          paths.simplifiedAccount.settings.serviceName.index,
-          SERVICE_EXTERNAL_ID,
-          ACCOUNT_TYPE
-        ))
-        sinon.assert.match(context.submitLink, formatSimplifiedAccountPathsFor(
-          paths.simplifiedAccount.settings.serviceName.edit,
-          SERVICE_EXTERNAL_ID,
-          ACCOUNT_TYPE
-        ))
-        sinon.assert.match(context.removeCyLink, formatSimplifiedAccountPathsFor(
-          paths.simplifiedAccount.settings.serviceName.removeCy,
-          SERVICE_EXTERNAL_ID,
-          ACCOUNT_TYPE
-        ))
+        sinon.assert.match(
+          context.backLink,
+          formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.serviceName.index,
+            SERVICE_EXTERNAL_ID,
+            ACCOUNT_TYPE
+          )
+        )
+        sinon.assert.match(
+          context.submitLink,
+          formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.serviceName.edit,
+            SERVICE_EXTERNAL_ID,
+            ACCOUNT_TYPE
+          )
+        )
+        sinon.assert.match(
+          context.removeCyLink,
+          formatSimplifiedAccountPathsFor(
+            paths.simplifiedAccount.settings.serviceName.removeCy,
+            SERVICE_EXTERNAL_ID,
+            ACCOUNT_TYPE
+          )
+        )
       })
     })
   })

--- a/src/controllers/simplified-account/settings/service-name/edit/edit-service-name.controller.ts
+++ b/src/controllers/simplified-account/settings/service-name/edit/edit-service-name.controller.ts
@@ -46,18 +46,21 @@ async function post(req: ServiceRequest<EditServiceNameBody>, res: ServiceRespon
   const validations = [
     body('serviceName')
       .trim()
+      .isLength({ max: SERVICE_NAME_MAX_LENGTH })
+      .withMessage(`Service name must be ${SERVICE_NAME_MAX_LENGTH} characters or fewer`)
+      .bail()
       .unescape()
       .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
-      .withMessage('You cannot use any of the following characters < > | in the service name')
-      .bail()
-      .isLength({ max: SERVICE_NAME_MAX_LENGTH })
-      .withMessage(`Service name must be ${SERVICE_NAME_MAX_LENGTH} characters or fewer`),
+      .withMessage('You cannot use any of the following characters < > | in the service name'),
   ]
   // we don't check presence for welsh names
   if (!editCy) {
     validations.push(
       body('serviceName')
         .trim()
+        .isLength({ max: SERVICE_NAME_MAX_LENGTH })
+        .withMessage(`Service name must be ${SERVICE_NAME_MAX_LENGTH} characters or fewer`)
+        .bail()
         .unescape()
         .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
         .withMessage('You cannot use any of the following characters < > | in the service name')

--- a/src/controllers/simplified-account/settings/service-name/edit/edit-service-name.controller.ts
+++ b/src/controllers/simplified-account/settings/service-name/edit/edit-service-name.controller.ts
@@ -57,12 +57,13 @@ async function post(req: ServiceRequest<EditServiceNameBody>, res: ServiceRespon
   if (!editCy) {
     validations.push(
       body('serviceName')
-      .trim()
-      .unescape()
-      .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
-      .withMessage('You cannot use any of the following characters < > | in the service name')
-      .bail()
-      .notEmpty().withMessage('Service name is required')
+        .trim()
+        .unescape()
+        .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
+        .withMessage('You cannot use any of the following characters < > | in the service name')
+        .bail()
+        .notEmpty()
+        .withMessage('Service name is required')
     )
   }
 

--- a/src/controllers/simplified-account/settings/service-name/edit/edit-service-name.controller.ts
+++ b/src/controllers/simplified-account/settings/service-name/edit/edit-service-name.controller.ts
@@ -46,12 +46,24 @@ async function post(req: ServiceRequest<EditServiceNameBody>, res: ServiceRespon
   const validations = [
     body('serviceName')
       .trim()
+      .unescape()
+      .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
+      .withMessage('You cannot use any of the following characters < > | in the service name')
+      .bail()
       .isLength({ max: SERVICE_NAME_MAX_LENGTH })
       .withMessage(`Service name must be ${SERVICE_NAME_MAX_LENGTH} characters or fewer`),
   ]
   // we don't check presence for welsh names
   if (!editCy) {
-    validations.push(body('serviceName').trim().notEmpty().withMessage('Service name is required'))
+    validations.push(
+      body('serviceName')
+      .trim()
+      .unescape()
+      .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
+      .withMessage('You cannot use any of the following characters < > | in the service name')
+      .bail()
+      .notEmpty().withMessage('Service name is required')
+    )
   }
 
   await Promise.all(validations.map((validation) => validation.run(req)))


### PR DESCRIPTION

Further information in the Jira ticket.

https://payments-platform.atlassian.net/browse/PP-15348

### How to reproduce

- Log on as a service admin
- Visit http://localhost:3000/service/{SERVICE-ID}/account/test/settings/service-name
- Enter or update the service name (English or Welsh) with: `<script>alert('hello')</script>`
- You should get an error message stating: You cannot use any of the following characters < > | in the service name

Previously the input would be saved, on refresh it would not be displayed and the alert would be executed and shown on the webpage.


### Accessibility (views have been added/changed)

n/a

### SCREENSHOT

<img width="1042" height="909" alt="service name" src="https://github.com/user-attachments/assets/e8a50a1c-6f82-46e4-a650-1be2a08db501" />

