### PR TITLE
PP-15384 Add inset text for redacted transactions

### DIFF
--- a/src/controllers/simplified-account/services/transactions/detail/transactions-detail.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/detail/transactions-detail.controller.ts
@@ -6,6 +6,7 @@ import { ServiceRequest, ServiceResponse } from '@utils/types/express'
 import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
 import { Transaction } from '@models/transaction/Transaction.class'
 import { TITLE_FRIENDLY_DATE_TIME } from '@models/constants/time-formats'
+import { TimeConstants } from '@utils/time/time-constants'
 
 async function get(req: ServiceRequest, res: ServiceResponse) {
   const [transaction, events] = await Promise.all([
@@ -19,6 +20,8 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
     disputes = await getDisputes(req.params.transactionExternalId, req.account.id)
     disputes.forEach((dispute) => dispute._locals.links.bind(req.service.externalId, req.account.type))
   }
+
+  const isOverSevenYearsOld = transaction.createdDate < TimeConstants.SEVEN_YEARS_AGO
 
   // sort by most recent first
   events.sort((eventA, eventB) => (eventA.timestamp > eventB.timestamp ? -1 : 1))
@@ -39,6 +42,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
       req.params.transactionExternalId
     ),
     messages: res.locals.flash?.messages ?? [],
+    isOverSevenYearsOld,
   })
 }
 

--- a/src/views/simplified-account/services/transactions/detail/index.njk
+++ b/src/views/simplified-account/services/transactions/detail/index.njk
@@ -10,6 +10,14 @@
 {% block serviceContent %}
   <h1 class="govuk-heading-l govuk-!-margin-top-6">Transaction details</h1>
 
+  {% if isOverSevenYearsOld %}
+    {{
+      govukInsetText({
+      text: "Some personal information has been redacted because this transaction is more than 7 years old."
+        })
+    }}
+  {% endif %}
+
   {% if not transaction.isFullyRefunded() and transaction.isRefundable() and permissions['refunds_create'] %}
     {{
       govukButton({

--- a/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
+++ b/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
@@ -242,6 +242,7 @@ describe('Transaction details page', () => {
       })
 
     cy.get('.govuk-summary-list__key').contains('3D Secure (3DS)').should('not.exist')
+    cy.get('.govuk-inset-text').should('not.exist')
   })
 
   it('should display partial refund amount', () => {
@@ -605,5 +606,21 @@ describe('Transaction details page', () => {
     ])
     cy.visit(TRANSACTION_URL)
     cy.contains('a.govuk-button', 'Refund payment').should('not.exist')
+  })
+
+  it('should display inset text if transaction if over 7 years old', () => {
+    const transactionCreatedTimestamp = DateTime.now().minus({ years: 7, months: 1 })
+    const oldTransaction = new TransactionFixture({ createdDate: transactionCreatedTimestamp })
+
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs,
+      getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(
+        oldTransaction
+      ),
+      getTransactionEvents(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION_EVENTS),
+    ])
+    cy.visit(TRANSACTION_URL)
+    cy.get('.govuk-inset-text').should('exist')
+    cy.get('.govuk-inset-text').should('contain.text', 'Some personal information has been redacted because this transaction is more than 7 years old.')
   })
 })

--- a/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
+++ b/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
@@ -608,7 +608,7 @@ describe('Transaction details page', () => {
     cy.contains('a.govuk-button', 'Refund payment').should('not.exist')
   })
 
-  it('should display inset text if transaction if over 7 years old', () => {
+  it('should display inset text if transaction is over 7 years old', () => {
     const transactionCreatedTimestamp = DateTime.now().minus({ years: 7, months: 1 })
     const oldTransaction = new TransactionFixture({ createdDate: transactionCreatedTimestamp })
 

--- a/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
+++ b/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
@@ -614,13 +614,14 @@ describe('Transaction details page', () => {
 
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
-      getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(
-        oldTransaction
-      ),
+      getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(oldTransaction),
       getTransactionEvents(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION_EVENTS),
     ])
     cy.visit(TRANSACTION_URL)
     cy.get('.govuk-inset-text').should('exist')
-    cy.get('.govuk-inset-text').should('contain.text', 'Some personal information has been redacted because this transaction is more than 7 years old.')
+    cy.get('.govuk-inset-text').should(
+      'contain.text',
+      'Some personal information has been redacted because this transaction is more than 7 years old.'
+    )
   })
 })


### PR DESCRIPTION
## What

PP-15384

- add inset text to explain redacted transactions
- this is rendered conditionally for transactions over 7 years old
- add Cypress tests
- changes are made only to updated transaction details page which is behind a feature flag  

### How

- create a transaction locally
- modify the `created_date` to be at least 7 years ago in your local database
- navigate to `http://localhost:3000/service/<SERVICE_ID>/account/test/transactions/<TRANSACTION_ID>`
- this inset text should be displayed

**NB after you modify the transaction it will NOT appear in the transaction list view because this currently only shows transactions less than 7 years old. This will be addressed in a subsequent PR.**

### Screenshots (views have been added/changed)

**NB screenshots are only to demonstrate conditional rendering of inset text based on date - fields have not been redacted locally**

>
> 
<img width="660" height="555" alt="Screenshot 2026-06-02 at 14 52 51" src="https://github.com/user-attachments/assets/dc01178a-8d83-47ac-991e-9b4a5f331942" />

***

<img width="670" height="478" alt="Screenshot 2026-06-02 at 14 51 50" src="https://github.com/user-attachments/assets/b4417886-0a31-4f2a-8144-61a3a24c81e8" />
