### PR TITLE
PP-15384 Fix inaccuracies in how old transactions are presented and described in admin tool

### DIFF
--- a/src/client-side/date-select.ts
+++ b/src/client-side/date-select.ts
@@ -38,20 +38,19 @@ function hideTimePicker() {
 }
 
 function clearDates() {
-  ; (document.getElementById('fromDate') as HTMLInputElement).value = ''
-    ; (document.getElementById('toDate') as HTMLInputElement).value = ''
+  ;(document.getElementById('fromDate') as HTMLInputElement).value = ''
+  ;(document.getElementById('toDate') as HTMLInputElement).value = ''
 }
 
 function setFromDate(date: DateTime | undefined) {
   if (date) {
-    ; (document.getElementById('fromDate') as HTMLInputElement).value = date.toFormat('dd/LL/yyyy')
+    ;(document.getElementById('fromDate') as HTMLInputElement).value = date.toFormat('dd/LL/yyyy')
   }
-
 }
 
 function setEndDate(date: DateTime | undefined) {
   if (date) {
-    ; (document.getElementById('toDate') as HTMLInputElement).value = date.toFormat('dd/LL/yyyy')
+    ;(document.getElementById('toDate') as HTMLInputElement).value = date.toFormat('dd/LL/yyyy')
   }
 }
 

--- a/src/client-side/date-select.ts
+++ b/src/client-side/date-select.ts
@@ -6,7 +6,7 @@ function register() {
     if (!(event.target instanceof HTMLSelectElement)) {
       return
     }
-    if (event.target.value === 'custom-range') {
+    if (event.target.value === 'custom-range' || event.target.value === 'all-time') {
       clearDates()
       return
     }
@@ -38,16 +38,21 @@ function hideTimePicker() {
 }
 
 function clearDates() {
-  ;(document.getElementById('fromDate') as HTMLInputElement).value = ''
-  ;(document.getElementById('toDate') as HTMLInputElement).value = ''
+  ; (document.getElementById('fromDate') as HTMLInputElement).value = ''
+    ; (document.getElementById('toDate') as HTMLInputElement).value = ''
 }
 
-function setFromDate(date: DateTime) {
-  ;(document.getElementById('fromDate') as HTMLInputElement).value = date.toFormat('dd/LL/yyyy')
+function setFromDate(date: DateTime | undefined) {
+  if (date) {
+    ; (document.getElementById('fromDate') as HTMLInputElement).value = date.toFormat('dd/LL/yyyy')
+  }
+
 }
 
-function setEndDate(date: DateTime) {
-  ;(document.getElementById('toDate') as HTMLInputElement).value = date.toFormat('dd/LL/yyyy')
+function setEndDate(date: DateTime | undefined) {
+  if (date) {
+    ; (document.getElementById('toDate') as HTMLInputElement).value = date.toFormat('dd/LL/yyyy')
+  }
 }
 
 export default function inject() {

--- a/src/controllers/simplified-account/services/dashboard/dashboard.controller.ts
+++ b/src/controllers/simplified-account/services/dashboard/dashboard.controller.ts
@@ -24,15 +24,21 @@ const logger = createLogger(__filename)
 async function get(req: ServiceRequest, res: ServiceResponse) {
   const currentPeriod = req.query.period as Period
   const { start, end } = getPeriodUKDateTimeRange(currentPeriod)
-  const transactionsPeriodQueryParams = `fromDate={fromDate}&fromTime={fromTime}&toDate={toDate}&toTime={toTime}`
-    .replace('{fromDate}', encodeURIComponent(start.toFormat('dd/MM/yyyy')))
-    .replace('{fromTime}', encodeURIComponent(start.toFormat('HH:mm:ss')))
-    .replace('{toDate}', encodeURIComponent(end.toFormat('dd/MM/yyyy')))
-    .replace('{toTime}', encodeURIComponent(end.toFormat('HH:mm:ss')))
+
+  const searchParams = new URLSearchParams();
+
+  if (start && end) {
+    searchParams.append('fromDate', start.toFormat('dd/MM/yyyy'));
+    searchParams.append('fromTime', start.toFormat('HH:mm:ss'));
+    searchParams.append('toDate', end.toFormat('dd/MM/yyyy'));
+    searchParams.append('toTime', end.toFormat('HH:mm:ss'));
+  }
+
+  const transactionsPeriodQueryParams = searchParams.toString();
 
   const humanDates = {
-    start: start.toLocaleString(DT_FULL),
-    end: end.toLocaleString(DT_FULL),
+    start: start?.toLocaleString(DT_FULL),
+    end: end?.toLocaleString(DT_FULL),
   }
 
   const agentInitiatedMotoPaymentLink = await getTelephonePaymentLink(req.user, req.service, req.account.id)
@@ -40,7 +46,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   return response(req, res, 'simplified-account/services/dashboard/index', {
     messages: res.locals.flash?.messages ?? [],
     currentPeriod,
-    activity: await getActivity(req.account.id, start, end),
+    activity: (start && end) ? await getActivity(req.account.id, start, end) : {},
     humanDates,
     possibleActions,
     dashboardActions: getActionsToDisplay(
@@ -62,15 +68,15 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
         switchMode:
           req.account.type === GatewayAccountType.LIVE
             ? formatServiceAndAccountPathsFor(
-                paths.simplifiedAccount.enterSandboxMode.index,
-                req.service.externalId,
-                GatewayAccountType.LIVE
-              )
+              paths.simplifiedAccount.enterSandboxMode.index,
+              req.service.externalId,
+              GatewayAccountType.LIVE
+            )
             : formatServiceAndAccountPathsFor(
-                paths.simplifiedAccount.exitSandboxMode.index,
-                req.service.externalId,
-                GatewayAccountType.TEST
-              ),
+              paths.simplifiedAccount.exitSandboxMode.index,
+              req.service.externalId,
+              GatewayAccountType.TEST
+            ),
         demoPayment: formatServiceAndAccountPathsFor(
           paths.simplifiedAccount.demoPayment.index,
           req.service.externalId,

--- a/src/controllers/simplified-account/services/dashboard/dashboard.controller.ts
+++ b/src/controllers/simplified-account/services/dashboard/dashboard.controller.ts
@@ -25,16 +25,16 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   const currentPeriod = req.query.period as Period
   const { start, end } = getPeriodUKDateTimeRange(currentPeriod)
 
-  const searchParams = new URLSearchParams();
+  const searchParams = new URLSearchParams()
 
   if (start && end) {
-    searchParams.append('fromDate', start.toFormat('dd/MM/yyyy'));
-    searchParams.append('fromTime', start.toFormat('HH:mm:ss'));
-    searchParams.append('toDate', end.toFormat('dd/MM/yyyy'));
-    searchParams.append('toTime', end.toFormat('HH:mm:ss'));
+    searchParams.append('fromDate', start.toFormat('dd/MM/yyyy'))
+    searchParams.append('fromTime', start.toFormat('HH:mm:ss'))
+    searchParams.append('toDate', end.toFormat('dd/MM/yyyy'))
+    searchParams.append('toTime', end.toFormat('HH:mm:ss'))
   }
 
-  const transactionsPeriodQueryParams = searchParams.toString();
+  const transactionsPeriodQueryParams = searchParams.toString()
 
   const humanDates = {
     start: start?.toLocaleString(DT_FULL),
@@ -46,7 +46,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   return response(req, res, 'simplified-account/services/dashboard/index', {
     messages: res.locals.flash?.messages ?? [],
     currentPeriod,
-    activity: (start && end) ? await getActivity(req.account.id, start, end) : {},
+    activity: start && end ? await getActivity(req.account.id, start, end) : {},
     humanDates,
     possibleActions,
     dashboardActions: getActionsToDisplay(
@@ -68,15 +68,15 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
         switchMode:
           req.account.type === GatewayAccountType.LIVE
             ? formatServiceAndAccountPathsFor(
-              paths.simplifiedAccount.enterSandboxMode.index,
-              req.service.externalId,
-              GatewayAccountType.LIVE
-            )
+                paths.simplifiedAccount.enterSandboxMode.index,
+                req.service.externalId,
+                GatewayAccountType.LIVE
+              )
             : formatServiceAndAccountPathsFor(
-              paths.simplifiedAccount.exitSandboxMode.index,
-              req.service.externalId,
-              GatewayAccountType.TEST
-            ),
+                paths.simplifiedAccount.exitSandboxMode.index,
+                req.service.externalId,
+                GatewayAccountType.TEST
+              ),
         demoPayment: formatServiceAndAccountPathsFor(
           paths.simplifiedAccount.demoPayment.index,
           req.service.externalId,

--- a/src/models/transaction/dto/TransactionSearchParams.dto.ts
+++ b/src/models/transaction/dto/TransactionSearchParams.dto.ts
@@ -47,11 +47,10 @@ export class TransactionSearchParamsData {
 
   setFromDate(params: TransactionSearchParams) {
     if (params.dateFilter === 'all-time') {
-      return undefined;
+      return undefined
     } else if (params.fromDate?.isValid) {
       return params.fromDate.toUTC().toISO()
-    }
-    else {
+    } else {
       return TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO()
     }
   }

--- a/src/models/transaction/dto/TransactionSearchParams.dto.ts
+++ b/src/models/transaction/dto/TransactionSearchParams.dto.ts
@@ -37,14 +37,23 @@ export class TransactionSearchParamsData {
     this.transaction_type = params.type ?? undefined
     this.reference = params.reference ?? undefined
     this.email = params.email ?? undefined
-    this.from_date = params.fromDate?.isValid
-      ? params.fromDate.toUTC().toISO()!
-      : TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO()
+    this.from_date = this.setFromDate(params) ?? undefined
     this.to_date = params.toDate?.isValid ? params.toDate.toUTC().toISO()! : undefined
     this.payment_states = params.paymentStates?.map(toLower).join(',')
     this.refund_states = params.refundStates?.map(toLower).join(',')
     this.dispute_states = params.disputeStates?.map(toLower).join(',')
     this.gateway_payout_id = params.gatewayPayoutId
+  }
+
+  setFromDate(params: TransactionSearchParams) {
+    if (params.dateFilter === 'all-time') {
+      return undefined;
+    } else if (params.fromDate?.isValid) {
+      return params.fromDate.toUTC().toISO()
+    }
+    else {
+      return TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO()
+    }
   }
 
   asQueryString(): string {

--- a/src/utils/simplified-account/services/dashboard/datetime-utils.test.ts
+++ b/src/utils/simplified-account/services/dashboard/datetime-utils.test.ts
@@ -40,17 +40,17 @@ describe('DateTime Utility', () => {
         const expectedStart = DateTime.fromISO('2025-01-15T00:00:00.000', { zone: 'Europe/London' })
         const expectedEnd = DateTime.fromISO('2025-01-15T14:30:00.000', { zone: 'Europe/London' })
 
-        expect(result.start.toISO()).to.equal(expectedStart.toISO())
-        expect(result.end.toISO()).to.equal(expectedEnd.toISO())
+        expect(result.start!.toISO()).to.equal(expectedStart.toISO())
+        expect(result.end!.toISO()).to.equal(expectedEnd.toISO())
       })
 
       it('should use UK locale and London timezone', () => {
         const result = getPeriodUKDateTimeRange('today')
 
-        expect(result.start.locale).to.equal('en-GB')
-        expect(result.start.zoneName).to.equal('Europe/London')
-        expect(result.end.locale).to.equal('en-GB')
-        expect(result.end.zoneName).to.equal('Europe/London')
+        expect(result.start!.locale).to.equal('en-GB')
+        expect(result.start!.zoneName).to.equal('Europe/London')
+        expect(result.end!.locale).to.equal('en-GB')
+        expect(result.end!.zoneName).to.equal('Europe/London')
       })
     })
 
@@ -61,8 +61,8 @@ describe('DateTime Utility', () => {
         const expectedStart = DateTime.fromISO('2025-01-14T00:00:00.000', { zone: 'Europe/London' })
         const expectedEnd = DateTime.fromISO('2025-01-14T23:59:59.999', { zone: 'Europe/London' })
 
-        expect(result.start.toISO()).to.equal(expectedStart.toISO())
-        expect(result.end.toISO()).to.equal(expectedEnd.toISO())
+        expect(result.start!.toISO()).to.equal(expectedStart.toISO())
+        expect(result.end!.toISO()).to.equal(expectedEnd.toISO())
       })
     })
 
@@ -73,13 +73,13 @@ describe('DateTime Utility', () => {
         const expectedStart = DateTime.fromISO('2025-01-08T00:00:00.000', { zone: 'Europe/London' })
         const expectedEnd = DateTime.fromISO('2025-01-14T23:59:59.999', { zone: 'Europe/London' })
 
-        expect(result.start.toISO()).to.equal(expectedStart.toISO())
-        expect(result.end.toISO()).to.equal(expectedEnd.toISO())
+        expect(result.start!.toISO()).to.equal(expectedStart.toISO())
+        expect(result.end!.toISO()).to.equal(expectedEnd.toISO())
       })
 
       it('should span exactly 7 days', () => {
         const result = getPeriodUKDateTimeRange('previous-seven-days')
-        const daysDiff = result.end.diff(result.start, 'days').days
+        const daysDiff = result.end!.diff(result.start!, 'days').days
 
         expect(Math.floor(daysDiff)).to.equal(6)
         expect(daysDiff).to.be.greaterThan(6.9)
@@ -93,13 +93,13 @@ describe('DateTime Utility', () => {
         const expectedStart = DateTime.fromISO('2024-12-16T00:00:00.000', { zone: 'Europe/London' })
         const expectedEnd = DateTime.fromISO('2025-01-14T23:59:59.999', { zone: 'Europe/London' })
 
-        expect(result.start.toISO()).to.equal(expectedStart.toISO())
-        expect(result.end.toISO()).to.equal(expectedEnd.toISO())
+        expect(result.start!.toISO()).to.equal(expectedStart.toISO())
+        expect(result.end!.toISO()).to.equal(expectedEnd.toISO())
       })
 
       it('should span exactly 30 days', () => {
         const result = getPeriodUKDateTimeRange('previous-thirty-days')
-        const daysDiff = result.end.diff(result.start, 'days').days
+        const daysDiff = result.end!.diff(result.start!, 'days').days
 
         expect(Math.floor(daysDiff)).to.equal(29)
         expect(daysDiff).to.be.greaterThan(29.9)
@@ -113,13 +113,13 @@ describe('DateTime Utility', () => {
         const expectedStart = DateTime.fromISO('2024-01-15T00:00:00.000', { zone: 'Europe/London' })
         const expectedEnd = DateTime.fromISO('2025-01-15T14:30:00.000Z', { zone: 'Europe/London' })
 
-        expect(result.start.toISO()).to.equal(expectedStart.toISO())
-        expect(result.end.toISO()).to.equal(expectedEnd.toISO())
+        expect(result.start!.toISO()).to.equal(expectedStart.toISO())
+        expect(result.end!.toISO()).to.equal(expectedEnd.toISO())
       })
 
       it('should span exactly 12 months', () => {
         const result = getPeriodUKDateTimeRange('last-12-months')
-        const daysDiff = result.end.diff(result.start, 'months').months
+        const daysDiff = result.end!.diff(result.start!, 'months').months
 
         expect(Math.floor(daysDiff)).to.equal(12)
         expect(daysDiff).to.be.greaterThan(11.9)
@@ -127,22 +127,11 @@ describe('DateTime Utility', () => {
     })
 
     describe('when period is "all-time"', () => {
-      it('should return range for 7 years ending now', () => {
+      it('should not return start or end time', () => {
         const result = getPeriodUKDateTimeRange('all-time')
 
-        const expectedStart = DateTime.fromISO('2018-01-15T00:00:00.000', { zone: 'Europe/London' })
-        const expectedEnd = DateTime.fromISO('2025-01-15T14:30:00.000Z', { zone: 'Europe/London' })
-
-        expect(result.start.toISO()).to.equal(expectedStart.toISO())
-        expect(result.end.toISO()).to.equal(expectedEnd.toISO())
-      })
-
-      it('should span exactly 12 months', () => {
-        const result = getPeriodUKDateTimeRange('all-time')
-        const daysDiff = result.end.diff(result.start, 'years').years
-
-        expect(Math.floor(daysDiff)).to.equal(7)
-        expect(daysDiff).to.be.greaterThan(6.9)
+        expect(result.start).to.equal(undefined)
+        expect(result.end).to.equal(undefined)
       })
     })
 
@@ -156,7 +145,7 @@ describe('DateTime Utility', () => {
 
         const expectedStart = DateTime.fromISO('2024-02-29T00:00:00.000', { zone: 'Europe/London' })
 
-        expect(result.start.toISO()).to.equal(expectedStart.toISO())
+        expect(result.start!.toISO()).to.equal(expectedStart.toISO())
       })
 
       it('should handle daylight saving time transitions', () => {
@@ -165,8 +154,8 @@ describe('DateTime Utility', () => {
 
         const result = getPeriodUKDateTimeRange('previous-seven-days')
 
-        expect(result.start.offset).to.equal(0)
-        expect(result.end.offset).to.equal(60)
+        expect(result.start!.offset).to.equal(0)
+        expect(result.end!.offset).to.equal(60)
       })
     })
 
@@ -185,7 +174,7 @@ describe('DateTime Utility', () => {
 
         periods.forEach((period) => {
           const result = getPeriodUKDateTimeRange(period)
-          expect(result.start.toMillis()).to.be.lessThan(result.end.toMillis())
+          expect(result.start!.toMillis()).to.be.lessThan(result.end!.toMillis())
         })
       })
     })
@@ -195,8 +184,8 @@ describe('DateTime Utility', () => {
         const result1 = getPeriodUKDateTimeRange('previous-seven-days')
         const result2 = getPeriodUKDateTimeRange('previous-seven-days')
 
-        expect(result1.start.toMillis()).to.equal(result2.start.toMillis())
-        expect(result1.end.toMillis()).to.equal(result2.end.toMillis())
+        expect(result1.start!.toMillis()).to.equal(result2.start!.toMillis())
+        expect(result1.end!.toMillis()).to.equal(result2.end!.toMillis())
       })
     })
   })

--- a/src/utils/simplified-account/services/dashboard/datetime-utils.ts
+++ b/src/utils/simplified-account/services/dashboard/datetime-utils.ts
@@ -11,8 +11,8 @@ export type Period =
   | 'all-time'
 
 interface DateTimeRange {
-  start: DateTime<true>
-  end: DateTime<true>
+  start: DateTime<true> | undefined
+  end: DateTime<true> | undefined
 }
 
 export const DT_FULL = {
@@ -26,7 +26,7 @@ export const DT_FULL = {
   hour12: true,
 } as DateTimeFormatOptions
 
-export function getPeriodUKDateTimeRange(period: Period): DateTimeRange {
+export function getPeriodUKDateTimeRange(period: Period | undefined): DateTimeRange {
   const now = DateTime.now().setLocale('en-GB').setZone('Europe/London') as DateTime<true>
 
   switch (period) {
@@ -64,8 +64,8 @@ export function getPeriodUKDateTimeRange(period: Period): DateTimeRange {
 
     case 'all-time': {
       return {
-        start: TimeConstants.SEVEN_YEARS_AGO,
-        end: now,
+        start: undefined,
+        end: undefined,
       }
     }
 

--- a/src/views/simplified-account/transactions/partials/_date-filter-select.njk
+++ b/src/views/simplified-account/transactions/partials/_date-filter-select.njk
@@ -41,7 +41,7 @@
     },
     {
       value: "all-time",
-      text: "All time (last 7 years)",
+      text: "Show all",
       selected: filters.dateFilter === 'all-time'
     }]
   })


### PR DESCRIPTION
## What

PP-15384

- update label of all-time filter
- remove date parameters of last 7 years

## How

- create a transaction locally
- modify the created_date to be at least 7 years ago in your local database
- navigate to transactions list page for your service
- select filter "Show all" from date filters
- your transaction should be visible, and no dates should appear in Start/End date

### Screenshots (views have been added/changed)

***

<img width="922" height="761" alt="Screenshot 2026-06-04 at 16 53 02" src="https://github.com/user-attachments/assets/e1f27175-e211-4a3f-ab17-26404b9deb2e" />
