### PR TITLE
PP-15031 Remove Express 4 tests

### DIFF
--- a/src/utils/replace-params-in-path.test.js
+++ b/src/utils/replace-params-in-path.test.js
@@ -18,17 +18,7 @@ describe('formattedPathFor', () => {
     })
   })
 
-  describe('with an Express 4 optional parameter (:param?)', () => {
-    it('should replace the param when a value is provided', () => {
-      expect(formattedPathFor('/transactions/:modeFilter?', 'live')).to.equal('/transactions/live')
-    })
-
-    it('should not replace a placeholder if no replacement is supplied', () => {
-      expect(formattedPathFor('/transactions/:modeFilter?')).to.equal('/transactions')
-    })
-  })
-
-  describe('with an Express 5 optional parameter ({/:param})', () => {
+  describe('with an optional parameter ({/:param})', () => {
     it('should replace the param when a value is provided', () => {
       expect(formattedPathFor('/transactions{/:modeFilter}', 'live')).to.equal('/transactions/live')
     })

--- a/src/utils/simplified-account/format/format-paths-for.test.js
+++ b/src/utils/simplified-account/format/format-paths-for.test.js
@@ -18,17 +18,7 @@ describe('formattedPathFor', () => {
     })
   })
 
-  describe('with an Express 4 optional parameter (:param?)', () => {
-    it('should replace the param when a value is provided', () => {
-      expect(formattedPathFor('/transactions/:modeFilter?', 'live')).to.equal('/transactions/live')
-    })
-
-    it('should not replace a placeholder if no replacement is supplied', () => {
-      expect(formattedPathFor('/transactions/:modeFilter?')).to.equal('/transactions')
-    })
-  })
-
-  describe('with an Express 5 optional parameter ({/:param})', () => {
+  describe('with an optional parameter ({/:param})', () => {
     it('should replace the param when a value is provided', () => {
       expect(formattedPathFor('/transactions{/:modeFilter}', 'live')).to.equal('/transactions/live')
     })


### PR DESCRIPTION


## What

PP-**15031**

- The app has been upgraded to Express 5
- This PR removes the Express 4 tests for optional params in the path
  - No longer required
  - We have tests for the Express 5 version of optional params

### How
- Generally check the app is working.

### Accessibility (views have been added/changed)

N/A

### Screenshots (views have been added/changed)

N/A