### PR TITLE
PP-15348 render webhook event page safely

### DIFF
--- a/src/views/simplified-account/settings/webhooks/event.njk
+++ b/src/views/simplified-account/settings/webhooks/event.njk
@@ -1,5 +1,6 @@
 {% extends "../settings-layout.njk" %}
 {% from "./macro/webhook-event-status.njk" import webhookEventStatus %}
+{% from "./json/json.njk" import json %}
 
 {% set heading = eventTypes[event.event_type | upper] %}
 {% set settingsPageTitle = heading + " event details - " + webhookDescription %}
@@ -44,12 +45,7 @@
     })
   }}
 
-  {{
-    govukDetails({
-      summaryText: heading + " event body",
-      html: '<pre class="json-block"><code>' + event.resource | dump(4) + '</code></pre>'
-    })
-  }}
+  {{ json(heading + " event body", event.resource) }}
 
   <h2 class="govuk-heading-m">Delivery attempts</h2>
   {% set attemptRows = [] %}

--- a/src/views/simplified-account/settings/webhooks/json/json.njk
+++ b/src/views/simplified-account/settings/webhooks/json/json.njk
@@ -1,0 +1,15 @@
+{% macro json(title, content) %}
+  <div class="govuk-body">
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text"> {{ title }} </span>
+      </summary>
+      <div class="govuk-details__text scrollflow">
+        <pre>
+        <code>{{ content | dump('\t') }}</code>
+        </pre
+        >
+      </div>
+    </details>
+  </div>
+{% endmacro %}

--- a/test/cypress/integration/simplified-account/service-settings/webhooks/webhook-event.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/webhooks/webhook-event.cy.js
@@ -117,10 +117,16 @@ describe('for an admin', () => {
 
   it('should show event body in detail component', () => {
     cy.get('.govuk-details summary').should('contain.text', 'Payment captured event body').click()
-    cy.get('.govuk-details div.govuk-details__text pre code').should(
-      'contain.text',
-      JSON.stringify(WEBHOOK_EVENT_RESOURCE, null, 4)
-    )
+    cy.get('.govuk-details div.govuk-details__text pre code')
+      .invoke('text')
+      .then((text) => {
+        return text.replaceAll('\t', '').replaceAll('\n', '').replaceAll(' ', '')
+      })
+      .then((trimmedText) => {
+        expect(trimmedText).to.eq(
+          JSON.stringify(WEBHOOK_EVENT_RESOURCE, null, 0).replaceAll('\n', '').replaceAll(' ', '')
+        )
+      })
   })
 
   it('should show active "Webhooks" link', () => {


### PR DESCRIPTION
## What

Refactor web event page to escape json so no malicious script can be executed.

<img width="692" height="382" alt="Screenshot 2026-05-07 at 16 55 46" src="https://github.com/user-attachments/assets/2f85fb04-0cc4-4990-aa1d-5e1ec7b9bc59" />


<img width="736" height="576" alt="Screenshot 2026-05-07 at 16 56 43" src="https://github.com/user-attachments/assets/84613390-7db0-4ac6-a04b-0a61a16c2b57" />

