### PR TITLE
PP-15349 Remove invalid fromDate/toDate from search params in transactions search

### DIFF
--- a/src/utils/filters.js
+++ b/src/utils/filters.js
@@ -7,16 +7,15 @@ const Paginator = require('../utils/paginator.js')
 const states = require('../utils/states')
 const _ = require('lodash')
 
-function validateFilters (filters) {
+function validateFilters(filters) {
   const pageSizeIsNull = !check.assigned(filters.pageSize)
   const pageSizeInRange = check.inRange(Number(filters.pageSize), 1, Paginator.MAX_PAGE_SIZE)
   const pageIsNull = !check.assigned(filters.page)
   const pageIsPositive = check.positive(Number(filters.page))
-  return (pageSizeIsNull || pageSizeInRange) &&
-    (pageIsNull || pageIsPositive)
+  return (pageSizeIsNull || pageSizeInRange) && (pageIsNull || pageIsPositive)
 }
 
-function trimFilterValues (filters) {
+function trimFilterValues(filters) {
   for (const [key, value] of Object.entries(filters)) {
     if (typeof value === 'string') {
       filters[key] = value.trim()
@@ -25,7 +24,7 @@ function trimFilterValues (filters) {
   return filters
 }
 
-function validateDateRange (filters) {
+function validateDateRange(filters) {
   const result = moment(filters.fromDate, 'DD/MM/YYYY').isAfter(moment(filters.toDate, 'DD/MM/YYYY')) ? 1 : -1
   let isInvalid = false
 
@@ -35,11 +34,11 @@ function validateDateRange (filters) {
   return {
     isInvalidDateRange: isInvalid,
     fromDateParam: filters.fromDate,
-    toDateParam: filters.toDate
+    toDateParam: filters.toDate,
   }
 }
 
-function getFilters (req) {
+function getFilters(req) {
   let filters = trimFilterValues(qs.parse(req.query))
   filters.selectedStates = []
   if (filters.state) {
@@ -54,15 +53,23 @@ function getFilters (req) {
     filters.selectedBrands = typeof filters.brand === 'string' ? [filters.brand] : filters.brand
   }
 
+  if (filters.fromDate && !moment(filters.fromDate, 'DD/MM/YYYY').isValid()) {
+    filters.fromDate = ''
+  }
+
+  if (filters.toDate && !moment(filters.toDate, 'DD/MM/YYYY').isValid()) {
+    filters.toDate = ''
+  }
+
   filters = _.omitBy(filters, _.isEmpty)
   return {
     dateRangeState: validateDateRange(filters),
     valid: validateFilters(filters),
-    result: filters
+    result: filters,
   }
 }
 
-function describeFilters (filters) {
+function describeFilters(filters) {
   let description = ''
   if (filters.fromDate) description += ` from <strong>${filters.fromDate}</strong>`
   if (filters.toDate) description += ` to <strong>${filters.toDate}</strong>`
@@ -77,7 +84,7 @@ function describeFilters (filters) {
   }
 
   if (filters.selectedBrands && filters.selectedBrands.length > 0) {
-    const brandStates = filters.selectedBrands.map(brand => {
+    const brandStates = filters.selectedBrands.map((brand) => {
       if (brand === 'jcb') {
         brand = 'JCB'
       }
@@ -92,5 +99,5 @@ function describeFilters (filters) {
 module.exports = {
   getFilters,
   describeFilters,
-  validateDateRange
+  validateDateRange,
 }

--- a/src/utils/filters.js
+++ b/src/utils/filters.js
@@ -53,11 +53,11 @@ function getFilters(req) {
     filters.selectedBrands = typeof filters.brand === 'string' ? [filters.brand] : filters.brand
   }
 
-  if (filters.fromDate && !moment(filters.fromDate, 'DD/MM/YYYY').isValid()) {
+  if (filters.fromDate && !moment(filters.fromDate, 'DD/MM/YYYY', true).isValid()) {
     filters.fromDate = ''
   }
 
-  if (filters.toDate && !moment(filters.toDate, 'DD/MM/YYYY').isValid()) {
+  if (filters.toDate && !moment(filters.toDate, 'DD/MM/YYYY', true).isValid()) {
     filters.toDate = ''
   }
 

--- a/src/utils/filters.js
+++ b/src/utils/filters.js
@@ -53,11 +53,14 @@ function getFilters(req) {
     filters.selectedBrands = typeof filters.brand === 'string' ? [filters.brand] : filters.brand
   }
 
-  if (filters.fromDate && !moment(filters.fromDate, 'DD/MM/YYYY', true).isValid()) {
+  if (
+    filters.fromDate &&
+    !moment(filters.fromDate, ['D/M/YYYY', 'DD/M/YYYY', 'D/MM/YYYY', 'DD/MM/YYYY'], true).isValid()
+  ) {
     filters.fromDate = ''
   }
 
-  if (filters.toDate && !moment(filters.toDate, 'DD/MM/YYYY', true).isValid()) {
+  if (filters.toDate && !moment(filters.toDate, ['D/M/YYYY', 'DD/M/YYYY', 'D/MM/YYYY', 'DD/MM/YYYY'], true).isValid()) {
     filters.toDate = ''
   }
 

--- a/src/utils/filters.test.js
+++ b/src/utils/filters.test.js
@@ -9,42 +9,131 @@ describe('filters', () => {
       it('should transform In progress display states to connector states correctly', function () {
         const { result } = filters.getFilters({ query: { state: 'In progress' } })
         expect(result).to.have.property('selectedStates').to.deep.equal(['In progress'])
-        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'capturable'])
+        expect(result)
+          .to.have.property('payment_states')
+          .to.deep.equal(['created', 'started', 'submitted', 'capturable'])
         expect(result).to.not.have.property('refund_states')
       })
 
       it('should transform some payment display states to connector states correctly', function () {
         const { result } = filters.getFilters({ query: { state: ['In progress', 'Timed out', 'Cancelled'] } })
         expect(result).to.have.property('selectedStates').to.deep.equal(['In progress', 'Timed out', 'Cancelled'])
-        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'capturable', 'timedout', 'cancelled'])
+        expect(result)
+          .to.have.property('payment_states')
+          .to.deep.equal(['created', 'started', 'submitted', 'capturable', 'timedout', 'cancelled'])
         expect(result).to.not.have.property('refund_states')
       })
 
       it('should transform all payment display states to connector states correctly', function () {
-        const { result } = filters.getFilters({ query: { state: ['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined'] } })
-        expect(result).to.have.property('selectedStates').to.deep.equal(['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined'])
-        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'capturable', 'success', 'error', 'cancelled', 'timedout', 'declined'])
+        const { result } = filters.getFilters({
+          query: { state: ['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined'] },
+        })
+        expect(result)
+          .to.have.property('selectedStates')
+          .to.deep.equal(['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined'])
+        expect(result)
+          .to.have.property('payment_states')
+          .to.deep.equal([
+            'created',
+            'started',
+            'submitted',
+            'capturable',
+            'success',
+            'error',
+            'cancelled',
+            'timedout',
+            'declined',
+          ])
         expect(result).to.not.have.property('refund_states')
       })
 
       it('should transform all refund display states to connector states correctly', function () {
-        const { result } = filters.getFilters({ query: { state: ['Refund success', 'Refund error', 'Refund submitted'] } })
-        expect(result).to.have.property('selectedStates').to.deep.equal(['Refund success', 'Refund error', 'Refund submitted'])
+        const { result } = filters.getFilters({
+          query: { state: ['Refund success', 'Refund error', 'Refund submitted'] },
+        })
+        expect(result)
+          .to.have.property('selectedStates')
+          .to.deep.equal(['Refund success', 'Refund error', 'Refund submitted'])
         expect(result).to.have.property('refund_states').to.deep.equal(['success', 'error', 'submitted'])
         expect(result).to.not.have.property('payment_states')
       })
 
       it('should transform both payment and refund display states to connector states correctly', function () {
-        const { result } = filters.getFilters({ query: { state: ['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined', 'Refund success', 'Refund error', 'Refund submitted'] } })
-        expect(result).to.have.property('selectedStates').to.deep.equal(['In progress', 'Success', 'Error', 'Cancelled', 'Timed out', 'Declined', 'Refund success', 'Refund error', 'Refund submitted'])
+        const { result } = filters.getFilters({
+          query: {
+            state: [
+              'In progress',
+              'Success',
+              'Error',
+              'Cancelled',
+              'Timed out',
+              'Declined',
+              'Refund success',
+              'Refund error',
+              'Refund submitted',
+            ],
+          },
+        })
+        expect(result)
+          .to.have.property('selectedStates')
+          .to.deep.equal([
+            'In progress',
+            'Success',
+            'Error',
+            'Cancelled',
+            'Timed out',
+            'Declined',
+            'Refund success',
+            'Refund error',
+            'Refund submitted',
+          ])
         expect(result).to.have.property('refund_states').to.deep.equal(['success', 'error', 'submitted'])
-        expect(result).to.have.property('payment_states').to.deep.equal(['created', 'started', 'submitted', 'capturable', 'success', 'error', 'cancelled', 'timedout', 'declined'])
+        expect(result)
+          .to.have.property('payment_states')
+          .to.deep.equal([
+            'created',
+            'started',
+            'submitted',
+            'capturable',
+            'success',
+            'error',
+            'cancelled',
+            'timedout',
+            'declined',
+          ])
       })
 
       it('should trim values from the query object', () => {
         const { result } = filters.getFilters({ query: { email: ' some-email@email.com ', reference: ' some-ref  ' } })
         expect(result.email).to.equal('some-email@email.com')
         expect(result.reference).to.equal('some-ref')
+      })
+      describe('date string sanitisation', () => {
+        it('should not alter valid date strings', () => {
+          const { result } = filters.getFilters({ query: { fromDate: '01/01/2026', toDate: '31/12/2026' } })
+          expect(result.fromDate).to.equal('01/01/2026')
+          expect(result.toDate).to.equal('31/12/2026')
+        })
+
+        it('should remove invalid dates from the query', () => {
+          const { result } = filters.getFilters({ query: { fromDate: '00/00/0000', toDate: '32/13/9999' } })
+          expect(result.fromDate).to.be.undefined
+          expect(result.toDate).to.be.undefined
+        })
+
+        it('should remove dates with invalid characters from the query', () => {
+          const { result } = filters.getFilters({ query: { fromDate: '01<01>2026', toDate: '31|12=2026' } })
+          expect(result.fromDate).to.be.undefined
+          expect(result.toDate).to.be.undefined
+        })
+
+        it('should remove dates with additional text', () => {
+          const { result } = filters.getFilters({
+            query: { fromDate: '01/01/2026 this is additional text', toDate: '31/12/2026 that should prevent parsing' },
+          })
+          expect(result.fromDate).to.be.undefined
+          expect(result.toDate).to.be.undefined
+        })
       })
     })
 
@@ -53,27 +142,31 @@ describe('filters', () => {
         const testFilter = {
           fromDate: 'from-date',
           toDate: 'to-date',
-          selectedStates: ['In progress', 'Refund success', 'Refund submitted']
+          selectedStates: ['In progress', 'Refund success', 'Refund submitted'],
         }
         const result = filters.describeFilters(testFilter)
-        expect(result.trim()).to.equal('from <strong>from-date</strong> to <strong>to-date</strong> with <strong>In progress</strong>, <strong>Refund success</strong> or <strong>Refund submitted</strong> states')
+        expect(result.trim()).to.equal(
+          'from <strong>from-date</strong> to <strong>to-date</strong> with <strong>In progress</strong>, <strong>Refund success</strong> or <strong>Refund submitted</strong> states'
+        )
       })
 
       it('should describe correctly when one state selected', function () {
         const testFilter = {
           fromDate: 'from-date',
           toDate: 'to-date',
-          selectedStates: ['Cancelled']
+          selectedStates: ['Cancelled'],
         }
         const result = filters.describeFilters(testFilter)
-        expect(result.trim()).to.equal('from <strong>from-date</strong> to <strong>to-date</strong> with <strong>Cancelled</strong> state')
+        expect(result.trim()).to.equal(
+          'from <strong>from-date</strong> to <strong>to-date</strong> with <strong>Cancelled</strong> state'
+        )
       })
 
       it('should describe correctly when no state selected', function () {
         const testFilter = {
           fromDate: 'from-date',
           toDate: 'to-date',
-          state: ''
+          state: '',
         }
         const result = filters.describeFilters(testFilter)
         expect(result.trim()).to.equal('from <strong>from-date</strong> to <strong>to-date</strong>')
@@ -84,7 +177,7 @@ describe('filters', () => {
       it('should validate the date range filter and return an array with the result and the associated from and to date', function () {
         const testFilter = {
           fromDate: '03/03/2023',
-          toDate: '01/03/2023'
+          toDate: '01/03/2023',
         }
         const result = filters.validateDateRange(testFilter)
         expect(result.isInvalidDateRange).to.equal(true)


### PR DESCRIPTION
## What

PP-15349
- update the transaction filter parsing to enforce correctly formatted dates in `toDate` and `fromDate` field
- removes any invalid date strings from the filter object
