### PR TITLE
PP-15409 PACT upgrade - install Alpine NPM module on CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM base AS builder
 COPY . .
 RUN npm ci --quiet
 RUN npm run compile
+RUN npm install @pact-foundation/pact-core-linux-x64-musl@19.2.0 --no-save
 
 FROM base AS final
 


### PR DESCRIPTION
## What

PP-**15409**

- This is to fix a issue on CI.
- We have tightened our npm security so that post install scripts do not run.
- This means that the relevant NPM module for Alpine Linux is not getting installed.
- So we need to manually update the Dockerfile so that the specific NPM module for Alpine Linux gets installed.

### How
- make sure the PACT tests are running successfully on the deploy environment.